### PR TITLE
feat: add Claude, Gemini, DeepSeek chat adapters

### DIFF
--- a/src/clis/claude/ask.ts
+++ b/src/clis/claude/ask.ts
@@ -1,0 +1,92 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+export const askCommand = cli({
+  site: 'claude',
+  name: 'ask',
+  description: 'Send a message to Claude and get response',
+  domain: 'claude.ai',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'prompt', type: 'string', required: true },
+    { name: 'timeout', type: 'int', default: 120 },
+    { name: 'new', type: 'boolean', default: false },
+  ],
+  columns: ['response'],
+  func: async (page: IPage, kwargs: Record<string, any>) => {
+    const prompt = kwargs.prompt as string;
+    const timeoutMs = ((kwargs.timeout as number) || 120) * 1000;
+    const startUrl = kwargs.new ? 'https://claude.ai/new' : 'https://claude.ai';
+
+    await page.goto(startUrl);
+    await page.wait(3);
+
+    const promptJson = JSON.stringify(prompt);
+
+    const sendResult = await page.evaluate(`(async () => {
+      try {
+        const ce = document.querySelector('div[contenteditable="true"]');
+        const ta = document.querySelector('textarea');
+        const input = ce || ta;
+        if (!input) return { ok: false, msg: 'no input found' };
+        input.focus();
+        if (ce) {
+          ce.innerHTML = '';
+          document.execCommand('insertText', false, ${promptJson});
+        } else {
+          ta.value = '';
+          document.execCommand('selectAll');
+          document.execCommand('insertText', false, ${promptJson});
+        }
+        await new Promise(r => setTimeout(r, 1500));
+        const btn = document.querySelector('button[aria-label="Send Message"]')
+          || document.querySelector('button[aria-label="Send"]')
+          || [...document.querySelectorAll('button[type="button"]')].find(b =>
+            !b.disabled && b.querySelector('svg') && b.closest('[class*="input"]'));
+        if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
+        const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
+        if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
+        (input).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+        return { ok: true, msg: 'enter' };
+      } catch (e) { return { ok: false, msg: e.toString() }; }
+    })()`);
+
+    if (!sendResult || !sendResult.ok) {
+      return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+    }
+
+    const startTime = Date.now();
+    let lastText = '';
+    let stableCount = 0;
+
+    while (Date.now() - startTime < timeoutMs) {
+      await page.wait(3);
+      const response = await page.evaluate(`(() => {
+        const msgs = document.querySelectorAll('[data-is-streaming], .font-claude-message, [class*="response"], [class*="assistant-message"]');
+        if (msgs.length) {
+          const last = msgs[msgs.length - 1];
+          const text = (last.innerText || '').trim();
+          if (text && text.length > 2) return text;
+        }
+        const all = [...document.querySelectorAll('[class*="message"]')];
+        if (all.length < 2) return '';
+        const last = all[all.length - 1];
+        return (last.innerText || '').trim();
+      })()`);
+
+      if (response && response.length > 2) {
+        if (response === lastText) {
+          stableCount++;
+          if (stableCount >= 2) return [{ response }];
+        } else {
+          stableCount = 0;
+        }
+      }
+      lastText = response || '';
+    }
+
+    if (lastText) return [{ response: lastText }];
+    return [{ response: '[NO RESPONSE]' }];
+  },
+});

--- a/src/clis/deepseek/ask.ts
+++ b/src/clis/deepseek/ask.ts
@@ -1,0 +1,88 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+export const askCommand = cli({
+  site: 'deepseek',
+  name: 'ask',
+  description: 'Send a message to DeepSeek and get response',
+  domain: 'chat.deepseek.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'prompt', type: 'string', required: true },
+    { name: 'timeout', type: 'int', default: 120 },
+    { name: 'think', type: 'boolean', default: false, help: 'Enable DeepThink (R1) mode' },
+  ],
+  columns: ['response'],
+  func: async (page: IPage, kwargs: Record<string, any>) => {
+    const prompt = kwargs.prompt as string;
+    const timeoutMs = ((kwargs.timeout as number) || 120) * 1000;
+
+    await page.goto('https://chat.deepseek.com');
+    await page.wait(3);
+
+    if (kwargs.think) {
+      await page.evaluate(`(() => {
+        const toggle = [...document.querySelectorAll('div[role="button"], button')].find(b =>
+          (b.textContent || '').includes('DeepThink') || (b.textContent || '').includes('深度思考'));
+        if (toggle) toggle.click();
+      })()`);
+      await page.wait(1);
+    }
+
+    const promptJson = JSON.stringify(prompt);
+
+    const sendResult = await page.evaluate(`(async () => {
+      try {
+        const ta = document.querySelector('textarea');
+        if (!ta) return { ok: false, msg: 'no textarea' };
+        ta.focus(); ta.value = '';
+        document.execCommand('selectAll');
+        document.execCommand('insertText', false, ${promptJson});
+        await new Promise(r => setTimeout(r, 1500));
+        const btn = [...document.querySelectorAll('button')].find(b =>
+          !b.disabled && b.querySelector('svg') && (
+            b.closest('[class*="input"]') || b.closest('[class*="chat"]') || b.closest('form')));
+        if (btn) { btn.click(); return { ok: true, msg: 'clicked' }; }
+        const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
+        if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
+        ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+        return { ok: true, msg: 'enter' };
+      } catch (e) { return { ok: false, msg: e.toString() }; }
+    })()`);
+
+    if (!sendResult || !sendResult.ok) {
+      return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+    }
+
+    const startTime = Date.now();
+    let lastText = '';
+    let stableCount = 0;
+
+    while (Date.now() - startTime < timeoutMs) {
+      await page.wait(3);
+      const response = await page.evaluate(`(() => {
+        const msgs = document.querySelectorAll('[class*="markdown"], [class*="message-content"], [class*="assistant"]');
+        if (msgs.length) {
+          const last = msgs[msgs.length - 1];
+          const text = (last.innerText || '').trim();
+          if (text && text.length > 2) return text;
+        }
+        return '';
+      })()`);
+
+      if (response && response.length > 2) {
+        if (response === lastText) {
+          stableCount++;
+          if (stableCount >= 2) return [{ response }];
+        } else {
+          stableCount = 0;
+        }
+      }
+      lastText = response || '';
+    }
+
+    if (lastText) return [{ response: lastText }];
+    return [{ response: '[NO RESPONSE]' }];
+  },
+});

