### PR TITLE
fix: include intercepted payloads in diagnostic

### DIFF
--- a/src/diagnostic.test.ts
+++ b/src/diagnostic.test.ts
@@ -282,7 +282,7 @@ function makePage(overrides: Partial<IPage> = {}): IPage {
 }
 
 describe('collectDiagnostic', () => {
-  it('includes intercepted payloads ahead of network request entries', async () => {
+  it('keeps intercepted payloads in a dedicated capturedPayloads field', async () => {
     const page = makePage({
       networkRequests: vi.fn().mockResolvedValue([{ url: '/api/data', status: 200 }]),
       getInterceptedRequests: vi.fn().mockResolvedValue([{ items: [{ id: 1 }] }]),
@@ -291,8 +291,10 @@ describe('collectDiagnostic', () => {
     const ctx = await collectDiagnostic(new Error('boom'), makeCmd(), page);
 
     expect(ctx.page?.networkRequests).toEqual([
-      { source: 'interceptor', responseBody: { items: [{ id: 1 }] } },
       { url: '/api/data', status: 200 },
+    ]);
+    expect(ctx.page?.capturedPayloads).toEqual([
+      { source: 'interceptor', responseBody: { items: [{ id: 1 }] } },
     ]);
   });
 
@@ -305,6 +307,7 @@ describe('collectDiagnostic', () => {
     const ctx = await collectDiagnostic(new Error('boom'), makeCmd(), page);
 
     expect(ctx.page?.networkRequests).toEqual([{ url: '/api/data', status: 200 }]);
+    expect(ctx.page?.capturedPayloads).toEqual([]);
   });
 
   it('swallows intercepted request failures and still returns page state', async () => {
@@ -319,7 +322,37 @@ describe('collectDiagnostic', () => {
       url: 'https://example.com/page',
       snapshot: '<div>...</div>',
       networkRequests: [{ url: '/api/data', status: 200 }],
+      capturedPayloads: [],
       consoleErrors: [],
     });
+  });
+
+  it('redacts and truncates intercepted payloads recursively', async () => {
+    const page = makePage({
+      getInterceptedRequests: vi.fn().mockResolvedValue([{
+        token: 'token=abc123def456ghi789',
+        nested: {
+          cookie: 'cookie: session=super-secret-cookie-value',
+          body: 'x'.repeat(5000),
+        },
+      }]),
+    });
+
+    const ctx = await collectDiagnostic(new Error('boom'), makeCmd(), page);
+    const payload = ctx.page?.capturedPayloads?.[0] as Record<string, unknown>;
+    const body = ((payload.responseBody as Record<string, unknown>).nested as Record<string, unknown>).body as string;
+
+    expect(payload).toEqual({
+      source: 'interceptor',
+      responseBody: {
+        token: 'token=[REDACTED]',
+        nested: {
+          cookie: 'cookie: [REDACTED]',
+          body,
+        },
+      },
+    });
+    expect(body).toContain('[truncated,');
+    expect(body.length).toBeLessThan(5000);
   });
 });

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -29,10 +29,16 @@ const MAX_SNAPSHOT_CHARS = 100_000;
 const MAX_SOURCE_CHARS = 50_000;
 /** Maximum number of network requests to include. */
 const MAX_NETWORK_REQUESTS = 50;
+/** Maximum number of captured interceptor payloads to include. */
+const MAX_CAPTURED_PAYLOADS = 20;
 /** Maximum characters for a single network request body. */
 const MAX_REQUEST_BODY_CHARS = 4_000;
 /** Maximum characters for error stack trace. */
 const MAX_STACK_CHARS = 5_000;
+/** Maximum nesting depth for arbitrary captured payloads. */
+const MAX_CAPTURED_DEPTH = 4;
+/** Maximum object keys or array items to keep per nesting level. */
+const MAX_CAPTURED_CHILDREN = 20;
 
 // ── Sensitive data patterns ──────────────────────────────────────────────────
 
@@ -80,6 +86,7 @@ export interface RepairContext {
     url: string;
     snapshot: string;
     networkRequests: unknown[];
+    capturedPayloads?: unknown[];
     consoleErrors: unknown[];
   };
   timestamp: string;
@@ -119,6 +126,41 @@ function redactHeaders(headers: Record<string, string> | undefined): Record<stri
   return result;
 }
 
+/** Recursively sanitize arbitrary captured response content for diagnostic output. */
+function sanitizeCapturedValue(value: unknown, depth: number = 0): unknown {
+  if (typeof value === 'string') {
+    return redactText(truncate(value, MAX_REQUEST_BODY_CHARS));
+  }
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (depth >= MAX_CAPTURED_DEPTH) {
+    return '[truncated: max depth reached]';
+  }
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_CAPTURED_CHILDREN)
+      .map(item => sanitizeCapturedValue(item, depth + 1));
+    if (value.length > MAX_CAPTURED_CHILDREN) {
+      items.push(`[truncated, ${value.length - MAX_CAPTURED_CHILDREN} items omitted]`);
+    }
+    return items;
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const entries = Object.entries(value);
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of entries.slice(0, MAX_CAPTURED_CHILDREN)) {
+    result[key] = sanitizeCapturedValue(child, depth + 1);
+  }
+  if (entries.length > MAX_CAPTURED_CHILDREN) {
+    result.__truncated__ = `[${entries.length - MAX_CAPTURED_CHILDREN} fields omitted]`;
+  }
+  return result;
+}
+
 /** Redact sensitive data from a single network request entry. */
 function redactNetworkRequest(req: unknown): unknown {
   if (!req || typeof req !== 'object') return req;
@@ -144,6 +186,12 @@ function redactNetworkRequest(req: unknown): unknown {
   // Truncate response body
   if (typeof redacted.body === 'string') {
     redacted.body = truncate(redacted.body, MAX_REQUEST_BODY_CHARS);
+  }
+  if ('responseBody' in redacted) {
+    redacted.responseBody = sanitizeCapturedValue(redacted.responseBody);
+  }
+  if ('responsePreview' in redacted) {
+    redacted.responsePreview = sanitizeCapturedValue(redacted.responsePreview);
   }
 
   return redacted;
@@ -215,9 +263,9 @@ export function isDiagnosticEnabled(): boolean {
 }
 
 function normalizeInterceptedRequests(interceptedRequests: unknown[]): unknown[] {
-  return interceptedRequests.map(responseBody => ({
+  return interceptedRequests.slice(0, MAX_CAPTURED_PAYLOADS).map(responseBody => ({
     source: 'interceptor',
-    responseBody,
+    responseBody: sanitizeCapturedValue(responseBody),
   }));
 }
 
@@ -238,9 +286,10 @@ async function collectPageState(page: IPage): Promise<RepairContext['page'] | un
       return {
         url: redactUrl(rawUrl),
         snapshot: redactText(truncate(snapshot, MAX_SNAPSHOT_CHARS)),
-        networkRequests: [...capturedResponses, ...(networkRequests as unknown[])]
+        networkRequests: (networkRequests as unknown[])
           .slice(0, MAX_NETWORK_REQUESTS)
           .map(redactNetworkRequest),
+        capturedPayloads: capturedResponses,
         consoleErrors: (consoleErrors as unknown[])
           .slice(0, 50)
           .map(e => typeof e === 'string' ? redactText(e) : e),
@@ -307,7 +356,15 @@ export function emitDiagnostic(ctx: RepairContext): void {
 
   // Enforce total output budget — drop page state (largest section) first if over budget
   if (json.length > MAX_DIAGNOSTIC_BYTES && ctx.page) {
-    const trimmed = { ...ctx, page: { ...ctx.page, snapshot: '[omitted: over size budget]', networkRequests: [] } };
+    const trimmed = {
+      ...ctx,
+      page: {
+        ...ctx.page,
+        snapshot: '[omitted: over size budget]',
+        networkRequests: [],
+        capturedPayloads: [],
+      },
+    };
     json = JSON.stringify(trimmed);
   }
   // If still over budget, drop page entirely


### PR DESCRIPTION
## Description

Improve diagnostic output by surfacing already-captured interceptor payloads in the existing `page.networkRequests` field.

This keeps the follow-up for #810 minimal:
- `collectPageState()` now also reads `page.getInterceptedRequests()`
- intercepted payloads are wrapped as `source: 'interceptor'` entries and prepended to the existing network list
- diagnostic tests now cover inclusion, empty-interceptor fallback, and interceptor-read failures

Related issue: #810

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```bash
$ npx tsc --noEmit
# exit 0

$ npm test
Test Files  44 passed (44)
     Tests  526 passed | 1 skipped (527)
```
