### PR TITLE
fix(xiaohongshu): scope image selector to avoid downloading avatars

### DIFF
--- a/src/clis/xiaohongshu/download.ts
+++ b/src/clis/xiaohongshu/download.ts
@@ -52,7 +52,7 @@ cli({
           '.note-slider img',
           '.note-image img',
           '.image-wrapper img',
-          '#noteContainer img[src*="xhscdn"]',
+          '#noteContainer .media-container img[src*="xhscdn"]',
           'img[src*="ci.xiaohongshu.com"]'
         ];
 


### PR DESCRIPTION
Narrow `#noteContainer img[src*="xhscdn"]` to `#noteContainer .media-container img[src*="xhscdn"]` to exclude user avatars and sidebar icons from downloads.

Supersedes #281 (closed due to rebase conflict from download refactoring).