### PR TITLE
fix(amazon): fall back discussion to product page

### DIFF
--- a/clis/amazon/discussion.js
+++ b/clis/amazon/discussion.js
@@ -34,11 +34,8 @@ function hasDiscussionSummary(payload) {
 function isSignInState(state) {
     const href = cleanText(state.href).toLowerCase();
     const title = cleanText(state.title).toLowerCase();
-    const bodyText = cleanText(state.body_text).toLowerCase();
     return href.includes('/ap/signin')
-        || title.includes('amazon sign-in')
-        || bodyText.includes('sign in')
-        || bodyText.includes('create account');
+        || title.includes('amazon sign-in');
 }
 async function readCurrentDiscussionPayload(page, limit) {
     return await page.evaluate(`

--- a/clis/amazon/discussion.js
+++ b/clis/amazon/discussion.js
@@ -1,6 +1,6 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { buildDiscussionUrl, buildProvenance, cleanText, extractAsin, normalizeProductUrl, parseRatingValue, parseReviewCount, trimRatingPrefix, uniqueNonEmpty, assertUsableState, gotoAndReadState, } from './shared.js';
+import { buildProductUrl, buildDiscussionUrl, buildProvenance, cleanText, extractAsin, normalizeProductUrl, parseRatingValue, parseReviewCount, trimRatingPrefix, uniqueNonEmpty, assertUsableState, gotoAndReadState, } from './shared.js';
 function normalizeDiscussionPayload(payload) {
     const sourceUrl = cleanText(payload.href) || buildDiscussionUrl(payload.href ?? '');
     const asin = extractAsin(payload.href ?? '') ?? null;
@@ -28,10 +28,19 @@ function normalizeDiscussionPayload(payload) {
         })),
     };
 }
-async function readDiscussionPayload(page, input, limit) {
-    const url = buildDiscussionUrl(input);
-    const state = await gotoAndReadState(page, url, 2500, 'discussion');
-    assertUsableState(state, 'discussion');
+function hasDiscussionSummary(payload) {
+    return Boolean(cleanText(payload.average_rating_text) || cleanText(payload.total_review_count_text));
+}
+function isSignInState(state) {
+    const href = cleanText(state.href).toLowerCase();
+    const title = cleanText(state.title).toLowerCase();
+    const bodyText = cleanText(state.body_text).toLowerCase();
+    return href.includes('/ap/signin')
+        || title.includes('amazon sign-in')
+        || bodyText.includes('sign in')
+        || bodyText.includes('create account');
+}
+async function readCurrentDiscussionPayload(page, limit) {
     return await page.evaluate(`
     (() => ({
       href: window.location.href,
@@ -52,6 +61,29 @@ async function readDiscussionPayload(page, input, limit) {
       })),
     }))()
   `);
+}
+async function readDiscussionPayload(page, input, limit) {
+    const reviewUrl = buildDiscussionUrl(input);
+    const reviewState = await gotoAndReadState(page, reviewUrl, 2500, 'discussion');
+    assertUsableState(reviewState, 'discussion');
+    const reviewPayload = await readCurrentDiscussionPayload(page, limit);
+    if (hasDiscussionSummary(reviewPayload)) {
+        return reviewPayload;
+    }
+    const productUrl = buildProductUrl(input);
+    const productState = await gotoAndReadState(page, productUrl, 2500, 'discussion');
+    assertUsableState(productState, 'discussion');
+    if (isSignInState(reviewState) && isSignInState(productState)) {
+        throw new AuthRequiredError('amazon.com', 'Amazon review discussion requires an active signed-in Amazon session in the shared Chrome profile.');
+    }
+    const productPayload = await readCurrentDiscussionPayload(page, limit);
+    if (hasDiscussionSummary(productPayload)) {
+        return productPayload;
+    }
+    if (isSignInState(reviewState)) {
+        throw new CommandExecutionError('amazon review page redirected to sign-in and product page fallback did not expose review summary', 'Open the product page in Chrome, verify reviews are visible, and retry.');
+    }
+    return reviewPayload;
 }
 cli({
     site: 'amazon',
@@ -88,4 +120,6 @@ cli({
 });
 export const __test__ = {
     normalizeDiscussionPayload,
+    hasDiscussionSummary,
+    isSignInState,
 };

--- a/clis/amazon/discussion.test.js
+++ b/clis/amazon/discussion.test.js
@@ -1,36 +1,143 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './discussion.js';
+import './discussion.js';
+
+function createPageMock(evaluateResults) {
+  const evaluate = vi.fn();
+  for (const result of evaluateResults) {
+    evaluate.mockResolvedValueOnce(result);
+  }
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate,
+    snapshot: vi.fn().mockResolvedValue(undefined),
+    click: vi.fn().mockResolvedValue(undefined),
+    typeText: vi.fn().mockResolvedValue(undefined),
+    pressKey: vi.fn().mockResolvedValue(undefined),
+    scrollTo: vi.fn().mockResolvedValue(undefined),
+    getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
+    tabs: vi.fn().mockResolvedValue([]),
+    selectTab: vi.fn().mockResolvedValue(undefined),
+    networkRequests: vi.fn().mockResolvedValue([]),
+    consoleMessages: vi.fn().mockResolvedValue([]),
+    scroll: vi.fn().mockResolvedValue(undefined),
+    autoScroll: vi.fn().mockResolvedValue(undefined),
+    installInterceptor: vi.fn().mockResolvedValue(undefined),
+    getInterceptedRequests: vi.fn().mockResolvedValue([]),
+    getCookies: vi.fn().mockResolvedValue([]),
+    screenshot: vi.fn().mockResolvedValue(''),
+    waitForCapture: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe('amazon discussion normalization', () => {
-    it('normalizes review summary and sample reviews', () => {
-        const result = __test__.normalizeDiscussionPayload({
-            href: 'https://www.amazon.com/product-reviews/B0FJS72893',
-            average_rating_text: '3.9 out of 5',
-            total_review_count_text: '27 global ratings',
-            qa_links: [],
-            review_samples: [
-                {
-                    title: '5.0 out of 5 stars Great value and quality',
-                    rating_text: '5.0 out of 5 stars',
-                    author: 'GTreader2',
-                    date_text: 'Reviewed in the United States on February 21, 2026',
-                    body: 'Small but mighty.',
-                    verified: true,
-                },
-            ],
-        });
-        expect(result.asin).toBe('B0FJS72893');
-        expect(result.average_rating_value).toBe(3.9);
-        expect(result.total_review_count).toBe(27);
-        expect(result.review_samples).toEqual([
-            {
-                title: 'Great value and quality',
-                rating_text: '5.0 out of 5 stars',
-                rating_value: 5,
-                author: 'GTreader2',
-                date_text: 'Reviewed in the United States on February 21, 2026',
-                body: 'Small but mighty.',
-                verified_purchase: true,
-            },
-        ]);
+  it('normalizes review summary and sample reviews', () => {
+    const result = __test__.normalizeDiscussionPayload({
+      href: 'https://www.amazon.com/product-reviews/B0FJS72893',
+      average_rating_text: '3.9 out of 5',
+      total_review_count_text: '27 global ratings',
+      qa_links: [],
+      review_samples: [
+        {
+          title: '5.0 out of 5 stars Great value and quality',
+          rating_text: '5.0 out of 5 stars',
+          author: 'GTreader2',
+          date_text: 'Reviewed in the United States on February 21, 2026',
+          body: 'Small but mighty.',
+          verified: true,
+        },
+      ],
     });
+
+    expect(result.asin).toBe('B0FJS72893');
+    expect(result.average_rating_value).toBe(3.9);
+    expect(result.total_review_count).toBe(27);
+    expect(result.review_samples).toEqual([
+      {
+        title: 'Great value and quality',
+        rating_text: '5.0 out of 5 stars',
+        rating_value: 5,
+        author: 'GTreader2',
+        date_text: 'Reviewed in the United States on February 21, 2026',
+        body: 'Small but mighty.',
+        verified_purchase: true,
+      },
+    ]);
+  });
+
+  it('falls back to the product page when the review page redirects to sign-in', async () => {
+    const command = getRegistry().get('amazon/discussion');
+    const page = createPageMock([
+      {
+        href: 'https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fproduct-reviews%2FB09HKN2ZRT',
+        title: 'Amazon Sign-In',
+        body_text: 'Sign in Create account',
+      },
+      {
+        href: 'https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fproduct-reviews%2FB09HKN2ZRT',
+        average_rating_text: '',
+        total_review_count_text: '',
+        review_samples: [],
+      },
+      {
+        href: 'https://www.amazon.com/dp/B09HKN2ZRT',
+        title: 'Amazon.com: Example product',
+        body_text: 'Hello, zejia-wu Reviews',
+      },
+      {
+        href: 'https://www.amazon.com/dp/B09HKN2ZRT',
+        average_rating_text: '4.4 out of 5',
+        total_review_count_text: '349 global ratings',
+        review_samples: [
+          {
+            title: '5.0 out of 5 stars Perfect for the office',
+            rating_text: '5.0 out of 5 stars',
+            author: 'Ken',
+            date_text: 'Reviewed in the United States on March 19, 2026',
+            body: 'Good for the office, no complaints.',
+            verified: true,
+          },
+        ],
+      },
+    ]);
+
+    const result = await command.func(page, { input: 'B09HKN2ZRT', limit: 1 });
+
+    expect(page.goto.mock.calls.map((call) => call[0])).toEqual([
+      'https://www.amazon.com/product-reviews/B09HKN2ZRT',
+      'https://www.amazon.com/dp/B09HKN2ZRT',
+    ]);
+    expect(result).toEqual([
+      expect.objectContaining({
+        asin: 'B09HKN2ZRT',
+        discussion_url: 'https://www.amazon.com/dp/B09HKN2ZRT',
+        average_rating_value: 4.4,
+        total_review_count: 349,
+      }),
+    ]);
+  });
+
+  it('throws AuthRequiredError when both review and product pages are gated', async () => {
+    const command = getRegistry().get('amazon/discussion');
+    const authState = {
+      href: 'https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fproduct-reviews%2FB09HKN2ZRT',
+      title: 'Amazon Sign-In',
+      body_text: 'Sign in Create account',
+    };
+    const page = createPageMock([
+      authState,
+      {
+        href: authState.href,
+        average_rating_text: '',
+        total_review_count_text: '',
+        review_samples: [],
+      },
+      authState,
+    ]);
+
+    await expect(command.func(page, { input: 'B09HKN2ZRT', limit: 1 })).rejects.toBeInstanceOf(AuthRequiredError);
+  });
 });

--- a/clis/amazon/discussion.test.js
+++ b/clis/amazon/discussion.test.js
@@ -140,4 +140,12 @@ describe('amazon discussion normalization', () => {
 
     await expect(command.func(page, { input: 'B09HKN2ZRT', limit: 1 })).rejects.toBeInstanceOf(AuthRequiredError);
   });
+
+  it('does not treat a public product page with sign-in copy as a gated page', () => {
+    expect(__test__.isSignInState({
+      href: 'https://www.amazon.com/dp/B09HKN2ZRT',
+      title: 'Amazon.com: Example product',
+      body_text: 'Hello, sign in Account & Lists Create account',
+    })).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- fall back from the review discussion page to the product page when Amazon redirects the review page to sign-in
- keep the auth-required error when both the review page and the product page are gated
- add regression coverage for the fallback and gated flows

## Verification
- pnpm run build
- source-level amazon discussion fallback regression