--- a/src/clis/gemini/ask.ts
+++ b/src/clis/gemini/ask.ts
@@ -1,0 +1,89 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+export const askCommand = cli({
+  site: 'gemini',
+  name: 'ask',
+  description: 'Send a message to Gemini and get response',
+  domain: 'gemini.google.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'prompt', type: 'string', required: true },
+    { name: 'timeout', type: 'int', default: 120 },
+  ],
+  columns: ['response'],
+  func: async (page: IPage, kwargs: Record<string, any>) => {
+    const prompt = kwargs.prompt as string;
+    const timeoutMs = ((kwargs.timeout as number) || 120) * 1000;
+
+    await page.goto('https://gemini.google.com/app');
+    await page.wait(3);
+
+    const promptJson = JSON.stringify(prompt);
+
+    const sendResult = await page.evaluate(`(async () => {
+      try {
+        const ce = document.querySelector('.ql-editor[contenteditable="true"]')
+          || document.querySelector('div[contenteditable="true"]');
+        const ta = document.querySelector('textarea');
+        const input = ce || ta;
+        if (!input) return { ok: false, msg: 'no input found' };
+        input.focus();
+        if (ce) {
+          ce.textContent = '';
+          document.execCommand('insertText', false, ${promptJson});
+        } else {
+          ta.value = '';
+          document.execCommand('selectAll');
+          document.execCommand('insertText', false, ${promptJson});
+        }
+        await new Promise(r => setTimeout(r, 1500));
+        const btn = document.querySelector('button.send-button')
+          || document.querySelector('button[aria-label="Send message"]')
+          || document.querySelector('button[mattooltip="Send"]')
+          || [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
+        if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
+        (input).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+        return { ok: true, msg: 'enter' };
+      } catch (e) { return { ok: false, msg: e.toString() }; }
+    })()`);
+
+    if (!sendResult || !sendResult.ok) {
+      return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+    }
+
+    const startTime = Date.now();
+    let lastText = '';
+    let stableCount = 0;
+
+    while (Date.now() - startTime < timeoutMs) {
+      await page.wait(3);
+      const response = await page.evaluate(`(() => {
+        const turns = document.querySelectorAll('model-response, .model-response-text, [class*="response-container"], message-content');
+        if (turns.length) {
+          const last = turns[turns.length - 1];
+          const text = (last.innerText || '').trim();
+          if (text && text.length > 2) return text;
+        }
+        const msgs = [...document.querySelectorAll('[class*="message"]')];
+        if (msgs.length < 2) return '';
+        const last = msgs[msgs.length - 1];
+        return (last.innerText || '').trim();
+      })()`);
+
+      if (response && response.length > 2) {
+        if (response === lastText) {
+          stableCount++;
+          if (stableCount >= 2) return [{ response }];
+        } else {
+          stableCount = 0;
+        }
+      }
+      lastText = response || '';
+    }
+
+    if (lastText) return [{ response: lastText }];
+    return [{ response: '[NO RESPONSE]' }];
+  },
+});


### PR DESCRIPTION
> **Context**: opencli already supports ChatGPT and Grok as AI chat adapters. Claude, Gemini, and DeepSeek are the **#2, #3, and #4 most-used AI chatbots worldwide** — not niche services, but the natural next entries in the same category.

## Changes

Three new AI chat site adapters, all following the existing `grok/ask.ts` pattern (`Strategy.COOKIE` + browser):

### 1. `src/clis/claude/ask.ts` — Anthropic Claude
- Domain: claude.ai
- 200M+ monthly visits, #2 AI chatbot globally
- `--new` flag to start a fresh conversation
- `opencli claude ask "explain async/await in Rust"`

### 2. `src/clis/gemini/ask.ts` — Google Gemini
- Domain: gemini.google.com
- 300M+ monthly visits, Google's flagship AI
- Handles Material Design contenteditable input
- `opencli gemini ask "compare PostgreSQL vs MySQL"`

### 3. `src/clis/deepseek/ask.ts` — DeepSeek
- Domain: chat.deepseek.com
- 120M+ monthly visits, top open-source AI model
- `--think` flag to enable DeepThink (R1) mode
- `opencli deepseek ask "implement a B-tree" --think`

### Architecture

All three follow the **exact same pattern** as `grok/ask.ts`:

```
navigate → find input → type prompt → click send → poll DOM for stable response
```

No new dependencies, no architectural changes. Just 3 files in the `src/clis/` directory.

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- Rebased on latest main (post-#152 refactor) ✅