### PR TITLE
fix: replace nonexistent extract step in plugin scaffold

### DIFF
--- a/src/plugin-scaffold.ts
+++ b/src/plugin-scaffold.ts
@@ -92,9 +92,7 @@ pipeline:
   - fetch:
       url: "https://httpbin.org/get?greeting=hello"
       method: GET
-  - extract:
-      type: json
-      selector: "$.args"
+  - select: "$.args"
 `;
   writeFile(targetDir, 'hello.yaml', yamlContent);
   files.push('hello.yaml');


### PR DESCRIPTION
## Summary
- Plugin scaffold YAML template used `extract` pipeline step which doesn't exist in the registry
- Replaced with `select` (JSONPath selection), which is the correct step for this operation
- Fixes the `Unknown pipeline step "extract"` error when running scaffolded plugins

Part of #810

## Test plan
- [ ] `opencli plugin create test-plugin` generates valid YAML
- [ ] Running the scaffolded `hello` command works end-to-end