### PR TITLE
fix: correct xiaohongshu creator metric parsing

### DIFF
--- a/src/clis/xiaohongshu/creator-note-detail.test.ts
+++ b/src/clis/xiaohongshu/creator-note-detail.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { IPage } from '../../types.js';
 import { getRegistry } from '../../registry.js';
-import { appendAudienceRows, appendTrendRows, parseCreatorNoteDetailText } from './creator-note-detail.js';
+import { appendAudienceRows, appendTrendRows, parseCreatorNoteDetailDomData, parseCreatorNoteDetailText } from './creator-note-detail.js';
 import './creator-note-detail.js';
 
 function createPageMock(evaluateResult: any): IPage {
+  const evaluate = Array.isArray(evaluateResult)
+    ? vi.fn()
+        .mockResolvedValueOnce(evaluateResult[0])
+        .mockResolvedValue(evaluateResult[evaluateResult.length - 1])
+    : vi.fn().mockResolvedValue(evaluateResult);
+
   return {
     goto: vi.fn().mockResolvedValue(undefined),
-    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+    evaluate,
     snapshot: vi.fn().mockResolvedValue(undefined),
     click: vi.fn().mockResolvedValue(undefined),
     typeText: vi.fn().mockResolvedValue(undefined),
@@ -93,6 +99,47 @@ describe('xiaohongshu creator-note-detail', () => {
     ]);
   });
 
