### PR TITLE
chore: bump version to 1.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
Bump version to 1.7.3.

## v1.7.3 Highlights (17 PRs)

### Security & Quality
- #981 — Code audit round 1: evaluate injection, CDP leak, manifest corruption guard
- #982 — Code audit round 2: pruneEmptyDirs safety, evaluateWithArgs, hot-reload, error cause chain
- #986 — Clean up stale .yaml adapter files (#953)

### Breaking Changes
- #989 — ChatGPT adapter rename: `chatgptweb` → `chatgpt`, `chatgpt` → `chatgpt-app`
- #991 — Unify OPENCLI_VERBOSE into DEBUG=opencli

### New Features
- #964 — Mubu adapter (5 commands)
- #973 — ChatGPT Web image generation
- #974 — Bilibili feed-detail
- #975 — Ke (贝壳找房) adapter (4 commands)
- #977 — Maimai talent search
- #976 — Discord-app delete command

### Fixes
- #979 — Douban search type classification
- #980 — Xiaohongshu anti-detection hardening
- #992 — Fix automation window not closing on failure

### Refactor
- #985 — Decouple extension version from CLI
- #987 — Remove unused OPENCLI_SKIP_FETCH

### Docs
- #983 — Document undocumented env vars