### PR TITLE
fix(bilibili): add missing domain for following cli

### DIFF
--- a/clis/bilibili/following.js
+++ b/clis/bilibili/following.js
@@ -5,6 +5,7 @@ cli({
     site: 'bilibili',
     name: 'following',
     description: '获取 Bilibili 用户的关注列表',
+    domain: 'www.bilibili.com',
     strategy: Strategy.COOKIE,
     args: [
         { name: 'uid', positional: true, required: false, help: '目标用户 ID（默认为当前登录用户）' },


### PR DESCRIPTION
## Description

<!-- Briefly describe your changes and link to any related issues. -->
Fix  the command `opencli bilibili following` is not work

Related issue:

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
