### PR TITLE
refactor: extract serialization helpers to registry.ts and stabilize arg schema

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { executeCommand } from './engine.js';
-import { Strategy, type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
+import { Strategy, type CliCommand, fullName, getRegistry, strategyLabel, serializeCommand, formatArgSummary, formatRegistryHelpText } from './registry.js';
 import { render as renderOutput } from './output.js';
 import { BrowserBridge, CDPBridge } from './browser/index.js';
 import { browserSession, DEFAULT_BROWSER_COMMAND_TIMEOUT, runWithTimeout } from './runtime.js';
@@ -23,29 +23,18 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
       const commands = [...registry.values()].sort((a, b) => fullName(a).localeCompare(fullName(b)));
       const fmt = opts.json && opts.format === 'table' ? 'json' : opts.format;
       const isStructured = fmt === 'json' || fmt === 'yaml';
-      const rows = commands.map(c => ({
-        command: fullName(c),
-        site: c.site,
-        name: c.name,
-        description: c.description,
-        strategy: strategyLabel(c),
-        browser: c.browser,
-        // Structured formats get full arg schema; table/csv/md get comma-joined names
-        args: isStructured
-          ? c.args.map(a => {
-              const arg: Record<string, unknown> = { name: a.name };
-              if (a.type) arg.type = a.type;
-              if (a.required) arg.required = true;
-              if (a.positional) arg.positional = true;
-              if (a.choices?.length) arg.choices = a.choices;
-              if (a.default != null) arg.default = a.default;
-              if (a.help) arg.help = a.help;
-              return arg;
-            })
-          : c.args.map(a => a.name).join(', '),
-        ...(isStructured ? { columns: c.columns ?? [], domain: c.domain ?? null } : {}),
-      }));
       if (fmt !== 'table') {
+        const rows = isStructured
+          ? commands.map(serializeCommand)
+          : commands.map(c => ({
+              command: fullName(c),
+              site: c.site,
+              name: c.name,
+              description: c.description,
+              strategy: strategyLabel(c),
+              browser: !!c.browser,
+              args: formatArgSummary(c.args),
+            }));
         renderOutput(rows, {
           fmt,
           columns: ['command', 'site', 'name', 'description', 'strategy', 'browser', 'args', ...(isStructured ? ['columns', 'domain'] : [])],
@@ -220,23 +209,7 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     }
     subCmd.option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table').option('-v, --verbose', 'Debug output', false);
 
-    // Enhance --help with registry metadata not shown by Commander
-    const helpExtra: string[] = [];
-    const choicesArgs = cmd.args.filter(a => a.choices?.length);
-    if (choicesArgs.length > 0) {
-      for (const a of choicesArgs) {
-        const prefix = a.positional ? `<${a.name}>` : `--${a.name}`;
-        const def = a.default != null ? `  (default: ${a.default})` : '';
-        helpExtra.push(`  ${prefix}: ${a.choices!.join(', ')}${def}`);
-      }
-    }
-    const metaParts: string[] = [];
-    metaParts.push(`Strategy: ${strategyLabel(cmd)}`);
-    metaParts.push(`Browser: ${cmd.browser ? 'yes' : 'no'}`);
-    if (cmd.domain) metaParts.push(`Domain: ${cmd.domain}`);
-    helpExtra.push(metaParts.join(' | '));
-    if (cmd.columns?.length) helpExtra.push(`Output columns: ${cmd.columns.join(', ')}`);
-    subCmd.addHelpText('after', '\n' + helpExtra.join('\n') + '\n');
+    subCmd.addHelpText('after', formatRegistryHelpText(cmd));
 
     subCmd.action(async (...actionArgs: any[]) => {
       // Commander passes positional args first, then options object, then the Command

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -89,3 +89,71 @@ export function strategyLabel(cmd: CliCommand): string {
 export function registerCommand(cmd: CliCommand): void {
   _registry.set(fullName(cmd), cmd);
 }
+
+// ── Serialization helpers (shared by list, --help, manifest) ────────────────
+
+export type SerializedArg = {
+  name: string;
+  type: string;
+  required: boolean;
+  positional: boolean;
+  choices: string[];
+  default: unknown;
+  help: string;
+};
+
+/** Stable arg schema — every field is always present (no sparse objects). */
+export function serializeArg(a: Arg): SerializedArg {
+  return {
+    name: a.name,
+    type: a.type ?? 'string',
+    required: !!a.required,
+    positional: !!a.positional,
+    choices: a.choices ?? [],
+    default: a.default ?? null,
+    help: a.help ?? '',
+  };
+}
+
+/** Full command metadata for structured output (json/yaml). */
+export function serializeCommand(cmd: CliCommand) {
+  return {
+    command: fullName(cmd),
+    site: cmd.site,
+    name: cmd.name,
+    description: cmd.description,
+    strategy: strategyLabel(cmd),
+    browser: !!cmd.browser,
+    args: cmd.args.map(serializeArg),
+    columns: cmd.columns ?? [],
+    domain: cmd.domain ?? null,
+  };
+}
+
+/** Human-readable arg summary: `<required> [optional]` style. */
+export function formatArgSummary(args: Arg[]): string {
+  return args
+    .map(a => {
+      if (a.positional) return a.required ? `<${a.name}>` : `[${a.name}]`;
+      return a.required ? `--${a.name}` : `[--${a.name}]`;
+    })
+    .join(' ');
+}
+
+/** Generate the --help appendix showing registry metadata not exposed by Commander. */
+export function formatRegistryHelpText(cmd: CliCommand): string {
+  const lines: string[] = [];
+  const choicesArgs = cmd.args.filter(a => a.choices?.length);
+  for (const a of choicesArgs) {
+    const prefix = a.positional ? `<${a.name}>` : `--${a.name}`;
+    const def = a.default != null ? `  (default: ${a.default})` : '';
+    lines.push(`  ${prefix}: ${a.choices!.join(', ')}${def}`);
+  }
+  const meta: string[] = [];
+  meta.push(`Strategy: ${strategyLabel(cmd)}`);
+  meta.push(`Browser: ${cmd.browser ? 'yes' : 'no'}`);
+  if (cmd.domain) meta.push(`Domain: ${cmd.domain}`);
+  lines.push(meta.join(' | '));
+  if (cmd.columns?.length) lines.push(`Output columns: ${cmd.columns.join(', ')}`);
+  return '\n' + lines.join('\n') + '\n';
+}


### PR DESCRIPTION
Follow-up to #142. Extracts inline serialization/help-text logic from cli.ts into reusable functions in registry.ts.

**Changes:**
- `serializeArg()`: stable arg schema (all fields always present)
- `serializeCommand()`: full command metadata for list json/yaml
- `formatArgSummary()`: human-readable `<required> [--optional]`
- `formatRegistryHelpText()`: --help appendix (choices/strategy/domain/columns)
- cli.ts: ~30 lines inline logic replaced with 1-line calls

**Verification:** tsc ✅ | 244 tests ✅ | smoke tests ✅