### PR TITLE
docs: add star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,10 @@ git push --follow-tags
 
 The CI will automatically build, create a GitHub release, and publish to npm.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=jackwener/opencli&type=Date)](https://star-history.com/#jackwener/opencli&Date)
+
 ## License
 
 [Apache-2.0](./LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -325,6 +325,10 @@ npm version minor   # 0.1.0 → 0.2.0
 git push --follow-tags
 ```
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=jackwener/opencli&type=Date)](https://star-history.com/#jackwener/opencli&Date)
+
 ## License
 
 [Apache-2.0](./LICENSE)


### PR DESCRIPTION
## Summary
- add the star history chart near the end of `README.md`
- mirror the same chart in `README.zh-CN.md`

This keeps the project growth graph visible from the repository homepage.