### PR TITLE
fix(cli): make operate verify work in source checkouts

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -51,7 +51,7 @@ vi.mock('./runtime.js', () => ({
   browserSession: mockBrowserSession,
 }));
 
-import { createProgram, resolveOperateVerifyInvocation } from './cli.js';
+import { createProgram, findPackageRoot, resolveOperateVerifyInvocation } from './cli.js';
 
 describe('built-in browser commands verbose wiring', () => {
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -134,18 +134,36 @@ describe('built-in browser commands verbose wiring', () => {
 });
 
 describe('resolveOperateVerifyInvocation', () => {
-  it('prefers the built dist entry when available', () => {
+  it('prefers the built entry declared in package metadata', () => {
     const projectRoot = path.join('repo-root');
     const exists = new Set([
-      path.join(projectRoot, 'dist', 'main.js'),
+      path.join(projectRoot, 'dist', 'src', 'main.js'),
     ]);
 
     expect(resolveOperateVerifyInvocation({
       projectRoot,
+      readFile: () => JSON.stringify({ bin: { opencli: 'dist/src/main.js' } }),
       fileExists: (candidate) => exists.has(candidate),
     })).toEqual({
       binary: process.execPath,
-      args: [path.join(projectRoot, 'dist', 'main.js')],
+      args: [path.join(projectRoot, 'dist', 'src', 'main.js')],
+      cwd: projectRoot,
+    });
+  });
+
+  it('falls back to compatibility built-entry candidates when package metadata is unavailable', () => {
+    const projectRoot = path.join('repo-root');
+    const exists = new Set([
+      path.join(projectRoot, 'dist', 'src', 'main.js'),
+    ]);
+
+    expect(resolveOperateVerifyInvocation({
+      projectRoot,
+      readFile: () => { throw new Error('no package json'); },
+      fileExists: (candidate) => exists.has(candidate),
+    })).toEqual({
+      binary: process.execPath,
+      args: [path.join(projectRoot, 'dist', 'src', 'main.js')],
       cwd: projectRoot,
     });
   });
@@ -184,5 +202,27 @@ describe('resolveOperateVerifyInvocation', () => {
       args: ['tsx', path.join(projectRoot, 'src', 'main.ts')],
       cwd: projectRoot,
     });
+  });
+});
+
+describe('findPackageRoot', () => {
+  it('walks up from dist/src to the package root', () => {
+    const packageRoot = path.join('repo-root');
+    const cliFile = path.join(packageRoot, 'dist', 'src', 'cli.js');
+    const exists = new Set([
+      path.join(packageRoot, 'package.json'),
+    ]);
+
+    expect(findPackageRoot(cliFile, (candidate) => exists.has(candidate))).toBe(packageRoot);
+  });
+
+  it('walks up from src to the package root', () => {
+    const packageRoot = path.join('repo-root');
+    const cliFile = path.join(packageRoot, 'src', 'cli.ts');
+    const exists = new Set([
+      path.join(packageRoot, 'package.json'),
+    ]);
+
+    expect(findPackageRoot(cliFile, (candidate) => exists.has(candidate))).toBe(packageRoot);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,6 @@ import { EXIT_CODES, getErrorMessage } from './errors.js';
 import { daemonStatus, daemonStop, daemonRestart } from './commands/daemon.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
-const OPENCLI_PROJECT_ROOT = path.resolve(path.dirname(CLI_FILE), '..');
 
 /** Create a browser page for operate commands. Uses 'operate' workspace for session persistence. */
 async function getOperatePage(): Promise<import('./types.js').IPage> {
@@ -1017,27 +1016,73 @@ export interface OperateVerifyInvocation {
   shell?: boolean;
 }
 
+export function findPackageRoot(startFile: string, fileExists: (path: string) => boolean = fs.existsSync): string {
+  let dir = path.dirname(startFile);
+
+  while (true) {
+    if (fileExists(path.join(dir, 'package.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not find package.json above ${startFile}`);
+    }
+    dir = parent;
+  }
+}
+
+function getBuiltEntryCandidates(packageRoot: string, readFile: (path: string) => string): string[] {
+  const candidates: string[] = [];
+  try {
+    const pkg = JSON.parse(readFile(path.join(packageRoot, 'package.json'))) as {
+      bin?: string | Record<string, string>;
+      main?: string;
+    };
+
+    if (typeof pkg.bin === 'string') {
+      candidates.push(path.join(packageRoot, pkg.bin));
+    } else if (pkg.bin && typeof pkg.bin === 'object' && typeof pkg.bin.opencli === 'string') {
+      candidates.push(path.join(packageRoot, pkg.bin.opencli));
+    }
+
+    if (typeof pkg.main === 'string') {
+      candidates.push(path.join(packageRoot, pkg.main));
+    }
+  } catch {
+    // Fall through to compatibility candidates below.
+  }
+
+  // Compatibility fallback for partially-built trees or older layouts.
+  candidates.push(
+    path.join(packageRoot, 'dist', 'src', 'main.js'),
+    path.join(packageRoot, 'dist', 'main.js'),
+  );
+
+  return [...new Set(candidates)];
+}
+
 export function resolveOperateVerifyInvocation(opts: {
   projectRoot?: string;
   platform?: NodeJS.Platform;
   fileExists?: (path: string) => boolean;
+  readFile?: (path: string) => string;
 } = {}): OperateVerifyInvocation {
-  const projectRoot = opts.projectRoot ?? OPENCLI_PROJECT_ROOT;
   const platform = opts.platform ?? process.platform;
   const fileExists = opts.fileExists ?? fs.existsSync;
+  const readFile = opts.readFile ?? ((filePath: string) => fs.readFileSync(filePath, 'utf-8'));
+  const projectRoot = opts.projectRoot ?? findPackageRoot(CLI_FILE, fileExists);
 
-  const distEntry = path.join(projectRoot, 'dist', 'main.js');
-  if (fileExists(distEntry)) {
-    return {
-      binary: process.execPath,
-      args: [distEntry],
-      cwd: projectRoot,
-    };
+  for (const builtEntry of getBuiltEntryCandidates(projectRoot, readFile)) {
+    if (fileExists(builtEntry)) {
+      return {
+        binary: process.execPath,
+        args: [builtEntry],
+        cwd: projectRoot,
+      };
+    }
   }
 
   const sourceEntry = path.join(projectRoot, 'src', 'main.ts');
   if (!fileExists(sourceEntry)) {
-    throw new Error(`Could not find opencli entrypoint under ${projectRoot}. Expected dist/main.js or src/main.ts.`);
+    throw new Error(`Could not find opencli entrypoint under ${projectRoot}. Expected built entry from package.json or src/main.ts.`);
   }
 
   const localTsxBin = path.join(projectRoot, 'node_modules', '.bin', platform === 'win32' ? 'tsx.cmd' : 'tsx');


### PR DESCRIPTION
## Description

Fix `opencli operate verify` so it works correctly in source checkouts, including Windows.

This change:
- replaces fragile file URL string handling with `fileURLToPath(...)`
- stops hardcoding `node dist/main.js` when the project has not been built yet
- prefers `dist/main.js` when available, and falls back to `tsx src/main.ts` in source checkouts
- adds regression tests covering built and source-checkout execution paths

Related issue:
- N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A — this PR does not add or modify an adapter.

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Checks run:
- `npx vitest run src/cli.test.ts`
- `npm run typecheck`
- `npm run build`

Verification after this change:
1.npx vitest run src/cli.test.ts
```npx vitest run src/cli.test.ts
 RUN  v4.1.1 E:/Inori_Code/Intrest/fromGit/opencli

 ✓  unit  src/cli.test.ts (8 tests) 35ms
   ✓ built-in browser commands verbose wiring (5)
     ✓ enables OPENCLI_VERBOSE for explore via the real CLI command 25ms
     ✓ enables OPENCLI_VERBOSE for generate via the real CLI command 2ms
     ✓ enables OPENCLI_VERBOSE for record via the real CLI command 2ms
     ✓ enables OPENCLI_VERBOSE for cascade via the real CLI command 2ms
     ✓ leaves OPENCLI_VERBOSE unset when verbose is omitted 1ms
   ✓ resolveOperateVerifyInvocation (3)
     ✓ prefers the built dist entry when available 1ms
     ✓ falls back to the local tsx binary in source checkouts on Windows 0ms
     ✓ falls back to npx tsx when local tsx is unavailable 0ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  22:31:36
   Duration  1.20s (transform 297ms, setup 0ms, import 975ms, tests 35ms, environment 0ms)
```
2.npm run typecheck
```npm run typecheck
> @jackwener/opencli@1.6.1 typecheck
> tsc --noEmit
```
3.npm run build
```npm run build

> @jackwener/opencli@1.6.1 typecheck
> tsc --noEmit

PS E:\Inori_Code\Intrest\fromGit\opencli> npm run build

> @jackwener/opencli@1.6.1 build
> npm run clean-dist && tsc && npm run clean-yaml && npm run copy-yaml && npm run build-manifest


> @jackwener/opencli@1.6.1 clean-dist
> node scripts/clean-dist.cjs


> @jackwener/opencli@1.6.1 clean-yaml
> node scripts/clean-yaml.cjs


> @jackwener/opencli@1.6.1 copy-yaml
> node scripts/copy-yaml.cjs


> @jackwener/opencli@1.6.1 build-manifest
> node dist/build-manifest.js

✅ Manifest compiled: 479 entries (121 YAML, 358 TS) → E:\Inori_Code\Intrest\fromGit\opencli\dist\cli-manifest.json
```