### PR TITLE
chore(clis/eastmoney): mirror 13 adapters + _secid helper as Phase A oracle

### DIFF
--- a/clis/eastmoney/_secid.js
+++ b/clis/eastmoney/_secid.js
@@ -1,0 +1,78 @@
+// Shared helpers for resolving eastmoney "secid" (市场.代码).
+//
+// Markets:
+//   1.XXXXXX → Shanghai A (SSE)
+//   0.XXXXXX → Shenzhen A (SZSE) or Beijing (BSE) — eastmoney groups both under 0
+//   116.XXXXX → Hong Kong
+//   105.SYMBOL → NASDAQ
+//   106.SYMBOL → NYSE
+//   107.SYMBOL → AMEX (US)
+
+const A_PREFIX_TO_MARKET = /** @param {string} c */ (c) => {
+  if (/^(60|68|90|113|900)/.test(c)) return '1';          // SH (A + STAR + old B)
+  if (/^(00|30|20)/.test(c)) return '0';                  // SZ (A + ChiNext + B)
+  if (/^(4|8|920|83|87)/.test(c)) return '0';             // BJ (eastmoney uses 0.)
+  return '0';
+};
+
+/**
+ * Resolve various user inputs to an eastmoney `secid`.
+ *  - "600000"         → "1.600000"
+ *  - "sh600000"       → "1.600000"
+ *  - "sz000001"       → "0.000001"
+ *  - "bj430047"       → "0.430047"
+ *  - "hk00700" / "00700.HK" → "116.00700"
+ *  - "us.AAPL" / "AAPL" → "105.AAPL"
+ *  - "1.600000"       → passed through
+ * @param {string} input
+ * @returns {string}
+ */
+// Known eastmoney market numeric prefixes. Narrow whitelist so that inputs like
+// "00700.HK" are NOT mistakenly treated as secids just because they look like
+// "<digits>.<alphanumeric>".
+const KNOWN_MARKET_PREFIXES = new Set(['0', '1', '100', '105', '106', '107', '116', '140', '150', '151', '152', '155', '156']);
+
+export function resolveSecid(input) {
+  const raw = String(input || '').trim();
+  if (!raw) throw new Error('empty symbol');
+  const secidMatch = raw.match(/^(\d{1,3})\.([A-Za-z0-9]+)$/);
+  if (secidMatch && KNOWN_MARKET_PREFIXES.has(secidMatch[1])) return raw; // already a secid
+  const lower = raw.toLowerCase();
+
+  // market-prefixed Chinese code
+  const pref = lower.match(/^(sh|sz|bj)(\d{6})$/);
+  if (pref) {
+    const [, mk, code] = pref;
+    return (mk === 'sh' ? '1' : '0') + '.' + code;
+  }
+
+  // hk prefix
+  const hk = lower.match(/^hk(\d{4,5})$/) || lower.match(/^(\d{4,5})\.hk$/);
+  if (hk) return '116.' + hk[1].padStart(5, '0');
+
+  // us.SYMBOL or SYMBOL.N/.O  (treat all as NASDAQ by default; .N as NYSE)
+  const usDot = lower.match(/^([a-z.\-]+)\.([no])$/);
+  if (usDot) return (usDot[2] === 'n' ? '106' : '105') + '.' + usDot[1].toUpperCase();
+  const usPref = lower.match(/^us\.([a-z.\-]+)$/);
+  if (usPref) return '105.' + usPref[1].toUpperCase();
+
+  // bare 6-digit Chinese code
+  if (/^\d{6}$/.test(raw)) return A_PREFIX_TO_MARKET(raw) + '.' + raw;
+
+  // bare US ticker — uppercase letters only
+  if (/^[A-Z.\-]{1,8}$/.test(raw)) return '105.' + raw;
+
+  throw new Error(`Unrecognized symbol: ${input}`);
+}
+
+/**
+ * Normalize a list of user inputs separated by comma / space / Chinese comma.
+ * @param {string} s
+ * @returns {string[]}
+ */
+export function splitSymbols(s) {
+  return String(s || '')
+    .split(/[,，\s]+/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}

--- a/clis/eastmoney/announcement.js
+++ b/clis/eastmoney/announcement.js
@@ -1,0 +1,52 @@
+// eastmoney announcement — listed company filings/announcements feed.
+//
+//   opencli eastmoney announcement
+//   opencli eastmoney announcement --market SHA --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+cli({
+  site: 'eastmoney',
+  name: 'announcement',
+  description: '上市公司公告（按交易所筛选）',
+  domain: 'np-anotice-stock.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'market', type: 'string', default: 'SHA,SZA,BJA', help: '交易所：SHA (沪) / SZA (深) / BJA (北) 可逗号分隔' },
+    { name: 'limit',  type: 'int',    default: 20,            help: '返回数量 (max 100)' },
+  ],
+  columns: ['time', 'code', 'name', 'title', 'category', 'url'],
+  func: async (_page, args) => {
+    const market = String(args.market ?? 'SHA,SZA,BJA').trim() || 'SHA,SZA,BJA';
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const url = new URL('https://np-anotice-stock.eastmoney.com/api/security/ann');
+    url.searchParams.set('page_size', String(limit));
+    url.searchParams.set('page_index', '1');
+    url.searchParams.set('ann_type', market);
+    url.searchParams.set('client_source', 'web');
+    url.searchParams.set('f_node', '0');
+    url.searchParams.set('s_node', '0');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `announcement failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const list = Array.isArray(data?.data?.list) ? data.data.list : [];
+    if (list.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no announcement data');
+
+    return list.slice(0, limit).map((it) => {
+      const primary = Array.isArray(it.codes) && it.codes.length > 0 ? it.codes[0] : {};
+      const cat = Array.isArray(it.columns) && it.columns.length > 0 ? it.columns[0]?.column_name : '';
+      return {
+        time: String(it.notice_date || it.display_time || '').slice(0, 19),
+        code: primary.stock_code || '',
+        name: primary.short_name || '',
+        title: it.title || it.title_ch || '',
+        category: cat || '',
+        url: `https://data.eastmoney.com/notices/detail/${primary.stock_code || ''}/${it.art_code || ''}.html`,
+      };
+    });
+  },
+});

