### PR TITLE
docs: turn language links into badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Make any website, Electron App, or Local Tool your CLI.**  
 > Zero risk · Reuse Chrome login · AI-powered discovery · Universal CLI Hub
 
-[中文文档](./README.zh-CN.md)
+[![中文文档](https://img.shields.io/badge/docs-%E4%B8%AD%E6%96%87-0F766E?style=flat-square)](./README.zh-CN.md)
 
 [![npm](https://img.shields.io/npm/v/@jackwener/opencli?style=flat-square)](https://www.npmjs.com/package/@jackwener/opencli)
 [![Node.js Version](https://img.shields.io/node/v/@jackwener/opencli?style=flat-square)](https://nodejs.org)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 > **把任何网站、本地工具、Electron 应用变成能够让 AI 调用的命令行！**  
 > 零风控 · 复用 Chrome 登录 · AI 自动发现接口 · 全能 CLI 枢纽
 
-[English](./README.md)
+[![English](https://img.shields.io/badge/docs-English-1D4ED8?style=flat-square)](./README.md)
 
 [![npm](https://img.shields.io/npm/v/@jackwener/opencli?style=flat-square)](https://www.npmjs.com/package/@jackwener/opencli)
 [![Node.js Version](https://img.shields.io/node/v/@jackwener/opencli?style=flat-square)](https://nodejs.org)


### PR DESCRIPTION
## Summary
- replace the standalone Chinese docs link in README with a badge
- make the English link in README.zh-CN symmetric with a matching badge style

## Verification
- checked the README diff locally