### PR TITLE
fix(external): use safe npm install for dws

### DIFF
--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -36,8 +36,8 @@
   homepage: "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
   tags: [dingtalk, collaboration, productivity, ai-agent]
   install:
-    mac: "curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh"
-    linux: "curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh"
+    mac: "npm install -g dingtalk-workspace-cli"
+    linux: "npm install -g dingtalk-workspace-cli"
 
 - name: wecom-cli
   binary: wecom-cli


### PR DESCRIPTION
## Summary
- change built-in `dws` auto-install from `curl | sh` to the official npm package
- add a registry regression test so built-in install commands must remain shell-safe

## Validation
- node node_modules/vitest/vitest.mjs run src/external.test.ts
- npm run typecheck

## Context
Fixes #1026.