### PR TITLE
fix(test): gate extended browser e2e tests behind OPENCLI_E2E=1

### DIFF
--- a/tests/e2e/browser-public-extended.test.ts
+++ b/tests/e2e/browser-public-extended.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Extended E2E tests for all other browser commands.
+ * Opt-in only: OPENCLI_E2E=1 npx vitest run
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runCli, parseJsonOutput } from './helpers.js';
+
+async function tryBrowserCommand(args: string[]): Promise<any[] | null> {
+  const { stdout, code } = await runCli(args, { timeout: 60_000 });
+  if (code !== 0) return null;
+  try {
+    const data = parseJsonOutput(stdout);
+    return Array.isArray(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+function expectDataOrSkip(data: any[] | null, label: string) {
+  if (data === null || data.length === 0) {
+    console.warn(`${label}: skipped — no data returned (likely bot detection or geo-blocking)`);
+    return;
+  }
+  expect(data.length).toBeGreaterThanOrEqual(1);
+}
+
+describe('browser extended public-data commands E2E', () => {
+
+  // ── bbc ──
+  it('bbc news returns headlines', async () => {
+    const data = await tryBrowserCommand(['bbc', 'news', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'bbc news');
+    if (data) {
+      expect(data[0]).toHaveProperty('title');
+    }
+  }, 60_000);
+
+  // ── bloomberg ──
+  it('bloomberg news returns article detail when the article page is accessible', async () => {
+    const feedResult = await runCli(['bloomberg', 'tech', '--limit', '1', '-f', 'json']);
+    if (feedResult.code !== 0) {
+      console.warn('bloomberg news: skipped — could not load Bloomberg tech feed');
+      return;
+    }
+
+    const feedItems = parseJsonOutput(feedResult.stdout);
+    const link = Array.isArray(feedItems) ? feedItems[0]?.link : null;
+    if (!link) {
+      console.warn('bloomberg news: skipped — tech feed returned no link');
+      return;
+    }
+
+    const data = await tryBrowserCommand(['bloomberg', 'news', link, '-f', 'json']);
+    expectDataOrSkip(data, 'bloomberg news');
+    if (data) {
+      expect(data[0]).toHaveProperty('title');
+      expect(data[0]).toHaveProperty('summary');
+      expect(data[0]).toHaveProperty('link');
+      expect(data[0]).toHaveProperty('mediaLinks');
+      expect(data[0]).toHaveProperty('content');
+    }
+  }, 60_000);
+
+  // ── weibo ──
+  it('weibo hot returns trending topics', async () => {
+    const data = await tryBrowserCommand(['weibo', 'hot', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'weibo hot');
+  }, 60_000);
+
+  it('weibo search returns results', async () => {
+    const data = await tryBrowserCommand(['weibo', 'search', 'openai', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'weibo search');
+  }, 60_000);
+
+  // ── reddit ──
+  it('reddit hot returns posts', async () => {
+    const data = await tryBrowserCommand(['reddit', 'hot', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'reddit hot');
+  }, 60_000);
+
+  it('reddit frontpage returns posts', async () => {
+    const data = await tryBrowserCommand(['reddit', 'frontpage', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'reddit frontpage');
+  }, 60_000);
+
+  // ── twitter ──
+  it('twitter trending returns trends', async () => {
+    const data = await tryBrowserCommand(['twitter', 'trending', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'twitter trending');
+  }, 60_000);
+
+  // ── xueqiu ──
+  it('xueqiu hot returns hot posts', async () => {
+    const data = await tryBrowserCommand(['xueqiu', 'hot', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'xueqiu hot');
+  }, 60_000);
+
+  it('xueqiu hot-stock returns stocks', async () => {
+    const data = await tryBrowserCommand(['xueqiu', 'hot-stock', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'xueqiu hot-stock');
+  }, 60_000);
+
+  // ── reuters ──
+  it('reuters search returns articles', async () => {
+    const data = await tryBrowserCommand(['reuters', 'search', 'technology', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'reuters search');
+  }, 60_000);
+
+  // ── youtube ──
+  it('youtube search returns videos', async () => {
+    const data = await tryBrowserCommand(['youtube', 'search', 'typescript tutorial', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'youtube search');
+  }, 60_000);
+
+  // ── smzdm ──
+  it('smzdm search returns deals', async () => {
+    const data = await tryBrowserCommand(['smzdm', 'search', '键盘', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'smzdm search');
+  }, 60_000);
+
+  // ── boss ──
+  it('boss search returns jobs', async () => {
+    const data = await tryBrowserCommand(['boss', 'search', 'golang', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'boss search');
+  }, 60_000);
+
+  // ── ctrip ──
+  it('ctrip search returns flights', async () => {
+    const data = await tryBrowserCommand(['ctrip', 'search', '-f', 'json']);
+    expectDataOrSkip(data, 'ctrip search');
+  }, 60_000);
+
+  // ── coupang ──
+  it('coupang search returns products', async () => {
+    const data = await tryBrowserCommand(['coupang', 'search', 'laptop', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'coupang search');
+  }, 60_000);
+
+  // ── xiaohongshu ──
+  it('xiaohongshu search returns notes', async () => {
+    const data = await tryBrowserCommand(['xiaohongshu', 'search', '美食', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'xiaohongshu search');
+  }, 60_000);
+
+  // ── google ──
+  it('google search returns results', async () => {
+    const data = await tryBrowserCommand(['google', 'search', 'typescript', '--limit', '5', '-f', 'json']);
+    expectDataOrSkip(data, 'google search');
+    if (data) {
+      expect(data[0]).toHaveProperty('type');
+      expect(data[0]).toHaveProperty('title');
+      expect(data[0]).toHaveProperty('url');
+    }
+  }, 60_000);
+
+  // ── yahoo-finance ──
+  it('yahoo-finance quote returns stock data', async () => {
+    const data = await tryBrowserCommand(['yahoo-finance', 'quote', '--symbol', 'AAPL', '-f', 'json']);
+    expectDataOrSkip(data, 'yahoo-finance quote');
+  }, 60_000);
+});

--- a/tests/e2e/browser-public.test.ts
+++ b/tests/e2e/browser-public.test.ts
@@ -1,5 +1,5 @@
 /**
- * E2E tests for browser commands that access PUBLIC data (no login required).
+ * E2E tests for core browser commands (bilibili, zhihu, v2ex).
  * These use OPENCLI_HEADLESS=1 to launch a headless Chromium.
  *
  * NOTE: Some sites may block headless browsers with bot detection.
@@ -9,9 +9,6 @@
 import { describe, it, expect } from 'vitest';
 import { runCli, parseJsonOutput } from './helpers.js';
 
-/**
- * Run a browser command — returns parsed data or null on failure.
- */
 async function tryBrowserCommand(args: string[]): Promise<any[] | null> {
   const { stdout, code } = await runCli(args, { timeout: 60_000 });
   if (code !== 0) return null;
@@ -23,10 +20,6 @@ async function tryBrowserCommand(args: string[]): Promise<any[] | null> {
   }
 }
 
-/**
- * Assert browser command returns data OR log a warning if blocked.
- * Empty results (bot detection, geo-blocking) are treated as a warning, not a failure.
- */
 function expectDataOrSkip(data: any[] | null, label: string) {
   if (data === null || data.length === 0) {
     console.warn(`${label}: skipped — no data returned (likely bot detection or geo-blocking)`);
@@ -37,47 +30,7 @@ function expectDataOrSkip(data: any[] | null, label: string) {
 
 describe('browser public-data commands E2E', () => {
 
-  // ── bbc (browser: true, strategy: public) ──
-  it('bbc news returns headlines', async () => {
-    const data = await tryBrowserCommand(['bbc', 'news', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'bbc news');
-    if (data) {
-      expect(data[0]).toHaveProperty('title');
-    }
-  }, 60_000);
-
-  it('bloomberg news returns article detail when the article page is accessible', async () => {
-    const feedResult = await runCli(['bloomberg', 'tech', '--limit', '1', '-f', 'json']);
-    if (feedResult.code !== 0) {
-      console.warn('bloomberg news: skipped — could not load Bloomberg tech feed');
-      return;
-    }
-
-    const feedItems = parseJsonOutput(feedResult.stdout);
-    const link = Array.isArray(feedItems) ? feedItems[0]?.link : null;
-    if (!link) {
-      console.warn('bloomberg news: skipped — tech feed returned no link');
-      return;
-    }
-
-    const data = await tryBrowserCommand(['bloomberg', 'news', link, '-f', 'json']);
-    expectDataOrSkip(data, 'bloomberg news');
-    if (data) {
-      expect(data[0]).toHaveProperty('title');
-      expect(data[0]).toHaveProperty('summary');
-      expect(data[0]).toHaveProperty('link');
-      expect(data[0]).toHaveProperty('mediaLinks');
-      expect(data[0]).toHaveProperty('content');
-    }
-  }, 60_000);
-
-  // ── v2ex daily (browser: true) ──
-  it('v2ex daily returns topics', async () => {
-    const data = await tryBrowserCommand(['v2ex', 'daily', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'v2ex daily');
-  }, 60_000);
-
-  // ── bilibili (browser: true, cookie strategy) ──
+  // ── bilibili ──
   it('bilibili hot returns trending videos', async () => {
     const data = await tryBrowserCommand(['bilibili', 'hot', '--limit', '5', '-f', 'json']);
     expectDataOrSkip(data, 'bilibili hot');
@@ -96,18 +49,7 @@ describe('browser public-data commands E2E', () => {
     expectDataOrSkip(data, 'bilibili search');
   }, 60_000);
 
-  // ── weibo (browser: true, cookie strategy) ──
-  it('weibo hot returns trending topics', async () => {
-    const data = await tryBrowserCommand(['weibo', 'hot', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'weibo hot');
-  }, 60_000);
-
-  it('weibo search returns results', async () => {
-    const data = await tryBrowserCommand(['weibo', 'search', 'openai', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'weibo search');
-  }, 60_000);
-
-  // ── zhihu (browser: true, cookie strategy) ──
+  // ── zhihu ──
   it('zhihu hot returns trending questions', async () => {
     const data = await tryBrowserCommand(['zhihu', 'hot', '--limit', '5', '-f', 'json']);
     expectDataOrSkip(data, 'zhihu hot');
@@ -121,90 +63,9 @@ describe('browser public-data commands E2E', () => {
     expectDataOrSkip(data, 'zhihu search');
   }, 60_000);
 
-  // ── reddit (browser: true, cookie strategy) ──
-  it('reddit hot returns posts', async () => {
-    const data = await tryBrowserCommand(['reddit', 'hot', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'reddit hot');
-  }, 60_000);
-
-  it('reddit frontpage returns posts', async () => {
-    const data = await tryBrowserCommand(['reddit', 'frontpage', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'reddit frontpage');
-  }, 60_000);
-
-  // ── twitter (browser: true) ──
-  it('twitter trending returns trends', async () => {
-    const data = await tryBrowserCommand(['twitter', 'trending', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'twitter trending');
-  }, 60_000);
-
-  // ── xueqiu (browser: true, cookie strategy) ──
-  it('xueqiu hot returns hot posts', async () => {
-    const data = await tryBrowserCommand(['xueqiu', 'hot', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'xueqiu hot');
-  }, 60_000);
-
-  it('xueqiu hot-stock returns stocks', async () => {
-    const data = await tryBrowserCommand(['xueqiu', 'hot-stock', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'xueqiu hot-stock');
-  }, 60_000);
-
-  // ── reuters (browser: true) ──
-  it('reuters search returns articles', async () => {
-    const data = await tryBrowserCommand(['reuters', 'search', 'technology', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'reuters search');
-  }, 60_000);
-
-  // ── youtube (browser: true) ──
-  it('youtube search returns videos', async () => {
-    const data = await tryBrowserCommand(['youtube', 'search', 'typescript tutorial', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'youtube search');
-  }, 60_000);
-
-  // ── smzdm (browser: true) ──
-  it('smzdm search returns deals', async () => {
-    const data = await tryBrowserCommand(['smzdm', 'search', '键盘', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'smzdm search');
-  }, 60_000);
-
-  // ── boss (browser: true) ──
-  it('boss search returns jobs', async () => {
-    const data = await tryBrowserCommand(['boss', 'search', 'golang', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'boss search');
-  }, 60_000);
-
-  // ── ctrip (browser: true) ──
-  it('ctrip search returns flights', async () => {
-    const data = await tryBrowserCommand(['ctrip', 'search', '-f', 'json']);
-    expectDataOrSkip(data, 'ctrip search');
-  }, 60_000);
-
-  // ── coupang (browser: true) ──
-  it('coupang search returns products', async () => {
-    const data = await tryBrowserCommand(['coupang', 'search', 'laptop', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'coupang search');
-  }, 60_000);
-
-  // ── xiaohongshu (browser: true) ──
-  it('xiaohongshu search returns notes', async () => {
-    const data = await tryBrowserCommand(['xiaohongshu', 'search', '美食', '--limit', '3', '-f', 'json']);
-    expectDataOrSkip(data, 'xiaohongshu search');
-  }, 60_000);
-
-  // ── google search (browser: true, public strategy) ──
-  it('google search returns results', async () => {
-    const data = await tryBrowserCommand(['google', 'search', 'typescript', '--limit', '5', '-f', 'json']);
-    expectDataOrSkip(data, 'google search');
-    if (data) {
-      expect(data[0]).toHaveProperty('type');
-      expect(data[0]).toHaveProperty('title');
-      expect(data[0]).toHaveProperty('url');
-    }
-  }, 60_000);
-
-  // ── yahoo-finance (browser: true) ──
-  it('yahoo-finance quote returns stock data', async () => {
-    const data = await tryBrowserCommand(['yahoo-finance', 'quote', '--symbol', 'AAPL', '-f', 'json']);
-    expectDataOrSkip(data, 'yahoo-finance quote');
+  // ── v2ex ──
+  it('v2ex daily returns topics', async () => {
+    const data = await tryBrowserCommand(['v2ex', 'daily', '--limit', '3', '-f', 'json']);
+    expectDataOrSkip(data, 'v2ex daily');
   }, 60_000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vitest/config';
 
+const includeExtendedE2e = process.env.OPENCLI_E2E === '1';
+
 export default defineConfig({
   test: {
     projects: [
@@ -8,10 +10,7 @@ export default defineConfig({
           name: 'unit',
           include: ['src/**/*.test.ts'],
           exclude: ['src/clis/**/*.test.ts'],
-          // Run unit tests before e2e tests to avoid project-level contention in CI.
-          sequence: {
-            groupOrder: 0,
-          },
+          sequence: { groupOrder: 0 },
         },
       },
       {
@@ -22,19 +21,31 @@ export default defineConfig({
             'src/clis/zhihu/**/*.test.ts',
             'src/clis/v2ex/**/*.test.ts',
           ],
-          sequence: {
-            groupOrder: 1,
-          },
+          sequence: { groupOrder: 1 },
         },
       },
       {
         test: {
           name: 'e2e',
-          include: ['tests/**/*.test.ts'],
+          include: [
+            'tests/e2e/browser-public.test.ts',
+            'tests/e2e/public-commands.test.ts',
+            'tests/e2e/management.test.ts',
+            'tests/e2e/output-formats.test.ts',
+            'tests/e2e/plugin-management.test.ts',
+            // Extended browser tests (20+ sites) — opt-in only:
+            //   OPENCLI_E2E=1 npx vitest run
+            ...(includeExtendedE2e ? ['tests/e2e/browser-public-extended.test.ts', 'tests/e2e/browser-auth.test.ts'] : []),
+          ],
           maxWorkers: 2,
-          sequence: {
-            groupOrder: 2,
-          },
+          sequence: { groupOrder: 2 },
+        },
+      },
+      {
+        test: {
+          name: 'smoke',
+          include: ['tests/smoke/**/*.test.ts'],
+          sequence: { groupOrder: 3 },
         },
       },
     ],


### PR DESCRIPTION
## Summary
- Split `browser-public.test.ts`: core sites (bilibili, zhihu, v2ex) run by default
- All other 20+ site tests moved to `browser-public-extended.test.ts`, gated behind `OPENCLI_E2E=1`
- Prevents AI agents from launching dozens of browser instances that overwhelm the user's browser

## Usage
```bash
# Default — only core sites
npx vitest run

# All browser tests
OPENCLI_E2E=1 npx vitest run
```

## Test plan
- [x] `npx vitest run` only runs unit + adapter + core e2e (no extended browser tests)
- [x] `browser-public-extended.test.ts` not included in default run