### PR TITLE
docs: add Awesome OpenCLI list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![npm](https://img.shields.io/npm/v/@jackwener/opencli?style=flat-square)](https://www.npmjs.com/package/@jackwener/opencli)
 [![Node.js Version](https://img.shields.io/node/v/@jackwener/opencli?style=flat-square)](https://nodejs.org)
 [![License](https://img.shields.io/npm/l/@jackwener/opencli?style=flat-square)](./LICENSE)
-[![Awesome OpenCLI Plugins](https://img.shields.io/badge/Explore-Awesome%20OpenCLI%20Plugins-0a66c2?style=flat-square&logo=github)](https://github.com/Alpha-Innovation-Labs/awesome-opencli)
+[![Awesome OpenCLI](https://img.shields.io/badge/Awesome-OpenCLI-0a66c2?style=flat-square&logo=github)](https://github.com/Alpha-Innovation-Labs/awesome-opencli)
 
 A CLI tool that turns **any website**, **Electron app**, or **local CLI tool** into a command-line interface — Bilibili, Zhihu, 小红书, Twitter/X, Reddit, YouTube, Antigravity, `gh`, `docker`, and [many more](#built-in-commands) — powered by browser session reuse and AI-native discovery.
 
@@ -303,7 +303,7 @@ opencli plugin uninstall my-tool                            # Remove
 | [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | TS | Multi-platform trending aggregator |
 | [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | YAML | 稀土掘金 (Juejin) hot articles |
 
-For more community plugins and integrations, check the [Awesome OpenCLI](https://github.com/Alpha-Innovation-Labs/awesome-opencli) list.
+For more community projects, tools, and ecosystem extensions, check [Awesome OpenCLI](https://github.com/Alpha-Innovation-Labs/awesome-opencli).
 
 See [Plugins Guide](./docs/guide/plugins.md) for creating your own plugin.
 


### PR DESCRIPTION
- Added an `Awesome OpenCLI` badge near the README top that links directly to the curated list.
- Added a short note in the Plugins section directing users to check Awesome OpenCLI for community projects, tools, and ecosystem extensions.

