### PR TITLE
fix(bilibili): use actual user UID instead of 0 for favorite command

### DIFF
--- a/src/clis/bilibili/favorite.ts
+++ b/src/clis/bilibili/favorite.ts
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
-import { apiGet, payloadData } from './utils.js';
+import { apiGet, payloadData, getSelfUid } from './utils.js';
 
 cli({
   site: 'bilibili',
@@ -15,9 +15,12 @@ cli({
   func: async (page, kwargs) => {
     const { limit = 20, page: pageNum = 1 } = kwargs;
 
+    // Get current user's UID
+    const uid = await getSelfUid(page);
+
     // Get default favorite folder ID
     const foldersPayload = await apiGet(page, '/x/v3/fav/folder/created/list-all', {
-      params: { up_mid: 0 },
+      params: { up_mid: uid },
       signed: true,
     });
     const folders = payloadData(foldersPayload)?.list ?? [];


### PR DESCRIPTION
## Summary

- Fix `bilibili favorite` command returning empty results
- Changed `up_mid: 0` to use the actual logged-in user's UID via `getSelfUid()`

## Problem

The `opencli bilibili favorite` command was always returning empty results because the API call used `up_mid: 0` which doesn't return any favorite folders.

## Solution

Import and use `getSelfUid()` to fetch the current user's UID before querying the favorite folders API.

## Test

Before fix:
```
$ opencli bilibili favorite
(no data)
```

After fix:
```
$ opencli bilibili favorite --limit 5
  bilibili/favorite
┌──────┬──────────────────────────────────────┬─────────────────┬─────────┐
│ Rank │ Title                                │ Author          │ Plays   │
├──────┼──────────────────────────────────────┼─────────────────┼─────────┤
│ 1    │ 神经网络通用近似定理详解              │ 数理分享        │ 9535    │
│ 2    │ DGX Spark vs Mac Studio              │ 至顶AI实验室    │ 30285   │
│ ...  │ ...                                  │ ...             │ ...     │
└──────┴──────────────────────────────────────┴─────────────────┴─────────┘
```