### PR TITLE
fix(e2e): accept CONFIG_ERROR in xiaoyuzhou E2E guard

### DIFF
--- a/tests/e2e/public-commands.test.ts
+++ b/tests/e2e/public-commands.test.ts
@@ -14,8 +14,12 @@ function isExpectedChineseSiteRestriction(code: number, stderr: string): boolean
   // Overseas CI runners may get HTTP errors, geo-blocks, DNS failures,
   // or receive mangled HTML that fails parsing. Some runners also fail
   // without surfacing a useful stderr payload.
+  // Exit code 78 (CONFIG_ERROR) covers adapters that migrated to authenticated
+  // APIs — credentials won't be available in CI.
   return /Error \[(FETCH_ERROR|PARSE_ERROR|NOT_FOUND)\]/.test(stderr)
     || /fetch failed/.test(stderr)
+    || /code: CONFIG/.test(stderr)
+    || code === 78
     || stderr.trim() === '';
 }
 


### PR DESCRIPTION
## Summary
- PR #1059 migrated xiaoyuzhou from SSR scraping to authenticated API
- E2E tests now fail with exit code 78 (CONFIG_ERROR) because CI runners don't have xiaoyuzhou auth credentials
- The `isExpectedChineseSiteRestriction` guard only caught FETCH_ERROR/PARSE_ERROR/NOT_FOUND — not config errors
- Added `code === 78` and `/code: CONFIG/` pattern to the guard

## Root cause
3 xiaoyuzhou E2E tests failing on main: `xiaoyuzhou podcast`, `xiaoyuzhou podcast-episodes`, `xiaoyuzhou episode` — all exit 78 instead of expected 0, not caught by the restriction guard.

## Test plan
- [x] Unit tests pass (209 files, 1618 tests)
- [ ] E2E tests should now skip xiaoyuzhou gracefully instead of failing