### PR TITLE
feat(spotify): add Spotify playback adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ git clone git@github.com:jackwener/opencli.git && cd opencli && npm install && n
 | **bilibili** | `hot` `search` `history` `feed` `ranking` `download` `comments` `dynamic` `favorite` `following` `me` `subtitle` `user-videos` |
 | **twitter** | `trending` `search` `timeline` `bookmarks` `post` `download` `profile` `article` `like` `likes` `notifications` `reply` `reply-dm` `thread` `follow` `unfollow` `followers` `following` `block` `unblock` `bookmark` `unbookmark` `delete` `hide-reply` `accept` |
 | **reddit** | `hot` `frontpage` `popular` `search` `subreddit` `user` `user-posts` `user-comments` `read` `save` `saved` `subscribe` `upvote` `upvoted` `comment` |
+| **spotify** | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat` |
 
 65+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,6 +173,7 @@ npm install -g @jackwener/opencli@latest
 | **douban** | `search` `top250` `subject` `photos` `download` `marks` `reviews` `movie-hot` `book-hot` | 浏览器 |
 | **facebook** | `feed` `profile` `search` `friends` `groups` `events` `notifications` `memories` `add-friend` `join-group` | 浏览器 |
 | **google** | `news` `search` `suggest` `trends` | 公开 |
+| **spotify** | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat` | OAuth API |
 | **36kr** | `news` `hot` `search` `article` | 公开 / 浏览器 |
 | **imdb** | `search` `title` `top` `trending` `person` `reviews` | 公开 |
 | **producthunt** | `posts` `today` `hot` `browse` | 公开 / 浏览器 |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -104,6 +104,7 @@ export default defineConfig({
                 { text: 'Barchart', link: '/adapters/browser/barchart' },
                 { text: 'Hugging Face', link: '/adapters/browser/hf' },
                 { text: 'Sina Finance', link: '/adapters/browser/sinafinance' },
+                { text: 'Spotify', link: '/adapters/browser/spotify' },
                 { text: 'Stack Overflow', link: '/adapters/browser/stackoverflow' },
                 { text: 'Wikipedia', link: '/adapters/browser/wikipedia' },
                 { text: 'Lobsters', link: '/adapters/browser/lobsters' },

--- a/docs/adapters/browser/spotify.md
+++ b/docs/adapters/browser/spotify.md
@@ -1,0 +1,62 @@
+# Spotify
+
+**Mode**: 🔑 OAuth API · **Domains**: `accounts.spotify.com`, `api.spotify.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli spotify auth` | Authenticate with Spotify and store tokens locally |
+| `opencli spotify status` | Show current playback status |
+| `opencli spotify play [query]` | Resume playback or search-and-play a track |
+| `opencli spotify pause` | Pause playback |
+| `opencli spotify next` | Skip to the next track |
+| `opencli spotify prev` | Skip to the previous track |
+| `opencli spotify volume <0-100>` | Set playback volume |
+| `opencli spotify search <query>` | Search Spotify tracks |
+| `opencli spotify queue <query>` | Add a track to the playback queue |
+| `opencli spotify shuffle <on|off>` | Toggle shuffle |
+| `opencli spotify repeat <off|track|context>` | Set repeat mode |
+
+## Usage Examples
+
+```bash
+# First-time setup
+opencli spotify auth
+
+# What is playing right now?
+opencli spotify status
+
+# Resume playback
+opencli spotify play
+
+# Search and immediately play a track
+opencli spotify play "Numb Linkin Park"
+
+# Search without playing
+opencli spotify search "Daft Punk" --limit 5 -f json
+
+# Queue a track
+opencli spotify queue "Get Lucky"
+
+# Playback controls
+opencli spotify pause
+opencli spotify next
+opencli spotify prev
+opencli spotify volume 35
+opencli spotify shuffle on
+opencli spotify repeat track
+```
+
+## Setup
+
+1. Create a Spotify app at <https://developer.spotify.com/dashboard>
+2. Add `http://127.0.0.1:8888/callback` to the app's Redirect URIs
+3. Fill in `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` in `~/.opencli/spotify.env`
+4. Run `opencli spotify auth`
+
+## Notes
+
+- Browser Bridge is not required.
+- Tokens are stored locally at `~/.opencli/spotify-tokens.json`.
+- Playback commands work best when you already have an active Spotify device/session.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -62,6 +62,7 @@ Run `opencli list` for the live registry.
 | **[barchart](/adapters/browser/barchart)** | `quote` `options` `greeks` `flow` | 🌐 Public |
 | **[hf](/adapters/browser/hf)** | `top` | 🌐 Public |
 | **[sinafinance](/adapters/browser/sinafinance)** | `news` | 🌐 Public |
+| **[spotify](/adapters/browser/spotify)** | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat` | 🔑 OAuth API |
 | **[stackoverflow](/adapters/browser/stackoverflow)** | `hot` `search` `bounties` `unanswered` | 🌐 Public |
 | **[wikipedia](/adapters/browser/wikipedia)** | `search` `summary` `random` `trending` | 🌐 Public |
 | **[lobsters](/adapters/browser/lobsters)** | `hot` `newest` `active` `tag` | 🌐 Public |

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -203,12 +203,13 @@ function main() {
   if (!existsSync(spotifyEnvFile)) {
     writeFileSync(spotifyEnvFile,
       `# Spotify credentials — get them at https://developer.spotify.com/dashboard\n` +
-      `SPOTIFY_CLIENT_ID=your_spotify_client_id_here\n` +
-      `SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here\n`,
+      `# Add http://127.0.0.1:8888/callback as a Redirect URI in your Spotify app\n` +
+      `SPOTIFY_CLIENT_ID=\n` +
+      `SPOTIFY_CLIENT_SECRET=\n`,
       'utf8'
     );
     console.log(`✓ Spotify credentials template created at ${spotifyEnvFile}`);
-    console.log(`  Edit the file and add your Client ID and Secret, then run: opencli spotify auth`);
+    console.log(`  Fill in your Client ID and Secret, then run: opencli spotify auth`);
   }
 
   // ── Browser Bridge setup hint ───────────────────────────────────────

