### PR TITLE
fix: auto-restart stale daemon and improve connection error messages

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -144,7 +144,28 @@ describe('BrowserBridge state', () => {
     await expect(bridge.connect()).rejects.toThrow('Session is closing');
   });
 
-  it('fails fast when daemon is running but extension is disconnected', async () => {
+  it('fails fast when daemon is running but extension is disconnected (same version)', async () => {
+    const { PKG_VERSION } = await import('./version.js');
+    vi.spyOn(daemonClient, 'getDaemonHealth').mockResolvedValue({
+      state: 'no-extension',
+      status: {
+        ok: true,
+        pid: 1,
+        uptime: 0,
+        daemonVersion: PKG_VERSION,
+        extensionConnected: false,
+        pending: 0,
+        memoryMB: 0,
+        port: 0,
+      },
+    });
+
+    const bridge = new BrowserBridge();
+
+    await expect(bridge.connect({ timeout: 0.1 })).rejects.toThrow('Browser Bridge extension not connected');
+  });
+
+  it('attempts stale daemon replacement when daemonVersion is missing', async () => {
     vi.spyOn(daemonClient, 'getDaemonHealth').mockResolvedValue({
       state: 'no-extension',
       status: {
@@ -157,10 +178,32 @@ describe('BrowserBridge state', () => {
         port: 0,
       },
     });
+    vi.spyOn(daemonClient, 'requestDaemonShutdown').mockResolvedValue(false);
 
     const bridge = new BrowserBridge();
 
-    await expect(bridge.connect({ timeout: 0.1 })).rejects.toThrow('Browser Bridge extension not connected');
+    await expect(bridge.connect({ timeout: 0.1 })).rejects.toThrow('Stale daemon could not be replaced');
+  });
+
+  it('attempts stale daemon replacement when daemonVersion mismatches', async () => {
+    vi.spyOn(daemonClient, 'getDaemonHealth').mockResolvedValue({
+      state: 'no-extension',
+      status: {
+        ok: true,
+        pid: 1,
+        uptime: 0,
+        daemonVersion: '0.0.1',
+        extensionConnected: false,
+        pending: 0,
+        memoryMB: 0,
+        port: 0,
+      },
+    });
+    vi.spyOn(daemonClient, 'requestDaemonShutdown').mockResolvedValue(false);
+
+    const bridge = new BrowserBridge();
+
+    await expect(bridge.connect({ timeout: 0.1 })).rejects.toThrow('Stale daemon could not be replaced');
   });
 });
 

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -81,16 +81,19 @@ export class BrowserBridge implements IBrowserFactory {
         if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
           process.stderr.write(`⚠️  Stale daemon detected (${reason}). Restarting...\n`);
         }
-        const stopped = await requestDaemonShutdown();
-        if (stopped) {
-          // Verify port is actually released before spawning
-          await this._waitForDaemonStop(3000);
-        } else {
-          if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
-            process.stderr.write('⚠️  Daemon did not respond to shutdown request.\n');
-          }
+        const shutdownAccepted = await requestDaemonShutdown();
+        const portReleased = shutdownAccepted && await this._waitForDaemonStop(3000);
+
+        if (!portReleased) {
+          // Stale daemon replacement failed — don't blindly spawn on an occupied port
+          throw new BrowserConnectError(
+            'Stale daemon could not be replaced',
+            `A stale daemon (${reason}) is running but did not shut down.\n` +
+            '  Run manually: opencli daemon stop && opencli doctor',
+            'daemon-not-running',
+          );
         }
-        // Fall through to the "No daemon — spawn one" path below
+        // Port released — fall through to spawn a fresh daemon
       } else {
         // Same version — wait for extension to connect
         if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -69,17 +69,27 @@ export class BrowserBridge implements IBrowserFactory {
 
     // Daemon running but no extension
     if (health.state === 'no-extension') {
-      // Check if daemon is stale (version mismatch = started by older CLI)
+      // Detect stale daemon: version mismatch OR missing daemonVersion (pre-version daemon)
       const daemonVersion = health.status?.daemonVersion;
-      const isStale = daemonVersion && daemonVersion !== PKG_VERSION;
+      const isStale = !daemonVersion || daemonVersion !== PKG_VERSION;
 
       if (isStale) {
         // Stale daemon — restart it so extension gets a fresh WebSocket endpoint
+        const reason = daemonVersion
+          ? `v${daemonVersion} ≠ v${PKG_VERSION}`
+          : `pre-version daemon, CLI is v${PKG_VERSION}`;
         if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
-          process.stderr.write(`⚠️  Stale daemon detected (v${daemonVersion} ≠ v${PKG_VERSION}). Restarting...\n`);
+          process.stderr.write(`⚠️  Stale daemon detected (${reason}). Restarting...\n`);
         }
-        await requestDaemonShutdown();
-        await new Promise(resolve => setTimeout(resolve, 500));
+        const stopped = await requestDaemonShutdown();
+        if (stopped) {
+          // Verify port is actually released before spawning
+          await this._waitForDaemonStop(3000);
+        } else {
+          if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
+            process.stderr.write('⚠️  Daemon did not respond to shutdown request.\n');
+          }
+        }
         // Fall through to the "No daemon — spawn one" path below
       } else {
         // Same version — wait for extension to connect
@@ -144,6 +154,17 @@ export class BrowserBridge implements IBrowserFactory {
       `Try running manually:\n  node ${daemonPath}\nMake sure port ${DEFAULT_DAEMON_PORT} is available.`,
       'daemon-not-running',
     );
+  }
+
+  /** Poll until daemon is fully stopped (port released). */
+  private async _waitForDaemonStop(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 200));
+      const h = await getDaemonHealth();
+      if (h.state === 'stopped') return true;
+    }
+    return false;
   }
 
   /** Poll getDaemonHealth() until state is 'ready' or deadline is reached. */

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -12,6 +12,7 @@ import { Page } from './page.js';
 import { getDaemonHealth, requestDaemonShutdown } from './daemon-client.js';
 import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import { BrowserConnectError } from '../errors.js';
