### PR TITLE
fix(tests,docs): use positional arg syntax for search commands

### DIFF
--- a/docs/adapters/browser/tiktok.md
+++ b/docs/adapters/browser/tiktok.md
@@ -29,7 +29,7 @@
 opencli tiktok profile --username tiktok
 
 # Search videos
-opencli tiktok search --query "cooking" --limit 10
+opencli tiktok search "cooking" --limit 10
 
 # Trending explore videos
 opencli tiktok explore --limit 20

--- a/tests/e2e/browser-auth.test.ts
+++ b/tests/e2e/browser-auth.test.ts
@@ -101,7 +101,7 @@ describe('login-required commands — graceful failure', () => {
   }, 60_000);
 
   it('linux-do search fails gracefully without login', async () => {
-    await expectGracefulAuthFailure(['linux-do', 'search', '--keyword', 'test', '--limit', '3', '-f', 'json'], 'linux-do search');
+    await expectGracefulAuthFailure(['linux-do', 'search', 'test', '--limit', '3', '-f', 'json'], 'linux-do search');
   }, 60_000);
 
   // ── xiaohongshu (requires login) ──

--- a/tests/e2e/browser-public.test.ts
+++ b/tests/e2e/browser-public.test.ts
@@ -92,7 +92,7 @@ describe('browser public-data commands E2E', () => {
   }, 60_000);
 
   it('bilibili search returns results', async () => {
-    const data = await tryBrowserCommand(['bilibili', 'search', '--keyword', 'typescript', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['bilibili', 'search', 'typescript', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'bilibili search');
   }, 60_000);
 
@@ -103,7 +103,7 @@ describe('browser public-data commands E2E', () => {
   }, 60_000);
 
   it('weibo search returns results', async () => {
-    const data = await tryBrowserCommand(['weibo', 'search', '--keyword', 'openai', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['weibo', 'search', 'openai', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'weibo search');
   }, 60_000);
 
@@ -117,7 +117,7 @@ describe('browser public-data commands E2E', () => {
   }, 60_000);
 
   it('zhihu search returns results', async () => {
-    const data = await tryBrowserCommand(['zhihu', 'search', '--keyword', 'playwright', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['zhihu', 'search', 'playwright', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'zhihu search');
   }, 60_000);
 
@@ -151,25 +151,25 @@ describe('browser public-data commands E2E', () => {
 
   // ── reuters (browser: true) ──
   it('reuters search returns articles', async () => {
-    const data = await tryBrowserCommand(['reuters', 'search', '--keyword', 'technology', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['reuters', 'search', 'technology', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'reuters search');
   }, 60_000);
 
   // ── youtube (browser: true) ──
   it('youtube search returns videos', async () => {
-    const data = await tryBrowserCommand(['youtube', 'search', '--keyword', 'typescript tutorial', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['youtube', 'search', 'typescript tutorial', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'youtube search');
   }, 60_000);
 
   // ── smzdm (browser: true) ──
   it('smzdm search returns deals', async () => {
-    const data = await tryBrowserCommand(['smzdm', 'search', '--keyword', '键盘', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['smzdm', 'search', '键盘', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'smzdm search');
   }, 60_000);
 
   // ── boss (browser: true) ──
   it('boss search returns jobs', async () => {
-    const data = await tryBrowserCommand(['boss', 'search', '--keyword', 'golang', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['boss', 'search', 'golang', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'boss search');
   }, 60_000);
 
@@ -181,13 +181,13 @@ describe('browser public-data commands E2E', () => {
 
   // ── coupang (browser: true) ──
   it('coupang search returns products', async () => {
-    const data = await tryBrowserCommand(['coupang', 'search', '--keyword', 'laptop', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['coupang', 'search', 'laptop', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'coupang search');
   }, 60_000);
 
   // ── xiaohongshu (browser: true) ──
   it('xiaohongshu search returns notes', async () => {
-    const data = await tryBrowserCommand(['xiaohongshu', 'search', '--keyword', '美食', '--limit', '3', '-f', 'json']);
+    const data = await tryBrowserCommand(['xiaohongshu', 'search', '美食', '--limit', '3', '-f', 'json']);
     expectDataOrSkip(data, 'xiaohongshu search');
   }, 60_000);
 


### PR DESCRIPTION
## Summary

Replace redundant `--keyword`/`--query` named flags with positional arg syntax for all search commands that declare `positional: true`.

## Changes

### Tests
- `tests/e2e/browser-public.test.ts`: 9 commands fixed (bilibili, weibo, zhihu, reuters, youtube, smzdm, boss, coupang, xiaohongshu)
- `tests/e2e/browser-auth.test.ts`: linux-do search fixed

### Docs
- `docs/adapters/browser/tiktok.md`: `--query "cooking"` → `"cooking"`

## Before / After

```diff
-await tryBrowserCommand(['bilibili', 'search', '--keyword', 'typescript', ...]);
+await tryBrowserCommand(['bilibili', 'search', 'typescript', ...]);
```