### PR TITLE
fix(xiaohongshu): verify title input sticks on publish

### DIFF
--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -22,10 +22,10 @@ const PUBLISH_URL = 'https://creator.xiaohongshu.com/publish/publish?from=menu_l
 const MAX_IMAGES = 9;
 const MAX_TITLE_LEN = 20;
 const UPLOAD_SETTLE_MS = 3000;
-/** Selectors for the title field, ordered by priority (new UI first). */
+/** Selectors for the title field, ordered by priority across current UI variants. */
 const TITLE_SELECTORS = [
-    // New creator center (2026-03) uses contenteditable for the title field.
-    // Placeholder observed: "填写标题会有更多赞哦"
+    // Some creator-center variants expose the title as contenteditable,
+    // others use a normal <input> with the same placeholder.
     '[contenteditable="true"][placeholder*="标题"]',
     '[contenteditable="true"][placeholder*="赞"]',
     '[contenteditable="true"][class*="title"]',
@@ -180,35 +180,156 @@ async function waitForUploads(page, maxWaitMs = 30_000) {
  * Returns { ok, sel }.
  */
 async function fillField(page, selectors, text, fieldName) {
-    const result = await page.evaluate(`
-    (function(selectors, text) {
+    const located = await page.evaluate(`
+    (function(selectors) {
+      const __opencli_xhs_fill_phase = "locate";
       for (const sel of selectors) {
         const candidates = document.querySelectorAll(sel);
         for (const el of candidates) {
           if (!el || el.offsetParent === null) continue;
-          el.focus();
-          if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
-            el.value = '';
-            document.execCommand('selectAll', false);
-            document.execCommand('insertText', false, text);
-            el.dispatchEvent(new Event('input', { bubbles: true }));
-            el.dispatchEvent(new Event('change', { bubbles: true }));
-          } else {
-            // contenteditable
-            el.textContent = '';
-            document.execCommand('selectAll', false);
-            document.execCommand('insertText', false, text);
-            el.dispatchEvent(new Event('input', { bubbles: true }));
-          }
-          return { ok: true, sel };
+          const kind = el.isContentEditable
+            ? 'contenteditable'
+            : (el.tagName === 'TEXTAREA' ? 'textarea' : 'input');
+          return { ok: true, sel, kind };
         }
       }
       return { ok: false };
-    })(${JSON.stringify(selectors)}, ${JSON.stringify(text)})
+    })(${JSON.stringify(selectors)})
   `);
-    if (!result.ok) {
+    if (!located.ok) {
         await page.screenshot({ path: `/tmp/xhs_publish_${fieldName}_debug.png` });
         throw new Error(`Could not find ${fieldName} input. Debug screenshot: /tmp/xhs_publish_${fieldName}_debug.png`);
+    }
+    const applyInPage = () => page.evaluate(`
+      ((selector, expectedText) => {
+        const __opencli_xhs_fill_phase = "apply";
+        const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+        const fireBeforeInput = (el, value) => {
+          try {
+            el.dispatchEvent(new InputEvent('beforeinput', {
+              bubbles: true,
+              data: value,
+              inputType: 'insertText',
+            }));
+          } catch {
+            el.dispatchEvent(new Event('beforeinput', { bubbles: true }));
+          }
+        };
+        const fireInput = (el, value) => {
+          try {
+            el.dispatchEvent(new InputEvent('input', {
+              bubbles: true,
+              data: value,
+              inputType: 'insertText',
+            }));
+          } catch {
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+        };
+        const el = Array.from(document.querySelectorAll(selector)).find(node => node && node.offsetParent !== null);
+        if (!el) return { ok: false, actual: '' };
+        el.focus();
+        fireBeforeInput(el, expectedText);
+        if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+          const proto = el.tagName === 'TEXTAREA'
+            ? HTMLTextAreaElement.prototype
+            : HTMLInputElement.prototype;
+          const nativeSetter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+          if (nativeSetter) nativeSetter.call(el, expectedText);
+          else el.value = expectedText;
+          fireInput(el, expectedText);
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+          el.blur();
+          return { ok: el.value === expectedText, actual: el.value || '' };
+        }
+        el.textContent = '';
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        const inserted = document.execCommand('insertText', false, expectedText);
+        if (!inserted) el.textContent = expectedText;
+        fireInput(el, expectedText);
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        el.blur();
+        const actual = normalize(el.innerText || el.textContent || '');
+        return { ok: actual === normalize(expectedText), actual };
+      })(${JSON.stringify(located.sel)}, ${JSON.stringify(text)})
+    `);
+    let result;
+    if (located.kind === 'contenteditable' && page.insertText) {
+        const prepared = await page.evaluate(`
+      ((selector, nextText) => {
+        const __opencli_xhs_fill_phase = "prepare";
+        const fireBeforeInput = (el, value) => {
+          try {
+            el.dispatchEvent(new InputEvent('beforeinput', {
+              bubbles: true,
+              data: value,
+              inputType: 'insertText',
+            }));
+          } catch {
+            el.dispatchEvent(new Event('beforeinput', { bubbles: true }));
+          }
+        };
+        const el = Array.from(document.querySelectorAll(selector)).find(node => node && node.offsetParent !== null);
+        if (!el) return { ok: false };
+        el.focus();
+        el.textContent = '';
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        fireBeforeInput(el, nextText);
+        return { ok: true };
+      })(${JSON.stringify(located.sel)}, ${JSON.stringify(text)})
+    `);
+        if (!prepared?.ok) {
+            await page.screenshot({ path: `/tmp/xhs_publish_${fieldName}_debug.png` });
+            throw new Error(`Could not prepare ${fieldName} input. Debug screenshot: /tmp/xhs_publish_${fieldName}_debug.png`);
+        }
+        try {
+            await page.insertText(text);
+            result = await page.evaluate(`
+      ((selector, expectedText) => {
+        const __opencli_xhs_fill_phase = "verify";
+        const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+        const fireInput = (el, value) => {
+          try {
+            el.dispatchEvent(new InputEvent('input', {
+              bubbles: true,
+              data: value,
+              inputType: 'insertText',
+            }));
+          } catch {
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+        };
+        const el = Array.from(document.querySelectorAll(selector)).find(node => node && node.offsetParent !== null);
+        if (!el) return { ok: false, actual: '' };
+        fireInput(el, expectedText);
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        el.blur();
+        const actual = normalize(el.innerText || el.textContent || '');
+        return { ok: actual === normalize(expectedText), actual };
+      })(${JSON.stringify(located.sel)}, ${JSON.stringify(text)})
+    `);
+        }
+        catch {
+            result = await applyInPage();
+        }
+    }
+    else {
+        result = await applyInPage();
+    }
+    if (!result?.ok) {
+        await page.screenshot({ path: `/tmp/xhs_publish_${fieldName}_debug.png` });
+        const actual = typeof result?.actual === 'string' ? result.actual : '';
+        throw new Error(`Failed to set ${fieldName}. Expected "${text}", got "${actual}". Debug screenshot: /tmp/xhs_publish_${fieldName}_debug.png`);
     }
 }
 async function selectImageTextTab(page) {

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -33,7 +33,214 @@ function createPageMock(evaluateResults, overrides = {}) {
         ...overrides,
     };
 }
+function createConditionalPageMock(evaluateImpl, overrides = {}) {
+    const page = createPageMock([], overrides);
+    page.evaluate.mockImplementation(async (js) => evaluateImpl(String(js)));
+    return page;
+}
 describe('xiaohongshu publish', () => {
+    it('uses native insertText for contenteditable title fields when available', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const insertText = vi.fn().mockResolvedValue(undefined);
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"prepare"'))
+                return { ok: true };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"verify"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, actual: '标题走原生输入' }
+                    : { ok: true, actual: '正文也走原生输入' };
+            }
+            if (code.includes('(function(selectors, text)')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '标题走原生输入' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable', actual: '正文也走原生输入' };
+            }
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll'))
+                return '发布成功';
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        }, {
+            insertText,
+        });
+        const result = await cmd.func(page, {
+            title: '标题走原生输入',
+            content: '正文也走原生输入',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        });
+        expect(insertText).toHaveBeenNthCalledWith(1, '标题走原生输入');
+        expect(insertText).toHaveBeenNthCalledWith(2, '正文也走原生输入');
+        expect(result).toEqual([
+            {
+                status: '✅ 发布成功',
+                detail: '"标题走原生输入" · 1张图片 · 发布成功',
+            },
+        ]);
+    });
+    it('aborts when the title does not stick after filling', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const insertText = vi.fn().mockResolvedValue(undefined);
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"'))
+                return { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable' };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"prepare"'))
+                return { ok: true };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"verify"'))
+                return { ok: false, actual: '' };
+            if (code.includes('(function(selectors, text)'))
+                return { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '' };
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll'))
+                return '发布成功';
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        }, {
+            insertText,
+        });
+        await expect(cmd.func(page, {
+            title: '标题没写进去',
+            content: '正文',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        })).rejects.toThrow('Failed to set title');
+        expect(insertText).toHaveBeenCalledWith('标题没写进去');
+    });
+    it('falls back to in-page insertion when contenteditable native insertText fails', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const insertText = vi.fn().mockRejectedValue(new Error('insertText returned no inserted flag'));
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"prepare"'))
+                return { ok: true };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"apply"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, actual: '原生失败后回退' }
+                    : { ok: true, actual: '正文也回退' };
+            }
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll'))
+                return '发布成功';
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        }, {
+            insertText,
+        });
+        const result = await cmd.func(page, {
+            title: '原生失败后回退',
+            content: '正文也回退',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        });
+        expect(insertText).toHaveBeenCalledWith('原生失败后回退');
+        expect(result).toEqual([
+            {
+                status: '✅ 发布成功',
+                detail: '"原生失败后回退" · 1张图片 · 发布成功',
+            },
+        ]);
+    });
+    it('aborts when an input title does not stick after filling', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"'))
+                return code.includes('input[maxlength')
+                    ? { ok: true, sel: 'input[maxlength="20"]', kind: 'input' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"apply"'))
+                return code.includes('input[maxlength')
+                    ? { ok: false, actual: '' }
+                    : { ok: true, actual: '正文' };
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll'))
+                return '发布成功';
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        });
+        await expect(cmd.func(page, {
+            title: '输入框标题没写进去',
+            content: '正文',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        })).rejects.toThrow('Failed to set title');
+    });
     it('prefers CDP setFileInput upload when the page supports it', async () => {
         const cmd = getRegistry().get('xiaohongshu/publish');
         expect(cmd?.func).toBeTypeOf('function');
@@ -48,8 +255,10 @@ describe('xiaohongshu publish', () => {
             'input[type="file"][accept*="image"],input[type="file"][accept*=".jpg"],input[type="file"][accept*=".jpeg"],input[type="file"][accept*=".png"],input[type="file"][accept*=".gif"],input[type="file"][accept*=".webp"]',
             false,
             true,
-            { ok: true, sel: 'input[maxlength="20"]' },
-            { ok: true, sel: '[contenteditable="true"][class*="content"]' },
+            { ok: true, sel: 'input[maxlength="20"]', kind: 'input' },
+            { ok: true, actual: 'CDP上传优先' },
+            { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
+            { ok: true, actual: '优先走 setFileInput 主路径' },
             true,
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
@@ -111,8 +320,10 @@ describe('xiaohongshu publish', () => {
             { ok: true, count: 1 },
             false,
             true, // waitForEditForm: editor appeared
-            { ok: true, sel: 'input[maxlength="20"]' },
-            { ok: true, sel: '[contenteditable="true"][class*="content"]' },
+            { ok: true, sel: 'input[maxlength="20"]', kind: 'input' },
+            { ok: true, actual: 'DeepSeek别乱问' },
+            { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
+            { ok: true, actual: '一篇真实一点的小红书正文' },
             true,
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
@@ -171,8 +382,10 @@ describe('xiaohongshu publish', () => {
             { ok: true, count: 1 }, // injectImages
             false, // waitForUploads: no progress indicator
             true, // waitForEditForm: editor appeared
-            { ok: true, sel: 'input[maxlength="20"]' },
-            { ok: true, sel: '[contenteditable="true"][class*="content"]' },
+            { ok: true, sel: 'input[maxlength="20"]', kind: 'input' },
+            { ok: true, actual: '延迟切换也能过' },
+            { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
+            { ok: true, actual: '图文页切换慢一点也继续等' },
             true,
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',


### PR DESCRIPTION
## Description

Fix xiaohongshu publish so title and body writes are verified before the command reports success.

The adapter now:
- handles both input and contenteditable title variants
- uses native `insertText` for contenteditable fields when available
- falls back to in-page insertion if native insert fails
- aborts when the title or body does not actually stick instead of returning a false success

Related issue:
Closes #1047

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

- `npx vitest run clis/xiaohongshu/publish.test.js clis/xiaohongshu/navigation.test.js`
  - 2 files passed, 20 tests passed
- `npx tsc --noEmit`
  - exit code 0
