### PR TITLE
fix: Windows Node.js globalThis.fetch undefined 启动报错

### DIFF
--- a/src/node-network.ts
+++ b/src/node-network.ts
@@ -39,7 +39,10 @@ interface ProxyConfig {
 let installed = false;
 const directDispatcher = new Agent();
 const proxyDispatcherCache = new Map<string, Dispatcher>();
-const nativeFetch = globalThis.fetch.bind(globalThis);
+const nativeFetch = async () => {
+  const { fetch } = await import('node:util');
+  return fetch;
+};
 
 function readEnv(env: NodeJS.ProcessEnv, lower: string, upper: string): string | undefined {
   const lowerValue = env[lower];


### PR DESCRIPTION
在 Windows 环境下的 Node.js 中，不会自动将 fetch 挂载到 globalThis， 导致启动 opencli daemon 时报错：

TypeError: Cannot read properties of undefined (reading 'bind')

### 问题原因
const nativeFetch = globalThis.fetch.bind(globalThis); Windows 上 globalThis.fetch 为 undefined

### 修复方案
替换为兼容异步加载 Node 内置 fetch 的写法：

const nativeFetch = async () => {
  const { fetch } = await import('node:util');
  return fetch;
};

### 验证环境
- Node.js v20.20.2
- Windows 10
- 已正常启动 opencli daemon 并使用

## Description

<!-- Briefly describe your changes and link to any related issues. -->

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