--- a/clis/eastmoney/convertible.js
+++ b/clis/eastmoney/convertible.js
@@ -1,0 +1,73 @@
+// eastmoney convertible — on-market convertible bond listing.
+//
+//   opencli eastmoney convertible
+//   opencli eastmoney convertible --sort premium --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const SORTS = {
+  change:   { fid: 'f3',   order: 'desc' },
+  drop:     { fid: 'f3',   order: 'asc' },
+  turnover: { fid: 'f6',   order: 'desc' },
+  price:    { fid: 'f2',   order: 'desc' },
+  premium:  { fid: 'f237', order: 'desc' }, // 转股溢价率
+  value:    { fid: 'f236', order: 'desc' }, // 转股价值
+  ytm:      { fid: 'f239', order: 'desc' }, // 到期收益率
+};
+
+cli({
+  site: 'eastmoney',
+  name: 'convertible',
+  description: '可转债行情列表（默认按成交额排序）',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'sort',  type: 'string', default: 'turnover', help: '排序：turnover / change / drop / price / premium' },
+    { name: 'limit', type: 'int',    default: 20,         help: '返回数量 (max 100)' },
+  ],
+  columns: ['rank', 'bondCode', 'bondName', 'bondPrice', 'bondChangePct', 'stockCode', 'stockName', 'stockPrice', 'stockChangePct', 'convPrice', 'convValue', 'convPremiumPct', 'remainingYears', 'ytm', 'listDate'],
+  func: async (_page, args) => {
+    const sortKey = String(args.sort ?? 'turnover').toLowerCase();
+    const sort = SORTS[sortKey];
+    if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const url = new URL('https://push2.eastmoney.com/api/qt/clist/get');
+    url.searchParams.set('pn', '1');
+    url.searchParams.set('pz', String(limit));
+    url.searchParams.set('po', sort.order === 'desc' ? '1' : '0');
+    url.searchParams.set('np', '1');
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('invt', '2');
+    url.searchParams.set('fid', sort.fid);
+    url.searchParams.set('fs', 'b:MK0354');
+    url.searchParams.set('fields', 'f12,f14,f2,f3,f6,f229,f230,f232,f234,f235,f236,f237,f238,f239,f243');
+    url.searchParams.set('ut', 'bd1d9ddb04089700cf9c27f6f7426281');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `convertible failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no convertible data');
+
+    return diff.slice(0, limit).map((it, i) => ({
+      rank: i + 1,
+      bondCode: it.f12,
+      bondName: it.f14,
+      bondPrice: it.f2,
+      bondChangePct: it.f3,
+      stockCode: it.f232,
+      stockName: it.f234,
+      stockPrice: it.f229,
+      stockChangePct: it.f230,
+      convPrice: it.f235,
+      convValue: it.f236,
+      convPremiumPct: it.f237,
+      remainingYears: it.f238,
+      ytm: it.f239,
+      listDate: String(it.f243 ?? ''),
+    }));
+  },
+});

--- a/clis/eastmoney/etf.js
+++ b/clis/eastmoney/etf.js
@@ -1,0 +1,65 @@
+// eastmoney etf — ETF ranking by change / turnover.
+//
+//   opencli eastmoney etf
+//   opencli eastmoney etf --sort change --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const SORTS = {
+  turnover: { fid: 'f6', order: 'desc' },
+  change:   { fid: 'f3', order: 'desc' },
+  drop:     { fid: 'f3', order: 'asc' },
+  volume:   { fid: 'f5', order: 'desc' },
+  rate:     { fid: 'f8', order: 'desc' },
+};
+
+cli({
+  site: 'eastmoney',
+  name: 'etf',
+  description: 'ETF 列表按成交额/涨跌幅排行',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'sort', type: 'string', default: 'turnover', help: '排序：turnover / change / drop / volume / rate' },
+    { name: 'limit', type: 'int',   default: 20,         help: '返回数量 (max 100)' },
+  ],
+  columns: ['rank', 'code', 'name', 'price', 'changePercent', 'change', 'turnover', 'volume', 'turnoverRate'],
+  func: async (_page, args) => {
+    const sortKey = String(args.sort ?? 'turnover').toLowerCase();
+    const sort = SORTS[sortKey];
+    if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const url = new URL('https://push2.eastmoney.com/api/qt/clist/get');
+    url.searchParams.set('pn', '1');
+    url.searchParams.set('pz', String(limit));
+    url.searchParams.set('po', sort.order === 'desc' ? '1' : '0');
+    url.searchParams.set('np', '1');
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('invt', '2');
+    url.searchParams.set('fid', sort.fid);
+    url.searchParams.set('fs', 'b:MK0021'); // 场内ETF
+    url.searchParams.set('fields', 'f12,f14,f2,f3,f4,f5,f6,f8');
+    url.searchParams.set('ut', 'bd1d9ddb04089700cf9c27f6f7426281');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `etf failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no ETF data');
+
+    return diff.slice(0, limit).map((it, i) => ({
+      rank: i + 1,
+      code: it.f12,
+      name: it.f14,
+      price: it.f2,
+      changePercent: it.f3,
+      change: it.f4,
+      turnover: it.f6,
+      volume: it.f5,
+      turnoverRate: it.f8,
+    }));
+  },
+});

