### PR TITLE
feat: add focus-window action and opencli <site> open

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -296,6 +296,8 @@ async function handleCommand(cmd: Command): Promise<Result> {
         return await handleNetworkCaptureStart(cmd, workspace);
       case 'network-capture-read':
         return await handleNetworkCaptureRead(cmd, workspace);
+      case 'focus-window':
+        return await handleFocusWindow(cmd, workspace);
       default:
         return { id: cmd.id, ok: false, error: `Unknown action: ${cmd.action}` };
     }
@@ -753,6 +755,24 @@ async function handleCloseWindow(cmd: Command, workspace: string): Promise<Resul
     automationSessions.delete(workspace);
   }
   return { id: cmd.id, ok: true, data: { closed: true } };
+}
+
+async function handleFocusWindow(cmd: Command, workspace: string): Promise<Result> {
+  const session = automationSessions.get(workspace);
+  if (session) {
+    try {
+      await chrome.windows.update(session.windowId, { focused: true });
+      return { id: cmd.id, ok: true, data: { focused: true } };
+    } catch {
+      // Window was closed externally — clean up and fall through to create
+      if (session.idleTimer) clearTimeout(session.idleTimer);
+      automationSessions.delete(workspace);
+    }
+  }
+  // No live session — create one and bring it to the foreground
+  const windowId = await getAutomationWindow(workspace);
+  await chrome.windows.update(windowId, { focused: true });
+  return { id: cmd.id, ok: true, data: { focused: true } };
 }
 
 async function handleSetFileInput(cmd: Command, workspace: string): Promise<Result> {

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -18,7 +18,8 @@ export type Action =
   | 'bind-current'
   | 'network-capture-start'
   | 'network-capture-read'
-  | 'cdp';
+  | 'cdp'
+  | 'focus-window';
 
 export interface Command {
   /** Unique request ID */

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -21,7 +21,7 @@ function generateId(): string {
 
 export interface DaemonCommand {
   id: string;
-  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'sessions' | 'set-file-input' | 'insert-text' | 'bind-current' | 'network-capture-start' | 'network-capture-read' | 'cdp';
+  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'sessions' | 'set-file-input' | 'insert-text' | 'bind-current' | 'network-capture-start' | 'network-capture-read' | 'focus-window' | 'cdp';
   tabId?: number;
   code?: string;
   workspace?: string;

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -126,6 +126,11 @@ export class Page extends BasePage {
     }
   }
 
+  /** Bring the automation window to the foreground. Creates one if none exists. */
+  async focusWindow(): Promise<void> {
+    await sendCommand('focus-window', { ...this._wsOpt() });
+  }
+
   async tabs(): Promise<unknown[]> {
     const result = await sendCommand('tabs', { op: 'list', ...this._wsOpt() });
     return Array.isArray(result) ? result : [];

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -13,6 +13,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { type CliCommand, fullName, getRegistry } from './registry.js';
+import { sendCommand } from './browser/daemon-client.js';
 import { formatRegistryHelpText } from './serialization.js';
 import { render as renderOutput } from './output.js';
 import { executeCommand } from './execution.js';
@@ -297,6 +298,8 @@ export function registerAllCommands(
   siteGroups: Map<string, Command>,
 ): void {
   const seen = new Set<CliCommand>();
+  const browserSites = new Set<string>();
+
   for (const [, cmd] of getRegistry()) {
     if (seen.has(cmd)) continue;
     seen.add(cmd);
@@ -306,5 +309,25 @@ export function registerAllCommands(
       siteGroups.set(cmd.site, siteCmd);
     }
     registerCommandToProgram(siteCmd, cmd);
+    if (cmd.browser) browserSites.add(cmd.site);
+  }
+
+  // Inject `open` subcommand for every site that has at least one browser command.
+  for (const site of browserSites) {
+    const siteCmd = siteGroups.get(site);
+    if (!siteCmd) continue;
+    if (siteCmd.commands.some((c: Command) => c.name() === 'open')) continue;
+    siteCmd
+      .command('open')
+      .description('Bring the automation window to the foreground')
+      .action(async () => {
+        try {
+          await sendCommand('focus-window', { workspace: `site:${site}` });
+          console.log(chalk.green(`✓ ${site} automation window is now in the foreground.`));
+        } catch (err) {
+          console.error(chalk.red(`Failed to focus window: ${err instanceof Error ? err.message : err}`));
+          process.exitCode = EXIT_CODES.GENERIC_ERROR;
+        }
+      });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,8 @@ export interface IPage {
    */
   insertText?(text: string): Promise<void>;
   closeWindow?(): Promise<void>;
+  /** Bring the automation window to the foreground. Creates one if none exists. */
+  focusWindow?(): Promise<void>;
   /** Returns the current page URL, or null if unavailable. */
   getCurrentUrl?(): Promise<string | null>;
   /** Returns the active tab ID, or undefined if not yet resolved. */


### PR DESCRIPTION
---
###   Description                                                              
                                                                  
  Adds a new focus-window action to the browser protocol, enabling users to
   bring the automation window to the foreground without interrupting the  
  current browser session.
                                                                           
  Closes #639                                                              
   
---

###   Problem
When opencli executes browser commands (e.g. opencli doubao     
  ask), operations happen in a background Chrome window that the user
  cannot see. There was no way to surface that window for debugging or     
  monitoring.                                                     

  Solution: Introduce a focus-window protocol action, and automatically    
  inject an open subcommand for every browser-capable site, so users can
  run opencli <site> open to bring the automation window into focus.       
                                                                  
---                                                      
                                                                  
###   Changes                                                                  
                                           
| File | Change |
| --- | --- |
| `extension/src/protocol.ts` | Add 'focus-window' to the Action union type |
| `extension/src/background.ts` | Add case 'focus-window' routing and handleFocusWindow() — focuses an existing session window or creates one if none exists |
| `src/browser/daemon-client.ts` | Sync DaemonCommand.action type with the updated protocol |
| `src/types.ts` | Add `focusWindow?(): Promise<void>` to the IPage interface |
| `src/browser/page.ts` | Implement `Page.focusWindow()` — sends focus-window command to daemon |
| `src/commanderAdapter.ts` | In registerAllCommands, collect browser-capable sites and auto-inject an open subcommand for each |
| `extension/dist/background.js` | Compiled extension output (per project convention, tracked in repo) |
    
 ---   
                                                                            
###   Checklist                                                       

  - I ran the checks relevant to this PR                                   
  - I updated tests or docs if needed
                                                                           
```bash
$ opencli bilibili hot --limit 5

  bilibili/hot
┌──────┬──────────────────────────────────────┬──────────────┬─────────┬─────────┐
│ Rank │ Title                                │ Author       │ Play    │ Danmaku │
├──────┼──────────────────────────────────────┼──────────────┼─────────┼─────────┤
│ 1    │ 因为胸部大自卑了30年，所以我决定…    │ 宝剑嫂       │ 6414530 │ 6889    │
├──────┼──────────────────────────────────────┼──────────────┼─────────┼─────────┤
│ 2    │ ⚡对 对 子 战 神 2⚡                 │ 洛温阿特金森 │ 3248796 │ 6660    │
├──────┼──────────────────────────────────────┼──────────────┼─────────┼─────────┤
│ 3    │ 李荣浩手撕单依纯！老实人真被逼急了！ │ LexBurner    │ 8421147 │ 42703   │
├──────┼──────────────────────────────────────┼──────────────┼─────────┼─────────┤
│ 4    │ 【苹果花】🎂 お誕生日おめでとう      │ 神奇斯塔尔   │ 24316   │ 16      │
├──────┼──────────────────────────────────────┼──────────────┼─────────┼─────────┤
│ 5    │ 尖塔回战·戮灭洄游（完整版）          │ 真空叶       │ 120217  │ 159     │
└──────┴──────────────────────────────────────┴──────────────┴─────────┴─────────┘
5 items · 4.0s · bilibili/hot

$ opencli bilibili open
✓ bilibili automation window is now in the foreground.
```                                                
 