### PR TITLE
fix: address code audit findings (C1-C4, I1, I4, I6)

### DIFF
--- a/clis/barchart/flow.js
+++ b/clis/barchart/flow.js
@@ -26,7 +26,7 @@ cli({
         const data = await page.evaluate(`
       (async () => {
         const limit = ${limit};
-        const typeFilter = '${optionType}'.toLowerCase();
+        const typeFilter = ${JSON.stringify(optionType)}.toLowerCase();
 
         // Wait for CSRF token to appear (Angular may inject it after initial render)
         let csrf = '';

--- a/clis/barchart/greeks.js
+++ b/clis/barchart/greeks.js
@@ -27,8 +27,8 @@ cli({
         await page.wait(4);
         const data = await page.evaluate(`
       (async () => {
-        const sym = '${symbol}';
-        const expDate = '${expiration}';
+        const sym = ${JSON.stringify(symbol)};
+        const expDate = ${JSON.stringify(expiration)};
         const limit = ${limit};
         const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
         const headers = { 'X-CSRF-TOKEN': csrf };

--- a/clis/barchart/options.js
+++ b/clis/barchart/options.js
@@ -26,8 +26,8 @@ cli({
         await page.wait(4);
         const data = await page.evaluate(`
       (async () => {
-        const sym = '${symbol}';
-        const type = '${optType}';
+        const sym = ${JSON.stringify(symbol)};
+        const type = ${JSON.stringify(optType)};
         const limit = ${limit};
         const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
         const headers = { 'X-CSRF-TOKEN': csrf };

--- a/clis/barchart/quote.js
+++ b/clis/barchart/quote.js
@@ -24,7 +24,7 @@ cli({
         await page.wait(4);
         const data = await page.evaluate(`
       (async () => {
-        const sym = '${symbol}';
+        const sym = ${JSON.stringify(symbol)};
         const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
 
         // Strategy 1: internal proxy API with CSRF token

--- a/clis/reuters/search.js
+++ b/clis/reuters/search.js
@@ -21,7 +21,7 @@ cli({
       (async () => {
         const count = ${count};
         const apiQuery = JSON.stringify({
-          keyword: '${kwargs.query.replace(/'/g, "\\'")}',
+          keyword: ${JSON.stringify(kwargs.query)},
           offset: 0, orderby: 'display_date:desc', size: count, website: 'reuters'
         });
         const apiUrl = 'https://www.reuters.com/pf/api/v3/content/fetch/articles-by-search-v2?query=' + encodeURIComponent(apiQuery);

--- a/clis/yahoo-finance/quote.js
+++ b/clis/yahoo-finance/quote.js
@@ -18,7 +18,7 @@ cli({
         await page.goto(`https://finance.yahoo.com/quote/${encodeURIComponent(symbol)}/`);
         const data = await page.evaluate(`
       (async () => {
-        const sym = '${symbol}';
+        const sym = ${JSON.stringify(symbol)};
 
         // Strategy 1: v8 chart API
         try {

--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -114,9 +114,10 @@ export function fetchAdapters() {
   const newOfficialFiles = new Set(walkFiles(BUILTIN_CLIS));
   const oldOfficialFiles = new Set(oldManifest?.files ?? []);
   const rawHashes = oldManifest?.hashes;
-  // Guard against corrupted manifest: if hashes is missing or wrong type,
-  // skip sync to avoid false-positive "changed" detection that deletes overrides.
-  if (oldManifest && (!rawHashes || typeof rawHashes !== 'object')) {
+  // Guard against corrupted manifest: if hashes is a non-object type (string, number,
+  // array), skip sync to avoid false-positive "changed" detection that deletes overrides.
+  // null/undefined are treated as empty (old manifests may lack the field).
+  if (rawHashes != null && (typeof rawHashes !== 'object' || Array.isArray(rawHashes))) {
     log('Warning: adapter-manifest.json has corrupted hashes — skipping sync. Will fix on next run.');
     return;
   }

--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -113,7 +113,14 @@ export function fetchAdapters() {
 
   const newOfficialFiles = new Set(walkFiles(BUILTIN_CLIS));
   const oldOfficialFiles = new Set(oldManifest?.files ?? []);
-  const oldHashes = oldManifest?.hashes ?? {};
+  const rawHashes = oldManifest?.hashes;
+  // Guard against corrupted manifest: if hashes is missing or wrong type,
+  // skip sync to avoid false-positive "changed" detection that deletes overrides.
+  if (oldManifest && (!rawHashes || typeof rawHashes !== 'object')) {
+    log('Warning: adapter-manifest.json has corrupted hashes — skipping sync. Will fix on next run.');
+    return;
+  }
+  const oldHashes = rawHashes ?? {};
   mkdirSync(USER_CLIS_DIR, { recursive: true });
 
   // 1. Compute new hashes and detect which sites have changes

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -66,6 +66,7 @@ export class CDPBridge implements IBrowserFactory {
       const ws = new WebSocket(wsUrl);
       const timeoutMs = (opts?.timeout ?? 10) * 1000;
       const timeout = setTimeout(() => {
+        this._ws = null;
         ws.close();
         reject(new Error('CDP connect timeout'));
       }, timeoutMs);

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -65,7 +65,10 @@ export class CDPBridge implements IBrowserFactory {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(wsUrl);
       const timeoutMs = (opts?.timeout ?? 10) * 1000;
-      const timeout = setTimeout(() => reject(new Error('CDP connect timeout')), timeoutMs);
+      const timeout = setTimeout(() => {
+        ws.close();
+        reject(new Error('CDP connect timeout'));
+      }, timeoutMs);
 
       ws.on('open', async () => {
         clearTimeout(timeout);
@@ -73,7 +76,11 @@ export class CDPBridge implements IBrowserFactory {
         try {
           await this.send('Page.enable');
           await this.send('Page.addScriptToEvaluateOnNewDocument', { source: generateStealthJs() });
-        } catch {}
+        } catch (err) {
+          ws.close();
+          reject(err instanceof Error ? err : new Error(String(err)));
+          return;
+        }
         resolve(new CDPPage(this));
       });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -424,9 +424,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       await page.wait(0.3);
       await page.typeText(index, text);
       // Detect autocomplete/combobox fields and wait for dropdown suggestions
+      const safeIndex = JSON.stringify(String(index));
       const isAutocomplete = await page.evaluate(`
         (() => {
-          const el = document.querySelector('[data-opencli-ref="${index}"]');
+          const el = document.querySelector('[data-opencli-ref=' + ${safeIndex} + ']');
           if (!el) return false;
           const role = el.getAttribute('role');
           const ac = el.getAttribute('aria-autocomplete');
@@ -445,9 +446,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   browser.command('select').argument('<index>', 'Element index of <select>').argument('<option>', 'Option text')
     .description('Select dropdown option')
     .action(browserAction(async (page, index, option) => {
+      const safeIdx = JSON.stringify(String(index));
       const result = await page.evaluate(`
         (function() {
-          var sel = document.querySelector('[data-opencli-ref="${index}"]');
+          var sel = document.querySelector('[data-opencli-ref=' + ${safeIdx} + ']');
           if (!sel || sel.tagName !== 'SELECT') return { error: 'Not a <select>' };
           var match = Array.from(sel.options).find(o => o.text.trim() === ${JSON.stringify(option)} || o.value === ${JSON.stringify(option)});
           if (!match) return { error: 'Option not found', available: Array.from(sel.options).map(o => o.text.trim()) };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -427,7 +427,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       const safeIndex = JSON.stringify(String(index));
       const isAutocomplete = await page.evaluate(`
         (() => {
-          const el = document.querySelector('[data-opencli-ref=' + ${safeIndex} + ']');
+          const el = document.querySelector('[data-opencli-ref="' + ${safeIndex} + '"]');
           if (!el) return false;
           const role = el.getAttribute('role');
           const ac = el.getAttribute('aria-autocomplete');
@@ -449,7 +449,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       const safeIdx = JSON.stringify(String(index));
       const result = await page.evaluate(`
         (function() {
-          var sel = document.querySelector('[data-opencli-ref=' + ${safeIdx} + ']');
+          var sel = document.querySelector('[data-opencli-ref="' + ${safeIdx} + '"]');
           if (!sel || sel.tagName !== 'SELECT') return { error: 'Not a <select>' };
           var match = Array.from(sel.options).find(o => o.text.trim() === ${JSON.stringify(option)} || o.value === ${JSON.stringify(option)});
           if (!match) return { error: 'Option not found', available: Array.from(sel.options).map(o => o.text.trim()) };

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -23,7 +23,7 @@ import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
 import { probeCDP, resolveElectronEndpoint } from './launcher.js';
 
-const _loadedModules = new Set<string>();
+const _loadedModules = new Map<string, Promise<void>>();
 
 export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: CommandArgs): CommandArgs {
   const result: CommandArgs = { ...kwargs };
@@ -79,16 +79,19 @@ async function runCommand(
   if (internal._lazy && internal._modulePath) {
     const modulePath = internal._modulePath;
     if (!_loadedModules.has(modulePath)) {
-      try {
-        await import(pathToFileURL(modulePath).href);
-        _loadedModules.add(modulePath);
-      } catch (err) {
-        throw new AdapterLoadError(
-          `Failed to load adapter module ${modulePath}: ${getErrorMessage(err)}`,
-          'Check that the adapter file exists and has no syntax errors.',
-        );
-      }
+      const loadPromise = import(pathToFileURL(modulePath).href).then(
+        () => {},
+        (err) => {
+          _loadedModules.delete(modulePath);
+          throw new AdapterLoadError(
+            `Failed to load adapter module ${modulePath}: ${getErrorMessage(err)}`,
+            'Check that the adapter file exists and has no syntax errors.',
+          );
+        },
+      );
+      _loadedModules.set(modulePath, loadPromise);
     }
+    await _loadedModules.get(modulePath);
 
     const updated = getRegistry().get(fullName(cmd));
     if (updated?.func) {
@@ -186,7 +189,10 @@ export async function executeCommand(
           try {
             await page.goto(preNavUrl);
           } catch (err) {
-            log.warn(`Pre-navigation to ${preNavUrl} failed: ${err instanceof Error ? err.message : err}`);
+            throw new CommandExecutionError(
+              `Pre-navigation to ${preNavUrl} failed: ${err instanceof Error ? err.message : err}`,
+              'Check that the site is reachable and the browser extension is running.',
+            );
           }
         }
         try {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -165,9 +165,9 @@ export function registerCommand(cmd: CliCommand): void {
   const normalized = normalizeCommand(cmd);
   const canonicalKey = fullName(normalized);
   const existing = _registry.get(canonicalKey);
-  if (existing) {
-    for (const [key, value] of _registry.entries()) {
-      if (value === existing && key !== canonicalKey) _registry.delete(key);
+  if (existing?.aliases) {
+    for (const alias of existing.aliases) {
+      _registry.delete(`${existing.site}/${alias}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes 7 issues identified in the systematic code audit:

### Security (Critical)
- **C1**: Fix `page.evaluate` injection in `browser type`/`browser select` commands and 6 adapter files (`barchart/flow`, `barchart/greeks`, `barchart/options`, `barchart/quote`, `reuters/search`, `yahoo-finance/quote`). User input was interpolated directly into JS template literals — now uses `JSON.stringify()`.
- **C2**: Close WebSocket on CDP connect timeout to prevent resource leak in `src/browser/cdp.ts`.
- **C3**: Reject CDP connect promise on `Page.enable` failure instead of silently swallowing the error.

### Reliability (Critical + Important)
- **C4**: Guard against corrupted `adapter-manifest.json` hashes to prevent false-positive override deletion in `scripts/fetch-adapters.js`.
- **I1**: Throw `CommandExecutionError` on pre-navigation failure instead of warn-and-continue in `src/execution.ts`.
- **I4**: Use `Map<string, Promise<void>>` for lazy module loading to prevent concurrent double-imports of the same adapter.

### Performance (Important)
- **I6**: Replace O(n) full-table registry alias scan with O(k) direct deletion using stored aliases array in `src/registry.ts`.

## Test plan
- [x] TypeScript typecheck passes
- [x] 34 unit tests pass (src/engine.test.ts + src/registry.test.ts)
- [ ] Manual: `opencli browser type` with special characters in selector index
- [ ] Manual: `opencli barchart flow` / `yahoo-finance quote AAPL` with quotes in args