### PR TITLE
fix(twitter): resolve article ID to tweet ID for article URLs

### DIFF
--- a/src/clis/twitter/article.ts
+++ b/src/clis/twitter/article.ts
@@ -16,10 +16,40 @@ cli({
   ],
   columns: ['title', 'author', 'content', 'url'],
   func: async (page, kwargs) => {
-    // Extract tweet ID from URL if needed
+    // Extract tweet ID from URL if needed.
+    // Article URLs (x.com/i/article/{articleId}) use a different ID than
+    // tweet status URLs — the GraphQL endpoint needs the parent tweet ID.
     let tweetId = kwargs['tweet-id'];
+    const isArticleUrl = /\/article\/\d+/.test(tweetId);
     const urlMatch = tweetId.match(/\/(?:status|article)\/(\d+)/);
     if (urlMatch) tweetId = urlMatch[1];
+
+    if (isArticleUrl) {
+      // Navigate to the article page and resolve the parent tweet ID from DOM
+      await page.goto(`https://x.com/i/article/${tweetId}`);
+      await page.wait(3);
+      const resolvedId = await page.evaluate(`
+        (function() {
+          var links = document.querySelectorAll('a[href*="/status/"]');
+          for (var i = 0; i < links.length; i++) {
+            var m = links[i].href.match(/\\/status\\/(\\d+)/);
+            if (m) return m[1];
+          }
+          var og = document.querySelector('meta[property="og:url"]');
+          if (og && og.content) {
+            var m2 = og.content.match(/\\/status\\/(\\d+)/);
+            if (m2) return m2[1];
+          }
+          return null;
+        })()
+      `);
+      if (!resolvedId || typeof resolvedId !== 'string') {
+        throw new CommandExecutionError(
+          `Could not resolve article ${tweetId} to a tweet ID. The article page may not contain a linked tweet.`,
+        );
+      }
+      tweetId = resolvedId;
+    }
 
     // Navigate to the tweet page for cookie context
     await page.goto(`https://x.com/i/status/${tweetId}`);


### PR DESCRIPTION
## Summary

- Article URLs (`x.com/i/article/{articleId}`) use a different ID than tweet status URLs
- The GraphQL `TweetResultByRestId` endpoint requires the parent tweet ID, not the article ID
- **Supersedes PR #688** — fixes the critical bug where all inputs (including status URLs) were routed through the article page

## Fix

- Detect article URLs upfront via regex before extracting the numeric ID
- For article URLs: navigate to article page, extract parent tweet ID from DOM links (`a[href*="/status/"]`) or `og:url` meta tag
- For status URLs or bare IDs: use directly as before (no behavior change)
- Throw explicit error if article→tweet resolution fails (instead of silently falling through)

## Test plan
- [ ] `opencli twitter article https://x.com/i/article/2038726133869625344` — should resolve to tweet ID and return article
- [ ] `opencli twitter article https://x.com/user/status/123456` — should work as before (no article resolution)
- [ ] `opencli twitter article 123456` — bare ID should work as before