### PR TITLE
fix: use %20 for spaces in Bilibili WBI signed requests

### DIFF
--- a/src/bilibili.ts
+++ b/src/bilibili.ts
@@ -60,7 +60,9 @@ export async function wbiSign(
   for (const key of Object.keys(allParams).sort()) {
     sorted[key] = String(allParams[key]).replace(/[!'()*]/g, '');
   }
-  const query = new URLSearchParams(sorted).toString();
+  // Bilibili WBI verification expects %20 for spaces, not + (URLSearchParams default).
+  // Using + causes signature mismatch → CORS-blocked error response → TypeError: Failed to fetch.
+  const query = new URLSearchParams(sorted).toString().replace(/\+/g, '%20');
   const wRid = await md5(query + mixinKey);
   sorted.w_rid = wRid;
   return sorted;
@@ -78,7 +80,7 @@ export async function apiGet(
   }
   const qs = new URLSearchParams(
     Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
-  );
+  ).toString().replace(/\+/g, '%20');
   const url = `${baseUrl}${path}?${qs}`;
   return fetchJson(page, url);
 }


### PR DESCRIPTION
## Summary

- Bilibili search fails with `TypeError: Failed to fetch` when keywords contain spaces (e.g. `"机器学习 入门教程"`)
- Root cause: `URLSearchParams.toString()` encodes spaces as `+`, but Bilibili's WBI signature verification expects `%20`
- Fix: `.replace(/\+/g, '%20')` on the query string in both `wbiSign()` and `apiGet()`

## Test plan

- [ ] `opencli bilibili search --keyword "机器学习 入门教程" --limit 5 -f json` — should return results instead of `TypeError`
- [ ] `opencli bilibili search --keyword "机器学习入门" --limit 5 -f json` — still works (no regression)
- [ ] `opencli bilibili search --keyword "test" --limit 5 -f json` — still works (no regression)

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)