### PR TITLE
fix(xiaohongshu): support full URL/short link and fix video extraction

### DIFF
--- a/src/clis/xiaohongshu/download.test.ts
+++ b/src/clis/xiaohongshu/download.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IPage } from '../../types.js';
+
+const { mockDownloadMedia, mockFormatCookieHeader } = vi.hoisted(() => ({
+  mockDownloadMedia: vi.fn(),
+  mockFormatCookieHeader: vi.fn(() => 'a=b'),
+}));
+
+vi.mock('../../download/media-download.js', () => ({
+  downloadMedia: mockDownloadMedia,
+}));
+
+vi.mock('../../download/index.js', () => ({
+  formatCookieHeader: mockFormatCookieHeader,
+}));
+
+import { getRegistry } from '../../registry.js';
+import './download.js';
+
+function createPageMock(evaluateResult: any): IPage {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+    snapshot: vi.fn().mockResolvedValue(undefined),
+    click: vi.fn().mockResolvedValue(undefined),
+    typeText: vi.fn().mockResolvedValue(undefined),
+    pressKey: vi.fn().mockResolvedValue(undefined),
+    scrollTo: vi.fn().mockResolvedValue(undefined),
+    getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
+    wait: vi.fn().mockResolvedValue(undefined),
+    tabs: vi.fn().mockResolvedValue([]),
+    closeTab: vi.fn().mockResolvedValue(undefined),
+    newTab: vi.fn().mockResolvedValue(undefined),
+    selectTab: vi.fn().mockResolvedValue(undefined),
+    networkRequests: vi.fn().mockResolvedValue([]),
+    consoleMessages: vi.fn().mockResolvedValue([]),
+    scroll: vi.fn().mockResolvedValue(undefined),
+    autoScroll: vi.fn().mockResolvedValue(undefined),
+    installInterceptor: vi.fn().mockResolvedValue(undefined),
+    getInterceptedRequests: vi.fn().mockResolvedValue([]),
+    getCookies: vi.fn().mockResolvedValue([{ name: 'sid', value: 'secret', domain: '.xiaohongshu.com' }]),
+    screenshot: vi.fn().mockResolvedValue(''),
+    waitForCapture: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('xiaohongshu download', () => {
+  const command = getRegistry().get('xiaohongshu/download');
+
+  beforeEach(() => {
+    mockDownloadMedia.mockReset();
+    mockFormatCookieHeader.mockClear();
+    mockDownloadMedia.mockResolvedValue([{ index: 1, type: 'video', status: 'success', size: '1 MB' }]);
+  });
+
+  it('preserves short links for navigation but uses canonical note id for output naming', async () => {
+    const page = createPageMock({
+      noteId: '69bc166f000000001a02069a',
+      media: [{ type: 'video', url: 'https://sns-video-hw.xhscdn.com/example.mp4' }],
+    });
+
+    const shortUrl = 'http://xhslink.com/o/4MKEjsZnhCz';
+    await command!.func!(page, { 'note-id': shortUrl, output: './out' });
+
+    expect((page.goto as any).mock.calls[0][0]).toBe(shortUrl);
+    expect(mockDownloadMedia).toHaveBeenCalledWith(
+      [{ type: 'video', url: 'https://sns-video-hw.xhscdn.com/example.mp4' }],
+      expect.objectContaining({
+        output: './out',
+        subdir: '69bc166f000000001a02069a',
+        filenamePrefix: '69bc166f000000001a02069a',
+        cookies: 'a=b',
+      }),
+    );
+  });
+
+  it('preserves full note URL with xsec_token for navigation', async () => {
+    const page = createPageMock({
+      noteId: '69bc166f000000001a02069a',
+      media: [{ type: 'image', url: 'https://ci.xiaohongshu.com/example.jpg' }],
+    });
+
+    const fullUrl =
+      'https://www.xiaohongshu.com/explore/69bc166f000000001a02069a?xsec_token=abc&xsec_source=pc_search';
+    await command!.func!(page, { 'note-id': fullUrl, output: './out' });
+
+    expect((page.goto as any).mock.calls[0][0]).toBe(fullUrl);
+    expect(mockDownloadMedia).toHaveBeenCalledWith(
+      [{ type: 'image', url: 'https://ci.xiaohongshu.com/example.jpg' }],
+      expect.objectContaining({
+        subdir: '69bc166f000000001a02069a',
+        filenamePrefix: '69bc166f000000001a02069a',
+      }),
+    );
+  });
+});

--- a/src/clis/xiaohongshu/download.ts
+++ b/src/clis/xiaohongshu/download.ts
@@ -11,14 +11,7 @@
 import { cli, Strategy } from '../../registry.js';
 import { formatCookieHeader } from '../../download/index.js';
 import { downloadMedia } from '../../download/media-download.js';
-
-/**
- * Extract a bare note ID from a URL or return the input as-is.
- */
-function extractNoteId(input: string): string {
-  const match = input.match(/\/(?:explore|discovery\/item|search_result)\/([0-9a-f]{24})/i);
-  return match ? match[1] : input;
-}
+import { buildNoteUrl, parseNoteId } from './note-helpers.js';
 
 cli({
   site: 'xiaohongshu',
@@ -32,15 +25,11 @@ cli({
   ],
   columns: ['index', 'type', 'status', 'size'],
   func: async (page, kwargs) => {
-    const rawInput = kwargs['note-id'];
+    const rawInput = String(kwargs['note-id']);
     const output = kwargs.output;
-    const noteId = extractNoteId(rawInput);
+    const noteId = parseNoteId(rawInput);
 
-    // Support full URL / short link; fall back to constructing explore URL
-    const targetUrl = rawInput.startsWith('http')
-      ? rawInput
-      : `https://www.xiaohongshu.com/explore/${noteId}`;
-    await page.goto(targetUrl);
+    await page.goto(buildNoteUrl(rawInput));
 
     // Extract note info and media URLs
     const data = await page.evaluate(`
@@ -51,6 +40,18 @@ cli({
           author: '',
           media: []
         };
+        const seenMedia = new Set();
+        const pushMedia = (type, url) => {
+          if (!url) return;
+          const key = type + ':' + url;
+          if (seenMedia.has(key)) return;
+          seenMedia.add(key);
+          result.media.push({ type, url });
+        };
+        const locationMatch = (location.pathname || '').match(/\\/(?:explore|note|search_result|discovery\\/item)\\/([a-f0-9]+)/i);
+        if (locationMatch) {
+          result.noteId = locationMatch[1];
+        }
 
         // Get title
         const titleEl = document.querySelector('.title, #detail-title, .note-content .title');
@@ -97,11 +98,11 @@ cli({
                 const vUrl = video.url || video.originVideoKey || video.consumer?.originVideoKey;
                 if (vUrl) {
                   const fullUrl = vUrl.startsWith('http') ? vUrl : 'https://sns-video-bd.xhscdn.com/' + vUrl;
-                  result.media.push({ type: 'video', url: fullUrl });
+                  pushMedia('video', fullUrl);
                 }
                 const streams = video.media?.stream?.h264 || [];
                 for (const stream of streams) {
-                  if (stream.masterUrl) result.media.push({ type: 'video', url: stream.masterUrl });
+                  if (stream.masterUrl) pushMedia('video', stream.masterUrl);
                 }
               }
             }
@@ -118,7 +119,7 @@ cli({
                 || text.match(/https?:\\/\\/[^"'\\s]*xhscdn[^"'\\s]*\\.mp4[^"'\\s]*/g);
               if (videoMatches) {
                 videoMatches.forEach(url => {
-                  result.media.push({ type: 'video', url: url.replace(/\\\\u002F/g, '/') });
+                  pushMedia('video', url.replace(/\\\\u002F/g, '/'));
                 });
               }
             }
@@ -137,7 +138,7 @@ cli({
             document.querySelectorAll(selector).forEach(v => {
               const src = v.src || v.getAttribute('src') || '';
               if (src && !src.startsWith('blob:')) {
-                result.media.push({ type: 'video', url: src });
+                pushMedia('video', src);
               }
             });
           }
@@ -145,7 +146,7 @@ cli({
 
         // Add images to media
         imageUrls.forEach(url => {
-          result.media.push({ type: 'image', url: url });
+          pushMedia('image', url);
         });
 
         return result;
@@ -158,12 +159,15 @@ cli({
 
     // Extract cookies for authenticated downloads
     const cookies = formatCookieHeader(await page.getCookies({ domain: 'xiaohongshu.com' }));
+    const resolvedNoteId = typeof data.noteId === 'string' && data.noteId.trim()
+      ? data.noteId.trim()
+      : noteId;
 
     return downloadMedia(data.media, {
       output,
-      subdir: noteId,
+      subdir: resolvedNoteId,
       cookies,
-      filenamePrefix: noteId,
+      filenamePrefix: resolvedNoteId,
       timeout: 60000,
     });
   },


### PR DESCRIPTION
## Summary

- **URL handling**: accept full URLs (with `xsec_token`) and short links (`xhslink.com`) in addition to bare note IDs. Bare note IDs construct `explore/{noteId}` which now lacks the `xsec_token` required by Xiaohongshu, causing all downloads to fail with "No media found".
- **Video extraction**: extract real video URLs from `window.__INITIAL_STATE__` and inline script JSON instead of relying on DOM `<video>` elements which return `blob:` URLs that cannot be downloaded via HTTP.

## Reproduction

```bash
# Before: fails — page loads but xsec_token missing, no content rendered
opencli xiaohongshu download 69bc166f000000001a02069a

# After: works with short link
opencli xiaohongshu download "http://xhslink.com/o/4MKEjsZnhCz"

# After: works with full URL
opencli xiaohongshu download "https://www.xiaohongshu.com/explore/69bc166f000000001a02069a?xsec_token=..."
```

## Test result

Successfully downloaded a 21.5 MB MP4 video note via short link.