### PR TITLE
feat(github): add repository search command

### DIFF
--- a/src/clis/github/search.yaml
+++ b/src/clis/github/search.yaml
@@ -1,0 +1,33 @@
+site: github
+name: search
+description: Search GitHub repositories
+domain: github.com
+strategy: public
+browser: false
+
+args:
+  query:
+    type: string
+    required: true
+    description: Search query
+  limit:
+    type: int
+    default: 15
+    description: Number of repositories
+
+pipeline:
+  - fetch:
+      url: https://api.github.com/search/repositories?q=${{ args.query }}&sort=stars&order=desc&per_page=${{ args.limit }}
+
+  - select: items
+
+  - map:
+      name: ${{ item.full_name }}
+      description: ${{ item.description }}
+      stars: ${{ item.stargazers_count }}
+      forks: ${{ item.forks_count }}
+      language: ${{ item.language }}
+
+  - limit: ${{ args.limit }}
+
+columns: [name, description, stars, forks, language]


### PR DESCRIPTION
Add GitHub as a new site adapter. Note: `gh` is already registered as an external CLI passthrough, but there was no native site adapter for GitHub. This adapter provides lightweight repo search without requiring `gh` installation.

## Changes

### 1. New site adapter: `src/clis/github/search.yaml` (33 LOC)

- YAML pipeline adapter using the public [GitHub REST API](https://docs.github.com/en/rest/search/search#search-repositories)
- Strategy: `public` — no authentication or browser session required
- Results sorted by stars descending
- Displays: repo name, description, stars, forks, language

### 2. Usage

```bash
opencli github search --query "cli tool"
opencli github search --query "language:go stars:>1000" --limit 10
opencli github search --query react --limit 5 -f json
```

### 3. Pipeline flow

```
fetch (api.github.com/search/repositories)
  → select: items
    → map: name, description, stars, forks, language
      → limit
```

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- GitHub API manually verified ✅

Made with [Cursor](https://cursor.com)