### PR TITLE
fix: add AbortSignal timeouts to public-API adapter fetches

### DIFF
--- a/clis/producthunt/utils.js
+++ b/clis/producthunt/utils.js
@@ -27,7 +27,13 @@ export async function fetchFeed(category) {
     const url = category
         ? `https://www.producthunt.com/feed?category=${encodeURIComponent(category)}`
         : 'https://www.producthunt.com/feed';
-    const resp = await fetch(url, { headers: { 'User-Agent': UA } });
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(10000) });
+    }
+    catch {
+        return [];
+    }
     if (!resp.ok)
         return [];
     const xml = await resp.text();

--- a/clis/sinablog/search.js
+++ b/clis/sinablog/search.js
@@ -18,6 +18,7 @@ async function searchSinaBlog(keyword, limit) {
             'User-Agent': 'Mozilla/5.0',
             Accept: 'application/json',
         },
+        signal: AbortSignal.timeout(5000),
     });
     if (!resp.ok)
         throw new Error(`Sina blog search failed: HTTP ${resp.status}`);

--- a/clis/sinablog/utils.js
+++ b/clis/sinablog/utils.js
@@ -96,7 +96,7 @@ export async function loadSinaBlogHot(page, limit) {
           url: item.url,
         };
         try {
-          const resp = await fetch(item.url, { credentials: 'include' });
+          const resp = await fetch(item.url, { credentials: 'include', signal: AbortSignal.timeout(5000) });
           if (resp.ok) {
             const html = await resp.text();
             const doc = new DOMParser().parseFromString(html, 'text/html');

--- a/clis/spotify/spotify.js
+++ b/clis/spotify/spotify.js
@@ -50,6 +50,7 @@ async function refreshAccessToken(refreshToken) {
             Authorization: 'Basic ' + Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64'),
         },
         body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refreshToken }),
+        signal: AbortSignal.timeout(10000),
     });
     if (!res.ok) {
         const err = await res.json().catch(() => ({}));
@@ -82,6 +83,7 @@ async function api(method, path, body) {
         method,
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: body ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(10000),
     });
     if (res.status === 204 || res.status === 202)
         return null;
@@ -133,6 +135,7 @@ cli({
                             Authorization: 'Basic ' + Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64'),
                         },
                         body: new URLSearchParams({ grant_type: 'authorization_code', code, redirect_uri: REDIRECT_URI }),
+                        signal: AbortSignal.timeout(10000),
                     });
                     if (!tokenRes.ok) {
                         const err = await tokenRes.json().catch(() => ({}));

--- a/clis/substack/search.js
+++ b/clis/substack/search.js
@@ -21,7 +21,7 @@ async function searchPosts(keyword, limit) {
     url.searchParams.set('query', keyword);
     url.searchParams.set('page', '0');
     url.searchParams.set('includePlatformResults', 'true');
-    const resp = await fetch(url, { headers: headers() });
+    const resp = await fetch(url, { headers: headers(), signal: AbortSignal.timeout(8000) });
     if (!resp.ok)
         throw new CommandExecutionError(`Substack post search failed: HTTP ${resp.status}`);
     const data = await resp.json();
@@ -39,7 +39,7 @@ async function searchPublications(keyword, limit) {
     const url = new URL('https://substack.com/api/v1/profile/search');
     url.searchParams.set('query', keyword);
     url.searchParams.set('page', '0');
-    const resp = await fetch(url, { headers: headers() });
+    const resp = await fetch(url, { headers: headers(), signal: AbortSignal.timeout(8000) });
     if (!resp.ok)
         throw new CommandExecutionError(`Substack publication search failed: HTTP ${resp.status}`);
     const data = await resp.json();

--- a/clis/yahoo-finance/quote.js
+++ b/clis/yahoo-finance/quote.js
@@ -23,7 +23,7 @@ cli({
         // Strategy 1: v8 chart API
         try {
           const chartUrl = 'https://query1.finance.yahoo.com/v8/finance/chart/' + encodeURIComponent(sym) + '?interval=1d&range=1d';
-          const resp = await fetch(chartUrl);
+          const resp = await fetch(chartUrl, { signal: AbortSignal.timeout(5000) });
           if (resp.ok) {
             const d = await resp.json();
             const chart = d?.chart?.result?.[0];


### PR DESCRIPTION
## Summary

Mirrors #1106 across the rest of the adapter layer: external `fetch()` calls without a timeout can hang indefinitely under network stalls, and every blocking call in an adapter propagates directly into a hung CLI command (the original symptom in #1082).

Adds `AbortSignal.timeout(...)` to **eight external fetches across six adapters**:

| File | # | Host | Timeout | Notes |
|---|---|---|---|---|
| `clis/spotify/spotify.js` | 3 | accounts.spotify.com, api.spotify.com | 10s | Token refresh, API calls, OAuth token exchange — hit on every command |
| `clis/substack/search.js` | 2 | substack.com/api/v1 | 8s | Post + publication search |
| `clis/producthunt/utils.js` | 1 | producthunt.com | 10s | RSS feed. Wrapped in try/catch to preserve existing `return []` graceful-degradation contract on network failure |
| `clis/sinablog/utils.js` | 1 | blog.sina.com.cn | 5s | **Highest blast radius** — per-article fetch inside a hot-list loop; one slow article currently blocks the whole command. Already in try/catch → timeout is graceful |
| `clis/sinablog/search.js` | 1 | search.sina.com.cn/api | 5s | |
| `clis/yahoo-finance/quote.js` | 1 | query1.finance.yahoo.com | 5s | Inside `page.evaluate`, Strategy-1 try/catch — timeout falls through to Strategy 2 (DOM parse) |

## Compatibility

`AbortSignal.timeout(ms)` is supported in Node 18+ (repo requires 21+) and Chrome 103+ (well below any currently-supported extension host). No new runtime dependency.

## Why these timeout values

- **10s** for auth/OAuth flows that can legitimately be slow.
- **8s** for public API search endpoints.
- **5s** for loops or best-effort fallback strategies where a failed fetch is expected to degrade gracefully rather than surface a hard error.

## What this PR is *not*

- **Not** refactoring per-adapter error handling — timeout just throws at the existing `await fetch()` boundary.
- **Not** adding new tests — the existing suite exercises all six files. A true timeout test would need network simulation or making `fetch` injectable, neither proportionate to a 15-line change.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` (unit + extension + adapter) — 231 files / 1870 passed
- [x] Pattern matches merged precedent #1106
- [ ] Smoke-check under network stall against Spotify / Sinablog (maintainer, if desired)

Closes no issue directly — generalizes #1106 to the rest of the adapter surface area.
