### PR TITLE
fix: clean up stale .yaml adapter files from older versions (#953)

### DIFF
--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -192,8 +192,8 @@ export function fetchAdapters() {
   let yamlCleaned = 0;
   for (const relPath of walkFiles(USER_CLIS_DIR)) {
     if (relPath.endsWith('.yaml') || relPath.endsWith('.yml')) {
-      const site = relPath.split('/')[0];
-      if (siteFiles.has(site)) {
+      const jsCounterpart = relPath.replace(/\.ya?ml$/, '.js');
+      if (newOfficialFiles.has(jsCounterpart)) {
         try {
           unlinkSync(join(USER_CLIS_DIR, relPath));
           pruneEmptyDirs(join(USER_CLIS_DIR, relPath), USER_CLIS_DIR);

--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -186,6 +186,24 @@ export function fetchAdapters() {
   }
   if (tsCleaned > 0) log(`Cleaned up ${tsCleaned} stale .ts adapter files`);
 
+  // 3b. Clean up stale .yaml/.yml adapter files left by older versions (pre-1.7.0)
+  // Older versions shipped adapters as YAML; current versions use .js only.
+  // These cause "Ignoring YAML adapter" warnings on every run (issue #953).
+  let yamlCleaned = 0;
+  for (const relPath of walkFiles(USER_CLIS_DIR)) {
+    if (relPath.endsWith('.yaml') || relPath.endsWith('.yml')) {
+      const site = relPath.split('/')[0];
+      if (siteFiles.has(site)) {
+        try {
+          unlinkSync(join(USER_CLIS_DIR, relPath));
+          pruneEmptyDirs(join(USER_CLIS_DIR, relPath), USER_CLIS_DIR);
+          yamlCleaned++;
+        } catch { /* ignore */ }
+      }
+    }
+  }
+  if (yamlCleaned > 0) log(`Cleaned up ${yamlCleaned} stale .yaml adapter files`);
+
   // 4. Clean up legacy compat shim files from ~/.opencli/
   // These were created by an older approach that placed re-export shims directly
   // in ~/.opencli/ (e.g., registry.js, errors.js, browser/). The current approach
@@ -256,7 +274,8 @@ export function fetchAdapters() {
   }, null, 2));
 
   log(`Synced adapters: ${cleared} local override(s) cleared` +
-    (tsCleaned > 0 ? `, ${tsCleaned} stale .ts files removed` : ''));
+    (tsCleaned > 0 ? `, ${tsCleaned} stale .ts files removed` : '') +
+    (yamlCleaned > 0 ? `, ${yamlCleaned} stale .yaml files removed` : ''));
 }
 
 function main() {


### PR DESCRIPTION
## Summary

Fixes #953 — users upgrading from v1.6.x see dozens of "Ignoring YAML adapter" warnings on every run.

- Old versions (pre-1.7.0) shipped adapters as `.yaml` files and copied them to `~/.opencli/clis/`
- v1.7.0+ migrated all adapters to `.js`, but the hash-based sync only tracks `.js` files
- Stale `.yaml` files in `~/.opencli/clis/` were never cleaned up, causing persistent warnings

Adds a cleanup step (3b) in `fetch-adapters.js` that removes `.yaml/.yml` files from user adapter directories when the corresponding site exists in the official package. Same pattern as the existing stale `.ts` cleanup (step 3).

## Test plan
- [x] 1490 unit tests pass
- [ ] Manual: create fake `.yaml` files in `~/.opencli/clis/hackernews/`, run `OPENCLI_FETCH=1 node scripts/fetch-adapters.js`, verify they are removed