### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.6.0](https://github.com/jackwener/opencli/compare/v1.5.9...v1.6.0) (2026-04-02)
+
+
+### Features
+
+* **opencli-operate:** add browser control commands for Claude Code skill ([#614](https://github.com/jackwener/opencli/issues/614))
+* **docs:** add tab completion to getting started guides ([#658](https://github.com/jackwener/opencli/issues/658))
+
+
+### Bug Fixes
+
+* **twitter:** resolve article ID to tweet ID before GraphQL query ([#688](https://github.com/jackwener/opencli/issues/688))
+* **xiaohongshu:** clarify empty note shell hint ([#686](https://github.com/jackwener/opencli/issues/686))
+* **skills:** add YAML frontmatter for discovery and improve descriptions ([#694](https://github.com/jackwener/opencli/issues/694))
+
+
+### Refactoring
+
+* centralize daemon transport client ([#692](https://github.com/jackwener/opencli/issues/692))
+
+
 ## [1.5.9](https://github.com/jackwener/opencli/compare/v1.5.8...v1.5.9) (2026-04-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "publishConfig": {
     "access": "public"
   },

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencli-usage
 description: "Use when running OpenCLI commands to interact with websites (Bilibili, Twitter, Reddit, Xiaohongshu, etc.), desktop apps (Cursor, Notion), or public APIs (HackerNews, arXiv). Covers installation, command reference, and output formats for 60+ adapters."
-version: 1.5.9
+version: 1.6.0
 author: jackwener
 tags: [opencli, cli, browser, web, chrome-extension, cdp, bilibili, twitter, reddit, xiaohongshu, github, youtube, AI, agent, automation]
 ---


### PR DESCRIPTION
## Summary
- Bump version to 1.6.0
- Update CHANGELOG with all changes since v1.5.9

## Changes since v1.5.9
- feat: opencli-operate browser control commands (#614)
- feat: tab completion in getting started guides (#658)
- fix(twitter): resolve article ID to tweet ID (#688)
- fix(xiaohongshu): clarify empty note shell hint (#686)
- fix(skills): add YAML frontmatter for discovery (#694)
- refactor: centralize daemon transport client (#692)