### PR TITLE
docs: fix stale .ts adapter references in skills and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Use site-specific commands such as `opencli hackernews top` or `opencli reddit h
 Use these commands when the site you need is not covered yet:
 
 - `explore` inspects the page, network activity, and capability surface.
-- `synthesize` turns exploration artifacts into evaluate-based YAML adapters.
+- `synthesize` turns exploration artifacts into evaluate-based JS adapters.
 - `generate` runs the verified generation path and returns either a usable command or a structured explanation of why completion was blocked or needs human review.
 
 ### `cascade`: auth strategy discovery
@@ -320,10 +320,10 @@ opencli plugin uninstall my-tool
 
 | Plugin | Type | Description |
 |--------|------|-------------|
-| [opencli-plugin-github-trending](https://github.com/ByteYue/opencli-plugin-github-trending) | TS | GitHub Trending repositories |
-| [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | TS | Multi-platform trending aggregator |
-| [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | TS | 稀土掘金 (Juejin) hot articles |
-| [opencli-plugin-vk](https://github.com/flobo3/opencli-plugin-vk) | TS | VK (VKontakte) wall, feed, and search |
+| [opencli-plugin-github-trending](https://github.com/ByteYue/opencli-plugin-github-trending) | JS | GitHub Trending repositories |
+| [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | JS | Multi-platform trending aggregator |
+| [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | JS | 稀土掘金 (Juejin) hot articles |
+| [opencli-plugin-vk](https://github.com/flobo3/opencli-plugin-vk) | JS | VK (VKontakte) wall, feed, and search |
 
 See [Plugins Guide](./docs/guide/plugins.md) for creating your own plugin.
 
@@ -335,7 +335,7 @@ See [Plugins Guide](./docs/guide/plugins.md) for creating your own plugin.
 
 ```bash
 opencli explore https://example.com --site mysite   # Discover APIs + capabilities
-opencli synthesize mysite                            # Generate TS adapters
+opencli synthesize mysite                            # Generate JS adapters
 opencli generate https://example.com --goal "hot"   # One-shot: explore → synthesize → register
 opencli cascade https://api.example.com/data         # Auto-probe: PUBLIC → COOKIE → HEADER
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -407,7 +407,7 @@ esac
 
 ## 插件
 
-通过社区贡献的插件扩展 OpenCLI。插件使用与内置命令相同的 YAML/TS 格式，启动时自动发现。
+通过社区贡献的插件扩展 OpenCLI。插件使用与内置命令相同的 JS 格式，启动时自动发现。
 
 ```bash
 opencli plugin install github:user/opencli-plugin-my-tool  # 安装
@@ -421,9 +421,10 @@ opencli plugin uninstall my-tool                            # 卸载
 
 | 插件 | 类型 | 描述 |
 |------|------|------|
-| [opencli-plugin-github-trending](https://github.com/ByteYue/opencli-plugin-github-trending) | YAML | GitHub Trending 仓库 |
-| [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | TS | 多平台热榜聚合 |
-| [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | YAML | 稀土掘金热门文章 |
+| [opencli-plugin-github-trending](https://github.com/ByteYue/opencli-plugin-github-trending) | JS | GitHub Trending 仓库 |
+| [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | JS | 多平台热榜聚合 |
+| [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | JS | 稀土掘金热门文章 |
+| [opencli-plugin-vk](https://github.com/flobo3/opencli-plugin-vk) | JS | VK (VKontakte) 动态、信息流和搜索 |
 
 详见 [插件指南](./docs/zh/guide/plugins.md) 了解如何创建自己的插件。
 

--- a/docs/guide/electron-app-cli.md
+++ b/docs/guide/electron-app-cli.md
@@ -48,11 +48,11 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
 
 For a new Electron adapter, implement these commands first in `clis/<app>/`:
 
-- `status.ts` — verify the app is reachable through CDP
-- `dump.ts` — inspect DOM and snapshot structure before guessing selectors
-- `read.ts` — extract the visible context you actually need
-- `send.ts` — inject text and submit through the real editor
-- `new.ts` — create a new session, tab, thread, or document
+- `status.js` — verify the app is reachable through CDP
+- `dump.js` — inspect DOM and snapshot structure before guessing selectors
+- `read.js` — extract the visible context you actually need
+- `send.js` — inject text and submit through the real editor
+- `new.js` — create a new session, tab, thread, or document
 
 This is the standard baseline because it gives you:
 - a connection check

--- a/docs/guide/electron-app-cli.md
+++ b/docs/guide/electron-app-cli.md
@@ -122,15 +122,15 @@ await page.wait(1);
 
 ## Where to put files
 
-For a TypeScript desktop adapter, the usual layout is:
+For a desktop adapter, the usual layout is:
 
 ```text
