### PR TITLE
feat: add Claude Code plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "opencli",
+  "owner": {
+    "name": "jackwener",
+    "url": "https://github.com/jackwener"
+  },
+  "plugins": [
+    {
+      "name": "opencli",
+      "source": "./",
+      "description": "Make any website or Electron App your CLI. Reuse Chrome login, zero risk, AI-powered discovery. Supports 50+ platforms including Bilibili, Zhihu, Twitter/X, YouTube, Reddit, HackerNews, V2EX, 小红书, 雪球, BOSS直聘 and more.",
+      "version": "1.4.1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` to enable plugin discovery and management through Claude Code's plugin system

## Details
This PR adds the necessary marketplace metadata file that allows this skill to be discovered and managed through Claude Code's built-in plugin marketplace.

Users can now install this skill by:
1. Adding this repo as a marketplace source in settings
2. Using `/plugins` to browse and install

🤖 Generated with [Claude Code](https://claude.com/claude-code)