### PR TITLE
feat(xiaoyuzhou): add episode download and transcript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ To load the source Browser Bridge extension:
 | **xiaoe** | `courses` `detail` `catalog` `play-url` `content` |
 | **quark** | `ls` `mkdir` `mv` `rename` `rm` `save` `share-tree` |
 | **uiverse** | `code` `preview` |
+| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` `download` |
 
 87+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
 
@@ -257,6 +258,7 @@ OpenCLI supports downloading images, videos, and articles from supported platfor
 | **douban** | Images | Poster / still image lists |
 | **pixiv** | Images | Original-quality illustrations, multi-page |
 | **1688** | Images, Videos | Downloads page-visible product media from item pages |
+| **xiaoyuzhou** | Audio | Downloads episode audio from public episode payloads |
 | **zhihu** | Articles (Markdown) | Exports with optional image download |
 | **weixin** | Articles (Markdown) | WeChat Official Account articles |
 
@@ -268,6 +270,7 @@ opencli xiaohongshu download "https://xhslink.com/..." --output ./xhs
 opencli bilibili download BV1xxx --output ./bilibili
 opencli twitter download elonmusk --limit 20 --output ./twitter
 opencli 1688 download 841141931191 --output ./1688-downloads
+opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 ```
 
 ## Output Formats

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ To load the source Browser Bridge extension:
 
 87+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
 
-`*` `opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
+`*` `opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`.
 
 ## CLI Hub
 
@@ -276,7 +276,7 @@ opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --output ./xiaoyuzhou-transcripts
 ```
 
-`opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
+`opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`.
 
 ## Output Formats
 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ To load the source Browser Bridge extension:
 | **xiaoe** | `courses` `detail` `catalog` `play-url` `content` |
 | **quark** | `ls` `mkdir` `mv` `rename` `rm` `save` `share-tree` |
 | **uiverse** | `code` `preview` |
-| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` `download` |
+| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` `download` `transcript*` |
 
 87+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
+
+`*` `opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
 
 ## CLI Hub
 
@@ -258,7 +260,7 @@ OpenCLI supports downloading images, videos, and articles from supported platfor
 | **douban** | Images | Poster / still image lists |
 | **pixiv** | Images | Original-quality illustrations, multi-page |
 | **1688** | Images, Videos | Downloads page-visible product media from item pages |
-| **xiaoyuzhou** | Audio | Downloads episode audio from public episode payloads |
+| **xiaoyuzhou** | Audio, Transcript | Downloads episode audio from public pages and transcript JSON/text with local credentials |
 | **zhihu** | Articles (Markdown) | Exports with optional image download |
 | **weixin** | Articles (Markdown) | WeChat Official Account articles |
 
@@ -271,7 +273,10 @@ opencli bilibili download BV1xxx --output ./bilibili
 opencli twitter download elonmusk --limit 20 --output ./twitter
 opencli 1688 download 841141931191 --output ./1688-downloads
 opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
+opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --output ./xiaoyuzhou-transcripts
 ```
+
+`opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
 
 ## Output Formats
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,7 +208,7 @@ npm link
 | **quark** | `ls` `mkdir` `mv` `rename` `rm` `save` `share-tree` | 浏览器 |
 | **uiverse** | `code` `preview` | 浏览器 |
 | **apple-podcasts** | `search` `episodes` `top` | 公开 |
-| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` | 公开 |
+| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` `download` | 公开 |
 | **zhihu** | `hot` `search` `question` `download` `follow` `like` `favorite` `comment` `answer` | 浏览器 |
 | **weixin** | `download` | 浏览器 |
 | **youtube** | `search` `video` `transcript` | 浏览器 |
@@ -320,6 +320,7 @@ OpenCLI 支持从各平台下载图片、视频和文章。
 | **Twitter/X** | 图片、视频 | 从用户媒体页或单条推文下载 |
 | **Pixiv** | 图片 | 下载原始画质插画，支持多页作品 |
 | **1688** | 图片、视频 | 下载商品页中可见的商品素材 |
+| **小宇宙** | 音频 | 从公开单集数据中下载音频文件 |
 | **知乎** | 文章（Markdown） | 导出文章，可选下载图片到本地 |
 | **微信公众号** | 文章（Markdown） | 导出微信公众号文章为 Markdown |
 | **豆瓣** | 图片 | 下载电影条目的海报 / 剧照图片 |
@@ -357,6 +358,9 @@ opencli douban download 30382501 --output ./douban
 
 # 下载 1688 商品页中的图片 / 视频素材
 opencli 1688 download 841141931191 --output ./1688-downloads
+
+# 下载小宇宙单集音频
+opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
 # 导出知乎文章为 Markdown
 opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -268,7 +268,7 @@ npm link
 
 87+ 适配器 — **[→ 查看完整命令列表](./docs/adapters/index.md)**
 
-`*` `opencli xiaoyuzhou transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`，或 `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`。
+`*` `opencli xiaoyuzhou transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`。
 
 ### 外部 CLI 枢纽
 
@@ -377,7 +377,7 @@ opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 opencli weixin download --url "https://mp.weixin.qq.com/s/xxx" --output ./weixin
 ```
 
-`opencli xiaoyuzhou transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`，或 `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`。
+`opencli xiaoyuzhou transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`。
 
 
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,7 +208,7 @@ npm link
 | **quark** | `ls` `mkdir` `mv` `rename` `rm` `save` `share-tree` | 浏览器 |
 | **uiverse** | `code` `preview` | 浏览器 |
 | **apple-podcasts** | `search` `episodes` `top` | 公开 |
-| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` `download` | 公开 |
+| **xiaoyuzhou** | `podcast` `podcast-episodes` `episode` `download` `transcript*` | 公开 |
 | **zhihu** | `hot` `search` `question` `download` `follow` `like` `favorite` `comment` `answer` | 浏览器 |
 | **weixin** | `download` | 浏览器 |
 | **youtube** | `search` `video` `transcript` | 浏览器 |
@@ -268,6 +268,8 @@ npm link
 
 87+ 适配器 — **[→ 查看完整命令列表](./docs/adapters/index.md)**
 
+`*` `opencli xiaoyuzhou transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`，或 `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`。
+
 ### 外部 CLI 枢纽
 
 OpenCLI 也可以作为你现有命令行工具的统一入口，负责发现、自动安装和纯透传执行。
@@ -320,7 +322,7 @@ OpenCLI 支持从各平台下载图片、视频和文章。
 | **Twitter/X** | 图片、视频 | 从用户媒体页或单条推文下载 |
 | **Pixiv** | 图片 | 下载原始画质插画，支持多页作品 |
 | **1688** | 图片、视频 | 下载商品页中可见的商品素材 |
-| **小宇宙** | 音频 | 从公开单集数据中下载音频文件 |
+| **小宇宙** | 音频、转录 | 从公开单集数据下载音频，并使用本地凭证下载转录 JSON / 文本 |
 | **知乎** | 文章（Markdown） | 导出文章，可选下载图片到本地 |
 | **微信公众号** | 文章（Markdown） | 导出微信公众号文章为 Markdown |
 | **豆瓣** | 图片 | 下载电影条目的海报 / 剧照图片 |
@@ -362,6 +364,9 @@ opencli 1688 download 841141931191 --output ./1688-downloads
 # 下载小宇宙单集音频
 opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
+# 下载小宇宙单集转录
+opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --output ./xiaoyuzhou-transcripts
+
 # 导出知乎文章为 Markdown
 opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
 
