### PR TITLE
Fix automation window not closing on command failure

### DIFF
--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -4,6 +4,8 @@ import { executeCommand, prepareCommandArgs } from './execution.js';
 import { TimeoutError } from './errors.js';
 import { cli, Strategy } from './registry.js';
 import { withTimeoutMs } from './runtime.js';
+import * as runtime from './runtime.js';
+import * as capRouting from './capabilityRouting.js';
 
 describe('executeCommand — non-browser timeout', () => {
   it('applies timeoutSeconds to non-browser commands', async () => {
@@ -44,6 +46,33 @@ describe('executeCommand — non-browser timeout', () => {
     await expect(
       withTimeoutMs(executeCommand(cmd, {}), 50, 'sentinel timeout'),
     ).rejects.toThrow('sentinel timeout');
+  });
+
+  it('calls closeWindow on browser command failure', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+
+    // Mock shouldUseBrowserSession to return true
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+
+    // Mock browserSession to invoke the callback with our mock page
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => {
+      return fn(mockPage);
+    });
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-close-on-error',
+      description: 'test closeWindow on failure',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      func: async () => { throw new Error('adapter failure'); },
+    });
+
+    await expect(executeCommand(cmd, {})).rejects.toThrow('adapter failure');
+    expect(closeWindow).toHaveBeenCalledTimes(1);
+
+    vi.restoreAllMocks();
   });
 
   it('does not re-run custom validation when args are already prepared', async () => {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -226,13 +226,17 @@ export async function executeCommand(
           await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
-          // Collect diagnostic while page is still alive (before browserSession closes it).
+          // Collect diagnostic while page is still alive (before closing the window).
           if (isDiagnosticEnabled()) {
             const internal = cmd as InternalCliCommand;
             const ctx = await collectDiagnostic(err, internal, page);
             emitDiagnostic(ctx);
             diagnosticEmitted = true;
           }
+          // Close the automation window on failure too — without this, the window
+          // lingers until the extension's idle timer fires (unreliable on Windows
+          // where MV3 service workers may be suspended before setTimeout triggers).
+          await page.closeWindow?.().catch(() => {});
           throw err;
         }
       }, { workspace: `site:${cmd.site}`, cdpEndpoint });


### PR DESCRIPTION
## Summary
- Add `page.closeWindow()` to the error path in `executeCommand()`, after diagnostic collection but before rethrowing
- Previously, only the success path closed the automation window; failures relied on the extension's 30s idle timer (unreliable on Windows due to MV3 service worker suspension)

## Root cause
The automation window lifecycle was only managed on the success path (`execution.ts:226`). On failure, the window was orphaned and depended on `setTimeout` in the extension's service worker — which Chrome can suspend before the callback fires, especially on Windows.

## Changes
- `src/execution.ts`: Add `closeWindow` call in catch block (after diagnostic, before throw)
- `src/execution.test.ts`: Add regression test verifying `closeWindow` is called on browser command failure

## Test plan
- [x] New test: `calls closeWindow on browser command failure` passes
- [x] All 197 test files pass (1491 tests)