### PR TITLE
fix: warn when user .ts adapters are silently skipped

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -193,6 +193,10 @@ async function discoverClisFromFs(dir: string): Promise<void> {
           log.warn(`Ignoring YAML adapter ${filePath} — YAML format is no longer supported. Convert to JavaScript using cli() from '@jackwener/opencli/registry'.`);
           return;
         }
+        if (file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts')) {
+          log.warn(`Ignoring TypeScript adapter ${filePath} — .ts adapters are no longer loaded. Rename to .js or convert to JavaScript.`);
+          return;
+        }
         if (file.endsWith('.js') && !file.endsWith('.d.js') && !file.endsWith('.test.js')) {
           if (!(await isCliModule(filePath))) return;
           await import(pathToFileURL(filePath).href).catch((err) => {


### PR DESCRIPTION
## Summary
- Add warning when `.ts` adapter files are found in user's `~/.opencli/clis/` directory
- Without this, users who created custom `.ts` adapters will see their commands silently disappear after upgrading to the JS-only version
- Follows the same pattern as the existing YAML warning (line 192-194)

## Context
Found by @codex-mini0 during release review. The `.ts` cleanup in #948 only handles official adapters with `.js` counterparts. User-created `.ts` adapters have no counterpart and were silently ignored with no warning.

## Test plan
- [ ] Create a `.ts` adapter in `~/.opencli/clis/demo/hello.ts`, run `opencli list` — should see warning in stderr
- [ ] `.js` adapters should continue to load normally