### PR TITLE
fix(xiaohongshu): detect current draft save success

### DIFF
--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -621,17 +621,17 @@ cli({
         // ── Step 8: Verify success ─────────────────────────────────────────────────
         await page.wait({ time: 4 });
         const finalUrl = await page.evaluate('() => location.href');
+        const successMarkers = isDraft
+            ? ['草稿已保存', '暂存成功', '保存成功', '上传成功']
+            : ['发布成功', '上传成功'];
         const successMsg = await page.evaluate(`
-      () => {
+      (markers => {
         for (const el of document.querySelectorAll('*')) {
           const text = (el.innerText || '').trim();
-          if (
-            el.children.length === 0 &&
-            (text.includes('发布成功') || text.includes('草稿已保存') || text.includes('暂存成功') || text.includes('上传成功'))
-          ) return text;
+          if (el.children.length === 0 && markers.some(marker => text.includes(marker))) return text;
         }
         return '';
-      }
+      })(${JSON.stringify(successMarkers)})
     `);
         const navigatedAway = !finalUrl.includes('/publish/publish');
         const isSuccess = successMsg.length > 0 || navigatedAway;

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -405,4 +405,104 @@ describe('xiaohongshu publish', () => {
             },
         ]);
     });
+    it('treats 保存成功 on the draft list as a successful draft save', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][class*="content"]')
+                    ? { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' }
+                    : { ok: true, sel: 'input[placeholder*="标题"]', kind: 'input' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"apply"')) {
+                return code.includes('[contenteditable="true"][class*="content"]')
+                    ? { ok: true, actual: '停留在发布页也算成功' }
+                    : { ok: true, actual: '草稿成功提示' };
+            }
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll')) {
+                return code.includes('保存成功') ? '保存成功' : '';
+            }
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        });
+        const result = await cmd.func(page, {
+            title: '草稿成功提示',
+            content: '停留在发布页也算成功',
+            images: imagePath,
+            topics: '',
+            draft: true,
+        });
+        expect(result).toEqual([
+            {
+                status: '✅ 暂存成功',
+                detail: '"草稿成功提示" · 1张图片 · 保存成功',
+            },
+        ]);
+    });
+    it('does not treat 保存成功 alone as a publish success signal', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][class*="content"]')
+                    ? { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' }
+                    : { ok: true, sel: 'input[placeholder*="标题"]', kind: 'input' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"apply"')) {
+                return code.includes('[contenteditable="true"][class*="content"]')
+                    ? { ok: true, actual: '发布提示不该复用草稿成功' }
+                    : { ok: true, actual: '发布成功提示' };
+            }
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll')) {
+                return code.includes('保存成功') ? '保存成功' : '';
+            }
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        });
+        const result = await cmd.func(page, {
+            title: '发布成功提示',
+            content: '发布提示不该复用草稿成功',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        });
+        expect(result).toEqual([
+            {
+                status: '⚠️ 操作完成，请在浏览器中确认',
+                detail: '"发布成功提示" · 1张图片 · https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image',
+            },
+        ]);
+    });
 });


### PR DESCRIPTION
## Description

Fix `xiaohongshu/publish --draft` for the current creator-center UI.

The current UI shows `保存成功` after a successful draft save while staying on `/publish/publish?...target=image`. The adapter did not treat that as success, so it returned a warning even though the draft was saved.

This change:
- makes success detection mode-specific
- accepts `保存成功` for draft saves
- keeps publish-mode success detection unchanged
- adds regression coverage for both the draft case and the publish-mode guard

Related issue:
#1047

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

- `npx tsc --noEmit`
  - exit code 0
- `npx vitest run clis/xiaohongshu/publish.test.js clis/xiaohongshu/navigation.test.js`
  - 2 files passed, 22 tests passed
- Live repro:
  - `node dist/src/main.js xiaohongshu publish --title 'T8' 'draft body t8' --images /tmp/opencli-xhs-repro.loZBiY/repro.png --draft`
  - Result:
    ```yaml
    - status: ✅ 暂存成功
      detail: '"T8" · 1张图片 · 保存成功'
    ```
