### PR TITLE
chore: release v1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.5.9](https://github.com/jackwener/opencli/compare/v1.5.8...v1.5.9) (2026-04-02)
+
+
+### Features
+
+* **amazon:** add browser adapter — bestsellers, search, product, offer, discussion ([#659](https://github.com/jackwener/opencli/issues/659))
+* **skills:** create skills/ directory structure with opencli-usage, opencli-explorer, opencli-oneshot ([#670](https://github.com/jackwener/opencli/issues/670))
+* **record:** add minimal record write candidates ([#665](https://github.com/jackwener/opencli/issues/665))
+
+
+### Refactoring
+
+* src cleanup — deduplicate errors, cache VM, extract BasePage, remove Playwright MCP legacy ([#667](https://github.com/jackwener/opencli/issues/667))
+* remove bind-current, restore owned-only browser automation model ([#664](https://github.com/jackwener/opencli/issues/664))
+
+
+### Chores
+
+* remove .agents directory ([#668](https://github.com/jackwener/opencli/issues/668))
+
+
 ## [1.5.8](https://github.com/jackwener/opencli/compare/v1.5.7...v1.5.8) (2026-04-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "publishConfig": {
     "access": "public"
   },

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencli-usage
 description: "OpenCLI usage guide — installation, prerequisites, and command reference organized by platform"
-version: 1.5.6
+version: 1.5.9
 author: jackwener
 tags: [cli, browser, web, chrome-extension, cdp, AI, agent]
 ---


### PR DESCRIPTION
## Summary
- Bump version to 1.5.9
- Update CHANGELOG with all changes since v1.5.8

### Changes since v1.5.8
- **feat(amazon):** add browser adapter — bestsellers, search, product, offer, discussion (#659)
- **feat(skills):** create skills/ directory structure with opencli-usage, opencli-explorer, opencli-oneshot (#670)
- **feat(record):** add minimal record write candidates (#665)
- **refactor:** src cleanup — deduplicate errors, cache VM, extract BasePage, remove Playwright MCP legacy (#667)
- **refactor:** remove bind-current, restore owned-only browser automation model (#664)
- **chore:** remove .agents directory (#668)

## After merge
Tag `v1.5.9` to trigger npm publish and GitHub Release.