### PR TITLE
docs: fix root SKILL.md and individual skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,14 @@ npm install -g @jackwener/opencli@latest
 OpenCLI provides [skills](./skills/) for AI agents (Claude Code, etc.):
 
 ```bash
+# Install all OpenCLI skills
 npx skills add jackwener/opencli
+
+# Or install specific skills
+npx skills add jackwener/opencli --skill opencli-usage      # Command reference
+npx skills add jackwener/opencli --skill opencli-operate     # Browser automation for AI agents
+npx skills add jackwener/opencli --skill opencli-explorer    # Adapter development guide
+npx skills add jackwener/opencli --skill opencli-oneshot     # Quick command reference
 ```
 
 ---


### PR DESCRIPTION
## Summary
Follow-up to #701. Fixes the root cause of `npx skills add jackwener/opencli --skill opencli-operate` failing.

**Root cause**: Root `SKILL.md` exists, so `npx skills` only discovers 1 skill ("opencli") and blocks sub-skill discovery. Need `--full-depth` flag for individual skill install.

**Changes:**
- Update root `SKILL.md`: fix version (1.5.6→1.6.1), fix skill paths, add 4th skill (opencli-oneshot), remove incorrect env vars and non-existent `record` command
- Add `--full-depth` flag to README skill install commands (EN + CN) so individual skills can be installed

## Test plan
- [ ] `npx skills add jackwener/opencli --full-depth --skill opencli-operate` succeeds
- [ ] `npx skills add jackwener/opencli` still installs the root skill