### PR TITLE
fix(plugin): prevent raw .ts import crash when esbuild transpilation fails

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -218,11 +218,14 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
       file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts')
     ) {
       const jsFile = file.replace(/\.ts$/, '.js');
+      // Prefer compiled .js — skip the .ts source file
       if (fileSet.has(jsFile)) return;
-      if (!(await isCliModule(filePath))) return;
-      await import(pathToFileURL(filePath).href).catch((err) => {
-        log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
-      });
+      // No compiled .js found — cannot import raw .ts in production Node.js.
+      // This typically means esbuild transpilation failed during plugin install.
+      log.warn(
+        `Plugin ${site}/${file}: no compiled .js found. ` +
+        `Run "opencli plugin update ${site}" to re-transpile, or install esbuild.`
+      );
     }
   }));
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -937,7 +937,10 @@ function transpilePluginTs(pluginDir: string): void {
     const esbuildBin = resolveEsbuildBin();
 
     if (!esbuildBin) {
-      log.debug('esbuild not found in host node_modules, via resolve, or in PATH, skipping TS transpilation');
+      log.warn(
+        'esbuild not found. TS plugin files will not be transpiled and may fail to load. ' +
+        'Install esbuild (`npm i -g esbuild`) or ensure it is available in the opencli host node_modules.'
+      );
       return;
     }
 
@@ -965,8 +968,8 @@ function transpilePluginTs(pluginDir: string): void {
         log.warn(`Failed to transpile ${tsFile}: ${getErrorMessage(err)}`);
       }
     }
-  } catch {
-    // Non-fatal: skip transpilation if anything goes wrong
+  } catch (err) {
+    log.warn(`TS transpilation setup failed: ${getErrorMessage(err)}`);
   }
 }
 


### PR DESCRIPTION
## Problem

Fixes #500

When a TS plugin is installed but esbuild is unavailable or transpilation fails silently, the plugin discovery attempts to `import()` the raw `.ts` file at runtime, causing:

```
⚠ Plugin hot-digest/aggregate.ts: Unknown file extension ".ts"
```

### Root Cause

1. `transpilePluginTs()` silently swallows all errors (bare `catch {}`), so if esbuild isn't available, no `.js` file is generated and no warning is shown
2. `discoverPluginDir()` sees the `.ts` file with no `.js` companion and attempts direct `import()`, which fails on production Node.js (only works under `tsx` in dev mode)

## Changes

### `src/discovery.ts`
- When a `.ts` plugin file has no compiled `.js` companion, **skip the import** and show an actionable warning:
  `Plugin hot-digest/aggregate.ts: no compiled .js found. Run "opencli plugin update hot-digest" to re-transpile, or install esbuild.`

### `src/plugin.ts`
- Upgrade "esbuild not found" message from `log.debug` → `log.warn` so users know TS plugins won't work
- Log the outer catch error instead of silently swallowing it

## Testing
- All 50 existing plugin tests pass
- Manual verification: removing `.js` from hot-digest plugin now shows a clear warning instead of crashing