### PR TITLE
fix(twitter): add 5s network timeout to resolveTwitterQueryId

### DIFF
--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -5,14 +5,19 @@ export function sanitizeQueryId(resolved, fallbackId) {
 export async function resolveTwitterQueryId(page, operationName, fallbackId) {
     const resolved = await page.evaluate(`async () => {
     const operationName = ${JSON.stringify(operationName)};
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
     try {
-      const ghResp = await fetch('https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json');
+      const ghResp = await fetch('https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json', { signal: controller.signal });
+      clearTimeout(timeout);
       if (ghResp.ok) {
         const data = await ghResp.json();
         const entry = data?.[operationName];
         if (entry && entry.queryId) return entry.queryId;
       }
-    } catch {}
+    } catch {
+      clearTimeout(timeout);
+    }
     try {
       const scripts = performance.getEntriesByType('resource')
         .filter(r => r.name.includes('client-web') && r.name.endsWith('.js'))


### PR DESCRIPTION
## Fix: twitter article command hangs on network stall

### Problem
The `opencli twitter article` command hangs indefinitely when network connectivity is unavailable. This occurs because `resolveTwitterQueryId()` in `clis/twitter/shared.js` fetches an external JSON file from GitHub without any timeout. If that fetch stalls (no response, no error), the function never resolves and the entire command hangs.

### Solution
Wrap the `fetch()` call inside `resolveTwitterQueryId()` with an `AbortController` that aborts after 5 seconds. On timeout (or any other network error), the code falls through to the existing script-scanning fallback strategy, which uses local `performance.getEntriesByType('resource')` and requires no network access.

### Changes
**clis/twitter/shared.js** — Added a 5-second `AbortController` timeout to the GitHub fetch. The `clearTimeout` is called in both the `catch` and after the successful response so there's no lingering timer.

### Testing
- Build passes: `npm run build` completes successfully
- TypeScript compilation: `npx tsc --noEmit` passes
- The change is minimal (net +6 lines) and only affects the single network call path

### Related
Fixes open issue #1082