### PR TITLE
fix: avoid in-page redirect in facebook search

### DIFF
--- a/src/clis/facebook/search.test.ts
+++ b/src/clis/facebook/search.test.ts
@@ -61,10 +61,9 @@ describe('facebook search pipeline', () => {
 
     expect(page.goto).toHaveBeenNthCalledWith(1, 'https://www.facebook.com');
     expect(page.goto).toHaveBeenNthCalledWith(2, 'https://www.facebook.com/search/top?q=AI%20agent', {
-      waitUntil: 'none',
-      settleMs: undefined,
+      waitUntil: undefined,
+      settleMs: 4000,
     });
-    expect(page.wait).toHaveBeenCalledWith(4);
     expect(page.evaluate).toHaveBeenCalledTimes(1);
     expect(String((page.evaluate as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] ?? '')).not.toContain('window.location.href');
   });

--- a/src/clis/facebook/search.yaml
+++ b/src/clis/facebook/search.yaml
@@ -19,9 +19,7 @@ pipeline:
 
   - navigate:
       url: https://www.facebook.com/search/top?q=${{ args.query | urlencode }}
-      waitUntil: none
-
-  - wait: 4
+      settleMs: 4000
 
   - evaluate: |
       (async () => {


### PR DESCRIPTION
## Description

Fix `facebook/search` so it navigates to the search results page in the pipeline before extracting DOM data, instead of triggering `window.location.href` inside `evaluate`.

Related issue: #625

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

- `npx vitest run src/clis/facebook/search.test.ts --project adapter`
- `npm test`
- `pnpm exec tsc --noEmit && pnpm run build`
