### PR TITLE
feat(browser): selector-first find + get/click/type/select (A2+A3)

### DIFF
--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -21,8 +21,39 @@ import {
   networkRequestsJs,
   waitForDomStableJs,
 } from './dom-helpers.js';
-import { resolveTargetJs, clickResolvedJs, typeResolvedJs, scrollResolvedJs } from './target-resolver.js';
-import { TargetError } from './target-errors.js';
+import {
+  resolveTargetJs,
+  clickResolvedJs,
+  typeResolvedJs,
+  scrollResolvedJs,
+  type ResolveOptions,
+} from './target-resolver.js';
+import { TargetError, type TargetErrorCode } from './target-errors.js';
+
+/**
+ * Execute `resolveTargetJs` once, throw structured `TargetError` on failure.
+ * Single helper so click/typeText/scrollTo share one resolution pathway,
+ * which is what the selector-first contract promises agents.
+ */
+async function runResolve(
+  page: { evaluate(js: string): Promise<unknown> },
+  ref: string,
+  opts: ResolveOptions = {},
+): Promise<{ matches_n: number }> {
+  const resolution = (await page.evaluate(resolveTargetJs(ref, opts))) as
+    | { ok: true; matches_n: number }
+    | { ok: false; code: TargetErrorCode; message: string; hint: string; candidates?: string[]; matches_n?: number };
+  if (!resolution.ok) {
+    throw new TargetError({
+      code: resolution.code,
+      message: resolution.message,
+      hint: resolution.hint,
+      candidates: resolution.candidates,
+      matches_n: resolution.matches_n,
+    });
+  }
+  return { matches_n: resolution.matches_n };
+}
 import { formatSnapshot } from '../snapshotFormatter.js';
 export abstract class BasePage implements IPage {
   protected _lastUrl: string | null = null;
@@ -61,15 +92,9 @@ export abstract class BasePage implements IPage {
 
   // ── Shared DOM helper implementations ──
 
-  async click(ref: string): Promise<void> {
+  async click(ref: string, opts: ResolveOptions = {}): Promise<{ matches_n: number }> {
     // Phase 1: Resolve target with fingerprint verification
-    const resolution = await this.evaluate(resolveTargetJs(ref)) as
-      | { ok: true }
-      | { ok: false; code: string; message: string; hint: string; candidates?: string[] };
-
-    if (!resolution.ok) {
-      throw new TargetError(resolution as { ok: false; code: 'not_found' | 'ambiguous' | 'stale_ref'; message: string; hint: string; candidates?: string[] });
-    }
+    const { matches_n } = await runResolve(this, ref, opts);
 
     // Phase 2: Execute click on resolved element
     const result = await this.evaluate(clickResolvedJs()) as
@@ -77,16 +102,14 @@ export abstract class BasePage implements IPage {
       | { status: string; x?: number; y?: number; w?: number; h?: number; error?: string }
       | null;
 
-    // Backwards compat: old format returned 'clicked' string
-    if (typeof result === 'string' || result == null) return;
+    if (typeof result === 'string' || result == null) return { matches_n };
 
-    // JS click succeeded
-    if (result.status === 'clicked') return;
+    if (result.status === 'clicked') return { matches_n };
 
     // JS click failed — try CDP native click if coordinates available
     if (result.x != null && result.y != null) {
       const success = await this.tryNativeClick(result.x, result.y);
-      if (success) return;
+      if (success) return { matches_n };
     }
 
     throw new Error(`Click failed: ${result.error ?? 'JS click and CDP fallback both failed'}`);
@@ -97,35 +120,18 @@ export abstract class BasePage implements IPage {
     return false;
   }
 
-  async typeText(ref: string, text: string): Promise<void> {
-    // Phase 1: Resolve target with fingerprint verification
-    const resolution = await this.evaluate(resolveTargetJs(ref)) as
-      | { ok: true }
-      | { ok: false; code: string; message: string; hint: string; candidates?: string[] };
-
-    if (!resolution.ok) {
-      throw new TargetError(resolution as { ok: false; code: 'not_found' | 'ambiguous' | 'stale_ref'; message: string; hint: string; candidates?: string[] });
-    }
-
-    // Phase 2: Execute type on resolved element
+  async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<{ matches_n: number }> {
+    const { matches_n } = await runResolve(this, ref, opts);
     await this.evaluate(typeResolvedJs(text));
+    return { matches_n };
   }
 
   async pressKey(key: string): Promise<void> {
     await this.evaluate(pressKeyJs(key));
   }
 
-  async scrollTo(ref: string): Promise<unknown> {
-    // Phase 1: Resolve target with fingerprint verification
-    const resolution = await this.evaluate(resolveTargetJs(ref)) as
-      | { ok: true }
-      | { ok: false; code: string; message: string; hint: string; candidates?: string[] };
-
-    if (!resolution.ok) {
-      throw new TargetError(resolution as { ok: false; code: 'not_found' | 'ambiguous' | 'stale_ref'; message: string; hint: string; candidates?: string[] });
-    }
-
-    // Phase 2: Scroll to resolved element
+  async scrollTo(ref: string, opts: ResolveOptions = {}): Promise<unknown> {
+    await runResolve(this, ref, opts);
     return this.evaluate(scrollResolvedJs());
   }
 

--- a/src/browser/find.test.ts
+++ b/src/browser/find.test.ts
@@ -38,6 +38,28 @@ describe('buildFindJs', () => {
     expect(js).toContain('visible: isVisible(el)');
   });
 
+  it('allocates fresh refs for untagged matches (write attribute + identity map)', () => {
+    const js = buildFindJs('.btn');
+    // On the just-annotated branch we must flip the attribute on the element
+    // so downstream `browser click <ref>` works off the find output.
+    expect(js).toContain("el.setAttribute('data-opencli-ref'");
+    // The fingerprint must also land in the shared identity map so the
+    // target resolver's stale-ref check has data to verify against.
+    expect(js).toContain('__opencli_ref_identity');
+    expect(js).toContain("identity['' + refNum] = fingerprintOf(el)");
+    // Allocation walks both the identity map and any existing data-opencli-ref
+    // annotations — guards against collisions after a soft nav.
+    expect(js).toContain("document.querySelectorAll('[data-opencli-ref]')");
+  });
+
+  it('fingerprint shape matches the snapshot / resolver contract', () => {
+    const js = buildFindJs('.btn');
+    // The six fields resolveTargetJs verifies in its stale_ref check.
+    for (const field of ['tag:', 'role:', 'text:', 'ariaLabel:', 'id:', 'testId:']) {
+      expect(js).toContain(field);
+    }
+  });
+
   it('embeds defaults for limit and textMax', () => {
     const js = buildFindJs('.btn');
     expect(js).toContain('LIMIT = 50');

--- a/src/browser/find.test.ts
+++ b/src/browser/find.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { buildFindJs, FIND_ATTR_WHITELIST, isFindError, type FindError } from './find.js';
+
+/**
+ * These tests validate the shape and options of the generated JS string
+ * (no DOM available in the default vitest unit env). Runtime behavior of
+ * the generated JS against a real DOM is covered by the browser e2e suite.
+ */
+
+describe('buildFindJs', () => {
+  it('produces syntactically valid JS that can be parsed', () => {
+    expect(() => new Function(`return (${buildFindJs('.btn')});`)).not.toThrow();
+  });
+
+  it('embeds the selector via JSON.stringify (injection-safe)', () => {
+    const js = buildFindJs('[data-x="a\"b"]');
+    // Unescaped literal break-out must not appear
+    expect(js).not.toContain('[data-x="a"b"]');
+    // The JSON-encoded form (with escaped quotes) should
+    expect(js).toContain(JSON.stringify('[data-x="a\"b"]'));
+  });
+
+  it('emits invalid_selector + selector_not_found branches', () => {
+    const js = buildFindJs('.btn');
+    expect(js).toContain("code: 'invalid_selector'");
+    expect(js).toContain("code: 'selector_not_found'");
+  });
+
+  it('emits matches_n + entries + per-entry shape', () => {
+    const js = buildFindJs('.btn');
+    expect(js).toContain('matches_n: matches.length');
+    expect(js).toContain('entries.push(');
+    // Per-entry keys reviewers signed off on: nth, ref, tag, role, text, attrs, visible
+    expect(js).toContain('nth: i');
+    expect(js).toContain('ref: refNum');
+    expect(js).toContain('tag: el.tagName.toLowerCase()');
+    expect(js).toContain("el.getAttribute('role')");
+    expect(js).toContain('visible: isVisible(el)');
+  });
+
+  it('embeds defaults for limit and textMax', () => {
+    const js = buildFindJs('.btn');
+    expect(js).toContain('LIMIT = 50');
+    expect(js).toContain('TEXT_MAX = 120');
+  });
+
+  it('overrides limit and textMax when requested', () => {
+    const js = buildFindJs('.btn', { limit: 3, textMax: 20 });
+    expect(js).toContain('LIMIT = 3');
+    expect(js).toContain('TEXT_MAX = 20');
+  });
+
+  it('embeds the attribute whitelist verbatim (no style/onclick leaking)', () => {
+    const js = buildFindJs('.btn');
+    // Whitelist fields appear inside the generated JS
+    for (const key of FIND_ATTR_WHITELIST) {
+      expect(js).toContain(`"${key}"`);
+    }
+    // Sensitive / high-noise attrs must stay out of the whitelist
+    expect(FIND_ATTR_WHITELIST).not.toContain('style' as never);
+    expect(FIND_ATTR_WHITELIST).not.toContain('onclick' as never);
+    expect(FIND_ATTR_WHITELIST).not.toContain('onload' as never);
+  });
+
+  it('keeps the whitelist small and explicit (guardrail against silent expansion)', () => {
+    expect(FIND_ATTR_WHITELIST).toEqual([
+      'id',
+      'class',
+      'name',
+      'type',
+      'placeholder',
+      'aria-label',
+      'title',
+      'href',
+      'value',
+      'role',
+      'data-testid',
+    ]);
+  });
+});
+
+describe('isFindError', () => {
+  it('narrows { error: ... } as FindError', () => {
+    const payload: unknown = { error: { code: 'invalid_selector', message: 'x' } };
+    expect(isFindError(payload)).toBe(true);
+    if (isFindError(payload)) {
+      const err: FindError = payload;
+      expect(err.error.code).toBe('invalid_selector');
+    }
+  });
+
+  it('rejects successful envelopes', () => {
+    expect(isFindError({ matches_n: 0, entries: [] })).toBe(false);
+    expect(isFindError(null)).toBe(false);
+    expect(isFindError(undefined)).toBe(false);
+    expect(isFindError('string')).toBe(false);
+  });
+});

--- a/src/browser/find.ts
+++ b/src/browser/find.ts
@@ -1,0 +1,153 @@
+/**
+ * `browser find --css <sel>` — structured CSS query.
+ *
+ * Returns every match of a selector as a JSON envelope agents can read
+ * without parsing free-text snapshot output. Each entry carries two
+ * identifiers — the original `data-opencli-ref` (if the element was
+ * tagged during an earlier snapshot) and a stable 0-based `nth` — so
+ * the agent can act on a specific result via either path:
+ *
+ *   browser click <ref>              // when ref is numeric
+ *   browser click "<sel>" --nth <n>  // always works
+ *
+ * Attributes are whitelisted to keep output small and high-signal.
+ * Invisible elements are still returned so agents can reason about
+ * offscreen vs truly-missing targets.
+ */
+
+/** Whitelist of attributes surfaced per entry. Keep small; agents do not need full DOM dumps. */
+export const FIND_ATTR_WHITELIST = [
+  'id',
+  'class',
+  'name',
+  'type',
+  'placeholder',
+  'aria-label',
+  'title',
+  'href',
+  'value',
+  'role',
+  'data-testid',
+] as const;
+
+export interface FindEntry {
+  /** Zero-based position within the match set — pair with `--nth` on downstream commands. */
+  nth: number;
+  /** Numeric data-opencli-ref if the element was tagged by a prior snapshot; null otherwise. */
+  ref: number | null;
+  tag: string;
+  role: string;
+  text: string;
+  attrs: Record<string, string>;
+  visible: boolean;
+}
+
+export interface FindResult {
+  matches_n: number;
+  entries: FindEntry[];
+}
+
+export interface FindError {
+  error: {
+    code: 'invalid_selector' | 'selector_not_found';
+    message: string;
+    hint?: string;
+  };
+}
+
+export interface FindOptions {
+  /** Max entries returned. Default 50 — enough to pick from without flooding context. */
+  limit?: number;
+  /** Max chars of trimmed text per entry. Default 120. */
+  textMax?: number;
+}
+
+/**
+ * Build the browser-side JS that performs the CSS query and emits the
+ * FindResult (or FindError) envelope. Evaluated inside `page.evaluate`.
+ */
+export function buildFindJs(selector: string, opts: FindOptions = {}): string {
+  const safeSel = JSON.stringify(selector);
+  const limit = opts.limit ?? 50;
+  const textMax = opts.textMax ?? 120;
+  const whitelist = JSON.stringify(FIND_ATTR_WHITELIST);
+
+  return `
+    (() => {
+      const sel = ${safeSel};
+      const LIMIT = ${limit};
+      const TEXT_MAX = ${textMax};
+      const ATTR_WHITELIST = ${whitelist};
+
+      let matches;
+      try {
+        matches = document.querySelectorAll(sel);
+      } catch (e) {
+        return {
+          error: {
+            code: 'invalid_selector',
+            message: 'Invalid CSS selector: ' + sel + ' (' + ((e && e.message) || String(e)) + ')',
+            hint: 'Check the selector syntax.',
+          },
+        };
+      }
+
+      if (matches.length === 0) {
+        return {
+          error: {
+            code: 'selector_not_found',
+            message: 'CSS selector ' + sel + ' matched 0 elements',
+            hint: 'Use browser state to inspect the page, or try a less specific selector.',
+          },
+        };
+      }
+
+      function pickAttrs(el) {
+        const out = {};
+        for (const key of ATTR_WHITELIST) {
+          const v = el.getAttribute(key);
+          if (v != null && v !== '') out[key] = v;
+        }
+        return out;
+      }
+
+      function isVisible(el) {
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) return false;
+        try {
+          const style = getComputedStyle(el);
+          if (style.display === 'none' || style.visibility === 'hidden') return false;
+          if (parseFloat(style.opacity || '1') === 0) return false;
+        } catch (_) {}
+        return true;
+      }
+
+      const take = Math.min(matches.length, LIMIT);
+      const entries = [];
+      for (let i = 0; i < take; i++) {
+        const el = matches[i];
+        const refAttr = el.getAttribute('data-opencli-ref');
+        const refNum = refAttr != null && /^\\d+$/.test(refAttr) ? parseInt(refAttr, 10) : null;
+        const text = (el.textContent || '').trim();
+        entries.push({
+          nth: i,
+          ref: refNum,
+          tag: el.tagName.toLowerCase(),
+          role: el.getAttribute('role') || '',
+          text: text.length > TEXT_MAX ? text.slice(0, TEXT_MAX) : text,
+          attrs: pickAttrs(el),
+          visible: isVisible(el),
+        });
+      }
+
+      return {
+        matches_n: matches.length,
+        entries,
+      };
+    })()
+  `;
+}
+
+export function isFindError(result: unknown): result is FindError {
+  return !!result && typeof result === 'object' && 'error' in result;
+}

--- a/src/browser/find.ts
+++ b/src/browser/find.ts
@@ -3,12 +3,19 @@
  *
  * Returns every match of a selector as a JSON envelope agents can read
  * without parsing free-text snapshot output. Each entry carries two
- * identifiers — the original `data-opencli-ref` (if the element was
- * tagged during an earlier snapshot) and a stable 0-based `nth` — so
- * the agent can act on a specific result via either path:
+ * identifiers — a numeric `ref` (matching the snapshot contract) and a
+ * stable 0-based `nth` — so the agent can act on a specific result via
+ * either path:
  *
  *   browser click <ref>              // when ref is numeric
  *   browser click "<sel>" --nth <n>  // always works
+ *
+ * Refs are *allocated on the spot* for matched elements that were not
+ * tagged by a prior snapshot: `data-opencli-ref` is set on the element
+ * and a fingerprint is written into `window.__opencli_ref_identity`
+ * (same shape the snapshot uses). That makes `find` a first-class entry
+ * point to the ref system — agents can skip running `browser state`
+ * when they already know the selector.
  *
  * Attributes are whitelisted to keep output small and high-signal.
  * Invisible elements are still returned so agents can reason about
@@ -33,8 +40,12 @@ export const FIND_ATTR_WHITELIST = [
 export interface FindEntry {
   /** Zero-based position within the match set — pair with `--nth` on downstream commands. */
   nth: number;
-  /** Numeric data-opencli-ref if the element was tagged by a prior snapshot; null otherwise. */
-  ref: number | null;
+  /**
+   * Numeric data-opencli-ref. Find assigns one if the element was not
+   * tagged by a prior snapshot, so downstream `browser click <ref>` works
+   * directly off the find output without requiring `browser state` first.
+   */
+  ref: number;
   tag: string;
   role: string;
   text: string;
@@ -122,12 +133,55 @@ export function buildFindJs(selector: string, opts: FindOptions = {}): string {
         return true;
       }
 
+      // Ref allocation: reuse \`window.__opencli_ref_identity\` (the same map
+      // snapshot populates) as the source of truth. For matched elements that
+      // don't already carry a \`data-opencli-ref\`, assign the next free numeric
+      // ref and write the fingerprint so the target resolver can verify it on
+      // downstream click/type/get calls.
+      const identity = (window.__opencli_ref_identity = window.__opencli_ref_identity || {});
+      let maxRef = 0;
+      for (const k in identity) {
+        const n = parseInt(k, 10);
+        if (!isNaN(n) && n > maxRef) maxRef = n;
+      }
+      // Also walk any \`data-opencli-ref\` already in the DOM in case the identity
+      // map was cleared but annotations remain (e.g. soft navigation without a
+      // fresh snapshot). Guarantees allocated refs don't collide.
+      try {
+        const tagged = document.querySelectorAll('[data-opencli-ref]');
+        for (let t = 0; t < tagged.length; t++) {
+          const v = tagged[t].getAttribute('data-opencli-ref');
+          const n = v != null && /^\\d+$/.test(v) ? parseInt(v, 10) : NaN;
+          if (!isNaN(n) && n > maxRef) maxRef = n;
+        }
+      } catch (_) {}
+
+      function fingerprintOf(el) {
+        return {
+          tag: el.tagName.toLowerCase(),
+          role: el.getAttribute('role') || '',
+          text: (el.textContent || '').trim().slice(0, 30),
+          ariaLabel: el.getAttribute('aria-label') || '',
+          id: el.id || '',
+          testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
+        };
+      }
+
       const take = Math.min(matches.length, LIMIT);
       const entries = [];
       for (let i = 0; i < take; i++) {
         const el = matches[i];
         const refAttr = el.getAttribute('data-opencli-ref');
-        const refNum = refAttr != null && /^\\d+$/.test(refAttr) ? parseInt(refAttr, 10) : null;
+        let refNum = refAttr != null && /^\\d+$/.test(refAttr) ? parseInt(refAttr, 10) : null;
+        if (refNum === null) {
+          refNum = ++maxRef;
+          try { el.setAttribute('data-opencli-ref', '' + refNum); } catch (_) {}
+          identity['' + refNum] = fingerprintOf(el);
+        } else if (!identity['' + refNum]) {
+          // Ref annotation survived but identity map was cleared — repopulate so the
+          // target resolver's fingerprint check passes on downstream calls.
+          identity['' + refNum] = fingerprintOf(el);
+        }
         const text = (el.textContent || '').trim();
         entries.push({
           nth: i,

--- a/src/browser/target-errors.test.ts
+++ b/src/browser/target-errors.test.ts
@@ -17,17 +17,54 @@ describe('TargetError', () => {
     expect(err.candidates).toBeUndefined();
   });
 
-  it('creates ambiguous error with candidates', () => {
+  it('creates selector_ambiguous error with candidates + matches_n', () => {
     const err = new TargetError({
-      code: 'ambiguous',
+      code: 'selector_ambiguous',
       message: 'CSS selector ".btn" matched 3 elements',
-      hint: 'Use a more specific selector.',
+      hint: 'Use a more specific selector, or pass --nth.',
       candidates: ['<button> "Login"', '<button> "Sign Up"', '<button> "Cancel"'],
+      matches_n: 3,
     });
 
-    expect(err.code).toBe('ambiguous');
+    expect(err.code).toBe('selector_ambiguous');
     expect(err.candidates).toHaveLength(3);
     expect(err.candidates![0]).toContain('Login');
+    expect(err.matches_n).toBe(3);
+  });
+
+  it('creates invalid_selector error', () => {
+    const err = new TargetError({
+      code: 'invalid_selector',
+      message: 'Invalid CSS selector: >>> (unexpected token)',
+      hint: 'Check the selector syntax.',
+    });
+
+    expect(err.code).toBe('invalid_selector');
+    expect(err.message).toContain('Invalid CSS selector');
+  });
+
+  it('creates selector_not_found error with matches_n=0', () => {
+    const err = new TargetError({
+      code: 'selector_not_found',
+      message: 'CSS selector ".missing" matched 0 elements',
+      hint: 'Check the page or use browser find.',
+      matches_n: 0,
+    });
+
+    expect(err.code).toBe('selector_not_found');
+    expect(err.matches_n).toBe(0);
+  });
+
+  it('creates selector_nth_out_of_range error', () => {
+    const err = new TargetError({
+      code: 'selector_nth_out_of_range',
+      message: 'matched 3 elements, but --nth=5 is out of range',
+      hint: 'Use --nth between 0 and 2.',
+      matches_n: 3,
+    });
+
+    expect(err.code).toBe('selector_nth_out_of_range');
+    expect(err.matches_n).toBe(3);
   });
 
   it('creates stale_ref error', () => {
@@ -43,18 +80,20 @@ describe('TargetError', () => {
 
   it('serializes to JSON for structured output', () => {
     const err = new TargetError({
-      code: 'ambiguous',
+      code: 'selector_ambiguous',
       message: 'matched 3',
       hint: 'be specific',
       candidates: ['a', 'b'],
+      matches_n: 3,
     });
 
     const json = err.toJSON();
     expect(json).toEqual({
-      code: 'ambiguous',
+      code: 'selector_ambiguous',
       message: 'matched 3',
       hint: 'be specific',
       candidates: ['a', 'b'],
+      matches_n: 3,
     });
   });
 

--- a/src/browser/target-errors.ts
+++ b/src/browser/target-errors.ts
@@ -5,21 +5,40 @@
  * goes through the unified resolver. When resolution fails, one of these
  * structured errors is thrown so that AI agents and adapter authors get
  * actionable diagnostics instead of a generic "Element not found".
+ *
+ * Numeric-ref codes (from snapshot indices):
+ *   - not_found: the ref no longer exists in the DOM
+ *   - stale_ref: the ref still exists but points to a different element
+ *
+ * CSS-selector codes (from `--selector <css>` entrypoints):
+ *   - invalid_selector:       selector syntax rejected by querySelectorAll
+ *   - selector_not_found:     0 matches
+ *   - selector_ambiguous:     >1 matches for a write op without --nth
+ *   - selector_nth_out_of_range: --nth beyond matches_n
  */
 
-export type TargetErrorCode = 'not_found' | 'ambiguous' | 'stale_ref';
+export type TargetErrorCode =
+  | 'not_found'
+  | 'stale_ref'
+  | 'invalid_selector'
+  | 'selector_not_found'
+  | 'selector_ambiguous'
+  | 'selector_nth_out_of_range';
 
 export interface TargetErrorInfo {
   code: TargetErrorCode;
   message: string;
   hint: string;
   candidates?: string[];
+  /** CSS-path match count, when the error was raised mid-resolution */
+  matches_n?: number;
 }
 
 export class TargetError extends Error {
   readonly code: TargetErrorCode;
   readonly hint: string;
   readonly candidates?: string[];
+  readonly matches_n?: number;
 
   constructor(info: TargetErrorInfo) {
     super(info.message);
@@ -27,6 +46,7 @@ export class TargetError extends Error {
     this.code = info.code;
     this.hint = info.hint;
     this.candidates = info.candidates;
+    this.matches_n = info.matches_n;
   }
 
   /** Serialize for structured output to AI agents */
@@ -36,6 +56,7 @@ export class TargetError extends Error {
       message: this.message,
       hint: this.hint,
       ...(this.candidates && { candidates: this.candidates }),
+      ...(this.matches_n !== undefined && { matches_n: this.matches_n }),
     };
   }
 }

--- a/src/browser/target-resolver.test.ts
+++ b/src/browser/target-resolver.test.ts
@@ -31,8 +31,30 @@ describe('resolveTargetJs', () => {
 
   it('generates JS with ambiguity detection for CSS selectors', () => {
     const js = resolveTargetJs('.btn');
-    expect(js).toContain('ambiguous');
+    expect(js).toContain('selector_ambiguous');
     expect(js).toContain('candidates');
+  });
+
+  it('generates JS that propagates --nth option into the CSS branch', () => {
+    const js = resolveTargetJs('.btn', { nth: 2 });
+    expect(js).toContain('selector_nth_out_of_range');
+    // opt.nth=2 should be inlined so the runtime picks matches[2]
+    expect(js).toMatch(/const nth = 2;?/);
+  });
+
+  it('generates JS that enables firstOnMulti for read commands', () => {
+    const js = resolveTargetJs('.btn', { firstOnMulti: true });
+    expect(js).toContain('firstOnMulti = true');
+  });
+
+  it('generates JS with invalid_selector branch for CSS syntax errors', () => {
+    const js = resolveTargetJs('.btn');
+    expect(js).toContain('invalid_selector');
+  });
+
+  it('generates JS with selector_not_found branch for 0 matches', () => {
+    const js = resolveTargetJs('#does-not-exist');
+    expect(js).toContain('selector_not_found');
   });
 
   it('generates JS that rejects unrecognized input', () => {

--- a/src/browser/target-resolver.test.ts
+++ b/src/browser/target-resolver.test.ts
@@ -57,10 +57,16 @@ describe('resolveTargetJs', () => {
     expect(js).toContain('selector_not_found');
   });
 
-  it('generates JS that rejects unrecognized input', () => {
-    const js = resolveTargetJs('???');
-    expect(js).toContain('not_found');
-    expect(js).toContain('Cannot parse target');
+  it('hands every non-numeric input to querySelectorAll (no regex shortlist)', () => {
+    // Inputs that the old isCssLike regex rejected — must all flow into the
+    // CSS branch so `find --css` and `get/click/type/select` accept the same surface.
+    for (const sel of [':root', '*', ':has(.foo)', '::shadow-root', '???']) {
+      const js = resolveTargetJs(sel);
+      expect(js).toContain('querySelectorAll');
+      // invalid selectors still route through invalid_selector at runtime,
+      // never through a frontend "Cannot parse target" rejection.
+      expect(js).not.toContain('Cannot parse target');
+    }
   });
 
   it('escapes ref value safely', () => {

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -1,31 +1,53 @@
 /**
  * Unified target resolver for browser actions.
  *
- * Replaces the ad-hoc 4-strategy fallback in dom-helpers.ts with a
- * principled resolution pipeline:
+ * Resolution pipeline:
  *
  * 1. Input classification: numeric → ref path, CSS-like → CSS path
  * 2. Ref path: lookup by data-opencli-ref, then verify fingerprint
- * 3. CSS path: querySelectorAll + uniqueness check
- * 4. Structured errors: stale_ref / ambiguous / not_found
+ * 3. CSS path: querySelectorAll + match-count policy (see ResolveOptions)
+ * 4. Structured errors:
+ *    - numeric: not_found / stale_ref
+ *    - CSS:     invalid_selector / selector_not_found / selector_ambiguous
+ *               / selector_nth_out_of_range
  *
  * All JS is generated as strings for page.evaluate() — runs in the browser.
  */
+
+export interface ResolveOptions {
+  /**
+   * When CSS matches multiple elements, pick the element at this 0-based
+   * index instead of raising `selector_ambiguous`. Raises
+   * `selector_nth_out_of_range` if `nth >= matches.length`.
+   */
+  nth?: number;
+  /**
+   * When CSS matches multiple elements, pick the first match instead of
+   * raising `selector_ambiguous`. Used by read commands (get text / value /
+   * attributes) to deliver a best-effort answer + matches_n in the envelope.
+   * Ignored when `nth` is also set (nth wins).
+   */
+  firstOnMulti?: boolean;
+}
 
 /**
  * Generate JS that resolves a target to a single DOM element.
  *
  * Returns a JS expression that evaluates to:
- *   { ok: true, el: Element }                      — success (el is assigned to `__resolved`)
- *   { ok: false, code, message, hint, candidates }  — structured error
+ *   { ok: true, matches_n }                         — success (el stored in `__resolved`)
+ *   { ok: false, code, message, hint, candidates, matches_n? }  — structured error
  *
- * The resolved element is stored in `__resolved` for the caller to use.
+ * The resolved element is stored in `window.__resolved` for downstream helpers.
  */
-export function resolveTargetJs(ref: string): string {
+export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string {
   const safeRef = JSON.stringify(ref);
+  const nthJs = opts.nth !== undefined ? String(opts.nth | 0) : 'null';
+  const firstOnMulti = opts.firstOnMulti === true ? 'true' : 'false';
   return `
     (() => {
       const ref = ${safeRef};
+      const nth = ${nthJs};
+      const firstOnMulti = ${firstOnMulti};
       const identity = window.__opencli_ref_identity || {};
 
       // ── Classify input ──
@@ -95,7 +117,7 @@ export function resolveTargetJs(ref: string): string {
         }
 
         window.__resolved = el;
-        return { ok: true };
+        return { ok: true, matches_n: 1 };
       }
 
       if (isCssLike) {
@@ -106,8 +128,8 @@ export function resolveTargetJs(ref: string): string {
         } catch (e) {
           return {
             ok: false,
-            code: 'not_found',
-            message: 'Invalid CSS selector: ' + ref,
+            code: 'invalid_selector',
+            message: 'Invalid CSS selector: ' + ref + ' (' + ((e && e.message) || String(e)) + ')',
             hint: 'Check the selector syntax. Use ref numbers from snapshot for reliable targeting.',
           };
         }
@@ -115,13 +137,28 @@ export function resolveTargetJs(ref: string): string {
         if (matches.length === 0) {
           return {
             ok: false,
-            code: 'not_found',
+            code: 'selector_not_found',
             message: 'CSS selector "' + ref + '" matched 0 elements',
-            hint: 'The element may not exist or may be hidden. Re-run \`opencli browser state\` to check.',
+            hint: 'The element may not exist or may be hidden. Re-run \`opencli browser state\` to check, or use \`opencli browser find --css\` to explore candidates.',
+            matches_n: 0,
           };
         }
 
-        if (matches.length > 1) {
+        if (nth !== null) {
+          if (nth < 0 || nth >= matches.length) {
+            return {
+              ok: false,
+              code: 'selector_nth_out_of_range',
+              message: 'CSS selector "' + ref + '" matched ' + matches.length + ' elements, but --nth=' + nth + ' is out of range',
+              hint: 'Use --nth between 0 and ' + (matches.length - 1) + ', or omit --nth to target the first match (read ops) or require explicit disambiguation (write ops).',
+              matches_n: matches.length,
+            };
+          }
+          window.__resolved = matches[nth];
+          return { ok: true, matches_n: matches.length };
+        }
+
+        if (matches.length > 1 && !firstOnMulti) {
           const candidates = [];
           const limit = Math.min(matches.length, 5);
           for (let i = 0; i < limit; i++) {
@@ -133,15 +170,17 @@ export function resolveTargetJs(ref: string): string {
           }
           return {
             ok: false,
-            code: 'ambiguous',
+            code: 'selector_ambiguous',
             message: 'CSS selector "' + ref + '" matched ' + matches.length + ' elements',
-            hint: 'Use a more specific selector, or use ref numbers from \`opencli browser state\` snapshot.',
+            hint: 'Pass --nth <n> (0-based) to pick one, or use a more specific selector. Use \`opencli browser find --css\` to list all candidates.',
             candidates: candidates,
+            matches_n: matches.length,
           };
         }
 
+        // Single match, OR multi-match with firstOnMulti (read path)
         window.__resolved = matches[0];
-        return { ok: true };
+        return { ok: true, matches_n: matches.length };
       }
 
       // ── Unrecognized input ──

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -3,7 +3,11 @@
  *
  * Resolution pipeline:
  *
- * 1. Input classification: numeric → ref path, CSS-like → CSS path
+ * 1. Input classification: all-digit → numeric ref path, otherwise → CSS path.
+ *    The CSS path passes the raw string to `querySelectorAll` and lets the
+ *    browser parser decide what's valid. No frontend regex whitelist — the
+ *    goal is that any selector accepted by `browser find --css` is accepted
+ *    by the same selector on `get/click/type/select`.
  * 2. Ref path: lookup by data-opencli-ref, then verify fingerprint
  * 3. CSS path: querySelectorAll + match-count policy (see ResolveOptions)
  * 4. Structured errors:
@@ -51,8 +55,11 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
       const identity = window.__opencli_ref_identity || {};
 
       // ── Classify input ──
+      // Numeric = snapshot ref. Everything else is handed to querySelectorAll
+      // and whatever the browser parser accepts is a valid selector. No regex
+      // shortlist up front: \`find --css\` and \`get/click/type/select\` must agree
+      // on the same selector surface (see contract note at the top of this file).
       const isNumeric = /^\\d+$/.test(ref);
-      const isCssLike = !isNumeric && /^[a-zA-Z#.\\[]/.test(ref);
 
       if (isNumeric) {
         // ── Ref path ──
@@ -120,8 +127,8 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
         return { ok: true, matches_n: 1 };
       }
 
-      if (isCssLike) {
-        // ── CSS selector path ──
+      // ── CSS selector path (any non-numeric input) ──
+      {
         let matches;
         try {
           matches = document.querySelectorAll(ref);
@@ -182,14 +189,6 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
         window.__resolved = matches[0];
         return { ok: true, matches_n: matches.length };
       }
-
-      // ── Unrecognized input ──
-      return {
-        ok: false,
-        code: 'not_found',
-        message: 'Cannot parse target: ' + ref,
-        hint: 'Use a numeric ref from snapshot (e.g. "12") or a CSS selector (e.g. "#submit").',
-      };
     })()
   `;
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { IPage } from './types.js';
+import { TargetError } from './browser/target-errors.js';
 
 const {
   mockBrowserConnect,
@@ -880,6 +881,381 @@ describe('browser get html command', () => {
     await program.parseAsync(['node', 'opencli', 'browser', 'get', 'html', '--as', 'yaml']);
 
     expect(lastJsonLog().error.code).toBe('invalid_format');
+    expect(process.exitCode).toBeDefined();
+  });
+});
+
+// Shared helper for the selector-first describe blocks below.
+// Each block spies console.log, mocks the IPage surface it touches, and
+// parses the last stringified call to inspect the JSON envelope — the
+// canonical agent-facing contract for the selector-first commands.
+function installSelectorFirstTestHarness(label: string, pageOverrides: () => Partial<IPage>) {
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  function lastLogArg(): unknown {
+    const calls = consoleLogSpy.mock.calls;
+    if (calls.length === 0) throw new Error('expected console.log call');
+    return calls[calls.length - 1][0];
+  }
+  function lastJsonLog(): any {
+    const arg = lastLogArg();
+    if (typeof arg !== 'string') throw new Error(`expected string arg, got ${typeof arg}`);
+    return JSON.parse(arg);
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    process.env.OPENCLI_CACHE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), `opencli-${label}-`));
+    consoleLogSpy.mockClear();
+    mockBrowserConnect.mockClear();
+    mockBrowserClose.mockReset().mockResolvedValue(undefined);
+
+    browserState.page = {
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      tabs: vi.fn().mockResolvedValue([{ page: 'tab-1', active: true }]),
+      ...pageOverrides(),
+    } as unknown as IPage;
+  });
+
+  return { lastJsonLog };
+}
+
+describe('browser find command', () => {
+  const { lastJsonLog } = installSelectorFirstTestHarness('find', () => ({
+    evaluate: vi.fn(),
+  }));
+
+  it('returns a {matches_n, entries} envelope for a matching selector', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      matches_n: 2,
+      entries: [
+        { nth: 0, ref: 5, tag: 'button', role: '', text: 'OK', attrs: { class: 'btn' }, visible: true },
+        { nth: 1, ref: null, tag: 'button', role: '', text: 'Cancel', attrs: { class: 'btn' }, visible: true },
+      ],
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find', '--css', '.btn']);
+
+    const out = lastJsonLog();
+    expect(out.matches_n).toBe(2);
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries[0].ref).toBe(5);
+    expect(out.entries[1].ref).toBeNull();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('forwards --limit / --text-max into the generated JS', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({ matches_n: 0, entries: [] });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find', '--css', '.btn', '--limit', '3', '--text-max', '20']);
+
+    const js = (browserState.page!.evaluate as any).mock.calls[0][0] as string;
+    expect(js).toContain('LIMIT = 3');
+    expect(js).toContain('TEXT_MAX = 20');
+  });
+
+  it('emits invalid_selector envelope when the page rejects selector syntax', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      error: { code: 'invalid_selector', message: 'Invalid CSS selector: ">>>"', hint: 'Check the selector syntax.' },
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find', '--css', '>>>']);
+
+    expect(lastJsonLog().error.code).toBe('invalid_selector');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('emits selector_not_found envelope when the selector matches nothing', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      error: { code: 'selector_not_found', message: 'CSS selector ".missing" matched 0 elements', hint: 'Use browser state to inspect the page.' },
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find', '--css', '.missing']);
+
+    expect(lastJsonLog().error.code).toBe('selector_not_found');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('rejects missing --css with usage_error (no evaluate call)', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find']);
+
+    expect(lastJsonLog().error.code).toBe('usage_error');
+    expect(browserState.page!.evaluate).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('rejects malformed --limit with usage_error (no evaluate call)', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find', '--css', '.btn', '--limit', 'abc']);
+
+    expect(lastJsonLog().error.code).toBe('usage_error');
+    expect(browserState.page!.evaluate).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
+  });
+});
+
+describe('browser get text/value/attributes commands', () => {
+  const { lastJsonLog } = installSelectorFirstTestHarness('get-sel', () => ({
+    evaluate: vi.fn(),
+  }));
+
+  it('emits {value, matches_n} envelope for a numeric ref', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    // 1st call: resolveTargetJs -> { ok: true, matches_n: 1 }
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    // 2nd call: getTextResolvedJs -> the element's text
+    evalMock.mockResolvedValueOnce('Hello world');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '7']);
+
+    expect(lastJsonLog()).toEqual({ value: 'Hello world', matches_n: 1 });
+  });
+
+  it('reports matches_n on multi-match CSS (read path: first match wins)', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 3 });
+    evalMock.mockResolvedValueOnce('first');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '.btn']);
+
+    expect(lastJsonLog()).toEqual({ value: 'first', matches_n: 3 });
+  });
+
+  it('parses the attributes payload back into a real object', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    // getAttributesResolvedJs returns a JSON-encoded string — the CLI must parse it
+    evalMock.mockResolvedValueOnce(JSON.stringify({ id: 'nav', class: 'hero' }));
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'attributes', '#nav']);
+
+    const out = lastJsonLog();
+    expect(out.matches_n).toBe(1);
+    expect(out.value).toEqual({ id: 'nav', class: 'hero' });
+  });
+
+  it('propagates selector_not_found from the resolver as an error envelope', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      ok: false,
+      code: 'selector_not_found',
+      message: 'CSS selector ".missing" matched 0 elements',
+      hint: 'Try a less specific selector.',
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '.missing']);
+
+    expect(lastJsonLog().error.code).toBe('selector_not_found');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('forwards --nth into the resolver opts and reports matches_n', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 4 });
+    evalMock.mockResolvedValueOnce('second');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'value', '.btn', '--nth', '1']);
+
+    const resolveJs = evalMock.mock.calls[0][0] as string;
+    // resolveTargetJs embeds nth as a raw number literal; look for the binding
+    expect(resolveJs).toContain('const nth = 1');
+    expect(lastJsonLog()).toEqual({ value: 'second', matches_n: 4 });
+  });
+
+  it('rejects malformed --nth with usage_error before touching the page', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '.btn', '--nth', 'abc']);
+
+    expect(lastJsonLog().error.code).toBe('usage_error');
+    expect(browserState.page!.evaluate).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
+  });
+});
+
+describe('browser click/type commands', () => {
+  const { lastJsonLog } = installSelectorFirstTestHarness('click-type', () => ({
+    evaluate: vi.fn().mockResolvedValue(false),
+    click: vi.fn().mockResolvedValue({ matches_n: 1 }),
+    typeText: vi.fn().mockResolvedValue({ matches_n: 1 }),
+    wait: vi.fn().mockResolvedValue(undefined),
+  }));
+
+  it('emits {clicked, target, matches_n} on success', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1 });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '#save']);
+
+    expect(browserState.page!.click).toHaveBeenCalledWith('#save', {});
+    expect(lastJsonLog()).toEqual({ clicked: true, target: '#save', matches_n: 1 });
+  });
+
+  it('forwards --nth as ResolveOptions.nth to page.click', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 3 });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '.btn', '--nth', '2']);
+
+    expect(browserState.page!.click).toHaveBeenCalledWith('.btn', { nth: 2 });
+    expect(lastJsonLog()).toEqual({ clicked: true, target: '.btn', matches_n: 3 });
+  });
+
+  it('surfaces selector_ambiguous from page.click as an error envelope', async () => {
+    (browserState.page!.click as any).mockRejectedValueOnce(new TargetError({
+      code: 'selector_ambiguous',
+      message: 'CSS selector ".btn" matched 3 elements; clicks require a unique target.',
+      hint: 'Pass --nth <n> to pick one (0-based).',
+      matches_n: 3,
+    }));
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '.btn']);
+
+    const err = lastJsonLog().error;
+    expect(err.code).toBe('selector_ambiguous');
+    expect(err.matches_n).toBe(3);
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('surfaces selector_nth_out_of_range from page.click as an error envelope', async () => {
+    (browserState.page!.click as any).mockRejectedValueOnce(new TargetError({
+      code: 'selector_nth_out_of_range',
+      message: '--nth 99 is out of range for CSS selector ".btn" (matches_n=3).',
+      hint: 'Pick an index in [0, 2].',
+      matches_n: 3,
+    }));
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '.btn', '--nth', '99']);
+
+    expect(lastJsonLog().error.code).toBe('selector_nth_out_of_range');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('rejects malformed --nth on click with usage_error before touching the page', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '.btn', '--nth', 'abc']);
+
+    expect(lastJsonLog().error.code).toBe('usage_error');
+    expect(browserState.page!.click).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('type: clicks, waits, then typeText — emits {typed, text, target, matches_n, autocomplete}', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1 });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1 });
+    (browserState.page!.evaluate as any).mockResolvedValueOnce(false); // isAutocomplete
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'type', '#q', 'hello']);
+
+    expect(browserState.page!.click).toHaveBeenCalledWith('#q', {});
+    expect(browserState.page!.wait).toHaveBeenCalledWith(0.3);
+    expect(browserState.page!.typeText).toHaveBeenCalledWith('#q', 'hello', {});
+    expect(lastJsonLog()).toEqual({
+      typed: true, text: 'hello', target: '#q', matches_n: 1, autocomplete: false,
+    });
+  });
+
+  it('type: waits an extra 0.4s when the input reports autocomplete=true', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1 });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1 });
+    (browserState.page!.evaluate as any).mockResolvedValueOnce(true);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'type', '#q', 'hi']);
+
+    const waitCalls = (browserState.page!.wait as any).mock.calls;
+    expect(waitCalls).toContainEqual([0.3]);
+    expect(waitCalls).toContainEqual([0.4]);
+    expect(lastJsonLog().autocomplete).toBe(true);
+  });
+
+  it('type: forwards --nth to both click and typeText', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 5 });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 5 });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'type', '.field', 'x', '--nth', '3']);
+
+    expect(browserState.page!.click).toHaveBeenCalledWith('.field', { nth: 3 });
+    expect(browserState.page!.typeText).toHaveBeenCalledWith('.field', 'x', { nth: 3 });
+  });
+});
+
+describe('browser select command', () => {
+  const { lastJsonLog } = installSelectorFirstTestHarness('select', () => ({
+    evaluate: vi.fn(),
+  }));
+
+  it('emits {selected, target, matches_n} on success', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ selected: 'US' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'select', '#country', 'US']);
+
+    expect(lastJsonLog()).toEqual({ selected: 'US', target: '#country', matches_n: 1 });
+  });
+
+  it('maps "Not a <select>" to a not_a_select error envelope', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ error: 'Not a <select>' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'select', '#not-select', 'US']);
+
+    const err = lastJsonLog().error;
+    expect(err.code).toBe('not_a_select');
+    expect(err.matches_n).toBe(1);
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('maps missing-option failures to an option_not_found envelope with available list', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ error: 'Option "XX" not found', available: ['US', 'CA'] });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'select', '#country', 'XX']);
+
+    const err = lastJsonLog().error;
+    expect(err.code).toBe('option_not_found');
+    expect(err.available).toEqual(['US', 'CA']);
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('surfaces selector_ambiguous from the resolver before calling selectResolvedJs', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      ok: false,
+      code: 'selector_ambiguous',
+      message: 'CSS selector ".dropdown" matched 2 elements.',
+      hint: 'Pass --nth <n>.',
+      matches_n: 2,
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'select', '.dropdown', 'US']);
+
+    expect(lastJsonLog().error.code).toBe('selector_ambiguous');
+    // The select payload JS must not fire when resolution fails
+    expect((browserState.page!.evaluate as any).mock.calls).toHaveLength(1);
     expect(process.exitCode).toBeDefined();
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -927,11 +927,14 @@ describe('browser find command', () => {
   }));
 
   it('returns a {matches_n, entries} envelope for a matching selector', async () => {
+    // `find` always returns numeric refs (existing on snapshot-tagged elements,
+    // allocated on the spot for fresh matches) — see reviewer contract in
+    // #opencli-browser msg 52c51eb6.
     (browserState.page!.evaluate as any).mockResolvedValueOnce({
       matches_n: 2,
       entries: [
         { nth: 0, ref: 5, tag: 'button', role: '', text: 'OK', attrs: { class: 'btn' }, visible: true },
-        { nth: 1, ref: null, tag: 'button', role: '', text: 'Cancel', attrs: { class: 'btn' }, visible: true },
+        { nth: 1, ref: 17, tag: 'button', role: '', text: 'Cancel', attrs: { class: 'btn' }, visible: true },
       ],
     });
     const program = createProgram('', '');
@@ -942,7 +945,7 @@ describe('browser find command', () => {
     expect(out.matches_n).toBe(2);
     expect(out.entries).toHaveLength(2);
     expect(out.entries[0].ref).toBe(5);
-    expect(out.entries[1].ref).toBeNull();
+    expect(out.entries[1].ref).toBe(17);
     expect(process.exitCode).toBeUndefined();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,8 +20,9 @@ import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled } from './external.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
-import { TargetError } from './browser/target-errors.js';
-import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs } from './browser/target-resolver.js';
+import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
+import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, clickResolvedJs, type ResolveOptions } from './browser/target-resolver.js';
+import { buildFindJs, isFindError, type FindResult, type FindError } from './browser/find.js';
 import { inferShape } from './browser/shape.js';
 import { assignKeys } from './browser/network-key.js';
 import { DEFAULT_TTL_MS, findEntry, loadNetworkCache, saveNetworkCache, type CachedNetworkEntry } from './browser/network-cache.js';
@@ -361,14 +362,57 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .command('browser')
     .description('Browser control — navigate, click, type, extract, wait (no LLM needed)');
 
-  /** Resolve a ref/CSS target via the unified resolver, throwing TargetError on failure. */
-  async function resolveRef(page: Awaited<ReturnType<typeof getBrowserPage>>, ref: string): Promise<void> {
-    const resolution = await page.evaluate(resolveTargetJs(ref)) as
-      | { ok: true }
-      | { ok: false; code: string; message: string; hint: string; candidates?: string[] };
+  /**
+   * Resolve a `<target>` (numeric ref or CSS selector) via the unified resolver.
+   * Returns the CSS match count so callers can propagate `matches_n` into the
+   * JSON envelope printed back to the agent.
+   */
+  async function resolveRef(
+    page: Awaited<ReturnType<typeof getBrowserPage>>,
+    ref: string,
+    opts: ResolveOptions = {},
+  ): Promise<{ matches_n: number }> {
+    const resolution = await page.evaluate(resolveTargetJs(ref, opts)) as
+      | { ok: true; matches_n: number }
+      | { ok: false; code: TargetErrorCode; message: string; hint: string; candidates?: string[]; matches_n?: number };
     if (!resolution.ok) {
-      throw new TargetError(resolution as { ok: false; code: 'not_found' | 'ambiguous' | 'stale_ref'; message: string; hint: string; candidates?: string[] });
+      throw new TargetError({
+        code: resolution.code,
+        message: resolution.message,
+        hint: resolution.hint,
+        candidates: resolution.candidates,
+        matches_n: resolution.matches_n,
+      });
     }
+    return { matches_n: resolution.matches_n };
+  }
+
+  /**
+   * Parse `--nth <n>` flag, returning the parsed 0-based index or a usage error.
+   * The surface mirrors `--depth` etc. in `browser get html --as json`: the flag
+   * is optional, must be a non-negative integer when present, and on failure we
+   * emit the structured error envelope rather than throwing past the command.
+   */
+  function parseNthFlag(raw: unknown): number | null | { error: string } {
+    if (raw === undefined || raw === null || raw === '') return null;
+    const str = String(raw);
+    if (!/^\d+$/.test(str)) {
+      return { error: `--nth must be a non-negative integer, got "${str}"` };
+    }
+    return Number.parseInt(str, 10);
+  }
+
+  /** Emit the `{ error: { code, message, hint?, candidates?, matches_n? } }` envelope used by the selector-first commands. */
+  function emitTargetError(err: TargetError): void {
+    console.log(JSON.stringify({
+      error: {
+        code: err.code,
+        message: err.message,
+        hint: err.hint,
+        ...(err.candidates && { candidates: err.candidates }),
+        ...(err.matches_n !== undefined && { matches_n: err.matches_n }),
+      },
+    }, null, 2));
   }
 
   /** Wrap browser actions with error handling and optional --json output */
@@ -384,12 +428,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           log.error(err.message);
           if (err.hint) log.error(`Hint: ${err.hint}`);
         } else if (err instanceof TargetError) {
+          // Agent-facing structured envelope on stdout + short human line on stderr.
+          emitTargetError(err);
           log.error(`[${err.code}] ${err.message}`);
           if (err.hint) log.error(`Hint: ${err.hint}`);
-          if (err.candidates?.length) {
-            log.error('Candidates:');
-            err.candidates.forEach((c, i) => log.error(`  ${i + 1}. ${c}`));
-          }
         } else {
           const msg = getErrorMessage(err);
           if (msg.includes('attach failed') || msg.includes('chrome-extension://')) {
@@ -542,6 +584,54 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
     }));
 