--- a/clis/eastmoney/holders.js
+++ b/clis/eastmoney/holders.js
@@ -1,0 +1,78 @@
+// eastmoney holders — top-10 float shareholders of an A-share (F10 data).
+//
+//   opencli eastmoney holders 600519
+//   opencli eastmoney holders sh600519 --limit 10
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+/**
+ * Convert a bare A-share symbol to eastmoney's SECUCODE form ("600519.SH").
+ * Accepts "600519", "sh600519", "sz000001", "bj430047", or full "600519.SH".
+ * @param {string} input
+ * @returns {string}
+ */
+function toSecucode(input) {
+  const raw = String(input || '').trim().toUpperCase();
+  if (/^\d{6}\.(SH|SZ|BJ)$/.test(raw)) return raw;
+  const pref = raw.match(/^(SH|SZ|BJ)(\d{6})$/);
+  if (pref) return `${pref[2]}.${pref[1]}`;
+  if (/^\d{6}$/.test(raw)) {
+    if (/^(60|68|90|113|900)/.test(raw)) return `${raw}.SH`;
+    if (/^(4|8|920|83|87)/.test(raw))    return `${raw}.BJ`;
+    return `${raw}.SZ`;
+  }
+  throw new Error(`Unrecognized A-share symbol: ${input}`);
+}
+
+cli({
+  site: 'eastmoney',
+  name: 'holders',
+  description: '十大流通股东（A股 F10 数据）',
+  domain: 'datacenter-web.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'symbol', required: true, positional: true, help: 'A股代码（600519 / sh600519 等）' },
+    { name: 'limit',  type: 'int',    default: 10,      help: '返回股东数（默认十大流通股东）' },
+  ],
+  columns: ['rank', 'reportDate', 'name', 'holdNum', 'floatRatio', 'change'],
+  func: async (_page, args) => {
+    /** @type {string} */
+    let secucode;
+    try { secucode = toSecucode(args.symbol); }
+    catch (err) { throw new CliError('INVALID_ARGUMENT', `${err instanceof Error ? err.message : err}`); }
+    const limit = Math.max(1, Math.min(Number(args.limit) || 10, 50));
+
+    const url = new URL('https://datacenter-web.eastmoney.com/api/data/v1/get');
+    url.searchParams.set('sortColumns', 'END_DATE,HOLDER_RANK');
+    url.searchParams.set('sortTypes', '-1,1');
+    url.searchParams.set('pageSize', String(Math.max(limit, 10)));
+    url.searchParams.set('pageNumber', '1');
+    url.searchParams.set('reportName', 'RPT_F10_EH_FREEHOLDERS');
+    url.searchParams.set('columns', 'SECUCODE,SECURITY_CODE,END_DATE,HOLDER_RANK,HOLDER_NAME,HOLD_NUM,FREE_HOLDNUM_RATIO,HOLD_NUM_CHANGE');
+    url.searchParams.set('source', 'HSF10');
+    url.searchParams.set('client', 'PC');
+    url.searchParams.set('filter', `(SECUCODE="${secucode}")`);
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `holders failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const rows = Array.isArray(data?.result?.data) ? data.result.data : [];
+    if (rows.length === 0) throw new CliError('NO_DATA', `No shareholder data for ${secucode}`);
+
+    // Only the most recent reporting period
+    const latest = String(rows[0].END_DATE || '').slice(0, 10);
+    return rows
+      .filter((it) => String(it.END_DATE || '').slice(0, 10) === latest)
+      .slice(0, limit)
+      .map((it) => ({
+        rank: it.HOLDER_RANK,
+        reportDate: latest,
+        name: it.HOLDER_NAME,
+        holdNum: it.HOLD_NUM,
+        floatRatio: it.FREE_HOLDNUM_RATIO,
+        change: it.HOLD_NUM_CHANGE,
+      }));
+  },
+});

--- a/clis/eastmoney/index-board.js
+++ b/clis/eastmoney/index-board.js
@@ -1,0 +1,96 @@
+// eastmoney index-board — live quotes for key Chinese market indices.
+//
+// Data source: push2.eastmoney.com (Tier 1 public JSON, no auth).
+//   opencli eastmoney index-board
+//   opencli eastmoney index-board --group all
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const INDEX_GROUPS = {
+  main: [
+    ['1.000001', '上证指数'],
+    ['0.399001', '深证成指'],
+    ['0.399006', '创业板指'],
+    ['1.000688', '科创50'],
+    ['1.000300', '沪深300'],
+    ['1.000905', '中证500'],
+  ],
+  hk: [
+    ['100.HSI', '恒生指数'],
+    ['100.HSCEI', '恒生国企'],
+    ['100.HSTECH', '恒生科技'],
+  ],
+  us: [
+    ['100.DJIA', '道琼斯'],
+    ['100.SPX', '标普500'],
+    ['100.NDX', '纳斯达克100'],
+    ['100.IXIC', '纳斯达克综指'],
+  ],
+};
+
+const FIELDS = 'f2,f3,f4,f12,f13,f14,f15,f16,f17,f18';
+
+cli({
+  site: 'eastmoney',
+  name: 'index-board',
+  description: '主要市场指数行情（A股 / 港股 / 美股）',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'group',
+      type: 'string',
+      default: 'main',
+      help: '指数分组：main (A股主要), hk (港股), us (美股), all',
+    },
+  ],
+  columns: ['code', 'name', 'price', 'changePercent', 'change', 'open', 'high', 'low', 'prevClose'],
+  func: async (_page, args) => {
+    const group = String(args.group ?? 'main').toLowerCase();
+    /** @type {[string,string][]} */
+    let entries;
+    if (group === 'all') {
+      entries = [...INDEX_GROUPS.main, ...INDEX_GROUPS.hk, ...INDEX_GROUPS.us];
+    } else if (INDEX_GROUPS[group]) {
+      entries = INDEX_GROUPS[group];
+    } else {
+      throw new CliError('INVALID_ARGUMENT', `Unknown group "${group}". Valid: main, hk, us, all`);
+    }
+
+    const secids = entries.map(([secid]) => secid).join(',');
+    const url = new URL('https://push2.eastmoney.com/api/qt/ulist.np/get');
+    url.searchParams.set('secids', secids);
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('fields', FIELDS);
+    url.searchParams.set('ut', 'bd1d9ddb04089700cf9c27f6f7426281');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0', Accept: 'application/json' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `eastmoney index-board failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no index data');
+
+    // Preserve the order defined in INDEX_GROUPS regardless of API ordering
+    const byCode = new Map(diff.map((it) => [String(it.f12), it]));
+    return entries
+      .map(([secid, fallbackName]) => {
+        const code = secid.split('.')[1];
+        const it = byCode.get(code);
+        if (!it) return null;
+        return {
+          code,
+          name: it.f14 || fallbackName,
+          price: it.f2,
+          changePercent: it.f3,
+          change: it.f4,
+          open: it.f17,
+          high: it.f15,
+          low: it.f16,
+          prevClose: it.f18,
+        };
+      })
+      .filter(Boolean);
+  },
+});

