### PR TITLE
feat(stealth): harden CDP debugger detection countermeasures

### DIFF
--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -71,6 +71,18 @@ async function ensureAttached(tabId: number): Promise<void> {
   } catch {
     // Some pages may not need explicit enable
   }
+
+  // Disable breakpoints so that `debugger;` statements in page code don't
+  // pause execution.  Anti-bot scripts use `debugger;` traps to detect CDP —
+  // they measure the time gap caused by the pause. Deactivating breakpoints
+  // makes the engine skip `debugger;` entirely, neutralising the timing
+  // side-channel without patching page JS.
+  try {
+    await chrome.debugger.sendCommand({ tabId }, 'Debugger.enable');
+    await chrome.debugger.sendCommand({ tabId }, 'Debugger.setBreakpointsActive', { active: false });
+  } catch {
+    // Non-fatal: best-effort hardening
+  }
 }
 
 export async function evaluate(tabId: number, expression: string): Promise<unknown> {

--- a/src/browser/stealth.test.ts
+++ b/src/browser/stealth.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { generateStealthJs } from './stealth.js';
+
+/**
+ * Tests for the stealth anti-detection module.
+ *
+ * We test the generated JS string for expected content and structure.
+ * Evaluating in Node is fragile because stealth patches target browser
+ * globals (navigator, Performance, HTMLIFrameElement) that don't exist
+ * or behave differently in Node. Instead we verify the code string
+ * contains the right patches and is syntactically valid.
+ */
+
+describe('generateStealthJs', () => {
+  it('returns a non-empty string', () => {
+    const code = generateStealthJs();
+    expect(typeof code).toBe('string');
+    expect(code.length).toBeGreaterThan(0);
+  });
+
+  it('is a valid self-contained IIFE', () => {
+    const code = generateStealthJs();
+    // Should start/end as an IIFE
+    expect(code.trim()).toMatch(/^\(\(\) => \{/);
+    expect(code.trim()).toMatch(/\}\)\(\)$/);
+  });
+
+  it('patches navigator.webdriver', () => {
+    const code = generateStealthJs();
+    expect(code).toContain("navigator, 'webdriver'");
+    expect(code).toContain('() => false');
+  });
+
+  it('stubs window.chrome', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('window.chrome');
+    expect(code).toContain('runtime');
+    expect(code).toContain('loadTimes');
+    expect(code).toContain('csi');
+  });
+
+  it('fakes navigator.plugins if empty', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('navigator.plugins');
+    expect(code).toContain('PDF Viewer');
+    expect(code).toContain('Chrome PDF Viewer');
+  });
+
+  it('ensures navigator.languages is non-empty', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('navigator.languages');
+    expect(code).toContain("'en-US'");
+  });
+
+  it('normalizes Permissions.query for notifications', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('Permissions');
+    expect(code).toContain('notifications');
+  });
+
+  it('cleans automation artifacts', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('__playwright');
+    expect(code).toContain('__puppeteer');
+    expect(code).toContain("'cdc_'");
+    expect(code).toContain("'__cdc_'");
+  });
+
+  it('filters CDP patterns from Error.stack', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('puppeteer_evaluation_script');
+    expect(code).toContain("'pptr:'");
+    expect(code).toContain("'debugger://'");
+  });
+
+  it('neutralizes debugger statement traps', () => {
+    const code = generateStealthJs();
+    // Should patch Function constructor with new.target / Reflect.construct
+    expect(code).toContain('_OrigFunction');
+    expect(code).toContain('_PatchedFunction');
+    expect(code).toContain('new.target');
+    expect(code).toContain('Reflect.construct');
+    // Should patch eval
+    expect(code).toContain('_origEval');
+    expect(code).toContain('_patchedEval');
+    // Regex to strip debugger (lookbehind for statement boundaries)
+    expect(code).toContain('_debuggerRe');
+  });
+
+  it('uses shared toString disguise via WeakMap', () => {
+    const code = generateStealthJs();
+    // Shared infrastructure at the top of the IIFE
+    expect(code).toContain('_origToString');
+    expect(code).toContain('WeakMap');
+    expect(code).toContain('_disguised');
+    expect(code).toContain('_disguise');
+    // Should NOT have per-instance toString overrides on Function/eval
+    // (they go through _disguise instead)
+  });
+
+  it('defends console method fingerprinting', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('_consoleMethods');
+    expect(code).toContain("'log'");
+    expect(code).toContain("'warn'");
+    expect(code).toContain("'error'");
+    expect(code).toContain('[native code]');
+    // Uses saved _origToString reference
+    expect(code).toContain('_origToString.call');
+  });
+
+  it('defends window dimension detection', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('outerWidth');
+    expect(code).toContain('outerHeight');
+    expect(code).toContain('innerWidth');
+    expect(code).toContain('innerHeight');
+  });
+
+  it('filters Performance API entries', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('getEntries');
+    expect(code).toContain('getEntriesByType');
+    expect(code).toContain('getEntriesByName');
+    expect(code).toContain('_suspiciousPatterns');
+  });
+
+  it('cleans document $cdc_ properties', () => {
+    const code = generateStealthJs();
+    expect(code).toContain("'$cdc_'");
+    expect(code).toContain("'$chrome_'");
+  });
+
+  it('patches iframe contentWindow.chrome consistency', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('contentWindow');
+    expect(code).toContain('HTMLIFrameElement');
+  });
+
+  it('uses non-enumerable guard flag on EventTarget.prototype', () => {
+    const code = generateStealthJs();
+    expect(code).toContain('EventTarget.prototype');
+    expect(code).toContain("'__lsn'");
+    expect(code).toContain('enumerable: false');
+  });
+
+  it('generates syntactically valid JavaScript', () => {
+    const code = generateStealthJs();
+    // new Function() parses the code without executing it in a real
+    // browser context, catching syntax errors from template literal issues.
+    expect(() => new Function(code)).not.toThrow();
+  });
+});

