### PR TITLE
fix(tests): update mocks for resolveBvid and Windows platform guards

### DIFF
--- a/src/clis/bilibili/comments.test.ts
+++ b/src/clis/bilibili/comments.test.ts
@@ -4,7 +4,8 @@ const { mockApiGet } = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
 }));
 
-vi.mock('./utils.js', () => ({
+vi.mock('./utils.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./utils.js')>()),
   apiGet: mockApiGet,
 }));
 
@@ -58,8 +59,8 @@ describe('bilibili comments', () => {
   it('throws when aid cannot be resolved', async () => {
     mockApiGet.mockResolvedValueOnce({ data: {} }); // no aid
 
-    await expect(command!.func!({} as any, { bvid: 'BV_invalid', limit: 5 })).rejects.toThrow(
-      'Cannot resolve aid for bvid: BV_invalid',
+    await expect(command!.func!({} as any, { bvid: 'BVinvalid123', limit: 5 })).rejects.toThrow(
+      'Cannot resolve aid for bvid: BVinvalid123',
     );
   });
 

--- a/src/clis/bilibili/subtitle.test.ts
+++ b/src/clis/bilibili/subtitle.test.ts
@@ -6,7 +6,8 @@ const { mockApiGet } = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
 }));
 
-vi.mock('./utils.js', () => ({
+vi.mock('./utils.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./utils.js')>()),
   apiGet: mockApiGet,
 }));
 

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -34,7 +34,7 @@ describe('detectProcess', () => {
     expect(result).toBe(false);
   });
 
-  it('returns true when pgrep finds a process', () => {
+  it.skipIf(process.platform === 'win32')('returns true when pgrep finds a process', () => {
     cp.execFileSync.mockReturnValue('12345\n');
     const result = detectProcess('Cursor');
     expect(result).toBe(true);


### PR DESCRIPTION
## Summary
- Fix bilibili subtitle/comments test mocks to include `resolveBvid` via `importOriginal` (broken after #740)
- Fix test BV ID format (`BV_invalid` → `BVinvalid123`) to match BV regex pattern
- Skip `detectProcess` pgrep test on Windows where it early-returns `false` (#744)

## Test plan
- [ ] CI passes on all platforms