### PR TITLE
feat(browser): agent-native payload — network bodies, html tree budgets, extract command

### DIFF
--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -10,6 +10,12 @@ const attached = new Set<number>();
 
 const tabFrameContexts = new Map<number, Map<string, number>>();
 
+// Large cap so agents stop hitting silent JSON.parse failures on real API bodies.
+// See src/browser/cdp.ts CDP_RESPONSE_BODY_CAPTURE_LIMIT for the matching constant
+// on the direct-CDP path. Keep in sync.
+const CDP_RESPONSE_BODY_CAPTURE_LIMIT = 8 * 1024 * 1024;
+const CDP_REQUEST_BODY_CAPTURE_LIMIT = 1 * 1024 * 1024;
+
 type NetworkCaptureEntry = {
   kind: 'cdp';
   url: string;
@@ -17,10 +23,14 @@ type NetworkCaptureEntry = {
   requestHeaders?: Record<string, string>;
   requestBodyKind?: string;
   requestBodyPreview?: string;
+  requestBodyFullSize?: number;
+  requestBodyTruncated?: boolean;
   responseStatus?: number;
   responseContentType?: string;
   responseHeaders?: Record<string, string>;
   responsePreview?: string;
+  responseBodyFullSize?: number;
+  responseBodyTruncated?: boolean;
   timestamp: number;
 };
 
@@ -473,12 +483,24 @@ export function registerListeners(): void {
       });
       if (!entry) return;
       entry.requestBodyKind = request?.hasPostData ? 'string' : 'empty';
