### PR TITLE
fix(browser): retry settle probe after SPA client-side redirect

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -45,6 +45,12 @@ describe('browser helpers', () => {
     await expect(__test__.withTimeoutMs(new Promise(() => {}), 10, 'timeout')).rejects.toThrow('timeout');
   });
 
+  it('retries settle only for target-invalidated errors', () => {
+    expect(__test__.isRetryableSettleError(new Error('{"code":-32000,"message":"Inspected target navigated or closed"}'))).toBe(true);
+    expect(__test__.isRetryableSettleError(new Error('attach failed: target no longer exists'))).toBe(false);
+    expect(__test__.isRetryableSettleError(new Error('malformed exec payload'))).toBe(false);
+  });
+
   it('prefers the real Electron app target over DevTools and blank pages', () => {
     const target = __test__.selectCDPTarget([
       {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -15,6 +15,7 @@ export type { DomSnapshotOptions } from './dom-snapshot.js';
 
 import { extractTabEntries, diffTabIndexes, appendLimited } from './tabs.js';
 import { __test__ as cdpTest } from './cdp.js';
+import { isRetryableSettleError } from './page.js';
 import { withTimeoutMs } from '../runtime.js';
 
 export const __test__ = {
@@ -24,4 +25,5 @@ export const __test__ = {
   withTimeoutMs,
   selectCDPTarget: cdpTest.selectCDPTarget,
   scoreCDPTarget: cdpTest.scoreCDPTarget,
+  isRetryableSettleError,
 };

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -28,6 +28,12 @@ import {
   waitForDomStableJs,
 } from './dom-helpers.js';
 
+export function isRetryableSettleError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes('Inspected target navigated or closed')
+    || (message.includes('-32000') && message.toLowerCase().includes('target'));
+}
+
 /**
  * Page — implements IPage by talking to the daemon via HTTP.
  */
@@ -81,14 +87,16 @@ export class Page implements IPage {
       };
       try {
         await sendCommand('exec', settleOpts);
-      } catch {
+      } catch (err) {
+        if (!isRetryableSettleError(err)) throw err;
         // SPA client-side redirects can invalidate the CDP target after
         // chrome.tabs reports 'complete'. Wait briefly for the new document
         // to load, then retry the settle probe once.
         try {
           await new Promise((r) => setTimeout(r, 200));
           await sendCommand('exec', settleOpts);
-        } catch {
+        } catch (retryErr) {
+          if (!isRetryableSettleError(retryErr)) throw retryErr;
           // Retry also failed — give up silently. Settle is best-effort
           // after successful navigation; the next real command will surface
           // any persistent target error immediately.


### PR DESCRIPTION
## Description

When SPA sites like `creator.xiaohongshu.com` trigger a client-side redirect after `chrome.tabs` reports `status: 'complete'`, the CDP target is invalidated. The `waitForDomStable` probe in `page.goto()` was unprotected, causing `-32000 "Inspected target navigated or closed"`.

This wraps the settle probe in try/catch with a single 200ms-delayed retry, consistent with the existing stealth injection error handling pattern (line 63-70). The retry gives the SPA redirect time to complete, while the outer catch ensures settle failure never crashes `goto()` since navigation itself already succeeded.

Related issue: #502, #467

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Minimal reproduction (before fix):
```
$ opencli xiaohongshu creator-profile --verbose
[pre-nav] Failed to navigate to https://creator.xiaohongshu.com:
{"code":-32000,"message":"Inspected target navigated or closed"}
```

After fix: settle probe retries once after 200ms, SPA redirect completes, page settles normally.