### PR TITLE
Feat/douban book subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 !extension/dist/
 *.tsbuildinfo
 .opencli/
+.worktrees/
 .mcp.json
 *.log
 .DS_Store

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4144,12 +4144,13 @@
     ],
     "type": "js",
     "modulePath": "douban/search.js",
-    "sourceFile": "douban/search.js"
+    "sourceFile": "douban/search.js",
+    "navigateBefore": false
   },
   {
     "site": "douban",
     "name": "subject",
-    "description": "获取电影详情",
+    "description": "获取豆瓣条目详情",
     "domain": "movie.douban.com",
     "strategy": "cookie",
     "browser": true,
@@ -4159,13 +4160,37 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "电影 ID"
+        "help": "豆瓣条目 ID"
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "default": "movie",
+        "required": false,
+        "help": "条目类型（movie=电影, book=图书）",
+        "choices": [
+          "movie",
+          "book"
+        ]
       }
     ],
     "columns": [
       "id",
+      "type",
       "title",
+      "subtitle",
       "originalTitle",
+      "authors",
+      "translators",
+      "publisher",
+      "publishDate",
+      "publishYear",
+      "pageCount",
+      "binding",
+      "price",
+      "series",
+      "isbn10",
+      "isbn13",
       "year",
       "rating",
       "ratingCount",
@@ -4179,7 +4204,8 @@
     ],
     "type": "js",
     "modulePath": "douban/subject.js",
