### PR TITLE
refactor: adopt CliError in social adapters

### DIFF
--- a/src/clis/reddit/comment.ts
+++ b/src/clis/reddit/comment.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page, kwargs) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required');
 
     await page.goto('https://www.reddit.com');
 

--- a/src/clis/reddit/save.ts
+++ b/src/clis/reddit/save.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page, kwargs) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required');
 
     await page.goto('https://www.reddit.com');
 

--- a/src/clis/reddit/saved.ts
+++ b/src/clis/reddit/saved.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -12,7 +13,7 @@ cli({
   ],
   columns: ['title', 'subreddit', 'score', 'comments', 'url'],
   func: async (page, kwargs) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required');
 
     await page.goto('https://www.reddit.com');
 
@@ -41,7 +42,10 @@ cli({
       }
     })()`);
 
-    if (result?.error) throw new Error(result.error);
+    if (result?.error) {
+      if (String(result.error).includes('Not logged in')) throw new AuthRequiredError('reddit.com', result.error);
+      throw new CommandExecutionError(result.error);
+    }
     return (result || []).slice(0, kwargs.limit);
   }
 });

--- a/src/clis/reddit/subscribe.ts
+++ b/src/clis/reddit/subscribe.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page, kwargs) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required');
 
     await page.goto('https://www.reddit.com');
 

--- a/src/clis/reddit/upvote.ts
+++ b/src/clis/reddit/upvote.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page, kwargs) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required');
 
     await page.goto('https://www.reddit.com');
 

--- a/src/clis/reddit/upvoted.ts
+++ b/src/clis/reddit/upvoted.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -12,7 +13,7 @@ cli({
   ],
   columns: ['title', 'subreddit', 'score', 'comments', 'url'],
   func: async (page, kwargs) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required');
 
     await page.goto('https://www.reddit.com');
 
@@ -41,7 +42,10 @@ cli({
       }
     })()`);
 
-    if (result?.error) throw new Error(result.error);
+    if (result?.error) {
+      if (String(result.error).includes('Not logged in')) throw new AuthRequiredError('reddit.com', result.error);
+      throw new CommandExecutionError(result.error);
+    }
     return (result || []).slice(0, kwargs.limit);
   }
 });

