### PR TITLE
fix: escape evaluate args in browser scripts

### DIFF
--- a/src/clis/reddit/hot.yaml
+++ b/src/clis/reddit/hot.yaml
@@ -18,9 +18,10 @@ pipeline:
 
   - evaluate: |
       (async () => {
-        const sub = '${{ args.subreddit }}';
+        const sub = ${{ args.subreddit | json }};
         const path = sub ? '/r/' + sub + '/hot.json' : '/hot.json';
-        const res = await fetch(path + '?limit=${{ args.limit }}&raw_json=1', {
+        const limit = ${{ args.limit }};
+        const res = await fetch(path + '?limit=' + limit + '&raw_json=1', {
           credentials: 'include'
         });
         const d = await res.json();

--- a/src/clis/zhihu/search.yaml
+++ b/src/clis/zhihu/search.yaml
@@ -19,7 +19,9 @@ pipeline:
   - evaluate: |
       (async () => {
         const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').replace(/<em>/g, '').replace(/<\/em>/g, '').trim();
-        const res = await fetch('https://www.zhihu.com/api/v4/search_v3?q=' + encodeURIComponent('${{ args.keyword }}') + '&t=general&offset=0&limit=${{ args.limit }}', {
+        const keyword = ${{ args.keyword | json }};
+        const limit = ${{ args.limit }};
+        const res = await fetch('https://www.zhihu.com/api/v4/search_v3?q=' + encodeURIComponent(keyword) + '&t=general&offset=0&limit=' + limit, {
           credentials: 'include'
         });
         const d = await res.json();

--- a/src/pipeline/template.test.ts
+++ b/src/pipeline/template.test.ts
@@ -75,6 +75,12 @@ describe('evalExpr', () => {
   it('applies length filter', () => {
     expect(evalExpr('item.items | length', { item: { items: [1, 2, 3] } })).toBe(3);
   });
+  it('applies json filter to strings with quotes', () => {
+    expect(evalExpr('args.keyword | json', { args: { keyword: "O'Reilly" } })).toBe('"O\'Reilly"');
+  });
+  it('applies json filter to nullish values', () => {
+    expect(evalExpr('args.keyword | json', { args: {} })).toBe('null');
+  });
 });
 
 describe('render', () => {

--- a/src/pipeline/template.ts
+++ b/src/pipeline/template.ts
@@ -75,7 +75,7 @@ export function evalExpr(expr: string, ctx: RenderContext): any {
  * Apply a named filter to a value.
  * Supported filters:
  *   default(val), join(sep), upper, lower, truncate(n), trim,
- *   replace(old,new), keys, length, first, last
+ *   replace(old,new), keys, length, first, last, json
  */
 function applyFilter(filterExpr: string, value: any): any {
   const match = filterExpr.match(/^(\w+)(?:\((.+)\))?$/);
@@ -117,6 +117,8 @@ function applyFilter(filterExpr: string, value: any): any {
       return Array.isArray(value) ? value[0] : value;
     case 'last':
       return Array.isArray(value) ? value[value.length - 1] : value;
+    case 'json':
+      return JSON.stringify(value ?? null);
     default:
       return value;
   }


### PR DESCRIPTION
## Summary
- add a `json` template filter so browser `evaluate` scripts can inject user input as valid JS literals
- use that filter in `zhihu search` and `reddit hot`, which were previously embedding raw string args into JavaScript source
- add template-engine coverage for quoted and nullish values

## Repro
Before this change, this worked:
```bash
PLAYWRIGHT_MCP_EXTENSION_TOKEN=... node dist/main.js zhihu search --keyword AI --limit 2 -f json
```

But this failed because the single quote broke the generated browser script:
```bash
PLAYWRIGHT_MCP_EXTENSION_TOKEN=... node dist/main.js zhihu search --keyword "O'Reilly" --limit 2 -f json
```

Error:
```text
Error: page._evaluateFunction: Passed function is not well-serializable!
```

## Verification
- `npm test -- --run src/pipeline/template.test.ts`
- `npm run build`
- confirmed `zhihu search --keyword "O'Reilly"` now returns JSON instead of throwing the serialization error