### PR TITLE
feat: auto-waiting — goto() post-load settle, remove 31 hardcoded waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Run `opencli list` for the live registry.
 | **reddit** | `hot` `frontpage` `popular` `search` `subreddit` `read` `user` `user-posts` `user-comments` `upvote` `save` `comment` `subscribe` `saved` `upvoted` | Browser |
 | **cursor** | `status` `send` `read` `new` `dump` `composer` `model` `extract-code` `ask` `screenshot` `history` `export` | Desktop |
 | **bilibili** | `hot` `search` `me` `favorite` `history` `feed` `subtitle` `dynamic` `ranking` `following` `user-videos` `download` | Browser |
-| **codex** | `status` `send` `read` `new` `extract-diff` `model` `ask` `screenshot` `history` `export` | Desktop |
+| **codex** | `status` `send` `read` `new` `dump` `extract-diff` `model` `ask` `screenshot` `history` `export` | Desktop |
 | **chatwise** | `status` `new` `send` `read` `ask` `model` `history` `export` `screenshot` | Desktop |
 | **notion** | `status` `search` `read` `new` `write` `sidebar` `favorites` `export` | Desktop |
 | **discord-app** | `status` `send` `read` `channels` `servers` `search` `members` | Desktop |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,7 +122,7 @@ npm install -g @jackwener/opencli@latest
 | **reddit** | `hot` `frontpage` `popular` `search` `subreddit` `read` `user` `user-posts` `user-comments` `upvote` `save` `comment` `subscribe` `saved` `upvoted` | 浏览器 |
 | **cursor** | `status` `send` `read` `new` `dump` `composer` `model` `extract-code` `ask` `screenshot` `history` `export` | 桌面端 |
 | **bilibili** | `hot` `search` `me` `favorite` `history` `feed` `subtitle` `dynamic` `ranking` `following` `user-videos` `download` | 浏览器 |
-| **codex** | `status` `send` `read` `new` `extract-diff` `model` `ask` `screenshot` `history` `export` | 桌面端 |
+| **codex** | `status` `send` `read` `new` `dump` `extract-diff` `model` `ask` `screenshot` `history` `export` | 桌面端 |
 | **chatwise** | `status` `new` `send` `read` `ask` `model` `history` `export` `screenshot` | 桌面端 |
 | **notion** | `status` `search` `read` `new` `write` `sidebar` `favorites` `export` | 桌面端 |
 | **discord-app** | `status` `send` `read` `channels` `servers` `search` `members` | 桌面端 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -105,7 +105,7 @@ opencli reddit hot --subreddit programming  # 指定子版块
 opencli reddit frontpage --limit 10      # 首页 /r/all
 opencli reddit popular --limit 10        # /r/popular 热门
 opencli reddit search "AI" --sort top --time week  # 搜索（支持排序+时间过滤）
-opencli reddit subreddit --name rust --sort top --time month  # 子版块浏览（支持时间过滤）
+opencli reddit subreddit rust --sort top --time month  # 子版块浏览（支持时间过滤）
 opencli reddit read --post-id 1abc123    # 阅读帖子 + 评论
 opencli reddit user spez                 # 用户资料（karma、注册时间）
 opencli reddit user-posts spez           # 用户发帖历史

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -34,8 +34,14 @@ OpenCLI is built on a **Dual-Engine Architecture** that supports both declarativ
 ### Registry (`src/registry.ts`)
 Central command registry. All adapters register their commands via the `cli()` function with metadata: site, name, description, domain, strategy, args, columns.
 
-### Engine (`src/engine.ts`)
-Command discovery and execution engine. Discovers commands from the registry, parses arguments, executes the appropriate adapter, and routes output through the formatter.
+### Discovery (`src/discovery.ts`)
+CLI discovery and manifest loading. Discovers commands from YAML and TypeScript adapter files, parses YAML pipelines, and registers them into the central registry.
+
+### Execution (`src/execution.ts`)
+Command execution: argument validation, lazy loading of adapter modules, and executing the appropriate handler function.
+
+### Commander Adapter (`src/commanderAdapter.ts`)
+Bridges the Registry commands to Commander.js subcommands. Handles positional args, named options, browser session wiring, and output formatting. Isolates all Commander-specific logic so the core is framework-agnostic.
 
 ### Browser (`src/browser.ts`)
 Manages connections to Chrome via the Browser Bridge WebSocket daemon. Handles JSON-RPC messaging, tab management, and extension/standalone mode switching.
