### PR TITLE
fix(twitter): repair lists scraping from detail pages

### DIFF
--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -2,6 +2,127 @@ import { AuthRequiredError, SelectorError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { isEmptyListsState, parseListCards } from './lists-parser.js';
 
+const LIST_DETAIL_PATH_RE = /^\/i\/lists\/\d+$/;
+const MEMBER_TEXT_RE = /(members?|位成员)/i;
+const FOLLOWER_TEXT_RE = /(followers?|位关注者)/i;
+const DETAIL_CHROME_LINE_RE = /^(to view keyboard shortcuts, press question mark|view keyboard shortcuts|home|explore|see new posts|lists)$/i;
+
+function hasListMetrics(text) {
+    return MEMBER_TEXT_RE.test(text) && FOLLOWER_TEXT_RE.test(text);
+}
+
+function stripLeadingChromeLines(text) {
+    const lines = String(text || '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+    while (lines.length && DETAIL_CHROME_LINE_RE.test(lines[0])) {
+        lines.shift();
+    }
+    return lines.join('\n');
+}
+
+function composeDetailText(primaryText, bodyText) {
+    const cleanPrimaryText = stripLeadingChromeLines(primaryText);
+    const cleanBodyText = stripLeadingChromeLines(bodyText);
+    if (hasListMetrics(cleanPrimaryText)) {
+        return cleanPrimaryText;
+    }
+    if (!cleanPrimaryText) {
+        return cleanBodyText;
+    }
+    if (!hasListMetrics(cleanBodyText)) {
+        return cleanPrimaryText;
+    }
+    const metricLines = String(cleanBodyText || '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => MEMBER_TEXT_RE.test(line) || FOLLOWER_TEXT_RE.test(line) || /\bprivate\b/i.test(line) || /\bpublic\b/i.test(line) || /锁定列表/.test(line));
+    return [cleanPrimaryText, ...metricLines].filter(Boolean).join('\n');
+}
+
+function normalizeOverviewCells(cells) {
+    if (!Array.isArray(cells)) {
+        return [];
+    }
+    return cells.map((cell, index) => {
+        if (typeof cell === 'string') {
+            return {
+                preview: cell,
+                signature: cell || `__cell_${index}`,
+            };
+        }
+        return {
+            preview: String(cell?.preview || ''),
+            signature: String(cell?.signature || cell?.preview || `__cell_${index}`),
+        };
+    });
+}
+
+async function readOverviewData(page) {
+    let overviewData = { cells: [], listCount: 0, readyCellCount: 0, pageText: '' };
+    for (let attempt = 0; attempt < 3; attempt++) {
+        overviewData = await page.evaluate(`() => ({
+            cells: Array.from(document.querySelectorAll('[data-testid="listCell"]'))
+                .map((cell, index) => {
+                const preview = (cell.innerText || '').trim();
+                const imageSrc = cell.querySelector('img')?.getAttribute('src') || '';
+                const backgroundStyle = cell.querySelector('[style*="background-image"]')?.getAttribute('style') || '';
+                return {
+                    preview,
+                    signature: [preview, imageSrc, backgroundStyle].filter(Boolean).join('|') || '__cell_' + index,
+                };
+            }),
+            pageText: document.body.innerText || '',
+        })`);
+        overviewData.cells = normalizeOverviewCells(overviewData.cells);
+        overviewData.listCount = overviewData.cells.length || Number(overviewData.listCount || 0);
+        overviewData.readyCellCount = overviewData.cells.length
+            ? overviewData.cells.filter((cell) => cell.preview).length
+            : Number(overviewData.listCount || 0);
+        if (overviewData.pageText && (overviewData.readyCellCount || isEmptyListsState(overviewData.pageText))) {
+            break;
+        }
+        if (attempt < 2) {
+            await page.wait(1);
+        }
+    }
+    return overviewData;
+}
+
+async function readDetailData(page) {
+    let detailData = { href: '', primaryText: '', text: '' };
+    let detailPath = '';
+    let detailText = '';
+    for (let attempt = 0; attempt < 3; attempt++) {
+        detailData = await page.evaluate(`() => ({
+            href: window.location.href || '',
+            primaryText: document.querySelector('[data-testid="primaryColumn"]')?.innerText || '',
+            text: document.body.innerText || '',
+        })`);
+        try {
+            detailPath = new URL(detailData?.href || '', 'https://x.com').pathname;
+        }
+        catch {
+            detailPath = '';
+        }
+        const primaryText = detailData?.primaryText || '';
+        const bodyText = detailData?.text || '';
+        detailText = composeDetailText(primaryText, bodyText);
+        if (LIST_DETAIL_PATH_RE.test(detailPath) && hasListMetrics(detailText)) {
+            break;
+        }
+        if (attempt < 2) {
+            await page.wait(1);
+        }
+    }
+    return {
+        detailData,
+        detailPath,
+        detailText,
+    };
+}
+
 cli({
     site: 'twitter',
     name: 'lists',
@@ -28,35 +149,120 @@ cli({
             }
             targetUser = href.replace('/', '');
         }
-        await page.goto(`https://x.com/${targetUser}/lists`);
+        const overviewUrl = `https://x.com/${targetUser}/lists`;
+        await page.goto(overviewUrl);
         await page.wait(3);
-        const pageData = await page.evaluate(`() => {
-            const cards = [];
-            const seen = new Set();
-            for (const anchor of Array.from(document.querySelectorAll('a[href*="/i/lists/"]'))) {
-                const href = anchor.getAttribute('href') || '';
-                if (!/\\/i\\/lists\\/\\d+/.test(href) || seen.has(href)) continue;
-                seen.add(href);
-                const container = anchor.closest('[data-testid="cellInnerDiv"]') || anchor;
-                const text = (container.innerText || anchor.innerText || '').trim();
-                if (!text) continue;
-                cards.push({ href, text });
-            }
-            return {
-                cards,
-                pageText: document.body.innerText || '',
-            };
-        }`);
-        if (!pageData?.pageText) {
+        let overviewData = await readOverviewData(page);
+        if (!overviewData?.pageText) {
             throw new SelectorError('Twitter lists', 'Empty page text');
         }
-        const results = parseListCards(pageData.cards);
-        if (results.length === 0) {
-            if (isEmptyListsState(pageData.pageText)) {
+        if (!overviewData.readyCellCount) {
+            if (isEmptyListsState(overviewData.pageText)) {
                 return [];
             }
-            throw new SelectorError('Twitter lists', `Could not parse list data`);
+            throw new SelectorError('Twitter lists', 'Could not find list cells');
         }
-        return results.slice(0, kwargs.limit);
+        const results = [];
+        const seenDetailPaths = new Set();
+        const seenCellSignatures = new Set();
+        let maxObservedListCount = overviewData.listCount;
+        let maxObservedReadyCellCount = overviewData.readyCellCount;
+        while (results.length < kwargs.limit) {
+            if (results.length > 0) {
+                await page.goto(overviewUrl);
+                await page.wait(3);
+                overviewData = await readOverviewData(page);
+            }
+            maxObservedListCount = Math.max(maxObservedListCount, overviewData.listCount);
+            maxObservedReadyCellCount = Math.max(maxObservedReadyCellCount, overviewData.readyCellCount);
+            if (!overviewData.readyCellCount) {
+                if (results.length < Math.min(kwargs.limit, maxObservedListCount)) {
+                    throw new SelectorError('Twitter lists', 'Could not find additional list cells');
+                }
+                break;
+            }
+            if (overviewData.cells.length
+                && overviewData.cells
+                    .filter((cell) => cell.preview)
+                    .every((cell) => seenCellSignatures.has(cell.signature))
+                && results.length >= Math.min(kwargs.limit, maxObservedReadyCellCount)) {
+                break;
+            }
+            let foundNewList = false;
+            const attemptedIndices = new Set();
+            let overviewSignature = JSON.stringify(overviewData.cells.map((cell) => `${cell.preview}|${cell.signature}`));
+            while (attemptedIndices.size < overviewData.listCount) {
+                const candidateIndices = Array.from({ length: overviewData.listCount }, (_, currentIndex) => currentIndex)
+                    .filter((currentIndex) => !attemptedIndices.has(currentIndex))
+                    .filter((currentIndex) => !overviewData.cells.length || !!overviewData.cells[currentIndex]?.preview)
+                    .sort((left, right) => {
+                    const leftBlank = !overviewData.cells[left]?.preview;
+                    const rightBlank = !overviewData.cells[right]?.preview;
+                    const leftSeen = overviewData.cells[left] && seenCellSignatures.has(overviewData.cells[left].signature);
+                    const rightSeen = overviewData.cells[right] && seenCellSignatures.has(overviewData.cells[right].signature);
+                    return Number(leftBlank) - Number(rightBlank)
+                        || Number(leftSeen) - Number(rightSeen)
+                        || left - right;
+                });
+                if (candidateIndices.length === 0) {
+                    break;
+                }
+                const currentIndex = candidateIndices[0];
+                attemptedIndices.add(currentIndex);
+                const clicked = await page.evaluate(`() => {
+                    const cells = Array.from(document.querySelectorAll('[data-testid="listCell"]'));
+                    const cell = cells[${currentIndex}];
+                    if (!cell) return false;
+                    cell.click();
+                    return true;
+                }`);
+                if (!clicked) {
+                    throw new SelectorError('Twitter list cell', `Could not open list at index ${currentIndex}`);
+                }
+                await page.wait(3);
+                const { detailData, detailPath, detailText } = await readDetailData(page);
+                if (!LIST_DETAIL_PATH_RE.test(detailPath)) {
+                    throw new SelectorError('Twitter list detail', 'Did not navigate to a list detail page');
+                }
+                if (!detailText) {
+                    throw new SelectorError('Twitter list detail', 'Empty page text');
+                }
+                if (!hasListMetrics(detailText)) {
+                    throw new SelectorError('Twitter list detail', 'List metrics did not load');
+                }
+                const parsed = parseListCards([{ href: detailData.href, text: detailText }]);
+                if (parsed.length === 0) {
+                    throw new SelectorError('Twitter lists', 'Could not parse list detail');
+                }
+                const cellSignature = overviewData.cells[currentIndex]?.signature || parsed[0].name;
+                seenCellSignatures.add(cellSignature);
+                if (seenDetailPaths.has(detailPath)) {
+                    if (attemptedIndices.size < overviewData.listCount) {
+                        await page.goto(overviewUrl);
+                        await page.wait(3);
+                        overviewData = await readOverviewData(page);
+                        maxObservedListCount = Math.max(maxObservedListCount, overviewData.listCount);
+                        maxObservedReadyCellCount = Math.max(maxObservedReadyCellCount, overviewData.readyCellCount);
+                        const nextSignature = JSON.stringify(overviewData.cells.map((cell) => `${cell.preview}|${cell.signature}`));
+                        if (nextSignature !== overviewSignature) {
+                            attemptedIndices.clear();
+                        }
+                        overviewSignature = nextSignature;
+                    }
+                    continue;
+                }
+                seenDetailPaths.add(detailPath);
+                results.push(parsed[0]);
+                foundNewList = true;
+                break;
+            }
+            if (!foundNewList) {
+                if (results.length < Math.min(kwargs.limit, maxObservedReadyCellCount)) {
+                    throw new SelectorError('Twitter lists', 'Could not find additional list cells');
+                }
+                break;
+            }
+        }
+        return results;
     }
 });

--- a/clis/twitter/lists.test.js
+++ b/clis/twitter/lists.test.js
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { isEmptyListsState, parseListCards } from './lists-parser.js';
+import './lists.js';
 
 describe('twitter lists parser', () => {
     it('parses english list cards without relying on page locale', () => {
@@ -46,5 +48,1596 @@ Private`,
         expect(isEmptyListsState(`@jack hasn't created any Lists yet`)).toBe(true);
         expect(isEmptyListsState('这个账号还没有创建任何列表')).toBe(true);
         expect(isEmptyListsState('AI Researchers 124 Members')).toBe(false);
+    });
+});
+
+describe('twitter lists command', () => {
+    it('reads visible list cells from the overview page and parses each detail page', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1617772739917647876',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+        ]);
+        expect(page.goto).toHaveBeenCalledTimes(1);
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/elonmusk/lists');
+    });
+
+    it('prefers focused detail text over full page chrome when parsing a list detail page', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1617772739917647876',
+                primaryText: `Monkeys
+@elonmusk
+See new posts
+Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                text: `To view keyboard shortcuts, press question mark
+View keyboard shortcuts
+Home
+Explore
+Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result[0]).toMatchObject({
+            name: 'Monkeys',
+            members: '0',
+            followers: '51.8K',
+            mode: 'public',
+        });
+    });
+
+    it('falls back to body text when primary text exists but has not loaded the metrics yet', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1617772739917647876',
+                primaryText: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+                text: `To view keyboard shortcuts, press question mark
+Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result[0]).toMatchObject({
+            name: 'Monkeys',
+            members: '0',
+            followers: '51.8K',
+            mode: 'public',
+        });
+    });
+
+    it('ignores leading primary-column chrome when body text has the missing follower metric', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1617772739917647876',
+                primaryText: `To view keyboard shortcuts, press question mark
+Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+                text: `To view keyboard shortcuts, press question mark
+Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result[0]).toMatchObject({
+            name: 'Monkeys',
+            members: '0',
+            followers: '51.8K',
+            mode: 'public',
+        });
+    });
+
+    it('fails instead of parsing overview text when click does not reach a list detail page', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/elonmusk/lists',
+                primaryText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+                text: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 1 }))
+            .rejects
+            .toThrow('Twitter list detail');
+    });
+
+    it('fails when click lands on a non-canonical list subroute instead of the detail page', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+51.8K followers including @HTX_Global`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1617772739917647876/members',
+                primaryText: `Members
+Monkeys
+Elon Musk
+@elonmusk`,
+                text: `Members
+Monkeys
+Elon Musk
+@elonmusk`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 1 }))
+            .rejects
+            .toThrow('Twitter list detail');
+    });
+
+    it('revisits the overview page to open the second visible list cell', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 2,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 2,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/2',
+                text: `Robots
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Robots',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+        expect(page.goto).toHaveBeenCalledTimes(2);
+        expect(page.goto).toHaveBeenNthCalledWith(1, 'https://x.com/elonmusk/lists');
+        expect(page.goto).toHaveBeenNthCalledWith(2, 'https://x.com/elonmusk/lists');
+    });
+
+    it('uses newly hydrated overview cells on revisit instead of freezing the initial list count', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 2,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/2',
+                text: `Robots
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Robots',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('uses the current overview ordering on revisit instead of reopening a duplicate list', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let activeOverview = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                activeOverview = overviewReads;
+                if (overviewReads === 1) {
+                    return {
+                        listCount: 1,
+                        cells: ['Monkeys\n51.8K followers including @HTX_Global'],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+                    };
+                }
+                return {
+                    listCount: 2,
+                    cells: [
+                        'Robots\n7.2K followers including @HTX_Global',
+                        'Monkeys\n51.8K followers including @HTX_Global',
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Robots
+Monkeys`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (activeOverview === 1 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview === 2 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/2',
+                        text: `Robots
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/1',
+                    text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Robots',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('distinguishes lists with the same visible preview text by cell signature', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let activeOverview = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                activeOverview = overviewReads;
+                if (overviewReads === 1) {
+                    return {
+                        listCount: 1,
+                        cells: [{ preview: 'Same Preview', signature: 'list-a' }],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                    };
+                }
+                return {
+                    listCount: 2,
+                    cells: [
+                        { preview: 'Same Preview', signature: 'list-a' },
+                        { preview: 'Same Preview', signature: 'list-b' },
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (activeOverview === 1 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview === 2 && lastClickedIndex === 1) {
+                    return {
+                        href: 'https://x.com/i/lists/2',
+                        text: `Beta List
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/1',
+                    text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Alpha List',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Beta List',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('does not stop early when two different lists collide on the same derived signature', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let activeOverview = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                activeOverview = overviewReads;
+                if (overviewReads === 1) {
+                    return {
+                        listCount: 1,
+                        cells: [{ preview: 'Same Preview', signature: 'same-sig' }],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                    };
+                }
+                return {
+                    listCount: 2,
+                    cells: [
+                        { preview: 'Same Preview', signature: 'same-sig' },
+                        { preview: 'Same Preview', signature: 'same-sig' },
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (activeOverview === 1 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview >= 2 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/2',
+                    text: `Beta List
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Alpha List',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Beta List',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('continues scanning when a different overview cell resolves to an already-seen detail href', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let activeOverview = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                activeOverview = overviewReads;
+                if (overviewReads === 1) {
+                    return {
+                        listCount: 1,
+                        cells: [{ preview: 'Alpha Preview', signature: 'list-a-first' }],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Alpha Preview`,
+                    };
+                }
+                return {
+                    listCount: 2,
+                    cells: [
+                        { preview: 'Alpha Preview', signature: 'list-a-second' },
+                        { preview: 'Beta Preview', signature: 'list-b' },
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Alpha Preview
+Beta Preview`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (activeOverview === 1 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview >= 2 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/2',
+                    text: `Beta List
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Alpha List',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Beta List',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('suppresses duplicates when the same canonical list detail is revisited with different query strings', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let activeOverview = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                activeOverview = overviewReads;
+                if (overviewReads === 1) {
+                    return {
+                        listCount: 1,
+                        cells: [{ preview: 'Alpha Preview', signature: 'list-a-first' }],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Alpha Preview`,
+                    };
+                }
+                return {
+                    listCount: 2,
+                    cells: [
+                        { preview: 'Alpha Preview', signature: 'list-a-second' },
+                        { preview: 'Beta Preview', signature: 'list-b' },
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Alpha Preview
+Beta Preview`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (activeOverview === 1 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1?foo=1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview >= 2 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1?foo=2',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/2',
+                    text: `Beta List
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Alpha List',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Beta List',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('retries from the refreshed index set when duplicate href recovery sees signature churn', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let activeOverview = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                activeOverview = overviewReads;
+                if (overviewReads === 1) {
+                    return {
+                        listCount: 1,
+                        cells: [{ preview: 'Same Preview', signature: 'sig-a-0' }],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                    };
+                }
+                if (overviewReads === 2) {
+                    return {
+                        listCount: 2,
+                        cells: [
+                            { preview: 'Same Preview', signature: 'sig-a-1' },
+                            { preview: 'Same Preview', signature: 'sig-b-1' },
+                        ],
+                        pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                    };
+                }
+                return {
+                    listCount: 2,
+                    cells: [
+                        { preview: 'Same Preview', signature: 'sig-b-2' },
+                        { preview: 'Same Preview', signature: 'sig-a-2' },
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Same Preview`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (activeOverview === 1 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview === 2 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/1',
+                        text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                    };
+                }
+                if (activeOverview === 3 && lastClickedIndex === 0) {
+                    return {
+                        href: 'https://x.com/i/lists/2',
+                        text: `Beta List
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/1',
+                    text: `Alpha List
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Alpha List',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Beta List',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('keeps DOM indices aligned when early list cells are still empty placeholders', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                return {
+                    listCount: 2,
+                    cells: [
+                        { preview: '', signature: 'placeholder-0' },
+                        { preview: 'Monkeys\n51.8K followers including @HTX_Global', signature: 'list-a' },
+                    ],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (lastClickedIndex !== 1) {
+                    return {
+                        href: 'https://x.com/elonmusk/lists',
+                        text: '',
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/1',
+                    text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+        ]);
+        expect(lastClickedIndex).toBe(1);
+    });
+
+    it('fails instead of silently truncating results when a later overview revisit never recovers', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 2,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 0,
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 0,
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 0,
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 2 }))
+            .rejects
+            .toThrow('Twitter lists');
+    });
+
+    it('fails instead of silently truncating when known list slots rerender as blank placeholders', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 2,
+                cells: [
+                    { preview: 'Monkeys\n51.8K followers including @HTX_Global', signature: 'list-a' },
+                    { preview: '', signature: 'placeholder-1' },
+                ],
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 2,
+                cells: [
+                    { preview: '', signature: 'placeholder-0' },
+                    { preview: '', signature: 'placeholder-1' },
+                ],
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 2,
+                cells: [
+                    { preview: '', signature: 'placeholder-0' },
+                    { preview: '', signature: 'placeholder-1' },
+                ],
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 2,
+                cells: [
+                    { preview: '', signature: 'placeholder-0' },
+                    { preview: '', signature: 'placeholder-1' },
+                ],
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 2 }))
+            .rejects
+            .toThrow('Twitter lists');
+    });
+
+    it('rechecks the overview page when list cells appear after initial page chrome', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 0,
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+        ]);
+        expect(page.wait).toHaveBeenCalledWith(1);
+    });
+
+    it('does not treat all-placeholder overview cells as ready data', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        let overviewReads = 0;
+        let lastClickedIndex = -1;
+
+        const evaluate = vi.fn(async (code) => {
+            if (code.includes("cells: Array.from(document.querySelectorAll('[data-testid=\"listCell\"]'))")) {
+                overviewReads += 1;
+                if (overviewReads < 3) {
+                    return {
+                        listCount: 1,
+                        cells: [{ preview: '', signature: 'placeholder-0' }],
+                        pageText: `Lists
+@elonmusk
+See new posts`,
+                    };
+                }
+                return {
+                    listCount: 1,
+                    cells: [{ preview: 'Monkeys\n51.8K followers including @HTX_Global', signature: 'list-a' }],
+                    pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+                };
+            }
+
+            if (code.includes('const cell = cells[')) {
+                const match = code.match(/const cell = cells\[(\d+)\]/);
+                lastClickedIndex = match ? Number(match[1]) : -1;
+                return true;
+            }
+
+            if (code.includes('primaryText:')) {
+                if (overviewReads < 3 || lastClickedIndex !== 0) {
+                    return {
+                        href: 'https://x.com/elonmusk/lists',
+                        text: '',
+                    };
+                }
+                return {
+                    href: 'https://x.com/i/lists/1',
+                    text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                };
+            }
+
+            throw new Error(`Unexpected evaluate call: ${code.slice(0, 80)}`);
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+        ]);
+        expect(page.wait).toHaveBeenCalledWith(1);
+    });
+
+    it('stops cleanly when only blank placeholder cells remain after harvesting all ready lists', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 3,
+                cells: [
+                    { preview: 'Monkeys\n51.8K followers including @HTX_Global', signature: 'list-a' },
+                    { preview: 'Robots\n7.2K followers including @HTX_Global', signature: 'list-b' },
+                    { preview: '', signature: 'placeholder-2' },
+                ],
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 3,
+                cells: [
+                    { preview: 'Monkeys\n51.8K followers including @HTX_Global', signature: 'list-a' },
+                    { preview: 'Robots\n7.2K followers including @HTX_Global', signature: 'list-b' },
+                    { preview: '', signature: 'placeholder-2' },
+                ],
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/2',
+                text: `Robots
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 3,
+                cells: [
+                    { preview: 'Monkeys\n51.8K followers including @HTX_Global', signature: 'list-a' },
+                    { preview: 'Robots\n7.2K followers including @HTX_Global', signature: 'list-b' },
+                    { preview: '', signature: 'placeholder-2' },
+                ],
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 3 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Robots',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+    });
+
+    it('rechecks the detail page when metrics have not rendered yet', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                primaryText: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+            })
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                primaryText: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 1 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+        ]);
+        expect(page.wait).toHaveBeenCalledWith(1);
+    });
+
+    it('fails when the canonical detail page never loads its list metrics', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 1,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                primaryText: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+            })
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                primaryText: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+            })
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                primaryText: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 1 }))
+            .rejects
+            .toThrow('Twitter list detail');
+    });
+
+    it('rechecks the overview page again before opening the second list after revisit', async () => {
+        const command = getRegistry().get('twitter/lists');
+        expect(command?.func).toBeTypeOf('function');
+
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                listCount: 2,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/1',
+                text: `Monkeys
+Elon Musk
+@elonmusk
+0 Members
+51.8K Followers`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 0,
+                pageText: `Lists
+@elonmusk
+See new posts`,
+            })
+            .mockResolvedValueOnce({
+                listCount: 2,
+                pageText: `Lists
+@elonmusk
+Your Lists
+Monkeys
+Robots`,
+            })
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce({
+                href: 'https://x.com/i/lists/2',
+                text: `Robots
+Elon Musk
+@elonmusk
+12 Members
+7.2K Followers`,
+            });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate,
+        };
+
+        const result = await command.func(page, { user: 'elonmusk', limit: 2 });
+
+        expect(result).toEqual([
+            {
+                name: 'Monkeys',
+                members: '0',
+                followers: '51.8K',
+                mode: 'public',
+            },
+            {
+                name: 'Robots',
+                members: '12',
+                followers: '7.2K',
+                mode: 'public',
+            },
+        ]);
+        expect(evaluate).toHaveBeenCalledTimes(7);
+        expect(page.wait).toHaveBeenCalledWith(1);
     });
 });


### PR DESCRIPTION
## Description

Repair `twitter lists` after X changed the lists overview page.

The command no longer relies on overview-page anchors. It now discovers `data-testid="listCell"` entries from the overview page, opens each canonical `/i/lists/<id>` detail page, and parses metrics from the detail view after filtering leading page chrome. It also keeps known list-slot counts separate from ready cells so temporary blank rerenders fail clearly instead of silently truncating results.

Closes #1046

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```json
[
  {
    "name": "Monkeys",
    "members": "0",
    "followers": "51.8K",
    "mode": "public"
  }
]
```

Checks run:
- `npx vitest run clis/twitter/lists.test.js`
- `npx tsc --noEmit`
- `npx tsx src/main.ts twitter lists elonmusk --limit 1 --format json -v`
