### PR TITLE
refactor: type discovery core

### DIFF
--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -18,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLIS_DIR = path.resolve(__dirname, 'clis');
 const OUTPUT = path.resolve(__dirname, '..', 'dist', 'cli-manifest.json');
 
-interface ManifestEntry {
+export interface ManifestEntry {
   site: string;
   name: string;
   description: string;
@@ -28,14 +28,14 @@ interface ManifestEntry {
   args: Array<{
     name: string;
     type?: string;
-    default?: any;
+    default?: unknown;
     required?: boolean;
     positional?: boolean;
     help?: string;
     choices?: string[];
   }>;
   columns?: string[];
-  pipeline?: any[];
+  pipeline?: Record<string, unknown>[];
   timeout?: number;
   /** 'yaml' or 'ts' — determines how executeCommand loads the handler */
   type: 'yaml' | 'ts';
@@ -43,6 +43,38 @@ interface ManifestEntry {
   modulePath?: string;
   /** Pre-navigation control — see CliCommand.navigateBefore */
   navigateBefore?: boolean | string;
+}
+
+interface YamlArgDefinition {
+  type?: string;
+  default?: unknown;
+  required?: boolean;
+  positional?: boolean;
+  description?: string;
+  help?: string;
+  choices?: string[];
+}
+
+interface YamlCliDefinition {
+  site?: string;
+  name?: string;
+  description?: string;
+  domain?: string;
+  strategy?: string;
+  browser?: boolean;
+  args?: Record<string, YamlArgDefinition>;
+  columns?: string[];
+  pipeline?: Record<string, unknown>[];
+  timeout?: number;
+  navigateBefore?: boolean | string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function extractBalancedBlock(
@@ -129,7 +161,7 @@ export function parseTsArgsBlock(argsBlock: string): ManifestEntry['args'] {
     const helpMatch = body.match(/help\s*:\s*['"`]([^'"`]*)['"`]/);
     const positionalMatch = body.match(/positional\s*:\s*(true|false)/);
 
-    let defaultVal: any = undefined;
+    let defaultVal: unknown = undefined;
     if (defaultMatch) {
       const raw = defaultMatch[1].trim();
       if (raw === 'true') defaultVal = true;
@@ -158,16 +190,17 @@ export function parseTsArgsBlock(argsBlock: string): ManifestEntry['args'] {
 function scanYaml(filePath: string, site: string): ManifestEntry | null {
   try {
     const raw = fs.readFileSync(filePath, 'utf-8');
-    const def = yaml.load(raw) as any;
-    if (!def || typeof def !== 'object') return null;
+    const def = yaml.load(raw) as YamlCliDefinition | null;
+    if (!isRecord(def)) return null;
+    const cliDef = def as YamlCliDefinition;
 
-    const strategyStr = def.strategy ?? (def.browser === false ? 'public' : 'cookie');
+    const strategyStr = cliDef.strategy ?? (cliDef.browser === false ? 'public' : 'cookie');
     const strategy = strategyStr.toUpperCase();
-    const browser = def.browser ?? (strategy !== 'PUBLIC');
+    const browser = cliDef.browser ?? (strategy !== 'PUBLIC');
 
     const args: ManifestEntry['args'] = [];
-    if (def.args && typeof def.args === 'object') {
-      for (const [argName, argDef] of Object.entries(def.args as Record<string, any>)) {
+    if (cliDef.args && typeof cliDef.args === 'object') {
+      for (const [argName, argDef] of Object.entries(cliDef.args)) {
         args.push({
           name: argName,
           type: argDef?.type ?? 'str',
@@ -180,21 +213,21 @@ function scanYaml(filePath: string, site: string): ManifestEntry | null {
     }
 
     return {
-      site: def.site ?? site,
-      name: def.name ?? path.basename(filePath, path.extname(filePath)),
-      description: def.description ?? '',
-      domain: def.domain,
+      site: cliDef.site ?? site,
+      name: cliDef.name ?? path.basename(filePath, path.extname(filePath)),
+      description: cliDef.description ?? '',
+      domain: cliDef.domain,
       strategy: strategy.toLowerCase(),
       browser,
       args,
-      columns: def.columns,
-      pipeline: def.pipeline,
-      timeout: def.timeout,
+      columns: cliDef.columns,
+      pipeline: cliDef.pipeline,
+      timeout: cliDef.timeout,
       type: 'yaml',
-      navigateBefore: def.navigateBefore,
+      navigateBefore: cliDef.navigateBefore,
     };
-  } catch (err: any) {
-    process.stderr.write(`Warning: failed to parse ${filePath}: ${err.message}\n`);
+  } catch (err) {
+    process.stderr.write(`Warning: failed to parse ${filePath}: ${getErrorMessage(err)}\n`);
     return null;
   }
 }
@@ -256,9 +289,9 @@ export function scanTs(filePath: string, site: string): ManifestEntry | null {
     if (navMatch) entry.navigateBefore = navMatch[1] === 'true' ? true : false;
 
     return entry;
-  } catch (err: any) {
+  } catch (err) {
     // If parsing fails, log a warning (matching scanYaml behaviour) and skip the entry.
-    process.stderr.write(`Warning: failed to scan ${filePath}: ${err.message}\n`);
+    process.stderr.write(`Warning: failed to scan ${filePath}: ${getErrorMessage(err)}\n`);
     return null;
   }
 }

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -18,6 +18,10 @@ import { render as renderOutput } from './output.js';
 import { executeCommand } from './execution.js';
 import { CliError } from './errors.js';
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Register a single CliCommand as a Commander subcommand.
  */
@@ -46,12 +50,13 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
 
   subCmd.addHelpText('after', formatRegistryHelpText(cmd));
 
-  subCmd.action(async (...actionArgs: any[]) => {
+  subCmd.action(async (...actionArgs: unknown[]) => {
     const actionOpts = actionArgs[positionalArgs.length] ?? {};
+    const optionsRecord = typeof actionOpts === 'object' && actionOpts !== null ? actionOpts as Record<string, unknown> : {};
     const startTime = Date.now();
 
     // ── Collect kwargs ──────────────────────────────────────────────────
-    const kwargs: Record<string, any> = {};
+    const kwargs: Record<string, unknown> = {};
     for (let i = 0; i < positionalArgs.length; i++) {
       const v = actionArgs[i];
       if (v !== undefined) kwargs[positionalArgs[i].name] = v;
@@ -59,36 +64,38 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
     for (const arg of cmd.args) {
       if (arg.positional) continue;
       const camelName = arg.name.replace(/-([a-z])/g, (_m, ch: string) => ch.toUpperCase());
-      const v = actionOpts[arg.name] ?? actionOpts[camelName];
+      const v = optionsRecord[arg.name] ?? optionsRecord[camelName];
       if (v !== undefined) kwargs[arg.name] = v;
     }
 
     // ── Execute + render ────────────────────────────────────────────────
     try {
-      if (actionOpts.verbose) process.env.OPENCLI_VERBOSE = '1';
+      const verbose = optionsRecord.verbose === true;
+      const format = typeof optionsRecord.format === 'string' ? optionsRecord.format : 'table';
+      if (verbose) process.env.OPENCLI_VERBOSE = '1';
 
-      const result = await executeCommand(cmd, kwargs, actionOpts.verbose);
+      const result = await executeCommand(cmd, kwargs, verbose);
 
-      if (actionOpts.verbose && (!result || (Array.isArray(result) && result.length === 0))) {
+      if (verbose && (!result || (Array.isArray(result) && result.length === 0))) {
         console.error(chalk.yellow('[Verbose] Warning: Command returned an empty result.'));
       }
       const resolved = getRegistry().get(fullName(cmd)) ?? cmd;
       renderOutput(result, {
-        fmt: actionOpts.format,
+        fmt: format,
         columns: resolved.columns,
         title: `${resolved.site}/${resolved.name}`,
         elapsed: (Date.now() - startTime) / 1000,
         source: fullName(resolved),
         footerExtra: resolved.footerExtra?.(kwargs),
       });
-    } catch (err: any) {
+    } catch (err) {
       if (err instanceof CliError) {
         console.error(chalk.red(`Error [${err.code}]: ${err.message}`));
         if (err.hint) console.error(chalk.yellow(`Hint: ${err.hint}`));
-      } else if (actionOpts.verbose && err.stack) {
+      } else if (optionsRecord.verbose === true && err instanceof Error && err.stack) {
         console.error(chalk.red(err.stack));
       } else {
-        console.error(chalk.red(`Error: ${err.message ?? err}`));
+        console.error(chalk.red(`Error: ${getErrorMessage(err)}`));
       }
       process.exitCode = 1;
     }

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -14,10 +14,49 @@ import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { type CliCommand, type InternalCliCommand, type Arg, Strategy, registerCommand } from './registry.js';
 import { log } from './logger.js';
+import type { ManifestEntry } from './build-manifest.js';
 
 /** Plugins directory: ~/.opencli/plugins/ */
 export const PLUGINS_DIR = path.join(os.homedir(), '.opencli', 'plugins');
 const CLI_MODULE_PATTERN = /\bcli\s*\(/;
+
+interface YamlArgDefinition {
+  type?: string;
+  default?: unknown;
+  required?: boolean;
+  positional?: boolean;
+  description?: string;
+  help?: string;
+  choices?: string[];
+}
+
+interface YamlCliDefinition {
+  site?: string;
+  name?: string;
+  description?: string;
+  domain?: string;
+  strategy?: string;
+  browser?: boolean;
+  args?: Record<string, YamlArgDefinition>;
+  columns?: string[];
+  pipeline?: Record<string, unknown>[];
+  timeout?: number;
+  navigateBefore?: boolean | string;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Strategy.COOKIE): Strategy {
+  if (!rawStrategy) return fallback;
+  const key = rawStrategy.toUpperCase() as keyof typeof Strategy;
+  return Strategy[key] ?? fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 /**
  * Discover and register CLI commands.
@@ -46,11 +85,11 @@ export async function discoverClis(...dirs: string[]): Promise<void> {
 async function loadFromManifest(manifestPath: string, clisDir: string): Promise<void> {
   try {
     const raw = await fs.promises.readFile(manifestPath, 'utf-8');
-    const manifest = JSON.parse(raw) as any[];
+    const manifest = JSON.parse(raw) as ManifestEntry[];
     for (const entry of manifest) {
       if (entry.type === 'yaml') {
         // YAML pipelines fully inlined in manifest — register directly
-        const strategy = (Strategy as any)[entry.strategy.toUpperCase()] ?? Strategy.COOKIE;
+        const strategy = parseStrategy(entry.strategy);
         const cmd: CliCommand = {
           site: entry.site,
           name: entry.name,
@@ -69,7 +108,7 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
       } else if (entry.type === 'ts' && entry.modulePath) {
         // TS adapters: register a lightweight stub.
         // The actual module is loaded lazily on first executeCommand().
-        const strategy = (Strategy as any)[(entry.strategy ?? 'cookie').toUpperCase()] ?? Strategy.COOKIE;
+        const strategy = parseStrategy(entry.strategy ?? 'cookie');
         const modulePath = path.resolve(clisDir, entry.modulePath);
         const cmd: InternalCliCommand = {
           site: entry.site,
@@ -89,8 +128,8 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
         registerCommand(cmd);
       }
     }
-  } catch (err: any) {
-    log.warn(`Failed to load manifest ${manifestPath}: ${err.message}`);
+  } catch (err) {
+    log.warn(`Failed to load manifest ${manifestPath}: ${getErrorMessage(err)}`);
   }
 }
 
@@ -99,7 +138,7 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
  */
 async function discoverClisFromFs(dir: string): Promise<void> {
   try { await fs.promises.access(dir); } catch { return; }
-  const promises: Promise<any>[] = [];
+  const promises: Promise<unknown>[] = [];
   const entries = await fs.promises.readdir(dir, { withFileTypes: true });
   
   for (const entry of entries) {
@@ -117,8 +156,8 @@ async function discoverClisFromFs(dir: string): Promise<void> {
       ) {
         if (!(await isCliModule(filePath))) continue;
         promises.push(
-          import(`file://${filePath}`).catch((err: any) => {
-            log.warn(`Failed to load module ${filePath}: ${err.message}`);
+          import(`file://${filePath}`).catch((err) => {
+            log.warn(`Failed to load module ${filePath}: ${getErrorMessage(err)}`);
           })
         );
       }
@@ -130,18 +169,19 @@ async function discoverClisFromFs(dir: string): Promise<void> {
 async function registerYamlCli(filePath: string, defaultSite: string): Promise<void> {
   try {
     const raw = await fs.promises.readFile(filePath, 'utf-8');
-    const def = yaml.load(raw) as any;
-    if (!def || typeof def !== 'object') return;
+    const def = yaml.load(raw) as YamlCliDefinition | null;
+    if (!isRecord(def)) return;
+    const cliDef = def as YamlCliDefinition;
 
-    const site = def.site ?? defaultSite;
-    const name = def.name ?? path.basename(filePath, path.extname(filePath));
-    const strategyStr = def.strategy ?? (def.browser === false ? 'public' : 'cookie');
-    const strategy = (Strategy as any)[strategyStr.toUpperCase()] ?? Strategy.COOKIE;
-    const browser = def.browser ?? (strategy !== Strategy.PUBLIC);
+    const site = cliDef.site ?? defaultSite;
+    const name = cliDef.name ?? path.basename(filePath, path.extname(filePath));
+    const strategyStr = cliDef.strategy ?? (cliDef.browser === false ? 'public' : 'cookie');
+    const strategy = parseStrategy(strategyStr);
+    const browser = cliDef.browser ?? (strategy !== Strategy.PUBLIC);
 
     const args: Arg[] = [];
-    if (def.args && typeof def.args === 'object') {
-      for (const [argName, argDef] of Object.entries(def.args as Record<string, any>)) {
+    if (cliDef.args && typeof cliDef.args === 'object') {
+      for (const [argName, argDef] of Object.entries(cliDef.args)) {
         args.push({
           name: argName,
           type: argDef?.type ?? 'str',
@@ -157,21 +197,21 @@ async function registerYamlCli(filePath: string, defaultSite: string): Promise<v
     const cmd: CliCommand = {
       site,
       name,
-      description: def.description ?? '',
-      domain: def.domain,
+      description: cliDef.description ?? '',
+      domain: cliDef.domain,
       strategy,
       browser,
       args,
-      columns: def.columns,
-      pipeline: def.pipeline,
-      timeoutSeconds: def.timeout,
+      columns: cliDef.columns,
+      pipeline: cliDef.pipeline,
+      timeoutSeconds: cliDef.timeout,
       source: filePath,
-      navigateBefore: def.navigateBefore,
+      navigateBefore: cliDef.navigateBefore,
     };
 
     registerCommand(cmd);
-  } catch (err: any) {
-    log.warn(`Failed to load ${filePath}: ${err.message}`);
+  } catch (err) {
+    log.warn(`Failed to load ${filePath}: ${getErrorMessage(err)}`);
   }
 }
 
@@ -196,7 +236,7 @@ export async function discoverPlugins(): Promise<void> {
 async function discoverPluginDir(dir: string, site: string): Promise<void> {
   const files = await fs.promises.readdir(dir);
   const fileSet = new Set(files);
-  const promises: Promise<any>[] = [];
+  const promises: Promise<unknown>[] = [];
   for (const file of files) {
     const filePath = path.join(dir, file);
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
@@ -204,8 +244,8 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
     } else if (file.endsWith('.js') && !file.endsWith('.d.js')) {
       if (!(await isCliModule(filePath))) continue;
       promises.push(
-        import(`file://${filePath}`).catch((err: any) => {
-          log.warn(`Plugin ${site}/${file}: ${err.message}`);
+        import(`file://${filePath}`).catch((err) => {
+          log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
         })
       );
     } else if (
@@ -216,8 +256,8 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
       if (fileSet.has(jsFile)) continue;
       if (!(await isCliModule(filePath))) continue;
       promises.push(
-        import(`file://${filePath}`).catch((err: any) => {
-          log.warn(`Plugin ${site}/${file}: ${err.message}`);
+        import(`file://${filePath}`).catch((err) => {
+          log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
         })
       );
     }
@@ -229,8 +269,8 @@ async function isCliModule(filePath: string): Promise<boolean> {
   try {
     const source = await fs.promises.readFile(filePath, 'utf-8');
     return CLI_MODULE_PATTERN.test(source);
-  } catch (err: any) {
-    log.warn(`Failed to inspect module ${filePath}: ${err.message}`);
+  } catch (err) {
+    log.warn(`Failed to inspect module ${filePath}: ${getErrorMessage(err)}`);
     return false;
   }
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -25,6 +25,22 @@ export interface ValidationReport {
   files: number;
 }
 
+interface ValidatedYamlCliDefinition {
+  site?: string;
+  name?: string;
+  pipeline?: unknown[];
+  columns?: unknown[];
+  args?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function validateClisWithTarget(dirs: string[], target?: string): ValidationReport {
   const results: FileValidationResult[] = [];
   let errors = 0; let warnings = 0; let files = 0;
@@ -53,8 +69,8 @@ function validateYamlFile(filePath: string): FileValidationResult {
   const errors: string[] = []; const warnings: string[] = [];
   try {
     const raw = fs.readFileSync(filePath, 'utf-8');
-    const def = yaml.load(raw) as any;
-    if (!def || typeof def !== 'object') { errors.push('Not a valid YAML object'); return { path: filePath, errors, warnings }; }
+    const def = yaml.load(raw) as ValidatedYamlCliDefinition | null;
+    if (!isRecord(def)) { errors.push('Not a valid YAML object'); return { path: filePath, errors, warnings }; }
     if (!def.site) errors.push('Missing "site"');
     if (!def.name) errors.push('Missing "name"');
     if (def.pipeline && !Array.isArray(def.pipeline)) errors.push('"pipeline" must be an array');
@@ -74,7 +90,7 @@ function validateYamlFile(filePath: string): FileValidationResult {
         }
       }
     }
-  } catch (e: any) { errors.push(`YAML parse error: ${e.message}`); }
+  } catch (e) { errors.push(`YAML parse error: ${getErrorMessage(e)}`); }
   return { path: filePath, errors, warnings };
 }
 
@@ -89,4 +105,3 @@ export function renderValidationReport(report: ValidationReport): string {
   }
   return lines.join('\n');
 }
-


### PR DESCRIPTION
## Summary
- tighten typing across manifest building, CLI discovery, validation, and Commander bridging
- replace broad `any` usage with explicit YAML/manifest shape types and shared error helpers
- keep runtime behavior unchanged while shrinking the discovery-layer loose typing surface

## Validation
- npm run typecheck
- npm run build
- npx vitest run src/build-manifest.test.ts src/engine.test.ts