### PR TITLE
feat(mastodon): add trending posts command

### DIFF
--- a/src/clis/mastodon/trending.yaml
+++ b/src/clis/mastodon/trending.yaml
@@ -1,0 +1,32 @@
+site: mastodon
+name: trending
+description: Trending posts on Mastodon
+domain: mastodon.social
+strategy: public
+browser: false
+
+args:
+  instance:
+    type: string
+    default: mastodon.social
+    description: Mastodon instance domain
+  limit:
+    type: int
+    default: 20
+    description: Number of posts
+
+pipeline:
+  - fetch:
+      url: https://${{ args.instance }}/api/v1/trends/statuses?limit=${{ args.limit }}
+
+  - map:
+      rank: ${{ index + 1 }}
+      author: ${{ item.account.acct }}
+      replies: ${{ item.replies_count }}
+      boosts: ${{ item.reblogs_count }}
+      likes: ${{ item.favourites_count }}
+      url: ${{ item.url }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, author, replies, boosts, likes, url]


### PR DESCRIPTION
Add Mastodon as a new site adapter, referenced from the Go CLI project [gomphotherium](https://github.com/mrusme/gomphotherium).

## Changes

### 1. New site adapter: `src/clis/mastodon/trending.yaml` (32 LOC)

- YAML pipeline adapter using the public [Mastodon API v1](https://docs.joinmastodon.org/methods/trends/#statuses)
- Strategy: `public` — no authentication or browser session required
- Configurable `--instance` to query any Mastodon-compatible instance (default: mastodon.social)
- Displays: rank, author handle, replies, boosts, likes, URL

### 2. Usage

```bash
opencli mastodon trending
opencli mastodon trending --instance hachyderm.io --limit 10
opencli mastodon trending --limit 5 -f json
```

### 3. Pipeline flow

```
fetch (mastodon.social/api/v1/trends/statuses)
  → map: rank, author, replies, boosts, likes, url
    → limit
```

### 4. Reference

Go CLI project: [mrusme/gomphotherium](https://github.com/mrusme/gomphotherium) — a command-line Mastodon client written in Go. This adapter covers trending content discovery via opencli's YAML pipeline.

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- Mastodon API manually verified ✅

Made with [Cursor](https://cursor.com)