### PR TITLE
feat(lobsters): add hot stories command

### DIFF
--- a/src/clis/lobsters/hot.yaml
+++ b/src/clis/lobsters/hot.yaml
@@ -1,0 +1,28 @@
+site: lobsters
+name: hot
+description: Lobste.rs hottest stories
+domain: lobste.rs
+strategy: public
+browser: false
+
+args:
+  limit:
+    type: int
+    default: 20
+    description: Number of stories
+
+pipeline:
+  - fetch:
+      url: https://lobste.rs/hottest.json
+
+  - map:
+      rank: ${{ index + 1 }}
+      title: ${{ item.title }}
+      score: ${{ item.score }}
+      author: ${{ item.submitter_user }}
+      comments: ${{ item.comment_count }}
+      url: ${{ item.url }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, title, score, author, comments]


### PR DESCRIPTION
Add Lobste.rs as a new site adapter — a curated tech news community popular among senior developers in the US and Europe.

## Changes

### New site adapter: `src/clis/lobsters/hot.yaml`

- Public JSON API, no auth needed
- Displays: rank, title, score, author, comment count
- `opencli lobsters hot` / `opencli lobsters hot --limit 10`

### Pipeline: `fetch → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)