### PR TITLE
feat(guardian): add news search command

### DIFF
--- a/src/clis/guardian/search.yaml
+++ b/src/clis/guardian/search.yaml
@@ -1,0 +1,32 @@
+site: guardian
+name: search
+description: Search The Guardian news articles
+domain: www.theguardian.com
+strategy: public
+browser: false
+
+args:
+  query:
+    type: string
+    required: true
+    description: Search query
+  limit:
+    type: int
+    default: 15
+    description: Number of articles
+
+pipeline:
+  - fetch:
+      url: https://content.guardianapis.com/search?api-key=test&q=${{ args.query }}&page-size=${{ args.limit }}&order-by=relevance
+
+  - select: response.results
+
+  - map:
+      title: ${{ item.webTitle }}
+      section: ${{ item.sectionName }}
+      date: ${{ item.webPublicationDate }}
+      url: ${{ item.webUrl }}
+
+  - limit: ${{ args.limit }}
+
+columns: [title, section, date, url]


### PR DESCRIPTION
Add The Guardian as a new site adapter — the UK's leading newspaper, widely read across Europe.

## Changes

### New site adapter: `src/clis/guardian/search.yaml`

- Free [Guardian Open Platform API](https://open-platform.theguardian.com/) with built-in test key
- Displays: title, section, publication date, URL
- `opencli guardian search --query "climate change"` / `opencli guardian search --query AI --limit 10`

### Pipeline: `fetch → select: response.results → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)