### PR TITLE
fix(weixin): rewrite publish time extraction

### DIFF
--- a/src/clis/weixin/download.ts
+++ b/src/clis/weixin/download.ts
@@ -54,6 +54,113 @@ export function normalizeWechatUrl(raw: string): string {
   return s;
 }
 
+/**
+ * Format a WeChat article timestamp as a UTC+8 datetime string.
+ * Accepts either Unix seconds or milliseconds.
+ */
+export function formatWechatTimestamp(rawTimestamp: string): string {
+  const ts = Number.parseInt(rawTimestamp, 10);
+  if (!Number.isFinite(ts) || ts <= 0) return '';
+
+  const timestampMs = rawTimestamp.length === 13 ? ts : ts * 1000;
+  const d = new Date(timestampMs);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  const utc8 = new Date(d.getTime() + 8 * 3600 * 1000);
+
+  return (
+    `${utc8.getUTCFullYear()}-` +
+    `${pad(utc8.getUTCMonth() + 1)}-` +
+    `${pad(utc8.getUTCDate())} ` +
+    `${pad(utc8.getUTCHours())}:` +
+    `${pad(utc8.getUTCMinutes())}:` +
+    `${pad(utc8.getUTCSeconds())}`
+  );
+}
+
+/**
+ * Extract the raw create_time value from supported WeChat inline script formats.
+ */
+export function extractWechatCreateTimeValue(htmlStr: string): string {
+  const jsDecodeMatch = htmlStr.match(
+    /create_time\s*:\s*JsDecode\('([^']+)'\)(?=[\s,;}]|$)/,
+  );
+  if (jsDecodeMatch) return jsDecodeMatch[1];
+
+  const directValueMatch = htmlStr.match(
+    /create_time\s*[:=]\s*(?:"([^"]+)"|'([^']+)'|([0-9A-Za-z]+))(?=[\s,;}]|$)/,
+  );
+  if (!directValueMatch) return '';
+
+  return directValueMatch[1] || directValueMatch[2] || directValueMatch[3] || '';
+}
+
+/**
+ * Extract the publish time from DOM text first, then fall back to numeric create_time values.
+ */
+export function extractWechatPublishTime(
+  publishTimeText: string | null | undefined,
+  htmlStr: string,
+): string {
+  const normalizedPublishTime = (publishTimeText || '').trim();
+  if (normalizedPublishTime) return normalizedPublishTime;
+
+  const rawCreateTime = extractWechatCreateTimeValue(htmlStr);
+  if (!/^\d{10}$|^\d{13}$/.test(rawCreateTime)) return '';
+
+  return formatWechatTimestamp(rawCreateTime);
+}
+
+/**
+ * Build a self-contained helper for execution inside page.evaluate().
+ */
+export function buildExtractWechatPublishTimeJs(): string {
+  return `(${function extractWechatPublishTimeInPage(
+    publishTimeText: string | null | undefined,
+    htmlStr: string,
+  ) {
+    function formatWechatTimestamp(rawTimestamp: string) {
+      const ts = Number.parseInt(rawTimestamp, 10);
+      if (!Number.isFinite(ts) || ts <= 0) return '';
+
+      const timestampMs = rawTimestamp.length === 13 ? ts : ts * 1000;
+      const d = new Date(timestampMs);
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const utc8 = new Date(d.getTime() + 8 * 3600 * 1000);
+
+      return (
+        `${utc8.getUTCFullYear()}-` +
+        `${pad(utc8.getUTCMonth() + 1)}-` +
+        `${pad(utc8.getUTCDate())} ` +
+        `${pad(utc8.getUTCHours())}:` +
+        `${pad(utc8.getUTCMinutes())}:` +
+        `${pad(utc8.getUTCSeconds())}`
+      );
+    }
+
+    function extractWechatCreateTimeValue(html: string) {
+      const jsDecodeMatch = html.match(
+        /create_time\s*:\s*JsDecode\('([^']+)'\)(?=[\s,;}]|$)/,
+      );
+      if (jsDecodeMatch) return jsDecodeMatch[1];
+
+      const directValueMatch = html.match(
+        /create_time\s*[:=]\s*(?:"([^"]+)"|'([^']+)'|([0-9A-Za-z]+))(?=[\s,;}]|$)/,
+      );
+      if (!directValueMatch) return '';
+
+      return directValueMatch[1] || directValueMatch[2] || directValueMatch[3] || '';
+    }
+
+    const normalizedPublishTime = (publishTimeText || '').trim();
+    if (normalizedPublishTime) return normalizedPublishTime;
+
+    const rawCreateTime = extractWechatCreateTimeValue(htmlStr);
+    if (!/^\d{10}$|^\d{13}$/.test(rawCreateTime)) return '';
+
+    return formatWechatTimestamp(rawCreateTime);
+  }.toString()})`;
+}
+
 // ============================================================
 // CLI Registration
 // ============================================================
