### PR TITLE
feat(external): add curlconverter to external CLI registry

### DIFF
--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -21,3 +21,11 @@
   tags: [docker, containers, devops]
   install:
     mac: "brew install --cask docker"
+
+- name: curlconverter
+  binary: curlconverter
+  description: "Convert curl commands to Python, JavaScript, Go, PHP and 40+ other languages"
+  homepage: "https://curlconverter.com"
+  tags: [curl, http, converter, code-gen]
+  install:
+    mac: "npm install -g curlconverter"


### PR DESCRIPTION
## Summary

Add curlconverter to opencli external CLI registry.

## What is curlconverter?

curlconverter converts curl commands to code in 48 programming languages.

## Usage

```bash
opencli curlconverter --language python - <<'EOF'
curl -X POST https://api.example.com -H 'Content-Type: application/json' -d '{"key":"value"}'
EOF
```

## Test Plan
- [x] Registered via opencli register curlconverter
- [x] opencli curlconverter --language python works
- [x] opencli curlconverter --language javascript works