--- a/clis/eastmoney/kline.js
+++ b/clis/eastmoney/kline.js
@@ -1,0 +1,87 @@
+// eastmoney kline — historical OHLCV for one stock, any timeframe.
+//
+// Data source: push2his.eastmoney.com (Tier 1 public JSON).
+//   opencli eastmoney kline 600519 --period day --limit 30
+//   opencli eastmoney kline sh600519 --period week --adjust forward
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+import { resolveSecid } from './_secid.js';
+
+const PERIOD_MAP = {
+  '1m': 1, '5m': 5, '15m': 15, '30m': 30, '60m': 60,
+  minute: 1, hour: 60,
+  day: 101, daily: 101,
+  week: 102, weekly: 102,
+  month: 103, monthly: 103,
+};
+
+const ADJUST_MAP = {
+  none: 0, no: 0, off: 0,
+  forward: 1, front: 1, 'pre': 1,
+  backward: 2, back: 2, 'post': 2,
+};
+
+cli({
+  site: 'eastmoney',
+  name: 'kline',
+  description: 'K线历史数据（分/日/周/月/前复权/后复权）',
+  domain: 'push2his.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'symbol', required: true, positional: true, help: '股票代码（A/HK/US 均可）' },
+    { name: 'period', type: 'string', default: 'day', help: '周期：1m/5m/15m/30m/60m/day/week/month' },
+    { name: 'adjust', type: 'string', default: 'forward', help: '复权：none / forward / backward' },
+    { name: 'limit',  type: 'int',    default: 30,        help: '返回最近 N 根（末尾）' },
+  ],
+  columns: ['date', 'open', 'close', 'high', 'low', 'volume', 'turnover', 'amplitude', 'changePercent', 'change', 'turnoverRate'],
+  func: async (_page, args) => {
+    const secid = resolveSecid(args.symbol);
+    const periodKey = String(args.period ?? 'day').toLowerCase();
+    const klt = PERIOD_MAP[periodKey];
+    if (klt == null) {
+      throw new CliError('INVALID_ARGUMENT', `Unknown period "${periodKey}". Valid: ${Object.keys(PERIOD_MAP).join(', ')}`);
+    }
+    const adjustKey = String(args.adjust ?? 'forward').toLowerCase();
+    const fqt = ADJUST_MAP[adjustKey];
+    if (fqt == null) {
+      throw new CliError('INVALID_ARGUMENT', `Unknown adjust "${adjustKey}". Valid: none / forward / backward`);
+    }
+    const limit = Math.max(1, Math.min(Number(args.limit) || 30, 1000));
+
+    const url = new URL('https://push2his.eastmoney.com/api/qt/stock/kline/get');
+    url.searchParams.set('secid', secid);
+    url.searchParams.set('klt', String(klt));
+    url.searchParams.set('fqt', String(fqt));
+    url.searchParams.set('beg', '0');
+    url.searchParams.set('end', '20500101');
+    url.searchParams.set('fields1', 'f1,f2,f3,f4,f5,f6');
+    url.searchParams.set('fields2', 'f51,f52,f53,f54,f55,f56,f57,f58,f59,f60,f61');
+    url.searchParams.set('ut', 'b2884a393a59ad64002292a3e90d46a5');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `eastmoney kline failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    /** @type {string[]} */
+    const raw = Array.isArray(data?.data?.klines) ? data.data.klines : [];
+    if (raw.length === 0) throw new CliError('NO_DATA', `No kline data for ${args.symbol}`);
+
+    return raw.slice(-limit).map((line) => {
+      const [date, open, close, high, low, volume, turnover, amplitude, changePercent, change, turnoverRate] = line.split(',');
+      return {
+        date,
+        open: Number(open),
+        close: Number(close),
+        high: Number(high),
+        low: Number(low),
+        volume: Number(volume),
+        turnover: Number(turnover),
+        amplitude: Number(amplitude),
+        changePercent: Number(changePercent),
+        change: Number(change),
+        turnoverRate: Number(turnoverRate),
+      };
+    });
+  },
+});

--- a/clis/eastmoney/kuaixun.js
+++ b/clis/eastmoney/kuaixun.js
@@ -1,0 +1,54 @@
+// eastmoney kuaixun — 7x24 real-time market news feed.
+//
+//   opencli eastmoney kuaixun
+//   opencli eastmoney kuaixun --column 102 --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+// Known columns on eastmoney 7x24:
+//   102 = 重要 (default)
+//   101 = 全部
+//   104 = 公司
+//   105 = 市场
+//   106 = 机构
+//   107 = 宏观
+
+cli({
+  site: 'eastmoney',
+  name: 'kuaixun',
+  description: '东方财富 7x24 财经快讯',
+  domain: 'np-listapi.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'column', type: 'string', default: '102', help: '频道：102 (重要) / 101 (全部) / 104 / 105 / 106 / 107' },
+    { name: 'limit',  type: 'int',    default: 20,    help: '返回数量 (max 100)' },
+  ],
+  columns: ['time', 'title', 'summary', 'stocks'],
+  func: async (_page, args) => {
+    const column = String(args.column ?? '102').trim();
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const url = new URL('https://np-listapi.eastmoney.com/comm/web/getFastNewsList');
+    url.searchParams.set('client', 'web');
+    url.searchParams.set('biz', 'web_724');
+    url.searchParams.set('fastColumn', column);
+    url.searchParams.set('sortEnd', '');
+    url.searchParams.set('pageSize', String(limit));
+    url.searchParams.set('req_trace', '1');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0', Accept: 'application/json' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `kuaixun failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const list = Array.isArray(data?.data?.fastNewsList) ? data.data.fastNewsList : [];
+    if (list.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no kuaixun data');
+
+    return list.slice(0, limit).map((it) => ({
+      time: it.showTime,
+      title: it.title,
+      summary: (it.summary || '').replace(/\s+/g, ' ').slice(0, 400),
+      stocks: Array.isArray(it.stockList) ? it.stockList.join(', ') : '',
+    }));
+  },
+});

