### PR TITLE
feat(jd,taobao,cnki): add JD, Taobao, and CNKI adapters

### DIFF
--- a/src/clis/cnki/search.ts
+++ b/src/clis/cnki/search.ts
@@ -1,0 +1,62 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'cnki',
+  name: 'search',
+  description: '中国知网论文搜索（海外版）',
+  domain: 'oversea.cnki.net',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'query', positional: true, required: true, help: '搜索关键词' },
+    { name: 'limit', type: 'int', default: 10, help: '返回结果数量 (max 20)' },
+  ],
+  columns: ['rank', 'title', 'authors', 'journal', 'date', 'url'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const limit = Math.min(kwargs.limit || 10, 20);
+    const query = encodeURIComponent(kwargs.query);
+
+    await page.goto(`https://oversea.cnki.net/kns/search?dbcode=CFLS&kw=${query}&korder=SU`);
+    await page.wait(8);
+
+    const data = await page.evaluate(`
+      (async () => {
+        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+        for (let i = 0; i < 40; i++) {
+          if (document.querySelector('.result-table-list tbody tr, #gridTable tbody tr')) break;
+          await new Promise(r => setTimeout(r, 500));
+        }
+        const rows = document.querySelectorAll('.result-table-list tbody tr, #gridTable tbody tr');
+        const results = [];
+        for (const row of rows) {
+          // CNKI table columns: checkbox | seq | title | authors | journal | date | source_db
+          const tds = row.querySelectorAll('td');
+          if (tds.length < 5) continue;
+
+          // Find the title — it's in td.name or the td with an <a> linking to article
+          const nameCell = row.querySelector('td.name') || tds[2];
+          const titleEl = nameCell?.querySelector('a');
+          const title = normalize(titleEl?.textContent).replace(/免费$/, '');
+          if (!title) continue;
+
+          let url = titleEl?.getAttribute('href') || '';
+          if (url && !url.startsWith('http')) url = 'https://oversea.cnki.net' + url;
+
+          // Authors and journal: find by class or positional
+          const authorCell = row.querySelector('td.author') || tds[3];
+          const journalCell = row.querySelector('td.source') || tds[4];
+          const dateCell = row.querySelector('td.date') || tds[5];
+
+          const authors = normalize(authorCell?.textContent);
+          const journal = normalize(journalCell?.textContent);
+          const date = normalize(dateCell?.textContent);
+
+          results.push({ rank: results.length + 1, title, authors, journal, date, url });
+          if (results.length >= ${limit}) break;
+        }
+        return results;
+      })()
+    `);
+    return Array.isArray(data) ? data : [];
+  },
+});

--- a/src/clis/jd/add-cart.ts
+++ b/src/clis/jd/add-cart.ts
@@ -1,0 +1,64 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'jd',
+  name: 'add-cart',
+  description: '京东加入购物车',
+  domain: 'item.jd.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'sku', positional: true, required: true, help: '商品 SKU ID' },
+    { name: 'num', type: 'int', default: 1, help: '数量' },
+  ],
+  columns: ['status', 'title', 'price', 'sku'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const sku = kwargs.sku;
+    const num = kwargs.num || 1;
+
+    await page.goto(`https://item.jd.com/${sku}.html`);
+    await page.wait(4);
+
+    // Get product info
+    const info = await page.evaluate(`
+      (() => {
+        const text = document.body?.innerText || '';
+        const titleMatch = document.title.match(/^【[^】]*】(.+?)【/);
+        const title = titleMatch ? titleMatch[1].trim() : document.title.split('-')[0].trim();
+        const priceMatch = text.match(/¥([\\d,.]+)/);
+        const price = priceMatch ? '¥' + priceMatch[1] : '';
+        return { title, price };
+      })()
+    `);
+
+    // Navigate to cart domain and use gate.action to add item
+    await page.goto(`https://cart.jd.com/gate.action?pid=${sku}&pcount=${num}&ptype=1`);
+    await page.wait(4);
+
+    const result = await page.evaluate(`
+      (() => {
+        const url = location.href;
+        const text = document.body?.innerText || '';
+        if (text.includes('已成功加入') || text.includes('商品已成功') || url.includes('addtocart')) {
+          return 'success';
+        }
+        if (text.includes('请登录') || text.includes('login') || url.includes('login')) {
+          return 'login_required';
+        }
+        return 'page:' + url.substring(0, 60) + ' | ' + text.substring(0, 100);
+      })()
+    `);
+
+    let status = '? 未知';
+    if (result === 'success') status = '✓ 已加入购物车';
+    else if (result === 'login_required') status = '✗ 需要登录京东';
+    else status = '? ' + result;
+
+    return [{
+      status,
+      title: (info?.title || '').slice(0, 80),
+      price: info?.price || '',
+      sku,
+    }];
+  },
+});