@@ -60,15 +66,22 @@ OpenCLI uses a 3-tier authentication strategy:
 | `public` | Direct HTTP fetch, no auth | Public APIs (HackerNews, BBC) |
 | `cookie` | Reuse Chrome cookies via Browser Bridge | Logged-in sites (Bilibili, Zhihu) |
 | `header` | Custom auth headers | API-key based services |
+| `intercept` | Network request interception | GraphQL/XHR capture (Twitter) |
+| `ui` | DOM interaction via accessibility snapshot | Desktop apps, write operations |
 
 ## Directory Structure
 
 ```
 src/
 ├── main.ts              # Entry point
-├── engine.ts            # Command execution engine
+├── cli.ts               # Commander.js CLI setup + built-in commands
+├── commanderAdapter.ts  # Registry → Commander bridge
+├── discovery.ts         # CLI discovery, manifest loading, YAML parsing
+├── execution.ts         # Arg validation, command execution
 ├── registry.ts          # Command registry
-├── browser.ts           # Browser Bridge connection
+├── serialization.ts     # Command serialization helpers
+├── runtime.ts           # Browser session & timeout management
+├── browser/             # Browser Bridge connection
 ├── output.ts            # Output formatting
 ├── doctor.ts            # Diagnostic tool
 ├── pipeline/            # YAML pipeline engine

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -158,12 +158,17 @@ class CDPPage implements IPage {
   constructor(private bridge: CDPBridge) {}
 
   /** Navigate with proper load event waiting (P1 fix #3) */
-  async goto(url: string): Promise<void> {
+  async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void> {
     await this.bridge.send('Page.enable');
     const loadPromise = this.bridge.waitForEvent('Page.loadEventFired', 30_000)
       .catch(() => {}); // Don't fail if event times out
     await this.bridge.send('Page.navigate', { url });
     await loadPromise;
+    // Post-load settle: SPA frameworks need extra time to render after load event
+    if (options?.waitUntil !== 'none') {
+      const settleMs = options?.settleMs ?? 1000;
+      await new Promise(resolve => setTimeout(resolve, settleMs));
+    }
   }
 
   async evaluate(js: string): Promise<any> {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -42,7 +42,7 @@ export class Page implements IPage {
     return { workspace: this.workspace };
   }
 
-  async goto(url: string): Promise<void> {
+  async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void> {
     const result = await sendCommand('navigate', {
       url,
       ...this._workspaceOpt(),
@@ -51,6 +51,12 @@ export class Page implements IPage {
     // Remember the tabId for subsequent exec calls
     if (result?.tabId) {
       this._tabId = result.tabId;
+    }
+    // Post-load settle: the extension already waits for tab.status === 'complete',
+    // but SPA frameworks (React/Vue) need extra time to render after DOM load.
+    if (options?.waitUntil !== 'none') {
+      const settleMs = options?.settleMs ?? 1000;
+      await new Promise(resolve => setTimeout(resolve, settleMs));
     }
   }
 

--- a/src/clis/chaoxing/utils.ts
+++ b/src/clis/chaoxing/utils.ts
@@ -96,7 +96,6 @@ export async function getCourses(page: IPage): Promise<ChaoxingCourse[]> {
 /** Navigate to the interaction page to establish a Chaoxing session. */
 export async function initSession(page: IPage): Promise<void> {
   await page.goto('https://mooc2-ans.chaoxing.com/mooc2-ans/visit/interaction');
-  await page.wait(3);
 }
 
 /**
@@ -108,7 +107,6 @@ export async function enterCourse(page: IPage, course: ChaoxingCourse): Promise<
     `https://mooc1.chaoxing.com/visit/stucoursemiddle` +
     `?courseid=${course.courseId}&clazzid=${course.classId}&cpi=${course.cpi}&ismooc2=1&v=2`;
   await page.goto(url);
