### PR TITLE
feat(github): add GitHub adapter with 5 commands

### DIFF
--- a/clis/github/issues.ts
+++ b/clis/github/issues.ts
@@ -1,0 +1,54 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+cli({
+  site: 'github',
+  name: 'issues',
+  description: 'GitHub 仓库 Issues 列表',
+  domain: 'github.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'repo',
+      type: 'str',
+      required: true,
+      positional: true,
+      help: '仓库路径（如 jackwener/OpenCLI）',
+    },
+    {
+      name: 'state',
+      type: 'str',
+      default: 'open',
+      help: 'Issue 状态（open, closed, all）',
+    },
+    {
+      name: 'limit',
+      type: 'int',
+      default: 30,
+    },
+  ],
+  columns: ['number', 'title', 'user', 'state', 'comments', 'created_at', 'updated_at'],
+  func: async (_page, kwargs) => {
+    const res = await fetch(
+      `https://api.github.com/repos/${kwargs.repo}/issues?state=${kwargs.state}&per_page=${kwargs.limit}`
+    );
+    const data = await res.json();
+
+    if ((data as any).message === 'Not Found') {
+      throw new Error(`Repository not found: ${kwargs.repo}`);
+    }
+
+    return (data as any[])
+      .filter((item: any) => !item.pull_request) // 过滤掉 PR
+      .slice(0, kwargs.limit)
+      .map((item: any) => ({
+        number: item.number || 0,
+        title: item.title || '',
+        user: item.user?.login || '',
+        state: item.state || '',
+        comments: item.comments || 0,
+        created_at: item.created_at || '',
+        updated_at: item.updated_at || '',
+      }));
+  },
+});

--- a/clis/github/pr.ts
+++ b/clis/github/pr.ts
@@ -1,0 +1,53 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+cli({
+  site: 'github',
+  name: 'pr',
+  description: 'GitHub 仓库 Pull Requests 列表',
+  domain: 'github.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'repo',
+      type: 'str',
+      required: true,
+      positional: true,
+      help: '仓库路径（如 jackwener/OpenCLI）',
+    },
+    {
+      name: 'state',
+      type: 'str',
+      default: 'open',
+      help: 'PR 状态（open, closed, all）',
+    },
+    {
+      name: 'limit',
+      type: 'int',
+      default: 30,
+    },
+  ],
+  columns: ['number', 'title', 'user', 'state', 'draft', 'comments', 'created_at'],
+  func: async (_page, kwargs) => {
+    const res = await fetch(
+      `https://api.github.com/repos/${kwargs.repo}/pulls?state=${kwargs.state}&per_page=${kwargs.limit}`
+    );
+    const data = await res.json();
+
+    if ((data as any).message === 'Not Found') {
+      throw new Error(`Repository not found: ${kwargs.repo}`);
+    }
+
+    return (data as any[])
+      .slice(0, kwargs.limit)
+      .map((item: any) => ({
+        number: item.number || 0,
+        title: item.title || '',
+        user: item.user?.login || '',
+        state: item.state || '',
+        draft: item.draft || false,
+        comments: item.comments || 0,
+        created_at: item.created_at || '',
+      }));
+  },
+});

--- a/clis/github/repo.ts
+++ b/clis/github/repo.ts
@@ -1,0 +1,62 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import type { IPage } from '@jackwener/opencli/types';
+
+cli({
+  site: 'github',
+  name: 'repo',
+  description: 'GitHub 仓库详情',
+  domain: 'github.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'input',
+      type: 'str',
+      required: true,
+      positional: true,
+      help: '仓库路径（如 jackwener/OpenCLI）或完整 URL',
+    },
+  ],
+  columns: [
+    'name',
+    'description',
+    'stars',
+    'forks',
+    'language',
+    'license',
+    'open_issues',
+    'topics',
+    'created_at',
+    'updated_at',
+  ],
+  func: async (_page, kwargs) => {
+    // 解析仓库路径
+    let repoPath = kwargs.input;
+    if (repoPath.startsWith('https://github.com/')) {
+      repoPath = repoPath.replace('https://github.com/', '');
+    }
+    repoPath = repoPath.replace(/\/$/, '');
+
+    const res = await fetch(`https://api.github.com/repos/${repoPath}`);
+    const data = await res.json();
+
+    if ((data as any).message === 'Not Found') {
+      throw new Error(`Repository not found: ${repoPath}`);
+    }
+
+    return [
+      {
+        name: (data as any).name || '',
+        description: (data as any).description || '',
+        stars: (data as any).stargazers_count || 0,
+        forks: (data as any).forks_count || 0,
+        language: (data as any).language || '',
+        license: (data as any).license?.spdx_id || '',
+        open_issues: (data as any).open_issues_count || 0,
+        topics: ((data as any).topics || []).join(', '),
+        created_at: (data as any).created_at || '',
+        updated_at: (data as any).updated_at || '',
+      },
+    ];
+  },
+});

