### PR TITLE
fix(sinafinance): match stock symbol in addition to name

### DIFF
--- a/clis/sinafinance/stock.js
+++ b/clis/sinafinance/stock.js
@@ -79,12 +79,15 @@ cli({
         if (!entries.length) {
             throw new CliError('NOT_FOUND', `No stock found for "${key}"`, 'Try a different name, code, or --market');
         }
-        // Pick best match: score by name similarity, tiebreak by market priority
+        // Pick best match: score by name/symbol similarity, tiebreak by market priority
         const needle = key.toLowerCase();
         const score = (e) => {
             const n = e.name.toLowerCase();
-            if (n === needle)
+            const s = e.symbol.toLowerCase();
+            if (s === needle || n === needle)
                 return 1;
+            if (s.includes(needle))
+                return needle.length / s.length;
             if (n.includes(needle))
                 return needle.length / n.length;
             return 0;

--- a/clis/sinafinance/stock.test.js
+++ b/clis/sinafinance/stock.test.js
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './stock.js';
+
+function textResponse(body) {
+    return {
+        ok: true,
+        arrayBuffer: async () => Buffer.from(body, 'utf8'),
+    };
+}
+
+describe('sinafinance stock command', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.stubGlobal('TextDecoder', class {
+            decode(buf) {
+                return Buffer.from(buf).toString('utf8');
+            }
+        });
+    });
+
+    it('prefers exact symbol match over partial symbol and name misses', async () => {
+        const cmd = getRegistry().get('sinafinance/stock');
+        expect(cmd?.func).toBeTypeOf('function');
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(textResponse('var suggestvalue="x,41,,AAPL,苹果;x,41,,AAPLU,Apple Units";'))
+            .mockResolvedValueOnce(textResponse('var hq_str_gb_AAPL="Apple Inc,189.98,1.23,0,1.56,0,188.50,180.00,195.00,175.00,1200000,0,3000000000000";'));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await cmd.func(null, { key: 'AAPL', market: 'auto' });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://suggest3.sinajs.cn/suggest/type=11,31,41&key=AAPL', expect.any(Object));
+        expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://hq.sinajs.cn/list=gb_AAPL', expect.any(Object));
+        expect(result[0]).toMatchObject({
+            Symbol: 'AAPL',
+            Name: 'Apple Inc',
+            Price: '189.98',
+        });
+    });
+
+    it('still matches by display name when the query targets the company name', async () => {
+        const cmd = getRegistry().get('sinafinance/stock');
+        expect(cmd?.func).toBeTypeOf('function');
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(textResponse('var suggestvalue="x,41,,AAPL,苹果;x,41,,AAPLU,Apple Units";'))
+            .mockResolvedValueOnce(textResponse('var hq_str_gb_AAPL="苹果公司,189.98,1.23,0,1.56,0,188.50,180.00,195.00,175.00,1200000,0,3000000000000";'));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await cmd.func(null, { key: '苹果', market: 'auto' });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://hq.sinajs.cn/list=gb_AAPL', expect.any(Object));
+        expect(result[0]).toMatchObject({
+            Symbol: 'AAPL',
+            Name: '苹果公司',
+        });
+    });
+});

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -92,7 +92,7 @@ Run `opencli list` for the live registry.
 | **[barchart](./browser/barchart.md)**             | `quote` `options` `greeks` `flow`                                                                                                              | 🌐 Public    |
 | **[binance](./browser/binance.md)**               | `price` `prices` `ticker` `pairs` `trades` `depth` `asks` `klines` `top` `gainers` `losers`                                                 | 🌐 Public    |
 | **[hf](./browser/hf.md)**                         | `top`                                                                                                                                          | 🌐 Public    |
-| **[sinafinance](./browser/sinafinance.md)**       | `news`                                                                                                                                         | 🌐 Public    |
+| **[sinafinance](./browser/sinafinance.md)**       | `news` `rolling-news` `stock` `stock-rank`                                                                                                     | 🌐 / 🔐      |
 | **[spotify](./browser/spotify.md)**               | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat`                                                      | 🔑 OAuth API |
 | **[stackoverflow](./browser/stackoverflow.md)**   | `hot` `search` `bounties` `unanswered`                                                                                                         | 🌐 Public    |
 | **[wikipedia](./browser/wikipedia.md)**           | `search` `summary` `random` `trending`                                                                                                         | 🌐 Public    |


### PR DESCRIPTION
## Description

The scoring function in `sinafinance stock` only compared user input against the Chinese display name (`p[4]` from suggest API), ignoring the symbol field (`p[3]`). This caused searches by ticker symbol to mismatch when the Chinese name doesn't contain the ticker.

For example, searching "AAPL" scored Apple Inc. at 0 (name="苹果" doesn't contain "aapl") while AAPLU scored 0.8 (name="AAPLU" contains "aapl"), returning wrong data.

The fix adds symbol matching with higher priority than name matching, so exact symbol matches (e.g. "aapl" === "aapl") score 1.0 and partial symbol matches rank above name-only matches.

Fixes #1157

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A

## Screenshots / Output

**Before:**
```
$ opencli sinafinance stock AAPL
- Symbol: AAPLU
  Name: AAPLU
  Price: '0.0000'
```

**After:**
```
$ opencli sinafinance stock AAPL
- Symbol: AAPL
  Name: 苹果
  Price: '273.1700'
  Change: '7.0000'
  ChangePercent: 2.63%
  Open: '273.7400'
  High: '288.3600'
  Low: '192.2100'
  Volume: '43249201'
  MarketCap: 4.01T
```

Other markets verified no regression:
```
$ opencli sinafinance stock 贵州茅台    # A股 OK
$ opencli sinafinance stock 腾讯控股    # 港股 OK
$ opencli sinafinance stock TSLA       # 美股 OK
$ opencli sinafinance stock 比亚迪      # A股 OK
```