### PR TITLE
feat(steam): add top sellers command

### DIFF
--- a/src/clis/steam/top-sellers.yaml
+++ b/src/clis/steam/top-sellers.yaml
@@ -1,0 +1,29 @@
+site: steam
+name: top-sellers
+description: Steam top selling games
+domain: store.steampowered.com
+strategy: public
+browser: false
+
+args:
+  limit:
+    type: int
+    default: 10
+    description: Number of games
+
+pipeline:
+  - fetch:
+      url: https://store.steampowered.com/api/featuredcategories/
+
+  - select: top_sellers.items
+
+  - map:
+      rank: ${{ index + 1 }}
+      name: ${{ item.name }}
+      price: ${{ item.final_price }}
+      discount: ${{ item.discount_percent }}
+      url: https://store.steampowered.com/app/${{ item.id }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, name, price, discount, url]


### PR DESCRIPTION
Add Steam as a new site adapter — the world's largest PC gaming platform, massively popular in the US, Europe, and Japan.

## Changes

### New site adapter: `src/clis/steam/top-sellers.yaml`

- Public Steam Store API, no auth needed
- Shows current top selling games with pricing
- Displays: rank, game name, price, discount %, store URL
- `opencli steam top-sellers` / `opencli steam top-sellers --limit 5`

### Pipeline: `fetch → select: top_sellers.items → map → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | API verified ✅

Made with [Cursor](https://cursor.com)