### PR TITLE
fix: discover symlinked adapter directories in ~/.opencli/clis/

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -938,6 +938,21 @@ cli({
       }
     });
 
+  // Filter Dirent entries to directories, including symlinks that point to directories
+  async function filterDirentDirs(entries: fs.Dirent[], parentDir: string): Promise<fs.Dirent[]> {
+    const results: fs.Dirent[] = [];
+    for (const e of entries) {
+      if (e.isDirectory()) { results.push(e); continue; }
+      if (e.isSymbolicLink()) {
+        try {
+          const stat = await fs.promises.stat(path.join(parentDir, e.name));
+          if (stat.isDirectory()) results.push(e);
+        } catch { /* broken or non-dir symlink */ }
+      }
+    }
+    return results;
+  }
+
   // ── Built-in: adapter management ─────────────────────────────────────────
   const adapterCmd = program.command('adapter').description('Manage CLI adapters');
 
@@ -950,11 +965,11 @@ cli({
       const builtinClisDir = BUILTIN_CLIS;
       try {
         const userEntries = await fs.promises.readdir(userClisDir, { withFileTypes: true });
-        const userSites = userEntries.filter(e => e.isDirectory()).map(e => e.name).sort();
+        const userSites = (await filterDirentDirs(userEntries, userClisDir)).map(e => e.name).sort();
         let builtinSites: string[] = [];
         try {
           const builtinEntries = await fs.promises.readdir(builtinClisDir, { withFileTypes: true });
-          builtinSites = builtinEntries.filter(e => e.isDirectory()).map(e => e.name).sort();
+          builtinSites = (await filterDirentDirs(builtinEntries, builtinClisDir)).map(e => e.name).sort();
         } catch { /* no builtin dir */ }
 
         if (userSites.length === 0) {
@@ -1017,7 +1032,7 @@ cli({
       if (opts.all) {
         try {
           const userEntries = await fs.promises.readdir(userClisDir, { withFileTypes: true });
-          const dirs = userEntries.filter(e => e.isDirectory());
+          const dirs = await filterDirentDirs(userEntries, userClisDir);
           if (dirs.length === 0) {
             console.log('No local sites to reset.');
             return;

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -164,7 +164,13 @@ async function discoverClisFromFs(dir: string): Promise<void> {
         try {
           const stat = await fs.promises.stat(siteDir);
           if (!stat.isDirectory()) return;
-        } catch { return; }
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+            log.warn(`Failed to inspect symlink ${siteDir}: ${getErrorMessage(err)}`);
+          }
+          return;
+        }
       }
       const files = await fs.promises.readdir(siteDir);
       await Promise.all(files.map(async (file) => {

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -155,10 +155,17 @@ async function discoverClisFromFs(dir: string): Promise<void> {
   const entries = await fs.promises.readdir(dir, { withFileTypes: true });
   
   const sitePromises = entries
-    .filter(entry => entry.isDirectory())
+    .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
     .map(async (entry) => {
       const site = entry.name;
       const siteDir = path.join(dir, site);
+      // For symlinks, verify the target is a directory
+      if (entry.isSymbolicLink()) {
+        try {
+          const stat = await fs.promises.stat(siteDir);
+          if (!stat.isDirectory()) return;
+        } catch { return; }
+      }
       const files = await fs.promises.readdir(siteDir);
       await Promise.all(files.map(async (file) => {
         const filePath = path.join(siteDir, file);

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -112,6 +112,36 @@ cli({
       await fs.promises.rm(tempOpencliRoot, { recursive: true, force: true });
     }
   });
+
+  it('discovers CLI modules from symlinked site directories', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-symlinked-site-'));
+    const userClisDir = path.join(tempRoot, 'clis');
+    const targetSiteDir = path.join(tempRoot, 'external-site');
+    const linkSiteDir = path.join(userClisDir, 'symlink-site');
+
+    try {
+      await fs.promises.mkdir(targetSiteDir, { recursive: true });
+      await fs.promises.mkdir(userClisDir, { recursive: true });
+      await fs.promises.writeFile(path.join(targetSiteDir, 'hello.js'), `
+import { cli, Strategy } from '${pathToFileURL(path.join(process.cwd(), 'src', 'registry.ts')).href}';
+cli({
+  site: 'symlink-site',
+  name: 'hello',
+  description: 'hello command',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  func: async () => [{ ok: true }],
+});
+`);
+      await fs.promises.symlink(targetSiteDir, linkSiteDir, 'dir');
+
+      await discoverClis(userClisDir);
+
+      expect(getRegistry().get('symlink-site/hello')).toBeDefined();
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('ensureUserAdapters', () => {


### PR DESCRIPTION
## Problem

`discoverClisFromFs()` in `discovery.ts` uses `entry.isDirectory()` to filter site directories, but `Dirent.isDirectory()` returns `false` for symbolic links even when the link target is a directory. This causes user adapters installed as symlinks to be silently skipped.

**Reproduction**: Create a symlinked adapter directory:
```bash
ln -s /path/to/project/adapters/mysite ~/.opencli/clis/mysite
```
The adapter is not discovered — `opencli mysite --help` shows the top-level help instead of the site's commands.

## Fix

Also check `entry.isSymbolicLink()` and verify the target is a directory via `fs.promises.stat()` before scanning the site directory.

## Testing

- Verified with 5 symlinked adapter directories (dingtalk-doc, ata, crash-detail, crash-stack, motu-crash)
- All adapters correctly discovered after the fix
- Non-directory symlinks are safely skipped via stat check