### PR TITLE
fix(zsxq): separate content field from title, remove title truncation

### DIFF
--- a/clis/zsxq/dynamics.js
+++ b/clis/zsxq/dynamics.js
@@ -37,7 +37,7 @@ cli({
                 time: d.create_time || topic.create_time || '',
                 group: topic.group?.name || '',
                 author: getTopicAuthor(topic),
-                title: getTopicText(topic).slice(0, 120),
+                title: getTopicText(topic),
                 comments: topic.comments_count ?? 0,
                 likes: topic.likes_count ?? 0,
                 url: getTopicUrl(topic.topic_id),

--- a/clis/zsxq/utils.js
+++ b/clis/zsxq/utils.js
@@ -186,8 +186,10 @@ export function getTopicAuthor(topic) {
         '');
 }
 export function getTopicText(topic) {
+    return (topic.title || '').replace(/\s+/g, ' ').trim();
+}
+export function getTopicContent(topic) {
     const primary = [
-        topic.title,
         topic.talk?.text,
         topic.question?.text,
         topic.answer?.text,
@@ -218,8 +220,8 @@ export function toTopicRow(topic) {
         type: topic.type || '',
         group: topic.group?.name || '',
         author: getTopicAuthor(topic),
-        title: getTopicText(topic).slice(0, 120),
-        content: getTopicText(topic),
+        title: getTopicText(topic),
+        content: getTopicContent(topic),
         comments: topic.comments_count ?? comments.length ?? 0,
         likes: topic.likes_count ?? 0,
         readers: topic.readers_count ?? topic.reading_count ?? 0,

--- a/clis/zsxq/utils.js
+++ b/clis/zsxq/utils.js
@@ -186,7 +186,8 @@ export function getTopicAuthor(topic) {
         '');
 }
 export function getTopicText(topic) {
-    return (topic.title || '').replace(/\s+/g, ' ').trim();
+    const title = (topic.title || '').replace(/\s+/g, ' ').trim();
+    return title || getTopicContent(topic);
 }
 export function getTopicContent(topic) {
     const primary = [

--- a/clis/zsxq/utils.test.js
+++ b/clis/zsxq/utils.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getTopicText, toTopicRow } from './utils.js';
+
+describe('zsxq utils', () => {
+    it('keeps title and content separate when both fields exist', () => {
+        const topic = {
+            topic_id: '123',
+            title: 'A full title that should not be truncated',
+            talk: { text: 'This is the full body text.' },
+        };
+
+        expect(getTopicText(topic)).toBe('A full title that should not be truncated');
+        expect(toTopicRow(topic)).toMatchObject({
+            title: 'A full title that should not be truncated',
+            content: 'This is the full body text.',
+        });
+    });
+
+    it('falls back to body text for title when explicit title is absent', () => {
+        const topic = {
+            topic_id: '456',
+            talk: { text: 'Body-only topic text should still appear as the title preview.' },
+        };
+
+        expect(getTopicText(topic)).toBe('Body-only topic text should still appear as the title preview.');
+        expect(toTopicRow(topic)).toMatchObject({
+            title: 'Body-only topic text should still appear as the title preview.',
+            content: 'Body-only topic text should still appear as the title preview.',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Split `getTopicText` to return only title, add `getTopicContent` for body text
- Remove `.slice(0, 120)` that was truncating titles
- `content` field now contains full body text instead of duplicating title

## Problem
- `title` was being truncated to 120 characters
- `content` field was identical to `title` (both used the same `getTopicText` function)

## Solution
- `getTopicText` now returns only `topic.title`
- New `getTopicContent` function extracts body text from `talk.text`, `question.text`, etc.
- `toTopicRow` uses `getTopicContent` for the `content` field

## Testing
Verified with json/yaml/plain/md/csv formats - `content` now shows full text.