### PR TITLE
feat(weibo,youtube): add Weibo commands and YouTube channel/comments

### DIFF
--- a/src/clis/bbc/news.ts
+++ b/src/clis/bbc/news.ts
@@ -1,6 +1,5 @@
 /**
  * BBC News headlines — public RSS feed, no browser needed.
- * Source: bb-sites/bbc/news.js
  */
 import { cli, Strategy } from '../../registry.js';
 

--- a/src/clis/ctrip/search.ts
+++ b/src/clis/ctrip/search.ts
@@ -1,6 +1,5 @@
 /**
  * 携程旅行搜索 — browser cookie, multi-strategy.
- * Source: bb-sites/ctrip/search.js (simplified to suggestion API)
  */
 import { cli, Strategy } from '../../registry.js';
 

--- a/src/clis/reuters/search.ts
+++ b/src/clis/reuters/search.ts
@@ -1,6 +1,5 @@
 /**
  * Reuters news search — API with HTML fallback.
- * Source: bb-sites/reuters/search.js
  */
 import { cli, Strategy } from '../../registry.js';
 

--- a/src/clis/weibo/comments.ts
+++ b/src/clis/weibo/comments.ts
@@ -1,0 +1,54 @@
+/**
+ * Weibo comments — get comments on a post.
+ */
+import { cli, Strategy } from '../../registry.js';
+
+cli({
+  site: 'weibo',
+  name: 'comments',
+  description: 'Get comments on a Weibo post',
+  domain: 'weibo.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'id', required: true, positional: true, help: 'Post ID (numeric idstr)' },
+    { name: 'limit', type: 'int', default: 20, help: 'Number of comments (max 50)' },
+  ],
+  columns: ['rank', 'author', 'text', 'likes', 'replies', 'time'],
+  func: async (page, kwargs) => {
+    const count = Math.min(kwargs.limit || 20, 50);
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+
+    const id = String(kwargs.id);
+    const data = await page.evaluate(`
+      (async () => {
+        const id = ${JSON.stringify(id)};
+        const count = ${count};
+        const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
+
+        const url = '/ajax/statuses/buildComments?flow=0&is_reload=1&id=' + id + '&is_show_bulletin=2&is_mix=0&count=' + count;
+        const resp = await fetch(url, {credentials: 'include'});
+        if (!resp.ok) return {error: 'HTTP ' + resp.status};
+        const data = await resp.json();
+        if (!data.ok) return {error: 'API error: ' + (data.msg || 'unknown')};
+
+        return (data.data || []).map((c, i) => {
+          const item = {
+            rank: i + 1,
+            author: c.user?.screen_name || '',
+            text: strip(c.text || ''),
+            likes: c.like_count || 0,
+            replies: c.total_number || 0,
+            time: c.created_at || '',
+          };
+          if (c.reply_comment) {
+            item.reply_to = (c.reply_comment.user?.screen_name || '') + ': ' + strip(c.reply_comment.text || '').substring(0, 80);
+          }
+          return item;
+        });
+      })()
+    `);
+    if (!Array.isArray(data)) return [];
+    return data;
+  },
+});

