### PR TITLE
feat(verify): fixture-based value validation + skill docs for COOKIE pitfalls

### DIFF
--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -138,12 +138,17 @@ DONE
        [ ] 找同站点或同类型最像的 adapter，cp 过来
        [ ] 改 name / URL / 字段映射
 [ ] 10. opencli browser verify <site>/<name>
+        [ ] 首轮通过后立刻 `--write-fixture` 生成 `~/.opencli/sites/<site>/verify/<cmd>.json` 种子
+        [ ] 手改种子：加 `patterns`（URL / 日期 / ID 格式）+ `notEmpty`（核心字段）+ 收紧 `rowCount`
+        [ ] 再跑一次 `opencli browser verify <site>/<name>`，确认 ✓ matches fixture
 [ ] 11. 字段值 vs 网页肉眼比对（别只看 "Adapter works!"）
 [ ] 12. 回写站点记忆（**verify 通过 + 肉眼比对对得上之后**，schema 见 `references/site-memory.md`）：
         [ ] `endpoints.json`：以 endpoint 的短名为 key，value = `{url, method, params.{required,optional}, response, verified_at: YYYY-MM-DD, notes}`
         [ ] `field-map.json`：只追加新代号。key = 字段代号，value = `{meaning, verified_at: YYYY-MM-DD, source}`；**已存在的 key 不要覆盖**，有冲突先和网页肉眼值对齐再写
         [ ] `notes.md`：顶部追加一段 `## YYYY-MM-DD by <agent/user>`，写本次写 adapter 时遇到的新坑 / 新结论
