### PR TITLE
chore: prune legacy config switches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,12 +136,8 @@ jobs:
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             npx vitest run tests/smoke/ --reporter=verbose
-        env:
-          OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Run smoke tests (macOS / Windows)
         if: runner.os != 'Linux'
         run: npx vitest run tests/smoke/ --reporter=verbose
-        env:
-          OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
     timeout-minutes: 15

--- a/.github/workflows/e2e-headed.yml
+++ b/.github/workflows/e2e-headed.yml
@@ -64,11 +64,7 @@ jobs:
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             npx vitest run tests/e2e/ --reporter=verbose
-        env:
-          OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Run E2E tests (macOS / Windows)
         if: runner.os != 'Linux'
         run: npx vitest run tests/e2e/ --reporter=verbose
-        env:
-          OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}

--- a/README.md
+++ b/README.md
@@ -154,8 +154,6 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `OPENCLI_DIAGNOSTIC` | `false` | Set to `1` to capture structured diagnostic context on failures |
-| `OUTPUT` | — | Override output format: `json`, `yaml`, or `table` |
-| `DEBUG` | — | Set to `opencli` for internal debug logging |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
 ## Update

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,8 +142,6 @@ OpenCLI 不只是网站 CLI，还可以：
 | `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
 | `OPENCLI_DIAGNOSTIC` | `false` | 设为 `1` 时在失败时输出结构化诊断上下文 |
-| `OUTPUT` | — | 覆盖输出格式：`json`、`yaml` 或 `table` |
-| `DEBUG` | — | 设为 `opencli` 开启内部调试日志 |
 | `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |
 
 ## 更新

