### PR TITLE
feat(echojs): add top stories command

### DIFF
--- a/src/clis/echojs/top.yaml
+++ b/src/clis/echojs/top.yaml
@@ -1,0 +1,29 @@
+site: echojs
+name: top
+description: Top stories on Echo JS
+domain: www.echojs.com
+strategy: public
+browser: false
+
+args:
+  limit:
+    type: int
+    default: 20
+    description: Number of stories
+
+pipeline:
+  - fetch:
+      url: https://www.echojs.com/api/getnews/top/0/30
+
+  - select: news
+
+  - map:
+      rank: ${{ index + 1 }}
+      title: ${{ item.title }}
+      upvotes: ${{ item.up }}
+      comments: ${{ item.comments }}
+      url: ${{ item.url }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, title, upvotes, comments, url]


### PR DESCRIPTION
Add Echo JS as a new site adapter — a JavaScript news community popular among frontend/JS developers in the US and Europe.

## Changes

### New site adapter: `src/clis/echojs/top.yaml`

- Public API, no auth needed
- Displays: rank, title, upvotes, comments, URL
- `opencli echojs top` / `opencli echojs top --limit 10`

### Pipeline: `fetch → select: news → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)