### PR TITLE
fix(deepseek): fix history titles and resume conversation on ask

### DIFF
--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -35,17 +35,33 @@ export const askCommand = cli({
             await page.goto(DEEPSEEK_URL);
             await page.wait(3);
         } else {
-            await ensureOnDeepSeek(page);
+            const navigated = await ensureOnDeepSeek(page);
+            if (navigated) {
+                // Workspace was recycled; try to resume the most recent
+                // conversation instead of starting a new one.
+                await page.evaluate(`(() => {
+                    var link = document.querySelector('a[href*="/a/chat/s/"]');
+                    if (link) link.click();
+                })()`);
+                await page.wait(2);
+            }
         }
 
         await page.wait(2);
 
-        const wantModel = kwargs.model || 'instant';
-        const modelResult = await withRetry(() => selectModel(page, wantModel));
-        if (!modelResult?.ok) {
-            throw new CommandExecutionError(`Could not switch to ${wantModel} model`);
+        // Model selector is only available on the new-chat page, not inside
+        // an existing conversation. Skip it when we resumed a prior thread.
+        const currentUrl = await page.evaluate('window.location.href') || '';
+        const inConversation = currentUrl.includes('/a/chat/s/');
+
+        if (!inConversation) {
+            const wantModel = kwargs.model || 'instant';
+            const modelResult = await withRetry(() => selectModel(page, wantModel));
+            if (!modelResult?.ok) {
+                throw new CommandExecutionError(`Could not switch to ${wantModel} model`);
+            }
+            if (modelResult?.toggled) await page.wait(0.5);
         }
-        if (modelResult?.toggled) await page.wait(0.5);
 
         const thinkResult = await withRetry(() => setFeature(page, 'DeepThink', wantThink));
         if (!thinkResult?.ok && wantThink) {

--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
 import {
     DEEPSEEK_DOMAIN, DEEPSEEK_URL, ensureOnDeepSeek, selectModel, setFeature,
     sendMessage, sendWithFile, getBubbleCount, waitForResponse, parseBoolFlag, withRetry,
@@ -53,9 +53,19 @@ export const askCommand = cli({
         // an existing conversation. Skip it when we resumed a prior thread.
         const currentUrl = await page.evaluate('window.location.href') || '';
         const inConversation = currentUrl.includes('/a/chat/s/');
+        const modelExplicit = kwargs.__opencliOptionSources?.model === 'cli';
+
+        const wantModel = kwargs.model || 'instant';
+        if (inConversation && modelExplicit) {
+            throw new CliError(
+                'ARGUMENT',
+                `Cannot switch to ${wantModel} model inside an existing conversation.`,
+                'Re-run with --new to start a fresh chat before selecting a model.',
+                EXIT_CODES.USAGE_ERROR,
+            );
+        }
 
         if (!inConversation) {
-            const wantModel = kwargs.model || 'instant';
             const modelResult = await withRetry(() => selectModel(page, wantModel));
             if (!modelResult?.ok) {
                 throw new CommandExecutionError(`Could not switch to ${wantModel} model`);

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
 
 const {
   mockEnsureOnDeepSeek,
@@ -218,6 +218,28 @@ describe('deepseek ask conversation resume', () => {
     });
 
     expect(rows).toEqual([{ response: 'follow-up reply' }]);
+    expect(mockSelectModel).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when --model is explicitly requested inside an existing conversation', async () => {
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/a/chat/s/abc-123');
+
+    await expect(askCommand.func(page, {
+      prompt: 'continue',
+      timeout: 120,
+      new: false,
+      model: 'expert',
+      think: false,
+      search: false,
+      __opencliOptionSources: { model: 'cli' },
+    })).rejects.toMatchObject(new CliError(
+      'ARGUMENT',
+      'Cannot switch to expert model inside an existing conversation.',
+      'Re-run with --new to start a fresh chat before selecting a model.',
+      EXIT_CODES.USAGE_ERROR,
+    ));
+
     expect(mockSelectModel).not.toHaveBeenCalled();
   });
 

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -43,11 +43,13 @@ describe('deepseek ask --file', () => {
   const page = {
     wait: vi.fn().mockResolvedValue(undefined),
     goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue('https://chat.deepseek.com/'),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockEnsureOnDeepSeek.mockResolvedValue(undefined);
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/');
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
     mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
     mockSetFeature.mockResolvedValue({ ok: true, toggled: false });
     mockSendWithFile.mockResolvedValue({ ok: true });
@@ -90,11 +92,13 @@ describe('deepseek ask --think', () => {
   const page = {
     wait: vi.fn().mockResolvedValue(undefined),
     goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue('https://chat.deepseek.com/'),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockEnsureOnDeepSeek.mockResolvedValue(undefined);
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/');
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
     mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
     mockSetFeature.mockResolvedValue({ ok: true, toggled: false });
     mockSendMessage.mockResolvedValue({ ok: true });
@@ -161,5 +165,80 @@ describe('deepseek ask --think', () => {
 
     // Row keys drive rendered columns; no thinking/thinking_time present.
     expect(Object.keys(rows[0])).toEqual(['response']);
+  });
+});
+
+describe('deepseek ask conversation resume', () => {
+  const page = {
+    wait: vi.fn().mockResolvedValue(undefined),
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetFeature.mockResolvedValue({ ok: true, toggled: false });
+    mockSendMessage.mockResolvedValue({ ok: true });
+    mockGetBubbleCount.mockResolvedValue(2);
+    mockWaitForResponse.mockResolvedValue('follow-up reply');
+  });
+
+  it('resumes the most recent conversation and skips model selection', async () => {
+    mockEnsureOnDeepSeek.mockResolvedValue(true);
+    // first evaluate: sidebar resume click (returns undefined)
+    page.evaluate.mockResolvedValueOnce(undefined);
+    // second evaluate: URL check (now inside a conversation)
+    page.evaluate.mockResolvedValueOnce('https://chat.deepseek.com/a/chat/s/abc-123');
+
+    const rows = await askCommand.func(page, {
+      prompt: 'follow up',
+      timeout: 120,
+      new: false,
+      model: 'instant',
+      think: false,
+      search: false,
+    });
+
+    expect(rows).toEqual([{ response: 'follow-up reply' }]);
+    expect(mockSelectModel).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalled();
+  });
+
+  it('skips model selection when already inside an existing conversation', async () => {
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/a/chat/s/abc-123');
+
+    const rows = await askCommand.func(page, {
+      prompt: 'continue',
+      timeout: 120,
+      new: false,
+      model: 'expert',
+      think: false,
+      search: false,
+    });
+
+    expect(rows).toEqual([{ response: 'follow-up reply' }]);
+    expect(mockSelectModel).not.toHaveBeenCalled();
+  });
+
+  it('still selects model when no conversation to resume', async () => {
+    mockEnsureOnDeepSeek.mockResolvedValue(true);
+    mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
+    // first evaluate: sidebar resume click (no link found)
+    page.evaluate.mockResolvedValueOnce(undefined);
+    // second evaluate: URL check (still on root page)
+    page.evaluate.mockResolvedValueOnce('https://chat.deepseek.com/');
+
+    const rows = await askCommand.func(page, {
+      prompt: 'hello',
+      timeout: 120,
+      new: false,
+      model: 'instant',
+      think: false,
+      search: false,
+    });
+
+    expect(rows).toEqual([{ response: 'follow-up reply' }]);
+    expect(mockSelectModel).toHaveBeenCalled();
   });
 });

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -15,10 +15,10 @@ export async function isOnDeepSeek(page) {
 }
 
 export async function ensureOnDeepSeek(page) {
-    if (!(await isOnDeepSeek(page))) {
-        await page.goto(DEEPSEEK_URL);
-        await page.wait(3);
-    }
+    if (await isOnDeepSeek(page)) return false;
+    await page.goto(DEEPSEEK_URL);
+    await page.wait(3);
+    return true;
 }
 
 export async function getPageState(page) {
@@ -252,8 +252,7 @@ export async function getConversationList(page) {
             const items = [];
             const links = document.querySelectorAll('a[href*="/a/chat/s/"]');
             links.forEach((link, i) => {
-                const titleEl = link.querySelector('div');
-                const title = titleEl ? titleEl.textContent.trim() : '';
+                const title = (link.innerText || '').trim().split('\\n')[0].trim();
                 const href = link.getAttribute('href') || '';
                 const idMatch = href.match(/\\/s\\/([a-f0-9-]+)/);
                 items.push({

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -70,6 +70,21 @@ describe('commanderAdapter arg passing', () => {
     expect(kwargs['prepare-only']).toBe(true);
   });
 
+  it('passes option value sources through for adapters that need explicit-vs-default semantics', async () => {
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'submit', './paper.pdf', '--prepare-only']);
+
+    expect(mockExecuteCommand).toHaveBeenCalled();
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(kwargs.__opencliOptionSources).toMatchObject({
+      'dry-run': 'default',
+      'prepare-only': 'cli',
+    });
+  });
+
   it('rejects invalid bool values before calling executeCommand', async () => {
     const program = new Command();
     const siteCmd = program.command('paperreview');

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -80,7 +80,6 @@ describe('commanderAdapter arg passing', () => {
     expect(mockExecuteCommand).toHaveBeenCalled();
     const kwargs = mockExecuteCommand.mock.calls[0][1];
     expect(kwargs.__opencliOptionSources).toMatchObject({
-      'dry-run': 'default',
       'prepare-only': 'cli',
     });
   });

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -74,6 +74,14 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         const v = optionsRecord[arg.name] ?? optionsRecord[camelName];
         if (v !== undefined) rawKwargs[arg.name] = v;
       }
+      const optionSources: Record<string, string> = {};
+      for (const arg of cmd.args) {
+        if (arg.positional) continue;
+        const camelName = arg.name.replace(/-([a-z])/g, (_m, ch: string) => ch.toUpperCase());
+        const source = subCmd.getOptionValueSource(camelName) ?? subCmd.getOptionValueSource(arg.name);
+        if (source) optionSources[arg.name] = source;
+      }
+      rawKwargs.__opencliOptionSources = optionSources;
       const kwargs = prepareCommandArgs(cmd, rawKwargs);
 
       const verbose = optionsRecord.verbose === true;

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -79,9 +79,11 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         if (arg.positional) continue;
         const camelName = arg.name.replace(/-([a-z])/g, (_m, ch: string) => ch.toUpperCase());
         const source = subCmd.getOptionValueSource(camelName) ?? subCmd.getOptionValueSource(arg.name);
-        if (source) optionSources[arg.name] = source;
+        if (source === 'cli') optionSources[arg.name] = source;
       }
-      rawKwargs.__opencliOptionSources = optionSources;
+      if (Object.keys(optionSources).length > 0) {
+        rawKwargs.__opencliOptionSources = optionSources;
+      }
       const kwargs = prepareCommandArgs(cmd, rawKwargs);
 
       const verbose = optionsRecord.verbose === true;


### PR DESCRIPTION
## Description

Fixes two bugs reported in #1149:

1. **`history` shows all titles as `(untitled)`**: DeepSeek changed their sidebar DOM. The first child `<div>` inside each conversation link is now an empty `<div class="ds-focus-ring">`, so `link.querySelector('div').textContent` always returns `''`. Switched to `link.innerText` which correctly returns the title text.

2. **`ask` creates a new conversation every time**: When the workspace is recycled after idle timeout (30s for site workspaces), `ensureOnDeepSeek` navigates to the root URL which is always a blank new-chat page. Now when `--new` is false (default) and navigation was required, the adapter clicks the most recent sidebar conversation link to resume it. Model selection is skipped when inside an existing conversation since the selector is only rendered on the new-chat page.

Fixes #1149

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A (existing adapter bug fix, no new commands or args added)

## Screenshots / Output

**Before (history titles):**
```
- Index: 1
  Title: (untitled)
- Index: 2
  Title: (untitled)
```

**After (history titles):**
```
- Index: 1
  Title: Hello World Python Code
- Index: 2
  Title: Today's date query
```

**Conversation resume test:**
```
$ opencli deepseek ask "say only the word banana" --new
- response: banana

# (wait 35s for workspace recycling)

$ opencli deepseek ask "what fruit did I just mention?"
- response: banana
```