### PR TITLE
fix(docs): remove dead link to deleted github adapter

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -74,7 +74,6 @@ export default defineConfig({
               collapsed: false,
               items: [
                 { text: 'HackerNews', link: '/adapters/browser/hackernews' },
-                { text: 'GitHub', link: '/adapters/browser/github' },
                 { text: 'BBC', link: '/adapters/browser/bbc' },
                 { text: 'Apple Podcasts', link: '/adapters/browser/apple-podcasts' },
                 { text: 'Xiaoyuzhou', link: '/adapters/browser/xiaoyuzhou' },

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -34,7 +34,6 @@ Run `opencli list` for the live registry.
 | Site | Commands | Mode |
 |------|----------|------|
 | **[hackernews](/adapters/browser/hackernews)** | `top` | 🌐 Public |
-| **[github](/adapters/browser/github)** | `search` | 🌐 Public |
 | **[bbc](/adapters/browser/bbc)** | `news` | 🌐 Public |
 | **[apple-podcasts](/adapters/browser/apple-podcasts)** | `search` `episodes` `top` | 🌐 Public |
 | **[xiaoyuzhou](/adapters/browser/xiaoyuzhou)** | `podcast` `podcast-episodes` `episode` | 🌐 Public |


### PR DESCRIPTION
## Problem

Commit 644b8bc removed the github adapter but left dead links in:
- `docs/adapters/index.md` (Public API Adapters table)
- `docs/.vitepress/config.mts` (sidebar)

This caused VitePress `docs:build` to fail with dead link error, breaking the Doc Coverage CI check on all open PRs.

## Fix

Removed the github adapter entries from both files.