### PR TITLE
fix(tests): update E2E exit code assertions for usage errors

### DIFF
--- a/tests/e2e/management.test.ts
+++ b/tests/e2e/management.test.ts
@@ -101,6 +101,6 @@ describe('management commands E2E', () => {
   // ── unknown command ──
   it('unknown command shows error', async () => {
     const { stderr, code } = await runCli(['nonexistent-command-xyz']);
-    expect(code).toBe(1);
+    expect(code).toBe(2);
   });
 });

--- a/tests/e2e/plugin-management.test.ts
+++ b/tests/e2e/plugin-management.test.ts
@@ -134,7 +134,7 @@ describe('plugin management E2E', () => {
 
   it('plugin update without name or --all shows error', async () => {
     const { stderr, code } = await runPluginCli(['plugin', 'update']);
-    expect(code).toBe(1);
+    expect(code).toBe(2);
     expect(stderr).toContain('specify a plugin name');
   });
 });


### PR DESCRIPTION
Fixes CI failures caused by the exit-codes feature (#564).

Argument/usage errors now correctly return exit code `2` (EX_USAGE). Two E2E tests were still asserting exit code `1` for these cases:
- `unknown command shows error` (management.test.ts)
- `plugin update without name or --all shows error` (plugin-management.test.ts)