### PR TITLE
feat(browser): add cross-origin iframe support via CDP execution contexts

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -154,6 +154,52 @@ describe('background tab isolation', () => {
     ]);
   });
 
+  it('lists cross-origin frames in the same order exposed by snapshot [F#] markers', async () => {
+    const { chrome } = createChromeMock();
+    chrome.debugger.sendCommand = vi.fn(async (_target: unknown, method: string) => {
+      if (method === 'Runtime.enable') return {};
+      if (method === 'Runtime.evaluate') return { result: { value: 1 } };
+      if (method === 'Page.getFrameTree') {
+        return {
+          frameTree: {
+            frame: { id: 'root', url: 'https://main.example/' },
+            childFrames: [
+              {
+                frame: { id: 'same-origin-parent', url: 'https://main.example/embed' },
+                childFrames: [
+                  {
+                    frame: { id: 'cross-origin-nested', url: 'https://x.example/widget', name: 'nested-x' },
+                    childFrames: [
+                      {
+                        frame: { id: 'hidden-descendant', url: 'https://x.example/inner' },
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                frame: { id: 'cross-origin-sibling', url: 'https://y.example/iframe', name: 'sibling-y' },
+              },
+            ],
+          },
+        };
+      }
+      return {};
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId('site:twitter', 1);
+
+    const result = await mod.__test__.handleCommand({ id: 'frames', action: 'frames', workspace: 'site:twitter' });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual([
+      { index: 0, frameId: 'cross-origin-nested', url: 'https://x.example/widget', name: 'nested-x' },
+      { index: 1, frameId: 'cross-origin-sibling', url: 'https://y.example/iframe', name: 'sibling-y' },
+    ]);
+  });
+
   it('creates new tabs inside the automation window', async () => {
     const { chrome, create } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -200,6 +200,63 @@ describe('background tab isolation', () => {
     ]);
   });
 
+  it('routes exec frameIndex through the same cross-origin frame ordering as handleFrames', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const evaluateInFrame = vi.fn(async () => 'frame-result');
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync: vi.fn(async () => 'main-result'),
+      evaluateInFrame,
+      getFrameTree: vi.fn(async () => ({
+        frameTree: {
+          frame: { id: 'root', url: 'https://main.example/' },
+          childFrames: [
+            {
+              frame: { id: 'same-origin-parent', url: 'https://main.example/embed' },
+              childFrames: [
+                { frame: { id: 'cross-origin-nested', url: 'https://x.example/widget', name: 'nested-x' } },
+              ],
+            },
+            {
+              frame: { id: 'cross-origin-sibling', url: 'https://y.example/iframe', name: 'sibling-y' },
+            },
+          ],
+        },
+      })),
+      screenshot: vi.fn(),
+      setFileInputFiles: vi.fn(),
+      insertText: vi.fn(),
+      startNetworkCapture: vi.fn(),
+      readNetworkCapture: vi.fn(async () => []),
+      ensureAttached: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId('site:twitter', 1);
+
+    const listResult = await mod.__test__.handleCommand({ id: 'frames', action: 'frames', workspace: 'site:twitter' });
+    const execResult = await mod.__test__.handleCommand({
+      id: 'exec-in-frame',
+      action: 'exec',
+      code: 'document.title',
+      frameIndex: 0,
+      workspace: 'site:twitter',
+    });
+
+    expect(listResult.ok).toBe(true);
+    expect(listResult.data).toEqual([
+      { index: 0, frameId: 'cross-origin-nested', url: 'https://x.example/widget', name: 'nested-x' },
+      { index: 1, frameId: 'cross-origin-sibling', url: 'https://y.example/iframe', name: 'sibling-y' },
+    ]);
+    expect(execResult.ok).toBe(true);
+    expect(evaluateInFrame).toHaveBeenCalledWith(1, 'document.title', 'cross-origin-nested', false);
+  });
+
   it('creates new tabs inside the automation window', async () => {
     const { chrome, create } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -267,6 +267,7 @@ function initialize(): void {
   initialized = true;
   chrome.alarms.create('keepalive', { periodInMinutes: 0.4 }); // ~24 seconds
   executor.registerListeners();
+  executor.registerFrameTracking();
   void connect();
   console.log('[opencli] OpenCLI extension initialized');
 }
@@ -334,6 +335,8 @@ async function handleCommand(cmd: Command): Promise<Result> {
         return await handleNetworkCaptureStart(cmd, workspace);
       case 'network-capture-read':
         return await handleNetworkCaptureRead(cmd, workspace);
+      case 'frames':
+        return await handleFrames(cmd, workspace);
       default:
         return { id: cmd.id, ok: false, error: `Unknown action: ${cmd.action}` };
     }
@@ -541,8 +544,51 @@ async function handleExec(cmd: Command, workspace: string): Promise<Result> {
   const tabId = await resolveTabId(cmdTabId, workspace);
   try {
     const aggressive = workspace.startsWith('browser:') || workspace.startsWith('operate:');
+    if (cmd.frameIndex != null) {
+      const tree = await executor.getFrameTree(tabId);
+      const childFrames: string[] = [];
+      function collectChildFrames(node: any, isChild: boolean) {
+        if (isChild) childFrames.push(node.frame.id);
+        for (const child of (node.childFrames || [])) collectChildFrames(child, true);
+      }
+      collectChildFrames(tree.frameTree, false);
+      if (cmd.frameIndex < 0 || cmd.frameIndex >= childFrames.length) {
+        return { id: cmd.id, ok: false, error: `Frame index ${cmd.frameIndex} out of range (${childFrames.length} child frames available)` };
+      }
+      const data = await executor.evaluateInFrame(tabId, cmd.code, childFrames[cmd.frameIndex], aggressive);
+      return pageScopedResult(cmd.id, tabId, data);
+    }
     const data = await executor.evaluateAsync(tabId, cmd.code, aggressive);
     return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function handleFrames(cmd: Command, workspace: string): Promise<Result> {
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    const tree = await executor.getFrameTree(tabId);
+    const frames: Array<{ index: number; frameId: string; url: string; name: string }> = [];
+    let idx = 0;
+
+    function flattenFrames(node: any, isChild: boolean) {
+      const frame = node.frame;
+      if (isChild) {
+        frames.push({
+          index: idx++,
+          frameId: frame.id,
+          url: frame.url || frame.unreachableUrl || '',
+          name: frame.name || '',
+        });
+      }
+      for (const child of (node.childFrames || [])) {
+        flattenFrames(child, true);
+      }
+    }
+    flattenFrames(tree.frameTree, false);
+    return { id: cmd.id, ok: true, data: frames };
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
   }
@@ -766,6 +812,7 @@ const CDP_ALLOWLIST = new Set([
   // Page metrics & screenshots
   'Page.getLayoutMetrics',
   'Page.captureScreenshot',
+  'Page.getFrameTree',
   // Runtime.enable needed for CDP attach setup (Runtime.evaluate goes through 'exec' action)
   'Runtime.enable',
   // Emulation (used by screenshot full-page)

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -408,6 +408,15 @@ function matchesBindCriteria(tab: chrome.tabs.Tab, cmd: Command): boolean {
   return true;
 }
 
+function getUrlOrigin(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
 function setWorkspaceSession(workspace: string, session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'>): void {
   const existing = automationSessions.get(workspace);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
@@ -573,21 +582,32 @@ async function handleFrames(cmd: Command, workspace: string): Promise<Result> {
     const frames: Array<{ index: number; frameId: string; url: string; name: string }> = [];
     let idx = 0;
 
-    function flattenFrames(node: any, isChild: boolean) {
-      const frame = node.frame;
-      if (isChild) {
+    function collectCrossOriginFrames(node: any, accessibleOrigin: string | null) {
+      for (const child of (node.childFrames || [])) {
+        const frame = child.frame;
+        const frameUrl = frame.url || frame.unreachableUrl || '';
+        const frameOrigin = getUrlOrigin(frameUrl);
+
+        // Mirror dom-snapshot's behavior:
+        // - same-origin frames are expanded inline and therefore do not get [F#] labels
+        // - cross-origin / blocked frames get surfaced once and we stop recursing into them
+        if (accessibleOrigin && frameOrigin && frameOrigin === accessibleOrigin) {
+          collectCrossOriginFrames(child, frameOrigin);
+          continue;
+        }
+
         frames.push({
           index: idx++,
           frameId: frame.id,
-          url: frame.url || frame.unreachableUrl || '',
+          url: frameUrl,
           name: frame.name || '',
         });
       }
-      for (const child of (node.childFrames || [])) {
-        flattenFrames(child, true);
-      }
     }
-    flattenFrames(tree.frameTree, false);
+
+    const rootFrame = tree.frameTree?.frame;
+    const rootUrl = rootFrame?.url || rootFrame?.unreachableUrl || '';
+    collectCrossOriginFrames(tree.frameTree, getUrlOrigin(rootUrl));
     return { id: cmd.id, ok: true, data: frames };
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -417,6 +417,38 @@ function getUrlOrigin(url: string | undefined): string | null {
   }
 }
 
+function enumerateCrossOriginFrames(tree: any): Array<{ index: number; frameId: string; url: string; name: string }> {
+  const frames: Array<{ index: number; frameId: string; url: string; name: string }> = [];
+
+  function collect(node: any, accessibleOrigin: string | null) {
+    for (const child of (node.childFrames || [])) {
+      const frame = child.frame;
+      const frameUrl = frame.url || frame.unreachableUrl || '';
+      const frameOrigin = getUrlOrigin(frameUrl);
+
+      // Mirror dom-snapshot's [F#] rules:
+      // - same-origin frames expand inline and do not get an [F#] slot
+      // - cross-origin / blocked frames get one slot and stop recursion there
+      if (accessibleOrigin && frameOrigin && frameOrigin === accessibleOrigin) {
+        collect(child, frameOrigin);
+        continue;
+      }
+
+      frames.push({
+        index: frames.length,
+        frameId: frame.id,
+        url: frameUrl,
+        name: frame.name || '',
+      });
+    }
+  }
+
+  const rootFrame = tree?.frameTree?.frame;
+  const rootUrl = rootFrame?.url || rootFrame?.unreachableUrl || '';
+  collect(tree.frameTree, getUrlOrigin(rootUrl));
+  return frames;
+}
+
 function setWorkspaceSession(workspace: string, session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'>): void {
   const existing = automationSessions.get(workspace);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
@@ -555,16 +587,11 @@ async function handleExec(cmd: Command, workspace: string): Promise<Result> {
     const aggressive = workspace.startsWith('browser:') || workspace.startsWith('operate:');
     if (cmd.frameIndex != null) {
       const tree = await executor.getFrameTree(tabId);
-      const childFrames: string[] = [];
-      function collectChildFrames(node: any, isChild: boolean) {
-        if (isChild) childFrames.push(node.frame.id);
-        for (const child of (node.childFrames || [])) collectChildFrames(child, true);
+      const frames = enumerateCrossOriginFrames(tree);
+      if (cmd.frameIndex < 0 || cmd.frameIndex >= frames.length) {
+        return { id: cmd.id, ok: false, error: `Frame index ${cmd.frameIndex} out of range (${frames.length} cross-origin frames available)` };
       }
-      collectChildFrames(tree.frameTree, false);
-      if (cmd.frameIndex < 0 || cmd.frameIndex >= childFrames.length) {
-        return { id: cmd.id, ok: false, error: `Frame index ${cmd.frameIndex} out of range (${childFrames.length} child frames available)` };
-      }
-      const data = await executor.evaluateInFrame(tabId, cmd.code, childFrames[cmd.frameIndex], aggressive);
+      const data = await executor.evaluateInFrame(tabId, cmd.code, frames[cmd.frameIndex].frameId, aggressive);
       return pageScopedResult(cmd.id, tabId, data);
     }
     const data = await executor.evaluateAsync(tabId, cmd.code, aggressive);
@@ -579,36 +606,7 @@ async function handleFrames(cmd: Command, workspace: string): Promise<Result> {
   const tabId = await resolveTabId(cmdTabId, workspace);
   try {
     const tree = await executor.getFrameTree(tabId);
-    const frames: Array<{ index: number; frameId: string; url: string; name: string }> = [];
-    let idx = 0;
-
-    function collectCrossOriginFrames(node: any, accessibleOrigin: string | null) {
-      for (const child of (node.childFrames || [])) {
-        const frame = child.frame;
-        const frameUrl = frame.url || frame.unreachableUrl || '';
-        const frameOrigin = getUrlOrigin(frameUrl);
-
-        // Mirror dom-snapshot's behavior:
-        // - same-origin frames are expanded inline and therefore do not get [F#] labels
-        // - cross-origin / blocked frames get surfaced once and we stop recursing into them
-        if (accessibleOrigin && frameOrigin && frameOrigin === accessibleOrigin) {
-          collectCrossOriginFrames(child, frameOrigin);
-          continue;
-        }
-
-        frames.push({
-          index: idx++,
-          frameId: frame.id,
-          url: frameUrl,
-          name: frame.name || '',
-        });
-      }
-    }
-
-    const rootFrame = tree.frameTree?.frame;
-    const rootUrl = rootFrame?.url || rootFrame?.unreachableUrl || '';
-    collectCrossOriginFrames(tree.frameTree, getUrlOrigin(rootUrl));
-    return { id: cmd.id, ok: true, data: frames };
+    return { id: cmd.id, ok: true, data: enumerateCrossOriginFrames(tree) };
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function createChromeMock() {
+  const debuggerEventListeners: Array<(source: { tabId?: number }, method: string, params: any) => void> = [];
+  const tabRemovedListeners: Array<(tabId: number) => void> = [];
   const tabs = {
     get: vi.fn(async (_tabId: number) => ({
       id: 1,
       windowId: 1,
       url: 'https://x.com/home',
     })),
-    onRemoved: { addListener: vi.fn() },
+    onRemoved: { addListener: vi.fn((fn: (tabId: number) => void) => { tabRemovedListeners.push(fn); }) },
     onUpdated: { addListener: vi.fn() },
   };
 
@@ -19,6 +21,7 @@ function createChromeMock() {
       return {};
     }),
     onDetach: { addListener: vi.fn() },
+    onEvent: { addListener: vi.fn((fn: (source: { tabId?: number }, method: string, params: any) => void) => { debuggerEventListeners.push(fn); }) },
   };
 
   const scripting = {
@@ -34,6 +37,8 @@ function createChromeMock() {
     },
     debuggerApi,
     scripting,
+    debuggerEventListeners,
+    tabRemovedListeners,
   };
 }
 
@@ -56,6 +61,34 @@ describe('cdp attach recovery', () => {
     expect(result).toBe('ok');
     expect(debuggerApi.attach).toHaveBeenCalledTimes(1);
     expect(scripting.executeScript).not.toHaveBeenCalled();
+  });
+
+  it('uses the default execution context for a frame when isolated worlds also exist', async () => {
+    const { chrome, debuggerApi, debuggerEventListeners } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    mod.registerFrameTracking();
+
+    expect(debuggerEventListeners).toHaveLength(1);
+    debuggerEventListeners[0](
+      { tabId: 1 },
+      'Runtime.executionContextCreated',
+      { context: { id: 11, auxData: { frameId: 'frame-1', isDefault: false } } },
+    );
+    debuggerEventListeners[0](
+      { tabId: 1 },
+      'Runtime.executionContextCreated',
+      { context: { id: 22, auxData: { frameId: 'frame-1', isDefault: true } } },
+    );
+
+    await mod.evaluateInFrame(1, 'document.title', 'frame-1');
+
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith(
+      { tabId: 1 },
+      'Runtime.evaluate',
+      expect.objectContaining({ contextId: 22 }),
+    );
   });
 
   // Dead test: chrome.scripting.executeScript was removed from cdp.ts;

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -281,7 +281,7 @@ export function registerFrameTracking(): void {
 
     if (method === 'Runtime.executionContextCreated') {
       const context = params.context;
-      if (!context?.auxData?.frameId) return;
+      if (!context?.auxData?.frameId || context.auxData.isDefault !== true) return;
       const frameId = context.auxData.frameId as string;
       if (!tabFrameContexts.has(tabId)) {
         tabFrameContexts.set(tabId, new Map());

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -8,6 +8,8 @@
 
 const attached = new Set<number>();
 
+const tabFrameContexts = new Map<number, Map<string, number>>();
+
 type NetworkCaptureEntry = {
   kind: 'cdp';
   url: string;
@@ -272,6 +274,83 @@ export async function insertText(
   await chrome.debugger.sendCommand({ tabId }, 'Input.insertText', { text });
 }
 
+export function registerFrameTracking(): void {
+  chrome.debugger.onEvent.addListener((source, method, params: any) => {
+    const tabId = source.tabId;
+    if (!tabId) return;
+
+    if (method === 'Runtime.executionContextCreated') {
+      const context = params.context;
+      if (!context?.auxData?.frameId) return;
+      const frameId = context.auxData.frameId as string;
+      if (!tabFrameContexts.has(tabId)) {
+        tabFrameContexts.set(tabId, new Map());
+      }
+      tabFrameContexts.get(tabId)!.set(frameId, context.id);
+    }
+
+    if (method === 'Runtime.executionContextDestroyed') {
+      const ctxId = params.executionContextId;
+      const contexts = tabFrameContexts.get(tabId);
+      if (contexts) {
+        for (const [fid, cid] of contexts) {
+          if (cid === ctxId) { contexts.delete(fid); break; }
+        }
+      }
+    }
+
+    if (method === 'Runtime.executionContextsCleared') {
+      tabFrameContexts.delete(tabId);
+    }
+  });
+
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    tabFrameContexts.delete(tabId);
+  });
+}
+
+export async function getFrameTree(tabId: number): Promise<any> {
+  await ensureAttached(tabId);
+  return chrome.debugger.sendCommand({ tabId }, 'Page.getFrameTree');
+}
+
+export async function evaluateInFrame(
+  tabId: number,
+  expression: string,
+  frameId: string,
+  aggressiveRetry: boolean = false,
+): Promise<unknown> {
+  await ensureAttached(tabId, aggressiveRetry);
+
+  await chrome.debugger.sendCommand({ tabId }, 'Runtime.enable').catch(() => {});
+
+  const contexts = tabFrameContexts.get(tabId);
+  const contextId = contexts?.get(frameId);
+
+  if (contextId === undefined) {
+    throw new Error(`No execution context found for frame ${frameId}. The frame may not be loaded yet.`);
+  }
+
+  const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+    expression,
+    contextId,
+    returnByValue: true,
+    awaitPromise: true,
+  }) as {
+    result?: { type: string; value?: unknown; description?: string; subtype?: string };
+    exceptionDetails?: { exception?: { description?: string }; text?: string };
+  };
+
+  if (result.exceptionDetails) {
+    const errMsg = result.exceptionDetails.exception?.description
+      || result.exceptionDetails.text
+      || 'Eval error';
+    throw new Error(errMsg);
+  }
+
+  return result.result?.value;
+}
+
 function normalizeCapturePatterns(pattern?: string): string[] {
   return String(pattern || '')
     .split('|')
@@ -349,6 +428,7 @@ export async function detach(tabId: number): Promise<void> {
   if (!attached.has(tabId)) return;
   attached.delete(tabId);
   networkCaptures.delete(tabId);
+  tabFrameContexts.delete(tabId);
   try { await chrome.debugger.detach({ tabId }); } catch { /* ignore */ }
 }
 
@@ -356,11 +436,13 @@ export function registerListeners(): void {
   chrome.tabs.onRemoved.addListener((tabId) => {
     attached.delete(tabId);
     networkCaptures.delete(tabId);
+    tabFrameContexts.delete(tabId);
   });
   chrome.debugger.onDetach.addListener((source) => {
     if (source.tabId) {
       attached.delete(source.tabId);
       networkCaptures.delete(source.tabId);
+      tabFrameContexts.delete(source.tabId);
     }
   });
   // Invalidate attached cache when tab URL changes to non-debuggable

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -18,7 +18,8 @@ export type Action =
   | 'bind-current'
   | 'network-capture-start'
   | 'network-capture-read'
-  | 'cdp';
+  | 'cdp'
+  | 'frames';
 
 export interface Command {
   /** Unique request ID */
@@ -65,6 +66,8 @@ export interface Command {
   windowFocused?: boolean;
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
+  /** Frame index for cross-frame operations (0-based, from 'frames' action) */
+  frameIndex?: number;
 }
 
 export interface Result {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -21,7 +21,7 @@ function generateId(): string {
 
 export interface DaemonCommand {
   id: string;
-  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'sessions' | 'set-file-input' | 'insert-text' | 'bind-current' | 'network-capture-start' | 'network-capture-read' | 'cdp';
+  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'sessions' | 'set-file-input' | 'insert-text' | 'bind-current' | 'network-capture-start' | 'network-capture-read' | 'cdp' | 'frames';
   /** Target page identity (targetId). Cross-layer contract with the extension. */
   page?: string;
   code?: string;
@@ -50,6 +50,8 @@ export interface DaemonCommand {
   windowFocused?: boolean;
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
+  /** Frame index for cross-frame operations (0-based, from 'frames' action) */
+  frameIndex?: number;
 }
 
 export interface DaemonResult {

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -800,7 +800,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       if (!doc || !doc.body) {
         const attrs = serializeAttrs(el);
         const frameLabel = '[F' + crossOriginIndex + ']';
-        lines.push(indent + '|iframe|' + frameLabel + '<iframe' + (attrs ? ' ' + attrs : '') + ' /> (cross-origin, use: opencli browser frames)');
+        lines.push(indent + '|iframe|' + frameLabel + '<iframe' + (attrs ? ' ' + attrs : '') + ' /> (cross-origin, use: opencli browser frames + browser eval --frame <index>)');
         crossOriginIndex++;
         return false;
       }
@@ -815,7 +815,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
     } catch {
       const attrs = serializeAttrs(el);
       const frameLabel = '[F' + crossOriginIndex + ']';
-      lines.push(indent + '|iframe|' + frameLabel + '<iframe' + (attrs ? ' ' + attrs : '') + ' /> (blocked, use: opencli browser frames)');
+      lines.push(indent + '|iframe|' + frameLabel + '<iframe' + (attrs ? ' ' + attrs : '') + ' /> (blocked, use: opencli browser frames + browser eval --frame <index>)');
       crossOriginIndex++;
       return false;
     }

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -618,6 +618,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   const currentHashes = [];
   const refIdentity = {};
   let iframeCount = 0;
+  let crossOriginIndex = 0;
 
   function walk(el, depth, parentPropagatingRect) {
     if (depth > MAX_DEPTH) return false;
@@ -798,7 +799,9 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       const doc = el.contentDocument;
       if (!doc || !doc.body) {
         const attrs = serializeAttrs(el);
-        lines.push(indent + '|iframe|<iframe' + (attrs ? ' ' + attrs : '') + ' /> (cross-origin)');
+        const frameLabel = '[F' + crossOriginIndex + ']';
+        lines.push(indent + '|iframe|' + frameLabel + '<iframe' + (attrs ? ' ' + attrs : '') + ' /> (cross-origin, use: opencli browser frames)');
+        crossOriginIndex++;
         return false;
       }
       iframeCount++;
@@ -811,7 +814,9 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       return has;
     } catch {
       const attrs = serializeAttrs(el);
-      lines.push(indent + '|iframe|<iframe' + (attrs ? ' ' + attrs : '') + ' /> (blocked)');
+      const frameLabel = '[F' + crossOriginIndex + ']';
+      lines.push(indent + '|iframe|' + frameLabel + '<iframe' + (attrs ? ' ' + attrs : '') + ' /> (blocked, use: opencli browser frames)');
+      crossOriginIndex++;
       return false;
     }
   }

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -266,6 +266,16 @@ export class Page extends BasePage {
     }
   }
 
+  async frames(): Promise<Array<{ index: number; frameId: string; url: string; name: string }>> {
+    const result = await sendCommand('frames', { ...this._cmdOpts() });
+    return Array.isArray(result) ? result : [];
+  }
+
+  async evaluateInFrame(js: string, frameIndex: number): Promise<unknown> {
+    const code = wrapForEval(js);
+    return sendCommand('exec', { code, frameIndex, ...this._cmdOpts() });
+  }
+
   async cdp(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
     return sendCommand('cdp', {
       cdpMethod: method,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -271,6 +271,10 @@ describe('browser tab targeting commands', () => {
       selectTab: vi.fn().mockResolvedValue(undefined),
       newTab: vi.fn().mockResolvedValue('tab-3'),
       closeTab: vi.fn().mockResolvedValue(undefined),
+      frames: vi.fn().mockResolvedValue([
+        { index: 0, frameId: 'frame-1', url: 'https://x.example/embed', name: 'x-embed' },
+      ]),
+      evaluateInFrame: vi.fn().mockResolvedValue('inside frame'),
       readNetworkCapture: vi.fn().mockResolvedValue([]),
     } as unknown as IPage;
   });
@@ -328,6 +332,26 @@ describe('browser tab targeting commands', () => {
     expect(browserState.page?.goto).toHaveBeenCalledWith('https://example.com');
     expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain('"url": "https://one.example"');
     expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain('"page": "tab-1"');
+  });
+
+  it('lists cross-origin frames via browser frames', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'frames']);
+
+    expect(browserState.page?.frames).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain('"frameId": "frame-1"');
+    expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain('"url": "https://x.example/embed"');
+  });
+
+  it('routes browser eval --frame through frame-targeted evaluation', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'eval', '--frame', '0', 'document.title']);
+
+    expect(browserState.page?.evaluateInFrame).toHaveBeenCalledWith('document.title', 0);
+    expect(browserState.page?.evaluate).not.toHaveBeenCalled();
+    expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain('inside frame');
   });
 
   it('does not promote a newly created tab to the persisted default target', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -595,6 +595,12 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       console.log(typeof snapshot === 'string' ? snapshot : JSON.stringify(snapshot, null, 2));
     }));
 
+  addBrowserTabOption(browser.command('frames').description('List cross-origin iframe targets in snapshot order'))
+    .action(browserAction(async (page) => {
+      const frames = await page.frames?.() ?? [];
+      console.log(JSON.stringify(frames, null, 2));
+    }));
+
   addBrowserTabOption(browser.command('screenshot').argument('[path]', 'Save to file (base64 if omitted)'))
     .description('Take screenshot')
     .action(browserAction(async (page, path) => {
@@ -722,9 +728,28 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   // ── Extract ──
 
-  addBrowserTabOption(browser.command('eval').argument('<js>', 'JavaScript code').description('Execute JS in page context, return result'))
-    .action(browserAction(async (page, js) => {
-      const result = await page.evaluate(js);
+  addBrowserTabOption(
+    browser.command('eval')
+      .argument('<js>', 'JavaScript code')
+      .option('--frame <index>', 'Cross-origin iframe index from "browser frames"')
+      .description('Execute JS in page context, return result'),
+  )
+    .action(browserAction(async (page, js, opts) => {
+      let result: unknown;
+      if (opts.frame !== undefined) {
+        const frameIndex = Number.parseInt(opts.frame, 10);
+        if (!Number.isInteger(frameIndex) || frameIndex < 0) {
+          console.error(`Invalid frame index "${opts.frame}". Use a 0-based index from "browser frames".`);
+          process.exitCode = EXIT_CODES.USAGE_ERROR;
+          return;
+        }
+        if (!page.evaluateInFrame) {
+          throw new Error('This browser session does not support frame-targeted evaluation');
+        }
+        result = await page.evaluateInFrame(js, frameIndex);
+      } else {
+        result = await page.evaluate(js);
+      }
       if (typeof result === 'string') console.log(result);
       else console.log(JSON.stringify(result, null, 2));
     }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,10 @@ export interface IPage {
   setActivePage?(page?: string): void;
   /** Send a raw CDP command via chrome.debugger passthrough. */
   cdp?(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  /** List cross-origin iframe targets in snapshot order. */
+  frames?(): Promise<Array<{ index: number; frameId: string; url: string; name: string }>>;
+  /** Evaluate JavaScript inside a cross-origin iframe identified by its frame index. */
+  evaluateInFrame?(js: string, frameIndex: number): Promise<unknown>;
   /** Click at native coordinates via CDP Input.dispatchMouseEvent. */
   nativeClick?(x: number, y: number): Promise<void>;
   /** Type text via CDP Input.insertText. */


### PR DESCRIPTION
## Summary

Add cross-origin iframe support using CDP execution contexts, enabling AI agents to discover and interact with elements inside cross-origin iframes without content scripts.

Closes #1077

## Problem

Currently, `opencli browser state` detects iframes but marks cross-origin ones as `(cross-origin)` with no way to interact. This is because:

1. **Snapshot**: `el.contentDocument` returns `null` for cross-origin iframes (browser security)
2. **Execution**: `Runtime.evaluate` via `chrome.debugger.sendCommand({ tabId })` only runs in the main frame
3. **Protocol**: No `frameIndex` field exists to target a specific frame

## Changes

6 files, +153/-4 lines — focused and backward-compatible.

### Extension layer

**`extension/src/protocol.ts`**
- Add `'frames'` to `Action` union type
- Add `frameIndex?: number` to `Command` interface

**`extension/src/cdp.ts`**
- Track per-tab frame execution contexts via `Runtime.executionContextCreated/Destroyed/Cleared` events
- Add `registerFrameTracking()` for event listener setup
- Add `getFrameTree(tabId)` — wraps CDP `Page.getFrameTree`
- Add `evaluateInFrame(tabId, expression, frameId)` — evaluate JS in a specific frame's context

**`extension/src/background.ts`**
- Call `registerFrameTracking()` during initialization
- Add `Page.getFrameTree` to `CDP_ALLOWLIST`
- Add `handleFrames()` — returns flat list of child frames with index/frameId/url/name
- Modify `handleExec()` — when `frameIndex` is set, resolve it to a frameId and use `evaluateInFrame()`
- Add `'frames'` case to command switch

### CLI layer

**`src/browser/daemon-client.ts`**
- Add `'frames'` to `DaemonCommand.action` union
- Add `frameIndex?: number` to `DaemonCommand`

**`src/browser/page.ts`**
- Add `frames()` method — list all child frames
- Add `evaluateInFrame(js, frameIndex)` — evaluate JS in a specific frame

**`src/browser/dom-snapshot.ts`**
- Tag cross-origin iframes with `[F0]`, `[F1]` indices in snapshot output
- Add hint text: `use: opencli browser frames`

## Design Decisions

1. **CDP execution contexts over content scripts**: Stays consistent with the existing pure-CDP architecture. No manifest changes needed, no `all_frames` injection.

2. **Frame index (not frameId)**: Users and AI agents work with simple 0-based indices from `opencli browser frames` output, not opaque CDP frame IDs.

3. **Per-command frameIndex (not stored state)**: Follows the same pattern as `windowFocused` and `idleTimeout` — stateless, per-command relay.

4. **Backward compatible**: `frameIndex` is optional everywhere. When absent, all behavior is identical to before.

## Usage

```bash
# List all frames (including cross-origin)
opencli browser frames

# Output:
# index: 0  url: https://ads.example.com/banner  name: ad-frame
# index: 1  url: https://payment.stripe.com/...   name: payment

# Execute JS in a specific frame
opencli browser eval --frame 1 "document.querySelector('input').value"

# DOM snapshot now shows frame indices
# |iframe|[F0]<iframe src="https://ads.example.com" /> (cross-origin, use: opencli browser frames)
```

## Testing

- ✅ TypeScript type-check passes (0 new errors in CLI, 0 new errors in extension)
- ✅ Backward compatible — no behavioral change without `frameIndex`
