### PR TITLE
fix(xiaohongshu): use /search_result/<id> for bare note IDs

### DIFF
--- a/clis/xiaohongshu/note-helpers.ts
+++ b/clis/xiaohongshu/note-helpers.ts
@@ -12,8 +12,8 @@ export function parseNoteId(input: string): string {
  *
  * XHS blocks direct `/explore/<id>` access without a valid `xsec_token`.
  * When the user passes a full URL (from search results), we preserve it
- * so the browser navigates with the token intact. For bare IDs we fall
- * back to the `/explore/<id>` path (works when cookies carry enough context).
+ * so the browser navigates with the token intact. For bare IDs we now use
+ * `/search_result/<id>` which works without xsec_token when cookies are present.
  */
 export function buildNoteUrl(input: string): string {
   const trimmed = input.trim();
@@ -21,5 +21,7 @@ export function buildNoteUrl(input: string): string {
     // Full URL — navigate as-is; the browser will follow any redirects
     return trimmed;
   }
-  return `https://www.xiaohongshu.com/explore/${trimmed}`;
+  // Use /search_result/<id> instead of /explore/<id> — works without xsec_token
+  // when the user is logged in via cookies (which is always the case with opencli).
+  return `https://www.xiaohongshu.com/search_result/${trimmed}`;
 }

--- a/clis/xiaohongshu/note.ts
+++ b/clis/xiaohongshu/note.ts
@@ -3,6 +3,10 @@
  *
  * Extracts title, author, description text, and engagement metrics
  * (likes, collects, comment count) via DOM extraction.
+ *
+ * Supports both bare note IDs and full URLs (with xsec_token).
+ * Bare IDs now use /search_result/<id> which works without xsec_token
+ * when the user is logged in via cookies.
  */
 
 import { cli, Strategy } from '../../registry.js';
@@ -21,7 +25,6 @@ cli({
   columns: ['field', 'value'],
   func: async (page, kwargs) => {
     const raw = String(kwargs['note-id']);
-    const isBareNoteId = !/^https?:\/\//.test(raw.trim());
     const noteId = parseNoteId(raw);
     const url = buildNoteUrl(raw);
 
@@ -70,22 +73,15 @@ cli({
     // normalize to '0' unless the value looks numeric.
     const numOrZero = (v: string) => /^\d+/.test(v) ? v : '0';
 
-    // XHS sometimes renders an empty shell page for bare /explore/<id> visits
-    // when the request lacks a valid xsec_token.  Title + author are always
-    // present on a real note, so their absence is the simplest reliable signal.
-    const emptyShell = !d.title && !d.author;
-    if (emptyShell) {
-      if (isBareNoteId) {
-        throw new EmptyResultError(
-          'xiaohongshu/note',
-          'Pass the full search_result URL with xsec_token, for example from `opencli xiaohongshu search`, instead of a bare note ID.',
-        );
-      }
+    // Title + author are always present on a real note page.
+    // If both are missing, the page likely failed to load properly.
+    if (!d.title && !d.author) {
       throw new EmptyResultError(
         'xiaohongshu/note',
-        'The note page loaded without visible content. Retry with a fresh URL or run with --verbose; if it persists, the page structure may have changed.',
+        'The note page loaded without visible content. The note may be deleted or restricted.',
       );
     }
+
     const rows = [
       { field: 'title', value: d.title || '' },
       { field: 'author', value: d.author || '' },


### PR DESCRIPTION
## Problem

`opencli xiaohongshu note <bare-id>` returns exit code 66 (empty result) because `buildNoteUrl` constructs `/explore/<id>` URLs. XHS now blocks this path without a valid `xsec_token`, rendering an empty shell page.

## Fix

Use `/search_result/<id>` instead of `/explore/<id>` for bare note IDs. This path works without `xsec_token` when the user is logged in via cookies (which is always the case with opencli browser-based commands).

## Changes

- `note-helpers.ts`: `buildNoteUrl` now returns `/search_result/<id>` for bare IDs
- `note.ts`: Remove `isBareNoteId` branching and simplify empty-shell error message

## Testing

Before (bare ID fails):
```
$ opencli xiaohongshu note 69ab16f4000000002203b15a
📭 xiaohongshu/note returned no data
(Command exited with code 66)
```

After (bare ID works):
```
$ opencli xiaohongshu note 69ab16f4000000002203b15a -f json
[
  {"field": "title", "value": "元辅怎么样打到顶级呢"},
  {"field": "author", "value": "程不识"},
  {"field": "content", "value": "..."},
  ...]
```

Full URLs with `xsec_token` continue to work as before.