### PR TITLE
feat(chatgpt): add experimental Windows desktop CDP path

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Run `opencli list` for the live registry.
 | **v2ex** | `hot` `latest` `topic` `daily` `me` `notifications` | Public / Browser |
 | **xueqiu** | `feed` `hot-stock` `hot` `search` `stock` `watchlist` | Browser |
 | **antigravity** | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` | Desktop |
-| **chatgpt** | `status` `new` `send` `read` `ask` | Desktop |
+| **chatgpt** | `status` `new` `send` `read` `ask` `reasoning` | Desktop |
 | **xiaohongshu** | `search` `notifications` `feed` `user` `download` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` | Browser |
 | **apple-podcasts** | `search` `episodes` `top` | Public |
 | **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | Public |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,7 +129,7 @@ npm install -g @jackwener/opencli@latest
 | **v2ex** | `hot` `latest` `topic` `daily` `me` `notifications` | 公开 / 浏览器 |
 | **xueqiu** | `feed` `hot-stock` `hot` `search` `stock` `watchlist` | 浏览器 |
 | **antigravity** | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` | 桌面端 |
-| **chatgpt** | `status` `new` `send` `read` `ask` | 桌面端 |
+| **chatgpt** | `status` `new` `send` `read` `ask` `reasoning` | 桌面端 |
 | **xiaohongshu** | `search` `notifications` `feed` `user` `download` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` | 浏览器 |
 | **apple-podcasts** | `search` `episodes` `top` | 公开 |
 | **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | 公开 |

--- a/docs/adapters/desktop/chatgpt.md
+++ b/docs/adapters/desktop/chatgpt.md
@@ -1,43 +1,154 @@
 # ChatGPT
 
-Control the **ChatGPT macOS Desktop App** directly from the terminal. OpenCLI supports two automation approaches for ChatGPT.
+Control the **ChatGPT Desktop App** from the terminal. OpenCLI currently supports two different automation paths for ChatGPT.
 
-## Approach 1: AppleScript (Default, No Setup)
+## Mode 1: AppleScript fallback on macOS
 
-The current built-in commands use native AppleScript automation — no extra launch flags needed.
+If `OPENCLI_CDP_ENDPOINT` is **not** set, the built-in ChatGPT adapter uses the original macOS-native AppleScript / Accessibility flow.
 
 ### Prerequisites