--- a/src/clis/weibo/feed.ts
+++ b/src/clis/weibo/feed.ts
@@ -1,0 +1,57 @@
+/**
+ * Weibo feed — home timeline from followed users.
+ */
+import { cli, Strategy } from '../../registry.js';
+import { getSelfUid } from './utils.js';
+
+cli({
+  site: 'weibo',
+  name: 'feed',
+  description: 'Weibo home timeline (posts from followed users)',
+  domain: 'weibo.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'limit', type: 'int', default: 15, help: 'Number of posts (max 50)' },
+  ],
+  columns: ['author', 'text', 'reposts', 'comments', 'likes', 'time', 'url'],
+  func: async (page, kwargs) => {
+    const count = Math.min(kwargs.limit || 15, 50);
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+    const uid = await getSelfUid(page);
+
+    const data = await page.evaluate(`
+      (async () => {
+        const uid = ${JSON.stringify(uid)};
+        const count = ${count};
+        const listId = '10001' + uid;
+        const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
+
+        const resp = await fetch('/ajax/feed/unreadfriendstimeline?list_id=' + listId + '&refresh=4&since_id=0&count=' + count, {credentials: 'include'});
+        if (!resp.ok) return {error: 'HTTP ' + resp.status};
+        const data = await resp.json();
+        if (!data.ok) return {error: 'API error: ' + (data.msg || 'unknown')};
+
+        return (data.statuses || []).slice(0, count).map(s => {
+          const u = s.user || {};
+          const item = {
+            author: u.screen_name || '',
+            text: (s.text_raw || strip(s.text || '')).substring(0, 200),
+            reposts: s.reposts_count || 0,
+            comments: s.comments_count || 0,
+            likes: s.attitudes_count || 0,
+            time: s.created_at || '',
+            url: 'https://weibo.com/' + (u.id || '') + '/' + (s.mblogid || ''),
+          };
+          if (s.retweeted_status) {
+            const rt = s.retweeted_status;
+            item.retweeted = (rt.user?.screen_name || '[deleted]') + ': ' + (rt.text_raw || strip(rt.text || '')).substring(0, 100);
+          }
+          return item;
+        });
+      })()
+    `);
+    if (!Array.isArray(data)) return [];
+    return data;
+  },
+});

--- a/src/clis/weibo/hot.ts
+++ b/src/clis/weibo/hot.ts
@@ -1,6 +1,5 @@
 /**
  * Weibo hot search — browser cookie API.
- * Source: bb-sites/weibo/hot.js
  */
 import { cli, Strategy } from '../../registry.js';
 

--- a/src/clis/weibo/me.ts
+++ b/src/clis/weibo/me.ts
@@ -1,0 +1,77 @@
+/**
+ * Weibo me — current logged-in user profile.
+ */
+import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError } from '../../errors.js';
+import { getSelfUid } from './utils.js';
+
+cli({
+  site: 'weibo',
+  name: 'me',
+  description: 'My Weibo profile info',
+  domain: 'weibo.com',
+  strategy: Strategy.COOKIE,
+  args: [],
+  columns: ['screen_name', 'uid', 'followers', 'following', 'statuses', 'verified', 'location'],
+  func: async (page) => {
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+    const uid = await getSelfUid(page);
+
+    const data = await page.evaluate(`
+      (async () => {
+        const uid = ${JSON.stringify(uid)};
+
+        // Try Vue store first
+        const app = document.querySelector('#app')?.__vue_app__;
+        const store = app?.config?.globalProperties?.$store;
+        const cfg = store?.state?.config?.config;
+        const u = cfg?.user;
+
+        // Fetch detail info
+        const detailResp = await fetch('/ajax/profile/detail?uid=' + uid, {credentials: 'include'});
+        const detail = detailResp.ok ? await detailResp.json() : null;
+        const d = detail?.data || {};
+
+        if (u && u.id) {
+          return {
+            screen_name: u.screen_name,
+            uid: u.id,
+            followers: u.followers_count,
+            following: u.friends_count,
+            statuses: u.statuses_count,
+            verified: u.verified || false,
+            location: u.location || '',
+            description: u.description || d.description || '',
+            avatar: u.avatar_hd || u.avatar_large || '',
+            profile_url: 'https://weibo.com' + (u.profile_url || '/u/' + u.id),
+          };
+        }
+
+        // Fallback: fetch profile API
+        const resp = await fetch('/ajax/profile/info?uid=' + uid, {credentials: 'include'});
+        if (!resp.ok) return {error: 'HTTP ' + resp.status};
+        const info = await resp.json();
+        if (!info.ok) return {error: 'API error'};
+        const p = info.data?.user;
+        if (!p) return {error: 'User data not found'};
+        return {
+          screen_name: p.screen_name,
+          uid: p.id,
+          followers: p.followers_count,
+          following: p.friends_count,
+          statuses: p.statuses_count,
+          verified: p.verified || false,
+          location: p.location || '',
+          description: p.description || d.description || '',
+          avatar: p.avatar_hd || p.avatar_large || '',
+          profile_url: 'https://weibo.com' + (p.profile_url || '/u/' + p.id),
+        };
+      })()
+    `);
+
+    if (!data || typeof data !== 'object') throw new CommandExecutionError('Failed to fetch profile');
+    if ((data as Record<string, unknown>).error) throw new CommandExecutionError(String((data as Record<string, unknown>).error));
+    return data as Record<string, unknown>;
+  },
+});

