### PR TITLE
docs(sinafinance): add missing commands to adapter index

### DIFF
--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -92,7 +92,7 @@ Run `opencli list` for the live registry.
 | **[barchart](./browser/barchart.md)**             | `quote` `options` `greeks` `flow`                                                                                                              | 🌐 Public    |
 | **[binance](./browser/binance.md)**               | `price` `prices` `ticker` `pairs` `trades` `depth` `asks` `klines` `top` `gainers` `losers`                                                 | 🌐 Public    |
 | **[hf](./browser/hf.md)**                         | `top`                                                                                                                                          | 🌐 Public    |
-| **[sinafinance](./browser/sinafinance.md)**       | `news`                                                                                                                                         | 🌐 Public    |
+| **[sinafinance](./browser/sinafinance.md)**       | `news` `rolling-news` `stock` `stock-rank`                                                                                                     | 🌐 / 🔐      |
 | **[spotify](./browser/spotify.md)**               | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat`                                                      | 🔑 OAuth API |
 | **[stackoverflow](./browser/stackoverflow.md)**   | `hot` `search` `bounties` `unanswered`                                                                                                         | 🌐 Public    |
 | **[wikipedia](./browser/wikipedia.md)**           | `search` `summary` `random` `trending`                                                                                                         | 🌐 Public    |


### PR DESCRIPTION
## Description

The adapter index table (`docs/adapters/index.md`) only listed `news` for sinafinance, but the adapter has four commands: `news`, `rolling-news`, `stock`, and `stock-rank`. The individual doc page (`docs/adapters/browser/sinafinance.md`) and sidebar config already document all four commands correctly.

This PR updates the index table to list all four commands and fixes the mode indicator from `Public` to `hybrid` since `rolling-news` and `stock-rank` require a browser.

Fixes #1156

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter) -- already exists
- [x] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter) -- already exists
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed -- no change needed

## Screenshots / Output

**Before (index.md):**
```
| sinafinance | `news` | 🌐 Public |
```

**After (index.md):**
```
| sinafinance | `news` `rolling-news` `stock` `stock-rank` | 🌐 / 🔐 |
```