### PR TITLE
fix(twitter): use DOM-only scraping for trending to match page results

### DIFF
--- a/src/clis/twitter/trending.ts
+++ b/src/clis/twitter/trending.ts
@@ -1,19 +1,6 @@
 import { cli, Strategy } from '../../registry.js';
 import { AuthRequiredError, EmptyResultError } from '../../errors.js';
 
-// ── Twitter GraphQL constants ──────────────────────────────────────────
-
-const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
-
-// ── Types ──────────────────────────────────────────────────────────────
-
-interface TrendItem {
-  rank: number;
-  topic: string;
-  tweets: string;
-  category: string;
-}
-
 // ── CLI definition ────────────────────────────────────────────────────
 
 cli({
@@ -34,79 +21,44 @@ cli({
     await page.goto('https://x.com/explore/tabs/trending');
     await page.wait(3);
 
-    // Extract CSRF token to verify login
+    // Verify login via CSRF cookie
     const ct0 = await page.evaluate(`(() => {
       return document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1] || null;
     })()`);
     if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
-    // Try legacy guide.json API first (faster than DOM scraping)
-    let trends: TrendItem[] = [];
-
-    const apiData = await page.evaluate(`(async () => {
-      const ct0 = document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1] || '';
-      const r = await fetch('/i/api/2/guide.json?include_page_configuration=true', {
-        credentials: 'include',
-        headers: {
-          'x-twitter-active-user': 'yes',
-          'x-csrf-token': ct0,
-          'authorization': 'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
+    // Scrape trends from DOM (consistent with what the user sees on the page)
+    // DOM children: [0] rank + category, [1] topic, optional post count,
+    // and a caret menu button identified by [data-testid="caret"].
+    await page.wait(2);
+    const trends = await page.evaluate(`(() => {
+      const items = [];
+      const cells = document.querySelectorAll('[data-testid="trend"]');
+      cells.forEach((cell) => {
+        const text = cell.textContent || '';
+        if (text.includes('Promoted')) return;
+        const container = cell.querySelector(':scope > div');
+        if (!container) return;
+        const divs = container.children;
+        if (divs.length < 2) return;
+        const topic = divs[1].textContent.trim();
+        if (!topic) return;
+        const catText = divs[0].textContent.trim();
+        const category = catText.replace(/^\\d+\\s*/, '').replace(/^\\xB7\\s*/, '').trim();
+        // Find post count: skip rank, topic, and the caret menu button
+        let tweets = 'N/A';
+        for (let j = 2; j < divs.length; j++) {
+          if (divs[j].matches('[data-testid="caret"]') || divs[j].querySelector('[data-testid="caret"]')) continue;
+          const t = divs[j].textContent.trim();
+          if (t && /\\d/.test(t)) { tweets = t; break; }
         }
+        items.push({ rank: items.length + 1, topic, tweets, category });
       });
-      return r.ok ? await r.json() : null;
+      return items;
     })()`);
 
-    if (apiData) {
-      const instructions = apiData?.timeline?.instructions || [];
-      const entries = instructions.flatMap((inst: any) => inst?.addEntries?.entries || inst?.entries || []);
-      const apiTrends = entries
-        .filter((e: any) => e.content?.timelineModule)
-        .flatMap((e: any) => e.content.timelineModule.items || [])
-        .map((t: any) => t?.item?.content?.trend)
-        .filter(Boolean);
-
-      trends = apiTrends.map((t: any, i: number) => ({
-        rank: i + 1,
-        topic: t.name,
-        tweets: t.tweetCount ? String(t.tweetCount) : 'N/A',
-        category: t.trendMetadata?.domainContext || '',
-      }));
-    }
-
-    // Fallback: scrape from the loaded DOM
-    if (trends.length === 0) {
-      await page.wait(2);
-      const domTrends = await page.evaluate(`(() => {
-        const items = [];
-        const cells = document.querySelectorAll('[data-testid="trend"]');
-        cells.forEach((cell) => {
-          const text = cell.textContent || '';
-          if (text.includes('Promoted')) return;
-          const container = cell.querySelector(':scope > div');
-          if (!container) return;
-          const divs = container.children;
-          // Structure: divs[0] = rank + category, divs[1] = topic name, divs[2] = extra
-          const topicEl = divs.length >= 2 ? divs[1] : null;
-          const topic = topicEl ? topicEl.textContent.trim() : '';
-          const catEl = divs.length >= 1 ? divs[0] : null;
-          const catText = catEl ? catEl.textContent.trim() : '';
-          const category = catText.replace(/^\\d+\\s*/, '').replace(/^\\xB7\\s*/, '').trim();
-          const extraEl = divs.length >= 3 ? divs[2] : null;
-          const extra = extraEl ? extraEl.textContent.trim() : '';
-          if (topic) {
-            items.push({ rank: items.length + 1, topic, tweets: extra || 'N/A', category });
-          }
-        });
-        return items;
-      })()`);
-
-      if (Array.isArray(domTrends) && domTrends.length > 0) {
-        trends = domTrends;
-      }
-    }
-
-    if (trends.length === 0) {
-      throw new EmptyResultError('twitter trending', 'API may have changed or login may be required.');
+    if (!Array.isArray(trends) || trends.length === 0) {
+      throw new EmptyResultError('twitter trending', 'No trends found. The page structure may have changed.');
     }
 
     return trends.slice(0, limit);


### PR DESCRIPTION
## Description

Remove the `guide.json` API path from `twitter trending` command. The API returned data inconsistent with what users see on the trending page, causing #463.

Now uses DOM-only scraping with semantic caret button detection (`data-testid="caret"`) instead of position-based heuristics, and validates post count text contains digits before displaying.

Related issue: #463

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```
  twitter/trending
┌──────┬───────────────────────────────────┬────────┬─────────────┐
│ Rank │ Topic                             │ Tweets │ Category    │
├──────┼───────────────────────────────────┼────────┼─────────────┤
│ 1    │ ストーカー                        │ N/A    │ 日本 的趋势 │
├──────┼───────────────────────────────────┼────────┼─────────────┤
│ 2    │ トライネン                        │ N/A    │ 日本 的趋势 │
├──────┼───────────────────────────────────┼────────┼─────────────┤
│ 3    │ #倍ビッグマックはデッッカすぎ     │ N/A    │ 美食 趋势   │
└──────┴───────────────────────────────────┴────────┴─────────────┘
```