### PR TITLE
docs(chatgpt): sync read docs with AX behavior

### DIFF
--- a/docs/adapters/desktop/chatgpt.md
+++ b/docs/adapters/desktop/chatgpt.md
@@ -14,7 +14,7 @@ The current built-in commands use native AppleScript automation — no extra lau
 - `opencli chatgpt status`: Check if the ChatGPT app is currently running.
 - `opencli chatgpt new`: Activate ChatGPT and press `Cmd+N` to start a new conversation.
 - `opencli chatgpt send "message"`: Copy your message to clipboard, activate ChatGPT, paste, and submit.
-- `opencli chatgpt read`: Copy the last AI response via `Cmd+Shift+C` and return it as text.
+- `opencli chatgpt read`: Read the last visible message from the focused ChatGPT window via the Accessibility tree.
 
 ## Approach 2: CDP (Advanced, Electron Debug Mode)
 
@@ -33,11 +33,11 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
 
 ## How It Works
 
-- **AppleScript mode**: Uses `osascript` and `pbcopy`/`pbpaste` for clipboard-based text transfer.
+- **AppleScript mode**: Uses `osascript` to control ChatGPT, `pbcopy`/`pbpaste` to paste prompts, and the macOS Accessibility tree to read visible chat messages.
 - **CDP mode**: Connects via Chrome DevTools Protocol to the Electron renderer process.
 
 ## Limitations
 
 - macOS only (AppleScript dependency)
 - AppleScript mode requires Accessibility permissions
-- `read` command copies the last response — earlier messages need manual scroll
+- `read` returns the last visible message in the focused ChatGPT window — scroll first if the message you want is not visible

--- a/src/clis/chatgpt/README.zh-CN.md
+++ b/src/clis/chatgpt/README.zh-CN.md
@@ -14,7 +14,7 @@
 - `opencli chatgpt status`：检查 ChatGPT 应用是否在运行。
 - `opencli chatgpt new`：激活 ChatGPT 并按 `Cmd+N` 开始新对话。
 - `opencli chatgpt send "消息"`：将消息复制到剪贴板，激活 ChatGPT，粘贴并提交。
-- `opencli chatgpt read`：通过 `Cmd+Shift+C` 复制最后一条 AI 回复并返回文本。
+- `opencli chatgpt read`：通过当前聚焦 ChatGPT 窗口的辅助功能树读取最后一条可见消息并返回文本。
 
 ## 方式二：CDP（高级，Electron 调试模式）
 
@@ -34,11 +34,11 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
 
 ## 工作原理
 
-- **AppleScript 模式**：使用 `osascript` 和 `pbcopy`/`pbpaste` 进行剪贴板文本传输，无需远程调试端口。
+- **AppleScript 模式**：使用 `osascript` 控制 ChatGPT，发送消息时借助 `pbcopy`/`pbpaste` 粘贴文本，读取消息时通过 macOS 辅助功能树获取当前可见聊天内容。
 - **CDP 模式**：通过 Chrome DevTools Protocol 连接到 Electron 渲染进程，直接操作 DOM。
 
 ## 限制
 
 - 仅支持 macOS（AppleScript 依赖）
 - AppleScript 模式需要辅助功能权限
-- `read` 命令复制最后一条回复，更早的消息需手动滚动
+- `read` 返回的是当前聚焦 ChatGPT 窗口里的最后一条可见消息；如果目标消息不在可见区域，需先手动滚动

--- a/src/clis/chatgpt/read.ts
+++ b/src/clis/chatgpt/read.ts
@@ -6,7 +6,7 @@ import { getVisibleChatMessages } from './ax.js';
 export const readCommand = cli({
   site: 'chatgpt',
   name: 'read',
-  description: 'Copy the most recent ChatGPT Desktop App response to clipboard and read it',
+  description: 'Read the last visible message from the focused ChatGPT Desktop window',
   domain: 'localhost',
   strategy: Strategy.PUBLIC,
   browser: false,


### PR DESCRIPTION
Description
Sync the ChatGPT desktop docs and `chatgpt read` help text with the AX-based read behavior that is already in `main`.

Problem
After #106 moved `chatgpt read` away from the `Cmd+Shift+C` clipboard shortcut, the public docs and help text still described the old clipboard-based behavior. That left the docs out of sync with the current implementation on `main`.

Approach
Updated the English docs, Chinese docs, and the `read` command description to match the current behavior:
- `send` still pastes via clipboard
- `read` now reads the last visible message from the focused ChatGPT window via the Accessibility tree
- the limitation now describes visibility/focus semantics instead of clipboard-copy semantics

Environment
- macOS 26.3
- ChatGPT Desktop app version 1.2026.048

Type of change
Documentation / help-text sync

Validation
- Confirmed the current implementation uses `getVisibleChatMessages()` in `src/clis/chatgpt/read.ts`
- Removed the old clipboard-specific wording from the touched docs/help surfaces
- `npm run typecheck` could not run in this environment because `tsc` is unavailable

Notes
- Scope is intentionally narrow: this PR only syncs docs/help text with current shipped behavior
- It does not expand the ChatGPT docs to cover `chatgpt ask`
