### PR TITLE
fix(cli): normalize boolean arg aliases in commander adapter

### DIFF
--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -76,3 +76,50 @@ describe('commanderAdapter arg passing', () => {
     expect(mockExecuteCommand).not.toHaveBeenCalled();
   });
 });
+
+describe('commanderAdapter boolean alias support', () => {
+  const cmd: CliCommand = {
+    site: 'reddit',
+    name: 'save',
+    description: 'Save a post',
+    browser: false,
+    args: [
+      { name: 'post-id', positional: true, required: true, help: 'Post ID' },
+      { name: 'undo', type: 'boolean', default: false, help: 'Unsave instead of save' },
+    ],
+    func: vi.fn(),
+  };
+
+  beforeEach(() => {
+    mockExecuteCommand.mockReset();
+    mockExecuteCommand.mockResolvedValue([]);
+    mockRenderOutput.mockReset();
+    delete process.env.OPENCLI_VERBOSE;
+    process.exitCode = undefined;
+  });
+
+  it('coerces default false for boolean args to a real boolean', async () => {
+    const program = new Command();
+    const siteCmd = program.command('reddit');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'reddit', 'save', 't3_abc123']);
+
+    expect(mockExecuteCommand).toHaveBeenCalled();
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(kwargs['post-id']).toBe('t3_abc123');
+    expect(kwargs.undo).toBe(false);
+  });
+
+  it('coerces explicit false for boolean args to a real boolean', async () => {
+    const program = new Command();
+    const siteCmd = program.command('reddit');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'reddit', 'save', 't3_abc123', '--undo', 'false']);
+
+    expect(mockExecuteCommand).toHaveBeenCalled();
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(kwargs.undo).toBe(false);
+  });
+});

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -33,7 +33,7 @@ import {
 import { checkDaemonStatus } from './browser/discover.js';
 
 export function normalizeArgValue(argType: string | undefined, value: unknown, name: string): unknown {
-  if (argType !== 'bool') return value;
+  if (argType !== 'bool' && argType !== 'boolean') return value;
   if (typeof value === 'boolean') return value;
   if (value == null || value === '') return false;
 


### PR DESCRIPTION
## Summary

This PR fixes boolean argument normalization in the Commander adapter by treating `type: 'boolean'` as an alias of `type: 'bool'`.

## Why

The registry currently uses both `bool` and `boolean` in command definitions.

However, `normalizeArgValue()` only recognized `bool`, so commands using `type: 'boolean'` could receive string values like `"false"` instead of the real boolean `false`.

Because `"false"` is truthy in JavaScript, this could flip command behavior in subtle but real ways.

## Impact

This affects commands that define boolean flags with `type: 'boolean'`, especially when the default is `false` or when the user explicitly passes `--flag false`.

Examples in the current tree include:

- `reddit save --undo`
- `boss mark --remove`
- `twitter reply-dm --skip-replied`

## Changes

- update `normalizeArgValue()` to accept both `bool` and `boolean`
- add regression tests for `type: 'boolean'`
- verify both default `false` and explicit `--undo false` are normalized to real booleans

## Verification

- `npx vitest run src/commanderAdapter.test.ts`
- `npm run typecheck`

Both passed locally.

## Scope

This PR intentionally keeps the fix minimal and does not add new metadata validation rules for argument types.
