### PR TITLE
fix: quality audit bug fixes across core modules

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -116,7 +116,12 @@ export class CDPBridge implements IBrowserFactory {
               for (const fn of listeners) fn(msg.params);
             }
           }
-        } catch {}
+        } catch (err) {
+          if (process.env.OPENCLI_VERBOSE) {
+            // eslint-disable-next-line no-console
+            console.error('[cdp] Failed to parse WebSocket message:', err instanceof Error ? err.message : err);
+          }
+        }
       });
     });
   }
@@ -300,8 +305,12 @@ class CDPPage extends BasePage {
               this._networkEntries[idx].responseBodyFullSize = fullSize;
               this._networkEntries[idx].responseBodyTruncated = truncated;
             }
-          }).catch(() => {
+          }).catch((err) => {
             // Body unavailable for some requests (e.g. uploads) — non-fatal
+            if (process.env.OPENCLI_VERBOSE) {
+              // eslint-disable-next-line no-console
+              console.error(`[cdp] getResponseBody failed for ${p.requestId}:`, err instanceof Error ? err.message : err);
+            }
           }).finally(() => {
             this._pendingBodyFetches.delete(bodyFetch);
           });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,7 +85,12 @@ async function captureNetworkItems(page: import('./types.js').IPage): Promise<Br
     }
   }
   const raw = await page.evaluate(`(function(){ var out = window.__opencli_net || []; window.__opencli_net = []; return JSON.stringify(out); })()`) as string;
-  try { return JSON.parse(raw) as BrowserNetworkItem[]; } catch { return []; }
+  try {
+    return JSON.parse(raw) as BrowserNetworkItem[];
+  } catch {
+    if (process.env.OPENCLI_VERBOSE) log.warn(`[network] Failed to parse interceptor buffer: ${typeof raw === 'string' ? raw.slice(0, 200) : String(raw)}`);
+    return [];
+  }
 }
 
 /** Drop static-resource / telemetry noise so agents see only API-shaped traffic. */
@@ -97,10 +102,17 @@ function filterNetworkItems(items: BrowserNetworkItem[]): BrowserNetworkItem[] {
   );
 }
 
