### PR TITLE
feat(coinglass): add funding rate command

### DIFF
--- a/src/clis/coinglass/funding-rate.yaml
+++ b/src/clis/coinglass/funding-rate.yaml
@@ -1,0 +1,43 @@
+site: coinglass
+name: funding-rate
+description: Crypto futures funding rates across exchanges
+domain: www.coinglass.com
+browser: true
+
+args:
+  limit:
+    type: int
+    default: 20
+    description: Number of coins
+
+pipeline:
+  - navigate: https://www.coinglass.com/FundingRate
+
+  - evaluate: |
+      (async () => {
+        const res = await fetch('https://fapi.coinglass.com/api/fundingRate/v2/home', {
+          credentials: 'include'
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const json = await res.json();
+        if (json.code !== '0' && json.code !== 0) throw new Error(json.msg || 'API error');
+        const list = json.data || [];
+        return list.map((item, i) => {
+          const rates = item.uMarginList || [];
+          const binance = rates.find(r => r.exchangeName === 'Binance');
+          const okx = rates.find(r => r.exchangeName === 'OKX');
+          const bybit = rates.find(r => r.exchangeName === 'Bybit');
+          const fmt = (r) => r ? (r.rate * 100).toFixed(4) + '%' : '-';
+          return {
+            rank: i + 1,
+            symbol: item.symbol,
+            binance: fmt(binance),
+            okx: fmt(okx),
+            bybit: fmt(bybit),
+          };
+        });
+      })()
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, symbol, binance, okx, bybit]


### PR DESCRIPTION
Add CoinGlass as a new site adapter for crypto futures funding rate data.

## Changes

### 1. New site adapter: `src/clis/coinglass/funding-rate.yaml` (43 LOC)

- YAML pipeline adapter using CoinGlass internal API via **browser strategy**
- Requires Browser Bridge — navigates to coinglass.com to obtain session cookies
- Aggregates funding rates across top exchanges (Binance, OKX, Bybit)
- Displays: rank, symbol, and per-exchange funding rate percentages

### 2. Usage

```bash
opencli coinglass funding-rate
opencli coinglass funding-rate --limit 10
opencli coinglass funding-rate -f json
```

### 3. Pipeline flow

```
navigate (coinglass.com/FundingRate)
  → evaluate: fetch internal API with credentials
    → parse per-exchange funding rates (Binance, OKX, Bybit)
      → limit
```

### 4. Notes

CoinGlass does not offer a free public API — all official endpoints require a paid API key ($35+/mo). This adapter uses the browser cookie strategy (same as bilibili, xueqiu, etc.) to access the internal frontend API via the user's browser session, requiring the Browser Bridge extension.

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- YAML schema valid ✅

Made with [Cursor](https://cursor.com)