### PR TITLE
refactor(validate): switch from YAML to registry-based validation

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,8 +1,5 @@
-/** Validate CLI definitions. */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import yaml from 'js-yaml';
-import { getErrorMessage } from './errors.js';
+/** Validate CLI definitions from the registry (JS-first). */
+import { getRegistry, fullName, type CliCommand } from './registry.js';
 
 /** All recognized pipeline step names */
 const KNOWN_STEP_NAMES = new Set([
@@ -12,89 +9,121 @@ const KNOWN_STEP_NAMES = new Set([
   'intercept', 'tap', 'download',
 ]);
 
-export interface FileValidationResult {
-  path: string;
+export interface CommandValidationResult {
+  /** Display label: "site/name" or source path if available */
+  label: string;
   errors: string[];
   warnings: string[];
 }
 
 export interface ValidationReport {
   ok: boolean;
-  results: FileValidationResult[];
+  results: CommandValidationResult[];
   errors: number;
   warnings: number;
-  files: number;
+  commands: number;
 }
 
-interface ValidatedYamlCliDefinition {
-  site?: string;
-  name?: string;
-  pipeline?: unknown[];
-  columns?: unknown[];
-  args?: Record<string, unknown>;
-}
+/**
+ * Validate registered CLI commands from the in-memory registry.
+ *
+ * The `_dirs` parameter is kept for call-site compatibility but is no longer
+ * used — validation now operates on the registry populated by `discoverClis()`.
+ */
+export function validateClisWithTarget(_dirs: string[], target?: string): ValidationReport {
+  const registry = getRegistry();
+  const results: CommandValidationResult[] = [];
+  let errors = 0; let warnings = 0;
 
-import { isRecord } from './utils.js';
+  // Deduplicate: registry maps both canonical "site/name" and aliases to the same command
+  const seen = new Set<CliCommand>();
 
+  for (const [key, cmd] of registry) {
+    if (seen.has(cmd)) continue;
+    // Only validate via canonical key to avoid duplicates from aliases
+    if (key !== fullName(cmd)) continue;
+    seen.add(cmd);
 
-export function validateClisWithTarget(dirs: string[], target?: string): ValidationReport {
-  const results: FileValidationResult[] = [];
-  let errors = 0; let warnings = 0; let files = 0;
-  for (const dir of dirs) {
-    if (!fs.existsSync(dir)) continue;
-    for (const site of fs.readdirSync(dir)) {
-      if (target && site !== target && !target.startsWith(site + '/')) continue;
-      const siteDir = path.join(dir, site);
-      if (!fs.statSync(siteDir).isDirectory()) continue;
-      for (const file of fs.readdirSync(siteDir)) {
-        if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
-        if (target && target.includes('/') && !target.endsWith(file.replace(/\.(yaml|yml)$/, ''))) continue;
-        files++;
-        const filePath = path.join(siteDir, file);
-        const r = validateYamlFile(filePath);
-        results.push(r);
-        errors += r.errors.length;
-        warnings += r.warnings.length;
+    // Target filter: "site" or "site/name"
+    if (target) {
+      if (target.includes('/')) {
+        if (key !== target) continue;
+      } else {
+        if (cmd.site !== target) continue;
       }
     }
+
+    const r = validateCommand(cmd);
+    results.push(r);
+    errors += r.errors.length;
+    warnings += r.warnings.length;
   }
-  return { ok: errors === 0, results, errors, warnings, files };
+
+  return { ok: errors === 0, results, errors, warnings, commands: results.length };
 }
 
-function validateYamlFile(filePath: string): FileValidationResult {
-  const errors: string[] = []; const warnings: string[] = [];
-  try {
-    const raw = fs.readFileSync(filePath, 'utf-8');
-    const def = yaml.load(raw) as ValidatedYamlCliDefinition | null;
-    if (!isRecord(def)) { errors.push('Not a valid YAML object'); return { path: filePath, errors, warnings }; }
-    if (!def.site) errors.push('Missing "site"');
-    if (!def.name) errors.push('Missing "name"');
-    if (def.pipeline && !Array.isArray(def.pipeline)) errors.push('"pipeline" must be an array');
-    if (def.columns && !Array.isArray(def.columns)) errors.push('"columns" must be an array');
-    if (def.args && typeof def.args !== 'object') errors.push('"args" must be an object');
-    // Validate pipeline step names (catch typos like 'navaigate')
-    if (Array.isArray(def.pipeline)) {
-      for (let i = 0; i < def.pipeline.length; i++) {
-        const step = def.pipeline[i];
-        if (step && typeof step === 'object') {
-          const stepKeys = Object.keys(step);
-          for (const key of stepKeys) {
-            if (!KNOWN_STEP_NAMES.has(key)) {
-              warnings.push(`Pipeline step ${i}: unknown step name "${key}" (did you mean one of: ${[...KNOWN_STEP_NAMES].join(', ')}?)`);
-            }
+function validateCommand(cmd: CliCommand): CommandValidationResult {
+  const label = fullName(cmd);
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!cmd.description) warnings.push('Missing description');
+
+  // Browser commands should specify a domain for cookie/header context
+  if (cmd.browser && !cmd.domain) {
+    warnings.push('Browser command without "domain" — cookie/header context may not work');
+  }
+
+  // Pipeline validation: check step names for typos
+  if (Array.isArray(cmd.pipeline)) {
+    for (let i = 0; i < cmd.pipeline.length; i++) {
+      const step = cmd.pipeline[i];
+      if (step && typeof step === 'object') {
+        for (const key of Object.keys(step)) {
+          if (!KNOWN_STEP_NAMES.has(key)) {
+            warnings.push(
+              `Pipeline step ${i}: unknown step name "${key}" (did you mean one of: ${[...KNOWN_STEP_NAMES].join(', ')}?)`
+            );
           }
         }
       }
     }
-  } catch (e) { errors.push(`YAML parse error: ${getErrorMessage(e)}`); }
-  return { path: filePath, errors, warnings };
+  }
+
+  // Commands should have either func or pipeline
+  if (!cmd.func && !cmd.pipeline) {
+    errors.push('Command has neither "func" nor "pipeline" — it cannot execute');
+  }
+
+  // Arg validation
+  if (cmd.args && cmd.args.length > 0) {
+    const argNames = new Set<string>();
+    let seenNonPositional = false;
+    for (const arg of cmd.args) {
+      if (argNames.has(arg.name)) {
+        errors.push(`Duplicate arg name "${arg.name}"`);
+      }
+      argNames.add(arg.name);
+
+      if (arg.positional && seenNonPositional) {
+        warnings.push(`Positional arg "${arg.name}" appears after named args`);
+      }
+      if (!arg.positional) seenNonPositional = true;
+    }
+  }
+
+  return { label, errors, warnings };
 }
 
 export function renderValidationReport(report: ValidationReport): string {
-  const lines = [`opencli validate: ${report.ok ? 'PASS' : 'FAIL'}`, `Checked ${report.results.length} CLI(s) in ${report.files} file(s)`, `Errors: ${report.errors}  Warnings: ${report.warnings}`];
+  const lines = [
+    `opencli validate: ${report.ok ? 'PASS' : 'FAIL'}`,
+    `Checked ${report.commands} command(s)`,
+    `Errors: ${report.errors}  Warnings: ${report.warnings}`,
+  ];
   for (const r of report.results) {
     if (r.errors.length > 0 || r.warnings.length > 0) {
-      lines.push(`\n${r.path}:`);
+      lines.push(`\n${r.label}:`);
       for (const e of r.errors) lines.push(`  ❌ ${e}`);
       for (const w of r.warnings) lines.push(`  ⚠️  ${w}`);
     }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -35,6 +35,23 @@ export function validateClisWithTarget(_dirs: string[], target?: string): Valida
   const results: CommandValidationResult[] = [];
   let errors = 0; let warnings = 0;
 
+  if (registry.size === 0) {
+    const r: CommandValidationResult = {
+      label: '(registry)',
+      errors: [],
+      warnings: ['Registry is empty — no commands discovered. Did discoverClis() run?'],
+    };
+    return { ok: true, results: [r], errors: 0, warnings: 1, commands: 0 };
+  }
+
+  // Resolve alias target: if target is "site/alias", find the canonical command
+  let resolvedTarget = target;
+  if (target?.includes('/') && !registry.has(target)) {
+    // target might be an alias key — look it up
+    const aliasCmd = registry.get(target);
+    if (aliasCmd) resolvedTarget = fullName(aliasCmd);
+  }
+
   // Deduplicate: registry maps both canonical "site/name" and aliases to the same command
   const seen = new Set<CliCommand>();
 
@@ -45,11 +62,11 @@ export function validateClisWithTarget(_dirs: string[], target?: string): Valida
     seen.add(cmd);
 
     // Target filter: "site" or "site/name"
-    if (target) {
-      if (target.includes('/')) {
-        if (key !== target) continue;
+    if (resolvedTarget) {
+      if (resolvedTarget.includes('/')) {
+        if (key !== resolvedTarget) continue;
       } else {
-        if (cmd.site !== target) continue;
+        if (cmd.site !== resolvedTarget) continue;
       }
     }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,5 @@
 /** Validate CLI definitions from the registry (JS-first). */
-import { getRegistry, fullName, type CliCommand } from './registry.js';
+import { getRegistry, fullName, type CliCommand, type InternalCliCommand } from './registry.js';
 
 /** All recognized pipeline step names */
 const KNOWN_STEP_NAMES = new Set([
@@ -90,8 +90,9 @@ function validateCommand(cmd: CliCommand): CommandValidationResult {
     }
   }
 
-  // Commands should have either func or pipeline
-  if (!cmd.func && !cmd.pipeline) {
+  // Commands should have either func, pipeline, or be a lazy-loaded module
+  const internal = cmd as InternalCliCommand;
+  if (!cmd.func && !cmd.pipeline && !internal._lazy) {
     errors.push('Command has neither "func" nor "pipeline" — it cannot execute');
   }
 


### PR DESCRIPTION
## Summary
- Rewrites `opencli validate` and `opencli verify` to use the in-memory registry instead of scanning YAML files
- YAML adapter format is no longer supported — the old validator was effectively dead code
- Adds new validation checks: missing description, browser commands without domain, commands without func/pipeline, duplicate arg names, positional arg ordering, pipeline step name typos

## Context
Part of the JS-first alignment work identified in #942 review. The validate/verify commands were still scanning for `.yaml`/`.yml` files while all adapters have migrated to JavaScript.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 594 tests pass
- [ ] `opencli validate` runs against registry and reports PASS
- [ ] `opencli validate hackernews` filters by site
- [ ] `opencli validate hackernews/top` filters by command