--- a/src/clis/weibo/post.ts
+++ b/src/clis/weibo/post.ts
@@ -1,0 +1,77 @@
+/**
+ * Weibo post — get a single post by ID.
+ */
+import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError } from '../../errors.js';
+
+cli({
+  site: 'weibo',
+  name: 'post',
+  description: 'Get a single Weibo post',
+  domain: 'weibo.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'id', required: true, positional: true, help: 'Post ID (numeric idstr or mblogid from URL)' },
+  ],
+  columns: ['field', 'value'],
+  func: async (page, kwargs) => {
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+
+    const id = String(kwargs.id);
+    const data = await page.evaluate(`
+      (async () => {
+        const id = ${JSON.stringify(id)};
+        const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
+
+        const resp = await fetch('/ajax/statuses/show?id=' + encodeURIComponent(id), {credentials: 'include'});
+        if (!resp.ok) return {error: 'HTTP ' + resp.status};
+        const s = await resp.json();
+        if (!s.ok && !s.idstr) return {error: 'Post not found'};
+
+        // Fetch long text if needed
+        let fullText = s.text_raw || strip(s.text || '');
+        if (s.isLongText || s.is_long_text) {
+          try {
+            const ltResp = await fetch('/ajax/statuses/longtext?id=' + s.idstr, {credentials: 'include'});
+            if (ltResp.ok) {
+              const lt = await ltResp.json();
+              if (lt.data?.longTextContent) fullText = strip(lt.data.longTextContent);
+            }
+          } catch {}
+        }
+
+        const u = s.user || {};
+        const result = {
+          id: s.idstr || String(s.id),
+          mblogid: s.mblogid,
+          author: u.screen_name || '',
+          text: fullText,
+          created_at: s.created_at,
+          source: strip(s.source || ''),
+          reposts: s.reposts_count || 0,
+          comments: s.comments_count || 0,
+          likes: s.attitudes_count || 0,
+          pic_count: s.pic_num || 0,
+          url: 'https://weibo.com/' + (u.id || '') + '/' + (s.mblogid || ''),
+        };
+
+        if (s.retweeted_status) {
+          const rt = s.retweeted_status;
+          result.retweeted_from = (rt.user?.screen_name || '[deleted]');
+          result.retweeted_text = rt.text_raw || strip(rt.text || '');
+        }
+
+        return result;
+      })()
+    `);
+
+    if (!data || typeof data !== 'object') throw new CommandExecutionError('Failed to fetch post');
+    if ((data as Record<string, unknown>).error) throw new CommandExecutionError(String((data as Record<string, unknown>).error));
+
+    return Object.entries(data as Record<string, unknown>).map(([field, value]) => ({
+      field,
+      value: String(value),
+    }));
+  },
+});