@@ -371,6 +376,8 @@ opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 # 导出微信公众号文章为 Markdown
 opencli weixin download --url "https://mp.weixin.qq.com/s/xxx" --output ./weixin
 ```
+
+`opencli xiaoyuzhou transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`，或 `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`。
 
 
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -15548,6 +15548,40 @@
   },
   {
     "site": "xiaoyuzhou",
+    "name": "download",
+    "description": "Download Xiaoyuzhou episode audio",
+    "domain": "www.xiaoyuzhoufm.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Episode ID (eid from podcast-episodes output)"
+      },
+      {
+        "name": "output",
+        "type": "str",
+        "default": "./xiaoyuzhou-downloads",
+        "required": false,
+        "help": "Output directory"
+      }
+    ],
+    "columns": [
+      "title",
+      "podcast",
+      "status",
+      "size",
+      "file"
+    ],
+    "type": "js",
+    "modulePath": "xiaoyuzhou/download.js",
+    "sourceFile": "xiaoyuzhou/download.js"
+  },
+  {
+    "site": "xiaoyuzhou",
     "name": "episode",
     "description": "View details of a Xiaoyuzhou podcast episode",
     "domain": "www.xiaoyuzhoufm.com",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -15582,6 +15582,55 @@
   },
   {
     "site": "xiaoyuzhou",
+    "name": "transcript",
+    "description": "Download Xiaoyuzhou transcript as JSON and text (requires local credentials)",
+    "domain": "www.xiaoyuzhoufm.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Episode ID (eid from podcast-episodes output)"
+      },
+      {
+        "name": "output",
+        "type": "str",
+        "default": "./xiaoyuzhou-transcripts",
+        "required": false,
+        "help": "Output directory"
+      },
+      {
+        "name": "json",
+        "type": "boolean",
+        "default": true,
+        "required": false,
+        "help": "Save transcript JSON file"
+      },
+      {
+        "name": "text",
+        "type": "boolean",
+        "default": true,
+        "required": false,
+        "help": "Save extracted transcript text file"
+      }
+    ],
+    "columns": [
+      "title",
+      "podcast",
+      "status",
+      "segments",
+      "json_file",
+      "text_file"
+    ],
+    "type": "js",
+    "modulePath": "xiaoyuzhou/transcript.js",
+    "sourceFile": "xiaoyuzhou/transcript.js"
+  },
+  {
+    "site": "xiaoyuzhou",
     "name": "episode",
     "description": "View details of a Xiaoyuzhou podcast episode",
     "domain": "www.xiaoyuzhoufm.com",

--- a/clis/xiaoyuzhou/auth.js
+++ b/clis/xiaoyuzhou/auth.js
@@ -19,7 +19,7 @@ export function getXiaoyuzhouCredentialFile() {
 }
 
 function createXiaoyuzhouAuthError(message) {
-    return new CliError('AUTH_REQUIRED', message, `Update ${getXiaoyuzhouCredentialFile()} with fresh Xiaoyuzhou credentials, or export XY_ACCESS_TOKEN and XY_REFRESH_TOKEN before retrying.`, EXIT_CODES.NOPERM);
+    return new CliError('AUTH_REQUIRED', message, `Update ${getXiaoyuzhouCredentialFile()} with fresh Xiaoyuzhou credentials before retrying.`, EXIT_CODES.NOPERM);
 }
 
 function coerceNumber(value) {
@@ -68,7 +68,7 @@ export function loadXiaoyuzhouCredentials(env = process.env) {
             const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
             const credentials = normalizeXiaoyuzhouCredentials(parsed);
             if (!credentials.access_token || !credentials.refresh_token) {
-                throw new ConfigError(`Xiaoyuzhou credential file is missing access_token or refresh_token: ${filePath}`, 'Recreate the file with valid credentials, or remove it and use XY_ACCESS_TOKEN / XY_REFRESH_TOKEN env vars.');
+                throw new ConfigError(`Xiaoyuzhou credential file is missing access_token or refresh_token: ${filePath}`, 'Recreate the file with valid credentials.');
             }
             return credentials;
         }
@@ -83,7 +83,7 @@ export function loadXiaoyuzhouCredentials(env = process.env) {
     if (fromEnv) {
         return fromEnv;
     }
-    throw new ConfigError(`Missing Xiaoyuzhou credentials. Expected ${filePath}`, `Create ${filePath} with access_token and refresh_token, or export XY_ACCESS_TOKEN and XY_REFRESH_TOKEN.`);
+    throw new ConfigError(`Missing Xiaoyuzhou credentials. Expected ${filePath}`, `Create ${filePath} with access_token and refresh_token.`);
 }
 
 export function saveXiaoyuzhouCredentials(credentials) {

--- a/clis/xiaoyuzhou/auth.js
+++ b/clis/xiaoyuzhou/auth.js
@@ -1,0 +1,324 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { CliError, CommandExecutionError, ConfigError, EXIT_CODES, getErrorMessage } from '@jackwener/opencli/errors';
+
+export const XIAOYUZHOU_API_BASE_URL = 'https://api.xiaoyuzhoufm.com';
+export const XIAOYUZHOU_TOKEN_TTL_MS = 20 * 60 * 1000;
+export const XIAOYUZHOU_REFRESH_SKEW_MS = 60 * 1000;
+export const XIAOYUZHOU_DEFAULT_DEVICE_ID = '81ADBFD6-6921-482B-9AB9-A29E7CC7BB55';
+export const XIAOYUZHOU_DEFAULT_DEVICE_PROPERTIES = '';
+export const XIAOYUZHOU_DEFAULT_USER_AGENT = 'Xiaoyuzhou/2.98.0 (build:2908; iOS 26.2.1)';
+
+function getNowMs() {
+    return Date.now();
+}
+
+export function getXiaoyuzhouCredentialFile() {
+    return path.join(os.homedir(), '.opencli', 'xiaoyuzhou.json');
+}
+
+function createXiaoyuzhouAuthError(message) {
+    return new CliError('AUTH_REQUIRED', message, `Update ${getXiaoyuzhouCredentialFile()} with fresh Xiaoyuzhou credentials, or export XY_ACCESS_TOKEN and XY_REFRESH_TOKEN before retrying.`, EXIT_CODES.NOPERM);
+}
+
+function coerceNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function normalizeXiaoyuzhouCredentials(raw = {}) {
+    const lastUpdatedTs = coerceNumber(raw.last_updated_ts ?? raw.lastUpdatedTs);
+    let expiresAt = coerceNumber(raw.expires_at ?? raw.expiresAt);
+    if (expiresAt > 0 && expiresAt < 10_000_000_000) {
+        expiresAt *= 1000;
+    }
+    if (!expiresAt && lastUpdatedTs > 0) {
+        expiresAt = lastUpdatedTs * 1000 + XIAOYUZHOU_TOKEN_TTL_MS;
+    }
+    return {
+        access_token: String(raw.access_token ?? raw.accessToken ?? '').trim(),
+        refresh_token: String(raw.refresh_token ?? raw.refreshToken ?? '').trim(),
+        expires_at: expiresAt,
+        device_id: String(raw.device_id ?? raw.deviceId ?? XIAOYUZHOU_DEFAULT_DEVICE_ID).trim() || XIAOYUZHOU_DEFAULT_DEVICE_ID,
+        device_properties: String(raw.device_properties ?? raw.deviceProperties ?? XIAOYUZHOU_DEFAULT_DEVICE_PROPERTIES),
+    };
+}
+
+export function loadXiaoyuzhouCredentialsFromEnv(env = process.env) {
+    const accessToken = String(env.XY_ACCESS_TOKEN ?? '').trim();
+    const refreshToken = String(env.XY_REFRESH_TOKEN ?? '').trim();
+    if (!accessToken || !refreshToken) {
+        return null;
+    }
+    return normalizeXiaoyuzhouCredentials({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        expires_at: env.XY_EXPIRES_AT ?? 0,
+        last_updated_ts: env.XY_LAST_UPDATED_TS ?? 0,
+        device_id: env.XY_DEVICE_ID ?? XIAOYUZHOU_DEFAULT_DEVICE_ID,
+        device_properties: env.XY_DEVICE_PROPERTIES ?? XIAOYUZHOU_DEFAULT_DEVICE_PROPERTIES,
+    });
+}
+
+export function loadXiaoyuzhouCredentials(env = process.env) {
+    const filePath = getXiaoyuzhouCredentialFile();
+    if (fs.existsSync(filePath)) {
+        try {
+            const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+            const credentials = normalizeXiaoyuzhouCredentials(parsed);
+            if (!credentials.access_token || !credentials.refresh_token) {
+                throw new ConfigError(`Xiaoyuzhou credential file is missing access_token or refresh_token: ${filePath}`, 'Recreate the file with valid credentials, or remove it and use XY_ACCESS_TOKEN / XY_REFRESH_TOKEN env vars.');
+            }
+            return credentials;
+        }
+        catch (error) {
+            if (error instanceof ConfigError) {
+                throw error;
+            }
+            throw new ConfigError(`Failed to parse Xiaoyuzhou credential file: ${filePath}`, `Ensure ${filePath} contains valid JSON. (${getErrorMessage(error)})`);
+        }
+    }
+    const fromEnv = loadXiaoyuzhouCredentialsFromEnv(env);
+    if (fromEnv) {
+        return fromEnv;
+    }
+    throw new ConfigError(`Missing Xiaoyuzhou credentials. Expected ${filePath}`, `Create ${filePath} with access_token and refresh_token, or export XY_ACCESS_TOKEN and XY_REFRESH_TOKEN.`);
+}
+
+export function saveXiaoyuzhouCredentials(credentials) {
+    const filePath = getXiaoyuzhouCredentialFile();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify({
+        access_token: credentials.access_token,
+        refresh_token: credentials.refresh_token,
+        expires_at: credentials.expires_at,
+        device_id: credentials.device_id,
+        device_properties: credentials.device_properties,
+    }, null, 2)}\n`, 'utf-8');
+}
+
+export function shouldRefreshXiaoyuzhouCredentials(credentials, now = getNowMs()) {
+    return Number.isFinite(credentials.expires_at)
+        && credentials.expires_at > 0
+        && now >= credentials.expires_at - XIAOYUZHOU_REFRESH_SKEW_MS;
+}
+
+export function buildXiaoyuzhouHeaders(credentials, options = {}) {
+    const {
+        contentType = 'application/json',
+        includeLocalTime = false,
+        includeRefreshToken = false,
+    } = options;
+    const headers = {
+        'Content-Type': contentType,
+        Host: 'api.xiaoyuzhoufm.com',
+        'User-Agent': XIAOYUZHOU_DEFAULT_USER_AGENT,
+        Market: 'AppStore',
+        'App-BuildNo': '2908',
+        OS: 'ios',
+        Manufacturer: 'Apple',
+        BundleID: 'app.podcast.cosmos',
+        Connection: 'keep-alive',
+        'abtest-info': '{"old_user_discovery_feed":"enable"}',
+        'Accept-Language': 'en-HK;q=1.0, zh-Hans-HK;q=0.9',
+        Model: 'iPhone18,1',
+        'app-permissions': '100000',
+        Accept: '*/*',
+        'App-Version': '2.98.0',
+        WifiConnected: 'true',
+        'OS-Version': '26.2.1',
+        'x-custom-xiaoyuzhou-app-dev': '',
+        'x-jike-device-id': credentials.device_id || XIAOYUZHOU_DEFAULT_DEVICE_ID,
+        'x-jike-device-properties': credentials.device_properties ?? XIAOYUZHOU_DEFAULT_DEVICE_PROPERTIES,
+    };
+    if (credentials.access_token) {
+        headers['x-jike-access-token'] = credentials.access_token;
+    }
+    if (includeRefreshToken && credentials.refresh_token) {
+        headers['x-jike-refresh-token'] = credentials.refresh_token;
+    }
+    if (includeLocalTime) {
+        headers['Local-Time'] = new Date().toISOString();
+        headers.Timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    }
+    return headers;
+}
+
+export async function refreshXiaoyuzhouCredentials(credentials, fetchImpl = fetch) {
+    if (!credentials.refresh_token) {
+        throw createXiaoyuzhouAuthError('Xiaoyuzhou refresh token is missing');
+    }
+    let response;
+    try {
+        response = await fetchImpl(`${XIAOYUZHOU_API_BASE_URL}/app_auth_tokens.refresh`, {
+            method: 'POST',
+            headers: buildXiaoyuzhouHeaders(credentials, {
+                contentType: 'application/x-www-form-urlencoded; charset=utf-8',
+                includeLocalTime: true,
+                includeRefreshToken: true,
+            }),
+            signal: AbortSignal.timeout(20_000),
+        });
+    }
+    catch (error) {
+        throw new CommandExecutionError(`Failed to refresh Xiaoyuzhou credentials: ${getErrorMessage(error)}`);
+    }
+    const bodyText = await response.text();
+    if (!response.ok) {
+        throw createXiaoyuzhouAuthError(`Xiaoyuzhou token refresh failed with HTTP ${response.status}${bodyText ? `: ${bodyText}` : ''}`);
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(bodyText);
+    }
+    catch (error) {
+        throw new CommandExecutionError(`Xiaoyuzhou refresh returned invalid JSON: ${getErrorMessage(error)}`);
+    }
+    if (!parsed?.success) {
+        throw createXiaoyuzhouAuthError('Xiaoyuzhou refresh API returned success=false');
+    }
+    const nextCredentials = normalizeXiaoyuzhouCredentials({
+        ...credentials,
+        access_token: parsed['x-jike-access-token'] || '',
+        refresh_token: parsed['x-jike-refresh-token'] || '',
+        expires_at: getNowMs() + XIAOYUZHOU_TOKEN_TTL_MS,
+    });
+    if (!nextCredentials.access_token || !nextCredentials.refresh_token) {
+        throw createXiaoyuzhouAuthError('Xiaoyuzhou refresh API returned empty access_token or refresh_token');
+    }
+    saveXiaoyuzhouCredentials(nextCredentials);
+    return nextCredentials;
+}
+
+function buildApiUrl(endpoint, query) {
+    const url = new URL(endpoint, XIAOYUZHOU_API_BASE_URL);
+    if (query) {
+        for (const [key, value] of Object.entries(query)) {
+            if (value !== undefined && value !== null && value !== '') {
+                url.searchParams.set(key, String(value));
+            }
+        }
+    }
+    return url.toString();
+}
+
+async function performXiaoyuzhouJsonRequest(endpoint, options, credentials, fetchImpl) {
+    const {
+        method = 'GET',
+        query,
+        body,
+    } = options;
+    let response;
+    try {
+        response = await fetchImpl(buildApiUrl(endpoint, query), {
+            method,
+            headers: buildXiaoyuzhouHeaders(credentials, {
+                contentType: 'application/json',
+                includeLocalTime: true,
+            }),
+            body: body === undefined ? undefined : JSON.stringify(body),
+            signal: AbortSignal.timeout(20_000),
+        });
+    }
+    catch (error) {
+        throw new CommandExecutionError(`Failed to reach Xiaoyuzhou API: ${getErrorMessage(error)}`);
+    }
+    return response;
+}
+
+export async function requestXiaoyuzhouJson(endpoint, options = {}, fetchImpl = fetch) {
+    let credentials = options.credentials ?? loadXiaoyuzhouCredentials();
+    if (shouldRefreshXiaoyuzhouCredentials(credentials)) {
+        credentials = await refreshXiaoyuzhouCredentials(credentials, fetchImpl);
+    }
+    let response = await performXiaoyuzhouJsonRequest(endpoint, options, credentials, fetchImpl);
+    if (response.status === 401) {
+        credentials = await refreshXiaoyuzhouCredentials(credentials, fetchImpl);
+        response = await performXiaoyuzhouJsonRequest(endpoint, options, credentials, fetchImpl);
+    }
+    const bodyText = await response.text();
+    if (!response.ok) {
+        throw new CommandExecutionError(`Xiaoyuzhou API request failed with HTTP ${response.status}${bodyText ? `: ${bodyText}` : ''}`);
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(bodyText);
+    }
+    catch (error) {
+        throw new CommandExecutionError(`Xiaoyuzhou API returned invalid JSON: ${getErrorMessage(error)}`);
+    }
+    if (parsed?.success === false) {
+        throw new CommandExecutionError(parsed?.message || parsed?.msg || 'Xiaoyuzhou API returned success=false');
+    }
+    return {
+        credentials,
+        raw: parsed,
+        data: parsed?.data,
+    };
+}
+
+export async function fetchXiaoyuzhouTranscriptBody(url, fetchImpl = fetch) {
+    let response;
+    try {
+        response = await fetchImpl(url, {
+            method: 'GET',
+            headers: {
+                'User-Agent': XIAOYUZHOU_DEFAULT_USER_AGENT,
+                Accept: '*/*',
+                Market: 'AppStore',
+            },
+            signal: AbortSignal.timeout(20_000),
+        });
+    }
+    catch (error) {
+        throw new CommandExecutionError(`Failed to fetch Xiaoyuzhou transcript content: ${getErrorMessage(error)}`);
+    }
+    const bodyText = await response.text();
+    if (!response.ok) {
+        throw new CommandExecutionError(`Xiaoyuzhou transcript download failed with HTTP ${response.status}${bodyText ? `: ${bodyText}` : ''}`);
+    }
+    return bodyText;
+}
+
+export function extractTranscriptText(transcriptBody) {
+    let parsed;
+    try {
+        parsed = JSON.parse(transcriptBody);
+    }
+    catch {
+        return { text: '', segmentCount: 0 };
+    }
+    let items = [];
+    if (Array.isArray(parsed)) {
+        items = parsed;
+    }
+    else if (parsed && typeof parsed === 'object') {
+        for (const key of ['segments', 'data', 'transcript', 'items']) {
+            if (Array.isArray(parsed[key])) {
+                items = parsed[key];
+                break;
+            }
+        }
+        if (items.length === 0) {
+            const directText = typeof parsed.text === 'string' ? parsed.text.trim() : '';
+            if (directText) {
+                return { text: directText, segmentCount: 1 };
+            }
+        }
+    }
+    const textItems = [];
+    for (const item of items) {
+        if (!item || typeof item !== 'object' || typeof item.text !== 'string') {
+            continue;
+        }
+        const cleaned = item.text.trim();
+        if (cleaned) {
+            textItems.push(cleaned);
+        }
+    }
+    return {
+        text: textItems.join('\n'),
+        segmentCount: textItems.length,
+    };
+}

