### PR TITLE
fix(chatgpt-app): use AX send flow and support zh-CN generating state

### DIFF
--- a/clis/chatgpt-app/ask.js
+++ b/clis/chatgpt-app/ask.js
@@ -1,7 +1,7 @@
-import { execSync, spawnSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ConfigError } from '@jackwener/opencli/errors';
-import { activateChatGPT, getVisibleChatMessages, selectModel, MODEL_CHOICES, isGenerating } from './ax.js';
+import { activateChatGPT, getVisibleChatMessages, selectModel, MODEL_CHOICES, isGenerating, sendPrompt } from './ax.js';
 export const askCommand = cli({
     site: 'chatgpt-app',
     name: 'ask',
@@ -27,26 +27,10 @@ export const askCommand = cli({
             activateChatGPT();
             selectModel(model);
         }
-        // Backup clipboard
-        let clipBackup = '';
-        try {
-            clipBackup = execSync('pbpaste', { encoding: 'utf-8' });
-        }
-        catch { }
         const messagesBefore = getVisibleChatMessages();
         // Send the message
-        spawnSync('pbcopy', { input: text });
         activateChatGPT();
-        const cmd = "osascript " +
-            "-e 'tell application \"System Events\"' " +
-            "-e 'keystroke \"v\" using command down' " +
-            "-e 'delay 0.2' " +
-            "-e 'keystroke return' " +
-            "-e 'end tell'";
-        execSync(cmd);
-        // Restore clipboard after the prompt is sent.
-        if (clipBackup)
-            spawnSync('pbcopy', { input: clipBackup });
+        sendPrompt(text);
         // Wait for response: poll until ChatGPT stops generating ("Stop generating" button disappears),
         // then read the final response text.
         const pollInterval = 2;

--- a/clis/chatgpt-app/ax.js
+++ b/clis/chatgpt-app/ax.js
@@ -60,6 +60,88 @@ for list in lists {
 let data = try! JSONSerialization.data(withJSONObject: best, options: [])
 print(String(data: data, encoding: .utf8)!)
 `;
+const AX_SEND_SCRIPT = `
+import Cocoa
+import ApplicationServices
+
+func attr(_ el: AXUIElement, _ name: String) -> AnyObject? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(el, name as CFString, &value) == .success else { return nil }
+    return value as AnyObject?
+}
+
+func s(_ el: AXUIElement, _ name: String) -> String? {
+    if let v = attr(el, name) as? String { return v }
+    return nil
+}
+
+func children(_ el: AXUIElement) -> [AXUIElement] {
+    (attr(el, kAXChildrenAttribute as String) as? [AnyObject] ?? []).map { $0 as! AXUIElement }
+}
+
+func collectEditableInputs(_ el: AXUIElement, into out: inout [AXUIElement], depth: Int = 0) {
+    guard depth < 25 else { return }
+    let role = s(el, kAXRoleAttribute as String) ?? ""
+    if role == kAXTextAreaRole as String || role == kAXTextFieldRole as String {
+        out.append(el)
+    }
+    for c in children(el) { collectEditableInputs(c, into: &out, depth: depth + 1) }
+}
+
+func findByDescriptions(_ el: AXUIElement, _ targets: [String], depth: Int = 0) -> AXUIElement? {
+    guard depth < 25 else { return nil }
+    let desc = s(el, kAXDescriptionAttribute as String) ?? ""
+    if targets.contains(desc) { return el }
+    for c in children(el) {
+        if let found = findByDescriptions(c, targets, depth: depth + 1) { return found }
+    }
+    return nil
+}
+
+func press(_ el: AXUIElement) {
+    AXUIElementPerformAction(el, kAXPressAction as CFString)
+}
+
+let args = CommandLine.arguments
+guard args.count > 1 else {
+    fputs("Missing prompt text\\n", stderr)
+    exit(1)
+}
+let text = args[1]
+
+guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: "com.openai.chat").first else {
+    fputs("ChatGPT not running\\n", stderr)
+    exit(1)
+}
+
+let axApp = AXUIElementCreateApplication(app.processIdentifier)
+guard let win = attr(axApp, kAXFocusedWindowAttribute as String) as! AXUIElement? else {
+    fputs("No focused ChatGPT window\\n", stderr)
+    exit(1)
+}
+
+var inputs: [AXUIElement] = []
+collectEditableInputs(win, into: &inputs)
+guard let input = inputs.last else {
+    fputs("Could not find editable input area\\n", stderr)
+    exit(1)
+}
+
+guard AXUIElementSetAttributeValue(input, kAXValueAttribute as CFString, text as CFTypeRef) == .success else {
+    fputs("Failed to set input value\\n", stderr)
+    exit(1)
+}
+
+Thread.sleep(forTimeInterval: 0.2)
+
+guard let sendButton = findByDescriptions(win, ["发送", "Send"]) else {
+    fputs("Could not find send button\\n", stderr)
+    exit(1)
+}
+
+press(sendButton)
+print("Sent")
+`;
 const AX_MODEL_SCRIPT = `
 import Cocoa
 import ApplicationServices
@@ -192,7 +274,8 @@ let axApp = AXUIElementCreateApplication(app.processIdentifier)
 guard let win = attr(axApp, kAXFocusedWindowAttribute as String) as! AXUIElement? else {
     print("false"); exit(0)
 }
-print(hasButton(win, desc: "Stop generating") ? "true" : "false")
+let targets = ["Stop generating", "停止生成"]
+print(targets.contains(where: { hasButton(win, desc: $0) }) ? "true" : "false")
 `;
 const MODEL_MAP = {
     'auto': { desc: 'Auto' },
@@ -220,6 +303,13 @@ export function selectModel(model) {
         maxBuffer: 10 * 1024 * 1024,
     }).trim();
     return output;
+}
+export function sendPrompt(text) {
+    return execFileSync('swift', ['-', text], {
+        input: AX_SEND_SCRIPT,
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+    }).trim();
 }
 export function isGenerating() {
     try {

--- a/clis/chatgpt-app/ax.js
+++ b/clis/chatgpt-app/ax.js
@@ -75,6 +75,10 @@ func s(_ el: AXUIElement, _ name: String) -> String? {
     return nil
 }
 
+func isEnabled(_ el: AXUIElement) -> Bool {
+    (attr(el, kAXEnabledAttribute as String) as? Bool) ?? true
+}
+
 func children(_ el: AXUIElement) -> [AXUIElement] {
     (attr(el, kAXChildrenAttribute as String) as? [AnyObject] ?? []).map { $0 as! AXUIElement }
 }
@@ -82,16 +86,29 @@ func children(_ el: AXUIElement) -> [AXUIElement] {
 func collectEditableInputs(_ el: AXUIElement, into out: inout [AXUIElement], depth: Int = 0) {
     guard depth < 25 else { return }
     let role = s(el, kAXRoleAttribute as String) ?? ""
-    if role == kAXTextAreaRole as String || role == kAXTextFieldRole as String {
+    if (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String) && isEnabled(el) {
         out.append(el)
     }
     for c in children(el) { collectEditableInputs(c, into: &out, depth: depth + 1) }
 }
 
+func isInput(_ el: AXUIElement) -> Bool {
+    let role = s(el, kAXRoleAttribute as String) ?? ""
+    return role == kAXTextAreaRole as String || role == kAXTextFieldRole as String
+}
+
+func focusedInput(_ axApp: AXUIElement) -> AXUIElement? {
+    guard let focused = attr(axApp, kAXFocusedUIElementAttribute as String) as! AXUIElement? else {
+        return nil
+    }
+    return isInput(focused) && isEnabled(focused) ? focused : nil
+}
+
 func findByDescriptions(_ el: AXUIElement, _ targets: [String], depth: Int = 0) -> AXUIElement? {
     guard depth < 25 else { return nil }
+    let role = s(el, kAXRoleAttribute as String) ?? ""
     let desc = s(el, kAXDescriptionAttribute as String) ?? ""
-    if targets.contains(desc) { return el }
+    if role == "AXButton" && targets.contains(desc) && isEnabled(el) { return el }
     for c in children(el) {
         if let found = findByDescriptions(c, targets, depth: depth + 1) { return found }
     }
@@ -122,7 +139,7 @@ guard let win = attr(axApp, kAXFocusedWindowAttribute as String) as! AXUIElement
 
 var inputs: [AXUIElement] = []
 collectEditableInputs(win, into: &inputs)
-guard let input = inputs.last else {
+guard let input = focusedInput(axApp) ?? inputs.last else {
     fputs("Could not find editable input area\\n", stderr)
     exit(1)
 }
@@ -134,12 +151,32 @@ guard AXUIElementSetAttributeValue(input, kAXValueAttribute as CFString, text as
 
 Thread.sleep(forTimeInterval: 0.2)
 
+guard s(input, kAXValueAttribute as String) == text else {
+    fputs("Failed to verify input value after AX set\\n", stderr)
+    exit(1)
+}
+
 guard let sendButton = findByDescriptions(win, ["发送", "Send"]) else {
     fputs("Could not find send button\\n", stderr)
     exit(1)
 }
 
 press(sendButton)
+
+var submitted = false
+for _ in 0..<15 {
+    Thread.sleep(forTimeInterval: 0.1)
+    if s(input, kAXValueAttribute as String) != text {
+        submitted = true
+        break
+    }
+}
+
+guard submitted else {
+    fputs("Prompt did not leave input after pressing send\\n", stderr)
+    exit(1)
+}
+
 print("Sent")
 `;
 const AX_MODEL_SCRIPT = `
@@ -340,3 +377,7 @@ export function getVisibleChatMessages() {
         .map((item) => item.replace(/[\uFFFC\u200B-\u200D\uFEFF]/g, '').trim())
         .filter((item) => item.length > 0);
 }
+export const __test__ = {
+    AX_SEND_SCRIPT,
+    AX_GENERATING_SCRIPT,
+};

--- a/clis/chatgpt-app/ax.test.js
+++ b/clis/chatgpt-app/ax.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './ax.js';
+
+describe('chatgpt-app AX send script', () => {
+    it('prefers the focused composer before falling back to the last editable input', () => {
+        expect(__test__.AX_SEND_SCRIPT).toContain('kAXFocusedUIElementAttribute');
+    });
+
+    it('fails fast when the AX set does not round-trip into the composer value', () => {
+        expect(__test__.AX_SEND_SCRIPT).toContain('Failed to verify input value after AX set');
+    });
+
+    it('does not report success until the prompt leaves the composer after send', () => {
+        expect(__test__.AX_SEND_SCRIPT).toContain('Prompt did not leave input after pressing send');
+    });
+});
+
+describe('chatgpt-app generating detection', () => {
+    it('supports both english and zh-CN stop-generating labels', () => {
+        expect(__test__.AX_GENERATING_SCRIPT).toContain('Stop generating');
+        expect(__test__.AX_GENERATING_SCRIPT).toContain('停止生成');
+    });
+});

--- a/clis/chatgpt-app/send.js
+++ b/clis/chatgpt-app/send.js
@@ -1,7 +1,6 @@
-import { execSync, spawnSync } from 'node:child_process';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { getErrorMessage } from '@jackwener/opencli/errors';
-import { activateChatGPT, selectModel, MODEL_CHOICES } from './ax.js';
+import { activateChatGPT, selectModel, MODEL_CHOICES, sendPrompt } from './ax.js';
 export const sendCommand = cli({
     site: 'chatgpt-app',
     name: 'send',
@@ -23,26 +22,8 @@ export const sendCommand = cli({
                 activateChatGPT();
                 selectModel(model);
             }
-            // Backup current clipboard content
-            let clipBackup = '';
-            try {
-                clipBackup = execSync('pbpaste', { encoding: 'utf-8' });
-            }
-            catch { /* clipboard may be empty */ }
-            // Copy text to clipboard
-            spawnSync('pbcopy', { input: text });
             activateChatGPT();
-            const cmd = "osascript " +
-                "-e 'tell application \"System Events\"' " +
-                "-e 'keystroke \"v\" using command down' " +
-                "-e 'delay 0.2' " +
-                "-e 'keystroke return' " +
-                "-e 'end tell'";
-            execSync(cmd);
-            // Restore original clipboard content
-            if (clipBackup) {
-                spawnSync('pbcopy', { input: clipBackup });
-            }
+            sendPrompt(text);
             return [{ Status: 'Success' }];
         }
         catch (err) {


### PR DESCRIPTION
## Summary

This fixes two regressions in `clis/chatgpt-app` on current macOS ChatGPT Desktop builds:

- `chatgpt-app send` / `ask` could report success without actually submitting the prompt when the clipboard-paste path failed to trigger the current input widget reliably.
- `chatgpt-app ask` could time out on Chinese UI because generation detection only checked the English label `Stop generating`.

## Root Cause

The current adapter depends on `pbcopy` + `osascript` paste/return. On the current ChatGPT Desktop UI, that path can succeed from the CLI's point of view while leaving the prompt unsent.

Also, the generation-state probe is locale-sensitive and misses the Chinese label `停止生成`.

## Changes

- Add `sendPrompt(text)` in `clis/chatgpt-app/ax.js`
- Send prompts via Accessibility by:
  - locating the focused ChatGPT input `AXTextArea` / `AXTextField`
  - setting `AXValue` directly
  - waiting briefly for UI state to update
  - pressing the `发送` or `Send` button
- Reuse `sendPrompt(text)` from both `send.js` and `ask.js`
- Expand generation detection to check both `Stop generating` and `停止生成`

## Verification

Environment:
- macOS
- ChatGPT Desktop app bundle: `com.openai.chat`
- OpenCLI CLI: `1.7.5`
- UI locale: Chinese

Commands verified:

```bash
opencli doctor
opencli chatgpt-app send "你好"
opencli chatgpt-app read -f plain
opencli chatgpt-app ask "你好"
```

Observed final result:

```text
- Role: User
  Text: 你好
- Role: Assistant
  Text: 你好！有什么我可以帮你一起搞定的吗？
```

## Notes

This patch is intentionally narrow and only touches:

- `clis/chatgpt-app/ax.js`
- `clis/chatgpt-app/send.js`
- `clis/chatgpt-app/ask.js`

Closes #1134