--- a/src/clis/weibo/user.ts
+++ b/src/clis/weibo/user.ts
@@ -1,0 +1,64 @@
+/**
+ * Weibo user — get user profile by uid or screen_name.
+ */
+import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError } from '../../errors.js';
+
+cli({
+  site: 'weibo',
+  name: 'user',
+  description: 'Get Weibo user profile',
+  domain: 'weibo.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'id', required: true, positional: true, help: 'User ID (numeric uid) or screen name' },
+  ],
+  columns: ['screen_name', 'uid', 'followers', 'following', 'statuses', 'verified', 'description', 'location', 'url'],
+  func: async (page, kwargs) => {
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+
+    const id = String(kwargs.id);
+    const data = await page.evaluate(`
+      (async () => {
+        const id = ${JSON.stringify(id)};
+        const isUid = /^\\d+$/.test(id);
+        const query = isUid ? 'uid=' + id : 'screen_name=' + encodeURIComponent(id);
+
+        const resp = await fetch('/ajax/profile/info?' + query, {credentials: 'include'});
+        if (!resp.ok) return {error: 'HTTP ' + resp.status};
+        const data = await resp.json();
+        if (!data.ok || !data.data?.user) return {error: 'User not found'};
+
+        const u = data.data.user;
+
+        // Fetch detail info
+        const detailResp = await fetch('/ajax/profile/detail?uid=' + u.id, {credentials: 'include'});
+        const detail = detailResp.ok ? await detailResp.json() : null;
+        const d = detail?.data || {};
+
+        return {
+          screen_name: u.screen_name,
+          uid: u.id,
+          followers: u.followers_count,
+          following: u.friends_count,
+          statuses: u.statuses_count,
+          verified: u.verified || false,
+          verified_reason: u.verified_reason || '',
+          description: u.description || d.description || '',
+          location: u.location || '',
+          gender: u.gender === 'm' ? 'male' : u.gender === 'f' ? 'female' : '',
+          avatar: u.avatar_hd || u.avatar_large || '',
+          url: 'https://weibo.com' + (u.profile_url || '/u/' + u.id),
+          birthday: d.birthday || '',
+          created_at: d.created_at || '',
+          ip_location: d.ip_location || '',
+        };
+      })()
+    `);
+
+    if (!data || typeof data !== 'object') throw new CommandExecutionError('Failed to fetch user profile');
+    if ((data as Record<string, unknown>).error) throw new CommandExecutionError(String((data as Record<string, unknown>).error));
+    return data as Record<string, unknown>;
+  },
+});

--- a/src/clis/weibo/utils.ts
+++ b/src/clis/weibo/utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared Weibo utilities — uid extraction.
+ */
+
+import type { IPage } from '../../types.js';
+import { AuthRequiredError } from '../../errors.js';
+
+/** Get the currently logged-in user's uid from Vue store or config API. */
+export async function getSelfUid(page: IPage): Promise<string> {
+  const uid = await page.evaluate(`
+    (() => {
+      const app = document.querySelector('#app')?.__vue_app__;
+      const store = app?.config?.globalProperties?.$store;
+      const uid = store?.state?.config?.config?.uid;
+      if (uid) return String(uid);
+      return null;
+    })()
+  `);
+  if (uid) return uid as string;
+
+  // Fallback: config API
+  const config = await page.evaluate(`
+    (async () => {
+      const resp = await fetch('/ajax/config/get_config', {credentials: 'include'});
+      if (!resp.ok) return null;
+      const data = await resp.json();
+      return data.ok && data.data?.uid ? String(data.data.uid) : null;
+    })()
+  `);
+  if (config) return config as string;
+  throw new AuthRequiredError('weibo.com');
+}

--- a/src/clis/yahoo-finance/quote.ts
+++ b/src/clis/yahoo-finance/quote.ts
@@ -1,6 +1,5 @@
 /**
  * Yahoo Finance stock quote — multi-strategy API fallback.
- * Source: bb-sites/yahoo-finance/quote.js
  */
 import { cli, Strategy } from '../../registry.js';
 

