### PR TITLE
fix(twitter): always use compose URL for reply to fix missing textarea

### DIFF
--- a/clis/twitter/reply.test.ts
+++ b/clis/twitter/reply.test.ts
@@ -53,8 +53,11 @@ describe('twitter reply command', () => {
       text: 'text-only reply',
     });
 
-    expect(page.goto).toHaveBeenCalledWith('https://x.com/_kop6/status/2040254679301718161?s=20');
-    expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="primaryColumn"]' });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://x.com/compose/post?in_reply_to=2040254679301718161',
+      { waitUntil: 'load', settleMs: 2500 }
+    );
+    expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
     expect(result).toEqual([
       {
         status: 'success',
@@ -86,8 +89,11 @@ describe('twitter reply command', () => {
       image: imagePath,
     });
 
-    expect(page.goto).toHaveBeenCalledWith('https://x.com/compose/post?in_reply_to=2040254679301718161');
-    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]' });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://x.com/compose/post?in_reply_to=2040254679301718161',
+      { waitUntil: 'load', settleMs: 2500 }
+    );
+    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
     expect(page.wait).toHaveBeenNthCalledWith(2, { selector: 'input[type="file"][data-testid="fileInput"]', timeout: 20 });
     expect(setFileInput).toHaveBeenCalledWith([imagePath], 'input[type="file"][data-testid="fileInput"]');
     expect(result).toEqual([

--- a/clis/twitter/reply.ts
+++ b/clis/twitter/reply.ts
@@ -267,16 +267,14 @@ cli({
         cleanupDir = path.dirname(localImagePath);
       }
 
-      // Dedicated composer is more reliable for image replies because the media
-      // toolbar and file input are consistently present there.
+      // Dedicated reply composer is more reliable than the inline tweet page
+      // reply box because the textarea and action button are mounted more
+      // consistently there.
+      await page.goto(buildReplyComposerUrl(kwargs.url), { waitUntil: 'load', settleMs: 2500 });
+      await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
       if (localImagePath) {
-        await page.goto(buildReplyComposerUrl(kwargs.url));
-        await page.wait({ selector: '[data-testid="tweetTextarea_0"]' });
         await page.wait({ selector: REPLY_FILE_INPUT_SELECTOR, timeout: 20 });
         await attachReplyImage(page, localImagePath);
-      } else {
-        await page.goto(kwargs.url);
-        await page.wait({ selector: '[data-testid="primaryColumn"]' });
       }
 
       const result = await submitReply(page, kwargs.text);


### PR DESCRIPTION
## Problem

When calling `opencli twitter reply` without an image, the code navigated to the tweet page URL and waited for `[data-testid="primaryColumn"]`. The inline reply composer is not reliably mounted in that context, causing:

```
Error: Could not find reply text area
```

This was a silent regression — the image path already used the reply composer URL correctly, but the text-only path did not.

## Fix

Unconditionally navigate to the reply composer URL (`/compose/post?in_reply_to=<tweet_id>`) for all replies, then wait for `[data-testid="tweetTextarea_0"]` before proceeding. The image attachment flow is unchanged.

## Testing

Verified locally with `opencli twitter reply --url <tweet_url> --text "..."` — reply posts successfully on both text-only and image paths.

Fixes #848