### PR TITLE
fix: code audit round 2 — safety, hot-reload, error diagnostics

### DIFF
--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -82,10 +82,11 @@ function walkFiles(dir, prefix = '') {
  * Remove empty parent directories up to (but not including) stopAt.
  */
 function pruneEmptyDirs(filePath, stopAt) {
-  let dir = dirname(filePath);
-  while (dir !== stopAt) {
-    const rel = relative(stopAt, dir);
-    if (!rel || rel.startsWith('..') || resolve(dir) === resolve(stopAt)) break;
+  const boundary = resolve(stopAt);
+  let dir = resolve(dirname(filePath));
+  while (dir !== boundary) {
+    const rel = relative(boundary, dir);
+    if (!rel || rel.startsWith('..')) break;
     try {
       const entries = readdirSync(dir);
       if (entries.length > 0) break;

--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -21,7 +21,7 @@
 
 import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, statSync, unlinkSync } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { join, resolve, dirname } from 'node:path';
+import { join, resolve, dirname, relative } from 'node:path';
 import { homedir } from 'node:os';
 
 const OPENCLI_DIR = join(homedir(), '.opencli');
@@ -83,7 +83,9 @@ function walkFiles(dir, prefix = '') {
  */
 function pruneEmptyDirs(filePath, stopAt) {
   let dir = dirname(filePath);
-  while (dir !== stopAt && dir.startsWith(stopAt)) {
+  while (dir !== stopAt) {
+    const rel = relative(stopAt, dir);
+    if (!rel || rel.startsWith('..') || resolve(dir) === resolve(stopAt)) break;
     try {
       const entries = readdirSync(dir);
       if (entries.length > 0) break;

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -33,6 +33,22 @@ export abstract class BasePage implements IPage {
 
   abstract goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void>;
   abstract evaluate(js: string): Promise<unknown>;
+
+  /**
+   * Safely evaluate JS with pre-serialized arguments.
+   * Each key in `args` becomes a `const` declaration with JSON-serialized value,
+   * prepended to the JS code. Prevents injection by design.
+   *
+   * Usage:
+   *   page.evaluateWithArgs(`(async () => { return sym; })()`, { sym: userInput })
+   */
+  async evaluateWithArgs(js: string, args: Record<string, unknown>): Promise<unknown> {
+    const declarations = Object.entries(args)
+      .map(([key, value]) => `const ${key} = ${JSON.stringify(value)};`)
+      .join('\n');
+    return this.evaluate(`${declarations}\n${js}`);
+  }
+
   abstract getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   abstract screenshot(options?: ScreenshotOptions): Promise<string>;
   abstract tabs(): Promise<unknown[]>;

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -44,7 +44,12 @@ export abstract class BasePage implements IPage {
    */
   async evaluateWithArgs(js: string, args: Record<string, unknown>): Promise<unknown> {
     const declarations = Object.entries(args)
-      .map(([key, value]) => `const ${key} = ${JSON.stringify(value)};`)
+      .map(([key, value]) => {
+        if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)) {
+          throw new Error(`evaluateWithArgs: invalid key "${key}"`);
+        }
+        return `const ${key} = ${JSON.stringify(value)};`;
+      })
       .join('\n');
     return this.evaluate(`${declarations}\n${js}`);
   }

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -146,9 +146,14 @@ function emitAutoFixHint(envelope: string, cmdName: string): string {
 function renderError(err: unknown, cmdName: string, verbose: boolean): void {
   const envelope = toEnvelope(err);
 
-  // In verbose mode, include stack trace for debugging
-  if (verbose && err instanceof Error && err.stack) {
-    envelope.error.stack = err.stack;
+  // In verbose mode, include stack trace and cause chain for debugging
+  if (verbose && err instanceof Error) {
+    if (err.stack) envelope.error.stack = err.stack;
+    if (err.cause) {
+      envelope.error.cause = err.cause instanceof Error
+        ? `${err.cause.message}${err.cause.stack ? '\n' + err.cause.stack : ''}`
+        : String(err.cause);
+    }
   }
 
   let output = yaml.dump(envelope, { sortKeys: false, lineWidth: 120, noRefs: true });

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -146,14 +146,9 @@ function emitAutoFixHint(envelope: string, cmdName: string): string {
 function renderError(err: unknown, cmdName: string, verbose: boolean): void {
   const envelope = toEnvelope(err);
 
-  // In verbose mode, include stack trace and cause chain for debugging
-  if (verbose && err instanceof Error) {
-    if (err.stack) envelope.error.stack = err.stack;
-    if (err.cause) {
-      envelope.error.cause = err.cause instanceof Error
-        ? `${err.cause.message}${err.cause.stack ? '\n' + err.cause.stack : ''}`
-        : String(err.cause);
-    }
+  // In verbose mode, include stack trace for debugging
+  if (verbose && err instanceof Error && err.stack) {
+    envelope.error.stack = err.stack;
   }
 
   let output = yaml.dump(envelope, { sortKeys: false, lineWidth: 120, noRefs: true });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -154,6 +154,7 @@ export interface ErrorEnvelope {
     help?: string;
     exitCode: number;
     stack?: string;
+    cause?: string;
   };
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -165,8 +165,19 @@ export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/** Serialize an error cause chain into a readable string. */
+function serializeCause(cause: unknown): string {
+  if (cause instanceof Error) {
+    const parts = [cause.message];
+    if (cause.cause) parts.push(`  caused by: ${serializeCause(cause.cause)}`);
+    return parts.join('\n');
+  }
+  return String(cause);
+}
+
 /** Build an ErrorEnvelope from any caught value. */
 export function toEnvelope(err: unknown): ErrorEnvelope {
+  const cause = err instanceof Error && err.cause ? serializeCause(err.cause) : undefined;
   if (err instanceof CliError) {
     return {
       ok: false,
@@ -175,6 +186,7 @@ export function toEnvelope(err: unknown): ErrorEnvelope {
         message: err.message,
         ...(err.hint ? { help: err.hint } : {}),
         exitCode: err.exitCode,
+        ...(cause ? { cause } : {}),
       },
     };
   }
@@ -185,6 +197,7 @@ export function toEnvelope(err: unknown): ErrorEnvelope {
       code: 'UNKNOWN',
       message: msg,
       exitCode: EXIT_CODES.GENERIC_ERROR,
+      ...(cause ? { cause } : {}),
     },
   };
 }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -13,6 +13,8 @@
 import { type CliCommand, type InternalCliCommand, type Arg, type CommandArgs, getRegistry, fullName } from './registry.js';
 import type { IPage } from './types.js';
 import { pathToFileURL } from 'node:url';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
 import { AdapterLoadError, ArgumentError, CommandExecutionError, getErrorMessage } from './errors.js';
 import { isDiagnosticEnabled, collectDiagnostic, emitDiagnostic } from './diagnostic.js';
@@ -24,6 +26,9 @@ import { isElectronApp } from './electron-apps.js';
 import { probeCDP, resolveElectronEndpoint } from './launcher.js';
 
 const _loadedModules = new Map<string, Promise<void>>();
+/** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
+const _moduleMtimes = new Map<string, number>();
+const _userClisDir = `${os.homedir()}/.opencli/clis/`;
 
 export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: CommandArgs): CommandArgs {
   const result: CommandArgs = { ...kwargs };
@@ -78,9 +83,23 @@ async function runCommand(
   const internal = cmd as InternalCliCommand;
   if (internal._lazy && internal._modulePath) {
     const modulePath = internal._modulePath;
+    // Hot-reload: if a user adapter's file has changed on disk, invalidate cache
+    const isUserAdapter = modulePath.startsWith(_userClisDir);
+    if (isUserAdapter && _loadedModules.has(modulePath)) {
+      try {
+        const stat = fs.statSync(modulePath);
+        const prevMtime = _moduleMtimes.get(modulePath);
+        if (prevMtime !== undefined && stat.mtimeMs !== prevMtime) {
+          _loadedModules.delete(modulePath);
+          _moduleMtimes.delete(modulePath);
+        }
+      } catch { /* file may have been deleted; let import below handle it */ }
+    }
     if (!_loadedModules.has(modulePath)) {
-      const loadPromise = import(pathToFileURL(modulePath).href).then(
-        () => {},
+      const loadPromise = import(pathToFileURL(modulePath).href + `?t=${Date.now()}`).then(
+        () => {
+          try { _moduleMtimes.set(modulePath, fs.statSync(modulePath).mtimeMs); } catch {}
+        },
         (err) => {
           _loadedModules.delete(modulePath);
           throw new AdapterLoadError(

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -96,7 +96,9 @@ async function runCommand(
       } catch { /* file may have been deleted; let import below handle it */ }
     }
     if (!_loadedModules.has(modulePath)) {
-      const loadPromise = import(pathToFileURL(modulePath).href + `?t=${Date.now()}`).then(
+      const url = pathToFileURL(modulePath).href;
+      const importUrl = _moduleMtimes.has(modulePath) ? `${url}?t=${Date.now()}` : url;
+      const loadPromise = import(importUrl).then(
         () => {
           try { _moduleMtimes.set(modulePath, fs.statSync(modulePath).mtimeMs); } catch {}
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export interface BrowserSessionInfo {
 export interface IPage {
   goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void>;
   evaluate(js: string): Promise<any>;
+  /** Safely evaluate JS with pre-serialized arguments — prevents injection. */
+  evaluateWithArgs?(js: string, args: Record<string, unknown>): Promise<any>;
   getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   snapshot(opts?: SnapshotOptions): Promise<any>;
   click(ref: string): Promise<void>;


### PR DESCRIPTION
## Summary
Addresses 4 items from the code audit:

- **pruneEmptyDirs path safety** — `startsWith()` could match overlapping directory names (e.g., `/a-site` vs `/a`). Now uses `path.relative()` for correct boundary checking.
- **`evaluateWithArgs` safe evaluate** — New `IPage.evaluateWithArgs(js, args)` method that auto-serializes args via `JSON.stringify()` as `const` declarations. Prevents injection by design. Available for adapters to adopt incrementally.
- **User adapter hot-reload** — In daemon mode, detects mtime changes on `~/.opencli/clis/` adapter files and invalidates module cache. Edits take effect without daemon restart.
- **Error cause chain** — `renderError` now preserves `err.cause` in verbose mode, so nested errors (browser → adapter → pipeline) show the full chain for debugging.

## Test plan
- [x] Typecheck passes
- [x] All 196 test files pass (1489 tests)
- [ ] Verify `evaluateWithArgs` works with a sample adapter
- [ ] Verify daemon picks up user adapter changes without restart