### PR TITLE
fix: DEBUG_SNAPSHOT should work without DEBUG=opencli

### DIFF
--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -24,8 +24,6 @@ import {
   waitForDomStableJs,
 } from './dom-helpers.js';
 import { formatSnapshot } from '../snapshotFormatter.js';
-import { log } from '../logger.js';
-
 export abstract class BasePage implements IPage {
   protected _lastUrl: string | null = null;
   /** Cached previous snapshot hashes for incremental diff marking */
@@ -156,7 +154,7 @@ export abstract class BasePage implements IPage {
     } catch (err) {
       // Log snapshot failure for debugging, then fallback to basic accessibility tree
       if (process.env.DEBUG_SNAPSHOT) {
-        log.debug(`[snapshot] DOM snapshot failed, falling back to accessibility tree: ${(err as Error)?.message?.slice(0, 200)}`);
+        process.stderr.write(`[snapshot] DOM snapshot failed, falling back to accessibility tree: ${(err as Error)?.message?.slice(0, 200)}\n`);
       }
       return this._basicSnapshot(opts);
     }


### PR DESCRIPTION
## Summary
- `DEBUG_SNAPSHOT=1` alone no longer showed snapshot fallback diagnostics after #945 migrated to `log.debug()`
- `log.debug()` has its own gate (`DEBUG` must include `opencli`), creating a double-gate that broke the original behavior
- Fix: use `process.stderr.write` directly since the `DEBUG_SNAPSHOT` guard already controls when this fires
- Also removes the now-unused `log` import from base-page.ts

## Context
Found by @mbp-codex-pr0 during release review of #945.

## Test plan
- [ ] `DEBUG_SNAPSHOT=1 opencli browser state` should show snapshot fallback diagnostics without needing `DEBUG=opencli`