--- a/src/clis/youtube/channel.ts
+++ b/src/clis/youtube/channel.ts
@@ -1,0 +1,155 @@
+/**
+ * YouTube channel — get channel info and recent videos via InnerTube API.
+ */
+import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError } from '../../errors.js';
+
+cli({
+  site: 'youtube',
+  name: 'channel',
+  description: 'Get YouTube channel info and recent videos',
+  domain: 'www.youtube.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'id', required: true, positional: true, help: 'Channel ID (UCxxxx) or handle (@name)' },
+    { name: 'limit', type: 'int', default: 10, help: 'Max recent videos (max 30)' },
+  ],
+  columns: ['field', 'value'],
+  func: async (page, kwargs) => {
+    const channelId = String(kwargs.id);
+    const limit = Math.min(kwargs.limit || 10, 30);
+    await page.goto('https://www.youtube.com');
+    await page.wait(2);
+
+    const data = await page.evaluate(`
+      (async () => {
+        const channelId = ${JSON.stringify(channelId)};
+        const limit = ${limit};
+        const cfg = window.ytcfg?.data_ || {};
+        const apiKey = cfg.INNERTUBE_API_KEY;
+        const context = cfg.INNERTUBE_CONTEXT;
+        if (!apiKey || !context) return {error: 'YouTube config not found'};
+
+        // Resolve handle to browseId if needed
+        let browseId = channelId;
+        if (channelId.startsWith('@')) {
+          const resolveResp = await fetch('/youtubei/v1/navigation/resolve_url?key=' + apiKey + '&prettyPrint=false', {
+            method: 'POST', credentials: 'include',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({context, url: 'https://www.youtube.com/' + channelId})
+          });
+          if (resolveResp.ok) {
+            const resolveData = await resolveResp.json();
+            browseId = resolveData.endpoint?.browseEndpoint?.browseId || channelId;
+          }
+        }
+
+        // Fetch channel data
+        const resp = await fetch('/youtubei/v1/browse?key=' + apiKey + '&prettyPrint=false', {
+          method: 'POST', credentials: 'include',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({context, browseId})
+        });
+        if (!resp.ok) return {error: 'Channel API returned HTTP ' + resp.status};
+        const data = await resp.json();
+
+        // Channel metadata
+        const metadata = data.metadata?.channelMetadataRenderer || {};
+        const header = data.header?.pageHeaderRenderer || data.header?.c4TabbedHeaderRenderer || {};
+
+        // Subscriber count from header
+        let subscriberCount = '';
+        try {
+          const rows = header.content?.pageHeaderViewModel?.metadata?.contentMetadataViewModel?.metadataRows || [];
+          for (const row of rows) {
+            for (const part of (row.metadataParts || [])) {
+              const text = part.text?.content || '';
+              if (text.includes('subscriber')) subscriberCount = text;
+            }
+          }
+        } catch {}
+        // Fallback for old c4TabbedHeaderRenderer format
+        if (!subscriberCount && header.subscriberCountText?.simpleText) {
+          subscriberCount = header.subscriberCountText.simpleText;
+        }
+
+        // Extract recent videos from Home tab
+        const tabs = data.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
+        const homeTab = tabs.find(t => t.tabRenderer?.selected);
+        const recentVideos = [];
+
+        if (homeTab) {
+          const sections = homeTab.tabRenderer?.content?.sectionListRenderer?.contents || [];
+          for (const section of sections) {
+            for (const shelf of (section.itemSectionRenderer?.contents || [])) {
+              for (const item of (shelf.shelfRenderer?.content?.horizontalListRenderer?.items || [])) {
+                // New lockupViewModel format
+                const lvm = item.lockupViewModel;
+                if (lvm && lvm.contentType === 'LOCKUP_CONTENT_TYPE_VIDEO' && recentVideos.length < limit) {
+                  const meta = lvm.metadata?.lockupMetadataViewModel;
+                  const rows = meta?.metadata?.contentMetadataViewModel?.metadataRows || [];
+                  const viewsAndTime = (rows[0]?.metadataParts || []).map(p => p.text?.content).filter(Boolean).join(' | ');
+                  let duration = '';
+                  for (const ov of (lvm.contentImage?.thumbnailViewModel?.overlays || [])) {
+                    for (const b of (ov.thumbnailBottomOverlayViewModel?.badges || [])) {
+                      if (b.thumbnailBadgeViewModel?.text) duration = b.thumbnailBadgeViewModel.text;
+                    }
+                  }
+                  recentVideos.push({
+                    title: meta?.title?.content || '',
+                    duration,
+                    views: viewsAndTime,
+                    url: 'https://www.youtube.com/watch?v=' + lvm.contentId,
+                  });
+                }
+                // Legacy gridVideoRenderer format
+                if (item.gridVideoRenderer && recentVideos.length < limit) {
+                  const v = item.gridVideoRenderer;
+                  recentVideos.push({
+                    title: v.title?.runs?.[0]?.text || v.title?.simpleText || '',
+                    duration: v.thumbnailOverlays?.[0]?.thumbnailOverlayTimeStatusRenderer?.text?.simpleText || '',
+                    views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
+                    url: 'https://www.youtube.com/watch?v=' + v.videoId,
+                  });
+                }
+              }
+            }
+          }
+        }
+
+        return {
+          name: metadata.title || '',
+          channelId: metadata.externalId || browseId,
+          handle: metadata.vanityChannelUrl?.split('/').pop() || '',
+          description: (metadata.description || '').substring(0, 500),
+          subscribers: subscriberCount,
+          url: metadata.channelUrl || 'https://www.youtube.com/channel/' + browseId,
+          keywords: metadata.keywords || '',
+          recentVideos,
+        };
+      })()
+    `);
+
+    if (!data || typeof data !== 'object') throw new CommandExecutionError('Failed to fetch channel data');
+    if ((data as Record<string, unknown>).error) throw new CommandExecutionError(String((data as Record<string, unknown>).error));
+
+    const result = data as Record<string, unknown>;
+    const videos = result.recentVideos as Array<Record<string, string>> | undefined;
+    delete result.recentVideos;
+
+    // Channel info as field/value pairs + recent videos as table
+    const rows = Object.entries(result).map(([field, value]) => ({
+      field,
+      value: String(value),
+    }));
+
+    if (videos && videos.length > 0) {
+      rows.push({ field: '---', value: '--- Recent Videos ---' });
+      for (const v of videos) {
+        rows.push({ field: v.title, value: `${v.duration} | ${v.views} | ${v.url}` });
+      }
+    }
+
+    return rows;
+  },
+});

