### PR TITLE
feat(cli): add --live and --focus flags for automation window lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ OpenCLI is not only for websites. It can also:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge |
-| `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open automation windows in the foreground (useful for debugging) |
+| `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open automation windows in the foreground (useful for debugging). The `--focus` flag sets this. |
+| `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation window open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,7 +155,8 @@ OpenCLI 不只是网站 CLI，还可以：
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `OPENCLI_DAEMON_PORT` | `19825` | daemon-extension 通信端口 |
-| `OPENCLI_WINDOW_FOCUSED` | `false` | 设为 `1` 时 automation 窗口在前台打开（适合调试） |
+| `OPENCLI_WINDOW_FOCUSED` | `false` | 设为 `1` 时 automation 窗口在前台打开（适合调试）。`--focus` 标志会设置此变量 |
+| `OPENCLI_LIVE` | `false` | 设为 `1` 时 adapter 命令执行完后保留 automation 窗口不关闭（适合检查页面）。`--live` 标志会设置此变量 |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | 浏览器连接超时（秒） |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -75,6 +75,62 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('skips closeWindow when OPENCLI_LIVE=1 (success path)', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    const prev = process.env.OPENCLI_LIVE;
+    process.env.OPENCLI_LIVE = '1';
+    try {
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'browser-live-success',
+        description: 'test closeWindow skipped with --live on success',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => [{ ok: true }],
+      });
+
+      await executeCommand(cmd, {});
+      expect(closeWindow).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.OPENCLI_LIVE;
+      else process.env.OPENCLI_LIVE = prev;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('skips closeWindow when OPENCLI_LIVE=1 (failure path)', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    const prev = process.env.OPENCLI_LIVE;
+    process.env.OPENCLI_LIVE = '1';
+    try {
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'browser-live-failure',
+        description: 'test closeWindow skipped with --live on failure',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => { throw new Error('adapter failure'); },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toThrow('adapter failure');
+      expect(closeWindow).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.OPENCLI_LIVE;
+      else process.env.OPENCLI_LIVE = prev;
+      vi.restoreAllMocks();
+    }
+  });
+
   it('does not re-run custom validation when args are already prepared', async () => {
     const validateArgs = vi.fn();
     const cmd: CliCommand = {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -216,6 +216,9 @@ export async function executeCommand(
             );
           }
         }
+        // --live / OPENCLI_LIVE=1 keeps the automation window open after the
+        // command finishes, so agents (or humans) can inspect the page state.
+        const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
           const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
             timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT,
@@ -223,7 +226,7 @@ export async function executeCommand(
           });
           // Adapter commands are one-shot — close the automation window immediately
           // instead of waiting for the 30s idle timeout.
-          await page.closeWindow?.().catch(() => {});
+          if (!keepOpen) await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
           // Collect diagnostic while page is still alive (before closing the window).
@@ -236,7 +239,7 @@ export async function executeCommand(
           // Close the automation window on failure too — without this, the window
           // lingers until the extension's idle timer fires (unreliable on Windows
           // where MV3 service workers may be suspended before setTimeout triggers).
-          await page.closeWindow?.().catch(() => {});
+          if (!keepOpen) await page.closeWindow?.().catch(() => {});
           throw err;
         }
       }, { workspace: `site:${cmd.site}`, cdpEndpoint });

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,23 @@ const __dirname = path.dirname(__filename);
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 
+// ── Session lifecycle flags ──────────────────────────────────────────────
+// `--live` / `--focus` are top-level-ish toggles that tweak the automation
+// window's lifecycle. We strip them from argv before Commander runs so they
+// can be placed anywhere and work on any subcommand (adapter or browser).
+{
+  const liveIdx = process.argv.indexOf('--live');
+  if (liveIdx !== -1) {
+    process.env.OPENCLI_LIVE = '1';
+    process.argv.splice(liveIdx, 1);
+  }
+  const focusIdx = process.argv.indexOf('--focus');
+  if (focusIdx !== -1) {
+    process.env.OPENCLI_WINDOW_FOCUSED = '1';
+    process.argv.splice(focusIdx, 1);
+  }
+}
+
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.
 const argv = process.argv.slice(2);


### PR DESCRIPTION
## Summary
- `--live` / `OPENCLI_LIVE=1` keeps the automation window open after an adapter command finishes (default: close immediately as before)
- `--focus` / `OPENCLI_WINDOW_FOCUSED=1` already existed as env var; now also a CLI flag so users don't have to shell-export
- Both parsed early and stripped from argv → work on any subcommand (adapter or browser), in any position

## Why
@WAWQAQ asked for a way to stop commands from auto-closing, so the page stays visible for inspection or follow-up commands. `--focus` was also brought up and turned out to already exist as an env var — exposing it as a flag makes it actually discoverable.

## Test plan
- [x] New `execution.test.ts` cases: `OPENCLI_LIVE=1` skips `closeWindow()` on both success and failure paths
- [x] Existing `calls closeWindow on browser command failure` case still passes (default behavior unchanged)
- [x] `npx vitest run src/execution.test.ts src/commanderAdapter.test.ts src/cli.test.ts` — 99 passed
- [x] `npm run build` green
- [x] Smoke: `opencli --live list` and `opencli list --focus` both parse correctly

## Not in scope
- No auto-teardown timer for the lingering window — the extension's existing 30s idle timeout still applies if the user doesn't explicitly close. Can revisit if agents end up leaking windows across long sessions.