### PR TITLE
fix: remove broken import for non-existent github adapter

### DIFF
--- a/src/clis/index.ts
+++ b/src/clis/index.ts
@@ -12,9 +12,6 @@ import './bilibili/history.js';
 import './bilibili/feed.js';
 import './bilibili/user-videos.js';
 
-// github
-import './github/search.js';
-
 // zhihu
 import './zhihu/question.js';
 


### PR DESCRIPTION
## Summary
- 修复 index.ts 中引用不存在的 github 适配器目录的问题
- 移除了对 `./github/search.js` 的导入，因为对应的 github 目录不存在

## Test plan
- [x] `npx tsx src/main.ts list` 运行成功