### PR TITLE
chore: release v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump version to 1.5.0

## Changes since v1.4.1

### Features
- **Plugin**: opencli-plugin.json manifest and monorepo plugin support (#475)
- **Zero onboarding**: extension version check and update notifier (#479)
- **Smart error dispatch**: inline Browser Bridge diagnosis (#481)
- **paperreview**: paperreview.ai adapter (#464)
- **imdb**: IMDb adapter with 6 commands (#472)
- **producthunt**: Product Hunt CLI adapter (#462)
- **36kr**: 36氪 CLI adapter (#461)
- **douban**: photo listing and download commands (#474)
- **twitter**: likes command (#448), time column in search (#473)
- **bilibili/xiaohongshu**: comments commands + rate-limiter plugin docs (#457)
- **linux-do**: refactored adapters with unified feed, tags, user commands (#434)
- **chatgpt**: model/mode selection and fix response polling (#438)
- **runtime**: Bun runtime compatibility (#459)
- **record**: API call recording from live browser sessions

### Refactor
- Deduplicate code, improve type safety, simplify error classes (#480)

### Fixes
- Extension release packaging validation (#470)
- Various adapter fixes (jd, xiaohongshu, weread, weixin)
- Stabilize http download temp file handling (#443)
- Restore executable permission on bin entries after tsc build (#446)