### PR TITLE
fix(v2ex): fetch hot topics through browser context

### DIFF
--- a/src/clis/v2ex/hot.yaml
+++ b/src/clis/v2ex/hot.yaml
@@ -12,18 +12,21 @@ args:
     description: Number of topics
 
 pipeline:
-  - navigate: https://www.v2ex.com/api/topics/hot.json
+  - navigate: https://www.v2ex.com/
 
   - evaluate: |
       (async () => {
-        // 获取页面中的JSON数据
-        const preElement = document.querySelector('pre');
-        if (preElement) {
-          const jsonText = preElement.textContent;
-          const data = JSON.parse(jsonText);
-          return data;
+        const response = await fetch('/api/topics/hot.json', {
+          credentials: 'include',
+          headers: {
+            accept: 'application/json, text/plain, */*',
+            'x-requested-with': 'XMLHttpRequest',
+          },
+        });
+        if (!response.ok) {
+          throw new Error(`V2EX hot API request failed: ${response.status}`);
         }
-        return [];
+        return await response.json();
       })()
 
   - map:


### PR DESCRIPTION
## Summary
- switch v2ex hot from direct non-browser fetch to browser-context API access
- open a normal V2EX page first, then fetch /api/topics/hot.json inside the page context
- avoid coupling the command to the API page rendering details

## Why
V2EX is rate-limiting or blocking direct API access from the non-browser path, while requests issued inside a real browser session still succeed.

## Validation
- rebased onto latest origin/main
- reviewed the final YAML pipeline logic
- GitHub checks were not reported on this PR branch at review time