### PR TITLE
fix(youtube): channel videos-tab fallback reads wrong tab from InnerTube response

### DIFF
--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -3,6 +3,21 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+export function extractSelectedRichGridContents(browseData) {
+    const tabs = browseData?.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
+    const readRichGrid = (tab) => tab?.tabRenderer?.content?.richGridRenderer?.contents;
+    const selectedTab = tabs.find(t => t?.tabRenderer?.selected);
+    const selectedContents = readRichGrid(selectedTab);
+    if (Array.isArray(selectedContents))
+        return selectedContents;
+    const fallbackContents = readRichGrid(tabs.find(t => {
+        const contents = readRichGrid(t);
+        return Array.isArray(contents) && contents.length > 0;
+    })) || readRichGrid(tabs.find(t => Array.isArray(readRichGrid(t))));
+    return Array.isArray(fallbackContents) ? fallbackContents : [];
+}
+
 cli({
     site: 'youtube',
     name: 'channel',
@@ -27,6 +42,7 @@ cli({
         const apiKey = cfg.INNERTUBE_API_KEY;
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return {error: 'YouTube config not found'};
+        const extractSelectedRichGridContents = ${extractSelectedRichGridContents.toString()};
 
         // Resolve handle to browseId if needed
         let browseId = channelId;
@@ -134,11 +150,9 @@ cli({
             if (videosResp.ok) {
               const videosData = await videosResp.json();
               // The InnerTube response includes ALL tabs (Home/Videos/Shorts/...),
-              // not just the requested one. Pick the selected tab — assuming
-              // tabs[0] silently misreads Home (empty) for channels that surface
-              // multiple tabs in the response.
-              const respTabs = videosData.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
-              const richGrid = respTabs.find(t => t.tabRenderer?.selected)?.tabRenderer?.content?.richGridRenderer?.contents || [];
+              // not just the requested one. Prefer the selected tab, but keep
+              // older single-tab responses working when YouTube omits selected.
+              const richGrid = extractSelectedRichGridContents(videosData);
               for (const item of richGrid) {
                 if (recentVideos.length >= limit) break;
                 const v = item.richItemRenderer?.content?.videoRenderer;
@@ -188,3 +202,7 @@ cli({
         return rows;
     },
 });
+
+export const __test__ = {
+    extractSelectedRichGridContents,
+};

--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -133,7 +133,12 @@ cli({
             });
             if (videosResp.ok) {
               const videosData = await videosResp.json();
-              const richGrid = videosData.contents?.twoColumnBrowseResultsRenderer?.tabs?.[0]?.tabRenderer?.content?.richGridRenderer?.contents || [];
+              // The InnerTube response includes ALL tabs (Home/Videos/Shorts/...),
+              // not just the requested one. Pick the selected tab — assuming
+              // tabs[0] silently misreads Home (empty) for channels that surface
+              // multiple tabs in the response.
+              const respTabs = videosData.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
+              const richGrid = respTabs.find(t => t.tabRenderer?.selected)?.tabRenderer?.content?.richGridRenderer?.contents || [];
               for (const item of richGrid) {
                 if (recentVideos.length >= limit) break;
                 const v = item.richItemRenderer?.content?.videoRenderer;

--- a/clis/youtube/channel.test.js
+++ b/clis/youtube/channel.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './channel.js';
+
+function tab(title, contents, selected = false) {
+    return {
+        tabRenderer: {
+            title,
+            selected,
+            content: {
+                richGridRenderer: {
+                    contents,
+                },
+            },
+        },
+    };
+}
+
+function browseData(tabs) {
+    return {
+        contents: {
+            twoColumnBrowseResultsRenderer: {
+                tabs,
+            },
+        },
+    };
+}
+
+describe('youtube channel helpers', () => {
+    it('uses the selected rich-grid tab instead of the first tab', () => {
+        const home = [{ richItemRenderer: { content: { videoRenderer: { videoId: 'home' } } } }];
+        const videos = [{ richItemRenderer: { content: { videoRenderer: { videoId: 'videos' } } } }];
+
+        expect(__test__.extractSelectedRichGridContents(browseData([
+            tab('Home', home),
+            tab('Videos', videos, true),
+        ]))).toBe(videos);
+    });
+
+    it('falls back to the first non-empty rich-grid tab when no tab is selected', () => {
+        const videos = [{ richItemRenderer: { content: { videoRenderer: { videoId: 'only' } } } }];
+
+        expect(__test__.extractSelectedRichGridContents(browseData([
+            tab('Home', []),
+            tab('Videos', videos),
+        ]))).toBe(videos);
+    });
+
+    it('is self-contained for browser evaluate injection', () => {
+        const extractSelectedRichGridContents = Function(
+            `return ${__test__.extractSelectedRichGridContents.toString()}`
+        )();
+        const videos = [{ richItemRenderer: { content: { videoRenderer: { videoId: 'serialized' } } } }];
+
+        expect(extractSelectedRichGridContents(browseData([
+            tab('Home', []),
+            tab('Videos', videos, true),
+        ]))).toEqual(videos);
+    });
+});


### PR DESCRIPTION
## Problem

After #1109 landed, `opencli youtube channel <id>` still returns empty `recent_videos` for channels whose Home tab is empty AND whose InnerTube `/youtubei/v1/browse` response includes multiple tabs.

**Reproducer**: `opencli youtube channel UC44DSuDgw7_qccvZzIK3Jpg` (杀鱼伟-Vi, ~3.1K subs, posts daily). Returns 0 videos despite the channel having 30+ recent uploads visible at https://www.youtube.com/channel/UC44DSuDgw7_qccvZzIK3Jpg/videos.

## Root cause

The Videos-tab fallback fetch sends a browse request with `params: videosTabParams`. The response includes **all** tabs (Home / Videos / Shorts / ...), with only the requested tab marked `selected: true`.

The current code reads `tabs?.[0]?.tabRenderer?.content?.richGridRenderer?.contents`. For multi-tab responses, `tabs[0]` is **Home (empty)**, so `richGrid` is `[]` and `recentVideos` stays empty.

PR #1109's test channels happened to return single-tab lists with Videos at index 0, which masked the bug.

Concrete shape on the reproducer channel:

```js
respTabs = [
  { tabRenderer: { title: 'Home',   selected: false, ...content: {} } },     // ← tabs[0]
  { tabRenderer: { title: 'Videos', selected: true,  ...content: { richGridRenderer: {contents: [...31 items]} } } },
  { tabRenderer: { title: 'Shorts', selected: false, ...content: {} } },
  { tabRenderer: { title: null,     selected: false, ...content: {} } },
]
```

## Fix

Find the tab with `selected: true` instead of assuming `tabs[0]`.

## Verification

```
$ opencli youtube channel UC44DSuDgw7_qccvZzIK3Jpg --limit 30 -f json
# Before: returns metadata only, 0 videos
# After:  returns 30 videos
```

`npm run typecheck` clean. `npm test` passes (1952 / 1952).

🤖 Generated with [Claude Code](https://claude.com/claude-code)