+import { PKG_VERSION } from '../version.js';
 
 const DAEMON_SPAWN_TIMEOUT = 10000; // 10s to wait for daemon + extension
 
@@ -66,22 +67,37 @@ export class BrowserBridge implements IBrowserFactory {
     // Fast path: everything ready
     if (health.state === 'ready') return;
 
-    // Daemon running but no extension — wait, then auto-restart daemon if still disconnected
+    // Daemon running but no extension
     if (health.state === 'no-extension') {
-      if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
-        process.stderr.write('⏳ Waiting for Chrome/Chromium extension to connect...\n');
-        process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
-      }
-      if (await this._pollUntilReady(timeoutMs)) return;
+      // Check if daemon is stale (version mismatch = started by older CLI)
+      const daemonVersion = health.status?.daemonVersion;
+      const isStale = daemonVersion && daemonVersion !== PKG_VERSION;
 
-      // Extension still not connected — restart the daemon to give the extension
-      // a fresh WebSocket endpoint (fixes stale daemon that missed extension registration)
-      if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
-        process.stderr.write('⚠️  Extension not responding. Restarting daemon...\n');
+      if (isStale) {
+        // Stale daemon — restart it so extension gets a fresh WebSocket endpoint
+        if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
+          process.stderr.write(`⚠️  Stale daemon detected (v${daemonVersion} ≠ v${PKG_VERSION}). Restarting...\n`);
+        }
+        await requestDaemonShutdown();
+        await new Promise(resolve => setTimeout(resolve, 500));
+        // Fall through to the "No daemon — spawn one" path below
+      } else {
+        // Same version — wait for extension to connect
+        if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
+          process.stderr.write('⏳ Waiting for Chrome/Chromium extension to connect...\n');
+          process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
+        }
+        if (await this._pollUntilReady(timeoutMs)) return;
+        throw new BrowserConnectError(
+          'Browser Bridge extension not connected',
+          'Make sure Chrome/Chromium is open and the extension is enabled.\n' +
+          'If the extension is installed, try: opencli daemon stop && opencli doctor\n' +
+          'If not installed:\n' +
+          '  1. Download: https://github.com/jackwener/opencli/releases\n' +
+          '  2. Open chrome://extensions → Developer Mode → Load unpacked',
+          'extension-not-connected',
+        );
       }
