### PR TITLE
docs: clarify release follow-up steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ See **[TESTING.md](./TESTING.md)** for how to run and write tests.
 
 [![Star History Chart](https://api.star-history.com/svg?repos=jackwener/opencli&type=Date)](https://star-history.com/#jackwener/opencli&Date)
 
+After publishing the new version, remember to update the browser extension in the Chrome Web Store as well, so the extension release stays in sync with the CLI release.
+
 ## License
 
 [Apache-2.0](./LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,6 +289,8 @@ opencli cascade https://api.example.com/data
 
 [![Star History Chart](https://api.star-history.com/svg?repos=jackwener/opencli&type=Date)](https://star-history.com/#jackwener/opencli&Date)
 
+发版完成后，记得也要去 Chrome Web Store 更新浏览器插件，保持插件版本和 CLI 版本同步。
+
 ## License
 
 [Apache-2.0](./LICENSE)


### PR DESCRIPTION
## Summary
- add a README reminder to update the Chrome Web Store extension after publishing a new CLI release
- fix the stale Node.js version note in `README.md` (`>= 20`)
- align both READMEs with the current `Apache-2.0` license text