### PR TITLE
Remove unused OPENCLI_SKIP_FETCH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `OPENCLI_DIAGNOSTIC` | `false` | Set to `1` to capture structured diagnostic context on failures |
-| `OPENCLI_SKIP_FETCH` | — | Set to `1` to skip adapter sync during `npm install -g` |
 | `OUTPUT` | — | Override output format: `json`, `yaml`, or `table` |
 | `DEBUG` | — | Set to `opencli` for internal debug logging |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,7 +142,6 @@ OpenCLI 不只是网站 CLI，还可以：
 | `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
 | `OPENCLI_DIAGNOSTIC` | `false` | 设为 `1` 时在失败时输出结构化诊断上下文 |
-| `OPENCLI_SKIP_FETCH` | — | 设为 `1` 跳过 `npm install -g` 时的适配器同步 |
 | `OUTPUT` | — | 覆盖输出格式：`json`、`yaml` 或 `table` |
 | `DEBUG` | — | 设为 `opencli` 开启内部调试日志 |
 | `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |

--- a/scripts/fetch-adapters.js
+++ b/scripts/fetch-adapters.js
@@ -281,9 +281,6 @@ export function fetchAdapters() {
 function main() {
   // Skip in CI
   if (process.env.CI || process.env.CONTINUOUS_INTEGRATION) return;
-  // Allow opt-out
-  if (process.env.OPENCLI_SKIP_FETCH === '1') return;
-
   // Only run on global install, explicit trigger, or first-run fallback
   const isGlobal = process.env.npm_config_global === 'true';
   const isExplicit = process.env.OPENCLI_FETCH === '1';


### PR DESCRIPTION
## Summary
- Remove `OPENCLI_SKIP_FETCH` environment variable from `fetch-adapters.js` and docs
- The adapter sync already has version caching (skips if same version) and makes no network requests, so this opt-out flag adds no value

## Changes
- `scripts/fetch-adapters.js`: removed the opt-out check
- `README.md` / `README.zh-CN.md`: removed env var table row

## Test plan
- [x] All 197 test files pass (1490 tests)