### PR TITLE
fix: correct SKILL.md github reference and add missing adapter docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,7 @@ Browser commands require:
 
 > **Note**: You must be logged into the target website in Chrome before running commands. Tabs opened during command execution are auto-closed afterwards.
 
-Public API commands (`hackernews`, `github search`, `v2ex`) need no browser.
+Public API commands (`hackernews`, `v2ex`) need no browser.
 
 ## Commands Reference
 
@@ -83,8 +83,10 @@ opencli xueqiu feed                      # 我的关注 timeline
 opencli xueqiu hot --limit 10            # 雪球热榜
 opencli xueqiu search "特斯拉"            # 搜索 (query positional)
 
-# GitHub (public)
-opencli github search "cli"              # 搜索仓库 (query positional)
+# GitHub (via gh External CLI)
+opencli gh repo list                     # 列出仓库 (passthrough to gh)
+opencli gh pr list --limit 5             # PR 列表
+opencli gh issue list                    # Issue 列表
 
 # Twitter/X (browser)
 opencli twitter trending --limit 10      # 热门话题

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,6 +68,9 @@ export default defineConfig({
                 { text: 'Chaoxing', link: '/adapters/browser/chaoxing' },
                 { text: 'Grok', link: '/adapters/browser/grok' },
                 { text: 'WeRead', link: '/adapters/browser/weread' },
+                { text: 'Douban', link: '/adapters/browser/douban' },
+                { text: 'Sina Blog', link: '/adapters/browser/sinablog' },
+                { text: 'Substack', link: '/adapters/browser/substack' },
               ],
             },
             {

--- a/docs/adapters/browser/douban.md
+++ b/docs/adapters/browser/douban.md
@@ -1,0 +1,38 @@
+# 豆瓣 (Douban)
+
+**Mode**: 🔐 Browser (Cookie) · **Domain**: `douban.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli douban movie-hot` | 豆瓣电影热门榜单 |
+| `opencli douban book-hot` | 豆瓣图书热门榜单 |
+| `opencli douban search` | 搜索豆瓣电影、图书或音乐 |
+
+## Usage Examples
+
+```bash
+# 电影热门
+opencli douban movie-hot --limit 10
+
+# 图书热门
+opencli douban book-hot --limit 10
+
+# 搜索电影
+opencli douban search "流浪地球"
+
+# 搜索图书
+opencli douban search --type book "三体"
+
+# 搜索音乐
+opencli douban search --type music "周杰伦"
+
+# JSON output
+opencli douban movie-hot -f json
+```
+
+## Prerequisites
+
+- Chrome logged into `douban.com`
+- Browser Bridge extension installed

--- a/docs/adapters/browser/sinablog.md
+++ b/docs/adapters/browser/sinablog.md
@@ -1,0 +1,36 @@
+# 新浪博客 (Sina Blog)
+
+**Mode**: 🌐 Public (search) / 🔐 Browser (hot, article, user) · **Domain**: `blog.sina.com.cn`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli sinablog hot` | 获取新浪博客热门文章/推荐 |
+| `opencli sinablog search` | 搜索新浪博客文章（通过新浪搜索，无需浏览器） |
+| `opencli sinablog article` | 获取新浪博客单篇文章详情 |
+| `opencli sinablog user` | 获取新浪博客用户的文章列表 |
+
+## Usage Examples
+
+```bash
+# 热门文章
+opencli sinablog hot --limit 10
+
+# 搜索文章（公开 API，无需浏览器）
+opencli sinablog search "人工智能"
+
+# 文章详情
+opencli sinablog article "https://blog.sina.com.cn/s/blog_xxx.html"
+
+# 用户文章列表
+opencli sinablog user 1234567890 --limit 10
+
+# JSON output
+opencli sinablog hot -f json
+```
+
+## Prerequisites
+
+- `search` command: No login required (public API)
+- `hot`, `article`, `user` commands: Chrome with `blog.sina.com.cn` accessible, Browser Bridge extension installed

--- a/docs/adapters/browser/substack.md
+++ b/docs/adapters/browser/substack.md
@@ -1,0 +1,38 @@
+# Substack
+
+**Mode**: 🌐 Public (search) / 🔐 Browser (feed, publication) · **Domain**: `substack.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli substack feed` | Substack 热门文章 Feed |
+| `opencli substack search` | 搜索 Substack 文章和 Newsletter（无需浏览器） |
+| `opencli substack publication` | 获取特定 Substack Newsletter 的最新文章 |
+
+## Usage Examples
+
+```bash
+# 热门 Feed
+opencli substack feed --limit 10
+
+# 按分类浏览
+opencli substack feed --category tech --limit 10
+
+# 搜索文章（公开 API，无需浏览器）
+opencli substack search "AI"
+
+# 搜索 Newsletter
+opencli substack search "technology" --type publications
+
+# 查看特定 Newsletter 的最新文章
+opencli substack publication "https://example.substack.com" --limit 10
+
+# JSON output
+opencli substack search "AI" -f json
+```
+
+## Prerequisites
+
+- `search` command: No login required (public API)
+- `feed`, `publication` commands: Chrome with `substack.com` accessible, Browser Bridge extension installed


### PR DESCRIPTION
## Changes

### SKILL.md fixes
- Replace non-existent `opencli github search` command with correct `opencli gh` external CLI passthrough examples (`gh repo list`, `gh pr list`, `gh issue list`)
- Remove `github search` from public API commands list (it was never a built-in adapter)

### Missing adapter docs (fixes CI doc-check)
- Add `docs/adapters/browser/douban.md` — 豆瓣 (movie-hot, book-hot, search)
- Add `docs/adapters/browser/sinablog.md` — 新浪博客 (hot, search, article, user)
- Add `docs/adapters/browser/substack.md` — Substack (feed, search, publication)
- Add these 3 pages to VitePress sidebar config

Doc coverage: **47/50 → 50/50** ✅