### PR TITLE
feat(chatgpt): add model/mode selection and fix response polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Run `opencli list` for the live registry.
 | **v2ex** | `hot` `latest` `topic` `node` `user` `member` `replies` `nodes` `daily` `me` `notifications` | Public / Browser |
 | **xueqiu** | `feed` `hot-stock` `hot` `search` `stock` `watchlist` `earnings-date` `fund-holdings` `fund-snapshot` | Browser |
 | **antigravity** | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` | Desktop |
-| **chatgpt** | `status` `new` `send` `read` `ask` | Desktop |
+| **chatgpt** | `status` `new` `send` `read` `ask` `model` | Desktop |
 | **xiaohongshu** | `search` `notifications` `feed` `user` `download` `publish` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` | Browser |
 | **apple-podcasts** | `search` `episodes` `top` | Public |
 | **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | Public |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,7 +134,7 @@ npm install -g @jackwener/opencli@latest
 | **v2ex** | `hot` `latest` `topic` `node` `user` `member` `replies` `nodes` `daily` `me` `notifications` | 公开 / 浏览器 |
 | **xueqiu** | `feed` `hot-stock` `hot` `search` `stock` `watchlist` `earnings-date` `fund-holdings` `fund-snapshot` | 浏览器 |
 | **antigravity** | `status` `send` `read` `new` `dump` `extract-code` `model` `watch` | 桌面端 |
-| **chatgpt** | `status` `new` `send` `read` `ask` | 桌面端 |
+| **chatgpt** | `status` `new` `send` `read` `ask` `model` | 桌面端 |
 | **xiaohongshu** | `search` `notifications` `feed` `user` `download` `publish` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` | 浏览器 |
 | **apple-podcasts** | `search` `episodes` `top` | 公开 |
 | **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | 公开 |

--- a/docs/adapters/desktop/chatgpt.md
+++ b/docs/adapters/desktop/chatgpt.md
@@ -14,8 +14,13 @@ The current built-in commands use native AppleScript automation — no extra lau
 - `opencli chatgpt status`: Check if the ChatGPT app is currently running.
 - `opencli chatgpt new`: Activate ChatGPT and press `Cmd+N` to start a new conversation.
 - `opencli chatgpt send "message"`: Copy your message to clipboard, activate ChatGPT, paste, and submit.
+- `opencli chatgpt send "message" --model thinking`: Switch model/mode first, then send the message.
 - `opencli chatgpt read`: Read the last visible message from the focused ChatGPT window via the Accessibility tree.
 - `opencli chatgpt ask "message"`: Send a prompt and wait for the visible reply in one shot.
+- `opencli chatgpt ask "message" --model instant`: Run a one-shot prompt using a specific model/mode.
+- `opencli chatgpt model thinking`: Switch the active ChatGPT model/mode without sending a message.
+
+Supported model choices: `auto`, `instant`, `thinking`, `5.2-instant`, `5.2-thinking`.
 
 ## Approach 2: CDP (Advanced, Electron Debug Mode)
 

--- a/src/clis/chatgpt/ask.ts
+++ b/src/clis/chatgpt/ask.ts
@@ -2,7 +2,7 @@ import { execSync, spawnSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
 import { ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
-import { getVisibleChatMessages, selectModel, MODEL_CHOICES, isGenerating } from './ax.js';
+import { activateChatGPT, getVisibleChatMessages, selectModel, MODEL_CHOICES, isGenerating } from './ax.js';
 
 export const askCommand = cli({
   site: 'chatgpt',
@@ -28,8 +28,8 @@ export const askCommand = cli({
 
     // Switch model before sending if requested
     if (model) {
+      activateChatGPT();
       selectModel(model);
-      execSync("osascript -e 'delay 0.5'");
     }
 
     // Backup clipboard
@@ -39,8 +39,7 @@ export const askCommand = cli({
 
     // Send the message
     spawnSync('pbcopy', { input: text });
-    execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
-    execSync("osascript -e 'delay 0.5'");
+    activateChatGPT();
 
     const cmd = "osascript " +
                 "-e 'tell application \"System Events\"' " +
@@ -71,8 +70,7 @@ export const askCommand = cli({
       if (!generationStarted && i < 3) continue; // give it a moment to start
 
       // Read final response
-      execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
-      execSync("osascript -e 'delay 0.3'");
+      activateChatGPT(0.3);
       const messagesNow = getVisibleChatMessages();
       if (messagesNow.length > messagesBefore.length) {
         const newMessages = messagesNow.slice(messagesBefore.length);

--- a/src/clis/chatgpt/ax.ts
+++ b/src/clis/chatgpt/ax.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 const AX_READ_SCRIPT = `
 import Cocoa
@@ -206,6 +206,11 @@ const MODEL_MAP: Record<ModelChoice, { desc: string; legacy?: boolean }> = {
 };
 
 export const MODEL_CHOICES = Object.keys(MODEL_MAP) as ModelChoice[];
