### PR TITLE
feat(pantip): add trending topics command

### DIFF
--- a/src/clis/pantip/trending.yaml
+++ b/src/clis/pantip/trending.yaml
@@ -1,0 +1,34 @@
+site: pantip
+name: trending
+description: Trending topics on Pantip (Thailand)
+domain: pantip.com
+browser: true
+
+args:
+  limit:
+    type: int
+    default: 20
+    description: Number of topics
+
+pipeline:
+  - navigate: https://pantip.com/trending
+
+  - evaluate: |
+      (async () => {
+        const res = await fetch('https://pantip.com/api/forum-service/home/get_tag_hit?limit=30', {
+          credentials: 'include'
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const json = await res.json();
+        const list = json.data || [];
+        return list.map((item, i) => ({
+          rank: i + 1,
+          title: item.title || item.tag_name,
+          hits: item.hit_count || item.hits,
+          url: item.url || ('https://pantip.com/tag/' + encodeURIComponent(item.tag_name)),
+        }));
+      })()
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, title, hits, url]


### PR DESCRIPTION
Add Pantip as a new site adapter — Thailand's largest and most influential online forum (like Reddit for Thai users), with 30M+ monthly visits.

## Changes

### New site adapter: `src/clis/pantip/trending.yaml`

- Browser strategy — navigates to pantip.com for session cookies
- Shows trending topics/tags with hit counts
- Displays: rank, title, hits, URL
- `opencli pantip trending` / `opencli pantip trending --limit 10`

### Pipeline: `navigate → evaluate (internal API fetch) → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | YAML schema valid ✅

Made with [Cursor](https://cursor.com)