### PR TITLE
fix(plugin): remove legacy LOCK_FILE/MONOREPOS_DIR constants

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -16,7 +16,6 @@ const { mockExecFileSync, mockExecSync } = vi.hoisted(() => ({
 }));
 
 const {
-  LOCK_FILE,
   _getCommitHash,
   _installDependencies,
   _postInstallMonorepoLifecycle,
@@ -31,6 +30,7 @@ const {
   _writeLockFile,
   _isSymlinkSync,
   _getMonoreposDir,
+  getLockFilePath,
 } = pluginModule;
 
 describe('parseSource', () => {
@@ -128,28 +128,28 @@ describe('validatePluginStructure', () => {
 });
 
 describe('lock file', () => {
-  const backupPath = `${LOCK_FILE}.test-backup`;
+  const backupPath = `${getLockFilePath()}.test-backup`;
   let hadOriginal = false;
 
   beforeEach(() => {
-    hadOriginal = fs.existsSync(LOCK_FILE);
+    hadOriginal = fs.existsSync(getLockFilePath());
     if (hadOriginal) {
       fs.mkdirSync(path.dirname(backupPath), { recursive: true });
-      fs.copyFileSync(LOCK_FILE, backupPath);
+      fs.copyFileSync(getLockFilePath(), backupPath);
     }
   });
 
   afterEach(() => {
     if (hadOriginal) {
-      fs.copyFileSync(backupPath, LOCK_FILE);
+      fs.copyFileSync(backupPath, getLockFilePath());
       fs.unlinkSync(backupPath);
       return;
     }
-    try { fs.unlinkSync(LOCK_FILE); } catch {}
+    try { fs.unlinkSync(getLockFilePath()); } catch {}
   });
 
   it('reads empty lock when file does not exist', () => {
-    try { fs.unlinkSync(LOCK_FILE); } catch {}
+    try { fs.unlinkSync(getLockFilePath()); } catch {}
     expect(_readLockFile()).toEqual({});
   });
 
@@ -173,8 +173,8 @@ describe('lock file', () => {
   });
 
   it('handles malformed lock file gracefully', () => {
-    fs.mkdirSync(path.dirname(LOCK_FILE), { recursive: true });
-    fs.writeFileSync(LOCK_FILE, 'not valid json');
+    fs.mkdirSync(path.dirname(getLockFilePath()), { recursive: true });
+    fs.writeFileSync(getLockFilePath(), 'not valid json');
     expect(_readLockFile()).toEqual({});
   });
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -39,9 +39,7 @@ export function getMonoreposDir(): string {
   return path.join(getHomeDir(), '.opencli', 'monorepos');
 }
 
-// Legacy const for backward compatibility (computed at load time)
-export const LOCK_FILE = path.join(os.homedir(), '.opencli', 'plugins.lock.json');
-export const MONOREPOS_DIR = path.join(os.homedir(), '.opencli', 'monorepos');
+
 
 export interface LockEntry {
   source: string;


### PR DESCRIPTION
## Problem

`plugin.ts` had two parallel path systems:
- Legacy constants (`LOCK_FILE`, `MONOREPOS_DIR`) computed at module load time via `os.homedir()`
- Getter functions (`getLockFilePath()`, `getMonoreposDir()`) that read `process.env.HOME` at call time

When tests set `HOME` for isolation, these diverge — the constants still point to the real home, while the functions point to the test directory.

## Fix

Remove the legacy constants. All code now uses `getLockFilePath()` and `getMonoreposDir()`. Updated `plugin.test.ts` to use `getLockFilePath()`.

## Testing

All 337 unit tests pass.