### PR TITLE
refactor: reduce core any usage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,7 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
         : undefined;
       const workspace = `explore:${inferHost(url, opts.site)}`;
       const result = await exploreUrl(url, {
-        BrowserFactory: getBrowserFactory() as any,
+        BrowserFactory: getBrowserFactory(),
         site: opts.site,
         goal: opts.goal,
         waitSeconds: parseFloat(opts.wait),
@@ -172,7 +172,7 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
       const workspace = `generate:${inferHost(url, opts.site)}`;
       const r = await generateCliFromUrl({
         url,
-        BrowserFactory: getBrowserFactory() as any,
+        BrowserFactory: getBrowserFactory(),
         builtinClis: BUILTIN_CLIS,
         userClis: USER_CLIS,
         goal: opts.goal,

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -18,12 +18,17 @@ import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMM
 
 /** Set of TS module paths that have been loaded */
 const _loadedModules = new Set<string>();
+type CommandArgs = Record<string, unknown>;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /**
  * Validates and coerces arguments based on the command's Arg definitions.
  */
-export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: Record<string, any>): Record<string, any> {
-  const result: Record<string, any> = { ...kwargs };
+export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: CommandArgs): CommandArgs {
+  const result: CommandArgs = { ...kwargs };
 
   for (const argDef of cmdArgs) {
     const val = result[argDef.name];
@@ -72,9 +77,9 @@ export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: Record<string, any
 async function runCommand(
   cmd: CliCommand,
   page: IPage | null,
-  kwargs: Record<string, any>,
+  kwargs: CommandArgs,
   debug: boolean,
-): Promise<any> {
+): Promise<unknown> {
   // Lazy-load TS module on first execution (manifest fast-path)
   const internal = cmd as InternalCliCommand;
   if (internal._lazy && internal._modulePath) {
@@ -83,9 +88,9 @@ async function runCommand(
       try {
         await import(`file://${modulePath}`);
         _loadedModules.add(modulePath);
-      } catch (err: any) {
+      } catch (err) {
         throw new AdapterLoadError(
-          `Failed to load adapter module ${modulePath}: ${err.message}`,
+          `Failed to load adapter module ${modulePath}: ${getErrorMessage(err)}`,
           'Check that the adapter file exists and has no syntax errors.',
         );
       }
@@ -127,14 +132,14 @@ function resolvePreNav(cmd: CliCommand): string | null {
  */
 export async function executeCommand(
   cmd: CliCommand,
-  rawKwargs: Record<string, any>,
+  rawKwargs: CommandArgs,
   debug: boolean = false,
-): Promise<any> {
-  let kwargs: Record<string, any>;
+): Promise<unknown> {
+  let kwargs: CommandArgs;
   try {
     kwargs = coerceAndValidateArgs(cmd.args, rawKwargs);
-  } catch (err: any) {
-    throw new Error(`[Argument Validation Error]\n${err.message}`);
+  } catch (err) {
+    throw new Error(`[Argument Validation Error]\n${getErrorMessage(err)}`);
   }
 
   if (shouldUseBrowserSession(cmd)) {

--- a/src/explore.ts
+++ b/src/explore.ts
@@ -9,10 +9,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { DEFAULT_BROWSER_EXPLORE_TIMEOUT, browserSession, runWithTimeout } from './runtime.js';
+import type { IBrowserFactory } from './runtime.js';
 import { VOLATILE_PARAMS, SEARCH_PARAMS, PAGINATION_PARAMS, LIMIT_PARAMS, FIELD_ROLES } from './constants.js';
 import { detectFramework } from './scripts/framework.js';
 import { discoverStores } from './scripts/store.js';
 import { interactFuzz } from './scripts/interact.js';
+import type { IPage } from './types.js';
 
 // ── Site name detection ────────────────────────────────────────────────────
 
@@ -68,7 +70,61 @@ interface InferredCapability {
   name: string; description: string; strategy: string; confidence: number;
   endpoint: string; itemPath: string | null;
   recommendedColumns: string[];
-  recommendedArgs: Array<{ name: string; type: string; required: boolean; default?: any }>;
+  recommendedArgs: Array<{ name: string; type: string; required: boolean; default?: unknown }>;
+  storeHint?: { store: string; action: string };
+}
+
+export interface ExploreManifest {
+  site: string;
+  target_url: string;
+  final_url: string;
+  title: string;
+  framework: Record<string, boolean>;
+  stores: Array<{ type: DiscoveredStore['type']; id: string; actions: string[] }>;
+  top_strategy: string;
+  explored_at?: string;
+}
+
+export interface ExploreAuthSummary {
+  top_strategy: string;
+  indicators: string[];
+  framework: Record<string, boolean>;
+}
+
+export interface ExploreEndpointArtifact {
+  pattern: string;
+  method: string;
+  url: string;
+  status: number | null;
+  contentType: string;
+  score: number;
+  queryParams: string[];
+  itemPath: string | null;
+  itemCount: number;
+  detectedFields: Record<string, string>;
+  authIndicators: string[];
+}
+
+export interface ExploreResult {
+  site: string;
+  target_url: string;
+  final_url: string;
+  title: string;
+  framework: Record<string, boolean>;
+  stores: DiscoveredStore[];
+  top_strategy: string;
+  endpoint_count: number;
+  api_endpoint_count: number;
+  capabilities: InferredCapability[];
+  auth_indicators: string[];
+  out_dir: string;
+}
+
+export interface ExploreBundle {
+  manifest: ExploreManifest;
+  endpoints: ExploreEndpointArtifact[];
+  capabilities: InferredCapability[];
+  auth: ExploreAuthSummary;
 }
 
 /**
@@ -167,7 +223,7 @@ function flattenFields(obj: unknown, prefix: string, maxDepth: number): string[]
   return names;
 }
 
-function scoreEndpoint(ep: { contentType: string; responseAnalysis: any; pattern: string; status: number | null; hasSearchParam: boolean; hasPaginationParam: boolean; hasLimitParam: boolean }): number {
+function scoreEndpoint(ep: { contentType: string; responseAnalysis: AnalyzedEndpoint['responseAnalysis']; pattern: string; status: number | null; hasSearchParam: boolean; hasPaginationParam: boolean; hasLimitParam: boolean }): number {
   let s = 0;
   if (ep.contentType.includes('json')) s += 10;
   if (ep.responseAnalysis) { s += 5; s += Math.min(ep.responseAnalysis.itemCount, 10); s += Object.keys(ep.responseAnalysis.detectedFields).length * 2; }
@@ -321,7 +377,7 @@ function inferCapabilitiesFromEndpoints(
 /** Write explore artifacts (manifest, endpoints, capabilities, auth, stores) to disk. */
 async function writeExploreArtifacts(
   targetDir: string,
-  result: Record<string, any>,
+  result: Omit<ExploreResult, 'out_dir'>,
   analyzedEndpoints: AnalyzedEndpoint[],
   stores: DiscoveredStore[],
 ): Promise<void> {
@@ -354,12 +410,12 @@ async function writeExploreArtifacts(
 export async function exploreUrl(
   url: string,
   opts: {
-    BrowserFactory: new () => any;
+    BrowserFactory: new () => IBrowserFactory;
     site?: string; goal?: string; authenticated?: boolean;
     outDir?: string; waitSeconds?: number; query?: string;
     clickLabels?: string[]; auto?: boolean; workspace?: string;
   },
-): Promise<Record<string, any>> {
+): Promise<ExploreResult> {
   const waitSeconds = opts.waitSeconds ?? 3.0;
   const exploreTimeout = Math.max(DEFAULT_BROWSER_EXPLORE_TIMEOUT, 45.0 + waitSeconds * 8.0);
 
@@ -467,7 +523,7 @@ export async function exploreUrl(
   }, { workspace: opts.workspace });
 }
 
-export function renderExploreSummary(result: Record<string, any>): string {
+export function renderExploreSummary(result: ExploreResult): string {
   const lines = [
     'opencli probe: OK', `Site: ${result.site}`, `URL: ${result.target_url}`,
     `Title: ${result.title || '(none)'}`, `Strategy: ${result.top_strategy}`,
@@ -492,7 +548,7 @@ export function renderExploreSummary(result: Record<string, any>): string {
   return lines.join('\n');
 }
 
-async function readPageMetadata(page: any /* IPage */): Promise<{ url: string; title: string }> {
+async function readPageMetadata(page: IPage): Promise<{ url: string; title: string }> {
   try {
     const result = await page.evaluate(`() => ({ url: window.location.href, title: document.title || '' })`);
     if (result && typeof result === 'object') return { url: String(result.url ?? ''), title: String(result.title ?? '') };

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -9,10 +9,59 @@
  */
 
 import { exploreUrl } from './explore.js';
-import { synthesizeFromExplore } from './synthesize.js';
+import type { IBrowserFactory } from './runtime.js';
+import { synthesizeFromExplore, type SynthesizeCandidateSummary, type SynthesizeResult } from './synthesize.js';
 
 // TODO: implement real CLI registration (copy candidate YAML to user clis dir)
-function registerCandidates(_opts: any): any { return { ok: true, count: 0 }; }
+interface RegisterCandidatesOptions {
+  target: string;
+  builtinClis?: string;
+  userClis?: string;
+  name?: string;
+}
+
+interface RegisterCandidatesResult {
+  ok: boolean;
+  count: number;
+}
+
+export interface GenerateCliOptions {
+  url: string;
+  BrowserFactory: new () => IBrowserFactory;
+  builtinClis?: string;
+  userClis?: string;
+  goal?: string | null;
+  site?: string;
+  waitSeconds?: number;
+  top?: number;
+  register?: boolean;
+  workspace?: string;
+}
+
+export interface GenerateCliResult {
+  ok: boolean;
+  goal?: string | null;
+  normalized_goal?: string | null;
+  site: string;
+  selected_candidate: SynthesizeCandidateSummary | null;
+  selected_command: string;
+  explore: {
+    endpoint_count: number;
+    api_endpoint_count: number;
+    capability_count: number;
+    top_strategy: string;
+    framework: Record<string, boolean>;
+  };
+  synthesize: {
+    candidate_count: number;
+    candidates: Array<Pick<SynthesizeCandidateSummary, 'name' | 'strategy' | 'confidence'>>;
+  };
+  register: RegisterCandidatesResult | null;
+}
+
+function registerCandidates(_opts: RegisterCandidatesOptions): RegisterCandidatesResult {
+  return { ok: true, count: 0 };
+}
 
 const CAPABILITY_ALIASES: Record<string, string[]> = {
   search:    ['search', '搜索', '查找', 'query', 'keyword'],
@@ -41,7 +90,7 @@ function normalizeGoal(goal?: string | null): string | null {
 /**
  * Select the best candidate matching the user's goal.
  */
-function selectCandidate(candidates: any[], goal?: string | null): any {
+function selectCandidate(candidates: SynthesizeResult['candidates'], goal?: string | null): SynthesizeCandidateSummary | null {
   if (!candidates.length) return null;
   if (!goal) return candidates[0]; // highest confidence first
 
@@ -58,12 +107,12 @@ function selectCandidate(candidates: any[], goal?: string | null): any {
   return partial ?? candidates[0];
 }
 
-export async function generateCliFromUrl(opts: any): Promise<any> {
+export async function generateCliFromUrl(opts: GenerateCliOptions): Promise<GenerateCliResult> {
   // Step 1: Deep Explore
   const exploreResult = await exploreUrl(opts.url, {
     BrowserFactory: opts.BrowserFactory,
     site: opts.site,
-    goal: normalizeGoal(opts.goal) ?? opts.goal,
+    goal: normalizeGoal(opts.goal) ?? opts.goal ?? undefined,
     waitSeconds: opts.waitSeconds ?? 3,
     workspace: opts.workspace,
   });
@@ -75,10 +124,10 @@ export async function generateCliFromUrl(opts: any): Promise<any> {
 
   // Step 3: Select best candidate for goal
   const selected = selectCandidate(synthesizeResult.candidates ?? [], opts.goal);
-  const selectedSite = selected?.site ?? synthesizeResult.site ?? exploreResult.site;
+  const selectedSite = synthesizeResult.site ?? exploreResult.site;
 
   // Step 4: Register (if requested)
-  let registerResult: any = null;
+  let registerResult: RegisterCandidatesResult | null = null;
   if (opts.register !== false && synthesizeResult.candidate_count > 0) {
     try {
       registerResult = registerCandidates({
@@ -108,7 +157,7 @@ export async function generateCliFromUrl(opts: any): Promise<any> {
     },
     synthesize: {
       candidate_count: synthesizeResult.candidate_count,
-      candidates: (synthesizeResult.candidates ?? []).map((c: any) => ({
+      candidates: (synthesizeResult.candidates ?? []).map((c) => ({
         name: c.name,
         strategy: c.strategy,
         confidence: c.confidence,
@@ -118,7 +167,7 @@ export async function generateCliFromUrl(opts: any): Promise<any> {
   };
 }
 
-export function renderGenerateSummary(r: any): string {
+export function renderGenerateSummary(r: GenerateCliResult): string {
   const lines = [
     `opencli generate: ${r.ok ? 'OK' : 'FAIL'}`,
     `Site: ${r.site}`,

--- a/src/synthesize.ts
+++ b/src/synthesize.ts
@@ -7,16 +7,96 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { VOLATILE_PARAMS, SEARCH_PARAMS, LIMIT_PARAMS, PAGINATION_PARAMS } from './constants.js';
+import type { ExploreAuthSummary, ExploreEndpointArtifact, ExploreManifest } from './explore.js';
 
 /** Renamed aliases for backward compatibility with local references */
 const SEARCH_PARAM_NAMES = SEARCH_PARAMS;
 const LIMIT_PARAM_NAMES = LIMIT_PARAMS;
 const PAGE_PARAM_NAMES = PAGINATION_PARAMS;
 
+interface RecommendedArg {
+  name: string;
+  type?: string;
+  required?: boolean;
+  default?: unknown;
+}
+
+interface StoreHint {
+  store: string;
+  action: string;
+}
+
+export interface SynthesizeCapability {
+  name: string;
+  description: string;
+  strategy: string;
+  confidence?: number;
+  endpoint?: string;
+  itemPath?: string | null;
+  recommendedColumns?: string[];
+  recommendedArgs?: RecommendedArg[];
+  recommended_args?: RecommendedArg[];
+  recommendedColumnsLegacy?: string[];
+  recommended_columns?: string[];
+  storeHint?: StoreHint;
+}
+
+export interface GeneratedArgDefinition {
+  type: string;
+  required?: boolean;
+  default?: unknown;
+  description?: string;
+}
+
+type CandidatePipelineStep =
+  | { navigate: string }
+  | { wait: number }
+  | { evaluate: string }
+  | { select: string }
+  | { map: Record<string, string> }
+  | { limit: string }
+  | { fetch: { url: string } }
+  | { tap: { store: string; action: string; timeout: number; capture?: string; select?: string | null } };
+
+export interface CandidateYaml {
+  site: string;
+  name: string;
+  description: string;
+  domain: string;
+  strategy: string;
+  browser: boolean;
+  args: Record<string, GeneratedArgDefinition>;
+  pipeline: CandidatePipelineStep[];
+  columns: string[];
+}
+
+export interface SynthesizeCandidateSummary {
+  name: string;
+  path: string;
+  strategy: string;
+  confidence?: number;
+}
+
+export interface SynthesizeResult {
+  site: string;
+  explore_dir: string;
+  out_dir: string;
+  candidate_count: number;
+  candidates: SynthesizeCandidateSummary[];
+}
+
+type ExploreManifestLike = Pick<ExploreManifest, 'target_url' | 'final_url'> & Partial<ExploreManifest>;
+interface LoadedExploreBundle {
+  manifest: ExploreManifest;
+  endpoints: ExploreEndpointArtifact[];
+  capabilities: SynthesizeCapability[];
+  auth: ExploreAuthSummary;
+}
+
 export function synthesizeFromExplore(
   target: string,
   opts: { outDir?: string; top?: number } = {},
-): Record<string, any> {
+): SynthesizeResult {
   const exploreDir = resolveExploreDir(target);
   const bundle = loadExploreBundle(exploreDir);
 
@@ -25,9 +105,9 @@ export function synthesizeFromExplore(
 
   const site = bundle.manifest.site;
   const capabilities = (bundle.capabilities ?? [])
-    .sort((a: any, b: any) => (b.confidence ?? 0) - (a.confidence ?? 0))
+    .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, opts.top ?? 3);
-  const candidates: any[] = [];
+  const candidates: SynthesizeCandidateSummary[] = [];
 
   for (const cap of capabilities) {
     const endpoint = chooseEndpoint(cap, bundle.endpoints);
@@ -44,7 +124,7 @@ export function synthesizeFromExplore(
   return { site, explore_dir: exploreDir, out_dir: targetDir, candidate_count: candidates.length, candidates };
 }
 
-export function renderSynthesizeSummary(result: Record<string, any>): string {
+export function renderSynthesizeSummary(result: SynthesizeResult): string {
   const lines = ['opencli synthesize: OK', `Site: ${result.site}`, `Source: ${result.explore_dir}`, `Candidates: ${result.candidate_count}`];
   for (const c of result.candidates ?? []) lines.push(`  • ${c.name} (${c.strategy}, ${((c.confidence ?? 0) * 100).toFixed(0)}% confidence) → ${c.path}`);
   return lines.join('\n');
@@ -57,33 +137,34 @@ export function resolveExploreDir(target: string): string {
   throw new Error(`Explore directory not found: ${target}`);
 }
 
-export function loadExploreBundle(exploreDir: string): Record<string, any> {
+export function loadExploreBundle(exploreDir: string): LoadedExploreBundle {
   return {
-    manifest: JSON.parse(fs.readFileSync(path.join(exploreDir, 'manifest.json'), 'utf-8')),
-    endpoints: JSON.parse(fs.readFileSync(path.join(exploreDir, 'endpoints.json'), 'utf-8')),
-    capabilities: JSON.parse(fs.readFileSync(path.join(exploreDir, 'capabilities.json'), 'utf-8')),
+    manifest: JSON.parse(fs.readFileSync(path.join(exploreDir, 'manifest.json'), 'utf-8')) as ExploreManifest,
+    endpoints: JSON.parse(fs.readFileSync(path.join(exploreDir, 'endpoints.json'), 'utf-8')) as ExploreEndpointArtifact[],
+    capabilities: JSON.parse(fs.readFileSync(path.join(exploreDir, 'capabilities.json'), 'utf-8')) as SynthesizeCapability[],
     auth: JSON.parse(fs.readFileSync(path.join(exploreDir, 'auth.json'), 'utf-8')),
   };
 }
 
-function chooseEndpoint(cap: any, endpoints: any[]): any | null {
+function chooseEndpoint(cap: SynthesizeCapability, endpoints: ExploreEndpointArtifact[]): ExploreEndpointArtifact | null {
   if (!endpoints.length) return null;
   // Match by endpoint pattern from capability
   if (cap.endpoint) {
-    const match = endpoints.find((e: any) => e.pattern === cap.endpoint || e.url?.includes(cap.endpoint));
+    const endpointPattern = cap.endpoint;
+    const match = endpoints.find((endpoint) => endpoint.pattern === endpointPattern || endpoint.url?.includes(endpointPattern));
     if (match) return match;
   }
-  return endpoints.sort((a: any, b: any) => (b.score ?? 0) - (a.score ?? 0))[0];
+  return [...endpoints].sort((a, b) => (b.score ?? 0) - (a.score ?? 0))[0];
 }
 
 // ── URL templating ─────────────────────────────────────────────────────────
 
-function buildTemplatedUrl(rawUrl: string, cap: any, _endpoint: any): string {
+function buildTemplatedUrl(rawUrl: string, cap: SynthesizeCapability, _endpoint: ExploreEndpointArtifact): string {
   try {
     const u = new URL(rawUrl);
     const base = `${u.protocol}//${u.host}${u.pathname}`;
     const params: Array<[string, string]> = [];
-    const hasKeyword = cap.recommendedArgs?.some((a: any) => a.name === 'keyword');
+    const hasKeyword = cap.recommendedArgs?.some((arg) => arg.name === 'keyword');
 
     u.searchParams.forEach((v, k) => {
       if (VOLATILE_PARAMS.has(k)) return;
@@ -101,7 +182,7 @@ function buildTemplatedUrl(rawUrl: string, cap: any, _endpoint: any): string {
  * Build inline evaluate script for browser-based fetch+parse.
  * Follows patterns from bilibili/hot.yaml and twitter/trending.yaml.
  */
-function buildEvaluateScript(url: string, itemPath: string, endpoint: any): string {
+function buildEvaluateScript(url: string, itemPath: string, endpoint: ExploreEndpointArtifact): string {
   const pathChain = itemPath.split('.').map((p: string) => `?.${p}`).join('');
   const detectedFields = endpoint?.detectedFields ?? {};
   const hasFields = Object.keys(detectedFields).length > 0;
@@ -127,9 +208,9 @@ function buildEvaluateScript(url: string, itemPath: string, endpoint: any): stri
 
 // ── YAML pipeline generation ───────────────────────────────────────────────
 
-function buildCandidateYaml(site: string, manifest: any, cap: any, endpoint: any): { name: string; yaml: any } {
+function buildCandidateYaml(site: string, manifest: ExploreManifestLike, cap: SynthesizeCapability, endpoint: ExploreEndpointArtifact): { name: string; yaml: CandidateYaml } {
   const needsBrowser = cap.strategy !== 'public';
-  const pipeline: any[] = [];
+  const pipeline: CandidatePipelineStep[] = [];
   const templatedUrl = buildTemplatedUrl(endpoint?.url ?? manifest.target_url, cap, endpoint);
 
   let domain = '';
@@ -139,7 +220,7 @@ function buildCandidateYaml(site: string, manifest: any, cap: any, endpoint: any
     // Store Action: navigate + wait + tap (declarative, clean)
     pipeline.push({ navigate: manifest.target_url });
     pipeline.push({ wait: 3 });
-    const tapStep: Record<string, any> = {
+    const tapStep: { store: string; action: string; timeout: number; capture?: string; select?: string | null } = {
       store: cap.storeHint.store,
       action: cap.storeHint.action,
       timeout: 8,
@@ -170,7 +251,7 @@ function buildCandidateYaml(site: string, manifest: any, cap: any, endpoint: any
   // Map fields
   const mapStep: Record<string, string> = {};
   const columns = cap.recommendedColumns ?? ['title', 'url'];
-  if (!cap.recommendedArgs?.some((a: any) => a.name === 'keyword')) mapStep['rank'] = '${{ index + 1 }}';
+  if (!cap.recommendedArgs?.some((arg) => arg.name === 'keyword')) mapStep['rank'] = '${{ index + 1 }}';
   const detectedFields = endpoint?.detectedFields ?? {};
   for (const col of columns) {
     const fieldPath = detectedFields[col];
@@ -180,9 +261,9 @@ function buildCandidateYaml(site: string, manifest: any, cap: any, endpoint: any
   pipeline.push({ limit: '${{ args.limit | default(20) }}' });
 
   // Args
-  const argsDef: Record<string, any> = {};
+  const argsDef: Record<string, GeneratedArgDefinition> = {};
   for (const arg of cap.recommendedArgs ?? []) {
-    const def: any = { type: arg.type ?? 'str' };
+    const def: GeneratedArgDefinition = { type: arg.type ?? 'str' };
     if (arg.required) def.required = true;
     if (arg.default != null) def.default = arg.default;
     if (arg.name === 'keyword') def.description = 'Search keyword';
@@ -203,7 +284,7 @@ function buildCandidateYaml(site: string, manifest: any, cap: any, endpoint: any
 }
 
 /** Backward-compatible export for scaffold.ts */
-export function buildCandidate(site: string, targetUrl: string, cap: any, endpoint: any): any {
+export function buildCandidate(site: string, targetUrl: string, cap: SynthesizeCapability, endpoint: ExploreEndpointArtifact): { name: string; yaml: CandidateYaml } {
   // Map old-style field names to new ones
   const normalizedCap = {
     ...cap,


### PR DESCRIPTION
## Summary
- tighten typing in the execution/explore/synthesize/generate orchestration path
- replace several core `any` usages with explicit result and option types
- keep CLI wiring aligned with typed browser factory contracts

## Validation
- npm run typecheck
- npm run build
- npx vitest run src/engine.test.ts