### PR TITLE
ci: add pkg.pr.new for continuous package previews

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,29 @@
+name: Publish Any Commit
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to pkg.pr.new
+        run: npx pkg-pr-new publish


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow (`.github/workflows/pkg-pr-new.yml`) that publishes preview versions of the package to [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) on every push and PR
- Allows reviewers and users to install and test exact commit builds via `npm i https://pkg.pr.new/@jackwener/opencli@{sha}`

## Prerequisites
- The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) must be installed on this repository

## Test plan
- [ ] Install the pkg.pr.new GitHub App on the repo
- [ ] Verify the workflow runs on this PR and publishes a preview
- [ ] Confirm the install link in the PR comment works