### PR TITLE
feat: register Google Workspace CLI (gws) + fix external CLI passthrough

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,9 @@ import { loadExternalClis, executeExternalCli, installExternalCli, registerExter
 
 export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
   const program = new Command();
-  program.name('opencli').description('Make any website your CLI. Zero setup. AI-powered.').version(PKG_VERSION);
+  // enablePositionalOptions: prevents parent from consuming flags meant for subcommands;
+  // prerequisite for passThroughOptions to forward --help/--version to external binaries
+  program.name('opencli').description('Make any website your CLI. Zero setup. AI-powered.').version(PKG_VERSION).enablePositionalOptions();
 
   // ── Built-in commands ──────────────────────────────────────────────────────
 
@@ -151,13 +153,11 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     if (program.commands.some(c => c.name() === ext.name)) continue;
     program.command(ext.name)
       .description(`(External) ${ext.description || ext.name}`)
+      .argument('[args...]')
       .allowUnknownOption()
-      .allowExcessArguments()
-      .action(() => {
-        // Retrieve args passed to the external CLI
-        // Commander consumes standard args before the action, so we must slice process.argv directly.
-        const extIndex = process.argv.indexOf(ext.name);
-        const args = process.argv.slice(extIndex + 1);
+      .passThroughOptions()
+      .helpOption(false)
+      .action((args: string[]) => {
         executeExternalCli(ext.name, args).catch(err => {
           console.error(chalk.red(`Error: ${err.message}`));
           process.exitCode = 1;

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -37,3 +37,12 @@
   tags: [docker, containers, devops]
   install:
     mac: "brew install --cask docker"
+
+- name: gws
+  binary: gws
+  description: "Google Workspace CLI — Docs, Sheets, Drive, Gmail, Calendar"
+  homepage: "https://github.com/googleworkspace/cli"
+  tags: [google, docs, sheets, drive, workspace]
+  install:
+    mac: "brew install googleworkspace-cli"
+    default: "npm install -g @googleworkspace/cli"


### PR DESCRIPTION
## Summary

- Register `gws` (Google Workspace CLI) as an external CLI, enabling `opencli gws` to transparently invoke it for Docs, Sheets, Drive, Gmail and Calendar operations
- Fix external CLI arg passthrough so positional args and flags (`--version`, `--help`) are correctly forwarded to external binaries

## Changes

**`src/external-clis.yaml`** — add `gws` entry with brew and npm install commands

**`src/cli.ts`** — fix Commander.js external CLI registration:
- `.enablePositionalOptions()` on parent program to prevent flag consumption
- `.argument('[args...]')` + `.passThroughOptions()` + `.helpOption(false)` for full passthrough
- Use Commander-collected `args` directly instead of `process.argv.indexOf` slicing

## Test plan

- [x] `opencli gws --version` → returns gws version (not opencli version)
- [x] `opencli gws --help` → shows gws help (not opencli help)
- [x] `opencli gh repo list --limit 3` → works (previously failed with "too many arguments")
- [x] `opencli bilibili hot --limit 3` → built-in commands unaffected
- [x] `opencli --version` → still returns opencli version
- [x] Unit tests: 24 files, 239 tests all passing

Closes #120