### PR TITLE
fix: add fallback guards to dictionary search for better error handling

### DIFF
--- a/src/clis/dictionary/search.yaml
+++ b/src/clis/dictionary/search.yaml
@@ -15,12 +15,12 @@ args:
 pipeline:
   - fetch:
       url: "https://api.dictionaryapi.dev/api/v2/entries/en/${{ args.word | urlencode }}"
-  
+
   - map:
       word: "${{ item.word }}"
       phonetic: "${{ (() => { if (item.phonetic) return item.phonetic; if (item.phonetics) { for (const p of item.phonetics) { if (p.text) return p.text; } } return ''; })() }}"
-      type: "${{ item.meanings[0].partOfSpeech }}"
-      definition: "${{ item.meanings[0].definitions[0].definition }}"
+      type: "${{ (() => { if (item.meanings && item.meanings[0] && item.meanings[0].partOfSpeech) return item.meanings[0].partOfSpeech; return 'N/A'; })() }}"
+      definition: "${{ (() => { if (item.meanings && item.meanings[0] && item.meanings[0].definitions && item.meanings[0].definitions[0] && item.meanings[0].definitions[0].definition) return item.meanings[0].definitions[0].definition; return 'No definition found in API.'; })() }}"
 
   - limit: 1
 


### PR DESCRIPTION
## Summary
Follow-up for PR #241 review feedback. Adds missing fallback guards to `dictionary search` to match the error handling pattern used in `synonyms` and `examples`.

## Changes
- `type`: Returns `'N/A'` when no partOfSpeech is available
- `definition`: Returns `'No definition found in API.'` when no definition is available

This prevents crashes when API returns sparse payload or incomplete word entries.

**Test:** 233 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)