-      await requestDaemonShutdown();
-      await new Promise(resolve => setTimeout(resolve, 500));
-      // Fall through to the "No daemon — spawn one" path below
     }
 
     // No daemon — spawn one

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs';
 import type { IPage } from '../types.js';
 import type { IBrowserFactory } from '../runtime.js';
 import { Page } from './page.js';
-import { getDaemonHealth } from './daemon-client.js';
+import { getDaemonHealth, requestDaemonShutdown } from './daemon-client.js';
 import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import { BrowserConnectError } from '../errors.js';
 
@@ -66,21 +66,22 @@ export class BrowserBridge implements IBrowserFactory {
     // Fast path: everything ready
     if (health.state === 'ready') return;
 
-    // Daemon running but no extension — wait for extension with progress
+    // Daemon running but no extension — wait, then auto-restart daemon if still disconnected
     if (health.state === 'no-extension') {
       if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
         process.stderr.write('⏳ Waiting for Chrome/Chromium extension to connect...\n');
         process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
       }
       if (await this._pollUntilReady(timeoutMs)) return;
-      throw new BrowserConnectError(
-        'Browser Bridge extension not connected',
-        'Install the Browser Bridge:\n' +
-        '  1. Download: https://github.com/jackwener/opencli/releases\n' +
-        '  2. In Chrome or Chromium, open chrome://extensions → Developer Mode → Load unpacked\n' +
-        '  Then run: opencli doctor',
-        'extension-not-connected',
-      );
+
+      // Extension still not connected — restart the daemon to give the extension
+      // a fresh WebSocket endpoint (fixes stale daemon that missed extension registration)
+      if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
+        process.stderr.write('⚠️  Extension not responding. Restarting daemon...\n');
+      }
+      await requestDaemonShutdown();
+      await new Promise(resolve => setTimeout(resolve, 500));
+      // Fall through to the "No daemon — spawn one" path below
     }
 
     // No daemon — spawn one
@@ -113,10 +114,11 @@ export class BrowserBridge implements IBrowserFactory {
     if (finalHealth.state === 'no-extension') {
       throw new BrowserConnectError(
         'Browser Bridge extension not connected',
-        'Install the Browser Bridge:\n' +
+        'Make sure Chrome/Chromium is open and the extension is enabled.\n' +
+        'If the extension is installed, try: opencli daemon stop && opencli doctor\n' +
+        'If not installed:\n' +
         '  1. Download: https://github.com/jackwener/opencli/releases\n' +
-        '  2. In Chrome or Chromium, open chrome://extensions → Developer Mode → Load unpacked\n' +
-        '  Then run: opencli doctor',
+        '  2. Open chrome://extensions → Developer Mode → Load unpacked',
         'extension-not-connected',
       );
     }

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -65,6 +65,7 @@ export interface DaemonStatus {
   ok: boolean;
   pid: number;
   uptime: number;
+  daemonVersion?: string;
   extensionConnected: boolean;
   extensionVersion?: string;
   extensionCompatRange?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled } from './external.js';
 import { registerAllCommands } from './commanderAdapter.js';
-import { EXIT_CODES, getErrorMessage } from './errors.js';
+import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
 import { TargetError } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs } from './browser/target-resolver.js';
 import { daemonStop } from './commands/daemon.js';
