### PR TITLE
docs: sync docs with codebase (v1.5.5, exit codes, hub table, new adapters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ git clone git@github.com:jackwener/opencli.git && cd opencli && npm install && n
 | **twitter** | `trending` `search` `timeline` `bookmarks` `post` `download` `profile` `article` `like` `likes` `notifications` `reply` `reply-dm` `thread` `follow` `unfollow` `followers` `following` `block` `unblock` `bookmark` `unbookmark` `delete` `hide-reply` `accept` |
 | **reddit** | `hot` `frontpage` `popular` `search` `subreddit` `user` `user-posts` `user-comments` `read` `save` `saved` `subscribe` `upvote` `upvoted` `comment` |
 
-65+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
+66+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
 
 ## CLI Hub
 
@@ -133,7 +133,6 @@ OpenCLI acts as a universal hub for your existing command-line tools — unified
 | **gh** | GitHub CLI | `opencli gh pr list --limit 5` |
 | **obsidian** | Obsidian vault management | `opencli obsidian search query="AI"` |
 | **docker** | Docker | `opencli docker ps` |
-| **gws** | Google Workspace CLI | `opencli gws docs list` |
 | **lark-cli** | Lark/Feishu — messages, docs, calendar, tasks, 200+ commands | `opencli lark-cli calendar +agenda` |
 | **vercel** | Vercel — deploy projects, manage domains, env vars, logs | `opencli vercel deploy --prod` |
 
@@ -190,6 +189,28 @@ All built-in commands support `--format` / `-f` with `table` (default), `json`, 
 opencli bilibili hot -f json    # Pipe to jq or LLMs
 opencli bilibili hot -f csv     # Spreadsheet-friendly
 opencli bilibili hot -v         # Verbose: show pipeline debug steps
+```
+
+## Exit Codes
+
+opencli follows Unix `sysexits.h` conventions so it integrates naturally with shell pipelines and CI scripts:
+
+| Code | Meaning | When |
+|------|---------|------|
+| `0` | Success | Command completed normally |
+| `1` | Generic error | Unexpected / unclassified failure |
+| `2` | Usage error | Bad arguments or unknown command |
+| `66` | Empty result | No data returned (`EX_NOINPUT`) |
+| `69` | Service unavailable | Browser Bridge not connected (`EX_UNAVAILABLE`) |
+| `75` | Temporary failure | Command timed out — retry (`EX_TEMPFAIL`) |
+| `77` | Auth required | Not logged in to target site (`EX_NOPERM`) |
+| `78` | Config error | Missing credentials or bad config (`EX_CONFIG`) |
+| `130` | Interrupted | Ctrl-C / SIGINT |
+
+```bash
+opencli spotify status || echo "exit $?"   # 69 if browser not running
+opencli github issues 2>/dev/null
+[ $? -eq 77 ] && opencli github auth       # auto-auth if not logged in
 ```
 
 ## Plugins

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,7 +183,10 @@ npm install -g @jackwener/opencli@latest
 | **substack** | `feed` `search` `publication` | 浏览器 |
 | **pixiv** | `ranking` `search` `user` `illusts` `detail` `download` | 浏览器 |
 | **tiktok** | `explore` `search` `profile` `user` `following` `follow` `unfollow` `like` `unlike` `comment` `save` `unsave` `live` `notifications` `friends` | 浏览器 |
+| **bluesky** | `search` `trending` `user` `profile` `thread` `feeds` `followers` `following` `starter-packs` | 公开 |
+| **douyin** | `videos` `publish` `drafts` `draft` `delete` `stats` `profile` `update` `hashtag` `location` `activities` `collections` | 浏览器 |
 
+66+ 适配器 — **[→ 查看完整命令列表](./docs/adapters/index.md)**
 
 ### 外部 CLI 枢纽
 
@@ -194,8 +197,8 @@ OpenCLI 也可以作为你现有命令行工具的统一入口，负责发现、
 | **gh** | GitHub CLI | `opencli gh pr list --limit 5` |
 | **obsidian** | Obsidian 仓库管理 | `opencli obsidian search query="AI"` |
 | **docker** | Docker 命令行工具 | `opencli docker ps` |
-| **readwise** | Readwise / Reader CLI | `opencli readwise login` |
-| **gws** | Google Workspace CLI — Docs, Sheets, Drive, Gmail, Calendar | `opencli gws docs list` |
+| **lark-cli** | 飞书 CLI — 消息、文档、日历、任务，200+ 命令 | `opencli lark-cli calendar +agenda` |
+| **vercel** | Vercel — 部署项目、管理域名、环境变量、日志 | `opencli vercel deploy --prod` |
 
 **零配置透传**：OpenCLI 会把你的输入原样转发给底层二进制，保留原生 stdout / stderr 行为。
 
@@ -293,6 +296,31 @@ opencli bilibili hot -f yaml    # YAML（更适合人类直接阅读）
 opencli bilibili hot -f md      # Markdown
 opencli bilibili hot -f csv     # CSV
 opencli bilibili hot -v         # 详细模式：展示管线执行步骤调试信息
+```
+
+## 退出码
+
+opencli 遵循 Unix `sysexits.h` 惯例，可无缝接入 shell 管道和 CI 脚本：
+
+| 退出码 | 含义 | 触发场景 |
+|--------|------|----------|
+| `0` | 成功 | 命令正常完成 |
+| `1` | 通用错误 | 未分类的意外错误 |
+| `2` | 用法错误 | 参数错误或未知命令 |
+| `66` | 无数据 | 命令返回空结果（`EX_NOINPUT`） |
+| `69` | 服务不可用 | Browser Bridge 未连接（`EX_UNAVAILABLE`） |
+| `75` | 临时失败 | 命令超时，可重试（`EX_TEMPFAIL`） |
+| `77` | 需要认证 | 未登录目标网站（`EX_NOPERM`） |
+| `78` | 配置错误 | 凭证缺失或配置有误（`EX_CONFIG`） |
+| `130` | 中断 | Ctrl-C / SIGINT |
+
+```bash
+opencli bilibili hot 2>/dev/null
+case $? in
+  0)   echo "ok" ;;
+  69)  echo "请先启动 Browser Bridge" ;;
+  77)  echo "请先登录 bilibili.com" ;;
+esac
 ```
 
 ## 插件

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencli
 description: "OpenCLI — Make any website or Electron App your CLI. Zero risk, AI-powered, reuse Chrome login."
-version: 1.4.1
+version: 1.5.5
 author: jackwener
 tags: [cli, browser, web, chrome-extension, cdp, bilibili, zhihu, twitter, github, v2ex, hackernews, reddit, xiaohongshu, xueqiu, youtube, boss, coupang, yollomi, AI, agent]
 ---


### PR DESCRIPTION
## Summary

Brings documentation in sync with the actual codebase. No code changes.

### SKILL.md
- Version `1.4.1` → `1.5.5`

### README.md
- Remove `gws` from CLI Hub table (never existed in `external-clis.yaml`)
- Bump adapter count `65+` → `66+`
- Add **Exit Codes** section (sysexits.h table + shell usage example)

### README.zh-CN.md
- Replace `readwise` + `gws` (not in `external-clis.yaml`) with `lark-cli` + `vercel` (which ARE registered)
- Add `bluesky` and `douyin` rows to built-in commands table (both exist in `src/clis/` but were missing from zh-CN docs)
- Add `66+ 适配器` count line (zh-CN had no count, EN had it)
- Add **退出码** section (mirrors English Exit Codes section added in #564)