### PR TITLE
feat(leetcode): add problems list command

### DIFF
--- a/src/clis/leetcode/problems.yaml
+++ b/src/clis/leetcode/problems.yaml
@@ -1,0 +1,30 @@
+site: leetcode
+name: problems
+description: LeetCode problem list with acceptance rates
+domain: leetcode.com
+strategy: public
+browser: false
+
+args:
+  limit:
+    type: int
+    default: 20
+    description: Number of problems (from newest)
+
+pipeline:
+  - fetch:
+      url: https://leetcode.com/api/problems/all/
+
+  - select: stat_status_pairs
+
+  - map:
+      id: ${{ item.stat.frontend_question_id }}
+      title: ${{ item.stat.question__title }}
+      difficulty: ${{ item.difficulty.level }}
+      acceptance: ${{ item.stat.total_acs }}
+      submissions: ${{ item.stat.total_submitted }}
+      paid: ${{ item.paid_only }}
+
+  - limit: ${{ args.limit }}
+
+columns: [id, title, difficulty, acceptance, submissions, paid]


### PR DESCRIPTION
Add LeetCode as a new site adapter — the most popular competitive programming platform, used by developers worldwide (US, Japan, Europe) for interview prep.

## Changes

### New site adapter: `src/clis/leetcode/problems.yaml`

- Public API, no auth needed
- Lists problems with ID, title, difficulty (1=Easy, 2=Medium, 3=Hard), acceptance count, submissions
- `opencli leetcode problems` / `opencli leetcode problems --limit 50`

### Pipeline: `fetch → select: stat_status_pairs → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)