### PR TITLE
feat: enhance --help with registry metadata and enrich list --json with full arg schema

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,8 +43,7 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
               return arg;
             })
           : c.args.map(a => a.name).join(', '),
-        ...(isStructured && c.columns?.length ? { columns: c.columns } : {}),
-        ...(isStructured && c.domain ? { domain: c.domain } : {}),
+        ...(isStructured ? { columns: c.columns ?? [], domain: c.domain ?? null } : {}),
       }));
       if (fmt !== 'table') {
         renderOutput(rows, {
@@ -225,15 +224,16 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     const choicesArgs = cmd.args.filter(a => a.choices?.length);
     if (choicesArgs.length > 0) {
       for (const a of choicesArgs) {
+        const prefix = a.positional ? `<${a.name}>` : `--${a.name}`;
         const def = a.default != null ? `  (default: ${a.default})` : '';
-        helpExtra.push(`  --${a.name}: ${a.choices!.join(', ')}${def}`);
+        helpExtra.push(`  ${prefix}: ${a.choices!.join(', ')}${def}`);
       }
     }
     const metaParts: string[] = [];
     metaParts.push(`Strategy: ${strategyLabel(cmd)}`);
     metaParts.push(`Browser: ${cmd.browser ? 'yes' : 'no'}`);
     if (cmd.domain) metaParts.push(`Domain: ${cmd.domain}`);
-    helpExtra.push(`\n${metaParts.join(' | ')}`);
+    helpExtra.push(metaParts.join(' | '));
     if (cmd.columns?.length) helpExtra.push(`Output columns: ${cmd.columns.join(', ')}`);
     subCmd.addHelpText('after', '\n' + helpExtra.join('\n') + '\n');
 


### PR DESCRIPTION
## Summary

Per maintainer feedback on the original `describe` command approach, this PR takes a simpler path:

1. **Enhanced `--help` for all built-in commands** — injects registry metadata that Commander doesn't show:
   - Argument choices (e.g. `--period: daily, weekly, monthly`)
   - Execution metadata: Strategy / Browser / Domain
   - Output columns

2. **Enhanced `list -f json/yaml`** — full argument schema for AI agent consumption:
   - `args` field now includes type, required, positional, choices, default, help
   - Added `columns` and `domain` fields (stable schema: always present, `[]`/`null` when empty)
   - Table/csv/md formats unchanged

Closes #141

## Examples

**Enhanced --help:**
```
$ opencli hf top --help
Usage: opencli hf top [options]
...
  --period: daily, weekly, monthly  (default: daily)

Strategy: public | Browser: no | Domain: huggingface.co
Output columns: rank, title, authors, likes
```

**Enhanced list --json (excerpt):**
```json
{
  "command": "hf/top",
  "args": [
    { "name": "period", "type": "str", "choices": ["daily","weekly","monthly"], "default": "daily" }
  ],
  "columns": ["rank", "title", "authors", "likes"],
  "domain": "huggingface.co"
}
```

## Design rationale

The original PR added a standalone `describe` command. Maintainer feedback: "should enhance --help directly — AI training data already includes `cli --help`, no need for a new command."

This is correct: `--help` is the standard CLI discovery mechanism. The real gap was that Commander's auto-generated help was missing `choices`, `columns`, and `strategy` from the registry. This PR fills that gap without introducing new commands.

For structured/programmatic consumption (AI agents), `list -f json` now provides the full argument schema.

## Test plan

- [x] 239 existing unit tests pass (zero regression)
- [x] `opencli twitter post --help` shows Strategy/Browser/Domain/Output columns
- [x] `opencli hf top --help` shows choices for --period
- [x] `opencli list -f json` includes full args schema with choices/default/type
- [x] Commands without choices/columns/domain render cleanly (no extra blank lines)