### PR TITLE
fix: use unique workspace per command execution (fixes #1114)

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -257,7 +257,7 @@ export async function executeCommand(
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { workspace: `site:${cmd.site}`, cdpEndpoint, contextId });
+      }, { workspace: `site:${cmd.site}:${crypto.randomUUID()}`, cdpEndpoint, contextId });
     } else {
       // Non-browser commands: apply timeout only when explicitly configured.
       const timeout = cmd.timeoutSeconds;


### PR DESCRIPTION
## Summary

Fix concurrent commands for the same site failing with `Detached while handling command`.

Closes #1114

## Root Cause

Browser command execution uses a workspace key based only on site name (`site:${cmd.site}`). When two commands for the same site run concurrently, they share the same browser session. If one finishes first and calls `page.closeWindow()`, the other command's page is detached mid-execution.

## Fix

Append `crypto.randomUUID()` to the workspace key so each command gets its own isolated browser session:

```
// Before
workspace: \`site:\${cmd.site}\`

// After  
workspace: \`site:\${cmd.site}:\${crypto.randomUUID()}\`
```

## Testing

- All 1767 existing tests pass
- `npx tsc --noEmit` clean
- Surgical 1-line change in `src/execution.ts`