-clis/<app>/status.ts
-clis/<app>/dump.ts
-clis/<app>/read.ts
-clis/<app>/send.ts
-clis/<app>/new.ts
-clis/<app>/utils.ts
+clis/<app>/status.js
+clis/<app>/dump.js
+clis/<app>/read.js
+clis/<app>/send.js
+clis/<app>/new.js
+clis/<app>/utils.js
 ```
 
 If the app grows beyond the baseline, add higher-level commands such as:

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -25,5 +25,5 @@ features:
     details: explore 发现 API，synthesize 生成适配器，cascade 查找认证策略。为 AI 优先工作流而生。
   - icon: ⚡
     title: 双引擎架构
-    details: 同时支持 YAML 声明式数据管道和强大的浏览器运行时 TypeScript 注入。
+    details: 同时支持声明式数据管道和强大的浏览器运行时 JavaScript 注入。
 ---

--- a/skills/opencli-autofix/SKILL.md
+++ b/skills/opencli-autofix/SKILL.md
@@ -69,7 +69,7 @@ This outputs a `RepairContext` JSON between `___OPENCLI_DIAGNOSTIC___` markers i
   "adapter": {
     "site": "example",
     "command": "example/search",
-    "sourcePath": "/path/to/clis/example/search.ts",
+    "sourcePath": "/path/to/clis/example/search.js",
     "source": "// full adapter source code"
   },
   "page": {

--- a/skills/opencli-explorer/SKILL.md
+++ b/skills/opencli-explorer/SKILL.md
@@ -69,7 +69,7 @@ opencli browser network
 opencli browser network --detail 0
 # 确认数据结构：{ code: 0, data: { total: 1342, list: [{mid, uname, ...}] } }
 opencli browser eval "fetch('/x/relation/followings?vmid=137702077&pn=1&ps=5', {credentials:'include'}).then(r=>r.json())"
-# → 有数据，结论：Tier 2 Cookie，写 following.ts
+# → 有数据，结论：Tier 2 Cookie，写 following.js
 ```
 
 ---

--- a/skills/opencli-explorer/references/adapter-templates.md
+++ b/skills/opencli-explorer/references/adapter-templates.md
@@ -20,7 +20,7 @@ localStorage 有 token + Bearer header 能拿到？  → Tier 2.5: localStorage 
 ## Tier 1 — 公开 API
 
 ```typescript
-// clis/v2ex/hot.ts
+// clis/v2ex/hot.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -51,7 +51,7 @@ cli({
 ## Tier 2 — Cookie 认证（最常用）
 
 ```typescript
-// clis/zhihu/hot.ts
+// clis/zhihu/hot.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -100,7 +100,7 @@ cli({
 适用于 JWT 存 `localStorage`、API 在独立 domain（如 `api.xxx.com`）的 SaaS：
 
 ```typescript
-// clis/slock/channels.ts
+// clis/slock/channels.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError } from '@jackwener/opencli/errors';
 
@@ -155,7 +155,7 @@ cli({
 ## Tier 3 — Header 认证（Twitter GraphQL）
 
 ```typescript
-// clis/twitter/lists.ts
+// clis/twitter/lists.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError } from '@jackwener/opencli/errors';
 
