### PR TITLE
docs: align command list with shipped adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![npm](https://img.shields.io/npm/v/@jackwener/opencli)](https://www.npmjs.com/package/@jackwener/opencli)
 
-A CLI tool that turns **any website** into a command-line interface. **28+ commands** across **16 sites** — bilibili, zhihu, xiaohongshu, twitter, reddit, github, v2ex, hackernews, bbc, weibo, boss, yahoo-finance, reuters, smzdm, ctrip, youtube — powered by browser session reuse and AI-native discovery.
+A CLI tool that turns **any website** into a command-line interface. **27 commands** across **15 sites** — bilibili, zhihu, xiaohongshu, twitter, reddit, v2ex, hackernews, bbc, weibo, boss, yahoo-finance, reuters, smzdm, ctrip, youtube — powered by browser session reuse and AI-native discovery.
 
 ## ✨ Highlights
 
@@ -72,7 +72,7 @@ Browser commands need:
 }
 ```
 
-Public API commands (`hackernews`, `github search`, `v2ex`) need no browser at all.
+Public API commands (`hackernews`, `v2ex`, `bbc`) need no browser at all.
 
 > **⚠️ Important**: Browser commands reuse your Chrome login session. You must be logged into the target website in Chrome before running commands. If you get empty data or errors, check your login status first.
 
@@ -92,7 +92,6 @@ Public API commands (`hackernews`, `github search`, `v2ex`) need no browser at a
 | **reuters** | `search` | 🔐 Browser |
 | **smzdm** | `search` | 🔐 Browser |
 | **ctrip** | `search` | 🔐 Browser |
-| **github** | `trending` `search` | 🔐 / 🌐 |
 | **v2ex** | `hot` `latest` `topic` | 🌐 Public |
 | **hackernews** | `top` | 🌐 Public |
 | **bbc** | `news` | 🌐 Public |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@ OpenCLI 通过 Chrome 浏览器 + [Playwright MCP Bridge](https://github.com/nic
 
 ## ✨ 亮点
 
-- 🌐 **28+ 命令，16 个站点** — B站、知乎、小红书、Twitter、Reddit、GitHub、V2EX、Hacker News、BBC、微博、BOSS直聘、Yahoo Finance、路透社、什么值得买、携程、YouTube
+- 🌐 **27 个命令，15 个站点** — B站、知乎、小红书、Twitter、Reddit、V2EX、Hacker News、BBC、微博、BOSS直聘、Yahoo Finance、路透社、什么值得买、携程、YouTube
 - 🔐 **零风控** — 复用 Chrome 登录态，无需存储任何凭证
 - 🤖 **AI 原生** — `explore` 自动发现 API，`synthesize` 生成适配器，`cascade` 探测认证策略
 - 📝 **声明式 YAML** — 大部分适配器只需 ~30 行 YAML
@@ -73,7 +73,7 @@ npm install -g @jackwener/opencli@latest
 }
 ```
 
-公共 API 命令（`hackernews`、`github search`、`v2ex`）无需浏览器。
+公共 API 命令（`hackernews`、`v2ex`、`bbc`）无需浏览器。
 
 > **⚠️ 重要**：浏览器命令复用你的 Chrome 登录状态。运行命令前，你必须已在 Chrome 中登录目标网站。如果获取到空数据或报错，请先检查登录状态。
 
@@ -93,7 +93,6 @@ npm install -g @jackwener/opencli@latest
 | **reuters** | `search` | 🔐 浏览器 |
 | **smzdm** | `search` | 🔐 浏览器 |
 | **ctrip** | `search` | 🔐 浏览器 |
-| **github** | `trending` `search` | 🔐 / 🌐 |
 | **v2ex** | `hot` `latest` `topic` | 🌐 公共 API |
 | **hackernews** | `top` | 🌐 公共 API |
 | **bbc** | `news` | 🌐 公共 API |

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: opencli
 description: "OpenCLI — Make any website your CLI. Zero risk, AI-powered, reuse Chrome login."
 version: 0.1.0
 author: jackwener
-tags: [cli, browser, web, mcp, playwright, bilibili, zhihu, twitter, github, v2ex, hackernews, reddit, xiaohongshu, AI, agent]
+tags: [cli, browser, web, mcp, playwright, bilibili, zhihu, twitter, v2ex, hackernews, reddit, xiaohongshu, AI, agent]
 ---
 
 # OpenCLI
@@ -34,7 +34,7 @@ Browser commands require:
 
 > **Note**: You must be logged into the target website in Chrome before running commands. Tabs opened during command execution are auto-closed afterwards.
 
-Public API commands (`hackernews`, `github search`, `v2ex`) need no browser.
+Public API commands (`hackernews`, `v2ex`, `bbc`) need no browser.
 
 ## Commands Reference
 
@@ -60,9 +60,9 @@ opencli xiaohongshu search --keyword "美食"  # 搜索笔记
 opencli xiaohongshu notifications             # 通知（mentions/likes/connections）
 opencli xiaohongshu feed --limit 10           # 推荐 Feed
 
-# GitHub (trending=browser, search=public)
-opencli github trending --limit 10       # GitHub Trending
-opencli github search --keyword "cli"    # 搜索仓库
+# Public API commands
+opencli bbc news --limit 10              # BBC News headlines
+opencli v2ex hot --limit 10              # V2EX 热门话题
 
 # Twitter/X (browser)
 opencli twitter trending --limit 10      # 热门话题


### PR DESCRIPTION
## Summary
- align README counts with the current shipped adapters (`27` commands across `15` sites)
- remove `github` command references that are not present in the current repo/runtime
- update the public API examples in `SKILL.md` to use commands that actually exist

## Verification
- ran `node dist/main.js list --json`
- confirmed the current runtime exposes 27 commands across 15 sites
- confirmed there is no `src/clis/github/` adapter directory in the repo