### PR TITLE
fix(test): set unique Vitest groupOrder for e2e project to unblock npm test

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
           name: 'e2e',
           include: ['tests/**/*.test.ts'],
           maxWorkers: 2,
+          sequence: {
+            groupOrder: 1,
+          },
         },
       },
     ],


### PR DESCRIPTION
## What
Fixes a Vitest multi-project configuration conflict that causes `npm test` to fail before running tests.

## Root Cause
`vitest.config.ts` defines two projects (`unit` and `e2e`), and `e2e` sets `maxWorkers: 2` while sharing the default `sequence.groupOrder` with `unit`.
Vitest v4 requires different `groupOrder` when project worker settings differ.

## Change
Updated `e2e` project config to use a unique group order:

- File: `vitest.config.ts`
- Added:
  - `sequence.groupOrder: 1`

## Validation
- Ran: `npx vitest run src/`
- Result: `12` files passed, `178` tests passed

## Impact
- Removes immediate test-run blocker from project configuration.
- No runtime or adapter behavior changes.