### PR TITLE
fix: correct misleading behaviors in engine, fix, and generate

### DIFF
--- a/autoresearch/commands/fix.ts
+++ b/autoresearch/commands/fix.ts
@@ -115,9 +115,10 @@ Do NOT modify test files.
 ${ctx.stuckHint ? `STUCK HINT: ${ctx.stuckHint}` : ''}`;
 
       try {
+        // Pass prompt via stdin `input` option to avoid shell metacharacter expansion
         const result = execSync(
-          `claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence "${prompt.replace(/"/g, '\\"')}"`,
-          { cwd: ROOT, timeout: 180_000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+          'claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence',
+          { cwd: ROOT, timeout: 180_000, encoding: 'utf-8', input: prompt, stdio: ['pipe', 'pipe', 'pipe'] }
         ).trim();
         const lines = result.split('\n').filter(l => l.trim());
         return lines[lines.length - 1]?.trim()?.slice(0, 120) || 'fix attempt';

--- a/autoresearch/engine.ts
+++ b/autoresearch/engine.ts
@@ -13,7 +13,7 @@
  * Phase 8: Repeat
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { type AutoResearchConfig, type IterationResult, type IterationStatus, extractMetric } from './config.js';
@@ -124,8 +124,12 @@ export class Engine {
 
   /** Phase 4: Commit changes */
   private commit(description: string): string | null {
-    // Stage all changes in scope (but not untracked outside scope)
-    exec('git add -A');
+    if (!this.config.scope.length) return null; // no scope = nothing to stage
+    // Stage only files matching scope globs (avoid staging unrelated changes)
+    // Use execFileSync to bypass shell glob expansion so git handles pathspecs directly
+    execFileSync('git', ['add', '--', ...this.config.scope], {
+      cwd: ROOT, timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
     const diff = exec('git diff --cached --quiet; echo $?');
     if (diff === '0') return null; // no changes
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,11 +1,8 @@
 /**
  * Generate: one-shot CLI creation from URL.
  *
- * Orchestrates the full pipeline:
- *   explore (Deep Explore) → synthesize (YAML generation) → register → verify
- *
- * Includes Strategy Cascade: if the initial strategy fails,
- * automatically downgrades and retries.
+ * Orchestrates the pipeline:
+ *   explore (Deep Explore) → synthesize (YAML generation + candidate ranking)
  */
 
 import { exploreUrl } from './explore.js';


### PR DESCRIPTION
## Description

Three places where code behavior contradicts its comments/documentation:

1. **engine.ts** — comment said "stage all changes in scope" but used `git add -A` which stages everything. Replaced with `execFileSync('git', ['add', '--', ...scope])` to bypass shell glob expansion and let git handle pathspecs directly. Added empty-scope guard to prevent degeneration into staging all files.

2. **fix.ts** — prompt was passed via shell string interpolation (`"${prompt}"`) where `$`, backticks, and other metacharacters would be expanded by the shell. Replaced with `execSync` `input` option to pass prompt via stdin.

3. **generate.ts** — comment claimed pipeline included `register → verify` and "Strategy Cascade" that were never implemented. Updated to reflect actual pipeline: `explore → synthesize (+ candidate ranking)`.

Related issue: #810

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```
$ npx tsc --noEmit   # pass
$ npm test           # 523 passed, 1 skipped
```