### PR TITLE
fix(execution): apply timeout to non-browser commands

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,8 +51,12 @@ export class AuthRequiredError extends CliError {
 }
 
 export class TimeoutError extends CliError {
-  constructor(label: string, seconds: number) {
-    super('TIMEOUT', `${label} timed out after ${seconds}s`, 'Try again, or increase timeout with OPENCLI_BROWSER_COMMAND_TIMEOUT env var');
+  constructor(label: string, seconds: number, hint?: string) {
+    super(
+      'TIMEOUT',
+      `${label} timed out after ${seconds}s`,
+      hint ?? 'Try again, or increase timeout with OPENCLI_BROWSER_COMMAND_TIMEOUT env var',
+    );
   }
 }
 

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { executeCommand } from './execution.js';
+import { TimeoutError } from './errors.js';
+import { cli, Strategy } from './registry.js';
+import { withTimeoutMs } from './runtime.js';
+
+describe('executeCommand — non-browser timeout', () => {
+  it('applies timeoutSeconds to non-browser commands', async () => {
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'non-browser-timeout',
+      description: 'test non-browser timeout',
+      browser: false,
+      strategy: Strategy.PUBLIC,
+      timeoutSeconds: 0.01,
+      func: () => new Promise(() => {}),
+    });
+
+    // Sentinel timeout at 200ms — if the inner 10ms timeout fires first,
+    // the error will be a TimeoutError with the command label, not 'sentinel'.
+    const error = await withTimeoutMs(executeCommand(cmd, {}), 200, 'sentinel timeout')
+      .catch((err) => err);
+
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect(error).toMatchObject({
+      code: 'TIMEOUT',
+      message: 'test-execution/non-browser-timeout timed out after 0.01s',
+    });
+  });
+
+  it('skips timeout when timeoutSeconds is 0', async () => {
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'non-browser-zero-timeout',
+      description: 'test zero timeout bypasses wrapping',
+      browser: false,
+      strategy: Strategy.PUBLIC,
+      timeoutSeconds: 0,
+      func: () => new Promise(() => {}),
+    });
+
+    // With timeout guard skipped, the sentinel fires instead.
+    await expect(
+      withTimeoutMs(executeCommand(cmd, {}), 50, 'sentinel timeout'),
+    ).rejects.toThrow('sentinel timeout');
+  });
+});

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -194,7 +194,17 @@ export async function executeCommand(
         });
       }, { workspace: `site:${cmd.site}` });
     } else {
-      result = await runCommand(cmd, null, kwargs, debug);
+      // Non-browser commands: apply timeout only when explicitly configured.
+      const timeout = cmd.timeoutSeconds;
+      if (timeout !== undefined && timeout > 0) {
+        result = await runWithTimeout(runCommand(cmd, null, kwargs, debug), {
+          timeout,
+          label: fullName(cmd),
+          hint: `Increase the adapter's timeoutSeconds setting (currently ${timeout}s)`,
+        });
+      } else {
+        result = await runCommand(cmd, null, kwargs, debug);
+      }
     }
   } catch (err) {
     hookCtx.error = err;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -30,11 +30,11 @@ export const DEFAULT_BROWSER_EXPLORE_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_
  */
 export async function runWithTimeout<T>(
   promise: Promise<T>,
-  opts: { timeout: number; label?: string },
+  opts: { timeout: number; label?: string; hint?: string },
 ): Promise<T> {
   const label = opts.label ?? 'Operation';
   return withTimeoutMs(promise, opts.timeout * 1000,
-    () => new TimeoutError(label, opts.timeout));
+    () => new TimeoutError(label, opts.timeout, opts.hint));
 }
 
 /**


### PR DESCRIPTION
## Description

Non-browser commands (`browser: false`) ran without any timeout protection, even when the adapter explicitly set `timeoutSeconds`. The browser branch already wrapped execution with `runWithTimeout()`, but the non-browser branch called `runCommand()` directly.

This adds the same `runWithTimeout()` wrapping when a positive `timeoutSeconds` is configured. Also adds an optional `hint` to `TimeoutError` so non-browser timeouts show a relevant message instead of the browser-specific env var hint.

Related issue: fixes the non-browser timeout gap identified in code audit

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```
 PASS  src/execution.test.ts
  executeCommand — non-browser timeout
    ✓ applies timeoutSeconds to non-browser commands (13ms)
    ✓ skips timeout when timeoutSeconds is 0 (52ms)
```