### PR TITLE
docs: tighten adapter authoring guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,8 +24,10 @@ Related issue:
 - [ ] Added doc page under `docs/adapters/` (if new adapter)
 - [ ] Updated `docs/adapters/index.md` table (if new adapter)
 - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
+- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
+- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
+- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`
 
 ## Screenshots / Output
 
 <!-- If applicable, paste CLI output or screenshots here. -->
-

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,6 +15,12 @@ tags: [cli, browser, web, chrome-extension, cdp, bilibili, zhihu, twitter, githu
 > 该文档包含完整的 API 发现工作流（必须使用浏览器探索）、5 级认证策略决策树、平台 SDK 速查表、`tap` 步骤调试流程、分页 API 模板、级联请求模式、以及常见陷阱。
 > **本文件（SKILL.md）仅提供命令参考和简化模板，不足以正确开发适配器。**
 
+> [!IMPORTANT]
+> 创建或修改 adapter 时，再额外遵守 3 条收口规则：
+> 1. 主参数优先用 positional arg，不要把 `query` / `id` / `url` 默认做成 `--query` / `--id` / `--url`
+> 2. 预期中的 adapter 失败优先抛 `CliError` 子类，不要直接 throw 原始 `Error`
+> 3. 新增 adapter 或新增用户可发现命令时，同步更新 adapter docs、`docs/adapters/index.md`、sidebar，以及 README/README.zh-CN 中受影响的入口
+
 ## Install & Run
 
 ```bash

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -28,6 +28,12 @@ npm link
 
 This is the most common type of contribution. Start with YAML when possible, and use TypeScript only when you need browser-side logic or multi-step flows.
 
+Before you start:
+
+- Prefer positional args for the command's primary subject (`search <query>`, `topic <id>`, `download <url>`). Reserve named flags for optional modifiers such as `--limit`, `--sort`, `--lang`, and `--output`.
+- Normalize expected adapter failures to `CliError` subclasses instead of raw `Error` whenever possible. Prefer `AuthRequiredError`, `EmptyResultError`, `CommandExecutionError`, `TimeoutError`, and `ArgumentError` so the top-level CLI can render better messages and hints.
+- If you add a new adapter or make a command newly discoverable, update the matching doc page and the user-facing indexes that expose it.
+
 ### YAML Adapter (Recommended for data-fetching commands)
 
 Create a file like `src/clis/<site>/<command>.yaml`:
@@ -71,6 +77,7 @@ Create a file like `src/clis/<site>/<command>.ts`:
 
 ```typescript
 import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError, EmptyResultError } from '../../errors.js';
 
 cli({
   site: 'mysite',
@@ -87,6 +94,8 @@ cli({
   func: async (page, kwargs) => {
     const { query, limit = 10 } = kwargs;
     // ... browser automation logic
+    if (!Array.isArray(data)) throw new CommandExecutionError('MySite returned an unexpected response');
+    if (!data.length) throw new EmptyResultError('mysite search', 'Try a different keyword');
     return data.slice(0, Number(limit)).map((item: any) => ({
       title: item.title,
       url: item.url,
@@ -110,6 +119,7 @@ opencli <site> <command> -v    # Verbose mode for debugging
 - **ES Modules** — use `.js` extensions in imports (TypeScript output).
 - **Naming**: `kebab-case` for files, `camelCase` for variables/functions, `PascalCase` for types/classes.
 - **No default exports** — use named exports.
+- **Errors** — throw `CliError` subclasses for expected adapter failures; avoid raw `Error` for normal adapter control flow.
 
 ## Commit Convention
 
@@ -136,3 +146,10 @@ chore: bump vitest to v4
    ```
 4. Commit using conventional commit format
 5. Push and open a PR
+
+If your PR adds a new adapter or changes user-facing commands, also verify:
+
+- Adapter docs exist under `docs/adapters/`
+- `docs/adapters/index.md` is updated for new adapters
+- VitePress sidebar includes the new doc page
+- `README.md` / `README.zh-CN.md` stay aligned when command discoverability changes

--- a/docs/developer/ts-adapter.md
+++ b/docs/developer/ts-adapter.md
@@ -6,6 +6,7 @@ Use TypeScript adapters when you need browser-side logic, multi-step flows, DOM 
 
 ```typescript
 import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError, EmptyResultError } from '../../errors.js';
 
 cli({
   site: 'mysite',
@@ -33,6 +34,9 @@ cli({
         return (await res.json()).results;
       })()
     `);
+
+    if (!Array.isArray(data)) throw new CommandExecutionError('MySite returned an unexpected response');
+    if (!data.length) throw new EmptyResultError('mysite search', 'Try a different keyword');
 
     return data.slice(0, Number(limit)).map((item: any) => ({
       title: item.title,
@@ -68,6 +72,20 @@ Contains parsed CLI arguments as key-value pairs. Always destructure with defaul
 ```typescript
 const { query, limit = 10, format = 'json' } = kwargs;
 ```
+
+For most search/read/detail commands, the main subject should be positional (`opencli mysite search "rust"`, `opencli mysite article 123`) instead of a named flag such as `--query` or `--id`. Keep named flags for optional modifiers.
+
+## Error Handling
+
+Prefer throwing `CliError` subclasses from `src/errors.ts` for expected adapter failures:
+
+- `AuthRequiredError` for missing login / cookies
+- `EmptyResultError` for empty but valid responses
+- `CommandExecutionError` for unexpected API or browser failures
+- `TimeoutError` for site timeouts
+- `ArgumentError` for invalid user input
+
+Avoid raw `Error` for normal adapter control flow. This keeps top-level CLI output consistent and preserves hints for users.
 
 ## AI-Assisted Development
 

--- a/docs/developer/yaml-adapter.md
+++ b/docs/developer/yaml-adapter.md
@@ -2,6 +2,8 @@
 
 YAML adapters are the recommended way to add new commands when the site offers a straightforward API. They use a declarative pipeline approach — no TypeScript required.
 
+Use YAML only when the command stays mostly declarative. If you find yourself embedding long JavaScript expressions, many fallbacks, or multi-step browser logic, move the command to a TypeScript adapter instead of growing an opaque template blob.
+
 ## Basic Structure
 
 ::: v-pre
@@ -32,6 +34,14 @@ pipeline:             # Data processing steps
 columns: [rank, title, score, url]
 ```
 :::
+
+For most commands, keep the primary subject positional. Good examples:
+
+- `opencli mysite search "rust"`
+- `opencli mysite topic 123`
+- `opencli mysite download "https://example.com/post/1"`
+
+Prefer named flags only for optional modifiers such as `--limit`, `--sort`, `--lang`, or `--output`.
 
 ## Pipeline Steps
 
@@ -106,3 +116,9 @@ Use `${{ ... }}` for dynamic values:
 ## Real Example
 
 See [`src/clis/hackernews/top.yaml`](https://github.com/jackwener/opencli/blob/main/src/clis/hackernews/top.yaml).
+
+## Guardrails
+
+- Add fallbacks for optional fields in `map` expressions when upstream payloads may be sparse.
+- Keep template expressions short and readable. If the expression starts looking like a mini program, switch to TypeScript.
+- If you add a new adapter, also add the matching doc page plus index/sidebar entries so `doc-coverage` stays green.


### PR DESCRIPTION
## Summary
- add adapter authoring guidance for positional primary args
- document preferred CliError subclass usage for expected adapter failures
- tighten doc/discoverability checklist in SKILL and PR template

## Validation
- npm run docs:build
