### PR TITLE
test(xiaohongshu): 脱敏 test 内容

### DIFF
--- a/src/clis/xiaohongshu/creator-note-detail.test.ts
+++ b/src/clis/xiaohongshu/creator-note-detail.test.ts
@@ -40,9 +40,9 @@ function createPageMock(evaluateResult: any): IPage {
 describe('xiaohongshu creator-note-detail', () => {
   it('parses note detail page text into info and metric rows', () => {
     const bodyText = `笔记数据详情
-一张图讲清 诡秘之主·耕种者途径
-#诡秘之主
-#耕种者序列
+示例内容复盘
+#测试标签
+#内容分析
 2026-03-18 20:01
 切换笔记
 笔记诊断
@@ -86,9 +86,9 @@ describe('xiaohongshu creator-note-detail', () => {
 6
 粉丝占比 0%`;
 
-    expect(parseCreatorNoteDetailText(bodyText, '69ba940500000000200384db')).toEqual([
-      { section: '笔记信息', metric: 'note_id', value: '69ba940500000000200384db', extra: '' },
-      { section: '笔记信息', metric: 'title', value: '一张图讲清 诡秘之主·耕种者途径', extra: '' },
+    expect(parseCreatorNoteDetailText(bodyText, 'cccccccccccccccccccccccc')).toEqual([
+      { section: '笔记信息', metric: 'note_id', value: 'cccccccccccccccccccccccc', extra: '' },
+      { section: '笔记信息', metric: 'title', value: '示例内容复盘', extra: '' },
       { section: '笔记信息', metric: 'published_at', value: '2026-03-18 20:01', extra: '' },
       { section: '基础数据', metric: '曝光数', value: '1733', extra: '粉丝占比 6.6%' },
       { section: '基础数据', metric: '观看数', value: '544', extra: '粉丝占比 7.2%' },
@@ -104,8 +104,8 @@ describe('xiaohongshu creator-note-detail', () => {
 
   it('parses structured note detail dom data into rows', () => {
     expect(parseCreatorNoteDetailDomData({
-      title: '神雕侠侣战力金字塔',
-      infoText: '神雕侠侣战力金字塔\n#武侠\n2025-12-04 19:45\n切换笔记',
+      title: '测试笔记一',
+      infoText: '测试笔记一\n#测试标签\n2025-12-04 19:45\n切换笔记',
       sections: [
         {
           title: '基础数据',
@@ -127,9 +127,9 @@ describe('xiaohongshu creator-note-detail', () => {
           ],
         },
       ],
-    }, '693155fc000000000d03b42c')).toEqual([
-      { section: '笔记信息', metric: 'note_id', value: '693155fc000000000d03b42c', extra: '' },
-      { section: '笔记信息', metric: 'title', value: '神雕侠侣战力金字塔', extra: '' },
+    }, 'bbbbbbbbbbbbbbbbbbbbbbbb')).toEqual([
+      { section: '笔记信息', metric: 'note_id', value: 'bbbbbbbbbbbbbbbbbbbbbbbb', extra: '' },
+      { section: '笔记信息', metric: 'title', value: '测试笔记一', extra: '' },
       { section: '笔记信息', metric: 'published_at', value: '2025-12-04 19:45', extra: '' },
       { section: '基础数据', metric: '曝光数', value: '898204', extra: '粉丝占比 0.5%' },
       { section: '基础数据', metric: '观看数', value: '148284', extra: '粉丝占比 0.6%' },

--- a/src/clis/xiaohongshu/creator-notes-summary.test.ts
+++ b/src/clis/xiaohongshu/creator-notes-summary.test.ts
@@ -7,14 +7,14 @@ import './creator-notes-summary.js';
 describe('xiaohongshu creator-notes-summary', () => {
   it('summarizes note list row and detail rows into one compact row', () => {
     const note: CreatorNoteRow = {
-      id: '69ba940500000000200384db',
-      title: '一张图讲清 诡秘之主·耕种者途径',
+      id: 'cccccccccccccccccccccccc',
+      title: '示例内容复盘',
       date: '2026年03月18日 20:01',
       views: 549,
       likes: 19,
       collects: 10,
       comments: 7,
-      url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=69ba940500000000200384db',
+      url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=cccccccccccccccccccccccc',
     };
 
     const rows: CreatorNoteDetailRow[] = [
@@ -34,8 +34,8 @@ describe('xiaohongshu creator-notes-summary', () => {
 
     expect(summarizeCreatorNote(note, rows, 1)).toEqual({
       rank: 1,
-      id: '69ba940500000000200384db',
-      title: '一张图讲清 诡秘之主·耕种者途径',
+      id: 'cccccccccccccccccccccccc',
+      title: '示例内容复盘',
       published_at: '2026-03-18 20:01',
       views: '549',
       likes: '19',
@@ -48,7 +48,7 @@ describe('xiaohongshu creator-notes-summary', () => {
       top_source_pct: '89.9%',
       top_interest: '二次元',
       top_interest_pct: '13%',
-      url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=69ba940500000000200384db',
+      url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=cccccccccccccccccccccccc',
     });
   });
 });

--- a/src/clis/xiaohongshu/creator-notes.test.ts
+++ b/src/clis/xiaohongshu/creator-notes.test.ts
@@ -46,7 +46,7 @@ describe('xiaohongshu creator-notes', () => {
     const bodyText = `笔记管理
 全部笔记(366)
 已发布
-神雕侠侣战力金字塔
+测试笔记一
 发布于 2025年12月04日 19:45
 148208
 324
@@ -58,7 +58,7 @@ describe('xiaohongshu creator-notes', () => {
 编辑
 删除
 仅自己可见
-终于等到了！！！
+测试笔记二
 发布于 2026年03月18日 12:39
 10
 0
@@ -70,7 +70,7 @@ describe('xiaohongshu creator-notes', () => {
     expect(parseCreatorNotesText(bodyText)).toEqual([
       {
         id: '',
-        title: '神雕侠侣战力金字塔',
+        title: '测试笔记一',
         date: '2025年12月04日 19:45',
         views: 148208,
         likes: 2279,
@@ -80,7 +80,7 @@ describe('xiaohongshu creator-notes', () => {
       },
       {
         id: '',
-        title: '终于等到了！！！',
+        title: '测试笔记二',
         date: '2026年03月18日 12:39',
         views: 10,
         likes: 0,
@@ -106,7 +106,7 @@ describe('xiaohongshu creator-notes', () => {
 4
 5
 权限设置`,
-        html: '&quot;noteId&quot;:&quot;69ba940500000000200384db&quot;',
+        html: '&quot;noteId&quot;:&quot;aaaaaaaaaaaaaaaaaaaaaaaa&quot;',
       },
     ]);
 
@@ -116,14 +116,14 @@ describe('xiaohongshu creator-notes', () => {
     expect(result).toEqual([
       {
         rank: 1,
-        id: '69ba940500000000200384db',
+        id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
         title: '示例笔记',
         date: '2026年03月19日 12:00',
         views: 10,
         likes: 3,
         collects: 4,
         comments: 2,
-        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=69ba940500000000200384db',
+        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=aaaaaaaaaaaaaaaaaaaaaaaa',
       },
     ]);
   });
@@ -136,8 +136,8 @@ describe('xiaohongshu creator-notes', () => {
       undefined,
       [
         {
-          id: '693155fc000000000d03b42c',
-          title: '神雕侠侣战力金字塔',
+          id: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+          title: '测试笔记一',
           date: '2025年12月04日 19:45',
           metrics: [148284, 319, 2280, 466, 33],
         },
@@ -149,14 +149,14 @@ describe('xiaohongshu creator-notes', () => {
     expect(result).toEqual([
       {
         rank: 1,
-        id: '693155fc000000000d03b42c',
-        title: '神雕侠侣战力金字塔',
+        id: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+        title: '测试笔记一',
         date: '2025年12月04日 19:45',
         views: 148284,
         likes: 2280,
         collects: 466,
         comments: 319,
-        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=693155fc000000000d03b42c',
+        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=bbbbbbbbbbbbbbbbbbbbbbbb',
       },
     ]);
   });
@@ -169,8 +169,8 @@ describe('xiaohongshu creator-notes', () => {
       data: {
         note_infos: [
           {
-            id: '69ba940500000000200384db',
-            title: '一张图讲清 诡秘之主·耕种者途径',
+            id: 'cccccccccccccccccccccccc',
+            title: '示例内容复盘',
             post_time: new Date('2026-03-18T20:01:00+08:00').getTime(),
             read_count: 521,
             like_count: 18,
@@ -187,28 +187,28 @@ describe('xiaohongshu creator-notes', () => {
     expect(result).toEqual([
       {
         rank: 1,
-        id: '69ba940500000000200384db',
-        title: '一张图讲清 诡秘之主·耕种者途径',
+        id: 'cccccccccccccccccccccccc',
+        title: '示例内容复盘',
         date: '2026年03月18日 20:01',
         views: 521,
         likes: 18,
         collects: 10,
         comments: 7,
-        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=69ba940500000000200384db',
+        url: 'https://creator.xiaohongshu.com/statistics/note-detail?noteId=cccccccccccccccccccccccc',
       },
     ]);
   });
 
   it('extracts note ids from creator note-manager html', () => {
     const html = `
-      <div>&quot;noteId&quot;:&quot;69ba940500000000200384db&quot;</div>
-      <div>&quot;noteId&quot;:&quot;69ba2c98000000001a026e0f&quot;</div>
-      <div>&quot;noteId&quot;:&quot;69ba940500000000200384db&quot;</div>
+      <div>&quot;noteId&quot;:&quot;aaaaaaaaaaaaaaaaaaaaaaaa&quot;</div>
+      <div>&quot;noteId&quot;:&quot;dddddddddddddddddddddddd&quot;</div>
+      <div>&quot;noteId&quot;:&quot;aaaaaaaaaaaaaaaaaaaaaaaa&quot;</div>
     `;
 
     expect(parseCreatorNoteIdsFromHtml(html)).toEqual([
-      '69ba940500000000200384db',
-      '69ba2c98000000001a026e0f',
+      'aaaaaaaaaaaaaaaaaaaaaaaa',
+      'dddddddddddddddddddddddd',
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- 脱敏 xiaohongshu creator 相关测试样例
- 将真实标题、标签文案和 noteId 替换为通用占位数据
- 保持测试行为不变，仅清理可追溯样例

## Verification
- npm run test:adapter -- src/clis/xiaohongshu/creator-notes.test.ts src/clis/xiaohongshu/creator-note-detail.test.ts src/clis/xiaohongshu/creator-notes-summary.test.ts