-    "sourceFile": "douban/subject.js"
+    "sourceFile": "douban/subject.js",
+    "navigateBefore": false
   },
   {
     "site": "douban",

--- a/clis/douban/search.js
+++ b/clis/douban/search.js
@@ -6,6 +6,7 @@ cli({
     description: '搜索豆瓣电影、图书或音乐',
     domain: 'search.douban.com',
     strategy: Strategy.COOKIE,
+    navigateBefore: false,
     args: [
         { name: 'type', default: 'movie', choices: ['movie', 'book', 'music'], help: '搜索类型（movie=电影, book=图书, music=音乐）' },
         { name: 'keyword', required: true, positional: true, help: '搜索关键词' },

--- a/clis/douban/search.test.js
+++ b/clis/douban/search.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+
+describe('douban search command', () => {
+    it('skips default pre-navigation because the adapter handles navigation itself', () => {
+        const command = getRegistry().get('douban/search');
+        expect(command).toBeDefined();
+        expect(command?.navigateBefore).toBe(false);
+    });
+});

--- a/clis/douban/subject.js
+++ b/clis/douban/subject.js
@@ -1,18 +1,35 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { loadDoubanSubjectDetail } from './utils.js';
+
 cli({
     site: 'douban',
     name: 'subject',
-    description: '获取电影详情',
+    description: '获取豆瓣条目详情',
     domain: 'movie.douban.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    navigateBefore: false,
     args: [
-        { name: 'id', required: true, positional: true, help: '电影 ID' },
+        { name: 'id', required: true, positional: true, help: '豆瓣条目 ID' },
+        { name: 'type', default: 'movie', choices: ['movie', 'book'], help: '条目类型（movie=电影, book=图书）' },
     ],
     columns: [
         'id',
+        'type',
         'title',
+        'subtitle',
         'originalTitle',
+        'authors',
+        'translators',
+        'publisher',
+        'publishDate',
+        'publishYear',
+        'pageCount',
+        'binding',
+        'price',
+        'series',
+        'isbn10',
+        'isbn13',
         'year',
         'rating',
         'ratingCount',
@@ -24,95 +41,5 @@ cli({
         'summary',
         'url',
     ],
-    pipeline: [
-        { navigate: 'https://movie.douban.com/subject/${{ args.id }}' },
-        { evaluate: `(async () => {
-  const id = '\${{ args.id }}';
-
-  // Wait for page to load
-  await new Promise(r => setTimeout(r, 2000));
-
-  // Extract title - v:itemreviewed contains "中文名 OriginalName"
-  const titleEl = document.querySelector('span[property="v:itemreviewed"]');
-  const fullTitle = titleEl?.textContent?.trim() || '';
-
-  // Split title and originalTitle
-  // Douban format: "中文名 OriginalName" - split by first space that separates CJK from non-CJK
-  let title = fullTitle;
-  let originalTitle = '';
-  const titleMatch = fullTitle.match(/^([\\u4e00-\\u9fff\\u3000-\\u303f\\uff00-\\uffef]+(?:\\s*[\\u4e00-\\u9fff\\u3000-\\u303f\\uff00-\\uffef·：:！？]+)*)\\s+(.+)$/);
-  if (titleMatch) {
-    title = titleMatch[1].trim();
-    originalTitle = titleMatch[2].trim();
-  }
-
-  // Extract year
-  const yearEl = document.querySelector('.year');
-  const year = yearEl?.textContent?.trim().replace(/[()（）]/g, '') || '';
-
-  // Extract rating
-  const ratingEl = document.querySelector('strong[property="v:average"]');
-  const rating = parseFloat(ratingEl?.textContent || '0');
-
-  // Extract rating count
-  const ratingCountEl = document.querySelector('span[property="v:votes"]');
-  const ratingCount = parseInt(ratingCountEl?.textContent || '0', 10);
-
-  // Extract genres
-  const genreEls = document.querySelectorAll('span[property="v:genre"]');
-  const genres = Array.from(genreEls).map(el => el.textContent?.trim()).filter(Boolean).join(',');
-
-  // Extract directors
-  const directorEls = document.querySelectorAll('a[rel="v:directedBy"]');
-  const directors = Array.from(directorEls).map(el => el.textContent?.trim()).filter(Boolean).join(',');
-
-  // Extract casts
-  const castEls = document.querySelectorAll('a[rel="v:starring"]');
-  const casts = Array.from(castEls).slice(0, 5).map(el => el.textContent?.trim()).filter(Boolean);
-
-  // Extract info section for country and duration
-  const infoEl = document.querySelector('#info');
-  const infoText = infoEl?.textContent || '';
-
-  // Extract country/region from #info as list
-  let country = [];
-  const countryMatch = infoText.match(/制片国家\\/地区:\\s*([^\\n]+)/);
-  if (countryMatch) {
-    country = countryMatch[1].trim().split(/\\s*\\/\\s*/).filter(Boolean);
-  }
-
-  // Extract duration from #info as pure number in min
-  const durationEl = document.querySelector('span[property="v:runtime"]');
-  let durationRaw = durationEl?.textContent?.trim() || '';
-  if (!durationRaw) {
-    const durationMatch = infoText.match(/片长:\\s*([^\\n]+)/);
-    if (durationMatch) {
-      durationRaw = durationMatch[1].trim();
-    }
-  }
-  const durationNumMatch = durationRaw.match(/(\\d+)/);
-  const duration = durationNumMatch ? parseInt(durationNumMatch[1], 10) : null;
-
-  // Extract summary
-  const summaryEl = document.querySelector('span[property="v:summary"]');
-  const summary = summaryEl?.textContent?.trim() || '';
-
-  return [{
-    id,
-    title,
-    originalTitle,
-    year,
-    rating,
-    ratingCount,
-    genres,
-    directors,
-    casts,
-    country,
-    duration,
-    summary: summary.substring(0, 200),
-    url: \`https://movie.douban.com/subject/\${id}\`
-  }];
-})()
-` },
-    ],
+    func: async (page, args) => [await loadDoubanSubjectDetail(page, args.id, args.type)],
 });

--- a/clis/douban/subject.test.js
+++ b/clis/douban/subject.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './subject.js';
+
+describe('douban subject command', () => {
+    it('skips default pre-navigation because the adapter handles subject navigation itself', () => {
+        const command = getRegistry().get('douban/subject');
+        expect(command).toBeDefined();
+        expect(command?.navigateBefore).toBe(false);
+    });
+});

--- a/clis/douban/utils.js
+++ b/clis/douban/utils.js
@@ -7,6 +7,79 @@ const DOUBAN_PHOTO_PAGE_SIZE = 30;
 const MAX_DOUBAN_PHOTOS = 500;
 const clampLimit = (limit) => clamp(limit || 20, 1, 50);
 const clampPhotoLimit = (limit) => clamp(limit || 120, 1, MAX_DOUBAN_PHOTOS);
+const DOUBAN_SEARCH_READY_SELECTOR = '.item-root .title-text, .item-root .title a, .result-list .result-item h3 a';
+const normalizeText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+function firstNonEmpty(values) {
+    for (const value of values) {
+        const normalized = normalizeText(value);
+        if (normalized)
+            return normalized;
+    }
+    return '';
+}
+function splitDoubanPeople(value) {
+    return normalizeText(value)
+        .split(/\s*\/\s*/)
+        .map((entry) => normalizeText(entry))
+        .filter(Boolean);
+}
+function parseDoubanBookInfoText(infoText) {
+    const lines = String(infoText || '')
+        .replace(/\r/g, '\n')
+        .split('\n')
+        .map((line) => normalizeText(line))
+        .filter(Boolean);
+    const map = {};
+    for (const line of lines) {
+        const match = line.match(/^([^:：]+)\s*[:：]\s*(.*)$/);
+        if (!match)
+            continue;
+        const label = normalizeText(match[1]);
+        const value = normalizeText(match[2]);
+        if (!label)
+            continue;
+        map[label] = value;
+    }
+    return map;
+}
+function parseDoubanRating(value) {
+    const normalized = normalizeText(value);
+    if (!normalized)
+        return 0;
+    const parsed = Number.parseFloat(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+function parseDoubanCount(value) {
+    const normalized = normalizeText(value).replace(/[^\d]/g, '');
+    if (!normalized)
+        return 0;
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+function parseDoubanPageCount(value) {
+    const match = normalizeText(value).match(/(\d+)/);
+    if (!match)
+        return null;
+    const parsed = Number.parseInt(match[1], 10);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+function extractDoubanPublishYear(value) {
+    const match = normalizeText(value).match(/\b(19|20)\d{2}\b/);
+    return match?.[0] || '';
+}
+function splitDoubanTitle(fullTitle) {
+    const normalized = normalizeText(fullTitle);
+    if (!normalized)
+        return { title: '', originalTitle: '' };
+    const match = normalized.match(/^([\u4e00-\u9fff\u3000-\u303f\uff00-\uffef]+(?:\s*[\u4e00-\u9fff\u3000-\u303f\uff00-\uffef·：:！？]+)*)\s+(.+)$/);
+    if (!match) {
+        return { title: normalized, originalTitle: '' };
+    }
+    return {
+        title: normalizeText(match[1]),
+        originalTitle: normalizeText(match[2]),
+    };
+}
 async function ensureDoubanReady(page) {
     const state = await page.evaluate(`
     (() => {
@@ -19,6 +92,34 @@ async function ensureDoubanReady(page) {
     if (state?.blocked) {
         throw new CliError('AUTH_REQUIRED', 'Douban requires a logged-in browser session before these commands can load data.', 'Please sign in to douban.com in the browser that opencli reuses, then rerun the command.');
     }
+}
+function isDetachedPageError(error) {
+    const message = error instanceof Error ? error.message : String(error || '');
+    return /Detached while handling command|Debugger is not attached to the tab|Target closed|No tab with id/i.test(message);
+}
+async function withDetachedRetry(task, options = {}) {
+    const attempts = Math.max(1, options.attempts || 2);
+    let lastError;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        try {
+            return await task();
+        }
+        catch (error) {
+            lastError = error;
+            if (attempt >= attempts - 1 || !isDetachedPageError(error)) {
+                throw error;
+            }
+        }
+    }
+    throw lastError;
+}
+function buildDoubanSearchUrl(type, keyword) {
+    const url = new URL(`https://search.douban.com/${encodeURIComponent(type)}/subject_search`);
+    url.searchParams.set('search_text', String(keyword || ''));
+    if (String(type || '').trim() === 'book') {
+        url.searchParams.set('cat', '1001');
+    }
+    return url.toString();
 }
 export function normalizeDoubanSubjectId(subjectId) {
     const normalized = String(subjectId || '').trim();
@@ -67,6 +168,144 @@ export function getDoubanPhotoExtension(url) {
         const ext = normalized.match(/\.(jpe?g|png|gif|webp|avif|bmp)(?:$|[?#])/i)?.[0];
         return ext ? ext.replace(/[?#].*$/, '') : '.jpg';
     }
+}
+export function normalizeDoubanBookSubject(raw) {
+    const info = parseDoubanBookInfoText(raw?.infoText);
+    const title = firstNonEmpty([raw?.title]);
+    const subtitle = firstNonEmpty([raw?.subtitle, info['副标题']]);
+    const originalTitle = firstNonEmpty([raw?.originalTitle, info['原作名']]);
+    const authors = splitDoubanPeople(firstNonEmpty([info['作者']]));
+    const translators = splitDoubanPeople(firstNonEmpty([info['译者']]));
+    const publisher = firstNonEmpty([info['出版社'], info['出品方']]);
+    const publishDate = firstNonEmpty([info['出版年']]);
+    const publishYear = extractDoubanPublishYear(publishDate);
+    const pageCount = parseDoubanPageCount(info['页数']);
+    const binding = firstNonEmpty([info['装帧']]);
+    const price = firstNonEmpty([info['定价']]);
+    const series = firstNonEmpty([info['丛书']]);
+    const isbnRaw = firstNonEmpty([info['ISBN']]).replace(/[^\dxX]/g, '');
+    const isbn10 = isbnRaw.length === 10 ? isbnRaw : '';
+    const isbn13 = isbnRaw.length === 13 ? isbnRaw : '';
+    return {
+        id: normalizeDoubanSubjectId(raw?.id),
+        type: 'book',
+        title,
+        subtitle,
+        originalTitle,
+        authors,
+        translators,
+        publisher,
+        publishDate,
+        publishYear,
+        pageCount,
+        binding,
+        price,
+        series,
+        isbn10,
+        isbn13,
+        rating: parseDoubanRating(raw?.rating),
+        ratingCount: parseDoubanCount(raw?.ratingCount),
+        summary: normalizeText(raw?.summary),
+        cover: firstNonEmpty([raw?.cover]),
+        url: firstNonEmpty([raw?.url]),
+    };
+}
+async function loadDoubanMovieSubject(page, subjectId) {
+    const normalizedId = normalizeDoubanSubjectId(subjectId);
+    const data = await withDetachedRetry(async () => {
+        await page.goto(`https://movie.douban.com/subject/${normalizedId}/`, { waitUntil: 'load', settleMs: 1500 });
+        await ensureDoubanReady(page);
+        await page.wait({ selector: 'span[property="v:itemreviewed"], #info', timeout: 8 }).catch(() => { });
+        return page.evaluate(`
+    (() => {
+      const id = ${JSON.stringify(normalizedId)};
+      const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+      const { title, originalTitle } = (${splitDoubanTitle.toString()})(normalize(document.querySelector('span[property="v:itemreviewed"]')?.textContent || ''));
+      const year = normalize(document.querySelector('.year')?.textContent).replace(/[()（）]/g, '');
+      const rating = parseFloat(normalize(document.querySelector('strong[property="v:average"]')?.textContent || '0')) || 0;
+      const ratingCount = parseInt(normalize(document.querySelector('span[property="v:votes"]')?.textContent || '0'), 10) || 0;
+      const genres = Array.from(document.querySelectorAll('span[property="v:genre"]'))
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean)
+        .join(',');
+      const directors = Array.from(document.querySelectorAll('a[rel="v:directedBy"]'))
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean)
+        .join(',');
+      const casts = Array.from(document.querySelectorAll('a[rel="v:starring"]'))
+        .slice(0, 5)
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean);
+      const infoText = document.querySelector('#info')?.textContent || '';
+      let country = [];
+      const countryMatch = infoText.match(/制片国家\\/地区:\\s*([^\\n]+)/);
+      if (countryMatch) {
+        country = countryMatch[1].trim().split(/\\s*\\/\\s*/).filter(Boolean);
+      }
+      const durationRaw = normalize(document.querySelector('span[property="v:runtime"]')?.textContent || '');
+      const durationMatch = durationRaw.match(/(\\d+)/);
+      const summary = normalize(document.querySelector('span[property="v:summary"]')?.textContent || '');
+      return {
+        id,
+        type: 'movie',
+        title,
+        originalTitle,
+        year,
+        rating,
+        ratingCount,
+        genres,
+        directors,
+        casts,
+        country,
+        duration: durationMatch ? parseInt(durationMatch[1], 10) : null,
+        summary: summary.slice(0, 200),
+        url: 'https://movie.douban.com/subject/' + id + '/',
+      };
+    })()
+  `);
+    });
+    return data;
+}
+async function loadDoubanBookSubject(page, subjectId) {
+    const normalizedId = normalizeDoubanSubjectId(subjectId);
+    const data = await withDetachedRetry(async () => {
+        await page.goto(`https://book.douban.com/subject/${normalizedId}/`, { waitUntil: 'load', settleMs: 1500 });
+        await ensureDoubanReady(page);
+        await page.wait({ selector: 'h1 span, #info', timeout: 8 }).catch(() => { });
+        return page.evaluate(`
+    (() => {
+      const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+      const pickSummary = () => {
+        const nodes = Array.from(document.querySelectorAll('#link-report .intro, .related_info .intro'));
+        for (let i = nodes.length - 1; i >= 0; i -= 1) {
+          const text = normalize(nodes[i]?.textContent);
+          if (text) return text;
+        }
+        return '';
+      };
+      return {
+        id: ${JSON.stringify(normalizedId)},
+        title: normalize(document.querySelector('h1 span')?.textContent || document.querySelector('h1')?.textContent || ''),
+        subtitle: '',
+        originalTitle: '',
+        infoText: document.querySelector('#info')?.innerText || document.querySelector('#info')?.textContent || '',
+        rating: normalize(document.querySelector('strong.rating_num, strong[property="v:average"]')?.textContent || ''),
+        ratingCount: normalize(document.querySelector('a.rating_people > span, span[property="v:votes"]')?.textContent || ''),
+        summary: pickSummary(),
+        cover: document.querySelector('#mainpic img')?.getAttribute('src') || '',
+        url: location.href,
+      };
+    })()
+  `);
+    });
+    return normalizeDoubanBookSubject(data);
+}
+export async function loadDoubanSubjectDetail(page, subjectId, subjectType = 'movie') {
+    const type = String(subjectType || 'movie').trim() === 'book' ? 'book' : 'movie';
+    if (type === 'book') {
+        return loadDoubanBookSubject(page, subjectId);
+    }
+    return loadDoubanMovieSubject(page, subjectId);
 }
 export async function loadDoubanSubjectPhotos(page, subjectId, options = {}) {
     const normalizedId = normalizeDoubanSubjectId(subjectId);
@@ -312,11 +551,13 @@ export function inferDoubanSearchResultType(searchType, item = {}) {
 }
 export async function searchDouban(page, type, keyword, limit) {
     const safeLimit = clampLimit(limit);
-    await page.goto(`https://search.douban.com/${encodeURIComponent(type)}/subject_search?search_text=${encodeURIComponent(keyword)}`);
-    await page.wait(2);
-    await ensureDoubanReady(page);
     const inferDoubanSearchResultTypeSource = inferDoubanSearchResultType.toString();
-    const data = await page.evaluate(`
+    const searchUrl = buildDoubanSearchUrl(type, keyword);
+    const data = await withDetachedRetry(async () => {
+        await page.goto(searchUrl, { waitUntil: 'load', settleMs: 1500 });
+        await ensureDoubanReady(page);
+        await page.wait({ selector: DOUBAN_SEARCH_READY_SELECTOR, timeout: 8 }).catch(() => { });
+        return page.evaluate(`
     (async () => {
       const type = ${JSON.stringify(type)};
       const inferDoubanSearchResultType = ${inferDoubanSearchResultTypeSource};
@@ -335,13 +576,13 @@ export async function searchDouban(page, type, keyword, limit) {
         await sleep(300);
       }
 
-      const items = Array.from(document.querySelectorAll('.item-root'));
+      const items = Array.from(document.querySelectorAll('.item-root, .result-list .result-item'));
 
       const results = [];
       for (const el of items) {
-        const titleEl = el.querySelector('.title-text, .title a, a[title]');
+        const titleEl = el.querySelector('.title-text, .title a, .title h3 a, h3 a, a[title]');
         const title = normalize(titleEl?.textContent) || normalize(titleEl?.getAttribute('title'));
-        let url = titleEl?.getAttribute('href') || '';
+        let url = titleEl?.getAttribute('href') || el.querySelector('a[href*="/subject/"]')?.getAttribute('href') || '';
         if (!title || !url) continue;
         if (!url.startsWith('http')) url = 'https://search.douban.com' + url;
         if (!url.includes('/subject/') || seen.has(url)) continue;
@@ -350,7 +591,7 @@ export async function searchDouban(page, type, keyword, limit) {
         const rawItem = rawItemsById.get(id) || {};
         const ratingText = normalize(el.querySelector('.rating_nums')?.textContent);
         const abstract = normalize(
-          el.querySelector('.meta.abstract, .meta, .abstract, p')?.textContent,
+          el.querySelector('.meta.abstract, .meta, .abstract, .subject-abstract, p')?.textContent,
         );
         results.push({
           rank: results.length + 1,
@@ -367,6 +608,7 @@ export async function searchDouban(page, type, keyword, limit) {
       return results;
     })()
   `);
+    });
     return Array.isArray(data) ? data : [];
 }
 /**

--- a/clis/douban/utils.test.js
+++ b/clis/douban/utils.test.js
@@ -1,6 +1,16 @@
 import vm from 'node:vm';
 import { describe, expect, it, vi } from 'vitest';
-import { getDoubanPhotoExtension, inferDoubanSearchResultType, loadDoubanSubjectPhotos, normalizeDoubanSubjectId, promoteDoubanPhotoUrl, resolveDoubanPhotoAssetUrl, searchDouban, } from './utils.js';
+import {
+    getDoubanPhotoExtension,
+    inferDoubanSearchResultType,
+    loadDoubanSubjectDetail,
+    loadDoubanSubjectPhotos,
+    normalizeDoubanBookSubject,
+    normalizeDoubanSubjectId,
+    promoteDoubanPhotoUrl,
+    resolveDoubanPhotoAssetUrl,
+    searchDouban,
+} from './utils.js';
 
 function createFakeNode(text = '', attrs = {}) {
     return {
@@ -10,17 +20,21 @@ function createFakeNode(text = '', attrs = {}) {
         },
     };
 }
+
 function createFakeSearchItem({ title, url, rating, abstract, cover }) {
     return {
         querySelector(selector) {
-            if (selector === '.title-text, .title a, a[title]') {
+            if (selector === '.title-text, .title a, .title h3 a, h3 a, a[title]') {
                 return createFakeNode(title, { href: url, title });
             }
             if (selector === '.rating_nums') {
                 return createFakeNode(rating);
             }
-            if (selector === '.meta.abstract, .meta, .abstract, p') {
+            if (selector === '.meta.abstract, .meta, .abstract, .subject-abstract, p') {
                 return createFakeNode(abstract);
+            }
+            if (selector === 'a[href*="/subject/"]') {
+                return createFakeNode('', { href: url });
             }
             if (selector === 'img') {
                 return createFakeNode('', { src: cover });
@@ -29,11 +43,15 @@ function createFakeSearchItem({ title, url, rating, abstract, cover }) {
         },
     };
 }
+
 async function runSearchEvaluate(script, rawItems, domItems) {
     const document = {
         querySelector(selector) {
             if (selector === '.item-root .title-text, .item-root .title a') {
-                return domItems[0]?.querySelector('.title-text, .title a, a[title]') || null;
+                return domItems[0]?.querySelector('.title-text, .title a, .title h3 a, h3 a, a[title]') || null;
+            }
+            if (selector === '.item-root .title-text, .item-root .title a, .result-list .result-item h3 a') {
+                return domItems[0]?.querySelector('.title-text, .title a, .title h3 a, h3 a, a[title]') || null;
             }
             return null;
         },
@@ -41,9 +59,13 @@ async function runSearchEvaluate(script, rawItems, domItems) {
             if (selector === '.item-root') {
                 return domItems;
             }
+            if (selector === '.item-root, .result-list .result-item') {
+                return domItems;
+            }
             return [];
         },
     };
+
     return vm.runInNewContext(script, {
         Map,
         Promise,
@@ -59,20 +81,25 @@ async function runSearchEvaluate(script, rawItems, domItems) {
         },
     });
 }
+
 describe('douban utils', () => {
     it('normalizes valid subject ids', () => {
         expect(normalizeDoubanSubjectId(' 30382501 ')).toBe('30382501');
     });
+
     it('rejects invalid subject ids', () => {
         expect(() => normalizeDoubanSubjectId('tt30382501')).toThrow('Invalid Douban subject ID');
     });
+
     it('promotes thumbnail urls to large photo urls', () => {
         expect(promoteDoubanPhotoUrl('https://img1.doubanio.com/view/photo/m/public/p2913450214.webp')).toBe('https://img1.doubanio.com/view/photo/l/public/p2913450214.webp');
         expect(promoteDoubanPhotoUrl('https://img9.doubanio.com/view/photo/s_ratio_poster/public/p2578474613.jpg')).toBe('https://img9.doubanio.com/view/photo/l/public/p2578474613.jpg');
     });
+
     it('rejects non-http photo urls during promotion', () => {
         expect(promoteDoubanPhotoUrl('data:image/gif;base64,abc')).toBe('');
     });
+
     it('prefers lazy-loaded photo urls over data placeholders', () => {
         expect(resolveDoubanPhotoAssetUrl([
             '',
@@ -80,9 +107,11 @@ describe('douban utils', () => {
             'data:image/gif;base64,abc',
         ], 'https://movie.douban.com/subject/30382501/photos?type=Rb')).toBe('https://img1.doubanio.com/view/photo/m/public/p2913450214.webp');
     });
+
     it('drops unsupported non-http photo urls when no real image url exists', () => {
         expect(resolveDoubanPhotoAssetUrl(['data:image/gif;base64,abc', 'blob:https://movie.douban.com/example'], 'https://movie.douban.com/subject/30382501/photos?type=Rb')).toBe('');
     });
+
     it('removes the default photo cap when scanning for an exact photo id', async () => {
         const evaluate = vi.fn()
             .mockResolvedValueOnce({ blocked: false, title: 'Some Movie', href: 'https://movie.douban.com/subject/30382501/photos?type=Rb' })
@@ -116,10 +145,12 @@ describe('douban utils', () => {
         expect(scanScript).toContain(`const limit = ${Number.MAX_SAFE_INTEGER};`);
         expect(scanScript).toContain('for (let pageIndex = 0; photos.length < limit; pageIndex += 1)');
     });
+
     it('keeps image extensions when download urls contain query params', () => {
         expect(getDoubanPhotoExtension('https://img1.doubanio.com/view/photo/l/public/p2913450214.webp?foo=1')).toBe('.webp');
         expect(getDoubanPhotoExtension('https://img1.doubanio.com/view/photo/l/public/p2913450214.jpeg')).toBe('.jpeg');
     });
+
     it('maps tv series results to tvshow in searchDouban output', async () => {
         const domItems = [
             createFakeSearchItem({
@@ -161,7 +192,149 @@ describe('douban utils', () => {
             { id: '36289423', type: 'movie', title: '射雕英雄传：侠之大者‎ (2025)' },
         ]);
     });
+
+    it('normalizes douban book subject raw data into structured fields', () => {
+        const normalized = normalizeDoubanBookSubject({
+            id: '2567698',
+            title: '小狗钱钱',
+            subtitle: '让孩子和家长共同成长的财商童话',
+            originalTitle: 'Ein Hund namens Money',
+            infoText: `
+作者: [德] 博多·舍费尔
+出版社: 南海出版公司
+副标题: 让孩子和家长共同成长的财商童话
+原作名: Ein Hund namens Money
+译者: 王钟欣 / 余茜
+出版年: 2014-1-1
+页数: 208
+定价: 26.00元
+装帧: 平装
+丛书: 新经典文库·爱心树童书
+ISBN: 9787544270871
+      `,
+            rating: '8.9',
+            ratingCount: '12345',
+            summary: '理财启蒙故事',
+            cover: 'https://img9.doubanio.com/view/subject/l/public/s29618581.jpg',
+            url: 'https://book.douban.com/subject/2567698/',
+        });
+        expect(normalized).toMatchObject({
+            id: '2567698',
+            type: 'book',
+            title: '小狗钱钱',
+            subtitle: '让孩子和家长共同成长的财商童话',
+            originalTitle: 'Ein Hund namens Money',
+            authors: ['[德] 博多·舍费尔'],
+            translators: ['王钟欣', '余茜'],
+            publisher: '南海出版公司',
+            publishDate: '2014-1-1',
+            publishYear: '2014',
+            pageCount: 208,
+            binding: '平装',
+            price: '26.00元',
+            series: '新经典文库·爱心树童书',
+            isbn13: '9787544270871',
+            rating: 8.9,
+            ratingCount: 12345,
+            summary: '理财启蒙故事',
+            cover: 'https://img9.doubanio.com/view/subject/l/public/s29618581.jpg',
+            url: 'https://book.douban.com/subject/2567698/',
+        });
+    });
+
+    it('loads book subject details from book.douban.com when type=book', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ blocked: false, title: '小狗钱钱 (豆瓣)', href: 'https://book.douban.com/subject/2567698/' })
+                .mockResolvedValueOnce({
+                id: '2567698',
+                title: '小狗钱钱',
+                subtitle: '',
+                originalTitle: '',
+                infoText: `
+作者: [德] 博多·舍费尔
+出版社: 南海出版公司
+出版年: 2014-1-1
+ISBN: 9787544270871
+        `,
+                rating: '8.9',
+                ratingCount: '12345',
+                summary: '理财启蒙故事',
+                cover: 'https://img9.doubanio.com/view/subject/l/public/s29618581.jpg',
+                url: 'https://book.douban.com/subject/2567698/',
+            }),
+        };
+        const detail = await loadDoubanSubjectDetail(page, '2567698', 'book');
+        expect(page.goto).toHaveBeenCalledWith('https://book.douban.com/subject/2567698/', {
+            waitUntil: 'load',
+            settleMs: 1500,
+        });
+        expect(page.wait).toHaveBeenCalledWith({ selector: 'h1 span, #info', timeout: 8 });
+        expect(detail).toMatchObject({
+            id: '2567698',
+            type: 'book',
+            title: '小狗钱钱',
+            authors: ['[德] 博多·舍费尔'],
+            publisher: '南海出版公司',
+            isbn13: '9787544270871',
+            rating: 8.9,
+            ratingCount: 12345,
+            url: 'https://book.douban.com/subject/2567698/',
+        });
+    });
+
+    it('retries transient detached navigation errors when loading douban search results', async () => {
+        const page = {
+            goto: vi.fn()
+                .mockRejectedValueOnce(new Error('Detached while handling command'))
+                .mockResolvedValueOnce(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({
+                blocked: false,
+                title: '经济学思维 - 豆瓣搜索',
+                href: 'https://search.douban.com/book/subject_search?search_text=%E7%BB%8F%E6%B5%8E%E5%AD%A6%E6%80%9D%E7%BB%B4&cat=1001',
+            })
+                .mockResolvedValueOnce([
+                {
+                    rank: 1,
+                    id: '26895402',
+                    type: 'book',
+                    title: '经济学思维',
+                    rating: 7.9,
+                    abstract: '李子畅 / 中信出版社 / 2016-7',
+                    url: 'https://book.douban.com/subject/26895402/',
+                    cover: 'https://img1.doubanio.com/view/subject/m/public/s29000000.jpg',
+                },
+            ]),
+        };
+        const results = await searchDouban(page, 'book', '经济学思维', 3);
+        expect(page.goto).toHaveBeenNthCalledWith(1, 'https://search.douban.com/book/subject_search?search_text=%E7%BB%8F%E6%B5%8E%E5%AD%A6%E6%80%9D%E7%BB%B4&cat=1001', {
+            waitUntil: 'load',
+            settleMs: 1500,
+        });
+        expect(page.goto).toHaveBeenCalledTimes(2);
+        expect(page.wait).toHaveBeenCalledWith({
+            selector: '.item-root .title-text, .item-root .title a, .result-list .result-item h3 a',
+            timeout: 8,
+        });
+        expect(results).toEqual([
+            {
+                rank: 1,
+                id: '26895402',
+                type: 'book',
+                title: '经济学思维',
+                rating: 7.9,
+                abstract: '李子畅 / 中信出版社 / 2016-7',
+                url: 'https://book.douban.com/subject/26895402/',
+                cover: 'https://img1.doubanio.com/view/subject/m/public/s29000000.jpg',
+            },
+        ]);
+    });
 });
+
 describe('inferDoubanSearchResultType', () => {
     it('returns tvshow for movie search results marked as TV', () => {
         expect(inferDoubanSearchResultType('movie', {
@@ -169,12 +342,14 @@ describe('inferDoubanSearchResultType', () => {
             labels: [{ text: '剧集' }],
         })).toBe('tvshow');
     });
+
     it('returns movie when a movie search result has no TV signal', () => {
         expect(inferDoubanSearchResultType('movie', {
             moreUrl: "onclick=\"moreurl(this,{is_tv:'0'})\"",
             labels: [{ text: '可播放' }],
         })).toBe('movie');
     });
+
     it('preserves non-movie search types', () => {
         expect(inferDoubanSearchResultType('book', {
             moreUrl: '',

--- a/docs/adapters/browser/douban.md
+++ b/docs/adapters/browser/douban.md
@@ -31,8 +31,12 @@ opencli douban search --type music "周杰伦"
 # 电影 Top 250
 opencli douban top250 --limit 10
 
-# 条目详情
+# 电影详情
 opencli douban subject 1292052
+
+# 图书详情
+opencli douban subject 2567698 --type book
+opencli douban subject 2567698 --type book -f json
 
 # 获取海报直链（默认 type=Rb）
 opencli douban photos 30382501 --limit 20
@@ -60,3 +64,5 @@ opencli douban top250 -f json
 
 - Chrome logged into `douban.com`
 - Browser Bridge extension installed
+
+图书搜索和图书详情在稳定批量使用时默认需要已登录的豆瓣浏览器会话。

--- a/tests/e2e/douban.test.ts
+++ b/tests/e2e/douban.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { parseJsonOutput, runCli } from './helpers.js';
+
+function isEnvironmentSkip(result: { code: number; stdout: string; stderr: string }) {
+  const text = `${result.stderr}\n${result.stdout}`;
+  return /AUTH_REQUIRED|Browser Bridge.*not connected|Extension.*not connected|异常请求|sec\.douban\.com|captcha/i.test(text);
+}
+
+async function runDoubanJsonOrSkip(args: string[], label: string) {
+  const result = await runCli(args, { timeout: 90_000 });
+  if (result.code !== 0) {
+    if (isEnvironmentSkip(result)) {
+      console.warn(`${label}: skipped — douban login or browser environment is unavailable`);
+      return null;
+    }
+    throw new Error(`${label} failed:\n${result.stderr || result.stdout}`);
+  }
+
+  const data = parseJsonOutput(result.stdout);
+  if (!Array.isArray(data)) {
+    throw new Error(`${label} returned non-array JSON:\n${result.stdout.slice(0, 500)}`);
+  }
+  return data;
+}
+
+describe('douban browser e2e', () => {
+  it('search --type book returns structured candidates', async () => {
+    const data = await runDoubanJsonOrSkip(['douban', 'search', '--type', 'book', '三体', '--limit', '3', '-f', 'json'], 'douban search book');
+    if (data === null) return;
+
+    expect(data.length).toBeGreaterThanOrEqual(1);
+    expect(data[0]).toHaveProperty('id');
+    expect(data[0]).toHaveProperty('title');
+    expect(data[0]).toHaveProperty('url');
+  }, 90_000);
+
+  it('subject --type book returns normalized detail fields', async () => {
+    const data = await runDoubanJsonOrSkip(['douban', 'subject', '2567698', '--type', 'book', '-f', 'json'], 'douban subject book');
+    if (data === null) return;
+
+    expect(data.length).toBe(1);
+    expect(data[0]).toMatchObject({
+      id: '2567698',
+      type: 'book',
+    });
+    expect(data[0]).toHaveProperty('title');
+    expect(data[0]).toHaveProperty('authors');
+    expect(data[0]).toHaveProperty('publisher');
+    expect(data[0]).toHaveProperty('rating');
+    expect(data[0]).toHaveProperty('url');
+  }, 90_000);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
             'tests/e2e/plugin-management.test.ts',
             // Extended browser tests (20+ sites) — opt-in only:
             //   OPENCLI_E2E=1 npx vitest run
-            ...(includeExtendedE2e ? ['tests/e2e/browser-public-extended.test.ts', 'tests/e2e/browser-auth.test.ts'] : []),
+            ...(includeExtendedE2e ? ['tests/e2e/browser-public-extended.test.ts', 'tests/e2e/browser-auth.test.ts', 'tests/e2e/douban.test.ts'] : []),
           ],
           maxWorkers: 2,
           sequence: { groupOrder: 2 },


### PR DESCRIPTION
## Description

  Extend the existing Douban adapter to support book subject details and make `douban search --type book` reliable enough for metadata enrichment workflows.

  This PR includes:

  - support for `opencli douban subject <id> --type book`
  - normalized book metadata fields from `book.douban.com`
  - fixes for `opencli douban search --type book`
  - adapter tests, browser e2e coverage, and Douban docs updates

  Related issue:
  - N/A

  ## Type of Change

  - [x] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 🌐 New site adapter
  - [x] 📝 Documentation
  - [ ] ␌ Refactor
  - [ ] 🔧 CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [x] Used positional args for the command's primary subject unless a named flag is clearly better
  - [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output

  ### Example commands

  ```bash
  opencli douban search --type book "三体" -f json
  opencli douban subject 2567698 --type book -f json

  ### Verification

  npm run test
  OPENCLI_E2E=1 npx vitest run --project e2e tests/e2e/douban.test.ts
  npm run build

  ### Result summary

  - npm run test: passed
  - OPENCLI_E2E=1 npx vitest run --project e2e tests/e2e/douban.test.ts: passed
  - npm run build: passed