### PR TITLE
fix: remove nonexistent readwise external CLI entry

### DIFF
--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -14,14 +14,6 @@
   install:
     mac: "brew install --cask obsidian"
 
-- name: readwise
-  binary: readwise
-  description: "Readwise & Reader CLI — highlights, annotations, reading list"
-  homepage: "https://github.com/readwiseio/readwise-cli"
-  tags: [reading, highlights]
-  install:
-    default: "npm install -g @readwiseio/readwise-cli"
-
 - name: docker
   binary: docker
   description: "Docker command-line interface"


### PR DESCRIPTION
## Summary
- npm package `@readwiseio/readwise-cli` returns 404
- GitHub repo `readwiseio/readwise-cli` doesn't exist
- Remove the fabricated entry

## Test plan
- [x] `npm view @readwiseio/readwise-cli` → 404