### PR TITLE
fix(arxiv): use correct query arg in search

### DIFF
--- a/src/clis/arxiv/search.ts
+++ b/src/clis/arxiv/search.ts
@@ -15,7 +15,7 @@ cli({
   columns: ['id', 'title', 'authors', 'published'],
   func: async (_page, args) => {
     const limit = Math.max(1, Math.min(Number(args.limit), 25));
-    const query = encodeURIComponent(`all:${args.keyword}`);
+    const query = encodeURIComponent(`all:${args.query}`);
     const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=relevance`);
     const entries = parseEntries(xml);
     if (!entries.length) throw new CliError('NOT_FOUND', 'No papers found', 'Try a different keyword');


### PR DESCRIPTION
## Summary
- Fix bug where `args.keyword` was used instead of `args.query` in `src/clis/arxiv/search.ts:18`, causing the search term to be `undefined`

Closes #334

## Test plan
- [x] Run `opencli arxiv search "LLM"` and verify relevant papers are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)