### PR TITLE
fix(xiaohongshu): check login wall before autoScroll in search (fixes #597)

### DIFF
--- a/src/browser/dom-helpers.test.ts
+++ b/src/browser/dom-helpers.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { waitForCaptureJs, waitForSelectorJs } from './dom-helpers.js';
+import { autoScrollJs, waitForCaptureJs, waitForSelectorJs } from './dom-helpers.js';
+
+describe('autoScrollJs', () => {
+  it('returns early without error when document.body is null', async () => {
+    const g = globalThis as any;
+    const origDoc = g.document;
+    g.document = { body: null, documentElement: {} };
+    g.window = g;
+    const code = autoScrollJs(3, 500);
+    // Should resolve without throwing
+    await expect(eval(code)).resolves.not.toThrow();
+    g.document = origDoc;
+    delete g.window;
+  });
+});
 
 describe('waitForCaptureJs', () => {
   it('returns a non-empty string', () => {

--- a/src/browser/dom-helpers.ts
+++ b/src/browser/dom-helpers.ts
@@ -109,6 +109,7 @@ export function scrollJs(direction: string, amount: number): string {
 export function autoScrollJs(times: number, delayMs: number): string {
   return `
     (async () => {
+      if (!document.body) return;
       for (let i = 0; i < ${times}; i++) {
         const lastHeight = document.body.scrollHeight;
         window.scrollTo(0, lastHeight);

--- a/src/clis/xiaohongshu/search.test.ts
+++ b/src/clis/xiaohongshu/search.test.ts
@@ -41,15 +41,16 @@ describe('xiaohongshu search', () => {
     expect(cmd?.func).toBeTypeOf('function');
 
     const page = createPageMock([
-      {
-        loginWall: true,
-        results: [],
-      },
+      // First evaluate: early login-wall check (returns true)
+      true,
     ]);
 
     await expect(cmd!.func!(page, { query: '特斯拉', limit: 5 })).rejects.toThrow(
       'Xiaohongshu search results are blocked behind a login wall'
     );
+
+    // autoScroll must NOT be called when a login wall is detected early
+    expect(page.autoScroll).not.toHaveBeenCalled();
   });
 
   it('returns ranked results with search_result url and author_url preserved', async () => {
@@ -62,6 +63,9 @@ describe('xiaohongshu search', () => {
       'https://www.xiaohongshu.com/user/profile/635a9c720000000018028b40?xsec_token=user-token&xsec_source=pc_search';
 
     const page = createPageMock([
+      // First evaluate: early login-wall check (returns false → no wall)
+      false,
+      // Second evaluate: main DOM extraction
       {
         loginWall: false,
         results: [
@@ -99,6 +103,9 @@ describe('xiaohongshu search', () => {
     expect(cmd?.func).toBeTypeOf('function');
 
     const page = createPageMock([
+      // First evaluate: early login-wall check (returns false → no wall)
+      false,
+      // Second evaluate: main DOM extraction
       {
         loginWall: false,
         results: [

--- a/src/clis/xiaohongshu/search.ts
+++ b/src/clis/xiaohongshu/search.ts
@@ -44,6 +44,19 @@ cli({
     );
     await page.wait(3);
 
+    // Early login-wall detection: XHS may show a login gate instead of
+    // results. Check *before* autoScroll to avoid crashing on a page
+    // that has no meaningful content to scroll through.
+    const loginCheck = await page.evaluate(`
+      (() => /登录后查看搜索结果/.test(document.body?.innerText || ''))()
+    `);
+    if (loginCheck) {
+      throw new AuthRequiredError(
+        'www.xiaohongshu.com',
+        'Xiaohongshu search results are blocked behind a login wall',
+      );
+    }
+
     // Scroll a couple of times to load more results
     await page.autoScroll({ times: 2 });
 


### PR DESCRIPTION
## Summary

Fixes #597. The `search` command crashes on Xiaohongshu when a login wall is presented because `autoScroll()` runs before the login-wall check, and `document.body` can be null in that state.

## Changes

1. **`search.ts`** — Added early login-wall detection (`page.evaluate` with regex for `登录后查看搜索结果`) **before** `autoScroll()`. Throws `AuthRequiredError` immediately if detected.

2. **`dom-helpers.ts`** — Added `if (!document.body) return;` guard in `autoScrollJs` as defensive fallback for all adapters.

3. **`search.test.ts`** — Updated login-wall test to verify `autoScroll` is never called when wall is detected.

4. **`dom-helpers.test.ts`** — Added test for null `document.body` handling.

## Testing

All 397 tests pass. `tsc --noEmit` clean.