### PR TITLE
fix(twitter): use the dedicated composer for replies

### DIFF
--- a/clis/twitter/reply.test.ts
+++ b/clis/twitter/reply.test.ts
@@ -40,7 +40,7 @@ function createPageMock(evaluateResults: any[], overrides: Partial<IPage> = {}):
 }
 
 describe('twitter reply command', () => {
-  it('keeps the text-only reply flow working', async () => {
+  it('uses the dedicated reply composer for text-only replies too', async () => {
     const cmd = getRegistry().get('twitter/reply');
     expect(cmd?.func).toBeTypeOf('function');
 
@@ -53,8 +53,11 @@ describe('twitter reply command', () => {
       text: 'text-only reply',
     });
 
-    expect(page.goto).toHaveBeenCalledWith('https://x.com/_kop6/status/2040254679301718161?s=20');
-    expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="primaryColumn"]' });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://x.com/compose/post?in_reply_to=2040254679301718161',
+      { waitUntil: 'load', settleMs: 2500 },
+    );
+    expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
     expect(result).toEqual([
       {
         status: 'success',
@@ -86,8 +89,11 @@ describe('twitter reply command', () => {
       image: imagePath,
     });
 
-    expect(page.goto).toHaveBeenCalledWith('https://x.com/compose/post?in_reply_to=2040254679301718161');
-    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]' });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://x.com/compose/post?in_reply_to=2040254679301718161',
+      { waitUntil: 'load', settleMs: 2500 },
+    );
+    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
     expect(page.wait).toHaveBeenNthCalledWith(2, { selector: 'input[type="file"][data-testid="fileInput"]', timeout: 20 });
     expect(setFileInput).toHaveBeenCalledWith([imagePath], 'input[type="file"][data-testid="fileInput"]');
     expect(result).toEqual([

--- a/clis/twitter/reply.ts
+++ b/clis/twitter/reply.ts
@@ -267,16 +267,12 @@ cli({
         cleanupDir = path.dirname(localImagePath);
       }
 
-      // Dedicated composer is more reliable for image replies because the media
-      // toolbar and file input are consistently present there.
+      // Dedicated composer is more reliable than the inline tweet page reply box.
+      await page.goto(buildReplyComposerUrl(kwargs.url), { waitUntil: 'load', settleMs: 2500 });
+      await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
       if (localImagePath) {
-        await page.goto(buildReplyComposerUrl(kwargs.url));
-        await page.wait({ selector: '[data-testid="tweetTextarea_0"]' });
         await page.wait({ selector: REPLY_FILE_INPUT_SELECTOR, timeout: 20 });
         await attachReplyImage(page, localImagePath);
-      } else {
-        await page.goto(kwargs.url);
-        await page.wait({ selector: '[data-testid="primaryColumn"]' });
       }
 
       const result = await submitReply(page, kwargs.text);


### PR DESCRIPTION
## Summary
- use the dedicated X reply composer for text-only replies as well as image replies
- wait for the actual reply textarea instead of the broader `primaryColumn` container
- update the adapter test to cover the composer-based text-only flow

## Testing
- `npx vitest run --project adapter clis/twitter/reply.test.ts`

Fixes #848.