### PR TITLE
fix: treat empty tab URL as debuggable (fixes first-run failure)

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -6,7 +6,7 @@ const WS_RECONNECT_MAX_DELAY = 6e4;
 
 const attached = /* @__PURE__ */ new Set();
 function isDebuggableUrl$1(url) {
-  if (!url) return false;
+  if (!url) return true;
   return !url.startsWith("chrome://") && !url.startsWith("chrome-extension://");
 }
 async function ensureAttached(tabId) {
@@ -242,6 +242,7 @@ async function getAutomationWindow(workspace) {
   automationSessions.set(workspace, session);
   console.log(`[opencli] Created automation window ${session.windowId} (${workspace})`);
   resetWindowIdleTimer(workspace);
+  await new Promise((resolve) => setTimeout(resolve, 200));
   return session.windowId;
 }
 chrome.windows.onRemoved.addListener((windowId) => {
@@ -302,7 +303,7 @@ async function handleCommand(cmd) {
   }
 }
 function isDebuggableUrl(url) {
-  if (!url) return false;
+  if (!url) return true;
   return !url.startsWith("chrome://") && !url.startsWith("chrome-extension://");
 }
 async function resolveTabId(tabId, workspace) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Bridge between opencli CLI and your browser — execute commands, read cookies, manage tabs.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -152,6 +152,8 @@ async function getAutomationWindow(workspace: string): Promise<number> {
   automationSessions.set(workspace, session);
   console.log(`[opencli] Created automation window ${session.windowId} (${workspace})`);
   resetWindowIdleTimer(workspace);
+  // Brief delay to let Chrome load the initial data: URI tab
+  await new Promise(resolve => setTimeout(resolve, 200));
   return session.windowId;
 }
 
@@ -229,7 +231,7 @@ async function handleCommand(cmd: Command): Promise<Result> {
 
 /** Check if a URL can be attached via CDP (not chrome:// or chrome-extension://) */
 function isDebuggableUrl(url?: string): boolean {
-  if (!url) return false;
+  if (!url) return true;  // empty/undefined = tab still loading, allow it
   return !url.startsWith('chrome://') && !url.startsWith('chrome-extension://');
 }
 

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -10,7 +10,7 @@ const attached = new Set<number>();
 
 /** Check if a URL can be attached via CDP */
 function isDebuggableUrl(url?: string): boolean {
-  if (!url) return false;
+  if (!url) return true;  // empty/undefined = tab still loading, allow it
   return !url.startsWith('chrome://') && !url.startsWith('chrome-extension://');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
First-run `doctor --live` fails because new tab URL is empty while loading. `isDebuggableUrl('')` was returning false. Now only rejects known non-debuggable URLs (`chrome://`, `chrome-extension://`).

Version bump to 1.2.5.