### PR TITLE
fix(doubao-app): connect to correct CDP target instead of background …

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -46,7 +46,7 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; cdpTargetFilter?: string }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
@@ -55,7 +55,7 @@ export class CDPBridge implements IBrowserFactory {
     let wsUrl = endpoint;
     if (endpoint.startsWith('http')) {
       const targets = await fetchJsonDirect(`${endpoint.replace(/\/$/, '')}/json`) as CDPTarget[];
-      const target = selectCDPTarget(targets);
+      const target = selectCDPTarget(targets, opts?.cdpTargetFilter);
       if (!target || !target.webSocketDebuggerUrl) {
         throw new Error('No inspectable targets found at CDP endpoint');
       }
@@ -250,8 +250,8 @@ function matchesCookieDomain(cookieDomain: string, targetDomain: string): boolea
     || normalizedTargetDomain.endsWith(`.${normalizedCookieDomain}`);
 }
 
-function selectCDPTarget(targets: CDPTarget[]): CDPTarget | undefined {
-  const preferredPattern = compilePreferredPattern(process.env.OPENCLI_CDP_TARGET);
+function selectCDPTarget(targets: CDPTarget[], appTargetFilter?: string): CDPTarget | undefined {
+  const preferredPattern = compilePreferredPattern(process.env.OPENCLI_CDP_TARGET ?? appTargetFilter);
 
   const ranked = targets
     .map((target, index) => ({ target, index, score: scoreCDPTarget(target, preferredPattern) }))
@@ -289,6 +289,10 @@ function scoreCDPTarget(target: CDPTarget, preferredPattern?: RegExp): number {
   if (url.startsWith('http://127.0.0.1') || url.startsWith('https://127.0.0.1')) score += 50;
   if (url.startsWith('about:blank')) score -= 120;
   if (url === '' || url === 'about:blank') score -= 40;
+  // Penalize Electron utility/background pages
+  if (url.includes('/background') || url.includes('new-tab-page')) score -= 200;
+  // Penalize pages whose title looks like a URL (framework/utility pages often use URL as title)
+  if (/^[a-z][\w-]*:\/\//.test(title)) score -= 150;
 
   if (title && title !== 'devtools') score += 25;
 

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -21,6 +21,8 @@ export interface ElectronAppEntry {
   displayName?: string;
   /** Additional launch args beyond --remote-debugging-port */
   extraArgs?: string[];
+  /** URL pattern to prefer when selecting a CDP target (e.g. 'doubao-chat/chat') */
+  targetFilter?: string;
 }
 
 export const builtinApps: Record<string, ElectronAppEntry> = {
@@ -29,7 +31,7 @@ export const builtinApps: Record<string, ElectronAppEntry> = {
   chatwise:      { port: 9228, processName: 'ChatWise',     bundleId: 'com.chatwise.app',               displayName: 'ChatWise' },
   notion:        { port: 9230, processName: 'Notion',       bundleId: 'notion.id',                      displayName: 'Notion' },
   'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
-  'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },
+  'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao', targetFilter: 'doubao-chat/chat' },
   antigravity:   { port: 9234, processName: 'Antigravity',  bundleId: 'dev.antigravity.app',            displayName: 'Antigravity' },
   chatgpt:       { port: 9236, processName: 'ChatGPT',      bundleId: 'com.openai.chat',                displayName: 'ChatGPT' },
 };

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -20,7 +20,7 @@ import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMM
 import { emitHook, type HookContext } from './hooks.js';
 import { checkDaemonStatus } from './browser/discover.js';
 import { log } from './logger.js';
-import { isElectronApp } from './electron-apps.js';
+import { isElectronApp, getElectronApp } from './electron-apps.js';
 import { resolveElectronEndpoint } from './launcher.js';
 
 const _loadedModules = new Set<string>();
@@ -173,10 +173,12 @@ export async function executeCommand(
     if (shouldUseBrowserSession(cmd)) {
       const electron = isElectronApp(cmd.site);
       let cdpEndpoint: string | undefined;
+      let cdpTargetFilter: string | undefined;
 
       if (electron) {
         // Electron apps: auto-detect, prompt restart if needed, launch with CDP
         cdpEndpoint = await resolveElectronEndpoint(cmd.site);
+        cdpTargetFilter = getElectronApp(cmd.site)?.targetFilter;
       } else {
         // Browser Bridge: fail-fast when daemon is up but extension is missing.
         // 300ms timeout avoids a full 2s wait on cold-start.
@@ -212,7 +214,7 @@ export async function executeCommand(
           timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT,
           label: fullName(cmd),
         });
-      }, { workspace: `site:${cmd.site}`, cdpEndpoint });
+      }, { workspace: `site:${cmd.site}`, cdpEndpoint, cdpTargetFilter });
     } else {
       // Non-browser commands: apply timeout only when explicitly configured.
       const timeout = cmd.timeoutSeconds;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -63,14 +63,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string }): Promise<IPage>;
+  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; cdpTargetFilter?: string }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { workspace?: string; cdpEndpoint?: string } = {},
+  opts: { workspace?: string; cdpEndpoint?: string; cdpTargetFilter?: string } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -78,6 +78,7 @@ export async function browserSession<T>(
       timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
       workspace: opts.workspace,
       cdpEndpoint: opts.cdpEndpoint,
+      cdpTargetFilter: opts.cdpTargetFilter,
     });
     return await fn(page);
   } finally {


### PR DESCRIPTION
- 问题描述
豆包桌面版更新后，opencli doubao-app send / ask 等命令报错
相关issues:
https://github.com/jackwener/opencli/issues/506
https://github.com/jackwener/opencli/issues/634

- 根因分析
CDP target 选择逻辑对 title/URL 中包含 app 名称（"doubao"）的页面加分。后台页的 title 就是它自己的 URL，恰好包含 "doubao"，得分反而高于真正的聊天页（title 是中文"豆包"）。结果 CDPBridge 连接到了空的后台页面，所有 DOM 选择器就会找不到输入框。

- 修复方案
精准修复：给 ElectronAppEntry 新增 targetFilter 字段，各 app 可指定首选目标 URL 模式，命中后 +1000 分（绝对优先）。为 doubao-app 设置 targetFilter: 'doubao-chat/chat'，将连接精准锁定到聊天页面。

- 验证
修复后，以下命令在本地均正常运行：
$ opencli doubao-app status   → Connected | doubao://doubao-chat/chat | 豆包
$ opencli doubao-app send "hi" → Sent
$ opencli doubao-app ask "你好" → 你好呀！
$ opencli doubao-app read      → 正常读取历史消息
单元测试全部通过（1108 passed）。