### PR TITLE
fix(extension): minimize automation window + reduce idle timeout

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -164,6 +164,7 @@ function connect() {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
+    ws?.send(JSON.stringify({ type: "hello", version: chrome.runtime.getManifest().version }));
   };
   ws.onmessage = async (event) => {
     try {
@@ -195,7 +196,7 @@ function scheduleReconnect() {
   }, delay);
 }
 const automationSessions = /* @__PURE__ */ new Map();
-const WINDOW_IDLE_TIMEOUT = 12e4;
+const WINDOW_IDLE_TIMEOUT = 3e4;
 function getWorkspaceKey(workspace) {
   return workspace?.trim() || "default";
 }
@@ -230,7 +231,8 @@ async function getAutomationWindow(workspace) {
     focused: false,
     width: 1280,
     height: 900,
-    type: "normal"
+    type: "normal",
+    state: "minimized"
   });
   const session = {
     windowId: win.id,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -106,7 +106,7 @@ type AutomationSession = {
 };
 
 const automationSessions = new Map<string, AutomationSession>();
-const WINDOW_IDLE_TIMEOUT = 120000; // 120s — longer to survive slow pipelines
+const WINDOW_IDLE_TIMEOUT = 30000; // 30s — quick cleanup after command finishes
 
 function getWorkspaceKey(workspace?: string): string {
   return workspace?.trim() || 'default';
@@ -152,6 +152,7 @@ async function getAutomationWindow(workspace: string): Promise<number> {
     width: 1280,
     height: 900,
     type: 'normal',
+    state: 'minimized',
   });
   const session: AutomationSession = {
     windowId: win.id!,


### PR DESCRIPTION
## Summary
- Create automation window with `state: 'minimized'` — no more visible blank `data:text/html` tab during command execution
- Reduce idle timeout from 120s to 30s — window auto-closes quickly after the last command finishes

## Why
Users see a jarring blank `data:text/html,<html></html>` page pop up when running browser commands. The window was created with `focused: false` but still visible in the taskbar. Minimizing it makes the automation fully invisible.

The 120s idle timeout was overly generous — most commands finish in <30s, and the lingering window confused users.

## Test plan
- [ ] Run a browser command, verify no visible window appears
- [ ] Verify command still works correctly with minimized window
- [ ] Verify window auto-closes ~30s after last command