### PR TITLE
feat(npmjs): add npm package search command

### DIFF
--- a/src/clis/npmjs/search.yaml
+++ b/src/clis/npmjs/search.yaml
@@ -1,0 +1,32 @@
+site: npmjs
+name: search
+description: Search npm packages
+domain: www.npmjs.com
+strategy: public
+browser: false
+
+args:
+  query:
+    type: string
+    required: true
+    description: Search query
+  limit:
+    type: int
+    default: 15
+    description: Number of packages
+
+pipeline:
+  - fetch:
+      url: https://registry.npmjs.org/-/v1/search?text=${{ args.query }}&size=${{ args.limit }}
+
+  - select: objects
+
+  - map:
+      name: ${{ item.package.name }}
+      version: ${{ item.package.version }}
+      description: ${{ item.package.description }}
+      weekly: ${{ item.downloads.weekly }}
+
+  - limit: ${{ args.limit }}
+
+columns: [name, version, description, weekly]


### PR DESCRIPTION
Add npmjs as a new site adapter for searching npm packages.

## Changes

### 1. New site adapter: `src/clis/npmjs/search.yaml` (32 LOC)

- YAML pipeline adapter using the public [npm registry search API](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md)
- Strategy: `public` — no authentication or browser session required
- Displays: package name, version, description, weekly downloads

### 2. Usage

```bash
opencli npmjs search --query react
opencli npmjs search --query vite --limit 5
```

### 3. Pipeline flow

```
fetch (registry.npmjs.org search API)
  → select: objects
    → map: name, version, description, weekly downloads
      → limit
```

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- npm registry API manually verified ✅