### PR TITLE
feat(coingecko): add top cryptocurrencies command

### DIFF
--- a/src/clis/coingecko/top.yaml
+++ b/src/clis/coingecko/top.yaml
@@ -1,0 +1,32 @@
+site: coingecko
+name: top
+description: Top cryptocurrencies by market cap
+domain: www.coingecko.com
+strategy: public
+browser: false
+
+args:
+  currency:
+    type: string
+    default: usd
+    description: Quote currency (usd, eur, cny, jpy, etc.)
+  limit:
+    type: int
+    default: 20
+    description: Number of coins
+
+pipeline:
+  - fetch:
+      url: https://api.coingecko.com/api/v3/coins/markets?vs_currency=${{ args.currency }}&order=market_cap_desc&per_page=${{ args.limit }}&page=1
+
+  - map:
+      rank: ${{ item.market_cap_rank }}
+      coin: ${{ item.name }}
+      symbol: ${{ item.symbol }}
+      price: ${{ item.current_price }}
+      24h%: ${{ item.price_change_percentage_24h }}
+      market_cap: ${{ item.market_cap }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, coin, symbol, price, 24h%, market_cap]


### PR DESCRIPTION
Add CoinGecko as a new site adapter, referenced from the official Go CLI project [coingecko-cli](https://github.com/coingecko/coingecko-cli) (98 stars).

## Changes

### 1. New site adapter: `src/clis/coingecko/top.yaml` (32 LOC)

- YAML pipeline adapter using the public [CoinGecko API v3](https://docs.coingecko.com/reference/coins-markets)
- Strategy: `public` — no authentication or browser session required
- Configurable `--currency` for quote currency (usd, eur, cny, jpy, etc.)
- Displays: rank, coin name, symbol, price, 24h change %, market cap

### 2. Usage

```bash
opencli coingecko top
opencli coingecko top --currency eur --limit 10
opencli coingecko top --limit 5 -f json
```

### 3. Pipeline flow

```
fetch (api.coingecko.com/api/v3/coins/markets)
  → map: rank, coin, symbol, price, 24h%, market_cap
    → limit
```

### 4. Reference

Go CLI project: [coingecko/coingecko-cli](https://github.com/coingecko/coingecko-cli) — official CoinGecko terminal client. This adapter covers the core market overview functionality via opencli's YAML pipeline.

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- CoinGecko API manually verified ✅