### PR TITLE
docs: sync documentation with PR #150 arg renames

### DIFF
--- a/.agents/skills/cross-project-adapter-migration/SKILL.md
+++ b/.agents/skills/cross-project-adapter-migration/SKILL.md
@@ -166,10 +166,10 @@ cli({
 
 ### 3.4 公共模式复用
 
-迁移过程中如果发现多个适配器共享逻辑，考虑提取到 `src/<site>.ts` 工具文件：
+迁移过程中如果发现多个适配器共享逻辑，考虑提取到 `src/clis/<site>/utils.ts` 工具文件：
 
 ```typescript
-// src/<site>.ts
+// src/clis/<site>/utils.ts
 export async function fetchWithAuth(page, url) { ... }
 export function parseItem(raw) { ... }
 ```

--- a/CLI-EXPLORER.md
+++ b/CLI-EXPLORER.md
@@ -196,7 +196,7 @@ cat src/clis/<site>/feed.ts   # 读最相似的那个
 
 写 TS 适配器之前，先看看你的目标站点有没有**现成的 helper 函数**可以复用：
 
-#### Bilibili (`src/bilibili.ts`)
+#### Bilibili (`src/clis/bilibili/utils.ts`)
 
 | 函数 | 用途 | 何时使用 |
 |------|------|----------|
@@ -342,10 +342,11 @@ name: search
 description: 知乎搜索
 
 args:
-  keyword:
+  query:
     type: str
     required: true
-    description: Search keyword
+    positional: true
+    description: Search query
   limit:
     type: int
     default: 10
@@ -355,7 +356,7 @@ pipeline:
 
   - evaluate: |
       (async () => {
-        const q = encodeURIComponent('${{ args.keyword }}');
+        const q = encodeURIComponent('${{ args.query }}');
         const res = await fetch('/api/v4/search_v3?q=' + q + '&t=general&limit=${{ args.limit }}', {
           credentials: 'include'
         });
@@ -455,7 +456,7 @@ cli({
   name: 'search',
   description: 'Search tweets',
   strategy: Strategy.HEADER,
-  args: [{ name: 'keyword', required: true }],
+  args: [{ name: 'query', required: true, positional: true }],
   columns: ['rank', 'author', 'text', 'likes'],
   func: async (page, kwargs) => {
     await page.goto('https://x.com');
@@ -474,7 +475,7 @@ cli({
           'X-Twitter-Auth-Type': 'OAuth2Session',
         };
 
-        const variables = JSON.stringify({ rawQuery: '${kwargs.keyword}', count: 20 });
+        const variables = JSON.stringify({ rawQuery: '${kwargs.query}', count: 20 });
         const url = '/i/api/graphql/xxx/SearchTimeline?variables=' + encodeURIComponent(variables);
         const res = await fetch(url, { headers, credentials: 'include' });
         return await res.json();
@@ -631,7 +632,7 @@ git add src/clis/mysite/ && git commit -m "feat(mysite): add hot" && git push
 ```typescript
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
-import { apiGet } from '../../bilibili.js'; // 复用平台 SDK
+import { apiGet } from './utils.js'; // 复用平台 SDK
 
 cli({
   site: 'bilibili',
@@ -694,7 +695,7 @@ cli({
 | 嵌套字段访问 | `${{ item.node?.title }}` 不工作 | 在 evaluate 中 flatten 数据，不在模板中用 optional chaining |
 | 缺少 `strategy: public` | 公开 API 也启动浏览器，7s → 1s | 公开 API 加上 `strategy: public` + `browser: false` |
 | evaluate 返回字符串 | map 步骤收到 `""` 而非数组 | pipeline 有 auto-parse，但建议在 evaluate 内 `.map()` 整形 |
-| 搜索参数被 URL 编码 | `${{ args.keyword }}` 被浏览器二次编码 | 在 evaluate 内用 `encodeURIComponent()` 手动编码 |
+| 搜索参数被 URL 编码 | `${{ args.query }}` 被浏览器二次编码 | 在 evaluate 内用 `encodeURIComponent()` 手动编码 |
 | Cookie 过期 | 返回 401 / 空数据 | 在浏览器里重新登录目标站点 |
 | Extension tab 残留 | Chrome 多出 `chrome-extension://` tab | 已自动清理；若残留，手动关闭即可 |
 | TS evaluate 格式 | `() => {}` 报 `result is not a function` | TS 中 `page.evaluate()` 必须用 IIFE：`(async () => { ... })()` |

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 A CLI tool that turns **any website** or **Electron app** into a command-line interface — Bilibili, Zhihu, 小红书, Twitter/X, Reddit, YouTube, Antigravity, and [many more](#built-in-commands) — powered by browser session reuse and AI-native discovery.
 
-💡 **Built for AI Agents**: Simply configure an instruction in your global `AGENT.md` or `.cursorrules` guiding the AI to execute `opencli list` via Bash to discover available tools. Register your favorite local CLIs (`opencli register mycli`), and the AI will automatically learn how to invoke all your tools perfectly!
+**Built for AI Agents**: Simply configure an instruction in your global `AGENT.md` or `.cursorrules` guiding the AI to execute `opencli list` via Bash to discover available tools. Register your favorite local CLIs (`opencli register mycli`), and the AI will automatically learn how to invoke all your tools perfectly!
 
-🔥 **CLI All Electron Apps! The Most Powerful Update Has Arrived!** 🔥
+**CLI All Electron Apps! The Most Powerful Update Has Arrived!**
 Turn ANY Electron application into a CLI tool! Recombine, script, and extend applications like Antigravity Ultra seamlessly. Now AI can control itself natively. Unlimited possibilities await!
 
 ---
@@ -130,12 +130,12 @@ Run `opencli list` for the live registry.
 | **xueqiu** | `feed` `hot-stock` `hot` `search` `stock` `watchlist` | Browser |
 | **antigravity** | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` | Desktop |
 | **chatgpt** | `status` `new` `send` `read` `ask` | Desktop |
-| **xiaohongshu** | `search` `notifications` `feed` `me` `user` `download` | Browser |
+| **xiaohongshu** | `search` `notifications` `feed` `user` `download` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` | Browser |
 | **apple-podcasts** | `search` `episodes` `top` | Public |
 | **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | Public |
 | **zhihu** | `hot` `search` `question` `download` | Browser |
 | **youtube** | `search` `video` `transcript` | Browser |
-| **boss** | `search` `detail` | Browser |
+| **boss** | `search` `detail` `recommend` `joblist` `greet` `batchgreet` `send` `chatlist` `chatmsg` `invite` `mark` `exchange` `resume` `stats` | Browser |
 | **coupang** | `search` `add-to-cart` | Browser |
 | **bbc** | `news` | Public |
 | **bloomberg** | `main` `markets` `economics` `industries` `tech` `politics` `businessweek` `opinions` `feeds` `news` | Public / Browser |
@@ -150,6 +150,15 @@ Run `opencli list` for the live registry.
 | **weibo** | `hot` | Browser |
 | **yahoo-finance** | `quote` | Browser |
 | **sinafinance** | `news` | 🌐 Public |
+| **barchart** | `quote` `options` `greeks` `flow` | Browser |
+| **chaoxing** | `assignments` `exams` | Browser |
+| **grok** | `ask` | Desktop |
+| **hf** | `top` | Public |
+| **jike** | `feed` `search` `create` `like` `comment` `repost` `notifications` `post` `topic` `user` | Browser |
+| **jimeng** | `generate` `history` | Browser |
+| **linux-do** | `hot` `latest` `search` `categories` `category` `topic` | Public |
+| **stackoverflow** | `hot` `search` `bounties` `unanswered` | Public |
+| **weread** | `shelf` `search` `book` `highlights` `notes` `notebooks` `ranking` | Browser |
 
 > **Bloomberg note**: The RSS-backed Bloomberg listing commands (`main`, section feeds, `feeds`) work without a browser. `bloomberg news` is for standard Bloomberg story/article pages that your current Chrome session can already access. Audio and some other non-standard pages may fail, and OpenCLI does not bypass Bloomberg paywall or entitlement checks.
 
@@ -220,23 +229,23 @@ brew install yt-dlp
 
 ```bash
 # Download images/videos from Xiaohongshu note
-opencli xiaohongshu download --note_id abc123 --output ./xhs
+opencli xiaohongshu download --note-id abc123 --output ./xhs
 
 # Download Bilibili video (requires yt-dlp)
 opencli bilibili download --bvid BV1xxx --output ./bilibili
 opencli bilibili download --bvid BV1xxx --quality 1080p  # Specify quality
 
 # Download Twitter media from user
-opencli twitter download --username elonmusk --limit 20 --output ./twitter
+opencli twitter download elonmusk --limit 20 --output ./twitter
 
 # Download single tweet media
 opencli twitter download --tweet-url "https://x.com/user/status/123" --output ./twitter
 
 # Export Zhihu article to Markdown
-opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
+opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
 
 # Export with local images
-opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --download-images
+opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 ```
 
 ### Pipeline Step (for YAML adapters)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,9 +11,9 @@
 
 OpenCLI 将任何网站或 Electron 应用（如 Antigravity）变成命令行工具 — B站、知乎、小红书、Twitter/X、Reddit、YouTube 等[多种站点与应用](#内置命令) — 复用浏览器登录态，AI 驱动探索。
 
-💡 **专为 AI Agent 打造**：只需在全局 `.cursorrules` 或 `AGENT.md` 中配置简单指令，引导 AI 通过 Bash 执行 `opencli list` 来检索可用的 CLI 工具及其用法。随后，将你常用的 CLI 列表整合注册进去（`opencli register mycli`），AI 便能瞬间学会自动调用相应的本地工具！
+**专为 AI Agent 打造**：只需在全局 `.cursorrules` 或 `AGENT.md` 中配置简单指令，引导 AI 通过 Bash 执行 `opencli list` 来检索可用的 CLI 工具及其用法。随后，将你常用的 CLI 列表整合注册进去（`opencli register mycli`），AI 便能瞬间学会自动调用相应的本地工具！
 
-🔥 **opencli 支持 CLI 化所有 electron 应用！最强大更新来袭！** 🔥
+**opencli 支持 CLI 化所有 electron 应用！最强大更新来袭！**
 CLI all electron！现在支持把所有 electron 应用 CLI 化，从而组合出各种神奇的能力。
 如果你在使用诸如 Antigravity Ultra 等工具时觉得不够灵活或难以扩展，现在通过 OpenCLI 把他 CLI 化，轻松打破界限。
 现在，**AI 可以自己控制自己**！结合 cc/openclaw 就可以远程控制任何 electron 应用！无限玩法！！
@@ -130,12 +130,12 @@ npm install -g @jackwener/opencli@latest
 | **xueqiu** | `feed` `hot-stock` `hot` `search` `stock` `watchlist` | 浏览器 |
 | **antigravity** | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` | 桌面端 |
 | **chatgpt** | `status` `new` `send` `read` `ask` | 桌面端 |
-| **xiaohongshu** | `search` `notifications` `feed` `me` `user` `download` | 浏览器 |
+| **xiaohongshu** | `search` `notifications` `feed` `user` `download` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` | 浏览器 |
 | **apple-podcasts** | `search` `episodes` `top` | 公开 |
 | **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | 公开 |
 | **zhihu** | `hot` `search` `question` `download` | 浏览器 |
 | **youtube** | `search` `video` `transcript` | 浏览器 |
-| **boss** | `search` `detail` | 浏览器 |
+| **boss** | `search` `detail` `recommend` `joblist` `greet` `batchgreet` `send` `chatlist` `chatmsg` `invite` `mark` `exchange` `resume` `stats` | 浏览器 |
 | **coupang** | `search` `add-to-cart` | 浏览器 |
 | **bbc** | `news` | 公共 API |
 | **bloomberg** | `main` `markets` `economics` `industries` `tech` `politics` `businessweek` `opinions` `feeds` `news` | 公共 API / 浏览器 |
@@ -150,6 +150,15 @@ npm install -g @jackwener/opencli@latest
 | **weibo** | `hot` | 浏览器 |
 | **yahoo-finance** | `quote` | 浏览器 |
 | **sinafinance** | `news` | 🌐 公开 |
+| **barchart** | `quote` `options` `greeks` `flow` | 浏览器 |
+| **chaoxing** | `assignments` `exams` | 浏览器 |
+| **grok** | `ask` | 桌面端 |
+| **hf** | `top` | 公开 |
+| **jike** | `feed` `search` `create` `like` `comment` `repost` `notifications` `post` `topic` `user` | 浏览器 |
+| **jimeng** | `generate` `history` | 浏览器 |
+| **linux-do** | `hot` `latest` `search` `categories` `category` `topic` | 公开 |
+| **stackoverflow** | `hot` `search` `bounties` `unanswered` | 公开 |
+| **weread** | `shelf` `search` `book` `highlights` `notes` `notebooks` `ranking` | 浏览器 |
 
 > **Bloomberg 说明**：Bloomberg 的 RSS 列表命令（`main`、各栏目 feed、`feeds`）无需浏览器即可使用。`bloomberg news` 适用于当前 Chrome 会话本身就能访问的标准 Bloomberg 文章页。音频页和部分非标准页面可能失败，OpenCLI 也不会绕过 Bloomberg 的付费墙、登录或权限校验。
 
@@ -198,23 +207,23 @@ brew install yt-dlp
 
 ```bash
 # 下载小红书笔记中的图片/视频
-opencli xiaohongshu download --note_id abc123 --output ./xhs
+opencli xiaohongshu download --note-id abc123 --output ./xhs
 
 # 下载B站视频（需要 yt-dlp）
 opencli bilibili download --bvid BV1xxx --output ./bilibili
 opencli bilibili download --bvid BV1xxx --quality 1080p  # 指定画质
 
 # 下载 Twitter 用户的媒体
-opencli twitter download --username elonmusk --limit 20 --output ./twitter
+opencli twitter download elonmusk --limit 20 --output ./twitter
 
 # 下载单条推文的媒体
 opencli twitter download --tweet-url "https://x.com/user/status/123" --output ./twitter
 
 # 导出知乎文章为 Markdown
-opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
+opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
 
-# 导出文章并下载图片到本地
-opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --download-images
+# 导出并下载图片
+opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 ```
 
 ### Pipeline Step（用于 YAML 适配器）

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opencli
-description: "OpenCLI — Make any website or Electron App your CLI. Zero risk, AI-powered, reuse Chrome login. 80+ commands across 19 sites."
+description: "OpenCLI — Make any website or Electron App your CLI. Zero risk, AI-powered, reuse Chrome login. 150+ commands across 30+ sites."
 version: 1.1.0
 author: jackwener
 tags: [cli, browser, web, chrome-extension, cdp, bilibili, zhihu, twitter, github, v2ex, hackernews, reddit, xiaohongshu, xueqiu, youtube, boss, coupang, AI, agent]
@@ -48,7 +48,7 @@ Public API commands (`hackernews`, `github search`, `v2ex`) need no browser.
 ```bash
 # Bilibili (browser)
 opencli bilibili hot --limit 10          # B站热门视频
-opencli bilibili search --keyword "rust"  # 搜索视频
+opencli bilibili search "rust"            # 搜索视频 (query positional)
 opencli bilibili me                       # 我的信息
 opencli bilibili favorite                 # 我的收藏
 opencli bilibili history --limit 20       # 观看历史
@@ -61,15 +61,19 @@ opencli bilibili following --limit 20     # 我的关注列表 (支持 --uid 查
 
 # 知乎 (browser)
 opencli zhihu hot --limit 10             # 知乎热榜
-opencli zhihu search --keyword "AI"      # 搜索
-opencli zhihu question --id 34816524     # 问题详情和回答
+opencli zhihu search "AI"                # 搜索 (query positional)
+opencli zhihu question 34816524            # 问题详情和回答 (id positional)
 
 # 小红书 (browser)
-opencli xiaohongshu search --keyword "美食"  # 搜索笔记
+opencli xiaohongshu search "美食"           # 搜索笔记 (query positional)
 opencli xiaohongshu notifications             # 通知（mentions/likes/connections）
 opencli xiaohongshu feed --limit 10           # 推荐 Feed
-opencli xiaohongshu me                        # 我的信息
-opencli xiaohongshu user --uid xxx             # 用户主页
+opencli xiaohongshu user xxx               # 用户主页 (id positional)
+opencli xiaohongshu creator-notes --limit 10   # 创作者笔记列表
+opencli xiaohongshu creator-note-detail --note-id xxx  # 笔记详情
+opencli xiaohongshu creator-notes-summary      # 笔记数据概览
+opencli xiaohongshu creator-profile            # 创作者资料
+opencli xiaohongshu creator-stats              # 创作者数据统计
 
 # 雪球 Xueqiu (browser)
 opencli xueqiu hot-stock --limit 10      # 雪球热门股票榜
@@ -77,15 +81,15 @@ opencli xueqiu stock --symbol SH600519   # 查看股票实时行情
 opencli xueqiu watchlist                 # 获取自选股/持仓列表
 opencli xueqiu feed                      # 我的关注 timeline
 opencli xueqiu hot --limit 10            # 雪球热榜
-opencli xueqiu search --keyword "特斯拉"  # 搜索
+opencli xueqiu search "特斯拉"            # 搜索 (query positional)
 
 # GitHub (public)
-opencli github search --keyword "cli"    # 搜索仓库
+opencli github search "cli"              # 搜索仓库 (query positional)
 
 # Twitter/X (browser)
 opencli twitter trending --limit 10      # 热门话题
 opencli twitter bookmarks --limit 20     # 获取收藏的书签推文
-opencli twitter search --keyword "AI"    # 搜索推文
+opencli twitter search "AI"              # 搜索推文 (query positional)
 opencli twitter profile elonmusk         # 用户资料
 opencli twitter timeline --limit 20      # 时间线
 opencli twitter thread 1234567890        # 推文 thread（原文 + 回复）
@@ -100,15 +104,15 @@ opencli reddit hot --limit 10            # 热门帖子
 opencli reddit hot --subreddit programming  # 指定子版块
 opencli reddit frontpage --limit 10      # 首页 /r/all
 opencli reddit popular --limit 10        # /r/popular 热门
-opencli reddit search --query "AI" --sort top --time week  # 搜索（支持排序+时间过滤）
+opencli reddit search "AI" --sort top --time week  # 搜索（支持排序+时间过滤）
 opencli reddit subreddit --name rust --sort top --time month  # 子版块浏览（支持时间过滤）
-opencli reddit read --post_id 1abc123    # 阅读帖子 + 评论
-opencli reddit user --username spez      # 用户资料（karma、注册时间）
-opencli reddit user-posts --username spez  # 用户发帖历史
-opencli reddit user-comments --username spez  # 用户评论历史
-opencli reddit upvote --post_id xxx --direction up  # 投票（up/down/none）
-opencli reddit save --post_id xxx        # 收藏帖子
-opencli reddit comment --post_id xxx --text "Great!"  # 发表评论
+opencli reddit read --post-id 1abc123    # 阅读帖子 + 评论
+opencli reddit user spez                 # 用户资料（karma、注册时间）
+opencli reddit user-posts spez           # 用户发帖历史
+opencli reddit user-comments spez        # 用户评论历史
+opencli reddit upvote --post-id xxx --direction up  # 投票（up/down/none）
+opencli reddit save --post-id xxx        # 收藏帖子
+opencli reddit comment --post-id xxx "Great!"  # 发表评论 (text positional)
 opencli reddit subscribe --subreddit python  # 订阅子版块
 opencli reddit saved --limit 10          # 我的收藏
 opencli reddit upvoted --limit 10        # 我的赞
@@ -116,7 +120,7 @@ opencli reddit upvoted --limit 10        # 我的赞
 # V2EX (public + browser)
 opencli v2ex hot --limit 10              # 热门话题
 opencli v2ex latest --limit 10           # 最新话题
-opencli v2ex topic --id 1024             # 主题详情
+opencli v2ex topic 1024                  # 主题详情 (id positional)
 opencli v2ex daily                       # 每日签到 (browser)
 opencli v2ex me                          # 我的信息 (browser)
 opencli v2ex notifications --limit 10    # 通知 (browser)
@@ -131,14 +135,26 @@ opencli bbc news --limit 10             # BBC News RSS headlines
 opencli weibo hot --limit 10            # 微博热搜
 
 # BOSS直聘 (browser)
-opencli boss search --query "AI agent"  # 搜索职位
-opencli boss detail --securityId xxx    # 职位详情
+opencli boss search "AI agent"          # 搜索职位 (query positional)
+opencli boss detail --security-id xxx    # 职位详情
+opencli boss recommend --limit 10        # 推荐职位
+opencli boss joblist --limit 10          # 职位列表
+opencli boss greet --security-id xxx     # 打招呼
+opencli boss batchgreet --job-id xxx     # 批量打招呼
+opencli boss send --uid xxx "消息内容"    # 发消息 (text positional)
+opencli boss chatlist --limit 10         # 聊天列表
+opencli boss chatmsg --security-id xxx   # 聊天记录
+opencli boss invite --security-id xxx    # 邀请沟通
+opencli boss mark --security-id xxx      # 标记管理
+opencli boss exchange --security-id xxx  # 交换联系方式
+opencli boss resume                    # 简历管理
+opencli boss stats                     # 数据统计
 
 # YouTube (browser)
-opencli youtube search --query "rust"   # 搜索视频
-opencli youtube video --url "https://www.youtube.com/watch?v=xxx"  # 视频元数据（标题、播放量、描述等）
-opencli youtube transcript --url "https://www.youtube.com/watch?v=xxx"  # 获取视频字幕/转录
-opencli youtube transcript --url "xxx" --lang zh-Hans --mode raw  # 指定语言 + 原始时间戳模式
+opencli youtube search "rust"            # 搜索视频 (query positional)
+opencli youtube video "https://www.youtube.com/watch?v=xxx"  # 视频元数据
+opencli youtube transcript "https://www.youtube.com/watch?v=xxx"  # 获取视频字幕/转录
+opencli youtube transcript "xxx" --lang zh-Hans --mode raw  # 指定语言 + 原始时间戳模式
 
 # Yahoo Finance (browser)
 opencli yahoo-finance quote --symbol AAPL  # 股票行情
@@ -147,13 +163,13 @@ opencli yahoo-finance quote --symbol AAPL  # 股票行情
 opencli sinafinance news --limit 10 --type 1  # 7x24实时快讯 (0=全部 1=A股 2=宏观 3=公司 4=数据 5=市场 6=国际 7=观点 8=央行 9=其它)
 
 # Reuters (browser)
-opencli reuters search --query "AI"     # 路透社搜索
+opencli reuters search "AI"              # 路透社搜索 (query positional)
 
 # 什么值得买 (browser)
-opencli smzdm search --keyword "耳机"    # 搜索好价
+opencli smzdm search "耳机"              # 搜索好价 (query positional)
 
 # 携程 (browser)
-opencli ctrip search --query "三亚"      # 搜索目的地
+opencli ctrip search "三亚"              # 搜索目的地 (query positional)
 
 # Antigravity (Electron/CDP)
 opencli antigravity status              # 检查 CDP 连接
@@ -163,6 +179,54 @@ opencli antigravity new                 # 清空聊天、开启新对话
 opencli antigravity extract-code        # 自动抽取 AI 回复中的代码块
 opencli antigravity model claude        # 切换底层模型
 opencli antigravity watch               # 流式监听增量消息
+
+# Barchart (browser)
+opencli barchart quote --symbol AAPL     # 股票行情
+opencli barchart options --symbol AAPL   # 期权链
+opencli barchart greeks --symbol AAPL    # 期权 Greeks
+opencli barchart flow --limit 20         # 异常期权活动
+
+# Jike 即刻 (browser)
+opencli jike feed --limit 10             # 动态流
+opencli jike search "AI"                 # 搜索 (query positional)
+opencli jike create "内容"                # 发布动态 (text positional)
+opencli jike like xxx                    # 点赞 (id positional)
+opencli jike comment xxx "评论"           # 评论 (id + text positional)
+opencli jike repost xxx                  # 转发 (id positional)
+opencli jike notifications               # 通知
+
+# Linux.do (public)
+opencli linux-do hot --limit 10          # 热门话题
+opencli linux-do latest --limit 10       # 最新话题
+opencli linux-do search "rust"           # 搜索 (query positional)
+opencli linux-do topic 1024              # 主题详情 (id positional)
+
+# StackOverflow (public)
+opencli stackoverflow hot --limit 10     # 热门问题
+opencli stackoverflow search "typescript"  # 搜索 (query positional)
+opencli stackoverflow bounties --limit 10  # 悬赏问题
+
+# WeRead 微信读书 (browser)
+opencli weread shelf --limit 10          # 书架
+opencli weread search "AI"               # 搜索图书 (query positional)
+opencli weread book xxx                  # 图书详情 (book-id positional)
+opencli weread highlights xxx            # 划线笔记 (book-id positional)
+opencli weread notes xxx                 # 想法笔记 (book-id positional)
+opencli weread ranking --limit 10        # 排行榜
+
+# Jimeng 即梦 AI (browser)
+opencli jimeng generate --prompt "描述"  # AI 生图
+opencli jimeng history --limit 10        # 生成历史
+
+# Grok (Desktop)
+opencli grok ask "问题"                  # 提问 Grok (text positional)
+
+# HuggingFace (public)
+opencli hf top --limit 10                # 热门模型
+
+# 超星学习通 (browser)
+opencli chaoxing assignments             # 作业列表
+opencli chaoxing exams                   # 考试列表
 ```
 
 ### Management Commands
@@ -300,7 +364,7 @@ cli({
   site: 'mysite',
   name: 'search',
   strategy: Strategy.INTERCEPT, // Or COOKIE
-  args: [{ name: 'keyword', required: true }],
+  args: [{ name: 'query', required: true, positional: true }],
   columns: ['rank', 'title', 'url'],
   func: async (page, kwargs) => {
     await page.goto('https://www.mysite.com/search');
@@ -351,7 +415,7 @@ cli({
 
 ```yaml
 # Arguments with defaults
-${{ args.keyword }}
+${{ args.query }}
 ${{ args.limit | default(20) }}
 
 # Current item (in map/filter)

--- a/docs/adapters/browser/arxiv.md
+++ b/docs/adapters/browser/arxiv.md
@@ -13,13 +13,13 @@
 
 ```bash
 # Search for papers
-opencli arxiv search --query "transformer attention" --limit 10
+opencli arxiv search "transformer attention" --limit 10
 
 # Get paper details by arXiv ID
-opencli arxiv paper --id 2301.00001
+opencli arxiv paper 2301.00001
 
 # JSON output
-opencli arxiv search --query "LLM" -f json
+opencli arxiv search "LLM" -f json
 ```
 
 ## Prerequisites

--- a/docs/adapters/browser/jike.md
+++ b/docs/adapters/browser/jike.md
@@ -24,16 +24,16 @@
 opencli jike feed --limit 10
 
 # Search posts
-opencli jike search --query "AI" --limit 20
+opencli jike search "AI" --limit 20
 
 # View post details and comments
-opencli jike post --id <post-id>
+opencli jike post <post-id>
 
 # Create a new post
 opencli jike create --content "Hello Jike!"
 
 # Like a post
-opencli jike like --id <post-id>
+opencli jike like <post-id>
 
 # JSON output
 opencli jike feed -f json

--- a/docs/adapters/browser/linux-do.md
+++ b/docs/adapters/browser/linux-do.md
@@ -30,10 +30,10 @@ opencli linux-do latest --limit 10
 opencli linux-do categories
 
 # Search topics
-opencli linux-do search --query "NixOS"
+opencli linux-do search "NixOS"
 
 # View topic details
-opencli linux-do topic --id 12345
+opencli linux-do topic 12345
 
 # JSON output
 opencli linux-do hot -f json

--- a/docs/adapters/browser/stackoverflow.md
+++ b/docs/adapters/browser/stackoverflow.md
@@ -18,7 +18,7 @@
 opencli stackoverflow hot --limit 10
 
 # Search questions
-opencli stackoverflow search --query "async await" --limit 20
+opencli stackoverflow search "async await" --limit 20
 
 # Active bounties
 opencli stackoverflow bounties --limit 10

--- a/docs/adapters/browser/weread.md
+++ b/docs/adapters/browser/weread.md
@@ -21,10 +21,10 @@
 opencli weread shelf --limit 20
 
 # Search books
-opencli weread search --query "三体"
+opencli weread search "三体"
 
 # View book details
-opencli weread book --id <book-id>
+opencli weread book <book-id>
 
 # Book rankings
 opencli weread ranking --limit 10
@@ -33,10 +33,10 @@ opencli weread ranking --limit 10
 opencli weread notebooks
 
 # View highlights for a book
-opencli weread highlights --id <book-id>
+opencli weread highlights <book-id>
 
 # View your notes
-opencli weread notes --id <book-id>
+opencli weread notes <book-id>
 
 # JSON output
 opencli weread shelf -f json

--- a/docs/adapters/browser/wikipedia.md
+++ b/docs/adapters/browser/wikipedia.md
@@ -13,16 +13,16 @@
 
 ```bash
 # Search articles
-opencli wikipedia search --query "quantum computing" --limit 10
+opencli wikipedia search "quantum computing" --limit 10
 
 # Get article summary
 opencli wikipedia summary --title "Artificial intelligence"
 
 # Search in other languages
-opencli wikipedia search --query "人工智能" --lang zh
+opencli wikipedia search "人工智能" --lang zh
 
 # JSON output
-opencli wikipedia search --query "Rust" -f json
+opencli wikipedia search "Rust" -f json
 ```
 
 ## Prerequisites

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -9,9 +9,13 @@
 | `opencli xiaohongshu search` | |
 | `opencli xiaohongshu notifications` | |
 | `opencli xiaohongshu feed` | |
-| `opencli xiaohongshu me` | |
 | `opencli xiaohongshu user` | |
 | `opencli xiaohongshu download` | |
+| `opencli xiaohongshu creator-notes` | |
+| `opencli xiaohongshu creator-note-detail` | |
+| `opencli xiaohongshu creator-notes-summary` | |
+| `opencli xiaohongshu creator-profile` | |
+| `opencli xiaohongshu creator-stats` | |
 
 ## Usage Examples
 

--- a/docs/advanced/download.md
+++ b/docs/advanced/download.md
@@ -26,23 +26,23 @@ brew install yt-dlp
 
 ```bash
 # Download images/videos from Xiaohongshu note
-opencli xiaohongshu download --note_id abc123 --output ./xhs
+opencli xiaohongshu download --note-id abc123 --output ./xhs
 
 # Download Bilibili video (requires yt-dlp)
 opencli bilibili download --bvid BV1xxx --output ./bilibili
 opencli bilibili download --bvid BV1xxx --quality 1080p
 
 # Download Twitter media from user
-opencli twitter download --username elonmusk --limit 20 --output ./twitter
+opencli twitter download elonmusk --limit 20 --output ./twitter
 
 # Download single tweet media
 opencli twitter download --tweet-url "https://x.com/user/status/123" --output ./twitter
 
 # Export Zhihu article to Markdown
-opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
+opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
 
 # Export with local images
-opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --download-images
+opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 ```
 
 ## Pipeline Step (YAML Adapters)


### PR DESCRIPTION
Sync docs with PR #150 kebab-case renames + positional args. 13 files, +165/-78. Details: keyword→query, snake_case→kebab-case IDs, positional args lose -- prefix, added 9 missing sites, fixed stale bilibili paths, removed ghost xiaohongshu me command.