### PR TITLE
feat(browser): rewrite network for agent-native discovery

### DIFF
--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -14,26 +14,34 @@
 opencli browser network
 ```
 
-输出里过掉这些噪音：
-- `.css / .js / .woff / .png / .svg / .webp / .mp4` — 静态资源
-- `googletagmanager / sentry / crazyegg / doubleclick / tracking / beacon` — 埋点
-- `/healthz / /ping / /heartbeat` — 健康检查
+默认输出是 JSON，每个候选都带：
+- `key` — 稳定引用（GraphQL 的 `operationName` 或 `METHOD host+pathname`）
+- `shape` — response body 的路径→类型映射（不含原 body，省 token）
+- `status / url / method / ct / size`
 
-剩下的每一条都是候选。挑 URL 里含业务词（`list / detail / quote / feed / timeline / stock / user` 等）的优先看：
+静态资源 / 埋点 / 追踪默认已过滤；需要全量看用 `--all`。
+
+### 按 shape 初筛
+
+挑 `key` 里含业务词（`list / detail / Timeline / User / Tweets / Quote`）的优先看 `shape`：
+
+- `$.data` 是 `object` 且下面出现 `array(N)` / `total` / `page` → 基本是它
+- 路径里出现 `nickname / avatar / title / price / tweets / items` → 就是它
+- shape 只有 `$: string` 或全是 HTML 噪音 → 下一条
+
+### 拉完整 body
+
+候选定了再拉完整 body（by key，不是 index — 数组顺序会随每次 capture 变）：
 
 ```bash
-opencli browser network --detail <N>
+opencli browser network --detail <key>
 ```
 
-看 response body 前 200 字节：
-
-- 含数组 / `total` / `page` 字段 → 基本是它
-- 含 `nickname / avatar / title / price` → 就是它
-- 是 HTML 或纯广告 → 下一条
+capture 会持久化到 `~/.opencli/cache/browser-network/<workspace>.json`（默认 TTL 24h），所以 `--detail` 即使跨多条其他命令也还在。
 
 ### 关键 request headers
 
-找到候选后，`--detail <N>` 里看请求头：
+`browser network` 当前只抓响应（body + status + ct），抓不到请求头。要看请求头就在 DevTools Network 面板里点这条 request，或用 `browser eval` 手动 `fetch(url)` 复现一次观察浏览器发出去的头：
 
 | 看到 | 含义 | 对应策略 |
 |------|------|---------|

--- a/skills/opencli-autofix/SKILL.md
+++ b/skills/opencli-autofix/SKILL.md
@@ -130,8 +130,8 @@ opencli browser open https://example.com/target-page && opencli browser state
 # Interact to trigger API calls
 opencli browser click <N> && opencli browser network
 
-# Inspect specific API response
-opencli browser network --detail <index>
+# Inspect specific API response (key is the `key` field from the default JSON output)
+opencli browser network --detail <key>
 ```
 
 ## Step 4: Patch the Adapter

--- a/src/browser/network-cache.test.ts
+++ b/src/browser/network-cache.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+    DEFAULT_TTL_MS,
+    findEntry,
+    getCachePath,
+    loadNetworkCache,
+    saveNetworkCache,
+    type CachedNetworkEntry,
+    type NetworkCacheFile,
+} from './network-cache.js';
+
+function makeEntry(key: string, body: unknown = { ok: true }): CachedNetworkEntry {
+    return { key, url: `https://x.com/${key}`, method: 'GET', status: 200, size: 2, ct: 'application/json', body };
+}
+
+describe('network-cache', () => {
+    let baseDir: string;
+
+    beforeEach(() => {
+        baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-netcache-'));
+    });
+    afterEach(() => {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it('sanitizes workspace names into safe filenames', () => {
+        const p = getCachePath('browser:default', baseDir);
+        expect(path.basename(p)).toBe('browser_default.json');
+    });
+
+    it('round-trips entries through save + load', () => {
+        saveNetworkCache('ws', [makeEntry('UserTweets'), makeEntry('UserByScreenName')], baseDir);
+        const res = loadNetworkCache('ws', { baseDir });
+        expect(res.status).toBe('ok');
+        expect(res.file?.entries).toHaveLength(2);
+        expect(res.file?.entries[0].key).toBe('UserTweets');
+    });
+
+    it('reports missing when cache file does not exist', () => {
+        expect(loadNetworkCache('nope', { baseDir }).status).toBe('missing');
+    });
+
+    it('reports expired when the cache is older than ttl', () => {
+        saveNetworkCache('ws', [makeEntry('A')], baseDir);
+        const future = Date.now() + DEFAULT_TTL_MS + 60_000;
+        const res = loadNetworkCache('ws', { baseDir, now: future });
+        expect(res.status).toBe('expired');
+        expect(res.file?.entries).toHaveLength(1);
+    });
+
+    it('reports corrupt for malformed json', () => {
+        const file = getCachePath('ws', baseDir);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, '{not json');
+        expect(loadNetworkCache('ws', { baseDir }).status).toBe('corrupt');
+    });
+
+    it('reports corrupt for wrong schema version', () => {
+        const file = getCachePath('ws', baseDir);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, JSON.stringify({ version: 0, entries: [] }));
+        expect(loadNetworkCache('ws', { baseDir }).status).toBe('corrupt');
+    });
+
+    it('findEntry returns matching entry or null', () => {
+        const file: NetworkCacheFile = {
+            version: 1, workspace: 'ws', savedAt: new Date().toISOString(),
+            entries: [makeEntry('A'), makeEntry('B')],
+        };
+        expect(findEntry(file, 'B')?.key).toBe('B');
+        expect(findEntry(file, 'missing')).toBeNull();
+    });
+});

