### PR TITLE
fix(daemon): allow Browser Bridge ping probe via targeted CORS

### DIFF
--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getResponseCorsHeaders } from './daemon.js';
+
+describe('getResponseCorsHeaders', () => {
+  it('allows the Browser Bridge extension origin to read /ping', () => {
+    expect(getResponseCorsHeaders('/ping', 'chrome-extension://abc123')).toEqual({
+      'Access-Control-Allow-Origin': 'chrome-extension://abc123',
+      Vary: 'Origin',
+    });
+  });
+
+  it('does not add CORS headers for ordinary web origins', () => {
+    expect(getResponseCorsHeaders('/ping', 'https://example.com')).toBeUndefined();
+  });
+
+  it('does not add CORS headers when origin is absent', () => {
+    expect(getResponseCorsHeaders('/ping')).toBeUndefined();
+  });
+
+  it('does not add CORS headers for command endpoints even from the extension origin', () => {
+    expect(getResponseCorsHeaders('/command', 'chrome-extension://abc123')).toBeUndefined();
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -9,7 +9,8 @@
  *   1. Origin check — reject HTTP/WS from non chrome-extension:// origins
  *   2. Custom header — require X-OpenCLI header (browsers can't send it
  *      without CORS preflight, which we deny)
- *   3. No CORS headers — responses never include Access-Control-Allow-Origin
+ *   3. No CORS headers on command endpoints — only /ping is readable from the
+ *      Browser Bridge extension origin so the extension can probe daemon reachability
  *   4. Body size limit — 1 MB max to prevent OOM
  *   5. WebSocket verifyClient — reject upgrade before connection is established
  *
@@ -67,9 +68,23 @@ function readBody(req: IncomingMessage): Promise<string> {
   });
 }
 
-function jsonResponse(res: ServerResponse, status: number, data: unknown): void {
-  res.writeHead(status, { 'Content-Type': 'application/json' });
+function jsonResponse(
+  res: ServerResponse,
+  status: number,
+  data: unknown,
+  extraHeaders?: Record<string, string>,
+): void {
+  res.writeHead(status, { 'Content-Type': 'application/json', ...extraHeaders });
   res.end(JSON.stringify(data));
+}
+
+export function getResponseCorsHeaders(pathname: string, origin?: string): Record<string, string> | undefined {
+  if (pathname !== '/ping') return undefined;
+  if (!origin || !origin.startsWith('chrome-extension://')) return undefined;
+  return {
+    'Access-Control-Allow-Origin': origin,
+    Vary: 'Origin',
+  };
 }
 
 async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
@@ -104,7 +119,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   // Timing side-channels can reveal daemon presence to local processes, which
   // is an accepted risk given the daemon is loopback-only and short-lived.
   if (req.method === 'GET' && pathname === '/ping') {
-    jsonResponse(res, 200, { ok: true });
+    jsonResponse(res, 200, { ok: true }, getResponseCorsHeaders(pathname, origin));
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow the Browser Bridge extension origin to read `GET /ping`
- keep command endpoints on the existing no-CORS boundary
- add unit coverage for `/ping` vs `/command` CORS behavior

## Why
Issue #1147 reports that the extension's pre-WebSocket `fetch(http://localhost:19825/ping)` probe is blocked by CORS. That diagnosis is correct on current main:
- `extension/src/background.ts` probes `/ping` before opening WebSocket
- `src/daemon.ts` intentionally returns no ACAO headers
- the probe fails early, so the extension never attempts the WebSocket connect path

## Change
This PR keeps the current design, but narrows one exception:
- only `GET /ping` reflects `Access-Control-Allow-Origin` for `chrome-extension://*` origins
- other paths still do not emit ACAO

## Review context
- A group review: green from `@First-principles-0` and `@codex-mini0` in the issue thread
- extra boundary locked in test: `/command` still gets no CORS headers even from extension origin

## Validation
I added `src/daemon.test.ts` for:
- `/ping` + extension origin => ACAO present
- `/ping` + web origin => no ACAO
- `/command` + extension origin => no ACAO

Local env note: this workspace currently lacks `vitest` and `tsc`, so I could not run the existing test/typecheck commands here.