### PR TITLE
fix: clean up legacy shim files and stale tmp files on upgrade

### DIFF
--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -153,16 +153,22 @@ export function fetchAdapters() {
   for (const dir of LEGACY_SHIM_DIRS) {
     const p = join(OPENCLI_DIR, dir);
     try {
-      // Only delete if it contains shim .js files, not user content
-      const entries = readdirSync(p);
-      const allShims = entries.every(e => e.endsWith('.js'));
-      if (allShims && entries.length > 0) {
-        const firstContent = readFileSync(join(p, entries[0]), 'utf-8');
-        if (firstContent.includes("export * from 'file://")) {
-          rmSync(p, { recursive: true });
-          legacyCleaned++;
-        }
+      // Delete individual shim files, then prune empty directory
+      for (const entry of readdirSync(p)) {
+        const fp = join(p, entry);
+        try {
+          if (!statSync(fp).isFile()) continue;
+          const content = readFileSync(fp, 'utf-8');
+          if (content.includes("export * from 'file://")) {
+            unlinkSync(fp);
+            legacyCleaned++;
+          }
+        } catch { /* skip unreadable entries */ }
       }
+      // Remove directory only if now empty
+      try {
+        if (readdirSync(p).length === 0) rmSync(p);
+      } catch { /* ignore */ }
     } catch { /* doesn't exist or not a directory */ }
   }
 

--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -128,7 +128,62 @@ export function fetchAdapters() {
     }
   }
 
-  // 3. Write updated manifest
+  // 3. Clean up legacy compat shim files from ~/.opencli/
+  // These were created by an older approach that placed re-export shims directly
+  // in ~/.opencli/ (e.g., registry.js, errors.js, browser/). The current approach
+  // uses a node_modules/@jackwener/opencli symlink instead.
+  const LEGACY_SHIM_FILES = [
+    'registry.js', 'errors.js', 'utils.js', 'launcher.js', 'logger.js', 'types.js',
+  ];
+  const LEGACY_SHIM_DIRS = [
+    'browser', 'download', 'errors', 'launcher', 'logger', 'pipeline', 'registry', 'types', 'utils',
+  ];
+  let legacyCleaned = 0;
+  for (const file of LEGACY_SHIM_FILES) {
+    const p = join(OPENCLI_DIR, file);
+    try {
+      const content = readFileSync(p, 'utf-8');
+      // Only delete if it's a re-export shim, not a user-created file
+      if (content.includes("export * from 'file://")) {
+        unlinkSync(p);
+        legacyCleaned++;
+      }
+    } catch { /* doesn't exist */ }
+  }
+  for (const dir of LEGACY_SHIM_DIRS) {
+    const p = join(OPENCLI_DIR, dir);
+    try {
+      // Only delete if it contains shim .js files, not user content
+      const entries = readdirSync(p);
+      const allShims = entries.every(e => e.endsWith('.js'));
+      if (allShims && entries.length > 0) {
+        const firstContent = readFileSync(join(p, entries[0]), 'utf-8');
+        if (firstContent.includes("export * from 'file://")) {
+          rmSync(p, { recursive: true });
+          legacyCleaned++;
+        }
+      }
+    } catch { /* doesn't exist or not a directory */ }
+  }
+
+  // 4. Clean up stale .plugins.lock.json.tmp-* files
+  let tmpCleaned = 0;
+  try {
+    for (const entry of readdirSync(OPENCLI_DIR)) {
+      if (entry.startsWith('.plugins.lock.json.tmp-')) {
+        try {
+          unlinkSync(join(OPENCLI_DIR, entry));
+          tmpCleaned++;
+        } catch { /* ignore */ }
+      }
+    }
+  } catch { /* ignore */ }
+
+  if (legacyCleaned > 0 || tmpCleaned > 0) {
+    log(`Cleaned up${legacyCleaned > 0 ? ` ${legacyCleaned} legacy shim files` : ''}${tmpCleaned > 0 ? `${legacyCleaned > 0 ? ',' : ''} ${tmpCleaned} stale tmp files` : ''}`);
+  }
+
+  // 5. Write updated manifest
   writeFileSync(MANIFEST_PATH, JSON.stringify({
     version: currentVersion,
     files: [...newOfficialFiles].sort(),


### PR DESCRIPTION
## Summary

Fixes the cluttered `~/.opencli/` directory reported by @WAWQAQ. Adds cleanup steps to `fetch-adapters.js` that run on every version upgrade:

1. **Remove legacy compat shim files** — `registry.js`, `errors.js`, `utils.js`, `launcher.js`, `logger.js`, `types.js` were created by an older approach using `file://` re-exports. Current approach uses `node_modules/@jackwener/opencli` symlink. Safety check: only deletes files containing `export * from 'file://`
2. **Remove legacy compat shim directories** — `browser/`, `download/`, `errors/`, `launcher/`, `logger/`, `pipeline/`, `registry/`, `types/`, `utils/` — same safety check
3. **Clean up stale `.plugins.lock.json.tmp-*` files** — left behind by crashed processes, accumulating over time (108 found on one machine)

All cleanup runs as part of the existing `fetchAdapters()` flow, triggered by version change on `npm install -g`.

## Test plan

- [x] `src/plugin.test.ts` — 72 tests passed (lock file logic unchanged)
- [x] Safety check verified: only deletes files matching `export * from 'file://` pattern
- [x] Cleanup runs after adapter copy but before manifest write — no risk to adapter state