### PR TITLE
refactor: centralize daemon transport client

### DIFF
--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchDaemonStatus,
+  isDaemonRunning,
+  isExtensionConnected,
+  requestDaemonShutdown,
+} from './daemon-client.js';
+
+describe('daemon-client', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchDaemonStatus sends the shared status request and returns parsed data', async () => {
+    const status = {
+      ok: true,
+      pid: 123,
+      uptime: 10,
+      extensionConnected: true,
+      extensionVersion: '1.2.3',
+      pending: 0,
+      lastCliRequestTime: Date.now(),
+      memoryMB: 32,
+      port: 19825,
+    };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(status),
+    } as Response);
+
+    await expect(fetchDaemonStatus()).resolves.toEqual(status);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/status$/),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-OpenCLI': '1' }),
+      }),
+    );
+  });
+
+  it('fetchDaemonStatus returns null on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(fetchDaemonStatus()).resolves.toBeNull();
+  });
+
+  it('requestDaemonShutdown POSTs to the shared shutdown endpoint', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+
+    await expect(requestDaemonShutdown()).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/shutdown$/),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-OpenCLI': '1' }),
+      }),
+    );
+  });
+
+  it('isDaemonRunning reflects shared status availability', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          pid: 123,
+          uptime: 10,
+          extensionConnected: false,
+          pending: 0,
+          lastCliRequestTime: Date.now(),
+          memoryMB: 16,
+          port: 19825,
+        }),
+    } as Response);
+
+    await expect(isDaemonRunning()).resolves.toBe(true);
+  });
+
+  it('isExtensionConnected reflects shared status payload', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          pid: 123,
+          uptime: 10,
+          extensionConnected: false,
+          pending: 0,
+          lastCliRequestTime: Date.now(),
+          memoryMB: 16,
+          port: 19825,
+        }),
+    } as Response);
+
+    await expect(isExtensionConnected()).resolves.toBe(false);
+  });
+});

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -11,6 +11,7 @@ import { isTransientBrowserError } from './errors.js';
 
 const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
+const OPENCLI_HEADERS = { 'X-OpenCLI': '1' };
 
 let _idCounter = 0;
 
@@ -44,18 +45,46 @@ export interface DaemonResult {
   error?: string;
 }
 
