### PR TITLE
fix(e2e): remove duplicate closing bracket causing vite:oxc parse error

### DIFF
--- a/tests/e2e/public-commands.test.ts
+++ b/tests/e2e/public-commands.test.ts
@@ -521,5 +521,4 @@ describe('public commands E2E', () => {
     expect(data[0]).toHaveProperty('word', 'perfect');
     expect(data[0]).toHaveProperty('example');
   }, 30_000);
-  }, 30_000);
 });


### PR DESCRIPTION
## Problem

The E2E Headed Chrome CI workflow fails with:

```
FAIL  e2e  tests/e2e/public-commands.test.ts
Error: Transform failed with 1 error:
[PARSE_ERROR] Error: Unexpected token
     ╭─[ tests/e2e/public-commands.test.ts:525:1 ]
 525 │ });
     │ ┬
     │ ╰──
─────╯
  Plugin: vite:oxc
```

## Root Cause

Commit 3d39574 (PR #241 — dictionary adapters) introduced a **duplicate `}, 30_000);`** at line 524 of `public-commands.test.ts`. The OXC transformer sees an extra closing bracket and fails to parse.

## Fix

Remove the extraneous line. One-line deletion.