+  it('parses structured note detail dom data into rows', () => {
+    expect(parseCreatorNoteDetailDomData({
+      title: '神雕侠侣战力金字塔',
+      infoText: '神雕侠侣战力金字塔\n#武侠\n2025-12-04 19:45\n切换笔记',
+      sections: [
+        {
+          title: '基础数据',
+          metrics: [
+            { label: '曝光数', value: '898204', extra: '粉丝占比 0.5%' },
+            { label: '观看数', value: '148284', extra: '粉丝占比 0.6%' },
+            { label: '封面点击率', value: '17.1%', extra: '粉丝 19.1%' },
+            { label: '平均观看时长', value: '30.1秒', extra: '粉丝 17.7秒' },
+            { label: '涨粉数', value: '101', extra: '' },
+          ],
+        },
+        {
+          title: '互动数据',
+          metrics: [
+            { label: '点赞数', value: '2280', extra: '粉丝占比 3.6%' },
+            { label: '评论数', value: '319', extra: '粉丝占比 9.4%' },
+            { label: '收藏数', value: '466', extra: '粉丝占比 9.4%' },
+            { label: '分享数', value: '33', extra: '粉丝占比 17.7%' },
+          ],
+        },
+      ],
+    }, '693155fc000000000d03b42c')).toEqual([
+      { section: '笔记信息', metric: 'note_id', value: '693155fc000000000d03b42c', extra: '' },
+      { section: '笔记信息', metric: 'title', value: '神雕侠侣战力金字塔', extra: '' },
+      { section: '笔记信息', metric: 'published_at', value: '2025-12-04 19:45', extra: '' },
+      { section: '基础数据', metric: '曝光数', value: '898204', extra: '粉丝占比 0.5%' },
+      { section: '基础数据', metric: '观看数', value: '148284', extra: '粉丝占比 0.6%' },
+      { section: '基础数据', metric: '封面点击率', value: '17.1%', extra: '粉丝 19.1%' },
+      { section: '基础数据', metric: '平均观看时长', value: '30.1秒', extra: '粉丝 17.7秒' },
+      { section: '基础数据', metric: '涨粉数', value: '101', extra: '' },
+      { section: '互动数据', metric: '点赞数', value: '2280', extra: '粉丝占比 3.6%' },
+      { section: '互动数据', metric: '评论数', value: '319', extra: '粉丝占比 9.4%' },
+      { section: '互动数据', metric: '收藏数', value: '466', extra: '粉丝占比 9.4%' },
+      { section: '互动数据', metric: '分享数', value: '33', extra: '粉丝占比 17.7%' },
+    ]);
+  });
+
   it('appends audience source and portrait rows from API payloads', () => {
     const rows = appendAudienceRows([], {
       audienceSource: {
@@ -171,40 +218,42 @@ describe('xiaohongshu creator-note-detail', () => {
     const cmd = getRegistry().get('xiaohongshu/creator-note-detail');
     expect(cmd?.func).toBeTypeOf('function');
 
-    const page = createPageMock(`笔记数据详情
-示例笔记
-2026-03-19 12:00
-曝光数
-100
-粉丝占比 10%
-观看数
-50
-粉丝占比 20%
-封面点击率
-12%
-粉丝 11%
-平均观看时长
-30秒
-粉丝 31秒
-涨粉数
-2
-点赞数
-8
-粉丝占比 25%
-评论数
-1
-粉丝占比 0%
-收藏数
-3
-粉丝占比 50%
-分享数
-0
-粉丝占比 0%`);
+    const page = createPageMock([
+      {
+        title: '示例笔记',
+        infoText: '示例笔记\n2026-03-19 12:00\n切换笔记',
+        sections: [
+          {
+            title: '基础数据',
+            metrics: [
+              { label: '曝光数', value: '100', extra: '粉丝占比 10%' },
+              { label: '观看数', value: '50', extra: '粉丝占比 20%' },
+              { label: '封面点击率', value: '12%', extra: '粉丝 11%' },
+              { label: '平均观看时长', value: '30秒', extra: '粉丝 31秒' },
+              { label: '涨粉数', value: '2', extra: '' },
+            ],
+          },
+          {
+            title: '互动数据',
+            metrics: [
+              { label: '点赞数', value: '8', extra: '粉丝占比 25%' },
+              { label: '评论数', value: '1', extra: '粉丝占比 0%' },
+              { label: '收藏数', value: '3', extra: '粉丝占比 50%' },
+              { label: '分享数', value: '0', extra: '粉丝占比 0%' },
+            ],
+          },
+        ],
+      },
+      null,
+      null,
+      null,
+      null,
+    ]);
 
     const result = await cmd!.func!(page, { note_id: 'demo-note-id' });
 
     expect((page.goto as any).mock.calls[0][0]).toBe('https://creator.xiaohongshu.com/statistics/note-detail?noteId=demo-note-id');
-    expect((page.evaluate as any).mock.calls[0][0]).toBe('() => document.body.innerText');
+    expect((page.evaluate as any).mock.calls[0][0]).toContain("document.querySelector('.note-title')");
     expect(result).toEqual([
       { section: '笔记信息', metric: 'note_id', value: 'demo-note-id', extra: '' },
       { section: '笔记信息', metric: 'title', value: '示例笔记', extra: '' },

--- a/src/clis/xiaohongshu/creator-note-detail.ts
+++ b/src/clis/xiaohongshu/creator-note-detail.ts
@@ -21,6 +21,23 @@ type CreatorNoteDetailRow = {
 
 export type { CreatorNoteDetailRow };
 
+type CreatorNoteDetailDomMetric = {
+  label: string;
+  value: string;
+  extra: string;
+};
+
+type CreatorNoteDetailDomSection = {
+  title: string;
+  metrics: CreatorNoteDetailDomMetric[];
+};
+
+type CreatorNoteDetailDomData = {
+  title: string;
+  infoText: string;
+  sections: CreatorNoteDetailDomSection[];
+};
+
 type AudienceSourceItem = {
   title?: string;
   value_with_double?: number;
@@ -87,6 +104,7 @@ const NOTE_DETAIL_METRICS = [
 ] as const;
 
 const NOTE_DETAIL_METRIC_LABELS = new Set<string>(NOTE_DETAIL_METRICS.map((metric) => metric.label));
+const NOTE_DETAIL_SECTIONS = new Set<string>(NOTE_DETAIL_METRICS.map((metric) => metric.section));
 const NOTE_DETAIL_NOISE_LINES = new Set([
   '切换笔记',
   '笔记诊断',
@@ -144,6 +162,11 @@ function findMetricValue(lines: string[], startIndex: number): { value: string; 
   return { value, extra };
 }
 
+function findPublishedAt(text: string): string {
+  const match = text.match(/\b\d{4}-\d{2}-\d{2} \d{2}:\d{2}\b/);
+  return match?.[0] ?? '';
+}
+
 export function parseCreatorNoteDetailText(bodyText: string, noteId: string): CreatorNoteDetailRow[] {
   const lines = bodyText
     .split('\n')
@@ -171,6 +194,35 @@ export function parseCreatorNoteDetailText(bodyText: string, noteId: string): Cr
   }
 
   return rows;
+}
+
+export function parseCreatorNoteDetailDomData(dom: CreatorNoteDetailDomData | null | undefined, noteId: string): CreatorNoteDetailRow[] {
+  if (!dom) return [];
+  const title = typeof dom.title === 'string' ? dom.title.trim() : '';
+  const infoText = typeof dom.infoText === 'string' ? dom.infoText : '';
+  const sections = Array.isArray(dom.sections) ? dom.sections : [];
+
+  const rows: CreatorNoteDetailRow[] = [
+    { section: '笔记信息', metric: 'note_id', value: noteId, extra: '' },
+    { section: '笔记信息', metric: 'title', value: title, extra: '' },
+    { section: '笔记信息', metric: 'published_at', value: findPublishedAt(infoText), extra: '' },
+  ];
+
+  for (const section of sections) {
+    if (!NOTE_DETAIL_SECTIONS.has(section.title)) continue;
+    for (const metric of section.metrics) {
+      if (!NOTE_DETAIL_METRIC_LABELS.has(metric.label)) continue;
+      rows.push({
+        section: section.title,
+        metric: metric.label,
+        value: metric.value,
+        extra: metric.extra,
+      });
+    }
+  }
+
+  const hasMetric = rows.some((row) => row.section !== '笔记信息' && row.value);
+  return hasMetric ? rows : [];
 }
 
 function toPercentString(value?: number): string {
@@ -325,12 +377,45 @@ async function captureNoteDetailPayload(page: IPage, noteId: string): Promise<No
   return captured > 0 ? payload : null;
 }
 
+async function captureNoteDetailDomData(page: IPage): Promise<CreatorNoteDetailDomData | null> {
+  const result = await page.evaluate(`() => {
+    const norm = (value) => (value || '').trim();
+    const sections = Array.from(document.querySelectorAll('.shell-container')).map((container) => {
+      const containerText = norm(container.innerText);
+      const title = containerText.startsWith('互动数据')
+        ? '互动数据'
+        : containerText.includes('基础数据')
+          ? '基础数据'
+          : '';
+      const metrics = Array.from(container.querySelectorAll('.block-container.block')).map((block) => ({
+        label: norm(block.querySelector('.des')?.innerText),
+        value: norm(block.querySelector('.content')?.innerText),
+        extra: norm(block.querySelector('.text-with-fans')?.innerText),
+      })).filter((metric) => metric.label && metric.value);
+      return { title, metrics };
+    }).filter((section) => section.title && section.metrics.length > 0);
+
+    return {
+      title: norm(document.querySelector('.note-title')?.innerText),
+      infoText: norm(document.querySelector('.note-info-content')?.innerText),
+      sections,
+    };
+  }`);
+
+  if (!result || typeof result !== 'object') return null;
+  return result as CreatorNoteDetailDomData;
+}
+
 export async function fetchCreatorNoteDetailRows(page: IPage, noteId: string): Promise<CreatorNoteDetailRow[]> {
   await page.goto(`https://creator.xiaohongshu.com/statistics/note-detail?noteId=${encodeURIComponent(noteId)}`);
   await page.wait(4);
 
-  const bodyText = await page.evaluate('() => document.body.innerText');
-  const rows = parseCreatorNoteDetailText(typeof bodyText === 'string' ? bodyText : '', noteId);
+  const domData = await captureNoteDetailDomData(page).catch(() => null);
+  let rows = parseCreatorNoteDetailDomData(domData, noteId);
+  if (rows.length === 0) {
+    const bodyText = await page.evaluate('() => document.body.innerText');
+    rows = parseCreatorNoteDetailText(typeof bodyText === 'string' ? bodyText : '', noteId);
+  }
   const apiPayload = await captureNoteDetailPayload(page, noteId).catch(() => null);
   appendTrendRows(rows, apiPayload ?? undefined);
   appendAudienceRows(rows, apiPayload ?? undefined);

--- a/src/clis/xiaohongshu/creator-notes.test.ts
+++ b/src/clis/xiaohongshu/creator-notes.test.ts
@@ -70,9 +70,9 @@ describe('xiaohongshu creator-notes', () => {
         title: '神雕侠侣战力金字塔',
         date: '2025年12月04日 19:45',
         views: 148208,
-        likes: 324,
-        collects: 2279,
-        comments: 465,
+        likes: 2279,
+        collects: 465,
+        comments: 324,
         url: '',
       },
       {
@@ -117,10 +117,43 @@ describe('xiaohongshu creator-notes', () => {
         title: '示例笔记',
         date: '2026年03月19日 12:00',
         views: 10,
-        likes: 2,
-        collects: 3,
-        comments: 4,
+        likes: 3,
+        collects: 4,
+        comments: 2,
         url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=69ba940500000000200384db',
+      },
+    ]);
+  });
+
+  it('prefers note card dom data when the analyze api is unavailable', async () => {
+    const cmd = getRegistry().get('xiaohongshu/creator-notes');
+    expect(cmd?.func).toBeTypeOf('function');
+
+    const page = createPageMock([
+      undefined,
+      [
+        {
+          id: '693155fc000000000d03b42c',
+          title: '神雕侠侣战力金字塔',
+          date: '2025年12月04日 19:45',
+          metrics: [148284, 319, 2280, 466, 33],
+        },
+      ],
+    ]);
+
+    const result = await cmd!.func!(page, { limit: 1 });
+
+    expect(result).toEqual([
+      {
+        rank: 1,
+        id: '693155fc000000000d03b42c',
+        title: '神雕侠侣战力金字塔',
+        date: '2025年12月04日 19:45',
+        views: 148284,
+        likes: 2280,
+        collects: 466,
+        comments: 319,
+        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=693155fc000000000d03b42c',
       },
     ]);
   });

--- a/src/clis/xiaohongshu/creator-notes.ts
+++ b/src/clis/xiaohongshu/creator-notes.ts
@@ -30,6 +30,13 @@ type CreatorNoteRow = {
 
 export type { CreatorNoteRow };
 
+type CreatorNoteDomCard = {
+  id: string;
+  title: string;
+  date: string;
+  metrics: number[];
+};
+
 type CreatorAnalyzeApiResponse = {
   error?: string;
   data?: {
@@ -97,9 +104,9 @@ export function parseCreatorNotesText(bodyText: string): CreatorNoteRow[] {
       title,
       date: dateMatch[1],
       views: metrics[0] ?? 0,
-      likes: metrics[1] ?? 0,
-      collects: metrics[2] ?? 0,
-      comments: metrics[3] ?? 0,
+      likes: metrics[2] ?? 0,
+      collects: metrics[3] ?? 0,
+      comments: metrics[1] ?? 0,
       url: '',
     });
 
@@ -121,6 +128,19 @@ export function parseCreatorNoteIdsFromHtml(bodyHtml: string): string[] {
   }
 
   return ids;
+}
+
+function mapDomCards(cards: CreatorNoteDomCard[]): CreatorNoteRow[] {
+  return cards.map((card) => ({
+    id: card.id,
+    title: card.title,
+    date: card.date,
+    views: card.metrics[0] ?? 0,
+    likes: card.metrics[2] ?? 0,
+    collects: card.metrics[3] ?? 0,
+    comments: card.metrics[1] ?? 0,
+    url: buildNoteDetailUrl(card.id),
+  }));
 }
 
 function mapAnalyzeItems(items: NonNullable<CreatorAnalyzeApiResponse['data']>['note_infos']): CreatorNoteRow[] {
@@ -194,6 +214,27 @@ export async function fetchCreatorNotes(page: IPage, limit: number): Promise<Cre
 
     const maxPageDowns = Math.max(0, Math.ceil(limit / 10) + 1);
     for (let i = 0; i <= maxPageDowns; i++) {
+      const domCards = await page.evaluate(`() => {
+        const noteIdRe = /"noteId":"([0-9a-f]{24})"/;
+        return Array.from(document.querySelectorAll('div.note[data-impression], div.note')).map((card) => {
+          const impression = card.getAttribute('data-impression') || '';
+          const id = impression.match(noteIdRe)?.[1] || '';
+          const title = (card.querySelector('.title, .raw')?.innerText || '').trim();
+          const dateText = (card.querySelector('.time_status, .time')?.innerText || '').trim();
+          const date = dateText.replace(/^发布于\\s*/, '');
+          const metrics = Array.from(card.querySelectorAll('.icon_list .icon'))
+            .map((el) => parseInt((el.innerText || '').trim(), 10))
+            .filter((value) => Number.isFinite(value));
+          return { id, title, date, metrics };
+        });
+      }`) as CreatorNoteDomCard[] | undefined;
+      const parsedDomNotes = mapDomCards(Array.isArray(domCards) ? domCards : []).filter((note) => note.title && note.date);
+      if (parsedDomNotes.length > 0) {
+        notes = parsedDomNotes;
+      }
+
+      if (notes.length >= limit || (notes.length > 0 && i === 0)) break;
+
       const body = await page.evaluate('() => ({ text: document.body.innerText, html: document.body.innerHTML })') as {
         text?: string;
         html?: string;


### PR DESCRIPTION
## Summary

Fix Xiaohongshu creator metric parsing on the latest `main`.

## What changed

- make `creator-note-detail` prefer structured DOM extraction for core and interaction metrics
- keep text parsing only as a fallback when structured note detail blocks are unavailable
- fix `creator-notes` note-manager fallback to parse real note cards instead of relying on fragile whole-page text ordering
- correct fallback metric mapping to match the real creator UI order
- add regression tests for note-card DOM parsing and note-detail DOM parsing

## Why

On the latest `main`, live creator commands were inconsistent:

- `creator-note-detail` could mis-parse the page and return broken rows like `封面点击率=点赞`
- `creator-notes` fallback could mis-map `likes / collects / comments`
- `creator-notes-summary` then inherited those wrong values

This PR makes the creator flows line up again with the real creator backend UI.

## Verification

Passed locally:

- `npx vitest run src/clis/xiaohongshu/creator-notes.test.ts src/clis/xiaohongshu/creator-note-detail.test.ts src/clis/xiaohongshu/creator-notes-summary.test.ts --reporter=verbose`
- `npm run build`

Live verification with logged-in creator session:

- `node dist/main.js xiaohongshu creator-notes --limit 2 -f json`
- `node dist/main.js xiaohongshu creator-note-detail --note_id 693155fc000000000d03b42c -f json`
- `node dist/main.js xiaohongshu creator-notes-summary --limit 2 -f json`

Confirmed values are aligned again across list/detail/summary.
