### PR TITLE
feat(powerchina): add search adapter for procurement notices

### DIFF
--- a/clis/powerchina/search.test.ts
+++ b/clis/powerchina/search.test.ts
@@ -3,8 +3,8 @@ import { __test__ } from './search.js';
 
 describe('powerchina search helpers', () => {
   it('builds candidate URLs with keyword variants', () => {
-    const candidates = __test__.buildSearchCandidates('电梯');
-    expect(candidates[0]).toContain('keyword=%E7%94%B5%E6%A2%AF');
+    const candidates = __test__.buildSearchCandidates('procurement');
+    expect(candidates[0]).toContain('keyword=procurement');
     expect(candidates.some((item) => item.includes('/search?keywords='))).toBe(true);
     expect(candidates.some((item) => item === 'https://bid.powerchina.cn/search')).toBe(true);
   });
@@ -23,4 +23,3 @@ describe('powerchina search helpers', () => {
     expect(deduped).toHaveLength(2);
   });
 });
-

--- a/clis/powerchina/search.ts
+++ b/clis/powerchina/search.ts
@@ -61,7 +61,7 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'query', required: true, positional: true, help: 'Search keyword, e.g. "电梯"' },
+    { name: 'query', required: true, positional: true, help: 'Search keyword, e.g. "procurement"' },
     { name: 'limit', type: 'int', default: 20, help: 'Number of results (max 50)' },
   ],
   columns: ['rank', 'title', 'date', 'url'],
@@ -163,4 +163,3 @@ export const __test__ = {
   buildSearchCandidates,
   dedupeCandidates,
 };
-

--- a/docs/adapters/browser/powerchina.md
+++ b/docs/adapters/browser/powerchina.md
@@ -1,0 +1,36 @@
+# PowerChina
+
+**Mode**: 🔐 Browser · **Domain**: `bid.powerchina.cn`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli powerchina search "<query>" --limit <n>` | Search PowerChina procurement notices and return normalized result rows |
+
+## Usage Examples
+
+```bash
+# Search by keyword
+opencli powerchina search "procurement" --limit 20 -f json
+
+# Search with another keyword
+opencli powerchina search "substation" --limit 10 -f json
+```
+
+## Prerequisites
+
+- Chrome running with an active `bid.powerchina.cn` session
+- [Browser Bridge extension](/guide/browser-bridge) installed
+
+## Notes
+
+- This adapter probes multiple search entry URLs and returns merged rows.
+- The `date` field is normalized to `YYYY-MM-DD` when date text is detectable.
+- Results are deduplicated by `title + url`.
+- `--limit` defaults to `20` and is capped at `50`.
+
+## Troubleshooting
+
+- If the site asks for login/verification, complete it in Chrome and retry.
+- If results are empty, validate the same keyword directly on the website first.


### PR DESCRIPTION
## Summary
- add `powerchina/search` browser adapter with multi-entry URL probing
- normalize date formats and dedupe by title+url
- add unit tests for candidate URL generation/date normalization/deduping

## Validation
- npx vitest run --project adapter clis/powerchina/search.test.ts