### PR TITLE
fix(zsxq): update topic test for group_id parameter

### DIFF
--- a/clis/zsxq/topic.test.js
+++ b/clis/zsxq/topic.test.js
@@ -11,11 +11,12 @@ describe('zsxq topic command', () => {
         const mockPage = {
             goto: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn()
-                .mockResolvedValueOnce(true)
+                .mockResolvedValueOnce(true) // ensureZsxqAuth
+                .mockResolvedValueOnce('12345') // getActiveGroupId
                 .mockResolvedValueOnce({
                 ok: true,
                 status: 404,
-                url: 'https://api.zsxq.com/v2/topics/404',
+                url: 'https://api.zsxq.com/v2/groups/12345/topics/404',
                 data: null,
             }),
         };
@@ -24,6 +25,6 @@ describe('zsxq topic command', () => {
             message: 'Topic 404 not found',
         });
         expect(mockPage.goto).toHaveBeenCalledWith('https://wx.zsxq.com');
-        expect(mockPage.evaluate).toHaveBeenCalledTimes(2);
+        expect(mockPage.evaluate).toHaveBeenCalledTimes(3);
     });
 });


### PR DESCRIPTION
## Summary
- Fix failing zsxq topic test after #963 added `group_id` parameter
- The test mock was missing the `getActiveGroupId` evaluate call, causing `browserJsonRequest` to receive `undefined`
- Added mock for `getActiveGroupId` and updated expected evaluate call count from 2 to 3

## Test plan
- [x] `npx vitest run clis/zsxq/topic.test.js` — passes
- [x] Full test suite — 194 files, 1460 passed, 2 skipped