### PR TITLE
fix: preserve zhihu hot question ids beyond safe integer

### DIFF
--- a/src/clis/zhihu/hot.yaml
+++ b/src/clis/zhihu/hot.yaml
@@ -17,12 +17,16 @@ pipeline:
         const res = await fetch('https://www.zhihu.com/api/v3/feed/topstory/hot-lists/total?limit=50', {
           credentials: 'include'
         });
-        const d = await res.json();
+        const text = await res.text();
+        const d = JSON.parse(
+          text.replace(/("id"\s*:\s*)(\d{16,})/g, '$1"$2"')
+        );
         return (d?.data || []).map((item) => {
           const t = item.target || {};
+          const questionId = t.id == null ? '' : String(t.id);
           return {
             title: t.title,
-            url: 'https://www.zhihu.com/question/' + t.id,
+            url: 'https://www.zhihu.com/question/' + questionId,
             answer_count: t.answer_count,
             follower_count: t.follower_count,
             heat: item.detail_text || '',


### PR DESCRIPTION
## Summary

Fix `zhihu hot` generating incorrect question URLs when Zhihu returns question IDs beyond JavaScript's safe integer range.

## Changes

- read the hot list response as raw text instead of calling `res.json()` directly
- preserve long numeric `id` fields as strings before parsing
- build question URLs from the stringified question id

## Verification

- `npm run lint`
- `npm test`

Closes #3.
