### PR TITLE
feat: add command-level CDP overrides / 增加命令级 CDP 覆盖

### DIFF
--- a/docs/adapters/desktop/antigravity.md
+++ b/docs/adapters/desktop/antigravity.md
@@ -16,10 +16,25 @@ Start the Antigravity desktop app with the Chrome DevTools `remote-debugging-por
 
 > Depending on your installation, the executable might be named differently, e.g., `Antigravity` instead of `Electron`.
 
-Then set the target port:
+Then either set the target port globally:
 
 ```bash
 export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
+```
+
+Or pass it per command, which is usually better when you switch between multiple desktop apps or multiple CDP ports:
+
+```bash
+opencli antigravity status --cdp-endpoint http://127.0.0.1:9224
+opencli antigravity send "hello" --cdp-endpoint http://127.0.0.1:9224
+```
+
+If the endpoint exposes multiple inspectable windows, prefer the correct one per command:
+
+```bash
+opencli antigravity status \
+  --cdp-endpoint http://127.0.0.1:9224 \
+  --cdp-target antigravity
 ```
 
 ## Commands

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import chalk from 'chalk';
 import { type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
 import { serializeCommand, formatArgSummary } from './serialization.js';
 import { render as renderOutput } from './output.js';
-import { getBrowserFactory, browserSession } from './runtime.js';
+import { extractBrowserEnvOverrides, getBrowserFactory, browserSession, withBrowserEnvOverrides } from './runtime.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled } from './external.js';
@@ -133,22 +133,26 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     .option('--wait <s>', '', '3')
     .option('--auto', 'Enable interactive fuzzing')
     .option('--click <labels>', 'Comma-separated labels to click before fuzzing')
+    .option('--cdp-endpoint <url>', 'Override the CDP endpoint for this command')
+    .option('--cdp-target <pattern>', 'Prefer a CDP target whose title or URL matches this pattern')
     .action(async (url, opts) => {
-      const { exploreUrl, renderExploreSummary } = await import('./explore.js');
-      const clickLabels = opts.click
-        ? opts.click.split(',').map((s: string) => s.trim())
-        : undefined;
-      const workspace = `explore:${inferHost(url, opts.site)}`;
-      const result = await exploreUrl(url, {
-        BrowserFactory: getBrowserFactory(),
-        site: opts.site,
-        goal: opts.goal,
-        waitSeconds: parseFloat(opts.wait),
-        auto: opts.auto,
-        clickLabels,
-        workspace,
+      await withBrowserEnvOverrides(extractBrowserEnvOverrides(opts), async () => {
+        const { exploreUrl, renderExploreSummary } = await import('./explore.js');
+        const clickLabels = opts.click
+          ? opts.click.split(',').map((s: string) => s.trim())
+          : undefined;
+        const workspace = `explore:${inferHost(url, opts.site)}`;
+        const result = await exploreUrl(url, {
+          BrowserFactory: getBrowserFactory(),
+          site: opts.site,
+          goal: opts.goal,
+          waitSeconds: parseFloat(opts.wait),
+          auto: opts.auto,
+          clickLabels,
+          workspace,
+        });
+        console.log(renderExploreSummary(result));
       });
-      console.log(renderExploreSummary(result));
     });
 
   program
@@ -167,18 +171,22 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     .argument('<url>')
     .option('--goal <text>')
     .option('--site <name>')
+    .option('--cdp-endpoint <url>', 'Override the CDP endpoint for this command')
+    .option('--cdp-target <pattern>', 'Prefer a CDP target whose title or URL matches this pattern')
     .action(async (url, opts) => {
-      const { generateCliFromUrl, renderGenerateSummary } = await import('./generate.js');
-      const workspace = `generate:${inferHost(url, opts.site)}`;
-      const r = await generateCliFromUrl({
-        url,
-        BrowserFactory: getBrowserFactory(),
-        goal: opts.goal,
-        site: opts.site,
-        workspace,
+      await withBrowserEnvOverrides(extractBrowserEnvOverrides(opts), async () => {
+        const { generateCliFromUrl, renderGenerateSummary } = await import('./generate.js');
+        const workspace = `generate:${inferHost(url, opts.site)}`;
+        const r = await generateCliFromUrl({
+          url,
+          BrowserFactory: getBrowserFactory(),
+          goal: opts.goal,
+          site: opts.site,
+          workspace,
+        });
+        console.log(renderGenerateSummary(r));
+        process.exitCode = r.ok ? 0 : 1;
       });
-      console.log(renderGenerateSummary(r));
-      process.exitCode = r.ok ? 0 : 1;
     });
 
   // ── Built-in: record ─────────────────────────────────────────────────────
@@ -191,18 +199,22 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     .option('--out <dir>', 'Output directory for candidates')
     .option('--poll <ms>', 'Poll interval in milliseconds', '2000')
     .option('--timeout <ms>', 'Auto-stop after N milliseconds (default: 60000)', '60000')
+    .option('--cdp-endpoint <url>', 'Override the CDP endpoint for this command')
+    .option('--cdp-target <pattern>', 'Prefer a CDP target whose title or URL matches this pattern')
     .action(async (url, opts) => {
-      const { recordSession, renderRecordSummary } = await import('./record.js');
-      const result = await recordSession({
-        BrowserFactory: getBrowserFactory(),
-        url,
-        site: opts.site,
-        outDir: opts.out,
-        pollMs: parseInt(opts.poll, 10),
-        timeoutMs: parseInt(opts.timeout, 10),
+      await withBrowserEnvOverrides(extractBrowserEnvOverrides(opts), async () => {
+        const { recordSession, renderRecordSummary } = await import('./record.js');
+        const result = await recordSession({
+          BrowserFactory: getBrowserFactory(),
+          url,
+          site: opts.site,
+          outDir: opts.out,
+          pollMs: parseInt(opts.poll, 10),
+          timeoutMs: parseInt(opts.timeout, 10),
+        });
+        console.log(renderRecordSummary(result));
+        process.exitCode = result.candidateCount > 0 ? 0 : 1;
       });
-      console.log(renderRecordSummary(result));
-      process.exitCode = result.candidateCount > 0 ? 0 : 1;
     });
 
   program
@@ -210,18 +222,22 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     .description('Strategy cascade: find simplest working strategy')
     .argument('<url>')
     .option('--site <name>')
+    .option('--cdp-endpoint <url>', 'Override the CDP endpoint for this command')
+    .option('--cdp-target <pattern>', 'Prefer a CDP target whose title or URL matches this pattern')
     .action(async (url, opts) => {
-      const { cascadeProbe, renderCascadeResult } = await import('./cascade.js');
-      const workspace = `cascade:${inferHost(url, opts.site)}`;
-      const result = await browserSession(getBrowserFactory(), async (page) => {
-        try {
-          const siteUrl = new URL(url);
-          await page.goto(`${siteUrl.protocol}//${siteUrl.host}`);
-          await page.wait(2);
-        } catch {}
-        return cascadeProbe(page, url);
-      }, { workspace });
-      console.log(renderCascadeResult(result));
+      await withBrowserEnvOverrides(extractBrowserEnvOverrides(opts), async () => {
+        const { cascadeProbe, renderCascadeResult } = await import('./cascade.js');
+        const workspace = `cascade:${inferHost(url, opts.site)}`;
+        const result = await browserSession(getBrowserFactory(), async (page) => {
+          try {
+            const siteUrl = new URL(url);
+            await page.goto(`${siteUrl.protocol}//${siteUrl.host}`);
+            await page.wait(2);
+          } catch {}
+          return cascadeProbe(page, url);
+        }, { workspace });
+        console.log(renderCascadeResult(result));
+      });
     });
 
   // ── Built-in: doctor / completion ──────────────────────────────────────────