-        [ ] `fixtures/<cmd>-<YYYYMMDDHHMM>.json`：存一份该 endpoint 的完整响应样本（去掉 cookie / token / 用户私有字段后再存），给后续 regression / 字段对比用
+        [ ] `verify/<cmd>.json`：**必填。** `opencli browser verify` 的期望值（args / rowCount / columns / types / patterns / notEmpty），Step 10 已经让你生成了，这里只是 checklist
+        [ ] `fixtures/<cmd>-<YYYYMMDDHHMM>.json`：存一份该 endpoint 的完整响应样本（去掉 cookie / token / 用户私有字段再存），给后续字段对比 / 离线 replay 用
+        [ ] 调试过程中如果在 repo / adapter 目录 dump 过临时文件（`.dbg-*.html` / `raw-*.json` / 等），**在 commit 前清干净**——这些本来就该落在 `~/.opencli/sites/<site>/fixtures/` 或 `/tmp/`
 ```
 
 ---
@@ -161,6 +166,9 @@ DONE
 | | 还推不出 | 先输出 raw，adapter 跑起来再迭代 |
 | Step 10 verify 失败 | `fltt` 漏了 / 字段映射错 | autofix skill |
 | | 某列永远是 `null` | 字段路径错了，回 Step 7 |
+| Step 10 verify fixture mismatch | `[pattern]` row[i] 报错 | 先肉眼比对网页值；值对 → 是 fixture pattern 太严，放宽；值不对 → 字段映射错 |
+| | `[column] missing column "X"` | 实际 response 没这列（站点改版 or args 影响）；重新 `--update-fixture` 或修 adapter |
+| | `[type]` actual null / undefined | 字段提取失败，回 Step 7 重抽；临时 fallback 用 union type `string\|null` 只有在语义真的可空时用 |
 | Step 11 数值不对 | 差 10000 倍 | 单位不统一（"万" vs "元"） |
 | | 百分比小 100 倍 | 响应已是 `0.025`，不要 × 100 |
 
@@ -189,6 +197,7 @@ DONE
 - 已知失败抛 `CliError('CODE', 'msg')` 或 `AuthRequiredError(domain)`，不要 silent `return []`
 - 写私人 adapter 用 `~/.opencli/clis/<site>/<name>.js`（免 build）；要提 PR 才 copy 到 `clis/<site>/<name>.js`
 - 站点记忆每轮回写：没记忆 → 用 skill → 产生记忆 → 下次变 5 分钟
+- **调试过程中的原始 dump / 抓包 / HTML 样本只能落在 `~/.opencli/sites/<site>/fixtures/` 或 `/tmp/`。严禁在 repo 根目录、`clis/<site>/` 或当前工作目录留 `.dbg-*.html / raw-*.json / sample.*` 这类临时文件**（PR diff 会带上去，别人 review 时很烦）。
 
 ---
 

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -165,6 +165,113 @@ func: async (_page, args) => {
 
 ---
 
+## COOKIE adapter 骨架（需要登录态）
+
+PUBLIC 模式不够（接口 401 / 302 到 login / 响应是"请登录"页）就走这里。要点三条：
+
+1. 读 cookie 走 `page.getCookies(...)`，**不要读 `document.cookie`**。
+2. 拿 HTML 走 Node 端 `fetch` + 手动解码，**不要塞进 `page.evaluate` 里**。
+3. Declaration 加 `browser: true`；不需要真的打开目标页时 `navigateBefore: false`。
+
+```javascript
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+
+const BASE = 'https://www.example.com';
+const HOST = 'www.example.com';
+const ROOT = '.example.com';  // 根域（auth 常在这里）
+
+async function readCookie(page) {
+    const seen = new Map();
+    for (const opts of [{ domain: HOST }, { domain: ROOT }]) {
+        try {
+            const cookies = await page.getCookies(opts);
+            for (const c of cookies || []) {
+                if (!seen.has(c.name)) seen.set(c.name, c.value);
+            }
+        } catch { /* try next domain */ }
+    }
+    return [...seen].map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
+async function fetchHtml(url, { cookie, encoding = 'utf-8', headers = {} } = {}) {
+    const resp = await fetch(url, {
+        headers: {
+            'User-Agent': 'Mozilla/5.0',
+            'Accept-Language': 'zh-CN,zh;q=0.9',
+            Referer: `${BASE}/`,
+            ...(cookie ? { Cookie: cookie } : {}),
+            ...headers,
+        },
+        redirect: 'follow',
+    });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `HTTP ${resp.status}`);
+    const buf = await resp.arrayBuffer();
+    return new TextDecoder(encoding).decode(buf);
+}
+
+cli({
+    site: 'example',
+    name: 'me',
+    description: '示例：需要登录的私有页面',
+    domain: HOST,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,    // 本命令不需要先开目标页
+    args: [{ name: 'limit', type: 'int', default: 20, help: '返回条数' }],
+    columns: ['index', 'title', 'time'],
+    func: async (page, args) => {
+        const cookie = await readCookie(page);
+        const html = await fetchHtml(`${BASE}/inbox`, { cookie, encoding: 'gbk' });
+
+        if (/请登录|需要登录|<title>Login/i.test(html)) {
+            throw new AuthRequiredError(HOST);
+        }
+
+        // parse html → rows
+        return rows.slice(0, Math.max(1, Number(args.limit) || 20));
+    },
+});
+```
+
+### 为什么不走 `page.evaluate(fetch(...))`
+
+三个坑，踩一个就重写：
+
+- **HttpOnly cookie 看不见**：绝大多数登录站点把 auth cookie 标 `HttpOnly`，`document.cookie` 永远读不到它，只能通过 CDP 的 cookie jar 拿（`page.getCookies`）。塞到 `page.evaluate` 里就等于回到 `document.cookie` 那条路，必挂。
+- **`navigateBefore: false` 时当前 tab 不在目标站**：页面 origin 可能是 `about:blank` 或上一条命令留下的别处，从那儿发 fetch 到目标域就是 cross-origin，浏览器 CORS 一挡就是 "Failed to fetch"。
+- **非 UTF-8 编码解码麻烦**：GBK / Big5 / Shift-JIS 的站（Discuz / phpBB 老版 / 日站）在 `page.evaluate` 里用 `response.text()` 拿到的是乱码，`TextDecoder('gbk').decode(buf)` 的写法只在 Node 侧干净。
+
+**规则**：HTML 型 COOKIE adapter 一律 Node 侧 `fetch`，浏览器只当 cookie jar 用。
+
+### Cookie 域的双查
+
+```javascript
+for (const opts of [{ domain: HOST }, { domain: ROOT }]) { ... }
+```
+
+不是所有站都这么玄学，但下面这几类踩坑最多：
+
+| 站点类型 | 坑 |
+|---------|----|
+| Discuz!X / phpBB / vBulletin 论坛 | Auth cookie 设在 `.<root>.com`，HttpOnly；业务页在 `www.<root>.com`。只查 `www.` 会漏 |
+| 多子域账户体系（`account.x.com` vs `api.x.com`） | 登录时写在 account 域，API 域读取时拿不到 |
+| 新版 Chrome SameSite=Lax 默认 | 某些 cookie 查 `url:` 才给返，查 `domain:` 不给 |
+
+双查成本很低，不确定就两个都查，用 Map 去重第一次出现的 name。
+
+### 明确的空态要返回哨兵行，不要 `[]`
+
+空态（"暂时没有提醒内容" / "暂无通知" / "No results"）返回 `[]`，下游 agent 会当成"接口挂了"而重试。正确做法是返回**一行明确写着当前状态的数据**：
+
+```javascript
+if (/暂时没有提醒内容/.test(html)) {
+    return [{ index: 0, from: '', summary: '暂时没有提醒内容', time: '', threadUrl: '' }];
+}
+```
+
+---
+
 ## 同类型 adapter 对照
 
 | 类型 | 代表 | 参考 |

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -288,6 +288,79 @@ if (/暂时没有提醒内容/.test(html)) {
 
 ---
 
+## Verify fixture（每个 adapter 配一份 `~/.opencli/sites/<site>/verify/<name>.json`）
+
+verify fixture 是"adapter 产出长什么样"的结构锚点。没有它，`opencli browser verify` 只能证"adapter 能跑完不抛"，证不出数据没错位。**必写**。
+
+详细 schema 见 `site-memory.md` 的 `verify/<cmd>.json` 节。这里只讲两个容易踩的地方：
+
+### args 形态：object vs array
+
+`args` 字段决定 verify 怎么调你的 adapter：
+
+- **对象形态** `{ "limit": 3 }` → 展开成 `--limit 3`，标准 named-flag adapter 用这个
+- **数组形态** `["123", "--limit", "3"]` → 原样 append 到命令后，**positional 主语型** adapter 必须用这个
+
+repo 约定"主语优先 positional"——thread 详情型、url 解析型、关键词搜索型都用 positional：
+
+```js
+// clis/1point3acres/thread.js — 接收 <tid> 作为主语
+cli({
+  site: '1point3acres',
+  name: 'thread',
+  args: [
+    { name: 'tid',   type: 'string', required: true, positional: true },
+    { name: 'limit', type: 'int',    default: 20 },
+  ],
+  // ...
+});
+```
+
+对应 fixture：
+
+```json
+{
+  "args": ["1234567", "--limit", "3"],
+  "expect": { "rowCount": { "min": 1, "max": 3 }, "...": "..." }
+}
+```
+
+**不要写成** `{ "tid": "1234567", "limit": 3 }`——这会被展开成 `--tid 1234567 --limit 3`，commander 把 `--tid` 当未知 flag 报错，或者 adapter 根本不认。
+
+### 种子 → 手改
+
+named-flag adapter（`hot` / `latest` 类）可以直接让工具生成种子：
+
+```bash
+# 1. 让 verify 先跑一遍，--write-fixture 生成种子（默认追加 --limit 3）
+opencli browser verify 1point3acres/hot --write-fixture
+
+# 2. 手改 ~/.opencli/sites/1point3acres/verify/hot.json
+#    - patterns: 加 URL / 日期 / ID 正则
+#    - notEmpty: 加核心字段（title / author / url）
+#    - rowCount: 收紧到业务合理区间
+
+# 3. 再跑 verify，fixture 吃得动就 OK
+opencli browser verify 1point3acres/hot
+```
+
+positional adapter 目前 `--write-fixture` 没法表达主语，**首份 fixture 要手写**：
+
+```bash
+# 1. 先直跑 adapter 看输出长啥样
+opencli 1point3acres thread 1173710 --limit 2 --format json | head
+
+# 2. 照着响应手写 ~/.opencli/sites/1point3acres/verify/thread.json
+#    （args 一定用数组: ["1173710", "--limit", "2"]）
+
+# 3. 跑 verify 核对
+opencli browser verify 1point3acres/thread
+```
+
+机器生成的种子只有 rowCount.min=1 / columns / types，挡不住字段值错位。**patterns + notEmpty 无论哪种情形都是肉写的**。
+
+---
+
 ## 私人 adapter vs repo 贡献
 
 ```

--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -172,6 +172,10 @@ opencli browser eval "document.cookie.split('; ').reduce((o,x)=>{const[k,v]=x.sp
 
 常见 token cookie 名：`ct0`（Twitter CSRF）、`xq_a_token`（雪球）、`SESSDATA`（B 站）、`_csrf / csrfToken`（通用）。
 
+**`document.cookie` 只能看到 non-HttpOnly 的 cookie。** 上面那条命令侦察阶段够用，真写 adapter 时 auth 经常是 HttpOnly，一定要用 `page.getCookies(...)` 从 CDP cookie jar 拿——见 `adapter-template.md` 的 "COOKIE adapter 骨架"。
+
+论坛 / BBS 引擎（Discuz!X / phpBB / vBulletin）还多一坑：auth cookie 设在**根域** `.example.com`（不是 `www.example.com`），且 HttpOnly。要查 `{ domain: '.<root>' }` **和** `{ domain: 'www.<root>' }` 两次，否则 adapter 在有 cookie 的前提下仍然 401。
+
 ### localStorage / sessionStorage 里
 
 ```bash

--- a/skills/opencli-adapter-author/references/site-memory.md
+++ b/skills/opencli-adapter-author/references/site-memory.md
@@ -61,10 +61,16 @@ agent 每跑一次相关 adapter 就可以自动写/读：
   notes.md               — 累积笔记（时间戳 + 写入人 + 发现）
   endpoints.json         — 已验证的 endpoint 目录
   field-map.json         — 字段代号 → 含义（key 为字段代号，value 为 {meaning, verified_at, source}）
-  fixtures/              — 样本响应（给 verify 做 regression 对比）
+  verify/                — `opencli browser verify` 期望值（值级校验锚点，每个 adapter 一份）
+    <cmd>.json
+  fixtures/              — 完整响应样本（给字段对比 / 离线 replay；**调试时的原始 dump 也只能落在这里或 /tmp/**）
     <cmd>-<ts>.json
   last-probe.log         — 最近一次侦察输出（下次接着用）
 ```
