### PR TITLE
feat(grok): add opt-in --web flow for grok ask

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -218,8 +218,9 @@ opencli weread ranking --limit 10        # 排行榜
 opencli jimeng generate --prompt "描述"  # AI 生图
 opencli jimeng history --limit 10        # 生成历史
 
-# Grok (Desktop)
-opencli grok ask "问题"                  # 提问 Grok (text positional)
+# Grok (default + explicit web)
+opencli grok ask --prompt "问题"         # 提问 Grok（兼容默认路径）
+opencli grok ask --prompt "问题" --web   # 显式 grok.com consumer web UI 路径
 
 # HuggingFace (public)
 opencli hf top --limit 10                # 热门模型

--- a/docs/adapters/browser/grok.md
+++ b/docs/adapters/browser/grok.md
@@ -1,24 +1,28 @@
 # Grok
 
-**Mode**: 🔐 Browser · **Domain**: `grok.com`
+**Mode**: Default Grok adapter + optional explicit consumer web path · **Domain**: `grok.com`
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `opencli grok ask` | Send a message to Grok and get response |
+| `opencli grok ask` | Keep the default Grok ask behavior |
+| `opencli grok ask --web` | Use the explicit grok.com consumer web UI flow |
 
 ## Usage Examples
 
 ```bash
-# Ask Grok a question
+# Default / compatibility path
 opencli grok ask --prompt "Explain quantum computing in simple terms"
 
-# Start a new chat session
-opencli grok ask --prompt "Hello" --new
+# Explicit consumer web path
+opencli grok ask --prompt "Explain quantum computing in simple terms" --web
+
+# Best-effort fresh chat on the consumer web path
+opencli grok ask --prompt "Hello" --web --new
 
 # Set custom timeout (default: 120s)
-opencli grok ask --prompt "Write a long essay" --timeout 180
+opencli grok ask --prompt "Write a long essay" --web --timeout 180
 ```
 
 ### Options
@@ -27,9 +31,23 @@ opencli grok ask --prompt "Write a long essay" --timeout 180
 |--------|-------------|
 | `--prompt` | The message to send (required) |
 | `--timeout` | Wait timeout in seconds (default: 120) |
-| `--new` | Start a new chat session (default: false) |
+| `--new` | Start a new chat before sending (default: false) |
+| `--web` | Opt into the explicit grok.com consumer web flow (default: false) |
+
+## Behavior
+
+- `opencli grok ask` keeps the upstream/default behavior intact.
+- `opencli grok ask --web` switches to the newer hardened consumer-web implementation.
+- The `--web` path adds stricter composer detection, clearer blocked/session-gated hints, and waits for a stabilized assistant bubble before returning.
 
 ## Prerequisites
 
-- Chrome running and **logged into** grok.com
+- The Grok adapter still depends on browser-backed access to `grok.com`
+- For `--web`, Chrome should already be running with an authenticated Grok consumer session
 - [Browser Bridge extension](/guide/browser-bridge) installed
+
+## Caveats
+
+- `--web` drives the Grok consumer web UI in the browser, not an API.
+- It depends on an already-authenticated session and can fail if Grok shows login, challenge, rate-limit, or other session-gating UI.
+- It may break when the Grok composer DOM, submit button behavior, or message bubble structure changes.

--- a/src/clis/grok/ask.test.ts
+++ b/src/clis/grok/ask.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './ask.js';
+
+describe('grok ask helpers', () => {
+  it('normalizes boolean flags for explicit web routing', () => {
+    expect(__test__.normalizeBooleanFlag(true)).toBe(true);
+    expect(__test__.normalizeBooleanFlag('true')).toBe(true);
+    expect(__test__.normalizeBooleanFlag('1')).toBe(true);
+    expect(__test__.normalizeBooleanFlag('yes')).toBe(true);
+    expect(__test__.normalizeBooleanFlag('on')).toBe(true);
+
+    expect(__test__.normalizeBooleanFlag(false)).toBe(false);
+    expect(__test__.normalizeBooleanFlag('false')).toBe(false);
+    expect(__test__.normalizeBooleanFlag(undefined)).toBe(false);
+  });
+
+  it('ignores baseline bubbles and the echoed prompt when choosing the latest assistant candidate', () => {
+    const candidate = __test__.pickLatestAssistantCandidate(
+      ['older assistant answer', 'Prompt text', 'Assistant draft', 'Assistant final'],
+      1,
+      'Prompt text',
+    );
+
+    expect(candidate).toBe('Assistant final');
+  });
+
+  it('returns empty when only the echoed prompt appeared after send', () => {
+    const candidate = __test__.pickLatestAssistantCandidate(
+      ['older assistant answer', 'Prompt text'],
+      1,
+      'Prompt text',
+    );
+
+    expect(candidate).toBe('');
+  });
+
+  it('tracks stabilization by incrementing repeats and resetting on changes', () => {
+    expect(__test__.updateStableState('', 0, 'First chunk')).toEqual({
+      previousText: 'First chunk',
+      stableCount: 0,
+    });
+
+    expect(__test__.updateStableState('First chunk', 0, 'First chunk')).toEqual({
+      previousText: 'First chunk',
+      stableCount: 1,
+    });
+
+    expect(__test__.updateStableState('First chunk', 1, 'Second chunk')).toEqual({
+      previousText: 'Second chunk',
+      stableCount: 0,
+    });
+  });
+});

