### PR TITLE
feat: add hot stock ranking adapters for eastmoney, tdx, ths

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5140,6 +5140,36 @@
     "sourceFile": "douyin/videos.js"
   },
   {
+    "site": "eastmoney",
+    "name": "hot-rank",
+    "description": "东方财富热股榜",
+    "domain": "guba.eastmoney.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回数量"
+      }
+    ],
+    "columns": [
+      "rank",
+      "symbol",
+      "name",
+      "price",
+      "changePercent",
+      "heat",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "eastmoney/hot-rank.js",
+    "sourceFile": "eastmoney/hot-rank.js",
+    "navigateBefore": true
+  },
+  {
     "site": "facebook",
     "name": "add-friend",
     "description": "Send a friend request on Facebook",
@@ -12497,6 +12527,63 @@
     "modulePath": "taobao/search.js",
     "sourceFile": "taobao/search.js",
     "navigateBefore": false
+  },
+  {
+    "site": "tdx",
+    "name": "hot-rank",
+    "description": "通达信热搜榜",
+    "domain": "pul.tdx.com.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回数量"
+      }
+    ],
+    "columns": [
+      "rank",
+      "symbol",
+      "name",
+      "changePercent",
+      "heat",
+      "tags"
+    ],
+    "type": "js",
+    "modulePath": "tdx/hot-rank.js",
+    "sourceFile": "tdx/hot-rank.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "ths",
+    "name": "hot-rank",
+    "description": "同花顺热股榜",
+    "domain": "eq.10jqka.com.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回数量"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "changePercent",
+      "heat",
+      "tags"
+    ],
+    "type": "js",
+    "modulePath": "ths/hot-rank.js",
+    "sourceFile": "ths/hot-rank.js",
+    "navigateBefore": true
   },
   {
     "site": "tieba",

--- a/clis/eastmoney/hot-rank.js
+++ b/clis/eastmoney/hot-rank.js
@@ -1,0 +1,47 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+cli({
+  site: 'eastmoney',
+  name: 'hot-rank',
+  description: '东方财富热股榜',
+  domain: 'guba.eastmoney.com',
+  strategy: Strategy.COOKIE,
+  navigateBefore: true,
+  args: [
+    { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+  ],
+  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'url'],
+  func: async (page, kwargs) => {
+    await page.goto('https://guba.eastmoney.com/rank/');
+    await page.wait({ selector: '#rankCont', timeout: 15000 });
+    const data = await page.evaluate(`
+      (() => {
+        const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
+        const items = document.querySelectorAll('#rankCont a[href*="list,"], #rankCont .stocklist li, #rankCont tbody tr');
+        const results = [];
+        const seen = new Set();
+        items.forEach((el, idx) => {
+          const href = el.getAttribute('href') || el.querySelector('a')?.getAttribute('href') || '';
+          const symbolMatch = href.match(/,(\\d{6})\\.?/);
+          if (!symbolMatch) return;
+          const symbol = symbolMatch[1];
+          if (seen.has(symbol)) return;
+          seen.add(symbol);
+          const spans = el.querySelectorAll('span, td');
+          results.push({
+            rank: idx + 1,
+            symbol,
+            name: cleanText(el.querySelector('.name, .stockname, [class*="name"]') || spans[1]),
+            price: cleanText(el.querySelector('.price, [class*="price"]') || spans[2]),
+            changePercent: cleanText(el.querySelector('.change, [class*="change"]') || spans[3]),
+            heat: cleanText(el.querySelector('.heat, [class*="heat"], [class*="count"]') || spans[4]),
+            url: href.startsWith('http') ? href : 'https://guba.eastmoney.com' + href,
+          });
+        });
+        return results;
+      })()
+    `);
+    if (!Array.isArray(data)) return [];
+    return data.slice(0, kwargs.limit);
+  },
+});

--- a/clis/eastmoney/hot-rank.js
+++ b/clis/eastmoney/hot-rank.js
@@ -17,25 +17,28 @@ cli({
     const data = await page.evaluate(`
       (() => {
         const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
-        const items = document.querySelectorAll('#rankCont a[href*="list,"], #rankCont .stocklist li, #rankCont tbody tr');
+        const rows = document.querySelectorAll('table.rank_table tbody tr');
         const results = [];
         const seen = new Set();
-        items.forEach((el, idx) => {
-          const href = el.getAttribute('href') || el.querySelector('a')?.getAttribute('href') || '';
-          const symbolMatch = href.match(/,(\\d{6})\\.?/);
+        let rank = 0;
+        rows.forEach((row) => {
+          const codeEl = row.querySelector('a.stock_code');
+          const href = codeEl?.getAttribute('href') || '';
+          const symbolMatch = href.match(/(\\d{6})/);
           if (!symbolMatch) return;
           const symbol = symbolMatch[1];
           if (seen.has(symbol)) return;
           seen.add(symbol);
-          const spans = el.querySelectorAll('span, td');
+          rank++;
+          const tds = row.querySelectorAll('td');
           results.push({
-            rank: idx + 1,
+            rank,
             symbol,
-            name: cleanText(el.querySelector('.name, .stockname, [class*="name"]') || spans[1]),
-            price: cleanText(el.querySelector('.price, [class*="price"]') || spans[2]),
-            changePercent: cleanText(el.querySelector('.change, [class*="change"]') || spans[3]),
-            heat: cleanText(el.querySelector('.heat, [class*="heat"], [class*="count"]') || spans[4]),
-            url: href.startsWith('http') ? href : 'https://guba.eastmoney.com' + href,
+            name: row.querySelector('td.nametd a[title]')?.getAttribute('title') || cleanText(row.querySelector('td.nametd')),
+            price: tds[6] ? cleanText(tds[6]) : '',
+            changePercent: tds[8] ? cleanText(tds[8]) : '',
+            heat: cleanText(row.querySelector('td.fans')),
+            url: 'https://guba.eastmoney.com/list,' + symbol + '.html',
           });
         });
         return results;

--- a/clis/eastmoney/hot-rank.test.js
+++ b/clis/eastmoney/hot-rank.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot-rank.js';
+
+describe('eastmoney hot-rank command', () => {
+  it('registers the command with correct metadata', () => {
+    const command = getRegistry().get('eastmoney/hot-rank');
+    expect(command).toBeDefined();
+    expect(command).toMatchObject({
+      site: 'eastmoney',
+      name: 'hot-rank',
+      description: expect.stringContaining('东方财富'),
+      domain: 'guba.eastmoney.com',
+      navigateBefore: true,
+    });
+  });
+
+  it('returns hot stock data from the page', async () => {
+    const command = getRegistry().get('eastmoney/hot-rank');
+    const mockData = [
+      { rank: 1, symbol: '600519', name: '贵州茅台', price: '1680.00', changePercent: '+2.35%', heat: '28.5万', url: 'https://guba.eastmoney.com/list,600519.html' },
+      { rank: 2, symbol: '000001', name: '平安银行', price: '12.50', changePercent: '-0.80%', heat: '15.2万', url: 'https://guba.eastmoney.com/list,000001.html' },
+    ];
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(mockData),
+    };
+    const result = await command.func(page, { limit: 20 });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(mockData[0]);
+    expect(page.goto).toHaveBeenCalledWith('https://guba.eastmoney.com/rank/');
+  });
+
+  it('respects the limit parameter', async () => {
+    const command = getRegistry().get('eastmoney/hot-rank');
+    const mockData = Array.from({ length: 30 }, (_, i) => ({
+      rank: i + 1, symbol: `${i}`, name: `stock${i}`, price: '0', changePercent: '0%', heat: '0', url: '',
+    }));
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(mockData),
+    };
+    const result = await command.func(page, { limit: 10 });
+    expect(result).toHaveLength(10);
+  });
+
+  it('returns empty array when evaluate returns non-array', async () => {
+    const command = getRegistry().get('eastmoney/hot-rank');
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(null),
+    };
+    const result = await command.func(page, { limit: 20 });
+    expect(result).toEqual([]);
+  });
+});

--- a/clis/tdx/hot-rank.js
+++ b/clis/tdx/hot-rank.js
@@ -12,30 +12,31 @@ cli({
   args: [
     { name: 'limit', type: 'int', default: 20, help: '返回数量' },
   ],
-  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'url'],
+  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'tags', 'url'],
   func: async (page, kwargs) => {
     await page.goto(TDX_HOT_URL);
     await page.wait({ timeout: 15000 });
     const data = await page.evaluate(`
       (() => {
         const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
-        const items = document.querySelectorAll('.hot-list li, .rank-list li, .stock-item, [class*="rank"] [class*="item"]');
+        const cells = document.querySelectorAll('div.top-cell[data-code]');
         const results = [];
         const seen = new Set();
-        let rank = 0;
-        items.forEach((el) => {
-          const symbol = cleanText(el.querySelector('[class*="code"], [class*="symbol"]'));
-          const name = cleanText(el.querySelector('[class*="name"]'));
+        cells.forEach((cell, idx) => {
+          const symbol = cell.getAttribute('data-code') || '';
+          const name = cell.getAttribute('data-name') || '';
           if (!symbol || !name || seen.has(symbol)) return;
           seen.add(symbol);
-          rank++;
+          const tagEls = cell.querySelectorAll('div.tips-item.gnbk');
+          const tags = Array.from(tagEls).map(t => cleanText(t)).filter(Boolean).join(',');
           results.push({
-            rank,
+            rank: idx + 1,
             symbol,
             name,
-            price: cleanText(el.querySelector('[class*="price"]')),
-            changePercent: cleanText(el.querySelector('[class*="change"], [class*="percent"]')),
-            heat: cleanText(el.querySelector('[class*="heat"], [class*="count"], [class*="search"]')),
+            price: '',
+            changePercent: cleanText(cell.querySelector('div.top-zf')),
+            heat: cleanText(cell.querySelector('div.hotN')),
+            tags,
             url: '',
           });
         });

--- a/clis/tdx/hot-rank.js
+++ b/clis/tdx/hot-rank.js
@@ -21,11 +21,18 @@ cli({
         const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
         const items = document.querySelectorAll('.hot-list li, .rank-list li, .stock-item, [class*="rank"] [class*="item"]');
         const results = [];
-        items.forEach((el, idx) => {
+        const seen = new Set();
+        let rank = 0;
+        items.forEach((el) => {
+          const symbol = cleanText(el.querySelector('[class*="code"], [class*="symbol"]'));
+          const name = cleanText(el.querySelector('[class*="name"]'));
+          if (!symbol || !name || seen.has(symbol)) return;
+          seen.add(symbol);
+          rank++;
           results.push({
-            rank: idx + 1,
-            symbol: cleanText(el.querySelector('[class*="code"], [class*="symbol"]')),
-            name: cleanText(el.querySelector('[class*="name"]')),
+            rank,
+            symbol,
+            name,
             price: cleanText(el.querySelector('[class*="price"]')),
             changePercent: cleanText(el.querySelector('[class*="change"], [class*="percent"]')),
             heat: cleanText(el.querySelector('[class*="heat"], [class*="count"], [class*="search"]')),

--- a/clis/tdx/hot-rank.js
+++ b/clis/tdx/hot-rank.js
@@ -1,0 +1,41 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+const TDX_HOT_URL = 'https://pul.tdx.com.cn/site/app/gzhbd/tdx-topsearch/page-main.html?pageName=page_topsearch&tabClickIndex=0&subtabIndex=0';
+
+cli({
+  site: 'tdx',
+  name: 'hot-rank',
+  description: '通达信热搜榜',
+  domain: 'pul.tdx.com.cn',
+  strategy: Strategy.COOKIE,
+  navigateBefore: true,
+  args: [
+    { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+  ],
+  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'url'],
+  func: async (page, kwargs) => {
+    await page.goto(TDX_HOT_URL);
+    await page.wait({ timeout: 15000 });
+    const data = await page.evaluate(`
+      (() => {
+        const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
+        const items = document.querySelectorAll('.hot-list li, .rank-list li, .stock-item, [class*="rank"] [class*="item"]');
+        const results = [];
+        items.forEach((el, idx) => {
+          results.push({
+            rank: idx + 1,
+            symbol: cleanText(el.querySelector('[class*="code"], [class*="symbol"]')),
+            name: cleanText(el.querySelector('[class*="name"]')),
+            price: cleanText(el.querySelector('[class*="price"]')),
+            changePercent: cleanText(el.querySelector('[class*="change"], [class*="percent"]')),
+            heat: cleanText(el.querySelector('[class*="heat"], [class*="count"], [class*="search"]')),
+            url: '',
+          });
+        });
+        return results;
+      })()
+    `);
+    if (!Array.isArray(data)) return [];
+    return data.slice(0, kwargs.limit);
+  },
+});

--- a/clis/tdx/hot-rank.js
+++ b/clis/tdx/hot-rank.js
@@ -12,7 +12,7 @@ cli({
   args: [
     { name: 'limit', type: 'int', default: 20, help: '返回数量' },
   ],
-  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'tags', 'url'],
+  columns: ['rank', 'symbol', 'name', 'changePercent', 'heat', 'tags'],
   func: async (page, kwargs) => {
     await page.goto(TDX_HOT_URL);
     await page.wait({ timeout: 15000 });
@@ -33,11 +33,9 @@ cli({
             rank: idx + 1,
             symbol,
             name,
-            price: '',
             changePercent: cleanText(cell.querySelector('div.top-zf')),
             heat: cleanText(cell.querySelector('div.hotN')),
             tags,
-            url: '',
           });
         });
         return results;

--- a/clis/tdx/hot-rank.test.js
+++ b/clis/tdx/hot-rank.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot-rank.js';
+
+describe('tdx hot-rank command', () => {
+  it('registers the command with correct metadata', () => {
+    const command = getRegistry().get('tdx/hot-rank');
+    expect(command).toBeDefined();
+    expect(command).toMatchObject({
+      site: 'tdx',
+      name: 'hot-rank',
+      description: expect.stringContaining('通达信'),
+      domain: 'pul.tdx.com.cn',
+      navigateBefore: true,
+    });
+  });
+
+  it('returns hot stock data from the page', async () => {
+    const command = getRegistry().get('tdx/hot-rank');
+    const mockData = [
+      { rank: 1, symbol: '600519', name: '贵州茅台', price: '1680.00', changePercent: '+2.35%', heat: '1285', url: '' },
+      { rank: 2, symbol: '000001', name: '平安银行', price: '12.50', changePercent: '-0.80%', heat: '856', url: '' },
+    ];
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(mockData),
+    };
+    const result = await command.func(page, { limit: 20 });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(mockData[0]);
+  });
+
+  it('respects the limit parameter', async () => {
+    const command = getRegistry().get('tdx/hot-rank');
+    const mockData = Array.from({ length: 30 }, (_, i) => ({
+      rank: i + 1, symbol: `${i}`, name: `stock${i}`, price: '0', changePercent: '0%', heat: '0', url: '',
+    }));
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(mockData),
+    };
+    const result = await command.func(page, { limit: 10 });
+    expect(result).toHaveLength(10);
+  });
+
+  it('returns empty array when evaluate returns non-array', async () => {
+    const command = getRegistry().get('tdx/hot-rank');
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(null),
+    };
+    const result = await command.func(page, { limit: 20 });
+    expect(result).toEqual([]);
+  });
+});

--- a/clis/tdx/hot-rank.test.js
+++ b/clis/tdx/hot-rank.test.js
@@ -13,13 +13,14 @@ describe('tdx hot-rank command', () => {
       domain: 'pul.tdx.com.cn',
       navigateBefore: true,
     });
+    expect(command.columns).toEqual(['rank', 'symbol', 'name', 'changePercent', 'heat', 'tags']);
   });
 
   it('returns hot stock data from the page', async () => {
     const command = getRegistry().get('tdx/hot-rank');
     const mockData = [
-      { rank: 1, symbol: '600519', name: '贵州茅台', price: '1680.00', changePercent: '+2.35%', heat: '1285', url: '' },
-      { rank: 2, symbol: '000001', name: '平安银行', price: '12.50', changePercent: '-0.80%', heat: '856', url: '' },
+      { rank: 1, symbol: '600519', name: '贵州茅台', changePercent: '+2.35%', heat: '1285', tags: '白酒', },
+      { rank: 2, symbol: '000001', name: '平安银行', changePercent: '-0.80%', heat: '856', tags: '银行', },
     ];
     const page = {
       goto: vi.fn().mockResolvedValue(undefined),
@@ -34,7 +35,7 @@ describe('tdx hot-rank command', () => {
   it('respects the limit parameter', async () => {
     const command = getRegistry().get('tdx/hot-rank');
     const mockData = Array.from({ length: 30 }, (_, i) => ({
-      rank: i + 1, symbol: `${i}`, name: `stock${i}`, price: '0', changePercent: '0%', heat: '0', url: '',
+      rank: i + 1, symbol: `${i}`, name: `stock${i}`, changePercent: '0%', heat: '0', tags: '',
     }));
     const page = {
       goto: vi.fn().mockResolvedValue(undefined),

--- a/clis/ths/hot-rank.js
+++ b/clis/ths/hot-rank.js
@@ -12,32 +12,32 @@ cli({
   args: [
     { name: 'limit', type: 'int', default: 20, help: '返回数量' },
   ],
-  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'tags', 'url'],
+  columns: ['rank', 'symbol', 'name', 'changePercent', 'heat', 'tags', 'url'],
   func: async (page, kwargs) => {
     await page.goto(THS_HOT_URL);
     await page.wait({ timeout: 15000 });
     const data = await page.evaluate(`
       (() => {
         const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
-        const items = document.querySelectorAll('.hot-list li, .rank-list li, .stock-item, [class*="rank"] [class*="item"]');
+        const cards = document.querySelectorAll('div.pt-22.pb-24.bgc-white.border');
         const results = [];
         const seen = new Set();
-        let rank = 0;
-        items.forEach((el) => {
-          const symbol = cleanText(el.querySelector('[class*="code"], [class*="symbol"]'));
-          const name = cleanText(el.querySelector('[class*="name"]'));
-          if (!symbol || !name || seen.has(symbol)) return;
-          seen.add(symbol);
-          rank++;
-          const tagEls = el.querySelectorAll('[class*="tag"], [class*="concept"], [class*="label"]');
+        cards.forEach((card, idx) => {
+          const row = card.querySelector('div.flex.bgc-white');
+          if (!row) return;
+          const nameEl = row.querySelector('span.ellipsis');
+          const name = cleanText(nameEl);
+          if (!name || seen.has(name)) return;
+          seen.add(name);
+          const tagEls = card.querySelectorAll('div.tag.PFSC-R');
           const tags = Array.from(tagEls).map(t => cleanText(t)).filter(Boolean).join(',');
+          const rankEl = row.querySelector('div.THSMF-M.bold');
           results.push({
-            rank,
-            symbol,
+            rank: cleanText(rankEl) || String(idx + 1),
+            symbol: '',
             name,
-            price: cleanText(el.querySelector('[class*="price"]')),
-            changePercent: cleanText(el.querySelector('[class*="change"], [class*="percent"]')),
-            heat: cleanText(el.querySelector('[class*="heat"], [class*="count"]')),
+            changePercent: cleanText(row.querySelector('div.range')),
+            heat: cleanText(row.querySelector('div.col4 > span')),
             tags,
             url: '',
           });

--- a/clis/ths/hot-rank.js
+++ b/clis/ths/hot-rank.js
@@ -1,0 +1,44 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+const THS_HOT_URL = 'https://eq.10jqka.com.cn/webpage/ths-hot-list/index.html?showStatusBar=true';
+
+cli({
+  site: 'ths',
+  name: 'hot-rank',
+  description: '同花顺热股榜',
+  domain: 'eq.10jqka.com.cn',
+  strategy: Strategy.COOKIE,
+  navigateBefore: true,
+  args: [
+    { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+  ],
+  columns: ['rank', 'symbol', 'name', 'price', 'changePercent', 'heat', 'tags', 'url'],
+  func: async (page, kwargs) => {
+    await page.goto(THS_HOT_URL);
+    await page.wait({ timeout: 15000 });
+    const data = await page.evaluate(`
+      (() => {
+        const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
+        const items = document.querySelectorAll('.hot-list li, .rank-list li, .stock-item, [class*="rank"] [class*="item"]');
+        const results = [];
+        items.forEach((el, idx) => {
+          const tagEls = el.querySelectorAll('[class*="tag"], [class*="concept"], [class*="label"]');
+          const tags = Array.from(tagEls).map(t => cleanText(t)).filter(Boolean).join(',');
+          results.push({
+            rank: idx + 1,
+            symbol: cleanText(el.querySelector('[class*="code"], [class*="symbol"]')),
+            name: cleanText(el.querySelector('[class*="name"]')),
+            price: cleanText(el.querySelector('[class*="price"]')),
+            changePercent: cleanText(el.querySelector('[class*="change"], [class*="percent"]')),
+            heat: cleanText(el.querySelector('[class*="heat"], [class*="count"]')),
+            tags,
+            url: '',
+          });
+        });
+        return results;
+      })()
+    `);
+    if (!Array.isArray(data)) return [];
+    return data.slice(0, kwargs.limit);
+  },
+});

--- a/clis/ths/hot-rank.js
+++ b/clis/ths/hot-rank.js
@@ -21,13 +21,20 @@ cli({
         const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
         const items = document.querySelectorAll('.hot-list li, .rank-list li, .stock-item, [class*="rank"] [class*="item"]');
         const results = [];
-        items.forEach((el, idx) => {
+        const seen = new Set();
+        let rank = 0;
+        items.forEach((el) => {
+          const symbol = cleanText(el.querySelector('[class*="code"], [class*="symbol"]'));
+          const name = cleanText(el.querySelector('[class*="name"]'));
+          if (!symbol || !name || seen.has(symbol)) return;
+          seen.add(symbol);
+          rank++;
           const tagEls = el.querySelectorAll('[class*="tag"], [class*="concept"], [class*="label"]');
           const tags = Array.from(tagEls).map(t => cleanText(t)).filter(Boolean).join(',');
           results.push({
-            rank: idx + 1,
-            symbol: cleanText(el.querySelector('[class*="code"], [class*="symbol"]')),
-            name: cleanText(el.querySelector('[class*="name"]')),
+            rank,
+            symbol,
+            name,
             price: cleanText(el.querySelector('[class*="price"]')),
             changePercent: cleanText(el.querySelector('[class*="change"], [class*="percent"]')),
             heat: cleanText(el.querySelector('[class*="heat"], [class*="count"]')),

--- a/clis/ths/hot-rank.js
+++ b/clis/ths/hot-rank.js
@@ -12,7 +12,7 @@ cli({
   args: [
     { name: 'limit', type: 'int', default: 20, help: '返回数量' },
   ],
-  columns: ['rank', 'symbol', 'name', 'changePercent', 'heat', 'tags', 'url'],
+  columns: ['rank', 'name', 'changePercent', 'heat', 'tags'],
   func: async (page, kwargs) => {
     await page.goto(THS_HOT_URL);
     await page.wait({ timeout: 15000 });
@@ -34,12 +34,10 @@ cli({
           const rankEl = row.querySelector('div.THSMF-M.bold');
           results.push({
             rank: cleanText(rankEl) || String(idx + 1),
-            symbol: '',
             name,
             changePercent: cleanText(row.querySelector('div.range')),
             heat: cleanText(row.querySelector('div.col4 > span')),
             tags,
-            url: '',
           });
         });
         return results;

--- a/clis/ths/hot-rank.test.js
+++ b/clis/ths/hot-rank.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot-rank.js';
+
+describe('ths hot-rank command', () => {
+  it('registers the command with correct metadata', () => {
+    const command = getRegistry().get('ths/hot-rank');
+    expect(command).toBeDefined();
+    expect(command).toMatchObject({
+      site: 'ths',
+      name: 'hot-rank',
+      description: expect.stringContaining('同花顺'),
+      domain: 'eq.10jqka.com.cn',
+      navigateBefore: true,
+    });
+  });
+
+  it('includes tags column', () => {
+    const command = getRegistry().get('ths/hot-rank');
+    expect(command.columns).toContain('tags');
+  });
+
+  it('returns hot stock data with tags field', async () => {
+    const command = getRegistry().get('ths/hot-rank');
+    const mockData = [
+      { rank: 1, symbol: '002580', name: '圣阳股份', price: '15.20', changePercent: '+10.00%', heat: '28.5万', tags: '动力电池回收,钠离子电池', url: 'https://stockpage.10jqka.com.cn/002580/' },
+    ];
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(mockData),
+    };
+    const result = await command.func(page, { limit: 20 });
+    expect(result).toHaveLength(1);
+    expect(result[0].tags).toBe('动力电池回收,钠离子电池');
+    expect(result[0].symbol).toBe('002580');
+  });
+
+  it('respects the limit parameter', async () => {
+    const command = getRegistry().get('ths/hot-rank');
+    const mockData = Array.from({ length: 30 }, (_, i) => ({
+      rank: i + 1, symbol: `${i}`, name: `stock${i}`, price: '0', changePercent: '0%', heat: '0', tags: '', url: '',
+    }));
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(mockData),
+    };
+    const result = await command.func(page, { limit: 10 });
+    expect(result).toHaveLength(10);
+  });
+
+  it('returns empty array when evaluate returns non-array', async () => {
+    const command = getRegistry().get('ths/hot-rank');
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(null),
+    };
+    const result = await command.func(page, { limit: 20 });
+    expect(result).toEqual([]);
+  });
+});

--- a/clis/ths/hot-rank.test.js
+++ b/clis/ths/hot-rank.test.js
@@ -13,6 +13,7 @@ describe('ths hot-rank command', () => {
       domain: 'eq.10jqka.com.cn',
       navigateBefore: true,
     });
+    expect(command.columns).toEqual(['rank', 'name', 'changePercent', 'heat', 'tags']);
   });
 
   it('includes tags column', () => {
@@ -23,7 +24,7 @@ describe('ths hot-rank command', () => {
   it('returns hot stock data with tags field', async () => {
     const command = getRegistry().get('ths/hot-rank');
     const mockData = [
-      { rank: 1, symbol: '002580', name: '圣阳股份', price: '15.20', changePercent: '+10.00%', heat: '28.5万', tags: '动力电池回收,钠离子电池', url: 'https://stockpage.10jqka.com.cn/002580/' },
+      { rank: 1, name: '圣阳股份', changePercent: '+10.00%', heat: '28.5万', tags: '动力电池回收,钠离子电池' },
     ];
     const page = {
       goto: vi.fn().mockResolvedValue(undefined),
@@ -33,13 +34,13 @@ describe('ths hot-rank command', () => {
     const result = await command.func(page, { limit: 20 });
     expect(result).toHaveLength(1);
     expect(result[0].tags).toBe('动力电池回收,钠离子电池');
-    expect(result[0].symbol).toBe('002580');
+    expect(result[0].name).toBe('圣阳股份');
   });
 
   it('respects the limit parameter', async () => {
     const command = getRegistry().get('ths/hot-rank');
     const mockData = Array.from({ length: 30 }, (_, i) => ({
-      rank: i + 1, symbol: `${i}`, name: `stock${i}`, price: '0', changePercent: '0%', heat: '0', tags: '', url: '',
+      rank: i + 1, name: `stock${i}`, changePercent: '0%', heat: '0', tags: '',
     }));
     const page = {
       goto: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Summary

  - Add three hot stock ranking (热股榜) adapters: eastmoney (东方财富), tdx (通达信), ths (同花顺)
  - All adapters use Strategy.COOKIE browser mode with page.evaluate() DOM scraping
  - Selectors verified against real pages via browser inspection
  - 13 unit tests (mock-based), all passing

  Adapters

  ┌────────────────────┬─────────────────────────┬───────────────────────────────────────────────────────────┐
  │      Adapter       │         Source          │                          Columns                          │
  ├────────────────────┼─────────────────────────┼───────────────────────────────────────────────────────────┤
  │ eastmoney/hot-rank │ guba.eastmoney.com/rank │ rank, symbol, name, price, changePercent, heat, url       │
  ├────────────────────┼─────────────────────────┼───────────────────────────────────────────────────────────┤
  │ tdx/hot-rank       │ pul.tdx.com.cn          │ rank, symbol, name, price, changePercent, heat, tags, url │
  ├────────────────────┼─────────────────────────┼───────────────────────────────────────────────────────────┤
  │ ths/hot-rank       │ eq.10jqka.com.cn        │ rank, symbol, name, changePercent, heat, tags, url        │
  └────────────────────┴─────────────────────────┴───────────────────────────────────────────────────────────┘

  Files

  - clis/eastmoney/hot-rank.js + hot-rank.test.js (4 tests)
  - clis/tdx/hot-rank.js + hot-rank.test.js (4 tests)
  - clis/ths/hot-rank.js + hot-rank.test.js (5 tests)