### PR TITLE
fix(completion): sync top-level command suggestions

### DIFF
--- a/src/completion.test.ts
+++ b/src/completion.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockGetRegistry } = vi.hoisted(() => ({
+  mockGetRegistry: vi.fn(() => new Map([
+    ['github/issues', { site: 'github', name: 'issues' }],
+  ])),
+}));
+
+vi.mock('./registry.js', () => ({
+  getRegistry: mockGetRegistry,
+}));
+
+import { getCompletions } from './completion.js';
+
+describe('getCompletions', () => {
+  it('includes top-level built-ins that are registered outside the site registry', () => {
+    const completions = getCompletions([], 1);
+
+    expect(completions).toContain('plugin');
+    expect(completions).toContain('install');
+    expect(completions).toContain('register');
+    expect(completions).not.toContain('setup');
+  });
+
+  it('still includes discovered site names', () => {
+    const completions = getCompletions([], 1);
+
+    expect(completions).toContain('github');
+  });
+});

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -24,7 +24,9 @@ const BUILTIN_COMMANDS = [
   'generate',
   'cascade',
   'doctor',
-  'setup',
+  'plugin',
+  'install',
+  'register',
   'completion',
 ];
 


### PR DESCRIPTION
## Description

Fix shell completion so top-level command suggestions match the current CLI surface. 
Btw, sorry for my last PR which didn't attach the test output. This time I atttached it below, thanks.

This change:
- removes stale `setup` from completion candidates
- adds missing top-level built-ins: `plugin`, `install`, and `register`
- adds a unit test covering the top-level completion list to prevent regressions

Related issue:
- N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A — this PR does not add or modify an adapter.

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Checks run:
- `npx vitest run src/completion.test.ts --project unit`
- `npm run typecheck`

Completion output after this change:
```npx vitest run src/completion.test.ts
E:\Inori_Code\Intrest\fromGit\opencli> npx vitest run src/completion.test.ts --project unit

 RUN  v4.1.1 E:/Inori_Code/Intrest/fromGit/opencli

 ✓  unit  src/completion.test.ts (2 tests) 4ms
   ✓ getCompletions (2)
     ✓ includes top-level built-ins that are registered outside the site registry 2ms
     ✓ still includes discovered site names 0ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  01:38:35
   Duration  239ms (transform 37ms, setup 0ms, import 82ms, tests 4ms, environment 0ms)
```

```npm run typecheck
E:\Inori_Code\Intrest\fromGit\opencli> npm run typecheck

> @jackwener/opencli@1.5.5 typecheck
> tsc --noEmit
```
