### PR TITLE
feat(browser): Advanced DOM Snapshot Engine — 13-layer pruning pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build",
-    "test": "vitest run",
-    "test:site": "node scripts/test-site.mjs",
-    "test:watch": "vitest",
+    "test": "vitest run --project unit",
+    "test:all": "vitest run",
+    "test:e2e": "vitest run --project e2e",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -11,6 +11,7 @@
 import { WebSocket, type RawData } from 'ws';
 import type { IPage } from '../types.js';
 import { wrapForEval } from './utils.js';
+import { generateSnapshotJs, scrollToRefJs, getFormStateJs } from './dom-snapshot.js';
 import {
   clickJs,
   typeTextJs,
@@ -193,9 +194,16 @@ class CDPPage implements IPage {
       : cookies;
   }
 
-  async snapshot(_opts?: any): Promise<any> {
-    // CDP doesn't have a built-in accessibility tree equivalent without additional setup
-    return '(snapshot not available in CDP mode)';
+  async snapshot(opts: { interactive?: boolean; compact?: boolean; maxDepth?: number; raw?: boolean; viewportExpand?: number; maxTextLength?: number } = {}): Promise<any> {
+    const snapshotJs = generateSnapshotJs({
+      viewportExpand: opts.viewportExpand ?? 800,
+      maxDepth: Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200)),
+      interactiveOnly: opts.interactive ?? false,
+      maxTextLength: opts.maxTextLength ?? 120,
+      includeScrollInfo: true,
+      bboxDedup: true,
+    });
+    return this.evaluate(snapshotJs);
   }
 
   // ── Shared DOM operations (P1 fix #5 — using dom-helpers.ts) ──