@@ -207,7 +207,7 @@ cli({
 ## Tier 4 — Intercept（Pinia Store 触发）
 
 ```typescript
-// clis/xiaohongshu/notifications.ts
+// clis/xiaohongshu/notifications.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -262,7 +262,7 @@ cli({
 不依赖 Pinia，通用于任何请求有签名的场景：
 
 ```typescript
-// clis/xiaohongshu/user.ts
+// clis/xiaohongshu/user.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -333,7 +333,7 @@ func: async (page, kwargs) => {
 
 ## 同站点多 adapter：提取 utils.ts
 
-同一站点写第二个 adapter 时，如果发现要复制 auth context 解析逻辑，就应该提取 `clis/<site>/utils.ts`。
+同一站点写第二个 adapter 时，如果发现要复制 auth context 解析逻辑，就应该提取 `clis/<site>/utils.js`。
 
 **判断标准**：两个 adapter 里出现了几乎相同的这几行：
 
@@ -348,7 +348,7 @@ const server = servers.find(s => s.slug === slug) || servers[0];
 **正确做法**：提取成 helper，所有 adapter import 复用：
 
 ```typescript
-// clis/mysite/utils.ts
+// clis/mysite/utils.js
 export async function getServerContext(slug: string | null): Promise<{ token: string; server: any }> {
   const token = localStorage.getItem('mysite_access_token');
   if (!token) return { error: 'Not logged in' };
@@ -361,7 +361,7 @@ export async function getServerContext(slug: string | null): Promise<{ token: st
 ```
 
 ```typescript
-// clis/mysite/channels.ts — import 复用
+// clis/mysite/channels.js — import 复用
 import { getServerContext } from './utils.js';
 
 func: async (page, kwargs) => {
@@ -376,7 +376,7 @@ func: async (page, kwargs) => {
 }
 ```
 
-> **现有参考**：`clis/bilibili/utils.ts` 里的 `fetchJson` / `apiGet` / `getSelfUid` 是同类实践。
+> **现有参考**：`clis/bilibili/utils.js` 里的 `fetchJson` / `apiGet` / `getSelfUid` 是同类实践。
 > `clis/slock/` 三个 adapter（tasks / members / send）都有重复的 server 解析逻辑，是反例。
 
 ---

--- a/skills/opencli-explorer/references/adapter-templates.md
+++ b/skills/opencli-explorer/references/adapter-templates.md
@@ -331,7 +331,7 @@ func: async (page, kwargs) => {
 
 ---
 
-## 同站点多 adapter：提取 utils.ts
+## 同站点多 adapter：提取 utils.js
 
 同一站点写第二个 adapter 时，如果发现要复制 auth context 解析逻辑，就应该提取 `clis/<site>/utils.js`。
 

--- a/skills/opencli-explorer/references/advanced-patterns.md
+++ b/skills/opencli-explorer/references/advanced-patterns.md
@@ -133,7 +133,7 @@ opencli mysite hot -f csv > data.csv       # 确认 CSV 可导入
 
 **问题**：Twitter/X 每次部署都会更新 GraphQL queryId，硬编码很快失效。
 
-**方案**：优先从 JS bundle 动态扫描，用 `operationName`（稳定）查 `queryId`（易变）。参考 `clis/twitter/shared.ts`：
+**方案**：优先从 JS bundle 动态扫描，用 `operationName`（稳定）查 `queryId`（易变）。参考 `clis/twitter/shared.js`：
 
 ```typescript
 const resolved = await page.evaluate(`async () => {
@@ -165,7 +165,7 @@ const resolved = await page.evaluate(`async () => {
 
 **问题**：CSS class 随前端重构随时变化。
 
-**方案**：按语义元素优先级逐级降级，只在最后才用 class hint。参考 `clis/web/read.ts`：
+**方案**：按语义元素优先级逐级降级，只在最后才用 class hint。参考 `clis/web/read.js`：
 
 ```typescript
 // 优先级 1: <article>（标准语义）
@@ -198,7 +198,7 @@ if (!contentEl) {
 
 **问题**：UI 迭代频繁，同一个输入框的选择器在新版本可能完全不同。
 
-**方案**：把选择器按优先级列成有序数组，注释变更日期和观察依据。参考 `clis/xiaohongshu/publish.ts`：
+**方案**：把选择器按优先级列成有序数组，注释变更日期和观察依据。参考 `clis/xiaohongshu/publish.js`：
 
 ```typescript
 // New creator center (2026-03) uses contenteditable for the title field.
@@ -222,7 +222,7 @@ for (const sel of TITLE_SELECTORS) {
 
 **问题**：后端 API 经常在驼峰/蛇形之间切换，或加入新字段名兼容旧客户端。
 
-**方案**：用 nullish coalescing 链覆盖所有可能字段名。参考 `clis/xiaohongshu/user-helpers.ts`：
+**方案**：用 nullish coalescing 链覆盖所有可能字段名。参考 `clis/xiaohongshu/user-helpers.js`：
 
 ```typescript
 // noteId 可能是 noteId / note_id / id，都要覆盖

--- a/skills/opencli-explorer/references/record-workflow.md
+++ b/skills/opencli-explorer/references/record-workflow.md
@@ -76,7 +76,7 @@ ls  .opencli/record/<site>/candidates/          # 候选 TS
 //       })()
 ```
 
-**转换为 TS CLI**（参考 `clis/tae/add-expense.ts` 风格）：
+**转换为 JS CLI**（参考 `clis/tae/add-expense.js` 风格）：
 
 ```typescript
 import { cli, Strategy } from '@jackwener/opencli/registry';

--- a/skills/opencli-oneshot/SKILL.md
+++ b/skills/opencli-oneshot/SKILL.md
@@ -119,10 +119,10 @@ localStorage 有 token + Bearer header 能拿到？  → Tier 2.5: localStorage 
 
 ## 模板
 
-### TS — Cookie/Public（最简，`func()` 模式）
+### JS — Cookie/Public（最简，`func()` 模式）
 
-```typescript
-// clis/<site>/<name>.ts
+```javascript
+// clis/<site>/<name>.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -155,10 +155,10 @@ cli({
 });
 ```
 
-### TS — localStorage Bearer（现代 SaaS）
+### JS — localStorage Bearer（现代 SaaS）
 
-```typescript
-// clis/<site>/<name>.ts
+```javascript
+// clis/<site>/<name>.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -195,10 +195,10 @@ cli({
 });
 ```
 
-### TS — Intercept（抓包模式）
+### JS — Intercept（抓包模式）
 
-```typescript
-// clis/<site>/<name>.ts
+```javascript
+// clis/<site>/<name>.js
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 cli({
@@ -288,8 +288,8 @@ cli({
 
 <!-- keep in sync with explorer SKILL.md §Step4 -->
 > **两种开发场景**：
-> - **Repo 贡献**：文件放 `clis/<site>/<name>.ts`，`npm run build` 后自动注册
-> - **私人 adapter**（本地使用，无需提 PR）：文件放 `~/.opencli/clis/<site>/<name>.ts`，无需 build
+> - **Repo 贡献**：文件放 `clis/<site>/<name>.js`，`npm run build` 后自动注册
+> - **私人 adapter**（本地使用，无需提 PR）：文件放 `~/.opencli/clis/<site>/<name>.js`，无需 build
 
 ```bash
 # Repo 贡献：build 后直接运行


### PR DESCRIPTION
## Summary
- Fix 28 instances of `.ts` adapter file references that should be `.js` across skills and docs
- Affected files: opencli-oneshot SKILL.md, opencli-autofix SKILL.md, opencli-explorer references (adapter-templates, advanced-patterns, record-workflow), electron-app-cli guide
- These would mislead users into creating `.ts` files that won't auto-register after the JS-first migration

## Test plan
- [ ] Verify no remaining `clis/<site>/<name>.ts` patterns in skills/
- [ ] Verify docs/guide references use `.js`