--- a/src/clis/substack/search.ts
+++ b/src/clis/substack/search.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 type SubstackPostResult = {
@@ -32,7 +33,7 @@ async function searchPosts(keyword: string, limit: number): Promise<SubstackPost
   url.searchParams.set('includePlatformResults', 'true');
 
   const resp = await fetch(url, { headers: headers() });
-  if (!resp.ok) throw new Error(`Substack post search failed: HTTP ${resp.status}`);
+  if (!resp.ok) throw new CommandExecutionError(`Substack post search failed: HTTP ${resp.status}`);
 
   const data = await resp.json() as { results?: any[] };
   const results = Array.isArray(data?.results) ? data.results : [];
@@ -52,7 +53,7 @@ async function searchPublications(keyword: string, limit: number): Promise<Subst
   url.searchParams.set('page', '0');
 
   const resp = await fetch(url, { headers: headers() });
-  if (!resp.ok) throw new Error(`Substack publication search failed: HTTP ${resp.status}`);
+  if (!resp.ok) throw new CommandExecutionError(`Substack publication search failed: HTTP ${resp.status}`);
 
   const data = await resp.json() as { results?: any[] };
   const results = Array.isArray(data?.results) ? data.results : [];

--- a/src/clis/substack/utils.ts
+++ b/src/clis/substack/utils.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 export function buildSubstackBrowseUrl(category?: string): string {
@@ -7,7 +8,7 @@ export function buildSubstackBrowseUrl(category?: string): string {
 }
 
 export async function loadSubstackFeed(page: IPage, url: string, limit: number): Promise<any[]> {
-  if (!page) throw new Error('Requires browser session');
+  if (!page) throw new CommandExecutionError('Browser session required for substack feed');
   await page.goto(url);
   await page.wait(5);
   const data = await page.evaluate(`
@@ -76,7 +77,7 @@ export async function loadSubstackFeed(page: IPage, url: string, limit: number):
 }
 
 export async function loadSubstackArchive(page: IPage, baseUrl: string, limit: number): Promise<any[]> {
-  if (!page) throw new Error('Requires browser session');
+  if (!page) throw new CommandExecutionError('Browser session required for substack archive');
   await page.goto(`${baseUrl}/archive`);
   await page.wait(5);
   const data = await page.evaluate(`

--- a/src/clis/twitter/accept.ts
+++ b/src/clis/twitter/accept.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -15,7 +16,7 @@ cli({
   ],
   columns: ['index', 'status', 'user', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter accept');
 
     const keywords: string[] = kwargs.query.split(',').map((k: string) => k.trim()).filter(Boolean);
     const maxAccepts: number = kwargs.max ?? 20;

--- a/src/clis/twitter/article.ts
+++ b/src/clis/twitter/article.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -153,7 +154,8 @@ cli({
     `);
 
     if (result?.error) {
-      throw new Error(result.error + (result.hint ? ` (${result.hint})` : ''));
+      if (String(result.error).includes('No ct0 cookie')) throw new AuthRequiredError('x.com', result.error);
+      throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
     }
 
     return result || [];

--- a/src/clis/twitter/block.ts
+++ b/src/clis/twitter/block.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter block');
     const username = kwargs.username.replace(/^@/, '');
 
     await page.goto(`https://x.com/${username}`);

--- a/src/clis/twitter/bookmark.ts
+++ b/src/clis/twitter/bookmark.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter bookmark');
 
     await page.goto(kwargs.url);
     await page.wait(5);

--- a/src/clis/twitter/follow.ts
+++ b/src/clis/twitter/follow.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter follow');
     const username = kwargs.username.replace(/^@/, '');
 
     await page.goto(`https://x.com/${username}`);

--- a/src/clis/twitter/followers.ts
+++ b/src/clis/twitter/followers.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, SelectorError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -26,7 +27,7 @@ cli({
         }`);
 
         if (!href) {
-            throw new Error('Could not find logged-in user profile link. Are you logged in?');
+            throw new AuthRequiredError('x.com', 'Could not find logged-in user profile link. Are you logged in?');
         }
         targetUser = href.replace('/', '');
     }
@@ -55,7 +56,7 @@ cli({
         return false;
     }`);
     if (!clicked) {
-        throw new Error('Could not find followers link on profile page. Twitter may have changed the layout.');
+        throw new SelectorError('Twitter followers link', 'Twitter may have changed the layout.');
     }
     await page.wait(5);
 

--- a/src/clis/twitter/following.ts
+++ b/src/clis/twitter/following.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, SelectorError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -26,7 +27,7 @@ cli({
         }`);
 
         if (!href) {
-            throw new Error('Could not find logged-in user profile link. Are you logged in?');
+            throw new AuthRequiredError('x.com', 'Could not find logged-in user profile link. Are you logged in?');
         }
         targetUser = href.replace('/', '');
     }
@@ -48,7 +49,7 @@ cli({
         return false;
     }`);
     if (!clicked) {
-        throw new Error('Could not find following link on profile page. Twitter may have changed the layout.');
+        throw new SelectorError('Twitter following link', 'Twitter may have changed the layout.');
     }
     await page.wait(5);
 

--- a/src/clis/twitter/hide-reply.ts
+++ b/src/clis/twitter/hide-reply.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter hide-reply');
 
     await page.goto(kwargs.url);
     await page.wait(5);

--- a/src/clis/twitter/like.ts
+++ b/src/clis/twitter/like.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter like');
 
     await page.goto(kwargs.url);
     await page.wait(5); // Wait for tweet to load completely

--- a/src/clis/twitter/notifications.ts
+++ b/src/clis/twitter/notifications.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -29,7 +30,7 @@ cli({
     // Verify SPA navigation succeeded
     const currentUrl = await page.evaluate('() => window.location.pathname');
     if (currentUrl !== '/notifications') {
-        throw new Error('SPA navigation to notifications failed. Twitter may have changed its routing.');
+        throw new CommandExecutionError('SPA navigation to notifications failed. Twitter may have changed its routing.');
     }
 
     // 4. Scroll to trigger pagination

--- a/src/clis/twitter/post.ts
+++ b/src/clis/twitter/post.ts
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 
 cli({
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message', 'text'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter post');
 
     // 1. Navigate directly to the compose tweet modal
     await page.goto('https://x.com/compose/tweet');

--- a/src/clis/twitter/profile.ts
+++ b/src/clis/twitter/profile.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 cli({
@@ -22,7 +23,7 @@ cli({
         const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
         return link ? link.getAttribute('href') : null;
       }`);
-      if (!href) throw new Error('Could not detect logged-in user. Are you logged in?');
+      if (!href) throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
       username = href.replace('/', '');
     }
 
@@ -121,7 +122,8 @@ cli({
     `);
 
     if (result?.error) {
-      throw new Error(result.error + (result.hint ? ` (${result.hint})` : ''));
+      if (String(result.error).includes('No ct0 cookie')) throw new AuthRequiredError('x.com', result.error);
+      throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
     }
 
     return result || [];

--- a/src/clis/twitter/reply-dm.ts
+++ b/src/clis/twitter/reply-dm.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -16,7 +17,7 @@ cli({
   ],
   columns: ['index', 'status', 'user', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter reply-dm');
 
     const messageText: string = kwargs.text;
     const maxSend: number = kwargs.max ?? 20;

--- a/src/clis/twitter/reply.ts
+++ b/src/clis/twitter/reply.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -14,7 +15,7 @@ cli({
   ],
   columns: ['status', 'message', 'text'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter reply');
 
     // 1. Navigate to the tweet page
     await page.goto(kwargs.url);

--- a/src/clis/twitter/search.ts
+++ b/src/clis/twitter/search.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -31,7 +32,7 @@ async function navigateToSearch(page: Pick<IPage, 'evaluate' | 'wait'>, query: s
     }
   }
 
-  throw new Error(
+  throw new CommandExecutionError(
     `SPA navigation to /search failed. Final path: ${lastPath || '(empty)'}. Twitter may have changed its routing.`,
   );
 }

--- a/src/clis/twitter/thread.ts
+++ b/src/clis/twitter/thread.ts
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
-import { AuthRequiredError } from '../../errors.js';
+import { AuthRequiredError, CommandExecutionError } from '../../errors.js';
 
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 
@@ -165,7 +165,7 @@ cli({
       }`);
 
       if (data?.error) {
-        if (allTweets.length === 0) throw new Error(`HTTP ${data.error}: Tweet not found or queryId expired`);
+        if (allTweets.length === 0) throw new CommandExecutionError(`HTTP ${data.error}: Tweet not found or queryId expired`);
         break;
       }
 

--- a/src/clis/twitter/timeline.ts
+++ b/src/clis/twitter/timeline.ts
@@ -1,3 +1,4 @@
+import { AuthRequiredError, CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 
 // ── Twitter GraphQL constants ──────────────────────────────────────────
@@ -194,7 +195,7 @@ cli({
     const ct0 = await page.evaluate(`() => {
       return document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1] || null;
     }`);
-    if (!ct0) throw new Error('Not logged into x.com (no ct0 cookie)');
+    if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
     // Dynamically resolve queryId for the selected endpoint
     const resolved = await page.evaluate(`async () => {
@@ -236,7 +237,7 @@ cli({
 
       if (data?.error) {
         if (allTweets.length === 0)
-          throw new Error(`HTTP ${data.error}: Failed to fetch timeline. queryId may have expired.`);
+          throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch timeline. queryId may have expired.`);
         break;
       }
 

--- a/src/clis/twitter/unblock.ts
+++ b/src/clis/twitter/unblock.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter unblock');
     const username = kwargs.username.replace(/^@/, '');
 
     await page.goto(`https://x.com/${username}`);

--- a/src/clis/twitter/unbookmark.ts
+++ b/src/clis/twitter/unbookmark.ts
@@ -1,3 +1,4 @@
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -13,7 +14,7 @@ cli({
   ],
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
-    if (!page) throw new Error('Requires browser');
+    if (!page) throw new CommandExecutionError('Browser session required for twitter unbookmark');
 
     await page.goto(kwargs.url);
     await page.wait(5);

--- a/src/clis/v2ex/daily.ts
+++ b/src/clis/v2ex/daily.ts
@@ -1,6 +1,7 @@
 /**
  * V2EX Daily Check-in adapter.
  */
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -15,7 +16,7 @@ cli({
   args: [],
   columns: ['status', 'message'],
   func: async (page: IPage | null) => {
-    if (!page) throw new Error('Browser page required');
+    if (!page) throw new CommandExecutionError('Browser page required');
 
     if (process.env.OPENCLI_VERBOSE) {
       console.error('[opencli:v2ex] Navigating to /mission/daily');
@@ -60,7 +61,7 @@ cli({
         console.error(`[opencli:v2ex:debug] Page Title: ${checkResult.debug_title}`);
         console.error(`[opencli:v2ex:debug] Page Body: ${checkResult.debug_body}`);
       }
-      throw new Error(checkResult.error);
+      throw new CommandExecutionError(checkResult.error);
     }
 
     if (checkResult.claimed) {

--- a/src/clis/v2ex/me.ts
+++ b/src/clis/v2ex/me.ts
@@ -1,6 +1,7 @@
 /**
  * V2EX Me (Profile/Balance) adapter.
  */
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -15,7 +16,7 @@ cli({
   args: [],
   columns: ['username', 'balance', 'unread_notifications', 'daily_reward_ready'],
   func: async (page: IPage | null) => {
-    if (!page) throw new Error('Browser page required');
+    if (!page) throw new CommandExecutionError('Browser page required');
 
     if (process.env.OPENCLI_VERBOSE) {
       console.error('[opencli:v2ex] Navigating to /');
@@ -95,7 +96,7 @@ cli({
         console.error(`[opencli:v2ex:debug] Page Title: ${data.debug_title}`);
         console.error(`[opencli:v2ex:debug] Page Body: ${data.debug_body}`);
       }
-      throw new Error(data.error);
+      throw new CommandExecutionError(data.error);
     }
 
     return [data];

--- a/src/clis/v2ex/notifications.ts
+++ b/src/clis/v2ex/notifications.ts
@@ -1,6 +1,7 @@
 /**
  * V2EX Notifications adapter.
  */
+import { CommandExecutionError } from '../../errors.js';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 
@@ -17,7 +18,7 @@ cli({
   ],
   columns: ['type', 'content', 'time'],
   func: async (page: IPage | null, kwargs) => {
-    if (!page) throw new Error('Browser page required');
+    if (!page) throw new CommandExecutionError('Browser page required');
 
     if (process.env.OPENCLI_VERBOSE) {
       console.error('[opencli:v2ex] Navigating to /notifications');
@@ -67,9 +68,7 @@ cli({
       }
     `);
 
-    if (!Array.isArray(data)) {
-      throw new Error('Failed to parse notifications data');
-    }
+    if (!Array.isArray(data)) throw new CommandExecutionError('Failed to parse notifications data');
 
     const limit = kwargs.limit || 20;
     return data.slice(0, limit);


### PR DESCRIPTION
## Summary
- replace raw `Error` throws in `twitter`, `reddit`, `v2ex`, and `substack` adapters with `CliError` subclasses
- use `AuthRequiredError` for missing login state and `CommandExecutionError` for execution/API failures
- normalize browser-required checks to consistent error messages

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`