### PR TITLE
fix: use pathToFileURL for dynamic imports

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -11,6 +11,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import yaml from 'js-yaml';
 import { type CliCommand, type InternalCliCommand, type Arg, Strategy, registerCommand } from './registry.js';
 import { log } from './logger.js';
@@ -46,6 +47,10 @@ interface YamlCliDefinition {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function toImportHref(filePath: string): string {
+  return pathToFileURL(filePath).href;
 }
 
 function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Strategy.COOKIE): Strategy {
@@ -156,7 +161,7 @@ async function discoverClisFromFs(dir: string): Promise<void> {
       ) {
         if (!(await isCliModule(filePath))) continue;
         promises.push(
-          import(`file://${filePath}`).catch((err) => {
+          import(toImportHref(filePath)).catch((err) => {
             log.warn(`Failed to load module ${filePath}: ${getErrorMessage(err)}`);
           })
         );
@@ -244,7 +249,7 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
     } else if (file.endsWith('.js') && !file.endsWith('.d.js')) {
       if (!(await isCliModule(filePath))) continue;
       promises.push(
-        import(`file://${filePath}`).catch((err) => {
+        import(toImportHref(filePath)).catch((err) => {
           log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
         })
       );
@@ -256,7 +261,7 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
       if (fileSet.has(jsFile)) continue;
       if (!(await isCliModule(filePath))) continue;
       promises.push(
-        import(`file://${filePath}`).catch((err) => {
+        import(toImportHref(filePath)).catch((err) => {
           log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
         })
       );

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { discoverClis, discoverPlugins, PLUGINS_DIR } from './discovery.js';
+import { discoverClis, discoverPlugins, PLUGINS_DIR, toImportHref } from './discovery.js';
 import { executeCommand } from './execution.js';
 import { getRegistry, cli, Strategy } from './registry.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 describe('discoverClis', () => {
+  it('encodes local paths as valid file import URLs', () => {
+    expect(toImportHref('/tmp/opencli path/hello.ts')).toBe('file:///tmp/opencli%20path/hello.ts');
+    expect(toImportHref('/tmp/opencli#hash/hello.ts')).toBe('file:///tmp/opencli%23hash/hello.ts');
+  });
+
   it('handles non-existent directories gracefully', async () => {
     // Should not throw for missing directories
     await expect(discoverClis('/tmp/nonexistent-opencli-test-dir')).resolves.not.toThrow();

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -9,6 +9,7 @@
  * 5. Lazy-loading of TS modules from manifest
  */
 
+import { pathToFileURL } from 'node:url';
 import { type CliCommand, type InternalCliCommand, type Arg, Strategy, getRegistry, fullName } from './registry.js';
 import type { IPage } from './types.js';
 import { executePipeline } from './pipeline.js';
@@ -86,7 +87,7 @@ async function runCommand(
     const modulePath = internal._modulePath;
     if (!_loadedModules.has(modulePath)) {
       try {
-        await import(`file://${modulePath}`);
+        await import(pathToFileURL(modulePath).href);
         _loadedModules.add(modulePath);
       } catch (err) {
         throw new AdapterLoadError(


### PR DESCRIPTION
## Summary
- replace raw `file://${...}` dynamic imports with `pathToFileURL(...).href`
- apply the fix to both filesystem discovery and manifest lazy-loading
- add a regression test covering local paths that need URL escaping

## Why
`vitest run` currently emits `Invalid file URL` warnings because local paths are interpolated directly into `file://` import specifiers. This is brittle for spaces, `#`, and other characters that require escaping, and it is especially fragile on Windows.

Using `pathToFileURL(...).href` produces valid import URLs consistently across platforms.

## Validation
- `npm test -- --run src/engine.test.ts`
- `npm run typecheck`