+  // ── Find (structured CSS query, agent-native) ──
+  //
+  // `browser find --css <sel>` lets agents jump straight from a semantic
+  // selector to a JSON list of matching elements, without having to parse
+  // the free-text state snapshot to recover indices.
+  addBrowserTabOption(
+    browser.command('find')
+      .option('--css <selector>', 'CSS selector (required)')
+      .option('--limit <n>', 'Max entries returned', '50')
+      .option('--text-max <n>', 'Max chars of trimmed text per entry', '120')
+      .description('Find DOM elements by CSS selector — returns JSON {matches_n, entries[]}'),
+  )
+    .action(browserAction(async (page, opts) => {
+      if (!opts.css || typeof opts.css !== 'string') {
+        console.log(JSON.stringify({
+          error: {
+            code: 'usage_error',
+            message: '--css <selector> is required',
+            hint: 'Example: opencli browser find --css ".btn.primary"',
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const limit = parseNthFlag(opts.limit);
+      if (limit && typeof limit === 'object' && 'error' in limit) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: limit.error.replace('--nth', '--limit') } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const textMax = parseNthFlag(opts.textMax);
+      if (textMax && typeof textMax === 'object' && 'error' in textMax) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: textMax.error.replace('--nth', '--text-max') } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const result = await page.evaluate(buildFindJs(opts.css, {
+        limit: limit as number | null ?? undefined,
+        textMax: textMax as number | null ?? undefined,
+      })) as FindResult | FindError;
+      if (isFindError(result)) {
+        console.log(JSON.stringify(result, null, 2));
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+        return;
+      }
+      console.log(JSON.stringify(result, null, 2));
+    }));
+
   // ── Get commands (structured data extraction) ──
 
   const get = browser.command('get').description('Get page properties');
@@ -556,19 +646,61 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       console.log(await page.getCurrentUrl?.() ?? await page.evaluate('location.href'));
     }));
 
