### PR TITLE
fix(xiaohongshu): adapt publish to new two-step creator center UI

### DIFF
--- a/src/clis/xiaohongshu/publish.test.ts
+++ b/src/clis/xiaohongshu/publish.test.ts
@@ -51,7 +51,7 @@ describe('xiaohongshu publish', () => {
     const page = createPageMock([
       'https://creator.xiaohongshu.com/publish/publish?from=menu_left',
       { ok: true, target: '上传图文', text: '上传图文' },
-      { hasTitleInput: true, hasImageInput: true, hasVideoSurface: false },
+      { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false },
       { ok: true, count: 1 },
       false,
       true, // waitForEditForm: editor appeared
@@ -92,10 +92,10 @@ describe('xiaohongshu publish', () => {
     const page = createPageMock([
       'https://creator.xiaohongshu.com/publish/publish?from=menu_left',
       { ok: false, visibleTexts: ['上传视频', '上传图文'] },
-      { hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
-      { hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
-      { hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
-      { hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
+      { state: 'video_surface', hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
+      { state: 'video_surface', hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
+      { state: 'video_surface', hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
+      { state: 'video_surface', hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
     ]);
 
     await expect(cmd!.func!(page, {
@@ -120,8 +120,8 @@ describe('xiaohongshu publish', () => {
     const page = createPageMock([
       'https://creator.xiaohongshu.com/publish/publish?from=menu_left',
       { ok: true, target: '上传图文', text: '上传图文' },
-      { hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
-      { hasTitleInput: true, hasImageInput: true, hasVideoSurface: false },
+      { state: 'video_surface', hasTitleInput: false, hasImageInput: false, hasVideoSurface: true },
+      { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false },
       { ok: true, count: 1 }, // injectImages
       false, // waitForUploads: no progress indicator
       true, // waitForEditForm: editor appeared

--- a/src/clis/xiaohongshu/publish.ts
+++ b/src/clis/xiaohongshu/publish.ts
@@ -221,12 +221,19 @@ async function selectImageTextTab(
   return result;
 }
 
-async function inspectPublishSurface(
-  page: IPage,
-): Promise<{ hasTitleInput: boolean; hasImageInput: boolean; hasVideoSurface: boolean }> {
+type PublishSurfaceState = 'video_surface' | 'image_surface' | 'editor_ready';
+
+type PublishSurfaceInspection = {
+  state: PublishSurfaceState;
+  hasTitleInput: boolean;
+  hasImageInput: boolean;
+  hasVideoSurface: boolean;
+};
+
+async function inspectPublishSurfaceState(page: IPage): Promise<PublishSurfaceInspection> {
   return page.evaluate(`
     () => {
-      const text = (document.body?.innerText || '').replace(/\\s+/g, ' ').trim();
+      const text = (document.body?.innerText || '').replace(/\s+/g, ' ').trim();
       const hasTitleInput = !!Array.from(document.querySelectorAll('input, textarea')).find((el) => {
         if (!el || el.offsetParent === null) return false;
         const placeholder = (el.getAttribute('placeholder') || '').trim();
@@ -250,30 +257,28 @@ async function inspectPublishSurface(
           accept.includes('.webp')
         );
       });
-      return {
-        hasTitleInput,
-        hasImageInput,
-        hasVideoSurface: text.includes('拖拽视频到此处点击上传') || text.includes('上传视频'),
-      };
+      const hasVideoSurface = text.includes('拖拽视频到此处点击上传') || text.includes('上传视频');
+      const state = hasTitleInput ? 'editor_ready' : hasImageInput || !hasVideoSurface ? 'image_surface' : 'video_surface';
+      return { state, hasTitleInput, hasImageInput, hasVideoSurface };
     }
   `);
 }
 
-async function waitForImageTextSurface(
+async function waitForPublishSurfaceState(
   page: IPage,
   maxWaitMs = 5_000,
-): Promise<{ hasTitleInput: boolean; hasImageInput: boolean; hasVideoSurface: boolean }> {
+): Promise<PublishSurfaceInspection> {
   const pollMs = 500;
   const maxAttempts = Math.max(1, Math.ceil(maxWaitMs / pollMs));
-  let surface = await inspectPublishSurface(page);
+  let surface = await inspectPublishSurfaceState(page);
 
   for (let i = 0; i < maxAttempts; i++) {
-    if (surface.hasTitleInput || surface.hasImageInput || !surface.hasVideoSurface) {
+    if (surface.state !== 'video_surface') {
       return surface;
     }
     if (i < maxAttempts - 1) {
       await page.wait({ time: pollMs / 1_000 });
-      surface = await inspectPublishSurface(page);
+      surface = await inspectPublishSurfaceState(page);
     }
   }
 
@@ -359,8 +364,8 @@ cli({
 
     // ── Step 2: Select 图文 (image+text) note type if tabs are present ─────────
     const tabResult = await selectImageTextTab(page);
-    const surface = await waitForImageTextSurface(page, tabResult?.ok ? 5_000 : 2_000);
-    if (!surface.hasTitleInput && !surface.hasImageInput && surface.hasVideoSurface) {
+    const surface = await waitForPublishSurfaceState(page, tabResult?.ok ? 5_000 : 2_000);
+    if (surface.state === 'video_surface') {
       await page.screenshot({ path: '/tmp/xhs_publish_tab_debug.png' });
       const detail = tabResult?.ok
         ? `clicked "${tabResult.text}"`


### PR DESCRIPTION
## Description

Adapt `xiaohongshu publish` to the new creator center two-step UI where images must be uploaded before the title/content editor form appears. Previously the command failed with "Could not find title input" because the editor only renders after image upload.

Related issue: #460

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Before (failing):
```
📭 Could not find title input. Debug screenshot: /tmp/xhs_publish_title_debug.png
```

After (working):
```
  xiaohongshu/publish
┌───────────────────────────────┬──────────────────────────────────┐
│ Status                        │ Detail                           │
├───────────────────────────────┼──────────────────────────────────┤
│ ⚠️ 操作完成，请在浏览器中确认 │ "测试标题" · 1张图片             │
└───────────────────────────────┴──────────────────────────────────┘
```