### PR TITLE
fix: eliminate shell injection patterns across clis

### DIFF
--- a/autoresearch/commands/debug.ts
+++ b/autoresearch/commands/debug.ts
@@ -124,8 +124,8 @@ Do NOT fix the code — just diagnose. Use opencli operate commands to investiga
 
     try {
       const result = execSync(
-        `claude -p --dangerously-skip-permissions --allowedTools "Bash(opencli:*),Bash(npm:*),Read,Grep,Glob" --output-format text --no-session-persistence "${prompt.replace(/"/g, '\\"')}"`,
-        { cwd: ROOT, timeout: 120_000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        'claude -p --dangerously-skip-permissions --allowedTools "Bash(opencli:*),Bash(npm:*),Read,Grep,Glob" --output-format text --no-session-persistence',
+        { cwd: ROOT, timeout: 120_000, encoding: 'utf-8', input: prompt, stdio: ['pipe', 'pipe', 'pipe'] }
       ).trim();
 
       // Extract hypothesis and result

--- a/autoresearch/commands/run.ts
+++ b/autoresearch/commands/run.ts
@@ -61,11 +61,12 @@ async function modify(ctx: ModifyContext, config: AutoResearchConfig): Promise<s
   console.log('  Claude Code making a change...');
   try {
     const result = execSync(
-      `claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence "${prompt.replace(/"/g, '\\"')}"`,
+      'claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence',
       {
         cwd: ROOT,
         timeout: 300_000,
         encoding: 'utf-8',
+        input: prompt,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: process.env,
       }

--- a/autoresearch/engine.ts
+++ b/autoresearch/engine.ts
@@ -126,10 +126,16 @@ export class Engine {
   private commit(description: string): string | null {
     if (!this.config.scope.length) return null; // no scope = nothing to stage
     // Stage only files matching scope globs (avoid staging unrelated changes)
-    // Use execFileSync to bypass shell glob expansion so git handles pathspecs directly
-    execFileSync('git', ['add', '--', ...this.config.scope], {
-      cwd: ROOT, timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    // Try each glob individually — skip globs that don't match any files
+    for (const glob of this.config.scope) {
+      try {
+        execFileSync('git', ['add', '--', glob], {
+          cwd: ROOT, timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      } catch {
+        // pathspec didn't match any files — skip silently
+      }
+    }
     const diff = exec('git diff --cached --quiet; echo $?');
     if (diff === '0') return null; // no changes
 

--- a/autoresearch/engine.ts
+++ b/autoresearch/engine.ts
@@ -134,7 +134,9 @@ export class Engine {
     if (diff === '0') return null; // no changes
 
     try {
-      execStrict(`git commit -m "experiment(operate): ${description.replace(/"/g, '\\"')}"`);
+      execFileSync('git', ['commit', '-m', `experiment(operate): ${description}`], {
+        cwd: ROOT, timeout: 30_000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
       return exec('git rev-parse --short HEAD');
     } catch {
       // Hook failure

--- a/autoresearch/eval-skill.ts
+++ b/autoresearch/eval-skill.ts
@@ -12,7 +12,7 @@
  *   npx tsx autoresearch/eval-skill.ts --task hn-top5     # Run single
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -113,12 +113,14 @@ At the very end of your response, output a JSON verdict on its own line:
 Always close the browser with 'opencli operate close' when done.`;
 
   try {
-    const output = execSync(
-      `claude -p --dangerously-skip-permissions --allowedTools "Bash(opencli:*)" --system-prompt ${JSON.stringify(skillContent)} --output-format json --no-session-persistence ${JSON.stringify(prompt)}`,
+    const output = execFileSync(
+      'claude',
+      ['-p', '--dangerously-skip-permissions', '--allowedTools', 'Bash(opencli:*)', '--system-prompt', skillContent, '--output-format', 'json', '--no-session-persistence'],
       {
         cwd: join(__dirname, '..'),
         timeout: (task.max_steps ?? 10) * 15_000,
         encoding: 'utf-8',
+        input: prompt,
         env: process.env,
         stdio: ['pipe', 'pipe', 'pipe'],
       }

--- a/clis/chatgpt/ask.ts
+++ b/clis/chatgpt/ask.ts
@@ -60,7 +60,7 @@ export const askCommand = cli({
     let generationStarted = false;
 
     for (let i = 0; i < maxPolls; i++) {
-      execSync(`sleep ${pollInterval}`);
+      spawnSync('sleep', [String(pollInterval)]);
       const generating = isGenerating();
       if (generating) {
         generationStarted = true;

--- a/clis/chatgpt/ax.ts
+++ b/clis/chatgpt/ax.ts
@@ -1,4 +1,4 @@
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const AX_READ_SCRIPT = `
 import Cocoa
@@ -208,8 +208,8 @@ const MODEL_MAP: Record<ModelChoice, { desc: string; legacy?: boolean }> = {
 export const MODEL_CHOICES = Object.keys(MODEL_MAP) as ModelChoice[];
 
 export function activateChatGPT(delaySeconds: number = 0.5): void {
-  execSync("osascript -e 'tell application \"ChatGPT\" to activate'");
-  execSync(`osascript -e 'delay ${delaySeconds}'`);
+  execFileSync('osascript', ['-e', 'tell application "ChatGPT" to activate']);
+  execFileSync('osascript', ['-e', `delay ${delaySeconds}`]);
 }
 
 export function selectModel(model: string): string {

--- a/clis/spotify/spotify.ts
+++ b/clis/spotify/spotify.ts
@@ -115,9 +115,11 @@ async function findTrackUri(query: string): Promise<{ uri: string; name: string;
 }
 
 function openBrowser(url: string): void {
-  const opener = process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open';
-  const args = process.platform === 'win32' ? ['', url] : [url];
-  execFileSync(opener, args, { stdio: 'ignore' });
+  if (process.platform === 'win32') {
+    execFileSync('cmd', ['/c', 'start', '', url], { stdio: 'ignore' });
+  } else {
+    execFileSync(process.platform === 'darwin' ? 'open' : 'xdg-open', [url], { stdio: 'ignore' });
+  }
 }
 
 // ── Commands ──────────────────────────────────────────────────────────────────

--- a/clis/spotify/spotify.ts
+++ b/clis/spotify/spotify.ts
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { createServer } from 'http';
 import { homedir } from 'os';
 import { join } from 'path';
-import { exec } from 'child_process';
+import { execFileSync } from 'child_process';
 import {
   assertSpotifyCredentialsConfigured,
   getFirstSpotifyTrack,
@@ -115,8 +115,9 @@ async function findTrackUri(query: string): Promise<{ uri: string; name: string;
 }
 
 function openBrowser(url: string): void {
-  const cmd = process.platform === 'win32' ? `start "" "${url}"` : process.platform === 'darwin' ? `open "${url}"` : `xdg-open "${url}"`;
-  exec(cmd);
+  const opener = process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['', url] : [url];
+  execFileSync(opener, args, { stdio: 'ignore' });
 }
 
 // ── Commands ──────────────────────────────────────────────────────────────────

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1453,9 +1453,8 @@ export function resolveEsbuildBin(): string | null {
 
   // Strategy 4: global esbuild in PATH
   try {
-    const lookupCmd = isWindows ? 'where esbuild' : 'which esbuild';
     // `where` on Windows may return multiple lines; take only the first match.
-    const globalBin = execSync(lookupCmd, { encoding: 'utf-8', stdio: 'pipe' }).trim().split('\n')[0].trim();
+    const globalBin = execFileSync(isWindows ? 'where' : 'which', ['esbuild'], { encoding: 'utf-8', stdio: 'pipe' }).trim().split('\n')[0].trim();
     if (globalBin && fs.existsSync(globalBin)) {
       return globalBin;
     }

--- a/src/record.ts
+++ b/src/record.ts
@@ -151,7 +151,7 @@ export function createRecordedEntry(input: {
 export function generateFullCaptureInterceptorJs(): string {
   return `
     (() => {
-      // Restore original fetch/XHR if previously patched, then re-patch (idempotent injection)
+      // Restore original fetch/XHR if previously patched, then re-patch (safe to call multiple times)
       if (window.__opencli_record_patched) {
         if (window.__opencli_orig_fetch) window.fetch = window.__opencli_orig_fetch;
         if (window.__opencli_orig_xhr_open) XMLHttpRequest.prototype.open = window.__opencli_orig_xhr_open;


### PR DESCRIPTION
## Summary
- **spotify/spotify.ts**: `openBrowser(url)` was interpolating external URLs into shell commands (`open "${url}"`). Replaced with `execFileSync('open', [url])` to prevent shell injection via crafted URLs.
- **chatgpt/ax.ts**: `activateChatGPT()` used `execSync` with shell string interpolation for osascript calls. Replaced both with `execFileSync('osascript', [...])`.
- **chatgpt/ask.ts**: Poll loop used `execSync(\`sleep ${pollInterval}\`)`. Replaced with `spawnSync('sleep', [String(pollInterval)])`.
- **record.ts**: Fixed misleading "idempotent injection" comment — the function unpatch+re-patches on each call (safe to call multiple times, but not idempotent).

Follows up on #826 which fixed the same class of issues in `engine.ts` and `fix.ts`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 541 passed, 1 skipped