### PR TITLE
fix(build-manifest): import compiled JS from dist/clis/ instead of raw TS

### DIFF
--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -19,7 +19,10 @@ import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 const PACKAGE_ROOT = findPackageRoot(fileURLToPath(import.meta.url));
 const CLIS_DIR = path.join(PACKAGE_ROOT, 'clis');
 const DIST_CLIS_DIR = path.join(PACKAGE_ROOT, 'dist', 'clis');
-const OUTPUT = getCliManifestPath(CLIS_DIR);
+// Write manifest next to the directory the runtime actually scans (dist/clis/).
+// main.ts resolves BUILTIN_CLIS to dist/clis/ (relative to dist/src/main.js),
+// so the manifest must be at dist/cli-manifest.json for discoverClis() to find it.
+const OUTPUT = getCliManifestPath(DIST_CLIS_DIR);
 
 export interface ManifestEntry {
   site: string;

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -18,6 +18,7 @@ import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 
 const PACKAGE_ROOT = findPackageRoot(fileURLToPath(import.meta.url));
 const CLIS_DIR = path.join(PACKAGE_ROOT, 'clis');
+const DIST_CLIS_DIR = path.join(PACKAGE_ROOT, 'dist', 'clis');
 const OUTPUT = getCliManifestPath(CLIS_DIR);
 
 export interface ManifestEntry {
@@ -132,6 +133,14 @@ export async function loadTsManifestEntries(
         })
         .map(([, cmd]) => cmd);
 
+    // Resolve sourceFile relative to clis/ (not dist/clis/).
+    // When scanning compiled JS from dist/clis/, map back to the original .ts path.
+    let sourceRelative = path.relative(CLIS_DIR, filePath);
+    if (filePath.startsWith(DIST_CLIS_DIR)) {
+      const distRelative = path.relative(DIST_CLIS_DIR, filePath);
+      sourceRelative = distRelative.replace(/\.js$/, '.ts');
+    }
+
     const seen = new Set<string>();
     return runtimeCommands
       .filter((cmd) => {
@@ -141,7 +150,7 @@ export async function loadTsManifestEntries(
         return true;
       })
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map(cmd => toManifestEntry(cmd, modulePath, path.relative(CLIS_DIR, filePath)));
+      .map(cmd => toManifestEntry(cmd, modulePath, sourceRelative));
   } catch (err) {
     // If parsing fails, log a warning (matching scanYaml behaviour) and skip the entry.
     process.stderr.write(`Warning: failed to scan ${filePath}: ${getErrorMessage(err)}\n`);
@@ -152,14 +161,21 @@ export async function loadTsManifestEntries(
 export async function buildManifest(): Promise<ManifestEntry[]> {
   const manifest = new Map<string, ManifestEntry>();
 
-  if (fs.existsSync(CLIS_DIR)) {
-    for (const site of fs.readdirSync(CLIS_DIR)) {
-      const siteDir = path.join(CLIS_DIR, site);
+  // Scan compiled JS in dist/clis/ instead of raw TS in clis/.
+  // Node's type stripping does not rewrite '.js' → '.ts' in import
+  // specifiers, so dynamically importing .ts source files fails whenever
+  // they contain relative imports like './utils.js'.  Importing the
+  // tsc-compiled .js avoids this entirely.
+  const scanDir = fs.existsSync(DIST_CLIS_DIR) ? DIST_CLIS_DIR : CLIS_DIR;
+
+  if (fs.existsSync(scanDir)) {
+    for (const site of fs.readdirSync(scanDir)) {
+      const siteDir = path.join(scanDir, site);
       if (!fs.statSync(siteDir).isDirectory()) continue;
       for (const file of fs.readdirSync(siteDir)) {
         if (
-          (file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts') && file !== 'index.ts') ||
-          (file.endsWith('.js') && !file.endsWith('.d.js') && !file.endsWith('.test.js') && file !== 'index.js')
+          (file.endsWith('.js') && !file.endsWith('.d.js') && !file.endsWith('.test.js') && file !== 'index.js') ||
+          (scanDir === CLIS_DIR && file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts') && file !== 'index.ts')
         ) {
           const filePath = path.join(siteDir, file);
           const entries = await loadTsManifestEntries(filePath, site);


### PR DESCRIPTION
## Summary
- `build-manifest` was dynamically importing `.ts` source files from `clis/`, but Node's type stripping doesn't rewrite `.js` → `.ts` in import specifiers, causing "Cannot find module" for any adapter with relative imports (`./utils.js`, `./shared.js`)
- **268 warnings** on every build, and **half of all adapters silently skipped** (254 vs 532 entries)
- Fix: scan `dist/clis/` (compiled JS) instead of `clis/` (raw TS) after `tsc` runs
- Falls back to `clis/` if `dist/clis/` doesn't exist
- `sourceFile` in manifest correctly maps back to the original `.ts` path

## Test plan
- [x] `npm run build` — zero warnings, 532 entries (was 254)
- [x] `vitest run src/build-manifest` — 4/4 tests pass
- [x] Manifest entries include correct `sourceFile` paths (`.ts` not `.js`)