### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.4.1](https://github.com/jackwener/opencli/compare/v1.4.0...v1.4.1) (2026-03-25)
+
+
+### Features
+
+* **douyin:** add Douyin creator center adapter — 14 commands, 8-phase publish pipeline ([#416](https://github.com/jackwener/opencli/issues/416))
+* **weibo,youtube:** add Weibo commands and YouTube channel/comments ([#418](https://github.com/jackwener/opencli/issues/418))
+* **twitter:** add filter option for search ([#410](https://github.com/jackwener/opencli/issues/410))
+* **extension:** add popup UI, privacy policy, and CSP for Chrome Web Store ([#415](https://github.com/jackwener/opencli/issues/415))
+* add url field to 9 search adapters (67% -> 97% coverage) ([#414](https://github.com/jackwener/opencli/issues/414))
+
+
+### Bug Fixes
+
+* **extension:** improve UX when daemon is not running — show hint in popup, reduce reconnect noise ([#424](https://github.com/jackwener/opencli/issues/424))
+* remove incorrect gws and readwise external CLI entries ([#419](https://github.com/jackwener/opencli/issues/419), [#420](https://github.com/jackwener/opencli/issues/420))
+
+
+### CI
+
+* limit default e2e to bilibili/zhihu/v2ex, gate extended browser tests ([#421](https://github.com/jackwener/opencli/issues/421), [#423](https://github.com/jackwener/opencli/issues/423))
+
+
 ## [1.4.0](https://github.com/jackwener/opencli/compare/v1.3.3...v1.4.0) (2026-03-25)
 
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencli
 description: "OpenCLI — Make any website or Electron App your CLI. Zero risk, AI-powered, reuse Chrome login."
-version: 1.4.0
+version: 1.4.1
 author: jackwener
 tags: [cli, browser, web, chrome-extension, cdp, bilibili, zhihu, twitter, github, v2ex, hackernews, reddit, xiaohongshu, xueqiu, youtube, boss, coupang, yollomi, AI, agent]
 ---

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in isolated Chrome windows via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump version to 1.4.1 (package.json, SKILL.md, extension/package.json, extension/manifest.json)
- Add CHANGELOG entry for v1.4.1

### Since v1.4.0
- **feat(douyin):** Douyin creator center adapter (14 commands)
- **feat(weibo,youtube):** Weibo commands and YouTube channel/comments
- **feat(twitter):** filter option for search
- **feat(extension):** popup UI, privacy policy, CSP for Chrome Web Store
- **fix(extension):** improve UX when daemon is not running
- **fix:** remove incorrect gws/readwise external CLI entries
- **ci:** limit default e2e scope

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Version is 1.4.1 in all files