### PR TITLE
feat(twitter): add block, unblock, and hide-reply commands

### DIFF
--- a/docs/adapters/browser/twitter.md
+++ b/docs/adapters/browser/twitter.md
@@ -24,6 +24,9 @@
 | `opencli twitter unfollow` | |
 | `opencli twitter bookmark` | |
 | `opencli twitter unbookmark` | |
+| `opencli twitter block` | |
+| `opencli twitter unblock` | |
+| `opencli twitter hide-reply` | |
 | `opencli twitter download` | |
 | `opencli twitter accept` | |
 | `opencli twitter reply-dm` | |

--- a/src/clis/twitter/block.ts
+++ b/src/clis/twitter/block.ts
@@ -1,0 +1,92 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+cli({
+  site: 'twitter',
+  name: 'block',
+  description: 'Block a Twitter user',
+  domain: 'x.com',
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (without @)' },
+  ],
+  columns: ['status', 'message'],
+  func: async (page: IPage | null, kwargs: any) => {
+    if (!page) throw new Error('Requires browser');
+    const username = kwargs.username.replace(/^@/, '');
+
+    await page.goto(`https://x.com/${username}`);
+    await page.wait(5);
+
+    const result = await page.evaluate(`(async () => {
+        try {
+            let attempts = 0;
+
+            // Check if already blocked (profile shows "Blocked" / unblock button)
+            while (attempts < 20) {
+                const blockedIndicator = document.querySelector('[data-testid$="-unblock"]');
+                if (blockedIndicator) {
+                    return { ok: true, message: 'Already blocking @${username}.' };
+                }
+
+                const moreBtn = document.querySelector('[data-testid="userActions"]');
+                if (moreBtn) break;
+
+                await new Promise(r => setTimeout(r, 500));
+                attempts++;
+            }
+
+            const moreBtn = document.querySelector('[data-testid="userActions"]');
+            if (!moreBtn) {
+                return { ok: false, message: 'Could not find user actions menu. Are you logged in?' };
+            }
+
+            // Open the more actions menu
+            moreBtn.click();
+            await new Promise(r => setTimeout(r, 1000));
+
+            // Find the Block menu item
+            const menuItems = document.querySelectorAll('[role="menuitem"]');
+            let blockItem = null;
+            for (const item of menuItems) {
+                if (item.textContent && item.textContent.includes('Block')) {
+                    blockItem = item;
+                    break;
+                }
+            }
+
+            if (!blockItem) {
+                return { ok: false, message: 'Could not find Block option in menu.' };
+            }
+
+            blockItem.click();
+            await new Promise(r => setTimeout(r, 1000));
+
+            // Confirm the block in the dialog
+            const confirmBtn = document.querySelector('[data-testid="confirmationSheetConfirm"]');
+            if (confirmBtn) {
+                confirmBtn.click();
+                await new Promise(r => setTimeout(r, 1500));
+            }
+
+            // Verify
+            const verify = document.querySelector('[data-testid$="-unblock"]');
+            if (verify) {
+                return { ok: true, message: 'Successfully blocked @${username}.' };
+            } else {
+                return { ok: false, message: 'Block action initiated but UI did not update.' };
+            }
+        } catch (e) {
+            return { ok: false, message: e.toString() };
+        }
+    })()`);
+
+    if (result.ok) await page.wait(2);
+
+    return [{
+      status: result.ok ? 'success' : 'failed',
+      message: result.message
+    }];
+  }
+});