-  addBrowserTabOption(get.command('text').argument('<index>', 'Element index').description('Element text content'))
-    .action(browserAction(async (page, index) => {
-      await resolveRef(page, String(index));
-      const text = await page.evaluate(getTextResolvedJs());
-      console.log(text ?? '(empty)');
-    }));
+  // Read commands (`get text/value/attributes`) always emit a JSON envelope:
+  //
+  //   { value, matches_n }                           — success
+  //   { error: { code, message, hint, matches_n? } } — structured failure
+  //
+  // `<target>` accepts either a numeric ref (from `browser state`/`browser find`)
+  // or a CSS selector. On multi-match CSS, the first element wins and the real
+  // match count is exposed via `matches_n`; `--nth <n>` picks a specific one.
+  const runGetCommand = async (
+    page: Awaited<ReturnType<typeof getBrowserPage>>,
+    target: string,
+    opts: { nth?: string },
+    evalJs: string,
+    field: 'text' | 'value' | 'attributes',
+  ): Promise<void> => {
+    const nth = parseNthFlag(opts.nth);
+    if (nth && typeof nth === 'object' && 'error' in nth) {
+      console.log(JSON.stringify({ error: { code: 'usage_error', message: nth.error } }, null, 2));
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
+      return;
+    }
+    const { matches_n } = await resolveRef(page, String(target), {
+      firstOnMulti: nth === null,
+      ...(typeof nth === 'number' ? { nth } : {}),
+    });
+    const raw = await page.evaluate(evalJs);
+    let value: unknown;
+    if (field === 'attributes') {
+      // getAttributesResolvedJs stringifies the attribute record — parse it back so
+      // the JSON envelope contains a real object rather than a nested JSON string.
+      try { value = raw == null ? {} : JSON.parse(String(raw)); }
+      catch { value = raw; }
+    } else {
+      value = raw ?? null;
+    }
+    console.log(JSON.stringify({ value, matches_n }, null, 2));
+  };
 
