### PR TITLE
fix(zhihu): make question runtime-compatible

### DIFF
--- a/src/clis/zhihu/question.test.ts
+++ b/src/clis/zhihu/question.test.ts
@@ -89,7 +89,7 @@ describe('zhihu question', () => {
       cmd!.func!(page, { id: '2021881398772981878', limit: 3 }),
     ).rejects.toMatchObject({
       code: 'FETCH_ERROR',
-      message: 'Zhihu question answers request failed Failed to fetch',
+      message: 'Zhihu question answers request failed: Failed to fetch',
     });
   });
 

--- a/src/clis/zhihu/question.ts
+++ b/src/clis/zhihu/question.ts
@@ -45,10 +45,10 @@ cli({
       if (result?.status === 401 || result?.status === 403) {
         throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch question data from Zhihu');
       }
-      const detail = result?.status > 0 ? `with HTTP ${result.status}` : (result?.error ?? '');
+      const detail = result?.status > 0 ? ` with HTTP ${result.status}` : (result?.error ? `: ${result.error}` : '');
       throw new CliError(
         'FETCH_ERROR',
-        `Zhihu question answers request failed ${detail}`.trim(),
+        `Zhihu question answers request failed${detail}`,
         'Try again later or rerun with -v for more detail',
       );
     }


### PR DESCRIPTION
## Summary
Fix `zhihu question` so it works in the real browser runtime again.

The command was using function-style `page.evaluate(...)`, but the runtime only supports string-based `evaluate`. This PR switches it to the supported form, navigates to the question page first, and keeps the existing auth / fetch error mapping.

## Validation
- `npx vitest run src/clis/zhihu/question.test.ts`
- `npm run build`
- `node dist/main.js zhihu question 2021881398772981878 --limit 2 -f json`
![Uploading 截屏2026-04-03 17.10.32.png…]()

Closes #604
