### PR TITLE
feat(hub): add lark-cli to external CLI hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ OpenCLI acts as a universal hub for your existing command-line tools — unified
 | **obsidian** | Obsidian vault management | `opencli obsidian search query="AI"` |
 | **docker** | Docker | `opencli docker ps` |
 | **gws** | Google Workspace CLI | `opencli gws docs list` |
+| **lark-cli** | Lark/Feishu — messages, docs, calendar, tasks, 200+ commands | `opencli lark-cli calendar +agenda` |
 
 **Register your own** — add any local CLI so AI agents can discover it via `opencli list`:
 

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -21,3 +21,11 @@
   tags: [docker, containers, devops]
   install:
     mac: "brew install --cask docker"
+
+- name: lark-cli
+  binary: lark-cli
+  description: "Lark/Feishu CLI — messages, documents, spreadsheets, calendar, tasks and 200+ commands for AI agents"
+  homepage: "https://github.com/larksuite/cli"
+  tags: [lark, feishu, collaboration, productivity, ai-agent]
+  install:
+    default: "npm install -g @larksuite/cli"


### PR DESCRIPTION
## Summary
- Add `lark-cli` (`@larksuite/cli`) to `src/external-clis.yaml` as a built-in external CLI
- Add lark-cli row to the CLI Hub table in README.md

lark-cli is the official Lark/Feishu open-platform CLI — 200+ commands across 11 domains (messages, docs, spreadsheets, calendar, tasks, video meetings) with 19 AI agent skills built-in.

Install via: `npm install -g @larksuite/cli`