### PR TITLE
fix(security): escape codegen strings and redact diagnostic body

### DIFF
--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -183,9 +183,9 @@ function redactNetworkRequest(req: unknown): unknown {
     redacted.responseHeaders = redactHeaders(redacted.responseHeaders as Record<string, string>);
   }
 
-  // Truncate response body
+  // Redact and truncate response body
   if (typeof redacted.body === 'string') {
-    redacted.body = truncate(redacted.body, MAX_REQUEST_BODY_CHARS);
+    redacted.body = redactText(truncate(redacted.body, MAX_REQUEST_BODY_CHARS));
   }
   if ('responseBody' in redacted) {
     redacted.responseBody = sanitizeCapturedValue(redacted.responseBody);

--- a/src/generate-verified.ts
+++ b/src/generate-verified.ts
@@ -488,8 +488,8 @@ function candidateToJs(candidate: CandidateYaml): string {
   const browser = detectBrowserFlag(candidate);
 
   const argsArray = Object.entries(candidate.args ?? {}).map(([name, def]) => {
-    const parts: string[] = [`name: '${name}'`];
-    if (def.type && def.type !== 'str') parts.push(`type: '${def.type}'`);
+    const parts: string[] = [`name: '${name.replace(/'/g, "\\'")}'`];
+    if (def.type && def.type !== 'str') parts.push(`type: '${def.type.replace(/'/g, "\\'")}'`);
     if (def.required) parts.push('required: true');
     if (def.default !== undefined) parts.push(`default: ${JSON.stringify(def.default)}`);
     if (def.description) parts.push(`help: '${def.description.replace(/'/g, "\\'")}'`);
@@ -527,10 +527,10 @@ function candidateToJs(candidate: CandidateYaml): string {
   lines.push("import { cli, Strategy } from '@jackwener/opencli/registry';");
   lines.push('');
   lines.push('cli({');
-  lines.push(`  site: '${candidate.site}',`);
-  lines.push(`  name: '${candidate.name}',`);
+  lines.push(`  site: '${candidate.site.replace(/'/g, "\\'")}',`);
+  lines.push(`  name: '${candidate.name.replace(/'/g, "\\'")}',`);
   if (candidate.description) lines.push(`  description: '${candidate.description.replace(/'/g, "\\'")}',`);
-  if (candidate.domain) lines.push(`  domain: '${candidate.domain}',`);
+  if (candidate.domain) lines.push(`  domain: '${candidate.domain.replace(/'/g, "\\'")}',`);
   lines.push(`  strategy: ${stratEnum},`);
   lines.push(`  browser: ${browser},`);
   if (argsArray.length > 0) {


### PR DESCRIPTION
## Summary

Fixes two bugs identified during post-migration first-principles review:

- **candidateToJs string injection**: `site`, `name`, `domain`, and arg `name`/`type` fields were written into generated JS adapter files without escaping single quotes. If any of these contained `'`, the generated adapter would have a syntax error. Now all string literals in codegen use `.replace(/'/g, "\\'")`
- **diagnostic body data leak**: `redactNetworkRequest` truncated the `body` field but did not pass it through `redactText()`, meaning JWTs or bearer tokens in response bodies could leak into AI repair context. `responseBody` and `responsePreview` already used `sanitizeCapturedValue` → `redactText`, but `body` was missed

## Test plan

- [x] `src/generate-verified.test.ts` — 28 tests passed
- [x] `src/diagnostic.test.ts` — 15 tests passed