### PR TITLE
fix: repair weread private api requests

### DIFF
--- a/src/clis/weread/book.ts
+++ b/src/clis/weread/book.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
-import { fetchWithPage } from './utils.js';
+import { fetchPrivateApi } from './utils.js';
 
 cli({
   site: 'weread',
@@ -13,7 +13,7 @@ cli({
   ],
   columns: ['title', 'author', 'publisher', 'intro', 'category', 'rating'],
   func: async (page: IPage, args) => {
-    const data = await fetchWithPage(page, '/book/info', { bookId: args.bookId });
+    const data = await fetchPrivateApi(page, '/book/info', { bookId: args.bookId });
     // newRating is 0-1000 scale per community docs; needs runtime verification
     const rating = data.newRating ? `${(data.newRating / 10).toFixed(1)}%` : '-';
     return [{

--- a/src/clis/weread/highlights.ts
+++ b/src/clis/weread/highlights.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
-import { fetchWithPage, formatDate } from './utils.js';
+import { fetchPrivateApi, formatDate } from './utils.js';
 
 cli({
   site: 'weread',
@@ -14,7 +14,7 @@ cli({
   ],
   columns: ['chapter', 'text', 'createTime'],
   func: async (page: IPage, args) => {
-    const data = await fetchWithPage(page, '/book/bookmarklist', { bookId: args.bookId });
+    const data = await fetchPrivateApi(page, '/book/bookmarklist', { bookId: args.bookId });
     const items: any[] = data?.updated ?? [];
     return items.slice(0, Number(args.limit)).map((item: any) => ({
       chapter: item.chapterName ?? '',

--- a/src/clis/weread/notebooks.ts
+++ b/src/clis/weread/notebooks.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
-import { fetchWithPage } from './utils.js';
+import { fetchPrivateApi } from './utils.js';
 
 cli({
   site: 'weread',
@@ -10,7 +10,7 @@ cli({
   strategy: Strategy.COOKIE,
   columns: ['title', 'author', 'noteCount', 'bookId'],
   func: async (page: IPage, _args) => {
-    const data = await fetchWithPage(page, '/user/notebooks');
+    const data = await fetchPrivateApi(page, '/user/notebooks');
     const books: any[] = data?.books ?? [];
     return books.map((item: any) => ({
       title: item.book?.title ?? '',

--- a/src/clis/weread/notes.ts
+++ b/src/clis/weread/notes.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
-import { fetchWithPage, formatDate } from './utils.js';
+import { fetchPrivateApi, formatDate } from './utils.js';
 
 cli({
   site: 'weread',
@@ -14,7 +14,7 @@ cli({
   ],
   columns: ['chapter', 'text', 'review', 'createTime'],
   func: async (page: IPage, args) => {
-    const data = await fetchWithPage(page, '/review/list', {
+    const data = await fetchPrivateApi(page, '/review/list', {
       bookId: args.bookId,
       listType: '11',
       mine: '1',

--- a/src/clis/weread/shelf.ts
+++ b/src/clis/weread/shelf.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
-import { fetchWithPage } from './utils.js';
+import { fetchPrivateApi } from './utils.js';
 
 cli({
   site: 'weread',
@@ -13,7 +13,7 @@ cli({
   ],
   columns: ['title', 'author', 'progress', 'bookId'],
   func: async (page: IPage, args) => {
-    const data = await fetchWithPage(page, '/shelf/sync', { synckey: '0', lectureSynckey: '0' });
+    const data = await fetchPrivateApi(page, '/shelf/sync', { synckey: '0', lectureSynckey: '0' });
     const books: any[] = data?.books ?? [];
     return books.slice(0, Number(args.limit)).map((item: any) => ({
       title: item.bookInfo?.title ?? item.title ?? '',

--- a/src/clis/weread/utils.test.ts
+++ b/src/clis/weread/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { formatDate, fetchWebApi, fetchWithPage } from './utils.js';
+import { formatDate, fetchWebApi } from './utils.js';
 
 describe('formatDate', () => {
   it('formats a typical Unix timestamp in UTC+8', () => {
@@ -69,36 +69,5 @@ describe('fetchWebApi', () => {
     }));
 
     await expect(fetchWebApi('/search/global')).rejects.toThrow('Invalid JSON');
-  });
-});
-
-describe('fetchWithPage', () => {
-  it('throws AUTH_REQUIRED on errcode -2010', async () => {
-    const mockPage = {
-      evaluate: vi.fn().mockResolvedValue({ errcode: -2010, errmsg: '用户不存在' }),
-    } as any;
-    await expect(fetchWithPage(mockPage, '/book/info')).rejects.toThrow('Not logged in');
-  });
-
-  it('throws API_ERROR on unknown errcode', async () => {
-    const mockPage = {
-      evaluate: vi.fn().mockResolvedValue({ errcode: -1, errmsg: 'unknown error' }),
-    } as any;
-    await expect(fetchWithPage(mockPage, '/book/info')).rejects.toThrow('unknown error');
-  });
-
-  it('returns data on success (errcode 0 or absent)', async () => {
-    const mockPage = {
-      evaluate: vi.fn().mockResolvedValue({ title: 'Test Book', errcode: 0 }),
-    } as any;
-    const result = await fetchWithPage(mockPage, '/book/info');
-    expect(result.title).toBe('Test Book');
-  });
-
-  it('throws FETCH_ERROR on HTTP error', async () => {
-    const mockPage = {
-      evaluate: vi.fn().mockResolvedValue({ _httpError: '403' }),
-    } as any;
-    await expect(fetchWithPage(mockPage, '/book/info')).rejects.toThrow('HTTP 403');
   });
 });

--- a/src/clis/weread/utils.ts
+++ b/src/clis/weread/utils.ts
@@ -3,15 +3,19 @@
  *
  * Two API domains:
  * - WEB_API (weread.qq.com/web/*): public, Node.js fetch
- * - API (i.weread.qq.com/*): private, browser page.evaluate with cookies
+ * - API (i.weread.qq.com/*): private, Node.js fetch with cookies from browser
  */
 
 import { CliError } from '../../errors.js';
-import type { IPage } from '../../types.js';
+import type { BrowserCookie, IPage } from '../../types.js';
 
 const WEB_API = 'https://weread.qq.com/web';
 const API = 'https://i.weread.qq.com';
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+function buildCookieHeader(cookies: BrowserCookie[]): string {
+  return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
+}
 
 /**
  * Fetch a public WeRead web endpoint (Node.js direct fetch).
@@ -36,28 +40,49 @@ export async function fetchWebApi(path: string, params?: Record<string, string>)
 }
 
 /**
- * Fetch a private WeRead API endpoint via browser page.evaluate.
- * Automatically carries cookies for authenticated requests.
+ * Fetch a private WeRead API endpoint with cookies extracted from the browser.
+ * The HTTP request itself runs in Node.js to avoid page-context CORS failures.
  */
-export async function fetchWithPage(page: IPage, path: string, params?: Record<string, string>): Promise<any> {
+export async function fetchPrivateApi(page: IPage, path: string, params?: Record<string, string>): Promise<any> {
   const url = new URL(`${API}${path}`);
   if (params) {
     for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   }
   const urlStr = url.toString();
-  const data = await page.evaluate(`
-    async () => {
-      const res = await fetch(${JSON.stringify(urlStr)}, { credentials: "include" });
-      if (!res.ok) return { _httpError: String(res.status) };
-      try { return await res.json(); }
-      catch { return { _httpError: 'JSON parse error (status ' + res.status + ')' }; }
-    }
-  `);
-  if (data?._httpError) {
-    throw new CliError('FETCH_ERROR', `HTTP ${data._httpError} for ${path}`, 'WeRead API may be temporarily unavailable');
+
+  const cookies = await page.getCookies({ url: urlStr });
+  const cookieHeader = buildCookieHeader(cookies);
+
+  let resp: Response;
+  try {
+    resp = await fetch(urlStr, {
+      headers: {
+        'User-Agent': UA,
+        'Origin': 'https://weread.qq.com',
+        'Referer': 'https://weread.qq.com/',
+        ...(cookieHeader ? { 'Cookie': cookieHeader } : {}),
+      },
+    });
+  } catch (error) {
+    throw new CliError(
+      'FETCH_ERROR',
+      `Failed to fetch ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      'WeRead API may be temporarily unavailable',
+    );
   }
-  if (data?.errcode === -2010) {
+
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    throw new CliError('PARSE_ERROR', `Invalid JSON response for ${path}`, 'WeRead may have returned an HTML error page');
+  }
+
+  if (resp.status === 401 || data?.errcode === -2010) {
     throw new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first');
+  }
+  if (!resp.ok) {
+    throw new CliError('FETCH_ERROR', `HTTP ${resp.status} for ${path}`, 'WeRead API may be temporarily unavailable');
   }
   if (data?.errcode != null && data.errcode !== 0) {
     throw new CliError('API_ERROR', data.errmsg ?? `WeRead API error ${data.errcode}`);

--- a/src/weread-private-api-regression.test.ts
+++ b/src/weread-private-api-regression.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from './registry.js';
+import { fetchPrivateApi } from './clis/weread/utils.js';
+import './clis/weread/shelf.js';
+
+describe('weread private API regression', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses browser cookies and Node fetch for private API requests', async () => {
+    const mockPage = {
+      getCookies: vi.fn()
+        .mockResolvedValueOnce([
+          { name: 'wr_name', value: 'alice', domain: 'weread.qq.com' },
+          { name: 'wr_vid', value: 'vid123', domain: 'i.weread.qq.com' },
+        ]),
+      evaluate: vi.fn(),
+    } as any;
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ title: 'Test Book', errcode: 0 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchPrivateApi(mockPage, '/book/info', { bookId: '123' });
+
+    expect(result.title).toBe('Test Book');
+    expect(mockPage.getCookies).toHaveBeenCalledTimes(1);
+    expect(mockPage.getCookies).toHaveBeenCalledWith({ url: 'https://i.weread.qq.com/book/info?bookId=123' });
+    expect(mockPage.evaluate).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://i.weread.qq.com/book/info?bookId=123',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: 'wr_name=alice; wr_vid=vid123',
+        }),
+      }),
+    );
+  });
+
+  it('maps unauthenticated private API responses to AUTH_REQUIRED', async () => {
+    const mockPage = {
+      getCookies: vi.fn().mockResolvedValue([]),
+      evaluate: vi.fn(),
+    } as any;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ errcode: -2010, errmsg: '用户不存在' }),
+    }));
+
+    await expect(fetchPrivateApi(mockPage, '/book/info')).rejects.toThrow('Not logged in');
+  });
+
+  it('maps non-auth API errors to API_ERROR', async () => {
+    const mockPage = {
+      getCookies: vi.fn().mockResolvedValue([]),
+      evaluate: vi.fn(),
+    } as any;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ errcode: -1, errmsg: 'unknown error' }),
+    }));
+
+    await expect(fetchPrivateApi(mockPage, '/book/info')).rejects.toThrow('unknown error');
+  });
+
+  it('maps non-401 HTTP failures to FETCH_ERROR', async () => {
+    const mockPage = {
+      getCookies: vi.fn().mockResolvedValue([]),
+      evaluate: vi.fn(),
+    } as any;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ errmsg: 'forbidden' }),
+    }));
+
+    await expect(fetchPrivateApi(mockPage, '/book/info')).rejects.toThrow('HTTP 403');
+  });
+
+  it('maps invalid JSON to PARSE_ERROR', async () => {
+    const mockPage = {
+      getCookies: vi.fn().mockResolvedValue([]),
+      evaluate: vi.fn(),
+    } as any;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    }));
+
+    await expect(fetchPrivateApi(mockPage, '/book/info')).rejects.toThrow('Invalid JSON');
+  });
+
+  it('routes weread shelf through the private API helper path', async () => {
+    const command = getRegistry().get('weread/shelf');
+    expect(command?.func).toBeTypeOf('function');
+
+    const mockPage = {
+      getCookies: vi.fn()
+        .mockResolvedValueOnce([
+          { name: 'wr_name', value: 'alice', domain: 'weread.qq.com' },
+          { name: 'wr_vid', value: 'vid123', domain: 'i.weread.qq.com' },
+        ]),
+      evaluate: vi.fn(),
+    } as any;
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        books: [{
+          title: 'Deep Work',
+          author: 'Cal Newport',
+          readingProgress: 42,
+          bookId: 'abc123',
+        }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await command!.func!(mockPage, { limit: 1 });
+
+    expect(mockPage.evaluate).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://i.weread.qq.com/shelf/sync?synckey=0&lectureSynckey=0',
+      expect.any(Object),
+    );
+    expect(mockPage.getCookies).toHaveBeenCalledWith({
+      url: 'https://i.weread.qq.com/shelf/sync?synckey=0&lectureSynckey=0',
+    });
+    expect(result).toEqual([
+      {
+        title: 'Deep Work',
+        author: 'Cal Newport',
+        progress: '42%',
+        bookId: 'abc123',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Related issue:
- Closes #431

Fix WeRead private commands failing with `TypeError: Failed to fetch` in real browser sessions.

Root cause:
- The private WeRead commands were calling `https://i.weread.qq.com/...` from page context via `page.evaluate(fetch(...))`
- In real browser sessions this could fail at the browser/network layer before we could normalize the error, which surfaced as raw `Failed to fetch`

What changed:
- Replaced the page-context private request path with a Node-side helper that:
  - reads cookies from the browser for the target private API URL
  - sends the request from Node with `Cookie`, `Origin`, `Referer`, and `User-Agent` headers
  - maps auth / HTTP / parse / API failures to `CliError`
- Switched all WeRead private commands to the new helper:
  - `weread book`
  - `weread shelf`
  - `weread notebooks`
  - `weread highlights`
  - `weread notes`
- Added executable top-level regression coverage for:
  - cookie extraction via `getCookies({ url })`
  - no fallback to `page.evaluate`
  - `AUTH_REQUIRED`, `API_ERROR`, `FETCH_ERROR`, `PARSE_ERROR`
  - one real command entrypoint (`weread/shelf`)

## Type of Change

- [x] Bug fix
- [ ] ✨ New feature
- [ ] New site adapter
- [ ] Documentation
- [x] ♻️ Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```bash
$ npm run typecheck
> tsc --noEmit

$ npm test
Test Files  23 passed (23)
Tests  288 passed (288)

$ npm run test:adapter
Test Files  2 passed (2)
Tests  3 passed (3)

$ npm run build
✅ Manifest compiled: 355 entries (106 YAML, 249 TS)

$ node dist/main.js weread shelf --limit 3 -f json
🔒 Not logged in to WeRead
→ Please log in to weread.qq.com in Chrome first

$ node dist/main.js weread notebooks -f json
🔒 Not logged in to WeRead
→ Please log in to weread.qq.com in Chrome first
```
