### PR TITLE
docs: sync --live and --focus window docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_DIAGNOSTIC` | `false` | Set to `1` to capture structured diagnostic context on failures |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
+`--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation window open until you run `opencli browser close` or the idle timeout expires.
+
 ## Update
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -165,6 +165,8 @@ OpenCLI 不只是网站 CLI，还可以：
 | `OPENCLI_DIAGNOSTIC` | `false` | 设为 `1` 时在失败时输出结构化诊断上下文 |
 | `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |
 
+`--focus` 同时适用于 `opencli browser *` 和浏览器型 adapter 命令。`--live` 主要是给 adapter 命令用的：`browser` 子命令本来就会一直保留 automation window，直到你手动执行 `opencli browser close` 或等空闲超时。
+
 ## 更新
 
 ```bash

--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: Bash(opencli:*), Read, Edit, Write, Grep
 
 全程用现有工具：`opencli browser *` / `opencli doctor` / `opencli browser init` / `opencli browser verify`。没有新命令。
 
+调试浏览器型 adapter 时，优先直接带上 `--live --focus`。这样命令跑完后 automation window 还在，而且在前台，方便你核对最终页面状态，而不是猜是抓数错了还是页面走偏了。
+
 ---
 
 ## 前置：看你落在哪

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -22,6 +22,14 @@ Until `doctor` is green, nothing else will work. Typical failures: Chrome not ru
 
 ---
 
+## Window lifecycle
+
+- `opencli browser *` commands already keep the automation session alive between calls. The window stays open until you run `opencli browser close` or the idle timeout expires.
+- `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation window in the foreground. Use it when you want to watch the page live.
+- `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation window open after the command returns so you can inspect the final page state.
+
+---
+
 ## Mental model
 
 1. **Selector-first target contract.** Every interaction command (`click`, `type`, `select`, `get text/value/attributes`) takes one `<target>`, which is *either* a numeric ref from `state`/`find` *or* a CSS selector. Use `--nth <n>` to disambiguate multiple CSS matches.


### PR DESCRIPTION
## Summary
- sync README and README.zh-CN with the current `--live` / `--focus` window lifecycle behavior
- add an explicit window lifecycle section to the `opencli-browser` skill
- add a debugging note to `opencli-adapter-author` so browser-backed adapters use `--live --focus` when inspecting final page state

## Verification
- npm run build