### PR TITLE
fix: ensure standard PATH is available for external CLIs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,16 @@
  * opencli — Make any website your CLI. AI-powered.
  */
 
+// Ensure standard system paths are available for child processes.
+// Some environments (GUI apps, cron, IDE terminals) launch with a minimal PATH
+// that excludes /usr/local/bin, /usr/sbin, etc., causing external CLIs to fail.
+if (process.platform !== 'win32') {
+  const std = ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin'];
+  const cur = new Set((process.env.PATH ?? '').split(':').filter(Boolean));
+  for (const p of std) cur.add(p);
+  process.env.PATH = [...cur].join(':');
+}
+
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Problem

When calling external CLIs (like `opencode`), child processes may not find system commands like `sysctl` because the PATH environment variable does not include standard system paths.

This causes errors like:
```
error: Executable not found in $PATH: "sysctl"
```

## Solution

Add standard paths to the environment when spawning external CLI processes.

## Test Case

```bash
# Register opencode
opencli register opencode --binary /usr/local/bin/opencode --desc "OpenCode AI coding agent"

# Before fix: fails with sysctl not found
opencli opencode --version

# After fix: works correctly
opencli opencode --version
# Output: 1.2.20
```

Fixes #284