### PR TITLE
feat(github): add GitHub adapter with 5 public API commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/clis/github/issues.yaml
+++ b/src/clis/github/issues.yaml
@@ -1,0 +1,45 @@
+site: github
+name: issues
+description: List issues for a GitHub repository
+domain: github.com
+strategy: public
+browser: false
+
+args:
+  owner:
+    type: string
+    required: true
+    description: Repository owner
+  name:
+    type: string
+    required: true
+    description: Repository name
+  state:
+    type: string
+    default: open
+    description: "Issue state: open, closed, all"
+  limit:
+    type: int
+    default: 10
+    description: Number of issues
+
+pipeline:
+  - fetch:
+      url: "https://api.github.com/repos/${{ args.owner }}/${{ args.name }}/issues?state=${{ args.state }}&per_page=${{ args.limit }}"
+      headers:
+        Accept: application/vnd.github.v3+json
+        User-Agent: opencli
+
+  - filter: "!item.pull_request"
+
+  - map:
+      number: "#${{ item.number }}"
+      title: "${{ (item.title || '').substring(0, 60) }}"
+      author: "${{ item.user.login }}"
+      labels: "${{ (item.labels || []).map(l => l.name).join(', ') }}"
+      comments: ${{ item.comments }}
+      created: "${{ item.created_at?.substring(0, 10) }}"
+
+  - limit: ${{ args.limit }}
+
+columns: [number, title, author, labels, comments, created]

--- a/src/clis/github/repo.yaml
+++ b/src/clis/github/repo.yaml
@@ -1,0 +1,36 @@
+site: github
+name: repo
+description: GitHub repository details
+domain: github.com
+strategy: public
+browser: false
+
+args:
+  owner:
+    type: string
+    required: true
+    description: Repository owner
+  name:
+    type: string
+    required: true
+    description: Repository name
+
+pipeline:
+  - fetch:
+      url: "https://api.github.com/repos/${{ args.owner }}/${{ args.name }}"
+      headers:
+        Accept: application/vnd.github.v3+json
+        User-Agent: opencli
+
+  - map:
+      name: "${{ item.full_name }}"
+      stars: ${{ item.stargazers_count }}
+      forks: ${{ item.forks_count }}
+      issues: ${{ item.open_issues_count }}
+      language: "${{ item.language || '-' }}"
+      license: "${{ item.license?.spdx_id || '-' }}"
+      created: "${{ item.created_at?.substring(0, 10) }}"
+      updated: "${{ item.pushed_at?.substring(0, 10) }}"
+      description: "${{ (item.description || '').substring(0, 80) }}"
+
+columns: [name, stars, forks, issues, language, license, description]

--- a/src/clis/github/search.yaml
+++ b/src/clis/github/search.yaml
@@ -1,0 +1,41 @@
+site: github
+name: search
+description: Search GitHub repositories
+domain: github.com
+strategy: public
+browser: false
+
+args:
+  query:
+    type: string
+    required: true
+    description: Search query
+  sort:
+    type: string
+    default: stars
+    description: "Sort by: stars, forks, updated"
+  limit:
+    type: int
+    default: 10
+    description: Number of results
+
+pipeline:
+  - fetch:
+      url: "https://api.github.com/search/repositories?q=${{ encodeURIComponent(args.query) }}&sort=${{ args.sort }}&per_page=${{ args.limit }}"
+      headers:
+        Accept: application/vnd.github.v3+json
+        User-Agent: opencli
+
+  - select: items
+
+  - map:
+      rank: ${{ index + 1 }}
+      name: "${{ item.full_name }}"
+      stars: ${{ item.stargazers_count }}
+      forks: ${{ item.forks_count }}
+      language: "${{ item.language || '-' }}"
+      description: "${{ (item.description || '').substring(0, 60) }}"
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, name, stars, forks, language, description]

