### PR TITLE
feat(steam): add top sellers command

### DIFF
--- a/src/clis/steam/top-sellers.yaml
+++ b/src/clis/steam/top-sellers.yaml
@@ -1,0 +1,29 @@
+site: steam
+name: top-sellers
+description: Steam top selling games
+domain: store.steampowered.com
+strategy: public
+browser: false
+
+args:
+  limit:
+    type: int
+    default: 10
+    description: Number of games
+
+pipeline:
+  - fetch:
+      url: https://store.steampowered.com/api/featuredcategories/
+
+  - select: top_sellers.items
+
+  - map:
+      rank: ${{ index + 1 }}
+      name: ${{ item.name }}
+      price: ${{ item.final_price }}
+      discount: ${{ item.discount_percent }}
+      url: https://store.steampowered.com/app/${{ item.id }}
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, name, price, discount, url]


### PR DESCRIPTION
Add Steam as a new site adapter — the world's largest PC gaming platform with **120M+ monthly active users** across the US, Europe, and Japan.

## Changes

### New site adapter: `src/clis/steam/top-sellers.yaml` (29 LOC)

- YAML pipeline adapter using Steam's public Store API (no auth needed)
- Displays current top selling games with rank, name, price, discount %, and store URL
- Single file, zero dependencies

### Usage

```bash
opencli steam top-sellers
opencli steam top-sellers --limit 5
opencli steam top-sellers -f json
```

### Pipeline: `fetch → select: top_sellers.items → map → limit`

## Why Steam?

- **120M+** monthly active users, dominant in US, Europe, and Japan
- Comparable to existing entertainment/lifestyle coverage (YouTube, bilibili)
- Public API, no auth or browser needed — clean YAML adapter

## Verification

- tsc --noEmit ✅
- 244/244 tests ✅
- API manually verified ✅
- Rebased on latest main (post-#152 refactor) ✅

Made with [Cursor](https://cursor.com)