+
+`verify/` vs `fixtures/` 别混：
+- `verify/<cmd>.json` 是**结构期望**（rowCount / columns / types / patterns / notEmpty），每 adapter 一份、会被 verify 读。
+- `fixtures/<cmd>-<ts>.json` 是**原始响应样本**，给人 / 下一个 agent 做字段比对用，verify 不会读。
 
 ### `endpoints.json` 格式（schema 锁死）
 
@@ -113,6 +119,47 @@ key = 字段代号（`f237` / `f152`），value 三件套：
 - `source`：怎么推出来的，让下次能复查（`field-decode-playbook sort-key` / `网页标签对照` / `bundle 搜索 var pricePct =`）
 - **已存在的 key 不要默默覆盖**。有冲突时先用 `fixtures/` 里的真实样本 + 网页肉眼值再确认一遍
 
+### `verify/<cmd>.json` 格式（schema 锁死）
+
+每个 adapter 一份，`opencli browser verify <site>/<cmd>` 会自动读。**没有这份 = verify 只能证"能跑"，证不出数据对**——所以是必填产物。
+
+```json
+{
+  "args": { "limit": 3 },
+  "expect": {
+    "rowCount": { "min": 1, "max": 3 },
+    "columns": ["rank", "tid", "title", "url"],
+    "types": {
+      "rank": "number",
+      "tid": "string|number",
+      "title": "string",
+      "url": "string"
+    },
+    "patterns": {
+      "url": "^https://www\\.1point3acres\\.com/bbs/thread-"
+    },
+    "notEmpty": ["title", "url"]
+  }
+}
+```
+
+字段说明：
+
+- `args`：verify 调 adapter 时要带的参数。支持两种形态：
+  - **对象**：`{ "limit": 3 }` → 展开成 `--limit 3`，用于标准 named flag 适配器
+  - **数组**：`["123", "--limit", "3"]` → **原样**追加到命令后，用于 positional 主语型适配器（`<tid>` / `<url>` / `<query>`）。repo 约定"主语优先 positional"，所以这类适配器只能用数组形态
+- `expect.rowCount.{min,max}`：包含边界。稳定列表接口收紧到 `[min, max]`，动态接口给一个宽区间
+- `expect.columns`：每行必须都有这些 key（严格要求——漏了就 fail）
+- `expect.types`：支持 `|` union（`string|null`）和 `any` 通配。写多少列类型看列的稳定性；波动大的列直接 `any` 比频繁改 fixture 好
+- `expect.patterns`：正则表达式 **字符串**（注意 `\\` 转义）。`null` / `undefined` 会被跳过，不要用正则校验可空字段
+- `expect.notEmpty`：trim 后不能为空的列。这是"adapter 没吃掉核心业务字段"的最后一道保险
+
+### 什么时候手写 vs `--write-fixture` 自动生成
+
+- Step 10 首轮通过：`opencli browser verify <site>/<cmd> --write-fixture` 会根据真实行生成一份 `deriveFixture` 种子（rowCount.min=1 / columns / types），没有 patterns/notEmpty。
+- 拿到种子后**必须手改**：加 `patterns`（URL / 日期 / ID 格式）、加 `notEmpty`（核心字段）、收紧 `rowCount`。纯机器生成的 fixture 挡不住数值错位。
+- 站点换版导致 fixture 过时：`--update-fixture` 覆盖。改之前**先用肉眼核对一次网页值**，别闭着眼把错的响应固化下来。
+
 ### `notes.md` 格式
 
 ```markdown
@@ -144,11 +191,15 @@ Step 2 开始前 → 读  ~/.opencli/sites/<site>/
                 命中后 → 不跳写 adapter，仍要跑 Step 5 (endpoint 验证) + Step 7 (字段抽查)
                         verified_at 超 30 天 → 当作过期，按冷启动走 Step 3 → 4
 
+Step 10 verify 首轮通过后 → 写 ~/.opencli/sites/<site>/verify/<cmd>.json
+                            - 先 `--write-fixture` 拿种子，再手改 patterns / notEmpty / rowCount
+                            - 没这份后续 verify 挡不住数据错位，**必填**
+
 Step 11 肉眼对比通过后 → 写 ~/.opencli/sites/<site>/
                         - endpoints.json：按 schema 追加或更新 verified_at
                         - field-map.json：只追加新 key，已有的不默默覆盖
                         - notes.md：顶部追加一段
-                        - fixtures/：脱敏后存一份响应样本
+                        - fixtures/：脱敏后存一份完整响应样本（区别于 verify/）
 ```
 
 **回写是 commit，不是 stash**：不过 Step 10 verify + Step 11 肉眼对比不写，防止把错的映射喂给下一轮。
@@ -160,6 +211,10 @@ Step 11 肉眼对比通过后 → 写 ~/.opencli/sites/<site>/
 - 真实账户 cookie / token — 不要保存任何鉴权凭据
 - 用户私有数据（返回体里有个人敏感字段的 → 脱敏再存 fixtures）
 - 过期超过 30 天的 last-probe.log（自动清）
+
+## 不要写进 **repo / adapter 目录** 的东西
+
+调试过程里的临时 dump（`.dbg-*.html` / `raw-*.json` / `sample-*` / `trace-*.txt`）**只能**落在 `~/.opencli/sites/<site>/fixtures/` 或系统 `/tmp/`。PR diff 会把 repo 根目录和 `clis/<site>/` 下的文件一起带走——别人 review 时看到一堆调试副产物会很烦。
 
 ---
 

