### PR TITLE
feat(extension): add open-user-tab support

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -595,6 +595,20 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
       await chrome.tabs.update(target.id, { active: true });
       return { id: cmd.id, ok: true, data: { selected: target.id } };
     }
+    case 'open-user-tab': {
+      if (!cmd.url || !isSafeNavigationUrl(cmd.url)) {
+        return { id: cmd.id, ok: false, error: 'Missing or invalid URL' };
+      }
+      // Find a user window that is NOT an automation window
+      const automationWindowIds = new Set([...automationSessions.values()].map(s => s.windowId));
+      const allWindows = await chrome.windows.getAll({ windowTypes: ['normal'] });
+      const userWindow = allWindows.find(w => w.id !== undefined && !automationWindowIds.has(w.id));
+      if (!userWindow?.id) {
+        return { id: cmd.id, ok: false, error: 'No existing Chrome window found. Open a Chrome window first.' };
+      }
+      const tab = await chrome.tabs.create({ windowId: userWindow.id, url: cmd.url, active: true });
+      return { id: cmd.id, ok: true, data: { tabId: tab.id, windowId: userWindow.id } };
+    }
     default:
       return { id: cmd.id, ok: false, error: `Unknown tabs op: ${cmd.op}` };
   }

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -20,8 +20,8 @@ export interface Command {
   workspace?: string;
   /** URL to navigate to (navigate action) */
   url?: string;
-  /** Sub-operation for tabs: list, new, close, select */
-  op?: 'list' | 'new' | 'close' | 'select';
+  /** Sub-operation for tabs: list, new, close, select, open-user-tab */
+  op?: 'list' | 'new' | 'close' | 'select' | 'open-user-tab';
   /** Tab index for tabs select/close */
   index?: number;
   /** Cookie domain filter */

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -123,6 +123,11 @@ export class Page extends BasePage {
     }
   }
 
+  /** Open a URL as a new tab in the user's existing Chrome window (not the automation window). */
+  async openUserTab(url: string): Promise<void> {
+    await sendCommand('tabs', { op: 'open-user-tab', url, ...this._wsOpt() });
+  }
+
   async tabs(): Promise<unknown[]> {
     const result = await sendCommand('tabs', { op: 'list', ...this._wsOpt() });
     return Array.isArray(result) ? result : [];

--- a/src/capabilityRouting.ts
+++ b/src/capabilityRouting.ts
@@ -11,6 +11,7 @@ export const BROWSER_ONLY_STEPS = new Set([
   'evaluate',
   'intercept',
   'tap',
+  'open-user-tab',
 ]);
 
 function pipelineNeedsBrowserSession(pipeline: Record<string, unknown>[]): boolean {

--- a/src/pipeline/registry.ts
+++ b/src/pipeline/registry.ts
@@ -6,7 +6,7 @@
 import type { IPage } from '../types.js';
 
 // Import core steps
-import { stepNavigate, stepClick, stepType, stepWait, stepPress, stepSnapshot, stepEvaluate } from './steps/browser.js';
+import { stepNavigate, stepClick, stepType, stepWait, stepPress, stepSnapshot, stepEvaluate, stepOpenUserTab } from './steps/browser.js';
 import { stepFetch } from './steps/fetch.js';
 import { stepSelect, stepMap, stepFilter, stepSort, stepLimit } from './steps/transform.js';
 import { stepIntercept } from './steps/intercept.js';
@@ -60,3 +60,4 @@ registerStep('limit', stepLimit);
 registerStep('intercept', stepIntercept);
 registerStep('tap', stepTap);
 registerStep('download', stepDownload);
+registerStep('open-user-tab', stepOpenUserTab);

--- a/src/pipeline/steps/browser.ts
+++ b/src/pipeline/steps/browser.ts
@@ -74,3 +74,9 @@ export async function stepEvaluate(page: IPage | null, params: unknown, data: un
   }
   return result;
 }
+
+export async function stepOpenUserTab(page: IPage | null, params: unknown, data: unknown, args: Record<string, unknown>): Promise<unknown> {
+  const url = String(render(params, { args, data }));
+  await page!.openUserTab?.(url);
+  return data;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,8 @@ export interface IPage {
    */
   setFileInput?(files: string[], selector?: string): Promise<void>;
   closeWindow?(): Promise<void>;
+  /** Open a URL as a new tab in the user's existing Chrome window (not the automation window). */
+  openUserTab?(url: string): Promise<void>;
   /** Returns the current page URL, or null if unavailable. */
   getCurrentUrl?(): Promise<string | null>;
   /** Returns the active tab ID, or undefined if not yet resolved. */


### PR DESCRIPTION
## Description
Adds support for opening a new tab in an existing Chrome window instead of only using the dedicated automation window.

## Changes
- Add `open-user-tab` operation to the extension protocol
- Implement extension handling to find a non-automation Chrome window and open a tab there
- Add `openUserTab()` to the browser page interface and implementation
- Add `open-user-tab` as a pipeline step
- Mark the step as browser-only for capability routing

## Why
Some commands should open content for the user in their normal Chrome window without being closed by the automation window lifecycle.

## Testing
- Reload the browser extension after building
- Run a command that uses `open-user-tab`
- Verify the URL opens as a new tab in an existing Chrome window
- Verify the automation window behavior remains unchanged for normal browser actions