### PR TITLE
refactor: adopt CliError in desktop UI adapters

### DIFF
--- a/src/clis/chatgpt/ask.ts
+++ b/src/clis/chatgpt/ask.ts
@@ -1,5 +1,6 @@
 import { execSync, spawnSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
+import { ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 import { getVisibleChatMessages } from './ax.js';
 
@@ -17,7 +18,7 @@ export const askCommand = cli({
   columns: ['Role', 'Text'],
   func: async (page: IPage | null, kwargs: any) => {
     if (process.platform !== 'darwin') {
-      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+      throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
     }
 
     const text = kwargs.text as string;

--- a/src/clis/chatgpt/new.ts
+++ b/src/clis/chatgpt/new.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
+import { ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const newCommand = cli({
@@ -13,7 +14,7 @@ export const newCommand = cli({
   columns: ['Status'],
   func: async (page: IPage | null) => {
     if (process.platform !== 'darwin') {
-      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+      throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
     }
 
     try {

--- a/src/clis/chatgpt/read.ts
+++ b/src/clis/chatgpt/read.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError, ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 import { getVisibleChatMessages } from './ax.js';
 
@@ -14,7 +15,7 @@ export const readCommand = cli({
   columns: ['Role', 'Text'],
   func: async (page: IPage | null) => {
     if (process.platform !== 'darwin') {
-      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+      throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
     }
 
     try {
@@ -28,7 +29,7 @@ export const readCommand = cli({
 
       return [{ Role: 'Assistant', Text: messages[messages.length - 1] }];
     } catch (err: any) {
-      throw new Error("Failed to read from ChatGPT: " + err.message);
+      throw new CommandExecutionError("Failed to read from ChatGPT: " + err.message);
     }
   },
 });

--- a/src/clis/chatgpt/status.ts
+++ b/src/clis/chatgpt/status.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError, ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const statusCommand = cli({
@@ -13,14 +14,14 @@ export const statusCommand = cli({
   columns: ['Status'],
   func: async (page: IPage | null) => {
     if (process.platform !== 'darwin') {
-      throw new Error('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
+      throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
     }
 
     try {
       const output = execSync("osascript -e 'application \"ChatGPT\" is running'", { encoding: 'utf-8' }).trim();
       return [{ Status: output === 'true' ? 'Running' : 'Stopped' }];
     } catch {
-      return [{ Status: 'Error querying application state' }];
+      throw new CommandExecutionError('Error querying ChatGPT application state');
     }
   },
 });

--- a/src/clis/chatwise/ask.ts
+++ b/src/clis/chatwise/ask.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const askCommand = cli({
@@ -26,14 +27,14 @@ export const askCommand = cli({
     `);
 
     // Send message
-    await page.evaluate(`
+    const injected = await page.evaluate(`
       (function(text) {
         let composer = document.querySelector('textarea');
         if (!composer) {
           const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'));
           composer = editables.length > 0 ? editables[editables.length - 1] : null;
         }
-        if (!composer) throw new Error('Could not find input');
+        if (!composer) return false;
         composer.focus();
         if (composer.tagName === 'TEXTAREA') {
           const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
@@ -42,8 +43,10 @@ export const askCommand = cli({
         } else {
           document.execCommand('insertText', false, text);
         }
+        return true;
       })(${JSON.stringify(text)})
     `);
+    if (!injected) throw new SelectorError('ChatWise input element');
 
     await page.wait(0.5);
     await page.pressKey('Enter');

--- a/src/clis/chatwise/model.ts
+++ b/src/clis/chatwise/model.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const modelCommand = cli({
@@ -44,7 +45,7 @@ export const modelCommand = cli({
       return [{ Status: 'Active', Model: currentModel }];
     } else {
       // Try to switch model
-      await page.evaluate(`
+      const opened = await page.evaluate(`
         (function(target) {
           const selectors = [
             '[class*="model"]',
@@ -54,11 +55,12 @@ export const modelCommand = cli({
           
           for (const sel of selectors) {
             const el = document.querySelector(sel);
-            if (el) { el.click(); return; }
+            if (el) { el.click(); return true; }
           }
-          throw new Error('Could not find model selector');
+          return false;
         })(${JSON.stringify(desiredModel)})
       `);
+      if (!opened) throw new SelectorError('ChatWise model selector');
 
       await page.wait(0.5);
 

--- a/src/clis/chatwise/send.ts
+++ b/src/clis/chatwise/send.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const sendCommand = cli({
@@ -13,7 +14,7 @@ export const sendCommand = cli({
   func: async (page: IPage, kwargs: any) => {
     const text = kwargs.text as string;
 
-    await page.evaluate(`
+    const injected = await page.evaluate(`
       (function(text) {
         // ChatWise input can be textarea or contenteditable
         let composer = document.querySelector('textarea');
@@ -22,7 +23,7 @@ export const sendCommand = cli({
           composer = editables.length > 0 ? editables[editables.length - 1] : null;
         }
 
-        if (!composer) throw new Error('Could not find ChatWise input element');
+        if (!composer) return false;
 
         composer.focus();
         
@@ -34,8 +35,10 @@ export const sendCommand = cli({
         } else {
           document.execCommand('insertText', false, text);
         }
+        return true;
       })(${JSON.stringify(text)})
     `);
+    if (!injected) throw new SelectorError('ChatWise input element');
 
     await page.wait(0.5);
     await page.pressKey('Enter');

--- a/src/clis/codex/ask.ts
+++ b/src/clis/codex/ask.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const askCommand = cli({
@@ -26,15 +27,17 @@ export const askCommand = cli({
     `);
 
     // Inject and send
-    await page.evaluate(`
+    const injected = await page.evaluate(`
       (function(text) {
         const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'));
         const composer = editables.length > 0 ? editables[editables.length - 1] : document.querySelector('textarea');
-        if (!composer) throw new Error('Could not find Codex input');
+        if (!composer) return false;
         composer.focus();
         document.execCommand('insertText', false, text);
+        return true;
       })(${JSON.stringify(text)})
     `);
+    if (!injected) throw new SelectorError('Codex input element');
     await page.wait(0.5);
     await page.pressKey('Enter');
 

--- a/src/clis/codex/send.ts
+++ b/src/clis/codex/send.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const sendCommand = cli({
@@ -13,7 +14,7 @@ export const sendCommand = cli({
   func: async (page: IPage, kwargs: any) => {
     const textToInsert = kwargs.text as string;
 
-    await page.evaluate(`
+    const injected = await page.evaluate(`
       (function(text) {
         let composer = document.querySelector('textarea, [contenteditable="true"]');
         
@@ -22,14 +23,14 @@ export const sendCommand = cli({
            composer = editables[editables.length - 1];
         }
 
-        if (!composer) {
-          throw new Error('Could not find Composer input element in Codex UI');
-        }
+        if (!composer) return false;
 
         composer.focus();
         document.execCommand('insertText', false, text);
+        return true;
       })(${JSON.stringify(textToInsert)})
     `);
+    if (!injected) throw new SelectorError('Codex Composer input element');
 
     // Wait for the UI to register the input
     await page.wait(0.5);

--- a/src/clis/cursor/ask.ts
+++ b/src/clis/cursor/ask.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const askCommand = cli({
@@ -33,7 +34,7 @@ export const askCommand = cli({
       })(${JSON.stringify(text)})`
     );
 
-    if (!injected) throw new Error('Could not find input element.');
+    if (!injected) throw new SelectorError('Cursor input element');
     await page.wait(0.5);
     await page.pressKey('Enter');
 

--- a/src/clis/cursor/composer.ts
+++ b/src/clis/cursor/composer.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const composerCommand = cli({
@@ -33,7 +34,7 @@ export const composerCommand = cli({
     );
 
     if (!typed) {
-      throw new Error('Could not find Cursor Composer input element after pressing Cmd+I.');
+      throw new SelectorError('Cursor Composer input element', 'Could not find Cursor Composer input element after pressing Cmd+I.');
     }
 
     await page.wait(0.5);

--- a/src/clis/cursor/read.ts
+++ b/src/clis/cursor/read.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { EmptyResultError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const readCommand = cli({
@@ -39,7 +40,7 @@ export const readCommand = cli({
     `);
 
     if (!history || history.length === 0) {
-      throw new Error('No conversation history found in Cursor.');
+      throw new EmptyResultError('cursor read', 'No conversation history found in Cursor.');
     }
 
     return history;

--- a/src/clis/cursor/send.ts
+++ b/src/clis/cursor/send.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { SelectorError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export const sendCommand = cli({
@@ -29,7 +30,7 @@ export const sendCommand = cli({
     );
 
     if (!injected) {
-      throw new Error('Could not find Cursor Composer input element.');
+      throw new SelectorError('Cursor Composer input element');
     }
 
     // Submit the command. In Cursor, Enter usually submits the chat.


### PR DESCRIPTION
## Summary
- replace raw `Error` throws in `chatgpt`, `cursor`, `codex`, and `chatwise` adapters with `CliError` subclasses
- use `ConfigError` for macOS-only ChatGPT desktop commands
- use `SelectorError` for missing UI inputs/selectors and `EmptyResultError` for empty Cursor history

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`