@@ -311,11 +311,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         const page = await getBrowserPage();
         await fn(page, ...args);
       } catch (err) {
-        const msg = getErrorMessage(err);
-        if (msg.includes('Extension not connected') || msg.includes('Daemon')) {
-          log.error(`Browser not connected. Try: opencli daemon stop && opencli doctor`);
-        } else if (msg.includes('attach failed') || msg.includes('chrome-extension://')) {
-          log.error(`Browser attach failed — another extension may be interfering. Try disabling 1Password.`);
+        if (err instanceof BrowserConnectError) {
+          log.error(err.message);
+          if (err.hint) log.error(`Hint: ${err.hint}`);
         } else if (err instanceof TargetError) {
           log.error(`[${err.code}] ${err.message}`);
           if (err.hint) log.error(`Hint: ${err.hint}`);
@@ -324,7 +322,12 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
             err.candidates.forEach((c, i) => log.error(`  ${i + 1}. ${c}`));
           }
         } else {
-          log.error(msg);
+          const msg = getErrorMessage(err);
+          if (msg.includes('attach failed') || msg.includes('chrome-extension://')) {
+            log.error(`Browser attach failed — another extension may be interfering. Try disabling 1Password.`);
+          } else {
+            log.error(msg);
+          }
         }
         process.exitCode = EXIT_CODES.GENERIC_ERROR;
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,7 +313,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       } catch (err) {
         const msg = getErrorMessage(err);
         if (msg.includes('Extension not connected') || msg.includes('Daemon')) {
-          log.error(`Browser not connected. Run 'opencli doctor' to diagnose.`);
+          log.error(`Browser not connected. Try: opencli daemon stop && opencli doctor`);
         } else if (msg.includes('attach failed') || msg.includes('chrome-extension://')) {
           log.error(`Browser attach failed — another extension may be interfering. Try disabling 1Password.`);
         } else if (err instanceof TargetError) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -24,6 +24,7 @@ import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { EXIT_CODES } from './errors.js';
 import { log } from './logger.js';
+import { PKG_VERSION } from './version.js';
 
 const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
 
@@ -123,6 +124,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       ok: true,
       pid: process.pid,
       uptime,
+      daemonVersion: PKG_VERSION,
       extensionConnected: extensionWs?.readyState === WebSocket.OPEN,
       extensionVersion,
       extensionCompatRange,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -133,10 +133,13 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     );
   } else if (daemonRunning && !extensionConnected) {
     const daemonVersion = health.status?.daemonVersion;
-    const isStale = daemonVersion && opts.cliVersion && daemonVersion !== opts.cliVersion;
+    const isStale = opts.cliVersion && (!daemonVersion || daemonVersion !== opts.cliVersion);
     if (isStale) {
+      const reason = daemonVersion
+        ? `daemon v${daemonVersion} ≠ CLI v${opts.cliVersion}`
+        : `daemon predates version reporting, CLI is v${opts.cliVersion}`;
       issues.push(
-        `Stale daemon detected: daemon v${daemonVersion} ≠ CLI v${opts.cliVersion}.\n` +
+        `Stale daemon detected: ${reason}.\n` +
         'The daemon was started by an older CLI version and may have missed the extension registration.\n' +
         '  Quick fix: opencli daemon stop && opencli doctor',
       );

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -60,6 +60,7 @@ export type DoctorReport = {
   cliVersion?: string;
   daemonRunning: boolean;
   daemonFlaky?: boolean;
+  daemonVersion?: string;
   extensionConnected: boolean;
   extensionFlaky?: boolean;
   extensionVersion?: string;
@@ -131,15 +132,24 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
       'This usually means the Browser Bridge service worker is reconnecting slowly or Chrome suspended it.',
     );
   } else if (daemonRunning && !extensionConnected) {
-    issues.push(
-      'Daemon is running but the Chrome/Chromium extension is not connected.\n' +
-      'If the extension is already installed, the daemon may be stale (started before the extension).\n' +
-      '  Quick fix: opencli daemon stop && opencli doctor\n' +
-      'If the extension is not installed:\n' +
-      '  1. Download from https://github.com/jackwener/opencli/releases\n' +
-      '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
-      '  3. Click "Load unpacked" → select the extension folder',
-    );
+    const daemonVersion = health.status?.daemonVersion;
+    const isStale = daemonVersion && opts.cliVersion && daemonVersion !== opts.cliVersion;
+    if (isStale) {
+      issues.push(
+        `Stale daemon detected: daemon v${daemonVersion} ≠ CLI v${opts.cliVersion}.\n` +
+        'The daemon was started by an older CLI version and may have missed the extension registration.\n' +
+        '  Quick fix: opencli daemon stop && opencli doctor',
+      );
+    } else {
+      issues.push(
+        'Daemon is running but the Chrome/Chromium extension is not connected.\n' +
+        'If the extension is already installed, try: opencli daemon stop && opencli doctor\n' +
+        'If the extension is not installed:\n' +
+        '  1. Download from https://github.com/jackwener/opencli/releases\n' +
+        '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
+        '  3. Click "Load unpacked" → select the extension folder',
+      );
+    }
   }
   if (connectivity && !connectivity.ok) {
     issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
@@ -179,6 +189,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     cliVersion: opts.cliVersion,
     daemonRunning,
     daemonFlaky,
+    daemonVersion: health.status?.daemonVersion,
     extensionConnected,
     extensionFlaky,
     extensionVersion,
@@ -198,7 +209,7 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
     : report.daemonRunning ? styleText('green', '[OK]') : styleText('red', '[MISSING]');
   const daemonLabel = report.daemonFlaky
     ? 'unstable (running during live check, then stopped)'
-    : report.daemonRunning ? `running on port ${DEFAULT_DAEMON_PORT}` : 'not running';
+    : report.daemonRunning ? `running on port ${DEFAULT_DAEMON_PORT}` + (report.daemonVersion ? ` (v${report.daemonVersion})` : '') : 'not running';
   lines.push(`${daemonIcon} Daemon: ${daemonLabel}`);
 
   // Extension status

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -133,7 +133,9 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   } else if (daemonRunning && !extensionConnected) {
     issues.push(
       'Daemon is running but the Chrome/Chromium extension is not connected.\n' +
-      'Please install the opencli Browser Bridge extension:\n' +
+      'If the extension is already installed, the daemon may be stale (started before the extension).\n' +
+      '  Quick fix: opencli daemon stop && opencli doctor\n' +
+      'If the extension is not installed:\n' +
       '  1. Download from https://github.com/jackwener/opencli/releases\n' +
       '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
       '  3. Click "Load unpacked" → select the extension folder',


### PR DESCRIPTION
## Summary
Fixes the issue where a stale daemon (started before extension was installed) causes persistent "Browser not connected" errors that users can't resolve without discovering `opencli daemon stop` on their own.

- **Auto-restart**: `bridge.ts` now auto-restarts the daemon when extension doesn't connect within the timeout, instead of just giving up. This gives the extension a fresh WebSocket endpoint to connect to.
- **Better error messages**: All three error surfaces (`cli.ts`, `bridge.ts`, `doctor.ts`) now suggest `opencli daemon stop && opencli doctor` as the quick fix, instead of only saying "install the extension" or "run opencli doctor".

## Root cause
The daemon is passive — it waits for the extension to connect via WebSocket at `/ext`. If the daemon starts before the extension is installed, and the extension's reconnection attempts fail (e.g., due to MV3 service worker suspension timing), the connection is never established. The old behavior was to wait 10s then tell the user to install the extension (which they already had).

## Test plan
- [x] All 203 test files pass (1546 tests)
- [ ] Manual: start daemon → install extension → verify auto-restart connects
- [ ] Manual: verify improved error message shows "daemon stop && doctor" hint