### PR TITLE
Add bookmark_count field to bookmarks command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -13161,12 +13161,14 @@
         "help": ""
       }
     ],
-    "columns": [
-      "author",
-      "text",
-      "likes",
-      "url"
-    ],
+  "columns": [
+    "author",
+    "text",
+    "likes",
+    "retweets",
+    "bookmarks",
+    "url"
+  ],
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
     "sourceFile": "twitter/bookmarks.js"

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -60,6 +60,7 @@ function extractBookmarkTweet(result, seen) {
         text: noteText || legacy.full_text || '',
         likes: legacy.favorite_count || 0,
         retweets: legacy.retweet_count || 0,
+        bookmarks: legacy.bookmark_count || 0,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
     };
@@ -106,7 +107,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['author', 'text', 'likes', 'url'],
+    columns: ['author', 'text', 'likes', 'retweets', 'bookmarks', 'url'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         await page.goto('https://x.com');


### PR DESCRIPTION
## Summary
Extract `bookmark_count` from the `legacy` object in Twitter GraphQL Bookmarks response and include it in the returned tweet object and table columns.

## Changes
- `clis/twitter/bookmarks.js`: Added `bookmarks: legacy.bookmark_count || 0` to tweet object
- Updated columns to include `bookmarks` field

## Motivation
The bookmarks timeline API returns `bookmark_count` for each tweet, but OpenCLI was not extracting and exposing this field. Useful for understanding tweet engagement beyond likes and retweets.