--- a/src/browser/network-cache.ts
+++ b/src/browser/network-cache.ts
@@ -1,0 +1,102 @@
+/**
+ * Persistent cache for browser network captures.
+ *
+ * The live capture buffer (JS interceptor / daemon ring) can be cleared
+ * by navigation or lost between CLI invocations. Agents still need
+ * stable references to request bodies after running other commands,
+ * so every `browser network` call snapshots its results to disk.
+ *
+ * Layout: <cacheDir>/browser-network/<workspace>.json
+ * Entries expire after DEFAULT_TTL_MS (24h).
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface CachedNetworkEntry {
+    key: string;
+    url: string;
+    method: string;
+    status: number;
+    size: number;
+    ct: string;
+    body: unknown;
+}
+
+export interface NetworkCacheFile {
+    version: 1;
+    workspace: string;
+    savedAt: string;
+    entries: CachedNetworkEntry[];
+}
+
+function getDefaultCacheDir(): string {
+    return process.env.OPENCLI_CACHE_DIR || path.join(os.homedir(), '.opencli', 'cache');
+}
+
+export function getCachePath(workspace: string, baseDir: string = getDefaultCacheDir()): string {
+    const safe = workspace.replace(/[^a-zA-Z0-9_-]+/g, '_');
+    return path.join(baseDir, 'browser-network', `${safe}.json`);
+}
+
+export function saveNetworkCache(
+    workspace: string,
+    entries: CachedNetworkEntry[],
+    baseDir?: string,
+): void {
+    const target = getCachePath(workspace, baseDir);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const payload: NetworkCacheFile = {
+        version: 1,
+        workspace,
+        savedAt: new Date().toISOString(),
+        entries,
+    };
+    fs.writeFileSync(target, JSON.stringify(payload), 'utf-8');
+}
+
+export interface LoadOptions {
+    baseDir?: string;
+    ttlMs?: number;
+    now?: number;
+}
+
+export interface LoadResult {
+    status: 'ok' | 'missing' | 'expired' | 'corrupt';
+    file?: NetworkCacheFile;
+    ageMs?: number;
+}
+
+export function loadNetworkCache(workspace: string, opts: LoadOptions = {}): LoadResult {
+    const target = getCachePath(workspace, opts.baseDir);
+    let raw: string;
+    try { raw = fs.readFileSync(target, 'utf-8'); }
+    catch { return { status: 'missing' }; }
+
+    let parsed: NetworkCacheFile;
+    try {
+        const obj = JSON.parse(raw);
+        if (!obj || obj.version !== 1 || !Array.isArray(obj.entries)) {
+            return { status: 'corrupt' };
+        }
+        parsed = obj as NetworkCacheFile;
+    } catch {
+        return { status: 'corrupt' };
+    }
+
+    const ttl = opts.ttlMs ?? DEFAULT_TTL_MS;
+    const now = opts.now ?? Date.now();
+    const savedAt = Date.parse(parsed.savedAt);
+    if (!Number.isFinite(savedAt)) return { status: 'corrupt' };
+    const ageMs = now - savedAt;
+    if (ageMs > ttl) return { status: 'expired', file: parsed, ageMs };
+
+    return { status: 'ok', file: parsed, ageMs };
+}
+
+export function findEntry(file: NetworkCacheFile, key: string): CachedNetworkEntry | null {
+    return file.entries.find((e) => e.key === key) ?? null;
+}

--- a/src/browser/network-key.test.ts
+++ b/src/browser/network-key.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { assignKeys, deriveKey } from './network-key.js';
+
+describe('deriveKey', () => {
+    it('extracts operationName from Twitter-style graphql URLs', () => {
+        expect(deriveKey({
+            method: 'GET',
+            url: 'https://x.com/i/api/graphql/6fWQaBPK51aGyC_VC7t9GQ/UserTweets?variables=...',
+        })).toBe('UserTweets');
+    });
+
+    it('handles graphql URLs without a query id', () => {
+        expect(deriveKey({
+            method: 'POST',
+            url: 'https://example.com/graphql/MyOp?vars=1',
+        })).toBe('MyOp');
+    });
+
+    it('uses METHOD host+pathname for REST calls', () => {
+        expect(deriveKey({
+            method: 'get',
+            url: 'https://api.example.com/v1/users?page=1',
+        })).toBe('GET api.example.com/v1/users');
+    });
+
+    it('falls back to truncated raw url when URL parsing fails', () => {
+        const key = deriveKey({ method: 'GET', url: 'not-a-valid-url' });
+        expect(key.startsWith('GET ')).toBe(true);
+        expect(key).toContain('not-a-valid-url');
+    });
+});
+
+describe('assignKeys', () => {
+    it('disambiguates collisions with #N suffixes', () => {
+        const out = assignKeys([
+            { url: 'https://x.com/i/api/graphql/a/UserTweets', method: 'GET' },
+            { url: 'https://x.com/i/api/graphql/b/UserTweets', method: 'GET' },
+            { url: 'https://api.example.com/v1/u', method: 'GET' },
+            { url: 'https://api.example.com/v1/u', method: 'GET' },
+            { url: 'https://api.example.com/v1/u', method: 'GET' },
+        ]);
+        expect(out.map(o => o.key)).toEqual([
+            'UserTweets',
+            'UserTweets#2',
+            'GET api.example.com/v1/u',
+            'GET api.example.com/v1/u#2',
+            'GET api.example.com/v1/u#3',
+        ]);
+    });
+
+    it('preserves extra fields on each request', () => {
+        const out = assignKeys([{ url: 'https://a.com/x', method: 'GET', status: 200 }]);
+        expect(out[0]).toMatchObject({ status: 200, key: 'GET a.com/x' });
+    });
+});

--- a/src/browser/network-key.ts
+++ b/src/browser/network-key.ts
@@ -9,7 +9,8 @@
  *                                       (the segment after a 22-char query id, or the last segment)
  *   Everything else: key = `METHOD host+pathname`
  *
- * On collision the caller appends `#N` (handled by assignKeys).
+ * On collision assignKeys suffixes duplicates as `base#2`, `base#3`, ... —
+ * the first occurrence stays bare (there is no `#1`).
  */
 
 export interface KeyableRequest {

--- a/src/browser/network-key.ts
+++ b/src/browser/network-key.ts
@@ -1,0 +1,68 @@
+/**
+ * Stable keys for network capture entries.
+ *
+ * Agents reference entries by key (e.g. `UserTweets`, `GET api.x.com/1.1/home`)
+ * instead of array index, so the mapping survives new captures.
+ *
+ * Rules:
+ *   GraphQL (URL contains `/graphql/`): key = operationName derived from URL path
+ *                                       (the segment after a 22-char query id, or the last segment)
+ *   Everything else: key = `METHOD host+pathname`
+ *
+ * On collision the caller appends `#N` (handled by assignKeys).
+ */
+
+export interface KeyableRequest {
+    url: string;
+    method: string;
+}
+
+export function deriveKey(req: KeyableRequest): string {
+    const parsed = safeParseUrl(req.url);
+    if (!parsed) return `${req.method.toUpperCase()} ${truncate(req.url, 120)}`;
+
+    const path = parsed.pathname;
+    if (path.includes('/graphql/')) {
+        const op = graphqlOperationName(path);
+        if (op) return op;
+    }
+
+    return `${req.method.toUpperCase()} ${parsed.host}${path}`;
+}
+
+export function assignKeys<T extends KeyableRequest>(requests: T[]): Array<T & { key: string }> {
+    const counts = new Map<string, number>();
+    const out: Array<T & { key: string }> = [];
+    for (const req of requests) {
+        const base = deriveKey(req);
+        const n = counts.get(base) ?? 0;
+        counts.set(base, n + 1);
+        const key = n === 0 ? base : `${base}#${n + 1}`;
+        out.push({ ...req, key });
+    }
+    return out;
+}
+
+function graphqlOperationName(pathname: string): string | null {
+    // Patterns we've seen in the wild:
+    //   /i/api/graphql/<queryId>/UserTweets
+    //   /graphql/<queryId>/SomeOp
+    //   /graphql/SomeOp                       (rare, no id)
+    const segments = pathname.split('/').filter(Boolean);
+    const idx = segments.indexOf('graphql');
+    if (idx < 0) return null;
+    const tail = segments.slice(idx + 1);
+    if (tail.length === 0) return null;
+    if (tail.length === 1) return tail[0];
+    // tail[0] is usually a query id; the operation name is the next segment.
+    return tail[1] || tail[0];
+}
+
+function safeParseUrl(url: string): URL | null {
+    try { return new URL(url); }
+    catch { return null; }
+}
+
+function truncate(s: string, max: number): string {
+    return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/src/browser/shape.test.ts
+++ b/src/browser/shape.test.ts
@@ -58,6 +58,13 @@ describe('inferShape', () => {
         expect(Object.keys(shape).length).toBeLessThan(500);
     });
 
+    it('stops descending into an array once the budget is hit by its own descriptor', () => {
+        // Budget just large enough for `$` + one deep array descriptor, not its element.
+        const shape = inferShape({ items: [{ deep: 1 }] }, { maxBytes: 40 });
+        expect(shape['$.items[0]']).toBeUndefined();
+        expect(shape['(truncated)']).toBeDefined();
+    });
+
     it('handles the Twitter UserTweets payload envelope', () => {
         const payload = {
             data: {

--- a/src/browser/shape.test.ts
+++ b/src/browser/shape.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { inferShape } from './shape.js';
+
+describe('inferShape', () => {
+    it('describes primitives at root', () => {
+        expect(inferShape('hello')).toEqual({ $: 'string' });
+        expect(inferShape(42)).toEqual({ $: 'number' });
+        expect(inferShape(true)).toEqual({ $: 'boolean' });
+        expect(inferShape(null)).toEqual({ $: 'null' });
+    });
+
+    it('summarizes long strings with their length', () => {
+        const long = 'x'.repeat(200);
+        expect(inferShape(long, { sampleStringLen: 80 })).toEqual({ $: 'string(len=200)' });
+    });
+
+    it('walks nested objects and emits dotted paths', () => {
+        const shape = inferShape({ user: { id: 1, name: 'bob' } });
+        expect(shape).toEqual({
+            $: 'object',
+            '$.user': 'object',
+            '$.user.id': 'number',
+            '$.user.name': 'string',
+        });
+    });
+
+    it('quotes unsafe keys using bracket notation', () => {
+        const shape = inferShape({ 'weird key': 1, '123bad': 2 });
+        expect(shape['$["weird key"]']).toBe('number');
+        expect(shape['$["123bad"]']).toBe('number');
+    });
+
+    it('samples the first array element and reports length', () => {
+        const shape = inferShape({ items: [{ a: 1 }, { a: 2 }, { a: 3 }] });
+        expect(shape['$.items']).toBe('array(3)');
+        expect(shape['$.items[0]']).toBe('object');
+        expect(shape['$.items[0].a']).toBe('number');
+    });
+
+    it('marks empty containers explicitly', () => {
+        const shape = inferShape({ arr: [], obj: {} });
+        expect(shape['$.arr']).toBe('array(0)');
+        expect(shape['$.obj']).toBe('object(empty)');
+    });
+
+    it('collapses subtrees past maxDepth', () => {
+        const deep = { a: { b: { c: { d: { e: { f: 'too deep' } } } } } };
+        const shape = inferShape(deep, { maxDepth: 2 });
+        expect(shape['$.a.b']).toMatch(/^object/);
+        expect(shape['$.a.b.c']).toBeUndefined();
+    });
+
+    it('truncates when the byte budget is exhausted', () => {
+        const wide: Record<string, unknown> = {};
+        for (let i = 0; i < 500; i++) wide[`field_${i}`] = i;
+        const shape = inferShape(wide, { maxBytes: 256 });
+        expect(shape['(truncated)']).toMatch(/256B/);
+        expect(Object.keys(shape).length).toBeLessThan(500);
+    });
+
+    it('handles the Twitter UserTweets payload envelope', () => {
+        const payload = {
+            data: {
+                user: {
+                    result: {
+                        rest_id: '42',
+                        timeline_v2: {
+                            timeline: {
+                                instructions: [
+                                    { type: 'TimelinePinEntry', entries: [] },
+                                    { entries: [{ entryId: 'tweet-1', content: { entryType: 'TimelineTimelineItem' } }] },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const shape = inferShape(payload, { maxDepth: 10 });
+        expect(shape['$.data.user.result.rest_id']).toBe('string');
+        expect(shape['$.data.user.result.timeline_v2.timeline.instructions']).toBe('array(2)');
+        expect(shape['$.data.user.result.timeline_v2.timeline.instructions[0]']).toBe('object');
+    });
+});

--- a/src/browser/shape.ts
+++ b/src/browser/shape.ts
@@ -66,7 +66,7 @@ export function inferShape(value: unknown, opts: InferShapeOptions = {}): Shape 
         if (Array.isArray(node)) {
             if (node.length === 0) { add(path, 'array(0)'); return; }
             if (depth >= maxDepth) { add(path, `array(${node.length})`); return; }
-            add(path, `array(${node.length})`);
+            if (!add(path, `array(${node.length})`)) return;
             walk(node[0], `${path}[0]`, depth + 1);
             return;
         }
@@ -76,7 +76,7 @@ export function inferShape(value: unknown, opts: InferShapeOptions = {}): Shape 
         const keys = Object.keys(obj);
         if (keys.length === 0) { add(path, 'object(empty)'); return; }
         if (depth >= maxDepth) { add(path, `object(keys=${keys.length})`); return; }
-        add(path, 'object');
+        if (!add(path, 'object')) return;
         for (const k of keys) {
             if (truncated) return;
             const childPath = isSafeIdent(k) ? `${path}.${k}` : `${path}[${JSON.stringify(k)}]`;

--- a/src/browser/shape.ts
+++ b/src/browser/shape.ts
@@ -1,0 +1,93 @@
+/**
+ * JSON shape inference for browser network response previews.
+ *
+ * Produces a flat path → type descriptor map so agents can understand
+ * response structure without paying the token cost of the full body.
+ *
+ * Descriptors:
+ *   string | number | boolean | null              primitives
+ *   string(len=N)                                 strings longer than sampleStringLen
+ *   array(0) | array(N)                           array at depth cap or summarized
+ *   object | object(empty)                        objects at depth cap or summarized
+ *   (truncated)                                   output size budget exceeded
+ */
+
+export interface InferShapeOptions {
+    /** Max path depth to descend into (default 6) */
+    maxDepth?: number;
+    /** Byte budget for the serialized output; truncates when exceeded (default 2048) */
+    maxBytes?: number;
+    /** Strings longer than this get summarized as `string(len=N)` (default 80) */
+    sampleStringLen?: number;
+}
+
+export type Shape = Record<string, string>;
+
+const ROOT = '$';
+
+export function inferShape(value: unknown, opts: InferShapeOptions = {}): Shape {
+    const maxDepth = opts.maxDepth ?? 6;
+    const maxBytes = opts.maxBytes ?? 2048;
+    const sampleStringLen = opts.sampleStringLen ?? 80;
+
+    const out: Shape = {};
+    let bytes = 2; // account for `{}` braces when serialized
+    let truncated = false;
+
+    const add = (path: string, desc: string): boolean => {
+        if (truncated) return false;
+        const entryBytes = JSON.stringify(path).length + JSON.stringify(desc).length + 2; // ":" + ","
+        if (bytes + entryBytes > maxBytes) {
+            out['(truncated)'] = `reached ${maxBytes}B budget`;
+            truncated = true;
+            return false;
+        }
+        out[path] = desc;
+        bytes += entryBytes;
+        return true;
+    };
+
+    const walk = (node: unknown, path: string, depth: number): void => {
+        if (truncated) return;
+
+        if (node === null) { add(path, 'null'); return; }
+        const t = typeof node;
+        if (t === 'string') {
+            const s = node as string;
+            add(path, s.length > sampleStringLen ? `string(len=${s.length})` : 'string');
+            return;
+        }
+        if (t === 'number' || t === 'boolean') { add(path, t); return; }
+        if (t === 'undefined' || t === 'function' || t === 'symbol' || t === 'bigint') {
+            add(path, t);
+            return;
+        }
+
+        if (Array.isArray(node)) {
+            if (node.length === 0) { add(path, 'array(0)'); return; }
+            if (depth >= maxDepth) { add(path, `array(${node.length})`); return; }
+            add(path, `array(${node.length})`);
+            walk(node[0], `${path}[0]`, depth + 1);
+            return;
+        }
+
+        // plain object
+        const obj = node as Record<string, unknown>;
+        const keys = Object.keys(obj);
+        if (keys.length === 0) { add(path, 'object(empty)'); return; }
+        if (depth >= maxDepth) { add(path, `object(keys=${keys.length})`); return; }
+        add(path, 'object');
+        for (const k of keys) {
+            if (truncated) return;
+            const childPath = isSafeIdent(k) ? `${path}.${k}` : `${path}[${JSON.stringify(k)}]`;
+            walk(obj[k], childPath, depth + 1);
+        }
+    };
+
+    walk(value, ROOT, 0);
+    return out;
+}
+
+function isSafeIdent(key: string): boolean {
+    return /^[A-Za-z_$][\w$]*$/.test(key);
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -412,6 +412,34 @@ describe('browser network command', () => {
     expect(out.error.code).toBe('cache_missing');
     expect(process.exitCode).toBeDefined();
   });
+
+  it('emits capture_failed when readNetworkCapture throws', async () => {
+    (browserState.page!.readNetworkCapture as any) = vi.fn().mockRejectedValue(new Error('CDP disconnected'));
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('capture_failed');
+    expect(out.error.message).toContain('CDP disconnected');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('surfaces cache_warning in the envelope when persistence fails', async () => {
+    const cacheDir = String(process.env.OPENCLI_CACHE_DIR);
+    // Pre-create the target path as a file where a directory is expected,
+    // forcing the mkdir inside saveNetworkCache to throw.
+    const clashDir = path.join(cacheDir, 'browser-network');
+    fs.writeFileSync(clashDir, 'not-a-directory');
+
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.cache_warning).toMatch(/Could not persist capture cache/);
+    expect(out.count).toBe(1);
+    expect(process.exitCode).toBeUndefined();
+  });
 });
 
 describe('findPackageRoot', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -295,6 +295,125 @@ describe('browser tab targeting commands', () => {
     expect(stderrSpy.mock.calls.flat().join('\n')).toContain('Target tab tab-stale is not part of the current browser session');
   });
 });
+
+describe('browser network command', () => {
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  function getNetworkCachePath(cacheDir: string): string {
+    return path.join(cacheDir, 'browser-network', 'browser_default.json');
+  }
+
+  function lastJsonLog(): any {
+    const calls = consoleLogSpy.mock.calls;
+    if (calls.length === 0) throw new Error('Expected at least one console.log call');
+    const last = calls[calls.length - 1][0];
+    if (typeof last !== 'string') throw new Error(`Expected string arg to console.log, got ${typeof last}`);
+    return JSON.parse(last);
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    process.env.OPENCLI_CACHE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-net-'));
+    consoleLogSpy.mockClear();
+    mockBrowserConnect.mockClear();
+    mockBrowserClose.mockReset().mockResolvedValue(undefined);
+
+    browserState.page = {
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      tabs: vi.fn().mockResolvedValue([{ page: 'tab-1', active: true }]),
+      evaluate: vi.fn().mockResolvedValue(''),
+      readNetworkCapture: vi.fn().mockResolvedValue([
+        {
+          url: 'https://x.com/i/api/graphql/qid/UserTweets?v=1',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/json',
+          responsePreview: JSON.stringify({ data: { user: { rest_id: '42' } } }),
+        },
+        {
+          url: 'https://cdn.example.com/app.js',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/javascript',
+          responsePreview: '// js',
+        },
+      ]),
+    } as unknown as IPage;
+  });
+
+  it('emits JSON with shape previews and persists the capture to disk', async () => {
+    const cacheDir = String(process.env.OPENCLI_CACHE_DIR);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(1);
+    expect(out.filtered_out).toBe(1);
+    expect(out.entries[0].key).toBe('UserTweets');
+    expect(out.entries[0].shape['$.data.user.rest_id']).toBe('string');
+    expect(out.entries[0]).not.toHaveProperty('body');
+    expect(fs.existsSync(getNetworkCachePath(cacheDir))).toBe(true);
+  });
+
+  it('--all includes static resources that the default filter drops', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network', '--all']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(2);
+    expect(out.entries.map((e: any) => e.key)).toContain('UserTweets');
+    expect(out.entries.map((e: any) => e.key)).toContain('GET cdn.example.com/app.js');
+  });
+
+  it('--raw emits full bodies inline for every entry', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network', '--raw']);
+
+    const out = lastJsonLog();
+    expect(out.entries[0].body).toEqual({ data: { user: { rest_id: '42' } } });
+  });
+
+  it('--detail <key> returns the full body for the requested entry', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+    consoleLogSpy.mockClear();
+    await program.parseAsync(['node', 'opencli', 'browser', 'network', '--detail', 'UserTweets']);
+
+    const out = lastJsonLog();
+    expect(out.key).toBe('UserTweets');
+    expect(out.body).toEqual({ data: { user: { rest_id: '42' } } });
+    expect(out.shape['$.data.user.rest_id']).toBe('string');
+  });
+
+  it('--detail reports key_not_found with the list of available keys', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+    consoleLogSpy.mockClear();
+    await program.parseAsync(['node', 'opencli', 'browser', 'network', '--detail', 'NopeOp']);
+
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('key_not_found');
+    expect(out.error.available_keys).toContain('UserTweets');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('--detail reports cache_missing when no capture has been persisted yet', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network', '--detail', 'UserTweets']);
+
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('cache_missing');
+    expect(process.exitCode).toBeDefined();
+  });
+});
+
 describe('findPackageRoot', () => {
   it('walks up from dist/src to the package root', () => {
     const packageRoot = path.join('repo-root');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -713,7 +713,14 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
 
       // Fresh capture path.
-      const rawItems = await captureNetworkItems(page);
+      let rawItems: BrowserNetworkItem[];
+      try {
+        rawItems = await captureNetworkItems(page);
+      } catch (err) {
+        emitNetworkError('capture_failed', `Could not read network capture: ${(err as Error).message}`);
+        return;
+      }
+
       const items = opts.all ? rawItems : filterNetworkItems(rawItems);
       const filteredOut = rawItems.length - items.length;
 
@@ -727,25 +734,27 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         ct: it.ct,
         body: it.body,
       }));
-      saveNetworkCache(workspace, cacheEntries);
-
-      if (opts.raw) {
-        console.log(JSON.stringify({
-          workspace,
-          captured_at: new Date().toISOString(),
-          count: cacheEntries.length,
-          filtered_out: filteredOut,
-          entries: cacheEntries,
-        }, null, 2));
-        return;
+      // Soft failure: the caller already has the data, so surface a warning
+      // via the output envelope rather than erroring out the whole command.
+      let cacheWarning: string | null = null;
+      try {
+        saveNetworkCache(workspace, cacheEntries);
+      } catch (err) {
+        cacheWarning = `Could not persist capture cache: ${(err as Error).message}. --detail lookups may miss this capture.`;
       }
 
-      console.log(JSON.stringify({
+      const envelope: Record<string, unknown> = {
         workspace,
         captured_at: new Date().toISOString(),
         count: cacheEntries.length,
         filtered_out: filteredOut,
-        entries: cacheEntries.map((e) => ({
+      };
+      if (cacheWarning) envelope.cache_warning = cacheWarning;
+
+      if (opts.raw) {
+        envelope.entries = cacheEntries;
+      } else {
+        envelope.entries = cacheEntries.map((e) => ({
           key: e.key,
           method: e.method,
           status: e.status,
@@ -753,9 +762,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           ct: e.ct,
           size: e.size,
           shape: inferShape(e.body),
-        })),
-        detail_hint: 'Run "browser network --detail <key>" for full body.',
-      }, null, 2));
+        }));
+        envelope.detail_hint = 'Run "browser network --detail <key>" for full body.';
+      }
+      console.log(JSON.stringify(envelope, null, 2));
     }));
 
   // ── Init (adapter scaffolding) ──

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,9 @@ import { registerAllCommands } from './commanderAdapter.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
 import { TargetError } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs } from './browser/target-resolver.js';
+import { inferShape } from './browser/shape.js';
+import { assignKeys } from './browser/network-key.js';
+import { DEFAULT_TTL_MS, findEntry, loadNetworkCache, saveNetworkCache, type CachedNetworkEntry } from './browser/network-cache.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 
@@ -37,6 +40,49 @@ type BrowserNetworkItem = {
   ct: string;
   body: unknown;
 };
+
+/**
+ * Normalize raw capture entries (from daemon/CDP `readNetworkCapture` or
+ * the JS interceptor's `window.__opencli_net`) into a consistent shape.
+ * Response preview is parsed as JSON when possible, otherwise kept as string.
+ */
+async function captureNetworkItems(page: import('./types.js').IPage): Promise<BrowserNetworkItem[]> {
+  if (page.readNetworkCapture) {
+    const raw = await page.readNetworkCapture();
+    return (raw as Array<Record<string, unknown>>).map((e) => {
+      const preview = (e.responsePreview as string) ?? null;
+      let body: unknown = null;
+      if (preview) {
+        try { body = JSON.parse(preview); } catch { body = preview; }
+      }
+      return {
+        url: (e.url as string) || '',
+        method: (e.method as string) || 'GET',
+        status: (e.responseStatus as number) || 0,
+        size: preview ? preview.length : 0,
+        ct: (e.responseContentType as string) || '',
+        body,
+      };
+    });
+  }
+  const raw = await page.evaluate(`(function(){ return JSON.stringify(window.__opencli_net || []); })()`) as string;
+  try { return JSON.parse(raw) as BrowserNetworkItem[]; } catch { return []; }
+}
+
+/** Drop static-resource / telemetry noise so agents see only API-shaped traffic. */
+function filterNetworkItems(items: BrowserNetworkItem[]): BrowserNetworkItem[] {
+  return items.filter((r) =>
+    (r.ct?.includes('json') || r.ct?.includes('xml') || r.ct?.includes('text/plain')) &&
+    !/\.(js|css|png|jpg|gif|svg|woff|ico|map)(\?|$)/i.test(r.url) &&
+    !/analytics|tracking|telemetry|beacon|pixel|gtag|fbevents/i.test(r.url),
+  );
+}
+
+/** Emit a structured error JSON so agents can branch on `error.code` without regex. */
+function emitNetworkError(code: string, message: string, extra: Record<string, unknown> = {}): void {
+  console.log(JSON.stringify({ error: { code, message, ...extra } }, null, 2));
+  process.exitCode = EXIT_CODES.USAGE_ERROR;
+}
 
 type BrowserTargetState = {
   defaultPage?: string;
@@ -615,70 +661,101 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     }));
 
   // ── Network (API discovery) ──
+  //
+  // Default output is JSON (agent-native). Each entry carries a stable `key`
+  // (GraphQL operationName or `METHOD host+pathname`) so agents can fetch
+  // full bodies with `--detail <key>` even after subsequent commands.
+  // Captures are persisted per workspace under ~/.opencli/cache/browser-network/.
 
   addBrowserTabOption(browser.command('network'))
-    .option('--detail <index>', 'Show full response body of request at index')
-    .option('--all', 'Show all requests including static resources')
-    .description('Show captured network requests (auto-captured since last open)')
+    .option('--detail <key>', 'Emit full body for the entry with this key')
+    .option('--all', 'Include static resources (js/css/images/telemetry)')
+    .option('--raw', 'Emit full bodies for every entry (skip shape preview)')
+    .option('--ttl <ms>', 'Cache TTL in ms for --detail lookups', String(DEFAULT_TTL_MS))
+    .description('Capture network requests as shape previews; retrieve full bodies by key')
     .action(browserAction(async (page, opts) => {
-      let items: BrowserNetworkItem[] = [];
-      if (page.readNetworkCapture) {
-        const raw = await page.readNetworkCapture();
-        // Normalize daemon/CDP capture entries to __opencli_net shape.
-        // Daemon returns: responseStatus, responseContentType, responsePreview
-        // CDP returns the same shape after PR A fix.
-        items = (raw as Array<Record<string, unknown>>).map(e => {
-          const preview = (e.responsePreview as string) ?? null;
-          let body: unknown = null;
-          if (preview) {
-            try { body = JSON.parse(preview); } catch { body = preview; }
-          }
-          return {
-            url: (e.url as string) || '',
-            method: (e.method as string) || 'GET',
-            status: (e.responseStatus as number) || 0,
-            size: preview ? preview.length : 0,
-            ct: (e.responseContentType as string) || '',
-            body,
-          };
-        });
-      } else {
-        // Fallback to JS interceptor data
-        const requests = await page.evaluate(`(function(){
-          var reqs = window.__opencli_net || [];
-          return JSON.stringify(reqs);
-        })()`) as string;
-        try { items = JSON.parse(requests); } catch { console.log('No network data captured. Run "browser open <url>" first.'); return; }
+      const ttlMs = parsePositiveIntOption(opts.ttl, 'ttl', DEFAULT_TTL_MS);
+      const workspace = DEFAULT_BROWSER_WORKSPACE;
+
+      // --detail short-circuits: read from cache only, no live capture needed.
+      if (typeof opts.detail === 'string' && opts.detail.length > 0) {
+        const res = loadNetworkCache(workspace, { ttlMs });
+        if (res.status === 'missing') {
+          emitNetworkError('cache_missing', `No cached capture. Run "browser network" first (in workspace "${workspace}").`);
+          return;
+        }
+        if (res.status === 'expired') {
+          emitNetworkError('cache_expired', `Cache is stale (age ${res.ageMs}ms > ttl ${ttlMs}ms). Re-run "browser network" to refresh.`);
+          return;
+        }
+        if (res.status === 'corrupt' || !res.file) {
+          emitNetworkError('cache_corrupt', 'Cache file is malformed; re-run "browser network" to regenerate.');
+          return;
+        }
+        const entry = findEntry(res.file, opts.detail);
+        if (!entry) {
+          emitNetworkError('key_not_found', `Key "${opts.detail}" not in cache.`, {
+            available_keys: res.file.entries.map((e) => e.key),
+          });
+          return;
+        }
+        console.log(JSON.stringify({
+          key: entry.key,
+          url: entry.url,
+          method: entry.method,
+          status: entry.status,
+          ct: entry.ct,
+          size: entry.size,
+          shape: inferShape(entry.body),
+          body: entry.body,
+        }, null, 2));
+        return;
       }
 
-      if (items.length === 0) { console.log('No requests captured.'); return; }
+      // Fresh capture path.
+      const rawItems = await captureNetworkItems(page);
+      const items = opts.all ? rawItems : filterNetworkItems(rawItems);
+      const filteredOut = rawItems.length - items.length;
 
-      // Filter out static resources unless --all
-      if (!opts.all) {
-        items = items.filter(r =>
-          (r.ct?.includes('json') || r.ct?.includes('xml') || r.ct?.includes('text/plain')) &&
-          !/\.(js|css|png|jpg|gif|svg|woff|ico|map)(\?|$)/i.test(r.url) &&
-          !/analytics|tracking|telemetry|beacon|pixel|gtag|fbevents/i.test(r.url)
-        );
+      const keyed = assignKeys(items);
+      const cacheEntries: CachedNetworkEntry[] = keyed.map((it) => ({
+        key: it.key,
+        url: it.url,
+        method: it.method,
+        status: it.status,
+        size: it.size,
+        ct: it.ct,
+        body: it.body,
+      }));
+      saveNetworkCache(workspace, cacheEntries);
+
+      if (opts.raw) {
+        console.log(JSON.stringify({
+          workspace,
+          captured_at: new Date().toISOString(),
+          count: cacheEntries.length,
+          filtered_out: filteredOut,
+          entries: cacheEntries,
+        }, null, 2));
+        return;
       }
 
-      if (opts.detail !== undefined) {
-        const idx = parseInt(opts.detail, 10);
-        const req = items[idx];
-        if (!req) { console.error(`Request #${idx} not found. ${items.length} requests available.`); process.exitCode = EXIT_CODES.USAGE_ERROR; return; }
-        console.log(`${req.method} ${req.url}`);
-        console.log(`Status: ${req.status} | Size: ${req.size} | Type: ${req.ct}`);
-        console.log('---');
-        console.log(typeof req.body === 'string' ? req.body : JSON.stringify(req.body, null, 2));
-      } else {
-        console.log(`Captured ${items.length} API requests:\n`);
-        items.forEach((r, i) => {
-          const bodyPreview = r.body ? (typeof r.body === 'string' ? r.body.slice(0, 60) : JSON.stringify(r.body).slice(0, 60)) : '';
-          console.log(`  [${i}] ${r.method} ${r.status} ${r.url.slice(0, 80)}`);
-          if (bodyPreview) console.log(`      ${bodyPreview}...`);
-        });
-        console.log(`\nUse --detail <index> to see full response body.`);
-      }
+      console.log(JSON.stringify({
+        workspace,
+        captured_at: new Date().toISOString(),
+        count: cacheEntries.length,
+        filtered_out: filteredOut,
+        entries: cacheEntries.map((e) => ({
+          key: e.key,
+          method: e.method,
+          status: e.status,
+          url: e.url,
+          ct: e.ct,
+          size: e.size,
+          shape: inferShape(e.body),
+        })),
+        detail_hint: 'Run "browser network --detail <key>" for full body.',
+      }, null, 2));
     }));
 
   // ── Init (adapter scaffolding) ──


### PR DESCRIPTION
## Summary

Replaces the index-based `browser network` listing + pretty-printed `--detail` with a structured JSON interface built around:

1. **Stable keys** — GraphQL ops use `operationName`, REST uses `METHOD host+pathname`, collisions get `#N`. Agents no longer reference entries by array index that shifts on every capture.
2. **Shape-first previews** — default output ships a compact `path → type` map (depth cap 6, 2KB/entry budget) instead of the full body. Agents see response structure without paying body tokens.
3. **Persistent capture cache** — every `browser network` run snapshots to `~/.opencli/cache/browser-network/<workspace>.json` (24h TTL), so `--detail <key>` still works after later commands clear the live buffer.

Structured error codes replace human-readable stderr messages so agents can branch on `error.code` without regex: `cache_missing`, `cache_expired`, `cache_corrupt`, `key_not_found` (the last returns `available_keys` inline).

### Example

```bash
$ opencli browser network
{
  "workspace": "browser:default",
  "captured_at": "2026-04-21T01:10:00.000Z",
  "count": 2,
  "filtered_out": 14,
  "entries": [
    {
      "key": "UserTweets",
      "method": "GET",
      "status": 200,
      "url": "https://x.com/i/api/graphql/qid/UserTweets?...",
      "ct": "application/json",
      "size": 84721,
      "shape": {
        "$": "object",
        "$.data": "object",
        "$.data.user": "object",
        "$.data.user.result": "object",
        "$.data.user.result.timeline_v2": "object"
      }
    },
    { "key": "UserByScreenName", "...": "..." }
  ],
  "detail_hint": "Run \"browser network --detail <key>\" for full body."
}

$ opencli browser network --detail UserTweets
{ "key": "UserTweets", "body": { "data": { ... } }, "shape": { ... } }
```

### Flags

- `--detail <key>` — full body for the given key (from cache)
- `--raw` — emit every full body inline (skip shape preview)
- `--all` — include static resources / telemetry that the default filter drops
- `--ttl <ms>` — override 24h cache TTL for `--detail` lookups

### Breaking changes

Default output format changed from human-readable text to JSON, and `--detail` now takes a key instead of a numeric index. No backward-compat shim — per the design goal "把 agent 的不确定性变成确定的 CLI 返回值".

Supersedes #1051 (@freemandealer's cache prototype, credited as co-author).

## Test plan

- [x] `src/browser/shape.test.ts` — primitives, nested objects, arrays, depth cap, long strings, byte budget, Twitter UserTweets envelope (9 tests)
- [x] `src/browser/network-key.test.ts` — graphql operationName extraction, REST fallback, collision `#N` suffixes (6 tests)
- [x] `src/browser/network-cache.test.ts` — round-trip save/load, missing/expired/corrupt states, filename sanitization (7 tests)
- [x] `src/cli.test.ts` — default JSON output, `--all`, `--raw`, `--detail <key>` happy path, `key_not_found` with `available_keys`, `cache_missing` (6 new tests)
- [x] `npm test` — 220 files, 1646 tests, 2 skipped, all green
- [x] `npm run build` — clean TypeScript build + manifest regeneration