### PR TITLE
feat(xiaohongshu): add published_at to search results

### DIFF
--- a/src/clis/xiaohongshu/search.test.ts
+++ b/src/clis/xiaohongshu/search.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { IPage } from '../../types.js';
 import { getRegistry } from '../../registry.js';
-import './search.js';
+import { noteIdToDate } from './search.js';
 
 function createPageMock(evaluateResults: any[]): IPage {
   const evaluate = vi.fn();
@@ -86,6 +86,7 @@ describe('xiaohongshu search', () => {
         title: '某鱼买FSD被坑了4万',
         author: '随风',
         likes: '261',
+        published_at: '2025-10-10',
         url: detailUrl,
         author_url: authorUrl,
       },
@@ -130,5 +131,42 @@ describe('xiaohongshu search', () => {
     // limit=1 should return only the first valid-titled result
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ rank: 1, title: 'Result A' });
+  });
+});
+
+describe('noteIdToDate (ObjectID timestamp parsing)', () => {
+  it('parses a known note ID to the correct China-timezone date', () => {
+    // 0x697f6c74 = 1769958516 → 2026-02-01 in UTC+8
+    expect(noteIdToDate('https://www.xiaohongshu.com/search_result/697f6c74000000002103de17')).toBe('2026-02-01');
+    // 0x68e90be8 → 2025-10-10 in UTC+8
+    expect(noteIdToDate('https://www.xiaohongshu.com/explore/68e90be80000000004022e66')).toBe('2025-10-10');
+  });
+
+  it('returns China date when UTC+8 crosses into the next day', () => {
+    // 0x69b739f0 = 2026-03-15 23:00 UTC = 2026-03-16 07:00 CST
+    // Without UTC+8 offset this would incorrectly return 2026-03-15
+    expect(noteIdToDate('https://www.xiaohongshu.com/search_result/69b739f00000000000000000')).toBe('2026-03-16');
+  });
+
+  it('handles /note/ path variant', () => {
+    expect(noteIdToDate('https://www.xiaohongshu.com/note/697f6c74000000002103de17')).toBe('2026-02-01');
+  });
+
+  it('handles URL with query parameters', () => {
+    expect(noteIdToDate('https://www.xiaohongshu.com/search_result/697f6c74000000002103de17?xsec_token=abc')).toBe('2026-02-01');
+  });
+
+  it('returns empty string for non-matching URLs', () => {
+    expect(noteIdToDate('https://www.xiaohongshu.com/user/profile/635a9c720000000018028b40')).toBe('');
+    expect(noteIdToDate('https://www.xiaohongshu.com/')).toBe('');
+  });
+
+  it('returns empty string for IDs shorter than 24 hex chars', () => {
+    expect(noteIdToDate('https://www.xiaohongshu.com/search_result/abcdef')).toBe('');
+  });
+
+  it('returns empty string when timestamp is out of range', () => {
+    // All zeros → ts = 0
+    expect(noteIdToDate('https://www.xiaohongshu.com/search_result/000000000000000000000000')).toBe('');
   });
 });

--- a/src/clis/xiaohongshu/search.ts
+++ b/src/clis/xiaohongshu/search.ts
@@ -9,6 +9,23 @@
 import { cli, Strategy } from '../../registry.js';
 import { AuthRequiredError } from '../../errors.js';
 
+/**
+ * Extract approximate publish date from a Xiaohongshu note URL.
+ * XHS note IDs follow MongoDB ObjectID format where the first 8 hex
+ * characters encode a Unix timestamp (the moment the ID was generated,
+ * which closely matches publish time but is not an official API field).
+ * e.g. "697f6c74..." → 0x697f6c74 = 1769958516 → 2026-02-01
+ */
+export function noteIdToDate(url: string): string {
+  const match = url.match(/\/(?:search_result|explore|note)\/([0-9a-f]{24})(?=[?#/]|$)/i);
+  if (!match) return '';
+  const hex = match[1].substring(0, 8);
+  const ts = parseInt(hex, 16);
+  if (!ts || ts < 1_000_000_000 || ts > 4_000_000_000) return '';
+  // Offset by UTC+8 (China Standard Time) so the date matches what XHS users see
+  return new Date((ts + 8 * 3600) * 1000).toISOString().slice(0, 10);
+}
+
 cli({
   site: 'xiaohongshu',
   name: 'search',
@@ -19,7 +36,7 @@ cli({
     { name: 'query', required: true, positional: true, help: 'Search keyword' },
     { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
   ],
-  columns: ['rank', 'title', 'author', 'likes', 'url'],
+  columns: ['rank', 'title', 'author', 'likes', 'published_at', 'url'],
   func: async (page, kwargs) => {
     const keyword = encodeURIComponent(kwargs.query);
     await page.goto(
@@ -97,6 +114,7 @@ cli({
       .map((item: any, i: number) => ({
         rank: i + 1,
         ...item,
+        published_at: noteIdToDate(item.url),
       }));
   },
 });


### PR DESCRIPTION
## Description

Add `published_at` column to `xiaohongshu search` by deriving approximate publish date from note IDs. XHS note IDs follow MongoDB ObjectID format where the first 8 hex characters encode a Unix timestamp. This is parsed client-side with UTC+8 offset for China timezone, requiring zero extra network requests.

Related issue: #484

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```
$ opencli xiaohongshu search '特斯拉' --limit 3
┌───────┬──────────────────────────────────────────┬──────────────────┬───────┬──────────────┬────────────────────┐
│ rank  │ title                                    │ author           │ likes │ published_at │ url                │
├───────┼──────────────────────────────────────────┼──────────────────┼───────┼──────────────┼────────────────────┤
│ 1     │ 廉价版特斯拉Model 3标准版生产线落地上海  │ 大厂新视野       │ 4     │ 2026-03-26   │ https://...        │
│ 2     │ 特斯拉最新价格预测...                    │ W隐于市W         │ 18    │ 2026-03-24   │ https://...        │
│ 3     │ 每日一家公司职场内幕——特斯拉（上海）      │ 打工没有自由     │ 221   │ 2025-12-29   │ https://...        │
└───────┴──────────────────────────────────────────┴──────────────────┴───────┴──────────────┴────────────────────┘
```