### PR TITLE
fix(zhihu): stop question command failing on unused detail fetch

### DIFF
--- a/src/clis/zhihu/question.test.ts
+++ b/src/clis/zhihu/question.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '../../registry.js';
+import { AuthRequiredError } from '../../errors.js';
 import './question.js';
 
 describe('zhihu question', () => {
@@ -7,12 +8,10 @@ describe('zhihu question', () => {
     const cmd = getRegistry().get('zhihu/question');
     expect(cmd?.func).toBeTypeOf('function');
 
-    const evaluate = vi.fn().mockImplementation(async (js: string) => {
-      if (js.includes('/api/v4/questions/2021881398772981878?include=')) {
-        return { error: true };
-      }
-
+    const evaluate = vi.fn().mockImplementation(async (_fn: unknown, args: { questionId: string; answerLimit: number }) => {
+      expect(args).toEqual({ questionId: '2021881398772981878', answerLimit: 3 });
       return {
+        ok: true,
         answers: [
           {
             author: { name: 'alice' },
@@ -37,5 +36,36 @@ describe('zhihu question', () => {
         content: 'Hello Zhihu',
       },
     ]);
+
+    expect(evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps auth-like answer failures to AuthRequiredError', async () => {
+    const cmd = getRegistry().get('zhihu/question');
+    expect(cmd?.func).toBeTypeOf('function');
+
+    const page = {
+      evaluate: vi.fn().mockResolvedValue({ ok: false, status: 403 }),
+    } as any;
+
+    await expect(
+      cmd!.func!(page, { id: '2021881398772981878', limit: 3 }),
+    ).rejects.toBeInstanceOf(AuthRequiredError);
+  });
+
+  it('preserves non-auth fetch failures as CliError instead of login errors', async () => {
+    const cmd = getRegistry().get('zhihu/question');
+    expect(cmd?.func).toBeTypeOf('function');
+
+    const page = {
+      evaluate: vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    } as any;
+
+    await expect(
+      cmd!.func!(page, { id: '2021881398772981878', limit: 3 }),
+    ).rejects.toMatchObject({
+      code: 'FETCH_ERROR',
+      message: 'Zhihu question answers request failed with HTTP 500',
+    });
   });
 });

--- a/src/clis/zhihu/question.ts
+++ b/src/clis/zhihu/question.ts
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '../../registry.js';
-import { AuthRequiredError } from '../../errors.js';
+import { AuthRequiredError, CliError } from '../../errors.js';
 
 cli({
   site: 'zhihu',
@@ -14,6 +14,7 @@ cli({
   columns: ['rank', 'author', 'votes', 'content'],
   func: async (page, kwargs) => {
     const { id, limit = 5 } = kwargs;
+    const answerLimit = Number(limit);
 
     const stripHtml = (html: string) =>
       (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
@@ -21,21 +22,31 @@ cli({
     // Only fetch answers here. The question detail endpoint is not used by the
     // current CLI output and can fail independently, which would incorrectly
     // turn a successful answers response into a login error.
-    const result = await page.evaluate(`
-      async () => {
+    const result = await (page as any).evaluate(
+      async ({ questionId, answerLimit }: { questionId: string; answerLimit: number }) => {
         const aResp = await fetch(
-          'https://www.zhihu.com/api/v4/questions/${id}/answers?limit=${limit}&offset=0&sort_by=default&include=data[*].content,voteup_count,comment_count,author',
-          { credentials: 'include' }
+          `https://www.zhihu.com/api/v4/questions/${questionId}/answers?limit=${answerLimit}&offset=0&sort_by=default&include=data[*].content,voteup_count,comment_count,author`,
+          { credentials: 'include' },
         );
-        if (!aResp.ok) return { error: true };
+        if (!aResp.ok) return { ok: false as const, status: aResp.status };
         const a = await aResp.json();
-        return { answers: a.data || [] };
+        return { ok: true as const, answers: Array.isArray(a?.data) ? a.data : [] };
+      },
+      { questionId: String(id), answerLimit },
+    );
+
+    if (!result?.ok) {
+      if (result?.status === 401 || result?.status === 403) {
+        throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch question data from Zhihu');
       }
-    `);
+      throw new CliError(
+        'FETCH_ERROR',
+        `Zhihu question answers request failed with HTTP ${result?.status ?? 'unknown'}`,
+        'Try again later or rerun with -v for more detail',
+      );
+    }
 
-    if (!result || result.error) throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch question data from Zhihu');
-
-    const answers = (result.answers ?? []).slice(0, Number(limit)).map((a: any, i: number) => ({
+    const answers = result.answers.slice(0, answerLimit).map((a: any, i: number) => ({
       rank: i + 1,
       author: a.author?.name ?? 'anonymous',
       votes: a.voteup_count ?? 0,


### PR DESCRIPTION
## Description

Fix `zhihu question` so it no longer fails when an unused question detail request returns `403`.

The adapter was fetching both question detail and answers in parallel, but only the answers response was actually used in the CLI output. In a real logged-in Browser Bridge session, the detail request now returns `403` with Zhihu error code `10003`, which caused the whole command to surface a misleading `AuthRequiredError` even though the answers request succeeded.

This change removes the unused detail request and keeps the command focused on the answers data it already renders.

Related issue:
- #604

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before the fix, this returned:

```bash
node dist/main.js zhihu question 2021881398772981878 --limit 3 -f json
🔒 Not logged in to www.zhihu.com
→ Please open Chrome and log in to https://www.zhihu.com
```

After the fix, the same command returns answer rows successfully.

Checks run:
- `npx vitest run src/clis/zhihu/question.test.ts --project adapter`
- `npm run test:adapter`
- `npm test`
- `npm run build`
- `npx tsx src/main.ts zhihu question 2021881398772981878 --limit 3 -f json`
- `node dist/main.js zhihu question 2021881398772981878 --limit 3 -f json`
