### PR TITLE
ci: migrate docs deployment to cross-repo build via opencli-website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,52 +1,17 @@
-name: Deploy Docs
+name: Trigger Website Rebuild (Docs Updated)
 
 on:
   push:
     branches: [main]
     paths: ['docs/**']
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
-  build:
+  dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Trigger opencli-website rebuild
+        uses: peter-evans/repository-dispatch@v3
         with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build docs
-        run: npm run docs:build
-
-      - uses: actions/configure-pages@v4
-
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/.vitepress/dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
+          repository: jackwener/opencli-website
+          event-type: docs-updated

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  base: '/',
+  base: '/docs/',
   title: 'OpenCLI',
   description: 'Make any website or Electron App your CLI — AI-powered, account-safe, self-healing.',
 

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,1 +1,0 @@
-opencli.info


### PR DESCRIPTION
## Description

Migrate docs deployment from direct GitHub Pages to a cross-repo build approach.
`opencli-website` will now clone this repo's `docs/` during its CI build, compile VitePress docs, and deploy both website + docs together.

- VitePress `base` changed from `/` to `/docs/` (docs will be served at `opencli.info/docs/`)
- `docs.yml` workflow replaced with `repository_dispatch` trigger to rebuild `opencli-website`
- Removed `docs/public/CNAME` (custom domain now managed by `opencli-website` repo)

Final result:
- `opencli.info/` → official website (from `opencli-website` repo)
- `opencli.info/docs/` → VitePress documentation (from this repo's `docs/`)

## Type of Change

- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Local build verified — VitePress output correctly uses `/docs/` prefix:
