### PR TITLE
feat(tiktok): add video URL to search results

### DIFF
--- a/src/clis/tiktok/search.yaml
+++ b/src/clis/tiktok/search.yaml
@@ -35,7 +35,7 @@ pipeline:
             rank: idx + 1,
             desc: (v.desc || '').replace(/\n/g, ' ').substring(0, 100),
             author: a.uniqueId || '',
-            url: 'https://www.tiktok.com/@' + (a.uniqueId || '') + '/video/' + (v.id || ''),
+            url: (a.uniqueId && v.id) ? 'https://www.tiktok.com/@' + a.uniqueId + '/video/' + v.id : '',
             plays: s.playCount || 0,
             likes: s.diggCount || 0,
             comments: s.commentCount || 0,


### PR DESCRIPTION
## What

Add a `url` field to the TikTok search adapter output.

## Why

The current `tiktok search` command returns `author`, `desc`, `plays`, `likes`, etc., but **no direct link to the video**. This makes it hard for downstream consumers (AI agents, data pipelines, scripts) to reference the actual video.

## How

Construct the URL from fields already returned by the TikTok API:

`https://www.tiktok.com/@{author.uniqueId}/video/{item.id}`

The `v.id` (video ID) is already present in the API response but was not previously surfaced.

## Changes

- `src/clis/tiktok/search.yaml`: added `url` field in the return object and added `url` to the `columns` list.

## Testing

Tested locally with `opencli tiktok search "AI skill" --limit 5 -f json` - all 5 results returned valid clickable URLs such as `https://www.tiktok.com/@learnwithseb/video/7509579188488178946`