### PR TITLE
feat: agent-native retrospective — analyze / verify guards / fixture content checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Guard: committed cli-manifest.json must match the one build regenerates.
+      # Prevents silent drift where unrelated adapter entries vanish or change
+      # across PRs (agent hits unexpected manifest diff → surgical-merge churn).
+      - name: Check cli-manifest.json is up-to-date
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if ! git diff --exit-code -- cli-manifest.json; then
+            echo "::error::cli-manifest.json is out of sync with the source. Run 'npm run build' and commit the result."
+            exit 1
+          fi
+
   # ── Unit tests (vitest shard) ──
   # PR: ubuntu + Node 22 only (fast feedback, 2 jobs).
   # Push to main/dev: full matrix for cross-platform/cross-version coverage (12 jobs).

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3274,7 +3274,7 @@
       {
         "name": "op",
         "type": "str",
-        "default": "/Users/jakevin/Pictures/chatgpt",
+        "default": "~/Pictures/chatgpt",
         "required": false,
         "help": "Output directory"
       },
@@ -6865,7 +6865,7 @@
       {
         "name": "op",
         "type": "str",
-        "default": "/Users/jakevin/tmp/gemini-images",
+        "default": "~/tmp/gemini-images",
         "required": false,
         "help": "Output directory shorthand"
       },
