### PR TITLE
fix(36kr): replace waitForCapture with DOM polling for search/hot

### DIFF
--- a/clis/36kr/hot.ts
+++ b/clis/36kr/hot.ts
@@ -1,5 +1,5 @@
 /**
- * 36kr hot-list — INTERCEPT strategy.
+ * 36kr hot-list — DOM scraping.
  *
  * Navigates to the 36kr hot-list page and scrapes rendered article links.
  * Supports category types: renqi (人气), zonghe (综合), shoucang (收藏), catalog (综合热门).
@@ -34,7 +34,8 @@ cli({
   name: 'hot',
   description: '36氪热榜 — trending articles (renqi/zonghe/shoucang/catalog)',
   domain: 'www.36kr.com',
-  strategy: Strategy.INTERCEPT,
+  strategy: Strategy.PUBLIC,
+  browser: true,
   args: [
     { name: 'limit', type: 'int', default: 20, help: 'Number of items (max 50)' },
     {
@@ -58,11 +59,13 @@ cli({
 
     const url = buildHotListUrl(listType);
 
-    await page.installInterceptor('36kr.com/api');
     await page.goto(url);
-    // waitForCapture times out on 36kr (API intercept fails), poll DOM instead
-    const _deadline = Date.now() + 5000;
-    while (Date.now() < _deadline && !(await page.evaluate('document.querySelectorAll("a[href*=\"/p/\"]").length'))) await new Promise(r => setTimeout(r, 300));
+    // Poll DOM until article links appear (36kr renders client-side)
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await page.evaluate('document.querySelectorAll("a[href*=\\"/p/\\"]").length')) break;
+      await new Promise(r => setTimeout(r, 300));
+    }
 
     // Scrape rendered article links from DOM (deduplicated)
     const domItems: any = await page.evaluate(`

--- a/clis/36kr/search.ts
+++ b/clis/36kr/search.ts
@@ -1,5 +1,5 @@
 /**
- * 36kr article search — INTERCEPT strategy.
+ * 36kr article search — DOM scraping.
  *
  * Navigates to the 36kr search results page and scrapes rendered articles.
  */
@@ -12,7 +12,8 @@ cli({
   name: 'search',
   description: '搜索36氪文章',
   domain: 'www.36kr.com',
-  strategy: Strategy.INTERCEPT,
+  strategy: Strategy.PUBLIC,
+  browser: true,
   args: [
     { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "AI", "OpenAI")' },
     { name: 'limit', type: 'int', default: 20, help: 'Number of results (max 50)' },
@@ -22,11 +23,13 @@ cli({
     const count = Math.min(Number(args.limit) || 20, 50);
     const query = encodeURIComponent(String(args.query ?? ''));
 
-    await page.installInterceptor('36kr.com/api');
     await page.goto(`https://www.36kr.com/search/articles/${query}`);
-    // waitForCapture times out on 36kr (API intercept fails), poll DOM instead
-    const _deadline = Date.now() + 5000;
-    while (Date.now() < _deadline && !(await page.evaluate('document.querySelectorAll("a[href*=\"/p/\"]").length'))) await new Promise(r => setTimeout(r, 300));
+    // Poll DOM until article links appear (36kr renders client-side)
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await page.evaluate('document.querySelectorAll("a[href*=\\"/p/\\"]").length')) break;
+      await new Promise(r => setTimeout(r, 300));
+    }
 
     const domItems: any = await page.evaluate(`
       (() => {


### PR DESCRIPTION
## Summary
- `36kr search` and `36kr hot` always fail with `No network capture within 6s` because `waitForCapture(6)` never intercepts a matching API request
- The DOM is already fully rendered with results by the time the timeout fires
- Replace 6-second intercept wait with DOM polling: check for `a[href*="/p/"]` every 300ms, return immediately once content is available

## Before
```
$ time opencli 36kr search "AI" --limit 3 -f json
💥 Unexpected error: Error: No network capture within 6s
7.450s total (always fails)
```

## After
```
$ time opencli 36kr search "AI" --limit 3 -f json
[{"rank":1,"title":"我教AI"学做人"...","url":"https://36kr.com/p/..."},...]
1.290s total (succeeds)
```

## Test plan
- [x] `opencli 36kr search "AI" --limit 3 -f json` returns results in ~1.3s
- [x] `opencli 36kr hot --limit 3 -f json` returns results in ~1.8s
- [x] Tested with both CDP mode and Browser Bridge mode on opencli 1.6.2