### PR TITLE
feat(gitlab): add project search command

### DIFF
--- a/src/clis/gitlab/search.yaml
+++ b/src/clis/gitlab/search.yaml
@@ -1,0 +1,31 @@
+site: gitlab
+name: search
+description: Search GitLab projects
+domain: gitlab.com
+strategy: public
+browser: false
+
+args:
+  query:
+    type: string
+    required: true
+    description: Search query
+  limit:
+    type: int
+    default: 15
+    description: Number of projects
+
+pipeline:
+  - fetch:
+      url: https://gitlab.com/api/v4/projects?search=${{ args.query }}&order_by=last_activity_at&sort=desc&per_page=${{ args.limit }}&visibility=public
+
+  - map:
+      name: ${{ item.path_with_namespace }}
+      description: ${{ item.description }}
+      stars: ${{ item.star_count }}
+      forks: ${{ item.forks_count }}
+      url: ${{ item.web_url }}
+
+  - limit: ${{ args.limit }}
+
+columns: [name, description, stars, forks, url]


### PR DESCRIPTION
Add GitLab as a new site adapter, referenced from the official Go CLI project [glab](https://github.com/gitlab-org/cli).

## Changes

### 1. New site adapter: `src/clis/gitlab/search.yaml` (31 LOC)

- YAML pipeline adapter using the public [GitLab REST API v4](https://docs.gitlab.com/api/projects.html#list-all-projects)
- Strategy: `public` — no authentication or browser session required
- Searches public projects, sorted by last activity
- Displays: project path, description, stars, forks, URL

### 2. Usage

```bash
opencli gitlab search --query kubernetes
opencli gitlab search --query "machine learning" --limit 10
opencli gitlab search --query rust --limit 5 -f json
```

### 3. Pipeline flow

```
fetch (gitlab.com/api/v4/projects?search=QUERY)
  → map: name, description, stars, forks, url
    → limit
```

### 4. Reference

Go CLI project: [gitlab-org/cli](https://github.com/gitlab-org/cli) (glab) — official GitLab CLI. This adapter covers project discovery functionality via opencli's YAML pipeline.

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- GitLab API manually verified ✅