--- a/src/clis/youtube/comments.ts
+++ b/src/clis/youtube/comments.ts
@@ -1,0 +1,97 @@
+/**
+ * YouTube comments — get video comments via InnerTube API.
+ */
+import { cli, Strategy } from '../../registry.js';
+import { CommandExecutionError } from '../../errors.js';
+import { parseVideoId } from './utils.js';
+
+cli({
+  site: 'youtube',
+  name: 'comments',
+  description: 'Get YouTube video comments',
+  domain: 'www.youtube.com',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'url', required: true, positional: true, help: 'YouTube video URL or video ID' },
+    { name: 'limit', type: 'int', default: 20, help: 'Max comments (max 100)' },
+  ],
+  columns: ['rank', 'author', 'text', 'likes', 'replies', 'time'],
+  func: async (page, kwargs) => {
+    const videoId = parseVideoId(kwargs.url);
+    const limit = Math.min(kwargs.limit || 20, 100);
+    await page.goto(`https://www.youtube.com/watch?v=${videoId}`);
+    await page.wait(3);
+
+    const data = await page.evaluate(`
+      (async () => {
+        const videoId = ${JSON.stringify(videoId)};
+        const limit = ${limit};
+        const cfg = window.ytcfg?.data_ || {};
+        const apiKey = cfg.INNERTUBE_API_KEY;
+        const context = cfg.INNERTUBE_CONTEXT;
+        if (!apiKey || !context) return {error: 'YouTube config not found'};
+
+        // Step 1: Get comment continuation token
+        let continuationToken = null;
+
+        // Try from current page ytInitialData
+        if (window.ytInitialData) {
+          const results = window.ytInitialData.contents?.twoColumnWatchNextResults?.results?.results?.contents || [];
+          const commentSection = results.find(i => i.itemSectionRenderer?.targetId === 'comments-section');
+          continuationToken = commentSection?.itemSectionRenderer?.contents?.[0]?.continuationItemRenderer?.continuationEndpoint?.continuationCommand?.token;
+        }
+
+        // Fallback: fetch via next API
+        if (!continuationToken) {
+          const nextResp = await fetch('/youtubei/v1/next?key=' + apiKey + '&prettyPrint=false', {
+            method: 'POST', credentials: 'include',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({context, videoId})
+          });
+          if (!nextResp.ok) return {error: 'Failed to get video data: HTTP ' + nextResp.status};
+          const nextData = await nextResp.json();
+          const results = nextData.contents?.twoColumnWatchNextResults?.results?.results?.contents || [];
+          const commentSection = results.find(i => i.itemSectionRenderer?.targetId === 'comments-section');
+          continuationToken = commentSection?.itemSectionRenderer?.contents?.[0]?.continuationItemRenderer?.continuationEndpoint?.continuationCommand?.token;
+        }
+
+        if (!continuationToken) return {error: 'No comment section found — comments may be disabled'};
+
+        // Step 2: Fetch comments
+        const commentResp = await fetch('/youtubei/v1/next?key=' + apiKey + '&prettyPrint=false', {
+          method: 'POST', credentials: 'include',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({context, continuation: continuationToken})
+        });
+        if (!commentResp.ok) return {error: 'Failed to fetch comments: HTTP ' + commentResp.status};
+        const commentData = await commentResp.json();
+
+        // Parse from frameworkUpdates (new ViewModel format)
+        const mutations = commentData.frameworkUpdates?.entityBatchUpdate?.mutations || [];
+        const commentEntities = mutations.filter(m => m.payload?.commentEntityPayload);
+
+        return commentEntities.slice(0, limit).map((m, i) => {
+          const p = m.payload.commentEntityPayload;
+          const props = p.properties || {};
+          const author = p.author || {};
+          const toolbar = p.toolbar || {};
+          return {
+            rank: i + 1,
+            author: author.displayName || '',
+            text: (props.content?.content || '').substring(0, 300),
+            likes: toolbar.likeCountNotliked || '0',
+            replies: toolbar.replyCount || '0',
+            time: props.publishedTime || '',
+          };
+        });
+      })()
+    `);
+
+    if (!Array.isArray(data)) {
+      const errMsg = data && typeof data === 'object' ? String((data as Record<string, unknown>).error || '') : '';
+      if (errMsg) throw new CommandExecutionError(errMsg);
+      return [];
+    }
+    return data;
+  },
+});

