### PR TITLE
fix(youtube): fall back to Videos tab when Home tab has no videos

### DIFF
--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -115,6 +115,35 @@ cli({
           }
         }
 
+        // If Home tab has no videos, try Videos tab
+        if (recentVideos.length === 0) {
+          const videosTab = tabs.find(t => t.tabRenderer?.title === 'Videos');
+          const videosTabParams = videosTab?.tabRenderer?.endpoint?.browseEndpoint?.params;
+          if (videosTabParams) {
+            const videosResp = await fetch('/youtubei/v1/browse?key=' + apiKey + '&prettyPrint=false', {
+              method: 'POST', credentials: 'include',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({context, browseId, params: videosTabParams})
+            });
+            if (videosResp.ok) {
+              const videosData = await videosResp.json();
+              const richGrid = videosData.contents?.twoColumnBrowseResultsRenderer?.tabs?.[0]?.tabRenderer?.content?.richGridRenderer?.contents || [];
+              for (const item of richGrid) {
+                if (recentVideos.length >= limit) break;
+                const v = item.richItemRenderer?.content?.videoRenderer;
+                if (v) {
+                  recentVideos.push({
+                    title: v.title?.runs?.[0]?.text || '',
+                    duration: v.lengthText?.simpleText || '',
+                    views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
+                    url: 'https://www.youtube.com/watch?v=' + v.videoId,
+                  });
+                }
+              }
+            }
+          }
+        }
+
         return {
           name: metadata.title || '',
           channelId: metadata.externalId || browseId,

--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -117,7 +117,13 @@ cli({
 
         // If Home tab has no videos, try Videos tab
         if (recentVideos.length === 0) {
-          const videosTab = tabs.find(t => t.tabRenderer?.title === 'Videos');
+          const videosTab = tabs.find(t => {
+            const tab = t.tabRenderer;
+            const url = tab?.endpoint?.commandMetadata?.webCommandMetadata?.url || '';
+            return tab?.tabIdentifier === 'VIDEOS'
+              || url.endsWith('/videos')
+              || tab?.title === 'Videos';
+          });
           const videosTabParams = videosTab?.tabRenderer?.endpoint?.browseEndpoint?.params;
           if (videosTabParams) {
             const videosResp = await fetch('/youtubei/v1/browse?key=' + apiKey + '&prettyPrint=false', {


### PR DESCRIPTION
## Problem

`opencli youtube channel <id>` returns an empty `recent_videos` list for some channels that have videos visible in the browser (Closes #1108).

## Root Cause

The command only extracts videos from the Home tab (`tabs.find(t => t.tabRenderer?.selected)`). Some channels don't have video shelves on their Home tab — they may have a minimal or empty Home layout — so the extraction finds nothing.

## Fix

When the Home tab yields zero videos, the command now:

1. Finds the Videos tab from the `tabs` array (`tabRenderer.title === 'Videos'`)
2. Makes a second InnerTube browse request using the Videos tab's `browseEndpoint.params`
3. Extracts videos from the `richGridRenderer` format used by the Videos tab

This is a pure fallback — channels that already show videos on their Home tab are unaffected.

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — all 1695 tests pass (222 files)
- Only `clis/youtube/channel.js` modified (+29 lines)