### PR TITLE
feat: add autofix issue reporter

### DIFF
--- a/designs/self-repair-protocol.md
+++ b/designs/self-repair-protocol.md
@@ -48,8 +48,8 @@ Agent runs: opencli <site> <command> [args...]
 **Only modify the adapter file identified by `RepairContext.adapter.sourcePath`.**
 
 The diagnostic resolves the actual editable source path at runtime — it may be:
-- `clis/<site>/*.ts` — repo-local adapters (dev/source checkout)
-- `~/.opencli/clis/<site>/*.ts` — user-local adapters (npm install scenario)
+- `clis/<site>/*.js` — repo-local adapters (dev/source checkout)
+- `~/.opencli/clis/<site>/*.js` — user-local adapters (npm install scenario)
 
 The agent must use the path from the diagnostic, not guess a repo-relative path. This is critical for npm-installed users where `clis/` is not in the repo.
 
@@ -98,12 +98,14 @@ The agent should recognize non-repairable failures and stop:
 |-----------|-------------|
 | `skills/opencli-autofix/SKILL.md` (renamed from `opencli-repair`) | AutoFix skill with safety boundaries, sourcePath-based scope, 3-round limit. The primary delivery mechanism for the self-repair protocol. |
 | `skills/opencli-usage/SKILL.md` (updated) | Self-Repair section for discoverability |
+| `scripts/autofix-issue.js` | Helper script that prepares a GitHub issue draft after a verified local autofix, and creates the issue after explicit user confirmation. |
 
 ### Delivery mechanism
 
 The `opencli-autofix` skill is the portable self-repair protocol. Any AI agent — regardless of framework, provider, or working directory — can load this skill to get the full autofix workflow. It is not tied to any specific agent framework or repo location.
 
 - **No new runtime code** — the diagnostic infrastructure already exists
+- **One package-local helper script** — `scripts/autofix-issue.js` prepares or files upstream issue drafts after successful local repairs
 - **No CLAUDE.md dependency** — the skill is the protocol, not a repo-local file
 
 ---
@@ -117,7 +119,8 @@ The `opencli-autofix` skill instructs agents:
 3. Parse the RepairContext (error code, adapter source, DOM snapshot)
 4. Read and fix the adapter at `RepairContext.adapter.sourcePath`
 5. Retry the original command
-6. Max 3 repair rounds, then stop
+6. If the retry passes, prepare a GitHub issue draft for `jackwener/OpenCLI`, ask the user, then file it when approved
+7. Max 3 repair rounds, then stop
 
 ---
 
@@ -134,7 +137,7 @@ The spec/runner framework is the "asset layer" — it turns ad-hoc repairs into 
 
 ## Usage
 
-No new commands. No new scripts. The agent loads the `opencli-autofix` skill and uses opencli normally:
+No new CLI command is required. The agent loads the `opencli-autofix` skill and uses opencli normally:
 
 ```bash
 # Agent runs a command as part of its task
@@ -145,5 +148,6 @@ opencli weibo hot --limit 5 -f json
 # 2. Reads the diagnostic context
 # 3. Fixes the adapter at RepairContext.adapter.sourcePath
 # 4. Retries: opencli weibo hot --limit 5 -f json
-# 5. Continues with the task
+# 5. If retry passes, runs scripts/autofix-issue.js to prepare an upstream issue draft
+# 6. Continues with the task
 ```

--- a/scripts/autofix-issue.d.ts
+++ b/scripts/autofix-issue.d.ts
@@ -1,0 +1,53 @@
+import type { RepairContext } from '../src/diagnostic.js';
+
+export const DEFAULT_UPSTREAM_REPO: string;
+export const DIAGNOSTIC_MARKER: string;
+export const NON_REPORTABLE_ERROR_CODES: Set<string>;
+
+export interface IssueDraft {
+  ok: true;
+  action: 'prepare' | 'skip';
+  canCreate: boolean;
+  repo: string;
+  title?: string;
+  body?: string;
+  skipReason?: string;
+  metadata?: {
+    site: string;
+    command: string;
+    errorCode: string;
+    sourcePath: string;
+    version: string;
+  };
+}
+
+export interface IssueCreateResult {
+  ok: true;
+  action: 'create';
+  repo: string;
+  title: string;
+  url: string;
+}
+
+export function getPackageVersion(): string;
+export function parseDiagnosticText(input: string): RepairContext;
+export function loadRepairContext(diagnosticPath: string): RepairContext;
+export function getSkipReason(repairContext: RepairContext): string | null;
+export function buildIssueDraft(input: {
+  repairContext: RepairContext;
+  summary?: string;
+  repo?: string;
+  version?: string;
+}): IssueDraft;
+export function writeJson(filePath: string, value: unknown): void;
+export function createIssueFromDraft(
+  draft: {
+    repo: string;
+    title?: string;
+    body?: string;
+    canCreate?: boolean;
+    skipReason?: string;
+  },
+  execFile?: (...args: any[]) => any
+): IssueCreateResult;
+export function main(argv?: string[]): void;