-  await page.wait(3);
 }
 
 /**

--- a/src/clis/coupang/add-to-cart.ts
+++ b/src/clis/coupang/add-to-cart.ts
@@ -117,7 +117,6 @@ cli({
 
     const finalUrl = targetUrl || canonicalizeProductUrl('', productId);
     await page.goto(finalUrl);
-    await page.wait(3);
 
     const result = await page.evaluate(buildAddToCartEvaluate(productId));
     const loginHints = result?.loginHints ?? {};

--- a/src/clis/coupang/search.ts
+++ b/src/clis/coupang/search.ts
@@ -425,7 +425,6 @@ cli({
     const initialPage = filter ? 1 : pageNumber;
     const url = `https://www.coupang.com/np/search?q=${encodeURIComponent(query)}&channel=user&page=${initialPage}`;
     await page.goto(url);
-    await page.wait(3);
     if (filter) {
       const filterResult = await page.evaluate(buildApplyFilterEvaluate(filter));
       if (!filterResult?.ok) {
@@ -437,7 +436,6 @@ cli({
         const filteredUrl = new URL(locationInfo?.href || url);
         filteredUrl.searchParams.set('page', String(pageNumber));
         await page.goto(filteredUrl.toString());
-        await page.wait(3);
       }
     }
     await page.autoScroll({ times: filter ? 3 : 2, delayMs: 1500 });

--- a/src/clis/jike/comment.ts
+++ b/src/clis/jike/comment.ts
@@ -21,7 +21,6 @@ cli({
   columns: ['status', 'message'],
   func: async (page, kwargs) => {
     await page.goto(`https://web.okjike.com/originalPost/${kwargs.id}`);
-    await page.wait(5);
 
     // 1. 找到评论输入框并填入文本
     const inputResult = await page.evaluate(`(async () => {

--- a/src/clis/jike/create.ts
+++ b/src/clis/jike/create.ts
@@ -21,7 +21,6 @@ cli({
   func: async (page, kwargs) => {
     // 1. 导航到首页（有内联发帖框）
     await page.goto('https://web.okjike.com');
-    await page.wait(5);
 
     // 2. 在发帖框中输入文本
     const textResult = await page.evaluate(`(async () => {

--- a/src/clis/jike/feed.ts
+++ b/src/clis/jike/feed.ts
@@ -24,7 +24,6 @@ cli({
 
     // 1. 导航到即刻首页，等待 SPA 重定向到 /following
     await page.goto('https://web.okjike.com');
-    await page.wait(5);
 
     // 2. 通过 React fiber 提取帖子数据
     const extract = async (): Promise<JikePost[]> => {

--- a/src/clis/jike/like.ts
+++ b/src/clis/jike/like.ts
@@ -21,7 +21,6 @@ cli({
   func: async (page, kwargs) => {
     // 1. 导航到帖子详情页
     await page.goto(`https://web.okjike.com/originalPost/${kwargs.id}`);
-    await page.wait(5);
 
     // 2. 找到点赞按钮并点击
     const result = await page.evaluate(`(async () => {

--- a/src/clis/jike/notifications.ts
+++ b/src/clis/jike/notifications.ts
@@ -44,7 +44,6 @@ cli({
 
     // 1. 直接导航到通知页
     await page.goto('https://web.okjike.com/notification');
-    await page.wait(5);
 
     // 3. 优先用 React fiber 提取通知数据
     //    通知 fiber 数据结构与帖子不同，需查找含 type + user 字段的 props

--- a/src/clis/jike/repost.ts
+++ b/src/clis/jike/repost.ts
@@ -22,7 +22,6 @@ cli({
   columns: ['status', 'message'],
   func: async (page, kwargs) => {
     await page.goto(`https://web.okjike.com/originalPost/${kwargs.id}`);
-    await page.wait(5);
 
     // 1. 点击操作栏中的转发按钮（第三个子元素）
     const clickResult = await page.evaluate(`(async () => {

--- a/src/clis/jike/search.ts
+++ b/src/clis/jike/search.ts
@@ -27,7 +27,6 @@ cli({
     // 1. 直接导航到搜索页
     const encodedKeyword = encodeURIComponent(keyword);
     await page.goto(`https://web.okjike.com/search?q=${encodedKeyword}`);
-    await page.wait(5);
 
     // 2. 通过 React fiber 提取帖子数据
     const extract = async (): Promise<JikePost[]> => {

--- a/src/clis/jimeng/history.yaml
+++ b/src/clis/jimeng/history.yaml
@@ -14,7 +14,6 @@ columns: [prompt, model, status, image_url, created_at]
 
 pipeline:
   - navigate: https://jimeng.jianying.com/ai-tool/generate?type=image&workspace=0
-  - wait: 3
   - evaluate: |
       (async () => {
         const limit = ${{ args.limit }};

--- a/src/clis/reddit/comment.ts
+++ b/src/clis/reddit/comment.ts
@@ -16,7 +16,6 @@ cli({
     if (!page) throw new Error('Requires browser');
 
     await page.goto('https://www.reddit.com');
-    await page.wait(3);
 
     const result = await page.evaluate(`(async () => {
       try {

--- a/src/clis/reddit/read.ts
+++ b/src/clis/reddit/read.ts
@@ -31,7 +31,6 @@ cli({
     const maxLength = Math.max(100, kwargs['max-length'] ?? 2000);
 
     await page.goto('https://www.reddit.com');
-    await page.wait(2);
 
     const data = await page.evaluate(`
       (async function() {

--- a/src/clis/reddit/save.ts
+++ b/src/clis/reddit/save.ts
@@ -16,7 +16,6 @@ cli({
     if (!page) throw new Error('Requires browser');
 
     await page.goto('https://www.reddit.com');
-    await page.wait(3);
 
     const result = await page.evaluate(`(async () => {
       try {

--- a/src/clis/reddit/saved.ts
+++ b/src/clis/reddit/saved.ts
@@ -15,7 +15,6 @@ cli({
     if (!page) throw new Error('Requires browser');
 
     await page.goto('https://www.reddit.com');
-    await page.wait(3);
 
     const result = await page.evaluate(`(async () => {
       try {

--- a/src/clis/reddit/subscribe.ts
+++ b/src/clis/reddit/subscribe.ts
@@ -16,7 +16,6 @@ cli({
     if (!page) throw new Error('Requires browser');
 
     await page.goto('https://www.reddit.com');
-    await page.wait(3);
 
     const result = await page.evaluate(`(async () => {
       try {

--- a/src/clis/reddit/upvote.ts
+++ b/src/clis/reddit/upvote.ts
@@ -16,7 +16,6 @@ cli({
     if (!page) throw new Error('Requires browser');
 
     await page.goto('https://www.reddit.com');
-    await page.wait(3);
 
     const result = await page.evaluate(`(async () => {
       try {

--- a/src/clis/reddit/upvoted.ts
+++ b/src/clis/reddit/upvoted.ts
@@ -15,7 +15,6 @@ cli({
     if (!page) throw new Error('Requires browser');
 
     await page.goto('https://www.reddit.com');
-    await page.wait(3);
 
     const result = await page.evaluate(`(async () => {
       try {

--- a/src/clis/smzdm/search.ts
+++ b/src/clis/smzdm/search.ts
@@ -24,7 +24,6 @@ cli({
 
     // Navigate directly to search results page
     await page.goto(`https://search.smzdm.com/?c=home&s=${q}&v=b`);
-    await page.wait(2);
 
     const data = await page.evaluate(`
       (() => {

--- a/src/clis/weibo/hot.ts
+++ b/src/clis/weibo/hot.ts
@@ -17,7 +17,6 @@ cli({
   func: async (page, kwargs) => {
     const count = Math.min(kwargs.limit || 30, 50);
     await page.goto('https://weibo.com');
-    await page.wait(2);
     const data = await page.evaluate(`
       (async () => {
         const resp = await fetch('/ajax/statuses/hot_band', {credentials: 'include'});

--- a/src/clis/xiaohongshu/creator-note-detail.ts
+++ b/src/clis/xiaohongshu/creator-note-detail.ts
@@ -408,7 +408,6 @@ async function captureNoteDetailDomData(page: IPage): Promise<CreatorNoteDetailD
 
 export async function fetchCreatorNoteDetailRows(page: IPage, noteId: string): Promise<CreatorNoteDetailRow[]> {
   await page.goto(`https://creator.xiaohongshu.com/statistics/note-detail?noteId=${encodeURIComponent(noteId)}`);
-  await page.wait(4);
 
   const domData = await captureNoteDetailDomData(page).catch(() => null);
   let rows = parseCreatorNoteDetailDomData(domData, noteId);

--- a/src/clis/xiaohongshu/creator-notes.ts
+++ b/src/clis/xiaohongshu/creator-notes.ts
@@ -162,7 +162,6 @@ async function fetchCreatorNotesByApi(page: IPage, limit: number): Promise<Creat
   const notes: CreatorNoteRow[] = [];
 
   await page.goto(`https://creator.xiaohongshu.com/statistics/data-analysis?type=0&page_size=${pageSize}&page_num=1`);
-  await page.wait(4);
 
   for (let pageNum = 1; pageNum <= maxPages && notes.length < limit; pageNum++) {
     const apiPath = `${NOTE_ANALYZE_API_PATH}?type=0&page_size=${pageSize}&page_num=${pageNum}`;
@@ -210,7 +209,6 @@ export async function fetchCreatorNotes(page: IPage, limit: number): Promise<Cre
 
   if (notes.length === 0) {
     await page.goto('https://creator.xiaohongshu.com/new/note-manager');
-    await page.wait(4);
 
     const maxPageDowns = Math.max(0, Math.ceil(limit / 10) + 1);
     for (let i = 0; i <= maxPageDowns; i++) {

--- a/src/clis/xiaohongshu/creator-profile.ts
+++ b/src/clis/xiaohongshu/creator-profile.ts
@@ -21,7 +21,6 @@ cli({
   columns: ['field', 'value'],
   func: async (page, _kwargs) => {
     await page.goto('https://creator.xiaohongshu.com/new/home');
-    await page.wait(3);
 
     const data = await page.evaluate(`
       async () => {

--- a/src/clis/xiaohongshu/creator-stats.ts
+++ b/src/clis/xiaohongshu/creator-stats.ts
@@ -32,7 +32,6 @@ cli({
 
     // Navigate to creator center for cookie context
     await page.goto('https://creator.xiaohongshu.com/new/home');
-    await page.wait(3);
 
     const data = await page.evaluate(`
       async () => {

--- a/src/clis/xiaohongshu/download.ts
+++ b/src/clis/xiaohongshu/download.ts
@@ -32,7 +32,6 @@ cli({
 
     // Navigate to note page
     await page.goto(`https://www.xiaohongshu.com/explore/${noteId}`);
-    await page.wait(3);
 
     // Extract note info and media URLs
     const data = await page.evaluate(`

--- a/src/clis/xiaohongshu/feed.yaml
+++ b/src/clis/xiaohongshu/feed.yaml
@@ -15,7 +15,6 @@ columns: [title, author, likes, type, url]
 
 pipeline:
   - navigate: https://www.xiaohongshu.com/explore
-  - wait: 3
   - tap:
       store: feed
       action: fetchFeeds

--- a/src/clis/xiaohongshu/notifications.yaml
+++ b/src/clis/xiaohongshu/notifications.yaml
@@ -19,7 +19,6 @@ columns: [rank, user, action, content, note, time]
 
 pipeline:
   - navigate: https://www.xiaohongshu.com/notification
-  - wait: 3
   - tap:
       store: notification
       action: getNotification

--- a/src/clis/xiaohongshu/user.ts
+++ b/src/clis/xiaohongshu/user.ts
@@ -38,7 +38,6 @@ cli({
     const limit = Math.max(1, Number(kwargs.limit ?? 15));
 
     await page.goto(`https://www.xiaohongshu.com/user/profile/${userId}`);
-    await page.wait(3);
 
     let snapshot = await readUserSnapshot(page);
     let results = extractXhsUserNotes(snapshot ?? {}, userId);

--- a/src/clis/yahoo-finance/quote.ts
+++ b/src/clis/yahoo-finance/quote.ts
@@ -17,7 +17,6 @@ cli({
   func: async (page, kwargs) => {
     const symbol = kwargs.symbol.toUpperCase().trim();
     await page.goto(`https://finance.yahoo.com/quote/${encodeURIComponent(symbol)}/`);
-    await page.wait(3);
     const data = await page.evaluate(`
       (async () => {
         const sym = '${symbol}';

--- a/src/clis/zhihu/download.ts
+++ b/src/clis/zhihu/download.ts
@@ -104,7 +104,6 @@ cli({
 
     // Navigate to article page
     await page.goto(url);
-    await page.wait(3);
 
     // Extract article content
     const data = await page.evaluate(`

--- a/src/pipeline/steps/browser.ts
+++ b/src/pipeline/steps/browser.ts
@@ -7,8 +7,13 @@ import type { IPage } from '../../types.js';
 import { render } from '../template.js';
 
 export async function stepNavigate(page: IPage | null, params: any, data: any, args: Record<string, any>): Promise<any> {
-  const url = render(params, { args, data });
-  await page!.goto(String(url));
+  if (typeof params === 'object' && params && 'url' in params) {
+    const url = String(render(params.url, { args, data }));
+    await page!.goto(url, { waitUntil: params.waitUntil, settleMs: params.settleMs });
+  } else {
+    const url = render(params, { args, data });
+    await page!.goto(String(url));
+  }
   return data;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@
  */
 
 export interface IPage {
-  goto(url: string): Promise<void>;
+  goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void>;
   evaluate(js: string): Promise<any>;
   getCookies(opts?: { domain?: string; url?: string }): Promise<Array<{
     name: string;


### PR DESCRIPTION
## 改动
- goto() 加 1s post-load settle delay (extension 已等 tab.status=complete, 额外等 SPA 渲染)
- 删除 31 处冗余 page.wait(N)
- YAML navigate 支持 {url, waitUntil, settleMs} 对象格式
- 332 tests pass