### PR TITLE
fix(main): navigate to domain before cookie/header strategy commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverClis, executeCommand } from './engine.js';
-import { type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
+import { Strategy, type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
 import { render as renderOutput } from './output.js';
 import { PlaywrightMCP } from './browser.js';
 import { browserSession, DEFAULT_BROWSER_COMMAND_TIMEOUT, runWithTimeout } from './runtime.js';
@@ -101,7 +101,13 @@ for (const [, cmd] of registry) {
     try {
       let result: any;
       if (cmd.browser) {
-        result = await browserSession(PlaywrightMCP, async (page) => runWithTimeout(executeCommand(cmd, page, kwargs, actionOpts.verbose), { timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT, label: fullName(cmd) }));
+        result = await browserSession(PlaywrightMCP, async (page) => {
+          // Cookie/header strategies need same-origin context for credentialed fetch
+          if ((cmd.strategy === Strategy.COOKIE || cmd.strategy === Strategy.HEADER) && cmd.domain) {
+            try { await page.goto(`https://${cmd.domain}`); await page.wait(2); } catch {}
+          }
+          return runWithTimeout(executeCommand(cmd, page, kwargs, actionOpts.verbose), { timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT, label: fullName(cmd) });
+        });
       } else { result = await executeCommand(cmd, null, kwargs, actionOpts.verbose); }
       if (actionOpts.verbose && (!result || (Array.isArray(result) && result.length === 0))) {
         console.error(chalk.yellow(`[Verbose] Warning: Command returned an empty result. If the website structural API changed or requires authentication, check the network or update the adapter.`));


### PR DESCRIPTION
## Summary

- Cookie/header strategy commands (e.g. `bilibili search`, `twitter timeline`, `zhihu hot`) fail with `Failed to fetch` when the active Chrome tab is on an unrelated domain
- Root cause: `fetch()` with `credentials: 'include'` is executed in-page, but cross-origin credentialed requests are blocked by the browser's same-origin policy
- Fix: navigate to `cmd.domain` before executing cookie/header strategy commands, mirroring the pre-navigation already done in the `cascade` command

## Repro

1. Have YouTube (or any non-bilibili page) as the active Chrome tab
2. Run `opencli bilibili search --keyword "test"`
3. → `Error: Failed to fetch`

After fix: opencli automatically navigates to `bilibili.com` first, then runs the API fetch in same-origin context.

## Changes

- `src/main.ts`: Add domain pre-navigation for `Strategy.COOKIE` and `Strategy.HEADER` commands before executing the command function
- Import `Strategy` enum from registry

## Test plan

- [x] `bilibili search` works regardless of active Chrome tab
- [x] `bilibili hot` (public strategy, no cookie) still works
- [x] `youtube search` (cookie strategy) still works
- [x] TypeScript type check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)