--- a/clis/eastmoney/longhu.js
+++ b/clis/eastmoney/longhu.js
@@ -1,0 +1,67 @@
+// eastmoney longhu — dragon & tiger list (龙虎榜).
+//
+//   opencli eastmoney longhu
+//   opencli eastmoney longhu --date 2025-12-10 --limit 20
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+function defaultTradeDate() {
+  // Default window = 30 days back; results sorted DESC so latest comes first.
+  // This avoids missing data on weekends/holidays when "yesterday" had no trading.
+  const d = new Date(Date.now() + 8 * 3600 * 1000);
+  d.setUTCDate(d.getUTCDate() - 30);
+  return d.toISOString().slice(0, 10);
+}
+
+cli({
+  site: 'eastmoney',
+  name: 'longhu',
+  description: '龙虎榜明细（A股交易所公开披露榜单）',
+  domain: 'datacenter-web.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'date',  type: 'string', default: '',  help: '开始交易日 YYYY-MM-DD (默认昨天)' },
+    { name: 'limit', type: 'int',    default: 20,  help: '返回数量 (max 100)' },
+  ],
+  columns: ['tradeDate', 'code', 'name', 'closePrice', 'changeRate', 'boardAmt', 'buyAmt', 'sellAmt', 'netAmt', 'turnover', 'dealRatio', 'market', 'reason'],
+  func: async (_page, args) => {
+    const sinceDate = String(args.date || '').trim() || defaultTradeDate();
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const url = new URL('https://datacenter-web.eastmoney.com/api/data/v1/get');
+    url.searchParams.set('sortColumns', 'TRADE_DATE,SECURITY_CODE');
+    url.searchParams.set('sortTypes', '-1,1');
+    url.searchParams.set('pageSize', String(limit));
+    url.searchParams.set('pageNumber', '1');
+    url.searchParams.set('reportName', 'RPT_DAILYBILLBOARD_DETAILS');
+    url.searchParams.set('columns', 'ALL');
+    url.searchParams.set('source', 'WEB');
+    url.searchParams.set('client', 'WEB');
+    url.searchParams.set('filter', `(TRADE_DATE>='${sinceDate}')`);
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `longhu failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    /** @type {any[]} */
+    const rows = Array.isArray(data?.result?.data) ? data.result.data : [];
+    if (rows.length === 0) throw new CliError('NO_DATA', `No longhu data since ${sinceDate}`);
+
+    return rows.slice(0, limit).map((it) => ({
+      tradeDate: String(it.TRADE_DATE || '').slice(0, 10),
+      code: it.SECURITY_CODE,
+      name: it.SECURITY_NAME_ABBR,
+      closePrice: it.CLOSE_PRICE,
+      changeRate: it.CHANGE_RATE,
+      boardAmt: it.BILLBOARD_DEAL_AMT,
+      buyAmt: it.BILLBOARD_BUY_AMT,
+      sellAmt: it.BILLBOARD_SELL_AMT,
+      netAmt: it.BILLBOARD_NET_AMT,
+      turnover: it.ACCUM_AMOUNT,
+      dealRatio: it.DEAL_AMOUNT_RATIO,
+      market: it.TRADE_MARKET,
+      reason: it.EXPLANATION,
+    }));
+  },
+});

--- a/clis/eastmoney/money-flow.js
+++ b/clis/eastmoney/money-flow.js
@@ -1,0 +1,78 @@
+// eastmoney money-flow — main-force net inflow ranking (沪深A今日/5日/10日).
+//
+//   opencli eastmoney money-flow
+//   opencli eastmoney money-flow --range 5d --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const A_MARKET = 'm:0+t:6,m:0+t:80,m:1+t:2,m:1+t:23,m:0+t:81+s:2048';
+
+// (main, super, big, medium, small) net inflow amount fields
+const RANGES = {
+  today: { fid: 'f62', fields: { net: 'f62', netPct: 'f184', super: 'f66', big: 'f72', medium: 'f78', small: 'f84' } },
+  '5d':  { fid: 'f164', fields: { net: 'f164', netPct: 'f165', super: 'f166', big: 'f169', medium: 'f172', small: 'f175' } },
+  '10d': { fid: 'f174', fields: { net: 'f174', netPct: 'f175', super: 'f176', big: 'f179', medium: 'f182', small: 'f185' } },
+};
+
+cli({
+  site: 'eastmoney',
+  name: 'money-flow',
+  description: '主力资金净流入排行（今日/5日/10日）',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'range', type: 'string', default: 'today', help: '周期：today / 5d / 10d' },
+    { name: 'order', type: 'string', default: 'desc', help: '排序：desc (净流入排行) / asc (净流出)' },
+    { name: 'limit', type: 'int', default: 20, help: '返回数量 (max 100)' },
+  ],
+  columns: ['rank', 'code', 'name', 'price', 'changePercent', 'mainNet', 'mainNetRatio', 'superNet', 'bigNet', 'mediumNet', 'smallNet'],
+  func: async (_page, args) => {
+    const rangeKey = String(args.range ?? 'today').toLowerCase();
+    const range = RANGES[rangeKey];
+    if (!range) {
+      throw new CliError('INVALID_ARGUMENT', `Unknown range "${rangeKey}". Valid: ${Object.keys(RANGES).join(', ')}`);
+    }
+    const po = String(args.order ?? 'desc').toLowerCase() === 'asc' ? '0' : '1';
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const fieldList = [
+      'f12', 'f14', 'f2', 'f3',
+      range.fields.net, range.fields.netPct,
+      range.fields.super, range.fields.big, range.fields.medium, range.fields.small,
+    ];
+
+    const url = new URL('https://push2.eastmoney.com/api/qt/clist/get');
+    url.searchParams.set('pn', '1');
+    url.searchParams.set('pz', String(limit));
+    url.searchParams.set('po', po);
+    url.searchParams.set('np', '1');
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('invt', '2');
+    url.searchParams.set('fid', range.fid);
+    url.searchParams.set('fs', A_MARKET);
+    url.searchParams.set('fields', fieldList.join(','));
+    url.searchParams.set('ut', 'b2884a393a59ad64002292a3e90d46a5');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `money-flow failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no money-flow data');
+
+    return diff.slice(0, limit).map((it, i) => ({
+      rank: i + 1,
+      code: it.f12,
+      name: it.f14,
+      price: it.f2,
+      changePercent: it.f3,
+      mainNet: it[range.fields.net],
+      mainNetRatio: it[range.fields.netPct],
+      superNet: it[range.fields.super],
+      bigNet: it[range.fields.big],
+      mediumNet: it[range.fields.medium],
+      smallNet: it[range.fields.small],
+    }));
+  },
+});

