### PR TITLE
fix: remove duplicate extension zip from releases

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -46,25 +46,20 @@ jobs:
         run: |
           EXT_VERSION=$(node -p "require('./extension/package.json').version")
           cd extension-package
-          zip -r ../opencli-extension.zip .
-          cp ../opencli-extension.zip ../opencli-extension-v${EXT_VERSION}.zip
+          zip -r ../opencli-extension-v${EXT_VERSION}.zip .
 
       - name: Upload Artifacts (Action Run)
         uses: actions/upload-artifact@v7
         with:
           name: opencli-extension-build
-          path: |
-            opencli-extension.zip
-            opencli-extension-v*.zip
+          path: opencli-extension-v*.zip
           retention-days: 7
 
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2.6.1
         with:
-          files: |
-            opencli-extension.zip
-            opencli-extension-v*.zip
+          files: opencli-extension-v*.zip
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,15 +42,13 @@ jobs:
         run: |
           EXT_VERSION=$(node -p "require('./extension/package.json').version")
           cd extension-package
-          zip -r ../opencli-extension.zip .
-          cp ../opencli-extension.zip ../opencli-extension-v${EXT_VERSION}.zip
+          zip -r ../opencli-extension-v${EXT_VERSION}.zip .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2.6.1
         with:
           generate_release_notes: true
           files: |
-            opencli-extension.zip
             opencli-extension-v*.zip
 
       - name: Publish to npm

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install -g @jackwener/opencli
 
 OpenCLI connects to Chrome/Chromium through a lightweight Browser Bridge extension plus a small local daemon. The daemon auto-starts when needed.
 
-1. Download the latest `opencli-extension.zip` from the GitHub [Releases page](https://github.com/jackwener/opencli/releases).
+1. Download the latest `opencli-extension-v{version}.zip` from the GitHub [Releases page](https://github.com/jackwener/opencli/releases).
 2. Unzip it, open `chrome://extensions`, and enable **Developer mode**.
 3. Click **Load unpacked** and select the unzipped folder.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@ npm install -g @jackwener/opencli
 
 OpenCLI 通过轻量 Browser Bridge 扩展和本地微型 daemon 与 Chrome/Chromium 通信。daemon 会按需自动启动。
 
-1. 到 GitHub [Releases 页面](https://github.com/jackwener/opencli/releases) 下载最新的 `opencli-extension.zip`。
+1. 到 GitHub [Releases 页面](https://github.com/jackwener/opencli/releases) 下载最新的 `opencli-extension-v{version}.zip`。
 2. 解压后打开 `chrome://extensions`，启用 **开发者模式**。
 3. 点击 **加载已解压的扩展程序**，选择解压后的目录。
 

--- a/docs/guide/browser-bridge.md
+++ b/docs/guide/browser-bridge.md
@@ -8,7 +8,7 @@ OpenCLI connects to your browser through a lightweight **Browser Bridge** Chrome
 
 ### Method 1: Download Pre-built Release (Recommended)
 
-1. Go to the GitHub [Releases page](https://github.com/jackwener/opencli/releases) and download the latest `opencli-extension.zip`.
+1. Go to the GitHub [Releases page](https://github.com/jackwener/opencli/releases) and download the latest `opencli-extension-v{version}.zip`.
 2. Unzip the file and open `chrome://extensions`, enable **Developer mode** (top-right toggle).
 3. Click **Load unpacked** and select the unzipped folder.
 

--- a/docs/zh/guide/browser-bridge.md
+++ b/docs/zh/guide/browser-bridge.md
@@ -8,7 +8,7 @@ OpenCLI 通过轻量级 **Browser Bridge** Chrome 扩展 + 微守护进程连接
 
 ### 方法 1：下载预构建版本（推荐）
 
-1. 前往 GitHub [Releases 页面](https://github.com/jackwener/opencli/releases) 下载最新的 `opencli-extension.zip`。
+1. 前往 GitHub [Releases 页面](https://github.com/jackwener/opencli/releases) 下载最新的 `opencli-extension-v{version}.zip`。
 2. 解压后打开 `chrome://extensions`，启用**开发者模式**。
 3. 点击**加载已解压的扩展程序**，选择解压后的文件夹。
 


### PR DESCRIPTION
## Summary
- Release workflow was creating both `opencli-extension.zip` and `opencli-extension-v{version}.zip` (identical content via `cp`), uploading both to GitHub releases
- Removed the unversioned `opencli-extension.zip` — only the versioned filename (`opencli-extension-v{version}.zip`) is now created and uploaded
- Fixed in both `release.yml` and `build-extension.yml`

## Test plan
- [ ] Verify next release only contains `opencli-extension-v{version}.zip`
- [ ] Clean up v1.7.3 duplicate asset: `gh release delete-asset v1.7.3 opencli-extension.zip`