### PR TITLE
feat: add xianyu-cli (闲鱼) as external CLI

### DIFF
--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -46,3 +46,11 @@
   install:
     mac: "brew install gws"
     default: "npm install -g @nicholasgasior/gws"
+
+- name: xianyu
+  binary: xianyu
+  description: "闲鱼 CLI — 搜索、比价、消息收发、全自动 Agent Flow 比价闭环"
+  homepage: "https://github.com/Donquijote-coder/xianyu-cli"
+  tags: [xianyu, goofish, shopping, secondhand, china]
+  install:
+    default: "pip install git+https://github.com/Donquijote-coder/xianyu-cli.git"


### PR DESCRIPTION
## Summary

- Add [xianyu-cli](https://github.com/Donquijote-coder/xianyu-cli) (闲鱼/Goofish) as an external CLI in `external-clis.yaml`
- xianyu-cli is a reverse-engineered CLI for China's largest second-hand marketplace

## Features

- **Auth**: QR code login, browser cookie extraction, credential management
- **Search**: keyword search, price filtering, credit-based sorting
- **Messaging**: send/receive messages, broadcast, image sending, real-time WebSocket monitoring with auto-reconnect
- **Agent Flow**: fully automated pricing pipeline — search → rank by credit → bulk inquire → collect replies → AI analysis → recommend best seller
- **Anti-detection**: cookie freeze, random delays, browser fingerprint simulation

## Install

```bash
pip install git+https://github.com/Donquijote-coder/xianyu-cli.git
```

## Test plan

- [x] Verified `xianyu --help` shows all commands
- [x] Verified `xianyu login`, `xianyu search`, `xianyu message send`, `xianyu agent-flow` work correctly
- [x] Entry added to `external-clis.yaml` follows existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)