### PR TITLE
refactor(extension): reuse async detach() in registerListeners

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -118,15 +118,8 @@ function registerListeners() {
 	chrome.debugger.onDetach.addListener((source) => {
 		if (source.tabId) attached.delete(source.tabId);
 	});
-	chrome.tabs.onUpdated.addListener((tabId, info) => {
-		if (info.url && !isDebuggableUrl$1(info.url)) {
-			if (attached.has(tabId)) {
-				attached.delete(tabId);
-				try {
-					chrome.debugger.detach({ tabId });
-				} catch {}
-			}
-		}
+	chrome.tabs.onUpdated.addListener(async (tabId, info) => {
+		if (info.url && !isDebuggableUrl$1(info.url)) await detach(tabId);
 	});
 }
 //#endregion

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -158,12 +158,9 @@ export function registerListeners(): void {
     if (source.tabId) attached.delete(source.tabId);
   });
   // Invalidate attached cache when tab URL changes to non-debuggable
-  chrome.tabs.onUpdated.addListener((tabId, info) => {
+  chrome.tabs.onUpdated.addListener(async (tabId, info) => {
     if (info.url && !isDebuggableUrl(info.url)) {
-      if (attached.has(tabId)) {
-        attached.delete(tabId);
-        try { chrome.debugger.detach({ tabId }); } catch { /* ignore */ }
-      }
+      await detach(tabId);
     }
   });
 }


### PR DESCRIPTION
Follow-up to #322.

Replace the inline sync `chrome.debugger.detach()` in `registerListeners` `onUpdated` callback with the shared async `detach()` function.

### Before
```typescript
chrome.tabs.onUpdated.addListener((tabId, info) => {
  if (info.url && !isDebuggableUrl(info.url)) {
    if (attached.has(tabId)) {
      attached.delete(tabId);
      try { chrome.debugger.detach({ tabId }); } catch { /* ignore */ }
    }
  }
});
```

### After
```typescript
chrome.tabs.onUpdated.addListener(async (tabId, info) => {
  if (info.url && !isDebuggableUrl(info.url)) {
    await detach(tabId);
  }
});
```

This ensures consistent cleanup behavior across all detach paths and properly awaits the debugger detach. Extension build verified ✅ (16.62 kB).