### PR TITLE
feat(browser): network --filter <fields> for agent-native request discovery

### DIFF
--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -29,6 +29,22 @@ opencli browser network
 - 路径里出现 `nickname / avatar / title / price / tweets / items` → 就是它
 - shape 只有 `$: string` 或全是 HTML 噪音 → 下一条
 
+### 按期望字段反查（`--filter`）
+
+已经知道目标 body 该含哪些字段就直接让 CLI 把列表筛到只剩候选，不用自己 scroll 翻 shape：
+
+```bash
+opencli browser network --filter author,text,likes
+```
+
+- 字段以英文逗号分隔；AND 语义，必须每个字段都作为 shape 路径的**任意一段**出现才保留（`$.data.items[0].author` 命中 `author`、`items`、`data` 都算）
+- 区分大小写（JSON key 本来就 case-sensitive）
+- 输出 envelope 新增 `filter` / `filter_dropped`，`count` 是过滤后数量
+- 0 命中不是 error，返回 `entries: []`；说明字段组合不对，换一组或去掉约束再试
+- 不要跟 `--detail` 一起用——`--detail` 按 key 取单条、`--filter` 是列表缩窄，组合会报 `invalid_args`
+- 空值 / `,,,` → `invalid_filter` 结构化错误
+- capture 依然按全量持久化，后续 `--detail <key>` 能找到被过滤掉的条目
+
 ### 拉完整 body
 
 候选定了再拉完整 body（by key，不是 index — 数组顺序会随每次 capture 变）：

--- a/skills/opencli-autofix/SKILL.md
+++ b/skills/opencli-autofix/SKILL.md
@@ -130,6 +130,9 @@ opencli browser open https://example.com/target-page && opencli browser state
 # Interact to trigger API calls
 opencli browser click <N> && opencli browser network
 
