### PR TITLE
fix(plugin): install monorepo sub-plugin deps when not hoisted

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -639,7 +639,7 @@ describe('postInstallMonorepoLifecycle', () => {
     fs.rmSync(repoDir, { recursive: true, force: true });
   });
 
-  it('installs dependencies once at the monorepo root, not in each sub-plugin', () => {
+  it('installs dependencies at the monorepo root and skips sub-plugins without own dependencies', () => {
     _postInstallMonorepoLifecycle(repoDir, [subDir]);
 
     const npmCalls = mockExecFileSync.mock.calls.filter(
@@ -649,6 +649,26 @@ describe('postInstallMonorepoLifecycle', () => {
     expect(npmCalls).toHaveLength(1);
     expect(npmCalls[0][2]).toMatchObject({ cwd: repoDir });
     expect(npmCalls.some(([, , opts]) => opts?.cwd === subDir)).toBe(false);
+  });
+
+  it('also installs dependencies in sub-plugins that declare their own production dependencies', () => {
+    // Give the sub-plugin its own production dependencies
+    fs.writeFileSync(path.join(subDir, 'package.json'), JSON.stringify({
+      name: 'opencli-plugin-alpha',
+      version: '1.0.0',
+      type: 'module',
+      dependencies: { undici: '^8.0.0' },
+    }));
+
+    _postInstallMonorepoLifecycle(repoDir, [subDir]);
+
+    const npmCalls = mockExecFileSync.mock.calls.filter(
+      ([cmd, args]) => cmd === 'npm' && Array.isArray(args) && args[0] === 'install',
+    );
+
+    expect(npmCalls).toHaveLength(2);
+    expect(npmCalls[0][2]).toMatchObject({ cwd: repoDir });
+    expect(npmCalls[1][2]).toMatchObject({ cwd: subDir });
   });
 });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -573,6 +573,18 @@ export function validatePluginStructure(pluginDir: string): ValidationResult {
   return { valid: errors.length === 0, errors };
 }
 
+/** Check whether a directory has its own production dependencies in package.json. */
+function hasOwnDependencies(dir: string): boolean {
+  const pkgPath = path.join(dir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return pkg.dependencies != null && Object.keys(pkg.dependencies).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function installDependencies(dir: string): void {
   const pkgJsonPath = path.join(dir, 'package.json');
   if (!fs.existsSync(pkgJsonPath)) return;
@@ -607,11 +619,20 @@ function postInstallLifecycle(pluginDir: string): void {
 }
 
 /**
- * Monorepo lifecycle: install shared deps once at repo root, then finalize each sub-plugin.
+ * Monorepo lifecycle: install shared deps at repo root, then install and finalize each sub-plugin.
+ *
+ * The root install covers monorepos that use npm workspaces to hoist dependencies.
+ * For monorepos that do NOT use workspaces, sub-plugins may declare their own
+ * production dependencies in their package.json.  We install those per sub-plugin
+ * so that runtime imports (e.g. `undici`) can be resolved from the sub-plugin
+ * directory.  When the root already satisfies all deps this is a fast no-op.
  */
 function postInstallMonorepoLifecycle(repoDir: string, pluginDirs: string[]): void {
   installDependencies(repoDir);
   for (const pluginDir of pluginDirs) {
+    if (pluginDir !== repoDir && hasOwnDependencies(pluginDir)) {
+      installDependencies(pluginDir);
+    }
     finalizePluginRuntime(pluginDir);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #722. @Astro-Han 

Monorepo sub-plugins that declare their own production `dependencies` (e.g. `undici`) fail at runtime when the monorepo root doesn't hoist those packages (no npm workspaces configured).

This adds a per-sub-plugin `npm install` for any sub-plugin whose `package.json` has non-empty `dependencies`. When the root already satisfies everything, this is a fast no-op.

## Changes

- Added `hasOwnDependencies(dir)` to check if a sub-plugin has production deps
- `postInstallMonorepoLifecycle` now calls `installDependencies` per sub-plugin when needed
- Updated and added tests covering both cases (with and without own deps)

## Test plan

- [x] All 74 existing plugin tests pass
- [x] New test: sub-plugin with `dependencies: { undici: "^8.0.0" }` gets its own `npm install`
- [x] Existing test: sub-plugin without deps still skips the extra install