--- a/clis/xiaoyuzhou/auth.js
+++ b/clis/xiaoyuzhou/auth.js
@@ -44,24 +44,7 @@ export function normalizeXiaoyuzhouCredentials(raw = {}) {
         device_properties: String(raw.device_properties ?? raw.deviceProperties ?? XIAOYUZHOU_DEFAULT_DEVICE_PROPERTIES),
     };
 }
-
-export function loadXiaoyuzhouCredentialsFromEnv(env = process.env) {
-    const accessToken = String(env.XY_ACCESS_TOKEN ?? '').trim();
-    const refreshToken = String(env.XY_REFRESH_TOKEN ?? '').trim();
-    if (!accessToken || !refreshToken) {
-        return null;
-    }
-    return normalizeXiaoyuzhouCredentials({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-        expires_at: env.XY_EXPIRES_AT ?? 0,
-        last_updated_ts: env.XY_LAST_UPDATED_TS ?? 0,
-        device_id: env.XY_DEVICE_ID ?? XIAOYUZHOU_DEFAULT_DEVICE_ID,
-        device_properties: env.XY_DEVICE_PROPERTIES ?? XIAOYUZHOU_DEFAULT_DEVICE_PROPERTIES,
-    });
-}
-
-export function loadXiaoyuzhouCredentials(env = process.env) {
+export function loadXiaoyuzhouCredentials() {
     const filePath = getXiaoyuzhouCredentialFile();
     if (fs.existsSync(filePath)) {
         try {
@@ -78,10 +61,6 @@ export function loadXiaoyuzhouCredentials(env = process.env) {
             }
             throw new ConfigError(`Failed to parse Xiaoyuzhou credential file: ${filePath}`, `Ensure ${filePath} contains valid JSON. (${getErrorMessage(error)})`);
         }
-    }
-    const fromEnv = loadXiaoyuzhouCredentialsFromEnv(env);
-    if (fromEnv) {
-        return fromEnv;
     }
     throw new ConfigError(`Missing Xiaoyuzhou credentials. Expected ${filePath}`, `Create ${filePath} with access_token and refresh_token.`);
 }

--- a/clis/xiaoyuzhou/auth.test.js
+++ b/clis/xiaoyuzhou/auth.test.js
@@ -19,7 +19,7 @@ vi.mock('node:os', () => ({
     homedir: mockHomedir,
 }));
 
-const { extractTranscriptText, getXiaoyuzhouCredentialFile, loadXiaoyuzhouCredentials, loadXiaoyuzhouCredentialsFromEnv, normalizeXiaoyuzhouCredentials, refreshXiaoyuzhouCredentials, requestXiaoyuzhouJson, shouldRefreshXiaoyuzhouCredentials, XIAOYUZHOU_TOKEN_TTL_MS } = await import('./auth.js');
+const { extractTranscriptText, getXiaoyuzhouCredentialFile, loadXiaoyuzhouCredentials, normalizeXiaoyuzhouCredentials, refreshXiaoyuzhouCredentials, requestXiaoyuzhouJson, shouldRefreshXiaoyuzhouCredentials, XIAOYUZHOU_TOKEN_TTL_MS } = await import('./auth.js');
 
 function createJsonResponse(status, payload) {
     return {
@@ -38,34 +38,14 @@ describe('xiaoyuzhou auth helpers', () => {
         vi.useRealTimers();
     });
 
-    it('loads bootstrap credentials from env and derives expiry from XY_LAST_UPDATED_TS', () => {
-        const credentials = loadXiaoyuzhouCredentialsFromEnv({
-            XY_ACCESS_TOKEN: 'access',
-            XY_REFRESH_TOKEN: 'refresh',
-            XY_LAST_UPDATED_TS: '1710000000',
-            XY_DEVICE_ID: 'device-1',
-            XY_DEVICE_PROPERTIES: 'props',
-        });
-        expect(credentials).toEqual({
-            access_token: 'access',
-            refresh_token: 'refresh',
-            expires_at: 1710000000 * 1000 + XIAOYUZHOU_TOKEN_TTL_MS,
-            device_id: 'device-1',
-            device_properties: 'props',
-        });
-    });
-
-    it('loads credential file before env fallback', () => {
+    it('loads credentials from the local credential file', () => {
         mockExistsSync.mockReturnValue(true);
         mockReadFileSync.mockReturnValue(JSON.stringify({
             access_token: 'file-access',
             refresh_token: 'file-refresh',
             expires_at: 123,
         }));
-        const credentials = loadXiaoyuzhouCredentials({
-            XY_ACCESS_TOKEN: 'env-access',
-            XY_REFRESH_TOKEN: 'env-refresh',
-        });
+        const credentials = loadXiaoyuzhouCredentials();
         expect(mockReadFileSync).toHaveBeenCalledWith(getXiaoyuzhouCredentialFile(), 'utf-8');
         expect(credentials.access_token).toBe('file-access');
         expect(credentials.refresh_token).toBe('file-refresh');

--- a/clis/xiaoyuzhou/auth.test.js
+++ b/clis/xiaoyuzhou/auth.test.js
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExistsSync, mockReadFileSync, mockMkdirSync, mockWriteFileSync, mockHomedir } = vi.hoisted(() => ({
+    mockExistsSync: vi.fn(),
+    mockReadFileSync: vi.fn(),
+    mockMkdirSync: vi.fn(),
+    mockWriteFileSync: vi.fn(),
+    mockHomedir: vi.fn(() => '/Users/tester'),
+}));
+
+vi.mock('node:fs', () => ({
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    mkdirSync: mockMkdirSync,
+    writeFileSync: mockWriteFileSync,
+}));
+
+vi.mock('node:os', () => ({
+    homedir: mockHomedir,
+}));
+
+const { extractTranscriptText, getXiaoyuzhouCredentialFile, loadXiaoyuzhouCredentials, loadXiaoyuzhouCredentialsFromEnv, normalizeXiaoyuzhouCredentials, refreshXiaoyuzhouCredentials, requestXiaoyuzhouJson, shouldRefreshXiaoyuzhouCredentials, XIAOYUZHOU_TOKEN_TTL_MS } = await import('./auth.js');
+
+function createJsonResponse(status, payload) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+    };
+}
+
+describe('xiaoyuzhou auth helpers', () => {
+    beforeEach(() => {
+        mockExistsSync.mockReset();
+        mockReadFileSync.mockReset();
+        mockMkdirSync.mockReset();
+        mockWriteFileSync.mockReset();
+        vi.useRealTimers();
+    });
+
+    it('loads bootstrap credentials from env and derives expiry from XY_LAST_UPDATED_TS', () => {
+        const credentials = loadXiaoyuzhouCredentialsFromEnv({
+            XY_ACCESS_TOKEN: 'access',
+            XY_REFRESH_TOKEN: 'refresh',
+            XY_LAST_UPDATED_TS: '1710000000',
+            XY_DEVICE_ID: 'device-1',
+            XY_DEVICE_PROPERTIES: 'props',
+        });
+        expect(credentials).toEqual({
+            access_token: 'access',
+            refresh_token: 'refresh',
+            expires_at: 1710000000 * 1000 + XIAOYUZHOU_TOKEN_TTL_MS,
+            device_id: 'device-1',
+            device_properties: 'props',
+        });
+    });
+
+    it('loads credential file before env fallback', () => {
+        mockExistsSync.mockReturnValue(true);
+        mockReadFileSync.mockReturnValue(JSON.stringify({
+            access_token: 'file-access',
+            refresh_token: 'file-refresh',
+            expires_at: 123,
+        }));
+        const credentials = loadXiaoyuzhouCredentials({
+            XY_ACCESS_TOKEN: 'env-access',
+            XY_REFRESH_TOKEN: 'env-refresh',
+        });
+        expect(mockReadFileSync).toHaveBeenCalledWith(getXiaoyuzhouCredentialFile(), 'utf-8');
+        expect(credentials.access_token).toBe('file-access');
+        expect(credentials.refresh_token).toBe('file-refresh');
+    });
+
+    it('refreshes credentials and persists the updated token file', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-04-15T00:00:00Z'));
+        const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(200, {
+            success: true,
+            'x-jike-access-token': 'new-access',
+            'x-jike-refresh-token': 'new-refresh',
+        }));
+        const refreshed = await refreshXiaoyuzhouCredentials(normalizeXiaoyuzhouCredentials({
+            access_token: 'old-access',
+            refresh_token: 'old-refresh',
+            device_id: 'device-1',
+            device_properties: 'props',
+        }), fetchMock);
+        expect(refreshed.access_token).toBe('new-access');
+        expect(refreshed.refresh_token).toBe('new-refresh');
+        expect(refreshed.expires_at).toBe(Date.now() + XIAOYUZHOU_TOKEN_TTL_MS);
+        expect(mockMkdirSync).toHaveBeenCalledWith('/Users/tester/.opencli', { recursive: true });
+        expect(mockWriteFileSync).toHaveBeenCalledWith('/Users/tester/.opencli/xiaoyuzhou.json', expect.stringContaining('"access_token": "new-access"'), 'utf-8');
+    });
+
+    it('retries once on 401 using refreshed credentials', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            text: vi.fn().mockResolvedValue('unauthorized'),
+        })
+            .mockResolvedValueOnce(createJsonResponse(200, {
+            success: true,
+            'x-jike-access-token': 'refreshed-access',
+            'x-jike-refresh-token': 'refreshed-refresh',
+        }))
+            .mockResolvedValueOnce(createJsonResponse(200, {
+            success: true,
+            data: { title: 'Transcript Episode' },
+        }));
+        const result = await requestXiaoyuzhouJson('/v1/episode/get', {
+            query: { eid: 'ep123' },
+            credentials: normalizeXiaoyuzhouCredentials({
+                access_token: 'old-access',
+                refresh_token: 'old-refresh',
+            }),
+        }, fetchMock);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(result.data).toEqual({ title: 'Transcript Episode' });
+        expect(result.credentials.access_token).toBe('refreshed-access');
+    });
+
+    it('extracts transcript text from segment arrays and direct text payloads', () => {
+        expect(extractTranscriptText(JSON.stringify({
+            segments: [{ text: 'hello ' }, { text: ' world' }],
+        }))).toEqual({
+            text: 'hello\nworld',
+            segmentCount: 2,
+        });
+        expect(extractTranscriptText(JSON.stringify({ text: 'full transcript' }))).toEqual({
+            text: 'full transcript',
+            segmentCount: 1,
+        });
+    });
+
+    it('detects credentials that are close to expiry', () => {
+        expect(shouldRefreshXiaoyuzhouCredentials({
+            expires_at: Date.now() - 1,
+        })).toBe(true);
+        expect(shouldRefreshXiaoyuzhouCredentials({
+            expires_at: Date.now() + 10 * 60 * 1000,
+        })).toBe(false);
+    });
+});