--- a/src/clis/jd/cart.ts
+++ b/src/clis/jd/cart.ts
@@ -1,0 +1,76 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'jd',
+  name: 'cart',
+  description: '查看京东购物车',
+  domain: 'cart.jd.com',
+  strategy: Strategy.COOKIE,
+  args: [],
+  columns: ['index', 'title', 'price', 'quantity', 'sku'],
+  navigateBefore: false,
+  func: async (page) => {
+    await page.goto('https://cart.jd.com/cart_index');
+    await page.wait(5);
+
+    const data = await page.evaluate(`
+      (async () => {
+        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+        for (let i = 0; i < 20; i++) {
+          if (document.body?.innerText?.length > 500) break;
+          await new Promise(r => setTimeout(r, 500));
+        }
+        const text = document.body?.innerText || '';
+
+        // Try API approach: fetch cart data via JD's cart API
+        try {
+          const resp = await fetch('https://api.m.jd.com/api?appid=JDC_mall_cart&functionId=pcCart_jc_getCurrentCart&body=%7B%22serInfo%22%3A%7B%22area%22%3A%2222_1930_50948_52157%22%7D%7D', {
+            credentials: 'include',
+            headers: { 'referer': 'https://cart.jd.com/' },
+          });
+          const json = await resp.json();
+          const cartData = json?.resultData?.cartInfo?.vendors || [];
+          const items = [];
+          for (const vendor of cartData) {
+            const sorted = vendor.sorted || [];
+            for (const item of sorted) {
+              const product = item.item || item;
+              if (!product.Id && !product.skuId) continue;
+              items.push({
+                index: items.length + 1,
+                title: normalize(product.name || product.Name || '').slice(0, 80),
+                price: product.price ? '¥' + product.price : '',
+                quantity: String(product.num || product.Num || 1),
+                sku: String(product.Id || product.skuId || ''),
+              });
+            }
+          }
+          if (items.length > 0) return items;
+        } catch {}
+
+        // Fallback: parse from page text
+        const lines = text.split('\\n').map(l => l.trim()).filter(Boolean);
+        const items = [];
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          const priceMatch = line.match(/¥([\\d,.]+)/);
+          if (priceMatch && i > 0) {
+            // Previous line might be the product title
+            const title = lines[i-1];
+            if (title && title.length > 5 && title.length < 200 && !title.startsWith('¥')) {
+              items.push({
+                index: items.length + 1,
+                title: title.slice(0, 80),
+                price: '¥' + priceMatch[1],
+                quantity: '',
+                sku: '',
+              });
+            }
+          }
+        }
+        return items;
+      })()
+    `);
+    return Array.isArray(data) ? data : [];
+  },
+});