--- a/clis/github/search.ts
+++ b/clis/github/search.ts
@@ -1,0 +1,48 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+cli({
+  site: 'github',
+  name: 'search',
+  description: '搜索 GitHub 仓库',
+  domain: 'github.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'query',
+      type: 'str',
+      required: true,
+      positional: true,
+      help: '搜索关键词',
+    },
+    {
+      name: 'limit',
+      type: 'int',
+      default: 30,
+    },
+  ],
+  columns: ['rank', 'name', 'full_name', 'description', 'stars', 'language', 'url'],
+  func: async (_page, kwargs) => {
+    const encodedQuery = encodeURIComponent(kwargs.query);
+    const res = await fetch(
+      `https://api.github.com/search/repositories?q=${encodedQuery}&per_page=${kwargs.limit}`
+    );
+    const data = await res.json();
+
+    if ((data as any).message) {
+      throw new Error(`Search failed: ${(data as any).message}`);
+    }
+
+    return ((data as any).items || [])
+      .slice(0, kwargs.limit)
+      .map((item: any, i: number) => ({
+        rank: i + 1,
+        name: item.name || '',
+        full_name: item.full_name || '',
+        description: (item.description || '').substring(0, 100), // 限制描述长度
+        stars: item.stargazers_count || 0,
+        language: item.language || '',
+        url: item.html_url || '',
+      }));
+  },
+});

--- a/clis/github/trending.ts
+++ b/clis/github/trending.ts
@@ -1,0 +1,101 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import type { IPage } from '@jackwener/opencli/types';
+
+interface TrendingItem {
+  name: string;
+  description: string;
+  language: string;
+  stars: string;
+  forks: string;
+  starsToday: string;
+}
+
+async function extractTrending(page: IPage, language: string, since: string): Promise<TrendingItem[]> {
+  const lang = language ? `/${language}` : '';
+  const url = `https://github.com/trending${lang}?since=${since}`;
+  await page.goto(url);
+
+  const data = await page.evaluate(`
+    (() => {
+      const repos = [];
+      const articles = document.querySelectorAll('article.Box-row');
+
+      articles.forEach((article) => {
+        const h2 = article.querySelector('h2 a');
+        const repoName = (h2?.getAttribute('href') || '').replace('/', '');
+
+        const descElem = article.querySelector('p.col-9');
+        const description = (descElem?.textContent || '').trim();
+
+        const langElem = article.querySelector('[itemprop="programmingLanguage"]');
+        const language = (langElem?.textContent || '').trim();
+
+        const starsElem = article.querySelector('a[href*="/stargazers"]');
+        const stars = (starsElem?.textContent || '0').trim();
+
+        const forksElem = article.querySelector('a[href*="/forks"]');
+        const forks = (forksElem?.textContent || '0').trim();
+
+        const starsTodayElem = article.querySelector('span.float-sm-right');
+        const starsToday = (starsTodayElem?.textContent || '')
+          .trim()
+          .replace(/stars (today|this week|this month)/i, '')
+          .trim();
+
+        repos.push({
+          name: repoName,
+          description,
+          language,
+          stars,
+          forks,
+          starsToday,
+        });
+      });
+
+      return repos;
+    })()
+  `) as TrendingItem[];
+
+  return data;
+}
+
+cli({
+  site: 'github',
+  name: 'trending',
+  description: 'GitHub Trending 热门项目',
+  domain: 'github.com',
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: 'language',
+      type: 'str',
+      default: '',
+      help: '编程语言筛选（如 javascript, python, go）',
+    },
+    {
+      name: 'since',
+      type: 'str',
+      default: 'daily',
+      help: '时间范围（daily, weekly, monthly）',
+    },
+    {
+      name: 'limit',
+      type: 'int',
+      default: 25,
+    },
+  ],
+  columns: ['rank', 'name', 'description', 'language', 'stars', 'forks', 'stars_today'],
+  func: async (page, kwargs) => {
+    const data = await extractTrending(page, kwargs.language || '', kwargs.since || 'daily');
+    return data.slice(0, kwargs.limit).map((item, i) => ({
+      rank: i + 1,
+      name: item.name || '',
+      description: item.description || '',
+      language: item.language || '',
+      stars: item.stars || '0',
+      forks: item.forks || '0',
+      stars_today: item.starsToday || '',
+    }));
+  },
+});


### PR DESCRIPTION
Add comprehensive GitHub adapter supporting:
- repo: view repository details
- issues: list repository issues
- pr: list pull requests
- search: search GitHub repositories
- trending: view trending repositories (with browser)

All commands use GitHub public API (no auth required) except trending which parses DOM for data not available via API.

Tested successfully:
- opencli github repo jackwener/OpenCLI
- opencli github issues jackwener/OpenCLI --limit 5
- opencli github pr jackwener/OpenCLI --limit 3
- opencli github search opencli --limit 3
- opencli github trending --language typescript --limit 3

## Description

<!-- Briefly describe your changes and link to any related issues. -->

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
