### PR TITLE
fix(twitter): relax reply composer textarea timeout to 15s

### DIFF
--- a/clis/twitter/reply.test.ts
+++ b/clis/twitter/reply.test.ts
@@ -57,7 +57,7 @@ describe('twitter reply command', () => {
       'https://x.com/compose/post?in_reply_to=2040254679301718161',
       { waitUntil: 'load', settleMs: 2500 },
     );
-    expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
+    expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
     expect(result).toEqual([
       {
         status: 'success',
@@ -93,7 +93,7 @@ describe('twitter reply command', () => {
       'https://x.com/compose/post?in_reply_to=2040254679301718161',
       { waitUntil: 'load', settleMs: 2500 },
     );
-    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
+    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
     expect(page.wait).toHaveBeenNthCalledWith(2, { selector: 'input[type="file"][data-testid="fileInput"]', timeout: 20 });
     expect(setFileInput).toHaveBeenCalledWith([imagePath], 'input[type="file"][data-testid="fileInput"]');
     expect(result).toEqual([

--- a/clis/twitter/reply.ts
+++ b/clis/twitter/reply.ts
@@ -269,7 +269,7 @@ cli({
 
       // Dedicated composer is more reliable than the inline tweet page reply box.
       await page.goto(buildReplyComposerUrl(kwargs.url), { waitUntil: 'load', settleMs: 2500 });
-      await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 8 });
+      await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
       if (localImagePath) {
         await page.wait({ selector: REPLY_FILE_INPUT_SELECTOR, timeout: 20 });
         await attachReplyImage(page, localImagePath);


### PR DESCRIPTION
## Summary
- Relax `tweetTextarea_0` wait timeout from 8s to 15s
- Compose page loads Draft.js editor which is heavier; 8s is too tight for slow networks
- Aligns with the file input timeout (20s) in magnitude

Follow-up to #860 (merged). Review finding from #855.

## Test plan
- [x] `npx vitest run clis/twitter/reply.test.ts` — 7 passed