### PR TITLE
feat: add arxiv and wikipedia to built-in commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Run `opencli list` for the live registry.
 | **bbc** | `news` | Public |
 | **ctrip** | `search` | Browser |
 | **github** | `search` | Public |
+| **arxiv** | `search` `paper` | Public |
+| **wikipedia** | `search` `summary` | Public |
 | **hackernews** | `top` | Public |
 | **linkedin** | `search` | Browser |
 | **reuters** | `search` | Browser |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,8 @@ npm install -g @jackwener/opencli@latest
 | **bbc** | `news` | 公共 API |
 | **ctrip** | `search` | 浏览器 |
 | **github** | `search` | 公共 API |
+| **arxiv** | `search` `paper` | 公开 |
+| **wikipedia** | `search` `summary` | 公开 |
 | **hackernews** | `top` | 公共 API |
 | **linkedin** | `search` | 浏览器 |
 | **reuters** | `search` | 浏览器 |

--- a/src/clis/arxiv/paper.ts
+++ b/src/clis/arxiv/paper.ts
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '../../registry.js';
+import { CliError } from '../../errors.js';
+import { arxivFetch, parseEntries } from './utils.js';
+
+cli({
+  site: 'arxiv',
+  name: 'paper',
+  description: 'Get arXiv paper details by ID',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'id', positional: true, required: true, help: 'arXiv paper ID (e.g. 1706.03762)' },
+  ],
+  columns: ['id', 'title', 'authors', 'published', 'abstract', 'url'],
+  func: async (_page, args) => {
+    const xml = await arxivFetch(`id_list=${encodeURIComponent(args.id)}`);
+    const entries = parseEntries(xml);
+    if (!entries.length) throw new CliError('NOT_FOUND', `Paper ${args.id} not found`, 'Check the arXiv ID format, e.g. 1706.03762');
+    return entries;
+  },
+});

--- a/src/clis/arxiv/search.ts
+++ b/src/clis/arxiv/search.ts
@@ -1,0 +1,24 @@
+import { cli, Strategy } from '../../registry.js';
+import { CliError } from '../../errors.js';
+import { arxivFetch, parseEntries } from './utils.js';
+
+cli({
+  site: 'arxiv',
+  name: 'search',
+  description: 'Search arXiv papers',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'keyword', positional: true, required: true, help: 'Search keyword (e.g. "attention is all you need")' },
+    { name: 'limit', type: 'int', default: 10, help: 'Max results (max 25)' },
+  ],
+  columns: ['id', 'title', 'authors', 'published'],
+  func: async (_page, args) => {
+    const limit = Math.max(1, Math.min(Number(args.limit), 25));
+    const query = encodeURIComponent(`all:${args.keyword}`);
+    const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=relevance`);
+    const entries = parseEntries(xml);
+    if (!entries.length) throw new CliError('NOT_FOUND', 'No papers found', 'Try a different keyword');
+    return entries.map(e => ({ id: e.id, title: e.title, authors: e.authors, published: e.published }));
+  },
+});

--- a/src/clis/arxiv/utils.ts
+++ b/src/clis/arxiv/utils.ts
@@ -1,0 +1,63 @@
+/**
+ * arXiv adapter utilities.
+ *
+ * arXiv exposes a public Atom/XML API — no key required.
+ * https://info.arxiv.org/help/api/index.html
+ */
+
+import { CliError } from '../../errors.js';
+
+export const ARXIV_BASE = 'https://export.arxiv.org/api/query';
+
+export async function arxivFetch(params: string): Promise<string> {
+  const resp = await fetch(`${ARXIV_BASE}?${params}`);
+  if (!resp.ok) {
+    throw new CliError('FETCH_ERROR', `arXiv API HTTP ${resp.status}`, 'Check your search term or paper ID');
+  }
+  return resp.text();
+}
+
+/** Extract the text content of the first matching XML tag. */
+function extract(xml: string, tag: string): string {
+  const m = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+  return m ? m[1].trim() : '';
+}
+
+/** Extract all text contents of a repeated XML tag. */
+function extractAll(xml: string, tag: string): string[] {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'g');
+  const results: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) results.push(m[1].trim());
+  return results;
+}
+
+export interface ArxivEntry {
+  id: string;
+  title: string;
+  authors: string;
+  abstract: string;
+  published: string;
+  url: string;
+}
+
+/** Parse Atom XML feed into structured entries. */
+export function parseEntries(xml: string): ArxivEntry[] {
+  const entryRe = /<entry>([\s\S]*?)<\/entry>/g;
+  const entries: ArxivEntry[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(xml)) !== null) {
+    const e = m[1];
+    const rawId = extract(e, 'id');
+    const arxivId = rawId.replace(/^https?:\/\/arxiv\.org\/abs\//, '').replace(/v\d+$/, '');
+    entries.push({
+      id: arxivId,
+      title: extract(e, 'title').replace(/\s+/g, ' '),
+      authors: extractAll(e, 'name').slice(0, 3).join(', '),
+      abstract: extract(e, 'summary').replace(/\s+/g, ' ').slice(0, 200) + '...',
+      published: extract(e, 'published').slice(0, 10),
+      url: `https://arxiv.org/abs/${arxivId}`,
+    });
+  }
+  return entries;
+}

