### PR TITLE
feat: add grok.com site support

### DIFF
--- a/src/clis/grok/ask.ts
+++ b/src/clis/grok/ask.ts
@@ -1,0 +1,91 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+export const askCommand = cli({
+  site: 'grok',
+  name: 'ask',
+  description: 'Send a message to Grok and get response',
+  domain: 'grok.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'prompt', type: 'string', required: true, help: 'Prompt to send to Grok' },
+    { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response (default: 120)' },
+    { name: 'new', type: 'boolean', default: false, help: 'Start a new conversation before sending' },
+  ],
+  columns: ['response'],
+  func: async (page: IPage, kwargs: any) => {
+    const prompt = kwargs.prompt as string;
+    const timeout = parseInt(kwargs.timeout as string, 10) || 120;
+    const timeoutMs = timeout * 1000;
+    const startNew = kwargs.new as boolean;
+
+    if (startNew) {
+      await page.goto('https://grok.com');
+      await page.wait(2);
+      await page.evaluate(`(() => {
+        const btn = [...document.querySelectorAll('a, button')].find(b => {
+          const t = (b.textContent || '').trim().toLowerCase();
+          return t.includes('new') || b.getAttribute('href') === '/';
+        });
+        if (btn) btn.click();
+      })()`);
+      await page.wait(2);
+    }
+
+    await page.goto('https://grok.com');
+    await page.wait(3);
+
+    const promptJson = JSON.stringify(prompt);
+
+    const sendResult = await page.evaluate(`(async () => {
+      try {
+        const box = document.querySelector('textarea');
+        if (!box) return { ok: false, msg: 'no textarea' };
+        box.focus(); box.value = '';
+        document.execCommand('selectAll');
+        document.execCommand('insertText', false, ${promptJson});
+        await new Promise(r => setTimeout(r, 1500));
+        const btn = document.querySelector('button[aria-label="\\u63d0\\u4ea4"]');
+        if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
+        const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
+        if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
+        box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+        return { ok: true, msg: 'enter' };
+      } catch (e) { return { ok: false, msg: e.toString() }; }
+    })()`);
+
+    if (!sendResult || !sendResult.ok) {
+      return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+    }
+
+    const startTime = Date.now();
+    let lastText = '';
+    let stableCount = 0;
+
+    while (Date.now() - startTime < timeoutMs) {
+      await page.wait(3);
+      const response = await page.evaluate(`(() => {
+        const bubbles = document.querySelectorAll('div.message-bubble, [data-testid="message-bubble"]');
+        if (bubbles.length < 2) return '';
+        const last = bubbles[bubbles.length - 1];
+        const text = (last.innerText || '').trim();
+        if (!text || text.length < 2) return '';
+        return text;
+      })()`);
+
+      if (response && response.length > 2) {
+        if (response === lastText) {
+          stableCount++;
+          if (stableCount >= 2) return [{ response }];
+        } else {
+          stableCount = 0;
+        }
+      }
+      lastText = response || '';
+    }
+
+    if (lastText) return [{ response: lastText }];
+    return [{ response: '[NO RESPONSE]' }];
+  },
+});

--- a/src/clis/grok/debug.ts
+++ b/src/clis/grok/debug.ts
@@ -1,0 +1,46 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+export const debugCommand = cli({
+  site: 'grok',
+  name: 'debug',
+  description: 'Debug grok page structure',
+  domain: 'grok.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  columns: ['data'],
+  func: async (page: IPage) => {
+    await page.goto('https://grok.com');
+    await page.wait(3);
+
+    const debug = await page.evaluate(`(() => {
+      const ta = document.querySelector('textarea');
+      if (!ta) return { error: 'no textarea' };
+
+      let parent = ta.parentElement;
+      const parents = [];
+      for (let i = 0; i < 5 && parent; i++) {
+        parents.push({
+          tag: parent.tagName,
+          class: parent.className?.substring(0, 80),
+          childCount: parent.children.length,
+        });
+        parent = parent.parentElement;
+      }
+
+      const form = ta.closest('form') || ta.closest('[class*="composer"]') || ta.closest('[class*="input"]') || ta.parentElement?.parentElement;
+      const buttons = form ? [...form.querySelectorAll('button')].map(b => ({
+        testid: b.getAttribute('data-testid'),
+        type: b.type,
+        disabled: b.disabled,
+        text: (b.textContent || '').substring(0, 30),
+        html: b.outerHTML.substring(0, 200),
+        rect: b.getBoundingClientRect().toJSON(),
+      })) : [];
+
+      return { parents, buttons, formTag: form?.tagName, formClass: form?.className?.substring(0, 80) };
+    })()`);
+
+    return [{ data: JSON.stringify(debug, null, 2) }];
+  },
+});


### PR DESCRIPTION
## 新增功能
为 opencli 新增 grok.com 站点支持，通过 Playwright CDP 协议自动化操作 grok.com，支持对话和调试功能。

## 实现细节
1. 核心命令：
   - `opencli grok ask --prompt "..."`：输入 prompt，自动提交、轮询等待回复、提取纯文本
   - `opencli grok debug`：打开 grok.com 页面用于调试
2. 技术方案：
   - 基于 Playwright CDP 协议，复用 opencli 现有的浏览器自动化框架
   - 支持超时配置（通过 OPENCLI_BROWSER_COMMAND_TIMEOUT 环境变量）
   - 多层 DOM 兜底选择器（div.message-bubble、[data-testid="message-bubble"]），兼容 DOM 结构变化
3. 代码结构：
   - 参考 chatgpt 站点的目录结构和代码风格
   - 用 TypeScript 编写，遵循项目 lint/format 规范

## 测试情况
已手动完整测试：
- ✅ opencli grok ask 正常返回，文本提取准确
- ✅ opencli grok debug 正常打开页面
- ✅ 超时配置生效
- ✅ DOM 兜底选择器兼容当前 grok.com 结构

感谢原作者的开源项目！