### PR TITLE
fix(extension): change automation window state from minimized to normal

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -232,7 +232,7 @@ async function getAutomationWindow(workspace) {
     width: 1280,
     height: 900,
     type: "normal",
-    state: "minimized"
+    state: "normal"
   });
   const session = {
     windowId: win.id,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -152,7 +152,7 @@ async function getAutomationWindow(workspace: string): Promise<number> {
     width: 1280,
     height: 900,
     type: 'normal',
-    state: 'minimized',
+    state: 'normal',
   });
   const session: AutomationSession = {
     windowId: win.id!,


### PR DESCRIPTION
## Description

`chrome.windows.create` with `state: 'minimized'` (introduced in #521) fails when combined with `width`/`height` parameters. The Chrome Extensions API [explicitly prohibits](https://developer.chrome.com/docs/extensions/reference/api/windows#method-create) this combination:

> The `minimized`, `maximized`, and `fullscreen` states cannot be combined with `left`, `top`, `width`, or `height`.

This caused `opencli doctor` (and all browser commands) to fail with "Invalid value for state".

Fix: revert `state: 'minimized'` to `state: 'normal'`. The 30s idle timeout from #521 is preserved.

Fixes #526

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Before (from #526):
```
[FAIL] Connectivity: failed (Invalid value for state)
```

After:
```
[OK] Connectivity: connected in 1.0s
```