### PR TITLE
docs(readme): restructure quick start, full command list, anti-detection highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A CLI tool that turns **any website**, **Electron app**, or **local CLI tool** i
 
 - **CLI All Electron** — CLI-ify apps like Antigravity Ultra! Now AI can control itself natively.
 - **Account-safe** — Reuses Chrome's logged-in state; your credentials never leave the browser.
+- **Anti-detection built-in** — Patches `navigator.webdriver`, stubs `window.chrome`, fakes plugin lists, cleans ChromeDriver/Playwright globals, and strips CDP frames from Error stack traces. Extensive anti-fingerprinting and risk-control evasion measures baked in at every layer.
 - **AI Agent ready** — `explore` discovers APIs, `synthesize` generates adapters, `cascade` finds auth strategies.
 - **External CLI Hub** — Discover, auto-install, and passthrough commands to any external CLI (gh, obsidian, docker, etc). Zero setup.
 - **Self-healing setup** — `opencli doctor` diagnoses and auto-starts the daemon, extension, and live browser connectivity.


### PR DESCRIPTION
## Summary

- Quick Start 重排：第一步为 Browser Bridge Extension 安装，For Developers 独立章节（Install from source + Load Source Extension）
- Built-in Commands 展开全部命令：xiaohongshu 13个、bilibili 13个、twitter 25个、reddit 15个
- Highlights 新增 Anti-detection：列出 navigator.webdriver、window.chrome stub、plugins/languages 修补、ChromeDriver/Playwright 全局清除、CDP stack trace 过滤等措施
- CLI Hub 行内注明 auto-install 行为