### PR TITLE
fix: update BrowserBridge test broken by PR #712

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -136,7 +136,7 @@ describe('BrowserBridge state', () => {
 
   it('fails fast when daemon is running but extension is disconnected', async () => {
     vi.spyOn(daemonClient, 'isExtensionConnected').mockResolvedValue(false);
-    vi.spyOn(daemonClient, 'isDaemonRunning').mockResolvedValue(true);
+    vi.spyOn(daemonClient, 'fetchDaemonStatus').mockResolvedValue({ extensionConnected: false } as any);
 
     const bridge = new BrowserBridge();
 


### PR DESCRIPTION
## Summary
- PR #712 refactored `_ensureDaemon` to use a single `fetchDaemonStatus()` call instead of separate `isDaemonRunning()` + `isExtensionConnected()`
- The test `fails fast when daemon is running but extension is disconnected` was still mocking the old `isDaemonRunning`, causing `fetchDaemonStatus()` to return `null` (no daemon) and fall through to the spawn-daemon path
- Fix: mock `fetchDaemonStatus` to return `{ extensionConnected: false }` so the test correctly exercises the "daemon running, extension missing" path

## Test plan
- [x] `npx vitest run --project unit src/browser.test.ts` — all 17 tests pass
- [x] `npx vitest run --project unit` — all 483 tests pass (0 failures)