### PR TITLE
[codex] fix weixin article download extraction

### DIFF
--- a/src/clis/weixin/download.ts
+++ b/src/clis/weixin/download.ts
@@ -111,6 +111,37 @@ export function extractWechatPublishTime(
 }
 
 /**
+ * Detect WeChat anti-bot / verification gate pages before we try to parse the article.
+ */
+export function detectWechatAccessIssue(
+  pageText: string | null | undefined,
+  htmlStr: string,
+): string {
+  const normalizedText = (pageText || '').replace(/\s+/g, ' ').trim();
+
+  if (
+    /环境异常/.test(normalizedText) &&
+    /(完成验证后即可继续访问|去验证)/.test(normalizedText)
+  ) {
+    return 'environment verification required';
+  }
+
+  if (/secitptpage\/verify\.html/.test(htmlStr) || /id=["']js_verify["']/.test(htmlStr)) {
+    return 'environment verification required';
+  }
+
+  return '';
+}
+
+export function pickFirstWechatMetaText(...candidates: Array<string | null | undefined>): string {
+  for (const candidate of candidates) {
+    const normalized = (candidate || '').replace(/\s+/g, ' ').trim();
+    if (normalized && normalized !== 'Name cleared') return normalized;
+  }
+  return '';
+}
+
+/**
  * Build a self-contained helper for execution inside page.evaluate().
  */
 export function buildExtractWechatPublishTimeJs(): string {
@@ -161,6 +192,31 @@ export function buildExtractWechatPublishTimeJs(): string {
   }.toString()})`;
 }
 
+/**
+ * Build a self-contained access-issue detector for execution inside page.evaluate().
+ */
+export function buildDetectWechatAccessIssueJs(): string {
+  return `(${function detectWechatAccessIssueInPage(
+    pageText: string | null | undefined,
+    htmlStr: string,
+  ) {
+    const normalizedText = (pageText || '').replace(/\s+/g, ' ').trim();
+
+    if (
+      /环境异常/.test(normalizedText) &&
+      /(完成验证后即可继续访问|去验证)/.test(normalizedText)
+    ) {
+      return 'environment verification required';
+    }
+
+    if (/secitptpage\/verify\.html/.test(htmlStr) || /id=["']js_verify["']/.test(htmlStr)) {
+      return 'environment verification required';
+    }
+
+    return '';
+  }.toString()})`;
+}
+
 // ============================================================
 // CLI Registration
 // ============================================================
@@ -196,18 +252,34 @@ cli({
           title: '',
           author: '',
           publishTime: '',
+          errorHint: '',
           contentHtml: '',
           codeBlocks: [],
           imageUrls: []
         };
 
-        // Title: #activity-name
-        const titleEl = document.querySelector('#activity-name');
-        result.title = titleEl ? titleEl.textContent.trim() : '';
+        const pickFirstText = (...selectors) => {
+          for (const selector of selectors) {
+            const text = document.querySelector(selector)?.textContent?.replace(/\\s+/g, ' ').trim() || '';
+            if (text && text !== 'Name cleared') return text;
+          }
+          return '';
+        };
 
-        // Author (WeChat Official Account name): #js_name
-        const authorEl = document.querySelector('#js_name');
-        result.author = authorEl ? authorEl.textContent.trim() : '';
+        // WeChat has multiple article templates. Newer pages use #js_text_title.
+        result.title = pickFirstText(
+          '#activity-name',
+          '#js_text_title',
+          '.rich_media_title',
+        );
+
+        result.author = pickFirstText(
+          '#js_name',
+          '.wx_follow_nickname',
+          '#profileBt .profile_nickname',
+          '.rich_media_meta.rich_media_meta_nickname',
+          '.rich_media_meta_nickname',
+        );
 
         // Publish time: prefer the rendered DOM text, then fall back to numeric create_time values.
         const publishTimeEl = document.querySelector('#publish_time');
@@ -216,6 +288,13 @@ cli({
           publishTimeEl ? publishTimeEl.textContent : '',
           document.documentElement.innerHTML,
         );
+
+        const detectWechatAccessIssue = ${buildDetectWechatAccessIssueJs()};
+        result.errorHint = detectWechatAccessIssue(
+          document.body ? document.body.innerText : '',
+          document.documentElement.innerHTML,
+        );
+        if (result.errorHint) return result;
 
         // Content processing
         const contentEl = document.querySelector('#js_content');
@@ -267,6 +346,16 @@ cli({
         return result;
       })()
     `);
