### PR TITLE
fix: remove stale SQLite file, add chatgpt platform guard, fix daemon exit code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ docs/.vitepress/cache
 .windsurf
 .claude
 .cortex
+
+# Database files
+*.db

--- a/src/clis/chatgpt/ask.ts
+++ b/src/clis/chatgpt/ask.ts
@@ -16,6 +16,10 @@ export const askCommand = cli({
   ],
   columns: ['Role', 'Text'],
   func: async (page: IPage | null, kwargs: any) => {
+    if (process.platform !== 'darwin') {
+      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+    }
+
     const text = kwargs.text as string;
     const timeout = parseInt(kwargs.timeout as string, 10) || 30;
 

--- a/src/clis/chatgpt/new.ts
+++ b/src/clis/chatgpt/new.ts
@@ -12,6 +12,10 @@ export const newCommand = cli({
   args: [],
   columns: ['Status'],
   func: async (page: IPage | null) => {
+    if (process.platform !== 'darwin') {
+      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+    }
+
     try {
       execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
       execSync("osascript -e 'delay 0.5'");

--- a/src/clis/chatgpt/read.ts
+++ b/src/clis/chatgpt/read.ts
@@ -13,6 +13,10 @@ export const readCommand = cli({
   args: [],
   columns: ['Role', 'Text'],
   func: async (page: IPage | null) => {
+    if (process.platform !== 'darwin') {
+      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+    }
+
     try {
       execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
       execSync("osascript -e 'delay 0.3'");

--- a/src/clis/chatgpt/status.ts
+++ b/src/clis/chatgpt/status.ts
@@ -12,6 +12,10 @@ export const statusCommand = cli({
   args: [],
   columns: ['Status'],
   func: async (page: IPage | null) => {
+    if (process.platform !== 'darwin') {
+      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+    }
+
     try {
       const output = execSync("osascript -e 'application \"ChatGPT\" is running'", { encoding: 'utf-8' }).trim();
       return [{ Status: output === 'true' ? 'Running' : 'Stopped' }];

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -272,7 +272,7 @@ httpServer.listen(PORT, '127.0.0.1', () => {
 httpServer.on('error', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EADDRINUSE') {
     console.error(`[daemon] Port ${PORT} already in use — another daemon is likely running. Exiting.`);
-    process.exit(0);
+    process.exit(1);
   }
   console.error('[daemon] Server error:', err.message);
   process.exit(1);


### PR DESCRIPTION
## Summary

- **Remove stale SQLite file**: Add `*.db` to `.gitignore` to prevent accidental database file commits
- **ChatGPT platform guard**: Add `process.platform !== 'darwin'` check before `osascript` calls in all 4 chatgpt commands (`ask`, `read`, `new`, `status`), throwing a clear error on non-macOS platforms instead of cryptic `ENOENT`
- **Daemon exit code**: Change `process.exit(0)` to `process.exit(1)` in the `EADDRINUSE` handler so the spawning CLI correctly detects the port conflict as a failure

## Test plan

- [ ] Verify `mydatabase.db` is ignored by git (`git check-ignore mydatabase.db`)
- [ ] Run `opencli chatgpt/status` on Linux — should get clear "requires macOS" error
- [ ] Start two daemon instances — second should exit with code 1