--- a/src/clis/github/trending.yaml
+++ b/src/clis/github/trending.yaml
@@ -1,0 +1,41 @@
+site: github
+name: trending
+description: GitHub trending repositories (by recent stars)
+domain: github.com
+strategy: public
+browser: false
+
+args:
+  language:
+    type: string
+    default: ""
+    description: "Filter by language (e.g. typescript, python, rust)"
+  since:
+    type: string
+    default: daily
+    description: "Time range: daily (7 days), weekly (30 days), monthly (90 days)"
+  limit:
+    type: int
+    default: 10
+    description: Number of repositories
+
+pipeline:
+  - fetch:
+      url: "https://api.github.com/search/repositories?q=stars%3A%3E50+created%3A%3E${{ (function(){ const d=new Date(); const days={daily:7,weekly:30,monthly:90}[args.since]||7; d.setDate(d.getDate()-days); return d.toISOString().substring(0,10) })() }}${{ args.language ? '+language%3A'+args.language : '' }}&sort=stars&order=desc&per_page=${{ args.limit }}"
+      headers:
+        Accept: application/vnd.github.v3+json
+        User-Agent: opencli
+
+  - select: items
+
+  - map:
+      rank: ${{ index + 1 }}
+      name: "${{ item.full_name }}"
+      stars: ${{ item.stargazers_count }}
+      forks: ${{ item.forks_count }}
+      language: "${{ item.language || '-' }}"
+      description: "${{ (item.description || '').substring(0, 60) }}"
+
+  - limit: ${{ args.limit }}
+
+columns: [rank, name, stars, forks, language, description]

--- a/src/clis/github/user.yaml
+++ b/src/clis/github/user.yaml
@@ -1,0 +1,32 @@
+site: github
+name: user
+description: GitHub user profile
+domain: github.com
+strategy: public
+browser: false
+
+args:
+  username:
+    type: string
+    required: true
+    description: GitHub username
+
+pipeline:
+  - fetch:
+      url: "https://api.github.com/users/${{ args.username }}"
+      headers:
+        Accept: application/vnd.github.v3+json
+        User-Agent: opencli
+
+  - map:
+      login: "${{ item.login }}"
+      name: "${{ item.name || '-' }}"
+      bio: "${{ (item.bio || '').substring(0, 60) }}"
+      repos: ${{ item.public_repos }}
+      followers: ${{ item.followers }}
+      following: ${{ item.following }}
+      company: "${{ item.company || '-' }}"
+      location: "${{ item.location || '-' }}"
+      created: "${{ item.created_at?.substring(0, 10) }}"
+
+columns: [login, name, repos, followers, following, location]


### PR DESCRIPTION
## What

Adds a native GitHub adapter with 5 commands using GitHub's public REST API. No authentication required, no browser needed.

## Commands

| Command | Description | Example |
|---------|-------------|---------|
| `github trending` | Trending repos (recent stars) | `opencli github trending --language python --limit 5` |
| `github search` | Search repositories | `opencli github search --query "agent memory" --limit 10` |
| `github repo` | Repository details | `opencli github repo --owner jackwener --name opencli` |
| `github user` | User profile | `opencli github user --username jackwener` |
| `github issues` | List repository issues | `opencli github issues --owner jackwener --name opencli --state open` |

## Why

GitHub is the most used developer platform and a natural fit for an AI-agent CLI tool. Surprisingly it wasn't covered yet. All commands are pure YAML declarative adapters — zero TypeScript, minimal maintenance.

## Implementation

- 5 YAML files in `src/clis/github/`
- Uses GitHub REST API v3 (`api.github.com`)
- `strategy: public`, `browser: false`
- Trending uses GitHub search API (sorted by stars, filtered by creation date) since the unofficial trending APIs are unreliable

## Testing

All 5 commands manually verified:

```
$ opencli github search --query openclaw --limit 3
┌──────┬───────────────────────────────────┬────────┬───────┬────────────┬───────────────────────┐
│ Rank │ Name                              │ Stars  │ Forks │ Language   │ Description           │
├──────┼───────────────────────────────────┼────────┼───────┼────────────┼───────────────────────┤
│ 1    │ openclaw/openclaw                 │ 340056 │ 67032 │ TypeScript │ Your own personal AI… │
└──────┴───────────────────────────────────┴────────┴───────┴────────────┴───────────────────────┘

$ opencli github trending --limit 3
┌──────┬───────────────────────┬───────┬───────┬────────────┬─────────────────────────┐
│ Rank │ Name                  │ Stars │ Forks │ Language   │ Description             │
├──────┼───────────────────────┼───────┼───────┼────────────┼─────────────────────────┤
│ 1    │ slavingia/skills      │ 5199  │ 368   │ -          │ Claude Code skills…     │
│ 2    │ larksuite/cli         │ 2622  │ 116   │ Go         │ A command-line tool…    │
│ 3    │ magnum6actual/flipoff │ 2308  │ 280   │ JavaScript │ Free split-flap…        │
└──────┴───────────────────────┴───────┴───────┴────────────┴─────────────────────────┘
```