### PR TITLE
docs: add missing adapter docs for jd and web

### DIFF
--- a/docs/adapters/browser/jd.md
+++ b/docs/adapters/browser/jd.md
@@ -1,0 +1,27 @@
+# JD.com
+
+**Mode**: 🔐 Browser · **Domain**: `item.jd.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli jd item <sku>` | Fetch product details (price, images, specs) |
+
+## Usage Examples
+
+```bash
+# Get product details by SKU
+opencli jd item 100291143898
+
+# Limit detail images
+opencli jd item 100291143898 --images 5
+
+# JSON output
+opencli jd item 100291143898 -f json
+```
+
+## Prerequisites
+
+- Chrome running and **logged into** jd.com
+- [Browser Bridge extension](/guide/browser-bridge) installed

--- a/docs/adapters/browser/web.md
+++ b/docs/adapters/browser/web.md
@@ -1,0 +1,30 @@
+# Web
+
+**Mode**: 🔐 Browser · **Domain**: any URL
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli web read <url>` | Fetch any web page and export as Markdown |
+
+## Usage Examples
+
+```bash
+# Read a web page and save as Markdown
+opencli web read https://example.com/article
+
+# Custom output directory
+opencli web read https://example.com/article --output ./my-articles
+
+# Skip image download
+opencli web read https://example.com/article --download-images false
+
+# JSON output
+opencli web read https://example.com/article -f json
+```
+
+## Prerequisites
+
+- Chrome running
+- [Browser Bridge extension](/guide/browser-bridge) installed


### PR DESCRIPTION
## Summary
- Add `docs/adapters/browser/jd.md` for JD.com item adapter
- Add `docs/adapters/browser/web.md` for generic web read adapter
- Fixes doc-coverage CI check: 55/57 → 57/57

## Test plan
- [x] `bash scripts/check-doc-coverage.sh --strict` passes (57/57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)