--- a/clis/xiaoyuzhou/download.js
+++ b/clis/xiaoyuzhou/download.js
@@ -1,0 +1,49 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+import { httpDownload, sanitizeFilename } from '@jackwener/opencli/download';
+import { formatBytes } from '@jackwener/opencli/download/progress';
+import { fetchPageProps } from './utils.js';
+
+cli({
+    site: 'xiaoyuzhou',
+    name: 'download',
+    description: 'Download Xiaoyuzhou episode audio',
+    domain: 'www.xiaoyuzhoufm.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Episode ID (eid from podcast-episodes output)' },
+        { name: 'output', default: './xiaoyuzhou-downloads', help: 'Output directory' },
+    ],
+    columns: ['title', 'podcast', 'status', 'size', 'file'],
+    func: async (_page, args) => {
+        const pageProps = await fetchPageProps(`/episode/${args.id}`);
+        const ep = pageProps.episode;
+        if (!ep) {
+            throw new CliError('NOT_FOUND', 'Episode not found', 'Please check the ID');
+        }
+        const audioUrl = ep.media?.source?.url;
+        if (!audioUrl) {
+            throw new CliError('PARSE_ERROR', 'Audio URL not found in episode payload', 'Episode payload does not expose media.source.url');
+        }
+        const output = String(args.output || './xiaoyuzhou-downloads');
+        const ext = path.extname(new URL(audioUrl).pathname) || '.mp3';
+        const title = String(ep.title || 'episode');
+        const filename = `${args.id}_${sanitizeFilename(title, 80) || 'episode'}${ext}`;
+        const outputDir = path.join(output, String(args.id));
+        fs.mkdirSync(outputDir, { recursive: true });
+        const destPath = path.join(outputDir, filename);
+        const result = await httpDownload(audioUrl, destPath, {
+            timeout: 60000,
+        });
+        return [{
+                title,
+                podcast: ep.podcast?.title || '-',
+                status: result.success ? 'success' : 'failed',
+                size: result.success ? formatBytes(result.size) : (result.error || 'unknown error'),
+                file: result.success ? destPath : '-',
+            }];
+    },
+});

