### PR TITLE
fix(jianyu): keep accessible detail urls in search

### DIFF
--- a/clis/jianyu/search.js
+++ b/clis/jianyu/search.js
@@ -89,12 +89,6 @@ function classifyDetailStatus(rawUrl) {
     try {
         const parsed = new URL(urlText);
         const path = cleanText(parsed.pathname).toLowerCase().replace(/\/+$/, '/') || '/';
-        if (path.includes('/jybx/')) {
-            return {
-                detail_status: 'ok',
-                detail_reason: 'jybx_detail',
-            };
-        }
         if (BLOCKED_DETAIL_PATH_PREFIXES.some((prefix) => path.includes(prefix))) {
             return {
                 detail_status: 'blocked',
@@ -108,8 +102,8 @@ function classifyDetailStatus(rawUrl) {
             };
         }
         return {
-            detail_status: 'entry_only',
-            detail_reason: 'non_jybx_entry',
+            detail_status: 'ok',
+            detail_reason: path.includes('/jybx/') ? 'jybx_detail' : 'detail_candidate',
         };
     }
     catch {

--- a/clis/jianyu/search.test.js
+++ b/clis/jianyu/search.test.js
@@ -31,7 +31,7 @@ describe('jianyu search helpers', () => {
         const filtered = __test__.filterNavigationRows('电梯', [
             { title: '招标公告', url: 'https://www.jianyu360.cn/list/stype/ZBGG.html', date: '' },
             { title: '帮助中心', url: 'https://www.jianyu360.cn/helpCenter/index', date: '' },
-            { title: '某项目电梯采购公告', url: 'https://shandong.jianyu360.cn/jybx/20260407_123.html', date: '2026-04-07' },
+            { title: '某项目电梯采购公告', url: 'https://www.jianyu360.cn/notice/detail/123', date: '2026-04-07' },
         ]);
         expect(filtered).toHaveLength(1);
         expect(filtered[0].title).toContain('电梯采购公告');
@@ -128,6 +128,15 @@ describe('jianyu search helpers', () => {
     it('classifies nologin links as blocked detail targets', () => {
         const signal = __test__.classifyDetailStatus('https://www.jianyu360.cn/nologin/content/ABC.html');
         expect(signal.detail_status).toBe('blocked');
+    });
+    it('classifies accessible detail urls as ok even when they are not jybx paths', () => {
+        const signal = __test__.classifyDetailStatus('https://www.jianyu360.cn/notice/detail/123');
+        expect(signal.detail_status).toBe('ok');
+        expect(signal.detail_reason).toBe('detail_candidate');
+    });
+    it('classifies list pages as entry_only', () => {
+        const signal = __test__.classifyDetailStatus('https://www.jianyu360.cn/list/stype/ZBGG.html');
+        expect(signal.detail_status).toBe('entry_only');
     });
     it('extracts stable notice id from jybx urls', () => {
         const id = __test__.extractNoticeId('https://shandong.jianyu360.cn/jybx/20260310_26030938267551.html');


### PR DESCRIPTION
## Summary
- stop treating non-`/jybx/` Jianyu detail URLs as `entry_only`
- keep blocking verification / paid-wall paths and navigation pages
- restore `/notice/detail/123` as a regression fixture and add URL-class coverage

## Why
`classifyDetailStatus()` currently only marks `/jybx/` as `ok`. That narrows search recall and drops other readable detail URLs such as `/notice/detail/...`, even though the rest of the Jianyu pipeline still treats those as valid detail pages.

## Test plan
- `node node_modules/vitest/vitest.mjs --project adapter run clis/jianyu/search.test.js clis/jianyu/shared/procurement-detail.test.js`
