### PR TITLE
docs(plugin): add juejin plugin to example plugins

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -135,6 +135,7 @@ On startup, if both `my-command.ts` and `my-command.js` exist, the `.js` version
 |------|------|-------------|
 | [opencli-plugin-github-trending](https://github.com/ByteYue/opencli-plugin-github-trending) | YAML | GitHub Trending repositories |
 | [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | TS | Multi-platform trending aggregator (zhihu, weibo, bilibili, v2ex, stackoverflow, reddit, linux-do) |
+| [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | YAML | 稀土掘金 (Juejin) hot articles, categories, and article feed |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) to the Example Plugins table in `docs/guide/plugins.md`
- YAML plugin with 3 commands: hot (热榜), categories (分类列表), articles (分类文章)

## Test plan

- Documentation change only, no code affected