### PR TITLE
chore: trim adapter test suite to bilibili, zhihu, v2ex

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,15 +18,9 @@ export default defineConfig({
         test: {
           name: 'adapter',
           include: [
-            'src/clis/zhihu/**/*.test.ts',
-            'src/clis/twitter/**/*.test.ts',
-            'src/clis/reddit/**/*.test.ts',
             'src/clis/bilibili/**/*.test.ts',
-            'src/clis/linkedin/**/*.test.ts',
-            'src/clis/grok/**/*.test.ts',
-            'src/clis/pixiv/**/*.test.ts',
-            'src/clis/douyin/_shared/**/*.test.ts',
-            'src/clis/douyin/*.test.ts',
+            'src/clis/zhihu/**/*.test.ts',
+            'src/clis/v2ex/**/*.test.ts',
           ],
           sequence: {
             groupOrder: 1,


### PR DESCRIPTION
## Summary
- Only keep bilibili, zhihu, v2ex in adapter test project
- Remove twitter, reddit, linkedin, grok, pixiv, douyin adapter tests from vitest config

## Test plan
- [x] `npx vitest run` only runs unit + adapter (3 sites) + e2e