### PR TITLE
docs: remove Why opencli, merge advantages into Highlights, add operate quickstart (CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,21 +70,9 @@ opencli bilibili hot --limit 5         # Browser command (requires Extension)
 
 ### 4. Browser Automation — Make Websites Accessible for AI Agents
 
-#### AI Agent Quickstart (1 step)
+Point your AI agent (Claude Code, Cursor) to [`skills/opencli-operate/SKILL.md`](./skills/opencli-operate/SKILL.md). It has everything needed — full command reference, examples, and workflow.
 
-Point your AI agent (Claude Code, Cursor) to [`skills/opencli-operate/SKILL.md`](./skills/opencli-operate/SKILL.md). It has everything needed.
-
-#### Human Quickstart (3 steps)
-
-```bash
-opencli operate open https://news.ycombinator.com    # 1. Open a page
-opencli operate state                                 # 2. See interactive elements
-opencli operate eval "document.title"                 # 3. Extract data
-```
-
-More commands: `click`, `type`, `select`, `keys`, `wait`, `get`, `screenshot`, `scroll`, `back`, `eval`, `network`, `init`, `verify`, `close`.
-
-See [`skills/opencli-operate/SKILL.md`](./skills/opencli-operate/SKILL.md) for full documentation.
+Available commands: `open`, `state`, `click`, `type`, `select`, `keys`, `wait`, `get`, `screenshot`, `scroll`, `back`, `eval`, `network`, `init`, `verify`, `close`.
 
 ### Update
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,21 +101,9 @@ npm install -g @jackwener/opencli@latest
 
 ### 浏览器自动化 — 让 AI Agent 直接控制浏览器
 
-#### AI Agent 快速接入（1 步）
+将 [`skills/opencli-operate/SKILL.md`](./skills/opencli-operate/SKILL.md) 指向你的 AI Agent（Claude Code、Cursor），即可开箱即用，内含完整命令参考与使用示例。
 
-将 [`skills/opencli-operate/SKILL.md`](./skills/opencli-operate/SKILL.md) 指向你的 AI Agent（Claude Code、Cursor），即可开箱即用。
-
-#### 人工快速上手（3 步）
-
-```bash
-opencli operate open https://news.ycombinator.com    # 1. 打开页面
-opencli operate state                                 # 2. 查看可交互元素
-opencli operate eval "document.title"                 # 3. 提取数据
-```
-
-更多命令：`click`、`type`、`select`、`keys`、`wait`、`get`、`screenshot`、`scroll`、`back`、`eval`、`network`、`init`、`verify`、`close`。
-
-完整文档见 [`skills/opencli-operate/SKILL.md`](./skills/opencli-operate/SKILL.md)。
+可用命令：`open`、`state`、`click`、`type`、`select`、`keys`、`wait`、`get`、`screenshot`、`scroll`、`back`、`eval`、`network`、`init`、`verify`、`close`。
 
 ### 安装 AI Skills
 


### PR DESCRIPTION
## Summary

- Remove `## Why opencli?` / `## 为什么选 opencli？` sections from both READMEs — these comparison tables are no longer needed as opencli now supports all the use cases
- Incorporate the 3 key advantages (Zero LLM cost, Deterministic, Broad coverage) from those sections into the `## Highlights` / `## 亮点` bullet lists
- Add `operate` mention to the "AI Agent ready" highlight
- Add browser automation / operate quickstart section to `README.zh-CN.md` (mirrors the existing English README step 4)

## Changes
- `README.md`: remove Why opencli section, add 3 advantage bullets + operate mention to Highlights
- `README.zh-CN.md`: same highlights update + add 浏览器自动化 quickstart section (was missing)