### PR TITLE
feat: 新增新浪财经7x24小时快讯

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Run `opencli list` for the live registry.
 | **smzdm** | `search` | 🔐 Browser |
 | **weibo** | `hot` | 🔐 Browser |
 | **yahoo-finance** | `quote` | 🔐 Browser |
+| **sina-finance** | `quote` | 🌐 Public |
 
 ### Desktop App Adapters
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,6 +136,7 @@ npm install -g @jackwener/opencli@latest
 | **smzdm** | `search` | 🔐 浏览器 |
 | **weibo** | `hot` | 🔐 浏览器 |
 | **yahoo-finance** | `quote` | 🔐 浏览器 |
+| **sina-finance** | `quote` | 🌐 公开 |
 
 ### 桌面应用适配器
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -143,6 +143,9 @@ opencli youtube transcript --url "xxx" --lang zh-Hans --mode raw  # 指定语言
 # Yahoo Finance (browser)
 opencli yahoo-finance quote --symbol AAPL  # 股票行情
 
+# 新浪财经
+opencli sinafinance 724 --limit 10 --type 1  # A股7x24小时实时快讯，Type of news, 0: 全部, 1: A股, 2: 宏观, 3: 公司, 4: 数据, 5: 市场, 6: 国际, 7: 观点, 8: 央行, 9: 其它
+
 # Reuters (browser)
 opencli reuters search --query "AI"     # 路透社搜索
 

--- a/src/clis/sinafinance/724.ts
+++ b/src/clis/sinafinance/724.ts
@@ -1,0 +1,55 @@
+import { cli, Strategy } from '../../registry.js';
+
+// 映射表：数组的索引(0,1,2...)代表用户输入的 type，数组的值代表新浪 API 真实的 tag ID
+const TYPE_MAP = [
+    0,   // index 0: 全部
+    10,  // index 1: A股
+    1,   // index 2: 宏观
+    3,   // index 3: 公司
+    4,   // index 4: 数据
+    5,   // index 5: 市场
+    102, // index 6: 国际
+    6,   // index 7: 观点
+    6,   // index 8: 央行 (原代码中观点和央行都是6，这里保留原逻辑)
+    8    // index 9: 其它
+];
+
+cli({
+    site: 'sinafinance',
+    name: '724',
+    description: '新浪财经 7x24 小时实时快讯',
+    domain: 'app.cj.sina.com.cn',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max results, max 50' },
+        // 0-9 分别对应什么
+        { name: 'type', type: 'int', default: 0, help: 'Type of news, 0: 全部, 1: A股, 2: 宏观, 3: 公司, 4: 数据, 5: 市场, 6: 国际, 7: 观点, 8: 央行, 9: 其它' },
+    ],
+    columns: ['id', 'time', 'content', 'views'],
+    func: async (_page, args) => {
+
+        // 将用户输入的 0-9 转换为 API 真实的 tag ID。
+        // 容错处理：如果用户输入了越界数字(比如 99)，默认回退到 0 (全部)
+        const apiTag = TYPE_MAP[args.type] !== undefined ? TYPE_MAP[args.type] : 0;
+
+        const params = new URLSearchParams({
+            page: '1',
+            size: String(args.limit),
+            tag: String(apiTag), // 使用映射后的真实 ID
+            _: String(Date.now())
+        });
+
+        const res = await fetch(`https://app.cj.sina.com.cn/api/news/pc?${params}`);
+        const json = await res.json();
+
+        const list = json?.result?.data?.feed?.list || [];
+
+        return list.map((item: any) => ({
+            id: item.id,
+            time: item.create_time,
+            content: item.rich_text,
+            views: item.view_num
+        }));
+    },
+});


### PR DESCRIPTION
## Description

新增`新浪财经-7x24小时快讯`

## How to use

```sh
# 参数说明：
# --limit：获取最近的快讯条目数，最多50条
# --type：获取的新闻类型。0: 全部, 1: A股, 2: 宏观, 3: 公司, 4: 数据, 5: 市场, 6: 国际, 7: 观点, 8: 央行, 9: 其它
opencli sinafinance get724 --limit 10 --type 2
```

## Screenshots / Output
<img width="779" height="728" alt="image" src="https://github.com/user-attachments/assets/3076070d-d6ce-479c-a12d-2fabed05ce25" />

