### PR TITLE
fix: graceful fallback when extension lacks network-capture support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,11 +313,11 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   operate.command('open').argument('<url>').description('Open URL in automation window')
     .action(operateAction(async (page, url) => {
       // Start session-level capture before navigation (catches initial requests)
-      await page.startNetworkCapture?.();
+      const hasSessionCapture = await page.startNetworkCapture?.().then(() => true).catch(() => false);
       await page.goto(url);
       await page.wait(2);
-      // Fallback: also inject JS interceptor for pages without session capture
-      if (!page.startNetworkCapture) {
+      // Fallback: inject JS interceptor when session capture is unavailable
+      if (!hasSessionCapture) {
         try { await page.evaluate(NETWORK_INTERCEPTOR_JS); } catch { /* non-fatal */ }
       }
       console.log(`Navigated to: ${await page.getCurrentUrl?.() ?? url}`);

--- a/src/explore.ts
+++ b/src/explore.ts
@@ -382,7 +382,7 @@ export async function exploreUrl(
   return browserSession(opts.BrowserFactory, async (page) => {
     return runWithTimeout((async () => {
       // Step 1: Navigate
-      await page.startNetworkCapture?.();
+      await page.startNetworkCapture?.().catch(() => {});
       await page.goto(url);
       await page.wait(waitSeconds);
 


### PR DESCRIPTION
## Summary
- Wrap `startNetworkCapture()` calls with `.catch()` in `explore.ts` and `cli.ts` (operate open)
- When the Browser Bridge extension doesn't support `network-capture-start` (older version), the CLI now degrades gracefully instead of crashing
- `operate open` falls back to the JS interceptor injection when session capture fails

## Problem
Users with an older Browser Bridge extension get a fatal crash when running `opencli explore`:
```
Error: Unknown action: network-capture-start
```
The daemon returns this when the extension predates the network-capture feature. The CLI should handle this gracefully since network capture is an enhancement, not a requirement.

## Test plan
- [ ] `opencli explore <url>` works with an older extension (graceful degradation)
- [ ] `opencli explore <url>` still captures network data with a current extension
- [ ] `opencli operate open <url>` falls back to JS interceptor when session capture fails