### PR TITLE
docs: add skills install to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ A CLI tool that turns **any website**, **Electron app**, or **local CLI tool** i
 
 ```bash
 npm install -g @jackwener/opencli
+
+# Install AI skills for Claude Code / Cursor
+npx skills add jackwener/opencli
 ```
 
 ### 3. Verify & Try

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,9 @@ OpenCLI 通过轻量化的 **Browser Bridge** Chrome/Chromium 扩展 + 微型 da
 
 ```bash
 npm install -g @jackwener/opencli
+
+# 安装 AI Skills（Claude Code / Cursor）
+npx skills add jackwener/opencli
 ```
 
 直接使用：


### PR DESCRIPTION
## Summary
- Add `npx skills add jackwener/opencli` to the install step in both English and Chinese READMEs
- Makes AI skills discoverable during initial setup

## Test plan
- [x] Verify README.md renders correctly
- [x] Verify README.zh-CN.md renders correctly