### PR TITLE
feat(weread): add ai-outline command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17056,6 +17056,48 @@
   },
   {
     "site": "weread",
+    "name": "ai-outline",
+    "description": "Get AI-generated outline for a book",
+    "domain": "weread.qq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "book-id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Book ID (from shelf or search results)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 200,
+        "required": false,
+        "help": "Max outline items to return"
+      },
+      {
+        "name": "depth",
+        "type": "int",
+        "default": 4,
+        "required": false,
+        "help": "Max outline depth (2=topics, 3=key points, 4=details)"
+      },
+      {
+        "name": "raw",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Output structured rows (chapter/idx/level/text) for programmatic use"
+      }
+    ],
+    "type": "js",
+    "modulePath": "weread/ai-outline.js",
+    "sourceFile": "weread/ai-outline.js",
+    "navigateBefore": "https://weread.qq.com"
+  },
+  {
+    "site": "weread",
     "name": "book",
     "description": "View book details on WeRead",
     "domain": "weread.qq.com",
@@ -17264,48 +17306,6 @@
     "type": "js",
     "modulePath": "weread/shelf.js",
     "sourceFile": "weread/shelf.js",
-    "navigateBefore": "https://weread.qq.com"
-  },
-  {
-    "site": "weread",
-    "name": "ai-outline",
-    "description": "Get AI-generated outline for a book",
-    "domain": "weread.qq.com",
-    "strategy": "cookie",
-    "browser": true,
-    "args": [
-      {
-        "name": "book-id",
-        "type": "str",
-        "required": true,
-        "positional": true,
-        "help": "Book ID (from shelf or search results)"
-      },
-      {
-        "name": "limit",
-        "type": "int",
-        "default": 200,
-        "required": false,
-        "help": "Max outline items to return"
-      },
-      {
-        "name": "depth",
-        "type": "int",
-        "default": 4,
-        "required": false,
-        "help": "Max outline depth (2=topics, 3=key points, 4=details)"
-      },
-      {
-        "name": "raw",
-        "type": "boolean",
-        "default": false,
-        "required": false,
-        "help": "Output structured rows (chapter/idx/level/text) for programmatic use"
-      }
-    ],
-    "type": "js",
-    "modulePath": "weread/ai-outline.js",
-    "sourceFile": "weread/ai-outline.js",
     "navigateBefore": "https://weread.qq.com"
   },
   {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17267,6 +17267,48 @@
     "navigateBefore": "https://weread.qq.com"
   },
   {
+    "site": "weread",
+    "name": "ai-outline",
+    "description": "Get AI-generated outline for a book",
+    "domain": "weread.qq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "book-id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Book ID (from shelf or search results)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 200,
+        "required": false,
+        "help": "Max outline items to return"
+      },
+      {
+        "name": "depth",
+        "type": "int",
+        "default": 4,
+        "required": false,
+        "help": "Max outline depth (2=topics, 3=key points, 4=details)"
+      },
+      {
+        "name": "raw",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Output structured rows (chapter/idx/level/text) for programmatic use"
+      }
+    ],
+    "type": "js",
+    "modulePath": "weread/ai-outline.js",
+    "sourceFile": "weread/ai-outline.js",
+    "navigateBefore": "https://weread.qq.com"
+  },
+  {
     "site": "wikipedia",
     "name": "random",
     "description": "Get a random Wikipedia article",

--- a/clis/weread/ai-outline.js
+++ b/clis/weread/ai-outline.js
@@ -42,7 +42,7 @@ async function postWebApiWithCookies(page, path, body) {
         throw new CliError('PARSE_ERROR', `Invalid JSON response for ${path}`, 'WeRead may have returned an HTML error page');
     }
 
-    if (data?.errCode === -2010 || data?.errCode === -2012) {
+    if (data?.errcode === -2010 || data?.errcode === -2012) {
         throw new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first');
     }
     if (!resp.ok) {
@@ -77,6 +77,7 @@ cli({
     description: 'Get AI-generated outline for a book',
     domain: 'weread.qq.com',
     strategy: Strategy.COOKIE,
+    defaultFormat: 'plain',
     args: [
         { name: 'book-id', positional: true, required: true, help: 'Book ID (from shelf or search results)' },
         { name: 'limit', type: 'int', default: 200, help: 'Max outline items to return' },

--- a/clis/weread/ai-outline.js
+++ b/clis/weread/ai-outline.js
@@ -1,0 +1,169 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+import { WEREAD_UA, WEREAD_WEB_ORIGIN, WEREAD_DOMAIN } from './utils.js';
+
+const WEB_API = `${WEREAD_WEB_ORIGIN}/web`;
+
+function buildCookieHeader(cookies) {
+    return cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+}
+
+async function postWebApiWithCookies(page, path, body) {
+    const url = `${WEB_API}${path}`;
+    const [apiCookies, domainCookies] = await Promise.all([
+        page.getCookies({ url }),
+        page.getCookies({ domain: WEREAD_DOMAIN }),
+    ]);
+    const merged = new Map();
+    for (const c of domainCookies) merged.set(c.name, c);
+    for (const c of apiCookies) merged.set(c.name, c);
+    const cookieHeader = buildCookieHeader(Array.from(merged.values()));
+
+    const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'User-Agent': WEREAD_UA,
+            'Content-Type': 'application/json',
+            'Origin': WEREAD_WEB_ORIGIN,
+            'Referer': `${WEREAD_WEB_ORIGIN}/`,
+            ...(cookieHeader ? { 'Cookie': cookieHeader } : {}),
+        },
+        body: JSON.stringify(body),
+    });
+
+    if (resp.status === 401) {
+        throw new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first');
+    }
+
+    let data;
+    try {
+        data = await resp.json();
+    } catch {
+        throw new CliError('PARSE_ERROR', `Invalid JSON response for ${path}`, 'WeRead may have returned an HTML error page');
+    }
+
+    if (data?.errCode === -2010 || data?.errCode === -2012) {
+        throw new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first');
+    }
+    if (!resp.ok) {
+        throw new CliError('FETCH_ERROR', `HTTP ${resp.status} for ${path}`, 'WeRead API may be temporarily unavailable');
+    }
+    return data;
+}
+
+async function postWebApi(path, body) {
+    const url = `${WEB_API}${path}`;
+    const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'User-Agent': WEREAD_UA,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+        throw new CliError('FETCH_ERROR', `HTTP ${resp.status} for ${path}`, 'WeRead API may be temporarily unavailable');
+    }
+    try {
+        return await resp.json();
+    } catch {
+        throw new CliError('PARSE_ERROR', `Invalid JSON response for ${path}`, 'WeRead may have returned an HTML error page');
+    }
+}
+
+cli({
+    site: 'weread',
+    name: 'ai-outline',
+    description: 'Get AI-generated outline for a book',
+    domain: 'weread.qq.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'book-id', positional: true, required: true, help: 'Book ID (from shelf or search results)' },
+        { name: 'limit', type: 'int', default: 200, help: 'Max outline items to return' },
+        { name: 'depth', type: 'int', default: 4, help: 'Max outline depth (2=topics, 3=key points, 4=details)' },
+        { name: 'raw', type: 'boolean', default: false, help: 'Output structured rows (chapter/idx/level/text) for programmatic use' },
+    ],
+    columns: undefined,
+    func: async (page, args) => {
+        const bookId = String(args['book-id'] || '').trim();
+        const rawMode = Boolean(args.raw);
+
+        const chapterData = await postWebApiWithCookies(page, '/book/chapterInfos', {
+            bookIds: [bookId],
+            sinces: [0],
+        });
+        const chapters = chapterData?.data?.[0]?.updated ?? [];
+        if (chapters.length === 0) {
+            throw new CliError('NOT_FOUND', 'No chapters found for this book', 'Check that the book ID is correct');
+        }
+
+        const chapterUids = chapters.map((c) => c.chapterUid);
+        const chapterNameMap = new Map();
+        for (const c of chapters) {
+            chapterNameMap.set(c.chapterUid, c.title ?? '');
+        }
+
+        const outlineData = await postWebApi('/book/outline', {
+            bookId,
+            chapterUids,
+        });
+
+        const itemsArray = outlineData?.itemsArray ?? [];
+        const maxDepth = Number(args.depth);
+        const rawRows = [];
+
+        for (const entry of itemsArray) {
+            const items = entry.items;
+            if (!Array.isArray(items) || items.length === 0) continue;
+
+            const chapterName = chapterNameMap.get(entry.chapterUid) ?? `Chapter ${entry.chapterUid}`;
+            let lastL3Idx = '';
+            let l4Counter = 0;
+
+            for (const item of items) {
+                const level = item.level ?? 1;
+                if (level <= 1) continue;
+                if (level > maxDepth) continue;
+
+                let idx = item.uiIdx ?? '';
+                if (level === 3 && idx) {
+                    lastL3Idx = idx;
+                    l4Counter = 0;
+                }
+                if (level === 4 && !idx && lastL3Idx) {
+                    l4Counter++;
+                    idx = `${lastL3Idx}.${l4Counter}`;
+                }
+
+                rawRows.push({ chapter: chapterName, idx, level, text: item.text ?? '' });
+            }
+        }
+
+        if (rawRows.length === 0) {
+            throw new CliError('NOT_FOUND', 'No AI outline available for this book', 'AI outlines may not be generated for all books');
+        }
+
+        if (rawMode) {
+            return rawRows.slice(0, Number(args.limit));
+        }
+
+        const grouped = new Map();
+        for (const row of rawRows) {
+            if (!grouped.has(row.chapter)) grouped.set(row.chapter, []);
+            grouped.get(row.chapter).push(row);
+        }
+
+        const results = [];
+        for (const [chapter, rows] of grouped) {
+            const lines = [`📖 ${chapter}`];
+            for (const row of rows) {
+                const indent = '  '.repeat(row.level - 2);
+                const prefix = row.level === 2 ? `${row.idx}. ` : `${row.idx} `;
+                lines.push(`${indent}${prefix}${row.text}`);
+            }
+            results.push({ outline: lines.join('\n') });
+        }
+
+        return results.slice(0, Number(args.limit));
+    },
+});

--- a/clis/weread/ai-outline.test.js
+++ b/clis/weread/ai-outline.test.js
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './ai-outline.js';
+
+describe('weread ai-outline', () => {
+    const command = getRegistry().get('weread/ai-outline');
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('registers ai-outline with plain default output', () => {
+        expect(command?.defaultFormat).toBe('plain');
+    });
+
+    it('maps chapterInfos auth-expired responses to AUTH_REQUIRED', async () => {
+        expect(command?.func).toBeTypeOf('function');
+        const page = {
+            getCookies: vi.fn()
+                .mockResolvedValueOnce([{ name: 'wr_vid', value: 'vid123', domain: '.weread.qq.com' }])
+                .mockResolvedValueOnce([{ name: 'wr_name', value: 'alice', domain: '.weread.qq.com' }]),
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ errcode: -2012, errmsg: '登录超时' }),
+        }));
+        await expect(command.func(page, { 'book-id': 'book-1' })).rejects.toMatchObject({
+            code: 'AUTH_REQUIRED',
+            message: 'Not logged in to WeRead',
+        });
+    });
+
+    it('returns structured rows for --raw and respects depth filtering', async () => {
+        expect(command?.func).toBeTypeOf('function');
+        const page = {
+            getCookies: vi.fn()
+                .mockResolvedValueOnce([{ name: 'wr_vid', value: 'vid123', domain: '.weread.qq.com' }])
+                .mockResolvedValueOnce([{ name: 'wr_name', value: 'alice', domain: '.weread.qq.com' }]),
+        };
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({
+                data: [{
+                        updated: [
+                            { chapterUid: 'c1', title: '第一章' },
+                        ],
+                    }],
+            }),
+        })
+            .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({
+                itemsArray: [{
+                        chapterUid: 'c1',
+                        items: [
+                            { level: 2, uiIdx: '1', text: '主题一' },
+                            { level: 3, uiIdx: '1.1', text: '要点一' },
+                            { level: 4, text: '细节一' },
+                        ],
+                    }],
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const rows = await command.func(page, { 'book-id': 'book-1', raw: true, depth: 3, limit: 10 });
+        expect(rows).toEqual([
+            { chapter: '第一章', idx: '1', level: 2, text: '主题一' },
+            { chapter: '第一章', idx: '1.1', level: 3, text: '要点一' },
+        ]);
+        expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://weread.qq.com/web/book/chapterInfos', expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+                Cookie: 'wr_name=alice; wr_vid=vid123',
+            }),
+        }));
+        expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://weread.qq.com/web/book/outline', expect.objectContaining({
+            method: 'POST',
+        }));
+    });
+});