--- a/clis/eastmoney/northbound.js
+++ b/clis/eastmoney/northbound.js
@@ -1,0 +1,57 @@
+// eastmoney northbound — live realtime cross-border capital flow (北向/南向).
+//
+// Returns the latest non-empty minute snapshot of cumulative net flow in 万元.
+//   opencli eastmoney northbound
+//   opencli eastmoney northbound --direction south
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+cli({
+  site: 'eastmoney',
+  name: 'northbound',
+  description: '沪深港通北向/南向资金当日分时净流入（万元）',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'direction', type: 'string', default: 'north', help: '方向：north (北向，即外资买A) / south (南向，即内地买港)' },
+    { name: 'limit',     type: 'int',    default: 10,      help: '返回最近 N 分钟' },
+  ],
+  columns: ['time', 'cumulativeNetYi', 'minuteNetYi', 'totalNetYi'],
+  func: async (_page, args) => {
+    const dir = String(args.direction ?? 'north').toLowerCase();
+    if (!['north', 'south', 'n', 's'].includes(dir)) {
+      throw new CliError('INVALID_ARGUMENT', `Unknown direction "${dir}". Valid: north / south`);
+    }
+    const limit = Math.max(1, Math.min(Number(args.limit) || 10, 240));
+
+    const url = new URL('https://push2.eastmoney.com/api/qt/kamtbs.rtmin/get');
+    url.searchParams.set('fields1', 'f1,f2,f3,f4');
+    url.searchParams.set('fields2', 'f51,f52,f54,f56');
+    url.searchParams.set('ut', 'b2884a393a59ad64002292a3e90d46a5');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `northbound failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const key = (dir === 'south' || dir === 's') ? 's2n' : 'n2s';
+    /** @type {string[]} */
+    const rows = Array.isArray(data?.data?.[key]) ? data.data[key] : [];
+    if (rows.length === 0) throw new CliError('NO_DATA', `No ${key} data returned`);
+
+    // CSV fields per entry: "HH:MM,cumulative_net(万), minute_net(万), total_net(万)"
+    // Drop rows with '-' (after market close or before open). Convert 万元 → 亿元 for readability.
+    const valid = rows
+      .map((r) => r.split(','))
+      .filter((c) => c.length >= 4 && c[1] !== '-');
+    if (valid.length === 0) {
+      throw new CliError('NO_DATA', `${key} has no valid minute data yet (markets may not be open)`);
+    }
+    return valid.slice(-limit).map(([time, cum, min, total]) => ({
+      time,
+      cumulativeNetYi: +(Number(cum) / 10000).toFixed(4),
+      minuteNetYi: +(Number(min) / 10000).toFixed(4),
+      totalNetYi: +(Number(total) / 10000).toFixed(4),
+    }));
+  },
+});

--- a/clis/eastmoney/quote.js
+++ b/clis/eastmoney/quote.js
@@ -1,0 +1,107 @@
+// eastmoney quote — live quote for one or more stocks (A/HK/US).
+//
+// Data source: push2.eastmoney.com (Tier 1 public JSON, no auth).
+// Supported inputs (comma / space separated):
+//   600000, sh600000, 000001, sz000001, 00700.HK, hk00700, AAPL, us.AAPL
+//
+//   opencli eastmoney quote 600000 --fields all
+//   opencli eastmoney quote "sh600000,sz000001,00700.HK"
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+import { resolveSecid, splitSymbols } from './_secid.js';
+
+const FIELDS = [
+  'f12', // code
+  'f13', // market
+  'f14', // name
+  'f2',  // price
+  'f3',  // changePercent
+  'f4',  // change
+  'f5',  // volume (手)
+  'f6',  // turnover (CNY)
+  'f7',  // amplitude %
+  'f8',  // turnoverRate %
+  'f9',  // peDynamic
+  'f10', // volumeRatio
+  'f15', // high
+  'f16', // low
+  'f17', // open
+  'f18', // prevClose
+  'f20', // marketCap
+  'f21', // floatMarketCap
+  'f23', // priceBook
+].join(',');
+
+function marketLabel(f13) {
+  if (f13 === 1) return 'SH';
+  if (f13 === 0) return 'SZ/BJ';
+  if (f13 === 116) return 'HK';
+  if (f13 === 105 || f13 === 106 || f13 === 107) return 'US';
+  return String(f13 ?? '');
+}
+
+cli({
+  site: 'eastmoney',
+  name: 'quote',
+  description: '个股实时行情（A股 / 港股 / 美股）— 来自 push2.eastmoney.com',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'symbols', required: true, positional: true, help: '股票代码（可用逗号/空格分隔多个）' },
+  ],
+  columns: [
+    'code', 'name', 'market', 'price', 'changePercent', 'change',
+    'open', 'high', 'low', 'prevClose', 'volume', 'turnover',
+    'turnoverRate', 'amplitude', 'peDynamic', 'priceBook',
+    'marketCap', 'floatMarketCap',
+  ],
+  func: async (_page, args) => {
+    const raw = splitSymbols(args.symbols);
+    if (raw.length === 0) {
+      throw new CliError('INVALID_ARGUMENT', 'At least one symbol is required');
+    }
+
+    /** @type {string[]} */
+    const secids = [];
+    for (const s of raw) {
+      try { secids.push(resolveSecid(s)); }
+      catch (err) { throw new CliError('INVALID_ARGUMENT', `Unrecognized symbol "${s}"`); }
+    }
+
+    // Multi-stock in one call via ulist.np
+    const url = new URL('https://push2.eastmoney.com/api/qt/ulist.np/get');
+    url.searchParams.set('secids', secids.join(','));
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('fields', FIELDS);
+    url.searchParams.set('ut', 'bd1d9ddb04089700cf9c27f6f7426281');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0', Accept: 'application/json' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `eastmoney quote failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no quotes', `Check symbols: ${raw.join(', ')}`);
+
+    return diff.map((it) => ({
+      code: it.f12,
+      name: it.f14,
+      market: marketLabel(it.f13),
+      price: it.f2,
+      changePercent: it.f3,
+      change: it.f4,
+      open: it.f17,
+      high: it.f15,
+      low: it.f16,
+      prevClose: it.f18,
+      volume: it.f5,
+      turnover: it.f6,
+      turnoverRate: it.f8,
+      amplitude: it.f7,
+      peDynamic: it.f9,
+      priceBook: it.f23,
+      marketCap: it.f20,
+      floatMarketCap: it.f21,
+    }));
+  },
+});

