### PR TITLE
feat(generate): implement registerCandidates to copy generated CLIs to user directory

### DIFF
--- a/docs/adapters/desktop/doubao-app.md
+++ b/docs/adapters/desktop/doubao-app.md
@@ -1,0 +1,40 @@
+# Doubao App
+
+Control the **Doubao AI desktop app** (豆包) directly from the terminal via Chrome DevTools Protocol (CDP).
+
+## Prerequisites
+
+1. Install the official Doubao desktop app.
+2. Launch Doubao with the remote debugging port enabled:
+
+```bash
+# macOS
+/Applications/Doubao.app/Contents/MacOS/Doubao \
+  --remote-debugging-port=9226
+```
+
+3. Set the CDP endpoint:
+
+```bash
+export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9226"
+```
+
+## Commands
+
+- `opencli doubao-app status`: Check if the Doubao app is running and accessible via CDP.
+- `opencli doubao-app new`: Start a new conversation.
+- `opencli doubao-app send "message"`: Send a message to the active conversation.
+- `opencli doubao-app read`: Read chat messages from the current conversation.
+- `opencli doubao-app ask "message"`: Send a prompt and wait for the assistant reply in one shot.
+- `opencli doubao-app screenshot`: Capture a screenshot of the current Doubao window.
+- `opencli doubao-app dump`: Dump the full conversation history from the current session.
+
+## How It Works
+
+Doubao Desktop is an Electron app. OpenCLI connects via the Chrome DevTools Protocol to the Electron renderer process and interacts with the chat UI using `data-testid` selectors exposed by the app.
+
+## Limitations
+
+- Requires Doubao to be launched with `--remote-debugging-port=9226`
+- CDP endpoint must be reachable at the configured address
+- `read` returns only the visible messages in the current conversation

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -8,11 +8,13 @@
  * automatically downgrades and retries.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { exploreUrl } from './explore.js';
 import type { IBrowserFactory } from './runtime.js';
 import { synthesizeFromExplore, type SynthesizeCandidateSummary, type SynthesizeResult } from './synthesize.js';
 
-// TODO: implement real CLI registration (copy candidate YAML to user clis dir)
 interface RegisterCandidatesOptions {
   target: string;
   builtinClis?: string;
@@ -59,8 +61,46 @@ export interface GenerateCliResult {
   register: RegisterCandidatesResult | null;
 }
 
-function registerCandidates(_opts: RegisterCandidatesOptions): RegisterCandidatesResult {
-  return { ok: true, count: 0 };
+function registerCandidates(opts: RegisterCandidatesOptions): RegisterCandidatesResult {
+  const userClisDir = opts.userClis ?? path.join(os.homedir(), '.opencli', 'clis');
+
+  // Read candidate list from the synthesize output directory
+  const indexPath = path.join(opts.target, 'candidates.json');
+  if (!fs.existsSync(indexPath)) {
+    return { ok: false, count: 0 };
+  }
+
+  let candidates: Array<{ name: string; path: string }>;
+  try {
+    const raw = fs.readFileSync(indexPath, 'utf-8');
+    const index = JSON.parse(raw) as { candidates: Array<{ name: string; path: string }> };
+    candidates = index.candidates ?? [];
+  } catch {
+    return { ok: false, count: 0 };
+  }
+
+  // Filter to a specific candidate if name is provided
+  if (opts.name) {
+    candidates = candidates.filter(c => c.name === opts.name);
+  }
+
+  fs.mkdirSync(userClisDir, { recursive: true });
+
+  let count = 0;
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate.path)) continue;
+
+    const destPath = path.join(userClisDir, path.basename(candidate.path));
+    if (fs.existsSync(destPath)) {
+      console.warn(`[opencli] Skipping ${path.basename(candidate.path)}: already exists in user CLI directory.`);
+      continue;
+    }
+
+    fs.copyFileSync(candidate.path, destPath);
+    count++;
+  }
+
+  return { ok: true, count };
 }
 
 const CAPABILITY_ALIASES: Record<string, string[]> = {


### PR DESCRIPTION
## Summary

- Implement the previously stubbed `registerCandidates` function in `src/generate.ts`
- Generated CLI YAML files are now actually copied to the user's CLI directory (`~/.opencli/clis/`)
- Reads `candidates.json` from the synthesize output directory to locate candidate YAML files
- Supports filtering by name when `opts.name` is provided
- Skips existing files with a warning to avoid overwriting user customizations
- Creates the user CLI directory if it doesn't exist

## Motivation

The `registerCandidates` function was a stub returning `{ ok: true, count: 0 }`, meaning `opencli generate` and `opencli record` workflows completed without error but silently registered nothing. Users received misleading success feedback.

## Test plan

- [ ] 309/309 existing tests pass
- [ ] `opencli generate <url>` now copies YAML to `~/.opencli/clis/`
- [ ] Running generate twice does not overwrite existing CLIs