### PR TITLE
feat(qiita): add article search command

### DIFF
--- a/src/clis/qiita/search.yaml
+++ b/src/clis/qiita/search.yaml
@@ -1,0 +1,31 @@
+site: qiita
+name: search
+description: Search Qiita developer articles
+domain: qiita.com
+strategy: public
+browser: false
+
+args:
+  query:
+    type: string
+    required: true
+    description: "Search query (supports tag:python, user:username)"
+  limit:
+    type: int
+    default: 15
+    description: Number of articles
+
+pipeline:
+  - fetch:
+      url: https://qiita.com/api/v2/items?page=1&per_page=${{ args.limit }}&query=${{ args.query }}
+
+  - map:
+      title: ${{ item.title }}
+      author: ${{ item.user.id }}
+      likes: ${{ item.likes_count }}
+      comments: ${{ item.comments_count }}
+      url: ${{ item.url }}
+
+  - limit: ${{ args.limit }}
+
+columns: [title, author, likes, comments, url]


### PR DESCRIPTION
Add Qiita as a new site adapter — Japan's largest developer knowledge-sharing community (like dev.to for Japan).

## Changes

### New site adapter: `src/clis/qiita/search.yaml`

- Public API v2, no auth needed
- Supports Qiita search syntax: `tag:python`, `user:username`, free text
- Displays: title, author, likes, comments, URL
- `opencli qiita search --query "tag:go"` / `opencli qiita search --query react`

### Pipeline: `fetch → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)