### PR TITLE
chore: bump version to 1.7.6, extension to 1.0.2

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in isolated Chrome windows via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- OpenCLI: 1.7.5 → 1.7.6
- Extension: 1.0.1 → 1.0.2

Since 1.7.5:
- #1122 — `--live` and `--focus` flags for automation window lifecycle
- #1119 — restore and upgrade opencli-browser skill
- #1116 — compound expansion + cascading stale-ref + bbox dedup
- #1112 — selector-first find + get/click/type/select
- #1110 — bilibili video command
- #1109 — youtube fallback to Videos tab
- #1106 — twitter query ID timeout fix
- #1104 — agent-native payload (network bodies, html tree, extract)
- #1103 — network --filter for agent-native discovery
- #1093 — deepseek file upload support