### PR TITLE
feat(fetch): add proxy support via standard proxy environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "commander": "^14.0.3",
         "js-yaml": "^4.1.0",
         "turndown": "^7.2.2",
+        "undici": "^7.24.5",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -3512,6 +3513,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "commander": "^14.0.3",
     "js-yaml": "^4.1.0",
     "turndown": "^7.2.2",
+    "undici": "^7.24.5",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/src/pipeline/steps/fetch.ts
+++ b/src/pipeline/steps/fetch.ts
@@ -8,8 +8,17 @@ import type { IPage } from '../../types.js';
 import { render } from '../template.js';
 
 import { isRecord, mapConcurrent } from '../../utils.js';
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
 
-
+/** Returns a fetch function that routes through the system proxy if configured. */
+function getProxyFetch(): typeof fetch {
+  const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    ?? process.env.HTTP_PROXY ?? process.env.http_proxy
+    ?? process.env.ALL_PROXY ?? process.env.all_proxy;
+  if (!proxyUrl) return fetch;
+  const dispatcher = new ProxyAgent(proxyUrl);
+  return (input, init) => undiciFetch(input as Parameters<typeof undiciFetch>[0], { ...(init as object), dispatcher }) as unknown as Promise<Response>;
+}
 
 /** Single URL fetch helper */
 async function fetchSingle(
@@ -29,7 +38,8 @@ async function fetchSingle(
   }
 
   if (page === null) {
-    const resp = await fetch(finalUrl, { method: method.toUpperCase(), headers: renderedHeaders });
+    const proxyFetch = getProxyFetch();
+    const resp = await proxyFetch(finalUrl, { method: method.toUpperCase(), headers: renderedHeaders });
     if (!resp.ok) {
       throw new CliError('FETCH_ERROR', `HTTP ${resp.status} ${resp.statusText} from ${finalUrl}`);
     }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  - The `fetch` pipeline step (used by all `strategy: public` adapters like HackerNews, Wikipedia, arXiv, etc.) previously called Node.js native `fetch` directly, which ignores system proxy settings                                                                                                                      
  - Added proxy support using `undici` `ProxyAgent`, reading standard proxy environment variables at runtime                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  ## How it works                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  When any of the following env vars are set, Node-side `fetch` calls are routed through the proxy. Browser-side fetch paths are unaffected (Chrome uses its own proxy settings).                                                                                                                                           
                                                                  
  ```bash                                                                                                                                                                                                                                                                                                                   
  HTTPS_PROXY=http://127.0.0.1:7890 opencli hackernews top        
  HTTP_PROXY=http://127.0.0.1:7890 opencli arxiv search --query "LLM"                                                                                                                                                                                                                                                       
  ALL_PROXY=socks5://127.0.0.1:7891 opencli wikipedia search --query "AI"                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
  Supported variables (in priority order): HTTPS_PROXY, https_proxy, HTTP_PROXY, http_proxy, ALL_PROXY, all_proxy                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  Changes                                                                                                                                                                                                                                                                                                                   
                                                                  
  - src/pipeline/steps/fetch.ts: added getProxyFetch() helper that returns a proxy-aware fetch when env vars are present, falls back to native fetch otherwise                                                                                                                                                              
  - package.json / package-lock.json: added undici dependency (the same library that powers Node.js built-in fetch)