### PR TITLE
ci: trigger website rebuild on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,10 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Trigger website rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
+          repository: jackwener/opencli-website
+          event-type: version-released


### PR DESCRIPTION
## Description

When a new version is released (v* tag push), trigger the opencli-website to rebuild via `repository_dispatch`. This ensures the website always displays the latest released version number.

Reuses the existing `WEBSITE_DEPLOY_TOKEN` secret (already used by `docs.yml`).

**Companion PR:** jackwener/opencli-website#1

## Type of Change

- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```yaml
# New step added to release.yml:
- name: Trigger website rebuild
  uses: peter-evans/repository-dispatch@v3
  with:
    token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
    repository: jackwener/opencli-website
    event-type: version-released
```