### PR TITLE
fix: use Playwright MCP executable-path flag

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -38,6 +38,30 @@ describe('browser helpers', () => {
     expect(__test__.appendLimited('12345', '67890', 8)).toBe('34567890');
   });
 
+  it('builds Playwright MCP args with kebab-case executable path', () => {
+    expect(__test__.buildMcpArgs({
+      mcpPath: '/tmp/cli.js',
+      executablePath: '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
+    })).toEqual([
+      '/tmp/cli.js',
+      '--extension',
+      '--executable-path',
+      '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
+    ]);
+
+    expect(__test__.buildMcpArgs({
+      mcpPath: '/tmp/cli.js',
+      cdpEndpoint: 'ws://127.0.0.1:9222/devtools/browser/abc',
+      executablePath: '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
+    })).toEqual([
+      '/tmp/cli.js',
+      '--cdp-endpoint',
+      'ws://127.0.0.1:9222/devtools/browser/abc',
+      '--executable-path',
+      '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
+    ]);
+  });
+
   it('times out slow promises', async () => {
     await expect(__test__.withTimeout(new Promise(() => {}), 10, 'timeout')).rejects.toThrow('timeout');
   });

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -579,20 +579,16 @@ export class PlaywrightMCP {
         }));
       }, timeout * 1000);
 
-      const mcpArgs: string[] = [mcpPath];
-      if (cdpEndpoint) {
-        mcpArgs.push('--cdp-endpoint', cdpEndpoint);
-      } else {
-        mcpArgs.push('--extension');
-      }
+      const mcpArgs = buildMcpArgs({
+        mcpPath,
+        cdpEndpoint,
+        executablePath: process.env.OPENCLI_BROWSER_EXECUTABLE_PATH,
+      });
       if (process.env.OPENCLI_VERBOSE) {
         console.error(`[opencli] CDP mode: ${cdpEndpoint ? `auto-discovered ${cdpEndpoint}` : 'fallback to --extension'}`);
         if (mode === 'extension') {
           console.error(`[opencli] Extension token: ${extensionToken ? `configured (fingerprint ${tokenFingerprint})` : 'missing'}`);
         }
-      }
-      if (process.env.OPENCLI_BROWSER_EXECUTABLE_PATH) {
-        mcpArgs.push('--executablePath', process.env.OPENCLI_BROWSER_EXECUTABLE_PATH);
       }
       debugLog(`Spawning node ${mcpArgs.join(' ')}`);
 
@@ -822,6 +818,19 @@ function appendLimited(current: string, chunk: string, limit: number): string {
   return next.slice(-limit);
 }
 
+function buildMcpArgs(input: { mcpPath: string; cdpEndpoint?: string | null; executablePath?: string | null }): string[] {
+  const args = [input.mcpPath];
+  if (input.cdpEndpoint) {
+    args.push('--cdp-endpoint', input.cdpEndpoint);
+  } else {
+    args.push('--extension');
+  }
+  if (input.executablePath) {
+    args.push('--executable-path', input.executablePath);
+  }
+  return args;
+}
+
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
@@ -843,6 +852,7 @@ export const __test__ = {
   extractTabEntries,
   diffTabIndexes,
   appendLimited,
+  buildMcpArgs,
   withTimeout,
   isCdpApiAvailable,
 };


### PR DESCRIPTION
## Summary

This fixes the Playwright MCP executable override flag passed by opencli.

opencli currently forwards the browser executable path to `@playwright/mcp` as `--executablePath`, but the Playwright MCP CLI expects `--executable-path`.

As a result, custom browser executable overrides do not work correctly in environments that rely on them, such as WSL launching Windows Chrome.

## What changed

- switch the forwarded CLI flag from `--executablePath` to `--executable-path`
- add regression coverage in `src/browser.test.ts`
- keep the change minimal and focused to the Playwright MCP launcher path

## Validation

- verified against multiple `@playwright/mcp` versions that the CLI flag is `--executable-path`
- focused browser tests pass
- build passes
- real-world validation succeeded in WSL using the Playwright MCP extension path with a Windows Chrome executable override

## Notes

This PR intentionally does not include unrelated experimental browser backend work. It only fixes the Playwright MCP executable-path forwarding bug and adds test coverage.
