### PR TITLE
docs: add opencli-plugin-vk to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ opencli plugin uninstall my-tool                            # Remove
 | [opencli-plugin-github-trending](https://github.com/ByteYue/opencli-plugin-github-trending) | YAML | GitHub Trending repositories |
 | [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | TS | Multi-platform trending aggregator |
 | [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | YAML | 稀土掘金 (Juejin) hot articles |
+| [opencli-plugin-vk](https://github.com/flobo3/opencli-plugin-vk) | TS | VK (VKontakte) wall, feed, and search |
 
 See [Plugins Guide](./docs/guide/plugins.md) for creating your own plugin.
 


### PR DESCRIPTION
Hey @Astro-Han! Thanks for the suggestion. 

Here is the PR adding `opencli-plugin-vk` to the plugins list in the README.

It provides commands for VK (VKontakte) to fetch walls, personal feeds, and search posts by extracting the `access_token` from the live session and hitting the internal API.

Context / Original issue: #329