-      entry.requestBodyPreview = String(request?.postData || '').slice(0, 4000);
+      {
+        const raw = String(request?.postData || '');
+        const fullSize = raw.length;
+        const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
+        entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
+        entry.requestBodyFullSize = fullSize;
+        entry.requestBodyTruncated = truncated;
+      }
       try {
         const postData = await chrome.debugger.sendCommand({ tabId }, 'Network.getRequestPostData', { requestId }) as { postData?: string };
         if (postData?.postData) {
+          const raw = postData.postData;
+          const fullSize = raw.length;
+          const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
           entry.requestBodyKind = 'string';
-          entry.requestBodyPreview = postData.postData.slice(0, 4000);
+          entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
+          entry.requestBodyFullSize = fullSize;
+          entry.requestBodyTruncated = truncated;
         }
       } catch {
         // Optional; some requests do not expose postData.
@@ -516,9 +538,12 @@ export function registerListeners(): void {
           base64Encoded?: boolean;
         };
         if (typeof body?.body === 'string') {
-          entry.responsePreview = body.base64Encoded
-            ? `base64:${body.body.slice(0, 4000)}`
-            : body.body.slice(0, 4000);
+          const fullSize = body.body.length;
+          const truncated = fullSize > CDP_RESPONSE_BODY_CAPTURE_LIMIT;
+          const stored = truncated ? body.body.slice(0, CDP_RESPONSE_BODY_CAPTURE_LIMIT) : body.body;
+          entry.responsePreview = body.base64Encoded ? `base64:${stored}` : stored;
+          entry.responseBodyFullSize = fullSize;
+          entry.responseBodyTruncated = truncated;
         }
       } catch {
         // Optional; bodies are unavailable for some requests (e.g. uploads).

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -40,6 +40,13 @@ interface RuntimeEvaluateResult {
 
 const CDP_SEND_TIMEOUT = 30_000;
 
+// Memory guard for in-process capture. The 4k cap we used to apply everywhere
+// silently truncated JSON so `JSON.parse` failed or gave partial objects — the
+// primary agent-facing bug. Now we keep the full body up to a large cap and
+// surface `responseBodyFullSize` + `responseBodyTruncated` so downstream layers
+// can tell the agent what happened instead of lying about the payload.
+export const CDP_RESPONSE_BODY_CAPTURE_LIMIT = 8 * 1024 * 1024;
+
 export class CDPBridge implements IBrowserFactory {
   private _ws: WebSocket | null = null;
   private _idCounter = 0;
@@ -179,7 +186,11 @@ class CDPPage extends BasePage {
   private _networkCapturePattern = '';
   private _networkEntries: Array<{
     url: string; method: string; responseStatus?: number;
-    responseContentType?: string; responsePreview?: string; timestamp: number;
+    responseContentType?: string;
+    responsePreview?: string;
+    responseBodyFullSize?: number;
+    responseBodyTruncated?: boolean;
+    timestamp: number;
   }> = [];
   private _pendingRequests = new Map<string, number>(); // requestId → index in _networkEntries
   private _pendingBodyFetches: Set<Promise<void>> = new Set(); // track in-flight getResponseBody calls
@@ -282,9 +293,12 @@ class CDPPage extends BasePage {
           const bodyFetch = this.bridge.send('Network.getResponseBody', { requestId: p.requestId }).then((result: unknown) => {
             const r = result as { body?: string; base64Encoded?: boolean } | undefined;
             if (typeof r?.body === 'string') {
-              this._networkEntries[idx].responsePreview = r.base64Encoded
-                ? `base64:${r.body.slice(0, 4000)}`
-                : r.body.slice(0, 4000);
+              const fullSize = r.body.length;
+              const truncated = fullSize > CDP_RESPONSE_BODY_CAPTURE_LIMIT;
+              const body = truncated ? r.body.slice(0, CDP_RESPONSE_BODY_CAPTURE_LIMIT) : r.body;
+              this._networkEntries[idx].responsePreview = r.base64Encoded ? `base64:${body}` : body;
+              this._networkEntries[idx].responseBodyFullSize = fullSize;
+              this._networkEntries[idx].responseBodyTruncated = truncated;
             }
           }).catch(() => {
             // Body unavailable for some requests (e.g. uploads) — non-fatal

--- a/src/browser/extract.test.ts
+++ b/src/browser/extract.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { buildExtractHtmlJs, chunkMarkdown, runExtractFromHtml } from './extract.js';
+
+describe('chunkMarkdown', () => {
+    it('returns the full content when it fits in one chunk', () => {
+        const content = 'short body';
+        const r = chunkMarkdown({ content, start: 0, chunkSize: 20000 });
+        expect(r.content).toBe(content);
+        expect(r.start).toBe(0);
+        expect(r.end).toBe(content.length);
+        expect(r.nextStartChar).toBeNull();
+    });
+
+    it('emits next_start_char when more content remains', () => {
+        // Build content long enough that chunkSize cuts it mid-stream.
+        const para = 'p'.repeat(400);
+        const content = [para, para, para].join('\n\n');
+        const r = chunkMarkdown({ content, start: 0, chunkSize: 500 });
+        expect(r.nextStartChar).not.toBeNull();
+        expect(r.nextStartChar).toBeGreaterThan(0);
+        expect(r.nextStartChar).toBeLessThan(content.length);
+    });
+
+    it('prefers to break at a paragraph boundary inside the boundary window', () => {
+        // chunkSize=500, window=15% → [425, 500). Place `\n\n` at 450 so it lands
+        // inside the window; the chunker should snap the cut back to it.
+        const a = 'a'.repeat(450);
+        const b = 'b'.repeat(400);
+        const content = `${a}\n\n${b}`;
+        const r = chunkMarkdown({ content, start: 0, chunkSize: 500 });
+        expect(r.content.endsWith('\n\n')).toBe(true);
+        expect(r.nextStartChar).toBe(r.end);
+        expect(content.slice(r.end).startsWith('b')).toBe(true);
+    });
+
+    it('falls back to a single newline when no paragraph boundary is in window', () => {
+        // 6 lines × 90 chars joined by `\n` → `\n` at 90, 181, 272, 363, 454.
+        // chunkSize=500 with window [425, 500) catches the `\n` at 454.
+        const line = 'l'.repeat(90);
+        const content = Array.from({ length: 6 }, () => line).join('\n');
+        const r = chunkMarkdown({ content, start: 0, chunkSize: 500 });
+        expect(r.content.endsWith('\n')).toBe(true);
+        expect(content.slice(r.end).startsWith('l')).toBe(true);
+    });
+
+    it('hard-cuts when no boundary is found within the window', () => {
+        const content = 'x'.repeat(5000);
+        const r = chunkMarkdown({ content, start: 0, chunkSize: 500 });
+        expect(r.end).toBe(500);
+        expect(r.content).toHaveLength(500);
+        expect(r.nextStartChar).toBe(500);
+    });
+
+    it('handles start >= content.length with an empty final chunk', () => {
+        const content = 'hello';
+        const r = chunkMarkdown({ content, start: 5, chunkSize: 100 });
+        expect(r.content).toBe('');
+        expect(r.nextStartChar).toBeNull();
+    });
+
+    it('resumes from a provided start cursor until the stream terminates', () => {
+        const content = `${'a'.repeat(100)}\n\n${'b'.repeat(100)}\n\n${'c'.repeat(100)}`;
+        const first = chunkMarkdown({ content, start: 0, chunkSize: 110 });
+        expect(first.nextStartChar).not.toBeNull();
+        const second = chunkMarkdown({ content, start: first.nextStartChar!, chunkSize: 110 });
+        expect(second.start).toBe(first.nextStartChar);
+        expect(second.content.length).toBeGreaterThan(0);
+        let cursor: number | null = second.nextStartChar;
+        let safety = 20;
+        while (cursor !== null && safety-- > 0) {
+            const step = chunkMarkdown({ content, start: cursor, chunkSize: 110 });
+            cursor = step.nextStartChar;
+        }
+        expect(cursor).toBeNull();
+    });
+
+    it('clamps chunk size to the configured minimum', () => {
+        const content = 'a'.repeat(2000);
+        const r = chunkMarkdown({ content, start: 0, chunkSize: 1 });
+        // MIN_CHUNK_SIZE is 100 — requesting 1 should still produce >= 100 chars.
+        expect(r.end).toBeGreaterThanOrEqual(100);
+    });
+});
+
+describe('runExtractFromHtml', () => {
+    it('converts HTML to markdown and wraps it in the chunking envelope', () => {
+        const html = '<article><h1>Title</h1><p>Hello <strong>world</strong>.</p></article>';
+        const r = runExtractFromHtml({
+            html,
+            url: 'https://example.com/a',
+            title: 'Example',
+            selector: 'article',
+            start: 0,
+            chunkSize: 20000,
+        });
+        expect(r.url).toBe('https://example.com/a');
+        expect(r.title).toBe('Example');
+        expect(r.selector).toBe('article');
+        expect(r.content).toContain('# Title');
+        expect(r.content).toContain('**world**');
+        expect(r.start).toBe(0);
+        expect(r.end).toBe(r.content.length);
+        expect(r.total_chars).toBe(r.content.length);
+        expect(r.next_start_char).toBeNull();
+    });
+
+    it('reports total_chars and chunk_size against the final markdown', () => {
+        const body = Array.from({ length: 30 }, (_, i) => `<p>paragraph ${i} ${'x'.repeat(200)}</p>`).join('');
+        const r = runExtractFromHtml({
+            html: `<main>${body}</main>`,
+            url: 'https://example.com/b',
+            title: 't',
+            selector: 'main',
+            start: 0,
+            chunkSize: 500,
+        });
+        expect(r.total_chars).toBeGreaterThan(r.end);
+        expect(r.chunk_size).toBe(r.end - r.start);
+        expect(r.next_start_char).toBe(r.end);
+    });
+});
+
+describe('buildExtractHtmlJs', () => {
+    it('embeds the selector as a JSON literal', () => {
+        const js = buildExtractHtmlJs('main.article');
+        expect(js).toContain('"main.article"');
+    });
+
+    it('uses null when no selector given', () => {
+        const js = buildExtractHtmlJs(null);
+        // The expression references `sel` and compares to null.
+        expect(js).toContain('const sel = null;');
+    });
+
+    it('includes the denoise selector list', () => {
+        const js = buildExtractHtmlJs(null);
+        expect(js).toContain("'script'");
+        expect(js).toContain("'nav'");
+        expect(js).toContain("'iframe'");
+        expect(js).toContain("'[aria-hidden=\"true\"]'");
+    });
+});

--- a/src/browser/extract.ts
+++ b/src/browser/extract.ts
@@ -1,0 +1,170 @@
+/**
+ * `browser extract` — agent-native article/content reading channel.
+ *
+ * Pipeline (from first principles — agents want the *content*, not the DOM):
+ *   1. Scope:    select `--selector` (default: document.body or <main>/<article>)
+ *   2. Denoise:  strip script/style/nav/header/footer/aside/iframe/svg/form, inline noise
+ *   3. Convert:  HTML → Markdown via shared `htmlToMarkdown` (turndown)
+ *   4. Chunk:    paragraph-boundary-aware slicing with `next_start_char` cursor
+ *
+ * Why a separate command:
+ * - `get html --as json` returns tree structure; useless for "read the article".
+ * - `get text` flattens everything; loses headings, lists, links.
+ * - Markdown is the agent-readable middle ground: structure preserved, noise gone.
+ *
+ * Continuation contract: the envelope always carries `start`, `end`,
+ * `total_chars`, and `next_start_char` (null when the last chunk was emitted).
+ * Agents pass `--start <next>` to continue. No session state required.
+ */
+
+import { htmlToMarkdown } from '../utils.js';
+
+const DEFAULT_CHUNK_SIZE = 20000;
+const MIN_CHUNK_SIZE = 100;
+const MAX_CHUNK_SIZE = 200000;
+const BOUNDARY_WINDOW_RATIO = 0.15;
+
+/**
+ * Returns the JS expression string used with `page.evaluate` to produce the
+ * cleaned HTML subtree that we then hand to `htmlToMarkdown`. We do the
+ * denoise/clone inside the page so we can use DOM APIs (querySelectorAll,
+ * cloneNode) rather than regex on serialized HTML.
+ */
+export function buildExtractHtmlJs(selector: string | null): string {
+    const selectorLiteral = selector ? JSON.stringify(selector) : 'null';
+    return `(() => {
+  const sel = ${selectorLiteral};
+  let root = null;
+  if (sel) {
+    try { root = document.querySelector(sel); }
+    catch (e) {
+      return { invalidSelector: true, reason: (e && e.message) || String(e) };
+    }
+    if (!root) return { notFound: true };
+  } else {
+    root = document.querySelector('main') || document.querySelector('article') || document.body || document.documentElement;
+  }
+  if (!root) return { notFound: true };
+  const clone = root.cloneNode(true);
+  const drop = [
+    'script', 'style', 'noscript', 'template',
+    'nav', 'header', 'footer', 'aside',
+    'iframe', 'svg', 'canvas',
+    'form', 'button', 'input', 'select', 'textarea',
+    '[role="navigation"]', '[role="banner"]', '[role="contentinfo"]', '[role="complementary"]',
+    '[aria-hidden="true"]',
+  ];
+  for (const q of drop) {
+    for (const n of clone.querySelectorAll(q)) n.remove();
+  }
+  // Also strip event-handler and style attributes that bloat markdown output.
+  const walker = document.createTreeWalker(clone, NodeFilter.SHOW_ELEMENT);
+  let n = walker.currentNode;
+  while (n) {
+    if (n.nodeType === 1) {
+      const el = n;
+      for (const a of [...el.attributes]) {
+        if (a.name.startsWith('on') || a.name === 'style' || a.name.startsWith('data-')) el.removeAttribute(a.name);
+      }
+    }
+    n = walker.nextNode();
+  }
+  return { ok: true, url: location.href, title: document.title || '', html: clone.outerHTML || '' };
+})()`;
+}
+
+export interface ExtractChunkOptions {
+    content: string;
+    start: number;
+    chunkSize: number;
+}
+
+export interface ExtractChunkResult {
+    content: string;
+    start: number;
+    end: number;
+    nextStartChar: number | null;
+}
+
+/**
+ * Slice `content` into one chunk starting at `start` with target size
+ * `chunkSize`. When the chunk would land mid-paragraph, we pull the break
+ * back to the nearest `\n\n` (or `\n`) within a small window to keep the
+ * output readable. If no boundary is found, we hard-cut at `start+chunkSize`.
+ */
+export function chunkMarkdown(opts: ExtractChunkOptions): ExtractChunkResult {
+    const { content, start } = opts;
+    const chunkSize = Math.max(MIN_CHUNK_SIZE, Math.min(MAX_CHUNK_SIZE, opts.chunkSize));
+    if (start >= content.length) {
+        return { content: '', start, end: start, nextStartChar: null };
+    }
+    const hardEnd = Math.min(content.length, start + chunkSize);
+    if (hardEnd === content.length) {
+        return { content: content.slice(start, hardEnd), start, end: hardEnd, nextStartChar: null };
+    }
+    const windowSize = Math.max(1, Math.floor(chunkSize * BOUNDARY_WINDOW_RATIO));
+    const windowStart = Math.max(start + 1, hardEnd - windowSize);
+    const slice = content.slice(windowStart, hardEnd);
+    const paraBreak = slice.lastIndexOf('\n\n');
+    let cut = hardEnd;
+    if (paraBreak >= 0) {
+        cut = windowStart + paraBreak + 2;
+    } else {
+        const lineBreak = slice.lastIndexOf('\n');
+        if (lineBreak >= 0) cut = windowStart + lineBreak + 1;
+    }
+    return {
+        content: content.slice(start, cut),
+        start,
+        end: cut,
+        nextStartChar: cut,
+    };
+}
+
+export interface RunExtractOptions {
+    html: string;
+    url: string;
+    title: string;
+    selector: string | null;
+    start: number;
+    chunkSize: number;
+}
+
+export interface RunExtractResult {
+    url: string;
+    title: string;
+    selector: string | null;
+    total_chars: number;
+    chunk_size: number;
+    start: number;
+    end: number;
+    next_start_char: number | null;
+    content: string;
+}
+
+/** End-to-end host-side pipeline: HTML → markdown → chunked envelope. */
+export function runExtractFromHtml(opts: RunExtractOptions): RunExtractResult {
+    const md = htmlToMarkdown(opts.html);
+    const chunk = chunkMarkdown({
+        content: md,
+        start: Math.max(0, opts.start),
+        chunkSize: opts.chunkSize || DEFAULT_CHUNK_SIZE,
+    });
+    return {
+        url: opts.url,
+        title: opts.title,
+        selector: opts.selector,
+        total_chars: md.length,
+        chunk_size: chunk.end - chunk.start,
+        start: chunk.start,
+        end: chunk.end,
+        next_start_char: chunk.nextStartChar,
+        content: chunk.content,
+    };
+}
+
+export const __extractInternals = {
+    DEFAULT_CHUNK_SIZE,
+    MIN_CHUNK_SIZE,
+    MAX_CHUNK_SIZE,
+};

--- a/src/browser/html-tree.test.ts
+++ b/src/browser/html-tree.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { buildHtmlTreeJs, type HtmlTreeResult } from './html-tree.js';
+import { buildHtmlTreeJs, type BuildHtmlTreeJsOptions, type HtmlTreeResult } from './html-tree.js';
 
 /**
  * The serializer runs in a page context via `page.evaluate`. In unit tests we
  * substitute `document` with a minimal stub that mirrors the DOM surface used
  * by the expression, then Function-eval the returned JS.
  */
-function runTreeJs(root: unknown, selectorMatches: unknown[], selector: string | null): HtmlTreeResult {
-    const js = buildHtmlTreeJs({ selector });
+function runTreeJs(
+    root: unknown,
+    selectorMatches: unknown[],
+    selector: string | null,
+    budgets: Omit<BuildHtmlTreeJsOptions, 'selector'> = {},
+): HtmlTreeResult {
+    const js = buildHtmlTreeJs({ selector, ...budgets });
     const fakeDocument = {
         querySelectorAll: () => selectorMatches,
         documentElement: root,
@@ -104,5 +109,77 @@ describe('buildHtmlTreeJs', () => {
         expect(result.invalidSelector).toBe(true);
         expect(result.selector).toBe('##$@@');
         expect(result.reason).toContain('not a valid selector');
+    });
+
+    it('omits `truncated` when no budget is hit', () => {
+        const root = el('div', {}, [el('span', {}, [txt('ok')])]);
+        const result = runTreeJs(root, [root], null, { depth: 5, childrenMax: 10, textMax: 100 });
+        expect(result.truncated).toBeUndefined();
+    });
+});
+
+describe('buildHtmlTreeJs budget knobs', () => {
+    it('caps tree at `depth` and reports truncated.depth', () => {
+        const deep = el('a', {}, [
+            el('b', {}, [
+                el('c', {}, [el('d', {}, [txt('deep')])]),
+            ]),
+        ]);
+        // depth=1 → root + one level of children; grandchildren should be dropped.
+        const result = runTreeJs(deep, [deep], null, { depth: 1 });
+        expect(result.tree?.tag).toBe('a');
+        expect(result.tree?.children).toHaveLength(1);
+        expect(result.tree?.children[0].tag).toBe('b');
+        // The "b" node had element children but we hit the depth budget before
+        // recursing into them — children array is empty, truncated.depth is true.
+        expect(result.tree?.children[0].children).toEqual([]);
+        expect(result.truncated?.depth).toBe(true);
+    });
+
+    it('depth=0 keeps only the root', () => {
+        const root = el('ul', {}, [
+            el('li', {}, [txt('a')]),
+            el('li', {}, [txt('b')]),
+        ]);
+        const result = runTreeJs(root, [root], null, { depth: 0 });
+        expect(result.tree?.children).toEqual([]);
+        expect(result.truncated?.depth).toBe(true);
+    });
+
+    it('caps children per node at `childrenMax` and reports children_dropped count', () => {
+        const root = el('ul', {}, [
+            el('li', {}, [txt('1')]),
+            el('li', {}, [txt('2')]),
+            el('li', {}, [txt('3')]),
+            el('li', {}, [txt('4')]),
+            el('li', {}, [txt('5')]),
+        ]);
+        const result = runTreeJs(root, [root], null, { childrenMax: 2 });
+        expect(result.tree?.children).toHaveLength(2);
+        expect(result.truncated?.children_dropped).toBe(3);
+    });
+
+    it('caps direct text per node at `textMax` and reports text_truncated count', () => {
+        const root = el('p', {}, [
+            txt('a'.repeat(50)),
+            el('span', {}, [txt('b'.repeat(50))]),
+        ]);
+        const result = runTreeJs(root, [root], null, { textMax: 10 });
+        expect(result.tree?.text).toHaveLength(10);
+        expect(result.tree?.children[0].text).toHaveLength(10);
+        expect(result.truncated?.text_truncated).toBe(2);
+    });
+
+    it('combines budgets and reports every hit', () => {
+        const root = el('ul', {}, [
+            el('li', {}, [txt('x'.repeat(20)), el('em', {}, [txt('y')])]),
+            el('li', {}, []),
+            el('li', {}, []),
+        ]);
+        const result = runTreeJs(root, [root], null, { depth: 1, childrenMax: 2, textMax: 5 });
+        expect(result.tree?.children).toHaveLength(2);
+        expect(result.truncated?.children_dropped).toBe(1);
+        expect(result.truncated?.text_truncated).toBe(1);
+        expect(result.truncated?.depth).toBe(true);
     });
 });

--- a/src/browser/html-tree.ts
+++ b/src/browser/html-tree.ts
@@ -10,17 +10,29 @@
  * whitespace-collapsed. Nested element text is left inside `children[].text`.
  * Ordering between text and elements is not preserved — agents that need it
  * should fall back to raw HTML mode.
+ *
+ * Budget knobs let the caller bound the output on large pages — previously an
+ * unscoped `get html --as json` could return a giant tree. Callers set any
+ * combination of `depth` / `childrenMax` / `textMax`; each hit is reported in
+ * the `truncated` envelope so agents know to narrow their selector or raise
+ * the budget.
  */
 
 export interface BuildHtmlTreeJsOptions {
     /** CSS selector to scope the tree; unscoped = documentElement */
     selector?: string | null;
+    /** Max depth below the root (0 = root only, no children). Omit = unlimited. */
+    depth?: number | null;
+    /** Max element children per node before the rest get dropped. Omit = unlimited. */
+    childrenMax?: number | null;
+    /** Max chars of direct text per node before truncation. Omit = unlimited. */
+    textMax?: number | null;
 }
 
 /**
  * Returns a JS expression string. When evaluated in a page context the
  * expression resolves to either
- *   `{selector, matched: number, tree: HtmlNode | null}` on success, or
+ *   `{selector, matched, tree, truncated}` on success, or
  *   `{selector, invalidSelector: true, reason}` when `querySelectorAll`
  *   throws a `SyntaxError` for an unparseable selector.
  *
@@ -31,8 +43,20 @@ export interface BuildHtmlTreeJsOptions {
  */
 export function buildHtmlTreeJs(opts: BuildHtmlTreeJsOptions = {}): string {
     const selectorLiteral = opts.selector ? JSON.stringify(opts.selector) : 'null';
+    const depthLiteral = Number.isFinite(opts.depth as number) && (opts.depth as number) >= 0
+        ? String(opts.depth)
+        : 'null';
+    const childrenMaxLiteral = Number.isFinite(opts.childrenMax as number) && (opts.childrenMax as number) >= 0
+        ? String(opts.childrenMax)
+        : 'null';
+    const textMaxLiteral = Number.isFinite(opts.textMax as number) && (opts.textMax as number) >= 0
+        ? String(opts.textMax)
+        : 'null';
     return `(() => {
   const selector = ${selectorLiteral};
+  const maxDepth = ${depthLiteral};
+  const maxChildren = ${childrenMaxLiteral};
+  const maxText = ${textMaxLiteral};
   let matches;
   if (selector) {
     try { matches = document.querySelectorAll(selector); }
@@ -44,23 +68,46 @@ export function buildHtmlTreeJs(opts: BuildHtmlTreeJsOptions = {}): string {
   }
   const matched = matches.length;
   const root = matches[0] || null;
-  function serialize(el) {
+  const trunc = { depth: false, children_dropped: 0, text_truncated: 0 };
+  function serialize(el, depth) {
     if (!el || el.nodeType !== 1) return null;
     const attrs = {};
     for (const a of el.attributes) attrs[a.name] = a.value;
     let text = '';
-    const children = [];
     for (const n of el.childNodes) {
-      if (n.nodeType === 3) {
-        text += n.nodeValue;
-      } else if (n.nodeType === 1) {
-        const child = serialize(n);
+      if (n.nodeType === 3) text += n.nodeValue;
+    }
+    text = text.replace(/\\s+/g, ' ').trim();
+    if (maxText !== null && text.length > maxText) {
+      text = text.slice(0, maxText);
+      trunc.text_truncated++;
+    }
+    const children = [];
+    if (maxDepth === null || depth < maxDepth) {
+      const childEls = [];
+      for (const n of el.childNodes) if (n.nodeType === 1) childEls.push(n);
+      const keep = maxChildren === null ? childEls.length : Math.min(childEls.length, maxChildren);
+      for (let i = 0; i < keep; i++) {
+        const child = serialize(childEls[i], depth + 1);
         if (child) children.push(child);
       }
+      if (maxChildren !== null && childEls.length > maxChildren) {
+        trunc.children_dropped += childEls.length - maxChildren;
+      }
+    } else {
+      // Budget hit: we're at max depth. Count any element children we would have visited.
+      for (const n of el.childNodes) if (n.nodeType === 1) { trunc.depth = true; break; }
     }
-    return { tag: el.tagName.toLowerCase(), attrs, text: text.replace(/\\s+/g, ' ').trim(), children };
+    return { tag: el.tagName.toLowerCase(), attrs, text, children };
   }
-  return { selector: selector, matched: matched, tree: root ? serialize(root) : null };
+  const tree = root ? serialize(root, 0) : null;
+  const truncatedOut = {};
+  if (trunc.depth) truncatedOut.depth = true;
+  if (trunc.children_dropped > 0) truncatedOut.children_dropped = trunc.children_dropped;
+  if (trunc.text_truncated > 0) truncatedOut.text_truncated = trunc.text_truncated;
+  const envelope = { selector: selector, matched: matched, tree: tree };
+  if (Object.keys(truncatedOut).length > 0) envelope.truncated = truncatedOut;
+  return envelope;
 })()`;
 }
 
@@ -71,8 +118,18 @@ export interface HtmlNode {
     children: HtmlNode[];
 }
 
+export interface HtmlTreeTruncationInfo {
+    /** At least one element child was dropped because depth budget was hit. */
+    depth?: true;
+    /** Count of element children dropped across the tree due to `childrenMax`. */
+    children_dropped?: number;
+    /** Count of nodes whose `text` was cut to `textMax`. */
+    text_truncated?: number;
+}
+
 export interface HtmlTreeResult {
     selector: string | null;
     matched: number;
     tree: HtmlNode | null;
+    truncated?: HtmlTreeTruncationInfo;
 }

--- a/src/browser/network-cache.ts
+++ b/src/browser/network-cache.ts
@@ -25,8 +25,12 @@ export interface CachedNetworkEntry {
     size: number;
     ct: string;
     body: unknown;
-    /** True when the capture layer had to cap the body to protect memory. */
-    bodyTruncated?: boolean;
+    /**
+     * Truncation signals use snake_case so `--raw` (which emits cache entries
+     * verbatim) matches the agent-facing contract used by list / --detail.
+     */
+    body_truncated?: boolean;
+    body_full_size?: number;
 }
 
 export interface NetworkCacheFile {

--- a/src/browser/network-cache.ts
+++ b/src/browser/network-cache.ts
@@ -21,9 +21,12 @@ export interface CachedNetworkEntry {
     url: string;
     method: string;
     status: number;
+    /** Full body size in chars (may exceed stored body length when truncated). */
     size: number;
     ct: string;
     body: unknown;
+    /** True when the capture layer had to cap the body to protect memory. */
+    bodyTruncated?: boolean;
 }
 
 export interface NetworkCacheFile {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -695,6 +695,32 @@ describe('browser network command', () => {
       expect(lastJsonLog().error.code).toBe('invalid_max_body');
       expect(process.exitCode).toBeDefined();
     });
+
+    it('--raw emits snake_case body_truncated / body_full_size, matching non-raw + detail', async () => {
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/huge',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/json',
+          responsePreview: 'truncated-prefix',
+          responseBodyFullSize: 20_000_000,
+          responseBodyTruncated: true,
+        },
+      ]);
+      const program = createProgram('', '');
+
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--raw']);
+
+      const out = lastJsonLog();
+      expect(out.entries).toHaveLength(1);
+      const entry = out.entries[0];
+      expect(entry.body_truncated).toBe(true);
+      expect(entry.body_full_size).toBe(20_000_000);
+      // Internal camelCase must not leak into the agent-facing envelope.
+      expect(entry).not.toHaveProperty('bodyTruncated');
+      expect(entry).not.toHaveProperty('bodyFullSize');
+    });
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -568,6 +568,134 @@ describe('browser network command', () => {
       expect(process.exitCode).toBeDefined();
     });
   });
+
+  describe('body truncation signals', () => {
+    it('flags body_truncated in list view when the capture layer capped the body', async () => {
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/huge',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/json',
+          responsePreview: '{"data":"x"}',
+          responseBodyFullSize: 99_999_999,
+          responseBodyTruncated: true,
+        },
+      ]);
+      const program = createProgram('', '');
+
+      await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+
+      const out = lastJsonLog();
+      expect(out.body_truncated_count).toBe(1);
+      expect(out.entries[0].body_truncated).toBe(true);
+      expect(out.entries[0].size).toBe(99_999_999);
+    });
+
+    it('--detail surfaces body_truncated + body_full_size when capture had to cap the body', async () => {
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/huge',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/json',
+          responsePreview: 'truncated-prefix-not-valid-json',
+          responseBodyFullSize: 50_000_000,
+          responseBodyTruncated: true,
+        },
+      ]);
+      const program = createProgram('', '');
+
+      await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+      consoleLogSpy.mockClear();
+      await program.parseAsync(['node', 'opencli', 'browser', 'network', '--detail', 'GET api.example.com/huge']);
+
+      const out = lastJsonLog();
+      expect(out.body_truncated).toBe(true);
+      expect(out.body_full_size).toBe(50_000_000);
+      expect(out.body_truncation_reason).toBe('capture-limit');
+    });
+
+    it('--max-body caps the emitted body and marks body_truncation_reason = max-body', async () => {
+      const longString = 'x'.repeat(5000);
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/plain',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'text/plain',
+          responsePreview: longString,
+        },
+      ]);
+      const program = createProgram('', '');
+
+      await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+      consoleLogSpy.mockClear();
+      await program.parseAsync([
+        'node', 'opencli', 'browser', 'network',
+        '--detail', 'GET api.example.com/plain',
+        '--max-body', '100',
+      ]);
+
+      const out = lastJsonLog();
+      expect(typeof out.body).toBe('string');
+      expect(out.body).toHaveLength(100);
+      expect(out.body_truncated).toBe(true);
+      expect(out.body_truncation_reason).toBe('max-body');
+      expect(out.body_full_size).toBe(5000);
+    });
+
+    it('--max-body leaves parsed JSON bodies untouched (no mid-object cut)', async () => {
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/json',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/json',
+          responsePreview: JSON.stringify({ data: { user: { rest_id: 'u1' } } }),
+        },
+      ]);
+      const program = createProgram('', '');
+
+      await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+      consoleLogSpy.mockClear();
+      await program.parseAsync([
+        'node', 'opencli', 'browser', 'network',
+        '--detail', 'GET api.example.com/json',
+        '--max-body', '10',
+      ]);
+
+      const out = lastJsonLog();
+      // JSON body already parsed at capture time — --max-body only applies to
+      // string bodies (which is where the agent-visible hazard lives).
+      expect(out.body).toEqual({ data: { user: { rest_id: 'u1' } } });
+      expect(out).not.toHaveProperty('body_truncated');
+    });
+
+    it('rejects non-numeric --max-body with invalid_max_body', async () => {
+      browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/x',
+          method: 'GET',
+          responseStatus: 200,
+          responseContentType: 'application/json',
+          responsePreview: '{"a":1}',
+        },
+      ]);
+      const program = createProgram('', '');
+
+      await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+      consoleLogSpy.mockClear();
+      await program.parseAsync([
+        'node', 'opencli', 'browser', 'network',
+        '--detail', 'GET api.example.com/x',
+        '--max-body', 'abc',
+      ]);
+
+      expect(lastJsonLog().error.code).toBe('invalid_max_body');
+      expect(process.exitCode).toBeDefined();
+    });
+  });
 });
 
 describe('browser get html command', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -468,8 +468,17 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   // ── Navigation ──
 
-  /** Network interceptor JS — injected on every open/navigate to capture fetch/XHR */
-  const NETWORK_INTERCEPTOR_JS = `(function(){if(window.__opencli_net)return;window.__opencli_net=[];var M=200,B=50000,F=window.fetch;window.fetch=async function(){var r=await F.apply(this,arguments);try{var ct=r.headers.get('content-type')||'';if(ct.includes('json')||ct.includes('text')){var c=r.clone(),t=await c.text();if(window.__opencli_net.length<M){var b=null;if(t.length<=B)try{b=JSON.parse(t)}catch(e){b=t}window.__opencli_net.push({url:r.url||(arguments[0]&&arguments[0].url)||String(arguments[0]),method:(arguments[1]&&arguments[1].method)||'GET',status:r.status,size:t.length,ct:ct,body:b})}}}catch(e){}return r};var X=XMLHttpRequest.prototype,O=X.open,S=X.send;X.open=function(m,u){this._om=m;this._ou=u;return O.apply(this,arguments)};X.send=function(){var x=this;x.addEventListener('load',function(){try{var ct=x.getResponseHeader('content-type')||'';if((ct.includes('json')||ct.includes('text'))&&window.__opencli_net.length<M){var t=x.responseText,b=null;if(t&&t.length<=B)try{b=JSON.parse(t)}catch(e){b=t}window.__opencli_net.push({url:x._ou,method:x._om||'GET',status:x.status,size:t?t.length:0,ct:ct,body:b})}}catch(e){}});return S.apply(this,arguments)}})()`;
+  /**
+   * Network interceptor JS — injected on every open/navigate to capture
+   * fetch/XHR bodies when the session-level capture channel (CDP/extension)
+   * isn't available. Keeps parity with the CDP path's truncation contract:
+   * when a body exceeds the per-entry cap, we keep a string prefix and set
+   * `bodyTruncated: true` + `bodyFullSize: <original length>` so `browser
+   * network` can propagate a visible signal to the agent instead of
+   * silently dropping the body. Per-entry cap is 1 MiB and the ring is
+   * capped at 200 entries, bounding worst-case in-page memory.
+   */
+  const NETWORK_INTERCEPTOR_JS = `(function(){if(window.__opencli_net)return;window.__opencli_net=[];var M=200,B=1048576,F=window.fetch;function capture(url,method,status,text,ct){if(window.__opencli_net.length>=M)return;var full=text?text.length:0,trunc=full>B,stored=trunc?text.slice(0,B):text,body=null;if(stored){if(trunc){body=stored}else{try{body=JSON.parse(stored)}catch(e){body=stored}}}var e={url:url,method:method||'GET',status:status,size:full,ct:ct,body:body};if(trunc){e.bodyTruncated=true;e.bodyFullSize=full}window.__opencli_net.push(e)}window.fetch=async function(){var r=await F.apply(this,arguments);try{var ct=r.headers.get('content-type')||'';if(ct.includes('json')||ct.includes('text')){var c=r.clone(),t=await c.text();capture(r.url||(arguments[0]&&arguments[0].url)||String(arguments[0]),(arguments[1]&&arguments[1].method)||'GET',r.status,t,ct)}}catch(e){}return r};var X=XMLHttpRequest.prototype,O=X.open,S=X.send;X.open=function(m,u){this._om=m;this._ou=u;return O.apply(this,arguments)};X.send=function(){var x=this;x.addEventListener('load',function(){try{var ct=x.getResponseHeader('content-type')||'';if(ct.includes('json')||ct.includes('text')){capture(x._ou,x._om||'GET',x.status,x.responseText||'',ct)}}catch(e){}});return S.apply(this,arguments)}})()`;
 
   addBrowserTabOption(browser.command('open').argument('<url>').description('Open URL in automation window'))
     .action(browserAction(async (page, url) => {
@@ -924,7 +933,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         const maxBody = Number.parseInt(rawMaxBody, 10);
 
         // Body shape/source:
-        // - If capture already truncated it (entry.bodyTruncated), the body is a string.
+        // - If capture already truncated it (entry.body_truncated), the body is a string.
         // - If the adapter stored a JSON value, it parsed cleanly at capture time; leave it.
         // - --max-body applies a transport-level cap when the caller wants to keep output small.
         let outputBody: unknown = entry.body;
@@ -933,7 +942,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           outputBody = entry.body.slice(0, maxBody);
           transportTruncated = true;
         }
-        const captureTruncated = entry.bodyTruncated === true;
+        const captureTruncated = entry.body_truncated === true;
 
         const detailEnvelope: Record<string, unknown> = {
           key: entry.key,
@@ -947,7 +956,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         };
         if (captureTruncated || transportTruncated) {
           detailEnvelope.body_truncated = true;
-          detailEnvelope.body_full_size = entry.size;
+          detailEnvelope.body_full_size = entry.body_full_size ?? entry.size;
           detailEnvelope.body_truncation_reason = captureTruncated
             ? 'capture-limit'
             : 'max-body';
@@ -977,7 +986,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         size: it.size,
         ct: it.ct,
         body: it.body,
-        ...(it.bodyTruncated ? { bodyTruncated: true } : {}),
+        ...(it.bodyTruncated ? { body_truncated: true } : {}),
+        ...(it.bodyTruncated && typeof it.bodyFullSize === 'number'
+          ? { body_full_size: it.bodyFullSize }
+          : {}),
       }));
       // Soft failure: the caller already has the data, so surface a warning
       // via the output envelope rather than erroring out the whole command.
@@ -1011,7 +1023,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
       if (cacheWarning) envelope.cache_warning = cacheWarning;
 
-      const truncatedCount = visible.filter((s) => s.entry.bodyTruncated).length;
+      const truncatedCount = visible.filter((s) => s.entry.body_truncated).length;
       if (truncatedCount > 0) {
         envelope.body_truncated_count = truncatedCount;
         envelope.body_truncated_hint = 'Some bodies exceeded the capture limit; their `shape` reflects only the captured prefix.';
@@ -1028,7 +1040,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           ct: s.entry.ct,
           size: s.entry.size,
           shape: s.shape,
-          ...(s.entry.bodyTruncated ? { body_truncated: true } : {}),
+          ...(s.entry.body_truncated ? { body_truncated: true } : {}),
         }));
         envelope.detail_hint = 'Run "browser network --detail <key>" for full body.';
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import { assignKeys } from './browser/network-key.js';
 import { DEFAULT_TTL_MS, findEntry, loadNetworkCache, saveNetworkCache, type CachedNetworkEntry } from './browser/network-cache.js';
 import { parseFilter, shapeMatchesFilter } from './browser/shape-filter.js';
 import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