@@ -8146,7 +8146,7 @@
       {
         "name": "path",
         "type": "str",
-        "default": "/Users/jakevin/Downloads/Instagram",
+        "default": "~/Downloads/Instagram",
         "required": false,
         "help": "Download directory"
       }

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1668,29 +1668,6 @@
   },
   {
     "site": "bilibili",
-    "name": "video",
-    "description": "Get Bilibili video metadata (title, author, duration, stats, etc.)",
-    "strategy": "cookie",
-    "browser": true,
-    "args": [
-      {
-        "name": "bvid",
-        "type": "str",
-        "required": true,
-        "positional": true,
-        "help": "BV ID, video URL, or b23.tv short link"
-      }
-    ],
-    "columns": [
-      "field",
-      "value"
-    ],
-    "type": "js",
-    "modulePath": "bilibili/video.js",
-    "sourceFile": "bilibili/video.js"
-  },
-  {
-    "site": "bilibili",
     "name": "user-videos",
     "description": "查看指定用户的投稿视频",
     "domain": "www.bilibili.com",
@@ -1738,6 +1715,30 @@
     "modulePath": "bilibili/user-videos.js",
     "sourceFile": "bilibili/user-videos.js",
     "navigateBefore": "https://www.bilibili.com"
+  },
+  {
+    "site": "bilibili",
+    "name": "video",
+    "description": "Get Bilibili video metadata (title, author, duration, stats, etc.)",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "bvid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "BV ID, video URL, or b23.tv short link"
+      }
+    ],
+    "columns": [
+      "field",
+      "value"
+    ],
+    "type": "js",
+    "modulePath": "bilibili/video.js",
+    "sourceFile": "bilibili/video.js",
+    "navigateBefore": true
   },
   {
     "site": "binance",
@@ -8937,13 +8938,20 @@
         "default": 20,
         "required": false,
         "help": "Number of results (max 50)"
+      },
+      {
+        "name": "since_days",
+        "type": "int",
+        "required": false,
+        "help": "Only keep rows published within N days"
       }
     ],
     "columns": [
       "rank",
       "content_type",
       "title",
-      "publish_time",
+      "published_at",
+      "detail_status",
       "project_code",
       "budget_or_limit",
       "url"
@@ -15714,7 +15722,9 @@
       "name",
       "text",
       "likes",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/likes.js",
@@ -16079,7 +16089,9 @@
       "created_at",
       "likes",
       "views",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/search.js",
@@ -16115,7 +16127,9 @@
       "text",
       "likes",
       "retweets",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/thread.js",
@@ -16158,7 +16172,9 @@
       "replies",
       "views",
       "created_at",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/timeline.js",
@@ -16224,7 +16240,9 @@
       "retweets",
       "replies",
       "views",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/tweets.js",

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -41,7 +41,7 @@ export const imageCommand = cli({
     timeoutSeconds: 240,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to ChatGPT' },
-        { name: 'op', default: path.join(os.homedir(), 'Pictures', 'chatgpt'), help: 'Output directory' },
+        { name: 'op', default: '~/Pictures/chatgpt', help: 'Output directory' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show ChatGPT link' },
     ],
     columns: ['status', 'file', 'link'],

--- a/clis/gemini/image.js
+++ b/clis/gemini/image.js
@@ -57,7 +57,7 @@ export const imageCommand = cli({
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to Gemini' },
         { name: 'rt', default: '1:1', help: 'Ratio shorthand for aspect ratio (1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3)' },
         { name: 'st', default: '', help: 'Style shorthand, e.g. anime, icon, watercolor' },
-        { name: 'op', default: path.join(os.homedir(), 'tmp', 'gemini-images'), help: 'Output directory shorthand' },
+        { name: 'op', default: '~/tmp/gemini-images', help: 'Output directory shorthand' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show Gemini page link' },
     ],
     columns: ['status', 'file', 'link'],

--- a/clis/instagram/download.js
+++ b/clis/instagram/download.js
@@ -202,7 +202,7 @@ cli({
     navigateBefore: false,
     args: [
         { name: 'url', positional: true, required: true, help: 'Instagram post / reel / tv URL' },
-        { name: 'path', default: path.join(os.homedir(), 'Downloads', 'Instagram'), help: 'Download directory' },
+        { name: 'path', default: '~/Downloads/Instagram', help: 'Download directory' },
     ],
     func: async (page, kwargs) => {
         const browserPage = ensurePage(page);

--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -111,9 +111,8 @@ DONE
        [ ] 命中后：**跳到第 5（endpoint 验证） + 第 7（字段核对）**，不能直接跳第 9 写 adapter
        [ ] memory 写入超过 30 天（看 `verified_at`）→ 当作过期，按冷启动走 Step 3 → 4
 [ ] 3. 侦察（site-recon.md）：
-       [ ] opencli browser open <url>
-       [ ] opencli browser wait time 3
-       [ ] opencli browser network
+       [ ] **首选**：`opencli browser analyze <url>` 一步拿 pattern + 反爬 + 最近 adapter + next step
+       [ ] `analyze` 结论模糊时再手跑：`open` → `wait time 2` (或 `wait xhr <regex>`) → `network`
        [ ] 定 Pattern（A / B / C / D / E）
 [ ] 4. API 发现（api-discovery.md）按 Pattern 选 §：
        [ ] Pattern A → §1 network 精读
@@ -187,6 +186,7 @@ DONE
 | `references/adapter-template.md` | Step 9 文件结构 + 活例子 `convertible.js` |
 | `references/site-memory.md` | 总览：in-repo 种子 + 本地 `~/.opencli/sites/` 的两层结构 |
 | `references/site-memory/<site>.md` | Step 2 读站点公共知识（eastmoney / xueqiu / bilibili / tonghuashun 已铺） |
+| `references/success-rate-pitfalls.md` | Step 7 / 11 踩坑前翻：10 种"verify 能过但数据是错的"静默失败 |
 
 ---
 

--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -16,12 +16,12 @@
 
 | cookie / body 信号 | 厂商 | 裸 Node fetch / curl 结果 | 策略 |
 |------------------|------|-----|-----|
-| `acw_sc__v2` / `acw_tc` / `ssxmod_itna`；body 含 `arg1 = '32-HEX'` 或 `/ntc_captcha/` | **Aliyun WAF** | 返回 slider HTML，不是真数据 | 必须 `page.evaluate(fetch(url, {credentials:'include'}))` **在浏览器上下文里** |
-| `__cf_bm` / `cf_clearance` / `__cfduid`；body 含 `Cloudflare Ray ID` / `Checking your browser` | **Cloudflare** | TLS 指纹被标记，失败 | 同上，浏览器上下文 |
+| `acw_sc__v2` / `acw_tc` / `ssxmod_itna`；body 含 `arg1 = '32-HEX'` 或 `/ntc_captcha/` | **Aliyun WAF** | 返回 slider HTML，不是真数据 | 先在浏览器上下文里验证 endpoint；HTML 型 COOKIE adapter 最终仍走 Node-side fetch + `page.getCookies()` |
+| `__cf_bm` / `cf_clearance` / `__cfduid`；body 含 `Cloudflare Ray ID` / `Checking your browser` | **Cloudflare** | TLS 指纹被标记，失败 | 同上：先 browser-context probe，最终 adapter 仍按模板选 fetch 路线 |
 | `_abck` / `bm_sz` / `bm_sv` | **Akamai** | 即使带 cookie 也常被挡 | 同上 |
 | body 含 `geetest` / `gt_captcha` | **Geetest** | 滑块/拼图，程序无解 | 超出 skill 范围，放弃或 UI 策略 |
 
-**规则**：看到上面四种任一个，**不要尝试裸 Node fetch**。从一开始就写 browser-context fetch。省掉"curl 试试 → 401 → 改 cookie → 还是 401 → 改头 → 发现响应根本不是数据"的一整轮时间。
+**规则**：看到上面四种任一个，先不要拿**裸** Node fetch 做 endpoint 验证。先用 browser-context probe 或目标 origin 页面确认接口能通；最终 adapter 的 fetch 路线仍按 `adapter-template.md` 选，HTML 型 COOKIE adapter 继续走 Node-side fetch + `page.getCookies()`。
 
 ### 0.2 跨 subdomain = CORS 默认关
 

--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -6,6 +6,44 @@
 
 ---
 
+## §0 进入 §1 之前：先看两条红线
+
+这两条不看清楚，后面的 endpoint 验证会一直在错的前提下兜圈子。
+
+### 0.1 反爬厂商 → 决定 fetch 能不能从 Node 走
+
+`opencli browser analyze <url>` 的 `anti_bot` 字段给答案；手查看 cookies 也行：
+
+| cookie / body 信号 | 厂商 | 裸 Node fetch / curl 结果 | 策略 |
+|------------------|------|-----|-----|
+| `acw_sc__v2` / `acw_tc` / `ssxmod_itna`；body 含 `arg1 = '32-HEX'` 或 `/ntc_captcha/` | **Aliyun WAF** | 返回 slider HTML，不是真数据 | 必须 `page.evaluate(fetch(url, {credentials:'include'}))` **在浏览器上下文里** |
+| `__cf_bm` / `cf_clearance` / `__cfduid`；body 含 `Cloudflare Ray ID` / `Checking your browser` | **Cloudflare** | TLS 指纹被标记，失败 | 同上，浏览器上下文 |
+| `_abck` / `bm_sz` / `bm_sv` | **Akamai** | 即使带 cookie 也常被挡 | 同上 |
+| body 含 `geetest` / `gt_captcha` | **Geetest** | 滑块/拼图，程序无解 | 超出 skill 范围，放弃或 UI 策略 |
+
+**规则**：看到上面四种任一个，**不要尝试裸 Node fetch**。从一开始就写 browser-context fetch。省掉"curl 试试 → 401 → 改 cookie → 还是 401 → 改头 → 发现响应根本不是数据"的一整轮时间。
+
+### 0.2 跨 subdomain = CORS 默认关
+
+`jobs.51job.com` 页面 fetch `cupid.51job.com` 的 API，默认会被浏览器 CORS 预检挡住——除非目标接口回了 `Access-Control-Allow-Origin`。
+
+判断：
+
+```bash
+opencli browser eval "fetch('https://<target-subdomain>/api/...', {credentials:'include'}).then(r=>r.status).catch(e=>'cors:'+e.message)"
+```
+
+- 返回 status 数字 → CORS 通，继续
+- 返回 `cors:...` 或 `TypeError: Failed to fetch` → 挡住了
+
+**挡住时**：不要把 `credentials:'include'` 当万能药——这只解决"带 cookie"，不解决"跨 origin"。降级路径：
+
+1. 换同 origin 的 endpoint（同一个 subdomain 下的 API 往往更宽松）
+2. 用 `opencli browser open https://<target-subdomain>/`，让页面在目标 subdomain 本身打开，再 fetch 相对路径
+3. 真跨域且无替代 → 走 `§5 intercept`，从页面自身发的请求里抓响应
+
+---
+
 ## §1 network 精读（首选，Pattern A / D 命中率最高）
 
 ### 拿候选

--- a/skills/opencli-adapter-author/references/site-memory.md
+++ b/skills/opencli-adapter-author/references/site-memory.md
@@ -153,12 +153,20 @@ key = 字段代号（`f237` / `f152`），value 三件套：
 - `expect.types`：支持 `|` union（`string|null`）和 `any` 通配。写多少列类型看列的稳定性；波动大的列直接 `any` 比频繁改 fixture 好
 - `expect.patterns`：正则表达式 **字符串**（注意 `\\` 转义）。`null` / `undefined` 会被跳过，不要用正则校验可空字段
 - `expect.notEmpty`：trim 后不能为空的列。这是"adapter 没吃掉核心业务字段"的最后一道保险
+- `expect.mustNotContain`：`Record<col, string[]>`。列值里不允许出现这些子串。用来挡"字段内容污染"——比如 `description` 里混进了 `address:` / `category:` 的邻居节点文字、`title` 前面粘了面包屑前缀。`notEmpty` 挡不住这种软污染
+- `expect.mustBeTruthy`：列数组。列值必须是 JS truthy。用来挡"silent `|| 0` / `|| false` 兜底"——数值列返回 0 / 空字符串 / false 都会被 `notEmpty` 放过，但业务上通常是"没抓到"
 
 ### 什么时候手写 vs `--write-fixture` 自动生成
 
-- Step 10 首轮通过：`opencli browser verify <site>/<cmd> --write-fixture` 会根据真实行生成一份 `deriveFixture` 种子（rowCount.min=1 / columns / types），没有 patterns/notEmpty。
-- 拿到种子后**必须手改**：加 `patterns`（URL / 日期 / ID 格式）、加 `notEmpty`（核心字段）、收紧 `rowCount`。纯机器生成的 fixture 挡不住数值错位。
+- `--write-fixture` 只是种子：生成 `rowCount.min=1` / `columns` / `types`，**没有** `patterns` / `notEmpty` / `mustNotContain` / `mustBeTruthy`——纯类型 fixture 挡不住数值错位 / 字段污染 / silent fallback。
+- 拿到种子后**必须手改**，四件套一起上：
+  - `patterns`：URL / 日期 / ID 等格式列
+  - `notEmpty`：核心业务字段
+  - `mustNotContain`：描述类文本列容易被兄弟节点污染时，把禁词（`address:` / `category:` 等）列出来
+  - `mustBeTruthy`：数值 / 布尔业务列，挡 `|| 0` / `|| false`
+- adapter 是 positional 主语型（`<tid>` / `<url>` / `<query>`）时，`--write-fixture` 的 `args` 要手写成数组形态。工具不会替你决定形态。
 - 站点换版导致 fixture 过时：`--update-fixture` 覆盖。改之前**先用肉眼核对一次网页值**，别闭着眼把错的响应固化下来。
+- **规避反模式：不要为了让 verify 通过去放松 pattern**。失败的 pattern 说明 adapter 输出有问题，要收紧 adapter，不是收紧 fixture。放松 fixture 等于默认把错数据接受下来。
 
 ### `notes.md` 格式
 

--- a/skills/opencli-adapter-author/references/site-recon.md
+++ b/skills/opencli-adapter-author/references/site-recon.md
@@ -6,11 +6,31 @@
 
 ---
 
-## 三步诊断
+## 一步诊断（推荐）
+
+```bash
+opencli browser analyze <url>
+```
+
+返回一份 JSON：
+
+```json
+{
+  "pattern": { "pattern": "A", "reason": "3 JSON XHR responses observed", "json_responses": 3, "auth_failures": 0 },
+  "anti_bot": { "detected": false, "vendor": null, "evidence": [], "implication": "No known anti-bot signatures. Node-side fetch may work; try COOKIE first, fall back to browser-context fetch if blocked." },
+  "initial_state": { "__INITIAL_STATE__": false, "__NUXT__": false, "__NEXT_DATA__": false, "__APOLLO_STATE__": false },
+  "nearest_adapter": { "site": "xueqiu", "example_commands": ["xueqiu search", "xueqiu hot"], "reason": "2 existing adapters target this site — reuse strategy/cookie config" },
+  "recommended_next_step": "Pick the most specific JSON endpoint from `opencli browser network` and try a bare Node fetch with cookies; escalate to browser-context fetch only if blocked."
+}
+```
+
+`analyze` 一步把 Pattern 分类 / 反爬厂商识别 / 最近 adapter 匹配 / 下一步建议给完。直接按 `recommended_next_step` 走，多数情况不用手跑三步诊断。
+
+## 手动三步诊断（analyze 给不出明确结论时）
 
 ```bash
 opencli browser open <url>
-opencli browser wait time 3
+opencli browser wait time 2
 opencli browser network
 ```
 
@@ -25,6 +45,8 @@ opencli browser network
 | `Content-Type: text/event-stream` / WebSocket 握手 | **E. 流式** | 行情 tick / chat |
 
 分不清时参考下面五节的其他信号。
+
+**数据是 SPA / 异步加载时，`wait time 2` 可能不够**。改用 `opencli browser wait xhr '/api/path-fragment'` 直接等具体接口到场，比盲 `wait time 5` 更稳。
 
 ---
 

--- a/skills/opencli-adapter-author/references/success-rate-pitfalls.md
+++ b/skills/opencli-adapter-author/references/success-rate-pitfalls.md
@@ -1,0 +1,144 @@
+# Success-Rate Pitfalls
+
+10 个**静默失败**（adapter 看起来能跑、verify 能过，但数据是错的）的坑。每条给：现象 → 根因 → 防御手段。
+
+不是风格建议。每条都对应过一次真实翻车。
+
+---
+
+## 1. fixture pattern 被放松以过 verify
+
+**现象**：`verify` 报 `pattern "url" does not match /^https?:\/\/.*\.com\/bbs\/thread-/`。agent 的"修法"是把 fixture 里的 pattern 改宽（`^https?://`），verify 一下就通过了。
+
+**根因**：adapter 丢了 URL 前缀 / 拼错了路径 / 吃到了相对路径。pattern 失败不是 fixture 太严，是 adapter 输出真的破了。
+
+**防御**：
+- `autofix` skill 现有纪律：**verify pattern 失败 = 收紧 adapter，不是收紧 fixture**（`opencli-autofix` SKILL.md §Rules for Patching 第 6 条）
+- 要改 fixture 的唯一合法理由：**站点本身换了格式**（例如 URL 规范迁移）。这种情况下在 `~/.opencli/sites/<site>/notes.md` 顶部写一段说明
+
+---
+
+## 2. 字段内容污染但 `notEmpty` / `columns` 都过
+
+**现象**：`description` 字段不为空，`verify` 通过。肉眼看输出发现描述里混了 `"address: 上海 category: IT"` 之类明显不属于描述的片段——兄弟 DOM 节点或父节点文字被一起 `textContent` 了。
+
+**根因**：`.container` 的 `textContent` 包括所有后代文字。调 `innerText` 仅好一点；用 `querySelector('.desc').textContent` 时，如果 `.desc` 里嵌套了 `.tag.address`，一样吃进去。
+
+**防御**：
+- fixture 用 `mustNotContain`：`{ "description": ["address:", "category:", "工作年限:"] }` 把已踩过的污染词列出来
+- adapter 侧：定位更精确的 selector，或抓到后 `.replace(/address:[^\n]*/g, '').trim()`
+- 别信 `textContent.trim()` 就完事
+
+---
+
+## 3. 字段语义分歧（两个字段看起来都对）
+
+**现象**：51job 列表有 `updatedate` 和 `publishDate`，eastmoney 债券有 `f10`（发行日）和 `f26`（上市日）。adapter 随便选一个，verify 通过，用户一对照发现时间错位 1 个月。
+
+**根因**：两个字段都是合法日期，format 也对，只是含义不同。`notEmpty` / `types` 都挡不住。
+
+**防御**：
+- Step 7 字段解码**必须和网页肉眼对至少一条已知记录**（"这条债券首页写的上市日是 2025-02-14"，看 adapter 输出对不对得上）
+- 字段写进 `field-map.json` 时 `meaning` 要精确到"上市日"而不是"日期"
+
+---
+
+## 4. 字段单位混淆（数值量级错）
+
+**现象**：eastmoney 返回 `totalMarketCap: 128`（单位：亿元），adapter 直接写进 `marketCap`，用户对照 K 线页看是 128 元。常见错位：
+
+| 接口返回 | 网页显示 | 实际单位 | 错误写法 |
+|---------|---------|----------|---------|
+| `0.025` | `2.5%` | 小数 | adapter 再 × 100 → 显示 250% |
+| `12800` | `1.28 万` | 元 | adapter 不除 10000 → 显示 12800 万 |
+| `f152 = 2` | `9.27` | 价格 = 原值 ÷ 10^f152 | adapter 忽略 f152 → 显示 927 |
+
+**防御**：
+- fixture 加 `mustBeTruthy` 挡 `|| 0` / `|| false` silent fallback（数值列应该有值，不是 0）
+- `field-map.json` 的 `meaning` 写单位：`"premium pct (0-1 fraction, NOT already × 100)"`
+- Step 11 肉眼比对不能只比"有没有数字"，要比数量级
+
+---
+
+## 5. JSON-in-attribute vs 渲染后 innerText
+
+**现象**：51job 把完整 JSON 塞在 `<div data-sensorsdata='{"job_title":"..."}'>` 里，用 innerText 取的是渲染后的截断显示文字（"Lead... ↩ 上海..."），字段边界丢了。
+
+**根因**：现代站点常把结构化数据放在 `data-*` 属性里，渲染层只挑部分显示。取 innerText 相当于丢掉了结构。
+
+**防御**：
+- 看到 `data-sensorsdata` / `data-ng-state` / `data-page-props` / `data-track` 类属性先读属性，不读 innerText
+- 先在 `browser eval` 里检查：`document.querySelector('.item').dataset` 看有没有 JSON 串
+- 搜 bundle 时也搜 `JSON.parse(el.dataset.*)` 模式看 vendor 把数据塞哪了
+
+---
+
+## 6. cookie 域 / origin 不一致的隐式假设
+
+**现象**：在 `jobs.51job.com` 页面调 `cupid.51job.com` 的接口，headless 里带了 cookie 也跨不过去——`credentials:'include'` 只管带 cookie，不管 CORS。
+
+**根因**：浏览器 CORS 预检默认关闭跨 subdomain 请求。`credentials:'include'` 不是万能药。
+
+**防御**：参见 `api-discovery.md §0.2`。判断：`fetch(target).catch(e=>'cors:'+e.message)` 看是不是 TypeError。降级路径：改用 same-origin endpoint / 改在目标 subdomain 上打开页面 / 走 `§5 intercept`。
+
+---
+
+## 7. 等不够就抓导致空 DOM / 空 network
+
+**现象**：`open url && wait time 2 && network` 看到 0 条业务 API。agent 以为是 Pattern C（静态），去 bundle 里找 baseURL，找不到就卡住。真相：SPA 3.5 秒才发出第一个 API。
+
+**根因**：`wait time N` 是盲等。不同站点 JS 执行速度差很多。
+
+**防御**：
+- 数据是异步加载时**不用 `wait time`**，用 `opencli browser wait xhr '/api/path-fragment'`，等具体 XHR 到场再 `network`
+- 不确定 endpoint 路径时：先 `wait time 2 && network`，看到候选路径再转 `wait xhr` 确认
+- 首诊断用 `opencli browser analyze <url>` 一步拿 `json_responses` 数量——=0 时才真的是 Pattern C
+
+---
+
+## 8. adapter 里的 falsy `|| 0` 兜底静默
+
+**现象**：`likes: data.likes || 0`。接口偶尔返回 `likes: null`（可能因字段名改了、权限问题等），adapter 写成 0，verify `types: {likes: 'number'}` 通过，用户看到的是"所有帖子 0 赞"。
+
+**根因**：`||` 兜底把"没抓到"变成"是 0"。`notEmpty` 挡不住 0，`types` 也不挡。
+
+**防御**：
+- fixture 用 `mustBeTruthy: ["likes", "count", ...]`——业务数值列必须 truthy
+- adapter 侧 prefer `?.` 而不是 `||`；真的想兜底就兜 `undefined`，让 verify 能看见
+- 全部 `|| 0` 要过一遍眼：这个 0 是合法值还是漏抓 fallback
+
+---
+
+## 9. 跨 session cookie 污染 / 登录态漂移
+
+**现象**：本地开发时用自己的登录态验 endpoint 能通，PR 一合 verify fixture 跑在 CI 环境里立刻 401——顺手把样本数据也固化进了 fixture，看起来"一切正常"。
+
+**根因**：fixture 样本是带登录态跑出来的。存 `~/.opencli/sites/<site>/fixtures/*.json` 没脱敏，把 cookie / token / 自己的 uid / 昵称存了进去。
+
+**防御**：
+- `site-memory.md` 的脱敏规则：存 fixtures 前去掉 cookie / token / 用户私有字段（手机号 / 邮箱 / 昵称 / uid）
+- 需要登录态的接口：adapter 用 `Strategy.COOKIE`，adapter 代码里**不写任何具体 cookie 值**，只声明"我需要 domain X 的 cookie"
+- verify 样本里看到 `Bearer ...` 或 32 位 hex token → 先删再存
+
+---
+
+## 10. adapter 默认 timeout 不统一
+
+**现象**：同一个站两个 adapter，一个默认 15s timeout，另一个默认 60s。慢接口在一个命令里 ok，在另一个一样的慢接口却 timeout 了。
+
+**根因**：模板没统一 timeout；agent 依赖"最像的邻居"复制，复制到的邻居选了短 timeout。
+
+**防御**：
+- 邻居 adapter 的 `requestTimeoutMs` / `browser.wait` 配置**不能盲抄**。每个 adapter 应该结合自己的接口特性设一个
+- 真实接口延迟：Step 5 endpoint 验证时用 `time curl`（或 `performance.now()` 包 fetch）量一下 p50 / p95，timeout 设 p95 × 2 比较安全
+- 出现偶发 timeout 别 retry 掩盖；记到 `notes.md`，下次就知道这接口 p95 偏高
+
+---
+
+## 总结：静默失败的共同特征
+
+1. **verify 绿 ≠ 数据对**。verify 只能证"结构没坏"，证不出"值对不对"。Step 11 肉眼比对是必须的。
+2. **"字段有值"是个比"字段为空"更危险的失败态**。空你会去查，有值你会 fallthrough。
+3. **fixture 四件套一起上**：`patterns` + `notEmpty` + `mustNotContain` + `mustBeTruthy`——每件挡一类问题，缺一个就漏。
+
+回写 `notes.md` 时把你踩的新坑写进去。下次就有第 11 条了。

--- a/skills/opencli-autofix/SKILL.md
+++ b/skills/opencli-autofix/SKILL.md
@@ -179,6 +179,7 @@ cat <RepairContext.adapter.sourcePath>
 3. **Prefer API over DOM scraping** — if you discover a JSON API during exploration, switch to it
 4. **Use `@jackwener/opencli/*` imports only** — never add third-party package imports
 5. **Test after patching** — run the command again to verify
+6. **Never relax `verify/<cmd>.json` fixtures to silence a failure.** A failing `patterns` / `notEmpty` / `mustNotContain` / `mustBeTruthy` rule means the adapter's output is broken. Tighten the adapter so it produces correct values; do not loosen the fixture to accept the broken values. The one legitimate reason to edit a fixture during repair is when the **site itself** changed shape (e.g. URL format migration) — in that case update the fixture and note the change in `~/.opencli/sites/<site>/notes.md`. Otherwise editing the fixture is covering up a silent correctness regression.
 
 ## Step 5: Verify the Fix
 

--- a/src/browser/analyze.test.ts
+++ b/src/browser/analyze.test.ts
@@ -76,7 +76,7 @@ describe('detectAntiBot', () => {
     const v = detectAntiBot(mkSignals());
     expect(v.detected).toBe(false);
     expect(v.vendor).toBeNull();
-    expect(v.implication).toMatch(/COOKIE first/);
+    expect(v.implication).toMatch(/Node-side COOKIE fetch first/);
   });
 });
 
@@ -184,6 +184,17 @@ describe('analyzeSite', () => {
     );
     expect(report.pattern.pattern).toBe('B');
     expect(report.recommended_next_step).toMatch(/__NUXT__|__INITIAL_STATE__|__NEXT_DATA__/);
+  });
+
+  it('includes __APOLLO_STATE__ in Pattern B next-step guidance', () => {
+    const report = analyzeSite(
+      mkSignals({
+        initialState: { __INITIAL_STATE__: false, __NUXT__: false, __NEXT_DATA__: false, __APOLLO_STATE__: true },
+      }),
+      new Map(),
+    );
+    expect(report.pattern.pattern).toBe('B');
+    expect(report.recommended_next_step).toMatch(/__APOLLO_STATE__/);
   });
 
   it('includes nearest_adapter when the registry has a match', () => {

--- a/src/browser/analyze.test.ts
+++ b/src/browser/analyze.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import {
+  analyzeSite,
+  detectAntiBot,
+  classifyPattern,
+  findNearestAdapter,
+  type PageSignals,
+} from './analyze.js';
+import type { CliCommand } from '../registry.js';
+
+function mkSignals(overrides: Partial<PageSignals> = {}): PageSignals {
+  return {
+    requestedUrl: 'https://example.com/',
+    finalUrl: 'https://example.com/',
+    cookieNames: [],
+    networkEntries: [],
+    initialState: {
+      __INITIAL_STATE__: false,
+      __NUXT__: false,
+      __NEXT_DATA__: false,
+      __APOLLO_STATE__: false,
+    },
+    title: 'Example',
+    ...overrides,
+  };
+}
+
+function mkCmd(site: string, name: string, domain?: string): CliCommand {
+  return {
+    site,
+    name,
+    description: '',
+    domain,
+    args: [],
+  };
+}
+
+describe('detectAntiBot', () => {
+  it('flags Aliyun WAF from cookie', () => {
+    const v = detectAntiBot(mkSignals({ cookieNames: ['JSESSIONID', 'acw_sc__v2'] }));
+    expect(v.detected).toBe(true);
+    expect(v.vendor).toBe('aliyun_waf');
+    expect(v.evidence).toContain('cookie:acw_sc__v2');
+    expect(v.implication).toMatch(/browser context/i);
+  });
+
+  it('flags Aliyun WAF from challenge HTML body', () => {
+    const v = detectAntiBot(
+      mkSignals({
+        networkEntries: [
+          {
+            url: 'https://x.com/',
+            status: 200,
+            contentType: 'text/html',
+            bodyPreview: "var arg1 = 'A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6';",
+          },
+        ],
+      }),
+    );
+    expect(v.detected).toBe(true);
+    expect(v.vendor).toBe('aliyun_waf');
+  });
+
+  it('flags Cloudflare from cf_clearance cookie', () => {
+    const v = detectAntiBot(mkSignals({ cookieNames: ['cf_clearance'] }));
+    expect(v.vendor).toBe('cloudflare');
+    expect(v.implication).toMatch(/Cloudflare/i);
+  });
+
+  it('flags Akamai from _abck cookie', () => {
+    const v = detectAntiBot(mkSignals({ cookieNames: ['_abck', 'bm_sz'] }));
+    expect(v.vendor).toBe('akamai');
+  });
+
+  it('returns no-match verdict with actionable fallback advice', () => {
+    const v = detectAntiBot(mkSignals());
+    expect(v.detected).toBe(false);
+    expect(v.vendor).toBeNull();
+    expect(v.implication).toMatch(/COOKIE first/);
+  });
+});
+
+describe('classifyPattern', () => {
+  it('returns A for JSON-heavy pages without SSR state', () => {
+    const v = classifyPattern(
+      mkSignals({
+        networkEntries: [
+          { url: 'https://x.com/api/a', status: 200, contentType: 'application/json', bodyPreview: '{}' },
+          { url: 'https://x.com/api/b', status: 200, contentType: 'application/json;charset=utf-8', bodyPreview: '{}' },
+        ],
+      }),
+    );
+    expect(v.pattern).toBe('A');
+    expect(v.json_responses).toBe(2);
+  });
+
+  it('returns B when __INITIAL_STATE__ is present, beating JSON signals', () => {
+    const v = classifyPattern(
+      mkSignals({
+        initialState: { __INITIAL_STATE__: true, __NUXT__: false, __NEXT_DATA__: false, __APOLLO_STATE__: false },
+        networkEntries: [
+          { url: 'https://x.com/api/a', status: 200, contentType: 'application/json', bodyPreview: '{}' },
+        ],
+      }),
+    );
+    expect(v.pattern).toBe('B');
+  });
+
+  it('returns D when auth failures dominate', () => {
+    const v = classifyPattern(
+      mkSignals({
+        networkEntries: [
+          { url: 'https://x.com/api/a', status: 401, contentType: 'application/json', bodyPreview: '' },
+          { url: 'https://x.com/api/b', status: 403, contentType: 'application/json', bodyPreview: '' },
+        ],
+      }),
+    );
+    expect(v.pattern).toBe('D');
+    expect(v.auth_failures).toBe(2);
+  });
+
+  it('returns C by default for static pages', () => {
+    const v = classifyPattern(mkSignals());
+    expect(v.pattern).toBe('C');
+  });
+});
+
+describe('findNearestAdapter', () => {
+  it('matches by domain suffix', () => {
+    const reg = new Map<string, CliCommand>([
+      ['51job search', mkCmd('51job', 'search', '51job.com')],
+      ['51job detail', mkCmd('51job', 'detail', '51job.com')],
+      ['xueqiu search', mkCmd('xueqiu', 'search', 'xueqiu.com')],
+    ]);
+    const v = findNearestAdapter('https://jobs.51job.com/', reg);
+    expect(v?.site).toBe('51job');
+    expect(v?.example_commands).toContain('51job search');
+  });
+
+  it('falls back to site-name containment when no domain is registered', () => {
+    const reg = new Map<string, CliCommand>([
+      ['51job search', mkCmd('51job', 'search')],
+    ]);
+    const v = findNearestAdapter('https://we.51job.com/', reg);
+    expect(v?.site).toBe('51job');
+  });
+
+  it('returns null when no adapter matches', () => {
+    const reg = new Map<string, CliCommand>([
+      ['xueqiu search', mkCmd('xueqiu', 'search', 'xueqiu.com')],
+    ]);
+    const v = findNearestAdapter('https://random-site.io/', reg);
+    expect(v).toBeNull();
+  });
+
+  it('prefers the site with the most commands', () => {
+    const reg = new Map<string, CliCommand>([
+      ['a search', mkCmd('a', 'search', 'a.com')],
+      ['b search', mkCmd('b', 'search', 'a.com')],
+      ['b detail', mkCmd('b', 'detail', 'a.com')],
+      ['b company', mkCmd('b', 'company', 'a.com')],
+    ]);
+    const v = findNearestAdapter('https://jobs.a.com/', reg);
+    expect(v?.site).toBe('b');
+  });
+});
+
+describe('analyzeSite', () => {
+  it('recommends browser-context fetch when WAF is detected', () => {
+    const report = analyzeSite(
+      mkSignals({ cookieNames: ['acw_sc__v2'] }),
+      new Map(),
+    );
+    expect(report.anti_bot.vendor).toBe('aliyun_waf');
+    expect(report.recommended_next_step).toMatch(/browser context/i);
+  });
+
+  it('recommends reading SSR state when Pattern B fires', () => {
+    const report = analyzeSite(
+      mkSignals({
+        initialState: { __INITIAL_STATE__: false, __NUXT__: true, __NEXT_DATA__: false, __APOLLO_STATE__: false },
+      }),
+      new Map(),
+    );
+    expect(report.pattern.pattern).toBe('B');
+    expect(report.recommended_next_step).toMatch(/__NUXT__|__INITIAL_STATE__|__NEXT_DATA__/);
+  });
+
+  it('includes nearest_adapter when the registry has a match', () => {
+    const reg = new Map<string, CliCommand>([
+      ['51job search', mkCmd('51job', 'search', '51job.com')],
+    ]);
+    const report = analyzeSite(
+      mkSignals({ finalUrl: 'https://we.51job.com/' }),
+      reg,
+    );
+    expect(report.nearest_adapter?.site).toBe('51job');
+  });
+});

--- a/src/browser/analyze.ts
+++ b/src/browser/analyze.ts
@@ -1,0 +1,346 @@
+/**
+ * `browser analyze <url>` — turn site-recon guesswork into deterministic CLI output.
+ *
+ * When an agent starts a new adapter, the first question is "which pattern am
+ * I looking at?" (A/B/C/D/E from site-recon docs) and "will Node-side fetch
+ * work, or will anti-bot middleware block me?". Today the agent has to open
+ * the page, poke `network`, try cURL, fail, guess again. This module condenses
+ * that into one call that returns a classification + evidence.
+ *
+ * Kept pure (no page imports) so the bulk is unit-testable; the CLI wrapper
+ * drives a real page, feeds the resulting signals here, and prints the verdict.
+ */
+
+import type { CliCommand } from '../registry.js';
+
+// ── Signals the CLI wrapper collects from a real page ──────────────────────
+
+export interface PageSignals {
+  /** URL we navigated to (may redirect; both fields help agents notice that). */
+  requestedUrl: string;
+  finalUrl: string;
+
+  /** document.cookie split into names; value not needed for detection. */
+  cookieNames: string[];
+
+  /**
+   * Response bodies captured during the navigation + first few seconds.
+   * We only need enough body text to spot WAF markers; the CLI truncates
+   * per-entry before feeding us.
+   */
+  networkEntries: Array<{
+    url: string;
+    status: number;
+    contentType: string;
+    /** First N chars of body; null when not available. */
+    bodyPreview: string | null;
+  }>;
+
+  /**
+   * Which globals the page exposes on `window`. We don't care about the values,
+   * just presence — distinguishes Pattern B (SSR state) from Pattern A.
+   */
+  initialState: {
+    __INITIAL_STATE__: boolean;
+    __NUXT__: boolean;
+    __NEXT_DATA__: boolean;
+    __APOLLO_STATE__: boolean;
+  };
+
+  /** Document title — only for the human-debug `summary` field. */
+  title: string;
+}
+
+// ── Anti-bot detection ────────────────────────────────────────────────────
+
+export type AntiBotVendor =
+  | 'aliyun_waf'
+  | 'cloudflare'
+  | 'akamai'
+  | 'geetest'
+  | 'unknown';
+
+export interface AntiBotVerdict {
+  detected: boolean;
+  vendor: AntiBotVendor | null;
+  evidence: string[];
+  /** One-line imperative instruction for the agent. */
+  implication: string;
+}
+
+/**
+ * WAF vendors we can reliably detect from cookies + response body markers
+ * alone. Signals are orthogonal per vendor — so when two vendors match
+ * simultaneously (rare), we keep all evidence and report the higher-signal
+ * vendor first.
+ */
+const WAF_SIGNATURES: Array<{
+  vendor: Exclude<AntiBotVendor, 'unknown'>;
+  cookiePatterns: RegExp[];
+  bodyPatterns: RegExp[];
+  implication: string;
+}> = [
+  {
+    vendor: 'aliyun_waf',
+    cookiePatterns: [/^acw_sc__v2$/, /^acw_tc$/, /^ssxmod_itna/],
+    bodyPatterns: [/arg1\s*=\s*['"][0-9A-F]{30,}/, /\/ntc_captcha\//i],
+    implication:
+      'Node-side fetch/curl will return the slider HTML. Use page.evaluate(fetch(url, {credentials:"include"})) in browser context instead.',
+  },
+  {
+    vendor: 'cloudflare',
+    cookiePatterns: [/^__cf_bm$/, /^cf_clearance$/, /^__cfduid$/],
+    bodyPatterns: [/Cloudflare Ray ID/i, /Checking your browser before accessing/i, /cf-chl-/i],
+    implication:
+      'Cloudflare bot check. Agent must drive a real browser session; Node-side fetch is flagged on TLS fingerprint.',
+  },
+  {
+    vendor: 'akamai',
+    cookiePatterns: [/^_abck$/, /^bm_sz$/, /^bm_sv$/],
+    bodyPatterns: [/akamai/i],
+    implication:
+      'Akamai Bot Manager. Browser-context fetch only; do not attempt bare Node fetch even with cookies.',
+  },
+  {
+    vendor: 'geetest',
+    cookiePatterns: [],
+    bodyPatterns: [/geetest/i, /gt_captcha/i],
+    implication:
+      'Geetest slider/puzzle captcha. Agent cannot bypass programmatically — requires UI strategy or human-in-loop.',
+  },
+];
+
+export function detectAntiBot(signals: PageSignals): AntiBotVerdict {
+  const evidence: string[] = [];
+  let match: typeof WAF_SIGNATURES[number] | null = null;
+
+  for (const sig of WAF_SIGNATURES) {
+    const hits: string[] = [];
+    for (const pat of sig.cookiePatterns) {
+      const hit = signals.cookieNames.find((c) => pat.test(c));
+      if (hit) hits.push(`cookie:${hit}`);
+    }
+    for (const pat of sig.bodyPatterns) {
+      for (const entry of signals.networkEntries) {
+        if (entry.bodyPreview && pat.test(entry.bodyPreview)) {
+          hits.push(`body:${entry.url}`);
+          break;
+        }
+      }
+    }
+    if (hits.length > 0 && !match) {
+      match = sig;
+      evidence.push(...hits);
+    }
+  }
+
+  if (!match) {
+    return {
+      detected: false,
+      vendor: null,
+      evidence: [],
+      implication: 'No known anti-bot signatures. Node-side fetch may work; try COOKIE first, fall back to browser-context fetch if blocked.',
+    };
+  }
+
+  return {
+    detected: true,
+    vendor: match.vendor,
+    evidence,
+    implication: match.implication,
+  };
+}
+
+// ── Pattern classification ────────────────────────────────────────────────
+
+export type Pattern = 'A' | 'B' | 'C' | 'D' | 'E' | 'unknown';
+
+export interface PatternVerdict {
+  pattern: Pattern;
+  reason: string;
+  /** How many JSON XHR/fetch responses we saw during navigation. */
+  json_responses: number;
+  /** Count of non-2xx API responses — hint for token-gated (Pattern D). */
+  auth_failures: number;
+}
+
+/**
+ * Apply the decision tree from `site-recon.md` mechanically.
+ *
+ * B beats A when initial-state globals are present: even if the page fetches
+ * more data via XHR afterwards, the SSR payload is the highest-leverage source.
+ * D (token-gated) dominates when we see 401/403 on what looks like API
+ * endpoints — without that, an authenticated route looks identical to A.
+ */
+export function classifyPattern(signals: PageSignals): PatternVerdict {
+  const jsonEntries = signals.networkEntries.filter((e) => /json/i.test(e.contentType));
+  const authFailures = signals.networkEntries.filter(
+    (e) => e.status === 401 || e.status === 403,
+  ).length;
+  const hasInitialState =
+    signals.initialState.__INITIAL_STATE__ ||
+    signals.initialState.__NUXT__ ||
+    signals.initialState.__NEXT_DATA__ ||
+    signals.initialState.__APOLLO_STATE__;
+
+  if (authFailures >= 2 && jsonEntries.length >= 1) {
+    return {
+      pattern: 'D',
+      reason: `${authFailures} auth-failing API responses seen — endpoint is token-gated`,
+      json_responses: jsonEntries.length,
+      auth_failures: authFailures,
+    };
+  }
+
+  if (hasInitialState) {
+    const which = Object.entries(signals.initialState)
+      .filter(([, v]) => v)
+      .map(([k]) => k);
+    return {
+      pattern: 'B',
+      reason: `SSR state global present: ${which.join(', ')}`,
+      json_responses: jsonEntries.length,
+      auth_failures: authFailures,
+    };
+  }
+
+  if (jsonEntries.length >= 1) {
+    return {
+      pattern: 'A',
+      reason: `${jsonEntries.length} JSON XHR/fetch responses observed — classic API pattern`,
+      json_responses: jsonEntries.length,
+      auth_failures: authFailures,
+    };
+  }
+
+  // No API, no SSR state — probably static HTML or a bundled SPA that lazy-loads.
+  // Pattern C (HTML scrape) is the default fallback; E (streaming) we can't
+  // reliably detect without watching WebSocket frames, so we label 'C' and
+  // leave the agent to upgrade to E manually if they see WS traffic.
+  return {
+    pattern: 'C',
+    reason: 'No JSON XHR and no SSR state — HTML scrape (Pattern C); escalate to E manually if WebSocket traffic appears',
+    json_responses: jsonEntries.length,
+    auth_failures: authFailures,
+  };
+}
+
+// ── Nearest-adapter lookup ────────────────────────────────────────────────
+
+export interface NearestAdapter {
+  site: string;
+  example_commands: string[];
+  reason: string;
+}
+
+/**
+ * Find existing adapters that target the same site.
+ *
+ * Keep the hostname match simple — agents extend naming conventions
+ * differently per site, so we match on the registered `domain` field and fall
+ * back to site-name containment. Returning `null` is fine; agents can always
+ * read site-memory docs.
+ */
+export function findNearestAdapter(
+  finalUrl: string,
+  registry: Map<string, CliCommand>,
+): NearestAdapter | null {
+  let host: string;
+  try {
+    host = new URL(finalUrl).hostname;
+  } catch {
+    return null;
+  }
+  // Strip leading www.; 'www' as a site identifier is never what an adapter uses.
+  const cleanedHost = host.replace(/^www\./, '');
+  // Extract apex (xx.com) and registrable parts for fuzzy match.
+  const parts = cleanedHost.split('.');
+  const apex = parts.slice(-2).join('.');
+  const siteKey = parts.length > 1 ? parts[parts.length - 2] : cleanedHost;
+
+  const hits = new Map<string, CliCommand[]>();
+  for (const cmd of registry.values()) {
+    const domain = cmd.domain?.toLowerCase();
+    const siteMatches =
+      (domain && (cleanedHost.endsWith(domain) || domain.endsWith(apex))) ||
+      cmd.site.toLowerCase() === siteKey?.toLowerCase() ||
+      cleanedHost.includes(cmd.site.toLowerCase());
+    if (siteMatches) {
+      const list = hits.get(cmd.site) ?? [];
+      list.push(cmd);
+      hits.set(cmd.site, list);
+    }
+  }
+  if (hits.size === 0) return null;
+
+  // Pick the site with the most commands — likely the most-developed adapter,
+  // and the best reference for a new command on the same host.
+  let best: [string, CliCommand[]] | null = null;
+  for (const entry of hits) {
+    if (!best || entry[1].length > best[1].length) best = entry;
+  }
+  if (!best) return null;
+
+  return {
+    site: best[0],
+    example_commands: best[1].slice(0, 5).map((c) => `${c.site} ${c.name}`),
+    reason: `${best[1].length} existing adapter${best[1].length === 1 ? '' : 's'} target this site — reuse strategy/cookie config`,
+  };
+}
+
+// ── Top-level assembly ────────────────────────────────────────────────────
+
+export interface AnalyzeReport {
+  requested_url: string;
+  final_url: string;
+  title: string;
+  pattern: PatternVerdict;
+  anti_bot: AntiBotVerdict;
+  initial_state: PageSignals['initialState'];
+  nearest_adapter: NearestAdapter | null;
+  recommended_next_step: string;
+}
+
+/**
+ * Synthesize the verdict from collected signals + registry.
+ *
+ * The `recommended_next_step` is deliberately a single imperative
+ * sentence — agents act on it directly instead of re-deriving advice from
+ * the structured fields.
+ */
+export function analyzeSite(
+  signals: PageSignals,
+  registry: Map<string, CliCommand>,
+): AnalyzeReport {
+  const pattern = classifyPattern(signals);
+  const antiBot = detectAntiBot(signals);
+  const nearest = findNearestAdapter(signals.finalUrl, registry);
+
+  let next: string;
+  if (antiBot.detected) {
+    next = antiBot.implication;
+  } else if (pattern.pattern === 'A') {
+    next = 'Pick the most specific JSON endpoint from `opencli browser network` and try a bare Node fetch with cookies; escalate to browser-context fetch only if blocked.';
+  } else if (pattern.pattern === 'B') {
+    next = 'Read the SSR global via `opencli browser eval "JSON.stringify(window.__INITIAL_STATE__ ?? window.__NUXT__ ?? window.__NEXT_DATA__)"` — no API needed.';
+  } else if (pattern.pattern === 'C') {
+    next = 'No API visible — use SSR HTML scrape (e.g. `opencli browser extract`) against the rendered page.';
+  } else if (pattern.pattern === 'D') {
+    next = 'Endpoints need auth. Re-open the page from a signed-in session, then retry analyze; see `field-decode-playbook` §4 for token tracing.';
+  } else if (pattern.pattern === 'E') {
+    next = 'WebSocket stream detected — find the underlying HTTP poll/long-poll endpoint; raw WS is not supported.';
+  } else {
+    next = 'No strong signal. Manually inspect `opencli browser network --all` and pick a pattern.';
+  }
+
+  return {
+    requested_url: signals.requestedUrl,
+    final_url: signals.finalUrl,
+    title: signals.title,
+    pattern,
+    anti_bot: antiBot,
+    initial_state: signals.initialState,
+    nearest_adapter: nearest,
+    recommended_next_step: next,
+  };
+}

--- a/src/browser/analyze.ts
+++ b/src/browser/analyze.ts
@@ -85,21 +85,21 @@ const WAF_SIGNATURES: Array<{
     cookiePatterns: [/^acw_sc__v2$/, /^acw_tc$/, /^ssxmod_itna/],
     bodyPatterns: [/arg1\s*=\s*['"][0-9A-F]{30,}/, /\/ntc_captcha\//i],
     implication:
-      'Node-side fetch/curl will return the slider HTML. Use page.evaluate(fetch(url, {credentials:"include"})) in browser context instead.',
+      'Direct Node-side fetch/curl will return the slider HTML. Validate the endpoint in browser context first; HTML COOKIE adapters still finish with Node-side fetch + page.getCookies.',
   },
   {
     vendor: 'cloudflare',
     cookiePatterns: [/^__cf_bm$/, /^cf_clearance$/, /^__cfduid$/],
     bodyPatterns: [/Cloudflare Ray ID/i, /Checking your browser before accessing/i, /cf-chl-/i],
     implication:
-      'Cloudflare bot check. Agent must drive a real browser session; Node-side fetch is flagged on TLS fingerprint.',
+      'Cloudflare bot check. Start from a real browser session; probe in browser context first. HTML COOKIE adapters still finish with Node-side fetch + page.getCookies.',
   },
   {
     vendor: 'akamai',
     cookiePatterns: [/^_abck$/, /^bm_sz$/, /^bm_sv$/],
     bodyPatterns: [/akamai/i],
     implication:
-      'Akamai Bot Manager. Browser-context fetch only; do not attempt bare Node fetch even with cookies.',
+      'Akamai Bot Manager. Probe in browser context first; keep final HTML COOKIE adapters on Node-side fetch + page.getCookies.',
   },
   {
     vendor: 'geetest',
@@ -139,7 +139,7 @@ export function detectAntiBot(signals: PageSignals): AntiBotVerdict {
       detected: false,
       vendor: null,
       evidence: [],
-      implication: 'No known anti-bot signatures. Node-side fetch may work; try COOKIE first, fall back to browser-context fetch if blocked.',
+      implication: 'No known anti-bot signatures. Try Node-side COOKIE fetch first; if endpoint validation is blocked, retry from browser context.',
     };
   }
 
@@ -322,7 +322,7 @@ export function analyzeSite(
   } else if (pattern.pattern === 'A') {
     next = 'Pick the most specific JSON endpoint from `opencli browser network` and try a bare Node fetch with cookies; escalate to browser-context fetch only if blocked.';
   } else if (pattern.pattern === 'B') {
-    next = 'Read the SSR global via `opencli browser eval "JSON.stringify(window.__INITIAL_STATE__ ?? window.__NUXT__ ?? window.__NEXT_DATA__)"` — no API needed.';
+    next = 'Read the SSR global via `opencli browser eval "JSON.stringify(window.__INITIAL_STATE__ ?? window.__NUXT__ ?? window.__NEXT_DATA__ ?? window.__APOLLO_STATE__)"` — no API needed.';
   } else if (pattern.pattern === 'C') {
     next = 'No API visible — use SSR HTML scrape (e.g. `opencli browser extract`) against the rendered page.';
   } else if (pattern.pattern === 'D') {

--- a/src/browser/verify-fixture.test.ts
+++ b/src/browser/verify-fixture.test.ts
@@ -113,6 +113,41 @@ describe('validateRows', () => {
     it('no failures when fixture has no expect block', () => {
         expect(validateRows([{ anything: 1 }], {})).toEqual([]);
     });
+
+    it('mustNotContain flags substring bleed in columns', () => {
+        const failures = validateRows(
+            [
+                { description: 'Lead engineer, 5 years exp. address: Shanghai. category: IT' },
+                { description: 'Clean text.' },
+            ],
+            {
+                expect: {
+                    mustNotContain: { description: ['address:', 'category:'] },
+                },
+            },
+        );
+        expect(failures).toHaveLength(2);
+        expect(failures.every((f) => f.rule === 'mustNotContain')).toBe(true);
+        expect(failures.every((f) => f.rowIndex === 0)).toBe(true);
+    });
+
+    it('mustNotContain skips null/undefined values', () => {
+        const failures = validateRows(
+            [{ description: null }, { description: undefined }],
+            { expect: { mustNotContain: { description: ['x'] } } },
+        );
+        expect(failures).toEqual([]);
+    });
+
+    it('mustBeTruthy catches silent 0 / false / "" fallbacks', () => {
+        const failures = validateRows(
+            [{ count: 10 }, { count: 0 }, { count: false }, { count: '' }, { count: null }],
+            { expect: { mustBeTruthy: ['count'] } },
+        );
+        expect(failures).toHaveLength(4);
+        expect(failures.every((f) => f.rule === 'mustBeTruthy')).toBe(true);
+        expect(failures.map((f) => f.rowIndex)).toEqual([1, 2, 3, 4]);
+    });
 });
 
 describe('deriveFixture', () => {

--- a/src/browser/verify-fixture.ts
+++ b/src/browser/verify-fixture.ts
@@ -19,7 +19,11 @@
  *       "columns":  ["a", "b"],                // every row must have these keys
  *       "types":    { "a": "string", "b": "number|string" },
  *       "patterns": { "url": "^https?://" },
- *       "notEmpty": ["title", "url"]           // trimmed string must be non-empty
+ *       "notEmpty": ["title", "url"],          // trimmed string must be non-empty
+ *       "mustNotContain": {                     // catch content-contamination bleed
+ *         "description": ["address:", "category:"]
+ *       },
+ *       "mustBeTruthy": ["count"]               // catch silent `|| 0` fallbacks
  *     }
  *   }
  */
@@ -33,6 +37,23 @@ export type FixtureExpect = {
   types?: Record<string, string>;
   patterns?: Record<string, string>;
   notEmpty?: string[];
+  /**
+   * Substrings/regex fragments that MUST NOT appear in the column value.
+   *
+   * Catches silent content contamination that `notEmpty` alone misses —
+   * e.g. a `description` field that accidentally carries "address: ..." /
+   * "category: ..." fragments from sibling DOM nodes, or a `title` that
+   * bled in a navigation-breadcrumb prefix. Each entry is matched as a
+   * plain substring against the stringified column value.
+   */
+  mustNotContain?: Record<string, string[]>;
+  /**
+   * Columns whose values must be truthy. Complements `notEmpty` (which
+   * only rejects empty-string/null/undefined) by also catching silent
+   * `|| 0` / `|| false` fallbacks in numeric/boolean fields. Fires when
+   * the value coerces to `false` in JS.
+   */
+  mustBeTruthy?: string[];
 };
 
 export type FixtureArgs = Record<string, unknown> | unknown[];
@@ -43,7 +64,7 @@ export type Fixture = {
 };
 
 export type ValidationFailure = {
-  rule: 'rowCount' | 'column' | 'type' | 'pattern' | 'notEmpty';
+  rule: 'rowCount' | 'column' | 'type' | 'pattern' | 'notEmpty' | 'mustNotContain' | 'mustBeTruthy';
   detail: string;
   rowIndex?: number;
 };
@@ -171,6 +192,31 @@ export function validateRows(rows: Row[], fixture: Fixture): ValidationFailure[]
       const v = row[col];
       if (v === null || v === undefined || String(v).trim() === '') {
         failures.push({ rule: 'notEmpty', detail: `"${col}" is empty`, rowIndex: i });
+      }
+    }
+    for (const [col, needles] of Object.entries(expect.mustNotContain ?? {})) {
+      if (!(col in row)) continue;
+      const v = row[col];
+      if (v === null || v === undefined) continue;
+      const haystack = String(v);
+      for (const needle of needles) {
+        if (haystack.includes(needle)) {
+          failures.push({
+            rule: 'mustNotContain',
+            detail: `"${col}" contains forbidden substring ${JSON.stringify(needle)}`,
+            rowIndex: i,
+          });
+        }
+      }
+    }
+    for (const col of expect.mustBeTruthy ?? []) {
+      if (!(col in row)) continue;
+      if (!row[col]) {
+        failures.push({
+          rule: 'mustBeTruthy',
+          detail: `"${col}" is falsy (${JSON.stringify(row[col])}) — likely silent fallback`,
+          rowIndex: i,
+        });
       }
     }
   });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -122,6 +122,7 @@ describe('browser tab targeting commands', () => {
       getActivePage: vi.fn().mockReturnValue('tab-1'),
       getCurrentUrl: vi.fn().mockResolvedValue('https://one.example'),
       startNetworkCapture: vi.fn().mockResolvedValue(true),
+      getCookies: vi.fn().mockResolvedValue([]),
       evaluate: vi.fn().mockResolvedValue({ ok: true }),
       tabs: vi.fn().mockResolvedValue([
         { index: 0, page: 'tab-1', url: 'https://one.example', title: 'one', active: true },
@@ -137,6 +138,14 @@ describe('browser tab targeting commands', () => {
       readNetworkCapture: vi.fn().mockResolvedValue([]),
     } as unknown as IPage;
   });
+
+  function lastJsonLog(): any {
+    const calls = consoleLogSpy.mock.calls;
+    if (calls.length === 0) throw new Error('Expected at least one console.log call');
+    const last = calls[calls.length - 1][0];
+    if (typeof last !== 'string') throw new Error(`Expected string arg to console.log, got ${typeof last}`);
+    return JSON.parse(last);
+  }
 
   it('binds browser commands to an explicit target tab via --tab', async () => {
     const program = createProgram('', '');
@@ -294,6 +303,98 @@ describe('browser tab targeting commands', () => {
     expect(process.exitCode).toBeDefined();
     expect(browserState.page?.closeTab).not.toHaveBeenCalled();
     expect(stderrSpy.mock.calls.flat().join('\n')).toContain('Target tab tab-stale is not part of the current browser session');
+  });
+
+  it('browser analyze merges HttpOnly cookie names from page.getCookies and drains stale capture before verdict', async () => {
+    browserState.page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      getCurrentUrl: vi.fn().mockResolvedValue('https://target.example'),
+      startNetworkCapture: vi.fn().mockResolvedValue(true),
+      getCookies: vi.fn().mockResolvedValue([{ name: 'cf_clearance', value: 'x', domain: '.target.example' }]),
+      evaluate: vi.fn().mockResolvedValue({
+        cookieNames: [],
+        initialState: {
+          __INITIAL_STATE__: false,
+          __NUXT__: false,
+          __NEXT_DATA__: false,
+          __APOLLO_STATE__: false,
+        },
+        title: 'Target',
+        finalUrl: 'https://target.example/',
+      }),
+      tabs: vi.fn().mockResolvedValue([{ index: 0, page: 'tab-1', url: 'https://target.example', title: 'Target', active: true }]),
+      readNetworkCapture: vi.fn()
+        .mockResolvedValueOnce([
+          {
+            url: 'https://stale.example/api/old',
+            method: 'GET',
+            responseStatus: 200,
+            responseContentType: 'application/json',
+            responsePreview: '{"stale":true}',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            url: 'https://target.example/waf',
+            method: 'GET',
+            responseStatus: 403,
+            responseContentType: 'text/html',
+            responsePreview: 'Cloudflare Ray ID',
+          },
+        ]),
+    } as unknown as IPage;
+
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'opencli', 'browser', 'analyze', 'https://target.example/']);
+
+    const out = lastJsonLog();
+    expect(browserState.page?.readNetworkCapture).toHaveBeenCalledTimes(2);
+    expect(out.anti_bot.vendor).toBe('cloudflare');
+    expect(out.anti_bot.evidence).toContain('cookie:cf_clearance');
+  });
+
+  it('browser wait xhr starts capture, injects interceptor on fallback, and ignores stale ring entries', async () => {
+    browserState.page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      getCurrentUrl: vi.fn().mockResolvedValue('https://target.example'),
+      startNetworkCapture: vi.fn().mockResolvedValue(false),
+      evaluate: vi.fn().mockResolvedValue(undefined),
+      tabs: vi.fn().mockResolvedValue([{ index: 0, page: 'tab-1', url: 'https://target.example', title: 'Target', active: true }]),
+      readNetworkCapture: vi.fn()
+        .mockResolvedValueOnce([
+          {
+            url: 'https://stale.example/api/old',
+            method: 'GET',
+            responseStatus: 200,
+            responseContentType: 'application/json',
+            responsePreview: '{"stale":true}',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            url: 'https://target.example/api/target',
+            method: 'GET',
+            responseStatus: 200,
+            responseContentType: 'application/json',
+            responsePreview: '{"ok":true}',
+          },
+        ]),
+    } as unknown as IPage;
+
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'opencli', 'browser', 'wait', 'xhr', '/api/target', '--timeout', '900']);
+
+    const out = lastJsonLog();
+    expect(browserState.page?.startNetworkCapture).toHaveBeenCalledTimes(1);
+    expect(browserState.page?.evaluate).toHaveBeenCalledWith(expect.stringContaining('window.__opencli_net'));
+    expect(browserState.page?.readNetworkCapture).toHaveBeenCalledTimes(2);
+    expect(out.matched.url).toBe('https://target.example/api/target');
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -356,6 +356,72 @@ describe('browser tab targeting commands', () => {
     expect(out.anti_bot.evidence).toContain('cookie:cf_clearance');
   });
 
+  it('browser analyze falls back to interceptor buffer when network capture is unsupported', async () => {
+    let bufferReads = 0;
+    browserState.page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      getCurrentUrl: vi.fn().mockResolvedValue('https://target.example'),
+      startNetworkCapture: vi.fn().mockResolvedValue(false),
+      getCookies: vi.fn().mockResolvedValue([{ name: 'cf_clearance', value: 'x', domain: '.target.example' }]),
+      evaluate: vi.fn().mockImplementation(async (arg: string) => {
+        if (typeof arg === 'string' && arg.includes('document.cookie')) {
+          return {
+            cookieNames: [],
+            initialState: {
+              __INITIAL_STATE__: false,
+              __NUXT__: false,
+              __NEXT_DATA__: false,
+              __APOLLO_STATE__: false,
+            },
+            title: 'Target',
+            finalUrl: 'https://target.example/',
+          };
+        }
+        if (typeof arg === 'string' && arg.includes('window.__opencli_net = []')) {
+          bufferReads += 1;
+          if (bufferReads === 1) {
+            return JSON.stringify([
+              {
+                url: 'https://stale.example/api/old',
+                method: 'GET',
+                status: 200,
+                size: 12,
+                ct: 'application/json',
+                body: { stale: true },
+              },
+            ]);
+          }
+          return JSON.stringify([
+            {
+              url: 'https://target.example/waf',
+              method: 'GET',
+              status: 403,
+              size: 17,
+              ct: 'text/html',
+              body: 'Cloudflare Ray ID',
+            },
+          ]);
+        }
+        return undefined;
+      }),
+      tabs: vi.fn().mockResolvedValue([{ index: 0, page: 'tab-1', url: 'https://target.example', title: 'Target', active: true }]),
+      readNetworkCapture: vi.fn().mockResolvedValue([]),
+    } as unknown as IPage;
+
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'opencli', 'browser', 'analyze', 'https://target.example/']);
+
+    const out = lastJsonLog();
+    expect(browserState.page?.readNetworkCapture).toHaveBeenCalledTimes(2);
+    expect(bufferReads).toBe(2);
+    expect(out.anti_bot.vendor).toBe('cloudflare');
+    expect(out.anti_bot.evidence).toContain('cookie:cf_clearance');
+    expect(out.anti_bot.evidence).toContain('body:https://target.example/waf');
+  });
+
   it('browser wait xhr starts capture, injects interceptor on fallback, and ignores stale ring entries', async () => {
     browserState.page = {
       goto: vi.fn().mockResolvedValue(undefined),
@@ -394,6 +460,57 @@ describe('browser tab targeting commands', () => {
     expect(browserState.page?.startNetworkCapture).toHaveBeenCalledTimes(1);
     expect(browserState.page?.evaluate).toHaveBeenCalledWith(expect.stringContaining('window.__opencli_net'));
     expect(browserState.page?.readNetworkCapture).toHaveBeenCalledTimes(2);
+    expect(out.matched.url).toBe('https://target.example/api/target');
+  });
+
+  it('browser wait xhr reads interceptor buffer when network capture is unsupported', async () => {
+    let bufferReads = 0;
+    browserState.page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      getCurrentUrl: vi.fn().mockResolvedValue('https://target.example'),
+      startNetworkCapture: vi.fn().mockResolvedValue(false),
+      evaluate: vi.fn().mockImplementation(async (arg: string) => {
+        if (typeof arg === 'string' && arg.includes('window.__opencli_net = []')) {
+          bufferReads += 1;
+          if (bufferReads === 1) {
+            return JSON.stringify([
+              {
+                url: 'https://stale.example/api/old',
+                method: 'GET',
+                status: 200,
+                size: 12,
+                ct: 'application/json',
+                body: { stale: true },
+              },
+            ]);
+          }
+          return JSON.stringify([
+            {
+              url: 'https://target.example/api/target',
+              method: 'GET',
+              status: 200,
+              size: 11,
+              ct: 'application/json',
+              body: { ok: true },
+            },
+          ]);
+        }
+        return undefined;
+      }),
+      tabs: vi.fn().mockResolvedValue([{ index: 0, page: 'tab-1', url: 'https://target.example', title: 'Target', active: true }]),
+      readNetworkCapture: vi.fn().mockResolvedValue([]),
+    } as unknown as IPage;
+
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'opencli', 'browser', 'wait', 'xhr', '/api/target', '--timeout', '900']);
+
+    const out = lastJsonLog();
+    expect(browserState.page?.startNetworkCapture).toHaveBeenCalledTimes(1);
+    expect(browserState.page?.readNetworkCapture).toHaveBeenCalledTimes(2);
+    expect(bufferReads).toBe(2);
     expect(out.matched.url).toBe('https://target.example/api/target');
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import { DEFAULT_TTL_MS, findEntry, loadNetworkCache, saveNetworkCache, type Cac
 import { parseFilter, shapeMatchesFilter } from './browser/shape-filter.js';
 import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
+import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 
@@ -98,6 +99,66 @@ function filterNetworkItems(items: BrowserNetworkItem[]): BrowserNetworkItem[] {
 function emitNetworkError(code: string, message: string, extra: Record<string, unknown> = {}): void {
   console.log(JSON.stringify({ error: { code, message, ...extra } }, null, 2));
   process.exitCode = EXIT_CODES.USAGE_ERROR;
+}
+
+/**
+ * Check whether the site-memory scaffolding exists under
+ * ~/.opencli/sites/<site>/. Agents have a strong tendency to forget to write
+ * endpoints.json / notes.md after a successful verify, which dooms the next
+ * agent to redo recon from scratch. Surfacing the current state as part of
+ * verify's final report converts that "silent skip" into a visible nudge;
+ * `--strict-memory` escalates it to a failure so agents driving a hardened
+ * workflow can't forget.
+ */
+export type SiteMemoryReport = {
+  ok: boolean;
+  siteDir: string;
+  endpoints: { present: boolean; count: number; path: string };
+  notes: { present: boolean; path: string };
+};
+
+export function checkSiteMemory(site: string): SiteMemoryReport {
+  const siteDir = path.join(os.homedir(), '.opencli', 'sites', site);
+  const endpointsPath = path.join(siteDir, 'endpoints.json');
+  const notesPath = path.join(siteDir, 'notes.md');
+  let endpointsCount = 0;
+  let endpointsPresent = fs.existsSync(endpointsPath);
+  if (endpointsPresent) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(endpointsPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        endpointsCount = Object.keys(parsed).length;
+      } else if (Array.isArray(parsed)) {
+        endpointsCount = parsed.length;
+      }
+    } catch {
+      endpointsPresent = false;
+    }
+  }
+  const notesPresent = fs.existsSync(notesPath);
+  return {
+    ok: endpointsPresent && endpointsCount > 0 && notesPresent,
+    siteDir,
+    endpoints: { present: endpointsPresent, count: endpointsCount, path: endpointsPath },
+    notes: { present: notesPresent, path: notesPath },
+  };
+}
+
+export function printSiteMemoryReport(report: SiteMemoryReport, strict: boolean | undefined): void {
+  if (report.ok) {
+    console.log(`  ✓ Memory: endpoints.json (${report.endpoints.count}), notes.md present at ${report.siteDir}`);
+    return;
+  }
+  const marker = strict ? '✗' : '⚠';
+  const missing: string[] = [];
+  if (!report.endpoints.present) missing.push('endpoints.json');
+  else if (report.endpoints.count === 0) missing.push('endpoints.json (empty)');
+  if (!report.notes.present) missing.push('notes.md');
+  console.log(`  ${marker} Memory: missing ${missing.join(', ')} under ${report.siteDir}`);
+  console.log(`    Write the endpoint you just verified + a 1-line session note so the next agent starts from minute 0, not minute 95.`);
+  if (!strict) {
+    console.log(`    (Re-run with --strict-memory to fail instead of warn.)`);
+  }
 }
 
 /** Coerce adapter JSON output into a row array. Accepts `[{...}]`, single `{}`, or `{items:[...]}`-style envelopes. */
@@ -631,6 +692,74 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
     }));
 
+  // ── Analyze (site recon, agent-native) ──
+  //
+  // Mechanizes the `site-recon.md` decision tree into one CLI call. The agent
+  // calls `browser analyze <url>` and gets back:
+  //
+  //   - pattern: A/B/C/D (mapped from network + SSR-globals signals)
+  //   - anti_bot: vendor + evidence + the one-liner for "what to do next"
+  //   - initial_state: which window globals are populated
+  //   - nearest_adapter: existing commands for the same site, if any
+  //   - recommended_next_step: a single imperative sentence
+  //
+  // Intent: replace the "open → eyeball network → curl → WAF → try again"
+  // feedback loop with a single deterministic verdict. Without this, agents
+  // burn ~20min per WAF-protected site re-discovering anti-bot posture.
+  addBrowserTabOption(browser.command('analyze').argument('<url>'))
+    .description('Classify site: anti-bot vendor, pattern (A/B/C/D), nearest adapter, recommended next step')
+    .action(browserAction(async (page, url) => {
+      const hasSessionCapture = await page.startNetworkCapture?.() ?? false;
+      await page.goto(url);
+      await page.wait(2);
+      if (!hasSessionCapture) {
+        try { await page.evaluate(NETWORK_INTERCEPTOR_JS); } catch { /* non-fatal */ }
+      }
+      // Best-effort: give the page another beat so XHR after DOMContentLoaded lands.
+      await page.wait(1);
+
+      const rawItems = await captureNetworkItems(page);
+      const networkEntries = rawItems.map((e) => ({
+        url: e.url,
+        status: e.status,
+        contentType: e.ct,
+        bodyPreview: typeof e.body === 'string'
+          ? e.body.slice(0, 2000)
+          : (e.body ? JSON.stringify(e.body).slice(0, 2000) : null),
+      }));
+
+      const probeJs = `(function(){
+        return {
+          cookieNames: (document.cookie || '').split(';').map(function(c){ return c.trim().split('=')[0]; }).filter(Boolean),
+          initialState: {
+            __INITIAL_STATE__: typeof window.__INITIAL_STATE__ !== 'undefined',
+            __NUXT__: typeof window.__NUXT__ !== 'undefined',
+            __NEXT_DATA__: typeof window.__NEXT_DATA__ !== 'undefined',
+            __APOLLO_STATE__: typeof window.__APOLLO_STATE__ !== 'undefined',
+          },
+          title: document.title || '',
+          finalUrl: location.href,
+        };
+      })()`;
+      const probe = await page.evaluate(probeJs) as {
+        cookieNames: string[];
+        initialState: PageSignals['initialState'];
+        title: string;
+        finalUrl: string;
+      };
+
+      const signals: PageSignals = {
+        requestedUrl: url,
+        finalUrl: probe.finalUrl,
+        cookieNames: probe.cookieNames,
+        networkEntries,
+        initialState: probe.initialState,
+        title: probe.title,
+      };
+      const report = analyzeSite(signals, getRegistry());
+      console.log(JSON.stringify(report, null, 2));
+    }));
+
   // ── Find (structured CSS query, agent-native) ──
   //
   // `browser find --css <sel>` lets agents jump straight from a semantic
@@ -1001,10 +1130,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   // ── Wait commands ──
 
   addBrowserTabOption(browser.command('wait'))
-    .argument('<type>', 'selector, text, or time')
-    .argument('[value]', 'CSS selector, text string, or seconds')
+    .argument('<type>', 'selector, text, time, or xhr')
+    .argument('[value]', 'CSS selector, text string, seconds, or XHR URL regex')
     .option('--timeout <ms>', 'Timeout in milliseconds', '10000')
-    .description('Wait for selector, text, or time (e.g. wait selector ".loaded", wait text "Success", wait time 3)')
+    .description('Wait for selector, text, time, or matching XHR (e.g. wait selector ".loaded", wait text "Success", wait time 3, wait xhr "/api/search")')
     .action(browserAction(async (page, type, value, opts) => {
       const timeout = parseInt(opts.timeout, 10);
       if (type === 'time') {
@@ -1019,8 +1148,42 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         if (!value) { console.error('Missing text'); process.exitCode = EXIT_CODES.USAGE_ERROR; return; }
         await page.wait({ text: value, timeout: timeout / 1000 });
         console.log(`Text "${value}" appeared`);
+      } else if (type === 'xhr') {
+        // Poll the capture ring until an entry matches the URL regex — turns
+        // the common "open page, wait N seconds, hope the data landed" idiom
+        // into a deterministic barrier keyed on the API the agent actually
+        // cares about. Prevents silent "empty DOM" failures on slow SPAs.
+        if (!value) { console.error('Missing XHR URL regex'); process.exitCode = EXIT_CODES.USAGE_ERROR; return; }
+        let re: RegExp;
+        try { re = new RegExp(value); } catch (err) {
+          console.error(`Invalid regex "${value}": ${err instanceof Error ? err.message : String(err)}`);
+          process.exitCode = EXIT_CODES.USAGE_ERROR;
+          return;
+        }
+        const deadline = Date.now() + timeout;
+        const pollMs = 400;
+        let matched: BrowserNetworkItem | null = null;
+        while (Date.now() < deadline && !matched) {
+          const items = await captureNetworkItems(page);
+          matched = items.find((e) => re.test(e.url)) ?? null;
+          if (!matched) await new Promise((r) => setTimeout(r, pollMs));
+        }
+        if (!matched) {
+          console.log(JSON.stringify({
+            error: {
+              code: 'xhr_not_seen',
+              message: `No captured XHR matched /${value}/ within ${timeout}ms`,
+              hint: 'Check the pattern against `browser network` output; the endpoint may not have fired yet, or capture is disabled.',
+            },
+          }, null, 2));
+          process.exitCode = EXIT_CODES.GENERIC_ERROR;
+          return;
+        }
+        console.log(JSON.stringify({
+          matched: { url: matched.url, status: matched.status, contentType: matched.ct },
+        }, null, 2));
       } else {
-        console.error(`Unknown wait type "${type}". Use: selector, text, or time`);
+        console.error(`Unknown wait type "${type}". Use: selector, text, time, or xhr`);
         process.exitCode = EXIT_CODES.USAGE_ERROR;
       }
     }));
@@ -1378,8 +1541,9 @@ cli({
     .option('--write-fixture', 'Write a starter fixture to ~/.opencli/sites/<site>/verify/<command>.json if none exists')
     .option('--update-fixture', 'Overwrite an existing fixture with one derived from current output')
     .option('--no-fixture', 'Ignore any fixture file for this run (no value-level validation)')
+    .option('--strict-memory', 'Fail (not just warn) when ~/.opencli/sites/<site>/endpoints.json or notes.md is missing')
     .description('Execute an adapter and validate output; uses fixture at ~/.opencli/sites/<site>/verify/<cmd>.json when present')
-    .action(async (name: string, opts: { fixture?: boolean; writeFixture?: boolean; updateFixture?: boolean } = {}) => {
+    .action(async (name: string, opts: { fixture?: boolean; writeFixture?: boolean; updateFixture?: boolean; strictMemory?: boolean } = {}) => {
       try {
         const parts = name.split('/');
         if (parts.length !== 2) { console.error('Name must be site/command format'); process.exitCode = EXIT_CODES.USAGE_ERROR; return; }
@@ -1481,6 +1645,11 @@ cli({
         const failures = validateRows(rows, fixture);
         if (failures.length === 0) {
           console.log(`\n  ✓ Adapter matches fixture (${fixturePath(site, command)}).`);
+          const memoryReport = checkSiteMemory(site);
+          printSiteMemoryReport(memoryReport, opts.strictMemory);
+          if (!memoryReport.ok && opts.strictMemory) {
+            process.exitCode = EXIT_CODES.GENERIC_ERROR;
+          }
           return;
         }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -715,6 +715,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       if (!hasSessionCapture) {
         try { await page.evaluate(NETWORK_INTERCEPTOR_JS); } catch { /* non-fatal */ }
       }
+      await captureNetworkItems(page);
       // Best-effort: give the page another beat so XHR after DOMContentLoaded lands.
       await page.wait(1);
 
@@ -747,11 +748,15 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         title: string;
         finalUrl: string;
       };
+      const browserCookieNames = (await page.getCookies({ url: probe.finalUrl || url }).catch(() => []))
+        .map((c) => c.name)
+        .filter(Boolean);
+      const cookieNames = [...new Set([...probe.cookieNames, ...browserCookieNames])];
 
       const signals: PageSignals = {
         requestedUrl: url,
         finalUrl: probe.finalUrl,
-        cookieNames: probe.cookieNames,
+        cookieNames,
         networkEntries,
         initialState: probe.initialState,
         title: probe.title,
@@ -1160,6 +1165,11 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           process.exitCode = EXIT_CODES.USAGE_ERROR;
           return;
         }
+        const hasSessionCapture = await page.startNetworkCapture?.() ?? false;
+        if (!hasSessionCapture) {
+          try { await page.evaluate(NETWORK_INTERCEPTOR_JS); } catch { /* non-fatal */ }
+        }
+        await captureNetworkItems(page);
         const deadline = Date.now() + timeout;
         const pollMs = 400;
         let matched: BrowserNetworkItem | null = null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1639,6 +1639,11 @@ cli({
 
         if (!fixture) {
           console.log(`\n  ✓ Adapter runs. (No fixture at ${fixturePath(site, command)} — consider --write-fixture to seed one.)`);
+          const memoryReport = checkSiteMemory(site);
+          printSiteMemoryReport(memoryReport, opts.strictMemory);
+          if (!memoryReport.ok && opts.strictMemory) {
+            process.exitCode = EXIT_CODES.GENERIC_ERROR;
+          }
           return;
         }
 
@@ -2172,4 +2177,3 @@ export function resolveBrowserVerifyInvocation(opts: {
     ...(platform === 'win32' ? { shell: true } : {}),
   };
 }
-

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,29 +60,31 @@ type BrowserNetworkItem = {
 async function captureNetworkItems(page: import('./types.js').IPage): Promise<BrowserNetworkItem[]> {
   if (page.readNetworkCapture) {
     const raw = await page.readNetworkCapture();
-    return (raw as Array<Record<string, unknown>>).map((e) => {
-      const preview = (e.responsePreview as string) ?? null;
-      let body: unknown = null;
-      if (preview) {
-        try { body = JSON.parse(preview); } catch { body = preview; }
-      }
-      const fullSize = typeof e.responseBodyFullSize === 'number'
-        ? (e.responseBodyFullSize as number)
-        : (preview ? preview.length : 0);
-      const truncated = e.responseBodyTruncated === true;
-      return {
-        url: (e.url as string) || '',
-        method: (e.method as string) || 'GET',
-        status: (e.responseStatus as number) || 0,
-        size: fullSize,
-        ct: (e.responseContentType as string) || '',
-        body,
-        bodyFullSize: fullSize,
-        bodyTruncated: truncated,
-      };
-    });
+    if (Array.isArray(raw) && raw.length > 0) {
+      return (raw as Array<Record<string, unknown>>).map((e) => {
+        const preview = (e.responsePreview as string) ?? null;
+        let body: unknown = null;
+        if (preview) {
+          try { body = JSON.parse(preview); } catch { body = preview; }
+        }
+        const fullSize = typeof e.responseBodyFullSize === 'number'
+          ? (e.responseBodyFullSize as number)
+          : (preview ? preview.length : 0);
+        const truncated = e.responseBodyTruncated === true;
+        return {
+          url: (e.url as string) || '',
+          method: (e.method as string) || 'GET',
+          status: (e.responseStatus as number) || 0,
+          size: fullSize,
+          ct: (e.responseContentType as string) || '',
+          body,
+          bodyFullSize: fullSize,
+          bodyTruncated: truncated,
+        };
+      });
+    }
   }
-  const raw = await page.evaluate(`(function(){ return JSON.stringify(window.__opencli_net || []); })()`) as string;
+  const raw = await page.evaluate(`(function(){ var out = window.__opencli_net || []; window.__opencli_net = []; return JSON.stringify(out); })()`) as string;
   try { return JSON.parse(raw) as BrowserNetworkItem[]; } catch { return []; }
 }
 


### PR DESCRIPTION
## Summary

Post-mortem on slow 1point3acres + 51job adapter sessions, consolidated into **one PR**. Scope = "reduce uncertainty and catch silent failures" — the two things that sink agent success rate on first-time adapters.

Principle guarding scope: agents do NOT fear repetition/boilerplate/handwriting; agents DO fear **uncertainty** (which path / which request / what to persist) and **silent failures** (verify-green but data is wrong). Every change here maps to one of those two.

## What changed

### New commands

- **`browser analyze <url>`** — one-shot site recon. Returns `pattern` (A/B/C/D classification), `anti_bot` (Aliyun WAF / Cloudflare / Akamai / Geetest vendor detection + evidence), `nearest_adapter` (registry lookup for adapter reuse), and a **single-sentence `recommended_next_step`**. Replaces the manual `open → wait → network → squint → guess` loop.
- **`browser wait xhr <regex>`** — poll for a specific XHR URL. Replaces blind `wait time 5` on SPA pages; data-arrival barriers become deterministic.

### New fixture rules (catch silent failures)

- **`mustNotContain: { col: [substrs] }`** — catches content contamination (sibling DOM bleed, breadcrumb prefixes, e.g. `description` accidentally containing `address:` / `category:` from a tag node). `notEmpty` does not catch this.
- **`mustBeTruthy: [col]`** — catches `|| 0` / `|| false` silent fallbacks on numeric/boolean columns. `notEmpty` / `types` do not catch this.

### Guards

- **`verify` post-success site-memory check** + `--strict-memory` flag. Verify-green now surfaces when `~/.opencli/sites/<site>/` was never written back; `--strict-memory` makes the missing memory a hard failure. Memory only materializes if authors write it; previously there was no feedback loop.
- **CI: `cli-manifest.json` drift guard**. Committed manifest must match a fresh `npm run build`. Main was already drifted (PR #1118 left bilibili/video reordering + a jianyu `since_days` arg not committed to the manifest); this PR regenerates it and the guard prevents the next drift.

### Docs (`opencli-adapter-author` + `opencli-autofix`)

- **New**: `references/success-rate-pitfalls.md` — 10 concrete silent-failure scenarios from real sessions, each with defense via fixture/adapter patterns.
- **`autofix`**: Discipline rule #6 — verify pattern failure = tighten adapter, **never loosen the fixture**. Fixture relaxation is the canonical way to silently accept broken data.
- **`site-recon.md`**: Leads with `browser analyze`; manual 3-step is the fallback. `wait time 3` → `wait time 2` (2s is enough; `wait xhr` is more robust still).
- **`api-discovery.md`**: New §0 covering WAF vendor detection and cross-subdomain CORS — the two gotchas that burned the 51job session (`acw_sc__v2` cookie meant the Node fetch was always going to return slider HTML; `cupid.51job.com` from `jobs.51job.com` was CORS-blocked even with `credentials:'include'`).
- **`site-memory.md`**: Documents the new fixture fields; adds explicit warning not to loosen `patterns` to pass verify.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/` — 845 passed / 2 skipped
- [x] `npm run build` idempotent (only drift is from main's preexisting stale manifest — which this PR fixes)
- [x] New unit tests: 16 for `analyze.ts` (WAF detection, pattern classification, nearest-adapter matching, top-level assembly) + 3 for fixture content rules
- [ ] Dogfood `browser analyze https://www.51job.com/` after merge — expects `anti_bot.vendor = aliyun_waf`
- [ ] Dogfood `browser wait xhr '/api/...'` on a slow SPA after merge

## Review focus

Two pairs of reviewers worth: agent-UX (skill docs + `analyze` output shape) and CLI correctness (`wait xhr` polling, `verify` memory-write check, manifest drift guard).

_Background: one PR consolidation explicitly approved by WAWQAQ (msg 0de55bc8, "有必要的我们都做，全部一次性做掉")._