### PR TITLE
fix: resolve version 0.0.0 and user CLI load failures (#788)

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -105,11 +105,16 @@ export async function ensureUserCliCompatShims(baseDir: string = USER_OPENCLI_DI
   const writes: Promise<void>[] = [];
 
   // Root-level shims (both with and without .js extension)
+  // Also generate src/ shims: adapters import ../../src/registry.js etc., which
+  // resolve to ~/.opencli/src/registry.js when running from ~/.opencli/clis/<site>/
+  const srcDir = path.join(baseDir, 'src');
+  await fs.promises.mkdir(srcDir, { recursive: true });
   for (const [shimName, moduleName] of rootShims) {
     const url = pathToFileURL(resolveHostRuntimeModulePath(moduleName)).href;
     const content = `export * from '${url}';\n`;
     writes.push(writeCompatShimIfNeeded(path.join(baseDir, shimName), content));
     writes.push(writeCompatShimIfNeeded(path.join(baseDir, `${shimName}.js`), content));
+    writes.push(writeCompatShimIfNeeded(path.join(srcDir, `${shimName}.js`), content));
   }
 
   // Subdirectory shims

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,14 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const pkgJsonPath = path.resolve(__dirname, '..', 'package.json');
+
+// Dev: __dirname is src/ (one level to root).
+// Prod: __dirname is dist/src/ (two levels to root).
+let _pkgDir = path.resolve(__dirname, '..');
+if (!fs.existsSync(path.join(_pkgDir, 'package.json'))) {
+  _pkgDir = path.resolve(_pkgDir, '..');
+}
+const pkgJsonPath = path.join(_pkgDir, 'package.json');
 
 export const PKG_VERSION: string = (() => {
   try {


### PR DESCRIPTION
## Description

Fixes #788. Two regressions introduced by #784 (`rootDir` change from `"src"` to `"."`):

- **version.ts**: single-level parent lookup for `package.json` broke because `version.js` now lives in `dist/src/` instead of `dist/`. Added fallback to walk up one more level when `package.json` isn't found at the first parent.
- **discovery.ts**: adapters copied to `~/.opencli/clis/` import `../../src/registry.js` etc., which resolves to `~/.opencli/src/`. Added `src/` compat shims derived from the existing `rootShims` list (single source of truth, no duplicate mapping).

Related issue: #788

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

version.ts fix (prod mode):
\`\`\`
$ node dist/src/version.js
version: 1.6.3
\`\`\`

src/ shims generated:
\`\`\`
~/.opencli/src/
  errors.js
  launcher.js
  logger.js
  registry.js
  types.js
  utils.js
\`\`\`

Unit tests: 42 files, 496 passed, 1 skipped.