--- a/src/clis/spotify/spotify.ts
+++ b/src/clis/spotify/spotify.ts
@@ -5,6 +5,13 @@ import { createServer } from 'http';
 import { homedir } from 'os';
 import { join } from 'path';
 import { exec } from 'child_process';
+import {
+  assertSpotifyCredentialsConfigured,
+  getFirstSpotifyTrack,
+  mapSpotifyTrackResults,
+  parseDotEnv,
+  resolveSpotifyCredentials,
+} from './utils.js';
 
 // ── Credentials ───────────────────────────────────────────────────────────────
 // Set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET as environment variables,
@@ -16,18 +23,13 @@ const ENV_FILE = join(homedir(), '.opencli', 'spotify.env');
 
 function loadEnv(): Record<string, string> {
   if (!existsSync(ENV_FILE)) return {};
-  return Object.fromEntries(
-    readFileSync(ENV_FILE, 'utf-8')
-      .split('\n')
-      .map(l => l.trim())
-      .filter(l => l && !l.startsWith('#') && l.includes('='))
-      .map(l => { const i = l.indexOf('='); return [l.slice(0, i).trim(), l.slice(i + 1).trim()] as [string, string]; })
-  );
+  return parseDotEnv(readFileSync(ENV_FILE, 'utf-8'));
 }
 
 const env = loadEnv();
