### PR TITLE
fix(scaffold): replace non-existent extract step with select

### DIFF
--- a/src/plugin-scaffold.ts
+++ b/src/plugin-scaffold.ts
@@ -92,9 +92,7 @@ pipeline:
   - fetch:
       url: "https://httpbin.org/get?greeting=hello"
       method: GET
-  - extract:
-      type: json
-      selector: "$.args"
+  - select: "args"
 `;
   writeFile(targetDir, 'hello.yaml', yamlContent);
   files.push('hello.yaml');


### PR DESCRIPTION
## Summary
- Fix plugin-scaffold YAML template using non-existent `extract` pipeline step
- Replace with `select: "args"` which correctly extracts the `args` field from fetch response
- The `extract` step was never registered in the pipeline registry; `select` is the correct step for JSON path navigation

## Context
`opencli plugin create` generates a sample `hello.yaml` that uses `- extract: { type: json, selector: "$.args" }`. This step doesn't exist in the pipeline registry (src/pipeline/registry.ts), so the generated command would fail at runtime.

## Test plan
- [x] TypeScript compilation passes
- [x] All 7 plugin-scaffold tests pass

Part of #810 (PR C)