### PR TITLE
fix(weread/book): add fallback selectors for reader page without cover

### DIFF
--- a/clis/weread/book.js
+++ b/clis/weread/book.js
@@ -37,17 +37,60 @@ function countSearchIdentities(entries) {
     }
     return counts;
 }
-export function parseReaderDocumentTitle(documentTitle) {
-    const parts = String(documentTitle || '')
-        .split(' - ')
-        .map((part) => part.trim())
-        .filter(Boolean);
-    if (parts.length < 3)
+export function strictTitleFromWereadDocumentTitle(rawTitle) {
+    const suffix = ' - 微信读书';
+    const normalized = String(rawTitle || '').trim();
+    if (!normalized.endsWith(suffix))
         return '';
-    const brand = parts.at(-1) || '';
-    if (!/微信读书/.test(brand))
+    const base = normalized.slice(0, -suffix.length).trim();
+    // Only accept the title when WeRead exposes the strict "<title> - 微信读书"
+    // shape. If extra separators remain, the page title is ambiguous.
+    return base.includes(' - ') ? '' : base;
+}
+export function extractReaderFallbackMetadata(doc) {
+    const text = (node) => node?.textContent?.trim() || '';
+    const firstText = (...sels) => { for (const s of sels) {
+        const v = text(doc.querySelector(s));
+        if (v)
+            return v;
+    } return ''; };
+    const bodyText = doc.body?.innerText?.replace(/\s+/g, ' ').trim() || '';
+    const extractRating = () => {
+        const match = bodyText.match(/微信读书推荐值\s*([0-9.]+%)/);
+        return match ? match[1] : '';
+    };
+    const extractPublisher = () => {
+        const direct = text(doc.querySelector('.introDialog_content_pub_line'));
+        return direct.startsWith('出版社') ? direct.replace(/^出版社\s*/, '').trim() : '';
+    };
+    const extractIntro = () => {
+        const selectors = [
+            '.horizontalReaderCoverPage_content_bookInfo_intro',
+            '.wr_flyleaf_page_bookIntro_content',
+            '.introDialog_content_intro_para',
+        ];
+        for (const selector of selectors) {
+            const value = text(doc.querySelector(selector));
+            if (value)
+                return value;
+        }
         return '';
-    return parts.at(-2) || '';
+    };
+    const categorySource = Array.from(doc.scripts || [])
+        .map((script) => script.textContent || '')
+        .find((scriptText) => scriptText.includes('"category"')) || '';
+    const categoryMatch = categorySource.match(/"category"\s*:\s*"([^"]+)"/);
+    const title = firstText('.horizontalReaderCoverPage_content_bookTitle', '.wr_flyleaf_page_bookInfo_bookTitle', '.outline_book_detail_header_title', '.readerTopBar_title_link') || strictTitleFromWereadDocumentTitle(doc.title || '');
+    const author = firstText('.horizontalReaderCoverPage_content_author', '.wr_flyleaf_page_bookInfo_author', '.outline_book_detail_header_author');
+    return {
+        title,
+        author,
+        publisher: extractPublisher(),
+        intro: extractIntro(),
+        category: categoryMatch ? categoryMatch[1].trim() : '',
+        rating: extractRating(),
+        metadataReady: Boolean(title || author),
+    };
 }
 /**
  * Reuse the public search page as a last-resort reader URL source when the
@@ -122,49 +165,7 @@ async function loadReaderFallbackResult(page, readerUrl) {
     await page.goto(readerUrl);
     await page.wait({ selector: '.horizontalReaderCoverPage_content_bookTitle, .wr_flyleaf_page_bookInfo_bookTitle, .readerTopBar_title_link', timeout: 10 });
     const result = await page.evaluate(`
-    (() => {
-      const parseReaderDocumentTitle = ${parseReaderDocumentTitle.toString()};
-      const text = (node) => node?.textContent?.trim() || '';
-      const firstText = (...sels) => { for (const s of sels) { const v = text(document.querySelector(s)); if (v) return v; } return ''; };
-      const bodyText = document.body?.innerText?.replace(/\\s+/g, ' ').trim() || '';
-      const extractRating = () => {
-        const match = bodyText.match(/微信读书推荐值\\s*([0-9.]+%)/);
-        return match ? match[1] : '';
-      };
-      const extractPublisher = () => {
-        const direct = text(document.querySelector('.introDialog_content_pub_line'));
-        return direct.startsWith('出版社') ? direct.replace(/^出版社\\s*/, '').trim() : '';
-      };
-      const extractIntro = () => {
-        const selectors = [
-          '.horizontalReaderCoverPage_content_bookInfo_intro',
-          '.wr_flyleaf_page_bookIntro_content',
-          '.introDialog_content_intro_para',
-        ];
-        for (const selector of selectors) {
-          const value = text(document.querySelector(selector));
-          if (value) return value;
-        }
-        return '';
-      };
-
-      const categorySource = Array.from(document.scripts)
-        .map((script) => script.textContent || '')
-        .find((scriptText) => scriptText.includes('"category"')) || '';
-      const categoryMatch = categorySource.match(/"category"\\s*:\\s*"([^"]+)"/);
-      const title = firstText('.horizontalReaderCoverPage_content_bookTitle', '.wr_flyleaf_page_bookInfo_bookTitle', '.outline_book_detail_header_title', '.readerTopBar_title_link');
-      const author = firstText('.horizontalReaderCoverPage_content_author', '.wr_flyleaf_page_bookInfo_author', '.outline_book_detail_header_author') || parseReaderDocumentTitle(document.title || '');
-
-      return {
-        title,
-        author,
-        publisher: extractPublisher(),
-        intro: extractIntro(),
-        category: categoryMatch ? categoryMatch[1].trim() : '',
-        rating: extractRating(),
-        metadataReady: Boolean(title || author),
-      };
-    })()
+    (${extractReaderFallbackMetadata.toString()})(document)
   `);
     return {
         title: String(result?.title || '').trim(),

--- a/clis/weread/book.js
+++ b/clis/weread/book.js
@@ -108,13 +108,12 @@ async function resolveSearchReaderUrl(title, author) {
  */
 async function loadReaderFallbackResult(page, readerUrl) {
     await page.goto(readerUrl);
-    await page.wait({ selector: '.horizontalReaderCoverPage_content_bookTitle, .wr_flyleaf_page_bookInfo_bookTitle', timeout: 10 });
+    await page.wait({ selector: '.horizontalReaderCoverPage_content_bookTitle, .wr_flyleaf_page_bookInfo_bookTitle, .readerTopBar_title_link', timeout: 10 });
     const result = await page.evaluate(`
     (() => {
       const text = (node) => node?.textContent?.trim() || '';
+      const firstText = (...sels) => { for (const s of sels) { const v = text(document.querySelector(s)); if (v) return v; } return ''; };
       const bodyText = document.body?.innerText?.replace(/\\s+/g, ' ').trim() || '';
-      const titleSelector = '.horizontalReaderCoverPage_content_bookTitle, .wr_flyleaf_page_bookInfo_bookTitle';
-      const authorSelector = '.horizontalReaderCoverPage_content_author, .wr_flyleaf_page_bookInfo_author';
       const extractRating = () => {
         const match = bodyText.match(/微信读书推荐值\\s*([0-9.]+%)/);
         return match ? match[1] : '';
@@ -140,8 +139,8 @@ async function loadReaderFallbackResult(page, readerUrl) {
         .map((script) => script.textContent || '')
         .find((scriptText) => scriptText.includes('"category"')) || '';
       const categoryMatch = categorySource.match(/"category"\\s*:\\s*"([^"]+)"/);
-      const title = text(document.querySelector(titleSelector));
-      const author = text(document.querySelector(authorSelector));
+      const title = firstText('.horizontalReaderCoverPage_content_bookTitle', '.wr_flyleaf_page_bookInfo_bookTitle', '.outline_book_detail_header_title', '.readerTopBar_title_link');
+      const author = firstText('.horizontalReaderCoverPage_content_author', '.wr_flyleaf_page_bookInfo_author', '.outline_book_detail_header_author') || (() => { const parts = (document.title || '').split(' - '); return parts.length >= 3 ? parts[1].trim() : ''; })();
 
       return {
         title,

--- a/clis/weread/book.js
+++ b/clis/weread/book.js
@@ -37,6 +37,18 @@ function countSearchIdentities(entries) {
     }
     return counts;
 }
+export function parseReaderDocumentTitle(documentTitle) {
+    const parts = String(documentTitle || '')
+        .split(' - ')
+        .map((part) => part.trim())
+        .filter(Boolean);
+    if (parts.length < 3)
+        return '';
+    const brand = parts.at(-1) || '';
+    if (!/微信读书/.test(brand))
+        return '';
+    return parts.at(-2) || '';
+}
 /**
  * Reuse the public search page as a last-resort reader URL source when the
  * cached shelf page cannot provide a trustworthy bookId-to-reader mapping.
@@ -111,6 +123,7 @@ async function loadReaderFallbackResult(page, readerUrl) {
     await page.wait({ selector: '.horizontalReaderCoverPage_content_bookTitle, .wr_flyleaf_page_bookInfo_bookTitle, .readerTopBar_title_link', timeout: 10 });
     const result = await page.evaluate(`
     (() => {
+      const parseReaderDocumentTitle = ${parseReaderDocumentTitle.toString()};
       const text = (node) => node?.textContent?.trim() || '';
       const firstText = (...sels) => { for (const s of sels) { const v = text(document.querySelector(s)); if (v) return v; } return ''; };
       const bodyText = document.body?.innerText?.replace(/\\s+/g, ' ').trim() || '';
@@ -140,7 +153,7 @@ async function loadReaderFallbackResult(page, readerUrl) {
         .find((scriptText) => scriptText.includes('"category"')) || '';
       const categoryMatch = categorySource.match(/"category"\\s*:\\s*"([^"]+)"/);
       const title = firstText('.horizontalReaderCoverPage_content_bookTitle', '.wr_flyleaf_page_bookInfo_bookTitle', '.outline_book_detail_header_title', '.readerTopBar_title_link');
-      const author = firstText('.horizontalReaderCoverPage_content_author', '.wr_flyleaf_page_bookInfo_author', '.outline_book_detail_header_author') || (() => { const parts = (document.title || '').split(' - '); return parts.length >= 3 ? parts[1].trim() : ''; })();
+      const author = firstText('.horizontalReaderCoverPage_content_author', '.wr_flyleaf_page_bookInfo_author', '.outline_book_detail_header_author') || parseReaderDocumentTitle(document.title || '');
 
       return {
         title,

--- a/clis/weread/commands.test.js
+++ b/clis/weread/commands.test.js
@@ -12,9 +12,9 @@ vi.mock('./utils.js', async () => {
 });
 import { getRegistry } from '@jackwener/opencli/registry';
 import './book.js';
-import { parseReaderDocumentTitle } from './book.js';
 import './highlights.js';
 import './notes.js';
+import { extractReaderFallbackMetadata, strictTitleFromWereadDocumentTitle } from './book.js';
 describe('weread book-id positional args', () => {
     const book = getRegistry().get('weread/book');
     const highlights = getRegistry().get('weread/highlights');
@@ -31,14 +31,6 @@ describe('weread book-id positional args', () => {
     beforeEach(() => {
         mockFetchPrivateApi.mockReset();
         vi.unstubAllGlobals();
-    });
-    it('parses author from the penultimate document.title segment when the book title contains hyphens', () => {
-        expect(parseReaderDocumentTitle('Part 1 - Part 2 - 作者甲 - 微信读书')).toBe('作者甲');
-        expect(parseReaderDocumentTitle('Foo - Bar - Baz - 微信读书')).toBe('Baz');
-    });
-    it('does not guess an author from non-reader document.title formats', () => {
-        expect(parseReaderDocumentTitle('Foo - Bar')).toBe('');
-        expect(parseReaderDocumentTitle('Foo - Bar - Baz')).toBe('');
     });
     it('passes the positional book-id to book details', async () => {
         mockFetchPrivateApi.mockResolvedValue({ title: 'Three Body', newRating: 880 });
@@ -363,6 +355,29 @@ describe('weread book-id positional args', () => {
         await expect(book.func(page, { 'book-id': 'BOOK_1' })).rejects.toMatchObject({
             code: 'AUTH_REQUIRED',
             message: 'Not logged in to WeRead',
+        });
+    });
+    it('does not guess author from document.title when the reader page skips cover metadata', async () => {
+        const nodes = new Map([
+            ['.readerTopBar_title_link', { textContent: 'Part 1 - Part 2' }],
+            ['.introDialog_content_pub_line', { textContent: '出版社 测试出版社' }],
+            ['.introDialog_content_intro_para', { textContent: '测试简介。' }],
+        ]);
+        const mockDocument = {
+            title: 'Part 1 - Part 2 - 作者甲 - 微信读书',
+            body: { innerText: '微信读书推荐值 88.8%' },
+            scripts: [],
+            querySelector: (selector) => nodes.get(selector) || null,
+        };
+        expect(strictTitleFromWereadDocumentTitle(mockDocument.title)).toBe('');
+        expect(extractReaderFallbackMetadata(mockDocument)).toEqual({
+            title: 'Part 1 - Part 2',
+            author: '',
+            publisher: '测试出版社',
+            intro: '测试简介。',
+            category: '',
+            rating: '88.8%',
+            metadataReady: true,
         });
     });
     it('passes the positional book-id to highlights', async () => {

--- a/clis/weread/commands.test.js
+++ b/clis/weread/commands.test.js
@@ -12,6 +12,7 @@ vi.mock('./utils.js', async () => {
 });
 import { getRegistry } from '@jackwener/opencli/registry';
 import './book.js';
+import { parseReaderDocumentTitle } from './book.js';
 import './highlights.js';
 import './notes.js';
 describe('weread book-id positional args', () => {
@@ -30,6 +31,14 @@ describe('weread book-id positional args', () => {
     beforeEach(() => {
         mockFetchPrivateApi.mockReset();
         vi.unstubAllGlobals();
+    });
+    it('parses author from the penultimate document.title segment when the book title contains hyphens', () => {
+        expect(parseReaderDocumentTitle('Part 1 - Part 2 - 作者甲 - 微信读书')).toBe('作者甲');
+        expect(parseReaderDocumentTitle('Foo - Bar - Baz - 微信读书')).toBe('Baz');
+    });
+    it('does not guess an author from non-reader document.title formats', () => {
+        expect(parseReaderDocumentTitle('Foo - Bar')).toBe('');
+        expect(parseReaderDocumentTitle('Foo - Bar - Baz')).toBe('');
     });
     it('passes the positional book-id to book details', async () => {
         mockFetchPrivateApi.mockResolvedValue({ title: 'Three Body', newRating: 880 });


### PR DESCRIPTION
## Summary
- When the private API session expires, `loadReaderFallbackResult` navigates to the reader URL. The page now sometimes skips the cover/flyleaf and renders reading content directly, causing `page.wait` for `.horizontalReaderCoverPage_content_bookTitle` / `.wr_flyleaf_page_bookInfo_bookTitle` to time out.
- Add `.readerTopBar_title_link` to the wait selector (always present in the top bar)
- Use cascading `firstText()` for title/author extraction: cover → flyleaf → outline panel → top bar → `document.title` parsing

## Test plan
- [x] `opencli weread book 31732574` — previously crashed with `SELECTOR` error, now returns title + author
- [x] Verify with a logged-in session that cover/flyleaf path still works (full metadata returned)

Fixes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)