### PR TITLE
chore(release): 1.5.4

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in isolated Chrome windows via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Bump version to 1.5.4.

## What's Changed since v1.5.3

### Bug Fixes
* **extension**: probe daemon via `/ping` before WebSocket to eliminate ERR_CONNECTION_REFUSED console noise (#534)
* **manifest**: preserve dynamic TS arg metadata in help output (#536)

### Features
* **hub**: add lark-cli to external CLI hub (#555)
* **hub**: add vercel CLI to external CLI hub (#556)

### Docs
* README restructure — Quick Start first, full command list, anti-detection highlight (#544)