-  addBrowserTabOption(get.command('value').argument('<index>', 'Element index').description('Input/textarea value'))
-    .action(browserAction(async (page, index) => {
-      await resolveRef(page, String(index));
-      const val = await page.evaluate(getValueResolvedJs());
-      console.log(val ?? '(empty)');
-    }));
+  addBrowserTabOption(
+    get.command('text')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'Pick the nth match (0-based) when <target> is a multi-match CSS selector')
+      .description('Element text content — JSON envelope {value, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) =>
+      runGetCommand(page, String(target), opts ?? {}, getTextResolvedJs(), 'text')));
+
+  addBrowserTabOption(
+    get.command('value')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'Pick the nth match (0-based) when <target> is a multi-match CSS selector')
+      .description('Input/textarea value — JSON envelope {value, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) =>
+      runGetCommand(page, String(target), opts ?? {}, getValueResolvedJs(), 'value')));
 
   addBrowserTabOption(
     get.command('html')
@@ -692,49 +824,122 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       console.log(html);
     }));
 
-  addBrowserTabOption(get.command('attributes').argument('<index>', 'Element index').description('Element attributes'))
-    .action(browserAction(async (page, index) => {
-      await resolveRef(page, String(index));
-      const attrs = await page.evaluate(getAttributesResolvedJs());
-      console.log(attrs ?? '{}');
-    }));
+  addBrowserTabOption(
+    get.command('attributes')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'Pick the nth match (0-based) when <target> is a multi-match CSS selector')
+      .description('Element attributes — JSON envelope {value, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) =>
+      runGetCommand(page, String(target), opts ?? {}, getAttributesResolvedJs(), 'attributes')));
 
   // ── Interact ──