### PR DESCRIPTION
## Summary
- Add `weread ai-outline` command that fetches AI-generated hierarchical outlines for books
- Two-step API: authenticated `chapterInfos` → public `outline` endpoint
- Dual output modes: human-readable (grouped by chapter) and `--raw` (structured rows for AI)
- `--depth` flag to control detail level (2=topics, 3=key points, 4=details)

## Details

### API Flow
1. `POST /web/book/chapterInfos` (needs login cookies) → chapter UIDs
2. `POST /web/book/outline` (public, no auth) → hierarchical outline with levels 1-4

### Output Examples

**Default** (`opencli weread ai-outline <book-id>`):
```
📖 第一章 童年
1. 朱元璋的童年经历
  1.1 朱元璋出生于贫苦农民家庭
    1.1.1 朱元璋出生时，红光满地，夜间房屋中出现异光。
```

**Structured** (`opencli weread ai-outline <book-id> --raw`):
```yaml
- chapter: 第一章 童年
  idx: '1.1'
  level: 3
  text: 朱元璋出生于贫苦农民家庭
```

## Test plan
- [x] Tested with book 822995 (88 chapters, 5975 outline items)
- [x] Verified no VIP required — only a logged-in weread.qq.com session
- [x] `--depth 3` correctly filters out L4 detail items
- [x] `--raw` outputs structured `chapter/idx/level/text` rows
- [x] L4 items auto-assigned sub-indexes (e.g. `1.1.1`, `1.1.2`)

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)