### PR TITLE
fix: resolve alias target correctly in validate command

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -44,12 +44,11 @@ export function validateClisWithTarget(_dirs: string[], target?: string): Valida
     return { ok: true, results: [r], errors: 0, warnings: 1, commands: 0 };
   }
 
-  // Resolve alias target: if target is "site/alias", find the canonical command
+  // Resolve alias target: if target is "site/alias", resolve to canonical "site/name"
   let resolvedTarget = target;
-  if (target?.includes('/') && !registry.has(target)) {
-    // target might be an alias key — look it up
-    const aliasCmd = registry.get(target);
-    if (aliasCmd) resolvedTarget = fullName(aliasCmd);
+  if (target?.includes('/')) {
+    const cmd = registry.get(target);
+    if (cmd) resolvedTarget = fullName(cmd);
   }
 
   // Deduplicate: registry maps both canonical "site/name" and aliases to the same command


### PR DESCRIPTION
## Summary
- Fix `validate site/alias` silently checking 0 commands instead of resolving to the canonical command
- Root cause: alias resolution logic was contradictory (`!registry.has` then `registry.get` on same key), and aliases registered as `site/alias` keys bypassed the block entirely
- Simplify to always resolve via `registry.get(target)` which handles both canonical and alias keys

## Context
Found by @codex-mini0 during release review. The bug was introduced in #943.

## Test plan
- [ ] `opencli validate hupu/mention` should now correctly resolve and validate the canonical command
- [ ] `opencli validate hupu/hot` (canonical name) should continue to work
- [ ] `opencli validate hupu` (site-level) should continue to work