--- a/src/clis/wikipedia/search.ts
+++ b/src/clis/wikipedia/search.ts
@@ -1,0 +1,30 @@
+import { cli, Strategy } from '../../registry.js';
+import { CliError } from '../../errors.js';
+import { wikiFetch } from './utils.js';
+
+cli({
+  site: 'wikipedia',
+  name: 'search',
+  description: 'Search Wikipedia articles',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'keyword', positional: true, required: true, help: 'Search keyword' },
+    { name: 'limit', type: 'int', default: 10, help: 'Max results' },
+    { name: 'lang', default: 'en', help: 'Language code (e.g. en, zh, ja)' },
+  ],
+  columns: ['title', 'snippet', 'url'],
+  func: async (_page, args) => {
+    const limit = Math.max(1, Math.min(Number(args.limit), 50));
+    const lang = args.lang || 'en';
+    const q = encodeURIComponent(args.keyword);
+    const data = await wikiFetch(lang, `/w/api.php?action=query&list=search&srsearch=${q}&srlimit=${limit}&format=json&utf8=1`);
+    const results = data?.query?.search;
+    if (!results?.length) throw new CliError('NOT_FOUND', 'No articles found', 'Try a different keyword');
+    return results.map((r: any) => ({
+      title: r.title,
+      snippet: r.snippet.replace(/<[^>]+>/g, '').slice(0, 120),
+      url: `https://${lang}.wikipedia.org/wiki/${encodeURIComponent(r.title.replace(/ /g, '_'))}`,
+    }));
+  },
+});

--- a/src/clis/wikipedia/summary.ts
+++ b/src/clis/wikipedia/summary.ts
@@ -1,0 +1,28 @@
+import { cli, Strategy } from '../../registry.js';
+import { CliError } from '../../errors.js';
+import { wikiFetch } from './utils.js';
+
+cli({
+  site: 'wikipedia',
+  name: 'summary',
+  description: 'Get Wikipedia article summary',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'title', positional: true, required: true, help: 'Article title (e.g. "Transformer (machine learning model)")' },
+    { name: 'lang', default: 'en', help: 'Language code (e.g. en, zh, ja)' },
+  ],
+  columns: ['title', 'description', 'extract', 'url'],
+  func: async (_page, args) => {
+    const lang = args.lang || 'en';
+    const title = encodeURIComponent(args.title.replace(/ /g, '_'));
+    const data = await wikiFetch(lang, `/api/rest_v1/page/summary/${title}`);
+    if (!data?.title) throw new CliError('NOT_FOUND', `Article "${args.title}" not found`, 'Try searching first: opencli wikipedia search <keyword>');
+    return [{
+      title: data.title,
+      description: data.description ?? '-',
+      extract: (data.extract ?? '').slice(0, 300),
+      url: data.content_urls?.desktop?.page ?? `https://${lang}.wikipedia.org/wiki/${title}`,
+    }];
+  },
+});

--- a/src/clis/wikipedia/utils.ts
+++ b/src/clis/wikipedia/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Wikipedia adapter utilities.
+ *
+ * Uses the public MediaWiki REST API and Action API — no key required.
+ * REST API: https://en.wikipedia.org/api/rest_v1/
+ * Action API: https://en.wikipedia.org/w/api.php
+ */
+
+import { CliError } from '../../errors.js';
+
+export async function wikiFetch(lang: string, path: string): Promise<any> {
+  const url = `https://${lang}.wikipedia.org${path}`;
+  const resp = await fetch(url, {
+    headers: { 'User-Agent': 'opencli/1.0 (https://github.com/jackwener/opencli)' },
+  });
+  if (!resp.ok) {
+    throw new CliError('FETCH_ERROR', `Wikipedia API HTTP ${resp.status}`, `Check your title or search term`);
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Description

Add two new public API adapters: **arXiv** and **Wikipedia**.

Both are `PUBLIC` strategy with `browser: false` — no login or Browser Bridge extension required.

**arXiv** (`src/clis/arxiv/`)
- `search <keyword>` — search papers by keyword, sorted by relevance
- `paper <id>` — get paper details by arXiv ID (e.g. `1706.03762`)
- Parses the public Atom/XML API without any extra dependencies

**Wikipedia** (`src/clis/wikipedia/`)
- `search <keyword>` — search articles via MediaWiki Action API
- `summary <title>` — get article summary via REST API v1
- Supports `--lang` for multilingual queries (en, zh, ja, etc.)

Related issue:

## Type of Change

- [x] 🌐 New site adapter

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```bash
$ opencli arxiv search "attention is all you need" --limit 3
$ opencli arxiv paper 1706.03762
$ opencli wikipedia search "transformer"
$ opencli wikipedia summary "Transformer (machine learning model)"
$ opencli wikipedia search "人工智能" --lang zh