--- a/src/clis/twitter/hide-reply.ts
+++ b/src/clis/twitter/hide-reply.ts
@@ -1,0 +1,70 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+cli({
+  site: 'twitter',
+  name: 'hide-reply',
+  description: 'Hide a reply on your tweet (useful for hiding bot/spam replies)',
+  domain: 'x.com',
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'url', type: 'string', required: true, positional: true, help: 'The URL of the reply tweet to hide' },
+  ],
+  columns: ['status', 'message'],
+  func: async (page: IPage | null, kwargs: any) => {
+    if (!page) throw new Error('Requires browser');
+
+    await page.goto(kwargs.url);
+    await page.wait(5);
+
+    const result = await page.evaluate(`(async () => {
+        try {
+            let attempts = 0;
+            let moreMenu = null;
+
+            while (attempts < 20) {
+                moreMenu = document.querySelector('[aria-label="More"]');
+                if (moreMenu) break;
+                await new Promise(r => setTimeout(r, 500));
+                attempts++;
+            }
+
+            if (!moreMenu) {
+                return { ok: false, message: 'Could not find the "More" menu on this tweet. Are you logged in?' };
+            }
+
+            moreMenu.click();
+            await new Promise(r => setTimeout(r, 1000));
+
+            // Look for the "Hide reply" menu item
+            const items = document.querySelectorAll('[role="menuitem"]');
+            let hideItem = null;
+            for (const item of items) {
+                if (item.textContent && item.textContent.includes('Hide reply')) {
+                    hideItem = item;
+                    break;
+                }
+            }
+
+            if (!hideItem) {
+                return { ok: false, message: 'Could not find "Hide reply" option. This may not be a reply on your tweet.' };
+            }
+
+            hideItem.click();
+            await new Promise(r => setTimeout(r, 1500));
+
+            return { ok: true, message: 'Reply successfully hidden.' };
+        } catch (e) {
+            return { ok: false, message: e.toString() };
+        }
+    })()`);
+
+    if (result.ok) await page.wait(2);
+
+    return [{
+      status: result.ok ? 'success' : 'failed',
+      message: result.message
+    }];
+  }
+});

--- a/src/clis/twitter/unblock.ts
+++ b/src/clis/twitter/unblock.ts
@@ -1,0 +1,75 @@
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+
+cli({
+  site: 'twitter',
+  name: 'unblock',
+  description: 'Unblock a Twitter user',
+  domain: 'x.com',
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (without @)' },
+  ],
+  columns: ['status', 'message'],
+  func: async (page: IPage | null, kwargs: any) => {
+    if (!page) throw new Error('Requires browser');
+    const username = kwargs.username.replace(/^@/, '');
+
+    await page.goto(`https://x.com/${username}`);
+    await page.wait(5);
+
+    const result = await page.evaluate(`(async () => {
+        try {
+            let attempts = 0;
+            let unblockBtn = null;
+
+            while (attempts < 20) {
+                // Check if not blocked (follow button visible means not blocked)
+                const followBtn = document.querySelector('[data-testid$="-follow"]');
+                if (followBtn) {
+                    return { ok: true, message: 'Not blocking @${username} (already unblocked).' };
+                }
+
+                unblockBtn = document.querySelector('[data-testid$="-unblock"]');
+                if (unblockBtn) break;
+
+                await new Promise(r => setTimeout(r, 500));
+                attempts++;
+            }
+
+            if (!unblockBtn) {
+                return { ok: false, message: 'Could not find Unblock button. Are you logged in?' };
+            }
+
+            // Click the unblock button — this opens a confirmation dialog
+            unblockBtn.click();
+            await new Promise(r => setTimeout(r, 1000));
+
+            // Confirm the unblock in the dialog
+            const confirmBtn = document.querySelector('[data-testid="confirmationSheetConfirm"]');
+            if (confirmBtn) {
+                confirmBtn.click();
+                await new Promise(r => setTimeout(r, 1000));
+            }
+
+            // Verify
+            const verify = document.querySelector('[data-testid$="-follow"]');
+            if (verify) {
+                return { ok: true, message: 'Successfully unblocked @${username}.' };
+            } else {
+                return { ok: false, message: 'Unblock action initiated but UI did not update.' };
+            }
+        } catch (e) {
+            return { ok: false, message: e.toString() };
+        }
+    })()`);
+
+    if (result.ok) await page.wait(2);
+
+    return [{
+      status: result.ok ? 'success' : 'failed',
+      message: result.message
+    }];
+  }
+});


### PR DESCRIPTION
## Summary
- Add `twitter block` / `twitter unblock` commands to block/unblock users by username, following the same UI strategy pattern as follow/unfollow
- Add `twitter hide-reply` command to hide bot/spam replies on your own tweet threads
- Update Twitter adapter docs with the new commands

## Test plan
- [x] Run `opencli twitter block <username>` and verify user is blocked
- [x] Run `opencli twitter unblock <username>` and verify user is unblocked
- [x] Run `opencli twitter hide-reply <tweet-url>` on a reply to your own tweet and verify it gets hidden
- [x] Verify idempotent behavior (blocking already-blocked user, unblocking already-unblocked user)