--- a/src/clis/jd/detail.ts
+++ b/src/clis/jd/detail.ts
@@ -1,0 +1,67 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'jd',
+  name: 'detail',
+  description: '京东商品详情',
+  domain: 'item.jd.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'sku', positional: true, required: true, help: '商品 SKU ID' },
+  ],
+  columns: ['field', 'value'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    await page.goto(`https://item.jd.com/${kwargs.sku}.html`);
+    await page.wait(5);
+
+    const data = await page.evaluate(`
+      (() => {
+        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+        const text = document.body?.innerText || '';
+
+        // Title from <title> tag
+        const titleMatch = document.title.match(/^【[^】]*】(.+?)【/);
+        const title = titleMatch ? titleMatch[1].trim() : normalize(document.title.split('【')[0]);
+
+        // Price
+        const priceMatch = text.match(/¥([\\d,.]+)/);
+        const price = priceMatch ? '¥' + priceMatch[1] : '';
+
+        // Rating summary - find "超XX%买家赞不绝口" or similar
+        const ratingMatch = text.match(/(超\\d+%[^\\n]{2,20})/);
+        const rating = ratingMatch ? ratingMatch[1] : '';
+
+        // Total reviews
+        const reviewMatch = text.match(/买家评价\\(([\\d万+]+)\\)/);
+        const reviews = reviewMatch ? reviewMatch[1] : '';
+
+        // Shop
+        const shopMatch = text.match(/(\\S{2,15}(?:京东自营旗舰店|旗舰店|专卖店|自营店))/);
+        const shop = shopMatch ? shopMatch[1] : '';
+
+        // Tags - extract "触感超舒适 163" patterns
+        const tagPattern = /([\u4e00-\u9fa5]{2,8})\\s+(\\d+)/g;
+        const tags = [];
+        let m;
+        const tagSection = text.substring(text.indexOf('买家评价'), text.indexOf('买家评价') + 500);
+        while ((m = tagPattern.exec(tagSection)) && tags.length < 6) {
+          if (parseInt(m[2]) > 1) tags.push(m[1] + '(' + m[2] + ')');
+        }
+
+        const results = [
+          { field: '商品名称', value: title },
+          { field: '价格', value: price },
+          { field: 'SKU', value: '${kwargs.sku}' },
+          { field: '店铺', value: shop },
+          { field: '评价数量', value: reviews },
+          { field: '好评率', value: rating },
+          { field: '评价标签', value: tags.join(' | ') },
+          { field: '链接', value: location.href },
+        ];
+        return results.filter(r => r.value);
+      })()
+    `);
+    return Array.isArray(data) ? data : [];
+  },
+});

--- a/src/clis/jd/reviews.ts
+++ b/src/clis/jd/reviews.ts
@@ -1,0 +1,64 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'jd',
+  name: 'reviews',
+  description: '京东商品评价',
+  domain: 'item.jd.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'sku', positional: true, required: true, help: '商品 SKU ID' },
+    { name: 'limit', type: 'int', default: 10, help: '返回评价数量 (max 20)' },
+  ],
+  columns: ['rank', 'user', 'content', 'date'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const limit = Math.min(kwargs.limit || 10, 20);
+    await page.goto(`https://item.jd.com/${kwargs.sku}.html`);
+    await page.wait(5);
+    // Scroll to load reviews section
+    await page.autoScroll({ times: 2, delayMs: 1500 });
+
+    const data = await page.evaluate(`
+      (async () => {
+        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+        const text = document.body?.innerText || '';
+
+        // JD new version: reviews are inline in page text
+        // Pattern: username \\n review_text \\n [date or next username]
+        // Find the review section after "买家评价"
+        const reviewStart = text.indexOf('买家评价');
+        const reviewEnd = text.indexOf('全部评价');
+        if (reviewStart < 0) return [];
+
+        const reviewSection = text.substring(reviewStart, reviewEnd > reviewStart ? reviewEnd : reviewStart + 3000);
+        const lines = reviewSection.split('\\n').map(l => l.trim()).filter(Boolean);
+
+        const results = [];
+        // Skip header lines, look for user-review pairs
+        // Users are like "c***4", "3***a", "A***7" or "jd_xxx"
+        // JD usernames contain * (masked), like "c***4", "3***a", "jd_xxx"
+        const userPattern = /^[a-zA-Z0-9*_]{3,15}$/;
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          if (userPattern.test(line) && line.includes('*') && i + 1 < lines.length) {
+            const user = line;
+            const content = lines[i + 1];
+            // Skip if content looks like a header/tag
+            if (content.length < 5 || content.match(/^(全部评价|问大家|查看更多)/)) continue;
+            results.push({
+              rank: results.length + 1,
+              user,
+              content: content.slice(0, 150),
+              date: '',
+            });
+            i++; // skip the content line
+            if (results.length >= ${limit}) break;
+          }
+        }
+        return results;
+      })()
+    `);
+    return Array.isArray(data) ? data : [];
+  },
+});