--- a/src/browser/stealth.ts
+++ b/src/browser/stealth.ts
@@ -150,6 +150,204 @@ export function generateStealthJs(): string {
         }
       } catch {}
 
+      // ── Shared toString disguise infrastructure ──
+      // Save the pristine Function.prototype.toString BEFORE any patches,
+      // so all subsequent disguises use the real native reference.
+      // Anti-bot scripts detect per-instance toString overrides via:
+      //   Function.hasOwnProperty('toString')          → true if patched
+      //   Function.prototype.toString.call(fn) !== fn.toString()
+      // Instead we patch Function.prototype.toString once with a WeakMap
+      // lookup, making disguised functions indistinguishable from native.
+      const _origToString = Function.prototype.toString;
+      const _disguised = new WeakMap();
+      try {
+        Object.defineProperty(Function.prototype, 'toString', {
+          value: function() {
+            const override = _disguised.get(this);
+            return override !== undefined ? override : _origToString.call(this);
+          },
+          writable: true, configurable: true,
+        });
+      } catch {}
+      const _disguise = (fn, name) => {
+        _disguised.set(fn, 'function ' + name + '() { [native code] }');
+        try { Object.defineProperty(fn, 'name', { value: name, configurable: true }); } catch {}
+        return fn;
+      };
+
+      // 8. Anti-debugger statement trap
+      //    Sites inject debugger statements to detect DevTools/CDP.
+      //    When a CDP debugger is attached, the statement pauses execution
+      //    and the site measures the time gap to confirm automation.
+      //    We neutralize this by overriding the Function constructor and
+      //    eval to strip debugger statements from dynamically created code.
+      //    Note: this does NOT affect static debugger statements in parsed
+      //    scripts — those require CDP Debugger.setBreakpointsActive(false)
+      //    which we handle at the extension level.
+      //    Caveat: the regex targets standalone debugger statements (preceded
+      //    by a statement boundary) to minimise false positives inside string
+      //    literals, but cannot perfectly distinguish all cases without a
+      //    full parser. This is an acceptable trade-off for stealth code.
+      try {
+        const _OrigFunction = Function;
+        // Match standalone debugger statements preceded by a statement
+        // boundary (start of string, semicolon, brace, or newline).
+        // This avoids most false positives inside string literals like
+        // "use debugger mode" while still catching the anti-bot patterns.
+        const _debuggerRe = /(?:^|(?<=[;{}\\n\\r]))\\s*debugger\\s*;?/g;
+        const _cleanDebugger = (src) => typeof src === 'string' ? src.replace(_debuggerRe, '') : src;
+        // Patch Function constructor to strip debugger from dynamic code.
+        // Support both Function('code') and new Function('code') via
+        // new.target / Reflect.construct.
+        const _PatchedFunction = function(...args) {
+          if (args.length > 0) {
+            args[args.length - 1] = _cleanDebugger(args[args.length - 1]);
+          }
+          if (new.target) {
+            return Reflect.construct(_OrigFunction, args, new.target);
+          }
+          return _OrigFunction.apply(this, args);
+        };
+        _PatchedFunction.prototype = _OrigFunction.prototype;
+        Object.setPrototypeOf(_PatchedFunction, _OrigFunction);
+        _disguise(_PatchedFunction, 'Function');
+        try { window.Function = _PatchedFunction; } catch {}
+
+        // Patch eval to strip debugger
+        const _origEval = window.eval;
+        const _patchedEval = function(code) {
+          return _origEval.call(this, _cleanDebugger(code));
+        };
+        _disguise(_patchedEval, 'eval');
+        try { window.eval = _patchedEval; } catch {}
+      } catch {}
+
+      // 9. Console method fingerprinting defense
+      //    When CDP Runtime.enable is called, Chrome replaces console.log etc.
+      //    with CDP-bound versions. These bound functions have a different
+      //    toString() output: "function log() { [native code] }" becomes
+      //    something like "function () { [native code] }" (no name) or the
+      //    bound function signature leaks. Anti-bot scripts check:
+      //      console.log.toString().includes('[native code]')
+      //      console.log.name === 'log'
+      //    We re-wrap console methods and register them via the shared
+      //    _disguise infrastructure so Function.prototype.toString.call()
+      //    also returns the correct native string.
+      try {
+        const _consoleMethods = ['log', 'warn', 'error', 'info', 'debug', 'table', 'trace', 'dir', 'group', 'groupEnd', 'groupCollapsed', 'clear', 'count', 'assert', 'profile', 'profileEnd', 'time', 'timeEnd', 'timeStamp'];
+        for (const _m of _consoleMethods) {
+          if (typeof console[_m] !== 'function') continue;
+          const _origMethod = console[_m];
+          const _nativeStr = 'function ' + _m + '() { [native code] }';
+          // Only patch if toString is wrong (i.e. CDP has replaced it)
+          try {
+            const _currentStr = _origToString.call(_origMethod);
+            if (_currentStr === _nativeStr) continue; // already looks native
+          } catch {}
+          const _wrapper = function() { return _origMethod.apply(console, arguments); };
+          Object.defineProperty(_wrapper, 'length', { value: _origMethod.length || 0, configurable: true });
+          _disguise(_wrapper, _m);
+          try { console[_m] = _wrapper; } catch {}
+        }
+      } catch {}
+
+      // 10. window.outerWidth/outerHeight defense
+      //     When DevTools or CDP debugger is attached, Chrome may alter the
+      //     window dimensions. Anti-bot scripts compare outerWidth/innerWidth
+      //     and outerHeight/innerHeight — a significant difference indicates
+      //     DevTools is open. We freeze the relationship so the delta stays
+      //     consistent with a normal browser window.
+      //     Thresholds: width delta > 100px or height delta > 200px indicates
+      //     a docked DevTools panel. When triggered, we report outerWidth
+      //     equal to innerWidth (normal for maximised windows) and
+      //     outerHeight as innerHeight + the captured "normal" delta (capped
+      //     to a reasonable range), so the result is plausible across OSes.
+      try {
+        const _normalWidthDelta = window.outerWidth - window.innerWidth;
+        const _normalHeightDelta = window.outerHeight - window.innerHeight;
+        // Only patch if the delta looks suspicious (e.g. DevTools docked)
+        if (_normalWidthDelta > 100 || _normalHeightDelta > 200) {
+          Object.defineProperty(window, 'outerWidth', {
+            get: () => window.innerWidth,
+            configurable: true,
+          });
+          // Use a clamped height offset (40-120px covers macOS ~78px,
+          // Windows ~40px, and Linux ~37-50px title bar heights).
+          const _heightOffset = Math.max(40, Math.min(120, _normalHeightDelta));
+          Object.defineProperty(window, 'outerHeight', {
+            get: () => window.innerHeight + _heightOffset,
+            configurable: true,
+          });
+        }
+      } catch {}
+
+      // 11. Performance API cleanup
+      //     CDP injects internal resources and timing entries that don't exist
+      //     in normal browsing. Filter entries with debugger/devtools URLs.
+      try {
+        const _origGetEntries = Performance.prototype.getEntries;
+        const _origGetByType = Performance.prototype.getEntriesByType;
+        const _origGetByName = Performance.prototype.getEntriesByName;
+        const _suspiciousPatterns = ['debugger', 'devtools', '__puppeteer', '__playwright', 'pptr:'];
+        const _filterEntries = (entries) => {
+          if (!Array.isArray(entries)) return entries;
+          return entries.filter(e => {
+            const name = e.name || '';
+            return !_suspiciousPatterns.some(p => name.includes(p));
+          });
+        };
+        Performance.prototype.getEntries = function() {
+          return _filterEntries(_origGetEntries.call(this));
+        };
+        Performance.prototype.getEntriesByType = function(type) {
+          return _filterEntries(_origGetByType.call(this, type));
+        };
+        Performance.prototype.getEntriesByName = function(name, type) {
+          return _filterEntries(_origGetByName.call(this, name, type));
+        };
+      } catch {}
+
+      // 12. WebDriver-related property defense
+      //     Some anti-bot systems check additional navigator properties
+      //     and document properties that may indicate automation.
+      try {
+        // document.$cdc_ properties (ChromeDriver specific, backup for #6)
+        for (const _prop of Object.getOwnPropertyNames(document)) {
+          if (_prop.startsWith('$cdc_') || _prop.startsWith('$chrome_')) {
+            try { delete document[_prop]; } catch {}
+          }
+        }
+      } catch {}
+
+      // 13. Iframe contentWindow.chrome consistency
+      //     Anti-bot scripts create iframes and check if
+      //     iframe.contentWindow.chrome exists and matches the parent.
+      //     CDP-controlled pages may have inconsistent iframe contexts.
+      try {
+        const _origHTMLIFrame = HTMLIFrameElement.prototype;
+        const _origContentWindow = Object.getOwnPropertyDescriptor(_origHTMLIFrame, 'contentWindow');
+        if (_origContentWindow && _origContentWindow.get) {
+          Object.defineProperty(_origHTMLIFrame, 'contentWindow', {
+            get: function() {
+              const _w = _origContentWindow.get.call(this);
+              if (_w) {
+                try {
+                  if (!_w.chrome) {
+                    Object.defineProperty(_w, 'chrome', {
+                      value: window.chrome,
+                      writable: true,
+                      configurable: true,
+                    });
+                  }
+                } catch {}
+              }
+              return _w;
+            },
+            configurable: true,
+          });
+        }
+      } catch {}
+
       return 'applied';
     })()
   `;


### PR DESCRIPTION
## Summary

- Add 6 new anti-detection patches to `stealth.ts` to hide CDP debugger fingerprints
- Add CDP-level `Debugger.setBreakpointsActive(false)` in extension to neutralize `debugger;` statement traps
- Add 18 unit tests for stealth module

## New Stealth Patches

| # | Patch | Detection Vector |
|---|-------|-----------------|
| — | Shared `Function.prototype.toString` disguise via `WeakMap` | `Function.hasOwnProperty('toString')`, `Function.prototype.toString.call(fn)` bypass |
| 8 | Anti-debugger statement trap | `debugger;` timing side-channel (JS-level `Function`/`eval` patching + CDP `Debugger.setBreakpointsActive`) |
| 9 | Console method fingerprinting | CDP `Runtime.enable` replaces console methods with bound functions that have different `toString()` |
| 10 | Window dimension defense | `outerWidth - innerWidth` / `outerHeight - innerHeight` delta detection |
| 11 | Performance API cleanup | `performance.getEntries()` leaking debugger/devtools entries |
| 12 | document.$cdc_ cleanup | ChromeDriver properties on `document` (backup for existing `window` cleanup) |
| 13 | Iframe contentWindow.chrome | Cross-frame `window.chrome` consistency check |

## Test plan
- [x] 18 stealth unit tests pass (including syntax validity check)
- [x] TypeScript compiles clean
- [x] All existing unit tests unaffected
- [ ] Manual test on Xiaohongshu to verify reduced risk control triggers