### PR TITLE
fix: resolve plugin host root from published dist layout

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -27,6 +27,7 @@ const {
   _readLockFile,
   _readLockFileWithWriter,
   _resolveEsbuildBin,
+  _resolveHostOpencliRoot,
   uninstallPlugin,
   updatePlugin,
   _parseSource,
@@ -400,6 +401,29 @@ describe('resolveEsbuildBin', () => {
     expect(typeof binPath).toBe('string');
     expect(fs.existsSync(binPath!)).toBe(true);
     expect(binPath).toMatch(/esbuild(\.cmd)?$/);
+  });
+});
+
+describe('resolveHostOpencliRoot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-host-root-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('walks up from compiled dist/src files to the package root', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: '@jackwener/opencli' }),
+    );
+    const distSrcDir = path.join(tmpDir, 'dist', 'src');
+    fs.mkdirSync(distSrcDir, { recursive: true });
+
+    expect(_resolveHostOpencliRoot(path.join(distSrcDir, 'plugin.js'))).toBe(tmpDir);
   });
 });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1381,11 +1381,7 @@ function parseSource(
  */
 function linkHostOpencli(pluginDir: string): void {
   try {
-    // Determine the host opencli package root from this module's location.
-    // Both dev (tsx src/plugin.ts) and prod (node dist/plugin.js) are one level
-    // deep, so path.dirname + '..' always gives us the package root.
-    const thisFile = fileURLToPath(import.meta.url);
-    const hostRoot = path.resolve(path.dirname(thisFile), '..');
+    const hostRoot = resolveHostOpencliRoot();
 
     const targetLink = path.join(pluginDir, 'node_modules', '@jackwener', 'opencli');
 
@@ -1411,8 +1407,7 @@ function linkHostOpencli(pluginDir: string): void {
  * Resolve the path to the esbuild CLI executable with fallback strategies.
  */
 export function resolveEsbuildBin(): string | null {
-  const thisFile = fileURLToPath(import.meta.url);
-  const hostRoot = path.resolve(path.dirname(thisFile), '..');
+  const hostRoot = resolveHostOpencliRoot();
 
   // Strategy 1 (Windows): prefer the .cmd wrapper which is executable via shell
   if (isWindows) {
@@ -1466,6 +1461,30 @@ export function resolveEsbuildBin(): string | null {
   return null;
 }
 
+function resolveHostOpencliRoot(startFile = fileURLToPath(import.meta.url)): string {
+  let dir = path.dirname(startFile);
+
+  while (true) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        if (pkg?.name === '@jackwener/opencli') {
+          return dir;
+        }
+      } catch {
+        // Keep walking; a malformed package.json should not hide an ancestor package root.
+      }
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return path.resolve(path.dirname(startFile), '..');
+}
+
 /**
  * Transpile TS plugin files to JS so they work in production mode.
  * Uses esbuild from the host opencli's node_modules for fast single-file transpilation.
@@ -1512,6 +1531,7 @@ function transpilePluginTs(pluginDir: string): void {
 }
 
 export {
+  resolveHostOpencliRoot as _resolveHostOpencliRoot,
   resolveEsbuildBin as _resolveEsbuildBin,
   getCommitHash as _getCommitHash,
   installDependencies as _installDependencies,


### PR DESCRIPTION
## Summary

Fixes plugin host package linking for published builds by resolving the real `@jackwener/opencli` package root from the running module path instead of assuming it is always one directory up.

In published installs, `src/plugin.ts` compiles under `dist/src/plugin.js`, so the old `dirname + '..'` logic could point plugin `node_modules/@jackwener/opencli` at `dist/` instead of the package root. That breaks package export resolution for imports like `@jackwener/opencli/registry`.

## Changes

- Add `resolveHostOpencliRoot()` to walk upward until it finds the host package `package.json`.
- Use that helper for plugin host symlinking and esbuild binary lookup.
- Add a regression test for resolving from a compiled `dist/src/plugin.js` layout.

## Validation

- `npm test -- --run src/plugin.test.ts`
- `npm run typecheck`

Fixes #843
Refs #722