--- a/src/browser/verify-fixture.test.ts
+++ b/src/browser/verify-fixture.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { deriveFixture, validateRows, type Fixture } from './verify-fixture.js';
+
+describe('validateRows', () => {
+    it('passes when rows meet all expectations', () => {
+        const fixture: Fixture = {
+            expect: {
+                rowCount: { min: 1, max: 3 },
+                columns: ['id', 'title', 'url'],
+                types: { id: 'number', title: 'string', url: 'string' },
+                patterns: { url: '^https://' },
+                notEmpty: ['title', 'url'],
+            },
+        };
+        const rows = [
+            { id: 1, title: 'a', url: 'https://x.com/a' },
+            { id: 2, title: 'b', url: 'https://x.com/b' },
+        ];
+        expect(validateRows(rows, fixture)).toEqual([]);
+    });
+
+    it('reports rowCount below min', () => {
+        const failures = validateRows([], { expect: { rowCount: { min: 1 } } });
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toMatchObject({ rule: 'rowCount' });
+        expect(failures[0].detail).toContain('at least 1');
+    });
+
+    it('reports rowCount above max', () => {
+        const failures = validateRows(
+            [{}, {}, {}, {}],
+            { expect: { rowCount: { max: 3 } } },
+        );
+        expect(failures).toHaveLength(1);
+        expect(failures[0].detail).toContain('at most 3');
+    });
+
+    it('reports missing columns per row', () => {
+        const failures = validateRows(
+            [{ a: 1 }, { a: 2, b: 3 }],
+            { expect: { columns: ['a', 'b'] } },
+        );
+        // row 0 missing 'b', row 1 complete
+        expect(failures).toEqual([
+            { rule: 'column', detail: 'missing column "b"', rowIndex: 0 },
+        ]);
+    });
+
+    it('reports type mismatch including null', () => {
+        const failures = validateRows(
+            [{ a: 'abc' }, { a: null }, { a: 42 }],
+            { expect: { types: { a: 'string' } } },
+        );
+        // row 0 string ok, row 1 null fail, row 2 number fail
+        expect(failures).toHaveLength(2);
+        expect(failures[0].rowIndex).toBe(1);
+        expect(failures[0].detail).toContain('null');
+        expect(failures[1].rowIndex).toBe(2);
+        expect(failures[1].detail).toContain('number');
+    });
+
+    it('accepts union types like "number|string"', () => {
+        const failures = validateRows(
+            [{ id: 1 }, { id: 'abc' }],
+            { expect: { types: { id: 'number|string' } } },
+        );
+        expect(failures).toEqual([]);
+    });
+
+    it('accepts "any" as wildcard type', () => {
+        const failures = validateRows(
+            [{ v: 1 }, { v: 'x' }, { v: null }, { v: [1, 2] }],
+            { expect: { types: { v: 'any' } } },
+        );
+        expect(failures).toEqual([]);
+    });
+
+    it('reports pattern mismatch with row index and truncated value', () => {
+        const failures = validateRows(
+            [{ url: 'https://ok.com' }, { url: 'not-a-url' }],
+            { expect: { patterns: { url: '^https?://' } } },
+        );
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toMatchObject({ rule: 'pattern', rowIndex: 1 });
+        expect(failures[0].detail).toContain('not-a-url');
+    });
+
+    it('skips pattern check for null/undefined values', () => {
+        const failures = validateRows(
+            [{ url: null }, { url: undefined }],
+            { expect: { patterns: { url: '^x' } } },
+        );
+        expect(failures).toEqual([]);
+    });
+
+    it('reports invalid regex without crashing', () => {
+        const failures = validateRows(
+            [{ a: 'x' }],
+            { expect: { patterns: { a: '[unclosed' } } },
+        );
+        expect(failures.some((f) => f.rule === 'pattern' && f.detail.includes('invalid'))).toBe(true);
+    });
+
+    it('treats empty/whitespace/null as failing notEmpty', () => {
+        const failures = validateRows(
+            [{ t: '' }, { t: '   ' }, { t: null }, { t: 'ok' }],
+            { expect: { notEmpty: ['t'] } },
+        );
+        expect(failures).toHaveLength(3);
+        expect(failures.map((f) => f.rowIndex)).toEqual([0, 1, 2]);
+    });
+
+    it('no failures when fixture has no expect block', () => {
+        expect(validateRows([{ anything: 1 }], {})).toEqual([]);
+    });
+});
+
+describe('deriveFixture', () => {
+    it('returns rowCount.min=0 when rows are empty', () => {
+        expect(deriveFixture([])).toEqual({ expect: { rowCount: { min: 0 } } });
+    });
+
+    it('extracts columns from first row and infers types per column', () => {
+        const fixture = deriveFixture([
+            { id: 1, title: 'a', url: 'https://x' },
+            { id: 2, title: 'b', url: 'https://y' },
+        ]);
+        expect(fixture.expect?.columns).toEqual(['id', 'title', 'url']);
+        expect(fixture.expect?.types).toEqual({
+            id: 'number',
+            title: 'string',
+            url: 'string',
+        });
+        expect(fixture.expect?.rowCount).toEqual({ min: 1 });
+    });
+
+    it('unions mixed types across rows as "a|b"', () => {
+        const fixture = deriveFixture([
+            { v: 1 },
+            { v: 'two' },
+            { v: null },
+        ]);
+        expect(fixture.expect?.types?.v).toBe('null|number|string');
+    });
+
+    it('embeds args when provided', () => {
+        const fixture = deriveFixture([{ x: 1 }], { limit: 5 });
+        expect(fixture.args).toEqual({ limit: 5 });
+    });
+
+    it('does not add patterns or notEmpty automatically', () => {
+        const fixture = deriveFixture([{ a: 'x' }]);
+        expect(fixture.expect?.patterns).toBeUndefined();
+        expect(fixture.expect?.notEmpty).toBeUndefined();
+    });
+});