--- a/src/clis/grok/ask.ts
+++ b/src/clis/grok/ask.ts
@@ -1,6 +1,290 @@
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
+const GROK_URL = 'https://grok.com/';
+const RESPONSE_SELECTOR = 'div.message-bubble, [data-testid="message-bubble"]';
+const BLOCKED_PREFIX = '[BLOCKED]';
+const NO_RESPONSE_PREFIX = '[NO RESPONSE]';
+const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
+
+type GrokSendResult = {
+  ok?: boolean;
+  msg?: string;
+  reason?: string;
+  detail?: string;
+};
+
+function blocked(message: string) {
+  return [{ response: `${BLOCKED_PREFIX} ${message} ${SESSION_HINT}` }];
+}
+
+function normalizeBubbleText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeBooleanFlag(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+
+function pickLatestAssistantCandidate(
+  bubbles: unknown[],
+  baselineCount: number,
+  prompt: string,
+): string {
+  const normalizedPrompt = prompt.trim();
+  const freshBubbles = bubbles
+    .slice(Math.max(0, baselineCount))
+    .map(normalizeBubbleText)
+    .filter(Boolean);
+
+  for (let i = freshBubbles.length - 1; i >= 0; i -= 1) {
+    if (freshBubbles[i] !== normalizedPrompt) return freshBubbles[i];
+  }
+
+  return '';
+}
+
+function updateStableState(previousText: string, stableCount: number, nextText: string) {
+  if (!nextText) return { previousText: '', stableCount: 0 };
+  if (nextText === previousText) return { previousText, stableCount: stableCount + 1 };
+  return { previousText: nextText, stableCount: 0 };
+}
+
+async function runDefaultAsk(
+  page: IPage,
+  prompt: string,
+  timeoutMs: number,
+  newChat: boolean,
+) {
+  if (newChat) {
+    await page.goto(GROK_URL);
+    await page.wait(2);
+    await page.evaluate(`(() => {
+      const btn = [...document.querySelectorAll('a, button')].find(b => {
+        const t = (b.textContent || '').trim().toLowerCase();
+        return t.includes('new') || b.getAttribute('href') === '/';
+      });
+      if (btn) btn.click();
+    })()`);
+    await page.wait(2);
+  }
+
+  await page.goto(GROK_URL);
+  await page.wait(3);
+
+  const promptJson = JSON.stringify(prompt);
+  const sendResult = await page.evaluate(`(async () => {
+    try {
+      const box = document.querySelector('textarea');
+      if (!box) return { ok: false, msg: 'no textarea' };
+      box.focus(); box.value = '';
+      document.execCommand('selectAll');
+      document.execCommand('insertText', false, ${promptJson});
+      await new Promise(r => setTimeout(r, 1500));
+      const btn = document.querySelector('button[aria-label="\\u63d0\\u4ea4"]');
+      if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
+      const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
+      if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
+      box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+      return { ok: true, msg: 'enter' };
+    } catch (e) { return { ok: false, msg: e.toString() }; }
+  })()`) as GrokSendResult;
+
+  if (!sendResult || !sendResult.ok) {
+    return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+  }
+
+  const startTime = Date.now();
+  let lastText = '';
+  let stableCount = 0;
+
+  while (Date.now() - startTime < timeoutMs) {
+    await page.wait(3);
+    const response = await page.evaluate(`(() => {
+      const bubbles = document.querySelectorAll('div.message-bubble, [data-testid="message-bubble"]');
+      if (bubbles.length < 2) return '';
+      const last = bubbles[bubbles.length - 1];
+      const text = (last.innerText || '').trim();
+      if (!text || text.length < 2) return '';
+      return text;
+    })()`);
+
+    if (response && response.length > 2) {
+      if (response === lastText) {
+        stableCount++;
+        if (stableCount >= 2) return [{ response }];
+      } else {
+        stableCount = 0;
+      }
+    }
+    lastText = response || '';
+  }
+
+  if (lastText) return [{ response: lastText }];
+  return [{ response: NO_RESPONSE_PREFIX }];
+}
+
+async function getBubbleTexts(page: IPage): Promise<string[]> {
+  const result = await page.evaluate(`(() => {
+    return Array.from(document.querySelectorAll(${JSON.stringify(RESPONSE_SELECTOR)}))
+      .map(node => (node instanceof HTMLElement ? node.innerText : node?.textContent || ''))
+      .map(text => (typeof text === 'string' ? text.trim() : ''))
+      .filter(Boolean);
+  })()`);
+
+  return Array.isArray(result) ? result.map(normalizeBubbleText).filter(Boolean) : [];
+}
+
+async function tryStartFreshChat(page: IPage): Promise<void> {
+  await page.evaluate(`(() => {
+    const isVisible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      const style = window.getComputedStyle(node);
+      return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+    };
+
+    const candidates = Array.from(document.querySelectorAll('a, button')).filter(node => {
+      if (!isVisible(node)) return false;
+      const text = (node.textContent || '').trim().toLowerCase();
+      const aria = (node.getAttribute('aria-label') || '').trim().toLowerCase();
+      const href = node.getAttribute('href') || '';
+      return text.includes('new chat')
+        || text.includes('new conversation')
+        || aria.includes('new chat')
+        || aria.includes('new conversation')
+        || href === '/';
+    });
+
+    const target = candidates[0];
+    if (target instanceof HTMLElement) target.click();
+  })()`);
+}
+
+async function sendPromptViaExplicitWeb(page: IPage, prompt: string) {
+  return page.evaluate(`(async () => {
+    const waitFor = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    const composerSelector = '.ProseMirror[contenteditable="true"]';
+    let composer = null;
+
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      const candidate = document.querySelector(composerSelector);
+      if (candidate instanceof HTMLElement) {
+        composer = candidate;
+        break;
+      }
+
+      await waitFor(1000);
+    }
+
+    if (!(composer instanceof HTMLElement)) {
+      return {
+        ok: false,
+        reason: 'Grok composer was not found on grok.com.',
+      };
+    }
+
+    const editor = composer.editor;
+    if (!editor?.commands?.focus || !editor?.commands?.insertContent) {
+      return {
+        ok: false,
+        reason: 'Grok composer editor API was unavailable.',
+      };
+    }
+
+    const isVisibleEnabledSubmit = (node) => {
+      if (!(node instanceof HTMLButtonElement)) return false;
+      const rect = node.getBoundingClientRect();
+      const style = window.getComputedStyle(node);
+      return !node.disabled
+        && rect.width > 0
+        && rect.height > 0
+        && style.visibility !== 'hidden'
+        && style.display !== 'none';
+    };
+
+    try {
+      if (editor.commands.clearContent) editor.commands.clearContent();
+      editor.commands.focus();
+      editor.commands.insertContent(${JSON.stringify(prompt)});
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'Failed to insert the prompt into the Grok composer.',
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    let submit = null;
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const candidate = Array.from(document.querySelectorAll('button[aria-label="Submit"]'))
+        .find(isVisibleEnabledSubmit);
+
+      if (candidate instanceof HTMLButtonElement) {
+        submit = candidate;
+        break;
+      }
+
+      await waitFor(500);
+    }
+
+    if (!(submit instanceof HTMLButtonElement)) {
+      return {
+        ok: false,
+        reason: 'Grok submit button did not reach a clickable ready state after prompt insertion.',
+      };
+    }
+
+    submit.click();
+    return { ok: true };
+  })()`);
+}
+
+async function runExplicitWebAsk(
+  page: IPage,
+  prompt: string,
+  timeoutMs: number,
+  newChat: boolean,
+) {
+  await page.goto(GROK_URL, { settleMs: 2000 });
+
+  if (newChat) {
+    await tryStartFreshChat(page);
+    await page.wait(2);
+  }
+
+  const baselineBubbles = await getBubbleTexts(page);
+  const sendResult = await sendPromptViaExplicitWeb(page, prompt) as GrokSendResult;
+
+  if (!sendResult?.ok) {
+    const details = sendResult?.detail ? ` ${sendResult.detail}` : '';
+    return blocked(`${sendResult?.reason || 'Unable to send the prompt to Grok.'}${details}`);
+  }
+
+  const startTime = Date.now();
+  let lastText = '';
+  let stableCount = 0;
+
+  while (Date.now() - startTime < timeoutMs) {
+    await page.wait(2);
+    const bubbleTexts = await getBubbleTexts(page);
+    const candidate = pickLatestAssistantCandidate(bubbleTexts, baselineBubbles.length, prompt);
+    const nextState = updateStableState(lastText, stableCount, candidate);
+    lastText = nextState.previousText;
+    stableCount = nextState.stableCount;
+
+    if (candidate && stableCount >= 2) {
+      return [{ response: candidate }];
+    }
+  }
+
+  if (lastText) return [{ response: lastText }];
+  return [{ response: `${NO_RESPONSE_PREFIX} No new assistant message bubble appeared within ${Math.round(timeoutMs / 1000)}s.` }];
+}
+
 export const askCommand = cli({
   site: 'grok',
   name: 'ask',
@@ -9,82 +293,29 @@ export const askCommand = cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'prompt', type: 'string', required: true },
-    { name: 'timeout', type: 'int', default: 120 },
-    { name: 'new', type: 'boolean', default: false },
+    { name: 'prompt', type: 'string', required: true, help: 'Prompt to send to Grok' },
+    { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response (default: 120)' },
+    { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending (default: false)' },
+    { name: 'web', type: 'boolean', default: false, help: 'Use the explicit grok.com consumer web flow (default: false)' },
   ],
   columns: ['response'],
   func: async (page: IPage, kwargs: Record<string, any>) => {
     const prompt = kwargs.prompt as string;
     const timeoutMs = ((kwargs.timeout as number) || 120) * 1000;
-    const newChat = kwargs.new as boolean;
+    const newChat = normalizeBooleanFlag(kwargs.new);
+    const useExplicitWeb = normalizeBooleanFlag(kwargs.web);
 
-    if (newChat) {
-      await page.goto('https://grok.com');
-      await page.wait(2);
-      await page.evaluate(`(() => {
-        const btn = [...document.querySelectorAll('a, button')].find(b => {
-          const t = (b.textContent || '').trim().toLowerCase();
-          return t.includes('new') || b.getAttribute('href') === '/';
-        });
-        if (btn) btn.click();
-      })()`);
-      await page.wait(2);
+    if (useExplicitWeb) {
+      return runExplicitWebAsk(page, prompt, timeoutMs, newChat);
     }
 
-    await page.goto('https://grok.com');
-    await page.wait(3);
-
-    const promptJson = JSON.stringify(prompt);
-
-    const sendResult = await page.evaluate(`(async () => {
-      try {
-        const box = document.querySelector('textarea');
-        if (!box) return { ok: false, msg: 'no textarea' };
-        box.focus(); box.value = '';
-        document.execCommand('selectAll');
-        document.execCommand('insertText', false, ${promptJson});
-        await new Promise(r => setTimeout(r, 1500));
-        const btn = document.querySelector('button[aria-label="\\u63d0\\u4ea4"]');
-        if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
-        const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
-        if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
-        box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
-        return { ok: true, msg: 'enter' };
-      } catch (e) { return { ok: false, msg: e.toString() }; }
-    })()`);
-
-    if (!sendResult || !sendResult.ok) {
-      return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
-    }
-
-    const startTime = Date.now();
-    let lastText = '';
-    let stableCount = 0;
-
-    while (Date.now() - startTime < timeoutMs) {
-      await page.wait(3);
-      const response = await page.evaluate(`(() => {
-        const bubbles = document.querySelectorAll('div.message-bubble, [data-testid="message-bubble"]');
-        if (bubbles.length < 2) return '';
-        const last = bubbles[bubbles.length - 1];
-        const text = (last.innerText || '').trim();
-        if (!text || text.length < 2) return '';
-        return text;
-      })()`);
-
-      if (response && response.length > 2) {
-        if (response === lastText) {
-          stableCount++;
-          if (stableCount >= 2) return [{ response }];
-        } else {
-          stableCount = 0;
-        }
-      }
-      lastText = response || '';
-    }
-
-    if (lastText) return [{ response: lastText }];
-    return [{ response: '[NO RESPONSE]' }];
+    return runDefaultAsk(page, prompt, timeoutMs, newChat);
   },
 });
+
+export const __test__ = {
+  pickLatestAssistantCandidate,
+  updateStableState,
+  normalizeBooleanFlag,
+  normalizeBubbleText,
+};


### PR DESCRIPTION
## Summary
- preserve the existing default `opencli grok ask` behavior
- add an explicit `--web` flag for the hardened browser-backed consumer web flow
- update Grok docs/examples to make the default vs opt-in web path clear

## Compatibility
- default `opencli grok ask --prompt ...` remains the existing/default implementation
- only `opencli grok ask --prompt ... --web` activates the newer grok.com consumer web path
- existing main args and default response shape stay intact by default

## Notes
- the `--web` flow requires an already-authenticated `grok.com` browser session
- this is still consumer-web automation and may be brittle around auth/session/challenge or DOM changes

## Validation
- `npx tsc --noEmit`
- `npx vitest run src/clis/grok/ask.test.ts`
- `npm run build`
- `npx tsx src/main.ts grok ask --prompt "Reply with exactly OK and nothing else." --web -f json`
