### PR TITLE
feat(connpass): add tech event search command

### DIFF
--- a/src/clis/connpass/search.yaml
+++ b/src/clis/connpass/search.yaml
@@ -1,0 +1,39 @@
+site: connpass
+name: search
+description: Search tech events on Connpass (Japan)
+domain: connpass.com
+browser: true
+
+args:
+  query:
+    type: string
+    description: Search keyword (e.g. Python, React, Go)
+  limit:
+    type: int
+    default: 20
+    description: Number of events
+
+pipeline:
+  - navigate: https://connpass.com
+
+  - evaluate: |
+      (async () => {
+        let url = 'https://connpass.com/api/v1/event/?order=2&count=${{ args.limit }}';
+        const q = '${{ args.query }}';
+        if (q) url += '&keyword=' + encodeURIComponent(q);
+        const res = await fetch(url, { credentials: 'include' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const json = await res.json();
+        return (json.events || []).map((e, i) => ({
+          rank: i + 1,
+          title: e.title,
+          date: (e.started_at || '').substring(0, 10),
+          place: e.place || 'Online',
+          accepted: e.accepted + '/' + (e.limit || '∞'),
+          url: e.event_url,
+        }));
+      })()
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, title, date, place, accepted, url]


### PR DESCRIPTION
Add Connpass as a new site adapter — Japan's largest tech event/meetup platform, essential for Japanese developers.

## Changes

### New site adapter: `src/clis/connpass/search.yaml`

- Browser strategy — navigates to connpass.com for session cookies (API blocked by CDN without browser context)
- Optional `--query` keyword filter
- Displays: rank, event title, date, venue, attendance (accepted/limit), URL
- `opencli connpass search` / `opencli connpass search --query Python`

### Pipeline: `navigate → evaluate (API fetch with keyword) → limit`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅ | YAML schema valid ✅

Made with [Cursor](https://cursor.com)