--- a/src/browser/verify-fixture.test.ts
+++ b/src/browser/verify-fixture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveFixture, validateRows, type Fixture } from './verify-fixture.js';
+import { deriveFixture, expandFixtureArgs, validateRows, type Fixture } from './verify-fixture.js';
 
 describe('validateRows', () => {
     it('passes when rows meet all expectations', () => {
@@ -148,9 +148,41 @@ describe('deriveFixture', () => {
         expect(fixture.args).toEqual({ limit: 5 });
     });
 
+    it('embeds positional argv array when provided', () => {
+        const fixture = deriveFixture([{ x: 1 }], ['123', '--limit', '3']);
+        expect(fixture.args).toEqual(['123', '--limit', '3']);
+    });
+
     it('does not add patterns or notEmpty automatically', () => {
         const fixture = deriveFixture([{ a: 'x' }]);
         expect(fixture.expect?.patterns).toBeUndefined();
         expect(fixture.expect?.notEmpty).toBeUndefined();
+    });
+});
+
+describe('expandFixtureArgs', () => {
+    it('returns [] for undefined', () => {
+        expect(expandFixtureArgs(undefined)).toEqual([]);
+    });
+
+    it('expands object form as --key value pairs', () => {
+        expect(expandFixtureArgs({ limit: 3, sort: 'hot' })).toEqual(['--limit', '3', '--sort', 'hot']);
+    });
+
+    it('passes array form verbatim, stringifying values', () => {
+        expect(expandFixtureArgs(['123456', '--limit', 3])).toEqual(['123456', '--limit', '3']);
+    });
+
+    it('handles empty object and empty array', () => {
+        expect(expandFixtureArgs({})).toEqual([]);
+        expect(expandFixtureArgs([])).toEqual([]);
+    });
+
+    it('preserves positional + flag mix (e.g. <tid> --limit 3)', () => {
+        expect(expandFixtureArgs(['https://example.com/thread-1', '--comments', '5'])).toEqual([
+            'https://example.com/thread-1',
+            '--comments',
+            '5',
+        ]);
     });
 });

--- a/src/browser/verify-fixture.ts
+++ b/src/browser/verify-fixture.ts
@@ -1,0 +1,186 @@
+/**
+ * Verify fixture: structural expectations for `opencli browser verify` output.
+ *
+ * The adapter-author skill runbook says every published adapter must write a
+ * fixture under `~/.opencli/sites/<site>/verify/<command>.json` so later verify
+ * runs can catch shape regressions (missing columns, wrong types, bleeding
+ * values) without relying on exact content match — BBS / news / market data is
+ * too volatile for value equality.
+ *
+ * Schema:
+ *   {
+ *     "args": { "limit": 3 },              // args to pass on verify invocation
+ *     "expect": {
+ *       "rowCount": { "min": 1, "max": 10 },  // inclusive bounds
+ *       "columns":  ["a", "b"],                // every row must have these keys
+ *       "types":    { "a": "string", "b": "number|string" },
+ *       "patterns": { "url": "^https?://" },
+ *       "notEmpty": ["title", "url"]           // trimmed string must be non-empty
+ *     }
+ *   }
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type FixtureExpect = {
+  rowCount?: { min?: number; max?: number };
+  columns?: string[];
+  types?: Record<string, string>;
+  patterns?: Record<string, string>;
+  notEmpty?: string[];
+};
+
+export type Fixture = {
+  args?: Record<string, unknown>;
+  expect?: FixtureExpect;
+};
+
+export type ValidationFailure = {
+  rule: 'rowCount' | 'column' | 'type' | 'pattern' | 'notEmpty';
+  detail: string;
+  rowIndex?: number;
+};
+
+export type Row = Record<string, unknown>;
+
+export function fixturePath(site: string, command: string): string {
+  return path.join(os.homedir(), '.opencli', 'sites', site, 'verify', `${command}.json`);
+}
+
+export function loadFixture(site: string, command: string): Fixture | null {
+  const p = fixturePath(site, command);
+  if (!fs.existsSync(p)) return null;
+  try {
+    const raw = fs.readFileSync(p, 'utf-8');
+    const parsed = JSON.parse(raw) as Fixture;
+    return parsed;
+  } catch (err) {
+    throw new Error(`Failed to parse fixture ${p}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function writeFixture(site: string, command: string, fixture: Fixture): string {
+  const p = fixturePath(site, command);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, `${JSON.stringify(fixture, null, 2)}\n`, 'utf-8');
+  return p;
+}
+
+/**
+ * Derive a reasonable fixture from sample output. Used by `--write-fixture`
+ * to seed a first draft the author can hand-tune.
+ *
+ * Heuristics:
+ * - rowCount.min = 1 if rows non-empty, else 0
+ * - columns = keys from the first row
+ * - types = typeof of the first row's values, with "number|string" for mixed
+ * - no auto patterns / notEmpty — author should add those deliberately
+ */
+export function deriveFixture(rows: Row[], args?: Record<string, unknown>): Fixture {
+  const expect: FixtureExpect = {};
+  if (rows.length === 0) {
+    expect.rowCount = { min: 0 };
+    return { ...(args ? { args } : {}), expect };
+  }
+  expect.rowCount = { min: 1 };
+
+  const first = rows[0];
+  const columns = Object.keys(first);
+  expect.columns = columns;
+
+  const types: Record<string, string> = {};
+  for (const col of columns) {
+    const observed = new Set<string>();
+    for (const row of rows) {
+      const v = row[col];
+      observed.add(jsType(v));
+    }
+    types[col] = [...observed].sort().join('|');
+  }
+  expect.types = types;
+
+  return { ...(args ? { args } : {}), expect };
+}
+
+export function validateRows(rows: Row[], fixture: Fixture): ValidationFailure[] {
+  const failures: ValidationFailure[] = [];
+  const expect = fixture.expect;
+  if (!expect) return failures;
+
+  if (expect.rowCount) {
+    const { min, max } = expect.rowCount;
+    if (typeof min === 'number' && rows.length < min) {
+      failures.push({ rule: 'rowCount', detail: `got ${rows.length} rows, expected at least ${min}` });
+    }
+    if (typeof max === 'number' && rows.length > max) {
+      failures.push({ rule: 'rowCount', detail: `got ${rows.length} rows, expected at most ${max}` });
+    }
+  }
+
+  const columns = expect.columns ?? [];
+  const types = expect.types ?? {};
+  const patterns = expect.patterns ?? {};
+  const notEmpty = expect.notEmpty ?? [];
+
+  const compiledPatterns: Record<string, RegExp> = {};
+  for (const [col, src] of Object.entries(patterns)) {
+    try {
+      compiledPatterns[col] = new RegExp(src);
+    } catch (err) {
+      failures.push({ rule: 'pattern', detail: `pattern for "${col}" invalid: ${err instanceof Error ? err.message : String(err)}` });
+    }
+  }
+
+  rows.forEach((row, i) => {
+    for (const col of columns) {
+      if (!(col in row)) {
+        failures.push({ rule: 'column', detail: `missing column "${col}"`, rowIndex: i });
+      }
+    }
+    for (const [col, declared] of Object.entries(types)) {
+      if (!(col in row)) continue;
+      const actual = jsType(row[col]);
+      if (!typeMatches(actual, declared)) {
+        failures.push({
+          rule: 'type',
+          detail: `"${col}" is ${actual}, expected ${declared}`,
+          rowIndex: i,
+        });
+      }
+    }
+    for (const [col, re] of Object.entries(compiledPatterns)) {
+      if (!(col in row)) continue;
+      const v = row[col];
+      if (v === null || v === undefined) continue;
+      if (!re.test(String(v))) {
+        failures.push({
+          rule: 'pattern',
+          detail: `"${col}"=${JSON.stringify(String(v).slice(0, 60))} does not match /${re.source}/`,
+          rowIndex: i,
+        });
+      }
+    }
+    for (const col of notEmpty) {
+      const v = row[col];
+      if (v === null || v === undefined || String(v).trim() === '') {
+        failures.push({ rule: 'notEmpty', detail: `"${col}" is empty`, rowIndex: i });
+      }
+    }
+  });
+
+  return failures;
+}
+
+function jsType(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v;
+}
+
+function typeMatches(actual: string, declared: string): boolean {
+  const allowed = declared.split('|').map((s) => s.trim()).filter(Boolean);
+  if (allowed.length === 0) return true;
+  if (allowed.includes('any')) return true;
+  return allowed.includes(actual);
+}

--- a/src/browser/verify-fixture.ts
+++ b/src/browser/verify-fixture.ts
@@ -9,7 +9,11 @@
  *
  * Schema:
  *   {
- *     "args": { "limit": 3 },              // args to pass on verify invocation
+ *     // args can be either:
+ *     //   - an object of named flags: { "limit": 3 }  → expands to `--limit 3`
+ *     //   - a raw argv array:         ["123", "--limit", "3"]  → passed verbatim
+ *     // Use the array form for adapters that take positional subjects (e.g. <tid>, <url>, <query>).
+ *     "args": { "limit": 3 },
  *     "expect": {
  *       "rowCount": { "min": 1, "max": 10 },  // inclusive bounds
  *       "columns":  ["a", "b"],                // every row must have these keys
@@ -31,8 +35,10 @@ export type FixtureExpect = {
   notEmpty?: string[];
 };
 
+export type FixtureArgs = Record<string, unknown> | unknown[];
+
 export type Fixture = {
-  args?: Record<string, unknown>;
+  args?: FixtureArgs;
   expect?: FixtureExpect;
 };
 
@@ -77,7 +83,7 @@ export function writeFixture(site: string, command: string, fixture: Fixture): s
  * - types = typeof of the first row's values, with "number|string" for mixed
  * - no auto patterns / notEmpty — author should add those deliberately
  */
-export function deriveFixture(rows: Row[], args?: Record<string, unknown>): Fixture {
+export function deriveFixture(rows: Row[], args?: FixtureArgs): Fixture {
   const expect: FixtureExpect = {};
   if (rows.length === 0) {
     expect.rowCount = { min: 0 };
@@ -170,6 +176,21 @@ export function validateRows(rows: Row[], fixture: Fixture): ValidationFailure[]
   });
 
   return failures;
+}
+
+/**
+ * Convert fixture args into argv tokens appended after the command name.
+ * - Array form is passed through verbatim (stringified), supporting positional subjects.
+ * - Object form is expanded to `--key value` pairs.
+ */
+export function expandFixtureArgs(args: FixtureArgs | undefined): string[] {
+  if (!args) return [];
+  if (Array.isArray(args)) return args.map((v) => String(v));
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(args)) {
+    out.push(`--${k}`, String(v));
+  }
+  return out;
 }
 
 function jsType(v: unknown): string {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -25,7 +25,7 @@ vi.mock('./browser/index.js', () => {
   };
 });
 
-import { createProgram, findPackageRoot, resolveBrowserVerifyInvocation } from './cli.js';
+import { createProgram, findPackageRoot, normalizeVerifyRows, renderVerifyPreview, resolveBrowserVerifyInvocation } from './cli.js';
 
 describe('resolveBrowserVerifyInvocation', () => {
   it('prefers the built entry declared in package metadata', () => {
@@ -1305,5 +1305,62 @@ describe('findPackageRoot', () => {
     ]);
 
     expect(findPackageRoot(cliFile, (candidate) => exists.has(candidate))).toBe(packageRoot);
+  });
+});
+
+describe('normalizeVerifyRows', () => {
+  it('returns an empty array for null / primitives', () => {
+    expect(normalizeVerifyRows(null)).toEqual([]);
+    expect(normalizeVerifyRows(undefined)).toEqual([]);
+    expect(normalizeVerifyRows('hello')).toEqual([]);
+  });
+
+  it('passes through array-of-objects', () => {
+    const rows = [{ a: 1 }, { a: 2 }];
+    expect(normalizeVerifyRows(rows)).toEqual(rows);
+  });
+
+  it('wraps array-of-primitives as { value } rows', () => {
+    expect(normalizeVerifyRows([1, 'two', null])).toEqual([
+      { value: 1 }, { value: 'two' }, { value: null },
+    ]);
+  });
+
+  it('unwraps common envelope shapes', () => {
+    expect(normalizeVerifyRows({ rows: [{ a: 1 }] })).toEqual([{ a: 1 }]);
+    expect(normalizeVerifyRows({ items: [{ b: 2 }] })).toEqual([{ b: 2 }]);
+    expect(normalizeVerifyRows({ data: [{ c: 3 }] })).toEqual([{ c: 3 }]);
+    expect(normalizeVerifyRows({ results: [{ d: 4 }] })).toEqual([{ d: 4 }]);
+  });
+
+  it('wraps a single object as a one-row array', () => {
+    expect(normalizeVerifyRows({ ok: true })).toEqual([{ ok: true }]);
+  });
+});
+
+describe('renderVerifyPreview', () => {
+  it('emits a placeholder for empty rows', () => {
+    expect(renderVerifyPreview([])).toContain('no rows');
+  });
+
+  it('prints column headers followed by row cells', () => {
+    const out = renderVerifyPreview([{ a: 'x', b: 1 }, { a: 'y', b: 2 }]);
+    const lines = out.split('\n');
+    expect(lines[0]).toContain('a');
+    expect(lines[0]).toContain('b');
+    expect(lines.some((l) => l.includes('x') && l.includes('1'))).toBe(true);
+    expect(lines.some((l) => l.includes('y') && l.includes('2'))).toBe(true);
+  });
+
+  it('truncates long cells and reports hidden rows / columns', () => {
+    const rows = Array.from({ length: 15 }, (_, i) => ({
+      a: i, b: 'x'.repeat(100), c: i, d: i, e: i, f: i, g: i, h: i,
+    }));
+    const out = renderVerifyPreview(rows, { maxRows: 5, maxCols: 3, cellMax: 10 });
+    expect(out).toContain('and 10 more row');
+    expect(out).toContain('more column');
+    // cell gets truncated
+    expect(out).toContain('xxxxxxxxxx');
+    expect(out).not.toContain('xxxxxxxxxxx'); // never 11 consecutive
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,53 @@ function emitNetworkError(code: string, message: string, extra: Record<string, u
   process.exitCode = EXIT_CODES.USAGE_ERROR;
 }
 
+/** Coerce adapter JSON output into a row array. Accepts `[{...}]`, single `{}`, or `{items:[...]}`-style envelopes. */
+export function normalizeVerifyRows(data: unknown): Record<string, unknown>[] {
+  if (Array.isArray(data)) {
+    return data.map((r) => (r && typeof r === 'object' ? r as Record<string, unknown> : { value: r }));
+  }
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>;
+    for (const k of ['rows', 'items', 'data', 'results']) {
+      if (Array.isArray(obj[k])) {
+        return (obj[k] as unknown[]).map((r) => (r && typeof r === 'object' ? r as Record<string, unknown> : { value: r }));
+      }
+    }
+    return [obj];
+  }
+  return [];
+}
+
+/** Render up to 10 rows as a compact padded table for eyeball inspection during verify. */
+export function renderVerifyPreview(
+  rows: Record<string, unknown>[],
+  opts: { maxRows?: number; maxCols?: number; cellMax?: number } = {},
+): string {
+  const maxRows = opts.maxRows ?? 10;
+  const maxCols = opts.maxCols ?? 6;
+  const cellMax = opts.cellMax ?? 40;
+  if (rows.length === 0) return '  (no rows)';
+
+  const allCols = Array.from(new Set(rows.flatMap((r) => Object.keys(r))));
+  const cols = allCols.slice(0, maxCols);
+  const shown = rows.slice(0, maxRows);
+  const cellOf = (v: unknown): string => {
+    if (v === null || v === undefined) return '';
+    const s = typeof v === 'object' ? JSON.stringify(v) : String(v);
+    return s.replace(/\s+/g, ' ').slice(0, cellMax);
+  };
+  const widths = cols.map((c) => Math.max(c.length, ...shown.map((r) => cellOf(r[c]).length)));
+  const fmtRow = (vals: string[]): string => vals.map((v, i) => v.padEnd(widths[i])).join('  ');
+
+  const out: string[] = [];
+  out.push(`  ${fmtRow(cols)}`);
+  out.push(`  ${widths.map((w) => '-'.repeat(w)).join('  ')}`);
+  for (const r of shown) out.push(`  ${fmtRow(cols.map((c) => cellOf(r[c])))}`);
+  if (rows.length > maxRows) out.push(`  ... and ${rows.length - maxRows} more row(s)`);
+  if (allCols.length > maxCols) out.push(`  (${allCols.length - maxCols} more column(s) hidden)`);
+  return out.join('\n');
+}
+
 type BrowserTargetState = {
   defaultPage?: string;
   updatedAt: string;
@@ -1328,8 +1375,11 @@ cli({
 
   browser.command('verify')
     .argument('<name>', 'Adapter name in site/command format (e.g. hn/top)')
-    .description('Execute an adapter and show results')
-    .action(async (name: string) => {
+    .option('--write-fixture', 'Write a starter fixture to ~/.opencli/sites/<site>/verify/<command>.json if none exists')
+    .option('--update-fixture', 'Overwrite an existing fixture with one derived from current output')
+    .option('--no-fixture', 'Ignore any fixture file for this run (no value-level validation)')
+    .description('Execute an adapter and validate output; uses fixture at ~/.opencli/sites/<site>/verify/<cmd>.json when present')
+    .action(async (name: string, opts: { fixture?: boolean; writeFixture?: boolean; updateFixture?: boolean } = {}) => {
       try {
         const parts = name.split('/');
         if (parts.length !== 2) { console.error('Name must be site/command format'); process.exitCode = EXIT_CODES.USAGE_ERROR; return; }
@@ -1341,7 +1391,7 @@ cli({
         }
 
         const { execFileSync } = await import('node:child_process');
-        const os = await import('node:os');
+        const { loadFixture, writeFixture, deriveFixture, validateRows, fixturePath } = await import('./browser/verify-fixture.js');
         const filePath = path.join(os.homedir(), '.opencli', 'clis', site, `${command}.js`);
         if (!fs.existsSync(filePath)) {
           console.error(`Adapter not found: ${filePath}`);
@@ -1353,15 +1403,26 @@ cli({
         console.log(`🔍 Verifying ${name}...\n`);
         console.log(`  Loading: ${filePath}`);
 
-        // Read adapter to check if it defines a 'limit' arg
+        const useFixture = opts.fixture !== false;
+        let fixture = useFixture ? loadFixture(site, command) : null;
+
+        // Build adapter args: fixture.args override the legacy --limit 3 heuristic.
         const adapterSrc = fs.readFileSync(filePath, 'utf-8');
         const hasLimitArg = /['"]limit['"]/.test(adapterSrc);
-        const limitFlag = hasLimitArg ? ' --limit 3' : '';
-        const limitArgs = hasLimitArg ? ['--limit', '3'] : [];
+        const fixtureArgs = fixture?.args ?? {};
+        const cliArgs: string[] = [];
+        for (const [k, v] of Object.entries(fixtureArgs)) cliArgs.push(`--${k}`, String(v));
+        if (cliArgs.length === 0 && hasLimitArg) cliArgs.push('--limit', '3');
+
+        const argDisplay = cliArgs.join(' ');
         const invocation = resolveBrowserVerifyInvocation();
 
+        // Always request JSON so we can validate structurally.
+        const execArgs = [...invocation.args, site, command, ...cliArgs, '--format', 'json'];
+
+        let rawJson: string;
         try {
-          const output = execFileSync(invocation.binary, [...invocation.args, site, command, ...limitArgs], {
+          rawJson = execFileSync(invocation.binary, execArgs, {
             cwd: invocation.cwd,
             timeout: 30000,
             encoding: 'utf-8',
@@ -1369,18 +1430,65 @@ cli({
             stdio: ['pipe', 'pipe', 'pipe'],
             ...(invocation.shell ? { shell: true } : {}),
           });
-          console.log(`  Executing: opencli ${site} ${command}${limitFlag}\n`);
-          console.log(output);
-          console.log(`\n  ✓ Adapter works!`);
         } catch (err) {
-          console.log(`  Executing: opencli ${site} ${command}${limitFlag}\n`);
-          // execFileSync attaches captured stdout/stderr on its thrown Error.
+          console.log(`  Executing: opencli ${site} ${command} ${argDisplay}\n`);
           const execErr = err as { stdout?: string | Buffer; stderr?: string | Buffer };
           if (execErr.stdout) console.log(String(execErr.stdout));
           if (execErr.stderr) console.error(String(execErr.stderr).slice(0, 500));
           console.log(`\n  ✗ Adapter failed. Fix the code and try again.`);
           process.exitCode = EXIT_CODES.GENERIC_ERROR;
+          return;
         }
+
+        console.log(`  Executing: opencli ${site} ${command} ${argDisplay}\n`);
+
+        let rows: Record<string, unknown>[];
+        try {
+          rows = normalizeVerifyRows(JSON.parse(rawJson));
+        } catch {
+          console.log(rawJson);
+          console.log('\n  ✗ Could not parse adapter output as JSON. Is `--format json` broken?');
+          process.exitCode = EXIT_CODES.GENERIC_ERROR;
+          return;
+        }
+
+        console.log(renderVerifyPreview(rows));
+        console.log(`\n  → ${rows.length} row${rows.length === 1 ? '' : 's'}`);
+
+        // ── Fixture handling ───────────────────────────────────────────
+        if (opts.writeFixture || opts.updateFixture) {
+          if (fixture && !opts.updateFixture) {
+            console.log(`\n  Fixture already exists at ${fixturePath(site, command)}.`);
+            console.log(`  Use --update-fixture to overwrite.`);
+          } else {
+            const derived = deriveFixture(rows, Object.keys(fixtureArgs).length > 0 ? fixtureArgs : (hasLimitArg ? { limit: 3 } : undefined));
+            const p = writeFixture(site, command, derived);
+            console.log(`\n  ${fixture ? '↻ Updated' : '✎ Wrote'} fixture: ${p}`);
+            console.log(`  Review and hand-tune the derived expectations (add patterns / notEmpty, tighten rowCount).`);
+            fixture = derived;
+          }
+        }
+
+        if (!fixture) {
+          console.log(`\n  ✓ Adapter runs. (No fixture at ${fixturePath(site, command)} — consider --write-fixture to seed one.)`);
+          return;
+        }
+
+        const failures = validateRows(rows, fixture);
+        if (failures.length === 0) {
+          console.log(`\n  ✓ Adapter matches fixture (${fixturePath(site, command)}).`);
+          return;
+        }
+
+        console.log(`\n  ✗ Adapter output does not match fixture:`);
+        for (const f of failures.slice(0, 20)) {
+          const where = f.rowIndex !== undefined ? `row[${f.rowIndex}] ` : '';
+          console.log(`    - [${f.rule}] ${where}${f.detail}`);
+        }
+        if (failures.length > 20) {
+          console.log(`    ... and ${failures.length - 20} more failure(s)`);
+        }
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
         process.exitCode = EXIT_CODES.GENERIC_ERROR;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1391,7 +1391,7 @@ cli({
         }
 
         const { execFileSync } = await import('node:child_process');
-        const { loadFixture, writeFixture, deriveFixture, validateRows, fixturePath } = await import('./browser/verify-fixture.js');
+        const { loadFixture, writeFixture, deriveFixture, validateRows, fixturePath, expandFixtureArgs } = await import('./browser/verify-fixture.js');
         const filePath = path.join(os.homedir(), '.opencli', 'clis', site, `${command}.js`);
         if (!fs.existsSync(filePath)) {
           console.error(`Adapter not found: ${filePath}`);
@@ -1407,11 +1407,12 @@ cli({
         let fixture = useFixture ? loadFixture(site, command) : null;
 
         // Build adapter args: fixture.args override the legacy --limit 3 heuristic.
+        //   - object form   { "limit": 3 }            → `--limit 3`
+        //   - array form    ["123", "--limit", "3"]   → verbatim (for positional subjects)
         const adapterSrc = fs.readFileSync(filePath, 'utf-8');
         const hasLimitArg = /['"]limit['"]/.test(adapterSrc);
-        const fixtureArgs = fixture?.args ?? {};
-        const cliArgs: string[] = [];
-        for (const [k, v] of Object.entries(fixtureArgs)) cliArgs.push(`--${k}`, String(v));
+        const fixtureArgs = fixture?.args;
+        const cliArgs: string[] = expandFixtureArgs(fixtureArgs);
         if (cliArgs.length === 0 && hasLimitArg) cliArgs.push('--limit', '3');
 
         const argDisplay = cliArgs.join(' ');
@@ -1461,7 +1462,10 @@ cli({
             console.log(`\n  Fixture already exists at ${fixturePath(site, command)}.`);
             console.log(`  Use --update-fixture to overwrite.`);
           } else {
-            const derived = deriveFixture(rows, Object.keys(fixtureArgs).length > 0 ? fixtureArgs : (hasLimitArg ? { limit: 3 } : undefined));
+            const seedArgs = fixtureArgs !== undefined
+              ? fixtureArgs
+              : (hasLimitArg ? { limit: 3 } : undefined);
+            const derived = deriveFixture(rows, seedArgs);
             const p = writeFixture(site, command, derived);
             console.log(`\n  ${fixture ? '↻ Updated' : '✎ Wrote'} fixture: ${p}`);
             console.log(`  Review and hand-tune the derived expectations (add patterns / notEmpty, tighten rowCount).`);


### PR DESCRIPTION
## Summary

Addresses the three P0/P1 items from the 1point3acres adapter retro:

**Runtime — `opencli browser verify` now validates values, not just "ran":**

- Reads `~/.opencli/sites/<site>/verify/<cmd>.json` when present and checks row count / columns / types / patterns / notEmpty against live adapter output.
- New flags `--write-fixture` / `--update-fixture` / `--no-fixture`.
- Backward-compatible: **no fixture ⇒ same behavior as today** (runs the adapter, prints the output, exits 0 on success).

```
$ opencli browser verify 1point3acres/hot
  → 3 rows

  ✗ Adapter output does not match fixture:
    - [pattern] row[0] "url"="https://…thread-..." does not match /^https://EXPECTED-BOGUS-HOST//
```

**Skill — `opencli-adapter-author` captures the gotchas that bit me writing the 1p3a COOKIE adapters:**

- `adapter-template.md` — new "COOKIE adapter 骨架" section:
  - Dual-domain `page.getCookies({ domain: '.x' })` + `({ domain: 'www.x' })` merge, so HttpOnly auth cookies on the root domain don't silently drop
  - Why Node-side `fetch(url, { headers: { Cookie } })` + `TextDecoder('gbk')` is the right shape for HTML / non-UTF-8 / `navigateBefore: false` adapters (vs `page.evaluate(fetch(...))`, which blows up with "Failed to fetch" under cross-origin or GBK)
  - Empty-state sentinel row over `return []`
- `api-discovery.md §4` — note that Discuz/phpBB/vBulletin engines set auth on the root domain, so a single-domain `getCookies` call comes up empty
- `SKILL.md` runbook — Step 10 folds `--write-fixture` into the adapter-author loop; Step 12 adds the `verify/<cmd>.json` deliverable and forbids `.dbg-*` / raw HTML dumps in the repo tree

## Fixture schema

```json
{
  "args": { "limit": 3 },
  "expect": {
    "rowCount": { "min": 1, "max": 3 },
    "columns": ["rank", "tid", "title", "url"],
    "types":   { "rank": "number", "tid": "string|number", "url": "string" },
    "patterns": { "url": "^https://www\\\\.example\\\\.com/" },
    "notEmpty": ["title", "url"]
  }
}
```

- `types` supports unions (`"number|string"`) and `"any"` wildcard
- `patterns` skip null/undefined values so optional fields don't false-positive
- Derived fixtures from `--write-fixture` omit `patterns`/`notEmpty` — author hand-tunes

## Test plan

- [x] `npx vitest run src/` — 58 files / 820 passed / 2 skipped (same as main + new tests across `verify-fixture.test.ts` and `cli.test.ts`)
- [x] `npx tsc --noEmit` clean
- [x] `opencli browser verify 1point3acres/hot` — no fixture → prints rows + hint
- [x] `--write-fixture` → seeds `~/.opencli/sites/1point3acres/verify/hot.json` with derived schema
- [x] Hand-tune patterns + notEmpty → re-verify → ✓ matches fixture
- [x] Flip pattern to wrong host → exit 1 + per-row failure list
- [x] `--no-fixture` → bypasses validation even when fixture exists
- [x] `--write-fixture` with existing fixture → no-op with hint to use `--update-fixture`

## Non-goals

- Exact-value equality match (BBS / market / news data is too volatile — shape-based checks catch the bugs that actually ship).
- Recording HTTP request/response fixtures for offline replay (covered separately by `~/.opencli/sites/<site>/fixtures/<cmd>-<timestamp>.json`, existing convention).