### PR TITLE
feat(zenn): add trending articles command

### DIFF
--- a/src/clis/zenn/trending.yaml
+++ b/src/clis/zenn/trending.yaml
@@ -1,0 +1,29 @@
+site: zenn
+name: trending
+description: Trending articles on Zenn
+domain: zenn.dev
+strategy: public
+browser: false
+
+args:
+  limit:
+    type: int
+    default: 20
+    description: Number of articles
+
+pipeline:
+  - fetch:
+      url: https://zenn.dev/api/articles?order=daily&count=${{ args.limit }}
+
+  - select: articles
+
+  - map:
+      title: ${{ item.title }}
+      author: ${{ item.user.username }}
+      likes: ${{ item.liked_count }}
+      comments: ${{ item.comments_count }}
+      url: https://zenn.dev${{ item.path }}
+
+  - limit: ${{ args.limit }}
+
+columns: [title, author, likes, comments, url]


### PR DESCRIPTION
Add Zenn as a new site adapter — Japan's modern developer knowledge platform (think Medium for Japanese engineers).

## Changes

### New site adapter: `src/clis/zenn/trending.yaml`

- Public API, no auth needed
- Shows daily trending tech articles
- Displays: title, author, likes, comments, URL
- `opencli zenn trending` / `opencli zenn trending --limit 10`

### Pipeline: `fetch → select: articles → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)