@@ -439,9 +455,13 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
     .command('serve')
     .description('Start Anthropic-compatible API proxy for Antigravity')
     .option('--port <port>', 'Server port (default: 8082)', '8082')
+    .option('--cdp-endpoint <url>', 'Override the CDP endpoint for this command')
+    .option('--cdp-target <pattern>', 'Prefer a CDP target whose title or URL matches this pattern')
     .action(async (opts) => {
-      const { startServe } = await import('./clis/antigravity/serve.js');
-      await startServe({ port: parseInt(opts.port) });
+      await withBrowserEnvOverrides(extractBrowserEnvOverrides(opts), async () => {
+        const { startServe } = await import('./clis/antigravity/serve.js');
+        await startServe({ port: parseInt(opts.port) });
+      });
     });
 
   // ── Dynamic adapter commands ──────────────────────────────────────────────

--- a/src/clis/antigravity/SKILL.md
+++ b/src/clis/antigravity/SKILL.md
@@ -12,14 +12,21 @@ The target Electron application MUST be launched with the remote-debugging-port 
 /Applications/Antigravity.app/Contents/MacOS/Electron --remote-debugging-port=9224
 \`\`\`
 
-The agent must configure the endpoint environment variable locally before invoking standard commands:
+The agent can either configure the endpoint environment variable locally once:
 \`\`\`bash
 export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
 \`\`\`
 
-If the endpoint exposes multiple inspectable targets, also set:
+Or pass it per command, which is better when switching between multiple apps:
+\`\`\`bash
+opencli antigravity status --cdp-endpoint http://127.0.0.1:9224
+\`\`\`
+
+If the endpoint exposes multiple inspectable targets, also set or pass:
 \`\`\`bash
 export OPENCLI_CDP_TARGET="antigravity"
+# or:
+opencli antigravity status --cdp-endpoint http://127.0.0.1:9224 --cdp-target antigravity
 \`\`\`
 
 ## High-Level Capabilities
@@ -37,6 +44,12 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
 opencli antigravity send "Write a python script to fetch HN top stories"
 # wait ~10-15 seconds for output to render
 opencli antigravity extract-code > hn_fetcher.py
+\`\`\`
+
+Equivalent per-command form:
+\`\`\`bash
+opencli antigravity send "Write a python script to fetch HN top stories" --cdp-endpoint http://127.0.0.1:9224
+opencli antigravity extract-code --cdp-endpoint http://127.0.0.1:9224 > hn_fetcher.py
 \`\`\`
 
 ### Reading Real-time Logs

--- a/src/clis/antigravity/serve.ts
+++ b/src/clis/antigravity/serve.ts
@@ -7,6 +7,7 @@
  *
  * Usage:
  *   OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224 opencli antigravity serve --port 8082
+ *   opencli antigravity serve --port 8082 --cdp-endpoint http://127.0.0.1:9224 --cdp-target antigravity
  *   ANTHROPIC_BASE_URL=http://localhost:8082 claude
  */
 
@@ -439,7 +440,8 @@ export async function startServe(opts: { port?: number } = {}): Promise<void> {
     if (!endpoint) {
       throw new Error(
         'OPENCLI_CDP_ENDPOINT is not set.\n' +
-        'Usage: OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224 opencli antigravity serve'
+        'Usage: OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9224 opencli antigravity serve\n' +
+        '   or: opencli antigravity serve --cdp-endpoint http://127.0.0.1:9224'
       );
     }
 

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import type { CliCommand } from './registry.js';
+
+const { mockExecuteCommand, mockRender } = vi.hoisted(() => ({
+  mockExecuteCommand: vi.fn(),
+  mockRender: vi.fn(),
+}));
+
+vi.mock('./execution.js', () => ({
+  executeCommand: mockExecuteCommand,
+}));
+
+vi.mock('./output.js', () => ({
+  render: mockRender,
+}));
+
+import { registerCommandToProgram } from './commanderAdapter.js';
+
+describe('registerCommandToProgram', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    process.exitCode = undefined;
+  });
+
+  it('applies command-level CDP overrides only while a browser command executes', async () => {
+    const seen: Array<{ endpoint?: string; target?: string }> = [];
+    mockExecuteCommand.mockImplementation(async () => {
+      seen.push({
+        endpoint: process.env.OPENCLI_CDP_ENDPOINT,
+        target: process.env.OPENCLI_CDP_TARGET,
+      });
+      return [];
+    });
+
+    const cmd: CliCommand = {
+      site: 'antigravity',
+      name: 'status',
+      description: 'status',
+      browser: true,
+      args: [],
+    };
+
+    const program = new Command();
+    const siteCmd = program.command('antigravity');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync([
+      'node',
+      'opencli',
+      'antigravity',
+      'status',
+      '--cdp-endpoint',
+      'http://127.0.0.1:9333',
+      '--cdp-target',
+      'launchpad',
+    ]);
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith(cmd, {}, false);
+    expect(seen).toEqual([
+      {
+        endpoint: 'http://127.0.0.1:9333',
+        target: 'launchpad',
+      },
+    ]);
+    expect(process.env.OPENCLI_CDP_ENDPOINT).toBeUndefined();
+    expect(process.env.OPENCLI_CDP_TARGET).toBeUndefined();
+  });
+});

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -17,6 +17,7 @@ import { formatRegistryHelpText } from './serialization.js';
 import { render as renderOutput } from './output.js';
 import { executeCommand } from './execution.js';
 import { CliError, ERROR_ICONS, getErrorMessage } from './errors.js';
+import { extractBrowserEnvOverrides, withBrowserEnvOverrides } from './runtime.js';
 
 /**
  * Register a single CliCommand as a Commander subcommand.
@@ -43,6 +44,11 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
   subCmd
     .option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table')
     .option('-v, --verbose', 'Debug output', false);
+  if (cmd.browser) {
+    subCmd
+      .option('--cdp-endpoint <url>', 'Override the CDP endpoint for this command')
+      .option('--cdp-target <pattern>', 'Prefer a CDP target whose title or URL matches this pattern');
+  }
 
   subCmd.addHelpText('after', formatRegistryHelpText(cmd));
 
@@ -69,8 +75,8 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
       const verbose = optionsRecord.verbose === true;
       const format = typeof optionsRecord.format === 'string' ? optionsRecord.format : 'table';
       if (verbose) process.env.OPENCLI_VERBOSE = '1';
-
-      const result = await executeCommand(cmd, kwargs, verbose);
+      const browserEnv = extractBrowserEnvOverrides(optionsRecord);
+      const result = await withBrowserEnvOverrides(browserEnv, async () => executeCommand(cmd, kwargs, verbose));
 
       if (verbose && (!result || (Array.isArray(result) && result.length === 0))) {
         console.error(chalk.yellow('[Verbose] Warning: Command returned an empty result.'));

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { extractBrowserEnvOverrides, withBrowserEnvOverrides } from './runtime.js';
+
+describe('browser env overrides', () => {
+  it('extracts browser overrides from commander-style option names', () => {
+    expect(extractBrowserEnvOverrides({
+      'cdp-endpoint': ' http://127.0.0.1:9333 ',
+      'cdp-target': ' antigravity ',
+    })).toEqual({
+      cdpEndpoint: 'http://127.0.0.1:9333',
+      cdpTarget: 'antigravity',
+    });
+  });
+
+  it('temporarily applies overrides and restores previous values', async () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'http://127.0.0.1:9222');
+    vi.stubEnv('OPENCLI_CDP_TARGET', 'codex');
+
+    let seenEndpoint: string | undefined;
+    let seenTarget: string | undefined;
+
+    await withBrowserEnvOverrides({
+      cdpEndpoint: 'http://127.0.0.1:9333',
+      cdpTarget: 'antigravity',
+    }, async () => {
+      seenEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
+      seenTarget = process.env.OPENCLI_CDP_TARGET;
+    });
+
+    expect(seenEndpoint).toBe('http://127.0.0.1:9333');
+    expect(seenTarget).toBe('antigravity');
+    expect(process.env.OPENCLI_CDP_ENDPOINT).toBe('http://127.0.0.1:9222');
+    expect(process.env.OPENCLI_CDP_TARGET).toBe('codex');
+  });
+
+  it('leaves unrelated browser env unchanged when an override is omitted', async () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'http://127.0.0.1:9222');
+    vi.stubEnv('OPENCLI_CDP_TARGET', 'cursor');
+
+    let seenEndpoint: string | undefined;
+    let seenTarget: string | undefined;
+
+    await withBrowserEnvOverrides({
+      cdpEndpoint: 'http://127.0.0.1:9333',
+    }, async () => {
+      seenEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
+      seenTarget = process.env.OPENCLI_CDP_TARGET;
+    });
+
+    expect(seenEndpoint).toBe('http://127.0.0.1:9333');
+    expect(seenTarget).toBe('cursor');
+    expect(process.env.OPENCLI_CDP_ENDPOINT).toBe('http://127.0.0.1:9222');
+    expect(process.env.OPENCLI_CDP_TARGET).toBe('cursor');
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,12 +2,53 @@ import { BrowserBridge, CDPBridge } from './browser/index.js';
 import type { IPage } from './types.js';
 import { TimeoutError } from './errors.js';
 
+export type BrowserEnvOverrides = {
+  cdpEndpoint?: string;
+  cdpTarget?: string;
+};
+
 /**
  * Returns the appropriate browser factory based on environment config.
  * Uses CDPBridge when OPENCLI_CDP_ENDPOINT is set, otherwise BrowserBridge.
  */
 export function getBrowserFactory(): new () => IBrowserFactory {
   return (process.env.OPENCLI_CDP_ENDPOINT ? CDPBridge : BrowserBridge) as unknown as new () => IBrowserFactory;
+}
+
+export function extractBrowserEnvOverrides(options?: Record<string, unknown> | null): BrowserEnvOverrides {
+  const input = options ?? {};
+  return {
+    cdpEndpoint: readStringOption(input['cdp-endpoint'] ?? input.cdpEndpoint),
+    cdpTarget: readStringOption(input['cdp-target'] ?? input.cdpTarget),
+  };
+}
+
+export async function withBrowserEnvOverrides<T>(
+  overrides: BrowserEnvOverrides,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const pairs: Array<[key: 'OPENCLI_CDP_ENDPOINT' | 'OPENCLI_CDP_TARGET', value: string | undefined]> = [
+    ['OPENCLI_CDP_ENDPOINT', overrides.cdpEndpoint],
+    ['OPENCLI_CDP_TARGET', overrides.cdpTarget],
+  ];
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of pairs) {
+    if (value === undefined) continue;
+    previous.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of pairs) {
+      if (value === undefined) continue;
+      const prior = previous.get(key);
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+  }
 }
 
 function parseEnvTimeout(envVar: string, fallback: number): number {
@@ -19,6 +60,12 @@ function parseEnvTimeout(envVar: string, fallback: number): number {
     return fallback;
   }
   return parsed;
+}
+
+function readStringOption(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 export const DEFAULT_BROWSER_CONNECT_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_CONNECT_TIMEOUT', 30);


### PR DESCRIPTION
## Summary / 摘要

This PR adds command-level CDP overrides so browser-backed commands can target different Chrome/Electron sessions without mutating global shell state.

这个 PR 为浏览器相关命令增加了命令级 CDP 覆盖参数，使不同的 Chrome / Electron 会话可以按命令单独指定，而不需要反复切换全局环境变量。

## Why / 背景与原因

Today `opencli` mainly relies on global environment variables such as `OPENCLI_CDP_ENDPOINT` and `OPENCLI_CDP_TARGET`.
That works for single-app usage, but it becomes awkward when switching between multiple Electron apps, multiple Chrome instances, or multiple debugging ports.

目前 `opencli` 主要依赖全局环境变量，例如 `OPENCLI_CDP_ENDPOINT` 和 `OPENCLI_CDP_TARGET`。
这种方式在单应用场景下可用，但一旦需要在多个 Electron 应用、多个 Chrome 实例、或者多个调试端口之间切换，就会很不方便。

Typical problems:

- only one active target can be selected through global state
- switching apps requires editing shell state repeatedly
- wrappers become necessary for otherwise simple workflows
- long-running commands such as `antigravity serve` are harder to route cleanly

典型问题包括：

- 只能通过全局状态选择一个当前目标
- 切换应用需要频繁修改 shell 环境
- 原本简单的工作流不得不额外包一层脚本
- 类似 `antigravity serve` 这种长运行命令也不容易干净地指定目标

## Changes / 修改内容

- add `--cdp-endpoint` and `--cdp-target` to browser-backed dynamic commands
- add the same command-level overrides to built-in browser commands such as `explore`, `generate`, `record`, and `cascade`
- add command-level overrides to `opencli antigravity serve`
- add runtime helpers to apply and restore CDP env overrides safely during command execution
- update Antigravity docs and skill docs to document per-command usage
- add unit tests for runtime override behavior and Commander integration

- 为浏览器相关的动态命令增加 `--cdp-endpoint` 和 `--cdp-target`
- 为 `explore`、`generate`、`record`、`cascade` 等内建浏览器命令增加同样的命令级覆盖能力
- 为 `opencli antigravity serve` 增加命令级覆盖能力
- 增加运行时 helper，在命令执行期间安全地设置并恢复 CDP 环境变量
- 更新 Antigravity 文档与技能说明，补充按命令传参的用法
- 增加对应单元测试，覆盖运行时覆盖逻辑和 Commander 接入行为

## Example / 示例

```bash
opencli antigravity status --cdp-endpoint http://127.0.0.1:9333 --cdp-target Launchpad
opencli antigravity serve --port 8082 --cdp-endpoint http://127.0.0.1:9333 --cdp-target antigravity
```

This makes multi-app workflows much easier without breaking existing env-based usage.

这样可以在不破坏现有环境变量用法的前提下，显著改善多应用场景下的使用体验。

## Verification / 验证

- `npm test`
- `npm run typecheck`