### PR TITLE
增加新浪财经热搜股票榜

### DIFF
--- a/src/clis/sinafinance/rolling-news.ts
+++ b/src/clis/sinafinance/rolling-news.ts
@@ -25,13 +25,12 @@ cli({
           const columnEl = el.querySelector('.c_chl');
           const dateEl = el.querySelector('.c_time');
           const url = titleEl?.getAttribute('href') || '';
-          const finalUrl = url ? (url.includes('?') ? url + '&from=opencli' : url + '?from=opencli') : '';
           if (!url) return;
           results.push({
             title: cleanText(titleEl?.textContent || ''),
             column: cleanText(columnEl?.textContent || ''),
             date: cleanText(dateEl?.textContent || ''),
-            url: finalUrl,
+            url: url,
           });
         });
         return results;

--- a/src/clis/sinafinance/stock-rank.ts
+++ b/src/clis/sinafinance/stock-rank.ts
@@ -10,59 +10,53 @@ cli({
   description: '新浪财经热搜榜',
   domain: 'finance.sina.cn',
   strategy: Strategy.COOKIE,
+  navigateBefore: false,
   args: [
-    { name: 'market', type: 'string', default: 'cn', help: 'Market: cn, ft, us,wh,hk' },
+    { name: 'market', type: 'string', default: 'cn', choices: ['cn', 'hk', 'us', 'wh', 'ft'], help: 'Market: cn (A股), hk (港股), us (美股), wh (外汇), ft (期货)' },
   ],
-  columns: ['Column', 'Name', 'Symbol', 'Market', 'Price', 'Change', 'Url'],
+  columns: ['rank', 'name', 'symbol', 'market', 'price', 'change', 'url'],
   func: async (page, _args) => {
-    await page.goto(`https://finance.sina.cn/`);
-    await page.wait({ selector: '#actionSearch', timeout: 10000 });
     const market = _args.market || 'cn';
+
+    await page.goto('https://finance.sina.cn/');
+    await page.wait({ selector: '#actionSearch', timeout: 10000 });
+
     const payload = await page.evaluate(`
       (async () => {
         const wait = (ms) => new Promise(r => setTimeout(r, ms));
         const cleanText = (value) => (value || '').replace(/\\s+/g, ' ').trim();
-        const waitForElement = async (selector, timeout = 5000) => {
-          const start = Date.now();
-          while (Date.now() - start < timeout) {
-            const el = document.querySelector(selector);
-            if (el) return el;
-            await new Promise(r => setTimeout(r, 100));
-          }
-          throw new Error('Timeout waiting for '+selector);
-        };
-        const searchBtn =  document.querySelector('#actionSearch');
+        const marketType = ${JSON.stringify(market)};
+
+        const searchBtn = document.querySelector('#actionSearch');
         if (searchBtn) {
           searchBtn.dispatchEvent(new Event('tap', { bubbles: true }));
           await wait(3000);
         }
-        const marketType = '${market}';
+
         const tabEl = document.querySelector('[data-type="' + marketType + '"]');
-        const marketName = tabEl.textContent;
-        if (marketType && marketType !== 'cn') {
-            if (tabEl) {
-              tabEl.click();
-              await wait(2000);
-            }
+        const marketName = tabEl?.textContent || marketType;
+        if (marketType !== 'cn' && tabEl) {
+          tabEl.click();
+          await wait(2000);
         }
+
         const results = [];
-        const rows = await document.querySelectorAll('#stock-list .j-stock-row');
-        rows.forEach(el => {
+        document.querySelectorAll('#stock-list .j-stock-row').forEach(el => {
           const rankEl = el.querySelector('.rank');
           const nameEl = el.querySelector('.j-sname');
           const codeEl = el.querySelector('.stock-code');
           const priceEl = el.querySelector('.j-price');
           const changeEl = el.querySelector('.j-change');
           const openUrl = el.getAttribute('open-url') || '';
-          const fullUrl = openUrl ? 'https:' + openUrl + (openUrl.includes('?') ? '&from=opencli' : '?from=opencli') : '';
+          const fullUrl = openUrl ? 'https:' + openUrl : '';
           results.push({
-            Column:rankEl?.textContent || '',
-            Name: cleanText(nameEl?.textContent || ''),
-            Symbol: cleanText(codeEl?.textContent || ''),
-            Market:marketName,
-            Price: cleanText(priceEl?.textContent || ''),
-            Change: cleanText(changeEl?.textContent || ''),
-            Url: fullUrl,
+            rank: cleanText(rankEl?.textContent || ''),
+            name: cleanText(nameEl?.textContent || ''),
+            symbol: cleanText(codeEl?.textContent || ''),
+            market: cleanText(marketName),
+            price: cleanText(priceEl?.textContent || ''),
+            change: cleanText(changeEl?.textContent || ''),
+            url: fullUrl,
           });
         });
         return results;


### PR DESCRIPTION
## Description

Add `sinafinance stock-rank` command - 新浪财经热搜榜

新增 `stock-rank` 命令，支持抓取新浪财经移动端首页股票热搜榜数据：

- 支持多个市场的股票热搜榜：A股(cn)、港股(hk)、美股(us)、外汇(wh)、期货(ft)

同时更新了 `docs/adapters/browser/sinafinance.md` 文档。

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation

## Checklist

- [x] Added doc page under `docs/adapters/` (updated existing sinafinance.md)
- [x] Used positional args for the command's primary subject (uses `--market` flag for market selection)

## Screenshots / Output

```bash
# A股热搜榜
$ opencli sinafinance stock-rank
Column | Name    | Symbol  | Market | Price  | Change | Url
-------+---------+---------+--------+--------+--------+-----
1      | 贵州茅台 | 600519  | A股    | 1850.0 | +2.3%  | https://finance.sina.com.cn/...

# 港股热搜榜
$ opencli sinafinance stock-rank --market hk

# 期货热搜榜
$ opencli sinafinance stock-rank --market ft

# 外汇热搜榜
$ opencli sinafinance stock-rank --market wh

# 美股热搜榜
$ opencli sinafinance stock-rank --market us
```