### PR TITLE
feat(bilibili): favorite command supports specifying fid

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1267,11 +1267,17 @@
   {
     "site": "bilibili",
     "name": "favorite",
-    "description": "我的默认收藏夹",
+    "description": "我的收藏夹",
     "domain": "www.bilibili.com",
     "strategy": "cookie",
     "browser": true,
     "args": [
+      {
+        "name": "fid",
+        "type": "int",
+        "required": false,
+        "help": "Favorite folder ID (defaults to first folder)"
+      },
       {
         "name": "limit",
         "type": "int",

--- a/clis/bilibili/favorite.js
+++ b/clis/bilibili/favorite.js
@@ -3,27 +3,32 @@ import { apiGet, payloadData, getSelfUid } from './utils.js';
 cli({
     site: 'bilibili',
     name: 'favorite',
-    description: '我的默认收藏夹',
+    description: '我的收藏夹',
     domain: 'www.bilibili.com',
     strategy: Strategy.COOKIE,
     args: [
+        { name: 'fid', type: 'int', required: false, help: 'Favorite folder ID (defaults to first folder)' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
     ],
     columns: ['rank', 'title', 'author', 'plays', 'url'],
     func: async (page, kwargs) => {
-        const { limit = 20, page: pageNum = 1 } = kwargs;
-        // Get current user's UID
-        const uid = await getSelfUid(page);
-        // Get default favorite folder ID
-        const foldersPayload = await apiGet(page, '/x/v3/fav/folder/created/list-all', {
-            params: { up_mid: uid },
-            signed: true,
-        });
-        const folders = payloadData(foldersPayload)?.list ?? [];
-        if (!folders.length)
-            return [];
-        const fid = folders[0].id;
+        const { fid: favoriteId, limit = 20, page: pageNum = 1 } = kwargs;
+        let fid;
+        if (favoriteId) {
+            fid = Number(favoriteId);
+        } else {
+            // Fall back to the default (first) favorite folder
+            const uid = await getSelfUid(page);
+            const foldersPayload = await apiGet(page, '/x/v3/fav/folder/created/list-all', {
+                params: { up_mid: uid },
+                signed: true,
+            });
+            const folders = payloadData(foldersPayload)?.list ?? [];
+            if (!folders.length)
+                return [];
+            fid = folders[0].id;
+        }
         // Fetch favorite items
         const payload = await apiGet(page, '/x/v3/fav/resource/list', {
             params: { media_id: fid, pn: pageNum, ps: Math.min(Number(limit), 40) },

--- a/docs/adapters/browser/bilibili.md
+++ b/docs/adapters/browser/bilibili.md
@@ -9,7 +9,7 @@
 | `opencli bilibili hot` | |
 | `opencli bilibili search` | |
 | `opencli bilibili me` | |
-| `opencli bilibili favorite` | |
+| `opencli bilibili favorite` | Read your first favorite folder, or a specific folder with `--fid` |
 | `opencli bilibili history` | |
 | `opencli bilibili feed` | Read the following feed, or a specific user's dynamics by uid/name |
 | `opencli bilibili feed-detail` | Read one dynamic in detail, including exclusive content |
@@ -31,6 +31,12 @@ opencli bilibili search 黑神话 --limit 10
 
 # Read one creator's videos
 opencli bilibili user-videos 2 --limit 10
+
+# Read your first favorite folder
+opencli bilibili favorite --limit 10
+
+# Read a specific favorite folder
+opencli bilibili favorite --fid 123456789 --limit 10
 
 # Read following feed
 opencli bilibili feed --limit 10
@@ -63,4 +69,5 @@ opencli bilibili hot -v
 
 - `opencli bilibili feed` without `uid` reads your following feed
 - `opencli bilibili feed <uid-or-name>` reads a specific user's dynamics
+- `opencli bilibili favorite` defaults to the first favorite folder when `--fid` is omitted
 - `feed-detail` expects the dynamic ID from a `https://t.bilibili.com/<id>` URL

--- a/skills/opencli-usage/commands.md
+++ b/skills/opencli-usage/commands.md
@@ -79,7 +79,8 @@ opencli bbc news --limit 10             # BBC News RSS headlines
 opencli bilibili hot --limit 10          # B站热门视频
 opencli bilibili search "rust"            # 搜索视频 (query positional)
 opencli bilibili me                       # 我的信息
-opencli bilibili favorite                 # 我的收藏
+opencli bilibili favorite                 # 我的默认收藏夹
+opencli bilibili favorite --fid 123456789 # 指定收藏夹
 opencli bilibili history --limit 20       # 观看历史
 opencli bilibili feed --limit 10          # 动态时间线
 opencli bilibili user-videos --uid 12345  # 用户投稿

--- a/skills/opencli-usage/commands.md
+++ b/skills/opencli-usage/commands.md
@@ -79,7 +79,7 @@ opencli bbc news --limit 10             # BBC News RSS headlines
 opencli bilibili hot --limit 10          # B站热门视频
 opencli bilibili search "rust"            # 搜索视频 (query positional)
 opencli bilibili me                       # 我的信息
-opencli bilibili favorite                 # 我的默认收藏夹
+opencli bilibili favorite                 # 我的收藏夹（默认第一个收藏夹）
 opencli bilibili favorite --fid 123456789 # 指定收藏夹
 opencli bilibili history --limit 20       # 观看历史
 opencli bilibili feed --limit 10          # 动态时间线


### PR DESCRIPTION
## Description

feat(bilibili): favorite command supports specifying fid

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

`npm run build`
`npm link`
`opencli bilibili favorite`
`opencli bilibili favorite --fid 123`
