### PR TITLE
docs: document undocumented environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `OPENCLI_DIAGNOSTIC` | `false` | Set to `1` to capture structured diagnostic context on failures |
+| `OPENCLI_SKIP_FETCH` | — | Set to `1` to skip adapter sync during `npm install -g` |
+| `OUTPUT` | — | Override output format: `json`, `yaml`, or `table` |
+| `DEBUG` | — | Set to `opencli` for internal debug logging |
+| `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
 ## Update
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,6 +142,10 @@ OpenCLI 不只是网站 CLI，还可以：
 | `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
 | `OPENCLI_DIAGNOSTIC` | `false` | 设为 `1` 时在失败时输出结构化诊断上下文 |
+| `OPENCLI_SKIP_FETCH` | — | 设为 `1` 跳过 `npm install -g` 时的适配器同步 |
+| `OUTPUT` | — | 覆盖输出格式：`json`、`yaml` 或 `table` |
+| `DEBUG` | — | 设为 `opencli` 开启内部调试日志 |
+| `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |
 
 ## 更新
 


### PR DESCRIPTION
## Summary
Add 4 missing environment variables to both README.md and README.zh-CN.md:

- `OPENCLI_SKIP_FETCH` — skip adapter sync during `npm install -g`
- `OUTPUT` — override output format (json/yaml/table)
- `DEBUG=opencli` — internal debug logging
- `DEBUG_SNAPSHOT` — DOM snapshot debug output

Fixes item #11 from the code audit.