### PR TITLE
feat(devto): add top articles command

### DIFF
--- a/src/clis/devto/top.yaml
+++ b/src/clis/devto/top.yaml
@@ -1,0 +1,32 @@
+site: devto
+name: top
+description: Top articles on Dev.to this week
+domain: dev.to
+strategy: public
+browser: false
+
+args:
+  tag:
+    type: string
+    description: Filter by tag (e.g. javascript, go, python)
+  limit:
+    type: int
+    default: 20
+    description: Number of articles
+
+pipeline:
+  - fetch:
+      url: https://dev.to/api/articles?top=7&per_page=${{ args.limit }}&tag=${{ args.tag }}
+
+  - map:
+      rank: ${{ index + 1 }}
+      title: ${{ item.title }}
+      author: ${{ item.user.username }}
+      reactions: ${{ item.positive_reactions_count }}
+      comments: ${{ item.comments_count }}
+      min: ${{ item.reading_time_minutes }}
+      url: ${{ item.url }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, title, author, reactions, comments, min]


### PR DESCRIPTION
Add Dev.to as a new site adapter, referenced from the Go CLI project [devto-cli](https://github.com/Gealber/devto-cli).

## Changes

### 1. New site adapter: `src/clis/devto/top.yaml` (32 LOC)

- YAML pipeline adapter using the public [Forem/Dev.to API](https://developers.forem.com/api/v1)
- Strategy: `public` — no authentication or browser session required
- Optional `--tag` filter for narrowing results (e.g. `javascript`, `go`, `python`)
- Displays: rank, title, author, reactions, comments, reading time (min)

### 2. Usage

```bash
opencli devto top
opencli devto top --tag go --limit 10
opencli devto top --tag typescript --limit 5 -f json
```

### 3. Pipeline flow

```
fetch (dev.to/api/articles?top=7)
  → map: rank, title, author, reactions, comments, reading time
    → limit
```

### 4. Reference

Go CLI project: [Gealber/devto-cli](https://github.com/Gealber/devto-cli) — this adapter covers equivalent functionality (browsing top/trending articles) via opencli's YAML pipeline.

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- Dev.to API manually verified ✅