### PR TITLE
refactor: remove unused newTab() and closeTab() from IPage

### DIFF
--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -35,8 +35,6 @@ export abstract class BasePage implements IPage {
   abstract getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   abstract screenshot(options?: ScreenshotOptions): Promise<string>;
   abstract tabs(): Promise<unknown[]>;
-  abstract closeTab(index?: number): Promise<void>;
-  abstract newTab(): Promise<void>;
   abstract selectTab(index: number): Promise<void>;
 
   // ── Shared DOM helper implementations ──

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -223,14 +223,6 @@ class CDPPage extends BasePage {
     return [];
   }
 
-  async closeTab(_index?: number): Promise<void> {
-    // Not supported in direct CDP mode
-  }
-
-  async newTab(): Promise<void> {
-    await this.bridge.send('Target.createTarget', { url: 'about:blank' });
-  }
-
   async selectTab(_index: number): Promise<void> {
     // Not supported in direct CDP mode
   }

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -129,18 +129,6 @@ export class Page extends BasePage {
     return Array.isArray(result) ? result : [];
   }
 
-  async closeTab(index?: number): Promise<void> {
-    await sendCommand('tabs', { op: 'close', ...this._wsOpt(), ...(index !== undefined ? { index } : {}) });
-    // Invalidate cached tabId — the closed tab might have been our active one.
-    // We can't know for sure (close-by-index doesn't return tabId), so reset.
-    this._tabId = undefined;
-  }
-
-  async newTab(): Promise<void> {
-    const result = await sendCommand('tabs', { op: 'new', ...this._wsOpt() }) as { tabId?: number };
-    if (result?.tabId) this._tabId = result.tabId;
-  }
-
   async selectTab(index: number): Promise<void> {
     const result = await sendCommand('tabs', { op: 'select', index, ...this._wsOpt() }) as { selected?: number };
     if (result?.selected) this._tabId = result.selected;

--- a/src/clis/douyin/_shared/browser-fetch.test.ts
+++ b/src/clis/douyin/_shared/browser-fetch.test.ts
@@ -8,7 +8,6 @@ function makePage(result: unknown): IPage {
     getCookies: vi.fn(), snapshot: vi.fn(), click: vi.fn(),
     typeText: vi.fn(), pressKey: vi.fn(), scrollTo: vi.fn(),
     getFormState: vi.fn(), wait: vi.fn(), tabs: vi.fn(),
-    closeTab: vi.fn(), newTab: vi.fn(), selectTab: vi.fn(),
     networkRequests: vi.fn(), consoleMessages: vi.fn(),
     scroll: vi.fn(), autoScroll: vi.fn(),
     installInterceptor: vi.fn(), getInterceptedRequests: vi.fn(),

--- a/src/clis/douyin/_shared/transcode.test.ts
+++ b/src/clis/douyin/_shared/transcode.test.ts
@@ -19,8 +19,6 @@ function makePage(): IPage {
     getFormState: vi.fn(),
     wait: vi.fn(),
     tabs: vi.fn(),
-    closeTab: vi.fn(),
-    newTab: vi.fn(),
     selectTab: vi.fn(),
     networkRequests: vi.fn(),
     consoleMessages: vi.fn(),

--- a/src/clis/douyin/draft.test.ts
+++ b/src/clis/douyin/draft.test.ts
@@ -86,8 +86,6 @@ function createPageMock(
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/facebook/search.test.ts
+++ b/src/clis/facebook/search.test.ts
@@ -32,8 +32,6 @@ function createMockPage(): IPage {
     getFormState: vi.fn().mockResolvedValue({}),
     wait: vi.fn(),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn(),
-    newTab: vi.fn(),
     selectTab: vi.fn(),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue(''),

--- a/src/clis/substack/utils.test.ts
+++ b/src/clis/substack/utils.test.ts
@@ -14,8 +14,6 @@ function createPageMock(evaluateResult: unknown): IPage {
     getFormState: vi.fn().mockResolvedValue({}),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/comments.test.ts
+++ b/src/clis/xiaohongshu/comments.test.ts
@@ -15,8 +15,6 @@ function createPageMock(evaluateResult: any): IPage {
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/creator-note-detail.test.ts
+++ b/src/clis/xiaohongshu/creator-note-detail.test.ts
@@ -22,8 +22,6 @@ function createPageMock(evaluateResult: any): IPage {
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/creator-notes.test.ts
+++ b/src/clis/xiaohongshu/creator-notes.test.ts
@@ -26,8 +26,6 @@ function createPageMock(evaluateResult: any, interceptedRequests: any[] = []): I
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/download.test.ts
+++ b/src/clis/xiaohongshu/download.test.ts
@@ -29,8 +29,6 @@ function createPageMock(evaluateResult: any): IPage {
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/note.test.ts
+++ b/src/clis/xiaohongshu/note.test.ts
@@ -16,8 +16,6 @@ function createPageMock(evaluateResult: any): IPage {
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/publish.test.ts
+++ b/src/clis/xiaohongshu/publish.test.ts
@@ -25,8 +25,6 @@ function createPageMock(evaluateResults: any[], overrides: Partial<IPage> = {}):
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/clis/xiaohongshu/search.test.ts
+++ b/src/clis/xiaohongshu/search.test.ts
@@ -20,8 +20,6 @@ function createPageMock(evaluateResults: any[]): IPage {
     getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
     wait: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn().mockResolvedValue(undefined),
-    newTab: vi.fn().mockResolvedValue(undefined),
     selectTab: vi.fn().mockResolvedValue(undefined),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/pipeline/executor.test.ts
+++ b/src/pipeline/executor.test.ts
@@ -20,8 +20,6 @@ function createMockPage(overrides: Partial<IPage> = {}): IPage {
     getFormState: vi.fn().mockResolvedValue({}),
     wait: vi.fn(),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn(),
-    newTab: vi.fn(),
     selectTab: vi.fn(),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue(''),

--- a/src/pipeline/steps/download.test.ts
+++ b/src/pipeline/steps/download.test.ts
@@ -34,8 +34,6 @@ function createMockPage(getCookies: IPage['getCookies']): IPage {
     getFormState: vi.fn().mockResolvedValue({}),
     wait: vi.fn(),
     tabs: vi.fn().mockResolvedValue([]),
-    closeTab: vi.fn(),
-    newTab: vi.fn(),
     selectTab: vi.fn(),
     networkRequests: vi.fn().mockResolvedValue([]),
     consoleMessages: vi.fn().mockResolvedValue([]),

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,8 +56,6 @@ export interface IPage {
   getFormState(): Promise<any>;
   wait(options: number | WaitOptions): Promise<void>;
   tabs(): Promise<any>;
-  closeTab(index?: number): Promise<void>;
-  newTab(): Promise<void>;
   selectTab(index: number): Promise<void>;
   networkRequests(includeStatic?: boolean): Promise<any>;
   consoleMessages(level?: string): Promise<any>;


### PR DESCRIPTION
## Summary

- Remove `newTab()` and `closeTab()` from the `IPage` interface, `BasePage` abstract class, and both implementations (`Page`, `CDPPage`)
- Remove corresponding test mocks from 14 test files
- **Zero production callers** existed for either method — they were only referenced in test mocks

## What's kept

- `selectTab()` and `tabs()` — have active production usage (e.g. doubao adapter)
- `scoreTarget` about:blank penalty — defensive measure against user-opened blank tabs
- Extension `op: 'new'` handler — keeps extension API complete

## Verification

- `tsc --noEmit` passes
- All unit tests pass (46/46 for affected files)
- Pre-existing e2e/smoke failures unrelated to this change

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Unit tests for affected files pass
- [x] Verified no production code calls `newTab()` or `closeTab()`
- [x] Verified `selectTab()` and `tabs()` still have production callers