### PR TITLE
fix(weixin): fix publish time extraction

### DIFF
--- a/src/clis/weixin/download.ts
+++ b/src/clis/weixin/download.ts
@@ -54,6 +54,62 @@ export function normalizeWechatUrl(raw: string): string {
   return s;
 }
 
+/**
+ * Format a WeChat article timestamp as a UTC+8 datetime string.
+ * Accepts either Unix seconds or milliseconds.
+ */
+function formatWechatTimestamp(rawTimestamp: string): string {
+  const ts = Number.parseInt(rawTimestamp, 10);
+  if (!Number.isFinite(ts) || ts <= 0) return '';
+
+  const timestampMs = rawTimestamp.length === 13 ? ts : ts * 1000;
+  const d = new Date(timestampMs);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  const utc8 = new Date(d.getTime() + 8 * 3600 * 1000);
+
+  return (
+    `${utc8.getUTCFullYear()}-` +
+    `${pad(utc8.getUTCMonth() + 1)}-` +
+    `${pad(utc8.getUTCDate())} ` +
+    `${pad(utc8.getUTCHours())}:` +
+    `${pad(utc8.getUTCMinutes())}:` +
+    `${pad(utc8.getUTCSeconds())}`
+  );
+}
+
+/**
+ * Extract the raw create_time value from supported WeChat inline script formats.
+ */
+function extractWechatCreateTimeValue(htmlStr: string): string {
+  const jsDecodeMatch = htmlStr.match(
+    /create_time\s*:\s*JsDecode\('([^']+)'\)(?=[\s,;}]|$)/,
+  );
+  if (jsDecodeMatch) return jsDecodeMatch[1];
+
+  const directValueMatch = htmlStr.match(
+    /create_time\s*[:=]\s*(?:"([^"]+)"|'([^']+)'|([0-9A-Za-z]+))(?=[\s,;}]|$)/,
+  );
+  if (!directValueMatch) return '';
+
+  return directValueMatch[1] || directValueMatch[2] || directValueMatch[3] || '';
+}
+
+/**
+ * Extract the publish time from DOM text first, then fall back to numeric create_time values.
+ */
+export function extractWechatPublishTime(
+  publishTimeText: string | null | undefined,
+  htmlStr: string,
+): string {
+  const normalizedPublishTime = (publishTimeText || '').trim();
+  if (normalizedPublishTime) return normalizedPublishTime;
+
+  const rawCreateTime = extractWechatCreateTimeValue(htmlStr);
+  if (!/^\d{10}$|^\d{13}$/.test(rawCreateTime)) return '';
+
+  return formatWechatTimestamp(rawCreateTime);
+}
+
 // ============================================================
 // CLI Registration
 // ============================================================
@@ -102,26 +158,13 @@ cli({
         const authorEl = document.querySelector('#js_name');
         result.author = authorEl ? authorEl.textContent.trim() : '';
 
-        // Publish time: extract create_time from script tags
-        const htmlStr = document.documentElement.innerHTML;
-        let timeMatch = htmlStr.match(/create_time\\s*:\\s*JsDecode\\('([^']+)'\\)/);
-        if (!timeMatch) timeMatch = htmlStr.match(/create_time\\s*:\\s*'(\\d+)'/);
-        if (!timeMatch) timeMatch = htmlStr.match(/create_time\\s*[:=]\\s*["']?(\\d+)["']?/);
-        if (timeMatch) {
-          const ts = parseInt(timeMatch[1], 10);
-          if (ts > 0) {
-            const d = new Date(ts * 1000);
-            const pad = n => String(n).padStart(2, '0');
-            const utc8 = new Date(d.getTime() + 8 * 3600 * 1000);
-            result.publishTime =
-              utc8.getUTCFullYear() + '-' +
-              pad(utc8.getUTCMonth() + 1) + '-' +
-              pad(utc8.getUTCDate()) + ' ' +
-              pad(utc8.getUTCHours()) + ':' +
-              pad(utc8.getUTCMinutes()) + ':' +
-              pad(utc8.getUTCSeconds());
-          }
-        }
+        // Publish time: prefer the rendered DOM text, then fall back to numeric create_time values.
+        const publishTimeEl = document.querySelector('#publish_time');
+        const extractWechatPublishTime = ${extractWechatPublishTime.toString()};
+        result.publishTime = extractWechatPublishTime(
+          publishTimeEl ? publishTimeEl.textContent : '',
+          document.documentElement.innerHTML,
+        );
 
         // Content processing
         const contentEl = document.querySelector('#js_content');

--- a/src/weixin-download.test.ts
+++ b/src/weixin-download.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+describe('weixin publish time extraction', () => {
+  it('prefers publish_time text over create_time-like date strings', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '2026年3月24日 22:38',
+      'var create_time = "2026年3月24日 22:38";',
+    );
+
+    expect(publishTime).toBe('2026年3月24日 22:38');
+  });
+
+  it('falls back to unix timestamp create_time values', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = "1711291080";',
+    );
+
+    expect(publishTime).toBe('2024-03-24 22:38:00');
+  });
+
+  it('does not partially match localized create_time strings when DOM publish time is missing', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = "2026年3月24日 22:38";',
+    );
+
+    expect(publishTime).toBe('');
+  });
+
+  it('accepts 13-digit millisecond timestamps only', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = "1711291080000";',
+    );
+
+    expect(publishTime).toBe('2024-03-24 22:38:00');
+  });
+
+  it('rejects malformed 11-digit numeric create_time values', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = "17112910800";',
+    );
+
+    expect(publishTime).toBe('');
+  });
+
+  it('rejects quoted timestamps with trailing garbage characters', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = "1711291080abc";',
+    );
+
+    expect(publishTime).toBe('');
+  });
+
+  it('rejects bare timestamps with trailing garbage characters', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = 1711291080abc;',
+    );
+
+    expect(publishTime).toBe('');
+  });
+
+  it('rejects garbage after a closed quoted timestamp', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      'var create_time = "1711291080"abc;',
+    );
+
+    expect(publishTime).toBe('');
+  });
+
+  it('accepts single-quoted timestamps assigned with equals', async () => {
+    const mod = await import('./clis/weixin/download.js');
+
+    expect(typeof mod.extractWechatPublishTime).toBe('function');
+    if (typeof mod.extractWechatPublishTime !== 'function') return;
+
+    const publishTime = mod.extractWechatPublishTime(
+      '',
+      "var create_time = '1711291080';",
+    );
+
+    expect(publishTime).toBe('2024-03-24 22:38:00');
+  });
+});


### PR DESCRIPTION
## Description

Fix `weixin download` publish time extraction for WeChat articles.

Related issue: #429

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [x] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Checks run:
- `npx vitest run src/weixin-download.test.ts src/clis/zhihu/download.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:adapter`

Summary:
- Prefer DOM `#publish_time` when available
- Fall back to `create_time` only when missing
- Accept only exact 10-digit or 13-digit timestamps and reject partial matches / malformed values
- Add targeted regression tests for localized date strings and timestamp edge cases
