### PR TITLE
fix: handle missing electron executable gracefully

### DIFF
--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -15,6 +15,8 @@ export interface ElectronAppEntry {
   port: number;
   /** macOS process name for detection via pgrep */
   processName: string;
+  /** Candidate executable names inside Contents/MacOS/, tried in order */
+  executableNames?: string[];
   /** macOS bundle ID for path discovery */
   bundleId?: string;
   /** Human-readable name for prompts */
@@ -30,7 +32,13 @@ export const builtinApps: Record<string, ElectronAppEntry> = {
   notion:        { port: 9230, processName: 'Notion',       bundleId: 'notion.id',                      displayName: 'Notion' },
   'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
   'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },
-  antigravity:   { port: 9234, processName: 'Antigravity',  bundleId: 'dev.antigravity.app',            displayName: 'Antigravity' },
+  antigravity:   {
+    port: 9234,
+    processName: 'Antigravity',
+    executableNames: ['Electron', 'Antigravity'],
+    bundleId: 'dev.antigravity.app',
+    displayName: 'Antigravity',
+  },
   chatgpt:       { port: 9236, processName: 'ChatGPT',      bundleId: 'com.openai.chat',                displayName: 'ChatGPT' },
 };
 

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { detectProcess, discoverAppPath, launchDetachedApp, probeCDP } from './launcher.js';
+import type { ElectronAppEntry } from './electron-apps.js';
+import { detectProcess, discoverAppPath, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
 
 interface MockChildProcess {
   once: ReturnType<typeof vi.fn>;
@@ -89,6 +90,7 @@ describe('discoverAppPath', () => {
 describe('launchDetachedApp', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    cp.spawn.mockReset();
   });
 
   it('unrefs the process after spawn succeeds', async () => {
@@ -115,5 +117,65 @@ describe('launchDetachedApp', () => {
       .rejects
       .toThrow('Could not launch Antigravity');
     expect(child.unref).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveExecutableCandidates', () => {
+  it('prefers explicit executable candidates over processName', () => {
+    const app: ElectronAppEntry = {
+      port: 9234,
+      processName: 'Antigravity',
+      executableNames: ['Electron', 'Antigravity'],
+    };
+
+    expect(resolveExecutableCandidates('/Applications/Antigravity.app', app)).toEqual([
+      '/Applications/Antigravity.app/Contents/MacOS/Electron',
+      '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
+    ]);
+  });
+});
+
+describe('launchElectronApp', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cp.spawn.mockReset();
+  });
+
+  it('falls back to the next executable candidate when the first is missing', async () => {
+    const firstChild = createMockChildProcess();
+    const secondChild = createMockChildProcess();
+    const app: ElectronAppEntry = {
+      port: 9234,
+      processName: 'Antigravity',
+      executableNames: ['Electron', 'Antigravity'],
+    };
+
+    cp.spawn
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => firstChild.emit('error', Object.assign(new Error('missing binary'), { code: 'ENOENT' })));
+        return firstChild as unknown as ReturnType<typeof cp.spawn>;
+      })
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => secondChild.emit('spawn'));
+        return secondChild as unknown as ReturnType<typeof cp.spawn>;
+      });
+
+    await expect(
+      launchElectronApp('/Applications/Antigravity.app', app, ['--remote-debugging-port=9234'], 'Antigravity'),
+    ).resolves.toBeUndefined();
+
+    expect(cp.spawn).toHaveBeenNthCalledWith(
+      1,
+      '/Applications/Antigravity.app/Contents/MacOS/Electron',
+      ['--remote-debugging-port=9234'],
+      { detached: true, stdio: 'ignore' },
+    );
+    expect(cp.spawn).toHaveBeenNthCalledWith(
+      2,
+      '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
+      ['--remote-debugging-port=9234'],
+      { detached: true, stdio: 'ignore' },
+    );
+    expect(secondChild.unref).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -11,6 +11,7 @@
 
 import { execFileSync, spawn } from 'node:child_process';
 import { request as httpRequest } from 'node:http';
+import * as path from 'node:path';
 import type { ElectronAppEntry } from './electron-apps.js';
 import { getElectronApp } from './electron-apps.js';
 import { confirmPrompt } from './tui.js';
@@ -101,6 +102,16 @@ function resolveExecutable(appPath: string, processName: string): string {
   return `${appPath}/Contents/MacOS/${processName}`;
 }
 
+function isMissingExecutableError(err: unknown, label: string): boolean {
+  return err instanceof CommandExecutionError
+    && err.message.startsWith(`Could not launch ${label}: executable not found at `);
+}
+
+export function resolveExecutableCandidates(appPath: string, app: ElectronAppEntry): string[] {
+  const executableNames = app.executableNames?.length ? app.executableNames : [app.processName];
+  return [...new Set(executableNames)].map((name) => resolveExecutable(appPath, name));
+}
+
 export async function launchDetachedApp(executable: string, args: string[], label: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn(executable, args, {
@@ -130,6 +141,37 @@ export async function launchDetachedApp(executable: string, args: string[], labe
       resolve();
     });
   });
+}
+
+export async function launchElectronApp(appPath: string, app: ElectronAppEntry, args: string[], label: string): Promise<void> {
+  const executables = resolveExecutableCandidates(appPath, app);
+  let lastMissingExecutableError: CommandExecutionError | undefined;
+
+  for (const executable of executables) {
+    log.debug(`[launcher] Launching: ${executable} ${args.join(' ')}`);
+    try {
+      await launchDetachedApp(executable, args, label);
+      return;
+    } catch (err) {
+      if (isMissingExecutableError(err, label)) {
+        lastMissingExecutableError = err as CommandExecutionError;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  if (executables.length > 1) {
+    throw new CommandExecutionError(
+      `Could not launch ${label}: no compatible executable found in ${path.join(appPath, 'Contents', 'MacOS')}`,
+      `Tried: ${executables.map((executable) => path.basename(executable)).join(', ')}. Install ${label}, reinstall it, or register a custom app path in ~/.opencli/apps.yaml`,
+    );
+  }
+
+  throw lastMissingExecutableError ?? new CommandExecutionError(
+    `Could not launch ${label}`,
+    `Install ${label}, reinstall it, or register a custom app path in ~/.opencli/apps.yaml`,
+  );
 }
 
 async function pollForReady(port: number): Promise<void> {
@@ -197,10 +239,8 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
   }
 
   // Step 4: Launch
-  const executable = resolveExecutable(appPath, processName);
   const args = [`--remote-debugging-port=${port}`, ...(app.extraArgs ?? [])];
-  log.debug(`[launcher] Launching: ${executable} ${args.join(' ')}`);
-  await launchDetachedApp(executable, args, label);
+  await launchElectronApp(appPath, app, args, label);
 
   // Step 5: Poll for readiness
   process.stderr.write(`  Waiting for ${label} on port ${port}...\n`);


### PR DESCRIPTION
## Intent

Fix the Electron app launch path so a missing executable does not crash the CLI with an unhandled child-process error.

## What changed

- add a guarded `launchDetachedApp()` helper in `src/launcher.ts`
- convert `spawn ENOENT` into a controlled `CommandExecutionError` with an actionable hint
- cover successful launch and ENOENT failure in `src/launcher.test.ts`

## Verification

- `npx vitest run src/launcher.test.ts src/electron-apps.test.ts src/engine.test.ts`
- `npm run typecheck`
- `npm run build`
- `node dist/main.js antigravity new` now returns a controlled launch error instead of an unhandled crash
