### PR TITLE
refactor(antigravity): keep timeout parsing local

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,16 @@ async function getBrowserPage(): Promise<import('./types.js').IPage> {
   return bridge.connect({ timeout: 30, workspace: 'browser:default' });
 }
 
+function parsePositiveIntOption(val: string | undefined, label: string, fallback: number): number {
+  if (val === undefined) return fallback;
+  const parsed = parseInt(val, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    console.error(`[cli] Invalid ${label}="${val}", using default ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
 function applyVerbose(opts: { verbose?: boolean }): void {
   if (opts.verbose) process.env.OPENCLI_VERBOSE = '1';
 }
@@ -1132,10 +1142,9 @@ cli({
     .action(async (opts) => {
       // @ts-expect-error JS adapter — no type declarations
       const { startServe } = await import('../clis/antigravity/serve.js');
-      const { parseTimeoutValue } = await import('./runtime.js');
       await startServe({
         port: parseInt(opts.port, 10),
-        timeout: opts.timeout ? parseTimeoutValue(opts.timeout, '--timeout', 120) : undefined,
+        timeout: opts.timeout ? parsePositiveIntOption(opts.timeout, '--timeout', 120) : undefined,
       });
     });
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,21 +13,15 @@ export function getBrowserFactory(site?: string): new () => IBrowserFactory {
   return BrowserBridge;
 }
 
-/**
- * Validates and parses a timeout value (seconds).
- */
-export function parseTimeoutValue(val: string | number | undefined, label: string, fallback: number): number {
-  if (val === undefined) return fallback;
-  const parsed = typeof val === 'number' ? val : parseInt(String(val), 10);
+function parseEnvTimeout(envVar: string, fallback: number): number {
+  const raw = process.env[envVar];
+  if (raw === undefined) return fallback;
+  const parsed = parseInt(raw, 10);
   if (Number.isNaN(parsed) || parsed <= 0) {
-    console.error(`[runtime] Invalid ${label}="${val}", using default ${fallback}s`);
+    log.warn(`[runtime] Invalid ${envVar}="${raw}", using default ${fallback}s`);
     return fallback;
   }
   return parsed;
-}
-
-export function parseEnvTimeout(envVar: string, fallback: number): number {
-  return parseTimeoutValue(process.env[envVar], envVar, fallback);
 }
 
 export const DEFAULT_BROWSER_CONNECT_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_CONNECT_TIMEOUT', 30);


### PR DESCRIPTION
## Summary
- follow up #859 by removing the antigravity-specific timeout helper from shared runtime
- keep `antigravity serve` timeout validation local to the CLI entrypoint
- preserve the merged timeout / reconnect behavior and CLI surface

## Why
PR #859 fixed a real antigravity issue, but part of its implementation briefly widened the shared runtime surface for an adapter-specific need. This follow-up narrows that blast radius without reverting the user-facing fix.

## Validation
- `node node_modules/vitest/vitest.mjs run src/package-exports.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `HOME=$(mktemp -d) ./node_modules/.bin/tsx src/main.ts antigravity serve --help`