### PR TITLE
fix(deamon&extension): preserve network capture and surface extension mismatch diagnostics

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -195,6 +195,46 @@ describe('background tab isolation', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('keeps the debugger attached during navigation when network capture is active', async () => {
+    const { chrome, tabs } = createChromeMock();
+    const onUpdatedListeners: Array<(id: number, info: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void> = [];
+    chrome.tabs.onUpdated.addListener = vi.fn((fn) => { onUpdatedListeners.push(fn); });
+    chrome.tabs.onUpdated.removeListener = vi.fn((fn) => {
+      const idx = onUpdatedListeners.indexOf(fn);
+      if (idx >= 0) onUpdatedListeners.splice(idx, 1);
+    });
+    chrome.tabs.update = vi.fn(async (tabId: number, updates: { active?: boolean; url?: string }) => {
+      const tab = tabs.find((entry) => entry.id === tabId);
+      if (!tab) throw new Error(`Unknown tab ${tabId}`);
+      if (updates.active !== undefined) tab.active = updates.active;
+      if (updates.url !== undefined) tab.url = updates.url;
+      tab.status = 'complete';
+      for (const listener of [...onUpdatedListeners]) {
+        listener(tabId, { status: 'complete', url: tab.url }, tab as chrome.tabs.Tab);
+      }
+      return tab;
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const detachMock = vi.fn(async () => {});
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => true),
+      detach: detachMock,
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId('site:eos', 1);
+
+    const result = await mod.__test__.handleNavigate(
+      { id: 'capture-nav', action: 'navigate', url: 'https://eos.douyin.com/livesite/live/current', workspace: 'site:eos' },
+      'site:eos',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(detachMock).not.toHaveBeenCalled();
+  });
+
   it('keeps hash routes distinct when comparing target URLs', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -543,13 +543,17 @@ async function handleNavigate(cmd: Command, workspace: string): Promise<Result> 
     return pageScopedResult(cmd.id, tabId, { title: beforeTab.title, url: beforeTab.url, timedOut: false });
   }
 
-  // Detach any existing debugger before top-level navigation.
+  // Detach any existing debugger before top-level navigation unless network
+  // capture is already armed on this tab. Otherwise we would clear the capture
+  // state right before the page load we are trying to observe.
   // Some sites (observed on creator.xiaohongshu.com flows) can invalidate the
   // current inspected target during navigation, which leaves a stale CDP attach
   // state and causes the next Runtime.evaluate to fail with
   // "Inspected target navigated or closed". Resetting here forces a clean
-  // re-attach after navigation.
-  await executor.detach(tabId);
+  // re-attach after navigation when capture is not active.
+  if (!executor.hasActiveNetworkCapture(tabId)) {
+    await executor.detach(tabId);
+  }
 
   await chrome.tabs.update(tabId, { url: targetUrl });
 

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -341,6 +341,10 @@ export async function readNetworkCapture(tabId: number): Promise<NetworkCaptureE
   return entries;
 }
 
+export function hasActiveNetworkCapture(tabId: number): boolean {
+  return networkCaptures.has(tabId);
+}
+
 export async function detach(tabId: number): Promise<void> {
   if (!attached.has(tabId)) return;
   attached.delete(tabId);

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -240,7 +240,7 @@ class CDPPage extends BasePage {
     return base64;
   }
 
-  async startNetworkCapture(pattern: string = ''): Promise<void> {
+  async startNetworkCapture(pattern: string = ''): Promise<boolean> {
     // Always update the filter pattern
     this._networkCapturePattern = pattern;
 
@@ -298,6 +298,7 @@ class CDPPage extends BasePage {
 
       this._networkCapturing = true;
     }
+    return true;
   }
 
   async readNetworkCapture(): Promise<unknown[]> {

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -83,8 +83,8 @@ describe('Page network capture compatibility', () => {
 
     const page = new Page('site:notebooklm');
 
-    await expect(page.startNetworkCapture()).resolves.toBeUndefined();
-    await expect(page.startNetworkCapture()).resolves.toBeUndefined();
+    await expect(page.startNetworkCapture()).resolves.toBe(false);
+    await expect(page.startNetworkCapture()).resolves.toBe(false);
 
     expect(sendCommandMock).toHaveBeenCalledTimes(1);
     expect(warnMock).toHaveBeenCalledTimes(1);
@@ -126,7 +126,7 @@ describe('Page network capture compatibility', () => {
 
     const page = new Page('site:notebooklm');
 
-    await expect(page.startNetworkCapture()).resolves.toBeUndefined();
+    await expect(page.startNetworkCapture()).resolves.toBe(false);
     await expect(page.readNetworkCapture()).resolves.toEqual([]);
 
     expect(warnMock).toHaveBeenCalledTimes(1);

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -1,11 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { sendCommandMock } = vi.hoisted(() => ({
+const { sendCommandMock, sendCommandFullMock } = vi.hoisted(() => ({
   sendCommandMock: vi.fn(),
+  sendCommandFullMock: vi.fn(),
+}));
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
 }));
 
 vi.mock('./daemon-client.js', () => ({
   sendCommand: sendCommandMock,
+  sendCommandFull: sendCommandFullMock,
+}));
+vi.mock('../logger.js', () => ({
+  log: {
+    warn: warnMock,
+  },
 }));
 
 import { Page } from './page.js';
@@ -13,6 +23,8 @@ import { Page } from './page.js';
 describe('Page.getCurrentUrl', () => {
   beforeEach(() => {
     sendCommandMock.mockReset();
+    sendCommandFullMock.mockReset();
+    warnMock.mockReset();
   });
 
   it('reads the real browser URL when no local navigation cache exists', async () => {
@@ -42,6 +54,8 @@ describe('Page.getCurrentUrl', () => {
 describe('Page.evaluate', () => {
   beforeEach(() => {
     sendCommandMock.mockReset();
+    sendCommandFullMock.mockReset();
+    warnMock.mockReset();
   });
 
   it('retries once when the inspected target navigated during exec', async () => {
@@ -54,5 +68,67 @@ describe('Page.evaluate', () => {
 
     expect(value).toBe(42);
     expect(sendCommandMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Page network capture compatibility', () => {
+  beforeEach(() => {
+    sendCommandMock.mockReset();
+    sendCommandFullMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it('treats unknown network-capture-start as unsupported and memoizes it', async () => {
+    sendCommandMock.mockRejectedValueOnce(new Error('Unknown action: network-capture-start'));
+
+    const page = new Page('site:notebooklm');
+
+    await expect(page.startNetworkCapture()).resolves.toBeUndefined();
+    await expect(page.startNetworkCapture()).resolves.toBeUndefined();
+
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('does not support network capture'));
+    expect(sendCommandMock).toHaveBeenCalledWith('network-capture-start', expect.objectContaining({
+      workspace: 'site:notebooklm',
+    }));
+  });
+
+  it('returns an empty capture when network-capture-read is unsupported', async () => {
+    sendCommandMock.mockRejectedValueOnce(new Error('Unknown action: network-capture-read'));
+
+    const page = new Page('site:notebooklm');
+
+    await expect(page.readNetworkCapture()).resolves.toEqual([]);
+    await expect(page.readNetworkCapture()).resolves.toEqual([]);
+
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(sendCommandMock).toHaveBeenCalledWith('network-capture-read', expect.objectContaining({
+      workspace: 'site:notebooklm',
+    }));
+  });
+
+  it('rethrows unrelated network capture failures', async () => {
+    sendCommandMock.mockRejectedValueOnce(new Error('Extension disconnected'));
+
+    const page = new Page('site:notebooklm');
+
+    await expect(page.startNetworkCapture()).rejects.toThrow('Extension disconnected');
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('warns only once even if both start and read hit the compatibility fallback', async () => {
+    sendCommandMock
+      .mockRejectedValueOnce(new Error('Unknown action: network-capture-start'))
+      .mockRejectedValueOnce(new Error('Unknown action: network-capture-read'));
+
+    const page = new Page('site:notebooklm');
+
+    await expect(page.startNetworkCapture()).resolves.toBeUndefined();
+    await expect(page.readNetworkCapture()).resolves.toEqual([]);
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -17,6 +17,14 @@ import { generateStealthJs } from './stealth.js';
 import { waitForDomStableJs } from './dom-helpers.js';
 import { BasePage } from './base-page.js';
 import { classifyBrowserError } from './errors.js';
+import { log } from '../logger.js';
+
+function isUnsupportedNetworkCaptureError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  const normalized = message.toLowerCase();
+  return (normalized.includes('unknown action') && normalized.includes('network-capture'))
+    || (normalized.includes('network capture') && normalized.includes('not supported'));
+}
 
 /**
  * Page — implements IPage by talking to the daemon via HTTP.
@@ -28,6 +36,8 @@ export class Page extends BasePage {
 
   /** Active page identity (targetId), set after navigate and used in all subsequent commands */
   private _page: string | undefined;
+  private _networkCaptureUnsupported = false;
+  private _networkCaptureWarned = false;
 
   /** Helper: spread workspace into command params */
   private _wsOpt(): { workspace: string } {
@@ -99,6 +109,16 @@ export class Page extends BasePage {
     return undefined;
   }
 
+  private _markUnsupportedNetworkCapture(): void {
+    this._networkCaptureUnsupported = true;
+    if (this._networkCaptureWarned) return;
+    this._networkCaptureWarned = true;
+    log.warn(
+      'Browser Bridge extension does not support network capture; continuing without it. ' +
+      'Explore output may miss API endpoints until you reload or reinstall the extension.',
+    );
+  }
+
   async evaluate(js: string): Promise<unknown> {
     const code = wrapForEval(js);
     try {
@@ -157,17 +177,30 @@ export class Page extends BasePage {
   }
 
   async startNetworkCapture(pattern: string = ''): Promise<void> {
-    await sendCommand('network-capture-start', {
-      pattern,
-      ...this._cmdOpts(),
-    });
+    if (this._networkCaptureUnsupported) return;
+    try {
+      await sendCommand('network-capture-start', {
+        pattern,
+        ...this._cmdOpts(),
+      });
+    } catch (err) {
+      if (!isUnsupportedNetworkCaptureError(err)) throw err;
+      this._markUnsupportedNetworkCapture();
+    }
   }
 
   async readNetworkCapture(): Promise<unknown[]> {
-    const result = await sendCommand('network-capture-read', {
-      ...this._cmdOpts(),
-    });
-    return Array.isArray(result) ? result : [];
+    if (this._networkCaptureUnsupported) return [];
+    try {
+      const result = await sendCommand('network-capture-read', {
+        ...this._cmdOpts(),
+      });
+      return Array.isArray(result) ? result : [];
+    } catch (err) {
+      if (!isUnsupportedNetworkCaptureError(err)) throw err;
+      this._markUnsupportedNetworkCapture();
+      return [];
+    }
   }
   /**
    * Set local file paths on a file input element via CDP DOM.setFileInputFiles.

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -178,16 +178,18 @@ export class Page extends BasePage {
     return base64;
   }
 
-  async startNetworkCapture(pattern: string = ''): Promise<void> {
-    if (this._networkCaptureUnsupported) return;
+  async startNetworkCapture(pattern: string = ''): Promise<boolean> {
+    if (this._networkCaptureUnsupported) return false;
     try {
       await sendCommand('network-capture-start', {
         pattern,
         ...this._cmdOpts(),
       });
+      return true;
     } catch (err) {
       if (!isUnsupportedNetworkCaptureError(err)) throw err;
       this._markUnsupportedNetworkCapture();
+      return false;
     }
   }
 

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -145,6 +145,8 @@ export class Page extends BasePage {
     } finally {
       this._page = undefined;
       this._lastUrl = null;
+      this._networkCaptureUnsupported = false;
+      this._networkCaptureWarned = false;
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { registerAllCommands } from './commanderAdapter.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
 import { TargetError } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs } from './browser/target-resolver.js';
-import { daemonStop } from './commands/daemon.js';
+import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
@@ -1058,6 +1058,10 @@ cli({
 
   // ── Built-in: daemon ──────────────────────────────────────────────────────
   const daemonCmd = program.command('daemon').description('Manage the opencli daemon');
+  daemonCmd
+    .command('status')
+    .description('Show daemon status')
+    .action(async () => { await daemonStatus(); });
   daemonCmd
     .command('stop')
     .description('Stop the daemon')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -342,7 +342,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   browser.command('open').argument('<url>').description('Open URL in automation window')
     .action(browserAction(async (page, url) => {
       // Start session-level capture before navigation (catches initial requests)
-      const hasSessionCapture = await page.startNetworkCapture?.().then(() => true).catch(() => false);
+      const hasSessionCapture = await page.startNetworkCapture?.() ?? false;
       await page.goto(url);
       await page.wait(2);
       // Fallback: inject JS interceptor when session capture is unavailable

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   fetchDaemonStatusMock,
@@ -13,7 +13,85 @@ vi.mock('../browser/daemon-client.js', () => ({
   requestDaemonShutdown: requestDaemonShutdownMock,
 }));
 
-import { daemonStop } from './daemon.js';
+import { daemonStatus, daemonStop } from './daemon.js';
+
+describe('daemonStatus', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    fetchDaemonStatusMock.mockReset();
+    requestDaemonShutdownMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports "not running" when daemon is unreachable', async () => {
+    fetchDaemonStatusMock.mockResolvedValue(null);
+
+    await daemonStatus();
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('not running'));
+  });
+
+  it('shows daemon info when running', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 12345,
+      uptime: 3661,
+      extensionConnected: true,
+      extensionVersion: '1.6.8',
+      pending: 0,
+      memoryMB: 64,
+      port: 19825,
+    });
+
+    await daemonStatus();
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('running'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('PID 12345'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1h 1m'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('connected'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('v1.6.8'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('64 MB'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('19825'));
+  });
+
+  it('shows disconnected when extension is not connected', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 99,
+      uptime: 120,
+      extensionConnected: false,
+      pending: 0,
+      memoryMB: 32,
+      port: 19825,
+    });
+
+    await daemonStatus();
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('disconnected'));
+  });
+
+  it('shows version unknown when the connected extension does not report one', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 99,
+      uptime: 120,
+      extensionConnected: true,
+      extensionVersion: undefined,
+      pending: 0,
+      memoryMB: 32,
+      port: 19825,
+    });
+
+    await daemonStatus();
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('version unknown'));
+  });
+});
 
 describe('daemonStop', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -1,10 +1,33 @@
 /**
- * CLI command for daemon lifecycle:
- *   opencli daemon stop — graceful shutdown
+ * CLI commands for daemon lifecycle:
+ *   opencli daemon status — show daemon state
+ *   opencli daemon stop   — graceful shutdown
  */
 
+import { styleText } from 'node:util';
 import { fetchDaemonStatus, requestDaemonShutdown } from '../browser/daemon-client.js';
+import { formatDuration } from '../download/progress.js';
 import { log } from '../logger.js';
+
+export async function daemonStatus(): Promise<void> {
+  const status = await fetchDaemonStatus();
+  if (!status) {
+    console.log(`Daemon: ${styleText('dim', 'not running')}`);
+    return;
+  }
+
+  const extensionLabel = !status.extensionConnected
+    ? styleText('yellow', 'disconnected')
+    : status.extensionVersion
+      ? `${styleText('green', 'connected')} ${styleText('dim', `(v${status.extensionVersion})`)}`
+      : `${styleText('yellow', 'connected')} ${styleText('dim', '(version unknown)')}`;
+
+  console.log(`Daemon: ${styleText('green', 'running')} (PID ${status.pid})`);
+  console.log(`Uptime: ${formatDuration(Math.round(status.uptime * 1000))}`);
+  console.log(`Extension: ${extensionLabel}`);
+  console.log(`Memory: ${status.memoryMB} MB`);
+  console.log(`Port: ${status.port}`);
+}
 
 export async function daemonStop(): Promise<void> {
   const status = await fetchDaemonStatus();

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -32,11 +32,12 @@ describe('doctor report rendering', () => {
     const text = strip(renderBrowserDoctorReport({
       daemonRunning: true,
       extensionConnected: true,
+      extensionVersion: '1.6.8',
       issues: [],
     }));
 
     expect(text).toContain('[OK] Daemon: running on port 19825');
-    expect(text).toContain('[OK] Extension: connected');
+    expect(text).toContain('[OK] Extension: connected (v1.6.8)');
     expect(text).toContain('Everything looks good!');
   });
 
@@ -61,6 +62,18 @@ describe('doctor report rendering', () => {
 
     expect(text).toContain('[OK] Daemon: running on port 19825');
     expect(text).toContain('[MISSING] Extension: not connected');
+  });
+
+  it('renders a warning when the extension version is unknown', () => {
+    const text = strip(renderBrowserDoctorReport({
+      daemonRunning: true,
+      extensionConnected: true,
+      issues: ['Extension is connected but did not report a version.'],
+    }));
+
+    expect(text).toContain('[WARN] Extension: connected (version unknown)');
+    expect(text).toContain('Extension is connected but did not report a version.');
+    expect(text).not.toContain('Everything looks good!');
   });
 
   it('renders connectivity OK when live test succeeds', () => {
@@ -111,12 +124,8 @@ describe('doctor report rendering', () => {
   });
 
   it('reports daemon not running when no-live and auto-start fails', async () => {
-    // no-live mode: getDaemonHealth called twice (initial check + final status)
-    // Initial: stopped → triggers auto-start attempt
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'stopped', status: null });
-    // Auto-start fails
     mockConnect.mockRejectedValueOnce(new Error('Could not start daemon'));
-    // Final: still stopped
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'stopped', status: null });
 
     const report = await runBrowserDoctor({ live: false });
@@ -130,12 +139,10 @@ describe('doctor report rendering', () => {
   });
 
   it('reports flapping when live check succeeds but final status shows extension disconnected', async () => {
-    // Live check succeeds
     mockConnect.mockResolvedValueOnce({
       evaluate: vi.fn().mockResolvedValue(2),
     });
     mockClose.mockResolvedValueOnce(undefined);
-    // After live check, getDaemonHealth shows no-extension
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } });
 
     const report = await runBrowserDoctor({ live: true });
@@ -149,12 +156,10 @@ describe('doctor report rendering', () => {
   });
 
   it('reports daemon flapping when live check succeeds but daemon disappears afterward', async () => {
-    // Live check succeeds
     mockConnect.mockResolvedValueOnce({
       evaluate: vi.fn().mockResolvedValue(2),
     });
     mockClose.mockResolvedValueOnce(undefined);
-    // After live check, getDaemonHealth shows stopped
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'stopped', status: null });
 
     const report = await runBrowserDoctor({ live: true });
@@ -184,16 +189,32 @@ describe('doctor report rendering', () => {
   });
 
   it('skips auto-start in no-live mode when daemon is already running', async () => {
-    // no-live mode but daemon already running (no-extension)
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } });
-    // Final status: same
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } });
 
     const report = await runBrowserDoctor({ live: false });
 
-    // Should NOT have tried auto-start since daemon was already running
     expect(mockConnect).not.toHaveBeenCalled();
     expect(report.daemonRunning).toBe(true);
     expect(report.extensionConnected).toBe(false);
+  });
+
+  it('reports an issue when the extension is connected but does not report a version', async () => {
+    const status = {
+      state: 'ready' as const,
+      status: {
+        extensionConnected: true,
+        extensionVersion: undefined,
+      },
+    };
+    mockGetDaemonHealth
+      .mockResolvedValueOnce(status)
+      .mockResolvedValueOnce(status);
+
+    const report = await runBrowserDoctor({ live: false });
+
+    expect(report.issues).toEqual(expect.arrayContaining([
+      expect.stringContaining('did not report a version'),
+    ]));
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -116,6 +116,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const sessions = opts.sessions && health.state === 'ready'
     ? await listSessions() as Array<{ workspace: string; windowId: number; tabCount: number; idleMsRemaining: number }>
     : undefined;
+  const extensionVersion = health.status?.extensionVersion;
 
   const issues: string[] = [];
   if (daemonFlaky) {
@@ -154,10 +155,16 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
       );
     }
   }
+  if (extensionConnected && !extensionVersion) {
+    issues.push(
+      'Extension is connected but did not report a version.\n' +
+      '  This usually means an outdated Browser Bridge extension.\n' +
+      '  Reload or reinstall the extension from: https://github.com/jackwener/opencli/releases',
+    );
+  }
   if (connectivity && !connectivity.ok) {
     issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
   }
-  const extensionVersion = health.status?.extensionVersion;
   const extensionCompatRange = health.status?.extensionCompatRange;
   if (extensionVersion && opts.cliVersion && extensionCompatRange) {
     if (!satisfiesRange(opts.cliVersion, extensionCompatRange)) {
@@ -216,13 +223,17 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
   lines.push(`${daemonIcon} Daemon: ${daemonLabel}`);
 
   // Extension status
-  const extIcon = report.extensionFlaky
+  const extIcon = report.extensionFlaky || (report.extensionConnected && !report.extensionVersion)
     ? styleText('yellow', '[WARN]')
     : report.extensionConnected ? styleText('green', '[OK]') : styleText('yellow', '[MISSING]');
   const extUpdateHint = report.extensionVersion && report.latestExtensionVersion && isNewerVersion(report.latestExtensionVersion, report.extensionVersion)
     ? styleText('yellow', ` → v${report.latestExtensionVersion} available`)
     : '';
-  const extVersion = report.extensionVersion ? styleText('dim', ` (v${report.extensionVersion})`) + extUpdateHint : '';
+  const extVersion = !report.extensionConnected
+    ? ''
+    : report.extensionVersion
+      ? styleText('dim', ` (v${report.extensionVersion})`) + extUpdateHint
+      : styleText('dim', ' (version unknown)');
   const extLabel = report.extensionFlaky
     ? 'unstable (connected during live check, then disconnected)'
     : report.extensionConnected ? 'connected' : 'not connected';

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export interface IPage {
   getInterceptedRequests(): Promise<any[]>;
   waitForCapture(timeout?: number): Promise<void>;
   screenshot(options?: ScreenshotOptions): Promise<string>;
-  startNetworkCapture?(pattern?: string): Promise<void>;
+  startNetworkCapture?(pattern?: string): Promise<boolean>;
   readNetworkCapture?(): Promise<unknown[]>;
   /**
    * Set local file paths on a file input element via CDP DOM.setFileInputFiles.


### PR DESCRIPTION
Older Browser Bridge installs can still connect to the daemon while missing two capabilities we now rely on: the network-capture actions and the extension version handshake. That created three user-facing failure modes with real impact:

1. `opencli explore ...` crashed with `Unknown action: network-capture-start` against an old extension, so exploration stopped before any site analysis finished.
2. `opencli doctor` and `opencli daemon status` could show a healthy connection even when the extension never reported a version, which hid the compatibility problem and sent users toward the wrong fix.
3. After reloading a new extension, `explore` could still report `Endpoints: 0 total, 0 API` because `handleNavigate()` detached the debugger before top-level navigation and cleared the active network capture state right before the page load we needed to observe.

Fix this in two layers:

- Teach `Page` to treat unsupported `network-capture-*` actions as an old-extension compatibility case. It now warns once, memoizes the unsupported state, and returns empty capture data instead of throwing.
- Teach `doctor` and `daemon status` to treat "connected but version unknown" as a warning instead of a healthy state, so version-handshake failures are visible immediately.
- Preserve the debugger attachment while network capture is armed, so the initial navigation keeps the capture state alive and the extension can record requests from the first page load.

Before:

- `opencli explore ...` -> `Error: Unknown action: network-capture-start`
- `opencli doctor` -> `[OK] Extension: connected` / `Everything looks good!`
- `opencli daemon status` -> `Extension: connected` even when the extension version was missing
- `opencli explore ...` after reloading the extension -> `Endpoints: 0 total, 0 API`

After:

- `opencli explore ...` on an old extension -> warns once and continues
- `opencli doctor` -> `[WARN] Extension: connected (version unknown)`
- `opencli daemon status` -> `Extension: connected (version unknown)`
- `opencli explore ...` on the reloaded extension keeps network capture armed across navigation instead of clearing it before the page load

## Description

<!-- Briefly describe your changes and link to any related issues. -->

Related issue:

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
