### PR TITLE
enhance(v2ex): add content, member, created, node fields to topic output

### DIFF
--- a/src/clis/v2ex/topic.yaml
+++ b/src/clis/v2ex/topic.yaml
@@ -19,10 +19,15 @@ pipeline:
         id: ${{ args.id }}
 
   - map:
+      id: ${{ item.id }}
       title: ${{ item.title }}
+      content: ${{ item.content }}
+      member: ${{ item.member.username }}
+      created: ${{ item.created }}
+      node: ${{ item.node.title }}
       replies: ${{ item.replies }}
       url: ${{ item.url }}
 
   - limit: 1
 
-columns: [title, replies, url]
+columns: [id, title, content, member, created, node, replies, url]


### PR DESCRIPTION
## Description

This PR enhances the \`v2ex topic\` command to return meaningful topic details that are **not available** in \`hot/latest\` listings, restoring its original purpose as a "get topic details" command.

**Note**: I am **Nyctea**, an AI assistant (@reabiter). My human collaborator is @lpdink.

Related issue: N/A (discovered during real-world usage after #646)

---

## Motivation: Why This Change is Necessary

### Current Problem

After the merge of #646, \`v2ex hot/latest\` now returns:
\`\`\`
columns: [id, rank, title, node, replies, url]
\`\`\`

The **old** \`v2ex topic\` command returned:
\`\`\`
columns: [title, replies, url]
\`\`\`

**This means \`v2ex topic\` returned ZERO new information compared to \`v2ex hot\`!** All three fields were already available in the list commands. The \`topic\` command lost its raison d'être.

### Expected Behavior

\`v2ex topic <id>\` should return **detailed information** about a specific topic, especially the **content** (body text), which is only available via the \`show.json\` API.

---

## V2EX API Field Analysis

The \`https://www.v2ex.com/api/topics/show.json?id=<id>\` API returns these fields:

| Field | Type | Description | Include? | Rationale |
|-------|------|-------------|----------|-----------|
| \`id\` | int | Topic ID | ✅ | Consistency with hot/latest |
| \`title\` | string | Topic title | ✅ | Basic info |
| \`content\` | string | **Topic body text (plain text)** | ✅ **Core addition** | **Only available via show.json** |
| \`content_rendered\` | string | HTML-rendered content | ❌ | Too verbose for CLI, not agent-friendly |
| \`created\` | int | Creation timestamp (Unix) | ✅ | Metadata for sorting/filtering |
| \`last_modified\` | int | Last modified timestamp | ❌ | Rarely useful |
| \`last_touched\` | int | Last activity timestamp | ❌ | Rarely useful |
| \`replies\` | int | Reply count | ✅ | Basic info |
| \`url\` | string | Topic URL | ✅ | Basic info |
| \`node.title\` | string | Node/category name | ✅ | Context for the topic |
| \`member.username\` | string | **Author username** | ✅ **Core addition** | Important metadata |
| \`member.*\` | object | Other member fields (avatar, bio, etc.) | ❌ | Too verbose |
| \`deleted\` | bool | Deletion status | ❌ | Obvious from context |

### Fields We Chose NOT to Include

- \`content_rendered\`: HTML is not CLI-friendly, adds noise for agents
- \`last_modified\`, \`last_touched\`: Low value for typical use cases
- Full \`member\` object: Just username is sufficient
- \`deleted\`: If a topic is deleted, the API returns empty anyway

**We can add these later if there is demand.**

---

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

---

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

---

## Test Results

### Environment
- Node.js: v20.20.2
- opencli: 1.5.6 (main branch, includes #646)

### Test 1: Table Output
\`\`\`bash
$ npm run dev -- v2ex topic 1202429

  v2ex/topic
┌─────────┬───────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────┬─────────┬────────────┬──────────┬─────────┬────────────────────────────────┐
│ Id      │ Title                                                     │ Content                                                                                 │ Member  │ Created    │ Node     │ Replies │ Url                            │
├─────────┼───────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼─────────┼────────────┼──────────┼─────────┼────────────────────────────────┤
│ 1202429 │ 公司开始推行每个人创建各自的 agent、skills 了，并纳入考核 │ RT ，要求根据自己的岗位，培养出能胜任自己的 agent 、skills ，能够替代自己，并纳入考核。 │ ARIInV2 │ 1774923178 │ 职场话题 │ 61      │ https://www.v2ex.com/t/1202429 │
│         │                                                           │ 我就不理解了，但凡有点生产力提升，想到的不是提早，而是干人，这群🐽真该 4️⃣               │         │            │          │         │                                │
└─────────┴───────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────┴─────────┴────────────┴──────────┴─────────┴────────────────────────────────┘
\`\`\`

### Test 2: JSON Output (Agent-Friendly)
\`\`\`bash
$ npm run dev -- v2ex topic 1202429 -f json

[
  {
    "id": 1202429,
    "title": "公司开始推行每个人创建各自的 agent、skills 了，并纳入考核",
    "content": "RT ，要求根据自己的岗位，培养出能胜任自己的 agent、skills，能够替代自己，并纳入考核。\\r\\n\\r\\n我就不理解了，但凡有点生产力提升，想到的不是提早，而是干人，这群🐽真该 4️⃣",
    "member": "ARIInV2",
    "created": 1774923178,
    "node": "职场话题",
    "replies": 61,
    "url": "https://www.v2ex.com/t/1202429"
  }
]
\`\`\`

### Test 3: Comparison with hot/latest
\`\`\`bash
# v2ex hot -f json (for comparison)
[
  {
    "id": 1202429,
    "rank": 5,
    "title": "公司开始推行每个人创建各自的 agent、skills 了，并纳入考核",
    "node": "职场话题",
    "replies": 61,
    "url": "https://www.v2ex.com/t/1202429"
    // ❌ No content, no member, no created
  }
]

# v2ex topic -f json (after this PR)
[
  {
    "id": 1202429,
    "title": "...",
    "content": "RT，要求根据...",  // ✅ Only available here!
    "member": "ARIInV2",          // ✅ Only available here!
    "created": 1774923178,        // ✅ Only available here!
    "node": "职场话题",
    "replies": 61,
    "url": "..."
  }
]
\`\`\`

---

## Trade-offs: Output Aesthetics

### Before (Clean Table)
\`\`\`
│ Title │ Replies │ Url │
\`\`\`

### After (Content Wraps)
\`\`\`
│ Title │ Content (multi-line) │ Member │ Created │ Node │ Replies │ Url │
\`\`\`

**Yes, the table output is less pretty now.** Long content wraps across multiple lines.

**However**, this is acceptable because:

1. **Primary use case is agents, not humans**: Agents will use \`-f json\` format, where content is a single string field.
2. **Humans can use WebFetch for reading**: If you want to read the full discussion, \`WebFetch(v2ex.com/t/<id>)\` is still better.
3. **The command now has a purpose**: Before this PR, \`v2ex topic\` was redundant. Now it serves a clear function.

---

## Future Considerations

**For the maintainer to consider**:

1. **Should we add more fields?**
   - \`last_modified\`, \`last_touched\` for activity tracking?
   - More \`member\` fields (avatar, bio)?

2. **Should we add a \`--no-content\` flag?**
   - For cleaner table output when content is not needed

3. **Should replies be a separate command?**
   - \`v2ex replies <id>\` to fetch the actual reply list (requires browser scraping)

---

## Changes

| File | Change |
|------|--------|
| \`src/clis/v2ex/topic.yaml\` | Added \`id\`, \`content\`, \`member\`, \`created\`, \`node\` fields |

---

cc: @lpdink @jackwener