### PR TITLE
feat(browser): compound expansion + cascading stale-ref + bbox 0.99 dedup

### DIFF
--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -27,8 +27,19 @@ import {
   typeResolvedJs,
   scrollResolvedJs,
   type ResolveOptions,
+  type TargetMatchLevel,
 } from './target-resolver.js';
 import { TargetError, type TargetErrorCode } from './target-errors.js';
+
+export interface ResolveSuccess {
+  matches_n: number;
+  /**
+   * Cascading stale-ref tier the resolver traversed. Callers surface this to
+   * agents so `stable` / `reidentified` hits are visibly distinct from a
+   * clean `exact` match — the page changed, the action still succeeded.
+   */
+  match_level: TargetMatchLevel;
+}
 
 /**
  * Execute `resolveTargetJs` once, throw structured `TargetError` on failure.
@@ -39,9 +50,9 @@ async function runResolve(
   page: { evaluate(js: string): Promise<unknown> },
   ref: string,
   opts: ResolveOptions = {},
-): Promise<{ matches_n: number }> {
+): Promise<ResolveSuccess> {
   const resolution = (await page.evaluate(resolveTargetJs(ref, opts))) as
-    | { ok: true; matches_n: number }
+    | { ok: true; matches_n: number; match_level: TargetMatchLevel }
     | { ok: false; code: TargetErrorCode; message: string; hint: string; candidates?: string[]; matches_n?: number };
   if (!resolution.ok) {
     throw new TargetError({
@@ -52,7 +63,7 @@ async function runResolve(
       matches_n: resolution.matches_n,
     });
   }
-  return { matches_n: resolution.matches_n };
+  return { matches_n: resolution.matches_n, match_level: resolution.match_level };
 }
 import { formatSnapshot } from '../snapshotFormatter.js';
 export abstract class BasePage implements IPage {
@@ -92,9 +103,9 @@ export abstract class BasePage implements IPage {
 
   // ── Shared DOM helper implementations ──
 
-  async click(ref: string, opts: ResolveOptions = {}): Promise<{ matches_n: number }> {
+  async click(ref: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
     // Phase 1: Resolve target with fingerprint verification
-    const { matches_n } = await runResolve(this, ref, opts);
+    const resolved = await runResolve(this, ref, opts);
 
     // Phase 2: Execute click on resolved element
     const result = await this.evaluate(clickResolvedJs()) as
@@ -102,14 +113,14 @@ export abstract class BasePage implements IPage {
       | { status: string; x?: number; y?: number; w?: number; h?: number; error?: string }
       | null;
 
-    if (typeof result === 'string' || result == null) return { matches_n };
+    if (typeof result === 'string' || result == null) return resolved;
 
-    if (result.status === 'clicked') return { matches_n };
+    if (result.status === 'clicked') return resolved;
 
     // JS click failed — try CDP native click if coordinates available
     if (result.x != null && result.y != null) {
       const success = await this.tryNativeClick(result.x, result.y);
-      if (success) return { matches_n };
+      if (success) return resolved;
     }
 
     throw new Error(`Click failed: ${result.error ?? 'JS click and CDP fallback both failed'}`);
@@ -120,10 +131,10 @@ export abstract class BasePage implements IPage {
     return false;
   }
 
-  async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<{ matches_n: number }> {
-    const { matches_n } = await runResolve(this, ref, opts);
+  async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
+    const resolved = await runResolve(this, ref, opts);
     await this.evaluate(typeResolvedJs(text));
-    return { matches_n };
+    return resolved;
   }
 
   async pressKey(key: string): Promise<void> {
@@ -131,8 +142,14 @@ export abstract class BasePage implements IPage {
   }
 
   async scrollTo(ref: string, opts: ResolveOptions = {}): Promise<unknown> {
-    await runResolve(this, ref, opts);
-    return this.evaluate(scrollResolvedJs());
+    const resolved = await runResolve(this, ref, opts);
+    const result = (await this.evaluate(scrollResolvedJs())) as Record<string, unknown> | null;
+    // Fold match_level into the scroll payload so the user-facing envelope
+    // carries it the same way click / type do.
+    if (result && typeof result === 'object') {
+      return { ...result, matches_n: resolved.matches_n, match_level: resolved.match_level };
+    }
+    return { matches_n: resolved.matches_n, match_level: resolved.match_level };
   }
 
   async getFormState(): Promise<Record<string, unknown>> {

--- a/src/browser/compound.test.ts
+++ b/src/browser/compound.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMPOUND_INFO_JS,
+  COMPOUND_LABEL_CAP,
+  COMPOUND_SELECT_OPTIONS_CAP,
+  type CompoundInfo,
+} from './compound.js';
+
+/**
+ * Tests run the JS source in a sandbox via `new Function`, feeding it
+ * minimal mock elements shaped like the DOM elements the real code sees
+ * at runtime. Avoids a full jsdom setup while still exercising the logic
+ * end-to-end instead of only snapshotting string markers.
+ */
+function runCompound(mockEl: unknown): CompoundInfo | null {
+  const fn = new Function('el', `${COMPOUND_INFO_JS}\nreturn compoundInfoOf(el);`);
+  return fn(mockEl) as CompoundInfo | null;
+}
+
+function mockInput(attrs: Record<string, string | undefined>, extras: Partial<{ value: string; multiple: boolean; files: { name: string }[] }> = {}) {
+  return {
+    tagName: 'INPUT',
+    value: extras.value,
+    multiple: extras.multiple,
+    files: extras.files,
+    getAttribute(name: string) {
+      return attrs[name] ?? null;
+    },
+  };
+}
+
+function mockSelect(options: { value: string; label?: string; text?: string; selected?: boolean; disabled?: boolean }[], multiple = false) {
+  const opts = options.map(o => ({ ...o, selected: !!o.selected }));
+  return {
+    tagName: 'SELECT',
+    multiple,
+    options: opts,
+    getAttribute: () => null,
+  };
+}
+
+describe('compoundInfoOf — date-like inputs', () => {
+  it('returns { control, format, current } for <input type=date>', () => {
+    const info = runCompound(mockInput({ type: 'date' }, { value: '2026-04-21' }));
+    expect(info).toEqual({ control: 'date', format: 'YYYY-MM-DD', current: '2026-04-21' });
+  });
+
+  it('surfaces min + max when present', () => {
+    const info = runCompound(mockInput({ type: 'date', min: '2026-01-01', max: '2026-12-31' }, { value: '2026-04-21' }));
+    expect(info).toMatchObject({ min: '2026-01-01', max: '2026-12-31' });
+  });
+
+  it('handles time / datetime-local / month / week with correct format strings', () => {
+    const formats: Record<string, string> = {
+      time: 'HH:MM',
+      'datetime-local': 'YYYY-MM-DDTHH:MM',
+      month: 'YYYY-MM',
+      week: 'YYYY-W##',
+    };
+    for (const [type, fmt] of Object.entries(formats)) {
+      const info = runCompound(mockInput({ type }, { value: '' })) as { format: string };
+      expect(info.format).toBe(fmt);
+    }
+  });
+
+  it('coerces null value into empty string instead of crashing', () => {
+    const info = runCompound(mockInput({ type: 'date' }));
+    expect(info).toMatchObject({ control: 'date', current: '' });
+  });
+});
+
+describe('compoundInfoOf — file inputs', () => {
+  it('returns { control: file, multiple, current[] }', () => {
+    const info = runCompound(mockInput({ type: 'file' }, {
+      multiple: true,
+      files: [{ name: 'a.png' }, { name: 'b.jpg' }],
+    }));
+    expect(info).toEqual({ control: 'file', multiple: true, current: ['a.png', 'b.jpg'] });
+  });
+
+  it('includes accept when present', () => {
+    const info = runCompound(mockInput({ type: 'file', accept: 'image/*' }, { multiple: false }));
+    expect(info).toMatchObject({ control: 'file', accept: 'image/*' });
+  });
+
+  it('returns empty current[] when nothing uploaded', () => {
+    const info = runCompound(mockInput({ type: 'file' }, { multiple: false }));
+    expect(info).toEqual({ control: 'file', multiple: false, current: [] });
+  });
+
+  it('caps file name at COMPOUND_LABEL_CAP', () => {
+    const longName = 'x'.repeat(COMPOUND_LABEL_CAP + 50);
+    const info = runCompound(mockInput({ type: 'file' }, { multiple: false, files: [{ name: longName }] })) as { current: string[] };
+    expect(info.current[0]!.length).toBe(COMPOUND_LABEL_CAP);
+  });
+});
+
+describe('compoundInfoOf — select', () => {
+  it('returns full options list with labels, values, selected flag', () => {
+    const info = runCompound(mockSelect([
+      { value: 'us', label: 'United States', selected: true },
+      { value: 'ca', label: 'Canada' },
+      { value: 'fr', label: 'France' },
+    ])) as { options: Array<{ label: string; value: string; selected: boolean }> };
+    expect(info.options).toHaveLength(3);
+    expect(info.options[0]).toEqual({ label: 'United States', value: 'us', selected: true });
+    expect(info.options[2]).toEqual({ label: 'France', value: 'fr', selected: false });
+  });
+
+  it('sets current to the selected label (single-select)', () => {
+    const info = runCompound(mockSelect([
+      { value: 'a', label: 'Alpha' },
+      { value: 'b', label: 'Bravo', selected: true },
+    ]));
+    expect(info).toMatchObject({ control: 'select', multiple: false, current: 'Bravo' });
+  });
+
+  it('sets current to an array of labels when multiple=true', () => {
+    const info = runCompound(mockSelect([
+      { value: 'a', label: 'Alpha', selected: true },
+      { value: 'b', label: 'Bravo' },
+      { value: 'c', label: 'Charlie', selected: true },
+    ], true));
+    expect(info).toMatchObject({ control: 'select', multiple: true, current: ['Alpha', 'Charlie'] });
+  });
+
+  it('falls back from option.label to option.text', () => {
+    const info = runCompound(mockSelect([
+      { value: 'a', text: 'FromText' },
+      { value: 'b', label: '', text: 'EmptyLabelFallback' },
+    ])) as { options: Array<{ label: string }> };
+    expect(info.options[0]!.label).toBe('FromText');
+    expect(info.options[1]!.label).toBe('EmptyLabelFallback');
+  });
+
+  it('marks disabled options', () => {
+    const info = runCompound(mockSelect([
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B', disabled: true },
+    ])) as { options: Array<{ disabled?: boolean }> };
+    expect(info.options[0]!.disabled).toBeUndefined();
+    expect(info.options[1]!.disabled).toBe(true);
+  });
+
+  it('caps options[] at COMPOUND_SELECT_OPTIONS_CAP but keeps true options_total', () => {
+    const big = Array.from({ length: COMPOUND_SELECT_OPTIONS_CAP + 25 }, (_, i) => ({
+      value: 'v' + i,
+      label: 'L' + i,
+    }));
+    const info = runCompound(mockSelect(big)) as { options: unknown[]; options_total: number };
+    expect(info.options.length).toBe(COMPOUND_SELECT_OPTIONS_CAP);
+    expect(info.options_total).toBe(COMPOUND_SELECT_OPTIONS_CAP + 25);
+  });
+
+  it('returns "" for current on single-select with no selected option', () => {
+    const info = runCompound(mockSelect([
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]));
+    expect(info).toMatchObject({ current: '' });
+  });
+});
+
+describe('compoundInfoOf — unsupported shapes', () => {
+  it('returns null for plain text input', () => {
+    expect(runCompound(mockInput({ type: 'text' }, { value: 'hi' }))).toBeNull();
+  });
+
+  it('returns null for non-form tags', () => {
+    expect(runCompound({ tagName: 'DIV', getAttribute: () => null })).toBeNull();
+  });
+
+  it('returns null for null / missing element', () => {
+    expect(runCompound(null)).toBeNull();
+    expect(runCompound({} as unknown)).toBeNull();
+  });
+});

