### PR TITLE
fix: install unresolved monorepo plugin deps

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -650,6 +650,26 @@ describe('postInstallMonorepoLifecycle', () => {
     expect(npmCalls[0][2]).toMatchObject({ cwd: repoDir });
     expect(npmCalls.some(([, , opts]) => opts?.cwd === subDir)).toBe(false);
   });
+
+  it('falls back to plugin-local install when sub-plugin dependencies are unresolved from the repo root', () => {
+    fs.writeFileSync(path.join(subDir, 'package.json'), JSON.stringify({
+      name: 'alpha-plugin',
+      type: 'module',
+      dependencies: {
+        undici: '^7.0.0',
+      },
+    }));
+
+    _postInstallMonorepoLifecycle(repoDir, [subDir]);
+
+    const npmCalls = mockExecFileSync.mock.calls.filter(
+      ([cmd, args]) => cmd === 'npm' && Array.isArray(args) && args[0] === 'install',
+    );
+
+    expect(npmCalls).toHaveLength(2);
+    expect(npmCalls[0][2]).toMatchObject({ cwd: repoDir });
+    expect(npmCalls[1][2]).toMatchObject({ cwd: subDir });
+  });
 });
 
 describe('updateAllPlugins', () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { PLUGINS_DIR } from './discovery.js';
 import { getErrorMessage, PluginError } from './errors.js';
@@ -589,6 +590,44 @@ function installDependencies(dir: string): void {
   }
 }
 
+function getMissingRuntimeDependencies(pluginDir: string): string[] {
+  const pkgJsonPath = path.join(pluginDir, 'package.json');
+  if (!fs.existsSync(pkgJsonPath)) return [];
+
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+
+  const declaredDeps = [
+    ...Object.keys((pkg.dependencies as Record<string, unknown> | undefined) ?? {}),
+    ...Object.keys((pkg.optionalDependencies as Record<string, unknown> | undefined) ?? {}),
+  ];
+  if (declaredDeps.length === 0) return [];
+
+  const requireFromPlugin = createRequire(path.join(pluginDir, '__opencli_plugin__.cjs'));
+  return declaredDeps.filter((dep) => {
+    try {
+      requireFromPlugin.resolve(dep);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
+
+function ensurePluginRuntimeDependencies(pluginDir: string): void {
+  const missing = getMissingRuntimeDependencies(pluginDir);
+  if (missing.length === 0) return;
+
+  log.debug(
+    `Installing plugin-local dependencies in ${pluginDir} because root install did not resolve: ${missing.join(', ')}`
+  );
+  installDependencies(pluginDir);
+}
+
 function finalizePluginRuntime(pluginDir: string): void {
   // Symlink host opencli so TS plugins resolve '@jackwener/opencli/registry'
   // against the running host, not a stale npm-published version.
@@ -612,6 +651,7 @@ function postInstallLifecycle(pluginDir: string): void {
 function postInstallMonorepoLifecycle(repoDir: string, pluginDirs: string[]): void {
   installDependencies(repoDir);
   for (const pluginDir of pluginDirs) {
+    ensurePluginRuntimeDependencies(pluginDir);
     finalizePluginRuntime(pluginDir);
   }
 }


### PR DESCRIPTION
## Problem
Monorepo plugin installs currently run `npm install --omit=dev` only once at the monorepo root. When a sub-plugin declares its own runtime dependencies but the monorepo does not expose that package through root workspaces, the compiled plugin loads from `~/.opencli/monorepos/.../packages/<plugin>/...` and crashes at runtime with module resolution errors such as `Cannot find package 'undici'`.

## Root Cause
The monorepo install lifecycle assumes the root install is always sufficient for every sub-plugin. It never checks whether a sub-plugin's declared runtime dependencies are actually resolvable from that sub-plugin directory before it is finalized and linked.

## Fix
Keep the existing root-level install, but add a targeted fallback for monorepo sub-plugins: if a sub-plugin's `dependencies` / `optionalDependencies` are still unresolved from its own directory after the root install, run `npm install --omit=dev` in that sub-plugin before finalizing it. This preserves the fast path for workspace monorepos while fixing non-workspace monorepos like the one reported in #722.

## Validation
- `npx vitest run src/plugin.test.ts`
- Added coverage for the unresolved-runtime-dependency fallback in monorepo installs

Closes #722