--- a/clis/xiaoyuzhou/download.test.js
+++ b/clis/xiaoyuzhou/download.test.js
@@ -1,0 +1,125 @@
+import path from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+const { mockFetchPageProps, mockHttpDownload, mockMkdirSync } = vi.hoisted(() => ({
+    mockFetchPageProps: vi.fn(),
+    mockHttpDownload: vi.fn(),
+    mockMkdirSync: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+    const actual = await vi.importActual('./utils.js');
+    return {
+        ...actual,
+        fetchPageProps: mockFetchPageProps,
+    };
+});
+
+vi.mock('@jackwener/opencli/download', () => ({
+    httpDownload: mockHttpDownload,
+    sanitizeFilename: vi.fn((value) => value.replace(/\s+/g, '_')),
+}));
+
+vi.mock('@jackwener/opencli/download/progress', () => ({
+    formatBytes: vi.fn((size) => `${size} B`),
+}));
+
+vi.mock('node:fs', () => ({
+    mkdirSync: mockMkdirSync,
+}));
+
+await import('./download.js');
+
+let cmd;
+
+function toPosixPath(value) {
+    return value.replaceAll(path.sep, '/');
+}
+
+beforeAll(() => {
+    cmd = getRegistry().get('xiaoyuzhou/download');
+    expect(cmd?.func).toBeTypeOf('function');
+});
+
+describe('xiaoyuzhou download', () => {
+    beforeEach(() => {
+        mockFetchPageProps.mockReset();
+        mockHttpDownload.mockReset();
+        mockMkdirSync.mockReset();
+    });
+
+    it('downloads audio from media.source.url into an episode subdirectory', async () => {
+        mockFetchPageProps.mockResolvedValue({
+            episode: {
+                title: 'Hello World',
+                podcast: { title: 'OpenCLI FM' },
+                media: {
+                    source: {
+                        url: 'https://media.xyzcdn.net/audio/hello-world.mp3?sign=abc',
+                    },
+                },
+            },
+        });
+        mockHttpDownload.mockResolvedValue({ success: true, size: 1234 });
+
+        const result = await cmd.func(null, {
+            id: 'ep123',
+            output: '/tmp/xiaoyuzhou-test',
+        });
+
+        expect(mockFetchPageProps).toHaveBeenCalledWith('/episode/ep123');
+        expect(toPosixPath(mockMkdirSync.mock.calls[0][0])).toBe('/tmp/xiaoyuzhou-test/ep123');
+        expect(mockMkdirSync.mock.calls[0][1]).toEqual({ recursive: true });
+        expect(mockHttpDownload).toHaveBeenCalledWith('https://media.xyzcdn.net/audio/hello-world.mp3?sign=abc', expect.stringContaining('/tmp/xiaoyuzhou-test/ep123/ep123_Hello_World.mp3'), {
+            timeout: 60000,
+        });
+        expect(result).toEqual([{
+                title: 'Hello World',
+                podcast: 'OpenCLI FM',
+                status: 'success',
+                size: '1234 B',
+                file: '/tmp/xiaoyuzhou-test/ep123/ep123_Hello_World.mp3',
+            }]);
+    });
+
+    it('preserves non-mp3 extensions from media.source.url', async () => {
+        mockFetchPageProps.mockResolvedValue({
+            episode: {
+                title: 'Lossless Episode',
+                podcast: { title: 'OpenCLI FM' },
+                media: {
+                    source: {
+                        url: 'https://media.xyzcdn.net/audio/lossless.m4a',
+                    },
+                },
+            },
+        });
+        mockHttpDownload.mockResolvedValue({ success: true, size: 2048 });
+
+        const result = await cmd.func(null, {
+            id: 'ep456',
+            output: '/tmp/xiaoyuzhou-test',
+        });
+
+        expect(mockHttpDownload.mock.calls[0][1]).toContain('ep456_Lossless_Episode.m4a');
+        expect(result[0].file).toBe('/tmp/xiaoyuzhou-test/ep456/ep456_Lossless_Episode.m4a');
+    });
+
+    it('throws when media.source.url is missing', async () => {
+        mockFetchPageProps.mockResolvedValue({
+            episode: {
+                title: 'No Audio',
+                podcast: { title: 'OpenCLI FM' },
+                media: {},
+            },
+        });
+
+        await expect(cmd.func(null, { id: 'ep789', output: '/tmp/xiaoyuzhou-test' })).rejects.toMatchObject({
+            code: 'PARSE_ERROR',
+            message: 'Audio URL not found in episode payload',
+            hint: 'Episode payload does not expose media.source.url',
+        });
+        expect(mockHttpDownload).not.toHaveBeenCalled();
+    });
+});

--- a/clis/xiaoyuzhou/transcript.js
+++ b/clis/xiaoyuzhou/transcript.js
@@ -1,0 +1,76 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CliError } from '@jackwener/opencli/errors';
+import { loadXiaoyuzhouCredentials, requestXiaoyuzhouJson, fetchXiaoyuzhouTranscriptBody, extractTranscriptText } from './auth.js';
+
+cli({
+    site: 'xiaoyuzhou',
+    name: 'transcript',
+    description: 'Download Xiaoyuzhou transcript as JSON and text (requires local credentials)',
+    domain: 'www.xiaoyuzhoufm.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Episode ID (eid from podcast-episodes output)' },
+        { name: 'output', default: './xiaoyuzhou-transcripts', help: 'Output directory' },
+        { name: 'json', type: 'boolean', default: true, help: 'Save transcript JSON file' },
+        { name: 'text', type: 'boolean', default: true, help: 'Save extracted transcript text file' },
+    ],
+    columns: ['title', 'podcast', 'status', 'segments', 'json_file', 'text_file'],
+    func: async (_page, kwargs) => {
+        if (kwargs.json === false && kwargs.text === false) {
+            throw new ArgumentError('At least one of --json or --text must be enabled', 'Example: opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --text true');
+        }
+        let credentials = loadXiaoyuzhouCredentials();
+        const episodeResponse = await requestXiaoyuzhouJson('/v1/episode/get', {
+            query: { eid: kwargs.id },
+            credentials,
+        });
+        credentials = episodeResponse.credentials;
+        const episode = episodeResponse.data;
+        if (!episode) {
+            throw new CliError('NOT_FOUND', 'Episode not found', 'Please check the episode ID');
+        }
+        const mediaId = String(episode.transcript?.mediaId || episode.media?.id || episode.transcriptMediaId || '').trim();
+        if (!mediaId) {
+            throw new CliError('PARSE_ERROR', 'mediaId not found in episode payload', 'Transcript metadata requires episode.transcript.mediaId, episode.media.id, or episode.transcriptMediaId');
+        }
+        const transcriptResponse = await requestXiaoyuzhouJson('/v1/episode-transcript/get', {
+            method: 'POST',
+            body: {
+                eid: kwargs.id,
+                mediaId,
+            },
+            credentials,
+        });
+        const transcriptMeta = transcriptResponse.data;
+        const transcriptUrl = String(transcriptMeta?.transcriptUrl || transcriptMeta?.url || '').trim();
+        if (!transcriptUrl) {
+            throw new CliError('EMPTY_RESULT', 'Transcript URL not found', 'This episode may not have transcript data available');
+        }
+        const transcriptBody = await fetchXiaoyuzhouTranscriptBody(transcriptUrl);
+        const { text, segmentCount } = extractTranscriptText(transcriptBody);
+        if (kwargs.text !== false && transcriptBody.trim() && !text.trim()) {
+            throw new CliError('PARSE_ERROR', 'Failed to extract transcript text', 'Transcript payload format is unsupported. Re-run with --json true to inspect the raw payload.');
+        }
+        const outputDir = path.join(String(kwargs.output || './xiaoyuzhou-transcripts'), String(kwargs.id));
+        fs.mkdirSync(outputDir, { recursive: true });
+        const jsonPath = path.join(outputDir, 'transcript.json');
+        const textPath = path.join(outputDir, 'transcript.txt');
+        if (kwargs.json !== false) {
+            fs.writeFileSync(jsonPath, transcriptBody, 'utf-8');
+        }
+        if (kwargs.text !== false) {
+            fs.writeFileSync(textPath, text, 'utf-8');
+        }
+        return [{
+                title: episode.title || 'episode',
+                podcast: episode.podcast?.title || '-',
+                status: 'success',
+                segments: kwargs.text === false ? '-' : String(segmentCount),
+                json_file: kwargs.json === false ? '-' : jsonPath,
+                text_file: kwargs.text === false ? '-' : textPath,
+            }];
+    },
+});

