### PR TITLE
refactor(xiaohongshu): replace blind retry with MutationObserver wait

### DIFF
--- a/src/clis/xiaohongshu/search.test.ts
+++ b/src/clis/xiaohongshu/search.test.ts
@@ -39,10 +39,8 @@ describe('xiaohongshu search', () => {
     expect(cmd?.func).toBeTypeOf('function');
 
     const page = createPageMock([
-      // First evaluate: MutationObserver wait (resolved, login wall detected)
-      true,
-      // Second evaluate: login-wall check (returns true)
-      true,
+      // First evaluate: MutationObserver wait (login wall detected)
+      'login_wall',
     ]);
 
     await expect(cmd!.func!(page, { query: '特斯拉', limit: 5 })).rejects.toThrow(
@@ -64,22 +62,17 @@ describe('xiaohongshu search', () => {
 
     const page = createPageMock([
       // First evaluate: MutationObserver wait (content appeared)
-      true,
-      // Second evaluate: login-wall check (returns false → no wall)
-      false,
-      // Third evaluate: main DOM extraction
-      {
-        loginWall: false,
-        results: [
-          {
-            title: '某鱼买FSD被坑了4万',
-            author: '随风',
-            likes: '261',
-            url: detailUrl,
-            author_url: authorUrl,
-          },
-        ],
-      },
+      'content',
+      // Second evaluate: main DOM extraction (returns array directly)
+      [
+        {
+          title: '某鱼买FSD被坑了4万',
+          author: '随风',
+          likes: '261',
+          url: detailUrl,
+          author_url: authorUrl,
+        },
+      ],
     ]);
 
     const result = await cmd!.func!(page, { query: '特斯拉', limit: 1 });
@@ -106,36 +99,31 @@ describe('xiaohongshu search', () => {
 
     const page = createPageMock([
       // First evaluate: MutationObserver wait (content appeared)
-      true,
-      // Second evaluate: login-wall check (returns false → no wall)
-      false,
-      // Third evaluate: main DOM extraction
-      {
-        loginWall: false,
-        results: [
-          {
-            title: 'Result A',
-            author: 'UserA',
-            likes: '10',
-            url: 'https://www.xiaohongshu.com/search_result/aaa',
-            author_url: '',
-          },
-          {
-            title: '',
-            author: 'UserB',
-            likes: '5',
-            url: 'https://www.xiaohongshu.com/search_result/bbb',
-            author_url: '',
-          },
-          {
-            title: 'Result C',
-            author: 'UserC',
-            likes: '3',
-            url: 'https://www.xiaohongshu.com/search_result/ccc',
-            author_url: '',
-          },
-        ],
-      },
+      'content',
+      // Second evaluate: main DOM extraction (returns array directly)
+      [
+        {
+          title: 'Result A',
+          author: 'UserA',
+          likes: '10',
+          url: 'https://www.xiaohongshu.com/search_result/aaa',
+          author_url: '',
+        },
+        {
+          title: '',
+          author: 'UserB',
+          likes: '5',
+          url: 'https://www.xiaohongshu.com/search_result/bbb',
+          author_url: '',
+        },
+        {
+          title: 'Result C',
+          author: 'UserC',
+          likes: '3',
+          url: 'https://www.xiaohongshu.com/search_result/ccc',
+          author_url: '',
+        },
+      ],
     ]);
 
     const result = (await cmd!.func!(page, { query: '测试', limit: 1 })) as any[];
@@ -151,19 +139,17 @@ describe('xiaohongshu search', () => {
 
     const page = createPageMock([
       // First evaluate: MutationObserver wait (content appeared)
-      true,
-      // Second evaluate: login-wall check
-      false,
-      // Third evaluate: extraction
-      { loginWall: false, results: [] },
+      'content',
+      // Second evaluate: extraction (returns empty array)
+      [],
     ]);
 
     const result = (await cmd!.func!(page, { query: '测试等待', limit: 5 })) as any[];
     expect(result).toHaveLength(0);
     // Only one navigation, no retry
     expect(page.goto).toHaveBeenCalledTimes(1);
-    // Three evaluate calls: wait + login check + extraction
-    expect(page.evaluate).toHaveBeenCalledTimes(3);
+    // Two evaluate calls: wait + extraction
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/clis/xiaohongshu/search.ts
+++ b/src/clis/xiaohongshu/search.ts
@@ -9,18 +9,26 @@
 import { cli, Strategy } from '../../registry.js';
 import { AuthRequiredError } from '../../errors.js';
 
-/** Wait for search results or login wall using MutationObserver (max 5s). */
+/**
+ * Wait for search results or login wall using MutationObserver (max 5s).
+ * Returns 'content' if note items appeared, 'login_wall' if login gate
+ * detected, or 'timeout' if neither appeared within the deadline.
+ */
 const WAIT_FOR_CONTENT_JS = `
   new Promise((resolve) => {
-    const check = () =>
-      document.querySelector('section.note-item') ||
-      /登录后查看搜索结果/.test(document.body?.innerText || '');
-    if (check()) return resolve(true);
+    const detect = () => {
+      if (document.querySelector('section.note-item')) return 'content';
+      if (/登录后查看搜索结果/.test(document.body?.innerText || '')) return 'login_wall';
+      return null;
+    };
+    const found = detect();
+    if (found) return resolve(found);
     const observer = new MutationObserver(() => {
-      if (check()) { observer.disconnect(); resolve(true); }
+      const result = detect();
+      if (result) { observer.disconnect(); resolve(result); }
     });
     observer.observe(document.body, { childList: true, subtree: true });
-    setTimeout(() => { observer.disconnect(); resolve(false); }, 5000);
+    setTimeout(() => { observer.disconnect(); resolve('timeout'); }, 5000);
   })
 `;
 
@@ -61,13 +69,9 @@ cli({
     // Wait for search results to render (or login wall to appear).
     // Uses MutationObserver to resolve as soon as content appears,
     // instead of a fixed delay + blind retry.
-    await page.evaluate(WAIT_FOR_CONTENT_JS);
+    const waitResult = await page.evaluate(WAIT_FOR_CONTENT_JS);
 
-    // Login-wall detection
-    const loginCheck = await page.evaluate(`
-      (() => /登录后查看搜索结果/.test(document.body?.innerText || ''))()
-    `);
-    if (loginCheck) {
+    if (waitResult === 'login_wall') {
       throw new AuthRequiredError(
         'www.xiaohongshu.com',
         'Xiaohongshu search results are blocked behind a login wall',
@@ -79,8 +83,6 @@ cli({
 
     const payload = await page.evaluate(`
       (() => {
-        const loginWall = /登录后查看搜索结果/.test(document.body.innerText || '');
-
         const normalizeUrl = (href) => {
           if (!href) return '';
           if (href.startsWith('http://') || href.startsWith('https://')) return href;
@@ -124,20 +126,11 @@ cli({
           });
         });
 
-        return {
-          loginWall,
-          results,
-        };
+        return results;
       })()
     `);
 
-    if (!payload || typeof payload !== 'object') return [];
-
-    if ((payload as any).loginWall) {
-      throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
-    }
-
-    const data: any[] = Array.isArray((payload as any).results) ? (payload as any).results : [];
+    const data: any[] = Array.isArray(payload) ? (payload as any[]) : [];
     return data
       .filter((item: any) => item.title)
       .slice(0, kwargs.limit)


### PR DESCRIPTION
## Summary

- Replaces the ugly `fetchAttempt()` + full re-navigation retry from PR #681 with a MutationObserver-based wait
- Waits for `section.note-item` or login wall text to appear in the DOM (5s timeout), resolving as soon as content renders
- Faster: no fixed 3s `page.wait()` before checking content, no 6-7s retry path
- More correct: addresses the root cause (delayed hydration) instead of working around it

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 11 xiaohongshu search tests pass (updated to reflect new evaluate sequence)
- [x] Retry test replaced with MutationObserver wait test verifying single navigation + 3 evaluate calls