### PR TITLE
perf: parallel file discovery and external CLI caching

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,9 +76,10 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
       for (const [site, cmds] of sites) {
         console.log(chalk.bold.cyan(`  ${site}`));
         for (const cmd of cmds) {
-          const tag = strategyLabel(cmd) === 'public'
+          const label = strategyLabel(cmd);
+          const tag = label === 'public'
             ? chalk.green('[public]')
-            : chalk.yellow(`[${strategyLabel(cmd)}]`);
+            : chalk.yellow(`[${label}]`);
           console.log(`    ${cmd.name} ${tag}${cmd.description ? chalk.dim(` — ${cmd.description}`) : ''}`);
         }
         console.log();

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -127,24 +127,20 @@ async function discoverClisFromFs(dir: string): Promise<void> {
       const site = entry.name;
       const siteDir = path.join(dir, site);
       const files = await fs.promises.readdir(siteDir);
-      const filePromises: Promise<unknown>[] = [];
-      for (const file of files) {
+      await Promise.all(files.map(async (file) => {
         const filePath = path.join(siteDir, file);
         if (file.endsWith('.yaml') || file.endsWith('.yml')) {
-          filePromises.push(registerYamlCli(filePath, site));
+          await registerYamlCli(filePath, site);
         } else if (
           (file.endsWith('.js') && !file.endsWith('.d.js')) ||
           (file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts'))
         ) {
-          if (!(await isCliModule(filePath))) continue;
-          filePromises.push(
-            import(pathToFileURL(filePath).href).catch((err) => {
-              log.warn(`Failed to load module ${filePath}: ${getErrorMessage(err)}`);
-            })
-          );
+          if (!(await isCliModule(filePath))) return;
+          await import(pathToFileURL(filePath).href).catch((err) => {
+            log.warn(`Failed to load module ${filePath}: ${getErrorMessage(err)}`);
+          });
         }
-      }
-      await Promise.all(filePromises);
+      }));
     });
   await Promise.all(sitePromises);
 }
@@ -195,11 +191,11 @@ async function registerYamlCli(filePath: string, defaultSite: string): Promise<v
 export async function discoverPlugins(): Promise<void> {
   try { await fs.promises.access(PLUGINS_DIR); } catch { return; }
   const entries = await fs.promises.readdir(PLUGINS_DIR, { withFileTypes: true });
-  for (const entry of entries) {
+  await Promise.all(entries.map(async (entry) => {
     const pluginDir = path.join(PLUGINS_DIR, entry.name);
-    if (!(await isDiscoverablePluginDir(entry, pluginDir))) continue;
+    if (!(await isDiscoverablePluginDir(entry, pluginDir))) return;
     await discoverPluginDir(pluginDir, entry.name);
-  }
+  }));
 }
 
 /**
@@ -209,33 +205,26 @@ export async function discoverPlugins(): Promise<void> {
 async function discoverPluginDir(dir: string, site: string): Promise<void> {
   const files = await fs.promises.readdir(dir);
   const fileSet = new Set(files);
-  const promises: Promise<unknown>[] = [];
-  for (const file of files) {
+  await Promise.all(files.map(async (file) => {
     const filePath = path.join(dir, file);
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
-      promises.push(registerYamlCli(filePath, site));
+      await registerYamlCli(filePath, site);
     } else if (file.endsWith('.js') && !file.endsWith('.d.js')) {
-      if (!(await isCliModule(filePath))) continue;
-      promises.push(
-        import(pathToFileURL(filePath).href).catch((err) => {
-          log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
-        })
-      );
+      if (!(await isCliModule(filePath))) return;
+      await import(pathToFileURL(filePath).href).catch((err) => {
+        log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
+      });
     } else if (
       file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts')
     ) {
-      // Skip .ts if a compiled .js sibling exists (production mode can't load .ts)
       const jsFile = file.replace(/\.ts$/, '.js');
-      if (fileSet.has(jsFile)) continue;
-      if (!(await isCliModule(filePath))) continue;
-      promises.push(
-        import(pathToFileURL(filePath).href).catch((err) => {
-          log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
-        })
-      );
+      if (fileSet.has(jsFile)) return;
+      if (!(await isCliModule(filePath))) return;
+      await import(pathToFileURL(filePath).href).catch((err) => {
+        log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
+      });
     }
-  }
-  await Promise.all(promises);
+  }));
 }
 
 async function isCliModule(filePath: string): Promise<boolean> {

--- a/src/external.ts
+++ b/src/external.ts
@@ -31,7 +31,10 @@ function getUserRegistryPath(): string {
   return path.join(home, '.opencli', 'external-clis.yaml');
 }
 
+let _cachedExternalClis: ExternalCliConfig[] | null = null;
+
 export function loadExternalClis(): ExternalCliConfig[] {
+  if (_cachedExternalClis) return _cachedExternalClis;
   const configs = new Map<string, ExternalCliConfig>();
 
   // 1. Load built-in
@@ -60,7 +63,8 @@ export function loadExternalClis(): ExternalCliConfig[] {
     log.warn(`Failed to parse user external-clis.yaml: ${getErrorMessage(err)}`);
   }
 
-  return Array.from(configs.values()).sort((a, b) => a.name.localeCompare(b.name));
+  _cachedExternalClis = Array.from(configs.values()).sort((a, b) => a.name.localeCompare(b.name));
+  return _cachedExternalClis;
 }
 
 export function isBinaryInstalled(binary: string): boolean {
@@ -237,5 +241,6 @@ export function registerExternalCli(name: string, opts?: RegisterOptions): void 
 
   const dump = yaml.dump(items, { indent: 2, sortKeys: true });
   fs.writeFileSync(userPath, dump, 'utf8');
+  _cachedExternalClis = null; // Invalidate cache so next load reflects the change
   console.log(chalk.dim(userPath));
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ const __dirname = path.dirname(__filename);
 const BUILTIN_CLIS = path.resolve(__dirname, 'clis');
 const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 
+// Sequential: plugins must run after built-in discovery so they can override built-in commands.
 await discoverClis(BUILTIN_CLIS, USER_CLIS);
 await discoverPlugins();
 


### PR DESCRIPTION
## Summary
- Parallelize file scanning in `discoverClisFromFs` and `discoverPluginDir` — `isCliModule` checks now run concurrently via `Promise.all(files.map(async ...))` instead of serial `for-of` with `await`
- Parallelize plugin directory scanning in `discoverPlugins`
- Cache `loadExternalClis()` result to avoid re-parsing YAML on repeated calls, with proper invalidation in `registerExternalCli`
- Cache `strategyLabel()` call in list command

## Test plan
- [x] `tsc --noEmit` passes
- [x] 568/569 tests pass (1 flaky e2e network test)
- [x] No semantic change: plugin override order preserved (sequential discovery kept intentionally)