--- a/src/clis/jd/search.ts
+++ b/src/clis/jd/search.ts
@@ -1,0 +1,71 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'jd',
+  name: 'search',
+  description: '京东商品搜索',
+  domain: 'search.jd.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'query', positional: true, required: true, help: '搜索关键词' },
+    { name: 'limit', type: 'int', default: 10, help: '返回结果数量 (max 30)' },
+  ],
+  columns: ['rank', 'title', 'price', 'shop', 'sku', 'url'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const limit = Math.min(kwargs.limit || 10, 30);
+    const query = encodeURIComponent(kwargs.query);
+    await page.goto(`https://search.jd.com/Search?keyword=${query}&enc=utf-8`);
+    await page.wait(5);
+    await page.autoScroll({ times: 2, delayMs: 1500 });
+
+    const data = await page.evaluate(`
+      (async () => {
+        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+        for (let i = 0; i < 20; i++) {
+          if (document.querySelectorAll('div[data-sku]').length > 0) break;
+          await new Promise(r => setTimeout(r, 500));
+        }
+        const items = document.querySelectorAll('div[data-sku]');
+        const results = [];
+        for (const el of items) {
+          const sku = el.getAttribute('data-sku') || '';
+          if (!sku) continue;
+          const text = normalize(el.textContent);
+          if (text.length < 10) continue;
+
+          // Parse product text: pattern is usually [badge?] title price shop ...
+          // Price: first ¥ number
+          const priceMatch = text.match(/¥([\\d,.]+)/);
+          const price = priceMatch ? '¥' + priceMatch[1] : '';
+
+          // Title: text before the price, strip leading badges like "海外无货" "京东超市"
+          let title = '';
+          if (priceMatch) {
+            const beforePrice = text.substring(0, text.indexOf('¥'));
+            title = beforePrice.replace(/^(海外无货|京东超市|自营|秒杀|新品|预售|PLUS)/, '').trim();
+          }
+          if (!title || title.length < 4) continue;
+
+          // Shop: look for "旗舰店" / "专卖店" / "自营" patterns
+          let shop = '';
+          const shopMatch = text.match(/(\\S{2,15}(?:旗舰店|专卖店|自营店|官方旗舰店|京东自营旗舰店|京东自营))/);
+          if (shopMatch) shop = shopMatch[1];
+
+          const url = 'https://item.jd.com/' + sku + '.html';
+          results.push({
+            rank: results.length + 1,
+            title: title.slice(0, 80),
+            price,
+            shop,
+            sku,
+            url,
+          });
+          if (results.length >= ${limit}) break;
+        }
+        return results;
+      })()
+    `);
+    return Array.isArray(data) ? data : [];
+  },
+});

--- a/src/clis/taobao/search.ts
+++ b/src/clis/taobao/search.ts
@@ -1,0 +1,92 @@
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'taobao',
+  name: 'search',
+  description: '淘宝商品搜索',
+  domain: 's.taobao.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'query', positional: true, required: true, help: '搜索关键词' },
+    { name: 'sort', default: 'default', choices: ['default', 'sale', 'price'], help: '排序 (default/sale销量/price价格)' },
+    { name: 'limit', type: 'int', default: 10, help: '返回结果数量 (max 40)' },
+  ],
+  columns: ['rank', 'title', 'price', 'sales', 'shop', 'location', 'url'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const limit = Math.min(kwargs.limit || 10, 40);
+    const query = encodeURIComponent(kwargs.query);
+    const sortMap: Record<string, string> = { default: '', sale: '&sort=sale-desc', price: '&sort=price-asc' };
+    const sortParam = sortMap[kwargs.sort] || '';
+
+    await page.goto('https://www.taobao.com');
+    await page.wait(2);
+    await page.evaluate(`location.href = 'https://s.taobao.com/search?q=${query}${sortParam}'`);
+    await page.wait(8);
+    await page.autoScroll({ times: 3, delayMs: 2000 });
+
+    const data = await page.evaluate(`
+      (async () => {
+        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+
+        // Check login
+        const bodyText = document.body?.innerText || '';
+        if (bodyText.length < 1000 && bodyText.includes('请登录')) {
+          return [{rank:0, title:'[未登录] 请在自动化窗口中登录淘宝', price:'', sales:'', shop:'', location:'', url:''}];
+        }
+
+        // Wait for cards
+        for (let i = 0; i < 30; i++) {
+          if (document.querySelectorAll('[class*="doubleCard--"]').length > 3) break;
+          await new Promise(r => setTimeout(r, 500));
+        }
+
+        const cards = document.querySelectorAll('[class*="doubleCard--"]');
+        const results = [];
+        const seenTitles = new Set();
+
+        for (const card of cards) {
+          // Title
+          const titleEl = card.querySelector('[class*="title--"]');
+          const title = titleEl ? normalize(titleEl.textContent) : '';
+          if (!title || title.length < 3 || seenTitles.has(title)) continue;
+          seenTitles.add(title);
+
+          // Price: integer + optional decimal
+          const intEl = card.querySelector('[class*="priceInt--"]');
+          const floatEl = card.querySelector('[class*="priceFloat--"]');
+          let price = '';
+          if (intEl) {
+            price = '¥' + normalize(intEl.textContent) + (floatEl ? normalize(floatEl.textContent) : '');
+          }
+
+          // Sales
+          const salesEl = card.querySelector('[class*="realSales--"]');
+          const sales = salesEl ? normalize(salesEl.textContent) : '';
+
+          // Shop name (strip leading "X年老店" prefix)
+          const shopEl = card.querySelector('[class*="shopName--"]');
+          let shop = shopEl ? normalize(shopEl.textContent) : '';
+          shop = shop.replace(/^\\d+年老店/, '').replace(/^回头客[\\d万]+/, '');
+
+          // Location
+          const locEls = card.querySelectorAll('[class*="procity--"]');
+          const location = Array.from(locEls).map(el => normalize(el.textContent)).join('');
+
+          // URL: first <a> in card (simba tracking link, redirects to product)
+          const linkEl = card.querySelector('a[href*="simba"], a[href*="taobao.com"], a[href*="tmall.com"]');
+          const url = linkEl ? linkEl.getAttribute('href')?.substring(0, 120) || '' : '';
+
+          results.push({ rank: results.length + 1, title: title.slice(0, 80), price, sales, shop, location, url });
+          if (results.length >= ${limit}) break;
+        }
+
+        if (results.length === 0) {
+          return [{rank:0, title:'[无结果] cards=' + cards.length, price:'', sales:'', shop:'', location:'', url: location.href}];
+        }
+        return results;
+      })()
+    `);
+    return Array.isArray(data) ? data : [];
+  },
+});


