### PR TITLE
fix: update import paths in boss adapters after utils.ts rename

### DIFF
--- a/src/clis/chatgpt/ask.ts
+++ b/src/clis/chatgpt/ask.ts
@@ -1,6 +1,6 @@
 import { execSync, spawnSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
-import { CommandExecutionError, ConfigError } from '../../errors.js';
+import { ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 import { getVisibleChatMessages } from './ax.js';
 

--- a/src/clis/chatgpt/status.ts
+++ b/src/clis/chatgpt/status.ts
@@ -2,7 +2,6 @@ import { execSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
 import { CommandExecutionError, ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
-import { ConfigError } from '../../errors.js';
 
 export const statusCommand = cli({
   site: 'chatgpt',


### PR DESCRIPTION
After #373 renamed  to , the import paths in  and  still referenced the old filename. This PR updates them to use the correct import path.