-1. Install the official [ChatGPT Desktop App](https://openai.com/chatgpt/mac/) from OpenAI.
+1. Install the official [ChatGPT desktop app](https://openai.com/chatgpt/download/).
 2. Grant **Accessibility permissions** to your terminal app in **System Settings → Privacy & Security → Accessibility**.
 
-### Commands
-- `opencli chatgpt status`: Check if the ChatGPT app is currently running.
-- `opencli chatgpt new`: Activate ChatGPT and press `Cmd+N` to start a new conversation.
-- `opencli chatgpt send "message"`: Copy your message to clipboard, activate ChatGPT, paste, and submit.
-- `opencli chatgpt read`: Read the last visible message from the focused ChatGPT window via the Accessibility tree.
+### Commands that use AppleScript today
+- `opencli chatgpt status`
+- `opencli chatgpt new`
+- `opencli chatgpt send "message"`
+- `opencli chatgpt read`
+- `opencli chatgpt ask "message"`
 
-## Approach 2: CDP (Advanced, Electron Debug Mode)
+Notes for the AppleScript path:
+- `read` returns the **last visible message** from the focused ChatGPT window via the macOS Accessibility tree.
+- `ask` is still the old **send + wait + read** AppleScript flow.
 
-ChatGPT Desktop is also an Electron app and can be launched with a remote debugging port:
+## Mode 2: Experimental CDP path
+
+If `OPENCLI_CDP_ENDPOINT` **is** set, OpenCLI switches `chatgpt status`, `chatgpt read`, `chatgpt reasoning`, and `chatgpt send` to a Chrome DevTools Protocol (CDP) path instead of AppleScript.
+
+This is the current experimental path for:
+
+- **Windows / WSL**
+- **macOS with ChatGPT launched in remote-debug mode**
+
+### What works today in CDP mode
+- `opencli chatgpt status`
+- `opencli chatgpt read`
+- `opencli chatgpt reasoning`
+- `opencli chatgpt reasoning pro`
+- `opencli chatgpt send "message"` *(async submit: returns immediately with `Status=Submitted`)*
+- `opencli chatgpt send --reasoning pro "solve this carefully"`
+
+### What is still out of scope / not promised in CDP mode
+- `opencli chatgpt new`
+- `opencli chatgpt ask`
+- shortcut-heavy flows like search/new-tab style actions
+
+Those still rely on the older macOS AppleScript path.
+
+## Experimental CDP setup
+
+### macOS example
 
 ```bash
 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT \
   --remote-debugging-port=9224
+
+export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
+# Optional but useful when multiple targets exist:
+export OPENCLI_CDP_TARGET="chatgpt"
 ```
+
+### Windows / WSL example
+
+The exact executable path can vary, but the important part is:
+
+1. **Fully quit ChatGPT first**
+2. launch the real Windows app with:
+
+```powershell
+ChatGPT.exe --remote-debugging-port=9224 --remote-debugging-address=127.0.0.1
+```
+
+3. then from WSL (or from the same machine if you are not using WSL):
 
 ```bash
 export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
+export OPENCLI_CDP_TARGET="chatgpt"   # optional but recommended
 ```
 
-> The CDP approach enables future advanced commands like DOM inspection, model switching, and code extraction.
+> On Windows, a **true cold launch matters**. If ChatGPT is already running, relaunch attempts with debug flags can fail misleadingly and expose no usable `/json` endpoint.
 
-## How It Works
+## Exact commands that now work in experimental CDP mode
 
-- **AppleScript mode**: Uses `osascript` to control ChatGPT, `pbcopy`/`pbpaste` to paste prompts, and the macOS Accessibility tree to read visible chat messages.
-- **CDP mode**: Connects via Chrome DevTools Protocol to the Electron renderer process.
+```bash
+opencli chatgpt status
+opencli chatgpt read
+opencli chatgpt reasoning
+opencli chatgpt reasoning pro
+opencli chatgpt send "hello from opencli"
+opencli chatgpt send --reasoning pro "solve this carefully"
+```
+
+## Recommended async flow for Pro / research tasks
+
+For long-running tasks, treat `send` as a **submit-only** step:
+
+```bash
+opencli chatgpt send --reasoning pro "Research this carefully and take your time"
+# returns immediately with Status=Submitted after the prompt is submitted
+
+opencli chatgpt status
+# optional: Busy=Yes means ChatGPT is still working
+
+opencli chatgpt read
+# later, fetch the current visible output
+```
+
+This is the intended product shape for the current ChatGPT desktop path: **submit now, read later**.
+
+### `opencli chatgpt status`
+Checks the active CDP target and reports useful session state such as:
+
+- current URL
+- current title
+- visible turn count
+- whether the composer looks ready
+- currently detected reasoning mode when the top-level picker can be read
+- whether ChatGPT appears busy / still generating
+
+### `opencli chatgpt read`
+Extracts visible conversation content from the current ChatGPT window in a narrow but real DOM-based way.
+
+This is the intended follow-up command after an async `opencli chatgpt send ...`.
+
+### `opencli chatgpt send "message"`
+Finds the active composer, injects your prompt, submits it, and then **returns immediately**.
+
+It does **not** wait for the assistant to finish a reply. `Status=Submitted` means OpenCLI injected the prompt and triggered submit — not that ChatGPT finished answering.
+
+If you pass `--reasoning <mode>`, OpenCLI first tries to switch the **top-level** ChatGPT picker to `instant`, `thinking`, or `pro` before sending. `auto` is accepted as an alias for `instant`.
+
+### `opencli chatgpt reasoning [mode]`
+Reads the current top-level ChatGPT reasoning mode when possible, or switches it when you pass `instant`, `thinking`, or `pro`.
+
+Important scope note:
+- this targets the **top-level header picker** only
+- it does **not** target reply-level retry/model-switch controls
+- it does **not** yet control Light / Standard / Extended / Heavy thinking-time options
+
+## How it works
+
+- **AppleScript mode**: uses `osascript`, clipboard transfer, and macOS Accessibility.
+- **CDP mode**: attaches directly to the ChatGPT Electron renderer process and reads / manipulates DOM state.
 
 ## Limitations
 
-- macOS only (AppleScript dependency)
-- AppleScript mode requires Accessibility permissions
-- `read` returns the last visible message in the focused ChatGPT window — scroll first if the message you want is not visible
+- The CDP path is still **experimental** and intentionally narrow.
+- Only `status`, `read`, `reasoning`, and `send` are currently implemented for the experimental Windows/WSL path.
+- `send` is intentionally submit-only / async for this path. If you want output, call `read` separately later.
+- `reasoning` currently targets only the top-level `Instant` / `Thinking` / `Pro` picker. It does **not** yet control Light / Standard / Extended / Heavy thinking-time options.
+- `new` and `ask` should still be treated as **macOS AppleScript-only** commands.
+- If multiple inspectable targets exist, set `OPENCLI_CDP_TARGET=chatgpt` (or another window-title fragment).
+- DOM selectors may drift as ChatGPT desktop changes.
+- In experimental CDP mode, `send` intentionally refuses to overwrite an existing draft already sitting in the composer.
+- On current Windows desktop builds, some long-running `send --reasoning pro` requests can remain in a busy / partially rendered state for minutes before the final answer settles. OpenCLI tries to report that state honestly via `status` / `read`, but it cannot force the ChatGPT app to finalize the response.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -53,7 +53,7 @@ Run `opencli list` for the live registry.
 | **[Cursor](/adapters/desktop/cursor)** | Control Cursor IDE | `status` `send` `read` `new` `dump` `composer` `model` `extract-code` `ask` `screenshot` `history` `export` |
 | **[Codex](/adapters/desktop/codex)** | Drive OpenAI Codex CLI agent | `status` `send` `read` `new` `extract-diff` `model` `ask` `screenshot` `history` `export` |
 | **[Antigravity](/adapters/desktop/antigravity)** | Control Antigravity Ultra | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` |
-| **[ChatGPT](/adapters/desktop/chatgpt)** | Automate ChatGPT macOS app | `status` `new` `send` `read` `ask` |
+| **[ChatGPT](/adapters/desktop/chatgpt)** | Automate ChatGPT desktop app (macOS AppleScript + experimental CDP) | `status` `new` `send` `read` `ask` `reasoning` |
 | **[ChatWise](/adapters/desktop/chatwise)** | Multi-LLM client | `status` `new` `send` `read` `ask` `model` `history` `export` `screenshot` |
 | **[Notion](/adapters/desktop/notion)** | Search, read, write pages | `status` `search` `read` `new` `write` `sidebar` `favorites` `export` |
 | **[Discord](/adapters/desktop/discord)** | Desktop messages & channels | `status` `send` `read` `channels` `servers` `search` `members` |

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -90,6 +90,25 @@ describe('browser helpers', () => {
 
     expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9226/codex');
   });
+
+  it('boosts ChatGPT targets during generic CDP target scoring', () => {
+    const target = __test__.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Session Overview',
+        url: 'https://example.com/dashboard',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9224/other',
+      },
+      {
+        type: 'page',
+        title: 'ChatGPT',
+        url: 'https://chatgpt.com/?window_style=main_view',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9224/chatgpt',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9224/chatgpt');
+  });
 });
 
 describe('BrowserBridge state', () => {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -341,6 +341,7 @@ function scoreCDPTarget(target: CDPTarget, preferredPattern?: RegExp): number {
   if (title.includes('codex')) score += 120;
   if (title.includes('cursor')) score += 120;
   if (title.includes('chatwise')) score += 120;
+  if (title.includes('chatgpt')) score += 120;
   if (title.includes('notion')) score += 120;
   if (title.includes('discord')) score += 120;
   if (title.includes('netease')) score += 120;
@@ -349,6 +350,7 @@ function scoreCDPTarget(target: CDPTarget, preferredPattern?: RegExp): number {
   if (url.includes('codex')) score += 100;
   if (url.includes('cursor')) score += 100;
   if (url.includes('chatwise')) score += 100;
+  if (url.includes('chatgpt') || url.includes('chat.openai')) score += 100;
   if (url.includes('notion')) score += 100;
   if (url.includes('discord')) score += 100;
   if (url.includes('netease')) score += 100;

--- a/src/clis/chatgpt/README.md
+++ b/src/clis/chatgpt/README.md
@@ -1,5 +1,23 @@
 # ChatGPT Adapter
 
-Control the **ChatGPT macOS Desktop App** from the terminal via AppleScript or CDP.
+Control the **ChatGPT Desktop App** from the terminal.
+
+## Current reality
+
+- **Default fallback**: macOS AppleScript / Accessibility automation
+- **Experimental CDP path**: when `OPENCLI_CDP_ENDPOINT` is set, `chatgpt status`, `chatgpt read`, `chatgpt reasoning`, and `chatgpt send` use CDP instead
+- **Async by default**: `chatgpt send` only submits the prompt and returns `Submitted`; use `chatgpt read` later to fetch output
+- **Windows / WSL support**: experimental and CDP-only for this pass
+- **Still AppleScript/macOS only**: `chatgpt new`, `chatgpt ask`
+- **Reasoning picker scope**: experimental CDP currently targets only the top-level `Instant` / `Thinking` / `Pro` picker (`auto` aliases to `instant`)
+- **Current caveat**: some Windows desktop builds can leave long-running Pro requests in a busy / partially rendered state for minutes
+
+### Recommended async flow
+
+```bash
+opencli chatgpt send --reasoning pro "Research this carefully and take your time"
+opencli chatgpt status   # optional: Busy=Yes while ChatGPT is still working
+opencli chatgpt read     # later, fetch the current visible output
+```
 
 📖 **Full documentation**: [docs/adapters/desktop/chatgpt](../../../docs/adapters/desktop/chatgpt.md)

--- a/src/clis/chatgpt/README.zh-CN.md
+++ b/src/clis/chatgpt/README.zh-CN.md
@@ -1,44 +1,23 @@
 # ChatGPT 桌面端适配器
 
-在终端中直接控制 **ChatGPT macOS 桌面应用**。OpenCLI 支持两种自动化方式。
+在终端中控制 **ChatGPT Desktop App**。
 
-## 方式一：AppleScript（默认，无需配置）
+## 当前现实
 
-内置命令使用原生 AppleScript 自动化，无需额外启动参数。
+- **默认回退路径**：macOS AppleScript / 辅助功能自动化
+- **实验性 CDP 路径**：当设置 `OPENCLI_CDP_ENDPOINT` 时，`chatgpt status`、`chatgpt read`、`chatgpt reasoning`、`chatgpt send` 会改走 CDP
+- **默认异步**：`chatgpt send` 只负责提交并返回 `Submitted`；稍后用 `chatgpt read` 读取输出
+- **Windows / WSL 支持**：本轮仅提供实验性、CDP-only 的窄支持
+- **仍然是 AppleScript / macOS only**：`chatgpt new`、`chatgpt ask`
+- **推理切换范围**：实验性 CDP 目前只控制顶层 `Instant / Thinking / Pro` 选择器（`auto` 会视为 `instant`）
+- **当前 caveat**：某些 Windows 桌面版里，长时间运行的 Pro 请求可能会在 Busy / 半成品界面状态停很久
 
-### 前置条件
-1. 安装官方 [ChatGPT Desktop App](https://openai.com/chatgpt/mac/)。
-2. 在 **系统设置 → 隐私与安全性 → 辅助功能** 中为终端应用授予权限。
-
-### 命令
-- `opencli chatgpt status`：检查 ChatGPT 应用是否在运行。
-- `opencli chatgpt new`：激活 ChatGPT 并按 `Cmd+N` 开始新对话。
-- `opencli chatgpt send "消息"`：将消息复制到剪贴板，激活 ChatGPT，粘贴并提交。
-- `opencli chatgpt read`：通过当前聚焦 ChatGPT 窗口的辅助功能树读取最后一条可见消息并返回文本。
-
-## 方式二：CDP（高级，Electron 调试模式）
-
-ChatGPT Desktop 同样是 Electron 应用，可以通过远程调试端口启动以实现更深度的自动化：
+### 推荐异步流程
 
 ```bash
-/Applications/ChatGPT.app/Contents/MacOS/ChatGPT \
-  --remote-debugging-port=9224
+opencli chatgpt send --reasoning pro "认真研究这个任务，不用急着回答"
+opencli chatgpt status   # 可选：Busy=Yes 表示还在跑
+opencli chatgpt read     # 稍后读取当前可见输出
 ```
 
-然后设置环境变量：
-```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
-```
-
-> **注意**：CDP 模式支持未来的高级命令（如 DOM 检查、模型切换、代码提取等），与 Cursor 和 Codex 适配器类似。
-
-## 工作原理
-
-- **AppleScript 模式**：使用 `osascript` 控制 ChatGPT，发送消息时借助 `pbcopy`/`pbpaste` 粘贴文本，读取消息时通过 macOS 辅助功能树获取当前可见聊天内容。
-- **CDP 模式**：通过 Chrome DevTools Protocol 连接到 Electron 渲染进程，直接操作 DOM。
-
-## 限制
-
-- 仅支持 macOS（AppleScript 依赖）
-- AppleScript 模式需要辅助功能权限
-- `read` 返回的是当前聚焦 ChatGPT 窗口里的最后一条可见消息；如果目标消息不在可见区域，需先手动滚动
+📖 **完整文档**： [docs/adapters/desktop/chatgpt](../../../docs/adapters/desktop/chatgpt.md)

--- a/src/clis/chatgpt/cdp.test.ts
+++ b/src/clis/chatgpt/cdp.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './cdp.js';
+
+describe('chatgpt cdp helpers', () => {
+  it('formats a ready ChatGPT CDP status row', () => {
+    expect(__test__.formatChatGPTStatusRow({
+      title: 'ChatGPT',
+      url: 'https://chatgpt.com/?window_style=main_view',
+      readyState: 'complete',
+      likelyChatGPT: true,
+      turnCount: 6,
+      composerFound: true,
+      composerTag: 'DIV',
+      composerEmpty: true,
+      draftLength: 0,
+      sendButtonEnabled: true,
+      busy: false,
+      reasoningMode: 'pro',
+      reasoningLabel: 'Pro',
+      reasoningTriggerFound: true,
+    })).toEqual({
+      Status: 'Connected',
+      Mode: 'CDP',
+      Url: 'https://chatgpt.com/?window_style=main_view',
+      Title: 'ChatGPT',
+      Turns: 6,
+      Composer: 'Ready',
+      Reasoning: 'Pro',
+      Busy: 'No',
+    });
+  });
+
+  it('formats send results as async submissions instead of completed replies', () => {
+    expect(__test__.formatChatGPTSendResultRow({
+      mode: 'CDP',
+      reasoningLabel: 'Pro',
+      submitMethod: 'button',
+      injectedText: 'Research this carefully',
+    })).toEqual({
+      Status: 'Submitted',
+      Mode: 'CDP',
+      Reasoning: 'Pro',
+      Submit: 'button',
+      InjectedText: 'Research this carefully',
+    });
+  });
+
+  it('normalizes raw turns and strips repeated UI chrome lines', () => {
+    expect(__test__.normalizeChatGPTTurns([
+      { role: 'user', text: 'Hello there' },
+      { role: 'assistant', text: 'Sure\nCopy\nShare' },
+      { role: 'assistant', text: 'Sure\nCopy\nShare' },
+      { role: 'assistant', text: '   ' },
+    ])).toEqual([
+      { Role: 'User', Text: 'Hello there' },
+      { Role: 'Assistant', Text: 'Sure' },
+    ]);
+  });
+
+  it('keeps single-line content even when it matches a UI label', () => {
+    expect(__test__.normalizeChatGPTText('Copy')).toBe('Copy');
+  });
+
+  it('strips localized reasoning-state chrome from multiline content', () => {
+    expect(__test__.normalizeChatGPTText('ChatGPT 说：\n已完成推理\n立即回答\nPartial answer\n来源')).toBe('Partial answer');
+  });
+
+  it('normalizes reasoning aliases to supported top-level modes', () => {
+    expect(__test__.normalizeChatGPTReasoningInput('auto')).toBe('instant');
+    expect(__test__.normalizeChatGPTReasoningInput('gpt-5.4 thinking')).toBe('thinking');
+    expect(__test__.normalizeChatGPTReasoningInput('pro')).toBe('pro');
+  });
+
+  it('detects reasoning mode labels from ChatGPT picker text', () => {
+    expect(__test__.detectChatGPTReasoningMode('GPT-5.4 Pro')).toBe('pro');
+    expect(__test__.detectChatGPTReasoningMode('Thinking')).toBe('thinking');
+    expect(__test__.detectChatGPTReasoningMode('Instant')).toBe('instant');
+    expect(__test__.detectChatGPTReasoningMode('Auto 自动决定思考时长')).toBe('instant');
+    expect(__test__.detectChatGPTReasoningMode('Something else')).toBe('');
+  });
+});

--- a/src/clis/chatgpt/cdp.ts
+++ b/src/clis/chatgpt/cdp.ts
@@ -1,0 +1,1067 @@
+import { CDPBridge } from '../../browser/index.js';
+import { CliError } from '../../errors.js';
+import { browserSession } from '../../runtime.js';
+import type { IPage } from '../../types.js';
+
+export type ChatGPTReasoningMode = 'instant' | 'thinking' | 'pro';
+
+export type ChatGPTReasoningState = {
+  mode: ChatGPTReasoningMode | '';
+  label: string;
+  triggerFound: boolean;
+  triggerLabel: string;
+};
+
+export type ChatGPTReasoningChange = {
+  status: 'Switched' | 'Already active';
+  requested: ChatGPTReasoningMode;
+  requestedLabel: string;
+  reasoning: ChatGPTReasoningMode | '';
+  reasoningLabel: string;
+};
+
+export type ChatGPTCDPProbe = {
+  title: string;
+  url: string;
+  readyState: string;
+  likelyChatGPT: boolean;
+  turnCount: number;
+  composerFound: boolean;
+  composerTag: string;
+  composerEmpty: boolean;
+  draftLength: number;
+  sendButtonEnabled: boolean;
+  busy: boolean;
+  reasoningMode: ChatGPTReasoningMode | '';
+  reasoningLabel: string;
+  reasoningTriggerFound: boolean;
+};
+
+type RawChatGPTTurn = {
+  role?: string | null;
+  text?: string | null;
+};
+
+type ChatGPTReasoningOption = {
+  mode: ChatGPTReasoningMode;
+  label: string;
+  aliases: string[];
+};
+
+type RawChatGPTReasoningState = {
+  mode?: string | null;
+  label?: string | null;
+  triggerFound?: boolean | null;
+  triggerLabel?: string | null;
+};
+
+type RawChatGPTReasoningSelection = {
+  opened?: boolean | null;
+  ok?: boolean | null;
+  label?: string | null;
+  triggerLabel?: string | null;
+  visibleLabels?: string[] | null;
+};
+
+export type ChatGPTTurn = {
+  Role: string;
+  Text: string;
+};
+
+const CHATGPT_CDP_HINT =
+  'Experimental ChatGPT desktop CDP mode: fully quit ChatGPT first if needed, launch it with ' +
+  '--remote-debugging-port=9224 --remote-debugging-address=127.0.0.1, then export ' +
+  'OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224. If multiple inspectable targets exist, set OPENCLI_CDP_TARGET=chatgpt.';
+
+const CHATGPT_REASONING_HINT =
+  'This experimental helper only targets the top-level ChatGPT picker for Instant / Thinking / Pro. ' +
+  'It does not yet control Light / Standard / Extended / Heavy thinking-time options.';
+
+const CHATGPT_UI_CHROME = new Set([
+  'Copy',
+  'Edit',
+  'Share',
+  'Retry',
+  'Regenerate',
+  'Read aloud',
+  'Good response',
+  'Bad response',
+  'More',
+  'You said:',
+  'ChatGPT said:',
+  '你说：',
+  'ChatGPT 说：',
+  'Sources',
+  '来源',
+  'Finished thinking',
+  'Answer immediately',
+  '已完成推理',
+  '立即回答',
+]);
+
+const CHATGPT_REASONING_OPTIONS: ChatGPTReasoningOption[] = [
+  {
+    mode: 'instant',
+    label: 'Instant',
+    aliases: ['instant', 'auto', 'gpt-5.3 instant', 'gpt53 instant', 'gpt 5.3 instant'],
+  },
+  {
+    mode: 'thinking',
+    label: 'Thinking',
+    aliases: ['thinking', 'gpt-5.4 thinking', 'gpt54 thinking', 'gpt 5.4 thinking'],
+  },
+  {
+    mode: 'pro',
+    label: 'Pro',
+    aliases: ['pro', 'gpt-5.4 pro', 'gpt54 pro', 'gpt 5.4 pro'],
+  },
+];
+
+export function hasChatGPTCDPConfigured(): boolean {
+  return !!process.env.OPENCLI_CDP_ENDPOINT;
+}
+
+export function chatGPTCDPHint(): string {
+  return CHATGPT_CDP_HINT;
+}
+
+export function chatGPTReasoningHint(): string {
+  return CHATGPT_REASONING_HINT;
+}
+
+export function chatGPTAsyncSendHint(): string {
+  return 'Async by default: `opencli chatgpt send` only submits the prompt and returns immediately. Use `opencli chatgpt read` later to fetch the output.';
+}
+
+export function formatChatGPTSendResultRow(opts: {
+  mode: 'CDP' | 'AppleScript';
+  reasoningLabel?: string;
+  submitMethod?: string;
+  injectedText: string;
+}): Record<string, string> {
+  return {
+    Status: 'Submitted',
+    Mode: opts.mode,
+    Reasoning: opts.reasoningLabel || '',
+    Submit: opts.submitMethod || '',
+    InjectedText: opts.injectedText,
+  };
+}
+
+export function normalizeChatGPTText(text: string | null | undefined): string {
+  const cleaned = String(text ?? '')
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .replace(/\r/g, '')
+    .trim();
+
+  if (!cleaned) return '';
+
+  const lines = cleaned
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length <= 1) return cleaned;
+
+  const filtered = lines.filter((line) => !CHATGPT_UI_CHROME.has(line));
+  return filtered.join('\n').trim();
+}
+
+export function detectChatGPTReasoningMode(text: string | null | undefined): ChatGPTReasoningMode | '' {
+  return findChatGPTReasoningOption(text)?.mode ?? '';
+}
+
+export function normalizeChatGPTReasoningInput(text: string | null | undefined): ChatGPTReasoningMode | '' {
+  const normalized = String(text ?? '').trim().toLowerCase();
+  if (!normalized) return '';
+  return CHATGPT_REASONING_OPTIONS.find((option) => option.aliases.includes(normalized) || option.mode === normalized)?.mode ?? '';
+}
+
+export function normalizeChatGPTTurns(rawTurns: RawChatGPTTurn[]): ChatGPTTurn[] {
+  const normalized: ChatGPTTurn[] = [];
+
+  for (const raw of rawTurns) {
+    const text = normalizeChatGPTText(raw?.text);
+    if (!text) continue;
+
+    const role = normalizeChatGPTRole(raw?.role);
+    const nextTurn = { Role: role, Text: text };
+    const prevTurn = normalized[normalized.length - 1];
+
+    if (prevTurn && prevTurn.Role === nextTurn.Role && prevTurn.Text === nextTurn.Text) {
+      continue;
+    }
+
+    normalized.push(nextTurn);
+  }
+
+  return normalized;
+}
+
+export function formatChatGPTStatusRow(probe: ChatGPTCDPProbe): Record<string, string | number> {
+  return {
+    Status: probe.likelyChatGPT ? 'Connected' : 'Connected (target unverified)',
+    Mode: 'CDP',
+    Url: probe.url,
+    Title: probe.title,
+    Turns: probe.turnCount,
+    Composer: !probe.composerFound
+      ? 'Missing'
+      : probe.composerEmpty
+        ? 'Ready'
+        : `Draft (${probe.draftLength} chars)`,
+    Reasoning: probe.reasoningLabel || 'Unknown',
+    Busy: probe.busy ? 'Yes' : 'No',
+  };
+}
+
+export async function probeChatGPTCDP(): Promise<ChatGPTCDPProbe> {
+  return withChatGPTCDP('status', async (page) => {
+    return await probeChatGPTPage(page);
+  });
+}
+
+export async function probeChatGPTReasoningCDP(): Promise<ChatGPTReasoningState> {
+  return withChatGPTCDP('reasoning', async (page) => {
+    return await readChatGPTReasoningState(page);
+  });
+}
+
+export async function switchChatGPTReasoningCDP(mode: string): Promise<ChatGPTReasoningChange> {
+  const requested = requireChatGPTReasoningMode(mode);
+  return withChatGPTCDP('reasoning', async (page) => {
+    return await setChatGPTReasoningMode(page, requested);
+  });
+}
+
+export async function readChatGPTCDP(): Promise<ChatGPTTurn[]> {
+  return withChatGPTCDP('read', async (page) => {
+    const rawTurns = await page.evaluate(readScript()) as RawChatGPTTurn[];
+    const turns = normalizeChatGPTTurns(Array.isArray(rawTurns) ? rawTurns : []);
+
+    if (turns.length > 0) return turns;
+
+    const probe = await probeChatGPTPage(page);
+    const detail = probe.likelyChatGPT
+      ? 'No visible conversation turns were found in the current ChatGPT window.'
+      : 'Connected CDP target does not look like ChatGPT. Try setting OPENCLI_CDP_TARGET=chatgpt.';
+
+    return [{ Role: 'System', Text: detail }];
+  });
+}
+
+export async function sendChatGPTCDP(
+  text: string,
+  opts: { reasoning?: string } = {},
+): Promise<Array<Record<string, string>>> {
+  const requestedReasoning = opts.reasoning ? requireChatGPTReasoningMode(opts.reasoning) : null;
+
+  return withChatGPTCDP('send', async (page) => {
+    const probe = await probeChatGPTPage(page);
+    if (probe.busy) {
+      throw new CliError(
+        'COMMAND_EXEC',
+        'ChatGPT is currently busy or still generating a response.',
+        'Wait for the current response to finish (or stop it in the UI) before using the experimental send path again.'
+      );
+    }
+
+    let reasoningLabel = probe.reasoningLabel || '';
+    if (requestedReasoning) {
+      const change = await setChatGPTReasoningMode(page, requestedReasoning);
+      reasoningLabel = change.reasoningLabel || change.requestedLabel;
+    }
+
+    await page.evaluate(injectScript(text));
+    await page.wait(0.25);
+
+    let submitMethod = await page.evaluate(submitScript()) as string | null;
+    if (!submitMethod) {
+      await page.pressKey('Enter');
+      submitMethod = 'keyboard-enter';
+    }
+
+    await page.wait(0.5);
+
+    return [
+      formatChatGPTSendResultRow({
+        mode: 'CDP',
+        reasoningLabel: reasoningLabel || 'Unknown',
+        submitMethod,
+        injectedText: text,
+      }),
+    ];
+  });
+}
+
+async function withChatGPTCDP<T>(commandName: string, fn: (page: IPage) => Promise<T>): Promise<T> {
+  const endpoint = process.env.OPENCLI_CDP_ENDPOINT;
+  if (!endpoint) {
+    throw new CliError('CONFIG', `OPENCLI_CDP_ENDPOINT is required for ChatGPT ${commandName} in experimental CDP mode.`, CHATGPT_CDP_HINT);
+  }
+
+  try {
+    return await browserSession(CDPBridge as any, fn, { workspace: 'site:chatgpt' });
+  } catch (err: any) {
+    if (err instanceof CliError) throw err;
+
+    const message = String(err?.message ?? err ?? 'Unknown error');
+    const looksLikeConnectFailure = /ECONNREFUSED|fetch failed|Failed to fetch CDP targets|No inspectable targets found|CDP connect timeout/i.test(message);
+
+    if (looksLikeConnectFailure) {
+      throw new CliError(
+        'BROWSER_CONNECT',
+        `Could not attach to the ChatGPT CDP endpoint at ${endpoint}.`,
+        CHATGPT_CDP_HINT,
+      );
+    }
+
+    const looksLikeSelectorFailure = /composer|ChatGPT|target|reasoning|picker/i.test(message);
+    throw new CliError(
+      looksLikeSelectorFailure ? 'COMMAND_EXEC' : 'BROWSER_CONNECT',
+      `ChatGPT ${commandName} failed in experimental CDP mode: ${message}`,
+      CHATGPT_CDP_HINT,
+    );
+  }
+}
+
+async function probeChatGPTPage(page: IPage): Promise<ChatGPTCDPProbe> {
+  const probe = await page.evaluate(statusScript()) as ChatGPTCDPProbe;
+  if (!probe || typeof probe !== 'object') {
+    throw new CliError('COMMAND_EXEC', 'ChatGPT CDP probe returned an invalid page state.', CHATGPT_CDP_HINT);
+  }
+
+  if (!probe.reasoningMode && probe.reasoningTriggerFound) {
+    const refined = await readChatGPTReasoningState(page);
+    if (refined.mode || refined.label) {
+      return {
+        ...probe,
+        reasoningMode: refined.mode || probe.reasoningMode,
+        reasoningLabel: refined.label || probe.reasoningLabel,
+        reasoningTriggerFound: refined.triggerFound || probe.reasoningTriggerFound,
+      };
+    }
+  }
+
+  return probe;
+}
+
+async function readChatGPTReasoningState(page: IPage): Promise<ChatGPTReasoningState> {
+  const initial = await page.evaluate(readReasoningStateScript()) as RawChatGPTReasoningState;
+  let triggerLabel = normalizeChatGPTText(initial?.triggerLabel);
+  let option = findChatGPTReasoningOption(initial?.label) ?? findChatGPTReasoningOption(triggerLabel);
+
+  if (!option && initial?.triggerFound) {
+    const opened = await page.evaluate(openReasoningPickerScript()) as RawChatGPTReasoningSelection;
+    if (opened?.opened) {
+      for (const delaySeconds of [0.75, 0.5]) {
+        await page.wait(delaySeconds);
+        const expanded = await page.evaluate(readReasoningStateScript()) as RawChatGPTReasoningState;
+        triggerLabel = normalizeChatGPTText(expanded?.triggerLabel || triggerLabel);
+        option = findChatGPTReasoningOption(expanded?.label) ?? findChatGPTReasoningOption(triggerLabel);
+        if (option) break;
+      }
+
+      try {
+        await page.pressKey('Escape');
+        await page.wait(0.1);
+      } catch {
+        // best-effort close only
+      }
+    }
+  }
+
+  return {
+    mode: option?.mode ?? '',
+    label: option?.label ?? '',
+    triggerFound: !!initial?.triggerFound,
+    triggerLabel,
+  };
+}
+
+async function setChatGPTReasoningMode(page: IPage, requested: ChatGPTReasoningOption): Promise<ChatGPTReasoningChange> {
+  const current = await readChatGPTReasoningState(page);
+  if (current.mode === requested.mode) {
+    return {
+      status: 'Already active',
+      requested: requested.mode,
+      requestedLabel: requested.label,
+      reasoning: current.mode,
+      reasoningLabel: current.label || requested.label,
+    };
+  }
+
+  const opened = await page.evaluate(openReasoningPickerScript()) as RawChatGPTReasoningSelection;
+  if (!opened?.opened) {
+    throw new CliError(
+      'COMMAND_EXEC',
+      'Could not find the ChatGPT reasoning/model picker in the current CDP target.',
+      `${CHATGPT_CDP_HINT} ${CHATGPT_REASONING_HINT}`,
+    );
+  }
+
+  await page.wait(0.75);
+
+  const selected = await page.evaluate(selectReasoningOptionScript(requested.mode)) as RawChatGPTReasoningSelection;
+  if (!selected?.ok) {
+    const visibleLabels = (Array.isArray(selected?.visibleLabels) ? selected.visibleLabels : [])
+      .map((label) => normalizeChatGPTText(label))
+      .filter(Boolean)
+      .slice(0, 8);
+    const detail = visibleLabels.length > 0 ? ` Visible options: ${visibleLabels.join(' | ')}` : '';
+
+    throw new CliError(
+      'COMMAND_EXEC',
+      `Could not find the ChatGPT reasoning mode "${requested.label}" in the current picker.${detail}`,
+      `${CHATGPT_CDP_HINT} ${CHATGPT_REASONING_HINT}`,
+    );
+  }
+
+  await page.wait(0.75);
+
+  const after = await readChatGPTReasoningState(page);
+  return {
+    status: 'Switched',
+    requested: requested.mode,
+    requestedLabel: requested.label,
+    reasoning: after.mode || requested.mode,
+    reasoningLabel: after.label || requested.label,
+  };
+}
+
+function normalizeChatGPTRole(role: string | null | undefined): string {
+  const value = String(role ?? '').trim().toLowerCase();
+  if (value === 'user' || value === 'human') return 'User';
+  if (value === 'assistant' || value === 'ai') return 'Assistant';
+  if (value === 'system') return 'System';
+  return 'Message';
+}
+
+function findChatGPTReasoningOption(text: string | null | undefined): ChatGPTReasoningOption | null {
+  const haystack = String(text ?? '').trim().toLowerCase();
+  if (!haystack) return null;
+
+  const direct = CHATGPT_REASONING_OPTIONS.find((option) =>
+    option.aliases.some((alias) => alias === haystack) || option.mode === haystack,
+  );
+  if (direct) return direct;
+
+  if (/\bgpt[-\s]?5(?:\.4)?\b.*\bpro\b|\bpro\b|研究级|专业/.test(haystack)) {
+    return CHATGPT_REASONING_OPTIONS[2] ?? null;
+  }
+  if (/\bgpt[-\s]?5(?:\.3)?\b.*\binstant\b|\binstant\b|\bauto\b|自动/.test(haystack)) {
+    return CHATGPT_REASONING_OPTIONS[0] ?? null;
+  }
+  if (/\bgpt[-\s]?5(?:\.4)?\b.*\bthinking\b|\bthinking\b|思考/.test(haystack)) {
+    return CHATGPT_REASONING_OPTIONS[1] ?? null;
+  }
+
+  return null;
+}
+
+function requireChatGPTReasoningMode(mode: string): ChatGPTReasoningOption {
+  const option = CHATGPT_REASONING_OPTIONS.find((candidate) =>
+    candidate.aliases.includes(String(mode ?? '').trim().toLowerCase()) || candidate.mode === String(mode ?? '').trim().toLowerCase(),
+  );
+
+  if (!option) {
+    throw new CliError(
+      'COMMAND_EXEC',
+      `Unsupported ChatGPT reasoning mode "${mode}".`,
+      `Use one of: instant, thinking, pro. Alias: auto → instant. ${CHATGPT_REASONING_HINT}`,
+    );
+  }
+
+  return option;
+}
+
+function domHelpersScript(): string {
+  return `
+    const normalizeText = (value) => String(value ?? '')
+      .replace(/[\\u200B-\\u200D\\uFEFF]/g, '')
+      .replace(/\\r/g, '')
+      .trim();
+
+    const elementText = (el) => {
+      if (!el) return '';
+      const value = typeof el.value === 'string' ? el.value : '';
+      const innerText = typeof el.innerText === 'string' ? el.innerText : '';
+      const textContent = typeof el.textContent === 'string' ? el.textContent : '';
+      return normalizeText(value || innerText || textContent);
+    };
+
+    const elementLabel = (el) => {
+      if (!el) return '';
+      const parts = [
+        el.getAttribute?.('aria-label') || '',
+        el.getAttribute?.('title') || '',
+        typeof el.innerText === 'string' ? el.innerText : '',
+        typeof el.textContent === 'string' ? el.textContent : '',
+        el.getAttribute?.('data-testid') || '',
+      ].filter(Boolean);
+      return normalizeText(parts.join(' '));
+    };
+
+    const isVisible = (el) => {
+      if (!el || !(el instanceof Element)) return false;
+      const style = window.getComputedStyle(el);
+      if (!style || style.display === 'none' || style.visibility === 'hidden') return false;
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+
+    const clickElement = (el) => {
+      if (!el) return;
+      if (typeof el.scrollIntoView === 'function') {
+        el.scrollIntoView({ block: 'center', inline: 'center' });
+      }
+      if (typeof el.focus === 'function') {
+        el.focus();
+      }
+      const PointerCtor = window.PointerEvent || null;
+      if (PointerCtor) {
+        el.dispatchEvent(new PointerCtor('pointerdown', { bubbles: true, cancelable: true }));
+      }
+      el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      if (PointerCtor) {
+        el.dispatchEvent(new PointerCtor('pointerup', { bubbles: true, cancelable: true }));
+      }
+      el.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+      if (typeof el.click === 'function') {
+        el.click();
+      } else {
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      }
+    };
+
+    const scoreComposer = (el) => {
+      if (!isVisible(el)) return Number.NEGATIVE_INFINITY;
+      let score = 0;
+      const dataTestId = (el.getAttribute('data-testid') || '').toLowerCase();
+      const ariaLabel = (el.getAttribute('aria-label') || '').toLowerCase();
+      const placeholder = (el.getAttribute('placeholder') || '').toLowerCase();
+
+      if (el.id === 'prompt-textarea') score += 400;
+      if (dataTestId.includes('composer')) score += 240;
+      if (dataTestId.includes('prompt')) score += 180;
+      if (dataTestId.includes('message')) score += 80;
+      if (el.tagName === 'TEXTAREA') score += 140;
+      if (el.getAttribute('contenteditable') === 'true') score += 120;
+      if (ariaLabel.includes('message')) score += 120;
+      if (placeholder.includes('message')) score += 120;
+      if (el.closest('form')) score += 80;
+      if (el.closest('footer')) score += 40;
+      if (el.disabled || el.getAttribute('aria-disabled') === 'true') score -= 500;
+
+      return score;
+    };
+
+    const selectComposer = () => {
+      const selector = [
+        '#prompt-textarea',
+        '[data-testid="composer-text-input"]',
+        '[data-testid*="composer"]',
+        'form textarea',
+        'form [contenteditable="true"]',
+        'textarea',
+        '[contenteditable="true"][data-lexical-editor="true"]',
+        '[contenteditable="true"]',
+      ].join(',');
+
+      let best = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+
+      for (const el of Array.from(document.querySelectorAll(selector))) {
+        const score = scoreComposer(el);
+        if (score > bestScore) {
+          best = el;
+          bestScore = score;
+        }
+      }
+
+      return best;
+    };
+
+    const selectSendButton = () => {
+      const selector = [
+        'button[data-testid="send-button"]',
+        'button[data-testid*="send"]',
+        'button[aria-label*="Send"]',
+        'form button[type="submit"]',
+        'form button',
+      ].join(',');
+
+      let best = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+
+      for (const el of Array.from(document.querySelectorAll(selector))) {
+        if (!isVisible(el)) continue;
+        let score = 0;
+        const dataTestId = (el.getAttribute('data-testid') || '').toLowerCase();
+        const ariaLabel = (el.getAttribute('aria-label') || el.textContent || '').toLowerCase();
+
+        if (dataTestId.includes('send')) score += 300;
+        if (ariaLabel.includes('send')) score += 240;
+        if (el.getAttribute('type') === 'submit') score += 100;
+        if (el.closest('form')) score += 60;
+        if (el.disabled || el.getAttribute('aria-disabled') === 'true') score -= 100;
+
+        if (score > bestScore) {
+          best = el;
+          bestScore = score;
+        }
+      }
+
+      return best;
+    };
+
+    const overlaySelector = [
+      '[role="menu"]',
+      '[role="listbox"]',
+      '[role="dialog"]',
+      '[data-radix-popper-content-wrapper]',
+      '[data-radix-menu-content]',
+      '[cmdk-root]',
+      '[cmdk-list]',
+      '[data-headlessui-state]',
+    ].join(',');
+
+    const detectReasoningMode = (value) => {
+      const text = normalizeText(value).toLowerCase();
+      if (!text) return null;
+      if (/\bgpt[-\s]?5(?:\.4)?\b.*\bpro\b|\bpro\b|研究级|专业/.test(text)) return { mode: 'pro', label: 'Pro' };
+      if (/\bgpt[-\s]?5(?:\.3)?\b.*\binstant\b|\binstant\b|\bauto\b|自动/.test(text)) return { mode: 'instant', label: 'Instant' };
+      if (/\bgpt[-\s]?5(?:\.4)?\b.*\bthinking\b|\bthinking\b|思考/.test(text)) return { mode: 'thinking', label: 'Thinking' };
+      return null;
+    };
+
+    const escapeSelectorValue = (value) => String(value ?? '').replace(/["\\\\]/g, '\\\\$&');
+
+    const isConversationTurnNode = (el) => {
+      if (!el || typeof el.closest !== 'function') return false;
+      return !!el.closest('[role="log"], [data-message-author-role], article[data-testid^="conversation-turn-"], [data-testid^="conversation-turn-"]');
+    };
+
+    const findReasoningMenuForTrigger = (trigger) => {
+      if (!trigger) return null;
+
+      const candidates = [];
+      const addCandidate = (node) => {
+        if (!node) return;
+        const container = typeof node.matches === 'function' && node.matches(overlaySelector)
+          ? node
+          : node.closest?.(overlaySelector) || node;
+        if (!container || !isVisible(container) || candidates.includes(container)) return;
+        candidates.push(container);
+      };
+
+      const controls = trigger.getAttribute('aria-controls') || '';
+      if (controls) {
+        addCandidate(document.getElementById(controls));
+      }
+
+      const triggerId = trigger.id || '';
+      if (triggerId) {
+        const selector = '[aria-labelledby="' + escapeSelectorValue(triggerId) + '"]';
+        addCandidate(document.querySelector(selector));
+      }
+
+      if ((trigger.getAttribute('data-testid') || '') === 'model-switcher-dropdown-button') {
+        for (const el of Array.from(document.querySelectorAll('[data-testid^="model-switcher-gpt-"]'))) {
+          if (!isVisible(el)) continue;
+          addCandidate(el.closest(overlaySelector) || el.parentElement || el);
+        }
+      }
+
+      return candidates[0] || null;
+    };
+
+    const scoreReasoningTrigger = (el) => {
+      if (!isVisible(el)) return Number.NEGATIVE_INFINITY;
+      const label = elementLabel(el);
+      const text = label.toLowerCase();
+      const match = detectReasoningMode(label);
+      const dataTestId = (el.getAttribute('data-testid') || '').toLowerCase();
+      const ariaHasPopup = (el.getAttribute('aria-haspopup') || '').toLowerCase();
+      let score = 0;
+
+      if (dataTestId === 'model-switcher-dropdown-button') score += 900;
+      if (match) score += 320;
+      if (text.includes('model') || text.includes('模型')) score += 220;
+      if (text.includes('reason') || text.includes('推理') || text.includes('思考')) score += 180;
+      if (dataTestId.includes('model')) score += 200;
+      if (dataTestId.includes('picker')) score += 160;
+      if (dataTestId.includes('mode')) score += 140;
+      if (ariaHasPopup === 'menu' || ariaHasPopup === 'listbox' || ariaHasPopup === 'dialog') score += 120;
+      if (el.tagName === 'BUTTON') score += 90;
+      if (el.getAttribute('role') === 'button') score += 70;
+      if (el.closest('form, footer')) score += 140;
+      if (el.closest('header')) score += 100;
+      if (/\bupgrade\b|\bsubscribe\b|\btrial\b|\bpremium\b|\bbilling\b|\bplan\b/.test(text)) score -= 280;
+      if (/retry|重试/.test(text)) score -= 260;
+      if (label.length > 40 && !text.includes('model') && !text.includes('模型')) score -= 80;
+      if (el.closest(overlaySelector)) score -= 260;
+      if (isConversationTurnNode(el)) score -= 520;
+      if (el.disabled || el.getAttribute('aria-disabled') === 'true') score -= 500;
+
+      return score;
+    };
+
+    const selectReasoningTrigger = () => {
+      const explicit = document.querySelector('button[data-testid="model-switcher-dropdown-button"]');
+      if (explicit && isVisible(explicit)) {
+        return explicit;
+      }
+
+      const selector = [
+        'button',
+        '[role="button"]',
+        '[aria-haspopup="menu"]',
+        '[aria-haspopup="listbox"]',
+        '[data-testid*="model"]',
+        '[data-testid*="picker"]',
+        '[data-testid*="mode"]',
+      ].join(',');
+
+      let best = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+
+      for (const el of Array.from(document.querySelectorAll(selector))) {
+        const score = scoreReasoningTrigger(el);
+        if (score > bestScore) {
+          best = el;
+          bestScore = score;
+        }
+      }
+
+      return bestScore >= 220 ? best : null;
+    };
+
+    const readOpenReasoningSelection = (menu) => {
+      if (!menu) return { mode: '', label: '' };
+
+      const selector = [
+        '[data-testid^="model-switcher-gpt-"]',
+        '[role="menuitem"]',
+        '[role="option"]',
+        'button',
+        '[role="button"]',
+        'li',
+      ].join(',');
+
+      let best = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+      let bestLabel = '';
+
+      for (const el of Array.from(menu.querySelectorAll(selector))) {
+        if (!isVisible(el)) continue;
+        const dataTestId = (el.getAttribute('data-testid') || '').toLowerCase();
+        const label = elementLabel(el);
+        const match = detectReasoningMode(label + ' ' + dataTestId);
+        if (!match) continue;
+
+        let score = 0;
+        if (dataTestId.startsWith('model-switcher-')) score += 260;
+        if (el.querySelector('.trailing svg, .trailing use')) score += 260;
+        if (el.getAttribute('aria-selected') === 'true' || el.getAttribute('aria-checked') === 'true') score += 220;
+        if (el.getAttribute('data-state') === 'checked' || el.getAttribute('data-selected') === 'true') score += 220;
+        if (el.getAttribute('role') === 'menuitem' || el.getAttribute('role') === 'option') score += 80;
+
+        if (score > bestScore) {
+          best = match;
+          bestScore = score;
+          bestLabel = label;
+        }
+      }
+
+      return {
+        mode: best ? best.mode : '',
+        label: best ? (best.label || bestLabel) : '',
+      };
+    };
+
+    const readReasoningState = () => {
+      const trigger = selectReasoningTrigger();
+      const triggerLabel = elementLabel(trigger);
+      const menu = findReasoningMenuForTrigger(trigger);
+      const current = readOpenReasoningSelection(menu);
+      const match = current.mode ? current : (detectReasoningMode(triggerLabel) || { mode: '', label: '' });
+
+      return {
+        mode: match ? match.mode : '',
+        label: match ? match.label : '',
+        triggerFound: !!trigger,
+        triggerLabel,
+      };
+    };  `;
+}
+
+function statusScript(): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+
+      const composer = selectComposer();
+      const sendButton = selectSendButton();
+      const stopButton = document.querySelector(
+        'button[aria-label*="Stop"], button[data-testid*="stop"], button[aria-label*="stop"]'
+      );
+      const turnNodes = Array.from(document.querySelectorAll([
+        '[data-message-author-role]',
+        'article[data-testid^="conversation-turn-"]',
+        '[data-testid^="conversation-turn-"]',
+        '[role="log"] > *',
+      ].join(','))).filter(isVisible);
+      const reasoning = readReasoningState();
+
+      const url = window.location.href || '';
+      const title = document.title || '';
+      const haystack = (title + ' ' + url).toLowerCase();
+      const draft = elementText(composer);
+
+      return {
+        title,
+        url,
+        readyState: document.readyState,
+        likelyChatGPT: /chatgpt|chat\\.openai|openai/.test(haystack),
+        turnCount: turnNodes.length,
+        composerFound: !!composer,
+        composerTag: composer ? composer.tagName : '',
+        composerEmpty: draft.length === 0,
+        draftLength: draft.length,
+        sendButtonEnabled: !!sendButton && !(sendButton.disabled || sendButton.getAttribute('aria-disabled') === 'true'),
+        busy: !!stopButton,
+        reasoningMode: reasoning.mode,
+        reasoningLabel: reasoning.label,
+        reasoningTriggerFound: reasoning.triggerFound,
+      };
+    })()
+  `;
+}
+
+function readScript(): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+
+      const seen = new Set();
+      const turns = [];
+      const selector = [
+        'article[data-testid^="conversation-turn-"]',
+        '[data-testid^="conversation-turn-"]',
+        '[data-message-author-role]',
+        '[role="log"] > *',
+      ].join(',');
+
+      for (const node of Array.from(document.querySelectorAll(selector))) {
+        const container =
+          node.closest('article[data-testid^="conversation-turn-"]') ||
+          node.closest('[data-testid^="conversation-turn-"]') ||
+          node.closest('[data-message-author-role]') ||
+          node;
+
+        if (!container || seen.has(container) || !isVisible(container)) continue;
+        seen.add(container);
+
+        const roleNode =
+          container.matches('[data-message-author-role]')
+            ? container
+            : container.querySelector('[data-message-author-role]');
+        const role =
+          container.getAttribute('data-turn') ||
+          (roleNode ? roleNode.getAttribute('data-message-author-role') : '') ||
+          '';
+
+        const contentNode =
+          container.querySelector('.markdown, .prose, [data-testid*="message-content"], [data-testid*="conversation-turn-content"], .whitespace-pre-wrap, p, li, pre, code') ||
+          container;
+        const text = elementText(contentNode || container);
+
+        if (!text) continue;
+        turns.push({ role, text });
+      }
+
+      if (turns.length > 0) return turns;
+
+      const fallback = elementText(document.querySelector('main, [role="main"], [role="log"]') || document.body);
+      if (!fallback) return [];
+
+      return [{ role: 'message', text: fallback }];
+    })()
+  `;
+}
+
+function readReasoningStateScript(): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+      return readReasoningState();
+    })()
+  `;
+}
+
+function openReasoningPickerScript(): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+
+      const trigger = selectReasoningTrigger();
+      if (!trigger) {
+        return { opened: false, triggerLabel: '' };
+      }
+
+      const triggerLabel = elementLabel(trigger);
+      const existingMenu = findReasoningMenuForTrigger(trigger);
+      if (existingMenu) {
+        return { opened: true, triggerLabel };
+      }
+
+      clickElement(trigger);
+      return { opened: true, triggerLabel };
+    })()
+  `;
+}
+
+function selectReasoningOptionScript(mode: ChatGPTReasoningMode): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+
+      const target = ${JSON.stringify(mode)};
+      const trigger = selectReasoningTrigger();
+      const menu = findReasoningMenuForTrigger(trigger);
+      const selector = [
+        '[data-testid^="model-switcher-gpt-"]',
+        '[role="menuitem"]',
+        '[role="option"]',
+        'button',
+        '[role="button"]',
+        'li',
+      ].join(',');
+
+      const candidates = menu ? Array.from(menu.querySelectorAll(selector)) : [];
+
+      const scoreReasoningOption = (el) => {
+        if (!isVisible(el)) return Number.NEGATIVE_INFINITY;
+        if (isConversationTurnNode(el)) return Number.NEGATIVE_INFINITY;
+
+        const dataTestId = (el.getAttribute('data-testid') || '').toLowerCase();
+        const label = elementLabel(el);
+        const match = detectReasoningMode(label + ' ' + dataTestId);
+        if (!match || match.mode !== target) return Number.NEGATIVE_INFINITY;
+
+        let score = 0;
+        if (match.mode === target) score += 420;
+        if (dataTestId.startsWith('model-switcher-')) score += 320;
+        if (target === 'pro' && dataTestId.includes('pro')) score += 180;
+        if (target === 'thinking' && dataTestId.includes('thinking')) score += 180;
+        if (target === 'instant' && (dataTestId.includes('gpt-5-3') || /\bauto\b|自动/.test(label.toLowerCase()))) score += 220;
+        if (el.closest(overlaySelector)) score += 180;
+        if (el.getAttribute('role') === 'menuitem' || el.getAttribute('role') === 'option') score += 100;
+        if (el.tagName === 'BUTTON') score += 60;
+        if (/\bupgrade\b|\bsubscribe\b|\btrial\b|\bpremium\b|\bbilling\b|\bplan\b/.test(label.toLowerCase())) score -= 320;
+        if (/retry|重试/.test(label.toLowerCase())) score -= 260;
+        if (el.getAttribute('aria-selected') === 'true' || el.getAttribute('aria-checked') === 'true' || el.getAttribute('data-state') === 'checked') score += 40;
+        if (el.disabled || el.getAttribute('aria-disabled') === 'true') score -= 600;
+        return score;
+      };
+
+      let best = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+      let bestLabel = '';
+
+      for (const el of candidates) {
+        const score = scoreReasoningOption(el);
+        if (score > bestScore) {
+          best = el;
+          bestScore = score;
+          bestLabel = elementLabel(el);
+        }
+      }
+
+      if (!best) {
+        const visibleLabels = candidates
+          .filter(isVisible)
+          .map((el) => elementLabel(el))
+          .filter(Boolean)
+          .slice(0, 12);
+        return { ok: false, visibleLabels };
+      }
+
+      clickElement(best);
+      return { ok: true, label: bestLabel };
+    })()
+  `;
+}
+
+function injectScript(text: string): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+
+      const text = ${JSON.stringify(text)};
+      const composer = selectComposer();
+      if (!composer) {
+        throw new Error('Could not find the ChatGPT composer in the current CDP target.');
+      }
+
+      const existing = elementText(composer);
+      if (existing.length > 0) {
+        throw new Error('The ChatGPT composer already contains draft text. Refusing to overwrite it in experimental CDP mode.');
+      }
+
+      composer.focus();
+
+      if (composer.tagName === 'TEXTAREA') {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
+        if (!setter) throw new Error('Could not access the textarea setter for the ChatGPT composer.');
+        setter.call(composer, text);
+        composer.dispatchEvent(new Event('input', { bubbles: true }));
+        composer.dispatchEvent(new Event('change', { bubbles: true }));
+      } else {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(composer);
+        range.collapse(false);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        document.execCommand('insertText', false, text);
+        composer.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+
+      return 'injected';
+    })()
+  `;
+}
+
+function submitScript(): string {
+  return `
+    (() => {
+      ${domHelpersScript()}
+
+      const sendButton = selectSendButton();
+      if (sendButton && !(sendButton.disabled || sendButton.getAttribute('aria-disabled') === 'true')) {
+        sendButton.click();
+        return 'button';
+      }
+
+      const composer = selectComposer();
+      const form = composer ? composer.closest('form') : null;
+      if (form && typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+        return 'form-requestSubmit';
+      }
+
+      return '';
+    })()
+  `;
+}
+
+export const __test__ = {
+  detectChatGPTReasoningMode,
+  formatChatGPTSendResultRow,
+  formatChatGPTStatusRow,
+  normalizeChatGPTReasoningInput,
+  normalizeChatGPTText,
+  normalizeChatGPTTurns,
+};

--- a/src/clis/chatgpt/read.ts
+++ b/src/clis/chatgpt/read.ts
@@ -1,18 +1,32 @@
 import { execSync } from 'node:child_process';
+import { CliError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 import { getVisibleChatMessages } from './ax.js';
+import { chatGPTCDPHint, hasChatGPTCDPConfigured, readChatGPTCDP } from './cdp.js';
 
 export const readCommand = cli({
   site: 'chatgpt',
   name: 'read',
-  description: 'Read the last visible message from the focused ChatGPT Desktop window',
+  description: 'Read the current ChatGPT conversation (use after async send to fetch output; experimental CDP when configured; AppleScript fallback on macOS)',
   domain: 'localhost',
   strategy: Strategy.PUBLIC,
   browser: false,
   args: [],
   columns: ['Role', 'Text'],
-  func: async (page: IPage | null) => {
+  func: async (_page: IPage | null) => {
+    if (hasChatGPTCDPConfigured()) {
+      return await readChatGPTCDP();
+    }
+
+    if (process.platform !== 'darwin') {
+      throw new CliError(
+        'CONFIG',
+        'ChatGPT read requires macOS AppleScript fallback or experimental CDP mode.',
+        chatGPTCDPHint(),
+      );
+    }
+
     try {
       execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
       execSync("osascript -e 'delay 0.3'");
@@ -24,7 +38,7 @@ export const readCommand = cli({
 
       return [{ Role: 'Assistant', Text: messages[messages.length - 1] }];
     } catch (err: any) {
-      throw new Error("Failed to read from ChatGPT: " + err.message);
+      throw new Error('Failed to read from ChatGPT: ' + err.message);
     }
   },
 });

--- a/src/clis/chatgpt/reasoning.ts
+++ b/src/clis/chatgpt/reasoning.ts
@@ -1,0 +1,55 @@
+import { CliError } from '../../errors.js';
+import { cli, Strategy } from '../../registry.js';
+import type { IPage } from '../../types.js';
+import {
+  chatGPTCDPHint,
+  hasChatGPTCDPConfigured,
+  probeChatGPTReasoningCDP,
+  switchChatGPTReasoningCDP,
+} from './cdp.js';
+
+export const reasoningCommand = cli({
+  site: 'chatgpt',
+  name: 'reasoning',
+  description: 'Get or switch the top-level ChatGPT reasoning mode in experimental CDP mode',
+  domain: 'localhost',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'mode',
+      required: false,
+      positional: true,
+      help: 'Reasoning mode to switch to (instant, thinking, pro; alias: auto → instant)',
+    },
+  ],
+  columns: ['Status', 'Mode', 'Reasoning', 'Requested'],
+  func: async (_page: IPage | null, kwargs: any) => {
+    if (!hasChatGPTCDPConfigured()) {
+      throw new CliError(
+        'CONFIG',
+        'ChatGPT reasoning switching currently requires experimental CDP mode.',
+        chatGPTCDPHint(),
+      );
+    }
+
+    const mode = kwargs.mode as string | undefined;
+    if (!mode) {
+      const state = await probeChatGPTReasoningCDP();
+      return [{
+        Status: 'Active',
+        Mode: 'CDP',
+        Reasoning: state.label || 'Unknown',
+        Requested: '',
+      }];
+    }
+
+    const result = await switchChatGPTReasoningCDP(mode);
+    return [{
+      Status: result.status,
+      Mode: 'CDP',
+      Reasoning: result.reasoningLabel || result.requestedLabel,
+      Requested: result.requestedLabel,
+    }];
+  },
+});

--- a/src/clis/chatgpt/send.ts
+++ b/src/clis/chatgpt/send.ts
@@ -1,48 +1,85 @@
 import { execSync, spawnSync } from 'node:child_process';
+import { CliError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
+import {
+  chatGPTAsyncSendHint,
+  chatGPTCDPHint,
+  formatChatGPTSendResultRow,
+  hasChatGPTCDPConfigured,
+  sendChatGPTCDP,
+} from './cdp.js';
 
 export const sendCommand = cli({
   site: 'chatgpt',
   name: 'send',
-  description: 'Send a message to the active ChatGPT Desktop App window',
+  description: 'Submit a message to ChatGPT Desktop and return immediately (use read later; experimental CDP when configured; AppleScript fallback on macOS)',
   domain: 'localhost',
   strategy: Strategy.PUBLIC,
   browser: false,
-  args: [{ name: 'text', required: true, positional: true, help: 'Message to send' }],
-  columns: ['Status'],
-  func: async (page: IPage | null, kwargs: any) => {
+  args: [
+    { name: 'text', required: true, positional: true, help: 'Message to submit (command returns immediately; use read later)' },
+    {
+      name: 'reasoning',
+      required: false,
+      help: 'Experimental CDP only: switch the top-level reasoning mode before submitting (instant, thinking, pro; auto → instant)',
+    },
+  ],
+  columns: ['Status', 'Mode', 'Reasoning', 'Submit', 'InjectedText'],
+  footerExtra: () => chatGPTAsyncSendHint(),
+  func: async (_page: IPage | null, kwargs: any) => {
     const text = kwargs.text as string;
+    const reasoning = kwargs.reasoning as string | undefined;
+
+    if (hasChatGPTCDPConfigured()) {
+      return await sendChatGPTCDP(text, { reasoning });
+    }
+
+    if (reasoning) {
+      throw new CliError(
+        'CONFIG',
+        'ChatGPT reasoning switching currently requires experimental CDP mode.',
+        chatGPTCDPHint(),
+      );
+    }
+
+    if (process.platform !== 'darwin') {
+      throw new CliError(
+        'CONFIG',
+        'ChatGPT send requires macOS AppleScript fallback or experimental CDP mode.',
+        chatGPTCDPHint(),
+      );
+    }
+
     try {
-      // Backup current clipboard content
       let clipBackup = '';
       try {
         clipBackup = execSync('pbpaste', { encoding: 'utf-8' });
-      } catch { /* clipboard may be empty */ }
+      } catch {
+        // clipboard may be empty
+      }
 
-      // Copy text to clipboard
       spawnSync('pbcopy', { input: text });
-      
+
       execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
       execSync("osascript -e 'delay 0.5'");
-      
+
       const cmd = "osascript " +
                   "-e 'tell application \"System Events\"' " +
                   "-e 'keystroke \"v\" using command down' " +
                   "-e 'delay 0.2' " +
                   "-e 'keystroke return' " +
                   "-e 'end tell'";
-                     
+
       execSync(cmd);
 
-      // Restore original clipboard content
       if (clipBackup) {
         spawnSync('pbcopy', { input: clipBackup });
       }
 
-      return [{ Status: 'Success' }];
+      return [formatChatGPTSendResultRow({ mode: 'AppleScript', submitMethod: 'clipboard-paste', injectedText: text })];
     } catch (err: any) {
-      return [{ Status: "Error: " + err.message }];
+      return [{ Status: 'Error: ' + err.message, Mode: 'AppleScript', Reasoning: '', Submit: '', InjectedText: text }];
     }
   },
 });

--- a/src/clis/chatgpt/status.ts
+++ b/src/clis/chatgpt/status.ts
@@ -1,22 +1,58 @@
 import { execSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
+import { formatChatGPTStatusRow, hasChatGPTCDPConfigured, probeChatGPTCDP } from './cdp.js';
 
 export const statusCommand = cli({
   site: 'chatgpt',
   name: 'status',
-  description: 'Check if ChatGPT Desktop App is running natively on macOS',
+  description: 'Check ChatGPT Desktop status (Busy shows whether ChatGPT is still generating; AppleScript fallback; experimental CDP when OPENCLI_CDP_ENDPOINT is set)',
   domain: 'localhost',
   strategy: Strategy.PUBLIC,
   browser: false,
   args: [],
-  columns: ['Status'],
-  func: async (page: IPage | null) => {
+  columns: ['Status', 'Mode', 'Url', 'Title', 'Turns', 'Composer', 'Reasoning', 'Busy'],
+  func: async (_page: IPage | null) => {
+    if (hasChatGPTCDPConfigured()) {
+      return [formatChatGPTStatusRow(await probeChatGPTCDP())];
+    }
+
+    if (process.platform !== 'darwin') {
+      return [{
+        Status: 'CDP required',
+        Mode: 'Unavailable',
+        Url: '',
+        Title: 'Set OPENCLI_CDP_ENDPOINT for experimental ChatGPT desktop control on this platform.',
+        Turns: '',
+        Composer: '',
+        Reasoning: '',
+        Busy: '',
+      }];
+    }
+
     try {
       const output = execSync("osascript -e 'application \"ChatGPT\" is running'", { encoding: 'utf-8' }).trim();
-      return [{ Status: output === 'true' ? 'Running' : 'Stopped' }];
+      return [{
+        Status: output === 'true' ? 'Running' : 'Stopped',
+        Mode: 'AppleScript',
+        Url: '',
+        Title: '',
+        Turns: '',
+        Composer: '',
+        Reasoning: '',
+        Busy: '',
+      }];
     } catch {
-      return [{ Status: 'Error querying application state' }];
+      return [{
+        Status: 'Error querying application state',
+        Mode: 'AppleScript',
+        Url: '',
+        Title: '',
+        Turns: '',
+        Composer: '',
+        Reasoning: '',
+        Busy: '',
+      }];
     }
   },
 });


### PR DESCRIPTION
## Summary
- add an experimental ChatGPT desktop CDP helper behind `OPENCLI_CDP_ENDPOINT`
- keep the existing macOS AppleScript fallback intact
- support `chatgpt status`, `chatgpt read`, `chatgpt reasoning`, and async-first `chatgpt send`
- update docs/README wording so the new behavior and current caveats are explicit

## What changed
- add `src/clis/chatgpt/cdp.ts` as the shared ChatGPT desktop CDP helper
- add `chatgpt reasoning [mode]` for the top-level `Instant` / `Thinking` / `Pro` picker
- add `chatgpt send --reasoning <mode>` so one-shot prompts can request the top-level mode before submit
- teach `chatgpt status` to report CDP session state, visible turn count, composer readiness, reasoning mode, and busy state
- teach `chatgpt read` to extract visible conversation turns from the ChatGPT desktop DOM
- make `chatgpt send` intentionally submit-only / async for the CDP path and return immediately after submission
- improve generic CDP target scoring so ChatGPT targets are preferred during attach
- add focused tests for ChatGPT CDP helpers and target scoring
- sync adapter docs/README tables with the new `reasoning` command and async-first send semantics

## Scope / caveats
- this is still an **experimental** ChatGPT desktop CDP path
- Windows / WSL support is intentionally narrow: `status`, `read`, `reasoning`, and `send`
- `new` and `ask` remain AppleScript/macOS-only
- `reasoning` currently targets only the **top-level** `Instant` / `Thinking` / `Pro` picker, not Light / Standard / Extended / Heavy thinking-time options or reply-level retry/model switchers
- `send` is intentionally **submit-only** for the CDP path: it returns after submission (`Submitted`) and expects callers to use `read` later
- current Windows desktop builds can still leave some long-running Pro requests in a busy / partially rendered state for minutes; this PR makes status/readback honest during that state, but does not claim to force the app to finalize the reply

## Validation
- `npm run typecheck`
- `npx vitest run src/browser.test.ts src/clis/chatgpt/cdp.test.ts`
- `npm run build`
- `npm run docs:build`
- `node dist/main.js list -f json | grep 'chatgpt/reasoning'`
- `node dist/main.js chatgpt status -f json`
- `OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224 node dist/main.js chatgpt status -f json`
- `OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224 node dist/main.js chatgpt read -f json`
- `node dist/main.js chatgpt send "hello" --reasoning pro -f json`
- `OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224 node dist/main.js chatgpt reasoning pro -f json`
