### PR TITLE
feat(discord-app): add delete command to remove a message by ID

### DIFF
--- a/clis/discord-app/delete.js
+++ b/clis/discord-app/delete.js
@@ -1,0 +1,114 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+function buildDeleteScript(messageId) {
+    return `(async () => {
+      try {
+          const messageId = ${JSON.stringify(messageId)};
+
+          // Find the message element by its ID attribute (format: chat-messages-{channelId}-{messageId})
+          const msgEl = document.querySelector('[id$="-' + messageId + '"]');
+          if (!msgEl) {
+              return { ok: false, message: 'Could not find a message with ID ' + messageId + ' in the current channel.' };
+          }
+
+          // Find the closest list item wrapper that Discord uses for messages
+          const listItem = msgEl.closest('[id^="chat-messages-"]') || msgEl;
+
+          // Hover over the message to reveal the action toolbar
+          listItem.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+          listItem.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+          await new Promise(r => setTimeout(r, 500));
+
+          // Look for the "More" button in the message toolbar
+          // Discord shows a toolbar with buttons when hovering over a message
+          const toolbar = listItem.querySelector('[class*="toolbar"]') ||
+              document.querySelector('[id^="message-actions-"]');
+          if (!toolbar) {
+              return { ok: false, message: 'Could not find the message action toolbar. Try scrolling so the message is fully visible.' };
+          }
+
+          const buttons = Array.from(toolbar.querySelectorAll('button, [role="button"], div[class*="button"]'));
+          const moreBtn = buttons.find(btn => {
+              const label = (btn.getAttribute('aria-label') || '').toLowerCase();
+              return label === 'more' || label.includes('more');
+          });
+          if (!moreBtn) {
+              return { ok: false, message: 'Could not find the "More" button on the message toolbar.' };
+          }
+
+          moreBtn.click();
+          await new Promise(r => setTimeout(r, 500));
+
+          // Find "Delete Message" in the context menu
+          const menuItems = Array.from(document.querySelectorAll('[role="menuitem"], [id*="message-actions"]'));
+          const deleteItem = menuItems.find(item => {
+              const text = (item.textContent || '').trim().toLowerCase();
+              return text.includes('delete message') || text === 'delete';
+          });
+
+          if (!deleteItem) {
+              // Close the menu by pressing Escape
+              document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+              return { ok: false, message: 'No "Delete Message" option found. You may not have permission to delete this message.' };
+          }
+
+          deleteItem.click();
+          await new Promise(r => setTimeout(r, 500));
+
+          // Confirm deletion in the modal dialog
+          const confirmBtn = document.querySelector('[type="submit"], button[class*="colorRed"], button[class*="danger"]');
+          if (!confirmBtn) {
+              return { ok: false, message: 'Delete confirmation dialog did not appear.' };
+          }
+
+          confirmBtn.click();
+          return { ok: true, message: 'Message ' + messageId + ' deleted successfully.' };
+      } catch (e) {
+          return { ok: false, message: e.toString() };
+      }
+  })()`;
+}
+
+cli({
+    site: 'discord-app',
+    name: 'delete',
+    description: 'Delete a message by its ID in the active Discord channel',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        {
+            name: 'message_id',
+            type: 'string',
+            required: true,
+            positional: true,
+            help: 'The ID of the message to delete (visible via Developer Mode or the read command)',
+        },
+    ],
+    columns: ['status', 'message'],
+    func: async (page, kwargs) => {
+        if (!page)
+            throw new CommandExecutionError('Browser session required for discord-app delete');
+        const messageId = kwargs.message_id;
+        if (!/^\d+$/.test(messageId)) {
+            throw new CommandExecutionError(
+                `Invalid message ID: "${messageId}". A Discord message ID is a numeric snowflake (e.g. 1234567890123456789).`
+            );
+        }
+        // Wait a moment for the chat to be fully loaded
+        await page.wait(0.5);
+        const result = await page.evaluate(buildDeleteScript(messageId));
+        if (result.ok) {
+            await page.wait(1);
+        }
+        return [{
+            status: result.ok ? 'success' : 'failed',
+            message: result.message,
+        }];
+    },
+});
+
+export const __test__ = {
+    buildDeleteScript,
+};

--- a/docs/adapters/browser/binance.md
+++ b/docs/adapters/browser/binance.md
@@ -1,0 +1,19 @@
+# Binance
+
+Access **Binance** market data from the terminal via the public API (no authentication required).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli binance price SYMBOL` | Quick price check for a trading pair |
+| `opencli binance prices` | Latest prices for all trading pairs |
+| `opencli binance ticker` | 24h ticker statistics for top pairs by volume |
+| `opencli binance top` | Top trading pairs by 24h volume |
+| `opencli binance gainers` | Top gaining pairs by 24h price change |
+| `opencli binance losers` | Top losing pairs by 24h price change |
+| `opencli binance pairs` | List active trading pairs |
+| `opencli binance klines SYMBOL` | Candlestick/kline data for a trading pair |
+| `opencli binance depth SYMBOL` | Order book bid prices |
+| `opencli binance asks SYMBOL` | Order book ask prices |
+| `opencli binance trades SYMBOL` | Recent trades for a trading pair |

--- a/docs/adapters/desktop/discord.md
+++ b/docs/adapters/desktop/discord.md
@@ -26,3 +26,4 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9232"
 | `opencli discord-app servers` | List all joined servers |
 | `opencli discord-app search "query"` | Search messages (Cmd+F) |
 | `opencli discord-app members` | List online members |
+| `opencli discord-app delete MESSAGE_ID` | Delete a message by its ID |


### PR DESCRIPTION
## Summary
- Adds a new `delete` command for `discord-app` that removes a message by its snowflake ID
- Uses the UI strategy: hovers the message to reveal the toolbar, clicks "More", selects "Delete Message", and confirms the dialog
- Validates the message ID format and provides clear error messages for each failure mode

## Usage
```bash
opencli discord-app delete <message_id>
```

Message IDs can be obtained via Discord's Developer Mode (right-click → Copy Message ID) or from DOM inspection with `opencli discord-app read`.

## Test plan
- [ ] Verify `delete` command appears in `opencli discord-app --help`
- [ ] Delete own message by ID in an active channel
- [ ] Confirm error message when message ID is not found
- [ ] Confirm error message when user lacks delete permission
- [ ] Ensure `npm run build` succeeds and manifest includes the new command

🤖 Generated with [Claude Code](https://claude.com/claude-code)