### PR TITLE
fix: fallback to undiciFetch when globalThis.fetch is unavailable

### DIFF
--- a/src/node-network.ts
+++ b/src/node-network.ts
@@ -39,7 +39,9 @@ interface ProxyConfig {
 let installed = false;
 const directDispatcher = new Agent();
 const proxyDispatcherCache = new Map<string, Dispatcher>();
-const nativeFetch = globalThis.fetch.bind(globalThis);
+const nativeFetch = globalThis.fetch
+  ? globalThis.fetch.bind(globalThis)
+  : (input, init) => undiciFetch(input, init);
 
 function readEnv(env: NodeJS.ProcessEnv, lower: string, upper: string): string | undefined {
   const lowerValue = env[lower];


### PR DESCRIPTION
## Problem
On Windows with older Node.js versions, `globalThis.fetch` is not available at module load time, causing the original `nativeFetch` definition to fail immediately.

## Solution
- Keep `nativeFetch` as a direct request function, preserving the original signature `(input, init) => Promise<Response>`.
- Fall back to `undiciFetch` synchronously when `globalThis.fetch` is unavailable.
- This maintains the existing no-proxy path behavior while fixing the startup error on Windows.

## Verification
- No breaking changes to the call site `return nativeFetch(input, init)`.
- Works both with native `fetch` and the `undiciFetch` fallback.