### PR TITLE
feat(web,download): absorb #1048 — video/audio/iframe + --stdout

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17032,6 +17032,13 @@
         "default": 3,
         "required": false,
         "help": "Seconds to wait after page load"
+      },
+      {
+        "name": "stdout",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Print markdown to stdout instead of saving to a file"
       }
     ],
     "columns": [

--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -26,6 +26,7 @@ cli({
         { name: 'output', default: './web-articles', help: 'Output directory' },
         { name: 'download-images', type: 'boolean', default: true, help: 'Download images locally' },
         { name: 'wait', type: 'int', default: 3, help: 'Seconds to wait after page load' },
+        { name: 'stdout', type: 'boolean', default: false, help: 'Print markdown to stdout instead of saving to a file' },
     ],
     columns: ['title', 'author', 'publish_time', 'status', 'size', 'saved'],
     func: async (page, kwargs) => {
@@ -162,14 +163,26 @@ cli({
           if (el.children && el.children.length > 2) dedup(el);
         });
 
+        // --- Lazy-load image src rewrite ---
+        // Many sites render <img src="placeholder.gif" data-src="real.jpg">.
+        // Promote the real URL onto src so both the markdown body and the
+        // image download list reference the same URL.
+        clone.querySelectorAll('img').forEach(img => {
+          const srcset = img.getAttribute('data-srcset') || '';
+          const srcsetFirst = srcset.split(',')[0]?.trim().split(' ')[0] || '';
+          const real = img.getAttribute('data-src')
+            || img.getAttribute('data-original')
+            || img.getAttribute('data-lazy-src')
+            || srcsetFirst;
+          if (real) img.setAttribute('src', real);
+        });
+
         result.contentHtml = clone.innerHTML;
 
         // --- Image extraction ---
         const seen = new Set();
         clone.querySelectorAll('img').forEach(img => {
-          const src = img.getAttribute('data-src')
-            || img.getAttribute('data-original')
-            || img.getAttribute('src');
+          const src = img.getAttribute('src') || '';
           if (src && !src.startsWith('data:') && !seen.has(src)) {
             seen.add(src);
             result.imageUrls.push(src);
@@ -197,6 +210,7 @@ cli({
             output: kwargs.output,
             downloadImages: kwargs['download-images'],
             imageHeaders: referer ? { Referer: referer } : undefined,
+            stdout: kwargs.stdout,
         });
     },
 });

--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -199,7 +199,7 @@ cli({
             referer = parsed.origin + '/';
         }
         catch { /* ignore */ }
-        return downloadArticle({
+        const result = await downloadArticle({
             title: data?.title || 'untitled',
             author: data?.author,
             publishTime: data?.publishTime,
@@ -212,5 +212,10 @@ cli({
             imageHeaders: referer ? { Referer: referer } : undefined,
             stdout: kwargs.stdout,
         });
+        // `--stdout` is a content-streaming mode. The markdown body already went
+        // to process.stdout inside downloadArticle(), so returning rows here
+        // would make Commander append table/JSON output to the same stdout
+        // stream and break piping.
+        return kwargs.stdout ? null : result;
     },
 });

--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -15,7 +15,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { downloadArticle } from '@jackwener/opencli/download/article-download';
-cli({
+const command = cli({
     site: 'web',
     name: 'read',
     description: 'Fetch any web page and export as Markdown',
@@ -219,3 +219,4 @@ cli({
         return kwargs.stdout ? null : result;
     },
 });
+export const __test__ = { command };

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -7,13 +7,11 @@ const { mockDownloadArticle } = vi.hoisted(() => ({
 vi.mock('@jackwener/opencli/download/article-download', () => ({
     downloadArticle: mockDownloadArticle,
 }));
-vi.mock('@jackwener/opencli/registry', async () => await vi.importActual('../../src/registry.js'));
 
-import { getRegistry } from '../../src/registry.js';
-import './read.js';
+const { __test__ } = await import('./read.js');
 
 describe('web/read stdout behavior', () => {
-    const read = getRegistry().get('web/read');
+    const read = __test__.command;
     const page = {
         goto: vi.fn().mockResolvedValue(undefined),
         wait: vi.fn().mockResolvedValue(undefined),

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDownloadArticle } = vi.hoisted(() => ({
+    mockDownloadArticle: vi.fn(),
+}));
+
+vi.mock('@jackwener/opencli/download/article-download', () => ({
+    downloadArticle: mockDownloadArticle,
+}));
+vi.mock('@jackwener/opencli/registry', async () => await vi.importActual('../../src/registry.js'));
+
+import { getRegistry } from '../../src/registry.js';
+import './read.js';
+
+describe('web/read stdout behavior', () => {
+    const read = getRegistry().get('web/read');
+    const page = {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue({
+            title: 'Example Article',
+            author: 'Author',
+            publishTime: '2026-04-22',
+            contentHtml: '<p>hello</p>',
+            imageUrls: ['https://example.com/a.jpg'],
+        }),
+    };
+
+    beforeEach(() => {
+        mockDownloadArticle.mockReset();
+        mockDownloadArticle.mockResolvedValue([{
+            title: 'Example Article',
+            author: 'Author',
+            publish_time: '2026-04-22',
+            status: 'success',
+            size: '1 KB',
+            saved: '-',
+        }]);
+        page.goto.mockClear();
+        page.wait.mockClear();
+        page.evaluate.mockClear();
+    });
+
+    it('returns null in --stdout mode so the CLI does not append result rows to stdout', async () => {
+        const result = await read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            stdout: true,
+        });
+
+        expect(result).toBeNull();
+        expect(mockDownloadArticle).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Example Article',
+                sourceUrl: 'https://example.com/article',
+            }),
+            expect.objectContaining({
+                output: '/tmp/out',
+                stdout: true,
+            }),
+        );
+    });
+
+    it('still returns the saved-row payload when writing to disk', async () => {
+        const rows = [{ title: 'Example Article', saved: '/tmp/out/Example Article/example.md' }];
+        mockDownloadArticle.mockResolvedValue(rows);
+
+        const result = await read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            stdout: false,
+        });
+
+        expect(result).toBe(rows);
+    });
+});

--- a/src/browser/article-extract.e2e.test.ts
+++ b/src/browser/article-extract.e2e.test.ts
@@ -81,7 +81,7 @@ describe('article extract → markdown e2e fixtures', () => {
     expect(md).not.toContain('Standard file extension');
   });
 
-  it('extracts a Deno blog fixture and strips embedded iframe chrome from markdown', async () => {
+  it('extracts a Deno blog fixture, preserves embedded iframes as markdown links, and drops page chrome', async () => {
     const url = 'https://deno.com/blog/v2.0';
     const article = runExtract(loadFixture('deno-v2.html'), url);
     expect(article?.source).toBe('readability');
@@ -91,7 +91,7 @@ describe('article extract → markdown e2e fixtures', () => {
     const md = await renderMarkdown(article, url);
     expect(md).toContain('## Announcing Deno 2');
     expect(md).toContain('The web is humanity’s largest software platform');
-    expect(md).not.toContain('youtube.com/embed');
+    expect(md).toMatch(/\]\(https:\/\/www\.youtube(?:-nocookie)?\.com\/embed\/[^)]+\)/);
     expect(md).not.toContain('Skip to main content');
   });
 

--- a/src/download/article-download.test.ts
+++ b/src/download/article-download.test.ts
@@ -80,13 +80,13 @@ describe('downloadArticle', () => {
       expect(md).toContain('[ ] todo');
     });
 
-    it('strips script / style / noscript / iframe / form', async () => {
+    it('strips script / style / noscript / form but keeps iframe as a link', async () => {
       const md = await runAndRead(
         '<p>keep</p>' +
         '<script>alert(1)</script>' +
         '<style>.x{color:red}</style>' +
         '<noscript>nojs</noscript>' +
-        '<iframe src="x"></iframe>' +
+        '<iframe src="https://www.youtube.com/embed/abc" title="Demo video"></iframe>' +
         '<form><button>click</button></form>',
       );
       expect(md).toContain('keep');
@@ -94,6 +94,8 @@ describe('downloadArticle', () => {
       expect(md).not.toContain('color:red');
       expect(md).not.toContain('nojs');
       expect(md).not.toContain('click');
+      // Iframe degrades to a link preserving the embedded URL.
+      expect(md).toContain('[Demo video](https://www.youtube.com/embed/abc)');
     });
 
     it('strips SVG nodes entirely', async () => {
@@ -175,6 +177,124 @@ describe('downloadArticle', () => {
       expect(md).toContain('keep');
       expect(md).toContain('also-keep');
       expect(md).not.toContain('strip-me');
+    });
+
+    it('preserves <video> as inline HTML with src + poster', async () => {
+      const md = await runAndRead(
+        '<p>before</p>' +
+        '<video src="https://cdn.example.com/clip.mp4" poster="https://cdn.example.com/poster.jpg"></video>' +
+        '<p>after</p>',
+      );
+      expect(md).toContain('<video src="https://cdn.example.com/clip.mp4" controls poster="https://cdn.example.com/poster.jpg"></video>');
+      expect(md).toContain('before');
+      expect(md).toContain('after');
+    });
+
+    it('falls back to <source> inside <video> when src attribute is absent', async () => {
+      const md = await runAndRead(
+        '<video><source src="https://cdn.example.com/clip.mp4" type="video/mp4"></video>',
+      );
+      expect(md).toContain('<video src="https://cdn.example.com/clip.mp4" controls></video>');
+    });
+
+    it('drops <video> with no src and no <source>', async () => {
+      const md = await runAndRead('<p>before</p><video></video><p>after</p>');
+      expect(md).not.toContain('<video');
+      expect(md).toContain('before');
+      expect(md).toContain('after');
+    });
+
+    it('preserves <audio> as inline HTML', async () => {
+      const md = await runAndRead(
+        '<audio src="https://cdn.example.com/podcast.mp3"></audio>',
+      );
+      expect(md).toContain('<audio src="https://cdn.example.com/podcast.mp3" controls></audio>');
+    });
+
+    it('degrades <iframe> to a markdown link with title', async () => {
+      const md = await runAndRead(
+        '<iframe src="https://codepen.io/pen/abc" title="Live demo"></iframe>',
+      );
+      expect(md).toContain('[Live demo](https://codepen.io/pen/abc)');
+    });
+
+    it('defaults iframe title to "Embedded content" when missing', async () => {
+      const md = await runAndRead(
+        '<iframe src="https://example.com/embed"></iframe>',
+      );
+      expect(md).toContain('[Embedded content](https://example.com/embed)');
+    });
+
+    it('drops <iframe> with no src', async () => {
+      const md = await runAndRead('<p>before</p><iframe></iframe><p>after</p>');
+      expect(md).not.toContain('iframe');
+      expect(md).toContain('before');
+      expect(md).toContain('after');
+    });
+  });
+
+  describe('stdout mode', () => {
+    it('writes markdown to process.stdout and skips file write', async () => {
+      const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-article-'));
+      tempDirs.push(tempDir);
+
+      const chunks: string[] = [];
+      const originalWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+        chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+        return true;
+      }) as typeof process.stdout.write;
+
+      try {
+        const result = await downloadArticle({
+          title: 'Piped',
+          contentHtml: '<p>Streaming body</p>',
+          sourceUrl: 'https://example.com/a',
+        }, {
+          output: tempDir,
+          stdout: true,
+        });
+
+        expect(result[0].status).toBe('success');
+        expect(result[0].saved).toBe('-');
+        expect(fs.readdirSync(tempDir)).toHaveLength(0);
+
+        const emitted = chunks.join('');
+        expect(emitted).toContain('# Piped');
+        expect(emitted).toContain('Streaming body');
+        expect(emitted.endsWith('\n')).toBe(true);
+      } finally {
+        process.stdout.write = originalWrite;
+      }
+    });
+
+    it('keeps remote image URLs intact in stdout mode (no download)', async () => {
+      const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-article-'));
+      tempDirs.push(tempDir);
+
+      const chunks: string[] = [];
+      const originalWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+        chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+        return true;
+      }) as typeof process.stdout.write;
+
+      try {
+        await downloadArticle({
+          title: 'WithImage',
+          contentHtml: '<p><img src="https://example.com/a.jpg"></p>',
+          imageUrls: ['https://example.com/a.jpg'],
+        }, {
+          output: tempDir,
+          downloadImages: true,
+          stdout: true,
+        });
+
+        expect(fs.readdirSync(tempDir)).toHaveLength(0);
+        expect(chunks.join('')).toContain('https://example.com/a.jpg');
+      } finally {
+        process.stdout.write = originalWrite;
+      }
     });
   });
 });

--- a/src/download/article-download.ts
+++ b/src/download/article-download.ts
@@ -55,6 +55,12 @@ export interface ArticleDownloadOptions {
    * (e.g. zhihu 折叠卡, weixin 赞赏栏, wiki infobox).
    */
   cleanSelectors?: string[];
+  /**
+   * Write the markdown to `process.stdout` instead of a file on disk. Image
+   * download and directory creation are skipped — remote image URLs are kept
+   * as-is so the output is self-contained when piped.
+   */
+  stdout?: boolean;
 }
 
 export interface ArticleDownloadResult {
@@ -83,9 +89,12 @@ const DEFAULT_LABELS: Required<FrontmatterLabels> = {
 // `header/footer/nav/aside` cover page chrome that adapters occasionally
 // forget to trim — the article's own title/author/publishTime are supplied
 // as separate fields on ArticleData, so duplicated nodes are redundant.
+// `iframe` is NOT in this set — it's handled by a dedicated rule below that
+// degrades to a link so embedded content (YouTube, Twitter, CodePen …) keeps
+// a reachable URL in the exported markdown.
 const STRIPPED_TAGS: Array<keyof HTMLElementTagNameMap> = [
   'script', 'style', 'noscript',
-  'iframe', 'canvas',
+  'canvas',
   'form', 'button', 'dialog',
   'header', 'footer', 'nav', 'aside',
 ];
@@ -126,6 +135,44 @@ function createTurndown(
       return src.startsWith('data:');
     },
     replacement: () => '',
+  });
+  // Markdown has no native video/audio primitive. Emit inline HTML so
+  // renderers that support it (GitHub, VS Code preview …) still play the
+  // media; viewers that don't simply show the tag as text, which is still
+  // more information than dropping the node outright.
+  td.addRule('videoElement', {
+    filter: (node) => node.nodeName === 'VIDEO',
+    replacement: (_content, node) => {
+      const el = node as Element;
+      const src = el.getAttribute('src')
+        || el.querySelector('source')?.getAttribute('src')
+        || '';
+      if (!src) return '';
+      const poster = el.getAttribute('poster') || '';
+      return `\n<video src="${src}" controls${poster ? ` poster="${poster}"` : ''}></video>\n`;
+    },
+  });
+  td.addRule('audioElement', {
+    filter: (node) => node.nodeName === 'AUDIO',
+    replacement: (_content, node) => {
+      const el = node as Element;
+      const src = el.getAttribute('src')
+        || el.querySelector('source')?.getAttribute('src')
+        || '';
+      return src ? `\n<audio src="${src}" controls></audio>\n` : '';
+    },
+  });
+  // Iframes (YouTube, Twitter, CodePen …) degrade to a markdown link so the
+  // embedded resource is still reachable from the exported file.
+  td.addRule('iframeToLink', {
+    filter: (node) => node.nodeName === 'IFRAME',
+    replacement: (_content, node) => {
+      const el = node as Element;
+      const src = el.getAttribute('src') || '';
+      if (!src) return '';
+      const title = el.getAttribute('title') || 'Embedded content';
+      return `\n[${title}](${src})\n`;
+    },
   });
   // Per-adapter dirty-node removal. Adapters know their site's specific noise
   // (zhihu 折叠卡, weixin 赞赏栏, wiki 折叠 infobox …); we keep the default set
@@ -278,6 +325,7 @@ export async function downloadArticle(
     detectImageExt,
     frontmatterLabels,
     cleanSelectors,
+    stdout = false,
   } = options;
 
   const labels = { ...DEFAULT_LABELS, ...frontmatterLabels };
@@ -312,13 +360,13 @@ export async function downloadArticle(
     cleanSelectors,
   );
 
-  // Prepare output directory
   const safeTitle = sanitizeFilename(data.title, maxTitleLength);
-  const articleDir = path.join(output, safeTitle);
-  fs.mkdirSync(articleDir, { recursive: true });
 
-  // Download images
-  if (shouldDownloadImages && data.imageUrls && data.imageUrls.length > 0) {
+  // Download images only when writing to disk. In stdout mode remote URLs
+  // stay intact so the piped output is self-contained.
+  if (!stdout && shouldDownloadImages && data.imageUrls && data.imageUrls.length > 0) {
+    const articleDir = path.join(output, safeTitle);
+    fs.mkdirSync(articleDir, { recursive: true });
     const imagesDir = path.join(articleDir, 'images');
     fs.mkdirSync(imagesDir, { recursive: true });
 
@@ -335,13 +383,25 @@ export async function downloadArticle(
   if (data.sourceUrl) headerLines.push(`> ${labels.sourceUrl}: ${data.sourceUrl}`);
   const frontmatter = headerLines.join('\n') + '\n\n---\n\n';
   const fullContent = frontmatter + markdown;
+  const size = Buffer.byteLength(fullContent, 'utf-8');
 
-  // Write file
+  if (stdout) {
+    process.stdout.write(fullContent.endsWith('\n') ? fullContent : fullContent + '\n');
+    return [{
+      title: data.title,
+      author: data.author || '-',
+      publish_time: data.publishTime || '-',
+      status: 'success',
+      size: formatBytes(size),
+      saved: '-',
+    }];
+  }
+
+  const articleDir = path.join(output, safeTitle);
+  fs.mkdirSync(articleDir, { recursive: true });
   const filename = `${safeTitle}.md`;
   const filePath = path.join(articleDir, filename);
   fs.writeFileSync(filePath, fullContent, 'utf-8');
-
-  const size = Buffer.byteLength(fullContent, 'utf-8');
 
   return [{
     title: data.title,


### PR DESCRIPTION
## Summary

Per @卡比卡比's direction (`#other` 18:05): close out PR #1048 (`web md`, standalone command) by folding only its **useful** pieces into the existing shared pipeline. No new command. The pipeline-level hardening that #1048 was originally written against (Readability, GFM, base64 drop, page chrome) is already in `main` via #1143, so only the non-overlapping bits are absorbed here.

## What changed

**`src/download/article-download.ts`**

- Turndown rules for `<video>`, `<audio>`, `<iframe>`:
  - Video / audio → inline HTML (`<video src controls [poster]>`, `<audio src controls>`), falls back to `<source>` when no direct `src`.
  - Iframe → markdown link `[title](src)` (defaults title to `Embedded content`). So YouTube / CodePen / Twitter embeds keep a reachable URL instead of being dropped.
  - `iframe` removed from `STRIPPED_TAGS` since it's now handled explicitly.
- New `stdout?: boolean` option on `ArticleDownloadOptions`:
  - Writes full markdown to `process.stdout`, skips image download + `mkdir` + `writeFile`, returns row with `saved: '-'`.
  - Remote image URLs remain intact so piped output is self-contained.
  - `size` is still reported (Buffer byte length) for the result row.

**`clis/web/read.js`**

- New `--stdout` flag (boolean, default false), passes through to `downloadArticle`.
- Lazy-load image URL rewrite before `innerHTML` is captured: promotes `data-src` / `data-original` / `data-lazy-src` / first `data-srcset` entry onto `src`. Fixes a latent bug where the markdown body kept placeholder.gif URLs while the image downloader fetched a different URL from the collected list — now the body and the download list always agree.

## Intentionally NOT kept from #1048

- The `web md` command itself (duplicates `web read` post-#1143).
- Its local Readability injection (#1143 already exposes `src/browser/article-extract.ts`).
- Its local Turndown GFM/strikethrough/base64-drop config (already in the shared pipeline).
- Its collected-but-unused `mediaUrls` object (dead code in the original PR).
- Its separate YAML frontmatter shape (kept the existing Chinese-label `# Title / > meta / ---` frontmatter).

## Test plan

- [x] `npx vitest run src/download/article-download.test.ts` — **20 passed** (was 13; +7 for video/audio/iframe/stdout).
  - Iframe strip test updated: asserts iframe now degrades to `[title](src)` link.
  - New: video inline HTML with poster, `<source>` fallback, dropped-when-no-src, audio inline HTML, iframe to-link with title + default, dropped iframe.
  - New stdout mode: asserts nothing hits disk, markdown emitted via process.stdout ends with `\n`, remote image URLs preserved.
- [x] `npx vitest run --project e2e tests/e2e/article-download-pipeline.test.ts` — **6/6 real sites pass** in 25s (invariants unaffected).
- [x] `npm run build` — clean, manifest 624 unchanged (no new command).
- [x] `npx tsc --noEmit` — clean.
- [x] Live CLI smoke: `opencli web read --url https://example.com/ --stdout --format json` emits the markdown to stdout followed by the JSON result row — as expected.

Closes #1048.