+
+    if (data?.errorHint === 'environment verification required') {
+      return [{
+        title: 'Error',
+        author: '-',
+        publish_time: '-',
+        status: 'failed — verification required in WeChat browser page',
+        size: '-',
+      }];
+    }
 
     return downloadArticle(
       {

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -11,15 +11,19 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import yaml from 'js-yaml';
 import { type CliCommand, type InternalCliCommand, type Arg, Strategy, registerCommand } from './registry.js';
 import { getErrorMessage } from './errors.js';
 import { log } from './logger.js';
 import type { ManifestEntry } from './build-manifest.js';
 
+/** User runtime directory: ~/.opencli */
+export const USER_OPENCLI_DIR = path.join(os.homedir(), '.opencli');
+/** User CLIs directory: ~/.opencli/clis */
+export const USER_CLIS_DIR = path.join(USER_OPENCLI_DIR, 'clis');
 /** Plugins directory: ~/.opencli/plugins/ */
-export const PLUGINS_DIR = path.join(os.homedir(), '.opencli', 'plugins');
+export const PLUGINS_DIR = path.join(USER_OPENCLI_DIR, 'plugins');
 /** Matches files that register commands via cli() or lifecycle hooks */
 const PLUGIN_MODULE_PATTERN = /\b(?:cli|onStartup|onBeforeExecute|onAfterExecute)\s*\(/;
 
@@ -32,6 +36,47 @@ function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Str
 }
 
 import { isRecord } from './utils.js';
+
+function resolveHostRuntimeModulePath(moduleName: string): string {
+  const runtimeDir = path.dirname(fileURLToPath(import.meta.url));
+  for (const ext of ['.js', '.ts']) {
+    const candidate = path.join(runtimeDir, `${moduleName}${ext}`);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return path.join(runtimeDir, `${moduleName}.js`);
+}
+
+async function writeCompatShimIfNeeded(filePath: string, content: string): Promise<void> {
+  try {
+    const existing = await fs.promises.readFile(filePath, 'utf-8');
+    if (existing === content) return;
+  } catch {
+    // Fall through to write missing shim
+  }
+  await fs.promises.writeFile(filePath, content, 'utf-8');
+}
+
+/**
+ * Create runtime shim files under ~/.opencli so legacy user TS CLIs can keep
+ * importing ../../registry(.js) and ../../errors(.js).
+ */
+export async function ensureUserCliCompatShims(baseDir: string = USER_OPENCLI_DIR): Promise<void> {
+  await fs.promises.mkdir(baseDir, { recursive: true });
+
+  const registryUrl = pathToFileURL(resolveHostRuntimeModulePath('registry-api')).href;
+  const errorsUrl = pathToFileURL(resolveHostRuntimeModulePath('errors')).href;
+
+  await Promise.all([
+    writeCompatShimIfNeeded(path.join(baseDir, 'registry'), `export * from '${registryUrl}';\n`),
+    writeCompatShimIfNeeded(path.join(baseDir, 'registry.js'), `export * from '${registryUrl}';\n`),
+    writeCompatShimIfNeeded(path.join(baseDir, 'errors'), `export * from '${errorsUrl}';\n`),
+    writeCompatShimIfNeeded(path.join(baseDir, 'errors.js'), `export * from '${errorsUrl}';\n`),
+    writeCompatShimIfNeeded(
+      path.join(baseDir, 'package.json'),
+      `${JSON.stringify({ name: 'opencli-user-runtime', private: true, type: 'module' }, null, 2)}\n`,
+    ),
+  ]);
+}
 
 /**
  * Discover and register CLI commands.

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { discoverClis, discoverPlugins, PLUGINS_DIR } from './discovery.js';
+import { discoverClis, discoverPlugins, ensureUserCliCompatShims, PLUGINS_DIR } from './discovery.js';
 import { executeCommand } from './execution.js';
 import { getRegistry, cli, Strategy } from './registry.js';
 import { clearAllHooks, onAfterExecute } from './hooks.js';
@@ -76,6 +76,39 @@ cli({
       expect(getRegistry().get('fallback-site/hello')).toBeDefined();
     } finally {
       await fs.promises.rm(tempBuildRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('loads legacy user TS CLI modules via compatibility shims', async () => {
+    const tempOpencliRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-user-clis-'));
+    const userClisDir = path.join(tempOpencliRoot, 'clis');
+    const siteDir = path.join(userClisDir, 'legacy-site');
+    const commandPath = path.join(siteDir, 'hello.ts');
+
+    try {
+      await ensureUserCliCompatShims(tempOpencliRoot);
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(commandPath, `
+import { cli, Strategy } from '../../registry';
+import { CommandExecutionError } from '../../errors';
+
+cli({
+  site: 'legacy-site',
+  name: 'hello',
+  description: 'hello command',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  func: async () => [{ ok: true, errorName: new CommandExecutionError('boom').name }],
+});
+`);
+
+      await discoverClis(userClisDir);
+
+      const cmd = getRegistry().get('legacy-site/hello');
+      expect(cmd).toBeDefined();
+      await expect(executeCommand(cmd!, {})).resolves.toEqual([{ ok: true, errorName: 'CommandExecutionError' }]);
+    } finally {
+      await fs.promises.rm(tempOpencliRoot, { recursive: true, force: true });
     }
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ if (process.platform !== 'win32') {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { discoverClis, discoverPlugins } from './discovery.js';
+import { discoverClis, discoverPlugins, ensureUserCliCompatShims, USER_CLIS_DIR } from './discovery.js';
 import { getCompletions } from './completion.js';
 import { runCli } from './cli.js';
 import { emitHook } from './hooks.js';
@@ -29,9 +29,10 @@ installNodeNetwork();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const BUILTIN_CLIS = path.resolve(__dirname, 'clis');
-const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
+const USER_CLIS = USER_CLIS_DIR;
 
 // Sequential: plugins must run after built-in discovery so they can override built-in commands.
+await ensureUserCliCompatShims();
 await discoverClis(BUILTIN_CLIS, USER_CLIS);
 await discoverPlugins();
 

--- a/src/weixin-download.test.ts
+++ b/src/weixin-download.test.ts
@@ -61,4 +61,31 @@ describe('weixin publish time extraction', () => {
       'var create_time = "1711291080";',
     )).toBe('2026年3月24日 22:38');
   });
+
+  it('detects WeChat verification gate pages', async () => {
+    const mod = await loadModule();
+
+    expect(mod.detectWechatAccessIssue(
+      '环境异常 当前环境异常，完成验证后即可继续访问。 去验证',
+      '<html><body><a id="js_verify">去验证</a></body></html>',
+    )).toBe('environment verification required');
+  });
+
+  it('browser access detector matches the server-side verifier', async () => {
+    const mod = await loadModule();
+
+    const detectInPage = eval(mod.buildDetectWechatAccessIssueJs()) as (pageText: string, htmlStr: string) => string;
+
+    expect(detectInPage(
+      '环境异常 当前环境异常，完成验证后即可继续访问。 去验证',
+      '<html>secitptpage/verify.html<a id="js_verify">去验证</a></html>',
+    )).toBe('environment verification required');
+  });
+
+  it('picks the first non-empty WeChat metadata field', async () => {
+    const mod = await loadModule();
+
+    expect(mod.pickFirstWechatMetaText('', 'Name cleared', '数字生命卡兹克')).toBe('数字生命卡兹克');
+    expect(mod.pickFirstWechatMetaText('', '  聊聊刚刚上线的PixVerse V6视频模型。  ')).toBe('聊聊刚刚上线的PixVerse V6视频模型。');
+  });
 });


### PR DESCRIPTION
## What changed
Improved `weixin/download` so it can extract article metadata from newer WeChat article templates, and added a small compatibility shim for legacy user TS CLIs under `~/.opencli/clis` that still import `../../registry` or `../../errors`.

## Why
Two separate issues were showing up in real usage:
1. `opencli weixin download` returned `failed — no title` for a valid article because newer WeChat pages render the article title and account name with different selectors than the adapter expected.
2. Legacy user CLI files in `~/.opencli/clis` emitted startup warnings because they imported `../../registry` and `../../errors` without the new runtime bridge.

## Impact
- Valid WeChat articles now download successfully on both older and newer page templates.
- OpenCLI startup is quieter and more backward compatible with previously generated user TS CLIs.

## Validation
- `npm run typecheck`
- `npm test -- src/weixin-download.test.ts src/engine.test.ts`
- `npm run build`
- `node dist/main.js weixin download --url https://mp.weixin.qq.com/s/RWruLrlbik8zbbiyHL13NQ --output /tmp/opencli-weixin-pr-check`