+# Narrow to the request you care about by the fields its body should have
+opencli browser network --filter author,text,likes
+
 # Inspect specific API response (key is the `key` field from the default JSON output)
 opencli browser network --detail <key>
 ```

--- a/src/browser/shape-filter.test.ts
+++ b/src/browser/shape-filter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import type { Shape } from './shape.js';
+import {
+    collectShapeSegments,
+    extractSegments,
+    parseFilter,
+    shapeMatchesFilter,
+} from './shape-filter.js';
+
+describe('parseFilter', () => {
+    it('splits comma-separated fields, trims, and drops empty tokens', () => {
+        const r = parseFilter('author, text , likes');
+        expect(r).toEqual({ fields: ['author', 'text', 'likes'] });
+    });
+
+    it('dedupes while preserving first-seen order', () => {
+        const r = parseFilter('a,b,a,c,b');
+        expect(r).toEqual({ fields: ['a', 'b', 'c'] });
+    });
+
+    it('rejects empty string as invalid_filter', () => {
+        const r = parseFilter('');
+        expect(r).toMatchObject({ reason: expect.stringContaining('non-empty') });
+    });
+
+    it('rejects whitespace-only as invalid_filter', () => {
+        const r = parseFilter('   ');
+        expect(r).toMatchObject({ reason: expect.stringContaining('non-empty') });
+    });
+
+    it('rejects commas-only as invalid_filter', () => {
+        const r = parseFilter(',,,');
+        expect(r).toMatchObject({ reason: expect.stringContaining('non-empty') });
+    });
+
+    it('accepts a single field', () => {
+        expect(parseFilter('author')).toEqual({ fields: ['author'] });
+    });
+});
+
+describe('extractSegments', () => {
+    it('returns empty for root', () => {
+        expect(extractSegments('$')).toEqual([]);
+    });
+
+    it('splits dotted path and drops $', () => {
+        expect(extractSegments('$.data.user.name')).toEqual(['data', 'user', 'name']);
+    });
+
+    it('drops numeric array indices', () => {
+        expect(extractSegments('$.items[0].author')).toEqual(['items', 'author']);
+        expect(extractSegments('$.rows[0][12]')).toEqual(['rows']);
+    });
+
+    it('unwraps bracket-quoted keys', () => {
+        expect(extractSegments('$.data["weird key"]')).toEqual(['data', 'weird key']);
+    });
+
+    it('handles bracket-quoted keys at root', () => {
+        expect(extractSegments('$["123bad"]')).toEqual(['123bad']);
+    });
+
+    it('mixes bracket keys and dot segments', () => {
+        expect(extractSegments('$.data.user["nick name"].age'))
+            .toEqual(['data', 'user', 'nick name', 'age']);
+    });
+});
+
+describe('collectShapeSegments', () => {
+    it('collects every segment name from every path in a shape', () => {
+        const shape: Shape = {
+            '$': 'object',
+            '$.data': 'object',
+            '$.data.items': 'array(3)',
+            '$.data.items[0]': 'object',
+            '$.data.items[0].author': 'string',
+            '$.data.items[0].text': 'string',
+        };
+        const segs = collectShapeSegments(shape);
+        expect(segs.has('data')).toBe(true);
+        expect(segs.has('items')).toBe(true);
+        expect(segs.has('author')).toBe(true);
+        expect(segs.has('text')).toBe(true);
+        expect(segs.has('$')).toBe(false);
+        expect(segs.has('[0]')).toBe(false);
+    });
+
+    it('returns an empty set for an empty shape', () => {
+        expect(collectShapeSegments({}).size).toBe(0);
+    });
+});
+
+describe('shapeMatchesFilter', () => {
+    const shape: Shape = {
+        '$': 'object',
+        '$.data': 'object',
+        '$.data.items': 'array(1)',
+        '$.data.items[0].author': 'string',
+        '$.data.items[0].text': 'string',
+        '$.data.items[0].likes': 'number',
+    };
+
+    it('returns true when every field matches some path segment (AND)', () => {
+        expect(shapeMatchesFilter(shape, ['author', 'text', 'likes'])).toBe(true);
+    });
+
+    it('matches nested container names, not just leaves (any-segment rule)', () => {
+        // `data` and `items` are container segments, not leaves; still must match.
+        expect(shapeMatchesFilter(shape, ['data', 'items'])).toBe(true);
+    });
+
+    it('returns false when any field is missing', () => {
+        expect(shapeMatchesFilter(shape, ['author', 'missing'])).toBe(false);
+    });
+
+    it('is case-sensitive', () => {
+        expect(shapeMatchesFilter(shape, ['Author'])).toBe(false);
+        expect(shapeMatchesFilter(shape, ['author'])).toBe(true);
+    });
+
+    it('empty filter list vacuously matches', () => {
+        expect(shapeMatchesFilter(shape, [])).toBe(true);
+    });
+
+    it('rejects requests whose shape has no body (empty shape)', () => {
+        expect(shapeMatchesFilter({}, ['author'])).toBe(false);
+    });
+});

--- a/src/browser/shape-filter.ts
+++ b/src/browser/shape-filter.ts
@@ -1,0 +1,114 @@
+/**
+ * Shape-based field filter for `browser network --filter <fields>`.
+ *
+ * Agents know what fields a target request's body should contain
+ * (e.g. "author, text, likes") but not which of the captured requests
+ * carries that body. This module lets the network command filter
+ * entries down to those whose inferred shape exposes every requested
+ * field name as some path segment.
+ *
+ * Matching is "any-segment" (not last-segment-only): a field matches
+ * if it equals any segment name of any path in the shape map. This
+ * keeps nested-container fields (e.g. `legacy`, `author` used as an
+ * object key with further nesting) findable.
+ */
+import type { Shape } from './shape.js';
+
+export interface ParsedFilter {
+    /** Deduped, order-preserving, trimmed non-empty field names. */
+    fields: string[];
+}
+
+export interface FilterParseError {
+    /** `invalid_filter` structured error reason for agents. */
+    reason: string;
+}
+
+/**
+ * Parse `--filter` argument value. Splits on `,`, trims, drops empties,
+ * and dedupes (first-seen wins). Returns `FilterParseError` when the
+ * result is empty after cleaning — which means the caller passed only
+ * whitespace, commas, or an empty string.
+ */
+export function parseFilter(raw: string): ParsedFilter | FilterParseError {
+    if (typeof raw !== 'string') {
+        return { reason: `--filter value must be a non-empty comma-separated field list` };
+    }
+    const parts = raw.split(',').map((p) => p.trim()).filter((p) => p.length > 0);
+    if (parts.length === 0) {
+        return { reason: `--filter value must be a non-empty comma-separated field list (got "${raw}")` };
+    }
+    const seen = new Set<string>();
+    const fields: string[] = [];
+    for (const p of parts) {
+        if (!seen.has(p)) { seen.add(p); fields.push(p); }
+    }
+    return { fields };
+}
+
+/**
+ * Extract named segments from a shape path. Drops the leading `$`,
+ * strips `[N]` array indices, and unwraps `["key"]` bracket-quoted
+ * keys back to their raw string.
+ *
+ * Examples:
+ *   `$`                              → []
+ *   `$.data.items[0].author`         → ['data','items','author']
+ *   `$.data.user["nick name"]`       → ['data','user','nick name']
+ *   `$.rows[0][1]`                   → ['rows']
+ */
+export function extractSegments(path: string): string[] {
+    if (!path || path === '$') return [];
+    const out: string[] = [];
+    // Start past the leading `$`; if path doesn't start with `$` treat
+    // it as a raw segment list (keeps us robust to unexpected input).
+    let i = path.startsWith('$') ? 1 : 0;
+    while (i < path.length) {
+        const c = path[i];
+        if (c === '.') { i++; continue; }
+        if (c === '[') {
+            // Either `[N]` (numeric) or `["key"]` (quoted key). Handle both.
+            const end = path.indexOf(']', i);
+            if (end === -1) break;
+            const inner = path.slice(i + 1, end);
+            i = end + 1;
+            if (inner.length >= 2 && inner.startsWith('"') && inner.endsWith('"')) {
+                try { out.push(JSON.parse(inner) as string); }
+                catch { out.push(inner.slice(1, -1)); }
+            }
+            // numeric index: drop
+            continue;
+        }
+        // Bare identifier: read up to next `.` or `[`
+        let j = i;
+        while (j < path.length && path[j] !== '.' && path[j] !== '[') j++;
+        out.push(path.slice(i, j));
+        i = j;
+    }
+    return out;
+}
+
+/**
+ * Collect the set of segment names used anywhere in a shape map.
+ * The returned set is what we test field membership against.
+ */
+export function collectShapeSegments(shape: Shape): Set<string> {
+    const acc = new Set<string>();
+    for (const p of Object.keys(shape)) {
+        for (const seg of extractSegments(p)) acc.add(seg);
+    }
+    return acc;
+}
+
+/**
+ * True iff every field in `fields` equals some segment name in `shape`.
+ * AND semantics: all fields must be present.
+ */
+export function shapeMatchesFilter(shape: Shape, fields: string[]): boolean {
+    if (fields.length === 0) return true;
+    const segs = collectShapeSegments(shape);
+    for (const f of fields) {
+        if (!segs.has(f)) return false;
+    }
+    return true;
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -440,6 +440,134 @@ describe('browser network command', () => {
     expect(out.count).toBe(1);
     expect(process.exitCode).toBeUndefined();
   });
+
+  describe('--filter', () => {
+    function apiResponse(url: string, body: unknown): Record<string, unknown> {
+      return {
+        url,
+        method: 'GET',
+        responseStatus: 200,
+        responseContentType: 'application/json',
+        responsePreview: JSON.stringify(body),
+      };
+    }
+
+    beforeEach(() => {
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        apiResponse(
+          'https://x.com/i/api/graphql/qid/UserTweets?v=1',
+          { data: { items: [{ author: 'a', text: 't', likes: 1 }] } },
+        ),
+        apiResponse(
+          'https://x.com/i/api/graphql/qid/UserProfile?v=1',
+          { data: { user: { id: 'u1', followers: 10 } } },
+        ),
+        apiResponse(
+          'https://x.com/i/api/graphql/qid/Settings?v=1',
+          { config: { theme: 'dark' } },
+        ),
+      ]);
+    });
+
+    it('narrows entries to those whose shape has ALL named fields', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'author,text,likes']);
+
+      const out = lastJsonLog();
+      expect(out.count).toBe(1);
+      expect(out.filter).toEqual(['author', 'text', 'likes']);
+      expect(out.filter_dropped).toBe(2);
+      expect(out.entries[0].key).toBe('UserTweets');
+    });
+
+    it('matches container segments too, not just leaf names (any-segment rule)', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'data,items']);
+
+      const out = lastJsonLog();
+      expect(out.count).toBe(1);
+      expect(out.entries[0].key).toBe('UserTweets');
+    });
+
+    it('drops entries that are missing any required field (AND semantics)', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'author,followers']);
+
+      const out = lastJsonLog();
+      expect(out.count).toBe(0);
+      expect(out.entries).toEqual([]);
+      expect(out.filter).toEqual(['author', 'followers']);
+      expect(out.filter_dropped).toBe(3);
+    });
+
+    it('returns empty entries (not an error) when nothing matches', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'nonexistent_field']);
+
+      const out = lastJsonLog();
+      expect(out.count).toBe(0);
+      expect(out.entries).toEqual([]);
+      expect(out).not.toHaveProperty('error');
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('is case-sensitive so agents do not conflate `Id` with `id`', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'Data']);
+
+      const out = lastJsonLog();
+      expect(out.count).toBe(0);
+    });
+
+    it('persists the full (unfiltered) capture so --detail lookups still find filtered-out keys', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'author,text,likes']);
+      consoleLogSpy.mockClear();
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--detail', 'UserProfile']);
+
+      const out = lastJsonLog();
+      expect(out.key).toBe('UserProfile');
+      expect(out.body).toEqual({ data: { user: { id: 'u1', followers: 10 } } });
+    });
+
+    it('composes with --raw: entries keep full bodies, filter still narrows', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'author', '--raw']);
+
+      const out = lastJsonLog();
+      expect(out.count).toBe(1);
+      expect(out.entries[0].body).toEqual({ data: { items: [{ author: 'a', text: 't', likes: 1 }] } });
+    });
+
+    it('reports invalid_filter for empty value', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', '']);
+
+      const out = lastJsonLog();
+      expect(out.error.code).toBe('invalid_filter');
+      expect(process.exitCode).toBeDefined();
+    });
+
+    it('reports invalid_filter for commas-only value', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', ',,,']);
+
+      const out = lastJsonLog();
+      expect(out.error.code).toBe('invalid_filter');
+      expect(process.exitCode).toBeDefined();
+    });
+
+    it('rejects --filter combined with --detail as invalid_args', async () => {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--filter', 'author', '--detail', 'UserTweets']);
+
+      const out = lastJsonLog();
+      expect(out.error.code).toBe('invalid_args');
+      expect(out.error.message).toContain('--filter');
+      expect(out.error.message).toContain('--detail');
+      expect(process.exitCode).toBeDefined();
+    });
+  });
 });
 
 describe('browser get html command', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesRe
 import { inferShape } from './browser/shape.js';
 import { assignKeys } from './browser/network-key.js';
 import { DEFAULT_TTL_MS, findEntry, loadNetworkCache, saveNetworkCache, type CachedNetworkEntry } from './browser/network-cache.js';
+import { parseFilter, shapeMatchesFilter } from './browser/shape-filter.js';
 import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
@@ -763,14 +764,36 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .option('--detail <key>', 'Emit full body for the entry with this key')
     .option('--all', 'Include static resources (js/css/images/telemetry)')
     .option('--raw', 'Emit full bodies for every entry (skip shape preview)')
+    .option('--filter <fields>', 'Comma-separated field names; keep only entries whose body shape has ALL names as path segments')
     .option('--ttl <ms>', 'Cache TTL in ms for --detail lookups', String(DEFAULT_TTL_MS))
     .description('Capture network requests as shape previews; retrieve full bodies by key')
     .action(browserAction(async (page, opts) => {
       const ttlMs = parsePositiveIntOption(opts.ttl, 'ttl', DEFAULT_TTL_MS);
       const workspace = DEFAULT_BROWSER_WORKSPACE;
+      const hasDetail = typeof opts.detail === 'string' && opts.detail.length > 0;
+      const hasFilter = typeof opts.filter === 'string';
+
+      // --detail and --filter do different things (one request by key vs. narrow
+      // the list by shape), don't compose, and combining them has no sensible
+      // semantic. Reject up front with a structured error instead of silently
+      // dropping one.
+      if (hasDetail && hasFilter) {
+        emitNetworkError('invalid_args', '--filter and --detail cannot be used together (one narrows a list, the other fetches a specific entry).');
+        return;
+      }
+
+      let filterFields: string[] | null = null;
+      if (hasFilter) {
+        const parsed = parseFilter(opts.filter as string);
+        if ('reason' in parsed) {
+          emitNetworkError('invalid_filter', parsed.reason);
+          return;
+        }
+        filterFields = parsed.fields;
+      }
 
       // --detail short-circuits: read from cache only, no live capture needed.
-      if (typeof opts.detail === 'string' && opts.detail.length > 0) {
+      if (hasDetail) {
         const res = loadNetworkCache(workspace, { ttlMs });
         if (res.status === 'missing') {
           emitNetworkError('cache_missing', `No cached capture. Run "browser network" first (in workspace "${workspace}").`);
@@ -835,25 +858,40 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         cacheWarning = `Could not persist capture cache: ${(err as Error).message}. --detail lookups may miss this capture.`;
       }
 
+      // Pair each cache entry with its shape up front so --filter can read
+      // segments without recomputing, and the --raw view can keep the full
+      // body. Cache persistence above stored the unfiltered set on purpose:
+      // later `--detail <key>` lookups must still see requests that the
+      // current --filter narrowed out.
+      const shaped = cacheEntries.map((e) => ({ entry: e, shape: inferShape(e.body) }));
+      const visible = filterFields
+        ? shaped.filter((s) => shapeMatchesFilter(s.shape, filterFields))
+        : shaped;
+      const filterDropped = filterFields ? shaped.length - visible.length : 0;
+
       const envelope: Record<string, unknown> = {
         workspace,
         captured_at: new Date().toISOString(),
-        count: cacheEntries.length,
+        count: visible.length,
         filtered_out: filteredOut,
       };
+      if (filterFields) {
+        envelope.filter = filterFields;
+        envelope.filter_dropped = filterDropped;
+      }
       if (cacheWarning) envelope.cache_warning = cacheWarning;
 
       if (opts.raw) {
-        envelope.entries = cacheEntries;
+        envelope.entries = visible.map((s) => s.entry);
       } else {
-        envelope.entries = cacheEntries.map((e) => ({
-          key: e.key,
-          method: e.method,
-          status: e.status,
-          url: e.url,
-          ct: e.ct,
-          size: e.size,
-          shape: inferShape(e.body),
+        envelope.entries = visible.map((s) => ({
+          key: s.entry.key,
+          method: s.entry.method,
+          status: s.entry.status,
+          url: s.entry.url,
+          ct: s.entry.ct,
+          size: s.entry.size,
+          shape: s.shape,
         }));
         envelope.detail_hint = 'Run "browser network --detail <key>" for full body.';
       }


### PR DESCRIPTION
## Summary

Agents on a page with a wall of network requests know which fields a target request's body should carry (e.g. `author`, `text`, `likes`) but not which of the captured requests is the one. This adds `opencli browser network --filter <fields>` so they can narrow the list directly instead of scrolling shapes.

```bash
opencli browser network --filter author,text,likes
# → only entries whose shape has ALL three fields as some path segment
```

- **Matching:** "any-segment" — field matches if it equals any segment of any shape path. Array indices `[N]` are stripped; `$[\"nick name\"]` unwraps. So `$.data.items[0].author.name` contains `data`, `items`, `author`, `name`.
- **Combination:** AND across fields.
- **Case-sensitive** (JSON keys are).
- **Parse:** `,`-split, trim, drop empties, dedupe preserving first-seen order.
- **Errors:**
  - `invalid_filter` for `\"\"` / whitespace-only / `,,,`
  - `invalid_args` when combined with `--detail` (mutually exclusive — one fetches a key, one narrows a list)
- **Empty match is not an error** — `entries: []`, `count: 0`, exit 0.
- **Envelope adds** `filter: [...]` (echo) and `filter_dropped: N` (dropped by --filter, separate from the existing static-resource `filtered_out`).
- **Cache still stores the unfiltered capture**, so later `--detail <key>` resolves requests that --filter hid.
- `--raw` / `--all` compose normally.

## Test plan

- [x] `node node_modules/vitest/vitest.mjs run src/browser/shape-filter.test.ts src/cli.test.ts` — 2 files / 68 tests pass
- [x] New unit module `src/browser/shape-filter.ts` covers parse, segment extraction (dotted, array indices, bracket keys), AND matching, case sensitivity
- [x] New integration tests in `src/cli.test.ts` cover: AND narrowing, container-segment match, 0-match empty result (not error), case sensitivity, `--filter + --raw`, `--filter + --detail → invalid_args`, `invalid_filter` for empty / commas-only, and that `--detail` still finds keys hidden by --filter (cache stays unfiltered)
- [x] Skill docs updated (`opencli-adapter-author/references/api-discovery.md`, `opencli-autofix/SKILL.md`) with the new flag
- [x] TypeScript \`tsc --noEmit\` clean