### PR TITLE
fix(weread): recover book details from cached shelf fallback

### DIFF
--- a/src/clis/weread/book.ts
+++ b/src/clis/weread/book.ts
@@ -1,7 +1,13 @@
 import { cli, Strategy } from '../../registry.js';
 import { CliError } from '../../errors.js';
 import type { IPage } from '../../types.js';
-import { fetchPrivateApi, resolveShelfReaderUrl } from './utils.js';
+import {
+  fetchPrivateApi,
+  fetchWebApi,
+  resolveShelfReader,
+  WEREAD_UA,
+  WEREAD_WEB_ORIGIN,
+} from './utils.js';
 
 interface ReaderFallbackResult {
   title: string;
@@ -11,6 +17,132 @@ interface ReaderFallbackResult {
   category: string;
   rating: string;
   metadataReady: boolean;
+}
+
+interface SearchHtmlEntry {
+  title: string;
+  author: string;
+  url: string;
+}
+
+function decodeHtmlText(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, '')
+    .replace(/&#x([0-9a-fA-F]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .trim();
+}
+
+function normalizeSearchText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function buildSearchIdentity(title: string, author: string): string {
+  return `${normalizeSearchText(title)}\u0000${normalizeSearchText(author)}`;
+}
+
+function countSearchTitles(entries: Array<{ title: string }>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    const key = normalizeSearchText(entry.title);
+    if (!key) continue;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return counts;
+}
+
+function countSearchIdentities(entries: Array<{ title: string; author: string }>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    const key = buildSearchIdentity(entry.title, entry.author);
+    if (!normalizeSearchText(entry.title) || !normalizeSearchText(entry.author)) continue;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Reuse the public search page as a last-resort reader URL source when the
+ * cached shelf page cannot provide a trustworthy bookId-to-reader mapping.
+ */
+async function resolveSearchReaderUrl(title: string, author: string): Promise<string> {
+  const normalizedTitle = normalizeSearchText(title);
+  const normalizedAuthor = normalizeSearchText(author);
+  if (!normalizedTitle) return '';
+
+  try {
+    const [data, htmlEntries] = await Promise.all([
+      fetchWebApi('/search/global', { keyword: normalizedTitle }),
+      (async (): Promise<SearchHtmlEntry[]> => {
+        const url = new URL('/web/search/books', WEREAD_WEB_ORIGIN);
+        url.searchParams.set('keyword', normalizedTitle);
+
+        const resp = await fetch(url.toString(), {
+          headers: { 'User-Agent': WEREAD_UA },
+        });
+        if (!resp.ok) return [];
+
+        const html = await resp.text();
+        const items = Array.from(
+          html.matchAll(/<li[^>]*class="wr_bookList_item"[^>]*>([\s\S]*?)<\/li>/g),
+        );
+
+        return items.map((match) => {
+          const chunk = match[1];
+          const hrefMatch = chunk.match(/<a[^>]*href="([^"]+)"[^>]*class="wr_bookList_item_link"[^>]*>|<a[^>]*class="wr_bookList_item_link"[^>]*href="([^"]+)"[^>]*>/);
+          const titleMatch = chunk.match(/<p[^>]*class="wr_bookList_item_title"[^>]*>([\s\S]*?)<\/p>/);
+          const authorMatch = chunk.match(/<p[^>]*class="wr_bookList_item_author"[^>]*>([\s\S]*?)<\/p>/);
+          const href = hrefMatch?.[1] || hrefMatch?.[2] || '';
+
+          return {
+            title: decodeHtmlText(titleMatch?.[1] || ''),
+            author: decodeHtmlText(authorMatch?.[1] || ''),
+            url: href ? new URL(href, WEREAD_WEB_ORIGIN).toString() : '',
+          };
+        }).filter((entry) => entry.title && entry.url);
+      })(),
+    ]);
+
+    const books: any[] = Array.isArray(data?.books) ? data.books : [];
+    const apiIdentityCounts = countSearchIdentities(
+      books.map((item: any) => ({
+        title: item.bookInfo?.title ?? '',
+        author: item.bookInfo?.author ?? '',
+      })),
+    );
+    const htmlIdentityCounts = countSearchIdentities(
+      htmlEntries.filter((entry) => entry.author),
+    );
+    const identityKey = buildSearchIdentity(normalizedTitle, normalizedAuthor);
+    if (
+      normalizedAuthor &&
+      (apiIdentityCounts.get(identityKey) || 0) === 1 &&
+      (htmlIdentityCounts.get(identityKey) || 0) === 1
+    ) {
+      const exactMatch = htmlEntries.find((entry) => buildSearchIdentity(entry.title, entry.author) === identityKey);
+      if (exactMatch?.url) return exactMatch.url;
+    }
+
+    const sameTitleHtmlEntries = htmlEntries.filter((entry) => normalizeSearchText(entry.title) === normalizedTitle);
+    if (normalizedAuthor && sameTitleHtmlEntries.some((entry) => normalizeSearchText(entry.author))) {
+      return '';
+    }
+
+    const apiTitleCounts = countSearchTitles(
+      books.map((item: any) => ({ title: item.bookInfo?.title ?? '' })),
+    );
+    const htmlTitleCounts = countSearchTitles(htmlEntries);
+    if ((apiTitleCounts.get(normalizedTitle) || 0) !== 1 || (htmlTitleCounts.get(normalizedTitle) || 0) !== 1) {
+      return '';
+    }
+
+    return htmlEntries.find((entry) => normalizeSearchText(entry.title) === normalizedTitle)?.url || '';
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -108,7 +240,15 @@ cli({
         throw error;
       }
 
-      const readerUrl = await resolveShelfReaderUrl(page, bookId);
+      const { readerUrl: resolvedReaderUrl, snapshot } = await resolveShelfReader(page, bookId);
+      let readerUrl = resolvedReaderUrl;
+      if (!readerUrl) {
+        const cachedBook = snapshot.rawBooks.find((book) => String(book?.bookId || '').trim() === bookId);
+        readerUrl = await resolveSearchReaderUrl(
+          String(cachedBook?.title || ''),
+          String(cachedBook?.author || ''),
+        );
+      }
       if (!readerUrl) {
         throw error;
       }

--- a/src/clis/weread/commands.test.ts
+++ b/src/clis/weread/commands.test.ts
@@ -23,8 +23,20 @@ describe('weread book-id positional args', () => {
   const highlights = getRegistry().get('weread/highlights');
   const notes = getRegistry().get('weread/notes');
 
+  const repeatValue = <T,>(value: T, count: number): T[] => Array.from({ length: count }, () => value);
+
+  const createPageStub = (...evaluateResults: unknown[]) => ({
+    getCookies: vi.fn().mockResolvedValue([
+      { name: 'wr_vid', value: '70486028', domain: '.weread.qq.com' },
+    ]),
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockImplementation(async () => evaluateResults.shift()),
+  });
+
   beforeEach(() => {
     mockFetchPrivateApi.mockReset();
+    vi.unstubAllGlobals();
   });
 
   it('passes the positional book-id to book details', async () => {
@@ -40,33 +52,27 @@ describe('weread book-id positional args', () => {
       new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
     );
 
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn()
-        .mockResolvedValueOnce({
-          cacheFound: true,
-          rawBooks: [
-            { bookId: 'MP_WXS_3634777637', title: '文明、现代化、价值投资与中国', author: '李录' },
-          ],
-          shelfIndexes: [
-            { bookId: 'MP_WXS_3634777637', idx: 0, role: 'book' },
-          ],
-        })
-        .mockResolvedValueOnce(['https://weread.qq.com/web/reader/6f5323f071bd7f7b6f521e8'])
-        .mockResolvedValueOnce({
-          title: '文明、现代化、价值投资与中国',
-          author: '李录',
-          publisher: '中信出版集团',
-          intro: '对中国未来几十年的预测。',
-          category: '',
-          rating: '84.1%',
-          metadataReady: true,
-        }),
-      getCookies: vi.fn().mockResolvedValue([
-        { name: 'wr_vid', value: '70486028', domain: '.weread.qq.com' },
-      ]),
-      wait: vi.fn().mockResolvedValue(undefined),
-    } as any;
+    const page = createPageStub(
+      {
+        cacheFound: true,
+        rawBooks: [
+          { bookId: 'MP_WXS_3634777637', title: '文明、现代化、价值投资与中国', author: '李录' },
+        ],
+        shelfIndexes: [
+          { bookId: 'MP_WXS_3634777637', idx: 0, role: 'book' },
+        ],
+      },
+      ['https://weread.qq.com/web/reader/6f5323f071bd7f7b6f521e8'],
+      {
+        title: '文明、现代化、价值投资与中国',
+        author: '李录',
+        publisher: '中信出版集团',
+        intro: '对中国未来几十年的预测。',
+        category: '',
+        rating: '84.1%',
+        metadataReady: true,
+      },
+    ) as any;
 
     const result = await book!.func!(page, { 'book-id': 'MP_WXS_3634777637' });
 
@@ -90,41 +96,35 @@ describe('weread book-id positional args', () => {
       new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
     );
 
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn()
-        .mockResolvedValueOnce({
-          cacheFound: true,
-          rawBooks: [
-            { bookId: 'MP_WXS_1', title: '公众号文章一', author: '作者甲' },
-            { bookId: 'BOOK_2', title: '普通书二', author: '作者乙' },
-            { bookId: 'MP_WXS_3', title: '公众号文章三', author: '作者丙' },
-          ],
-          shelfIndexes: [
-            { bookId: 'MP_WXS_1', idx: 0, role: 'mp' },
-            { bookId: 'BOOK_2', idx: 1, role: 'book' },
-            { bookId: 'MP_WXS_3', idx: 2, role: 'mp' },
-          ],
-        })
-        .mockResolvedValueOnce([
-          'https://weread.qq.com/web/reader/mp1',
-          'https://weread.qq.com/web/reader/book2',
-          'https://weread.qq.com/web/reader/mp3',
-        ])
-        .mockResolvedValueOnce({
-          title: '公众号文章一',
-          author: '作者甲',
-          publisher: '微信读书',
-          intro: '第一篇文章。',
-          category: '',
-          rating: '',
-          metadataReady: true,
-        }),
-      getCookies: vi.fn().mockResolvedValue([
-        { name: 'wr_vid', value: '70486028', domain: '.weread.qq.com' },
-      ]),
-      wait: vi.fn().mockResolvedValue(undefined),
-    } as any;
+    const page = createPageStub(
+      {
+        cacheFound: true,
+        rawBooks: [
+          { bookId: 'MP_WXS_1', title: '公众号文章一', author: '作者甲' },
+          { bookId: 'BOOK_2', title: '普通书二', author: '作者乙' },
+          { bookId: 'MP_WXS_3', title: '公众号文章三', author: '作者丙' },
+        ],
+        shelfIndexes: [
+          { bookId: 'MP_WXS_1', idx: 0, role: 'mp' },
+          { bookId: 'BOOK_2', idx: 1, role: 'book' },
+          { bookId: 'MP_WXS_3', idx: 2, role: 'mp' },
+        ],
+      },
+      [
+        'https://weread.qq.com/web/reader/mp1',
+        'https://weread.qq.com/web/reader/book2',
+        'https://weread.qq.com/web/reader/mp3',
+      ],
+      {
+        title: '公众号文章一',
+        author: '作者甲',
+        publisher: '微信读书',
+        intro: '第一篇文章。',
+        category: '',
+        rating: '',
+        metadataReady: true,
+      },
+    ) as any;
 
     const result = await book!.func!(page, { 'book-id': 'MP_WXS_1' });
 
@@ -146,36 +146,208 @@ describe('weread book-id positional args', () => {
     mockFetchPrivateApi.mockRejectedValue(
       new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
     );
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network disabled')));
 
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn()
-        .mockResolvedValueOnce({
-          cacheFound: true,
-          rawBooks: [
-            { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
-            { bookId: 'BOOK_2', title: '第二本', author: '作者乙' },
-          ],
-          shelfIndexes: [
-            { bookId: 'BOOK_2', idx: 0, role: 'book' },
-          ],
-        })
-        .mockResolvedValueOnce([
-          'https://weread.qq.com/web/reader/book2',
-          'https://weread.qq.com/web/reader/book1',
-        ]),
-      getCookies: vi.fn().mockResolvedValue([
-        { name: 'wr_vid', value: '70486028', domain: '.weread.qq.com' },
-      ]),
-      wait: vi.fn().mockResolvedValue(undefined),
-    } as any;
+    const page = createPageStub(
+      {
+        cacheFound: true,
+        rawBooks: [
+          { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
+          { bookId: 'BOOK_2', title: '第二本', author: '作者乙' },
+        ],
+        shelfIndexes: [
+          { bookId: 'BOOK_2', idx: 0, role: 'book' },
+        ],
+      },
+      [
+        'https://weread.qq.com/web/reader/book2',
+        'https://weread.qq.com/web/reader/book1',
+      ],
+    ) as any;
 
     await expect(book!.func!(page, { 'book-id': 'BOOK_1' })).rejects.toMatchObject({
       code: 'AUTH_REQUIRED',
       message: 'Not logged in to WeRead',
     });
     expect(page.goto).toHaveBeenCalledTimes(1);
-    expect(page.goto).toHaveBeenCalledWith('https://weread.qq.com/web/shelf');
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://weread.qq.com/web/shelf');
+  });
+
+  it('falls back to the public search page when a cached ordinary book has no trusted shelf reader url', async () => {
+    mockFetchPrivateApi.mockRejectedValue(
+      new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
+    );
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          books: [
+            {
+              bookInfo: {
+                title: '数据化运营：系统方法与实践案例',
+                author: '赵宏田 江丽萍 李宁',
+                bookId: '22920382',
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(`
+          <ul class="search_bookDetail_list">
+            <li class="wr_bookList_item">
+              <a class="wr_bookList_item_link" href="/web/reader/book229"></a>
+              <p class="wr_bookList_item_title">数据化运营：系统方法与实践案例</p>
+              <p class="wr_bookList_item_author">赵宏田 江丽萍 李宁</p>
+            </li>
+          </ul>
+        `),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const staleSnapshot = {
+      cacheFound: true,
+      rawBooks: [
+        { bookId: '22920382', title: '数据化运营：系统方法与实践案例', author: '赵宏田 江丽萍 李宁' },
+      ],
+      shelfIndexes: [
+        { bookId: 'stale-entry', idx: 0, role: 'book' },
+      ],
+    };
+    const page = createPageStub(
+      ...repeatValue(staleSnapshot, 2),
+      {
+        title: '数据化运营：系统方法与实践案例',
+        author: '赵宏田 江丽萍 李宁',
+        publisher: '电子工业出版社',
+        intro: '一本关于数据化运营的方法论书籍。',
+        category: '',
+        rating: '',
+        metadataReady: true,
+      },
+    ) as any;
+
+    const result = await book!.func!(page, { 'book-id': '22920382' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/web/search/global?keyword=');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('/web/search/books?keyword=');
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://weread.qq.com/web/shelf');
+    expect(page.goto).toHaveBeenNthCalledWith(2, 'https://weread.qq.com/web/reader/book229');
+    expect(result).toEqual([
+      {
+        title: '数据化运营：系统方法与实践案例',
+        author: '赵宏田 江丽萍 李宁',
+        publisher: '电子工业出版社',
+        intro: '一本关于数据化运营的方法论书籍。',
+        category: '',
+        rating: '',
+      },
+    ]);
+  });
+
+  it('rethrows AUTH_REQUIRED when search fallback finds the same title with a different visible author', async () => {
+    mockFetchPrivateApi.mockRejectedValue(
+      new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
+    );
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          books: [
+            {
+              bookInfo: {
+                title: '文明',
+                author: '作者乙',
+                bookId: 'wrong-book',
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(`
+          <ul class="search_bookDetail_list">
+            <li class="wr_bookList_item">
+              <a class="wr_bookList_item_link" href="/web/reader/wrong-reader"></a>
+              <p class="wr_bookList_item_title">文明</p>
+              <p class="wr_bookList_item_author">作者乙</p>
+            </li>
+          </ul>
+        `),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const staleSnapshot = {
+      cacheFound: true,
+      rawBooks: [
+        { bookId: 'BOOK_1', title: '文明', author: '作者甲' },
+      ],
+      shelfIndexes: [
+        { bookId: 'stale-entry', idx: 0, role: 'book' },
+      ],
+    };
+    const page = createPageStub(
+      ...repeatValue(staleSnapshot, 2),
+    ) as any;
+
+    await expect(book!.func!(page, { 'book-id': 'BOOK_1' })).rejects.toMatchObject({
+      code: 'AUTH_REQUIRED',
+      message: 'Not logged in to WeRead',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://weread.qq.com/web/shelf');
+  });
+
+  it('falls back to raw cache order when shelf indexes never hydrate but rendered reader urls cover every cached entry', async () => {
+    mockFetchPrivateApi.mockRejectedValue(
+      new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
+    );
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network disabled')));
+
+    const emptyIndexSnapshot = {
+      cacheFound: true,
+      rawBooks: [
+        { bookId: '22920382', title: '数据化运营：系统方法与实践案例', author: '赵宏田 江丽萍 李宁' },
+        { bookId: 'MP_WXS_3634777637', title: '方伟看10年', author: '公众号' },
+      ],
+      shelfIndexes: [],
+    };
+    const page = createPageStub(
+      ...repeatValue(emptyIndexSnapshot, 2),
+      [
+        'https://weread.qq.com/web/reader/book229',
+        'https://weread.qq.com/web/reader/mp3634',
+      ],
+      {
+        title: '方伟看10年',
+        author: '公众号',
+        publisher: '',
+        intro: '公众号文章详情。',
+        category: '',
+        rating: '',
+        metadataReady: true,
+      },
+    ) as any;
+
+    const result = await book!.func!(page, { 'book-id': 'MP_WXS_3634777637' });
+
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://weread.qq.com/web/shelf');
+    expect(page.goto).toHaveBeenNthCalledWith(2, 'https://weread.qq.com/web/reader/mp3634');
+    expect(result).toEqual([
+      {
+        title: '方伟看10年',
+        author: '公众号',
+        publisher: '',
+        intro: '公众号文章详情。',
+        category: '',
+        rating: '',
+      },
+    ]);
   });
 
   it('waits for shelf indexes to hydrate before resolving a trusted reader url', async () => {
@@ -183,48 +355,42 @@ describe('weread book-id positional args', () => {
       new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
     );
 
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn()
-        .mockResolvedValueOnce({
-          cacheFound: true,
-          rawBooks: [
-            { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
-            { bookId: 'BOOK_2', title: '第二本', author: '作者乙' },
-          ],
-          shelfIndexes: [
-            { bookId: 'BOOK_2', idx: 0, role: 'book' },
-          ],
-        })
-        .mockResolvedValueOnce({
-          cacheFound: true,
-          rawBooks: [
-            { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
-            { bookId: 'BOOK_2', title: '第二本', author: '作者乙' },
-          ],
-          shelfIndexes: [
-            { bookId: 'BOOK_2', idx: 0, role: 'book' },
-            { bookId: 'BOOK_1', idx: 1, role: 'book' },
-          ],
-        })
-        .mockResolvedValueOnce([
-          'https://weread.qq.com/web/reader/book2',
-          'https://weread.qq.com/web/reader/book1',
-        ])
-        .mockResolvedValueOnce({
-          title: '第一本',
-          author: '作者甲',
-          publisher: '出版社甲',
-          intro: '简介甲',
-          category: '',
-          rating: '',
-          metadataReady: true,
-        }),
-      getCookies: vi.fn().mockResolvedValue([
-        { name: 'wr_vid', value: '70486028', domain: '.weread.qq.com' },
-      ]),
-      wait: vi.fn().mockResolvedValue(undefined),
-    } as any;
+    const page = createPageStub(
+      {
+        cacheFound: true,
+        rawBooks: [
+          { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
+          { bookId: 'BOOK_2', title: '第二本', author: '作者乙' },
+        ],
+        shelfIndexes: [
+          { bookId: 'BOOK_2', idx: 0, role: 'book' },
+        ],
+      },
+      {
+        cacheFound: true,
+        rawBooks: [
+          { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
+          { bookId: 'BOOK_2', title: '第二本', author: '作者乙' },
+        ],
+        shelfIndexes: [
+          { bookId: 'BOOK_2', idx: 0, role: 'book' },
+          { bookId: 'BOOK_1', idx: 1, role: 'book' },
+        ],
+      },
+      [
+        'https://weread.qq.com/web/reader/book2',
+        'https://weread.qq.com/web/reader/book1',
+      ],
+      {
+        title: '第一本',
+        author: '作者甲',
+        publisher: '出版社甲',
+        intro: '简介甲',
+        category: '',
+        rating: '',
+        metadataReady: true,
+      },
+    ) as any;
 
     const result = await book!.func!(page, { 'book-id': 'BOOK_1' });
 
@@ -247,35 +413,29 @@ describe('weread book-id positional args', () => {
       new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first'),
     );
 
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn()
-        .mockResolvedValueOnce({
-          cacheFound: true,
-          rawBooks: [
-            { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
-          ],
-          shelfIndexes: [
-            { bookId: 'BOOK_1', idx: 0, role: 'book' },
-          ],
-        })
-        .mockResolvedValueOnce([
-          'https://weread.qq.com/web/reader/book1',
-        ])
-        .mockResolvedValueOnce({
-          title: '',
-          author: '',
-          publisher: '',
-          intro: '这是正文第一段，不应该被当成简介。',
-          category: '',
-          rating: '',
-          metadataReady: false,
-        }),
-      getCookies: vi.fn().mockResolvedValue([
-        { name: 'wr_vid', value: '70486028', domain: '.weread.qq.com' },
-      ]),
-      wait: vi.fn().mockResolvedValue(undefined),
-    } as any;
+    const page = createPageStub(
+      {
+        cacheFound: true,
+        rawBooks: [
+          { bookId: 'BOOK_1', title: '第一本', author: '作者甲' },
+        ],
+        shelfIndexes: [
+          { bookId: 'BOOK_1', idx: 0, role: 'book' },
+        ],
+      },
+      [
+        'https://weread.qq.com/web/reader/book1',
+      ],
+      {
+        title: '',
+        author: '',
+        publisher: '',
+        intro: '这是正文第一段，不应该被当成简介。',
+        category: '',
+        rating: '',
+        metadataReady: false,
+      },
+    ) as any;
 
     await expect(book!.func!(page, { 'book-id': 'BOOK_1' })).rejects.toMatchObject({
       code: 'AUTH_REQUIRED',

--- a/src/clis/weread/utils.ts
+++ b/src/clis/weread/utils.ts
@@ -42,6 +42,11 @@ export interface WebShelfEntry {
   readerUrl: string;
 }
 
+export interface WebShelfReaderResolution {
+  snapshot: WebShelfSnapshot;
+  readerUrl: string | null;
+}
+
 interface WebShelfStorageKeys {
   rawBooksKey: string;
   shelfIndexesKey: string;
@@ -331,11 +336,29 @@ async function waitForTrustedWebShelfSnapshot(page: IPage, snapshot: WebShelfSna
  * shelf cache order with the visible shelf links rendered on the page.
  */
 export async function resolveShelfReaderUrl(page: IPage, bookId: string): Promise<string | null> {
+  const resolution = await resolveShelfReader(page, bookId);
+  return resolution.readerUrl;
+}
+
+/**
+ * Resolve the current reader URL for a shelf entry and return the parsed shelf
+ * snapshot used during resolution, so callers can reuse cached title/author
+ * metadata without loading the shelf page twice.
+ */
+export async function resolveShelfReader(page: IPage, bookId: string): Promise<WebShelfReaderResolution> {
   const { snapshot: initialSnapshot, currentVid } = await loadWebShelfSnapshotWithVid(page);
   const snapshot = await waitForTrustedWebShelfSnapshot(page, initialSnapshot, currentVid);
-  if (!snapshot.cacheFound) return null;
+  if (!snapshot.cacheFound) {
+    return { snapshot, readerUrl: null };
+  }
+  const rawBookIds = getUniqueRawBookIds(snapshot);
   const trustedIndexedBookIds = getTrustedIndexedBookIds(snapshot);
-  if (trustedIndexedBookIds.length === 0) return null;
+  const canUseRawOrderFallback = trustedIndexedBookIds.length === 0
+    && rawBookIds.length > 0
+    && snapshot.shelfIndexes.length === 0;
+  if (trustedIndexedBookIds.length === 0 && !canUseRawOrderFallback) {
+    return { snapshot, readerUrl: null };
+  }
 
   const readerUrls = await page.evaluate(`
     (() => Array.from(document.querySelectorAll('a.shelfBook[href]'))
@@ -345,11 +368,17 @@ export async function resolveShelfReaderUrl(page: IPage, bookId: string): Promis
       })
       .filter(Boolean))
   `) as string[];
-  if (readerUrls.length !== trustedIndexedBookIds.length) return null;
+  const expectedEntryCount = trustedIndexedBookIds.length > 0 ? trustedIndexedBookIds.length : rawBookIds.length;
+  if (readerUrls.length !== expectedEntryCount) {
+    return { snapshot, readerUrl: null };
+  }
   const entries = buildWebShelfEntries(snapshot, readerUrls);
 
   const entry = entries.find((candidate) => candidate.bookId === bookId);
-  return entry?.readerUrl || null;
+  return {
+    snapshot,
+    readerUrl: entry?.readerUrl || null,
+  };
 }
 
 /** Format a Unix timestamp (seconds) to YYYY-MM-DD in UTC+8. Returns '-' for invalid input. */


### PR DESCRIPTION
## Description

Fix WeRead `book` detail fallback when private API auth has expired.

This PR improves the detail fallback chain in two cases:
- reuse the first parsed shelf snapshot instead of reloading `/web/shelf` before search fallback
- allow a safe raw-order fallback when `shelfIndexes` never hydrate but rendered shelf reader links still cover the cached entries

It also adds regression tests for:
- ordinary book fallback through public search
- rejecting same-title results when the visible author does not match
- raw-order fallback for cached entries when shelf indexes remain empty

Related issue:
- #610

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```bash
$ node dist/main.js weread shelf --limit 200 -f json
⚠  WeRead private API auth expired; showing cached shelf data from localStorage. Results may be stale, and detail commands may still require re-login.

$ node dist/main.js weread book 29196155 -f json
[
  {
    "title": "文明、现代化、价值投资与中国",
    "author": "李录",
    "publisher": "中信出版集团"
  }
]
```