--- a/clis/eastmoney/rank.js
+++ b/clis/eastmoney/rank.js
@@ -1,0 +1,94 @@
+// eastmoney rank — market mover list across common segments.
+//
+// Data source: push2.eastmoney.com/api/qt/clist/get (Tier 1 public JSON).
+//   opencli eastmoney rank
+//   opencli eastmoney rank --market cyb --sort turnover --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const MARKETS = {
+  'hs-a':   'm:0+t:6,m:0+t:80,m:1+t:2,m:1+t:23,m:0+t:81+s:2048', // 沪深 A
+  'sh-a':   'm:1+t:2,m:1+t:23',                                   // 沪 A
+  'sz-a':   'm:0+t:6,m:0+t:80',                                   // 深 A
+  'bj-a':   'm:0+t:81+s:2048',                                    // 北证 A
+  'cyb':    'm:0+t:80',                                           // 创业板
+  'kcb':    'm:1+t:23',                                           // 科创板
+  'hk':     'm:116+t:3,m:116+t:4,m:116+t:1,m:116+t:2',            // 港股
+  'us':     'm:105,m:106,m:107',                                  // 美股
+};
+
+const SORTS = {
+  change: { fid: 'f3',  order: 'desc' }, // 涨幅榜
+  drop:   { fid: 'f3',  order: 'asc'  }, // 跌幅榜
+  turnover:{ fid: 'f6', order: 'desc' }, // 成交额
+  volume: { fid: 'f5',  order: 'desc' }, // 成交量
+  amplitude:{ fid:'f7', order: 'desc' }, // 振幅
+  rate:   { fid: 'f8',  order: 'desc' }, // 换手率
+};
+
+const FIELDS =
+  'f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23';
+
+cli({
+  site: 'eastmoney',
+  name: 'rank',
+  description: '东财市场涨跌/成交排行（沪深/北证/创/科/港/美）',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'market', type: 'string', default: 'hs-a', help: '市场：hs-a / sh-a / sz-a / bj-a / cyb / kcb / hk / us' },
+    { name: 'sort',   type: 'string', default: 'change', help: '排序：change / drop / turnover / volume / amplitude / rate' },
+    { name: 'limit',  type: 'int',    default: 20,       help: '返回数量 (max 100)' },
+  ],
+  columns: ['rank', 'code', 'name', 'price', 'changePercent', 'change', 'turnover', 'volume', 'turnoverRate', 'peDynamic', 'marketCap'],
+  func: async (_page, args) => {
+    const market = String(args.market ?? 'hs-a').toLowerCase();
+    const sortKey = String(args.sort ?? 'change').toLowerCase();
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const fs = MARKETS[market];
+    if (!fs) {
+      throw new CliError('INVALID_ARGUMENT', `Unknown market "${market}". Valid: ${Object.keys(MARKETS).join(', ')}`);
+    }
+    const sort = SORTS[sortKey];
+    if (!sort) {
+      throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
+    }
+
+    const url = new URL('https://push2.eastmoney.com/api/qt/clist/get');
+    url.searchParams.set('pn', '1');
+    url.searchParams.set('pz', String(limit));
+    url.searchParams.set('po', sort.order === 'desc' ? '1' : '0');
+    url.searchParams.set('np', '1');
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('invt', '2');
+    url.searchParams.set('fid', sort.fid);
+    url.searchParams.set('fs', fs);
+    url.searchParams.set('fields', FIELDS);
+    url.searchParams.set('ut', 'bd1d9ddb04089700cf9c27f6f7426281');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0', Accept: 'application/json' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `eastmoney rank failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) {
+      throw new CliError('NO_DATA', 'eastmoney returned no rank data', `market=${market} sort=${sortKey}`);
+    }
+
+    return diff.slice(0, limit).map((it, i) => ({
+      rank: i + 1,
+      code: it.f12,
+      name: it.f14,
+      price: it.f2,
+      changePercent: it.f3,
+      change: it.f4,
+      turnover: it.f6,
+      volume: it.f5,
+      turnoverRate: it.f8,
+      peDynamic: it.f9,
+      marketCap: it.f20,
+    }));
+  },
+});