@@ -102,26 +209,13 @@ cli({
         const authorEl = document.querySelector('#js_name');
         result.author = authorEl ? authorEl.textContent.trim() : '';
 
-        // Publish time: extract create_time from script tags
-        const htmlStr = document.documentElement.innerHTML;
-        let timeMatch = htmlStr.match(/create_time\\s*:\\s*JsDecode\\('([^']+)'\\)/);
-        if (!timeMatch) timeMatch = htmlStr.match(/create_time\\s*:\\s*'(\\d+)'/);
-        if (!timeMatch) timeMatch = htmlStr.match(/create_time\\s*[:=]\\s*["']?(\\d+)["']?/);
-        if (timeMatch) {
-          const ts = parseInt(timeMatch[1], 10);
-          if (ts > 0) {
-            const d = new Date(ts * 1000);
-            const pad = n => String(n).padStart(2, '0');
-            const utc8 = new Date(d.getTime() + 8 * 3600 * 1000);
-            result.publishTime =
-              utc8.getUTCFullYear() + '-' +
-              pad(utc8.getUTCMonth() + 1) + '-' +
-              pad(utc8.getUTCDate()) + ' ' +
-              pad(utc8.getUTCHours()) + ':' +
-              pad(utc8.getUTCMinutes()) + ':' +
-              pad(utc8.getUTCSeconds());
-          }
-        }
+        // Publish time: prefer the rendered DOM text, then fall back to numeric create_time values.
+        const publishTimeEl = document.querySelector('#publish_time');
+        const extractWechatPublishTime = ${buildExtractWechatPublishTimeJs()};
+        result.publishTime = extractWechatPublishTime(
+          publishTimeEl ? publishTimeEl.textContent : '',
+          document.documentElement.innerHTML,
+        );
 
         // Content processing
         const contentEl = document.querySelector('#js_content');

--- a/src/weixin-download.test.ts
+++ b/src/weixin-download.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+async function loadModule() {
+  return import('./clis/weixin/download.js');
+}
+
+describe('weixin publish time extraction', () => {
+  it('prefers publish_time text over create_time-like date strings', async () => {
+    const mod = await loadModule();
+
+    expect(mod.extractWechatPublishTime(
+      '2026年3月24日 22:38',
+      'var create_time = "2026年3月24日 22:38";',
+    )).toBe('2026年3月24日 22:38');
+  });
+
+  it('falls back to unix timestamp create_time values', async () => {
+    const mod = await loadModule();
+
+    expect(mod.extractWechatPublishTime(
+      '',
+      'var create_time = "1711291080";',
+    )).toBe('2024-03-24 22:38:00');
+  });
+
+  it('rejects malformed create_time values', async () => {
+    const mod = await loadModule();
+
+    expect(mod.extractWechatPublishTime(
+      '',
+      'var create_time = "2026年3月24日 22:38";',
+    )).toBe('');
+    expect(mod.extractWechatPublishTime(
+      '',
+      'var create_time = "1711291080abc";',
+    )).toBe('');
+    expect(mod.extractWechatPublishTime(
+      '',
+      'var create_time = "17112910800";',
+    )).toBe('');
+  });
+
+  it('builds a self-contained browser helper that matches fallback behavior', async () => {
+    const mod = await loadModule();
+
+    const extractInPage = eval(mod.buildExtractWechatPublishTimeJs()) as (publishTimeText: string, htmlStr: string) => string;
+
+    expect(extractInPage(
+      '',
+      'var create_time = "1711291080";',
+    )).toBe('2024-03-24 22:38:00');
+  });
+
+  it('browser helper still prefers DOM publish_time text', async () => {
+    const mod = await loadModule();
+
+    const extractInPage = eval(mod.buildExtractWechatPublishTimeJs()) as (publishTimeText: string, htmlStr: string) => string;
+
+    expect(extractInPage(
+      '2026年3月24日 22:38',
+      'var create_time = "1711291080";',
+    )).toBe('2026年3月24日 22:38');
+  });
+});


### PR DESCRIPTION
## Summary

This replaces the closed PR #437 with a clean rewrite of Weixin publish time extraction.

- prefer rendered `#publish_time` text when present
- fall back to exact 10-digit or 13-digit `create_time` timestamps only
- inject a self-contained helper into `page.evaluate()` so the browser path does not depend on module-scope helpers
- add regression tests for both pure extraction logic and the actual stringified browser helper path

## Why rewrite

The previous approach serialized `extractWechatPublishTime` into the page, but that function depended on module-scope helpers that were not available in the browser context. That meant the fallback path could still fail at runtime when `#publish_time` was missing.

## Validation

- `npx vitest run src/weixin-download.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`

Related issue: #429
Replaces: #437
