### PR TITLE
fix: align positional primary args and docs

### DIFF
--- a/docs/adapters/browser/barchart.md
+++ b/docs/adapters/browser/barchart.md
@@ -1,6 +1,6 @@
 # Barchart
 
-**Mode**: 🌐 Public · **Domain**: `barchart.com`
+**Mode**: 🔐 Browser · **Domain**: `barchart.com`
 
 ## Commands
 
@@ -15,13 +15,13 @@
 
 ```bash
 # Get stock quote
-opencli barchart quote --symbol AAPL
+opencli barchart quote AAPL
 
 # View options chain
-opencli barchart options --symbol TSLA
+opencli barchart options TSLA
 
 # Options greeks overview
-opencli barchart greeks --symbol NVDA
+opencli barchart greeks NVDA
 
 # Unusual options flow
 opencli barchart flow --limit 20 -f json
@@ -29,4 +29,5 @@ opencli barchart flow --limit 20 -f json
 
 ## Prerequisites
 
-- No browser required — uses public API
+- Chrome running and able to open `barchart.com`
+- [Browser Bridge extension](/guide/browser-bridge) installed

--- a/docs/adapters/browser/bilibili.md
+++ b/docs/adapters/browser/bilibili.md
@@ -25,6 +25,15 @@
 # Quick start
 opencli bilibili hot --limit 5
 
+# Search videos
+opencli bilibili search 黑神话 --limit 10
+
+# Read one creator's videos
+opencli bilibili user-videos 2 --limit 10
+
+# Fetch subtitles
+opencli bilibili subtitle BV1xx411c7mD --lang zh-CN
+
 # JSON output
 opencli bilibili hot -f json
 

--- a/docs/adapters/browser/medium.md
+++ b/docs/adapters/browser/medium.md
@@ -1,31 +1,32 @@
 # Medium
 
-**Mode**: 🌐 Public · **Domain**: `medium.com`
+**Mode**: 🌗 Mixed · **Domain**: `medium.com`
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `opencli medium publication` | Get recent articles from a publication |
-| `opencli medium tag` | Get top articles for a tag |
+| `opencli medium feed` | Get hot Medium posts, optionally scoped to a topic |
+| `opencli medium search` | Search Medium posts by keyword |
 | `opencli medium user` | Get recent articles by a user |
 
 ## Usage Examples
 
 ```bash
-# Get articles from a publication
-opencli medium publication --name towards-data-science
+# Get the general Medium feed
+opencli medium feed --limit 10
 
-# Get top articles for a tag
-opencli medium tag --name programming
+# Search posts by keyword
+opencli medium search ai
 
 # Get articles by a user
-opencli medium user --name @username
+opencli medium user @username
 
-# JSON output
-opencli medium tag --name ai -f json
+# Topic feed as JSON
+opencli medium feed --topic programming -f json
 ```
 
 ## Prerequisites
 
-None — all commands use public endpoints, no browser or login required.
+- `opencli medium search` can run without a browser
+- `opencli medium feed` and `opencli medium user` require Browser Bridge access to `medium.com`

--- a/docs/adapters/browser/reddit.md
+++ b/docs/adapters/browser/reddit.md
@@ -28,6 +28,15 @@
 # Quick start
 opencli reddit hot --limit 5
 
+# Read one subreddit
+opencli reddit subreddit python --limit 10
+
+# Read a post thread
+opencli reddit read 1abc123 --depth 2
+
+# Comment on a post
+opencli reddit comment 1abc123 "Great post"
+
 # JSON output
 opencli reddit hot -f json
 

--- a/docs/adapters/browser/xueqiu.md
+++ b/docs/adapters/browser/xueqiu.md
@@ -7,6 +7,7 @@
 | Command | Description |
 |---------|-------------|
 | `opencli xueqiu feed` | |
+| `opencli xueqiu earnings-date` | |
 | `opencli xueqiu hot-stock` | |
 | `opencli xueqiu hot` | |
 | `opencli xueqiu search` | |
@@ -18,6 +19,15 @@
 ```bash
 # Quick start
 opencli xueqiu feed --limit 5
+
+# Search stocks
+opencli xueqiu search 茅台
+
+# View one stock
+opencli xueqiu stock SH600519
+
+# Upcoming earnings dates
+opencli xueqiu earnings-date SH600519 --next
 
 # JSON output
 opencli xueqiu feed -f json

--- a/docs/adapters/browser/yahoo-finance.md
+++ b/docs/adapters/browser/yahoo-finance.md
@@ -1,6 +1,6 @@
 # Yahoo Finance
 
