### PR TITLE
docs: sync Highlights cleanup to zh-CN README and docs site

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,14 +16,16 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 
 除了网站能力，OpenCLI 还是一个 **CLI 枢纽**：你可以把 `gh`、`docker` 等本地工具统一注册到 `opencli` 下，也可以通过桌面端适配器控制 Cursor、Codex、Antigravity、ChatGPT、Notion 等 Electron 应用。
 
-## 为什么是 OpenCLI
+## 亮点
 
-- **同一个心智模型**：网站、浏览器自动化、Electron 应用、本地 CLI 都走同一个入口。
-- **复用真实会话**：浏览器命令直接使用你已经登录的 Chrome/Chromium，而不是重新造一套认证。
-- **输出稳定**：适配器命令返回固定结构，适合 shell、脚本、CI 和 AI Agent 工具调用。
-- **面向 AI Agent**：`browser` 负责实时操作，`explore` 负责探索接口，`synthesize` 负责生成适配器，`cascade` 负责探测认证路径。
-- **运行成本低**：已有命令运行时不消耗模型 token。
-- **天然可扩展**：既能用内置能力，也能注册本地 CLI，或直接往 `clis/` 丢 `.js` 适配器。
+- **桌面应用控制** — 通过 CDP 直接在终端驱动 Electron 应用（Cursor、Codex、ChatGPT、Notion 等）。
+- **浏览器自动化** — `browser` 让 AI Agent 直接控制浏览器：点击、输入、提取、截图，完全可编程。
+- **网站 → CLI** — 把任何网站变成确定性 CLI：87+ 内置适配器，或用 `opencli generate` 生成新的。
+- **账号安全** — 复用 Chrome/Chromium 登录态，凭证永远不会离开浏览器。
+- **面向 AI Agent** — `explore` 发现 API，`synthesize` 生成适配器，`cascade` 探测认证策略，`browser` 直接控制浏览器。
+- **CLI 枢纽** — 统一发现、自动安装、纯透传任何外部 CLI（gh、docker、obsidian 等）。
+- **零 LLM 成本** — 运行时不消耗模型 token，跑 10,000 次也不花一分钱。
+- **确定性输出** — 相同命令，相同输出结构，每次一致。可管道、可脚本、CI 友好。
 
 ## 快速开始
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,12 +11,13 @@ OpenCLI turns **any website** or **Electron app** into a command-line interface 
 
 ## Highlights
 
-- **CLI All Electron** — CLI-ify apps like Antigravity Ultra! Now AI can control itself natively.
+- **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT, Notion, etc.) directly from the terminal via CDP.
+- **Browser Automation** — `browser` gives AI agents direct browser control: click, type, extract, screenshot — fully scriptable.
+- **Website → CLI** — Turn any website into a deterministic CLI: 87+ pre-built adapters, or generate your own with `opencli generate`.
 - **Account-safe** — Reuses Chrome's logged-in state; your credentials never leave the browser.
-- **AI Agent ready** — `explore` discovers APIs, `synthesize` generates adapters, `cascade` finds auth strategies.
-- **Self-healing setup** — `opencli doctor` auto-starts the daemon and diagnoses extension + live browser connectivity.
-- **Dynamic Loader** — Simply drop `.js` adapters into the `clis/` folder for auto-registration.
-- **Dual-Engine Architecture** — Supports both declarative pipeline adapters and robust browser runtime TypeScript injections.
+- **AI Agent ready** — `explore` discovers APIs, `synthesize` generates adapters, `cascade` finds auth strategies, `browser` controls the browser directly.
+- **Zero LLM cost** — No tokens consumed at runtime. Run 10,000 times and pay nothing.
+- **Deterministic** — Same command, same output schema, every time. Pipeable, scriptable, CI-friendly.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,21 +15,21 @@ hero:
 
 features:
   - icon: 🖥️
-    title: CLI All Electron
-    details: Turn ANY Electron application into a CLI tool — Cursor, Codex, Antigravity, ChatGPT, Notion, and more. AI can control itself natively.
+    title: Desktop App Control
+    details: Drive Electron apps (Cursor, Codex, ChatGPT, Notion, etc.) directly from the terminal via CDP.
+  - icon: 🌐
+    title: Browser Automation
+    details: "AI agents get direct browser control: click, type, extract, screenshot — any interaction, fully scriptable."
   - icon: 🔐
     title: Account Safe
     details: Reuses Chrome's logged-in state. Your credentials never leave the browser — no tokens, no exposed passwords.
   - icon: 🤖
     title: AI Agent Ready
     details: "explore discovers APIs, synthesize generates adapters, cascade finds auth strategies. Built for AI-first workflows."
-  - icon: ⚡
-    title: Dual-Engine Architecture
-    details: Supports both declarative pipeline adapters and robust browser runtime TypeScript injections for maximum flexibility.
-  - icon: 🔧
-    title: Self-Healing Setup
-    details: "opencli doctor auto-starts the daemon and diagnoses extension + live browser connectivity."
-  - icon: 📦
-    title: Dynamic Loader
-    details: Simply drop .js adapters into the clis/ folder for auto-registration. Zero boilerplate.
+  - icon: 💰
+    title: Zero LLM Cost
+    details: No tokens consumed at runtime. Run 10,000 times and pay nothing.
+  - icon: 🔁
+    title: Deterministic
+    details: Same command, same output schema, every time. Pipeable, scriptable, CI-friendly.
 ---

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -15,15 +15,21 @@ hero:
 
 features:
   - icon: 🖥️
-    title: CLI 所有 Electron 应用
-    details: 将任何 Electron 应用变成 CLI 工具 — Cursor、Codex、Antigravity、ChatGPT、Notion 等。AI 可以原生控制自身。
+    title: 桌面应用控制
+    details: 通过 CDP 直接在终端驱动 Electron 应用（Cursor、Codex、ChatGPT、Notion 等）。
+  - icon: 🌐
+    title: 浏览器自动化
+    details: AI Agent 直接控制浏览器：点击、输入、提取、截图 — 任何交互，完全可编程。
   - icon: 🔐
     title: 账号安全
     details: 复用 Chrome 登录态，凭证永远不会离开浏览器 — 无 token，无密码泄露。
   - icon: 🤖
     title: AI Agent 就绪
     details: explore 发现 API，synthesize 生成适配器，cascade 查找认证策略。为 AI 优先工作流而生。
-  - icon: ⚡
-    title: 双引擎架构
-    details: 同时支持声明式数据管道和强大的浏览器运行时 JavaScript 注入。
+  - icon: 💰
+    title: 零 LLM 成本
+    details: 运行时不消耗模型 token。跑 10,000 次也不花一分钱。
+  - icon: 🔁
+    title: 确定性输出
+    details: 相同命令，相同输出结构，每次一致。可管道、可脚本、CI 友好。
 ---


### PR DESCRIPTION
## Summary
Follow-up to #1008 — sync the Highlights changes to remaining doc surfaces:
- **README.zh-CN.md**: "为什么是 OpenCLI" → "亮点", content aligned with EN Highlights
- **docs/index.md**: feature cards updated (Desktop App Control, Browser Automation, Zero LLM Cost, Deterministic)
- **docs/zh/index.md**: Chinese feature cards synced
- **docs/guide/getting-started.md**: Highlights section aligned

## Test plan
- [ ] Visual review of docs site and README rendering