### PR TITLE
fix: match the requested tweet before deleting on X

### DIFF
--- a/src/clis/twitter/delete.test.ts
+++ b/src/clis/twitter/delete.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { CommandExecutionError } from '../../errors.js';
 import { getRegistry } from '../../registry.js';
 import { __test__ } from './delete.js';
 import './delete.js';
@@ -65,5 +66,26 @@ describe('twitter delete command', () => {
       },
     ]);
     expect(page.wait).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes invalid tweet URLs into CommandExecutionError', async () => {
+    const cmd = getRegistry().get('twitter/delete');
+    expect(cmd?.func).toBeTypeOf('function');
+
+    const page = {
+      goto: vi.fn(),
+      wait: vi.fn(),
+      evaluate: vi.fn(),
+    };
+
+    await expect(
+      cmd!.func!(page as any, {
+        url: 'https://x.com/alice/home',
+      }),
+    ).rejects.toThrow(CommandExecutionError);
+
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(page.wait).not.toHaveBeenCalled();
+    expect(page.evaluate).not.toHaveBeenCalled();
   });
 });

--- a/src/clis/twitter/delete.ts
+++ b/src/clis/twitter/delete.ts
@@ -85,7 +85,13 @@ cli({
   columns: ['status', 'message'],
   func: async (page: IPage | null, kwargs: any) => {
     if (!page) throw new CommandExecutionError('Browser session required for twitter delete');
-    const tweetId = extractTweetId(kwargs.url);
+    let tweetId = '';
+    try {
+      tweetId = extractTweetId(kwargs.url);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new CommandExecutionError(message);
+    }
 
     await page.goto(kwargs.url);
     await page.wait({ selector: '[data-testid="primaryColumn"]' }); // Wait for tweet to load completely


### PR DESCRIPTION
## Description

Match `twitter delete` against the requested status id before opening the tweet menu.

The previous implementation clicked the first `[aria-label="More"]` button on the page, which is not reliable on reply threads and conversation pages. This change extracts the tweet id from the requested URL, finds the matching `article`, and only then opens that tweet's `More -> Delete -> Confirm` flow.

Related issue: #780

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```shell
npm run typecheck
npm run test:adapter -- --run src/clis/twitter/delete.test.ts
```
