### PR TITLE
fix: use ClipboardEvent paste for Twitter text input

### DIFF
--- a/src/clis/twitter/post.ts
+++ b/src/clis/twitter/post.ts
@@ -26,8 +26,13 @@ cli({
             const box = document.querySelector('[data-testid="tweetTextarea_0"]');
             if (box) {
                 box.focus();
-                // insertText is the most reliable way to trigger React's onChange events
-                document.execCommand('insertText', false, ${JSON.stringify(kwargs.text)});
+                // Use ClipboardEvent paste: Draft.js handles paste robustly,
+                // while execCommand('insertText') corrupts state on multi-paragraph text (\n\n)
+                const dt = new DataTransfer();
+                dt.setData('text/plain', ${JSON.stringify(kwargs.text)});
+                box.dispatchEvent(new ClipboardEvent('paste', {
+                    bubbles: true, cancelable: true, clipboardData: dt
+                }));
             } else {
                 return { ok: false, message: 'Could not find the tweet composer text area.' };
             }

--- a/src/clis/twitter/reply.ts
+++ b/src/clis/twitter/reply.ts
@@ -28,7 +28,13 @@ cli({
             const box = document.querySelector('[data-testid="tweetTextarea_0"]');
             if (box) {
                 box.focus();
-                document.execCommand('insertText', false, ${JSON.stringify(kwargs.text)});
+                // Use ClipboardEvent paste: Draft.js handles paste robustly,
+                // while execCommand('insertText') corrupts state on multi-paragraph text (\n\n)
+                const dt = new DataTransfer();
+                dt.setData('text/plain', ${JSON.stringify(kwargs.text)});
+                box.dispatchEvent(new ClipboardEvent('paste', {
+                    bubbles: true, cancelable: true, clipboardData: dt
+                }));
             } else {
                 return { ok: false, message: 'Could not find the reply text area. Are you logged in?' };
             }


### PR DESCRIPTION
## Summary

- Replace `document.execCommand('insertText')` with `ClipboardEvent` paste in `post.ts` and `reply.ts`
- Fixes multi-paragraph text (`\n\n`) being lost in Twitter's Draft.js editor

Closes #93

## Test plan

- [ ] `opencli twitter post --text "Line 1\n\nLine 2\n\nhttps://example.com"` — all paragraphs appear in tweet
- [ ] `opencli twitter post --text "Single line"` — still works as before
- [ ] `opencli twitter reply --url <tweet_url> --text "Para 1\n\nPara 2"` — reply contains both paragraphs