### PR TITLE
feat(deepseek): add ask command

### DIFF
--- a/src/clis/deepseek/ask.ts
+++ b/src/clis/deepseek/ask.ts
@@ -1,0 +1,88 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+export const askCommand = cli({
+  site: 'deepseek',
+  name: 'ask',
+  description: 'Send a message to DeepSeek and get response',
+  domain: 'chat.deepseek.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'prompt', type: 'string', required: true },
+    { name: 'timeout', type: 'int', default: 120 },
+    { name: 'think', type: 'boolean', default: false, help: 'Enable deep thinking mode (R1)' },
+  ],
+  columns: ['response'],
+  func: async (page: IPage, kwargs: Record<string, any>) => {
+    const prompt = kwargs.prompt as string;
+    const timeoutMs = ((kwargs.timeout as number) || 120) * 1000;
+
+    await page.goto('https://chat.deepseek.com');
+    await page.wait(3);
+
+    if (kwargs.think) {
+      await page.evaluate(`(() => {
+        const toggle = document.querySelector('[class*="think"], [class*="deep-think"]')
+          || [...document.querySelectorAll('button, div[role="button"]')].find(b =>
+            (b.textContent || '').toLowerCase().includes('think'));
+        if (toggle) toggle.click();
+      })()`);
+      await page.wait(1);
+    }
+
+    const promptJson = JSON.stringify(prompt);
+
+    const sendResult = await page.evaluate(`(async () => {
+      try {
+        const ta = document.querySelector('textarea');
+        if (!ta) return { ok: false, msg: 'no textarea' };
+        ta.focus();
+        ta.value = '';
+        document.execCommand('selectAll');
+        document.execCommand('insertText', false, ${promptJson});
+        await new Promise(r => setTimeout(r, 800));
+        const btn = [...document.querySelectorAll('button')].find(b =>
+          !b.disabled && b.querySelector('svg') && (
+            b.closest('[class*="input"]') || b.closest('[class*="chat"]') || b.closest('form')
+          ));
+        if (btn) { btn.click(); return { ok: true }; }
+        ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+        return { ok: true, msg: 'enter' };
+      } catch (e) { return { ok: false, msg: e.toString() }; }
+    })()`);
+
+    if (!sendResult?.ok) {
+      return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+    }
+
+    const startTime = Date.now();
+    let lastText = '';
+    let stableCount = 0;
+
+    while (Date.now() - startTime < timeoutMs) {
+      await page.wait(3);
+      const response = await page.evaluate(`(() => {
+        const msgs = document.querySelectorAll('[class*="markdown"], [class*="message-content"], [class*="assistant"]');
+        if (msgs.length) {
+          const last = msgs[msgs.length - 1];
+          return (last.innerText || '').trim();
+        }
+        return '';
+      })()`);
+
+      if (response && response.length > 2) {
+        if (response === lastText) {
+          stableCount++;
+          if (stableCount >= 2) return [{ response }];
+        } else {
+          stableCount = 0;
+        }
+      }
+      lastText = response || '';
+    }
+
+    if (lastText) return [{ response: lastText }];
+    return [{ response: '[NO RESPONSE]' }];
+  },
+});


### PR DESCRIPTION
Add DeepSeek as a new site adapter — one of the most popular open-source AI models, widely used by developers globally after the R1 release.

## Changes

### New site adapter: \`src/clis/deepseek/ask.ts\`

- TypeScript adapter with \`Strategy.COOKIE\` (browser)
- \`--think\` flag to enable DeepSeek R1 deep thinking mode
- Polls DOM for stable response with configurable timeout
- \`opencli deepseek ask "implement quicksort"\` / \`opencli deepseek ask "prove P!=NP" --think --timeout 180\`

### Pattern: same as \`grok/ask.ts\`

## Verification
- tsc --noEmit ✅ | 244/244 tests ✅

Made with [Cursor](https://cursor.com)