--- a/src/browser/compound.test.ts
+++ b/src/browser/compound.test.ts
@@ -159,6 +159,32 @@ describe('compoundInfoOf — select', () => {
     ]));
     expect(info).toMatchObject({ current: '' });
   });
+
+  // Regression: the previous loop stopped walking options once it hit
+  // COMPOUND_SELECT_OPTIONS_CAP, so a long country dropdown with the
+  // selected country sitting at index 80 would be reported with current="".
+  // Agents then thought nothing was selected and picked another country.
+  it('populates current even when the selected option sits past the serialization cap', () => {
+    const big = Array.from({ length: COMPOUND_SELECT_OPTIONS_CAP + 25 }, (_, i) => ({
+      value: 'v' + i,
+      label: 'L' + i,
+      selected: i === COMPOUND_SELECT_OPTIONS_CAP + 10,
+    }));
+    const info = runCompound(mockSelect(big)) as { current: string; options: unknown[]; options_total: number };
+    expect(info.current).toBe('L' + (COMPOUND_SELECT_OPTIONS_CAP + 10));
+    expect(info.options.length).toBe(COMPOUND_SELECT_OPTIONS_CAP);
+    expect(info.options_total).toBe(COMPOUND_SELECT_OPTIONS_CAP + 25);
+  });
+
+  it('multi-select: current[] includes labels for selected options beyond the cap', () => {
+    const big = Array.from({ length: COMPOUND_SELECT_OPTIONS_CAP + 10 }, (_, i) => ({
+      value: 'v' + i,
+      label: 'L' + i,
+      selected: i === 3 || i === COMPOUND_SELECT_OPTIONS_CAP + 5,
+    }));
+    const info = runCompound(mockSelect(big, true)) as { current: string[] };
+    expect(info.current).toEqual(['L3', 'L' + (COMPOUND_SELECT_OPTIONS_CAP + 5)]);
+  });
 });
 
 describe('compoundInfoOf — unsupported shapes', () => {

--- a/src/browser/compound.ts
+++ b/src/browser/compound.ts
@@ -1,0 +1,144 @@
+/**
+ * Compound-component expansion for high-agent-failure form controls.
+ *
+ * Agents burn turns on three recurring input categories because the raw
+ * attribute dump from `browser state` under-specifies them:
+ *
+ *   - date / time / datetime-local / month / week — agents type
+ *     free-form strings and the browser silently ignores mismatched formats.
+ *   - select — the snapshot caps visible options at ~6; agents don't know
+ *     the full option set, can't match by label, and waste turns clicking
+ *     to open the dropdown just to read options.
+ *   - file — the snapshot shows current filenames but not `accept` or
+ *     `multiple`; agents re-upload or pick unsupported MIME types.
+ *
+ * `compoundInfoOf(el)` returns a structured JSON summary agents can rely
+ * on. Included in `browser find --css` envelope so the agent gets the
+ * rich view without extra round-trips.
+ *
+ * Emitted as a JS source string (`COMPOUND_INFO_JS`) so it can be inlined
+ * into the generated evaluate scripts under find / snapshot / eval.
+ */
+
+export type DateLikeControl = 'date' | 'time' | 'datetime-local' | 'month' | 'week';
+
+export interface DateCompound {
+  control: DateLikeControl;
+  format: string;
+  current: string;
+  min?: string;
+  max?: string;
+}
+
+export interface SelectOption {
+  label: string;
+  value: string;
+  selected: boolean;
+  disabled?: boolean;
+}
+
+export interface SelectCompound {
+  control: 'select';
+  multiple: boolean;
+  current: string | string[];
+  options: SelectOption[];
+  options_total: number;
+}
+
+export interface FileCompound {
+  control: 'file';
+  multiple: boolean;
+  current: string[];
+  accept?: string;
+}
+
+export type CompoundInfo = DateCompound | SelectCompound | FileCompound;
+
+/** Max options included in a SelectCompound.options[]. Above this, `options_total` still reflects the true count. */
+export const COMPOUND_SELECT_OPTIONS_CAP = 50;
+
+/** Max characters per option label / file name. */
+export const COMPOUND_LABEL_CAP = 80;
+
+/**
+ * JavaScript source declaring `compoundInfoOf(el)`. Inlined into the JS
+ * emitted by `buildFindJs` (and any other evaluate script that needs the
+ * rich compound view). Returns a `CompoundInfo` object or `null`.
+ */
+export const COMPOUND_INFO_JS = `
+function compoundInfoOf(el) {
+  if (!el || !el.tagName) return null;
+  const tag = el.tagName;
+  const LABEL_CAP = ${COMPOUND_LABEL_CAP};
+  const OPTS_CAP = ${COMPOUND_SELECT_OPTIONS_CAP};
+  if (tag === 'INPUT') {
+    const type = (el.getAttribute('type') || 'text').toLowerCase();
+    const FORMATS = {
+      'date': 'YYYY-MM-DD',
+      'time': 'HH:MM',
+      'datetime-local': 'YYYY-MM-DDTHH:MM',
+      'month': 'YYYY-MM',
+      'week': 'YYYY-W##',
+    };
+    if (FORMATS[type]) {
+      const info = {
+        control: type,
+        format: FORMATS[type],
+        current: (el.value == null ? '' : String(el.value)),
+      };
+      const min = el.getAttribute('min');
+      if (min) info.min = min;
+      const max = el.getAttribute('max');
+      if (max) info.max = max;
+      return info;
+    }
+    if (type === 'file') {
+      const info = {
+        control: 'file',
+        multiple: !!el.multiple,
+        current: [],
+      };
+      const accept = el.getAttribute('accept');
+      if (accept) info.accept = accept;
+      try {
+        if (el.files && el.files.length) {
+          for (let i = 0; i < el.files.length; i++) {
+            const name = (el.files[i].name || '').slice(0, LABEL_CAP);
+            info.current.push(name);
+          }
+        }
+      } catch (_) {}
+      return info;
+    }
+    return null;
+  }
+  if (tag === 'SELECT') {
+    const multiple = !!el.multiple;
+    const options = [];
+    const selectedLabels = [];
+    let total = 0;
+    try {
+      const opts = el.options || [];
+      total = opts.length;
+      const cap = Math.min(opts.length, OPTS_CAP);
+      for (let i = 0; i < cap; i++) {
+        const o = opts[i];
+        const labelRaw = (o.label != null && o.label !== '') ? o.label : (o.text || '');
+        const label = String(labelRaw).trim().slice(0, LABEL_CAP);
+        const entry = { label: label, value: o.value, selected: !!o.selected };
+        if (o.disabled) entry.disabled = true;
+        options.push(entry);
+        if (o.selected) selectedLabels.push(label);
+      }
+    } catch (_) {}
+    return {
+      control: 'select',
+      multiple: multiple,
+      current: multiple ? selectedLabels : (selectedLabels[0] || ''),
+      options: options,
+      options_total: total,
+    };
+  }
+  return null;
+}
+`;

--- a/src/browser/compound.ts
+++ b/src/browser/compound.ts
@@ -120,14 +120,19 @@ function compoundInfoOf(el) {
     try {
       const opts = el.options || [];
       total = opts.length;
-      const cap = Math.min(opts.length, OPTS_CAP);
-      for (let i = 0; i < cap; i++) {
+      // Walk ALL options so \`current\` reflects selections that sit beyond the
+      // serialization cap. Only the first OPTS_CAP entries get pushed into
+      // options[]; anything past the cap still contributes to selectedLabels
+      // so agents see the true current state of big dropdowns.
+      for (let i = 0; i < opts.length; i++) {
         const o = opts[i];
         const labelRaw = (o.label != null && o.label !== '') ? o.label : (o.text || '');
         const label = String(labelRaw).trim().slice(0, LABEL_CAP);
-        const entry = { label: label, value: o.value, selected: !!o.selected };
-        if (o.disabled) entry.disabled = true;
-        options.push(entry);
+        if (i < OPTS_CAP) {
+          const entry = { label: label, value: o.value, selected: !!o.selected };
+          if (o.disabled) entry.disabled = true;
+          options.push(entry);
+        }
         if (o.selected) selectedLabels.push(label);
       }
     } catch (_) {}

--- a/src/browser/dom-snapshot.test.ts
+++ b/src/browser/dom-snapshot.test.ts
@@ -116,6 +116,9 @@ describe('generateSnapshotJs', () => {
     // BBox dedup
     expect(js).toContain('isContainedBy');
     expect(js).toContain('PROPAGATING_TAGS');
+    expect(js).toContain('PROPAGATING_ROLES');
+    expect(js).toContain('isBboxPropagator');
+    expect(js).toContain('isDistinctivelyInteractive');
 
     // Shadow DOM
     expect(js).toContain('shadowRoot');
@@ -175,6 +178,60 @@ describe('generateSnapshotJs', () => {
     expect(js).toContain('scrollTop');
     expect(js).toContain('|scroll|');
     expect(js).toContain('page_scroll');
+  });
+});
+
+describe('BBox 99% containment filter', () => {
+  it('propagates bbox for both PROPAGATING_TAGS and PROPAGATING_ROLES', () => {
+    const js = generateSnapshotJs();
+    // Role-based propagator list covers the common wrapper-as-control patterns
+    // that show up as <div role=button><svg/><span/></div> on modern SPAs.
+    for (const role of ['button', 'link', 'menuitem', 'tab', 'option']) {
+      expect(js).toContain(`'${role}'`);
+    }
+    // propagate site uses the unified helper, not only the tag set
+    expect(js).toContain('isBboxPropagator(el, tag)');
+  });
+
+  it('suppresses interactive descendants at 0.99 containment when they are not distinctive', () => {
+    const js = generateSnapshotJs();
+    expect(js).toContain('isContainedBy(rect, parentPropagatingRect, 0.99)');
+    expect(js).toContain('!isDistinctivelyInteractive(el)');
+    // The suppression path flips the local interactive flag so the node is
+    // still emitted (for text / shape) but does not get its own [N] ref.
+    expect(js).toContain('interactive = false');
+  });
+
+  it('does not suppress inputs / href-bearing anchors even when fully contained', () => {
+    const js = generateSnapshotJs();
+    // Guards inside isDistinctivelyInteractive
+    expect(js).toContain("tag === 'input'");
+    expect(js).toContain("tag === 'select'");
+    expect(js).toContain("tag === 'textarea'");
+    expect(js).toContain("tag === 'a'");
+    expect(js).toContain("el.hasAttribute('href')");
+    // aria-label / aria-labelledby / id / test-id / name preserve distinctness
+    expect(js).toContain("el.hasAttribute('aria-label')");
+    expect(js).toContain("el.hasAttribute('aria-labelledby')");
+    expect(js).toContain("el.id");
+    expect(js).toContain("el.getAttribute('data-testid')");
+    expect(js).toContain("el.hasAttribute('name')");
+  });
+
+  it('keeps the existing 0.95 non-interactive dedup tier in place', () => {
+    const js = generateSnapshotJs();
+    // The original non-interactive bbox filter is still present alongside the
+    // new interactive tier — two complementary thresholds, not a replacement.
+    expect(js).toContain('isContainedBy(rect, parentPropagatingRect, 0.95)');
+  });
+
+  it('bbox containment branches are gated on BBOX_DEDUP flag', () => {
+    const off = generateSnapshotJs({ bboxDedup: false });
+    // When the option is off, the filter becomes inert (BBOX_DEDUP = false)
+    // but the inlined helpers still ship — we only guard at the call sites.
+    expect(off).toContain('BBOX_DEDUP = false');
+    expect(off).toContain('isBboxPropagator');
+    expect(off).toContain('isDistinctivelyInteractive');
   });
 });
 

--- a/src/browser/dom-snapshot.test.ts
+++ b/src/browser/dom-snapshot.test.ts
@@ -345,4 +345,18 @@ describe('Search Element Detection', () => {
     const js = generateSnapshotJs();
     expect(js).toContain('isSearchElement(el)');
   });
+
+  // Blocker B regression: compound contract must be emitted by `browser state`,
+  // not only by `browser find --css`. Otherwise agents inspecting the default
+  // snapshot still have to round-trip `find` on every date/select/file control.
+  it('inlines compoundInfoOf() and attaches compound info to each interactive ref', () => {
+    const js = generateSnapshotJs();
+    expect(js).toContain('function compoundInfoOf(el)');
+    // Wiring: the walk body should call compoundInfoOf on every interactive node
+    expect(js).toContain('compoundInfoOf(el)');
+    // And collect them into a per-ref map keyed by the same [N] index as the tree
+    expect(js).toContain('compoundInfos');
+    // And emit a sidecar section after the tree so agents can find the JSON
+    expect(js).toContain("'compounds ('");
+  });
 });

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -263,6 +263,38 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
 
   const PROPAGATING_TAGS = new Set(['a', 'button']);
 
+  // Roles whose element wraps its own interactive descendants (icon spans
+  // inside a role=button, chevron inside role=link). When we see one of these,
+  // we propagate its bbox to children so we can suppress duplicate refs on
+  // undistinctive descendants that are ≥99% contained.
+  const PROPAGATING_ROLES = new Set(['button', 'link', 'menuitem', 'tab', 'option']);
+
+  function isBboxPropagator(el, tag) {
+    if (PROPAGATING_TAGS.has(tag)) return true;
+    const role = el.getAttribute('role');
+    return !!(role && PROPAGATING_ROLES.has(role));
+  }
+
+  // True when an interactive element still deserves its own [N] ref even
+  // though it's visually subsumed by a propagating ancestor. Anything with
+  // an aria-label, aria-labelledby, id, test id, name, or its own form
+  // semantics is treated as distinctive — everything else (naked spans /
+  // divs / svgs that merely inherit click from the parent button) gets
+  // folded into the parent so the snapshot doesn't ship [1]<button>[2]<svg>.
+  function isDistinctivelyInteractive(el) {
+    if (el.hasAttribute('aria-label')) return true;
+    if (el.hasAttribute('aria-labelledby')) return true;
+    if (el.id) return true;
+    if (el.getAttribute('data-testid') || el.getAttribute('data-test')) return true;
+    if (el.hasAttribute('name')) return true;
+    const tag = el.tagName.toLowerCase();
+    // Real form controls always stand on their own, even when nested in a label/button
+    if (tag === 'input' || tag === 'select' || tag === 'textarea') return true;
+    // Anchors with their own href are distinct targets
+    if (tag === 'a' && el.hasAttribute('href')) return true;
+    return false;
+  }
+
   const AD_PATTERNS = [
     'googleadservices.com', 'doubleclick.net', 'googlesyndication.com',
     'facebook.com/tr', 'analytics.google.com', 'connect.facebook.net',
@@ -668,7 +700,9 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       if (!(tag === 'input' && el.type === 'file')) return false;
     }
 
-    const interactive = isInteractive(el);
+    // \`interactive\` gets demoted below if bbox containment folds this node
+    // into a propagating ancestor — using \`let\` so the dedup pass can mutate it.
+    let interactive = isInteractive(el);
 
     // Viewport threshold pruning
     if (hasArea && !isInExpandedViewport(rect)) {
@@ -689,7 +723,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
     const scrollInfo = getScrollInfo(el);
     const isScrollable = scrollInfo !== null;
 
-    // BBox dedup
+    // BBox dedup — tier 1 (non-interactive descendants, 0.95 threshold)
     let excludedByParent = false;
     if (BBOX_DEDUP && parentPropagatingRect && !interactive) {
       if (hasArea && isContainedBy(rect, parentPropagatingRect, 0.95)) {
@@ -701,8 +735,19 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       }
     }
 
+    // BBox dedup — tier 2 (interactive descendants, 0.99 threshold, browser-use style).
+    // This kills the "[1]<button> [2]<svg> [3]<span>" noise on icon-buttons by
+    // folding the icon / chevron into the button's ref. The 0.99 threshold + the
+    // isDistinctivelyInteractive gate together ensure we only drop nodes that
+    // add no new actionable surface — a nested <input> or <a href> stays.
+    if (BBOX_DEDUP && parentPropagatingRect && interactive && hasArea) {
+      if (isContainedBy(rect, parentPropagatingRect, 0.99) && !isDistinctivelyInteractive(el)) {
+        interactive = false;
+      }
+    }
+
     let propagateRect = parentPropagatingRect;
-    if (BBOX_DEDUP && PROPAGATING_TAGS.has(tag) && hasArea) propagateRect = rect;
+    if (BBOX_DEDUP && hasArea && isBboxPropagator(el, tag)) propagateRect = rect;
 
     // Process children
     const origLen = lines.length;

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -22,7 +22,16 @@
  * Additional tools:
  *   - scrollToRefJs(ref) — scroll to a data-opencli-ref element
  *   - getFormStateJs()  — extract all form fields as structured JSON
+ *
+ * Compound sidecar:
+ *   After the tree, a `compounds:` section lists rich JSON for every
+ *   date/select/file ref — format, full option list (up to cap) with
+ *   `options_total` reflecting the true count, file `accept` + `multiple`.
+ *   This is what the snapshot's inline attr dump cannot express and what
+ *   agents kept blowing turns on.
  */
+
+import { COMPOUND_INFO_JS } from './compound.js';
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -195,6 +204,8 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   return `
 (() => {
   'use strict';
+
+  ${COMPOUND_INFO_JS}
 
   // ── Config ─────────────────────────────────────────────────────────
   const VIEWPORT_EXPAND = ${viewportExpand};
@@ -649,6 +660,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   const hiddenInteractives = [];
   const currentHashes = [];
   const refIdentity = {};
+  const compoundInfos = {};
   let iframeCount = 0;
   let crossOriginIndex = 0;
 
@@ -811,6 +823,10 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
         id: el.id || '',
         testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
       };
+      // Compound contract for date/select/file — captured per-ref so the
+      // sidecar maps one-to-one with the [N] tokens in the tree.
+      const compound = compoundInfoOf(el);
+      if (compound) compoundInfos['' + interactiveIndex] = compound;
     }
 
     // Tag + attributes
@@ -890,6 +906,19 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       lines.push('  <' + h.tag + '>' + label + ' ~' + h.pagesAway + ' pages ' + h.direction);
     }
     if (hiddenInteractives.length > 10) lines.push('  …' + (hiddenInteractives.length - 10) + ' more');
+  }
+
+  // Compound sidecar — rich JSON for date/select/file refs. Keys align with [N] tokens in the tree.
+  const compoundRefs = Object.keys(compoundInfos);
+  if (compoundRefs.length > 0) {
+    lines.push('---');
+    lines.push('compounds (' + compoundRefs.length + '):');
+    compoundRefs.sort(function (a, b) { return parseInt(a, 10) - parseInt(b, 10); });
+    for (const ref of compoundRefs) {
+      try {
+        lines.push('  [' + ref + '] ' + JSON.stringify(compoundInfos[ref]));
+      } catch {}
+    }
   }
 
   // Footer

--- a/src/browser/find.test.ts
+++ b/src/browser/find.test.ts
@@ -84,6 +84,20 @@ describe('buildFindJs', () => {
     expect(FIND_ATTR_WHITELIST).not.toContain('onload' as never);
   });
 
+  it('inlines compoundInfoOf and attaches compound field per entry', () => {
+    const js = buildFindJs('input, select');
+    // Helper definition is inlined so each matched element can be classified.
+    expect(js).toContain('function compoundInfoOf(el)');
+    // The emitted entry opts in only when compound data is present — no noisy
+    // compound: null on every non-form element.
+    expect(js).toContain('const compound = compoundInfoOf(el);');
+    expect(js).toContain('if (compound) entry.compound = compound;');
+    // Spot-check all three compound families are covered in the inlined helper.
+    expect(js).toContain("'YYYY-MM-DD'");
+    expect(js).toContain("control: 'file'");
+    expect(js).toContain("control: 'select'");
+  });
+
   it('keeps the whitelist small and explicit (guardrail against silent expansion)', () => {
     expect(FIND_ATTR_WHITELIST).toEqual([
       'id',

--- a/src/browser/find.ts
+++ b/src/browser/find.ts
@@ -20,7 +20,15 @@
  * Attributes are whitelisted to keep output small and high-signal.
  * Invisible elements are still returned so agents can reason about
  * offscreen vs truly-missing targets.
+ *
+ * When a matched element is a compound form control (date-like input,
+ * select, file input), the entry gains a `compound` field with the
+ * rich view from `compound.ts`. This is what kills the three biggest
+ * agent-fail modes on form pages (wrong date format, guessed options,
+ * re-uploaded files) without forcing agents to probe further.
  */
+
+import { COMPOUND_INFO_JS, type CompoundInfo } from './compound.js';
 
 /** Whitelist of attributes surfaced per entry. Keep small; agents do not need full DOM dumps. */
 export const FIND_ATTR_WHITELIST = [
@@ -51,6 +59,12 @@ export interface FindEntry {
   text: string;
   attrs: Record<string, string>;
   visible: boolean;
+  /**
+   * Rich view for date / time / datetime-local / month / week / select /
+   * file inputs. Omitted (undefined) for all other element types. See
+   * `compound.ts` for the shape.
+   */
+  compound?: CompoundInfo;
 }
 
 export interface FindResult {
@@ -89,6 +103,8 @@ export function buildFindJs(selector: string, opts: FindOptions = {}): string {
       const LIMIT = ${limit};
       const TEXT_MAX = ${textMax};
       const ATTR_WHITELIST = ${whitelist};
+
+      ${COMPOUND_INFO_JS}
 
       let matches;
       try {
@@ -183,7 +199,7 @@ export function buildFindJs(selector: string, opts: FindOptions = {}): string {
           identity['' + refNum] = fingerprintOf(el);
         }
         const text = (el.textContent || '').trim();
-        entries.push({
+        const entry = {
           nth: i,
           ref: refNum,
           tag: el.tagName.toLowerCase(),
@@ -191,7 +207,10 @@ export function buildFindJs(selector: string, opts: FindOptions = {}): string {
           text: text.length > TEXT_MAX ? text.slice(0, TEXT_MAX) : text,
           attrs: pickAttrs(el),
           visible: isVisible(el),
-        });
+        };
+        const compound = compoundInfoOf(el);
+        if (compound) entry.compound = compound;
+        entries.push(entry);
       }
 
       return {

--- a/src/browser/html-tree.test.ts
+++ b/src/browser/html-tree.test.ts
@@ -31,18 +31,39 @@ function runTreeJsInvalid(selector: string, errorMessage: string): unknown {
     return fn(fakeDocument);
 }
 
-function el(tag: string, attrs: Record<string, string>, children: Array<ChildOf>): FakeEl {
+function el(tag: string, attrs: Record<string, string>, children: Array<ChildOf>, extras: Partial<CompoundExtras> = {}): FakeEl {
     return {
         nodeType: 1,
         tagName: tag.toUpperCase(),
         attributes: Object.entries(attrs).map(([name, value]) => ({ name, value })),
         childNodes: children,
+        getAttribute: (name: string) => (name in attrs ? attrs[name]! : null),
+        value: extras.value,
+        multiple: extras.multiple,
+        files: extras.files,
+        options: extras.options,
     };
 }
 
 function txt(value: string): FakeText { return { nodeType: 3, nodeValue: value }; }
 
-type FakeEl = { nodeType: 1; tagName: string; attributes: Array<{ name: string; value: string }>; childNodes: Array<ChildOf> };
+type CompoundExtras = {
+    value: string;
+    multiple: boolean;
+    files: Array<{ name: string }>;
+    options: Array<{ value: string; label?: string; text?: string; selected?: boolean; disabled?: boolean }>;
+};
+type FakeEl = {
+    nodeType: 1;
+    tagName: string;
+    attributes: Array<{ name: string; value: string }>;
+    childNodes: Array<ChildOf>;
+    getAttribute: (name: string) => string | null;
+    value?: string;
+    multiple?: boolean;
+    files?: Array<{ name: string }>;
+    options?: Array<{ value: string; label?: string; text?: string; selected?: boolean; disabled?: boolean }>;
+};
 type FakeText = { nodeType: 3; nodeValue: string };
 type ChildOf = FakeEl | FakeText;
 
@@ -168,6 +189,29 @@ describe('buildHtmlTreeJs budget knobs', () => {
         expect(result.tree?.text).toHaveLength(10);
         expect(result.tree?.children[0].text).toHaveLength(10);
         expect(result.truncated?.text_truncated).toBe(2);
+    });
+
+    // Blocker B regression: compound contract must ride along with the
+    // json tree so `browser get html --as json` surfaces the full contract
+    // to agents without an extra round-trip.
+    it('attaches compound info to date/file/select nodes and omits it elsewhere', () => {
+        const date = el('input', { type: 'date', min: '2026-01-01' }, [], { value: '2026-04-21' });
+        const file = el('input', { type: 'file', accept: 'image/*' }, [], { multiple: true, files: [{ name: 'a.png' }] });
+        const sel = el('select', { name: 'country' }, [], {
+            options: [
+                { value: 'us', label: 'United States', selected: true },
+                { value: 'ca', label: 'Canada' },
+            ],
+        });
+        const plain = el('input', { type: 'text' }, [], { value: 'hi' });
+        const root = el('form', {}, [date, file, sel, plain]);
+        const result = runTreeJs(root, [root], null) as HtmlTreeResult & {
+            tree: { children: Array<{ compound?: unknown }> };
+        };
+        expect(result.tree?.children[0].compound).toMatchObject({ control: 'date', format: 'YYYY-MM-DD', current: '2026-04-21', min: '2026-01-01' });
+        expect(result.tree?.children[1].compound).toMatchObject({ control: 'file', multiple: true, current: ['a.png'], accept: 'image/*' });
+        expect(result.tree?.children[2].compound).toMatchObject({ control: 'select', multiple: false, current: 'United States' });
+        expect(result.tree?.children[3].compound).toBeUndefined();
     });
 
     it('combines budgets and reports every hit', () => {

--- a/src/browser/html-tree.ts
+++ b/src/browser/html-tree.ts
@@ -16,7 +16,16 @@
  * combination of `depth` / `childrenMax` / `textMax`; each hit is reported in
  * the `truncated` envelope so agents know to narrow their selector or raise
  * the budget.
+ *
+ * Compound controls (date / time / datetime-local / month / week / select /
+ * file) gain a `compound` field so agents inspecting the JSON tree see the
+ * full contract — date format, full option list (up to cap) with selections
+ * preserved for options beyond the cap, file `accept` and `multiple`. Without
+ * this wiring agents repeatedly guess values on these controls from the raw
+ * attributes, which is the failure mode compound.ts was built to eliminate.
  */
+
+import { COMPOUND_INFO_JS, type CompoundInfo } from './compound.js';
 
 export interface BuildHtmlTreeJsOptions {
     /** CSS selector to scope the tree; unscoped = documentElement */
@@ -53,6 +62,7 @@ export function buildHtmlTreeJs(opts: BuildHtmlTreeJsOptions = {}): string {
         ? String(opts.textMax)
         : 'null';
     return `(() => {
+  ${COMPOUND_INFO_JS}
   const selector = ${selectorLiteral};
   const maxDepth = ${depthLiteral};
   const maxChildren = ${childrenMaxLiteral};
@@ -98,7 +108,10 @@ export function buildHtmlTreeJs(opts: BuildHtmlTreeJsOptions = {}): string {
       // Budget hit: we're at max depth. Count any element children we would have visited.
       for (const n of el.childNodes) if (n.nodeType === 1) { trunc.depth = true; break; }
     }
-    return { tag: el.tagName.toLowerCase(), attrs, text, children };
+    const node = { tag: el.tagName.toLowerCase(), attrs, text, children };
+    const compound = compoundInfoOf(el);
+    if (compound) node.compound = compound;
+    return node;
   }
   const tree = root ? serialize(root, 0) : null;
   const truncatedOut = {};
@@ -116,6 +129,11 @@ export interface HtmlNode {
     attrs: Record<string, string>;
     text: string;
     children: HtmlNode[];
+    /**
+     * Rich view for date/select/file controls. Omitted for non-compound elements
+     * so agents can rely on `compound != null` as a signal.
+     */
+    compound?: CompoundInfo;
 }
 
 export interface HtmlTreeTruncationInfo {

--- a/src/browser/target-resolver.test.ts
+++ b/src/browser/target-resolver.test.ts
@@ -75,4 +75,59 @@ describe('resolveTargetJs', () => {
     expect(js).not.toContain('alert(1); "');
     expect(js).toContain('\\"');
   });
+
+  it('tags every success envelope with match_level so agents can tell tiers apart', () => {
+    const numericJs = resolveTargetJs('7');
+    const cssJs = resolveTargetJs('.btn');
+    // Exact / reidentified emit the literal directly; stable flows through the
+    // classifier's `level` variable. All three strings must appear in the JS.
+    expect(numericJs).toContain("match_level: 'exact'");
+    expect(numericJs).toContain("match_level: 'reidentified'");
+    expect(numericJs).toContain("return 'stable'");
+    // Stable + exact share the same emit site (match_level: level) — make sure
+    // we didn't hardcode one of them and drop the other.
+    expect(numericJs).toContain('match_level: level');
+    // CSS path is always exact (selector ran successfully).
+    expect(cssJs).toContain("match_level: 'exact'");
+  });
+
+  it('cascading ref path — classifier + reidentifier are both wired in', () => {
+    const js = resolveTargetJs('3');
+    // Classifier distinguishes the three tiers
+    expect(js).toContain('function classifyMatch');
+    expect(js).toContain("return 'exact'");
+    expect(js).toContain("return 'stable'");
+    expect(js).toContain("return 'mismatch'");
+    // Strong id is the only thing that can rescue a drifted fingerprint
+    expect(js).toContain('hadStrongId');
+    // Reidentify searches live DOM with the same fingerprint shape the
+    // snapshot / find writers emit — id / testId / aria-label only.
+    expect(js).toContain('function reidentify');
+    expect(js).toContain('getElementById');
+    expect(js).toContain('[data-testid="');
+    expect(js).toContain('[aria-label="');
+    // Unique match required — never silently picks one of many candidates.
+    expect(js).toContain('candidates.length === 1');
+    // Recovered element is re-tagged + identity map refreshed so subsequent
+    // resolves land on 'exact' instead of re-walking the cascade.
+    expect(js).toContain("setAttribute('data-opencli-ref', ref)");
+    expect(js).toContain('identity[ref] = fingerprintOf(recovered)');
+  });
+
+  it('reidentify runs both when data-opencli-ref is missing AND when fingerprint is mismatched', () => {
+    const js = resolveTargetJs('9');
+    // Two call sites: one in the !el branch, one after classifyMatch returns mismatch.
+    const count = js.split('reidentify(fp)').length - 1;
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  it('falls through to stale_ref only after reidentify exhausts', () => {
+    const js = resolveTargetJs('4');
+    // The stale_ref emit must sit *below* a reidentify attempt so the cascade
+    // is what produces the error — not the original strict check.
+    const reidentifyIdx = js.indexOf('const recovered = reidentify(fp);');
+    const staleIdx = js.indexOf("code: 'stale_ref'");
+    expect(reidentifyIdx).toBeGreaterThan(-1);
+    expect(staleIdx).toBeGreaterThan(reidentifyIdx);
+  });
 });

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -8,7 +8,8 @@
  *    browser parser decide what's valid. No frontend regex whitelist — the
  *    goal is that any selector accepted by `browser find --css` is accepted
  *    by the same selector on `get/click/type/select`.
- * 2. Ref path: lookup by data-opencli-ref, then verify fingerprint
+ * 2. Ref path: cascading match levels (see below), using data-opencli-ref
+ *    plus the fingerprint map populated by snapshot + find.
  * 3. CSS path: querySelectorAll + match-count policy (see ResolveOptions)
  * 4. Structured errors:
  *    - numeric: not_found / stale_ref
@@ -16,6 +17,25 @@
  *               / selector_nth_out_of_range
  *
  * All JS is generated as strings for page.evaluate() — runs in the browser.
+ *
+ * ── Cascading stale-ref (browser-use style) ──────────────────────────
+ * Strict equality on the fingerprint rejected too many live pages — SPA
+ * re-renders swap text / role while keeping id + testId. The resolver
+ * now walks three tiers before giving up:
+ *
+ *   1. EXACT        — tag + strong id (id or testId) agree, ≤1 soft mismatch
+ *   2. STABLE       — tag + strong id agree, soft signals drifted (aria-label,
+ *                     role, text) — agent gets a warning but the action
+ *                     proceeds so dynamic pages don't stall
+ *   3. REIDENTIFIED — original ref either missing from the DOM or fully
+ *                     mismatched, but the fingerprint uniquely identifies
+ *                     a single other live element via id / testId /
+ *                     aria-label. Re-tag that element with the old ref and
+ *                     surface match_level so the caller knows we swapped.
+ *
+ * Only when all three fail do we emit `stale_ref`. Every success envelope
+ * carries `match_level` so downstream CLIs can surface the weakest tier
+ * a caller actually traversed.
  */
 
 export interface ResolveOptions {
@@ -34,12 +54,19 @@ export interface ResolveOptions {
   firstOnMulti?: boolean;
 }
 
+/** Tier the resolver traversed to land the target. Callers may surface this to agents. */
+export type TargetMatchLevel = 'exact' | 'stable' | 'reidentified';
+
 /**
  * Generate JS that resolves a target to a single DOM element.
  *
  * Returns a JS expression that evaluates to:
- *   { ok: true, matches_n }                         — success (el stored in `__resolved`)
+ *   { ok: true, matches_n, match_level }            — success (el stored in `__resolved`)
  *   { ok: false, code, message, hint, candidates, matches_n? }  — structured error
+ *
+ * `match_level` is always set on success:
+ *   - CSS path → 'exact'
+ *   - numeric ref path → whichever tier matched ('exact' / 'stable' / 'reidentified')
  *
  * The resolved element is stored in `window.__resolved` for downstream helpers.
  */
@@ -62,11 +89,100 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
       const isNumeric = /^\\d+$/.test(ref);
 
       if (isNumeric) {
-        // ── Ref path ──
+        // ── Ref path (cascading match levels) ──
+
+        // Shared helper: compute a fingerprint off a live element, same shape
+        // snapshot + find populate into \`__opencli_ref_identity\`. Kept inline
+        // (not imported) because this source string is compiled standalone.
+        function fingerprintOf(node) {
+          return {
+            tag: node.tagName.toLowerCase(),
+            role: node.getAttribute('role') || '',
+            text: (node.textContent || '').trim().slice(0, 30),
+            ariaLabel: node.getAttribute('aria-label') || '',
+            id: node.id || '',
+            testId: node.getAttribute('data-testid') || node.getAttribute('data-test') || '',
+          };
+        }
+
+        // Classify how strongly a live element matches a stored fingerprint.
+        // Returns one of 'exact' | 'stable' | 'mismatch'.
+        //
+        // 'exact'  — tag + every non-empty stored field agrees (±text prefix).
+        // 'stable' — tag agrees AND at least one strong id (id or testId) still
+        //            matches; soft signals (aria-label, role, text) may have
+        //            drifted. This covers SPA re-render / i18n label swaps.
+        // 'mismatch' otherwise.
+        function classifyMatch(fp, liveFp) {
+          if (fp.tag !== liveFp.tag) return 'mismatch';
+
+          const idMatch = !fp.id || fp.id === liveFp.id;
+          const testIdMatch = !fp.testId || fp.testId === liveFp.testId;
+          const roleMatch = !fp.role || fp.role === liveFp.role;
+          const ariaMatch = !fp.ariaLabel || fp.ariaLabel === liveFp.ariaLabel;
+          const textMatch = !fp.text || (
+            !!liveFp.text && (liveFp.text.startsWith(fp.text) || fp.text.startsWith(liveFp.text))
+          );
+
+          if (idMatch && testIdMatch && roleMatch && ariaMatch && textMatch) return 'exact';
+
+          // Strong id decides: if id + testId still agree and we had at least one
+          // of them, accept as stable regardless of soft-signal drift.
+          const hadStrongId = !!fp.id || !!fp.testId;
+          if (hadStrongId && idMatch && testIdMatch) return 'stable';
+
+          return 'mismatch';
+        }
+
+        // Try to recover a stale ref by searching the page for a live element
+        // whose fingerprint still matches. Uniqueness is required — if two
+        // candidates match equally well, we refuse rather than silently pick
+        // the wrong one. Covers ref annotations lost to a re-mount.
+        function reidentify(fp) {
+          if (!fp) return null;
+          const candidates = [];
+          function tryAdd(el) {
+            if (el && el.nodeType === 1 && classifyMatch(fp, fingerprintOf(el)) !== 'mismatch') {
+              if (candidates.indexOf(el) === -1) candidates.push(el);
+            }
+          }
+          // Prefer strong-id lookups. If id / testId is present and yields a
+          // unique element, that's our hit.
+          try {
+            if (fp.id) {
+              const byId = document.getElementById(fp.id);
+              if (byId) tryAdd(byId);
+            }
+            if (fp.testId) {
+              const byTestIdA = document.querySelectorAll('[data-testid="' + fp.testId.replace(/"/g, '\\\\"') + '"]');
+              for (let i = 0; i < byTestIdA.length; i++) tryAdd(byTestIdA[i]);
+              const byTestIdB = document.querySelectorAll('[data-test="' + fp.testId.replace(/"/g, '\\\\"') + '"]');
+              for (let i = 0; i < byTestIdB.length; i++) tryAdd(byTestIdB[i]);
+            }
+            // aria-label is only a useful shortlist when nothing stronger is set
+            if (candidates.length === 0 && fp.ariaLabel) {
+              const byAria = document.querySelectorAll('[aria-label="' + fp.ariaLabel.replace(/"/g, '\\\\"') + '"]');
+              for (let i = 0; i < byAria.length; i++) tryAdd(byAria[i]);
+            }
+          } catch (_) { /* bad selectors from weird fp values — skip */ }
+          return candidates.length === 1 ? candidates[0] : null;
+        }
+
+        const fp = identity[ref];
         let el = document.querySelector('[data-opencli-ref="' + ref + '"]');
         if (!el) el = document.querySelector('[data-ref="' + ref + '"]');
 
+        // If the ref tag is gone from the DOM, last-chance reidentify.
         if (!el) {
+          const recovered = reidentify(fp);
+          if (recovered) {
+            try {
+              recovered.setAttribute('data-opencli-ref', ref);
+              identity[ref] = fingerprintOf(recovered);
+            } catch (_) {}
+            window.__resolved = recovered;
+            return { ok: true, matches_n: 1, match_level: 'reidentified' };
+          }
           return {
             ok: false,
             code: 'not_found',
@@ -75,56 +191,41 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
           };
         }
 
-        // ── Fingerprint verification (identity vector) ──
-        const fp = identity[ref];
-        if (fp) {
-          const tag = el.tagName.toLowerCase();
-          const text = (el.textContent || '').trim().slice(0, 30);
-          const role = el.getAttribute('role') || '';
-          const ariaLabel = el.getAttribute('aria-label') || '';
-          const id = el.id || '';
-          const testId = el.getAttribute('data-testid') || el.getAttribute('data-test') || '';
-
-          // Hard fail: tag must always match
-          const tagMatch = fp.tag === tag;
-
-          // Soft signals: each non-empty stored field that mismatches counts against
-          var mismatches = 0;
-          var checks = 0;
-          if (fp.id) { checks++; if (fp.id !== id) mismatches++; }
-          if (fp.testId) { checks++; if (fp.testId !== testId) mismatches++; }
-          if (fp.ariaLabel) { checks++; if (fp.ariaLabel !== ariaLabel) mismatches++; }
-          if (fp.role) { checks++; if (fp.role !== role) mismatches++; }
-          if (fp.text) {
-            checks++;
-            // Text: allow prefix match (page text can grow), but empty current text never matches
-            if (!text || (!text.startsWith(fp.text) && !fp.text.startsWith(text))) mismatches++;
-          }
-
-          // Stale if tag changed, or if any uniquely identifying field (id/testId) changed,
-          // or if majority of soft signals mismatch
-          var isStale = !tagMatch;
-          if (!isStale && checks > 0) {
-            // id and testId are strong identifiers — any mismatch on these is decisive
-            if (fp.id && fp.id !== id) isStale = true;
-            else if (fp.testId && fp.testId !== testId) isStale = true;
-            // For remaining signals, stale if more than half mismatch
-            else if (mismatches > checks / 2) isStale = true;
-          }
-
-          if (isStale) {
-            return {
-              ok: false,
-              code: 'stale_ref',
-              message: 'ref=' + ref + ' was <' + fp.tag + '>' + (fp.text ? '"' + fp.text + '"' : '')
-                + ' but now points to <' + tag + '>' + (text ? '"' + text.slice(0, 30) + '"' : ''),
-              hint: 'The page has changed since the last snapshot. Re-run \`opencli browser state\` to refresh.',
-            };
-          }
+        // No stored fingerprint (older page / unknown ref) — accept as exact.
+        if (!fp) {
+          window.__resolved = el;
+          return { ok: true, matches_n: 1, match_level: 'exact' };
         }
 
-        window.__resolved = el;
-        return { ok: true, matches_n: 1 };
+        const liveFp = fingerprintOf(el);
+        const level = classifyMatch(fp, liveFp);
+
+        if (level === 'exact' || level === 'stable') {
+          window.__resolved = el;
+          return { ok: true, matches_n: 1, match_level: level };
+        }
+
+        // Tag / strong-id mismatch — try to find the real element elsewhere
+        // before giving up. Covers e.g. a modal re-mount that discarded the
+        // data-opencli-ref attribute on the surviving node.
+        const recovered = reidentify(fp);
+        if (recovered && recovered !== el) {
+          try {
+            el.removeAttribute('data-opencli-ref');
+            recovered.setAttribute('data-opencli-ref', ref);
+            identity[ref] = fingerprintOf(recovered);
+          } catch (_) {}
+          window.__resolved = recovered;
+          return { ok: true, matches_n: 1, match_level: 'reidentified' };
+        }
+
+        return {
+          ok: false,
+          code: 'stale_ref',
+          message: 'ref=' + ref + ' was <' + fp.tag + '>' + (fp.text ? '"' + fp.text + '"' : '')
+            + ' but now points to <' + liveFp.tag + '>' + (liveFp.text ? '"' + liveFp.text.slice(0, 30) + '"' : ''),
+          hint: 'The page has changed since the last snapshot. Re-run \`opencli browser state\` to refresh.',
+        };
       }
 
       // ── CSS selector path (any non-numeric input) ──
@@ -162,7 +263,7 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
             };
           }
           window.__resolved = matches[nth];
-          return { ok: true, matches_n: matches.length };
+          return { ok: true, matches_n: matches.length, match_level: 'exact' };
         }
 
         if (matches.length > 1 && !firstOnMulti) {
@@ -187,7 +288,7 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
 
         // Single match, OR multi-match with firstOnMulti (read path)
         window.__resolved = matches[0];
-        return { ok: true, matches_n: matches.length };
+        return { ok: true, matches_n: matches.length, match_level: 'exact' };
       }
     })()
   `;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1010,33 +1010,33 @@ describe('browser get text/value/attributes commands', () => {
     evaluate: vi.fn(),
   }));
 
-  it('emits {value, matches_n} envelope for a numeric ref', async () => {
+  it('emits {value, matches_n, match_level} envelope for a numeric ref', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    // 1st call: resolveTargetJs -> { ok: true, matches_n: 1 }
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    // 1st call: resolveTargetJs -> { ok: true, matches_n: 1, match_level: 'exact' }
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
     // 2nd call: getTextResolvedJs -> the element's text
     evalMock.mockResolvedValueOnce('Hello world');
     const program = createProgram('', '');
 
     await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '7']);
 
-    expect(lastJsonLog()).toEqual({ value: 'Hello world', matches_n: 1 });
+    expect(lastJsonLog()).toEqual({ value: 'Hello world', matches_n: 1, match_level: 'exact' });
   });
 
   it('reports matches_n on multi-match CSS (read path: first match wins)', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 3 });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 3, match_level: 'exact' });
     evalMock.mockResolvedValueOnce('first');
     const program = createProgram('', '');
 
     await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '.btn']);
 
-    expect(lastJsonLog()).toEqual({ value: 'first', matches_n: 3 });
+    expect(lastJsonLog()).toEqual({ value: 'first', matches_n: 3, match_level: 'exact' });
   });
 
   it('parses the attributes payload back into a real object', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
     // getAttributesResolvedJs returns a JSON-encoded string — the CLI must parse it
     evalMock.mockResolvedValueOnce(JSON.stringify({ id: 'nav', class: 'hero' }));
     const program = createProgram('', '');
@@ -1045,6 +1045,7 @@ describe('browser get text/value/attributes commands', () => {
 
     const out = lastJsonLog();
     expect(out.matches_n).toBe(1);
+    expect(out.match_level).toBe('exact');
     expect(out.value).toEqual({ id: 'nav', class: 'hero' });
   });
 
@@ -1065,7 +1066,7 @@ describe('browser get text/value/attributes commands', () => {
 
   it('forwards --nth into the resolver opts and reports matches_n', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 4 });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 4, match_level: 'exact' });
     evalMock.mockResolvedValueOnce('second');
     const program = createProgram('', '');
 
@@ -1074,7 +1075,7 @@ describe('browser get text/value/attributes commands', () => {
     const resolveJs = evalMock.mock.calls[0][0] as string;
     // resolveTargetJs embeds nth as a raw number literal; look for the binding
     expect(resolveJs).toContain('const nth = 1');
-    expect(lastJsonLog()).toEqual({ value: 'second', matches_n: 4 });
+    expect(lastJsonLog()).toEqual({ value: 'second', matches_n: 4, match_level: 'exact' });
   });
 
   it('rejects malformed --nth with usage_error before touching the page', async () => {
@@ -1091,29 +1092,38 @@ describe('browser get text/value/attributes commands', () => {
 describe('browser click/type commands', () => {
   const { lastJsonLog } = installSelectorFirstTestHarness('click-type', () => ({
     evaluate: vi.fn().mockResolvedValue(false),
-    click: vi.fn().mockResolvedValue({ matches_n: 1 }),
-    typeText: vi.fn().mockResolvedValue({ matches_n: 1 }),
+    click: vi.fn().mockResolvedValue({ matches_n: 1, match_level: 'exact' }),
+    typeText: vi.fn().mockResolvedValue({ matches_n: 1, match_level: 'exact' }),
     wait: vi.fn().mockResolvedValue(undefined),
   }));
 
-  it('emits {clicked, target, matches_n} on success', async () => {
-    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1 });
+  it('emits {clicked, target, matches_n, match_level} on success', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
     const program = createProgram('', '');
 
     await program.parseAsync(['node', 'opencli', 'browser', 'click', '#save']);
 
     expect(browserState.page!.click).toHaveBeenCalledWith('#save', {});
-    expect(lastJsonLog()).toEqual({ clicked: true, target: '#save', matches_n: 1 });
+    expect(lastJsonLog()).toEqual({ clicked: true, target: '#save', matches_n: 1, match_level: 'exact' });
+  });
+
+  it('surfaces match_level=stable when resolver falls back to fingerprint match', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'stable' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '7']);
+
+    expect(lastJsonLog()).toEqual({ clicked: true, target: '7', matches_n: 1, match_level: 'stable' });
   });
 
   it('forwards --nth as ResolveOptions.nth to page.click', async () => {
-    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 3 });
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 3, match_level: 'exact' });
     const program = createProgram('', '');
 
     await program.parseAsync(['node', 'opencli', 'browser', 'click', '.btn', '--nth', '2']);
 
     expect(browserState.page!.click).toHaveBeenCalledWith('.btn', { nth: 2 });
-    expect(lastJsonLog()).toEqual({ clicked: true, target: '.btn', matches_n: 3 });
+    expect(lastJsonLog()).toEqual({ clicked: true, target: '.btn', matches_n: 3, match_level: 'exact' });
   });
 
   it('surfaces selector_ambiguous from page.click as an error envelope', async () => {
@@ -1158,9 +1168,9 @@ describe('browser click/type commands', () => {
     expect(process.exitCode).toBeDefined();
   });
 
-  it('type: clicks, waits, then typeText — emits {typed, text, target, matches_n, autocomplete}', async () => {
-    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1 });
-    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1 });
+  it('type: clicks, waits, then typeText — emits {typed, text, target, matches_n, match_level, autocomplete}', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
     (browserState.page!.evaluate as any).mockResolvedValueOnce(false); // isAutocomplete
     const program = createProgram('', '');
 
@@ -1170,13 +1180,13 @@ describe('browser click/type commands', () => {
     expect(browserState.page!.wait).toHaveBeenCalledWith(0.3);
     expect(browserState.page!.typeText).toHaveBeenCalledWith('#q', 'hello', {});
     expect(lastJsonLog()).toEqual({
-      typed: true, text: 'hello', target: '#q', matches_n: 1, autocomplete: false,
+      typed: true, text: 'hello', target: '#q', matches_n: 1, match_level: 'exact', autocomplete: false,
     });
   });
 
   it('type: waits an extra 0.4s when the input reports autocomplete=true', async () => {
-    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1 });
-    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1 });
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
     (browserState.page!.evaluate as any).mockResolvedValueOnce(true);
     const program = createProgram('', '');
 
@@ -1186,11 +1196,24 @@ describe('browser click/type commands', () => {
     expect(waitCalls).toContainEqual([0.3]);
     expect(waitCalls).toContainEqual([0.4]);
     expect(lastJsonLog().autocomplete).toBe(true);
+    expect(lastJsonLog().match_level).toBe('exact');
+  });
+
+  it('type: surfaces match_level=reidentified when ref had to be reidentified by fingerprint', async () => {
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'reidentified' });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'reidentified' });
+    (browserState.page!.evaluate as any).mockResolvedValueOnce(false);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'type', '9', 'hi']);
+
+    // The typeText call is the authoritative match_level source for the `type` envelope.
+    expect(lastJsonLog().match_level).toBe('reidentified');
   });
 
   it('type: forwards --nth to both click and typeText', async () => {
-    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 5 });
-    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 5 });
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 5, match_level: 'exact' });
+    (browserState.page!.typeText as any).mockResolvedValueOnce({ matches_n: 5, match_level: 'exact' });
     const program = createProgram('', '');
 
     await program.parseAsync(['node', 'opencli', 'browser', 'type', '.field', 'x', '--nth', '3']);
@@ -1205,20 +1228,20 @@ describe('browser select command', () => {
     evaluate: vi.fn(),
   }));
 
-  it('emits {selected, target, matches_n} on success', async () => {
+  it('emits {selected, target, matches_n, match_level} on success', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
     evalMock.mockResolvedValueOnce({ selected: 'US' });
     const program = createProgram('', '');
 
     await program.parseAsync(['node', 'opencli', 'browser', 'select', '#country', 'US']);
 
-    expect(lastJsonLog()).toEqual({ selected: 'US', target: '#country', matches_n: 1 });
+    expect(lastJsonLog()).toEqual({ selected: 'US', target: '#country', matches_n: 1, match_level: 'exact' });
   });
 
   it('maps "Not a <select>" to a not_a_select error envelope', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
     evalMock.mockResolvedValueOnce({ error: 'Not a <select>' });
     const program = createProgram('', '');
 
@@ -1232,7 +1255,7 @@ describe('browser select command', () => {
 
   it('maps missing-option failures to an option_not_found envelope with available list', async () => {
     const evalMock = browserState.page!.evaluate as any;
-    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1 });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
     evalMock.mockResolvedValueOnce({ error: 'Option "XX" not found', available: ['US', 'CA'] });
     const program = createProgram('', '');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ import { loadExternalClis, executeExternalCli, installExternalCli, registerExter
 import { registerAllCommands } from './commanderAdapter.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
-import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, clickResolvedJs, type ResolveOptions } from './browser/target-resolver.js';
+import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, clickResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
 import { buildFindJs, isFindError, type FindResult, type FindError } from './browser/find.js';
 import { inferShape } from './browser/shape.js';
 import { assignKeys } from './browser/network-key.js';
@@ -371,9 +371,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     page: Awaited<ReturnType<typeof getBrowserPage>>,
     ref: string,
     opts: ResolveOptions = {},
-  ): Promise<{ matches_n: number }> {
+  ): Promise<{ matches_n: number; match_level: TargetMatchLevel }> {
     const resolution = await page.evaluate(resolveTargetJs(ref, opts)) as
-      | { ok: true; matches_n: number }
+      | { ok: true; matches_n: number; match_level: TargetMatchLevel }
       | { ok: false; code: TargetErrorCode; message: string; hint: string; candidates?: string[]; matches_n?: number };
     if (!resolution.ok) {
       throw new TargetError({
@@ -384,7 +384,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         matches_n: resolution.matches_n,
       });
     }
-    return { matches_n: resolution.matches_n };
+    return { matches_n: resolution.matches_n, match_level: resolution.match_level };
   }
 
   /**
@@ -667,7 +667,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
-    const { matches_n } = await resolveRef(page, String(target), {
+    const { matches_n, match_level } = await resolveRef(page, String(target), {
       firstOnMulti: nth === null,
       ...(typeof nth === 'number' ? { nth } : {}),
     });
@@ -681,7 +681,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     } else {
       value = raw ?? null;
     }
-    console.log(JSON.stringify({ value, matches_n }, null, 2));
+    console.log(JSON.stringify({ value, matches_n, match_level }, null, 2));
   };
 
   addBrowserTabOption(
@@ -868,8 +868,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         process.exitCode = EXIT_CODES.USAGE_ERROR;
         return;
       }
-      const { matches_n } = await page.click(String(target), parsed.opts);
-      console.log(JSON.stringify({ clicked: true, target: String(target), matches_n }, null, 2));
+      const { matches_n, match_level } = await page.click(String(target), parsed.opts);
+      console.log(JSON.stringify({ clicked: true, target: String(target), matches_n, match_level }, null, 2));
     }));
 
   addBrowserTabOption(
@@ -889,7 +889,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       // Click first (focuses the field), wait briefly, then type.
       await page.click(String(target), parsed.opts);
       await page.wait(0.3);
-      const { matches_n } = await page.typeText(String(target), String(text), parsed.opts);
+      const { matches_n, match_level } = await page.typeText(String(target), String(text), parsed.opts);
       // __resolved is already set by the resolver call inside page.typeText
       const isAutocomplete = await page.evaluate(isAutocompleteResolvedJs()) as boolean;
       if (isAutocomplete) await page.wait(0.4);
@@ -898,6 +898,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         text: String(text),
         target: String(target),
         matches_n,
+        match_level,
         autocomplete: !!isAutocomplete,
       }, null, 2));
     }));
@@ -916,7 +917,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         process.exitCode = EXIT_CODES.USAGE_ERROR;
         return;
       }
-      const { matches_n } = await resolveRef(page, String(target), parsed.opts);
+      const { matches_n, match_level } = await resolveRef(page, String(target), parsed.opts);
       const result = await page.evaluate(selectResolvedJs(String(option))) as
         | { error?: string; selected?: string; available?: string[] }
         | null;
@@ -939,6 +940,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         selected: result?.selected ?? String(option),
         target: String(target),
         matches_n,
+        match_level,
       }, null, 2));
     }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,8 +51,8 @@ export interface IPage {
   evaluateWithArgs?(js: string, args: Record<string, unknown>): Promise<any>;
   getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   snapshot(opts?: SnapshotOptions): Promise<any>;
-  click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number }>;
-  typeText(ref: string, text: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number }>;
+  click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
+  typeText(ref: string, text: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
   pressKey(key: string): Promise<void>;
   scrollTo(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<any>;
   getFormState(): Promise<any>;


### PR DESCRIPTION
## Summary

Three agent-native upgrades inspired by [browser-use](https://github.com/browser-use/browser-use), bundled as one PR because they share the same target / snapshot / find surface.

Priority ordering matches the agent-success lens WAWQAQ set: **#2 compound (highest lift) → #1 cascading stale-ref → #4 bbox containment**.

### 1. Compound-component expansion — `src/browser/compound.ts` (new)

`browser find --css` entries now carry a `compound` field for the three input categories agents burn turns on:

- **date / time / datetime-local / month / week** — `{control, format: "YYYY-MM-DD", current, min?, max?}` so agents stop typing `"April 21 2026"` into date inputs and silently failing.
- **select** — `{control: "select", multiple, current, options: [{label, value, selected, disabled?}], options_total}`. Snapshots cap options at 6; this caps at 50 with full `options_total`. Agents can match by label without opening the dropdown.
- **file** — `{control: "file", multiple, accept?, current: [names]}` so agents don't re-upload what's already there.

Helper is shipped as an inlined JS source string so it can be reused by snapshot / eval later without a second code path.

### 2. Cascading stale-ref — `src/browser/target-resolver.ts`

Strict fingerprint equality was stalling SPA re-renders / i18n label swaps. Ref path now walks three tiers before giving up:

| tier           | condition                                                                    |
|----------------|------------------------------------------------------------------------------|
| `exact`        | tag + every non-empty stored field agrees                                    |
| `stable`       | tag + strong id (id / testId) agrees; soft signals may have drifted          |
| `reidentified` | original ref missing or mismatched, but fp uniquely identifies a live node — re-tag + refresh identity map |

Every success envelope now carries `match_level`. Only when all three tiers miss do we emit `stale_ref`.

### 3. BBox 0.99 containment filter — `src/browser/dom-snapshot.ts`

Adds a second dedup tier on top of the existing 0.95 non-interactive one. When a parent is a propagator (tag `a` / `button` OR role `button` / `link` / `menuitem` / `tab` / `option`) and a child is interactive but *undistinctive* (no `aria-label` / `id` / `data-testid` / `name` / own form-control), fold it into the parent.

Removes the `[1]<button> [2]<svg> [3]<span>` ref-explosion on icon buttons. Nested `<input>` / `<a href>` stay distinct by design.

## Test plan

- [x] `src/browser/compound.test.ts` — 18 cases exercising date / select / file variants via a sandbox-executed `compoundInfoOf(el)`
- [x] `src/browser/find.test.ts` — asserts `compoundInfoOf` is inlined and entries opt-in only when compound data exists
- [x] `src/browser/target-resolver.test.ts` — asserts all three `match_level` values appear, classifier + reidentifier are wired, fallthrough ordering is correct
- [x] `src/browser/dom-snapshot.test.ts` — asserts 0.99 tier coexists with 0.95 tier, `PROPAGATING_ROLES` / `isBboxPropagator` / `isDistinctivelyInteractive` are emitted
- [x] Full run: 287/287 in `src/browser/` + `src/cli.test.ts` pass
- [x] `tsc --noEmit` clean

cc @codex-mini1 @First-principles-1 for review.