### PR TITLE
fix(main): navigate to domain before cookie/header strategy commands in CDP mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverClis, executeCommand } from './engine.js';
-import { type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
+import { Strategy, type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
 import { render as renderOutput } from './output.js';
 import { PlaywrightMCP } from './browser.js';
 import { browserSession, DEFAULT_BROWSER_COMMAND_TIMEOUT, runWithTimeout } from './runtime.js';
@@ -101,7 +101,15 @@ for (const [, cmd] of registry) {
     try {
       let result: any;
       if (cmd.browser) {
-        result = await browserSession(PlaywrightMCP, async (page) => runWithTimeout(executeCommand(cmd, page, kwargs, actionOpts.verbose), { timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT, label: fullName(cmd) }));
+        result = await browserSession(PlaywrightMCP, async (page) => {
+          // Cookie/header strategies require same-origin context for credentialed fetch.
+          // In CDP mode the active tab may be on an unrelated domain, causing CORS failures.
+          // Navigate to the command's domain first (mirrors cascade command behavior).
+          if ((cmd.strategy === Strategy.COOKIE || cmd.strategy === Strategy.HEADER) && cmd.domain) {
+            try { await page.goto(`https://${cmd.domain}`); await page.wait(2); } catch {}
+          }
+          return runWithTimeout(executeCommand(cmd, page, kwargs, actionOpts.verbose), { timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT, label: fullName(cmd) });
+        });
       } else { result = await executeCommand(cmd, null, kwargs, actionOpts.verbose); }
       if (actionOpts.verbose && (!result || (Array.isArray(result) && result.length === 0))) {
         console.error(chalk.yellow(`[Verbose] Warning: Command returned an empty result. If the website structural API changed or requires authentication, check the network or update the adapter.`));


### PR DESCRIPTION
## Summary

Cookie/header strategy commands fail with `Failed to fetch` when using CDP mode (`OPENCLI_CDP_ENDPOINT`) and the active Chrome tab is on an unrelated domain.

**Root cause:** `fetch()` with `credentials: 'include'` runs in the context of the current page. In CDP mode, this is the user's active tab (e.g. YouTube), not the target domain (e.g. bilibili.com). The browser blocks cross-origin credentialed requests per same-origin policy.

**Fix:** Navigate to `cmd.domain` before executing cookie/header strategy commands, mirroring the pre-navigation already done in the `cascade` command (main.ts line ~155).

## Repro

```bash
# Enable CDP mode
export OPENCLI_CDP_ENDPOINT=1

# Have any non-bilibili tab active in Chrome
opencli bilibili search --keyword "test"
# → Error: Failed to fetch
```

## Changes

- `src/main.ts`: Add domain pre-navigation for `Strategy.COOKIE` and `Strategy.HEADER` commands
- Import `Strategy` enum from registry

## Test plan

- [x] `bilibili search` works regardless of active Chrome tab (CDP mode)
- [x] `bilibili hot` (public strategy) unaffected
- [x] `youtube search` (cookie strategy) works
- [x] Extension mode unaffected (new tab starts as about:blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)