### PR TITLE
feat(doubao): add --thread support for ask/send/read

### DIFF
--- a/clis/doubao/ask.test.ts
+++ b/clis/doubao/ask.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IPage } from '@jackwener/opencli/types';
+
+const mocks = vi.hoisted(() => ({
+  getDoubaoVisibleTurns: vi.fn(),
+  getDoubaoTranscriptLines: vi.fn(),
+  navigateToConversation: vi.fn(),
+  sendDoubaoMessage: vi.fn(),
+  waitForDoubaoResponse: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+  const actual = await vi.importActual<typeof import('./utils.js')>('./utils.js');
+  return {
+    ...actual,
+    getDoubaoVisibleTurns: mocks.getDoubaoVisibleTurns,
+    getDoubaoTranscriptLines: mocks.getDoubaoTranscriptLines,
+    navigateToConversation: mocks.navigateToConversation,
+    sendDoubaoMessage: mocks.sendDoubaoMessage,
+    waitForDoubaoResponse: mocks.waitForDoubaoResponse,
+  };
+});
+
+import { askCommand } from './ask.js';
+
+function createPageMock(): IPage {
+  return {
+    wait: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IPage;
+}
+
+describe('doubao ask --thread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDoubaoVisibleTurns.mockResolvedValue([]);
+    mocks.getDoubaoTranscriptLines.mockResolvedValue([]);
+    mocks.sendDoubaoMessage.mockResolvedValue('button');
+    mocks.waitForDoubaoResponse.mockResolvedValue('继续');
+  });
+
+  it('navigates to the requested conversation id before sending', async () => {
+    const page = createPageMock();
+
+    await askCommand.func!(page, {
+      text: '继续',
+      thread: 'https://www.doubao.com/chat/1234567890123',
+      timeout: '60',
+    });
+
+    expect(mocks.navigateToConversation).toHaveBeenCalledWith(page, '1234567890123');
+    expect(mocks.sendDoubaoMessage).toHaveBeenCalledWith(page, '继续');
+  });
+});

--- a/clis/doubao/ask.ts
+++ b/clis/doubao/ask.ts
@@ -1,6 +1,14 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import type { IPage } from '@jackwener/opencli/types';
-import { DOUBAO_DOMAIN, getDoubaoTranscriptLines, getDoubaoVisibleTurns, sendDoubaoMessage, waitForDoubaoResponse } from './utils.js';
+import {
+  DOUBAO_DOMAIN,
+  getDoubaoTranscriptLines,
+  getDoubaoVisibleTurns,
+  navigateToConversation,
+  parseDoubaoConversationId,
+  sendDoubaoMessage,
+  waitForDoubaoResponse,
+} from './utils.js';
 
 export const askCommand = cli({
   site: 'doubao',
@@ -13,12 +21,19 @@ export const askCommand = cli({
   timeoutSeconds: 180,
   args: [
     { name: 'text', required: true, positional: true, help: 'Prompt to send' },
+    { name: 'thread', required: false, help: 'Conversation ID (numeric or full URL)' },
     { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },
   ],
   columns: ['Role', 'Text'],
   func: async (page: IPage, kwargs: any) => {
     const text = kwargs.text as string;
+    const thread = typeof kwargs.thread === 'string' ? kwargs.thread.trim() : '';
     const timeout = parseInt(kwargs.timeout as string, 10) || 60;
+
+    if (thread) {
+      await navigateToConversation(page, parseDoubaoConversationId(thread));
+    }
+
     const beforeTurns = await getDoubaoVisibleTurns(page);
     const beforeLines = await getDoubaoTranscriptLines(page);
 

--- a/clis/doubao/read.test.ts
+++ b/clis/doubao/read.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IPage } from '@jackwener/opencli/types';
+
+const mocks = vi.hoisted(() => ({
+  getDoubaoVisibleTurns: vi.fn(),
+  navigateToConversation: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+  const actual = await vi.importActual<typeof import('./utils.js')>('./utils.js');
+  return {
+    ...actual,
+    getDoubaoVisibleTurns: mocks.getDoubaoVisibleTurns,
+    navigateToConversation: mocks.navigateToConversation,
+  };
+});
+
+import { readCommand } from './read.js';
+
+describe('doubao read --thread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDoubaoVisibleTurns.mockResolvedValue([
+      { Role: 'Assistant', Text: '这是指定会话' },
+    ]);
+  });
+
+  it('navigates to the requested conversation id before reading', async () => {
+    const page = {} as IPage;
+
+    const result = await readCommand.func!(page, {
+      thread: 'https://www.doubao.com/chat/1234567890123',
+    });
+
+    expect(mocks.navigateToConversation).toHaveBeenCalledWith(page, '1234567890123');
+    expect(result).toEqual([
+      { Role: 'Assistant', Text: '这是指定会话' },
+    ]);
+  });
+});

