### PR TITLE
chore: bump version to 1.7.5, extension to 1.0.1

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in isolated Chrome windows via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- OpenCLI: 1.7.4 → 1.7.5
- Extension: 1.0.0 → 1.0.1

Since 1.7.4 (23 commits):
- #1094 — skill consolidation (6→3)
- #1091 — eastmoney 13 adapters
- #1088 — DeepSeek adapter
- #1084 — cross-origin iframe support
- #1081 — table formatting (reverted by #1085)
- #1072 — multi-tab routing hardening
- #1042 — download saved path
- #1080 — docs rewrite
- #1076 — twitter GraphQL lists

## Test plan
- CI green on main (`afa5e60`)
- Version bump only, no code changes