### PR TITLE
fix(explore): add contentType URL inference to array branch

### DIFF
--- a/src/explore.ts
+++ b/src/explore.ts
@@ -165,12 +165,15 @@ function parseNetworkRequests(raw: unknown): NetworkEntry[] {
           try { body = JSON.parse(preview); } catch { body = preview; }
         }
       }
+      const url = String(e.url ?? e.request?.url ?? e.requestUrl ?? '');
+      // Infer contentType from URL patterns when no explicit type is available,
+      // matching the same heuristic used in the string-parsing branch above
+      const contentType = e.contentType ?? e.responseContentType ?? e.response?.contentType
+        ?? ((url.includes('/api/') || url.includes('/x/') || url.endsWith('.json')) ? 'application/json' : '');
       return {
         method: (e.method ?? 'GET').toUpperCase(),
-        url: String(e.url ?? e.request?.url ?? e.requestUrl ?? ''),
-        status: e.status ?? e.responseStatus ?? e.statusCode ?? null,
-        contentType: e.contentType ?? e.responseContentType ?? e.response?.contentType ?? '',
-        responseBody: body, requestHeaders: e.requestHeaders,
+        url, status: e.status ?? e.responseStatus ?? e.statusCode ?? null,
+        contentType, responseBody: body, requestHeaders: e.requestHeaders,
       };
     });
   }


### PR DESCRIPTION
## Description

`parseNetworkRequests` has two branches: string-parsing and array-parsing. The string branch infers `application/json` from URL patterns (`/api/`, `/x/`, `.json`), but the array branch relied solely on explicit contentType fields from the input object.

When CDP or extension capture data arrives without a contentType field, API endpoints silently scored 0 in `isUsefulEndpoint` and were dropped from explore results. This made explore ineffective on sites where the capture layer doesn't populate contentType.

The fix applies the same URL-pattern heuristic as a fallback in the array branch.

Related issue: #810

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```diff
+      const url = String(e.url ?? e.request?.url ?? e.requestUrl ?? '');
+      // Infer contentType from URL patterns when no explicit type is available,
+      // matching the same heuristic used in the string-parsing branch above
+      const contentType = e.contentType ?? e.responseContentType ?? e.response?.contentType
+        ?? ((url.includes('/api/') || url.includes('/x/') || url.endsWith('.json')) ? 'application/json' : '');
       return {
         method: (e.method ?? 'GET').toUpperCase(),
-        url: String(e.url ?? e.request?.url ?? e.requestUrl ?? ''),
-        status: e.status ?? e.responseStatus ?? e.statusCode ?? null,
-        contentType: e.contentType ?? e.responseContentType ?? e.response?.contentType ?? '',
-        responseBody: body, requestHeaders: e.requestHeaders,
+        url, status: e.status ?? e.responseStatus ?? e.statusCode ?? null,
+        contentType, responseBody: body, requestHeaders: e.requestHeaders,
       };
```