+import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 
@@ -41,12 +42,18 @@ type BrowserNetworkItem = {
   size: number;
   ct: string;
   body: unknown;
+  /** Full body size in chars before any capture-layer truncation. */
+  bodyFullSize?: number;
+  /** True when the capture layer had to cap the stored body to protect memory. */
+  bodyTruncated?: boolean;
 };
 
 /**
  * Normalize raw capture entries (from daemon/CDP `readNetworkCapture` or
  * the JS interceptor's `window.__opencli_net`) into a consistent shape.
  * Response preview is parsed as JSON when possible, otherwise kept as string.
+ * `bodyFullSize` / `bodyTruncated` surface capture-layer truncation so the
+ * agent-facing envelope can warn when the body isn't whole.
  */
 async function captureNetworkItems(page: import('./types.js').IPage): Promise<BrowserNetworkItem[]> {
   if (page.readNetworkCapture) {
@@ -57,13 +64,19 @@ async function captureNetworkItems(page: import('./types.js').IPage): Promise<Br
       if (preview) {
         try { body = JSON.parse(preview); } catch { body = preview; }
       }
+      const fullSize = typeof e.responseBodyFullSize === 'number'
+        ? (e.responseBodyFullSize as number)
+        : (preview ? preview.length : 0);
+      const truncated = e.responseBodyTruncated === true;
       return {
         url: (e.url as string) || '',
         method: (e.method as string) || 'GET',
         status: (e.responseStatus as number) || 0,
-        size: preview ? preview.length : 0,
+        size: fullSize,
         ct: (e.responseContentType as string) || '',
         body,
+        bodyFullSize: fullSize,
+        bodyTruncated: truncated,
       };
     });
   }