--- a/scripts/autofix-issue.js
+++ b/scripts/autofix-issue.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+/**
+ * Prepare or create GitHub issues for successful local autofix repairs.
+ *
+ * This helper is intentionally package-local instead of a public CLI command:
+ * agents call it after a repair succeeds, but normal end users don't need it in
+ * the main command surface.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+export const DEFAULT_UPSTREAM_REPO = process.env.OPENCLI_UPSTREAM_REPO || 'jackwener/OpenCLI';
+export const DIAGNOSTIC_MARKER = '___OPENCLI_DIAGNOSTIC___';
+export const NON_REPORTABLE_ERROR_CODES = new Set([
+  'AUTH_REQUIRED',
+  'BROWSER_CONNECT',
+  'ARGUMENT',
+  'CONFIG',
+]);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(__dirname, '..');
+
+export function getPackageVersion() {
+  try {
+    return JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8')).version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+export function parseDiagnosticText(input) {
+  const markerBlock = new RegExp(`${DIAGNOSTIC_MARKER}\\n([\\s\\S]*?)\\n${DIAGNOSTIC_MARKER}`);
+  const match = input.match(markerBlock);
+  const jsonText = match ? match[1] : input.trim();
+  return JSON.parse(jsonText);
+}
+
+export function loadRepairContext(diagnosticPath) {
+  return parseDiagnosticText(readFileSync(diagnosticPath, 'utf8'));
+}
+
+export function getSkipReason(repairContext) {
+  const code = repairContext?.error?.code;
+  if (!code) return 'Missing diagnostic error code.';
+  if (NON_REPORTABLE_ERROR_CODES.has(code)) {
+    return `${code} is an environment or usage issue, not an adapter bug.`;
+  }
+  return null;
+}
+
+function codeFence(text) {
+  return ['```text', text.trim() || '(none)', '```'].join('\n');
+}
+
+function escapeInlineCode(value) {
+  return String(value ?? '').replaceAll('`', '\\`');
+}
+
+function buildIssueTitle(repairContext) {
+  const command = repairContext?.adapter?.command || 'unknown';
+  const code = repairContext?.error?.code || 'UNKNOWN';
+  return `[autofix] ${command}: ${code}`;
+}
+
+export function buildIssueDraft({
+  repairContext,
+  summary = 'Autofix repaired the adapter locally and the retry passed.',
+  repo = DEFAULT_UPSTREAM_REPO,
+  version = getPackageVersion(),
+}) {
+  const skipReason = getSkipReason(repairContext);
+  if (skipReason) {
+    return {
+      ok: true,
+      action: 'skip',
+      canCreate: false,
+      skipReason,
+      repo,
+    };
+  }
+
+  const sourcePath = repairContext?.adapter?.sourcePath || '(not available)';
+  const pageUrl = repairContext?.page?.url;
+  const body = [
+    '## Summary',
+    'OpenCLI autofix repaired this adapter locally, and the retry passed.',
+    '',
+    '## Adapter',
+    `- Site: \`${escapeInlineCode(repairContext.adapter.site)}\``,
+    `- Command: \`${escapeInlineCode(repairContext.adapter.command)}\``,
+    `- Local override path: \`${escapeInlineCode(sourcePath)}\``,
+    `- OpenCLI version: \`${escapeInlineCode(version)}\``,
+    ...(pageUrl ? [`- Failing URL: \`${escapeInlineCode(pageUrl)}\``] : []),
+    '',
+    '## Original failure',
+    `- Error code: \`${escapeInlineCode(repairContext.error.code)}\``,
+    '',
+    codeFence(repairContext.error.message),
+    '',
+    '## Local fix summary',
+    codeFence(summary),
+    '',
+    '## Diagnostic timestamp',
+    `- Captured at: \`${escapeInlineCode(repairContext.timestamp || new Date().toISOString())}\``,
+    '',
+    '_Issue draft prepared by OpenCLI autofix after a verified local repair._',
+    '',
+  ].join('\n');
+
+  return {
+    ok: true,
+    action: 'prepare',
+    canCreate: true,
+    repo,
+    title: buildIssueTitle(repairContext),
+    body,
+    metadata: {
+      site: repairContext.adapter.site,
+      command: repairContext.adapter.command,
+      errorCode: repairContext.error.code,
+      sourcePath,
+      version,
+    },
+  };
+}
+
+export function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export function createIssueFromDraft(draft, execFile = execFileSync) {
+  if (!draft?.title || !draft?.body) {
+    throw new Error('Draft is missing title or body.');
+  }
+  execFile('gh', ['auth', 'status'], { stdio: 'ignore' });
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'opencli-autofix-issue-'));
+  const bodyPath = join(tempDir, 'body.md');
+  try {
+    writeFileSync(bodyPath, draft.body, 'utf8');
+    const url = execFile(
+      'gh',
+      ['issue', 'create', '--repo', draft.repo, '--title', draft.title, '--body-file', bodyPath],
+      { encoding: 'utf8' },
+    ).trim();
+    return {
+      ok: true,
+      action: 'create',
+      repo: draft.repo,
+      title: draft.title,
+      url,
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function requireString(value, flagName) {
+  if (!value || typeof value !== 'string') {
+    throw new Error(`Missing required ${flagName}`);
+  }
+  return value;
+}
+
+function printJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const [command] = argv;
+  if (command !== 'prepare' && command !== 'create') {
+    throw new Error('Usage: autofix-issue.js <prepare|create> [options]');
+  }
+
+  const parsed = parseArgs({
+    args: argv.slice(1),
+    options: {
+      diagnostic: { type: 'string' },
+      draft: { type: 'string' },
+      summary: { type: 'string' },
+      'summary-file': { type: 'string' },
+      repo: { type: 'string', default: DEFAULT_UPSTREAM_REPO },
+      output: { type: 'string' },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (command === 'prepare') {
+    const diagnosticPath = requireString(parsed.values.diagnostic, '--diagnostic');
+    const summaryFile = parsed.values['summary-file'];
+    const summary = summaryFile
+      ? readFileSync(summaryFile, 'utf8')
+      : (parsed.values.summary || 'Autofix repaired the adapter locally and the retry passed.');
+    const draft = buildIssueDraft({
+      repairContext: loadRepairContext(diagnosticPath),
+      summary,
+      repo: parsed.values.repo,
+    });
+    if (parsed.values.output) writeJson(parsed.values.output, draft);
+    printJson(draft);
+    return;
+  }
+
+  const draftPath = requireString(parsed.values.draft, '--draft');
+  const draft = JSON.parse(readFileSync(draftPath, 'utf8'));
+  if (!draft?.canCreate) {
+    throw new Error(`Draft is not creatable: ${draft?.skipReason || 'unknown reason'}`);
+  }
+  if (parsed.values.repo) draft.repo = parsed.values.repo;
+  const result = createIssueFromDraft(draft);
+  printJson(result);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/autofix-issue.js
+++ b/scripts/autofix-issue.js
@@ -10,7 +10,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -39,7 +39,12 @@ export function parseDiagnosticText(input) {
   const markerBlock = new RegExp(`${DIAGNOSTIC_MARKER}\\n([\\s\\S]*?)\\n${DIAGNOSTIC_MARKER}`);
   const match = input.match(markerBlock);
   const jsonText = match ? match[1] : input.trim();
-  return JSON.parse(jsonText);
+  try {
+    return JSON.parse(jsonText);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse diagnostic output: ${message}`);
+  }
 }
 
 export function loadRepairContext(diagnosticPath) {
@@ -61,6 +66,12 @@ function codeFence(text) {
 
 function escapeInlineCode(value) {
   return String(value ?? '').replaceAll('`', '\\`');
+}
+
+function normalizePathForIssue(filePath) {
+  if (!filePath) return '(not available)';
+  const home = homedir();
+  return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
 }
 
 function buildIssueTitle(repairContext) {
@@ -86,7 +97,7 @@ export function buildIssueDraft({
     };
   }
 
-  const sourcePath = repairContext?.adapter?.sourcePath || '(not available)';
+  const sourcePath = normalizePathForIssue(repairContext?.adapter?.sourcePath);
   const pageUrl = repairContext?.page?.url;
   const body = [
     '## Summary',
@@ -139,7 +150,11 @@ export function createIssueFromDraft(draft, execFile = execFileSync) {
   if (!draft?.title || !draft?.body) {
     throw new Error('Draft is missing title or body.');
   }
-  execFile('gh', ['auth', 'status'], { stdio: 'ignore' });
+  try {
+    execFile('gh', ['auth', 'status'], { stdio: 'ignore' });
+  } catch {
+    throw new Error('GitHub CLI (gh) is not installed or not authenticated. Run: gh auth login');
+  }
 
   const tempDir = mkdtempSync(join(tmpdir(), 'opencli-autofix-issue-'));
   const bodyPath = join(tempDir, 'body.md');

--- a/skills/opencli-autofix/SKILL.md
+++ b/skills/opencli-autofix/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: opencli-autofix
-description: Automatically fix broken OpenCLI adapters when commands fail. Load this skill when an opencli command fails — it guides you through diagnosing the failure via OPENCLI_DIAGNOSTIC, patching the adapter, and retrying. Works with any AI agent.
-allowed-tools: Bash(opencli:*), Read, Edit, Write
+description: Automatically fix broken OpenCLI adapters when commands fail. Load this skill when an opencli command fails — it guides you through diagnosing the failure via OPENCLI_DIAGNOSTIC, patching the adapter, retrying, and preparing an upstream GitHub issue draft after a verified local fix. Works with any AI agent.
+allowed-tools: Bash(opencli:*), Bash(gh:*), Read, Edit, Write
 ---
 
 # OpenCLI AutoFix — Automatic Adapter Self-Repair
 
-When an `opencli` command fails because a website changed its DOM, API, or response schema, **automatically diagnose, fix the adapter, and retry** — don't just report the error.
+When an `opencli` command fails because a website changed its DOM, API, or response schema, **automatically diagnose, fix the adapter, retry, and prepare an upstream issue draft after the fix is verified** — don't just report the error.
 
 ## Safety Boundaries
 
@@ -186,6 +186,51 @@ opencli <site> <command> [args...]
 
 If it still fails, go back to Step 1 and collect fresh diagnostics. You have a budget of **3 repair rounds** (diagnose → fix → retry). If the same error persists after a fix, try a different approach. After 3 rounds, stop and report what was tried.
 
+## Step 6: Prepare an Upstream Issue Draft
+
+If the retry **passes**, treat that as a signal that the local adapter drifted from upstream. Prepare a GitHub issue draft so the repair can flow back to `jackwener/OpenCLI`.
+
+**Rules:**
+- **Only do this after a verified local fix** — retry must pass
+- **Ask before filing** — prepare the draft automatically, then confirm with the user before creating the issue
+- **Do not file** for `AUTH_REQUIRED`, `BROWSER_CONNECT`, CAPTCHA, or obvious local environment problems
+
+### Source checkout
+
+```bash
+node scripts/autofix-issue.js prepare \
+  --diagnostic diagnostic.json \
+  --summary "Updated selector/API path locally; retry passed." \
+  --output autofix-issue.json
+```
+
+### npm/global install
+
+```bash
+node ~/.opencli/node_modules/@jackwener/opencli/scripts/autofix-issue.js prepare \
+  --diagnostic diagnostic.json \
+  --summary "Updated selector/API path locally; retry passed." \
+  --output autofix-issue.json
+```
+
+This generates a structured draft with:
+- site
+- command
+- original error code
+- local override path
+- OpenCLI version
+- a concise fix summary
+
+Show that draft to the user. If they confirm and `gh auth status` passes, create the issue:
+
+```bash
+# Source checkout
+node scripts/autofix-issue.js create --draft autofix-issue.json
+
+# npm/global install
+node ~/.opencli/node_modules/@jackwener/opencli/scripts/autofix-issue.js create --draft autofix-issue.json
+```
+
 ## When to Stop
 
 **Hard stops (do not modify code):**
@@ -218,4 +263,9 @@ In all stop cases, clearly communicate the situation to the user rather than mak
 
 6. AI verifies: opencli zhihu hot
    → Success: returns hot topics
+
+7. AI prepares upstream issue draft:
+   → `node scripts/autofix-issue.js prepare --diagnostic diag.json --summary "...retry passed..." --output autofix-issue.json`
+
+8. AI asks the user, then files the issue if approved
 ```

--- a/src/autofix-issue.test.ts
+++ b/src/autofix-issue.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildIssueDraft,
+  createIssueFromDraft,
+  DEFAULT_UPSTREAM_REPO,
+  getSkipReason,
+  loadRepairContext,
+  parseDiagnosticText,
+} from '../scripts/autofix-issue.js';
+import type { RepairContext } from './diagnostic.js';
+
+function makeContext(overrides: Partial<RepairContext> = {}): RepairContext {
+  return {
+    error: {
+      code: 'SELECTOR',
+      message: 'Could not find element: .old-selector',
+    },
+    adapter: {
+      site: 'zhihu',
+      command: 'zhihu/hot',
+      sourcePath: '/Users/demo/.opencli/clis/zhihu/hot.js',
+    },
+    page: {
+      url: 'https://www.zhihu.com/hot',
+      snapshot: '<div />',
+      networkRequests: [],
+      consoleErrors: [],
+    },
+    timestamp: '2026-04-10T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('parseDiagnosticText', () => {
+  it('parses raw JSON diagnostic', () => {
+    const ctx = makeContext();
+    expect(parseDiagnosticText(JSON.stringify(ctx))).toEqual(ctx);
+  });
+
+  it('parses marker-delimited diagnostic output', () => {
+    const ctx = makeContext();
+    const raw = `stderr...\n___OPENCLI_DIAGNOSTIC___\n${JSON.stringify(ctx)}\n___OPENCLI_DIAGNOSTIC___\n`;
+    expect(parseDiagnosticText(raw)).toEqual(ctx);
+  });
+});
+
+describe('loadRepairContext', () => {
+  it('loads context from a diagnostic file', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-diag-'));
+    const file = path.join(dir, 'diagnostic.json');
+    const ctx = makeContext();
+    fs.writeFileSync(file, `___OPENCLI_DIAGNOSTIC___\n${JSON.stringify(ctx)}\n___OPENCLI_DIAGNOSTIC___\n`);
+
+    expect(loadRepairContext(file)).toEqual(ctx);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('getSkipReason', () => {
+  it('skips environment issues', () => {
+    expect(getSkipReason(makeContext({
+      error: { code: 'AUTH_REQUIRED', message: 'login required' },
+    }))).toContain('AUTH_REQUIRED');
+  });
+
+  it('allows repairable adapter issues', () => {
+    expect(getSkipReason(makeContext())).toBeNull();
+  });
+});
+
+describe('buildIssueDraft', () => {
+  it('builds a creatable issue draft for verified local fixes', () => {
+    const ctx = makeContext();
+    const draft = buildIssueDraft({
+      repairContext: ctx,
+      summary: 'Updated selector from .old-selector to .new-selector; retry passed.',
+      version: '1.7.0',
+    });
+
+    expect(draft.canCreate).toBe(true);
+    expect(draft.repo).toBe(DEFAULT_UPSTREAM_REPO);
+    expect(draft.title).toContain('zhihu/hot');
+    expect(draft.title).toContain('SELECTOR');
+    expect(draft.body).toContain('Updated selector from .old-selector to .new-selector; retry passed.');
+    expect(draft.body).toContain('/Users/demo/.opencli/clis/zhihu/hot.js');
+    expect(draft.body).toContain('1.7.0');
+  });
+
+  it('returns a skip draft for non-reportable failures', () => {
+    const draft = buildIssueDraft({
+      repairContext: makeContext({
+        error: { code: 'BROWSER_CONNECT', message: 'daemon not running' },
+      }),
+      summary: 'No-op',
+      version: '1.7.0',
+    });
+
+    expect(draft.canCreate).toBe(false);
+    expect(draft.action).toBe('skip');
+    expect(draft.skipReason).toContain('BROWSER_CONNECT');
+  });
+});
+
+describe('createIssueFromDraft', () => {
+  it('checks gh auth then creates the issue', () => {
+    const draft = buildIssueDraft({
+      repairContext: makeContext(),
+      summary: 'Retry passed.',
+      version: '1.7.0',
+    });
+    const exec = vi
+      .fn()
+      .mockImplementationOnce(() => '')
+      .mockImplementationOnce(() => 'https://github.com/jackwener/OpenCLI/issues/999\n');
+
+    const result = createIssueFromDraft(draft, exec);
+
+    expect(exec).toHaveBeenNthCalledWith(1, 'gh', ['auth', 'status'], { stdio: 'ignore' });
+    expect(exec.mock.calls[1][0]).toBe('gh');
+    expect(exec.mock.calls[1][1]).toContain('issue');
+    expect(result.url).toContain('/issues/999');
+  });
+});

--- a/src/autofix-issue.test.ts
+++ b/src/autofix-issue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { homedir } from 'node:os';
 import {
   buildIssueDraft,
   createIssueFromDraft,
@@ -18,7 +19,7 @@ function makeContext(overrides: Partial<RepairContext> = {}): RepairContext {
     adapter: {
       site: 'zhihu',
       command: 'zhihu/hot',
-      sourcePath: '/Users/demo/.opencli/clis/zhihu/hot.js',
+      sourcePath: `${homedir()}/.opencli/clis/zhihu/hot.js`,
     },
     page: {
       url: 'https://www.zhihu.com/hot',
@@ -41,6 +42,10 @@ describe('parseDiagnosticText', () => {
     const ctx = makeContext();
     const raw = `stderr...\n___OPENCLI_DIAGNOSTIC___\n${JSON.stringify(ctx)}\n___OPENCLI_DIAGNOSTIC___\n`;
     expect(parseDiagnosticText(raw)).toEqual(ctx);
+  });
+
+  it('wraps invalid JSON with a clearer error', () => {
+    expect(() => parseDiagnosticText('not-json')).toThrow('Failed to parse diagnostic output:');
   });
 });
 
@@ -86,7 +91,7 @@ describe('buildIssueDraft', () => {
     expect(draft.title).toContain('zhihu/hot');
     expect(draft.title).toContain('SELECTOR');
     expect(draft.body).toContain('Updated selector from .old-selector to .new-selector; retry passed.');
-    expect(draft.body).toContain('/Users/demo/.opencli/clis/zhihu/hot.js');
+    expect(draft.body).toContain('~/.opencli/clis/zhihu/hot.js');
     expect(draft.body).toContain('1.7.0');
   });
 
@@ -123,5 +128,19 @@ describe('createIssueFromDraft', () => {
     expect(exec.mock.calls[1][0]).toBe('gh');
     expect(exec.mock.calls[1][1]).toContain('issue');
     expect(result.url).toContain('/issues/999');
+  });
+
+  it('surfaces a friendly error when gh is unavailable', () => {
+    const draft = buildIssueDraft({
+      repairContext: makeContext(),
+      summary: 'Retry passed.',
+      version: '1.7.0',
+    });
+    const exec = vi.fn().mockImplementationOnce(() => {
+      throw new Error('spawn gh ENOENT');
+    });
+
+    expect(() => createIssueFromDraft(draft, exec))
+      .toThrow('GitHub CLI (gh) is not installed or not authenticated. Run: gh auth login');
   });
 });


### PR DESCRIPTION
## Summary
- add a package-local `scripts/autofix-issue.js` helper to prepare or create upstream GitHub issues after a verified local autofix
- add tests for diagnostic parsing, reportability gating, draft generation, and `gh issue create` flow
- update `opencli-autofix` skill and self-repair protocol docs to include the new post-fix issue reporter step

## Validation
- `npx vitest run src/autofix-issue.test.ts src/diagnostic.test.ts`
- `npm run typecheck`
- `node scripts/autofix-issue.js prepare --diagnostic <tmpfile> --summary \"Updated selector; retry passed.\" --output <tmpfile>`

## Notes
- default upstream repo is `jackwener/OpenCLI`
- prepare mode asks first by producing a draft; create mode requires a separate explicit call
- skips obvious environment/usage failures like `AUTH_REQUIRED` and `BROWSER_CONNECT`
