### PR TITLE
fix(douban): classify tv search results correctly

### DIFF
--- a/clis/douban/utils.js
+++ b/clis/douban/utils.js
@@ -293,17 +293,42 @@ export async function loadDoubanMovieHot(page, limit) {
   `);
     return Array.isArray(data) ? data : [];
 }
+export function inferDoubanSearchResultType(searchType, item = {}) {
+    const fallbackType = String(searchType || '').trim() || 'movie';
+    if (fallbackType !== 'movie') {
+        return fallbackType;
+    }
+    const moreUrl = String(item.moreUrl || item.more_url || '').trim();
+    const isTv = moreUrl.match(/is_tv:\s*['"]?([01])['"]?/)?.[1] || '';
+    if (isTv === '1') {
+        return 'tvshow';
+    }
+    const labels = Array.isArray(item.labels)
+        ? item.labels
+            .map((label) => typeof label === 'string' ? label.trim() : String(label?.text || '').trim())
+            .filter(Boolean)
+        : [];
+    return labels.includes('剧集') ? 'tvshow' : fallbackType;
+}
 export async function searchDouban(page, type, keyword, limit) {
     const safeLimit = clampLimit(limit);
     await page.goto(`https://search.douban.com/${encodeURIComponent(type)}/subject_search?search_text=${encodeURIComponent(keyword)}`);
     await page.wait(2);
     await ensureDoubanReady(page);
+    const inferDoubanSearchResultTypeSource = inferDoubanSearchResultType.toString();
     const data = await page.evaluate(`
     (async () => {
       const type = ${JSON.stringify(type)};
+      const inferDoubanSearchResultType = ${inferDoubanSearchResultTypeSource};
       const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
       const seen = new Set();
       const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const rawItems = Array.isArray(window.__DATA__?.items) ? window.__DATA__.items : [];
+      const rawItemsById = new Map(
+        rawItems
+          .map((item) => [String(item?.id || '').trim(), item])
+          .filter(([id]) => id),
+      );
 
       for (let i = 0; i < 20; i += 1) {
         if (document.querySelector('.item-root .title-text, .item-root .title a')) break;
@@ -321,14 +346,16 @@ export async function searchDouban(page, type, keyword, limit) {
         if (!url.startsWith('http')) url = 'https://search.douban.com' + url;
         if (!url.includes('/subject/') || seen.has(url)) continue;
         seen.add(url);
+        const id = url.match(/subject\\/(\\d+)/)?.[1] || '';
+        const rawItem = rawItemsById.get(id) || {};
         const ratingText = normalize(el.querySelector('.rating_nums')?.textContent);
         const abstract = normalize(
           el.querySelector('.meta.abstract, .meta, .abstract, p')?.textContent,
         );
         results.push({
           rank: results.length + 1,
-          id: url.match(/subject\\/(\\d+)/)?.[1] || '',
-          type,
+          id,
+          type: inferDoubanSearchResultType(type, rawItem),
           title,
           rating: ratingText.includes('.') ? parseFloat(ratingText) : 0,
           abstract: abstract.slice(0, 100) + (abstract.length > 100 ? '...' : ''),

--- a/clis/douban/utils.test.js
+++ b/clis/douban/utils.test.js
@@ -1,5 +1,64 @@
+import vm from 'node:vm';
 import { describe, expect, it, vi } from 'vitest';
-import { getDoubanPhotoExtension, loadDoubanSubjectPhotos, normalizeDoubanSubjectId, promoteDoubanPhotoUrl, resolveDoubanPhotoAssetUrl, } from './utils.js';
+import { getDoubanPhotoExtension, inferDoubanSearchResultType, loadDoubanSubjectPhotos, normalizeDoubanSubjectId, promoteDoubanPhotoUrl, resolveDoubanPhotoAssetUrl, searchDouban, } from './utils.js';
+
+function createFakeNode(text = '', attrs = {}) {
+    return {
+        textContent: text,
+        getAttribute(name) {
+            return attrs[name] || '';
+        },
+    };
+}
+function createFakeSearchItem({ title, url, rating, abstract, cover }) {
+    return {
+        querySelector(selector) {
+            if (selector === '.title-text, .title a, a[title]') {
+                return createFakeNode(title, { href: url, title });
+            }
+            if (selector === '.rating_nums') {
+                return createFakeNode(rating);
+            }
+            if (selector === '.meta.abstract, .meta, .abstract, p') {
+                return createFakeNode(abstract);
+            }
+            if (selector === 'img') {
+                return createFakeNode('', { src: cover });
+            }
+            return null;
+        },
+    };
+}
+async function runSearchEvaluate(script, rawItems, domItems) {
+    const document = {
+        querySelector(selector) {
+            if (selector === '.item-root .title-text, .item-root .title a') {
+                return domItems[0]?.querySelector('.title-text, .title a, a[title]') || null;
+            }
+            return null;
+        },
+        querySelectorAll(selector) {
+            if (selector === '.item-root') {
+                return domItems;
+            }
+            return [];
+        },
+    };
+    return vm.runInNewContext(script, {
+        Map,
+        Promise,
+        document,
+        window: { __DATA__: { items: rawItems } },
+        location: {
+            href: 'https://search.douban.com/movie/subject_search?search_text=%E5%B0%84%E9%9B%95%E8%8B%B1%E9%9B%84%E4%BC%A0',
+            origin: 'https://search.douban.com',
+        },
+        setTimeout(fn) {
+            fn();
+            return 0;
+        },
+    });
+}
 describe('douban utils', () => {
     it('normalizes valid subject ids', () => {
         expect(normalizeDoubanSubjectId(' 30382501 ')).toBe('30382501');
@@ -60,5 +119,66 @@ describe('douban utils', () => {
     it('keeps image extensions when download urls contain query params', () => {
         expect(getDoubanPhotoExtension('https://img1.doubanio.com/view/photo/l/public/p2913450214.webp?foo=1')).toBe('.webp');
         expect(getDoubanPhotoExtension('https://img1.doubanio.com/view/photo/l/public/p2913450214.jpeg')).toBe('.jpeg');
+    });
+    it('maps tv series results to tvshow in searchDouban output', async () => {
+        const domItems = [
+            createFakeSearchItem({
+                title: '射雕英雄传‎ (2017)',
+                url: 'https://movie.douban.com/subject/26663086/',
+                rating: '7.9',
+                abstract: '中国大陆 / 剧情 / 武侠 / 古装 / 45分钟',
+                cover: 'https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2411844029.webp',
+            }),
+            createFakeSearchItem({
+                title: '射雕英雄传：侠之大者‎ (2025)',
+                url: 'https://movie.douban.com/subject/36289423/',
+                rating: '5.2',
+                abstract: '中国大陆 / 武侠 / 146分钟',
+                cover: 'https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2917502509.webp',
+            }),
+        ];
+        const rawItems = [
+            {
+                id: 26663086,
+                labels: [{ text: '剧集' }, { text: '可播放' }],
+                more_url: "onclick=\"moreurl(this,{from:'mv_subject_search',subject_id:'26663086',is_tv:'1'})\"",
+            },
+            {
+                id: 36289423,
+                labels: [{ text: '可播放' }],
+                more_url: "onclick=\"moreurl(this,{from:'mv_subject_search',subject_id:'36289423',is_tv:'0'})\"",
+            },
+        ];
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ blocked: false, title: '射雕英雄传 - 电影 - 豆瓣搜索', href: 'https://search.douban.com/movie/subject_search?search_text=%E5%B0%84%E9%9B%95%E8%8B%B1%E9%9B%84%E4%BC%A0' })
+                .mockImplementationOnce((script) => runSearchEvaluate(script, rawItems, domItems)),
+        };
+        await expect(searchDouban(page, 'movie', '射雕英雄传', 20)).resolves.toMatchObject([
+            { id: '26663086', type: 'tvshow', title: '射雕英雄传‎ (2017)' },
+            { id: '36289423', type: 'movie', title: '射雕英雄传：侠之大者‎ (2025)' },
+        ]);
+    });
+});
+describe('inferDoubanSearchResultType', () => {
+    it('returns tvshow for movie search results marked as TV', () => {
+        expect(inferDoubanSearchResultType('movie', {
+            moreUrl: "onclick=\"moreurl(this,{is_tv:'1'})\"",
+            labels: [{ text: '剧集' }],
+        })).toBe('tvshow');
+    });
+    it('returns movie when a movie search result has no TV signal', () => {
+        expect(inferDoubanSearchResultType('movie', {
+            moreUrl: "onclick=\"moreurl(this,{is_tv:'0'})\"",
+            labels: [{ text: '可播放' }],
+        })).toBe('movie');
+    });
+    it('preserves non-movie search types', () => {
+        expect(inferDoubanSearchResultType('book', {
+            moreUrl: '',
+            labels: [{ text: '图书' }],
+        })).toBe('book');
     });
 });


### PR DESCRIPTION
## Description

Fix `douban search` so TV series results returned from movie search are classified as `tvshow` instead of always inheriting the search type `movie`.

Related issue: #978

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Relevant verification:

```bash
node dist/src/main.js validate
# PASS

npx tsc --noEmit
# PASS

npx vitest run --project adapter clis/douban/*.test.js
# PASS
```

Note: `npm test` currently fails on an unrelated existing adapter test:

```bash
clis/zsxq/topic.test.js > zsxq topic command > maps topic detail 404 responses to NOT_FOUND before fetching comments
TypeError: Cannot read properties of undefined (reading 'status')
```
