### PR TITLE
feat(plugin): support multi-source plugin install (ssh, git@, generic https)

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -31,9 +31,19 @@ Plugins live in `~/.opencli/plugins/<name>/`. Each subdirectory is scanned at st
 ### Supported Source Formats
 
 ```bash
+# GitHub shorthand
 opencli plugin install github:user/repo
 opencli plugin install github:user/repo/subplugin   # install specific sub-plugin from monorepo
 opencli plugin install https://github.com/user/repo
+
+# Any git-cloneable URL
+opencli plugin install https://gitlab.example.com/team/repo.git
+opencli plugin install ssh://git@gitlab.example.com/team/repo.git
+opencli plugin install git@gitlab.example.com:team/repo.git
+
+# Local plugin (for development)
+opencli plugin install file:///path/to/plugin
+opencli plugin install /path/to/plugin
 ```
 
 The repo name prefix `opencli-plugin-` is automatically stripped for the local directory name. For example, `opencli-plugin-hot-digest` becomes `hot-digest`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -253,7 +253,7 @@ export function runCli(BUILTIN_CLIS: string, USER_CLIS: string): void {
 
   pluginCmd
     .command('install')
-    .description('Install a plugin from GitHub')
+    .description('Install a plugin from a git repository')
     .argument('<source>', 'Plugin source (e.g. github:user/repo)')
     .action(async (source: string) => {
       const { installPlugin } = await import('./plugin.js');

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -99,6 +99,71 @@ describe('parseSource', () => {
     const result = _parseSource(localDir);
     expect(result!.name).toBe('foo');
   });
+
+  // ── Generic git URL support ──
+  it('parses ssh:// URLs', () => {
+    const result = _parseSource('ssh://git@gitlab.com/team/opencli-plugin-tools.git');
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'ssh://git@gitlab.com/team/opencli-plugin-tools.git',
+      name: 'tools',
+    });
+  });
+
+  it('parses ssh:// URLs without .git suffix', () => {
+    const result = _parseSource('ssh://git@gitlab.com/team/my-plugin');
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'ssh://git@gitlab.com/team/my-plugin',
+      name: 'my-plugin',
+    });
+  });
+
+  it('parses git@ SCP-style URLs', () => {
+    const result = _parseSource('git@gitlab.com:team/my-plugin.git');
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'git@gitlab.com:team/my-plugin.git',
+      name: 'my-plugin',
+    });
+  });
+
+  it('parses git@ SCP-style URLs and strips opencli-plugin- prefix', () => {
+    const result = _parseSource('git@github.com:user/opencli-plugin-awesome.git');
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'git@github.com:user/opencli-plugin-awesome.git',
+      name: 'awesome',
+    });
+  });
+
+  it('parses generic HTTPS git URLs (non-GitHub)', () => {
+    const result = _parseSource('https://codehub.example.com/Team/App/opencli-plugins-app.git');
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'https://codehub.example.com/Team/App/opencli-plugins-app.git',
+      name: 'opencli-plugins-app',
+    });
+  });
+
+  it('parses generic HTTPS git URLs without .git suffix', () => {
+    const result = _parseSource('https://gitlab.example.com/org/my-plugin');
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'https://gitlab.example.com/org/my-plugin.git',
+      name: 'my-plugin',
+    });
+  });
+
+  it('still prefers GitHub shorthand over generic HTTPS for github.com', () => {
+    const result = _parseSource('https://github.com/user/repo');
+    // Should be handled by the GitHub-specific matcher (normalizes URL)
+    expect(result).toEqual({
+      type: 'git',
+      cloneUrl: 'https://github.com/user/repo.git',
+      name: 'repo',
+    });
+  });
 });
 
 describe('validatePluginStructure', () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -255,6 +255,9 @@ export function installPlugin(source: string): string | string[] {
       `  github:user/repo\n` +
       `  github:user/repo/subplugin\n` +
       `  https://github.com/user/repo\n` +
+      `  https://<host>/<path>/repo.git\n` +
+      `  ssh://git@<host>/<path>/repo.git\n` +
+      `  git@<host>:user/repo.git\n` +
       `  file:///absolute/path\n` +
       `  /absolute/path`
     );
@@ -831,6 +834,42 @@ function parseSource(
       cloneUrl: `https://github.com/${user}/${repo}.git`,
       name,
     };
+  }
+
+  // ── Generic git URL support ─────────────────────────────────────────────
+
+  // ssh://git@host/path/to/repo.git
+  const sshUrlMatch = source.match(/^ssh:\/\/[^/]+\/(.*?)(?:\.git)?$/);
+  if (sshUrlMatch) {
+    const pathPart = sshUrlMatch[1];
+    const segments = pathPart.split('/');
+    const repoSegment = segments.pop()!;
+    const name = repoSegment.replace(/^opencli-plugin-/, '');
+    return { type: 'git', cloneUrl: source, name };
+  }
+
+  // git@host:user/repo.git (SCP-style)
+  const scpMatch = source.match(/^git@[^:]+:(.+?)(?:\.git)?$/);
+  if (scpMatch) {
+    const pathPart = scpMatch[1];
+    const segments = pathPart.split('/');
+    const repoSegment = segments.pop()!;
+    const name = repoSegment.replace(/^opencli-plugin-/, '');
+    return { type: 'git', cloneUrl: source, name };
+  }
+
+  // Generic https/http git URL (non-GitHub hosts)
+  const genericHttpMatch = source.match(
+    /^https?:\/\/[^/]+\/(.+?)(?:\.git)?$/,
+  );
+  if (genericHttpMatch) {
+    const pathPart = genericHttpMatch[1];
+    const segments = pathPart.split('/');
+    const repoSegment = segments.pop()!;
+    const name = repoSegment.replace(/^opencli-plugin-/, '');
+    // Ensure clone URL ends with .git
+    const cloneUrl = source.endsWith('.git') ? source : `${source}.git`;
+    return { type: 'git', cloneUrl, name };
   }
 
   return null;


### PR DESCRIPTION
## Summary

Extends `parseSource()` to accept any git-cloneable URL, not just GitHub:

- `ssh://git@host/path/repo.git`
- `git@host:user/repo.git` (SCP-style)
- `https://any-host.com/path/repo.git`

GitHub shorthand (`github:user/repo`) and local paths continue to work unchanged.

## Changes

- **`src/plugin.ts`**: Added 3 new URL matchers (SSH, SCP, generic HTTPS) to `parseSource()` as fallbacks after the existing GitHub-specific patterns. Updated the error message in `installPlugin()` to list all supported formats.
- **`src/cli.ts`**: Changed CLI description from 'Install a plugin from GitHub' → 'Install a plugin from a git repository'.
- **`src/plugin.test.ts`**: Added 7 new unit tests covering all new URL formats.
- **`docs/guide/plugins.md`**: Updated 'Supported Source Formats' section with new URL examples.

## Testing

- All 507 tests pass (55 test files, 0 failures)
- 7 new parseSource tests cover SSH, SCP-style, generic HTTPS, prefix stripping, and GitHub priority

Closes #492