### PR TITLE
chore: bump version to 1.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3713,7 +3713,7 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.6.4",
+      "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
       "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump version from 1.6.4 to 1.6.5

Includes package exports migration (PR #795) and #788/#791 fixes.