--- a/clis/xiaoyuzhou/transcript.test.js
+++ b/clis/xiaoyuzhou/transcript.test.js
@@ -1,0 +1,195 @@
+import path from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+const { mockLoadCredentials, mockRequestJson, mockFetchTranscriptBody, mockMkdirSync, mockWriteFileSync } = vi.hoisted(() => ({
+    mockLoadCredentials: vi.fn(),
+    mockRequestJson: vi.fn(),
+    mockFetchTranscriptBody: vi.fn(),
+    mockMkdirSync: vi.fn(),
+    mockWriteFileSync: vi.fn(),
+}));
+
+vi.mock('./auth.js', async () => {
+    const actual = await vi.importActual('./auth.js');
+    return {
+        ...actual,
+        loadXiaoyuzhouCredentials: mockLoadCredentials,
+        requestXiaoyuzhouJson: mockRequestJson,
+        fetchXiaoyuzhouTranscriptBody: mockFetchTranscriptBody,
+    };
+});
+
+vi.mock('node:fs', () => ({
+    mkdirSync: mockMkdirSync,
+    writeFileSync: mockWriteFileSync,
+}));
+
+await import('./transcript.js');
+
+let cmd;
+
+function toPosixPath(value) {
+    return value.replaceAll(path.sep, '/');
+}
+
+beforeAll(() => {
+    cmd = getRegistry().get('xiaoyuzhou/transcript');
+    expect(cmd?.func).toBeTypeOf('function');
+});
+
+describe('xiaoyuzhou transcript', () => {
+    beforeEach(() => {
+        mockLoadCredentials.mockReset();
+        mockRequestJson.mockReset();
+        mockFetchTranscriptBody.mockReset();
+        mockMkdirSync.mockReset();
+        mockWriteFileSync.mockReset();
+        mockLoadCredentials.mockReturnValue({ access_token: 'access', refresh_token: 'refresh' });
+    });
+
+    it('downloads transcript json and extracted text files', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                title: 'Transcript Episode',
+                podcast: { title: 'OpenCLI FM' },
+                transcript: { mediaId: 'media-123' },
+            },
+        })
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                transcriptUrl: 'https://cdn.example.com/transcript.json',
+            },
+        });
+        mockFetchTranscriptBody.mockResolvedValue(JSON.stringify({
+            segments: [{ text: 'hello' }, { text: 'world' }],
+        }));
+        const result = await cmd.func(null, {
+            id: 'ep123',
+            output: '/tmp/xiaoyuzhou-transcripts',
+            json: true,
+            text: true,
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(1, '/v1/episode/get', {
+            query: { eid: 'ep123' },
+            credentials: { access_token: 'access', refresh_token: 'refresh' },
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(2, '/v1/episode-transcript/get', {
+            method: 'POST',
+            body: { eid: 'ep123', mediaId: 'media-123' },
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+        });
+        expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/xiaoyuzhou-transcripts/ep123', { recursive: true });
+        expect(mockWriteFileSync).toHaveBeenNthCalledWith(1, '/tmp/xiaoyuzhou-transcripts/ep123/transcript.json', expect.any(String), 'utf-8');
+        expect(mockWriteFileSync).toHaveBeenNthCalledWith(2, '/tmp/xiaoyuzhou-transcripts/ep123/transcript.txt', 'hello\nworld', 'utf-8');
+        expect(result).toEqual([{
+                title: 'Transcript Episode',
+                podcast: 'OpenCLI FM',
+                status: 'success',
+                segments: '2',
+                json_file: '/tmp/xiaoyuzhou-transcripts/ep123/transcript.json',
+                text_file: '/tmp/xiaoyuzhou-transcripts/ep123/transcript.txt',
+            }]);
+    });
+
+    it('derives mediaId from episode.media.id when transcript.mediaId is absent', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                title: 'Transcript Episode',
+                podcast: { title: 'OpenCLI FM' },
+                media: { id: 'media-456' },
+            },
+        })
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                transcriptUrl: 'https://cdn.example.com/transcript.json',
+            },
+        });
+        mockFetchTranscriptBody.mockResolvedValue(JSON.stringify({ text: 'hello' }));
+        await cmd.func(null, {
+            id: 'ep456',
+            output: '/tmp/xiaoyuzhou-transcripts',
+            json: false,
+            text: true,
+        });
+        expect(mockRequestJson.mock.calls[1][1].body.mediaId).toBe('media-456');
+        expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+        expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/xiaoyuzhou-transcripts/ep456/transcript.txt', 'hello', 'utf-8');
+    });
+
+    it('throws when transcript url is missing', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                title: 'Transcript Episode',
+                podcast: { title: 'OpenCLI FM' },
+                transcript: { mediaId: 'media-123' },
+            },
+        })
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {},
+        });
+        await expect(cmd.func(null, {
+            id: 'ep123',
+            output: '/tmp/xiaoyuzhou-transcripts',
+            json: true,
+            text: true,
+        })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+            message: 'Transcript URL not found',
+        });
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('throws parse_error when transcript text extraction fails', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                title: 'Transcript Episode',
+                podcast: { title: 'OpenCLI FM' },
+                transcript: { mediaId: 'media-123' },
+            },
+        })
+            .mockResolvedValueOnce({
+            credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
+            data: {
+                transcriptUrl: 'https://cdn.example.com/transcript.json',
+            },
+        });
+        mockFetchTranscriptBody.mockResolvedValue(JSON.stringify({
+            segments: [{ startAt: 0, endAt: 1 }],
+        }));
+        await expect(cmd.func(null, {
+            id: 'ep123',
+            output: '/tmp/xiaoyuzhou-transcripts',
+            json: true,
+            text: true,
+        })).rejects.toMatchObject({
+            code: 'PARSE_ERROR',
+            message: 'Failed to extract transcript text',
+        });
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('rejects disabling both json and text outputs', async () => {
+        await expect(cmd.func(null, {
+            id: 'ep123',
+            output: '/tmp/xiaoyuzhou-transcripts',
+            json: false,
+            text: false,
+        })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: 'At least one of --json or --text must be enabled',
+        });
+        expect(mockRequestJson).not.toHaveBeenCalled();
+    });
+});

