### PR TITLE
fix(xiaoyuzhou): correct podcast-episodes API endpoint

### DIFF
--- a/clis/xiaoyuzhou/podcast-episodes.js
+++ b/clis/xiaoyuzhou/podcast-episodes.js
@@ -20,9 +20,9 @@ cli({
             throw new CliError('INVALID_ARGUMENT', 'limit must be a positive integer', 'Example: --limit 5');
         }
         const credentials = loadXiaoyuzhouCredentials();
-        const response = await requestXiaoyuzhouJson('/v1/podcast/listEpisode', {
+        const response = await requestXiaoyuzhouJson('/v1/episode/list', {
             method: 'POST',
-            body: { pid: args.id, limit: requestedLimit },
+            body: { pid: args.id, order: 'desc', limit: requestedLimit },
             credentials,
         });
         const episodes = response.data ?? [];

--- a/clis/xiaoyuzhou/podcast-episodes.test.js
+++ b/clis/xiaoyuzhou/podcast-episodes.test.js
@@ -1,0 +1,78 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+const { mockRequestJson, mockLoadCredentials } = vi.hoisted(() => ({
+    mockRequestJson: vi.fn(),
+    mockLoadCredentials: vi.fn(),
+}));
+
+vi.mock('./auth.js', async () => {
+    const actual = await vi.importActual('./auth.js');
+    return {
+        ...actual,
+        requestXiaoyuzhouJson: mockRequestJson,
+        loadXiaoyuzhouCredentials: mockLoadCredentials,
+    };
+});
+
+await import('./podcast-episodes.js');
+
+let cmd;
+
+beforeAll(() => {
+    cmd = getRegistry().get('xiaoyuzhou/podcast-episodes');
+    expect(cmd?.func).toBeTypeOf('function');
+});
+
+describe('xiaoyuzhou podcast-episodes', () => {
+    beforeEach(() => {
+        mockRequestJson.mockReset();
+        mockLoadCredentials.mockReset();
+        mockLoadCredentials.mockReturnValue({ access_token: 'access', refresh_token: 'refresh' });
+    });
+
+    it('calls the fixed episode list endpoint with desc ordering', async () => {
+        mockRequestJson.mockResolvedValue({
+            data: [
+                {
+                    eid: 'ep-1',
+                    title: 'Episode 1',
+                    duration: 3661,
+                    playCount: 42,
+                    pubDate: '2026-04-20T10:00:00.000Z',
+                },
+            ],
+        });
+
+        const result = await cmd.func(null, {
+            id: 'podcast-1',
+            limit: 3,
+        });
+
+        expect(mockRequestJson).toHaveBeenCalledWith('/v1/episode/list', {
+            method: 'POST',
+            body: { pid: 'podcast-1', order: 'desc', limit: 3 },
+            credentials: { access_token: 'access', refresh_token: 'refresh' },
+        });
+        expect(result).toEqual([
+            {
+                eid: 'ep-1',
+                title: 'Episode 1',
+                duration: '61:01',
+                plays: 42,
+                date: '2026-04-20',
+            },
+        ]);
+    });
+
+    it('rejects non-positive limits before hitting the API', async () => {
+        await expect(cmd.func(null, {
+            id: 'podcast-1',
+            limit: 0,
+        })).rejects.toMatchObject({
+            code: 'INVALID_ARGUMENT',
+            message: 'limit must be a positive integer',
+        });
+        expect(mockRequestJson).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Problem

\`opencli xiaoyuzhou podcast-episodes <id>\` returns HTTP 404 for every podcast:

\`\`\`
ok: false
error:
  code: COMMAND_EXEC
  message: 'Xiaoyuzhou API request failed with HTTP 404: Not Found'
\`\`\`

The code in \`clis/xiaoyuzhou/podcast-episodes.js\` is calling \`POST /v1/podcast/listEpisode\`, which does not exist on Xiaoyuzhou's API. This appears to be a typo introduced in #1059 (the SSR→API migration).

## Fix

Two small changes to \`clis/xiaoyuzhou/podcast-episodes.js\`:

1. **Endpoint:** \`/v1/podcast/listEpisode\` → \`/v1/episode/list\`
2. **Request body:** add required \`order: 'desc'\` (server returns 400 without it; \`desc\` = newest first, matches typical podcast-feed UX)

The correct endpoint was verified two ways:
- By packet-capturing the Xiaoyuzhou iOS app
- Cross-checked against [\`ultrazg/xyz\`](https://github.com/ultrazg/xyz), a widely-used Go wrapper over Xiaoyuzhou's API — their [\`/episode_list\`](https://github.com/ultrazg/xyz/blob/main/doc/docs/episodeList.md) handler calls \`POST /v1/episode/list\` with the same \`{pid, order, limit}\` body.

## Test

Tested against real podcast \`626b46ea9cbbf0451cf5a962\` (张小珺｜商业访谈录, 140 episodes):

**Before:**
\`\`\`
$ opencli xiaoyuzhou podcast-episodes 626b46ea9cbbf0451cf5a962 --limit 3
ok: false
error:
  code: COMMAND_EXEC
  message: 'Xiaoyuzhou API request failed with HTTP 404: Not Found'
\`\`\`

**After:**
\`\`\`
$ opencli xiaoyuzhou podcast-episodes 626b46ea9cbbf0451cf5a962 --limit 3
┌──────────────────────────┬──────────────────────────────────────────┬──────────┬───────┬────────────┐
│ Eid                      │ Title                                    │ Duration │ Plays │ Date       │
├──────────────────────────┼──────────────────────────────────────────┼──────────┼───────┼────────────┤
│ 69e4e6951d989496e7fecc7b │ 137. 对洪乐潼的4小时访谈：AI for Math... │ 264:17   │ 9375  │ 2026-04-20 │
│ 69de68cfb977fb2c47f1ee14 │ 136. 全球大模型季报第9集：和广密聊...    │ 82:40   │ 53362 │ 2026-04-14 │
│ 69d8bbdfe2c8be3155dcc2fe │ 135. 和自然选择创始人Tristan聊...        │ 112:54   │ 18655 │ 2026-04-10 │
└──────────────────────────┴──────────────────────────────────────────┴──────────┴───────┴────────────┘
\`\`\`

No new dependencies, no API surface changes, no impact on other \`xiaoyuzhou\` commands.