### PR TITLE
fix(twitter): use search input for SPA navigation instead of pushState

### DIFF
--- a/src/clis/twitter/search.test.ts
+++ b/src/clis/twitter/search.test.ts
@@ -153,6 +153,88 @@ describe('twitter search command', () => {
     expect(pushStateCall).toContain('f=top');
   });
 
+  it('falls back to search input when pushState fails twice', async () => {
+    const command = getRegistry().get('twitter/search');
+    expect(command?.func).toBeTypeOf('function');
+
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(undefined)     // pushState attempt 1
+      .mockResolvedValueOnce('/explore')    // pathname check 1 — not /search
+      .mockResolvedValueOnce(undefined)     // pushState attempt 2
+      .mockResolvedValueOnce('/explore')    // pathname check 2 — still not /search
+      .mockResolvedValueOnce({ ok: true })  // search input fallback succeeds
+      .mockResolvedValueOnce('/search');    // pathname check after fallback
+
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      installInterceptor: vi.fn().mockResolvedValue(undefined),
+      evaluate,
+      autoScroll: vi.fn().mockResolvedValue(undefined),
+      getInterceptedRequests: vi.fn().mockResolvedValue([
+        {
+          data: {
+            search_by_raw_query: {
+              search_timeline: {
+                timeline: {
+                  instructions: [
+                    {
+                      type: 'TimelineAddEntries',
+                      entries: [
+                        {
+                          entryId: 'tweet-99',
+                          content: {
+                            itemContent: {
+                              tweet_results: {
+                                result: {
+                                  rest_id: '99',
+                                  legacy: {
+                                    full_text: 'fallback works',
+                                    favorite_count: 3,
+                                    created_at: 'Wed Apr 02 12:00:00 +0000 2026',
+                                  },
+                                  core: {
+                                    user_results: {
+                                      result: {
+                                        core: { screen_name: 'bob' },
+                                      },
+                                    },
+                                  },
+                                  views: { count: '5' },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ]),
+    };
+
+    const result = await command!.func!(page as any, { query: 'test fallback', filter: 'top', limit: 5 });
+
+    expect(result).toEqual([
+      {
+        id: '99',
+        author: 'bob',
+        text: 'fallback works',
+        created_at: 'Wed Apr 02 12:00:00 +0000 2026',
+        likes: 3,
+        views: '5',
+        url: 'https://x.com/i/status/99',
+      },
+    ]);
+    // 6 evaluate calls: 2x pushState + 2x pathname check + 1x fallback + 1x pathname check
+    expect(evaluate).toHaveBeenCalledTimes(6);
+    expect(page.autoScroll).toHaveBeenCalled();
+  });
+
   it('throws with the final path after both attempts fail', async () => {
     const command = getRegistry().get('twitter/search');
     expect(command?.func).toBeTypeOf('function');

--- a/src/clis/twitter/search.ts
+++ b/src/clis/twitter/search.ts
@@ -54,7 +54,8 @@ async function navigateToSearch(page: Pick<IPage, 'evaluate' | 'wait'>, query: s
 
       const nativeSetter = Object.getOwnPropertyDescriptor(
         window.HTMLInputElement.prototype, 'value'
-      ).set;
+      )?.set;
+      if (!nativeSetter) return { ok: false };
       nativeSetter.call(input, ${queryStr});
       input.dispatchEvent(new Event('input', { bubbles: true }));
       input.dispatchEvent(new Event('change', { bubbles: true }));


### PR DESCRIPTION
## Summary

- The `pushState + popstate` approach works in most environments but fails intermittently for some users (#690)
- Added a **fallback** strategy: when pushState fails after 2 retries, type query into the search input on `/explore` and press Enter
- Both strategies use **selector-based waiting** (`[data-testid="primaryColumn"]`) with graceful fallthrough on timeout
- The pushState approach remains the **primary** strategy

## Root Cause

The failure is **intermittent**, not permanent. Likely causes include Twitter A/B tests, timing race conditions (pathname not updated when checked), or browser/session state differences. In my testing, pushState failed consistently at first, then succeeded consistently later — consistent with server-side variation.

## Changes

- Wrap the `primaryColumn` selector wait in a try/catch so a timeout doesn't throw immediately — it falls through to the path check
- After 2 failed pushState attempts, fall back to the search input approach (nativeSetter + Enter keydown)
- The fallback also uses selector-based waiting, not fixed delays
- For `live` filter with the fallback path, click the "Latest" tab after navigation

## Testing

- Original pushState: failed 2/2, then later passed 3/3 (confirms intermittent nature)
- Search input fallback: passed 2/2 when pushState was failing
- Combined (this PR): covers both scenarios

Fixes #690