### PR TITLE
feat(weibo): support for-you and following feed types

### DIFF
--- a/clis/weibo/feed.js
+++ b/clis/weibo/feed.js
@@ -1,20 +1,32 @@
 /**
- * Weibo feed — home timeline from followed users.
+ * Weibo feed — for-you or following timeline.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { getSelfUid } from './utils.js';
+const TIMELINE_ENDPOINTS = {
+    'for-you': 'unreadfriendstimeline',
+    following: 'friendstimeline',
+};
 cli({
     site: 'weibo',
     name: 'feed',
-    description: 'Weibo home timeline (posts from followed users)',
+    description: 'Fetch Weibo timeline (for-you or following)',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
     args: [
+        {
+            name: 'type',
+            default: 'for-you',
+            choices: ['for-you', 'following'],
+            help: 'Timeline type: for-you (algorithmic) or following (chronological)',
+        },
         { name: 'limit', type: 'int', default: 15, help: 'Number of posts (max 50)' },
     ],
     columns: ['author', 'text', 'reposts', 'comments', 'likes', 'time', 'url'],
     func: async (page, kwargs) => {
         const count = Math.min(kwargs.limit || 15, 50);
+        const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';
+        const endpoint = TIMELINE_ENDPOINTS[timelineType];
         await page.goto('https://weibo.com');
         await page.wait(2);
         const uid = await getSelfUid(page);
@@ -22,13 +34,14 @@ cli({
       (async () => {
         const uid = ${JSON.stringify(uid)};
         const count = ${count};
+        const endpoint = ${JSON.stringify(endpoint)};
         const listId = '10001' + uid;
         const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
 
-        const resp = await fetch('/ajax/feed/unreadfriendstimeline?list_id=' + listId + '&refresh=4&since_id=0&count=' + count, {credentials: 'include'});
-        if (!resp.ok) return {error: 'HTTP ' + resp.status};
+        const resp = await fetch('/ajax/feed/' + endpoint + '?list_id=' + listId + '&refresh=4&since_id=0&count=' + count, { credentials: 'include' });
+        if (!resp.ok) return { error: 'HTTP ' + resp.status };
         const data = await resp.json();
-        if (!data.ok) return {error: 'API error: ' + (data.msg || 'unknown')};
+        if (!data.ok) return { error: 'API error: ' + (data.msg || 'unknown') };
 
         return (data.statuses || []).slice(0, count).map(s => {
           const u = s.user || {};

--- a/docs/adapters/browser/weibo.md
+++ b/docs/adapters/browser/weibo.md
@@ -8,7 +8,7 @@
 |---------|-------------|
 | `opencli weibo hot` | 微博热搜 |
 | `opencli weibo search` | Search Weibo posts by keyword |
-| `opencli weibo feed` | 首页时间线 |
+| `opencli weibo feed` | 首页时间线（`for-you` / `following`） |
 | `opencli weibo user` | 用户信息 |
 | `opencli weibo me` | 我的信息 |
 | `opencli weibo post` | 发微博 |
@@ -25,6 +25,12 @@ opencli weibo hot -f json
 
 # Search
 opencli weibo search "OpenAI" --limit 5
+
+# Home timeline (default: for-you / 推荐流)
+opencli weibo feed --limit 10
+
+# Following-only timeline (strict chronological following feed)
+opencli weibo feed --type following --limit 10
 
 # Verbose mode
 opencli weibo hot -v


### PR DESCRIPTION
## Description

现在拉取 opencli weibo feed 是拉的是 unreadfriendstimeline 这个接口，也就是对应全部关注的消息流，这个如果好友消息读完了，拉到的就都是乱七八糟的推荐消息
<img width="1850" height="1132" alt="image" src="https://github.com/user-attachments/assets/0cdadc24-385e-4d5e-ae6b-333be1921161" />

于是我加了一个拉取 friendstimeline 的逻辑，这个是对应的最新微博的接口，这个是严格拉取关注人的微博，且按时间排序，不会拉到未关注人的微博

<img width="1730" height="528" alt="image" src="https://github.com/user-attachments/assets/2e867079-6ab4-4486-99a1-547e2c9f69f5" />

参数命名上参考了 twitter 的命名风格
- following 对应最新微博的 friendstimeline 的逻辑
- for-you 对应了全部关注的推荐逻辑

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [☑️] ✨ New feature
- [☑️] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [☑️] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

opencli weibo feed help 
<img width="1244" height="522" alt="image" src="https://github.com/user-attachments/assets/4e83c845-c9ab-4d5e-b0f1-c493e86a465a" />

opencli weibo feed 和原有逻辑一致
<img width="2026" height="778" alt="image" src="https://github.com/user-attachments/assets/1c15df4b-cf94-4bf6-86bf-57473c03e7b8" />

opencli weibo feed --type following 拉取关注人的最新微博
<img width="2022" height="648" alt="image" src="https://github.com/user-attachments/assets/fcdc7260-bff4-4f08-8501-6d1b270e650a" />




<!-- If applicable, paste CLI output or screenshots here. -->
