### PR TITLE
fix(1688): review fixes for adapter

### DIFF
--- a/src/clis/1688/item.ts
+++ b/src/clis/1688/item.ts
@@ -203,7 +203,7 @@ function extractKeywordLine(bodyText: string, keywords: string[]): string | null
 }
 
 function extractSalesText(bodyText: string): string | null {
-  const match = bodyText.match(/(?:全网销量|已售)\s*\d+(?:\.\d+)?\+?[件套个]?/);
+  const match = bodyText.match(/(?:全网销量|已售)\s*\d+(?:\.\d+)?\+?\s*[件套个单]?/);
   return match ? cleanText(match[0]) : null;
 }
 

--- a/src/clis/1688/search.test.ts
+++ b/src/clis/1688/search.test.ts
@@ -31,6 +31,20 @@ describe('1688 search normalization', () => {
     expect(result.return_rate_text).toBe('回头率52%');
   });
 
+  it('does not use hover_price_text as MOQ source', () => {
+    const result = __test__.normalizeSearchCandidate({
+      item_url: 'https://detail.1688.com/offer/887904326744.html',
+      title: 'test',
+      container_text: 'test ¥56.00',
+      price_text: '¥ 56 .00',
+      hover_price_text: '¥56.00 3件起批',
+      moq_text: null,
+    }, 'https://s.1688.com/selloffer/offer_search.htm?charset=utf8&keywords=test');
+    // hover_price_text should not be used for MOQ extraction
+    expect(result.moq_text).toBeNull();
+    expect(result.moq_value).toBeNull();
+  });
+
   it('extracts offer id from mobile detail search links', () => {
     const result = __test__.normalizeSearchCandidate({
       item_url: 'http://detail.m.1688.com/page/index.html?offerId=910933345396&sortType=&pageId=',

--- a/src/clis/1688/search.ts
+++ b/src/clis/1688/search.ts
@@ -88,7 +88,6 @@ function normalizeSearchCandidate(
   const priceRange = parsePriceText(priceText || containerText);
   const moq = parseMoqText(firstNonEmpty([
     normalizeInlineText(candidate.moq_text),
-    normalizeInlineText(extractMoqText(candidate.hover_price_text)),
     normalizeInlineText(extractMoqText(containerText)),
   ]));
   const canonicalSellerUrl = canonicalizeSellerUrl(cleanText(candidate.seller_url));
@@ -111,7 +110,7 @@ function normalizeSearchCandidate(
     offer_id: extractOfferId(canonicalItemUrl ?? '') ?? null,
     member_id: extractMemberId(canonicalSellerUrl ?? '') ?? null,
     shop_id: extractShopId(canonicalSellerUrl ?? '') ?? null,
-    title: cleanText(candidate.title) || firstLine(containerText) || null,
+    title: cleanText(candidate.title) || firstWord(containerText) || null,
     item_url: canonicalItemUrl,
     seller_name: cleanText(candidate.seller_name) || null,
     seller_url: canonicalSellerUrl,
@@ -154,7 +153,7 @@ function extractSalesText(text: string | null | undefined): string {
   return match ? cleanText(match[0]) : '';
 }
 
-function firstLine(text: string): string {
+function firstWord(text: string): string {
   return text.split(/\s+/).find(Boolean) ?? '';
 }
 
@@ -398,6 +397,6 @@ export const __test__ = {
   normalizeSearchCandidate,
   extractMoqText,
   extractSalesText,
-  firstLine,
+  firstWord,
   buildDedupeKey,
 };


### PR DESCRIPTION
## Summary
- Remove `hover_price_text` as MOQ source in search to prevent price fields being misinterpreted as MOQ data
- Rename `firstLine()` to `firstWord()` to match actual behavior (splits by whitespace, not newlines)
- Add missing "单" unit to item.ts `extractSalesText` regex
- Add test case verifying `hover_price_text` is not used for MOQ extraction

## Test plan
- [x] All 11 existing 1688 tests pass
- [x] New test verifies hover_price_text exclusion
- [x] TypeScript typecheck passes