### PR TITLE
fix(extension): fail packaging when manifest entry files are missing

### DIFF
--- a/extension/scripts/package-release.mjs
+++ b/extension/scripts/package-release.mjs
@@ -45,6 +45,31 @@ function addLocalAsset(files, ref) {
   if (isLocalAsset(ref)) files.add(ref);
 }
 
+function collectManifestEntrypoints(manifest) {
+  const files = new Set(['manifest.json']);
+
+  addLocalAsset(files, manifest.background?.service_worker);
+  addLocalAsset(files, manifest.action?.default_popup);
+  addLocalAsset(files, manifest.options_page);
+  addLocalAsset(files, manifest.devtools_page);
+  addLocalAsset(files, manifest.side_panel?.default_path);
+
+  for (const ref of Object.values(manifest.icons ?? {})) addLocalAsset(files, ref);
+  for (const ref of Object.values(manifest.action?.default_icon ?? {})) addLocalAsset(files, ref);
+  for (const contentScript of manifest.content_scripts ?? []) {
+    for (const jsFile of contentScript.js ?? []) addLocalAsset(files, jsFile);
+    for (const cssFile of contentScript.css ?? []) addLocalAsset(files, cssFile);
+  }
+  for (const page of manifest.sandbox?.pages ?? []) addLocalAsset(files, page);
+  for (const overridePage of Object.values(manifest.chrome_url_overrides ?? {})) addLocalAsset(files, overridePage);
+  for (const entry of manifest.web_accessible_resources ?? []) {
+    for (const resource of entry.resources ?? []) addLocalAsset(files, resource);
+  }
+  if (manifest.default_locale) files.add('_locales');
+
+  return [...files];
+}
+
 async function collectHtmlDependencies(relativeHtmlPath, files, visited) {
   if (visited.has(relativeHtmlPath)) return;
   visited.add(relativeHtmlPath);
@@ -70,39 +95,17 @@ async function collectHtmlDependencies(relativeHtmlPath, files, visited) {
 }
 
 async function collectManifestAssets(manifest) {
-  const files = new Set(['manifest.json']);
+  const files = new Set(collectManifestEntrypoints(manifest));
   const htmlPages = [];
 
-  addLocalAsset(files, manifest.background?.service_worker);
   if (manifest.action?.default_popup) {
-    addLocalAsset(files, manifest.action.default_popup);
     htmlPages.push(manifest.action.default_popup);
   }
-  addLocalAsset(files, manifest.options_page);
   if (manifest.options_page) htmlPages.push(manifest.options_page);
-  addLocalAsset(files, manifest.devtools_page);
   if (manifest.devtools_page) htmlPages.push(manifest.devtools_page);
-  addLocalAsset(files, manifest.side_panel?.default_path);
   if (manifest.side_panel?.default_path) htmlPages.push(manifest.side_panel.default_path);
-
-  for (const ref of Object.values(manifest.icons ?? {})) addLocalAsset(files, ref);
-  for (const ref of Object.values(manifest.action?.default_icon ?? {})) addLocalAsset(files, ref);
-  for (const contentScript of manifest.content_scripts ?? []) {
-    for (const jsFile of contentScript.js ?? []) addLocalAsset(files, jsFile);
-    for (const cssFile of contentScript.css ?? []) addLocalAsset(files, cssFile);
-  }
-  for (const page of manifest.sandbox?.pages ?? []) {
-    addLocalAsset(files, page);
-    htmlPages.push(page);
-  }
-  for (const overridePage of Object.values(manifest.chrome_url_overrides ?? {})) {
-    addLocalAsset(files, overridePage);
-    htmlPages.push(overridePage);
-  }
-  for (const entry of manifest.web_accessible_resources ?? []) {
-    for (const resource of entry.resources ?? []) addLocalAsset(files, resource);
-  }
-  if (manifest.default_locale) files.add('_locales');
+  for (const page of manifest.sandbox?.pages ?? []) htmlPages.push(page);
+  for (const overridePage of Object.values(manifest.chrome_url_overrides ?? {})) htmlPages.push(overridePage);
 
   const visited = new Set();
   for (const htmlPage of htmlPages) {
@@ -128,20 +131,24 @@ async function copyEntry(relativePath, outDir) {
   await fs.copyFile(fromPath, toPath);
 }
 
+async function findMissingEntries(baseDir, entries) {
+  const missingEntries = [];
+  for (const relativePath of entries) {
+    const absolutePath = path.join(baseDir, relativePath);
+    if (!(await exists(absolutePath))) {
+      missingEntries.push(relativePath);
+    }
+  }
+  return missingEntries;
+}
+
 async function main() {
   const { outDir } = parseArgs(process.argv.slice(2));
   const manifestPath = path.join(extensionDir, 'manifest.json');
   const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
 
   const requiredEntries = await collectManifestAssets(manifest);
-  const missingEntries = [];
-
-  for (const relativePath of requiredEntries) {
-    const absolutePath = path.join(extensionDir, relativePath);
-    if (!(await exists(absolutePath))) {
-      missingEntries.push(relativePath);
-    }
-  }
+  const missingEntries = await findMissingEntries(extensionDir, requiredEntries);
 
   if (missingEntries.length > 0) {
     console.error('Missing files referenced by the extension package:');
@@ -154,6 +161,16 @@ async function main() {
 
   for (const relativePath of requiredEntries) {
     await copyEntry(relativePath, outDir);
+  }
+
+  // Guard against regressions where manifest entry files (e.g. action.default_popup)
+  // are accidentally omitted from the packaged directory.
+  const packagedEntrypoints = collectManifestEntrypoints(manifest);
+  const missingPackagedEntrypoints = await findMissingEntries(outDir, packagedEntrypoints);
+  if (missingPackagedEntrypoints.length > 0) {
+    console.error('Packaged extension is missing files referenced by manifest.json:');
+    for (const missingEntry of missingPackagedEntrypoints) console.error(`- ${missingEntry}`);
+    process.exit(1);
   }
 
   console.log(`Extension package prepared at ${path.relative(repoRoot, outDir) || outDir}`);


### PR DESCRIPTION
## Summary
- add `collectManifestEntrypoints()` for direct manifest file references (including `action.default_popup`)
- keep html dependency collection for secondary popup assets (like `popup.js`)
- add a post-copy integrity check to fail `package:release` when manifest-referenced files are missing in output

## Why
`v1.4.1` release zip can miss popup assets while `manifest.json` still references `popup.html`, causing extension install failure:

> The default_popup file in the manifest doesn't exist

This change prevents shipping a broken extension package again.

## Verification
- `cd extension && npm run package:release -- --out ../tmp-ext-verify`
- verified packaged output contains `manifest.json`, `dist/background.js`, `popup.html`, and `popup.js`

Closes #469