### PR TITLE
fix: remove incorrect gws external CLI entry

### DIFF
--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -29,12 +29,3 @@
   tags: [docker, containers, devops]
   install:
     mac: "brew install --cask docker"
-
-- name: gws
-  binary: gws
-  description: "Google Workspace CLI — Docs, Sheets, Drive, Gmail, Calendar"
-  homepage: "https://github.com/nicholasgasior/gws"
-  tags: [google, docs, sheets, drive, workspace]
-  install:
-    mac: "brew install gws"
-    default: "npm install -g @nicholasgasior/gws"


### PR DESCRIPTION
## Summary
- `brew install gws` installs a git workspace manager (StreakyCobra/gws), not Google Workspace CLI
- The npm package `@nicholasgasior/gws` doesn't exist
- Remove the misleading entry entirely

## Test plan
- [x] Verify `external-clis.yaml` no longer references gws