-/**
- * Check if daemon is running.
- */
-export async function isDaemonRunning(): Promise<boolean> {
+export interface DaemonStatus {
+  ok: boolean;
+  pid: number;
+  uptime: number;
+  extensionConnected: boolean;
+  extensionVersion?: string;
+  pending: number;
+  lastCliRequestTime: number;
+  memoryMB: number;
+  port: number;
+}
+
+async function requestDaemon(pathname: string, init?: RequestInit & { timeout?: number }): Promise<Response> {
+  const { timeout = 2000, headers, ...rest } = init ?? {};
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 2000);
-    const res = await fetch(`${DAEMON_URL}/status`, {
-      headers: { 'X-OpenCLI': '1' },
+    return await fetch(`${DAEMON_URL}${pathname}`, {
+      ...rest,
+      headers: { ...OPENCLI_HEADERS, ...headers },
       signal: controller.signal,
     });
+  } finally {
     clearTimeout(timer);
+  }
+}
+
+export async function fetchDaemonStatus(opts?: { timeout?: number }): Promise<DaemonStatus | null> {
+  try {
+    const res = await requestDaemon('/status', { timeout: opts?.timeout ?? 2000 });
+    if (!res.ok) return null;
+    return await res.json() as DaemonStatus;
+  } catch {
+    return null;
+  }
+}
+
+export async function requestDaemonShutdown(opts?: { timeout?: number }): Promise<boolean> {
+  try {
+    const res = await requestDaemon('/shutdown', { method: 'POST', timeout: opts?.timeout ?? 5000 });
     return res.ok;
   } catch {
     return false;
@@ -63,23 +92,18 @@ export async function isDaemonRunning(): Promise<boolean> {
 }
 
 /**
+ * Check if daemon is running.
+ */
+export async function isDaemonRunning(): Promise<boolean> {
+  return (await fetchDaemonStatus()) !== null;
+}
+
+/**
  * Check if daemon is running AND the extension is connected.
  */
 export async function isExtensionConnected(): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 2000);
-    const res = await fetch(`${DAEMON_URL}/status`, {
-      headers: { 'X-OpenCLI': '1' },
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    if (!res.ok) return false;
-    const data = await res.json() as { extensionConnected?: boolean };
-    return !!data.extensionConnected;
-  } catch {
-    return false;
-  }
+  const status = await fetchDaemonStatus();
+  return !!status?.extensionConnected;
 }
 
 /**
@@ -98,16 +122,12 @@ export async function sendCommand(
     const id = generateId();
     const command: DaemonCommand = { id, action, ...params };
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 30000);
-
-      const res = await fetch(`${DAEMON_URL}/command`, {
+      const res = await requestDaemon('/command', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-OpenCLI': '1' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(command),
-        signal: controller.signal,
+        timeout: 30000,
       });
-      clearTimeout(timer);
 
       const result = (await res.json()) as DaemonResult;
 

--- a/src/browser/discover.ts
+++ b/src/browser/discover.ts
@@ -2,8 +2,7 @@
  * Daemon discovery — checks if the daemon is running.
  */
 
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
-import { isDaemonRunning } from './daemon-client.js';
+import { fetchDaemonStatus, isDaemonRunning } from './daemon-client.js';
 
 export { isDaemonRunning };
 
@@ -15,21 +14,13 @@ export async function checkDaemonStatus(opts?: { timeout?: number }): Promise<{
   extensionConnected: boolean;
   extensionVersion?: string;
 }> {
-  try {
-    const port = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), opts?.timeout ?? 2000);
-    try {
-      const res = await fetch(`http://127.0.0.1:${port}/status`, {
-        headers: { 'X-OpenCLI': '1' },
-        signal: controller.signal,
-      });
-      const data = await res.json() as { ok: boolean; extensionConnected: boolean; extensionVersion?: string };
-      return { running: true, extensionConnected: data.extensionConnected, extensionVersion: data.extensionVersion };
-    } finally {
-      clearTimeout(timer);
-    }
-  } catch {
+  const status = await fetchDaemonStatus({ timeout: opts?.timeout ?? 2000 });
+  if (!status) {
     return { running: false, extensionConnected: false };
   }
+  return {
+    running: true,
+    extensionConnected: status.extensionConnected,
+    extensionVersion: status.extensionVersion,
+  };
 }

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+const {
+  fetchDaemonStatusMock,
+  requestDaemonShutdownMock,
+} = vi.hoisted(() => ({
+  fetchDaemonStatusMock: vi.fn(),
+  requestDaemonShutdownMock: vi.fn(),
+}));
+
 vi.mock('chalk', () => ({
   default: {
     green: (s: string) => s,
@@ -16,6 +24,11 @@ vi.mock('../browser/bridge.js', () => ({
   },
 }));
 
+vi.mock('../browser/daemon-client.js', () => ({
+  fetchDaemonStatus: fetchDaemonStatusMock,
+  requestDaemonShutdown: requestDaemonShutdownMock,
+}));
+
 import { daemonStatus, daemonStop, daemonRestart } from './daemon.js';
 
 describe('daemon commands', () => {
@@ -25,6 +38,8 @@ describe('daemon commands', () => {
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchDaemonStatusMock.mockReset();
+    requestDaemonShutdownMock.mockReset();
   });
 
   afterEach(() => {
@@ -34,7 +49,7 @@ describe('daemon commands', () => {
 
   describe('daemonStatus', () => {
     it('shows "not running" when daemon is unreachable', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+      fetchDaemonStatusMock.mockResolvedValue(null);
 
       await daemonStatus();
 
@@ -42,7 +57,7 @@ describe('daemon commands', () => {
     });
 
     it('shows "not running" when daemon returns non-ok response', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+      fetchDaemonStatusMock.mockResolvedValue(null);
 
       await daemonStatus();
 
@@ -61,13 +76,7 @@ describe('daemon commands', () => {
         port: 19825,
       };
 
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(status),
-        }),
-      );
+      fetchDaemonStatusMock.mockResolvedValue(status);
 
       await daemonStatus();
 
@@ -91,13 +100,7 @@ describe('daemon commands', () => {
         port: 19825,
       };
 
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(status),
-        }),
-      );
+      fetchDaemonStatusMock.mockResolvedValue(status);
 
       await daemonStatus();
 
@@ -107,7 +110,7 @@ describe('daemon commands', () => {
 
   describe('daemonStop', () => {
     it('reports "not running" when daemon is unreachable', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+      fetchDaemonStatusMock.mockResolvedValue(null);
 
       await daemonStop();
 
@@ -115,59 +118,36 @@ describe('daemon commands', () => {
     });
 
     it('sends shutdown and reports success', async () => {
-      const statusResponse = {
+      fetchDaemonStatusMock.mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
-            ok: true,
-            pid: 12345,
-            uptime: 100,
-            extensionConnected: true,
-            pending: 0,
-            lastCliRequestTime: Date.now(),
-            memoryMB: 50,
-            port: 19825,
-          }),
-      };
-      const shutdownResponse = { ok: true };
-
-      const mockFetch = vi.fn()
-        .mockResolvedValueOnce(statusResponse)
-        .mockResolvedValueOnce(shutdownResponse);
-      vi.stubGlobal('fetch', mockFetch);
+        pid: 12345,
+        uptime: 100,
+        extensionConnected: true,
+        pending: 0,
+        lastCliRequestTime: Date.now(),
+        memoryMB: 50,
+        port: 19825,
+      });
+      requestDaemonShutdownMock.mockResolvedValue(true);
 
       await daemonStop();
 
-      // Verify shutdown was called with POST
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      const shutdownCall = mockFetch.mock.calls[1];
-      expect(shutdownCall[0]).toContain('/shutdown');
-      expect(shutdownCall[1]).toMatchObject({ method: 'POST' });
-
+      expect(requestDaemonShutdownMock).toHaveBeenCalledTimes(1);
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Daemon stopped'));
     });
 
     it('reports failure when shutdown request fails', async () => {
-      const statusResponse = {
+      fetchDaemonStatusMock.mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
-            ok: true,
-            pid: 12345,
-            uptime: 100,
-            extensionConnected: true,
-            pending: 0,
-            lastCliRequestTime: Date.now(),
-            memoryMB: 50,
-            port: 19825,
-          }),
-      };
-      const shutdownResponse = { ok: false };
-
-      const mockFetch = vi.fn()
-        .mockResolvedValueOnce(statusResponse)
-        .mockResolvedValueOnce(shutdownResponse);
-      vi.stubGlobal('fetch', mockFetch);
+        pid: 12345,
+        uptime: 100,
+        extensionConnected: true,
+        pending: 0,
+        lastCliRequestTime: Date.now(),
+        memoryMB: 50,
+        port: 19825,
+      });
+      requestDaemonShutdownMock.mockResolvedValue(false);
 
       await daemonStop();
 
@@ -188,7 +168,7 @@ describe('daemon commands', () => {
     };
 
     it('starts daemon directly when not running', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+      fetchDaemonStatusMock.mockResolvedValue(null);
       mockConnect.mockResolvedValue(undefined);
 
       await daemonRestart();
@@ -198,36 +178,22 @@ describe('daemon commands', () => {
     });
 
     it('stops then starts when daemon is running', async () => {
-      const mockFetch = vi.fn()
-        // First call: fetchStatus in daemonRestart — daemon is running
-        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(statusData) })
-        // Second call: requestShutdown — success
-        .mockResolvedValueOnce({ ok: true })
-        // Subsequent calls: polling fetchStatus until unreachable
-        .mockRejectedValue(new Error('ECONNREFUSED'));
-
-      vi.stubGlobal('fetch', mockFetch);
+      fetchDaemonStatusMock
+        .mockResolvedValueOnce(statusData)
+        .mockResolvedValueOnce(null);
+      requestDaemonShutdownMock.mockResolvedValue(true);
       mockConnect.mockResolvedValue(undefined);
 
       await daemonRestart();
 
-      // Verify shutdown was called
-      const shutdownCall = mockFetch.mock.calls[1];
-      expect(shutdownCall[0]).toContain('/shutdown');
-      expect(shutdownCall[1]).toMatchObject({ method: 'POST' });
-
+      expect(requestDaemonShutdownMock).toHaveBeenCalledTimes(1);
       expect(mockConnect).toHaveBeenCalledWith({ timeout: 10 });
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Daemon restarted'));
     });
 
     it('aborts when shutdown fails', async () => {
-      const mockFetch = vi.fn()
-        // fetchStatus — daemon is running
-        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(statusData) })
-        // requestShutdown — failure
-        .mockResolvedValueOnce({ ok: false });
-
-      vi.stubGlobal('fetch', mockFetch);
+      fetchDaemonStatusMock.mockResolvedValue(statusData);
+      requestDaemonShutdownMock.mockResolvedValue(false);
 
       await daemonRestart();
 

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -6,55 +6,7 @@
  */
 
 import chalk from 'chalk';
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
-
-const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
-const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
-
-interface DaemonStatus {
-  ok: boolean;
-  pid: number;
-  uptime: number;
-  extensionConnected: boolean;
-  pending: number;
-  lastCliRequestTime: number;
-  memoryMB: number;
-  port: number;
-}
-
-async function fetchStatus(): Promise<DaemonStatus | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 2000);
-  try {
-    const res = await fetch(`${DAEMON_URL}/status`, {
-      headers: { 'X-OpenCLI': '1' },
-      signal: controller.signal,
-    });
-    if (!res.ok) return null;
-    return await res.json() as DaemonStatus;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function requestShutdown(): Promise<boolean> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
-  try {
-    const res = await fetch(`${DAEMON_URL}/shutdown`, {
-      method: 'POST',
-      headers: { 'X-OpenCLI': '1' },
-      signal: controller.signal,
-    });
-    return res.ok;
-  } catch {
-    return false;
-  } finally {
-    clearTimeout(timer);
-  }
-}
+import { fetchDaemonStatus, requestDaemonShutdown } from '../browser/daemon-client.js';
 
 function formatUptime(seconds: number): string {
   const h = Math.floor(seconds / 3600);
@@ -74,7 +26,7 @@ function formatTimeSince(timestampMs: number): string {
 }
 
 export async function daemonStatus(): Promise<void> {
-  const status = await fetchStatus();
+  const status = await fetchDaemonStatus();
   if (!status) {
     console.log(`Daemon: ${chalk.dim('not running')}`);
     return;
@@ -89,13 +41,13 @@ export async function daemonStatus(): Promise<void> {
 }
 
 export async function daemonStop(): Promise<void> {
-  const status = await fetchStatus();
+  const status = await fetchDaemonStatus();
   if (!status) {
     console.log(chalk.dim('Daemon is not running.'));
     return;
   }
 
-  const ok = await requestShutdown();
+  const ok = await requestDaemonShutdown();
   if (ok) {
     console.log(chalk.green('Daemon stopped.'));
   } else {
@@ -105,9 +57,9 @@ export async function daemonStop(): Promise<void> {
 }
 
 export async function daemonRestart(): Promise<void> {
-  const status = await fetchStatus();
+  const status = await fetchDaemonStatus();
   if (status) {
-    const ok = await requestShutdown();
+    const ok = await requestDaemonShutdown();
     if (!ok) {
       console.error(chalk.red('Failed to stop daemon.'));
       process.exitCode = 1;
@@ -117,7 +69,7 @@ export async function daemonRestart(): Promise<void> {
     const deadline = Date.now() + 5000;
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, 200));
-      if (!(await fetchStatus())) break;
+      if (!(await fetchDaemonStatus())) break;
     }
   }
 


### PR DESCRIPTION
## Summary
- centralize daemon , , and  transport in 
- route  and  through the shared daemon client instead of duplicating protocol fetches
- add focused tests for the shared daemon client and updated daemon command wiring

## Testing
- npx vitest run src/browser/daemon-client.test.ts src/commands/daemon.test.ts
- npm run typecheck