+  //
+  // Write commands (`click/type/select`) share the same `<target>` contract
+  // as the read commands but *reject* multi-match CSS as `selector_ambiguous`
+  // unless the caller passes `--nth <n>`. That asymmetry is intentional:
+  // clicking "one of three buttons" at random is almost never what the agent
+  // meant. Every branch emits a JSON envelope on stdout; error envelopes go
+  // through the unified TargetError handler in browserAction.
 
-  addBrowserTabOption(browser.command('click').argument('<index>', 'Element index from state').description('Click element by index'))
-    .action(browserAction(async (page, index) => {
-      await page.click(index);
-      console.log(`Clicked element [${index}]`);
+  /**
+   * Parse the `--nth` flag and convert it to `ResolveOptions`.
+   * Returns `{ error }` when the flag was malformed (so the command can
+   * print the structured usage error and exit) or `{ opts }` to feed
+   * into resolveRef / page.click / page.typeText.
+   */
+  function nthToResolveOpts(raw: unknown): { error: string } | { opts: ResolveOptions } {
+    const parsed = parseNthFlag(raw);
+    if (parsed && typeof parsed === 'object' && 'error' in parsed) return parsed;
+    if (typeof parsed === 'number') return { opts: { nth: parsed } };
+    return { opts: {} };
+  }
+
+  addBrowserTabOption(
+    browser.command('click')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Click element — JSON envelope {clicked, target, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) => {
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const { matches_n } = await page.click(String(target), parsed.opts);
+      console.log(JSON.stringify({ clicked: true, target: String(target), matches_n }, null, 2));
     }));
 
-  addBrowserTabOption(browser.command('type').argument('<index>', 'Element index').argument('<text>', 'Text to type'))
-    .description('Click element, then type text')
-    .action(browserAction(async (page, index, text) => {
-      await page.click(index);
+  addBrowserTabOption(
+    browser.command('type')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .argument('<text>', 'Text to type')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Click element, then type text — JSON envelope {typed, text, target, matches_n, autocomplete}'),
+  )
+    .action(browserAction(async (page, target, text, opts) => {
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      // Click first (focuses the field), wait briefly, then type.
+      await page.click(String(target), parsed.opts);
       await page.wait(0.3);
-      await page.typeText(index, text);
-      // Detect autocomplete/combobox fields and wait for dropdown suggestions
-      // __resolved is already set by typeText's resolver call
-      const isAutocomplete = await page.evaluate(isAutocompleteResolvedJs());
-      if (isAutocomplete) {
-        await page.wait(0.4);
-        console.log(`Typed "${text}" into autocomplete [${index}] — use state to see suggestions`);
-      } else {
-        console.log(`Typed "${text}" into element [${index}]`);
-      }
+      const { matches_n } = await page.typeText(String(target), String(text), parsed.opts);
+      // __resolved is already set by the resolver call inside page.typeText
+      const isAutocomplete = await page.evaluate(isAutocompleteResolvedJs()) as boolean;
+      if (isAutocomplete) await page.wait(0.4);
+      console.log(JSON.stringify({
+        typed: true,
+        text: String(text),
+        target: String(target),
+        matches_n,
+        autocomplete: !!isAutocomplete,
+      }, null, 2));
     }));
 
-  addBrowserTabOption(browser.command('select').argument('<index>', 'Element index of <select>').argument('<option>', 'Option text'))
-    .description('Select dropdown option')
-    .action(browserAction(async (page, index, option) => {
-      await resolveRef(page, String(index));
-      const result = await page.evaluate(selectResolvedJs(option)) as { error?: string; selected?: string; available?: string[] } | null;
-      if (result?.error) {
-        console.error(`Error: ${result.error}${result.available ? ` — Available: ${result.available.join(', ')}` : ''}`);
-        process.exitCode = EXIT_CODES.GENERIC_ERROR;
-      } else {
-        console.log(`Selected "${result?.selected}" in element [${index}]`);
+  addBrowserTabOption(
+    browser.command('select')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector of a <select> element')
+      .argument('<option>', 'Option text (or value) to select')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Select dropdown option — JSON envelope {selected, target, matches_n}'),
+  )
+    .action(browserAction(async (page, target, option, opts) => {
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
       }
+      const { matches_n } = await resolveRef(page, String(target), parsed.opts);
+      const result = await page.evaluate(selectResolvedJs(String(option))) as
+        | { error?: string; selected?: string; available?: string[] }
+        | null;
+      if (result?.error) {
+        // The select-specific "Not a <select>" / "Option not found" errors
+        // are domain-level failures — emit a structured envelope so agents
+        // can branch on code rather than scrape a log line.
+        console.log(JSON.stringify({
+          error: {
+            code: result.error === 'Not a <select>' ? 'not_a_select' : 'option_not_found',
+            message: result.error,
+            ...(result.available && { available: result.available }),
+            matches_n,
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+        return;
+      }
+      console.log(JSON.stringify({
+        selected: result?.selected ?? String(option),
+        target: String(target),
+        matches_n,
+      }, null, 2));
     }));
 
   addBrowserTabOption(browser.command('keys').argument('<key>', 'Key to press (Enter, Escape, Tab, Control+a)'))

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,10 +51,10 @@ export interface IPage {
   evaluateWithArgs?(js: string, args: Record<string, unknown>): Promise<any>;
   getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   snapshot(opts?: SnapshotOptions): Promise<any>;
-  click(ref: string): Promise<void>;
-  typeText(ref: string, text: string): Promise<void>;
+  click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number }>;
+  typeText(ref: string, text: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number }>;
   pressKey(key: string): Promise<void>;
-  scrollTo(ref: string): Promise<any>;
+  scrollTo(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<any>;
   getFormState(): Promise<any>;
   wait(options: number | WaitOptions): Promise<void>;
   tabs(): Promise<any>;


### PR DESCRIPTION
## Summary

Lands A2 + A3 in a single PR per #opencli-browser discussion.

**A2 — `browser find --css <sel>`**: structured CSS query. Returns `{matches_n, entries[]}` so agents can go from a semantic selector straight to a list of candidates, without parsing free-text snapshot output. Each entry exposes `nth / ref / tag / role / text / attrs / visible`. Invisible elements are still returned so agents can reason about offscreen vs truly-missing targets. Attribute whitelist kept small on purpose (id, class, name, type, placeholder, aria-label, title, href, value, role, data-testid) — no `style` / `onclick` leaks, locked by test.

**A3 — selector-first read path**: `browser get text/value/attributes <target>` now accept either a numeric ref (legacy snapshot index) or a CSS selector. On multi-match CSS, the first element wins; `matches_n` is always reported so agents notice ambiguity. `--nth <n>` picks a specific one.

**Bonus scope (approved by @codex-mini1 + @First-principles-1)** — `click / type / select` share the same contract:
- Write ops *reject* multi-match CSS without `--nth` as `selector_ambiguous` (clicking one of three buttons at random is almost never what the agent meant).
- Numeric ref path unchanged.
- `click` → `{clicked, target, matches_n}`, `type` → `{typed, text, target, matches_n, autocomplete}`, `select` → `{selected, target, matches_n}` / `{error: { code: 'not_a_select' | 'option_not_found', available? }}`.

**Unified error envelope** — every selector-first command emits
```
{ error: { code, message, hint?, candidates?, matches_n? } }
```
codes: `invalid_selector` / `selector_not_found` / `selector_ambiguous` / `selector_nth_out_of_range` (CSS) + `not_found` / `stale_ref` (numeric ref) + `usage_error` (malformed `--nth` / `--css`).

**Shared resolver** — `resolveTargetJs` is the single source of truth for numeric-vs-CSS classification. `click / typeText / scrollTo` share one `runResolve` helper in `BasePage`; the CLI reuses it via `resolveRef`.

Per @WAWQAQ's directive, no back-compat shims — the new surface is the surface.

## Test plan
- [x] `src/browser/find.test.ts` — locks generated-JS shape, injection-safety, attr whitelist, per-entry shape, error branches
- [x] `src/browser/target-resolver.test.ts` — updated for new CSS error codes
- [x] `src/browser/target-errors.test.ts` — updated union + matches_n field
- [x] `src/cli.test.ts` — new describe blocks for `find`, `get text/value/attributes`, `click/type`, `select`: success envelope, selector_ambiguous, selector_nth_out_of_range, not_a_select, option_not_found, usage_error on malformed `--nth`
- [x] `pnpm typecheck` clean
- [x] 125 targeted tests green

## Reviewers
@codex-mini1 @First-principles-1