--- a/docs/adapters/browser/xiaoyuzhou.md
+++ b/docs/adapters/browser/xiaoyuzhou.md
@@ -9,20 +9,30 @@
 | `opencli xiaoyuzhou podcast` | |
 | `opencli xiaoyuzhou podcast-episodes` | |
 | `opencli xiaoyuzhou episode` | |
+| `opencli xiaoyuzhou download` | Download episode audio |
 
 ## Usage Examples
 
 ```bash
-# Quick start
-opencli xiaoyuzhou podcast --limit 5
+# Podcast profile
+opencli xiaoyuzhou podcast 6013f9f58e2f7ee375cf4216
+
+# Recent episodes
+opencli xiaoyuzhou podcast-episodes 6013f9f58e2f7ee375cf4216 --limit 5
+
+# Episode details
+opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0
+
+# Download episode audio
+opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
 # JSON output
-opencli xiaoyuzhou podcast -f json
+opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0 -f json
 
 # Verbose mode
-opencli xiaoyuzhou podcast -v
+opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 -v
 ```
 
 ## Prerequisites
 
-- No browser required — uses public API
+- No browser required — uses public episode pages

--- a/docs/adapters/browser/xiaoyuzhou.md
+++ b/docs/adapters/browser/xiaoyuzhou.md
@@ -40,7 +40,7 @@ opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 -v
 ## Prerequisites
 
 - No browser required — uses public episode pages
-- `transcript` requires local Xiaoyuzhou app credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN` env vars for bootstrap
+- `transcript` requires local Xiaoyuzhou app credentials in `~/.opencli/xiaoyuzhou.json`
 
 Example credential file:
 

--- a/docs/adapters/browser/xiaoyuzhou.md
+++ b/docs/adapters/browser/xiaoyuzhou.md
@@ -10,6 +10,7 @@
 | `opencli xiaoyuzhou podcast-episodes` | |
 | `opencli xiaoyuzhou episode` | |
 | `opencli xiaoyuzhou download` | Download episode audio |
+| `opencli xiaoyuzhou transcript` | Download transcript JSON and extracted text (requires local credentials) |
 
 ## Usage Examples
 
@@ -26,13 +27,29 @@ opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0
 # Download episode audio
 opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
+# Download transcript JSON + text
+opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --output ./xiaoyuzhou-transcripts
+
 # JSON output
 opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0 -f json
 
 # Verbose mode
-opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 -v
+opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 -v
 ```
 
 ## Prerequisites
 
 - No browser required — uses public episode pages