@@ -210,6 +218,14 @@ class CDPPage implements IPage {
 
   async pressKey(key: string): Promise<void> {
     await this.evaluate(pressKeyJs(key));
+  }
+
+  async scrollTo(ref: string): Promise<any> {
+    return this.evaluate(scrollToRefJs(ref));
+  }
+
+  async getFormState(): Promise<any> {
+    return this.evaluate(getFormStateJs());
   }
 
   async wait(options: any): Promise<void> {

--- a/src/browser/dom-helpers.ts
+++ b/src/browser/dom-helpers.ts
@@ -11,8 +11,21 @@ export function clickJs(ref: string): string {
   return `
     (() => {
       const ref = ${safeRef};
-      const el = document.querySelector('[data-ref="' + ref + '"]')
-        || document.querySelectorAll('a, button, input, [role="button"], [tabindex]')[parseInt(ref, 10) || 0];
+      // 1. data-opencli-ref (set by snapshot engine)
+      let el = document.querySelector('[data-opencli-ref="' + ref + '"]');
+      // 2. data-ref (legacy)
+      if (!el) el = document.querySelector('[data-ref="' + ref + '"]');
+      // 3. CSS selector
+      if (!el && ref.match(/^[a-zA-Z#.\\[]/)) {
+        try { el = document.querySelector(ref); } catch {}
+      }
+      // 4. Numeric index into interactive elements
+      if (!el) {
+        const idx = parseInt(ref, 10);
+        if (!isNaN(idx)) {
+          el = document.querySelectorAll('a, button, input, select, textarea, [role="button"], [tabindex]:not([tabindex="-1"])')[idx];
+        }
+      }
       if (!el) throw new Error('Element not found: ' + ref);
       el.scrollIntoView({ behavior: 'instant', block: 'center' });
       el.click();
@@ -28,13 +41,31 @@ export function typeTextJs(ref: string, text: string): string {
   return `
     (() => {
       const ref = ${safeRef};
-      const el = document.querySelector('[data-ref="' + ref + '"]')
-        || document.querySelectorAll('input, textarea, [contenteditable]')[parseInt(ref, 10) || 0];
+      // 1. data-opencli-ref (set by snapshot engine)
+      let el = document.querySelector('[data-opencli-ref="' + ref + '"]');
+      // 2. data-ref (legacy)
+      if (!el) el = document.querySelector('[data-ref="' + ref + '"]');
+      // 3. CSS selector
+      if (!el && ref.match(/^[a-zA-Z#.\\[]/)) {
+        try { el = document.querySelector(ref); } catch {}
+      }
+      // 4. Numeric index into typeable elements
+      if (!el) {
+        const idx = parseInt(ref, 10);
+        if (!isNaN(idx)) {
+          el = document.querySelectorAll('input, textarea, [contenteditable="true"]')[idx];
+        }
+      }
       if (!el) throw new Error('Element not found: ' + ref);
       el.focus();
-      el.value = ${safeText};
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-      el.dispatchEvent(new Event('change', { bubbles: true }));
+      if (el.isContentEditable) {
+        el.textContent = ${safeText};
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      } else {
+        el.value = ${safeText};
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      }
       return 'typed';
     })()
   `;

--- a/src/browser/dom-snapshot.test.ts
+++ b/src/browser/dom-snapshot.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for dom-snapshot.ts: DOM snapshot engine.
+ *
+ * Since the engine generates JavaScript strings for in-page evaluation,
+ * these tests validate:
+ * 1. The generated code is syntactically valid JS
+ * 2. Options are correctly embedded
+ * 3. The output structure matches expected format
+ * 4. All features are present (Shadow DOM, iframe, table, diff, etc.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateSnapshotJs, scrollToRefJs, getFormStateJs } from './dom-snapshot.js';
+
+describe('generateSnapshotJs', () => {
+  it('returns a non-empty string', () => {
+    const js = generateSnapshotJs();
+    expect(typeof js).toBe('string');
+    expect(js.length).toBeGreaterThan(100);
+  });
+
+  it('generates syntactically valid JS (can be parsed)', () => {
+    const js = generateSnapshotJs();
+    expect(() => new Function(js)).not.toThrow();
+  });
+
+  it('embeds default options correctly', () => {
+    const js = generateSnapshotJs();
+    expect(js).toContain('VIEWPORT_EXPAND = 800');
+    expect(js).toContain('MAX_DEPTH = 50');
+    expect(js).toContain('INTERACTIVE_ONLY = false');
+    expect(js).toContain('MAX_TEXT_LEN = 120');
+    expect(js).toContain('INCLUDE_SCROLL_INFO = true');
+    expect(js).toContain('BBOX_DEDUP = true');
+    expect(js).toContain('INCLUDE_SHADOW_DOM = true');
+    expect(js).toContain('INCLUDE_IFRAMES = true');
+    expect(js).toContain('PAINT_ORDER_CHECK = true');
+    expect(js).toContain('ANNOTATE_REFS = true');
+    expect(js).toContain('REPORT_HIDDEN = true');
+    expect(js).toContain('FILTER_ADS = true');
+    expect(js).toContain('MARKDOWN_TABLES = true');
+    expect(js).toContain('PREV_HASHES = null');
+  });
+
+  it('embeds custom options correctly', () => {
+    const js = generateSnapshotJs({
+      viewportExpand: 2000,
+      maxDepth: 30,
+      interactiveOnly: true,
+      maxTextLength: 200,
+      includeScrollInfo: false,
+      bboxDedup: false,
+      includeShadowDom: false,
+      includeIframes: false,
+      maxIframes: 3,
+      paintOrderCheck: false,
+      annotateRefs: false,
+      reportHidden: false,
+      filterAds: false,
+      markdownTables: false,
+    });
+    expect(js).toContain('VIEWPORT_EXPAND = 2000');
+    expect(js).toContain('MAX_DEPTH = 30');
+    expect(js).toContain('INTERACTIVE_ONLY = true');
+    expect(js).toContain('MAX_TEXT_LEN = 200');
+    expect(js).toContain('INCLUDE_SCROLL_INFO = false');
+    expect(js).toContain('BBOX_DEDUP = false');
+    expect(js).toContain('INCLUDE_SHADOW_DOM = false');
+    expect(js).toContain('INCLUDE_IFRAMES = false');
+    expect(js).toContain('MAX_IFRAMES = 3');
+    expect(js).toContain('PAINT_ORDER_CHECK = false');
+    expect(js).toContain('ANNOTATE_REFS = false');
+    expect(js).toContain('REPORT_HIDDEN = false');
+    expect(js).toContain('FILTER_ADS = false');
+    expect(js).toContain('MARKDOWN_TABLES = false');
+  });
+
+  it('clamps maxDepth between 1 and 200', () => {
+    expect(generateSnapshotJs({ maxDepth: -5 })).toContain('MAX_DEPTH = 1');
+    expect(generateSnapshotJs({ maxDepth: 999 })).toContain('MAX_DEPTH = 200');
+    expect(generateSnapshotJs({ maxDepth: 75 })).toContain('MAX_DEPTH = 75');
+  });
+
+  it('wraps output as an IIFE', () => {
+    const js = generateSnapshotJs();
+    expect(js.startsWith('(() =>')).toBe(true);
+    expect(js.trimEnd().endsWith(')()')).toBe(true);
+  });
+
+  it('embeds previousHashes for incremental diff', () => {
+    const hashes = JSON.stringify(['12345', '67890']);
+    const js = generateSnapshotJs({ previousHashes: hashes });
+    expect(js).toContain('new Set(["12345","67890"])');
+  });
+
+  it('includes all core features in generated code', () => {
+    const js = generateSnapshotJs();
+
+    // Tag filtering
+    expect(js).toContain('SKIP_TAGS');
+    expect(js).toContain("'script'");
+    expect(js).toContain("'style'");
+
+    // SVG collapsing
+    expect(js).toContain('SVG_CHILDREN');
+
+    // Interactive detection
+    expect(js).toContain('INTERACTIVE_TAGS');
+    expect(js).toContain('INTERACTIVE_ROLES');
+    expect(js).toContain('isInteractive');
+
+    // Visibility
+    expect(js).toContain('isVisibleByCSS');
+    expect(js).toContain('isInExpandedViewport');
+
+    // BBox dedup
+    expect(js).toContain('isContainedBy');
+    expect(js).toContain('PROPAGATING_TAGS');
+
+    // Shadow DOM
+    expect(js).toContain('shadowRoot');
+    expect(js).toContain('|shadow|');
+
+    // iframe
+    expect(js).toContain('walkIframe');
+    expect(js).toContain('|iframe|');
+
+    // Paint order
+    expect(js).toContain('isOccludedByOverlay');
+    expect(js).toContain('elementFromPoint');
+
+    // Ad filtering
+    expect(js).toContain('isAdElement');
+    expect(js).toContain('AD_PATTERNS');
+
+    // data-ref annotation
+    expect(js).toContain('data-opencli-ref');
+
+    // Hidden elements report
+    expect(js).toContain('hiddenInteractives');
+    expect(js).toContain('hidden_interactive');
+
+    // Incremental diff
+    expect(js).toContain('hashElement');
+    expect(js).toContain('currentHashes');
+    expect(js).toContain('__opencli_prev_hashes');
+
+    // Table serialization
+    expect(js).toContain('serializeTable');
+    expect(js).toContain('|table|');
+
+    // Synthetic attributes
+    expect(js).toContain("'YYYY-MM-DD'");
+    expect(js).toContain('value=••••');
+
+    // Page metadata
+    expect(js).toContain('location.href');
+    expect(js).toContain('document.title');
+  });
+
+  it('contains proper attribute whitelist', () => {
+    const js = generateSnapshotJs();
+    const expectedAttrs = [
+      'aria-label', 'aria-expanded', 'aria-checked', 'aria-selected',
+      'placeholder', 'href', 'role', 'data-testid', 'autocomplete',
+    ];
+    for (const attr of expectedAttrs) {
+      expect(js).toContain(`'${attr}'`);
+    }
+  });
+
+  it('includes scroll info formatting', () => {
+    const js = generateSnapshotJs();
+    expect(js).toContain('scrollHeight');
+    expect(js).toContain('scrollTop');
+    expect(js).toContain('|scroll|');
+    expect(js).toContain('page_scroll');
+  });
+});
+
+describe('scrollToRefJs', () => {
+  it('generates valid JS', () => {
+    const js = scrollToRefJs('42');
+    expect(() => new Function(js)).not.toThrow();
+  });
+
+  it('targets data-opencli-ref', () => {
+    const js = scrollToRefJs('7');
+    expect(js).toContain('data-opencli-ref');
+    expect(js).toContain('scrollIntoView');
+    expect(js).toContain('"7"');
+  });
+
+  it('falls back to data-ref', () => {
+    const js = scrollToRefJs('3');
+    expect(js).toContain('data-ref');
+  });
+
+  it('returns scrolled info', () => {
+    const js = scrollToRefJs('1');
+    expect(js).toContain('scrolled: true');
+    expect(js).toContain('tag:');
+  });
+});
+
+describe('getFormStateJs', () => {
+  it('generates valid JS', () => {
+    const js = getFormStateJs();
+    expect(() => new Function(js)).not.toThrow();
+  });
+
+  it('collects form elements', () => {
+    const js = getFormStateJs();
+    expect(js).toContain('document.forms');
+    expect(js).toContain('form.elements');
+  });
+
+  it('collects orphan fields', () => {
+    const js = getFormStateJs();
+    expect(js).toContain('orphanFields');
+    expect(js).toContain('el.form');
+  });
+
+  it('handles different input types', () => {
+    const js = getFormStateJs();
+    expect(js).toContain('checkbox');
+    expect(js).toContain('radio');
+    expect(js).toContain('password');
+    expect(js).toContain('contenteditable');
+  });
+
+  it('extracts labels', () => {
+    const js = getFormStateJs();
+    expect(js).toContain('aria-label');
+    expect(js).toContain('label[for=');
+    expect(js).toContain('closest');
+    expect(js).toContain('placeholder');
+  });
+
+  it('masks passwords', () => {
+    const js = getFormStateJs();
+    expect(js).toContain('••••');
+  });
+
+  it('includes data-opencli-ref in output', () => {
+    const js = getFormStateJs();
+    expect(js).toContain('data-opencli-ref');
+  });
+});

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -1,0 +1,770 @@
+/**
+ * DOM Snapshot Engine — Advanced DOM pruning for LLM consumption.
+ *
+ * Inspired by browser-use's multi-layer pruning pipeline, adapted for opencli's
+ * Chrome Extension + CDP architecture. Runs entirely in-page via Runtime.evaluate.
+ *
+ * Pipeline:
+ *   1. Walk DOM tree, collect visibility + layout + interactivity signals
+ *   2. Prune invisible, zero-area, non-content elements
+ *   3. SVG & decoration collapse
+ *   4. Shadow DOM traversal
+ *   5. Same-origin iframe content extraction
+ *   6. Bounding-box parent-child dedup (link/button wrapping children)
+ *   7. Paint-order occlusion detection (overlay/modal coverage)
+ *   8. Attribute whitelist filtering
+ *   9. Table-aware serialization (markdown tables)
+ *  10. Token-efficient serialization with interactive indices
+ *  11. data-ref annotation for click/type targeting
+ *  12. Hidden interactive element hints (scroll-to-reveal)
+ *  13. Incremental diff (mark new elements with *)
+ *
+ * Additional tools:
+ *   - scrollToRefJs(ref) — scroll to a data-opencli-ref element
+ *   - getFormStateJs()  — extract all form fields as structured JSON
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export interface SnapshotOptions {
+  /** Extra pixels beyond viewport to include (default 800) */
+  viewportExpand?: number;
+  /** Maximum DOM depth to traverse (default 50) */
+  maxDepth?: number;
+  /** Only emit interactive elements and their landmark ancestors */
+  interactiveOnly?: boolean;
+  /** Maximum text content length per node (default 120) */
+  maxTextLength?: number;
+  /** Include scroll position info on scrollable containers (default true) */
+  includeScrollInfo?: boolean;
+  /** Enable bounding-box parent-child dedup (default true) */
+  bboxDedup?: boolean;
+  /** Traverse Shadow DOM roots (default true) */
+  includeShadowDom?: boolean;
+  /** Extract same-origin iframe content (default true) */
+  includeIframes?: boolean;
+  /** Maximum number of iframes to process (default 5) */
+  maxIframes?: number;
+  /** Enable paint-order occlusion detection (default true) */
+  paintOrderCheck?: boolean;
+  /** Annotate interactive elements with data-opencli-ref (default true) */
+  annotateRefs?: boolean;
+  /** Report hidden interactive elements outside viewport (default true) */
+  reportHidden?: boolean;
+  /** Filter ad/noise elements (default true) */
+  filterAds?: boolean;
+  /** Serialize tables as markdown (default true) */
+  markdownTables?: boolean;
+  /** Previous snapshot hash set (JSON array of hashes) for diff marking (default null) */
+  previousHashes?: string | null;
+}
+
+// ─── Utility JS Generators ───────────────────────────────────────────
+
+/**
+ * Generate JS to scroll to an element identified by data-opencli-ref.
+ * Completes the snapshot→action loop: snapshot identifies `[3]<button>`,
+ * caller can then `scrollToRef('3')` to bring it into view.
+ */
+export function scrollToRefJs(ref: string): string {
+  const safeRef = JSON.stringify(ref);
+  return `
+    (() => {
+      const ref = ${safeRef};
+      const el = document.querySelector('[data-opencli-ref="' + ref + '"]')
+        || document.querySelector('[data-ref="' + ref + '"]');
+      if (!el) throw new Error('Element not found: ref=' + ref);
+      el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      return { scrolled: true, tag: el.tagName.toLowerCase(), text: (el.textContent || '').trim().slice(0, 80) };
+    })()
+  `.trim();
+}
+
+/**
+ * Generate JS to extract all form field values from the page.
+ * Returns structured JSON: { forms: [{ id, action, fields: [{ tag, type, name, value, ... }] }] }
+ */
+export function getFormStateJs(): string {
+  return `
+    (() => {
+      const result = { forms: [], orphanFields: [] };
+
+      // Collect all forms
+      for (const form of document.forms) {
+        const formData = {
+          id: form.id || null,
+          name: form.name || null,
+          action: form.action || null,
+          method: (form.method || 'get').toUpperCase(),
+          fields: [],
+        };
+        for (const el of form.elements) {
+          const field = extractField(el);
+          if (field) formData.fields.push(field);
+        }
+        if (formData.fields.length > 0) result.forms.push(formData);
+      }
+
+      // Collect orphan fields (not inside a form)
+      const allInputs = document.querySelectorAll('input, textarea, select, [contenteditable="true"]');
+      for (const el of allInputs) {
+        if (el.form) continue; // already in a form
+        const field = extractField(el);
+        if (field) result.orphanFields.push(field);
+      }
+
+      function extractField(el) {
+        const tag = el.tagName.toLowerCase();
+        const type = (el.getAttribute('type') || (tag === 'textarea' ? 'textarea' : tag === 'select' ? 'select' : 'text')).toLowerCase();
+        if (type === 'hidden' || type === 'submit' || type === 'button' || type === 'reset') return null;
+        const name = el.name || el.id || null;
+        const ref = el.getAttribute('data-opencli-ref') || null;
+        const label = findLabel(el);
+        let value;
+        if (tag === 'select') {
+          const opt = el.options?.[el.selectedIndex];
+          value = opt ? opt.textContent.trim() : '';
+        } else if (type === 'checkbox' || type === 'radio') {
+          value = el.checked;
+        } else if (type === 'password') {
+          value = el.value ? '••••' : '';
+        } else if (el.isContentEditable) {
+          value = (el.textContent || '').trim().slice(0, 200);
+        } else {
+          value = (el.value || '').slice(0, 200);
+        }
+        return { tag, type, name, ref, label, value, required: el.required || false, disabled: el.disabled || false };
+      }
+
+      function findLabel(el) {
+        // 1. aria-label
+        if (el.getAttribute('aria-label')) return el.getAttribute('aria-label');
+        // 2. associated <label>
+        if (el.id) {
+          const label = document.querySelector('label[for="' + el.id + '"]');
+          if (label) return label.textContent.trim().slice(0, 80);
+        }
+        // 3. parent label
+        const parentLabel = el.closest('label');
+        if (parentLabel) return parentLabel.textContent.trim().slice(0, 80);
+        // 4. placeholder
+        return el.placeholder || null;
+      }
+
+      return result;
+    })()
+  `.trim();
+}
+
+// ─── Main Snapshot JS Generator ──────────────────────────────────────
+
+/**
+ * Generate JavaScript code that, when evaluated in a page context via CDP
+ * Runtime.evaluate, returns a pruned DOM snapshot string optimised for LLMs.
+ *
+ * The snapshot output format:
+ *   [42]<button type=submit>Search</button>
+ *   |scroll|<div> (0.5↑ 3.2↓)
+ *     *[58]<a href=/r/1>Result 1</a>
+ *     [59]<a href=/r/2>Result 2</a>
+ *
+ * - `[id]` — interactive element with backend index for targeting
+ * - `*` prefix — newly appeared element (incremental diff)
+ * - `|scroll|` — scrollable container with page counts
+ * - `|shadow|` — Shadow DOM boundary
+ * - `|iframe|` — iframe content
+ * - `|table|` — markdown table rendering
+ */
+export function generateSnapshotJs(opts: SnapshotOptions = {}): string {
+  const viewportExpand = opts.viewportExpand ?? 800;
+  const maxDepth = Math.max(1, Math.min(opts.maxDepth ?? 50, 200));
+  const interactiveOnly = opts.interactiveOnly ?? false;
+  const maxTextLength = opts.maxTextLength ?? 120;
+  const includeScrollInfo = opts.includeScrollInfo ?? true;
+  const bboxDedup = opts.bboxDedup ?? true;
+  const includeShadowDom = opts.includeShadowDom ?? true;
+  const includeIframes = opts.includeIframes ?? true;
+  const maxIframes = opts.maxIframes ?? 5;
+  const paintOrderCheck = opts.paintOrderCheck ?? true;
+  const annotateRefs = opts.annotateRefs ?? true;
+  const reportHidden = opts.reportHidden ?? true;
+  const filterAds = opts.filterAds ?? true;
+  const markdownTables = opts.markdownTables ?? true;
+  const previousHashes = opts.previousHashes ?? null;
+
+  return `
+(() => {
+  'use strict';
+
+  // ── Config ─────────────────────────────────────────────────────────
+  const VIEWPORT_EXPAND = ${viewportExpand};
+  const MAX_DEPTH = ${maxDepth};
+  const INTERACTIVE_ONLY = ${interactiveOnly};
+  const MAX_TEXT_LEN = ${maxTextLength};
+  const INCLUDE_SCROLL_INFO = ${includeScrollInfo};
+  const BBOX_DEDUP = ${bboxDedup};
+  const INCLUDE_SHADOW_DOM = ${includeShadowDom};
+  const INCLUDE_IFRAMES = ${includeIframes};
+  const MAX_IFRAMES = ${maxIframes};
+  const PAINT_ORDER_CHECK = ${paintOrderCheck};
+  const ANNOTATE_REFS = ${annotateRefs};
+  const REPORT_HIDDEN = ${reportHidden};
+  const FILTER_ADS = ${filterAds};
+  const MARKDOWN_TABLES = ${markdownTables};
+  const PREV_HASHES = ${previousHashes ? `new Set(${previousHashes})` : 'null'};
+
+  // ── Constants ──────────────────────────────────────────────────────
+
+  const SKIP_TAGS = new Set([
+    'script', 'style', 'noscript', 'link', 'meta', 'head',
+    'template', 'br', 'wbr', 'col', 'colgroup',
+  ]);
+
+  const SVG_CHILDREN = new Set([
+    'path', 'rect', 'g', 'circle', 'ellipse', 'line', 'polyline',
+    'polygon', 'use', 'defs', 'clippath', 'mask', 'pattern',
+    'text', 'tspan', 'lineargradient', 'radialgradient', 'stop',
+    'filter', 'fegaussianblur', 'fecolormatrix', 'feblend',
+    'symbol', 'marker', 'foreignobject', 'desc', 'title',
+  ]);
+
+  const INTERACTIVE_TAGS = new Set([
+    'a', 'button', 'input', 'select', 'textarea', 'details',
+    'summary', 'option', 'optgroup',
+  ]);
+
+  const INTERACTIVE_ROLES = new Set([
+    'button', 'link', 'menuitem', 'option', 'radio', 'checkbox',
+    'tab', 'textbox', 'combobox', 'slider', 'spinbutton',
+    'searchbox', 'switch', 'menuitemcheckbox', 'menuitemradio',
+    'treeitem', 'gridcell', 'row',
+  ]);
+
+  const LANDMARK_ROLES = new Set([
+    'main', 'navigation', 'banner', 'search', 'region',
+    'complementary', 'contentinfo', 'form', 'dialog',
+  ]);
+
+  const LANDMARK_TAGS = new Set([
+    'nav', 'main', 'header', 'footer', 'aside', 'form',
+    'search', 'dialog', 'section', 'article',
+  ]);
+
+  const ATTR_WHITELIST = new Set([
+    'id', 'name', 'type', 'value', 'placeholder', 'title', 'alt',
+    'role', 'aria-label', 'aria-expanded', 'aria-checked', 'aria-selected',
+    'aria-disabled', 'aria-valuemin', 'aria-valuemax', 'aria-valuenow',
+    'aria-haspopup', 'aria-live', 'aria-required',
+    'href', 'src', 'action', 'method', 'for', 'checked', 'selected',
+    'disabled', 'required', 'multiple', 'accept', 'min', 'max',
+    'pattern', 'maxlength', 'minlength', 'data-testid', 'data-test',
+    'contenteditable', 'tabindex', 'autocomplete',
+  ]);
+
+  const PROPAGATING_TAGS = new Set(['a', 'button']);
+
+  const AD_PATTERNS = [
+    'googleadservices.com', 'doubleclick.net', 'googlesyndication.com',
+    'facebook.com/tr', 'analytics.google.com', 'connect.facebook.net',
+    'ad.doubleclick', 'pagead', 'adsense',
+  ];
+
+  const AD_SELECTOR_RE = /\\b(ad[_-]?(?:banner|container|wrapper|slot|unit|block|frame|leaderboard|sidebar)|google[_-]?ad|sponsored|adsbygoogle|banner[_-]?ad)\\b/i;
+
+  // ── Viewport & Layout Helpers ──────────────────────────────────────
+
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  function isInExpandedViewport(rect) {
+    if (!rect || (rect.width === 0 && rect.height === 0)) return false;
+    return rect.bottom > -VIEWPORT_EXPAND && rect.top < vh + VIEWPORT_EXPAND &&
+           rect.right > -VIEWPORT_EXPAND && rect.left < vw + VIEWPORT_EXPAND;
+  }
+
+  function isVisibleByCSS(el) {
+    const style = el.style;
+    if (style.display === 'none') return false;
+    if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+    if (style.opacity === '0') return false;
+    try {
+      const cs = window.getComputedStyle(el);
+      if (cs.display === 'none') return false;
+      if (cs.visibility === 'hidden') return false;
+      if (parseFloat(cs.opacity) <= 0) return false;
+      if (cs.clip === 'rect(0px, 0px, 0px, 0px)' && cs.position === 'absolute') return false;
+      if (cs.overflow === 'hidden' && el.offsetWidth === 0 && el.offsetHeight === 0) return false;
+    } catch {}
+    return true;
+  }
+
+  // ── Paint Order Occlusion ──────────────────────────────────────────
+
+  function isOccludedByOverlay(el) {
+    if (!PAINT_ORDER_CHECK) return false;
+    try {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return false;
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      if (cx < 0 || cy < 0 || cx > vw || cy > vh) return false;
+      const topEl = document.elementFromPoint(cx, cy);
+      if (!topEl || topEl === el || el.contains(topEl) || topEl.contains(el)) return false;
+      const cs = window.getComputedStyle(topEl);
+      if (parseFloat(cs.opacity) < 0.5) return false;
+      const bg = cs.backgroundColor;
+      if (bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') return false;
+      return true;
+    } catch { return false; }
+  }
+
+  // ── Ad/Noise Detection ─────────────────────────────────────────────
+
+  function isAdElement(el) {
+    if (!FILTER_ADS) return false;
+    try {
+      const id = el.id || '';
+      const cls = el.className || '';
+      const testStr = id + ' ' + (typeof cls === 'string' ? cls : '');
+      if (AD_SELECTOR_RE.test(testStr)) return true;
+      if (el.tagName === 'IFRAME') {
+        const src = el.src || '';
+        for (const p of AD_PATTERNS) { if (src.includes(p)) return true; }
+      }
+      if (el.hasAttribute('data-ad') || el.hasAttribute('data-ad-slot') ||
+          el.hasAttribute('data-adunit') || el.hasAttribute('data-google-query-id')) return true;
+    } catch {}
+    return false;
+  }
+
+  // ── Interactivity Detection ────────────────────────────────────────
+
+  function isInteractive(el) {
+    const tag = el.tagName.toLowerCase();
+    if (INTERACTIVE_TAGS.has(tag)) {
+      if (tag === 'label' && el.hasAttribute('for')) return false;
+      if (el.disabled && (tag === 'button' || tag === 'input')) return false;
+      return true;
+    }
+    const role = el.getAttribute('role');
+    if (role && INTERACTIVE_ROLES.has(role)) return true;
+    if (el.hasAttribute('onclick') || el.hasAttribute('onmousedown') || el.hasAttribute('ontouchstart')) return true;
+    if (el.hasAttribute('tabindex') && el.getAttribute('tabindex') !== '-1') return true;
+    try { if (window.getComputedStyle(el).cursor === 'pointer') return true; } catch {}
+    if (el.isContentEditable && el.getAttribute('contenteditable') !== 'false') return true;
+    return false;
+  }
+
+  function isLandmark(el) {
+    const role = el.getAttribute('role');
+    if (role && LANDMARK_ROLES.has(role)) return true;
+    return LANDMARK_TAGS.has(el.tagName.toLowerCase());
+  }
+
+  // ── Scrollability Detection ────────────────────────────────────────
+
+  function getScrollInfo(el) {
+    if (!INCLUDE_SCROLL_INFO) return null;
+    const sh = el.scrollHeight, ch = el.clientHeight;
+    const sw = el.scrollWidth, cw = el.clientWidth;
+    const isV = sh > ch + 5, isH = sw > cw + 5;
+    if (!isV && !isH) return null;
+    try {
+      const cs = window.getComputedStyle(el);
+      const scrollable = ['auto', 'scroll', 'overlay'];
+      const tag = el.tagName.toLowerCase();
+      const isBody = tag === 'body' || tag === 'html';
+      if (isV && !isBody && !scrollable.includes(cs.overflowY)) return null;
+      const info = {};
+      if (isV) {
+        const above = ch > 0 ? +(el.scrollTop / ch).toFixed(1) : 0;
+        const below = ch > 0 ? +((sh - ch - el.scrollTop) / ch).toFixed(1) : 0;
+        if (above > 0 || below > 0) info.v = { above, below };
+      }
+      if (isH && scrollable.includes(cs.overflowX)) {
+        info.h = { pct: cw > 0 ? Math.round(el.scrollLeft / (sw - cw) * 100) : 0 };
+      }
+      return Object.keys(info).length > 0 ? info : null;
+    } catch { return null; }
+  }
+
+  // ── BBox Containment Check ─────────────────────────────────────────
+
+  function isContainedBy(childRect, parentRect, threshold) {
+    if (!childRect || !parentRect) return false;
+    const cArea = childRect.width * childRect.height;
+    if (cArea === 0) return false;
+    const xO = Math.max(0, Math.min(childRect.right, parentRect.right) - Math.max(childRect.left, parentRect.left));
+    const yO = Math.max(0, Math.min(childRect.bottom, parentRect.bottom) - Math.max(childRect.top, parentRect.top));
+    return (xO * yO) / cArea >= threshold;
+  }
+
+  // ── Text Helpers ───────────────────────────────────────────────────
+
+  function getDirectText(el) {
+    let text = '';
+    for (const child of el.childNodes) {
+      if (child.nodeType === 3) {
+        const t = child.textContent.trim();
+        if (t) text += (text ? ' ' : '') + t;
+      }
+    }
+    return text;
+  }
+
+  function capText(s) {
+    if (!s) return '';
+    const t = s.replace(/\\s+/g, ' ').trim();
+    return t.length > MAX_TEXT_LEN ? t.slice(0, MAX_TEXT_LEN) + '…' : t;
+  }
+
+  // ── Element Hashing (for incremental diff) ─────────────────────────
+
+  function hashElement(el) {
+    // Simple hash: tag + id + className + textContent prefix
+    const tag = el.tagName || '';
+    const id = el.id || '';
+    const cls = (typeof el.className === 'string' ? el.className : '').slice(0, 50);
+    const text = (el.textContent || '').trim().slice(0, 40);
+    const s = tag + '|' + id + '|' + cls + '|' + text;
+    let h = 0;
+    for (let i = 0; i < s.length; i++) {
+      h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+    }
+    return '' + (h >>> 0); // unsigned
+  }
+
+  // ── Attribute Serialization ────────────────────────────────────────
+
+  function serializeAttrs(el) {
+    const parts = [];
+    for (const attr of el.attributes) {
+      if (!ATTR_WHITELIST.has(attr.name)) continue;
+      let val = attr.value.trim();
+      if (!val) continue;
+      if (val.length > 120) val = val.slice(0, 100) + '…';
+      if (attr.name === 'type' && val.toLowerCase() === el.tagName.toLowerCase()) continue;
+      if (attr.name === 'value' && el.getAttribute('type') === 'password') { parts.push('value=••••'); continue; }
+      if (attr.name === 'href') {
+        if (val.startsWith('javascript:')) continue;
+        try {
+          const u = new URL(val, location.origin);
+          if (u.origin === location.origin) val = u.pathname + u.search + u.hash;
+        } catch {}
+      }
+      parts.push(attr.name + '=' + val);
+    }
+    // Synthetic attributes
+    const tag = el.tagName;
+    if (tag === 'INPUT') {
+      const type = (el.getAttribute('type') || 'text').toLowerCase();
+      const fmts = { 'date':'YYYY-MM-DD', 'time':'HH:MM', 'datetime-local':'YYYY-MM-DDTHH:MM', 'month':'YYYY-MM', 'week':'YYYY-W##' };
+      if (fmts[type]) parts.push('format=' + fmts[type]);
+      if (['text','email','tel','url','search','number','date','time','datetime-local','month','week'].includes(type)) {
+        if (el.value && !parts.some(p => p.startsWith('value='))) parts.push('value=' + capText(el.value));
+      }
+      if (type === 'password' && el.value && !parts.some(p => p.startsWith('value='))) parts.push('value=••••');
+      if ((type === 'checkbox' || type === 'radio') && el.checked && !parts.some(p => p.startsWith('checked'))) parts.push('checked');
+      if (type === 'file' && el.files && el.files.length > 0) parts.push('files=' + Array.from(el.files).map(f => f.name).join(','));
+    }
+    if (tag === 'TEXTAREA' && el.value && !parts.some(p => p.startsWith('value='))) parts.push('value=' + capText(el.value));
+    if (tag === 'SELECT') {
+      const sel = el.options?.[el.selectedIndex];
+      if (sel && !parts.some(p => p.startsWith('value='))) parts.push('value=' + capText(sel.textContent));
+      const optEls = Array.from(el.options || []).slice(0, 6);
+      if (optEls.length > 0) {
+        const ot = optEls.map(o => capText(o.textContent).slice(0, 30));
+        if (el.options.length > 6) ot.push('…' + (el.options.length - 6) + ' more');
+        parts.push('options=[' + ot.join('|') + ']');
+      }
+    }
+    return parts.join(' ');
+  }
+
+  // ── Table → Markdown Serialization ─────────────────────────────────
+
+  function serializeTable(table, depth) {
+    if (!MARKDOWN_TABLES) return false;
+    try {
+      const rows = table.querySelectorAll('tr');
+      if (rows.length === 0 || rows.length > 50) return false; // skip huge tables
+      const grid = [];
+      let maxCols = 0;
+      for (const row of rows) {
+        const cells = [];
+        for (const cell of row.querySelectorAll('th, td')) {
+          let text = capText(cell.textContent || '');
+          // Include interactive elements in cells
+          const links = cell.querySelectorAll('a[href]');
+          if (links.length === 1 && text) {
+            const href = links[0].getAttribute('href');
+            if (href && !href.startsWith('javascript:')) {
+              try {
+                const u = new URL(href, location.origin);
+                text = '[' + text + '](' + (u.origin === location.origin ? u.pathname + u.search : href) + ')';
+              } catch { text = '[' + text + '](' + href + ')'; }
+            }
+          }
+          cells.push(text || '');
+        }
+        if (cells.length > 0) {
+          grid.push(cells);
+          if (cells.length > maxCols) maxCols = cells.length;
+        }
+      }
+      if (grid.length < 2 || maxCols === 0) return false; // need at least header + 1 row
+      // Pad rows to maxCols
+      for (const row of grid) { while (row.length < maxCols) row.push(''); }
+      // Compute column widths
+      const widths = [];
+      for (let c = 0; c < maxCols; c++) {
+        let w = 3;
+        for (const row of grid) { if (row[c].length > w) w = Math.min(row[c].length, 40); }
+        widths.push(w);
+      }
+      const indent = '  '.repeat(depth);
+      const tableLines = [];
+      // Header
+      tableLines.push(indent + '| ' + grid[0].map((c, i) => c.padEnd(widths[i])).join(' | ') + ' |');
+      tableLines.push(indent + '| ' + widths.map(w => '-'.repeat(w)).join(' | ') + ' |');
+      // Body
+      for (let r = 1; r < grid.length; r++) {
+        tableLines.push(indent + '| ' + grid[r].map((c, i) => c.padEnd(widths[i])).join(' | ') + ' |');
+      }
+      return tableLines;
+    } catch { return false; }
+  }
+
+  // ── Main Tree Walk ─────────────────────────────────────────────────
+
+  let interactiveIndex = 0;
+  const lines = [];
+  const hiddenInteractives = [];
+  const currentHashes = [];
+  let iframeCount = 0;
+
+  function walk(el, depth, parentPropagatingRect) {
+    if (depth > MAX_DEPTH) return false;
+    if (el.nodeType !== 1) return false;
+
+    const tag = el.tagName.toLowerCase();
+    if (SKIP_TAGS.has(tag)) return false;
+    if (isAdElement(el)) return false;
+
+    // SVG: emit tag, collapse children
+    if (tag === 'svg') {
+      const attrs = serializeAttrs(el);
+      const interactive = isInteractive(el);
+      let prefix = '';
+      if (interactive) {
+        interactiveIndex++;
+        if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', '' + interactiveIndex);
+        prefix = '[' + interactiveIndex + ']';
+      }
+      lines.push('  '.repeat(depth) + prefix + '<svg' + (attrs ? ' ' + attrs : '') + ' />');
+      return interactive;
+    }
+    if (SVG_CHILDREN.has(tag)) return false;
+
+    // Table: try markdown serialization before generic walk
+    if (tag === 'table' && MARKDOWN_TABLES) {
+      const tableLines = serializeTable(el, depth);
+      if (tableLines) {
+        const indent = '  '.repeat(depth);
+        lines.push(indent + '|table|');
+        for (const tl of tableLines) lines.push(tl);
+        return false; // tables usually non-interactive
+      }
+      // Fall through to generic walk if markdown failed
+    }
+
+    // iframe handling
+    if (tag === 'iframe' && INCLUDE_IFRAMES && iframeCount < MAX_IFRAMES) {
+      return walkIframe(el, depth);
+    }
+
+    // Visibility check
+    let rect;
+    try { rect = el.getBoundingClientRect(); } catch { return false; }
+    const hasArea = rect.width > 0 && rect.height > 0;
+    if (hasArea && !isVisibleByCSS(el)) {
+      if (!(tag === 'input' && el.type === 'file')) return false;
+    }
+
+    const interactive = isInteractive(el);
+
+    // Viewport threshold pruning
+    if (hasArea && !isInExpandedViewport(rect)) {
+      if (interactive && REPORT_HIDDEN) {
+        const scrollDist = rect.top > vh ? rect.top - vh : -rect.bottom;
+        const pagesAway = Math.abs(scrollDist / vh).toFixed(1);
+        const direction = rect.top > vh ? 'below' : 'above';
+        const text = capText(getDirectText(el) || el.getAttribute('aria-label') || el.getAttribute('title') || '');
+        hiddenInteractives.push({ tag, text, direction, pagesAway });
+      }
+      return false;
+    }
+
+    // Paint order occlusion
+    if (interactive && hasArea && isOccludedByOverlay(el)) return false;
+
+    const landmark = isLandmark(el);
+    const scrollInfo = getScrollInfo(el);
+    const isScrollable = scrollInfo !== null;
+
+    // BBox dedup
+    let excludedByParent = false;
+    if (BBOX_DEDUP && parentPropagatingRect && !interactive) {
+      if (hasArea && isContainedBy(rect, parentPropagatingRect, 0.95)) {
+        const hasSemantic = el.hasAttribute('aria-label') ||
+          (el.getAttribute('role') && INTERACTIVE_ROLES.has(el.getAttribute('role')));
+        if (!hasSemantic && !['input','select','textarea','label'].includes(tag)) {
+          excludedByParent = true;
+        }
+      }
+    }
+
+    let propagateRect = parentPropagatingRect;
+    if (BBOX_DEDUP && PROPAGATING_TAGS.has(tag) && hasArea) propagateRect = rect;
+
+    // Process children
+    const origLen = lines.length;
+    let hasInteractiveDescendant = false;
+
+    for (const child of el.children) {
+      const r = walk(child, depth + 1, propagateRect);
+      if (r) hasInteractiveDescendant = true;
+    }
+
+    // Shadow DOM
+    if (INCLUDE_SHADOW_DOM && el.shadowRoot) {
+      const shadowOrigLen = lines.length;
+      for (const child of el.shadowRoot.children) {
+        const r = walk(child, depth + 1, propagateRect);
+        if (r) hasInteractiveDescendant = true;
+      }
+      if (lines.length > shadowOrigLen) {
+        lines.splice(shadowOrigLen, 0, '  '.repeat(depth + 1) + '|shadow|');
+      }
+    }
+
+    const childLinesCount = lines.length - origLen;
+    const text = capText(getDirectText(el));
+
+    // Decide whether to emit
+    if (INTERACTIVE_ONLY && !interactive && !landmark && !hasInteractiveDescendant && !text) {
+      lines.length = origLen;
+      return false;
+    }
+    if (excludedByParent && !interactive && !isScrollable) return hasInteractiveDescendant;
+    if (!interactive && !isScrollable && !text && childLinesCount === 0 && !landmark) return false;
+
+    // ── Emit node ────────────────────────────────────────────────────
+    const indent = '  '.repeat(depth);
+    let line = indent;
+
+    // Incremental diff: mark new elements with *
+    if (PREV_HASHES) {
+      const h = hashElement(el);
+      currentHashes.push(h);
+      if (!PREV_HASHES.has(h)) line += '*';
+    } else {
+      currentHashes.push(hashElement(el));
+    }
+
+    // Scroll marker
+    if (isScrollable && !interactive) line += '|scroll|';
+
+    // Interactive index + data-ref
+    if (interactive) {
+      interactiveIndex++;
+      if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', '' + interactiveIndex);
+      line += isScrollable ? '|scroll[' + interactiveIndex + ']|' : '[' + interactiveIndex + ']';
+    }
+
+    // Tag + attributes
+    const attrs = serializeAttrs(el);
+    line += '<' + tag;
+    if (attrs) line += ' ' + attrs;
+
+    // Scroll info suffix, inline text, or self-close
+    if (isScrollable && scrollInfo) {
+      const parts = [];
+      if (scrollInfo.v) parts.push(scrollInfo.v.above + '↑ ' + scrollInfo.v.below + '↓');
+      if (scrollInfo.h) parts.push('h:' + scrollInfo.h.pct + '%');
+      line += ' /> (' + parts.join(', ') + ')';
+    } else if (text && childLinesCount === 0) {
+      line += '>' + text + '</' + tag + '>';
+    } else {
+      line += ' />';
+    }
+
+    lines.splice(origLen, 0, line);
+    if (text && childLinesCount > 0) lines.splice(origLen + 1, 0, indent + '  ' + text);
+
+    return interactive || hasInteractiveDescendant;
+  }
+
+  // ── iframe Processing ──────────────────────────────────────────────
+
+  function walkIframe(el, depth) {
+    const indent = '  '.repeat(depth);
+    try {
+      const doc = el.contentDocument;
+      if (!doc || !doc.body) {
+        const attrs = serializeAttrs(el);
+        lines.push(indent + '|iframe|<iframe' + (attrs ? ' ' + attrs : '') + ' /> (cross-origin)');
+        return false;
+      }
+      iframeCount++;
+      const attrs = serializeAttrs(el);
+      lines.push(indent + '|iframe|<iframe' + (attrs ? ' ' + attrs : '') + ' />');
+      let has = false;
+      for (const child of doc.body.children) {
+        if (walk(child, depth + 1, null)) has = true;
+      }
+      return has;
+    } catch {
+      const attrs = serializeAttrs(el);
+      lines.push(indent + '|iframe|<iframe' + (attrs ? ' ' + attrs : '') + ' /> (blocked)');
+      return false;
+    }
+  }
+
+  // ── Entry Point ────────────────────────────────────────────────────
+
+  lines.push('url: ' + location.href);
+  lines.push('title: ' + document.title);
+  lines.push('viewport: ' + vw + 'x' + vh);
+  const pageScrollInfo = getScrollInfo(document.documentElement) || getScrollInfo(document.body);
+  if (pageScrollInfo && pageScrollInfo.v) {
+    lines.push('page_scroll: ' + pageScrollInfo.v.above + '↑ ' + pageScrollInfo.v.below + '↓');
+  }
+  lines.push('---');
+
+  const root = document.body || document.documentElement;
+  if (root) walk(root, 0, null);
+
+  // Hidden interactive elements hint
+  if (REPORT_HIDDEN && hiddenInteractives.length > 0) {
+    lines.push('---');
+    lines.push('hidden_interactive (' + hiddenInteractives.length + '):');
+    const shown = hiddenInteractives.slice(0, 10);
+    for (const h of shown) {
+      const label = h.text ? ' "' + h.text + '"' : '';
+      lines.push('  <' + h.tag + '>' + label + ' ~' + h.pagesAway + ' pages ' + h.direction);
+    }
+    if (hiddenInteractives.length > 10) lines.push('  …' + (hiddenInteractives.length - 10) + ' more');
+  }
+
+  // Footer
+  lines.push('---');
+  lines.push('interactive: ' + interactiveIndex + ' | iframes: ' + iframeCount);
+
+  // Store hashes on window for next diff snapshot
+  try { window.__opencli_prev_hashes = JSON.stringify(currentHashes); } catch {}
+
+  return lines.join('\\n');
+})()
+  `.trim();
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -9,6 +9,8 @@ export { Page } from './page.js';
 export { BrowserBridge, BrowserBridge as PlaywrightMCP } from './mcp.js';
 export { CDPBridge } from './cdp.js';
 export { isDaemonRunning } from './daemon-client.js';
+export { generateSnapshotJs, scrollToRefJs, getFormStateJs } from './dom-snapshot.js';
+export type { SnapshotOptions } from './dom-snapshot.js';
 
 import { extractTabEntries, diffTabIndexes, appendLimited } from './tabs.js';
 import { __test__ as cdpTest } from './cdp.js';

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -14,6 +14,7 @@ import { formatSnapshot } from '../snapshotFormatter.js';
 import type { IPage } from '../types.js';
 import { sendCommand } from './daemon-client.js';
 import { wrapForEval } from './utils.js';
+import { generateSnapshotJs, scrollToRefJs, getFormStateJs } from './dom-snapshot.js';
 import {
   clickJs,
   typeTextJs,
@@ -79,7 +80,30 @@ export class Page implements IPage {
     return Array.isArray(result) ? result : [];
   }
 
-  async snapshot(opts: { interactive?: boolean; compact?: boolean; maxDepth?: number; raw?: boolean } = {}): Promise<any> {
+  async snapshot(opts: { interactive?: boolean; compact?: boolean; maxDepth?: number; raw?: boolean; viewportExpand?: number; maxTextLength?: number } = {}): Promise<any> {
+    // Primary: use the advanced DOM snapshot engine with multi-layer pruning
+    const snapshotJs = generateSnapshotJs({
+      viewportExpand: opts.viewportExpand ?? 800,
+      maxDepth: Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200)),
+      interactiveOnly: opts.interactive ?? false,
+      maxTextLength: opts.maxTextLength ?? 120,
+      includeScrollInfo: true,
+      bboxDedup: true,
+    });
+
+    try {
+      const result = await sendCommand('exec', { code: snapshotJs, ...this._workspaceOpt(), ...this._tabOpt() });
+      // The advanced engine already produces a clean, pruned, LLM-friendly output.
+      // Do NOT pass through formatSnapshot — its format is incompatible.
+      return result;
+    } catch {
+      // Fallback: basic DOM snapshot (original implementation)
+      return this._basicSnapshot(opts);
+    }
+  }
+
+  /** Fallback basic snapshot — original buildTree approach */
+  private async _basicSnapshot(opts: { interactive?: boolean; compact?: boolean; maxDepth?: number; raw?: boolean } = {}): Promise<any> {
     const maxDepth = Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200));
     const code = `
       (async () => {
@@ -93,7 +117,7 @@ export class Page implements IPage {
 
           let indent = '  '.repeat(depth);
           let line = indent + role;
-          if (name) line += ' "' + name.replace(/"/g, '\\\\"') + '"';
+          if (name) line += ' "' + name.replace(/"/g, '\\\\\\"') + '"';
           if (node.tagName?.toLowerCase() === 'a' && node.href) line += ' [' + node.href + ']';
           if (node.tagName?.toLowerCase() === 'input') line += ' [' + (node.type || 'text') + ']';
 
@@ -127,6 +151,16 @@ export class Page implements IPage {
   async pressKey(key: string): Promise<void> {
     const code = pressKeyJs(key);
     await sendCommand('exec', { code, ...this._workspaceOpt(), ...this._tabOpt() });
+  }
+
+  async scrollTo(ref: string): Promise<any> {
+    const code = scrollToRefJs(ref);
+    return sendCommand('exec', { code, ...this._workspaceOpt(), ...this._tabOpt() });
+  }
+
+  async getFormState(): Promise<any> {
+    const code = getFormStateJs();
+    return sendCommand('exec', { code, ...this._workspaceOpt(), ...this._tabOpt() });
   }
 
   async wait(options: number | { text?: string; time?: number; timeout?: number }): Promise<void> {

--- a/src/clis/xiaohongshu/creator-note-detail.test.ts
+++ b/src/clis/xiaohongshu/creator-note-detail.test.ts
@@ -18,6 +18,8 @@ function createPageMock(evaluateResult: any): IPage {
     click: vi.fn().mockResolvedValue(undefined),
     typeText: vi.fn().mockResolvedValue(undefined),
     pressKey: vi.fn().mockResolvedValue(undefined),
+    scrollTo: vi.fn().mockResolvedValue(undefined),
+    getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
     closeTab: vi.fn().mockResolvedValue(undefined),

--- a/src/clis/xiaohongshu/creator-notes.test.ts
+++ b/src/clis/xiaohongshu/creator-notes.test.ts
@@ -22,6 +22,8 @@ function createPageMock(evaluateResult: any, interceptedRequests: any[] = []): I
     click: vi.fn().mockResolvedValue(undefined),
     typeText: vi.fn().mockResolvedValue(undefined),
     pressKey: vi.fn().mockResolvedValue(undefined),
+    scrollTo: vi.fn().mockResolvedValue(undefined),
+    getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
     closeTab: vi.fn().mockResolvedValue(undefined),

--- a/src/pipeline/executor.test.ts
+++ b/src/pipeline/executor.test.ts
@@ -16,6 +16,8 @@ function createMockPage(overrides: Partial<IPage> = {}): IPage {
     click: vi.fn(),
     typeText: vi.fn(),
     pressKey: vi.fn(),
+    scrollTo: vi.fn().mockResolvedValue(undefined),
+    getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn(),
     tabs: vi.fn().mockResolvedValue([]),
     closeTab: vi.fn(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,19 @@ export interface IPage {
     httpOnly?: boolean;
     expirationDate?: number;
   }>>;
-  snapshot(opts?: { interactive?: boolean; compact?: boolean; maxDepth?: number; raw?: boolean }): Promise<any>;
+  snapshot(opts?: {
+    interactive?: boolean;
+    compact?: boolean;
+    maxDepth?: number;
+    raw?: boolean;
+    viewportExpand?: number;
+    maxTextLength?: number;
+  }): Promise<any>;
   click(ref: string): Promise<void>;
   typeText(ref: string, text: string): Promise<void>;
   pressKey(key: string): Promise<void>;
+  scrollTo(ref: string): Promise<any>;
+  getFormState(): Promise<any>;
   wait(options: number | { text?: string; time?: number; timeout?: number }): Promise<void>;
   tabs(): Promise<any>;
   closeTab(index?: number): Promise<void>;


### PR DESCRIPTION
## Summary

Adds an advanced DOM snapshot engine inspired by browser-use's multi-layer pruning, adapted for opencli's Chrome Extension + CDP architecture.

### New Features

| Feature | Description |
|---------|-------------|
| **13-layer pruning pipeline** | Tag filter → SVG collapse → ad detection → CSS visibility → viewport threshold → paint-order occlusion → Shadow DOM → iframe → BBox dedup → attribute whitelist → table→markdown → serialization → hidden element hints |
| **`scrollTo(ref)`** | Scroll to `data-opencli-ref` elements found in snapshot |
| **`getFormState()`** | Extract all form fields as structured JSON with labels |
| **Incremental diff** | Mark new elements with `*` prefix across snapshots |
| **Table→Markdown** | `<table>` elements serialized as markdown tables |
| **data-opencli-ref** | Auto-annotate interactive elements for precise targeting |
| **4-layer click/type** | `data-opencli-ref` → `data-ref` → CSS selector → index fallback |

### Files Changed (11)

- **New**: `src/browser/dom-snapshot.ts` (core engine + utilities)
- **New**: `src/browser/dom-snapshot.test.ts` (21 tests)
- **Modified**: `page.ts`, `cdp.ts`, `dom-helpers.ts`, `index.ts`, `types.ts`
- **Test mocks**: 3 files updated for new IPage methods
- **package.json**: Split test scripts (unit/e2e/all)

### Testing

- ✅ TypeScript: zero errors
- ✅ 29 test files, 283 tests, all passing (~1s)