### PR TITLE
refactor: unify OPENCLI_VERBOSE and DEBUG=opencli

### DIFF
--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -214,10 +214,11 @@ export async function typeAndSendMessage(page, text) {
     return true;
 }
 /**
- * Verbose log helper — prints when OPENCLI_VERBOSE is set (via -v flag or env var).
+ * Verbose log helper — prints when OPENCLI_VERBOSE is set, with DEBUG=opencli
+ * kept as a compatibility fallback.
  */
 export function verbose(msg) {
-    if (process.env.OPENCLI_VERBOSE) {
+    if (process.env.OPENCLI_VERBOSE || process.env.DEBUG?.includes('opencli')) {
         console.error(`[opencli:boss] ${msg}`);
     }
 }

--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -214,10 +214,10 @@ export async function typeAndSendMessage(page, text) {
     return true;
 }
 /**
- * Verbose log helper — prints when OPENCLI_VERBOSE or DEBUG=opencli is set.
+ * Verbose log helper — prints when OPENCLI_VERBOSE is set (via -v flag or env var).
  */
 export function verbose(msg) {
-    if (process.env.OPENCLI_VERBOSE || process.env.DEBUG?.includes('opencli')) {
+    if (process.env.OPENCLI_VERBOSE) {
         console.error(`[opencli:boss] ${msg}`);
     }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,11 +8,7 @@
 import { styleText } from 'node:util';
 
 function isVerbose(): boolean {
-  return !!process.env.OPENCLI_VERBOSE;
-}
-
-function isDebug(): boolean {
-  return !!process.env.DEBUG?.includes('opencli');
+  return !!process.env.OPENCLI_VERBOSE || !!process.env.DEBUG?.includes('opencli');
 }
 
 export const log = {
@@ -41,18 +37,16 @@ export const log = {
     process.stderr.write(`${styleText('red', '✖')}  ${msg}\n`);
   },
 
-  /** Verbose output (only when OPENCLI_VERBOSE is set or -v flag) */
+  /** Verbose output (shown when -v flag, OPENCLI_VERBOSE, or DEBUG=opencli is set) */
   verbose(msg: string): void {
     if (isVerbose()) {
       process.stderr.write(`${styleText('dim', '[verbose]')} ${msg}\n`);
     }
   },
 
-  /** Debug output (only when DEBUG includes 'opencli') */
+  /** @deprecated Use log.verbose() instead. Kept as alias for backward compatibility. */
   debug(msg: string): void {
-    if (isDebug()) {
-      process.stderr.write(`${styleText('dim', '[debug]')} ${msg}\n`);
-    }
+    this.verbose(msg);
   },
 
   /** Step-style debug (for pipeline steps, etc.) */


### PR DESCRIPTION
## Summary

- `DEBUG=opencli` and `OPENCLI_VERBOSE` controlled separate logger methods (`log.debug()` vs `log.verbose()`), creating redundant debug mechanisms
- Unified them: `log.verbose()` now checks both `OPENCLI_VERBOSE` and `DEBUG=opencli`
- `log.debug()` becomes an alias for `log.verbose()` (no breaking change for existing callers)
- `clis/boss/utils.js` simplified to only check `OPENCLI_VERBOSE`
- `-v` flag remains the primary user-facing way to enable verbose output
- `DEBUG=opencli` still works as fallback for backward compatibility

Only 2 files changed, 6 insertions, 12 deletions.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 197 files, 1490 passed, 2 skipped
- [ ] CI passes