### PR TITLE
feat(jd): add JD.com product details adapter

### DIFF
--- a/src/clis/jd/item.test.ts
+++ b/src/clis/jd/item.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '../../registry.js';
+import './item.js';
+
+describe('jd item adapter', () => {
+  const command = getRegistry().get('jd/item');
+
+  it('registers the command with correct shape', () => {
+    expect(command).toBeDefined();
+    expect(command!.site).toBe('jd');
+    expect(command!.name).toBe('item');
+    expect(command!.domain).toBe('item.jd.com');
+    expect(command!.strategy).toBe('cookie');
+    expect(typeof command!.func).toBe('function');
+  });
+
+  it('has sku as a required positional arg', () => {
+    const skuArg = command!.args.find((a) => a.name === 'sku');
+    expect(skuArg).toBeDefined();
+    expect(skuArg!.required).toBe(true);
+    expect(skuArg!.positional).toBe(true);
+  });
+
+  it('has images arg with default 10', () => {
+    const imagesArg = command!.args.find((a) => a.name === 'images');
+    expect(imagesArg).toBeDefined();
+    expect(imagesArg!.default).toBe(10);
+  });
+
+  it('includes expected columns', () => {
+    expect(command!.columns).toEqual(
+      expect.arrayContaining(['title', 'price', 'shop', 'specs', 'mainImages', 'detailImages']),
+    );
+  });
+});

--- a/src/clis/jd/item.ts
+++ b/src/clis/jd/item.ts
@@ -29,6 +29,7 @@ cli({
   columns: ['title', 'price', 'shop', 'specs', 'mainImages', 'detailImages'],
   func: async (page, kwargs) => {
     const sku = kwargs.sku;
+    const maxImages = kwargs.images as number;
     const url = `https://item.jd.com/${sku}.html`;
 
     await page.goto(url, { waitUntil: 'load' });
@@ -44,6 +45,7 @@ cli({
 
     const data = await page.evaluate(`
       (() => {
+        const maxImg = ${maxImages};
         // 尝试多种价格选择器
         const skuMatch = location.pathname.match(/(\\d+)\\.html/);
         const sku = skuMatch ? skuMatch[1] : '';
@@ -68,12 +70,12 @@ cli({
         // 主图
         const mainImgs = unique
           .filter(u => u.includes('/n1/') || u.includes('/n3/') || u.includes('/n4/') || u.includes('/img/'))
-          .slice(0, 10);
+          .slice(0, maxImg);
 
         // 详情图
         const detailImgs = unique
           .filter(u => u.includes('/babel/') || u.includes('/popshop/'))
-          .slice(0, 10);
+          .slice(0, maxImg);
 
         // 规格参数：从页面文本提取
         const text = document.body.innerText;


### PR DESCRIPTION
## Summary

Add `jd item` adapter for fetching JD.com (京东) product details.

## Features

- **Product info**: title, price, shop name
- **Specifications**: brand, model, capacity, energy rating, etc.
- **Images**: main product images and detail images

## Usage

```bash
opencli jd item 100291143898        # Table output
opencli jd item 100291143898 --format json  # JSON output
```

## Example Output

```json
{
  "title": "【美的MGH24PROMAX...",
  "price": "10999.00",
  "shop": "京东自营",
  "specs": {
    "品牌": "美的（Midea）",
    "型号": "MGH24PROMAX-W(G)+MGH24PROMAX-W(H)",
    "洗涤容量": "12kg",
    "烘干容量": "12kg",
    ...
  }
}
```

## Test Plan

- [x] Build succeeds: `npm run build` ✓
- [x] Adapter registered in manifest (333 entries)
- [x] Tested with SKU 100291143898