--- a/src/clis/youtube/search.ts
+++ b/src/clis/youtube/search.ts
@@ -1,6 +1,5 @@
 /**
  * YouTube search — innertube API via browser session.
- * Source: bb-sites/youtube/search.js
  */
 import { cli, Strategy } from '../../registry.js';
 


### PR DESCRIPTION
## Summary
- **Weibo**: add `feed`, `me`, `user`, `post`, `comments` commands with cookie-based auth via internal API
  - `utils.ts`: shared `getSelfUid()` with proper `AuthRequiredError`
  - `comments.ts`: rank column included in output
  - `post.ts`: handles both `isLongText` and `is_long_text` API field names
- **YouTube**: add `channel` (info + recent videos) and `comments` via InnerTube API
  - `channel.ts`: subscriber count fallback for old `c4TabbedHeaderRenderer` format
- Remove internal source references from file headers across all sites

## Test plan
- [ ] `opencli weibo hot` — verify hot search works
- [ ] `opencli weibo feed` — verify feed with login
- [ ] `opencli weibo post <id>` — verify single post fetch with long text
- [ ] `opencli weibo comments <id>` — verify rank column appears
- [ ] `opencli youtube channel @handle` — verify channel info
- [ ] `opencli youtube comments <videoId>` — verify comment listing
- [ ] `npx tsc --noEmit` passes