### PR TITLE
fix: restore executable permission on bin entries after tsc build

### DIFF
--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -353,6 +353,29 @@ function main(): void {
   const yamlCount = manifest.filter(e => e.type === 'yaml').length;
   const tsCount = manifest.filter(e => e.type === 'ts').length;
   console.log(`✅ Manifest compiled: ${manifest.length} entries (${yamlCount} YAML, ${tsCount} TS) → ${OUTPUT}`);
+
+  // Restore executable permissions on bin entries.
+  // tsc does not preserve the +x bit, so after a clean rebuild the CLI
+  // entry-point loses its executable permission, causing "Permission denied".
+  // See: https://github.com/jackwener/opencli/issues/446
+  if (process.platform !== 'win32') {
+    const pkgPath = path.resolve(__dirname, '..', 'package.json');
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      const bins: Record<string, string> = typeof pkg.bin === 'string'
+        ? { [pkg.name ?? 'cli']: pkg.bin }
+        : pkg.bin ?? {};
+      for (const binPath of Object.values(bins)) {
+        const abs = path.resolve(__dirname, '..', binPath);
+        if (fs.existsSync(abs)) {
+          fs.chmodSync(abs, 0o755);
+          console.log(`✅ Restored executable permission: ${binPath}`);
+        }
+      }
+    } catch {
+      // Best-effort; never break the build for a permission fix.
+    }
+  }
 }
 
 const entrypoint = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null;


### PR DESCRIPTION
## Problem

`npm run build` causes `Permission denied` when running `opencli` afterwards.

**Root cause**: The build pipeline runs `clean-dist` (deletes entire `dist/`), then `tsc` regenerates all files — but TypeScript compiler does **not** set executable permissions on output files. So `dist/main.js` ends up with `-rw-r--r--` (644) instead of `-rwxr-xr-x` (755).

## Fix

At the end of `build-manifest.ts` `main()` (the last step in the build pipeline), read `bin` entries from `package.json` and `chmod 0o755` them.

- **Zero new files** — no extra scripts needed
- **Cross-platform** — skipped on Windows (`process.platform !== 'win32'`)
- **Best-effort** — wrapped in `try/catch`, never breaks the build
- **Not hardcoded** — reads from `package.json` `bin` field

Closes #446