### PR TITLE
feat(cdp): implement session-level network capture for CDPPage

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -234,6 +234,7 @@ class CDPPage extends BasePage {
     this._networkCapturePattern = pattern;
     this._networkEntries = [];
     this._pendingRequests.clear();
+    this._pendingBodyFetches.clear();
 
     if (!this._networkCapturing) {
       await this.bridge.send('Network.enable');

--- a/src/explore.ts
+++ b/src/explore.ts
@@ -155,13 +155,24 @@ function parseNetworkRequests(raw: unknown): NetworkEntry[] {
     return entries;
   }
   if (Array.isArray(raw)) {
-    return raw.filter(e => e && typeof e === 'object').map(e => ({
-      method: (e.method ?? 'GET').toUpperCase(),
-      url: String(e.url ?? e.request?.url ?? e.requestUrl ?? ''),
-      status: e.status ?? e.statusCode ?? null,
-      contentType: e.contentType ?? e.response?.contentType ?? '',
-      responseBody: e.responseBody, requestHeaders: e.requestHeaders,
-    }));
+    return raw.filter(e => e && typeof e === 'object').map(e => {
+      // Handle both legacy shape (status/contentType/responseBody) and
+      // extension/CDP capture shape (responseStatus/responseContentType/responsePreview)
+      let body = e.responseBody;
+      if (body === undefined && e.responsePreview !== undefined) {
+        const preview = e.responsePreview;
+        if (typeof preview === 'string') {
+          try { body = JSON.parse(preview); } catch { body = preview; }
+        }
+      }
+      return {
+        method: (e.method ?? 'GET').toUpperCase(),
+        url: String(e.url ?? e.request?.url ?? e.requestUrl ?? ''),
+        status: e.status ?? e.responseStatus ?? e.statusCode ?? null,
+        contentType: e.contentType ?? e.responseContentType ?? e.response?.contentType ?? '',
+        responseBody: body, requestHeaders: e.requestHeaders,
+      };
+    });
   }
   return [];
 }


### PR DESCRIPTION
## Summary
- Implement `startNetworkCapture()` and `readNetworkCapture()` on CDPPage using CDP Network domain events
- Update `explore.ts` to prefer session capture over Performance API `networkRequests()`
- This is the first transport implementation of "session-level passive capture" — daemon mode already has it, now direct CDP mode does too

## Details
**CDPPage changes** (`src/browser/cdp.ts`):
- `startNetworkCapture(pattern?)`: enables `Network.enable`, listens to `Network.requestWillBeSent` and `Network.responseReceived`, collects full request/response data including response bodies via `Network.getResponseBody`
- `readNetworkCapture()`: returns collected entries and clears buffer

**Explore changes** (`src/explore.ts`):
- Calls `page.startNetworkCapture?.()` before `page.goto()` to capture initial page load requests
- Prefers `page.readNetworkCapture()` over `page.networkRequests()` when available, with fallback

## Why this matters
explore previously used `networkRequests()` which only returns URL+timing from the Performance API. With session capture, explore gets method/status/headers/body — enabling much better API endpoint discovery and candidate generation.

## Test plan
- [x] TypeScript compilation passes
- [x] Existing CDP tests pass
- [ ] Manual test: `opencli explore <url>` with CDP endpoint should capture full network data

Part of #810 (PR A)