### PR TITLE
fix: add github alias for GitHub CLI passthrough

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -83,8 +83,9 @@ opencli xueqiu feed                      # 我的关注 timeline
 opencli xueqiu hot --limit 10            # 雪球热榜
 opencli xueqiu search "特斯拉"            # 搜索 (query positional)
 
-# GitHub (public)
-opencli github search "cli"              # 搜索仓库 (query positional)
+# GitHub CLI
+opencli github repo view cli/cli         # `github` 兼容别名，实际透传到 `gh`
+opencli gh search repos "cli"            # 搜索仓库
 
 # Twitter/X (browser)
 opencli twitter trending --limit 10      # 热门话题

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { render as renderOutput } from './output.js';
 import { getBrowserFactory, browserSession } from './runtime.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
-import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled } from './external.js';
+import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, resolveExternalCli } from './external.js';
 import { registerAllCommands } from './commanderAdapter.js';
 
 export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
@@ -309,13 +309,13 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     .description('Install an external CLI')
     .argument('<name>', 'Name of the external CLI')
     .action((name: string) => {
-      const ext = externalClis.find(e => e.name === name);
-      if (!ext) {
+      const resolved = resolveExternalCli(externalClis, name);
+      if (!resolved) {
         console.error(chalk.red(`External CLI '${name}' not found in registry.`));
         process.exitCode = 1;
         return;
       }
-      installExternalCli(ext);
+      installExternalCli(resolved.cli);
     });
 
   program
@@ -343,15 +343,18 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
   }
 
   for (const ext of externalClis) {
-    if (program.commands.some(c => c.name() === ext.name)) continue;
-    program
-      .command(ext.name)
-      .description(`(External) ${ext.description || ext.name}`)
-      .argument('[args...]')
-      .allowUnknownOption()
-      .passThroughOptions()
-      .helpOption(false)
-      .action((args: string[]) => passthroughExternal(ext.name, args));
+    for (const name of [ext.name, ...(ext.aliases ?? [])]) {
+      if (program.commands.some(c => c.name() === name)) continue;
+      const aliasSuffix = name === ext.name ? '' : ` (alias for ${ext.name})`;
+      program
+        .command(name)
+        .description(`(External) ${ext.description || ext.name}${aliasSuffix}`)
+        .argument('[args...]')
+        .allowUnknownOption()
+        .passThroughOptions()
+        .helpOption(false)
+        .action((args: string[]) => passthroughExternal(name, args));
+    }
   }
 
   // ── Antigravity serve (long-running, special case) ────────────────────────

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -1,5 +1,6 @@
 - name: gh
   binary: gh
+  aliases: [github]
   description: "GitHub CLI — repos, PRs, issues, releases, gists"
   homepage: "https://cli.github.com"
   tags: [github, git, dev]

--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExternalCli, type ExternalCliConfig } from './external.js';
+
+describe('resolveExternalCli', () => {
+  const configs: ExternalCliConfig[] = [
+    {
+      name: 'gh',
+      binary: 'gh',
+      aliases: ['github'],
+      description: 'GitHub CLI',
+    },
+  ];
+
+  it('matches canonical command names', () => {
+    const resolved = resolveExternalCli(configs, 'gh');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.cli.name).toBe('gh');
+  });
+
+  it('matches alias command names', () => {
+    const resolved = resolveExternalCli(configs, 'github');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.cli.name).toBe('gh');
+    expect(resolved?.matchedName).toBe('github');
+  });
+
+  it('returns null for unknown names', () => {
+    expect(resolveExternalCli(configs, 'gitlab')).toBeNull();
+  });
+});

--- a/src/external.ts
+++ b/src/external.ts
@@ -19,10 +19,16 @@ export interface ExternalCliInstall {
 export interface ExternalCliConfig {
   name: string;
   binary: string;
+  aliases?: string[];
   description?: string;
   homepage?: string;
   tags?: string[];
   install?: ExternalCliInstall;
+}
+
+export interface ResolvedExternalCli {
+  cli: ExternalCliConfig;
+  matchedName: string;
 }
 
 function getUserRegistryPath(): string {
@@ -60,6 +66,14 @@ export function loadExternalClis(): ExternalCliConfig[] {
   }
 
   return Array.from(configs.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function resolveExternalCli(configs: ExternalCliConfig[], name: string): ResolvedExternalCli | null {
+  for (const cli of configs) {
+    if (cli.name === name) return { cli, matchedName: name };
+    if (cli.aliases?.includes(name)) return { cli, matchedName: name };
+  }
+  return null;
 }
 
 export function isBinaryInstalled(binary: string): boolean {
@@ -110,10 +124,11 @@ export function installExternalCli(cli: ExternalCliConfig): boolean {
 
 export function executeExternalCli(name: string, args: string[], preloaded?: ExternalCliConfig[]): void {
   const configs = preloaded ?? loadExternalClis();
-  const cli = configs.find((c) => c.name === name);
-  if (!cli) {
+  const resolved = resolveExternalCli(configs, name);
+  if (!resolved) {
     throw new Error(`External CLI '${name}' not found in registry.`);
   }
+  const { cli } = resolved;
 
   // 1. Check if installed
   if (!isBinaryInstalled(cli.binary)) {

--- a/tests/e2e/management.test.ts
+++ b/tests/e2e/management.test.ts
@@ -98,6 +98,13 @@ describe('management commands E2E', () => {
     expect(stdout).toContain('validate');
   });
 
+  it('github alias forwards to gh', async () => {
+    const { stdout, code } = await runCli(['github', '--help']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('Work seamlessly with GitHub from the command line.');
+    expect(stdout).toContain('gh <command> <subcommand> [flags]');
+  });
+
   // ── unknown command ──
   it('unknown command shows error', async () => {
     const { stderr, code } = await runCli(['nonexistent-command-xyz']);


### PR DESCRIPTION
## Summary
- add `github` as an alias for the built-in external `gh` CLI registration
- resolve external CLI aliases consistently for install and passthrough execution
- add unit and E2E coverage for the alias behavior
- update the example documentation to reflect the actual behavior

## Problem
Issue #114 reports that `opencli github` is documented but fails with:

```text
error: unknown command 'github'
```

The current codebase registers `gh` as an external CLI, but does not expose `github` as a command alias.

## Solution
This PR adds alias support to external CLI definitions and registers `github` as an alias of `gh`. That keeps the documented command working without changing the existing `gh` passthrough behavior.

## Verification
- `npm run typecheck`
- `npx vitest run src/external.test.ts --project unit`
- `npx vitest run tests/e2e/management.test.ts --project e2e`
- `node dist/main.js github --help`

Closes #114.
