### PR TITLE
fix: use JSON.stringify for safe JS string interpolation in evaluate()

### DIFF
--- a/src/explore.ts
+++ b/src/explore.ts
@@ -319,11 +319,11 @@ export async function exploreUrl(
            // First: targeted clicks by label (e.g. "字幕", "CC", "评论")
            if (opts.clickLabels?.length) {
              for (const label of opts.clickLabels) {
-               const safeLabel = label.replace(/'/g, "\\'");
+               const safeLabel = JSON.stringify(label);
                await page.evaluate(`
                  (() => {
                    const el = [...document.querySelectorAll('button, [role="button"], [role="tab"], a, span')]
-                     .find(e => e.textContent && e.textContent.trim().includes('${safeLabel}'));
+                     .find(e => e.textContent && e.textContent.trim().includes(${safeLabel}));
                    if (el) el.click();
                  })()
                `);

--- a/src/synthesize.ts
+++ b/src/synthesize.ts
@@ -116,7 +116,7 @@ function buildEvaluateScript(url: string, itemPath: string, endpoint: any): stri
 
   return [
     '(async () => {',
-    `  const res = await fetch('${url}', {`,
+    `  const res = await fetch(${JSON.stringify(url)}, {`,
     `    credentials: 'include'`,
     '  });',
     '  const data = await res.json();',


### PR DESCRIPTION
## Description

Replace ad-hoc string escaping with JSON.stringify() for values interpolated into JavaScript code strings passed to page.evaluate().

- explore.ts: clickLabels were escaped with only single-quote replacement, which breaks on labels containing backslashes or newlines. JSON.stringify() handles all edge cases correctly.

- synthesize.ts: buildEvaluateScript() embedded URLs directly inside single quotes. JSON.stringify() safely handles URLs containing special characters.
Related issue:

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
