### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.1](https://github.com/jackwener/opencli/compare/v1.6.0...v1.6.1) (2026-04-02)
+
+
+### Bug Fixes
+
+* sync package-lock.json version with package.json ([#698](https://github.com/jackwener/opencli/issues/698))
+
+
 ## [1.6.0](https://github.com/jackwener/opencli/compare/v1.5.9...v1.6.0) (2026-04-02)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Patch release to fix `InvalidNPMLockfile` error when installing via bun/npm.

### Bug Fixes
- sync package-lock.json version with package.json (#698)

### Changes
- `package.json`: 1.6.0 → 1.6.1
- `package-lock.json`: 1.6.0 → 1.6.1 (both root and packages[""])
- `CHANGELOG.md`: add v1.6.1 entry