### PR TITLE
fix(douyin): narrow getDraftCommand return type to fix TS2722 build failure

### DIFF
--- a/src/clis/douyin/draft.test.ts
+++ b/src/clis/douyin/draft.test.ts
@@ -31,7 +31,7 @@ function getDraftCommand() {
   const registry = getRegistry();
   const cmd = [...registry.values()].find(c => c.site === 'douyin' && c.name === 'draft');
   if (!cmd?.func) throw new Error('douyin draft command not registered');
-  return cmd;
+  return cmd as typeof cmd & { func: NonNullable<typeof cmd.func> };
 }
 
 afterAll(() => {


### PR DESCRIPTION
## Summary

- Fix `tsc --noEmit` build failure introduced by #640's draft test refactoring
- `getDraftCommand()` returns `CliCommand` where `func` is optional, causing TS2722 at every `cmd.func(...)` call site
- Add type narrowing assertion: `cmd as typeof cmd & { func: NonNullable<typeof cmd.func> }` so TypeScript knows `func` is defined after the runtime guard

## Test plan

- [x] `npx tsc --noEmit` passes (no draft.test.ts errors)
- [x] `npx vitest run src/clis/douyin/draft.test.ts --project adapter` — 10/10 pass