### PR TITLE
feat(hub): add vercel CLI to external CLI hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ OpenCLI acts as a universal hub for your existing command-line tools — unified
 | **docker** | Docker | `opencli docker ps` |
 | **gws** | Google Workspace CLI | `opencli gws docs list` |
 | **lark-cli** | Lark/Feishu — messages, docs, calendar, tasks, 200+ commands | `opencli lark-cli calendar +agenda` |
+| **vercel** | Vercel — deploy projects, manage domains, env vars, logs | `opencli vercel deploy --prod` |
 
 **Register your own** — add any local CLI so AI agents can discover it via `opencli list`:
 

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -29,3 +29,11 @@
   tags: [lark, feishu, collaboration, productivity, ai-agent]
   install:
     default: "npm install -g @larksuite/cli"
+
+- name: vercel
+  binary: vercel
+  description: "Vercel CLI — deploy projects, manage domains, env vars, logs and serverless functions"
+  homepage: "https://vercel.com/docs/cli"
+  tags: [vercel, deployment, serverless, frontend, devops]
+  install:
+    default: "npm install -g vercel"


### PR DESCRIPTION
## Summary
- Add `vercel` to `src/external-clis.yaml` as a built-in external CLI
- Add vercel row to the CLI Hub table in README.md

Vercel CLI supports deploying projects, managing domains, env vars, logs, and serverless functions. Install via `npm install -g vercel`.