+- `transcript` requires local Xiaoyuzhou app credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN` env vars for bootstrap
+
+Example credential file:
+
+```json
+{
+  "access_token": "your-access-token",
+  "refresh_token": "your-refresh-token",
+  "device_id": "81ADBFD6-6921-482B-9AB9-A29E7CC7BB55",
+  "device_properties": "",
+  "expires_at": 0
+}
+```

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -75,7 +75,7 @@ Run `opencli list` for the live registry.
 | **[devto](./browser/devto.md)**                   | `top` `tag` `user`                                                                                                                             | 🌐 Public    |
 | **[dictionary](./browser/dictionary.md)**         | `search` `synonyms` `examples`                                                                                                                 | 🌐 Public    |
 | **[apple-podcasts](./browser/apple-podcasts.md)** | `search` `episodes` `top`                                                                                                                      | 🌐 Public    |
-| **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode`                                                                                                         | 🌐 Public    |
+| **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download`                                                                                              | 🌐 Public    |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
 | **[paperreview](./browser/paperreview.md)**       | `submit` `review` `feedback`                                                                                                                   | 🌐 Public    |

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -75,7 +75,7 @@ Run `opencli list` for the live registry.
 | **[devto](./browser/devto.md)**                   | `top` `tag` `user`                                                                                                                             | 🌐 Public    |
 | **[dictionary](./browser/dictionary.md)**         | `search` `synonyms` `examples`                                                                                                                 | 🌐 Public    |
 | **[apple-podcasts](./browser/apple-podcasts.md)** | `search` `episodes` `top`                                                                                                                      | 🌐 Public    |
-| **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download`                                                                                              | 🌐 Public    |
+| **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download` `transcript` (local credentials required)                                                   | 🌐 Public    |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
 | **[paperreview](./browser/paperreview.md)**       | `submit` `review` `feedback`                                                                                                                   | 🌐 Public    |

--- a/docs/advanced/download.md
+++ b/docs/advanced/download.md
@@ -10,6 +10,7 @@ OpenCLI supports downloading images, videos, and articles from supported platfor
 | **bilibili** | Videos | Requires `yt-dlp` installed |
 | **twitter** | Images, Videos | Downloads from user media tab or single tweet |
 | **douban** | Images | Downloads poster / still image lists from movie subjects |
+| **xiaoyuzhou** | Audio | Downloads episode audio from public episode payloads |
 | **zhihu** | Articles (Markdown) | Exports articles with optional image download |
 | **weixin** | Articles (Markdown) | Exports WeChat Official Account articles |
 
@@ -43,6 +44,9 @@ opencli twitter download --tweet-url "https://x.com/user/status/123" --output ./
 
 # Download Douban posters / stills
 opencli douban download 30382501 --output ./douban
+
+# Download Xiaoyuzhou episode audio
+opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
 # Export Zhihu article to Markdown
 opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu

--- a/docs/advanced/download.md
+++ b/docs/advanced/download.md
@@ -10,7 +10,7 @@ OpenCLI supports downloading images, videos, and articles from supported platfor
 | **bilibili** | Videos | Requires `yt-dlp` installed |
 | **twitter** | Images, Videos | Downloads from user media tab or single tweet |
 | **douban** | Images | Downloads poster / still image lists from movie subjects |
-| **xiaoyuzhou** | Audio | Downloads episode audio from public episode payloads |
+| **xiaoyuzhou** | Audio, Transcript | Downloads episode audio from public pages and transcript JSON/text with local credentials |
 | **zhihu** | Articles (Markdown) | Exports articles with optional image download |
 | **weixin** | Articles (Markdown) | Exports WeChat Official Account articles |
 
@@ -48,6 +48,9 @@ opencli douban download 30382501 --output ./douban
 # Download Xiaoyuzhou episode audio
 opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
+# Download Xiaoyuzhou transcript JSON + text
+opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --output ./xiaoyuzhou-transcripts
+
 # Export Zhihu article to Markdown
 opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
 
@@ -57,6 +60,8 @@ opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 # Export WeChat article to Markdown
 opencli weixin download --url "https://mp.weixin.qq.com/s/xxx" --output ./weixin
 ```
+
+`opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
 
 ## Pipeline Step
 

--- a/docs/advanced/download.md
+++ b/docs/advanced/download.md
@@ -61,7 +61,7 @@ opencli zhihu download "https://zhuanlan.zhihu.com/p/xxx" --download-images
 opencli weixin download --url "https://mp.weixin.qq.com/s/xxx" --output ./weixin
 ```
 
-`opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
+`opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`.
 
 ## Pipeline Step
 

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -126,7 +126,7 @@ Type legend: 🌐 = Browser (needs Chrome login) · ✅ = Public API (no browser
 | **xianyu** | 🌐 | `search` `item` `chat` |
 | **xiaoe** | 🌐 | `courses` `catalog` `content` `detail` `play-url` |
 | **xiaohongshu** | 🌐 | `search` `notifications` `feed` `user` `note` `comments` `download` `publish` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` |
-| **xiaoyuzhou** | ✅ | `podcast` `podcast-episodes` `episode` |
+| **xiaoyuzhou** | ✅ | `podcast` `podcast-episodes` `episode` `download` |
 | **xueqiu** | 🌐 | `hot-stock` `stock` `watchlist` `feed` `hot` `search` `comments` `earnings-date` `fund-holdings` `fund-snapshot` |
 | **yahoo-finance** | 🌐 | `quote` |
 | **yollomi** | 🌐 | `models` `generate` `video` `upload` `remove-bg` `edit` `background` `face-swap` `object-remover` `restore` `try-on` `upscale` |

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -135,7 +135,7 @@ Type legend: 🌐 = Browser (needs Chrome login) · ✅ = Public API (no browser
 | **zhihu** | 🌐 | `hot` `search` `question` |
 | **zsxq** | 🌐 | `groups` `dynamics` `topics` `topic` `search` |
 
-`*` `opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
+`*` `opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`.
 
 ### Desktop Apps (CDP/Electron)
 

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -126,7 +126,7 @@ Type legend: 🌐 = Browser (needs Chrome login) · ✅ = Public API (no browser
 | **xianyu** | 🌐 | `search` `item` `chat` |
 | **xiaoe** | 🌐 | `courses` `catalog` `content` `detail` `play-url` |
 | **xiaohongshu** | 🌐 | `search` `notifications` `feed` `user` `note` `comments` `download` `publish` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` |
-| **xiaoyuzhou** | ✅ | `podcast` `podcast-episodes` `episode` `download` |
+| **xiaoyuzhou** | ✅ | `podcast` `podcast-episodes` `episode` `download` `transcript*` |
 | **xueqiu** | 🌐 | `hot-stock` `stock` `watchlist` `feed` `hot` `search` `comments` `earnings-date` `fund-holdings` `fund-snapshot` |
 | **yahoo-finance** | 🌐 | `quote` |
 | **yollomi** | 🌐 | `models` `generate` `video` `upload` `remove-bg` `edit` `background` `face-swap` `object-remover` `restore` `try-on` `upscale` |
@@ -134,6 +134,8 @@ Type legend: 🌐 = Browser (needs Chrome login) · ✅ = Public API (no browser
 | **yuanbao** | 🌐 | `new` `ask` |
 | **zhihu** | 🌐 | `hot` `search` `question` |
 | **zsxq** | 🌐 | `groups` `dynamics` `topics` `topic` `search` |
+
+`*` `opencli xiaoyuzhou transcript` requires local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`, or `XY_ACCESS_TOKEN` / `XY_REFRESH_TOKEN`.
 
 ### Desktop Apps (CDP/Electron)
 

--- a/skills/opencli-usage/commands.md
+++ b/skills/opencli-usage/commands.md
@@ -755,6 +755,7 @@ opencli xiaohongshu creator-stats              # 创作者数据统计
 opencli xiaoyuzhou podcast 12345          # 播客资料 (id positional)
 opencli xiaoyuzhou podcast-episodes 12345 # 播客剧集列表 (id positional)
 opencli xiaoyuzhou episode 12345          # 单集详情 (id positional)
+opencli xiaoyuzhou download 12345         # 下载单集音频 (id positional)
 ```
 
 ## Xueqiu (雪球) 🌐

--- a/skills/opencli-usage/commands.md
+++ b/skills/opencli-usage/commands.md
@@ -756,6 +756,7 @@ opencli xiaoyuzhou podcast 12345          # 播客资料 (id positional)
 opencli xiaoyuzhou podcast-episodes 12345 # 播客剧集列表 (id positional)
 opencli xiaoyuzhou episode 12345          # 单集详情 (id positional)
 opencli xiaoyuzhou download 12345         # 下载单集音频 (id positional)
+opencli xiaoyuzhou transcript 12345       # 下载单集转录 JSON / 文本（需要本地凭证）
 ```
 
 ## Xueqiu (雪球) 🌐


### PR DESCRIPTION
## Description

- add `opencli xiaoyuzhou download` for episode audio downloads from public episode payloads
- add `opencli xiaoyuzhou transcript` for transcript JSON/text downloads with local credential-file auth
- add Xiaoyuzhou auth helpers and adapter tests
- update manifest and user-facing docs for the new commands
- remove env credential fallback so the transcript auth contract matches the docs

Related issue:

N/A

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Added doc page under `docs/adapters/` (if new adapter)
- [x] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [x] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

- `npx vitest run clis/xiaoyuzhou/auth.test.js clis/xiaoyuzhou/transcript.test.js clis/xiaoyuzhou/download.test.js`
- 3 test files passed, 13 tests passed