--- a/clis/doubao/read.ts
+++ b/clis/doubao/read.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import type { IPage } from '@jackwener/opencli/types';
-import { DOUBAO_DOMAIN, getDoubaoVisibleTurns } from './utils.js';
+import { DOUBAO_DOMAIN, getDoubaoVisibleTurns, navigateToConversation, parseDoubaoConversationId } from './utils.js';
 
 export const readCommand = cli({
   site: 'doubao',
@@ -10,9 +10,17 @@ export const readCommand = cli({
   strategy: Strategy.COOKIE,
   browser: true,
   navigateBefore: false,
-  args: [],
+  args: [
+    { name: 'thread', required: false, help: 'Conversation ID (numeric or full URL)' },
+  ],
   columns: ['Role', 'Text'],
-  func: async (page: IPage) => {
+  func: async (page: IPage, kwargs: Record<string, unknown>) => {
+    const thread = typeof kwargs.thread === 'string' ? kwargs.thread.trim() : '';
+
+    if (thread) {
+      await navigateToConversation(page, parseDoubaoConversationId(thread));
+    }
+
     const turns = await getDoubaoVisibleTurns(page);
     if (turns.length > 0) return turns;
     return [{ Role: 'System', Text: 'No visible Doubao messages were found.' }];

--- a/clis/doubao/send.test.ts
+++ b/clis/doubao/send.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IPage } from '@jackwener/opencli/types';
+
+const mocks = vi.hoisted(() => ({
+  navigateToConversation: vi.fn(),
+  sendDoubaoMessage: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+  const actual = await vi.importActual<typeof import('./utils.js')>('./utils.js');
+  return {
+    ...actual,
+    navigateToConversation: mocks.navigateToConversation,
+    sendDoubaoMessage: mocks.sendDoubaoMessage,
+  };
+});
+
+import { sendCommand } from './send.js';
+
+describe('doubao send --thread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sendDoubaoMessage.mockResolvedValue('button');
+  });
+
+  it('navigates to the requested conversation id before sending', async () => {
+    const page = {} as IPage;
+
+    await sendCommand.func!(page, {
+      text: '补充一句',
+      thread: '1234567890123',
+    });
+
+    expect(mocks.navigateToConversation).toHaveBeenCalledWith(page, '1234567890123');
+    expect(mocks.sendDoubaoMessage).toHaveBeenCalledWith(page, '补充一句');
+  });
+});

--- a/clis/doubao/send.ts
+++ b/clis/doubao/send.ts
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import type { IPage } from '@jackwener/opencli/types';
-import { DOUBAO_DOMAIN, DOUBAO_CHAT_URL, sendDoubaoMessage } from './utils.js';
+import { DOUBAO_DOMAIN, navigateToConversation, parseDoubaoConversationId, sendDoubaoMessage } from './utils.js';
 
 export const sendCommand = cli({
   site: 'doubao',
@@ -10,10 +10,19 @@ export const sendCommand = cli({
   strategy: Strategy.COOKIE,
   browser: true,
   navigateBefore: false,
-  args: [{ name: 'text', required: true, positional: true, help: 'Message to send' }],
+  args: [
+    { name: 'text', required: true, positional: true, help: 'Message to send' },
+    { name: 'thread', required: false, help: 'Conversation ID (numeric or full URL)' },
+  ],
   columns: ['Status', 'SubmittedBy', 'InjectedText'],
   func: async (page: IPage, kwargs: any) => {
     const text = kwargs.text as string;
+    const thread = typeof kwargs.thread === 'string' ? kwargs.thread.trim() : '';
+
+    if (thread) {
+      await navigateToConversation(page, parseDoubaoConversationId(thread));
+    }
+
     const submittedBy = await sendDoubaoMessage(page, text);
 
     return [{

--- a/docs/adapters/browser/doubao.md
+++ b/docs/adapters/browser/doubao.md
@@ -28,12 +28,16 @@ Browser adapter for [Doubao Chat](https://www.doubao.com/chat).
 opencli doubao status
 opencli doubao new
 opencli doubao send "帮我总结这段文档"
+opencli doubao send --thread 1234567890123 "补充一句"
 opencli doubao read
+opencli doubao read --thread https://www.doubao.com/chat/1234567890123
 opencli doubao ask "请写一个 Python 快速排序示例" --timeout 90
+opencli doubao ask --thread 1234567890123 "继续刚才那个思路"
 ```
 
 ## Notes
 
 - The adapter targets the web chat page at `https://www.doubao.com/chat`
+- `send`, `read`, and `ask` accept `--thread <id|url>` to operate on a specific existing conversation
 - `new` first tries the visible "New Chat / 新对话" button, then falls back to the new-thread route
 - `ask` uses DOM polling, so very long generations may need a larger `--timeout`


### PR DESCRIPTION
## Description

Add optional `--thread <id|url>` support to `opencli doubao ask`, `send`, and `read` so they can target a specific existing Doubao conversation instead of relying on the currently reused browser tab.

This keeps the semantics aligned with `opencli doubao detail <id>`:
- accepts either a numeric conversation id
- or a full `https://www.doubao.com/chat/<id>` URL

Also included:
- focused adapter tests for `ask`, `send`, and `read`
- updated adapter docs with `--thread` examples

Related issue:
- N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```bash
$ npx vitest run clis/doubao/*.test.ts

 RUN  v4.1.1 /Users/hanfox/Desktop/code/self/agent/agentx/iamwho/opencli

 Test Files  6 passed (6)
      Tests  11 passed (11)
```