### PR TITLE
fix: infer browser mode for public TS adapters and stabilize Chaoxing tests

### DIFF
--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -231,6 +231,7 @@ function scanTs(filePath: string, site: string): ManifestEntry {
     // Extract browser: false (some adapters bypass browser entirely)
     const browserMatch = src.match(/browser\s*:\s*(true|false)/);
     if (browserMatch) entry.browser = browserMatch[1] === 'true';
+    else entry.browser = entry.strategy !== 'public';
 
     // Extract columns
     const colMatch = src.match(/columns\s*:\s*\[([^\]]*)\]/);

--- a/src/chaoxing.test.ts
+++ b/src/chaoxing.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import { formatTimestamp, workStatusLabel } from './chaoxing.js';
 
+function localDatePrefixFromMillis(ts: number): string {
+  const d = new Date(ts);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 describe('formatTimestamp', () => {
   it('formats millisecond timestamp', () => {
-    // 2026-01-15 08:30 UTC+8
     const ts = new Date('2026-01-15T00:30:00Z').getTime();
     const result = formatTimestamp(ts);
-    expect(result).toMatch(/2026-01-15/);
+    expect(result).toMatch(new RegExp(`^${localDatePrefixFromMillis(ts)}\\s`));
   });
 
   it('formats second timestamp', () => {
-    const ts = Math.floor(new Date('2026-06-01T12:00:00Z').getTime() / 1000);
+    const millis = new Date('2026-06-01T12:00:00Z').getTime();
+    const ts = Math.floor(millis / 1000);
     const result = formatTimestamp(ts);
-    expect(result).toMatch(/2026-06-01/);
+    expect(result).toMatch(new RegExp(`^${localDatePrefixFromMillis(millis)}\\s`));
   });
 
   it('returns empty for null/undefined/0', () => {


### PR DESCRIPTION
## Summary
- infer `browser: false` in the generated manifest when a TypeScript adapter uses `strategy: Strategy.PUBLIC` and does not set `browser` explicitly
- make the Chaoxing timestamp tests compare against the local date prefix derived from the same timestamp instead of hard-coding a calendar day

## Why
The runtime registry already treats `Strategy.PUBLIC` adapters as non-browser commands by default, but the build-time manifest scanner still defaulted TypeScript entries to `browser: true` unless it found an explicit `browser:` field. That made manifest-driven metadata and `opencli list` output incorrect for public TS adapters.

The Chaoxing timestamp tests were also timezone-sensitive because they expected fixed date strings from UTC timestamps. On machines outside the original timezone, the formatter could still be correct while the tests failed.

## Validation
- `npm run build`
- `npx vitest run src/build-manifest.test.ts src/chaoxing.test.ts tests/e2e/management.test.ts`
- spot-checked generated manifest entries for `bbc/news`, `apple-podcasts/search`, `weread/search`, and `wechat/status`, which now all emit `browser: false`
