### PR TITLE
feat(douyin): add user-videos command with top comments

### DIFF
--- a/src/clis/douyin/user-videos.test.ts
+++ b/src/clis/douyin/user-videos.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '../../errors.js';
+import { getRegistry } from '../../registry.js';
+import './user-videos.js';
+
+function makePage(...evaluateResults: unknown[]) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn()
+      .mockImplementation(() => Promise.resolve(evaluateResults.shift())),
+  } as any;
+}
+
+describe('douyin user-videos command', () => {
+  it('throws ArgumentError when limit is not a positive integer', async () => {
+    const cmd = getRegistry().get('douyin/user-videos');
+    const page = makePage();
+
+    await expect(cmd!.func!(page, { sec_uid: 'test', limit: 0 })).rejects.toThrow(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('surfaces top-level Douyin API errors through browserFetch semantics', async () => {
+    const cmd = getRegistry().get('douyin/user-videos');
+    const page = makePage({ status_code: 8, status_msg: 'bad uid' });
+
+    await expect(cmd!.func!(page, { sec_uid: 'bad', limit: 3 })).rejects.toThrow(CommandExecutionError);
+    expect(page.goto).toHaveBeenCalledWith('https://www.douyin.com/user/bad');
+    expect(page.evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes normalized limit to the API and preserves mapped rows', async () => {
+    const cmd = getRegistry().get('douyin/user-videos');
+    const page = makePage(
+      {
+        aweme_list: [{
+          aweme_id: '1',
+          desc: 'Video 1',
+          video: { duration: 2300, play_addr: { url_list: ['https://video.example/1.mp4'] } },
+          statistics: { digg_count: 12 },
+        }],
+      },
+      [{ aweme_id: '1', desc: 'Video 1', video: { duration: 2300, play_addr: { url_list: ['https://video.example/1.mp4'] } }, statistics: { digg_count: 12 }, top_comments: [] }],
+    );
+
+    const rows = await cmd!.func!(page, { sec_uid: 'good', limit: 1 });
+
+    expect(page.evaluate).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('count=1'),
+    );
+    expect(rows).toEqual([{
+      index: 1,
+      aweme_id: '1',
+      title: 'Video 1',
+      duration: 2,
+      digg_count: 12,
+      play_url: 'https://video.example/1.mp4',
+      top_comments: [],
+    }]);
+  });
+});

--- a/src/clis/douyin/user-videos.ts
+++ b/src/clis/douyin/user-videos.ts
@@ -1,5 +1,7 @@
 import { cli, Strategy } from '../../registry.js';
+import { ArgumentError } from '../../errors.js';
 import type { IPage } from '../../types.js';
+import { browserFetch } from './_shared/browser-fetch.js';
 
 cli({
   site: 'douyin',
@@ -13,31 +15,35 @@ cli({
   ],
   columns: ['index', 'aweme_id', 'title', 'duration', 'digg_count', 'play_url', 'top_comments'],
   func: async (page: IPage, kwargs) => {
+    const limit = Number(kwargs.limit);
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new ArgumentError('limit must be a positive integer');
+    }
+
     await page.goto(`https://www.douyin.com/user/${kwargs.sec_uid as string}`);
     await page.wait(3);
 
+    const params = new URLSearchParams({
+      sec_user_id: String(kwargs.sec_uid),
+      max_cursor: '0',
+      count: String(limit),
+      aid: '6383',
+    });
+    const data = await browserFetch(
+      page,
+      'GET',
+      `https://www.douyin.com/aweme/v1/web/aweme/post/?${params.toString()}`,
+    ) as { aweme_list?: Array<Record<string, unknown>> };
+    const awemeList = (data.aweme_list || []).slice(0, limit);
+
     const result = await page.evaluate(`
       (async () => {
-        const secUid = ${JSON.stringify(kwargs.sec_uid)};
-        const limit = ${JSON.stringify(kwargs.limit)};
-
-        const params = new URLSearchParams({
-          sec_user_id: secUid,
-          max_cursor: '0',
-          count: String(limit),
-          aid: '6383',
-        });
-        const res = await fetch('/aweme/v1/web/aweme/post/?' + params.toString(), {
-          credentials: 'include',
-          headers: { referer: 'https://www.douyin.com/' },
-        });
-        const data = await res.json();
-        const awemeList = (data.aweme_list || []).slice(0, limit);
+        const awemeList = ${JSON.stringify(awemeList)};
 
         const withComments = await Promise.all(awemeList.map(async (v) => {
           try {
             const cp = new URLSearchParams({
-              aweme_id: v.aweme_id,
+              aweme_id: String(v.aweme_id),
               count: '10',
               cursor: '0',
               aid: '6383',


### PR DESCRIPTION
## Summary

- Adds `opencli douyin user-videos <sec_uid>` command to fetch a public user's video list
- Concurrently fetches top 10 comments per video using `Promise.all`
- Outputs: `index`, `aweme_id`, `title`, `duration`, `digg_count`, `play_url`, `top_comments`

## Usage

```bash
# Get the last 20 videos from a user (default)
opencli douyin user-videos MS4wLjABAAAA...

# Get only the 5 most recent
opencli douyin user-videos MS4wLjABAAAA... --limit 5
```

## Test plan

- [ ] Run `opencli douyin user-videos <sec_uid>` with a valid public account and confirm video rows appear
- [ ] Verify `top_comments` field contains up to 10 comments with `text`, `digg_count`, `nickname`
- [ ] Run with `--limit 3` and confirm exactly 3 rows are returned
- [ ] Run with an invalid `sec_uid` and confirm a graceful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)