### PR TITLE
feat(twitter): expose has_media and media_urls columns

### DIFF
--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { resolveTwitterQueryId, sanitizeQueryId } from './shared.js';
+import { resolveTwitterQueryId, sanitizeQueryId, extractMedia } from './shared.js';
 const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 const LIKES_QUERY_ID = 'RozQdCp4CilQzrcuU0NY5w';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'qRednkZG-rn1P6b48NINmQ';
@@ -99,6 +99,7 @@ function extractLikedTweet(result, seen) {
         retweets: legacy.retweet_count || 0,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(legacy),
     };
 }
 function parseLikes(data, seen) {
@@ -144,7 +145,7 @@ cli({
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (without @). Defaults to logged-in user.' },
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['author', 'name', 'text', 'likes', 'url'],
+    columns: ['author', 'name', 'text', 'likes', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         let username = (kwargs.username || '').replace(/^@/, '');

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -1,5 +1,6 @@
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { extractMedia } from './shared.js';
 /**
  * Trigger Twitter search SPA navigation with fallback strategies.
  *
@@ -102,7 +103,7 @@ cli({
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'] },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url'],
+    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const query = kwargs.query;
         const filter = kwargs.filter === 'live' ? 'live' : 'top';
@@ -156,7 +157,8 @@ cli({
                         created_at: tweet.legacy?.created_at || '',
                         likes: tweet.legacy?.favorite_count || 0,
                         views: tweet.views?.count || '0',
-                        url: `https://x.com/i/status/${tweet.rest_id}`
+                        url: `https://x.com/i/status/${tweet.rest_id}`,
+                        ...extractMedia(tweet.legacy),
                     });
                 }
             }

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -75,6 +75,8 @@ describe('twitter search command', () => {
                 likes: 7,
                 views: '12',
                 url: 'https://x.com/i/status/1',
+                has_media: false,
+                media_urls: [],
             },
         ]);
         expect(page.installInterceptor).toHaveBeenCalledWith('SearchTimeline');
@@ -203,6 +205,8 @@ describe('twitter search command', () => {
                 likes: 3,
                 views: '5',
                 url: 'https://x.com/i/status/99',
+                has_media: false,
+                media_urls: [],
             },
         ]);
         // 6 evaluate calls: 2x pushState + 2x pathname check + 1x fallback + 1x pathname check

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -30,6 +30,34 @@ export async function resolveTwitterQueryId(page, operationName, fallbackId) {
   }`);
     return sanitizeQueryId(resolved, fallbackId);
 }
+/**
+ * Extract media flags and URLs from a tweet's `legacy` object.
+ *
+ * Prefers `extended_entities.media` (superset with full video_info) and falls
+ * back to `entities.media` when the extended form is missing. For videos and
+ * animated GIFs, returns the mp4 variant URL; for photos, returns
+ * `media_url_https`.
+ */
+export function extractMedia(legacy) {
+    const media = legacy?.extended_entities?.media || legacy?.entities?.media;
+    if (!Array.isArray(media) || media.length === 0) {
+        return { has_media: false, media_urls: [] };
+    }
+    const urls = [];
+    for (const m of media) {
+        if (!m) continue;
+        if (m.type === 'video' || m.type === 'animated_gif') {
+            const variants = m.video_info?.variants || [];
+            const mp4 = variants.find((v) => v?.content_type === 'video/mp4');
+            const url = mp4?.url || m.media_url_https;
+            if (url) urls.push(url);
+        } else {
+            if (m.media_url_https) urls.push(m.media_url_https);
+        }
+    }
+    return { has_media: urls.length > 0, media_urls: urls };
+}
 export const __test__ = {
     sanitizeQueryId,
+    extractMedia,
 };

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './shared.js';
+
+const { extractMedia } = __test__;
+
+describe('twitter extractMedia', () => {
+    it('returns false + empty list when legacy has no media', () => {
+        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [] });
+        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [] });
+        expect(extractMedia({ extended_entities: { media: [] } })).toEqual({
+            has_media: false,
+            media_urls: [],
+        });
+    });
+
+    it('extracts photo urls from extended_entities', () => {
+        const result = extractMedia({
+            extended_entities: {
+                media: [
+                    { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/a.jpg' },
+                    { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/b.jpg' },
+                ],
+            },
+        });
+        expect(result.has_media).toBe(true);
+        expect(result.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+    });
+
+    it('prefers mp4 variant for video and animated_gif', () => {
+        const result = extractMedia({
+            extended_entities: {
+                media: [
+                    {
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/media/thumb.jpg',
+                        video_info: {
+                            variants: [
+                                { content_type: 'application/x-mpegURL', url: 'https://video.twimg.com/x.m3u8' },
+                                { content_type: 'video/mp4', url: 'https://video.twimg.com/x.mp4' },
+                            ],
+                        },
+                    },
+                    {
+                        type: 'animated_gif',
+                        media_url_https: 'https://pbs.twimg.com/tweet_video_thumb/g.jpg',
+                        video_info: {
+                            variants: [
+                                { content_type: 'video/mp4', url: 'https://video.twimg.com/g.mp4' },
+                            ],
+                        },
+                    },
+                ],
+            },
+        });
+        expect(result.has_media).toBe(true);
+        expect(result.media_urls).toEqual([
+            'https://video.twimg.com/x.mp4',
+            'https://video.twimg.com/g.mp4',
+        ]);
+    });
+
+    it('falls back to media_url_https when no mp4 variant is available', () => {
+        const result = extractMedia({
+            extended_entities: {
+                media: [
+                    {
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/media/thumb.jpg',
+                        video_info: { variants: [] },
+                    },
+                ],
+            },
+        });
+        expect(result).toEqual({
+            has_media: true,
+            media_urls: ['https://pbs.twimg.com/media/thumb.jpg'],
+        });
+    });
+
+    it('falls back to entities.media when extended_entities is missing', () => {
+        const result = extractMedia({
+            entities: {
+                media: [
+                    { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/c.jpg' },
+                ],
+            },
+        });
+        expect(result).toEqual({
+            has_media: true,
+            media_urls: ['https://pbs.twimg.com/media/c.jpg'],
+        });
+    });
+});

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { extractMedia } from './shared.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 const TWEET_DETAIL_QUERY_ID = 'nBS-WpgA6ZG0CyNHD517JQ';
@@ -54,6 +55,7 @@ function extractTweet(r, seen) {
         in_reply_to: l.in_reply_to_status_id_str || undefined,
         created_at: l.created_at,
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(l),
     };
 }
 function parseTweetDetail(data, seen) {
@@ -101,7 +103,7 @@ cli({
         { name: 'tweet-id', positional: true, type: 'string', required: true },
         { name: 'limit', type: 'int', default: 50 },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -1,6 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { resolveTwitterQueryId } from './shared.js';
+import { resolveTwitterQueryId, extractMedia } from './shared.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 const HOME_TIMELINE_QUERY_ID = 'c-CzHF1LboFilMpsx4ZCrQ';
@@ -85,6 +85,7 @@ function extractTweet(result, seen) {
         views,
         created_at: l.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(l),
     };
 }
 function parseHomeTimeline(data, seen) {
@@ -148,7 +149,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { resolveTwitterQueryId, sanitizeQueryId } from './shared.js';
+import { resolveTwitterQueryId, sanitizeQueryId, extractMedia } from './shared.js';
 
 const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 const USER_TWEETS_QUERY_ID = '6fWQaBPK51aGyC_VC7t9GQ';
@@ -105,6 +105,7 @@ function extractTweet(result, seen) {
         is_retweet: isRetweet,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(legacy),
     };
 }
 
@@ -151,7 +152,7 @@ cli({
         { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (with or without @)' },
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },
     ],
-    columns: ['author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url'],
+    columns: ['author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = Math.max(1, Math.min(200, kwargs.limit || 20));
         const username = String(kwargs.username || '').replace(/^@/, '').trim();

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -5,7 +5,7 @@ import { __test__ } from './tweets.js';
 describe('twitter tweets helpers', () => {
     it('registers is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
-        expect(cmd?.columns).toEqual(['author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url']);
+        expect(cmd?.columns).toEqual(['author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls']);
     });
 
     it('falls back when queryId contains unsafe characters', () => {


### PR DESCRIPTION
## Summary

Adds `has_media` (boolean) and `media_urls` (string[]) columns to the Twitter read commands — `search`, `timeline`, `tweets`, `thread`, `likes` — so downstream pipelines can filter tweets that carry photos / videos / GIFs without launching `twitter download` per tweet.

Closes #1107.

This is an additive, non-breaking column change. The existing INTERCEPT / COOKIE payloads already carry `legacy.extended_entities.media`; the adapter-side change is purely in the row-mapping layer, so no new network work is introduced. Pattern mirrors #465 (the `time` / `created_at` column).

## Approach

- New shared helper `extractMedia(legacy)` in `clis/twitter/shared.js`:
  - Photos: `media_url_https`
  - Videos / animated GIFs: prefer the `video/mp4` variant from `video_info.variants`, fall back to `media_url_https` thumbnail if no mp4 is present
  - Fall back to `legacy.entities.media` when `extended_entities` is missing
  - Returns `{ has_media: false, media_urls: [] }` for the empty case
- All five read adapters import the helper and spread its output into each row.
- New columns are appended to the end of each `columns` array so existing column-index consumers aren't disrupted.

## Tests

- New `clis/twitter/shared.test.js` covers the helper directly: empty case, photos, video mp4-variant selection, animated_gif, `entities.media` fallback, and the no-variants fallback.
- Updated `search.test.js` result assertions and `tweets.test.js` columns assertion to include the new fields.

```
npm test          → 225 files, 1769 passed
npm run typecheck → clean
```
