### PR TITLE
feat(producthunt): add daily top products command

### DIFF
--- a/src/clis/producthunt/top.yaml
+++ b/src/clis/producthunt/top.yaml
@@ -1,0 +1,56 @@
+site: producthunt
+name: top
+description: "Today's top products on Product Hunt"
+domain: www.producthunt.com
+browser: true
+
+args:
+  limit:
+    type: int
+    default: 15
+    description: Number of products
+
+pipeline:
+  - navigate: https://www.producthunt.com
+
+  - evaluate: |
+      (async () => {
+        const res = await fetch('https://www.producthunt.com/frontend/graphql', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query: `{
+              homefeed(first: ${{ args.limit }}) {
+                edges {
+                  node {
+                    ... on Post {
+                      name
+                      tagline
+                      votesCount
+                      commentsCount
+                      website
+                      slug
+                    }
+                  }
+                }
+              }
+            }`
+          })
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const json = await res.json();
+        const edges = json?.data?.homefeed?.edges || [];
+        return edges.map((e, i) => ({
+          rank: i + 1,
+          name: e.node.name,
+          tagline: e.node.tagline,
+          votes: e.node.votesCount,
+          comments: e.node.commentsCount,
+          url: 'https://www.producthunt.com/posts/' + e.node.slug,
+        }));
+      })()
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, name, tagline, votes, comments, url]


### PR DESCRIPTION
Add Product Hunt as a new site adapter — the #1 platform for discovering new tech products, hugely popular in the US and among global tech enthusiasts.

## Changes

### New site adapter: `src/clis/producthunt/top.yaml`

- Browser strategy — navigates to producthunt.com, queries internal GraphQL API
- Requires Browser Bridge extension
- Displays: rank, product name, tagline, votes, comments, URL
- `opencli producthunt top` / `opencli producthunt top --limit 5`

### Pipeline: `navigate → evaluate (GraphQL fetch) → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | YAML schema valid ✅

Made with [Cursor](https://cursor.com)