### PR TITLE
chore(release): 1.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Bump OpenCLI to 1.5.6 for release.

- update package.json version to 1.5.6
- sync package-lock top-level package version
- local validation: npm run typecheck, npm run build