### PR DESCRIPTION
## Summary

- Add 7 new adapters for JD.com (京东), Taobao (淘宝), and CNKI (知网)
- **JD**: full shopping workflow — search, detail, reviews, add-to-cart, view cart
- **Taobao**: search with clean structured extraction from obfuscated DOM
- **CNKI**: overseas portal search (`oversea.cnki.net`)

## JD (京东) — 5 commands

| Command | Strategy | Description |
|---------|----------|-------------|
| `jd search <query>` | cookie + DOM | Search products (title, price, shop, SKU) |
| `jd detail <sku>` | cookie + DOM | Product detail (rating, review count, tags) |
| `jd reviews <sku>` | cookie + DOM | User reviews extraction |
| `jd add-cart <sku>` | cookie + navigate | Add to cart via `cart.jd.com/gate.action` |
| `jd cart` | cookie + API | View cart contents |

JD's new frontend uses fully obfuscated CSS classes — all extraction is done via `div[data-sku]` attribute and text pattern matching rather than class selectors.

## Taobao (淘宝) — 1 command

| Command | Strategy | Description |
|---------|----------|-------------|
| `taobao search <query>` | cookie + DOM | Product search with sort options (default/sale/price) |

Taobao's DOM uses obfuscated class names with semantic prefixes (e.g. `title--xxx`, `priceInt--xxx`, `realSales--xxx`, `shopName--xxx`, `procity--xxx`). The adapter matches on these prefixes via `[class*="prefix--"]` selectors, producing clean structured output.

**Note**: Taobao search requires login. Users need to log in once in the opencli automation window.

## CNKI (知网) — 1 command

| Command | Strategy | Description |
|---------|----------|-------------|
| `cnki search <query>` | cookie + DOM | Chinese academic paper search |

Uses `oversea.cnki.net` to avoid domestic access restrictions (the main `kns.cnki.net` returns 418 for non-browser requests and blocks CDP attach).

## Test plan

- [x] `npx tsc --noEmit` — type check passed
- [x] `npx vitest run src/` — all unit tests passed
- [x] `opencli validate` — 86 CLI definitions validated, 0 errors
- [x] Manual testing: JD search, detail, reviews, add-cart, cart all verified
- [x] Manual testing: Taobao search with clean field extraction verified
- [x] Manual testing: CNKI overseas search verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)