+
+export function activateChatGPT(delaySeconds: number = 0.5): void {
+  execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
+  execSync(`osascript -e 'delay ${delaySeconds}'`);
+}
 
 export function selectModel(model: string): string {
   const entry = MODEL_MAP[model as ModelChoice];

--- a/src/clis/chatgpt/model.ts
+++ b/src/clis/chatgpt/model.ts
@@ -1,8 +1,7 @@
-import { execSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
 import { ConfigError } from '../../errors.js';
 import type { IPage } from '../../types.js';
-import { selectModel, MODEL_CHOICES } from './ax.js';
+import { activateChatGPT, selectModel, MODEL_CHOICES } from './ax.js';
 
 export const modelCommand = cli({
   site: 'chatgpt',
@@ -21,9 +20,7 @@ export const modelCommand = cli({
     }
 
     const model = kwargs.model as string;
-    execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
-    execSync("osascript -e 'delay 0.5'");
-
+    activateChatGPT();
     const result = selectModel(model);
     return [{ Status: 'Success', Model: result }];
   },

--- a/src/clis/chatgpt/send.ts
+++ b/src/clis/chatgpt/send.ts
@@ -2,7 +2,7 @@ import { execSync, spawnSync } from 'node:child_process';
 import { cli, Strategy } from '../../registry.js';
 import type { IPage } from '../../types.js';
 import { getErrorMessage } from '../../errors.js';
-import { selectModel, MODEL_CHOICES } from './ax.js';
+import { activateChatGPT, selectModel, MODEL_CHOICES } from './ax.js';
 
 export const sendCommand = cli({
   site: 'chatgpt',
@@ -22,8 +22,8 @@ export const sendCommand = cli({
     try {
       // Switch model before sending if requested
       if (model) {
+        activateChatGPT();
         selectModel(model);
-        execSync("osascript -e 'delay 0.5'");
       }
 
       // Backup current clipboard content
@@ -35,8 +35,7 @@ export const sendCommand = cli({
       // Copy text to clipboard
       spawnSync('pbcopy', { input: text });
 
-      execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
-      execSync("osascript -e 'delay 0.5'");
+      activateChatGPT();
 
       const cmd = "osascript " +
                   "-e 'tell application \"System Events\"' " +


### PR DESCRIPTION
## Summary
- Add `--model` option to `ask` and `send` commands for selecting ChatGPT model/mode before sending
- Add new `opencli chatgpt model <model>` standalone command for switching models
- Fix `ask` command returning partial/thinking intermediate text instead of waiting for the full response

## Supported models
`auto`, `instant`, `thinking`, `5.2-instant`, `5.2-thinking`

## Usage
```bash
# Switch model standalone
opencli chatgpt model thinking

# Ask with model selection
opencli chatgpt ask "hello" --model thinking --timeout 60

# Send with model selection
opencli chatgpt send "hello" --model instant
```

## Implementation details

### Model selection (`ax.ts`)
- Clicks the **"Options"** button (stable `desc="Options"`) to open the model popover
- Searches **only within the AXPopover** element to avoid matching sidebar items (e.g. "Auto" prefix previously matched "Automatic Trading on Chain")
- For legacy models (`5.2-instant`, `5.2-thinking`): clicks "Legacy models" first to expand the submenu, then selects the model
- Uses `desc` prefix matching within the popover for robustness

### Response polling fix (`ask.ts`)
- **Before**: Broke out of the poll loop as soon as any new text appeared — captured thinking intermediate text in thinking mode
- **After**: Polls `isGenerating()` which checks if the "Stop generating" button exists in the AX tree. Only reads the final response after generation completes

### Files changed
| File | Change |
|------|--------|
| `src/clis/chatgpt/ax.ts` | Add `AX_MODEL_SCRIPT`, `AX_GENERATING_SCRIPT`, `selectModel()`, `isGenerating()`, `MODEL_CHOICES` |
| `src/clis/chatgpt/ask.ts` | Add `--model` arg, fix polling to wait for generation completion |
| `src/clis/chatgpt/send.ts` | Add `--model` arg |
| `src/clis/chatgpt/model.ts` | **New** — standalone model switching command |

## Test plan
- [x] `opencli chatgpt model auto` — switches to Auto
- [x] `opencli chatgpt model thinking` — switches to Thinking
- [x] `opencli chatgpt model 5.2-thinking` — opens Legacy submenu, selects GPT-5.2 Thinking
- [x] `opencli chatgpt model auto` after legacy model — correctly selects Auto (not sidebar items)
- [x] `opencli chatgpt ask "what is 2+2?" --model thinking` — waits for full response, not thinking text
- [x] `opencli chatgpt ask "explain quantum computing in 3 sentences" --model thinking --timeout 60` — returns complete response