--- a/clis/eastmoney/sectors.js
+++ b/clis/eastmoney/sectors.js
@@ -1,0 +1,76 @@
+// eastmoney sectors — industry / concept / region sector board ranking.
+//
+//   opencli eastmoney sectors
+//   opencli eastmoney sectors --type concept --sort money-flow --limit 30
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const SECTOR_TYPES = {
+  industry: 'm:90+t:2',
+  concept:  'm:90+t:3',
+  region:   'm:90+t:1',
+};
+
+const SORTS = {
+  change: { fid: 'f3', order: 'desc' },
+  drop:   { fid: 'f3', order: 'asc' },
+  'money-flow': { fid: 'f62', order: 'desc' },
+  'out-flow':   { fid: 'f62', order: 'asc' },
+  turnover: { fid: 'f6', order: 'desc' },
+};
+
+cli({
+  site: 'eastmoney',
+  name: 'sectors',
+  description: '板块排行（行业/概念/地域）按涨跌幅、主力资金或成交额排序',
+  domain: 'push2.eastmoney.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'type', type: 'string', default: 'industry', help: '板块类型：industry / concept / region' },
+    { name: 'sort', type: 'string', default: 'change',   help: '排序：change / drop / money-flow / out-flow / turnover' },
+    { name: 'limit', type: 'int',   default: 20,         help: '返回数量 (max 100)' },
+  ],
+  columns: ['rank', 'code', 'name', 'price', 'changePercent', 'mainNet', 'leadStock', 'leadChangePercent', 'upCount', 'downCount'],
+  func: async (_page, args) => {
+    const typeKey = String(args.type ?? 'industry').toLowerCase();
+    const fs = SECTOR_TYPES[typeKey];
+    if (!fs) throw new CliError('INVALID_ARGUMENT', `Unknown sector type "${typeKey}". Valid: ${Object.keys(SECTOR_TYPES).join(', ')}`);
+    const sortKey = String(args.sort ?? 'change').toLowerCase();
+    const sort = SORTS[sortKey];
+    if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
+    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+
+    const url = new URL('https://push2.eastmoney.com/api/qt/clist/get');
+    url.searchParams.set('pn', '1');
+    url.searchParams.set('pz', String(limit));
+    url.searchParams.set('po', sort.order === 'desc' ? '1' : '0');
+    url.searchParams.set('np', '1');
+    url.searchParams.set('fltt', '2');
+    url.searchParams.set('invt', '2');
+    url.searchParams.set('fid', sort.fid);
+    url.searchParams.set('fs', fs);
+    url.searchParams.set('fields', 'f12,f14,f2,f3,f62,f104,f105,f128,f136,f140,f141');
+    url.searchParams.set('ut', 'b2884a393a59ad64002292a3e90d46a5');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `sectors failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
+    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no sector data');
+
+    return diff.slice(0, limit).map((it, i) => ({
+      rank: i + 1,
+      code: it.f12,
+      name: it.f14,
+      price: it.f2,
+      changePercent: it.f3,
+      mainNet: it.f62,
+      leadStock: it.f128,
+      leadChangePercent: it.f136,
+      upCount: it.f104,
+      downCount: it.f105,
+    }));
+  },
+});


### PR DESCRIPTION
## Summary

Mirror the remaining 13 read-oriented eastmoney adapters and the shared `_secid.js` helper from the author's local workspace into the repo. After this PR, `clis/eastmoney/` contains the full Phase A codegen regression oracle described in **OpenCLI Improvement Spec v1.1 §B.10**.

**Oracle counting (unified, per spec §B.10 / codex-mini0 final)**:
> repo oracle = 14 adapters total under `clis/eastmoney/`, where `hot-rank.js` already exists and this PR mirrors the remaining 13 adapters plus `_secid.js` helper.

## Why this PR is standalone (oracle-only)

Per spec v1.1 §B.10, the oracle mirror is intentionally decoupled from the framework PR:
- Framework PR diffs stay clean (only framework / skill code)
- Oracle PR is pure data → trivial review
- Merge order is fixed: **this PR first → framework PR can run Phase A codegen diff gate**

## Files

All 14 files are pure fetch-based read adapters (no browser / no write / no auth state), written using the existing `@jackwener/opencli/registry` + `@jackwener/opencli/errors` exports. They were generated and live-verified during task #177.

- `_secid.js` — KNOWN_MARKET_PREFIXES whitelist + regex dispatch; resolves `600519` / `sh600519` / `00700.HK` / `us.AAPL` → `market.code` secid. Canonical example of the spec v1.1 §B.7 helper contract (pure normalize, serializable I/O, no env / fs / net / session, does not drive pagination / retry / fallback).
- `quote.js` — batch quote (A / HK / US via `secids=1.600000,0.000001,...`)
- `rank.js` — ranking across hs-a / sh-a / sz-a / bj-a / cyb / kcb / HK / US x 6 sorts
- `index-board.js` — main / hk / us indices
- `kline.js` — K-line history, 8 periods x 3 adjusts. **Exercises spec §B.9 CSV `row_format`**: `data.klines = ["20250101,open,close,high,low,vol,...", ...]` decoded by positional index.
- `sectors.js` — industry / concept / region x 5 sorts
- `money-flow.js` — main-force net inflow today / 5d / 10d
- `etf.js` — ETF list by turnover / change / volume / rate
- `convertible.js` — convertible bond listing. **Exercises spec §B.9 `:row_index` special source**: `rank: i + 1` (1-based derived column).
- `northbound.js` — northbound / southbound realtime, wan->yi conversion
- `longhu.js` — longhubang (30-day default window)
- `holders.js` — top 10 free-float holders
- `announcement.js` — listed company announcements SHA / SZA / BJA
- `kuaixun.js` — 7x24 newswire (columns 102 / 101 / 104 / 105 / 106 / 107)

## Schema-expressiveness coverage

These adapters intentionally cover the two gaps discovered during spec prep (F2) that drove spec v1.1 §B.9:

| gap | driving adapter | schema feature |
|---|---|---|
| CSV row with positional decode | `kline.js` | `row_format: csv` + `delimiter` + `from: <int index>` + `transform: date_yyyymmdd` |
| Computed column from row index | `convertible.js` | `from: :row_index, offset: 1` |

Plus `_secid.js` as the canonical §B.7 helper case.

## Test plan

- [x] All 14 adapters were live-verified during task #177 before mirroring.
- [x] `hot-rank.js` (already in repo) is untouched.
- [ ] Phase A framework PR (separate, follow-up) will run `opencli validate eastmoney` + per-command live diff against these 14 adapters; any schema gap surfaced there feeds back into spec v1.1.

## Refs

- Task #177 (OpenCLI Improvement Spec v1.1)
- Spec §B.7 (helper contract) / §B.9 (row model) / §B.10 (oracle layering)
- Thread #OpenCLI:6df17bdb (reviewer consensus on option (a) — mirror now)