### PR TITLE
feat(xueqiu): add earnings-date command

### DIFF
--- a/src/clis/xueqiu/earnings-date.yaml
+++ b/src/clis/xueqiu/earnings-date.yaml
@@ -1,0 +1,67 @@
+site: xueqiu
+name: earnings-date
+description: 获取股票预计财报发布日期（公司大事）
+domain: xueqiu.com
+browser: true
+
+args:
+  symbol:
+    type: str
+    description: 股票代码，如 SH600519、SZ000858、00700
+  next:
+    type: bool
+    default: false
+    description: 仅返回最近一次未发布的财报日期
+  limit:
+    type: int
+    default: 10
+    description: 返回数量，默认 10
+
+pipeline:
+  - navigate: https://xueqiu.com
+  - evaluate: |
+      (async () => {
+        const symbol = (${{ args.symbol | json }} || '').toUpperCase();
+        const onlyNext = ${{ args.next }};
+        if (!symbol) throw new Error('Missing argument: symbol');
+        const resp = await fetch(
+          `https://stock.xueqiu.com/v5/stock/screener/event/list.json?symbol=${encodeURIComponent(symbol)}&page=1&size=100`,
+          { credentials: 'include' }
+        );
+        if (!resp.ok) throw new Error('HTTP ' + resp.status + ' Hint: Not logged in?');
+        const d = await resp.json();
+        if (!d.data || !d.data.items) throw new Error('获取失败: ' + JSON.stringify(d));
+
+        // subtype 2 = 预计财报发布
+        let items = d.data.items.filter(item => item.subtype === 2);
+
+        const now = Date.now();
+        let results = items.map(item => {
+          const ts = item.timestamp;
+          const dateStr = ts ? new Date(ts).toISOString().split('T')[0] : null;
+          const isFuture = ts && ts > now;
+          return {
+            date: dateStr,
+            report: item.message,
+            status: isFuture ? '⏳ 未发布' : '✅ 已发布',
+            _ts: ts,
+            _future: isFuture
+          };
+        });
+
+        if (onlyNext) {
+          const future = results.filter(r => r._future).sort((a, b) => a._ts - b._ts);
+          results = future.length ? [future[0]] : [];
+        }
+
+        return results;
+      })()
+
+  - map:
+      date: ${{ item.date }}
+      report: ${{ item.report }}
+      status: ${{ item.status }}
+
+  - limit: ${{ args.limit }}
+
+columns: [date, report, status]


### PR DESCRIPTION
## Summary

Add new YAML adapter `xueqiu/earnings-date` to fetch upcoming earnings report dates from xueqiu company events API (`/v5/stock/screener/event/list.json`).

Supports **A-share** (e.g. `SH600519`) and **H-share** (e.g. `00700`) stocks.

## Usage

```bash
# List all earnings dates (A-share)
opencli xueqiu earnings-date --symbol SH600519

# List all earnings dates (H-share)
opencli xueqiu earnings-date --symbol 00700

# Show only the next upcoming (unreleased) earnings date
opencli xueqiu earnings-date --symbol 01810 --next

# JSON output
opencli xueqiu earnings-date --symbol SH600519 -f json

# Limit results
opencli xueqiu earnings-date --symbol SZ000858 --limit 5
```

## Example Output

```
┌────────────┬────────────────────┬───────────┐
│ Date       │ Report             │ Status    │
├────────────┼────────────────────┼───────────┤
│ 2026-03-23 │ 发布2025财年四季报 │ ⏳ 未发布 │
├────────────┼────────────────────┼───────────┤
│ 2025-11-17 │ 发布2025财年三季报 │ ✅ 已发布 │
└────────────┴────────────────────┴───────────┘
```

## Arguments

| Arg | Type | Default | Description |
|-----|------|---------|-------------|
| `--symbol` | str | *(required)* | Stock symbol (e.g. `SH600519`, `SZ000858`, `00700`) |
| `--next` | bool | `false` | Only return the closest upcoming unreleased earni?s date |
| `--limit` | int | `10` | Max number of results |

## Implementation Details

- Queries xueqiu company events API and filters by `subtype === 2` (scheduled earnings release)
- Displays ⏳/✅ status based on whether the report date is in the future or past
- `--next` flag sorts future events by date and returns only the nearest one
