### PR TITLE
fix(bilibili): resolve full video URLs and preserve full description

### DIFF
--- a/clis/bilibili/video.js
+++ b/clis/bilibili/video.js
@@ -15,7 +15,16 @@ cli({
     if (!page) {
       throw new CommandExecutionError('Browser session required for bilibili video');
     }
-    const bvid = await resolveBvid(kwargs.bvid);
+
+    // Resolve BV ID from three advertised input forms:
+    //   1. Bare "BV..." id
+    //   2. Full bilibili.com/video/<BV>... URL (with or without query string / www / m.)
+    //   3. b23.tv short link (delegated to resolveBvid)
+    // resolveBvid() alone handles (1) and (3) but not (2), so we pre-extract
+    // from bilibili URLs before falling through.
+    const input = String(kwargs.bvid ?? '').trim();
+    const bilibiliUrlMatch = input.match(/bilibili\.com\/(?:video|bangumi\/play)\/(BV[A-Za-z0-9]+)/i);
+    const bvid = bilibiliUrlMatch ? bilibiliUrlMatch[1] : await resolveBvid(input);
 
     // Navigate to video page first so subsequent api call shares a primed session.
     await page.goto(`https://www.bilibili.com/video/${bvid}/`);
@@ -35,8 +44,6 @@ cli({
     const dur = d.duration || 0;
     const mm = Math.floor(dur / 60);
     const ss = dur % 60;
-    const desc = (d.desc || '').replace(/\s+/g, ' ').trim();
-    const descTrunc = desc.length > 200 ? desc.slice(0, 200) + '…' : desc;
 
     return [
       { field: 'bvid',         value: d.bvid ?? '' },
@@ -55,7 +62,7 @@ cli({
       { field: 'share',        value: String(stat.share ?? '') },
       { field: 'parts',        value: String(d.videos ?? 1) },
       { field: 'thumbnail',    value: d.pic ?? '' },
-      { field: 'description',  value: descTrunc },
+      { field: 'description',  value: d.desc ?? '' },
     ];
   },
 });

--- a/clis/bilibili/video.test.js
+++ b/clis/bilibili/video.test.js
@@ -78,4 +78,55 @@ describe('bilibili video', () => {
       (err) => err instanceof CommandExecutionError && /啥都木有|-404/.test(err.message),
     );
   });
+
+  it('extracts BV ID from full bilibili.com URL input', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '' },
+    });
+
+    await command.func(page, { bvid: 'https://www.bilibili.com/video/BV1xx411c7mD/' });
+
+    expect(page.goto).toHaveBeenCalledWith('https://www.bilibili.com/video/BV1xx411c7mD/');
+    expect(mockApiGet).toHaveBeenCalledWith(page, '/x/web-interface/view', { params: { bvid: 'BV1xx411c7mD' } });
+  });
+
+  it('extracts BV ID from bilibili URL with trailing query string', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1Je9EBnEha', stat: {}, owner: {}, desc: '' },
+    });
+
+    await command.func(page, {
+      bvid: 'https://www.bilibili.com/video/BV1Je9EBnEha/?spm_id_from=333.1007&vd_source=abc',
+    });
+
+    expect(mockApiGet).toHaveBeenCalledWith(page, '/x/web-interface/view', { params: { bvid: 'BV1Je9EBnEha' } });
+  });
+
+  it('extracts BV ID from m.bilibili.com mobile URL', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '' },
+    });
+
+    await command.func(page, { bvid: 'https://m.bilibili.com/video/BV1xx411c7mD' });
+
+    expect(mockApiGet).toHaveBeenCalledWith(page, '/x/web-interface/view', { params: { bvid: 'BV1xx411c7mD' } });
+  });
+
+  it('returns full description without truncation or whitespace collapse', async () => {
+    const longDesc = '第一行描述\n\n第二段，有多个空格   和换行\n\n' + 'x'.repeat(500);
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: longDesc },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1xx411c7mD' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+    // JSON/YAML consumers must receive the complete description verbatim,
+    // including original whitespace and length > 200 chars.
+    expect(byField.description).toBe(longDesc);
+    expect(byField.description.length).toBeGreaterThan(200);
+  });
 });


### PR DESCRIPTION
## Description

Follow-up to #1110. The Copilot reviewer on that PR flagged two issues that were not blocking but real — addressed here.

### Bug 1: advertised video URL input is broken

Help text and docs say `opencli bilibili video <bvid>` accepts `BV ID, video URL, or b23.tv short link`, but the implementation passed the raw argument to `resolveBvid()`, which only handles bare `BV...` and `b23.tv` forms. A canonical `https://www.bilibili.com/video/BV.../` got rewritten to `https://b23.tv/www.bilibili.com/video/BV.../` and failed before ever calling the view API.

**Fix:** pre-extract BV from bilibili URLs (www / m. / with or without query string, also matches `bangumi/play/<BV>`) before delegating to `resolveBvid()`.

### Bug 2: description truncation loses data in JSON output

The command was truncating `description` to 200 chars and collapsing whitespace before returning it. `-f json` / `-f yaml` consumers silently lost the full `desc` value. Other bilibili adapters return raw fields.

**Fix:** return `d.desc` verbatim.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR (`npx tsc --noEmit`, `npm test`, live smoke test of all 3 input forms)
- [x] I updated tests or docs if needed
- [x] I included output below

### Documentation (if adding/modifying an adapter)

- [x] Used positional args for the command's primary subject
- [x] Normalized expected adapter failures to `CliError` subclasses
- [ ] Added doc page under `docs/adapters/` (no doc change — help text was already correct, only impl now matches)
- [ ] Updated `docs/adapters/index.md` table
- [ ] Updated sidebar
- [ ] Updated `README.md` / `README.zh-CN.md`

## Screenshots / Output

Before the fix, the advertised URL form failed at `resolveBvid` before reaching the API. After:

```console
# 1. full bilibili URL
$ opencli bilibili video 'https://www.bilibili.com/video/BV1Je9EBnEha/' -f yaml
- field: bvid
  value: BV1Je9EBnEha
- field: title
  value: 三层结构笔记法，打造完整知识流！
- field: author
  value: 'IOI科技 (mid: 507578555)'
...

# 2. URL with query string (spm_id_from, vd_source, etc. — common from clipboard)
$ opencli bilibili video 'https://www.bilibili.com/video/BV1Je9EBnEha/?spm_id_from=xxx' -f yaml
- field: bvid
  value: BV1Je9EBnEha
...

# 3. bare BV — regression
$ opencli bilibili video BV1Je9EBnEha -f yaml
- field: bvid
  value: BV1Je9EBnEha
...
```

### Tests

Added 4 regression tests in `clis/bilibili/video.test.js`:
1. Full `https://www.bilibili.com/video/BV.../` URL → BV extracted
2. URL with trailing query string → BV extracted
3. `m.bilibili.com` mobile URL → BV extracted
4. description > 200 chars preserved verbatim (no truncation, no whitespace collapse)

All 6 tests pass. Full suite: **228 test files / 1806 passed / 2 skipped**.