### PR TITLE
fix(gemini+grok): restore ask on current UIs

### DIFF
--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -299,7 +299,11 @@ function readGeminiSnapshotScript() {
         transcriptLines,
         composerHasText: composerText.length > 0,
         isGenerating,
-        structuredTurnsTrusted: turns.length > 0 || transcriptLines.length === 0,
+        // After filtering out zero-state greetings, empty turns means
+        // "no actual conversation yet" — still trust the structured diff.
+        // Previously this flipped to false on the /app root because the
+        // welcome text produced transcriptLines > 0.
+        structuredTurnsTrusted: true,
       };
     })()
   `;
@@ -417,9 +421,22 @@ function getTurnsScript() {
       ];
 
       const roots = selectors.flatMap((selector) => Array.from(document.querySelectorAll(selector)));
+      // Filter out zero-state welcome text ("Hi <user>, Where should we start?")
+      // which Gemini renders inside .visible-primary-message containers using
+      // .message-text class. These match our turn selectors but are NOT actual
+      // conversation turns, breaking the strict prefix match in diffTrustedStructuredTurns.
+      const isInRealConversation = (el) => {
+        if (el.closest('[class*="conversation-container"]')) return true;
+        if (el.closest('chat-history, [class*="chat-history"]')) return true;
+        // Exclude zero-state greeting areas
+        if (el.closest('[class*="visible-primary-message"]')) return false;
+        if (el.closest('[class*="zero-state"], [class*="empty-state"], [class*="zero_state"]')) return false;
+        return false;
+      };
       const unique = roots
         .filter((el, index, all) => all.indexOf(el) === index)
         .filter(isVisible)
+        .filter(isInRealConversation)
         .sort((left, right) => {
           if (left === right) return 0;
           const relation = left.compareDocumentPosition(right);
@@ -1917,7 +1934,12 @@ export async function waitForGeminiResponse(page, baseline, promptText, timeoutS
                 lastStructured = structuredCandidate;
                 structuredStableCount = 1;
             }
-            if (!current.isGenerating && structuredStableCount >= 2) {
+            // Gemini's send-button aria-label sticks at "Stop response" after
+            // the response has already finished streaming, making isGenerating
+            // unreliable as a completion signal. Fall back to: if the candidate
+            // text has been stable for ~8 seconds (4 polls at 2s each), treat
+            // it as done regardless of isGenerating.
+            if ((!current.isGenerating && structuredStableCount >= 2) || structuredStableCount >= 4) {
                 return structuredCandidate;
             }
             continue;

--- a/clis/grok/ask.js
+++ b/clis/grok/ask.js
@@ -63,19 +63,47 @@ async function runDefaultAsk(page, prompt, timeoutMs, newChat) {
         await page.wait(3);
     }
     const promptJson = JSON.stringify(prompt);
+    // Grok's input is a contenteditable div now, not a <textarea>. Use native
+    // CDP typing (page.nativeType) so React recognizes the input and enables Submit.
+    const composerHandle = await page.evaluate(`(() => {
+      const box = document.querySelector('div[contenteditable="true"]')
+                  || document.querySelector('textarea');
+      if (!box) return { ok: false, msg: 'no composer' };
+      box.focus();
+      // Clear any existing text
+      if (box.tagName === 'TEXTAREA') { box.value = ''; }
+      else { box.textContent = ''; box.dispatchEvent(new InputEvent('input', { bubbles: true })); }
+      return { ok: true };
+    })()`);
+    if (!composerHandle?.ok) {
+        return [{ response: '[SEND FAILED] ' + JSON.stringify(composerHandle) }];
+    }
+    if (page.nativeType) {
+        try { await page.nativeType(prompt); } catch { }
+    } else {
+        await page.evaluate(`(() => {
+      const box = document.querySelector('div[contenteditable="true"]') || document.querySelector('textarea');
+      if (!box) return;
+      if (box.tagName === 'TEXTAREA') { box.value = ${promptJson}; }
+      else { box.textContent = ${promptJson}; }
+      box.dispatchEvent(new InputEvent('input', { bubbles: true, data: ${promptJson}, inputType: 'insertText' }));
+    })()`);
+    }
+    await page.wait(1.5);
     const sendResult = await page.evaluate(`(async () => {
     try {
-      const box = document.querySelector('textarea');
-      if (!box) return { ok: false, msg: 'no textarea' };
-      box.focus(); box.value = '';
-      document.execCommand('selectAll');
-      document.execCommand('insertText', false, ${promptJson});
-      await new Promise(r => setTimeout(r, 1500));
-      const btn = document.querySelector('button[aria-label="\\u63d0\\u4ea4"]');
-      if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
+      // English aria (current Grok UI)
+      const btnEN = document.querySelector('button[aria-label="Submit"]');
+      if (btnEN && !btnEN.disabled && btnEN.getAttribute('aria-disabled') !== 'true') {
+        btnEN.click(); return { ok: true, msg: 'clicked-en' };
+      }
+      // Chinese aria (older UI)
+      const btnCN = document.querySelector('button[aria-label="\\u63d0\\u4ea4"]');
+      if (btnCN && !btnCN.disabled) { btnCN.click(); return { ok: true, msg: 'clicked-cn' }; }
       const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
       if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
-      box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+      const box = document.querySelector('div[contenteditable="true"]') || document.querySelector('textarea');
+      if (box) box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
       return { ok: true, msg: 'enter' };
     } catch (e) { return { ok: false, msg: e.toString() }; }
   })()`);


### PR DESCRIPTION
Two adapters drifted away from their targets' current DOMs. Both
`gemini ask` and `grok ask` return `[NO RESPONSE]` or timeout until
these patches.

## gemini (3 bugs)

Against `gemini.google.com/app` on opencli v1.7.4 + extension v1.0.1.

1. **Turn-selector pollution in zero-state.** The `/app` welcome
   (`Hi <user>, Where should we start?`) renders inside
   `.visible-primary-message` with a `.message-text` span, which matches
   the `[class*="message"]` turn selector. That gave `before.turns =
   [{Role:'Assistant', Text:'Where should we start?'}]`. After sending,
   the first real turn is User, so `hasGeminiTurnPrefix` returned false
   and the whole structured diff path died.
   Fix: require turn elements to live inside `.conversation-container`
   / `chat-history`, and exclude zero-state greeting containers.

2. **`structuredTurnsTrusted` flipped false on zero-state.** With
   `turns.length === 0` and welcome transcript lines present, the
   structured diff was short-circuited as untrusted. Now that (1)
   removes the false turn, this signal no longer carries information —
   trust the structured diff unconditionally.

3. **Sticky `isGenerating` after response completes.** Gemini's
   send-button keeps `aria-label="Stop response"` long after streaming
   ends, so `waitForGeminiResponse` never exits via
   `!isGenerating && stable >= 2`. Fallback: accept `stable >= 4` (~8s
   at 2s polls) as a completion signal regardless of `isGenerating`.

Verified: 5/5 `opencli gemini ask` calls succeed in 13–14s end-to-end on Fast mode.

## grok (1 bug, two symptoms)

Against `grok.com` on the same setup.

- grok.com migrated from `<textarea>` to a `<div contenteditable="true">`
  composer. Old adapter only queried `textarea`, missing the real
  composer. `document.execCommand('insertText')` on the wrong element
  produced stale partial content, leaving Submit disabled.
- Current Submit button uses `aria-label="Submit"`; adapter only looked
  for `aria-label="提交"` first.

Fix:
- Prefer `div[contenteditable="true"]`, fall back to `textarea`.
- Use `page.nativeType` (CDP `Input.insertText`) so React's input
  listener fires and re-enables Submit.
- Check `aria-label="Submit"` before `aria-label="提交"`.

Verified: 3/3 `opencli grok ask` calls succeed in 12–13s end-to-end.
Before: 3/3 timed out at 53s.

## Tests

```
$ npm test -- clis/gemini/   # 5 files, 64 tests pass
$ npm test -- clis/grok/     # 2 files, 19 tests pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)