### PR TITLE
fix(extension): improve UX when daemon is not running

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -183,9 +183,11 @@ function connect() {
     ws?.close();
   };
 }
+const MAX_EAGER_ATTEMPTS = 6;
 function scheduleReconnect() {
   if (reconnectTimer) return;
   reconnectAttempts++;
+  if (reconnectAttempts > MAX_EAGER_ATTEMPTS) return;
   const delay = Math.min(WS_RECONNECT_BASE_DELAY * Math.pow(2, reconnectAttempts - 1), WS_RECONNECT_MAX_DELAY);
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -38,6 +38,22 @@
     .dot.connecting { background: #ff9500; }
     .status-text { font-size: 13px; color: #555; }
     .status-text strong { color: #333; }
+    .hint {
+      margin-top: 10px;
+      padding: 8px 10px;
+      border-radius: 6px;
+      background: #f0f4ff;
+      font-size: 11px;
+      color: #666;
+      line-height: 1.5;
+      display: none;
+    }
+    .hint code {
+      background: #e8ecf1;
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 11px;
+    }
     .footer {
       margin-top: 14px;
       text-align: center;
@@ -56,6 +72,9 @@
   <div class="status-row">
     <span class="dot disconnected" id="dot"></span>
     <span class="status-text" id="status">Checking...</span>
+  </div>
+  <div class="hint" id="hint">
+    This is normal. The extension connects automatically when you run any <code>opencli</code> command.
   </div>
   <div class="footer">
     <a href="https://github.com/jackwener/opencli" target="_blank">Documentation</a>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -2,19 +2,24 @@
 chrome.runtime.sendMessage({ type: 'getStatus' }, (resp) => {
   const dot = document.getElementById('dot');
   const status = document.getElementById('status');
+  const hint = document.getElementById('hint');
   if (chrome.runtime.lastError || !resp) {
     dot.className = 'dot disconnected';
     status.innerHTML = '<strong>No daemon connected</strong>';
+    hint.style.display = 'block';
     return;
   }
   if (resp.connected) {
     dot.className = 'dot connected';
     status.innerHTML = '<strong>Connected to daemon</strong>';
+    hint.style.display = 'none';
   } else if (resp.reconnecting) {
     dot.className = 'dot connecting';
     status.innerHTML = '<strong>Reconnecting...</strong>';
+    hint.style.display = 'none';
   } else {
     dot.className = 'dot disconnected';
     status.innerHTML = '<strong>No daemon connected</strong>';
+    hint.style.display = 'block';
   }
 });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -74,10 +74,17 @@ function connect(): void {
   };
 }
 
+/**
+ * After MAX_EAGER_ATTEMPTS (reaching 60s backoff), stop scheduling reconnects.
+ * The keepalive alarm (~24s) will still call connect() periodically, but at a
+ * much lower frequency — reducing console noise when the daemon is not running.
+ */
+const MAX_EAGER_ATTEMPTS = 6; // 2s, 4s, 8s, 16s, 32s, 60s — then stop
+
 function scheduleReconnect(): void {
   if (reconnectTimer) return;
   reconnectAttempts++;
-  // Exponential backoff: 2s, 4s, 8s, 16s, ..., capped at 60s
+  if (reconnectAttempts > MAX_EAGER_ATTEMPTS) return; // let keepalive alarm handle it
   const delay = Math.min(WS_RECONNECT_BASE_DELAY * Math.pow(2, reconnectAttempts - 1), WS_RECONNECT_MAX_DELAY);
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;


### PR DESCRIPTION
## Summary
- Show helpful hint in popup when disconnected: "This is normal. The extension connects automatically when you run any `opencli` command."
- Stop eager reconnect after 6 attempts (reaching 60s backoff) to reduce `ERR_CONNECTION_REFUSED` noise in DevTools console; keepalive alarm still retries every ~24s at low frequency.

## Test plan
- [ ] Load extension without daemon running, click popup icon — verify hint is shown
- [ ] Start daemon, verify popup shows "Connected to daemon" and hint hides
- [ ] Check DevTools console — errors should stop after ~2 minutes instead of looping indefinitely