### PR TITLE
feat(jianyu): add search adapter for bid notices

### DIFF
--- a/clis/jianyu/search.test.ts
+++ b/clis/jianyu/search.test.ts
@@ -3,8 +3,8 @@ import { __test__ } from './search.js';
 
 describe('jianyu search helpers', () => {
   it('builds supsearch URL with required query params', () => {
-    const url = __test__.buildSearchUrl('电梯');
-    expect(url).toContain('keywords=%E7%94%B5%E6%A2%AF');
+    const url = __test__.buildSearchUrl('procurement');
+    expect(url).toContain('keywords=procurement');
     expect(url).toContain('selectType=title');
     expect(url).toContain('searchGroup=1');
   });
@@ -24,4 +24,3 @@ describe('jianyu search helpers', () => {
     expect(deduped).toHaveLength(2);
   });
 });
-

--- a/clis/jianyu/search.ts
+++ b/clis/jianyu/search.ts
@@ -54,7 +54,7 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'query', required: true, positional: true, help: 'Search keyword, e.g. "电梯"' },
+    { name: 'query', required: true, positional: true, help: 'Search keyword, e.g. "procurement"' },
     { name: 'limit', type: 'int', default: 20, help: 'Number of results (max 50)' },
   ],
   columns: ['rank', 'title', 'date', 'url'],
@@ -154,4 +154,3 @@ export const __test__ = {
   normalizeDate,
   dedupeCandidates,
 };
-

--- a/docs/adapters/browser/jianyu.md
+++ b/docs/adapters/browser/jianyu.md
@@ -12,10 +12,10 @@
 
 ```bash
 # Search by keyword
-opencli jianyu search "电梯" --limit 20 -f json
+opencli jianyu search "procurement" --limit 20 -f json
 
 # Search another keyword with a smaller window
-opencli jianyu search "施工升降机" --limit 10 -f json
+opencli jianyu search "substation" --limit 10 -f json
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- add `jianyu/search` browser adapter for Jianyu bid notice search
- normalize date formats and dedupe by title+url
- add unit tests for URL builder/date normalization/deduping

## Validation
- npx vitest run --project adapter clis/jianyu/search.test.ts