-**Mode**: 🌐 Public · **Domain**: `finance.yahoo.com`
+**Mode**: 🔐 Browser · **Domain**: `finance.yahoo.com`
 
 ## Commands
 
@@ -12,15 +12,16 @@
 
 ```bash
 # Quick start
-opencli yahoo-finance quote --limit 5
+opencli yahoo-finance quote AAPL
 
 # JSON output
-opencli yahoo-finance quote -f json
+opencli yahoo-finance quote TSLA -f json
 
 # Verbose mode
-opencli yahoo-finance quote -v
+opencli yahoo-finance quote NVDA -v
 ```
 
 ## Prerequisites
 
-- No browser required — uses public API
+- Chrome running and able to open `finance.yahoo.com`
+- [Browser Bridge extension](/guide/browser-bridge) installed

--- a/src/clis/barchart/greeks.ts
+++ b/src/clis/barchart/greeks.ts
@@ -12,7 +12,7 @@ cli({
   domain: 'www.barchart.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'symbol', required: true, help: 'Stock ticker (e.g. AAPL)' },
+    { name: 'symbol', required: true, positional: true, help: 'Stock ticker (e.g. AAPL)' },
     { name: 'expiration', type: 'str', help: 'Expiration date (YYYY-MM-DD). Defaults to the nearest available expiration.' },
     { name: 'limit', type: 'int', default: 10, help: 'Number of near-the-money strikes per type' },
   ],

--- a/src/clis/barchart/options.ts
+++ b/src/clis/barchart/options.ts
@@ -11,7 +11,7 @@ cli({
   domain: 'www.barchart.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'symbol', required: true, help: 'Stock ticker (e.g. AAPL)' },
+    { name: 'symbol', required: true, positional: true, help: 'Stock ticker (e.g. AAPL)' },
     { name: 'type', type: 'str', default: 'Call', help: 'Option type: Call or Put', choices: ['Call', 'Put'] },
     { name: 'limit', type: 'int', default: 20, help: 'Max number of strikes to return' },
   ],

--- a/src/clis/barchart/quote.ts
+++ b/src/clis/barchart/quote.ts
@@ -11,7 +11,7 @@ cli({
   domain: 'www.barchart.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'symbol', required: true, help: 'Stock ticker (e.g. AAPL, MSFT, TSLA)' },
+    { name: 'symbol', required: true, positional: true, help: 'Stock ticker (e.g. AAPL, MSFT, TSLA)' },
   ],
   columns: [
     'symbol', 'name', 'price', 'change', 'changePct',

--- a/src/clis/bilibili/download.ts
+++ b/src/clis/bilibili/download.ts
@@ -28,7 +28,7 @@ cli({
   domain: 'www.bilibili.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'bvid', required: true, help: 'Video BV ID (e.g., BV1xxx)' },
+    { name: 'bvid', required: true, positional: true, help: 'Video BV ID (e.g., BV1xxx)' },
     { name: 'output', default: './bilibili-downloads', help: 'Output directory' },
     { name: 'quality', default: 'best', help: 'Video quality (best, 1080p, 720p, 480p)' },
   ],

--- a/src/clis/bilibili/subtitle.ts
+++ b/src/clis/bilibili/subtitle.ts
@@ -8,7 +8,7 @@ cli({
   description: '获取 Bilibili 视频的字幕',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'bvid', required: true },
+    { name: 'bvid', required: true, positional: true },
     { name: 'lang', required: false, help: '字幕语言代码 (如 zh-CN, en-US, ai-zh)，默认取第一个' },
   ],
   columns: ['index', 'from', 'to', 'content'],

--- a/src/clis/bilibili/user-videos.ts
+++ b/src/clis/bilibili/user-videos.ts
@@ -8,7 +8,7 @@ cli({
   domain: 'www.bilibili.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'uid', required: true, help: 'User UID or username' },
+    { name: 'uid', required: true, positional: true, help: 'User UID or username' },
     { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
     { name: 'order', default: 'pubdate', help: 'Sort: pubdate, click, stow' },
     { name: 'page', type: 'int', default: 1, help: 'Page number' },

--- a/src/clis/boss/chatmsg.ts
+++ b/src/clis/boss/chatmsg.ts
@@ -10,7 +10,7 @@ cli({
   navigateBefore: false,
   browser: true,
   args: [
-    { name: 'uid', required: true, help: 'Encrypted UID (from chatlist)' },
+    { name: 'uid', required: true, positional: true, help: 'Encrypted UID (from chatlist)' },
     { name: 'page', type: 'int', default: 1, help: 'Page number' },
   ],
   columns: ['from', 'type', 'text', 'time'],

--- a/src/clis/boss/exchange.ts
+++ b/src/clis/boss/exchange.ts
@@ -13,7 +13,7 @@ cli({
   navigateBefore: false,
   browser: true,
   args: [
-    { name: 'uid', required: true, help: 'Encrypted UID of the candidate' },
+    { name: 'uid', required: true, positional: true, help: 'Encrypted UID of the candidate' },
     { name: 'type', default: 'phone', choices: ['phone', 'wechat'], help: 'Exchange type: phone or wechat' },
   ],
   columns: ['status', 'detail'],

--- a/src/clis/boss/resume.ts
+++ b/src/clis/boss/resume.ts
@@ -21,7 +21,7 @@ cli({
   navigateBefore: false,
   browser: true,
   args: [
-    { name: 'uid', required: true, help: 'Encrypted UID of the candidate (from chatlist)' },
+    { name: 'uid', required: true, positional: true, help: 'Encrypted UID of the candidate (from chatlist)' },
   ],
   columns: [
     'name', 'gender', 'age', 'experience', 'degree', 'active_time',

--- a/src/clis/douban/search.ts
+++ b/src/clis/douban/search.ts
@@ -9,7 +9,7 @@ cli({
   strategy: Strategy.COOKIE,
   args: [
     { name: 'type', default: 'movie', choices: ['movie', 'book', 'music'], help: '搜索类型（movie=电影, book=图书, music=音乐）' },
-    { name: 'keyword', required: true, help: '搜索关键词' },
+    { name: 'keyword', required: true, positional: true, help: '搜索关键词' },
     { name: 'limit', type: 'int', default: 20, help: '返回结果数量' },
   ],
   columns: ['rank', 'title', 'rating', 'abstract', 'url'],

--- a/src/clis/medium/search.ts
+++ b/src/clis/medium/search.ts
@@ -8,7 +8,7 @@ cli({
   domain: 'medium.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'keyword', required: true, help: '搜索关键词' },
+    { name: 'keyword', required: true, positional: true, help: '搜索关键词' },
     { name: 'limit', type: 'int', default: 20, help: '返回的文章数量' },
   ],
   columns: ['rank', 'title', 'author', 'date', 'readTime', 'claps'],

--- a/src/clis/medium/user.ts
+++ b/src/clis/medium/user.ts
@@ -8,7 +8,7 @@ cli({
   domain: 'medium.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'username', required: true, help: 'Medium 用户名（如 @username 或 username）' },
+    { name: 'username', required: true, positional: true, help: 'Medium 用户名（如 @username 或 username）' },
     { name: 'limit', type: 'int', default: 20, help: '返回的文章数量' },
   ],
   columns: ['rank', 'title', 'date', 'readTime', 'claps', 'url'],

--- a/src/clis/reddit/comment.ts
+++ b/src/clis/reddit/comment.ts
@@ -8,7 +8,7 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'post-id', type: 'string', required: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
+    { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
     { name: 'text', type: 'string', required: true, positional: true, help: 'Comment text' },
   ],
   columns: ['status', 'message'],

--- a/src/clis/reddit/read.ts
+++ b/src/clis/reddit/read.ts
@@ -15,7 +15,7 @@ cli({
   domain: 'reddit.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'post-id', required: true, help: 'Post ID (e.g. 1abc123) or full URL' },
+    { name: 'post-id', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or full URL' },
     { name: 'sort', default: 'best', help: 'Comment sort: best, top, new, controversial, old, qa' },
     { name: 'limit', type: 'int', default: 25, help: 'Number of top-level comments' },
     { name: 'depth', type: 'int', default: 2, help: 'Max reply depth (1=no replies, 2=one level of replies, etc.)' },

--- a/src/clis/reddit/save.ts
+++ b/src/clis/reddit/save.ts
@@ -8,7 +8,7 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'post-id', type: 'string', required: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
+    { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
     { name: 'undo', type: 'boolean', default: false, help: 'Unsave instead of save' },
   ],
   columns: ['status', 'message'],

--- a/src/clis/reddit/subreddit.yaml
+++ b/src/clis/reddit/subreddit.yaml
@@ -8,6 +8,7 @@ browser: true
 args:
   name:
     type: string
+    positional: true
     required: true
   sort:
     type: string

--- a/src/clis/reddit/subscribe.ts
+++ b/src/clis/reddit/subscribe.ts
@@ -8,7 +8,7 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'subreddit', type: 'string', required: true, help: 'Subreddit name (e.g. python)' },
+    { name: 'subreddit', type: 'string', required: true, positional: true, help: 'Subreddit name (e.g. python)' },
     { name: 'undo', type: 'boolean', default: false, help: 'Unsubscribe instead of subscribe' },
   ],
   columns: ['status', 'message'],

--- a/src/clis/reddit/upvote.ts
+++ b/src/clis/reddit/upvote.ts
@@ -8,7 +8,7 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'post-id', type: 'string', required: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
+    { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
     { name: 'direction', type: 'string', default: 'up', help: 'Vote direction: up, down, none' },
   ],
   columns: ['status', 'message'],

--- a/src/clis/sinablog/article.ts
+++ b/src/clis/sinablog/article.ts
@@ -8,7 +8,7 @@ cli({
   domain: 'blog.sina.com.cn',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'url', required: true, help: '文章URL（如 https://blog.sina.com.cn/s/blog_xxx.html）' },
+    { name: 'url', required: true, positional: true, help: '文章URL（如 https://blog.sina.com.cn/s/blog_xxx.html）' },
   ],
   columns: ['title', 'author', 'date', 'category', 'readCount', 'commentCount'],
   func: async (page, args) => loadSinaBlogArticle(page, args.url),

--- a/src/clis/sinablog/search.ts
+++ b/src/clis/sinablog/search.ts
@@ -48,7 +48,7 @@ cli({
   strategy: Strategy.PUBLIC,
   browser: false,
   args: [
-    { name: 'keyword', required: true, help: '搜索关键词' },
+    { name: 'keyword', required: true, positional: true, help: '搜索关键词' },
     { name: 'limit', type: 'int', default: 20, help: '返回的文章数量' },
   ],
   columns: ['rank', 'title', 'author', 'date', 'description', 'url'],

--- a/src/clis/sinablog/user.ts
+++ b/src/clis/sinablog/user.ts
@@ -8,7 +8,7 @@ cli({
   domain: 'blog.sina.com.cn',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'uid', required: true, help: '新浪博客用户ID（如 1234567890）' },
+    { name: 'uid', required: true, positional: true, help: '新浪博客用户ID（如 1234567890）' },
     { name: 'limit', type: 'int', default: 20, help: '返回的文章数量' },
   ],
   columns: ['rank', 'title', 'author', 'date', 'readCount', 'url'],

--- a/src/clis/substack/publication.ts
+++ b/src/clis/substack/publication.ts
@@ -8,7 +8,7 @@ cli({
   domain: 'substack.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'url', required: true, help: 'Newsletter URL（如 https://example.substack.com）' },
+    { name: 'url', required: true, positional: true, help: 'Newsletter URL（如 https://example.substack.com）' },
     { name: 'limit', type: 'int', default: 20, help: '返回的文章数量' },
   ],
   columns: ['rank', 'title', 'date', 'description', 'url'],

--- a/src/clis/substack/search.ts
+++ b/src/clis/substack/search.ts
@@ -77,7 +77,7 @@ cli({
   strategy: Strategy.PUBLIC,
   browser: false,
   args: [
-    { name: 'keyword', required: true, help: '搜索关键词' },
+    { name: 'keyword', required: true, positional: true, help: '搜索关键词' },
     { name: 'type', default: 'posts', choices: ['posts', 'publications'], help: '搜索类型（posts=文章, publications=Newsletter）' },
     { name: 'limit', type: 'int', default: 20, help: '返回结果数量' },
   ],

--- a/src/clis/yahoo-finance/quote.ts
+++ b/src/clis/yahoo-finance/quote.ts
@@ -11,7 +11,7 @@ cli({
   domain: 'finance.yahoo.com',
   strategy: Strategy.COOKIE,
   args: [
-    { name: 'symbol', required: true, help: 'Stock ticker (e.g. AAPL, MSFT, TSLA)' },
+    { name: 'symbol', required: true, positional: true, help: 'Stock ticker (e.g. AAPL, MSFT, TSLA)' },
   ],
   columns: ['symbol', 'name', 'price', 'change', 'changePercent', 'open', 'high', 'low', 'volume', 'marketCap'],
   func: async (page, kwargs) => {


### PR DESCRIPTION
## Summary
- convert a broad set of primary command inputs from named options to positional args
- keep manifest/discovery output aligned so packaged builds expose the same CLI shape
- refresh adapter docs and examples to match the updated command syntax

## Validation
- npm run typecheck
- npm run build
- npx vitest run src/build-manifest.test.ts src/engine.test.ts
- custom manifest check for 27 positional command entries