--- a/TESTING.md
+++ b/TESTING.md
@@ -208,7 +208,7 @@ it('producthunt me fails gracefully without login', async () => {
 |---|---|---|
 | `e2e-headed` | push/PR 到 `main`,`dev`，或手动触发 | 安装真实 Chrome，`xvfb-run` 执行 `tests/e2e/` |
 
-E2E 与 smoke 都使用 `./.github/actions/setup-chrome` 准备真实 Chrome，并通过 `OPENCLI_BROWSER_EXECUTABLE_PATH` 注入浏览器路径。
+E2E 与 smoke 都使用 `./.github/actions/setup-chrome` 准备真实 Chrome。
 
 ### Sharding
 
@@ -233,12 +233,7 @@ opencli 通过 Browser Bridge 扩展连接浏览器：
 | 扩展已安装 / 已连接 | Extension 模式 | 本地用户，连接已登录的 Chrome |
 | 无扩展 token | CLI 自行拉起浏览器 | CI、无登录态或纯自动化场景 |
 
-CI 中使用 `OPENCLI_BROWSER_EXECUTABLE_PATH` 指定真实 Chrome 路径：
-
-```yaml
-env:
-  OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-```
+CI 通过 `./.github/actions/setup-chrome` 准备真实 Chrome，再直接执行测试。
 
 ---
 

--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -214,11 +214,10 @@ export async function typeAndSendMessage(page, text) {
     return true;
 }
 /**
- * Verbose log helper — prints when OPENCLI_VERBOSE is set, with DEBUG=opencli
- * kept as a compatibility fallback.
+ * Verbose log helper — prints when OPENCLI_VERBOSE is set.
  */
 export function verbose(msg) {
-    if (process.env.OPENCLI_VERBOSE || process.env.DEBUG?.includes('opencli')) {
+    if (process.env.OPENCLI_VERBOSE) {
         console.error(`[opencli:boss] ${msg}`);
     }
 }

--- a/docs/advanced/remote-chrome.md
+++ b/docs/advanced/remote-chrome.md
@@ -62,11 +62,3 @@ steps:
         --remote-debugging-port=9222 &
 ```
 :::
-
-Set the browser executable path:
-::: v-pre
-```yaml
-env:
-  OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-```
-:::

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -209,7 +209,7 @@ it('producthunt me fails gracefully without login', async () => {
 |---|---|---|
 | `e2e-headed` | push/PR 到 `main`,`dev`，或手动触发 | 安装真实 Chrome，`xvfb-run` 执行 `tests/e2e/` |
 
-E2E 与 smoke 都使用 `./.github/actions/setup-chrome` 准备真实 Chrome，并通过 `OPENCLI_BROWSER_EXECUTABLE_PATH` 注入浏览器路径。
+E2E 与 smoke 都使用 `./.github/actions/setup-chrome` 准备真实 Chrome。
 
 ### Sharding
 
@@ -236,14 +236,7 @@ opencli 通过 Browser Bridge 扩展连接浏览器：
 | 扩展已安装 / 已连接 | Extension 模式 | 本地用户，连接已登录的 Chrome |
 | 无扩展 token | CLI 自行拉起浏览器 | CI、无登录态或纯自动化场景 |
 
-CI 中使用 `OPENCLI_BROWSER_EXECUTABLE_PATH` 指定真实 Chrome 路径：
-
-::: v-pre
-```yaml
-env:
-  OPENCLI_BROWSER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-```
-:::
+CI 通过 `./.github/actions/setup-chrome` 准备真实 Chrome，再直接执行测试。
 
 ---
 

--- a/docs/superpowers/plans/2026-03-31-daemon-lifecycle-redesign.md
+++ b/docs/superpowers/plans/2026-03-31-daemon-lifecycle-redesign.md
@@ -35,7 +35,7 @@
 In `src/constants.ts`, add after the `DEFAULT_DAEMON_PORT` line:
 
 ```typescript
-/** Default idle timeout before daemon auto-exits (ms). Override via OPENCLI_DAEMON_TIMEOUT env var. */
+/** Default idle timeout before daemon auto-exits (ms). */
 export const DEFAULT_DAEMON_IDLE_TIMEOUT = 4 * 60 * 60 * 1000; // 4 hours
 ```
 
@@ -174,7 +174,7 @@ Replace the `IDLE_TIMEOUT` constant (line 27):
 import { DEFAULT_DAEMON_PORT, DEFAULT_DAEMON_IDLE_TIMEOUT } from './constants.js';
 
 const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
-const IDLE_TIMEOUT = Number(process.env.OPENCLI_DAEMON_TIMEOUT ?? DEFAULT_DAEMON_IDLE_TIMEOUT);
+const IDLE_TIMEOUT = DEFAULT_DAEMON_IDLE_TIMEOUT;
 ```
 
 Replace the idle timer state and `resetIdleTimer` function (lines 37, 49-57) with the `IdleManager` class:

--- a/docs/superpowers/specs/2026-03-31-daemon-lifecycle-redesign.md
+++ b/docs/superpowers/specs/2026-03-31-daemon-lifecycle-redesign.md
@@ -54,12 +54,11 @@ If either signal is active, the daemon stays alive. This means:
 - Recent CLI activity keeps the daemon alive even if Extension temporarily
   disconnects (Chrome restarting, Extension updating)
 
-**Timeout value:** 4 hours by default, configurable via `OPENCLI_DAEMON_TIMEOUT`
-environment variable. Value in milliseconds. Set to `0` to disable timeout entirely.
+**Timeout value:** 4 hours by default.
 
 ```typescript
 const DEFAULT_IDLE_TIMEOUT = 4 * 60 * 60 * 1000; // 4 hours
-const IDLE_TIMEOUT = Number(process.env.OPENCLI_DAEMON_TIMEOUT ?? DEFAULT_IDLE_TIMEOUT);
+const IDLE_TIMEOUT = DEFAULT_IDLE_TIMEOUT;
 ```
 
 **Timer implementation:**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,7 @@
 import { styleText } from 'node:util';
 
 function isVerbose(): boolean {
-  return !!process.env.OPENCLI_VERBOSE || !!process.env.DEBUG?.includes('opencli');
+  return !!process.env.OPENCLI_VERBOSE;
 }
 
 export const log = {
@@ -37,14 +37,14 @@ export const log = {
     process.stderr.write(`${styleText('red', '✖')}  ${msg}\n`);
   },
 
-  /** Verbose output (shown when -v flag, OPENCLI_VERBOSE, or DEBUG=opencli is set) */
+  /** Verbose output (shown when -v flag or OPENCLI_VERBOSE is set) */
   verbose(msg: string): void {
     if (isVerbose()) {
       process.stderr.write(`${styleText('dim', '[verbose]')} ${msg}\n`);
     }
   },
 
-  /** @deprecated Use log.verbose() instead. Kept as alias for backward compatibility. */
+  /** Alias for verbose output. */
   debug(msg: string): void {
     this.verbose(msg);
   },

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -3,7 +3,6 @@ import { render } from './output.js';
 
 describe('output TTY detection', () => {
   const originalIsTTY = process.stdout.isTTY;
-  const originalEnv = process.env.OUTPUT;
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -12,8 +11,6 @@ describe('output TTY detection', () => {
 
   afterEach(() => {
     Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, writable: true });
-    if (originalEnv === undefined) delete process.env.OUTPUT;
-    else process.env.OUTPUT = originalEnv;
     logSpy.mockRestore();
   });
 
@@ -38,24 +35,6 @@ describe('output TTY detection', () => {
     render([{ name: 'alice' }], { fmt: 'json' });
     const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
     expect(JSON.parse(out)).toEqual([{ name: 'alice' }]);
-  });
-
-  it('OUTPUT env var overrides default table in non-TTY', () => {
-    Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true });
-    process.env.OUTPUT = 'json';
-    render([{ name: 'alice' }], { fmt: 'table' });
-    const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    expect(JSON.parse(out)).toEqual([{ name: 'alice' }]);
-  });
-
-  it('explicit -f flag takes precedence over OUTPUT env var', () => {
-    Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true });
-    process.env.OUTPUT = 'json';
-    render([{ name: 'alice' }], { fmt: 'csv', fmtExplicit: true });
-    const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    expect(out).toContain('name');
-    expect(out).toContain('alice');
-    expect(out).not.toContain('"name"');  // not JSON
   });
 
   it('explicit -f table overrides non-TTY auto-downgrade', () => {

--- a/src/output.ts
+++ b/src/output.ts
@@ -30,11 +30,8 @@ function resolveColumns(rows: Record<string, unknown>[], opts: RenderOptions): s
 export function render(data: unknown, opts: RenderOptions = {}): void {
   let fmt = opts.fmt ?? 'table';
   // Non-TTY auto-downgrade only when format was NOT explicitly passed by user.
-  // Priority: explicit -f (any value) > OUTPUT env var > TTY auto-detect > table
   if (!opts.fmtExplicit) {
-    const envFmt = process.env.OUTPUT?.trim().toLowerCase();
-    if (envFmt) fmt = envFmt;
-    else if (fmt === 'table' && !process.stdout.isTTY) fmt = 'yaml';
+    if (fmt === 'table' && !process.stdout.isTTY) fmt = 'yaml';
   }
   if (data === null || data === undefined) {
     console.log(data);

--- a/tests/e2e/browser-public.test.ts
+++ b/tests/e2e/browser-public.test.ts
@@ -1,6 +1,6 @@
 /**
  * E2E tests for core browser commands (bilibili, zhihu, v2ex, IMDb).
- * These use OPENCLI_HEADLESS=1 to launch a headless Chromium.
+ * These launch a headless Chromium in CI.
  *
  * NOTE: Some sites may block headless browsers with bot detection.
  * Tests are wrapped with tryBrowserCommand() which allows graceful failure.


### PR DESCRIPTION
## Summary
- remove OUTPUT env override and DEBUG=opencli fallback from runtime behavior
- stop exposing dead or internal-only config names in public docs and workflow examples
- drop stale OPENCLI_BROWSER_EXECUTABLE_PATH injections from CI workflows

## Verification
- npm run typecheck
- npx vitest run src/output.test.ts --reporter=verbose
- manual logger checks for OPENCLI_VERBOSE vs DEBUG fallback removal