@@ -553,6 +566,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       .option('--selector <css>', 'CSS selector scope (first match)')
       .option('--as <format>', 'Output format: "html" (default) or "json" for structured tree', 'html')
       .option('--max <n>', 'Max characters of raw HTML to return (0 = unlimited)', '0')
+      .option('--depth <n>', '(--as json) Max tree depth below root (0 = root only, 0 disables = unlimited via empty)', '')
+      .option('--children-max <n>', '(--as json) Max element children kept per node (empty = unlimited)', '')
+      .option('--text-max <n>', '(--as json) Max chars of direct text kept per node (empty = unlimited)', '')
       .description('Page HTML (or scoped); use --as json for a {tag, attrs, text, children} tree'),
   )
     .action(browserAction(async (page, opts) => {
@@ -574,7 +590,28 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       const max = Number.parseInt(rawMax, 10);
 
       if (format === 'json') {
-        const js = buildHtmlTreeJs({ selector: opts.selector ?? null });
+        const parseBudget = (flag: string, value: unknown): number | null | { error: string } => {
+          const raw = value === undefined || value === null ? '' : String(value);
+          if (raw === '') return null;
+          if (!/^\d+$/.test(raw)) return { error: `${flag} must be a non-negative integer, got "${raw}"` };
+          return Number.parseInt(raw, 10);
+        };
+        const depth = parseBudget('--depth', opts.depth);
+        const childrenMax = parseBudget('--children-max', opts.childrenMax);
+        const textMax = parseBudget('--text-max', opts.textMax);
+        for (const budget of [depth, childrenMax, textMax]) {
+          if (budget && typeof budget === 'object' && 'error' in budget) {
+            console.log(JSON.stringify({ error: { code: 'invalid_budget', message: budget.error } }, null, 2));
+            process.exitCode = EXIT_CODES.USAGE_ERROR;
+            return;
+          }
+        }
+        const js = buildHtmlTreeJs({
+          selector: opts.selector ?? null,
+          depth: depth as number | null,
+          childrenMax: childrenMax as number | null,
+          textMax: textMax as number | null,
+        });
         const result = await page.evaluate(js) as HtmlTreeResult | { selector: string; invalidSelector: true; reason: string } | null;
         if (result && typeof result === 'object' && 'invalidSelector' in result && result.invalidSelector) {
           console.log(JSON.stringify({
@@ -753,6 +790,70 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       else console.log(JSON.stringify(result, null, 2));
     }));
 
+  // ── Extract (content reading) ──
+  //
+  // `extract` answers the "read this page" question that `get html` / `get text`
+  // can't: denoise → markdown → paragraph-aware chunking. Agents walk long pages
+  // by passing back the `next_start_char` cursor instead of juggling selectors.
+
+  addBrowserTabOption(
+    browser.command('extract')
+      .option('--selector <css>', 'CSS selector scope; defaults to <main>/<article>/<body>')
+      .option('--chunk-size <chars>', 'Target chunk size in chars', '20000')
+      .option('--start <char>', 'Start offset (use next_start_char from a previous extract)', '0')
+      .description('Extract page content as markdown, paragraph-aware chunks for long pages'),
+  )
+    .action(browserAction(async (page, opts) => {
+      const rawChunk = String(opts.chunkSize ?? '20000');
+      if (!/^\d+$/.test(rawChunk) || Number.parseInt(rawChunk, 10) <= 0) {
+        console.log(JSON.stringify({ error: { code: 'invalid_chunk_size', message: `--chunk-size must be a positive integer, got "${opts.chunkSize}"` } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const rawStart = String(opts.start ?? '0');
+      if (!/^\d+$/.test(rawStart)) {
+        console.log(JSON.stringify({ error: { code: 'invalid_start', message: `--start must be a non-negative integer, got "${opts.start}"` } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const chunkSize = Number.parseInt(rawChunk, 10);
+      const start = Number.parseInt(rawStart, 10);
+      const selector = typeof opts.selector === 'string' && opts.selector.length > 0 ? opts.selector : null;
+
+      const js = buildExtractHtmlJs(selector);
+      const res = await page.evaluate(js) as
+        | { ok: true; url: string; title: string; html: string }
+        | { invalidSelector: true; reason: string }
+        | { notFound: true }
+        | null;
+
+      if (!res) {
+        console.log(JSON.stringify({ error: { code: 'extract_failed', message: 'Page returned no root element.' } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      if ('invalidSelector' in res) {
+        console.log(JSON.stringify({ error: { code: 'invalid_selector', message: `Selector "${selector}" is not a valid CSS selector: ${res.reason}` } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      if ('notFound' in res) {
+        console.log(JSON.stringify({ error: { code: 'selector_not_found', message: selector ? `Selector "${selector}" matched 0 elements.` : 'Page has no body/main/article element.' } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+
+      const envelope = runExtractFromHtml({
+        html: res.html,
+        url: res.url,
+        title: res.title,
+        selector,
+        start,
+        chunkSize,
+      });
+      console.log(JSON.stringify(envelope, null, 2));
+    }));
+
   // ── Network (API discovery) ──
   //
   // Default output is JSON (agent-native). Each entry carries a stable `key`
@@ -765,6 +866,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .option('--all', 'Include static resources (js/css/images/telemetry)')
     .option('--raw', 'Emit full bodies for every entry (skip shape preview)')
     .option('--filter <fields>', 'Comma-separated field names; keep only entries whose body shape has ALL names as path segments')
+    .option('--max-body <chars>', 'With --detail: cap the emitted body at N chars (0 = unlimited, default)', '0')
     .option('--ttl <ms>', 'Cache TTL in ms for --detail lookups', String(DEFAULT_TTL_MS))
     .description('Capture network requests as shape previews; retrieve full bodies by key')
     .action(browserAction(async (page, opts) => {
@@ -814,7 +916,26 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           });
           return;
         }
-        console.log(JSON.stringify({
+        const rawMaxBody = String(opts.maxBody ?? '0');
+        if (!/^\d+$/.test(rawMaxBody)) {
+          emitNetworkError('invalid_max_body', `--max-body must be a non-negative integer, got "${opts.maxBody}"`);
+          return;
+        }
+        const maxBody = Number.parseInt(rawMaxBody, 10);
+
+        // Body shape/source:
+        // - If capture already truncated it (entry.bodyTruncated), the body is a string.
+        // - If the adapter stored a JSON value, it parsed cleanly at capture time; leave it.
+        // - --max-body applies a transport-level cap when the caller wants to keep output small.
+        let outputBody: unknown = entry.body;
+        let transportTruncated = false;
+        if (maxBody > 0 && typeof entry.body === 'string' && entry.body.length > maxBody) {
+          outputBody = entry.body.slice(0, maxBody);
+          transportTruncated = true;
+        }
+        const captureTruncated = entry.bodyTruncated === true;
+
+        const detailEnvelope: Record<string, unknown> = {
           key: entry.key,
           url: entry.url,
           method: entry.method,
@@ -822,8 +943,16 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           ct: entry.ct,
           size: entry.size,
           shape: inferShape(entry.body),
-          body: entry.body,
-        }, null, 2));
+          body: outputBody,
+        };
+        if (captureTruncated || transportTruncated) {
+          detailEnvelope.body_truncated = true;
+          detailEnvelope.body_full_size = entry.size;
+          detailEnvelope.body_truncation_reason = captureTruncated
+            ? 'capture-limit'
+            : 'max-body';
+        }
+        console.log(JSON.stringify(detailEnvelope, null, 2));
         return;
       }
 
@@ -848,6 +977,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         size: it.size,
         ct: it.ct,
         body: it.body,
+        ...(it.bodyTruncated ? { bodyTruncated: true } : {}),
       }));
       // Soft failure: the caller already has the data, so surface a warning
       // via the output envelope rather than erroring out the whole command.
@@ -881,6 +1011,12 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
       if (cacheWarning) envelope.cache_warning = cacheWarning;
 
+      const truncatedCount = visible.filter((s) => s.entry.bodyTruncated).length;
+      if (truncatedCount > 0) {
+        envelope.body_truncated_count = truncatedCount;
+        envelope.body_truncated_hint = 'Some bodies exceeded the capture limit; their `shape` reflects only the captured prefix.';
+      }
+
       if (opts.raw) {
         envelope.entries = visible.map((s) => s.entry);
       } else {
@@ -892,6 +1028,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           ct: s.entry.ct,
           size: s.entry.size,
           shape: s.shape,
+          ...(s.entry.bodyTruncated ? { body_truncated: true } : {}),
         }));
         envelope.detail_hint = 'Run "browser network --detail <key>" for full body.';
       }


### PR DESCRIPTION
## Why

Three independent agent-usage gaps in the `browser` surface, addressed as one complete change per direction from #opencli-browser thread:

1. **`network --detail` silently cut response bodies at 4000 chars**, breaking `JSON.parse` on any non-trivial API response. Purely invisible to the agent.
2. **`get html --as json` had no budget knobs**, so the agent either got a full-page tree dump or nothing — no middle ground when scoping down.
3. **No content-reading channel existed.** Agents were misusing `get html` to try to read articles, which returns DOM structure, not prose.

All three are about the same thing from first principles: agent-readable payload shape, with visible truncation so the agent can continue rather than fail silently.

## What changed

### `browser network` — body truncation becomes visible

- `src/browser/cdp.ts` + `extension/src/cdp.ts`: raise the silent 4KB slice to an **8MB** memory-guard cap and record `responseBodyFullSize` / `responseBodyTruncated` (extension path also gets request-body mirrors).
- `src/browser/network-cache.ts`: `CachedNetworkEntry.bodyTruncated` propagates through.
- `src/cli.ts` `browser network`:
  - List view now emits `body_truncated_count` + per-entry `body_truncated` flag.
  - `--detail` envelope emits `body_truncated`, `body_full_size`, `body_truncation_reason: 'capture-limit' | 'max-body'`.
  - New `--max-body <chars>` flag for explicit caller-side cap (default `0` = unlimited).

### `browser get html --as json` — budget knobs

- `src/browser/html-tree.ts`: add `depth` / `childrenMax` / `textMax` budgets to the in-page serializer. The result envelope includes `truncated: {depth, children_dropped, text_truncated}` **only when a budget was actually hit**.
- `src/cli.ts`: expose as `--depth <n>` / `--children-max <n>` / `--text-max <n>`.

### `browser extract` — new agent-native reading channel

- `src/browser/extract.ts` (new):
  - `buildExtractHtmlJs(selector)` — in-page clone + denoise (strip `script/style/nav/header/footer/aside/iframe/form/button/...` + `role=navigation/banner/contentinfo/complementary` + `aria-hidden=true`; scrub `on*`/`style`/`data-*` attrs).
  - `htmlToMarkdown` (existing helper) → structure-aware `chunkMarkdown` that snaps chunk end to the nearest `\n\n` (or `\n`) within a 15% boundary window, falling back to a hard cut.
  - Stateless resume via `next_start_char` cursor.
- `src/cli.ts`: new `browser extract [url] --selector <sel> --start <n> --chunk-size <n>` command.

## Truncation signal contract (all three channels)

Every channel makes cuts **visible** to the agent in the envelope:

| Channel | Signals |
|---|---|
| network list | `body_truncated_count`, per-entry `body_truncated` |
| network detail | `body_truncated`, `body_full_size`, `body_truncation_reason` |
| get html json | `truncated: { depth?, children_dropped?, text_truncated? }` (only when hit) |
| extract | `total_chars`, `chunk_size`, `start`, `end`, `next_start_char` |

## Test plan

- [x] `pnpm test src/browser/extract.test.ts` — 13 tests pass (chunking boundaries, resume chain, min-clamp, envelope wrapping)
- [x] `pnpm test src/browser/html-tree.test.ts` — all green incl. 5 new budget tests
- [x] `pnpm test src/cli.test.ts` — all green incl. 5 new body-truncation-signal tests
- [x] `pnpm typecheck` — clean
- [ ] Manual smoke: `browser network --detail ... --max-body 500` returns `body_truncated: true` + `body_full_size`
- [ ] Manual smoke: `browser extract <url>` on a real article page + resume via `--start <next>`

## Scope discipline

- No new dependencies (turndown was already in `package.json`; `htmlToMarkdown` already exists in `src/utils.ts`).
- No changes to list-view default behavior except the new `body_truncated_count` field (additive).
- No backwards-incompatible changes to existing flags.

cc @codex-mini1 @First-principles-1 — requesting review per thread assignment.