-const CLIENT_ID     = env.SPOTIFY_CLIENT_ID     || process.env.SPOTIFY_CLIENT_ID     || '';
-const CLIENT_SECRET = env.SPOTIFY_CLIENT_SECRET || process.env.SPOTIFY_CLIENT_SECRET || '';
+const credentials = resolveSpotifyCredentials(env);
+const CLIENT_ID     = credentials.clientId;
+const CLIENT_SECRET = credentials.clientSecret;
 const REDIRECT_URI  = 'http://127.0.0.1:8888/callback';
 const SCOPES = [
   'user-read-playback-state',
@@ -107,9 +109,9 @@ async function api(method: string, path: string, body?: unknown): Promise<any> {
 
 async function findTrackUri(query: string): Promise<{ uri: string; name: string; artist: string }> {
   const data = await api('GET', `/search?q=${encodeURIComponent(query)}&type=track&limit=1`);
-  const track = data?.tracks?.items?.[0];
+  const track = getFirstSpotifyTrack(data);
   if (!track) throw new CliError('EMPTY_RESULT', `No track found for: ${query}`);
-  return { uri: track.uri, name: track.name, artist: track.artists.map((a: any) => a.name).join(', ') };
+  return track;
 }
 
 function openBrowser(url: string): void {
@@ -128,18 +130,7 @@ cli({
   args: [],
   columns: ['status'],
   func: async () => {
-    if (!CLIENT_ID || !CLIENT_SECRET) {
-      const envFile = join(homedir(), '.opencli', 'spotify.env');
-      throw new CliError(
-        'CONFIG',
-        `Missing Spotify credentials.\n\n` +
-        `1. Go to https://developer.spotify.com/dashboard and create an app\n` +
-        `2. Copy your Client ID and Client Secret\n` +
-        `3. Open the file: ${envFile}\n` +
-        `4. Replace the placeholder values and save\n` +
-        `5. Run: opencli spotify auth`
-      );
-    }
+    assertSpotifyCredentialsConfigured(credentials, ENV_FILE);
     return new Promise((resolve, reject) => {
       const server = createServer(async (req, res) => {
         try {
@@ -287,8 +278,9 @@ cli({
   func: async (_page, kwargs) => {
     const limit = Math.min(50, Math.max(1, Math.round(kwargs.limit)));
     const data = await api('GET', `/search?q=${encodeURIComponent(kwargs.query)}&type=track&limit=${limit}`);
-    if (!data?.tracks?.items) throw new CliError('EMPTY_RESULT', `No results found for: ${kwargs.query}`);
-    return data.tracks.items.map((t: any) => ({ track: t.name, artist: t.artists.map((a: any) => a.name).join(', '), album: t.album.name, uri: t.uri }));
+    const results = mapSpotifyTrackResults(data);
+    if (!results.length) throw new CliError('EMPTY_RESULT', `No results found for: ${kwargs.query}`);
+    return results;
   },
 });
 

--- a/src/clis/spotify/utils.test.ts
+++ b/src/clis/spotify/utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertSpotifyCredentialsConfigured,
+  getFirstSpotifyTrack,
+  hasConfiguredSpotifyCredentials,
+  mapSpotifyTrackResults,
+  parseDotEnv,
+  resolveSpotifyCredentials,
+} from './utils.js';
+
+describe('spotify utils', () => {
+  it('parses dotenv-style credential files', () => {
+    const env = parseDotEnv(`
+      # Spotify credentials
+      SPOTIFY_CLIENT_ID=abc123
+      SPOTIFY_CLIENT_SECRET=def456
+    `);
+
+    expect(env).toEqual({
+      SPOTIFY_CLIENT_ID: 'abc123',
+      SPOTIFY_CLIENT_SECRET: 'def456',
+    });
+  });
+
+  it('prefers explicit process env over file values', () => {
+    const credentials = resolveSpotifyCredentials(
+      {
+        SPOTIFY_CLIENT_ID: 'file-id',
+        SPOTIFY_CLIENT_SECRET: 'file-secret',
+      },
+      {
+        SPOTIFY_CLIENT_ID: 'env-id',
+        SPOTIFY_CLIENT_SECRET: 'env-secret',
+      },
+    );
+
+    expect(credentials).toEqual({
+      clientId: 'env-id',
+      clientSecret: 'env-secret',
+    });
+  });
+
+  it('treats placeholder values as unconfigured credentials', () => {
+    expect(hasConfiguredSpotifyCredentials({
+      clientId: 'your_spotify_client_id_here',
+      clientSecret: 'your_spotify_client_secret_here',
+    })).toBe(false);
+  });
+
+  it('throws a helpful CONFIG error for empty or placeholder credentials', () => {
+    expect(() => assertSpotifyCredentialsConfigured({
+      clientId: '',
+      clientSecret: '',
+    }, '/tmp/spotify.env')).toThrow(/Missing Spotify credentials/);
+
+    expect(() => assertSpotifyCredentialsConfigured({
+      clientId: 'your_spotify_client_id_here',
+      clientSecret: 'real-secret',
+    }, '/tmp/spotify.env')).toThrow(/Fill in SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET/);
+  });
+
+  it('maps search payloads into stable track summaries', () => {
+    const results = mapSpotifyTrackResults({
+      tracks: {
+        items: [
+          {
+            name: 'Numb',
+            artists: [{ name: 'Linkin Park' }, { name: 'Jay-Z' }],
+            album: { name: 'Encore' },
+            uri: 'spotify:track:123',
+          },
+        ],
+      },
+    });
+
+    expect(results).toEqual([
+      {
+        track: 'Numb',
+        artist: 'Linkin Park, Jay-Z',
+        album: 'Encore',
+        uri: 'spotify:track:123',
+      },
+    ]);
+    expect(getFirstSpotifyTrack({ tracks: { items: [] } })).toBeNull();
+  });
+});

--- a/src/clis/spotify/utils.ts
+++ b/src/clis/spotify/utils.ts
@@ -1,0 +1,92 @@
+import { CliError } from '../../errors.js';
+
+export interface SpotifyCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface SpotifyTrackSummary {
+  track: string;
+  artist: string;
+  album: string;
+  uri: string;
+}
+
+const SPOTIFY_PLACEHOLDER_PATTERNS = [
+  /^your_spotify_client_id_here$/i,
+  /^your_spotify_client_secret_here$/i,
+  /^your_.+_here$/i,
+];
+
+export function parseDotEnv(content: string): Record<string, string> {
+  return Object.fromEntries(
+    content
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#') && line.includes('='))
+      .map(line => {
+        const index = line.indexOf('=');
+        return [line.slice(0, index).trim(), line.slice(index + 1).trim()] as [string, string];
+      }),
+  );
+}
+
+export function resolveSpotifyCredentials(
+  fileEnv: Record<string, string>,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): SpotifyCredentials {
+  return {
+    clientId: processEnv.SPOTIFY_CLIENT_ID || fileEnv.SPOTIFY_CLIENT_ID || '',
+    clientSecret: processEnv.SPOTIFY_CLIENT_SECRET || fileEnv.SPOTIFY_CLIENT_SECRET || '',
+  };
+}
+
+export function isPlaceholderCredential(value: string | null | undefined): boolean {
+  const normalized = value?.trim() || '';
+  if (!normalized) return false;
+  return SPOTIFY_PLACEHOLDER_PATTERNS.some(pattern => pattern.test(normalized));
+}
+
+export function hasConfiguredSpotifyCredentials(credentials: SpotifyCredentials): boolean {
+  return Boolean(credentials.clientId.trim()) &&
+    Boolean(credentials.clientSecret.trim()) &&
+    !isPlaceholderCredential(credentials.clientId) &&
+    !isPlaceholderCredential(credentials.clientSecret);
+}
+
+export function assertSpotifyCredentialsConfigured(credentials: SpotifyCredentials, envFile: string): void {
+  if (hasConfiguredSpotifyCredentials(credentials)) return;
+
+  throw new CliError(
+    'CONFIG',
+    `Missing Spotify credentials.\n\n` +
+    `1. Go to https://developer.spotify.com/dashboard and create an app\n` +
+    `2. Add ${'http://127.0.0.1:8888/callback'} as a Redirect URI\n` +
+    `3. Copy your Client ID and Client Secret\n` +
+    `4. Open the file: ${envFile}\n` +
+    `5. Fill in SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET, then save\n` +
+    `6. Run: opencli spotify auth`,
+  );
+}
+
+export function mapSpotifyTrackResults(data: any): SpotifyTrackSummary[] {
+  const items = data?.tracks?.items;
+  if (!Array.isArray(items)) return [];
+
+  return items.map((track: any) => ({
+    track: track?.name || '',
+    artist: Array.isArray(track?.artists) ? track.artists.map((artist: any) => artist.name).join(', ') : '',
+    album: track?.album?.name || '',
+    uri: track?.uri || '',
+  }));
+}
+
+export function getFirstSpotifyTrack(data: any): { uri: string; name: string; artist: string } | null {
+  const track = mapSpotifyTrackResults(data)[0];
+  if (!track) return null;
+  return {
+    uri: track.uri,
+    name: track.track,
+    artist: track.artist,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a new `spotify` adapter under `src/clis/spotify/`
- Uses `Strategy.PUBLIC` — no browser required, direct calls to the Spotify Web API
- OAuth2 authentication with automatic token refresh (tokens stored in `~/.opencli/spotify-tokens.json`)
- Credentials loaded from `~/.opencli/spotify.env` or environment variables

> **Note:** Spotify Premium is required for all playback control commands (play, pause, next, prev, volume, queue, shuffle, repeat). The `search` and `status` commands work with free accounts.

> **Note:** This adapter does **not** interact with the Spotify desktop app directly. It sends commands to the Spotify Web API, which forwards them to whichever Spotify client is currently active on your account (desktop app, mobile app, or web player at open.spotify.com). At least one of these must be open and logged in for playback commands to work — otherwise the API returns a 404 "No active device" error.

## Commands

| Command | Description | Requires Premium |
|---|---|---|
| `opencli spotify auth` | OAuth authentication (run once) | No |
| `opencli spotify status` | Show current playback | No |
| `opencli spotify search <query>` | Search tracks | No |
| `opencli spotify play [query]` | Search and play a track/artist, or resume | Yes |
| `opencli spotify pause` | Pause playback | Yes |
| `opencli spotify next` | Skip to next track | Yes |
| `opencli spotify prev` | Skip to previous track | Yes |
| `opencli spotify volume <0-100>` | Set volume | Yes |
| `opencli spotify queue <query>` | Add track to queue | Yes |
| `opencli spotify shuffle on\|off` | Toggle shuffle | Yes |
| `opencli spotify repeat off\|track\|context` | Set repeat mode | Yes |

## Setup

1. Create an app on [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) with redirect URI `http://127.0.0.1:8888/callback`
2. Create `~/.opencli/spotify.env` with your `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET`
3. Run `opencli spotify auth` once to authenticate
4. Open Spotify on any device (desktop app, mobile app, or web player) and make sure you are logged in
5. Use any playback command — it will control whichever device is active

## Test plan

- [ ] `opencli spotify auth` opens browser and saves tokens
- [ ] `opencli spotify play "Bohemian Rhapsody"` starts playback
- [ ] `opencli spotify status` returns current track info
- [ ] `opencli spotify pause` / `next` / `prev` work correctly
- [ ] `opencli spotify volume 50` sets volume
- [ ] Token refresh works automatically after expiry