+/** Exit codes by network error code — usage errors vs runtime failures. */
+const NETWORK_ERROR_EXIT: Record<string, number> = {
+  invalid_args: EXIT_CODES.USAGE_ERROR,
+  invalid_filter: EXIT_CODES.USAGE_ERROR,
+  invalid_max_body: EXIT_CODES.USAGE_ERROR,
+};
+
 /** Emit a structured error JSON so agents can branch on `error.code` without regex. */
 function emitNetworkError(code: string, message: string, extra: Record<string, unknown> = {}): void {
   console.log(JSON.stringify({ error: { code, message, ...extra } }, null, 2));
-  process.exitCode = EXIT_CODES.USAGE_ERROR;
+  process.exitCode = NETWORK_ERROR_EXIT[code] ?? EXIT_CODES.GENERIC_ERROR;
 }
 
 /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -299,6 +299,7 @@ wss.on('connection', (ws: WebSocket) => {
     if (extensionWs === ws) {
       extensionWs = null;
       extensionVersion = null;
+      extensionCompatRange = null;
       // Reject pending requests in case 'close' does not follow this 'error'
       for (const [, p] of pending) {
         clearTimeout(p.timer);

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -89,108 +89,93 @@ export async function httpDownload(
 ): Promise<{ success: boolean; size: number; error?: string }> {
   const { cookies, headers = {}, timeout = 30000, onProgress, maxRedirects = 10 } = options;
 
-  return new Promise((resolve) => {
-    const requestHeaders: Record<string, string> = {
-      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
-      ...headers,
-    };
+  const requestHeaders: Record<string, string> = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
+    ...headers,
+  };
 
-    if (cookies) {
-      requestHeaders['Cookie'] = cookies;
+  if (cookies) {
+    requestHeaders['Cookie'] = cookies;
+  }
+
+  const tempPath = `${destPath}.tmp`;
+
+  const cleanupTempFile = async () => {
+    try {
+      await fs.promises.rm(tempPath, { force: true });
+    } catch {
+      // Ignore cleanup errors so the original failure is preserved.
+    }
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    const response = await fetchWithNodeNetwork(url, {
+      headers: requestHeaders,
+      signal: controller.signal,
+      redirect: 'manual',
+    });
+    clearTimeout(timer);
+
+    // Handle redirects before creating any file handles.
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (location) {
+        if (redirectCount >= maxRedirects) {
+          return { success: false, size: 0, error: `Too many redirects (> ${maxRedirects})` };
+        }
+        const redirectUrl = resolveRedirectUrl(url, location);
+        const originalHost = new URL(url).hostname;
+        const redirectHost = new URL(redirectUrl).hostname;
+        const redirectOptions = originalHost === redirectHost
+          ? options
+          : { ...options, cookies: undefined, headers: stripCookieHeaders(options.headers) };
+        return httpDownload(
+          redirectUrl,
+          destPath,
+          redirectOptions,
+          redirectCount + 1,
+        );
+      }
     }
 
-    const tempPath = `${destPath}.tmp`;
-    let settled = false;
+    if (response.status !== 200) {
+      return { success: false, size: 0, error: `HTTP ${response.status}` };
+    }
 
-    const finish = (result: { success: boolean; size: number; error?: string }) => {
-      if (settled) return;
-      settled = true;
-      resolve(result);
-    };
+    if (!response.body) {
+      return { success: false, size: 0, error: 'Empty response body' };
+    }
 
-    const cleanupTempFile = async () => {
-      try {
-        await fs.promises.rm(tempPath, { force: true });
-      } catch {
-        // Ignore cleanup errors so the original failure is preserved.
-      }
-    };
+    const totalSize = parseInt(response.headers.get('content-length') || '0', 10);
+    let received = 0;
+    const progressStream = new Transform({
+      transform(chunk, _encoding, callback) {
+        received += chunk.length;
+        if (onProgress) onProgress(received, totalSize);
+        callback(null, chunk);
+      },
+    });
 
-    void (async () => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeout);
-      try {
-        const response = await fetchWithNodeNetwork(url, {
-          headers: requestHeaders,
-          signal: controller.signal,
-          redirect: 'manual',
-        });
-        clearTimeout(timer);
-
-        // Handle redirects before creating any file handles.
-        if (response.status >= 300 && response.status < 400) {
-          const location = response.headers.get('location');
-          if (location) {
-            if (redirectCount >= maxRedirects) {
-              finish({ success: false, size: 0, error: `Too many redirects (> ${maxRedirects})` });
-              return;
-            }
-            const redirectUrl = resolveRedirectUrl(url, location);
-            const originalHost = new URL(url).hostname;
-            const redirectHost = new URL(redirectUrl).hostname;
-            const redirectOptions = originalHost === redirectHost
-              ? options
-              : { ...options, cookies: undefined, headers: stripCookieHeaders(options.headers) };
-            finish(await httpDownload(
-              redirectUrl,
-              destPath,
-              redirectOptions,
-              redirectCount + 1,
-            ));
-            return;
-          }
-        }
-
-        if (response.status !== 200) {
-          finish({ success: false, size: 0, error: `HTTP ${response.status}` });
-          return;
-        }
-
-        if (!response.body) {
-          finish({ success: false, size: 0, error: 'Empty response body' });
-          return;
-        }
-
-        const totalSize = parseInt(response.headers.get('content-length') || '0', 10);
-        let received = 0;
-        const progressStream = new Transform({
-          transform(chunk, _encoding, callback) {
-            received += chunk.length;
-            if (onProgress) onProgress(received, totalSize);
-            callback(null, chunk);
-          },
-        });
-
-        try {
-          await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-          await pipeline(
-            Readable.fromWeb(response.body as unknown as WebReadableStream),
-            progressStream,
-            fs.createWriteStream(tempPath),
-          );
-          await fs.promises.rename(tempPath, destPath);
-          finish({ success: true, size: received });
-        } catch (err) {
-          await cleanupTempFile();
-          finish({ success: false, size: 0, error: getErrorMessage(err) });
-        }
-      } catch (err) {
-        clearTimeout(timer);
-        await cleanupTempFile();
-        finish({ success: false, size: 0, error: err instanceof Error ? err.message : String(err) });
-      }
-    })();
-  });
+    try {
+      await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+      await pipeline(
+        Readable.fromWeb(response.body as unknown as WebReadableStream),
+        progressStream,
+        fs.createWriteStream(tempPath),
+      );
+      await fs.promises.rename(tempPath, destPath);
+      return { success: true, size: received };
+    } catch (err) {
+      await cleanupTempFile();
+      return { success: false, size: 0, error: getErrorMessage(err) };
+    }
+  } catch (err) {
+    clearTimeout(timer);
+    await cleanupTempFile();
+    return { success: false, size: 0, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 export function resolveRedirectUrl(currentUrl: string, location: string): string {
@@ -223,7 +208,9 @@ export function exportCookiesToNetscape(
     const includeSubdomains = 'TRUE';
     const cookiePath = cookie.path || '/';
     const secure = cookie.secure ? 'TRUE' : 'FALSE';
-    const expiry = Math.floor(Date.now() / 1000) + 86400 * 365; // 1 year from now
+    const expiry = typeof cookie.expirationDate === 'number' && cookie.expirationDate > 0
+      ? Math.floor(cookie.expirationDate)
+      : Math.floor(Date.now() / 1000) + 86400 * 365; // fallback: 1 year from now
     const safeName = cookie.name.replace(/[\t\n\r]/g, '');
     const safeValue = cookie.value.replace(/[\t\n\r]/g, '');
     lines.push(`${domain}\t${includeSubdomains}\t${cookiePath}\t${secure}\t${expiry}\t${safeName}\t${safeValue}`);

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -118,4 +118,18 @@ describe('toEnvelope', () => {
     expect(envelope.error.code).toBe('UNKNOWN');
     expect(envelope.error.message).toBe('string error');
   });
+
+  it('serializes deep cause chains without stack overflow', () => {
+    // Build a 20-level deep cause chain — should truncate at depth 10
+    let deepErr: Error = new Error('root');
+    for (let i = 0; i < 20; i++) {
+      deepErr = new Error(`level-${i}`, { cause: deepErr });
+    }
+    const topErr = new CommandExecutionError('top');
+    (topErr as { cause?: unknown }).cause = deepErr;
+    const envelope = toEnvelope(topErr);
+    const causeStr = envelope.error.cause ?? '';
+    expect(causeStr).toContain('(cause chain truncated)');
+    expect(causeStr).not.toContain('root'); // root is beyond depth 10
+  });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -166,10 +166,11 @@ export function getErrorMessage(error: unknown): string {
 }
 
 /** Serialize an error cause chain into a readable string. */
-function serializeCause(cause: unknown): string {
+function serializeCause(cause: unknown, depth: number = 0): string {
+  if (depth > 10) return '(cause chain truncated)';
   if (cause instanceof Error) {
     const parts = [cause.message];
-    if (cause.cause) parts.push(`  caused by: ${serializeCause(cause.cause)}`);
+    if (cause.cause) parts.push(`  caused by: ${serializeCause(cause.cause, depth + 1)}`);
     return parts.join('\n');
   }
   return String(cause);

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -59,7 +59,7 @@ export function detectProcess(processName: string): boolean {
 /**
  * Kill a process by name. Sends SIGTERM first, then SIGKILL after grace period.
  */
-export function killProcess(processName: string): void {
+export async function killProcess(processName: string): Promise<void> {
   if (process.platform === 'win32') return; // pkill not available on Windows
   try {
     execFileSync('pkill', ['-x', processName], { stdio: 'pipe' });
@@ -70,7 +70,7 @@ export function killProcess(processName: string): void {
   const deadline = Date.now() + KILL_GRACE_MS;
   while (Date.now() < deadline) {
     if (!detectProcess(processName)) return;
-    execFileSync('sleep', ['0.2'], { stdio: 'pipe' });
+    await new Promise((r) => setTimeout(r, 200));
   }
 
   try {
@@ -238,7 +238,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
       );
     }
     process.stderr.write(`  Restarting ${label}...\n`);
-    killProcess(processName);
+    await killProcess(processName);
   }
 
   // Step 3: Discover path

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -37,6 +37,13 @@ describe('output TTY detection', () => {
     expect(JSON.parse(out)).toEqual([{ name: 'alice' }]);
   });
 
+  it('shows elapsed time when elapsed is 0', () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true });
+    render([{ name: 'alice' }], { fmt: 'table', columns: ['name'], elapsed: 0 });
+    const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    expect(out).toContain('0.0s');
+  });
+
   it('explicit -f table overrides non-TTY auto-downgrade', () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true });
     render([{ name: 'alice' }], { fmt: 'table', fmtExplicit: true, columns: ['name'] });

--- a/src/output.ts
+++ b/src/output.ts
@@ -72,7 +72,7 @@ function renderTable(data: unknown, opts: RenderOptions): void {
   console.log(table.toString());
   const footer: string[] = [];
   footer.push(`${rows.length} items`);
-  if (opts.elapsed) footer.push(`${opts.elapsed.toFixed(1)}s`);
+  if (opts.elapsed !== undefined) footer.push(`${opts.elapsed.toFixed(1)}s`);
   if (opts.source) footer.push(opts.source);
   if (opts.footerExtra) footer.push(opts.footerExtra);
   console.log(styleText('dim', footer.join(' · ')));


### PR DESCRIPTION
## Summary

Fixes 8 issues found during systematic code quality audit:

**Bugs fixed:**
- `output.ts:75`: `elapsed=0` skipped due to falsy check → changed to `!== undefined`
- `cdp.ts:119`: WebSocket message parse errors silently swallowed → log in verbose mode
- `cdp.ts:303`: `getResponseBody` failures silently swallowed → log in verbose mode
- `launcher.ts:70-73`: `execFileSync('sleep')` blocks event loop → async `setTimeout`
- `daemon.ts:297`: `extensionCompatRange` not reset in error handler → added `= null`
- `download/index.ts:119-193`: Promise constructor anti-pattern (void async IIFE) → direct async
- `download/index.ts:226`: cookie expiry hardcoded to 1 year → use `cookie.expirationDate`
- `errors.ts:169`: `serializeCause` unbounded recursion → added depth limit (max 10)

## Test plan
- [x] `tsc --noEmit` passes (only pre-existing jsdom error)
- [x] `vitest run --project unit` — 827 pass, 9 pre-existing failures unchanged