### PR TITLE
fix: sync package-lock.json version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.5.9",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

- v1.6.0 release commit (#697) bumped `package.json` to 1.6.0 but forgot to update `package-lock.json` (still 1.5.9)
- This causes `bun install` to fail with `InvalidNPMLockfile: failed to migrate lockfile` when installing from npm

## Fix

Update both version fields in `package-lock.json` (root and `packages[""]`) to match `package.json` v1.6.0.