### PR TITLE
feat(youtube): add --type shorts to channel command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19636,6 +19636,13 @@
         "default": 10,
         "required": false,
         "help": "Max recent videos (max 30)"
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "Tab to read: '' (default — Home tab + Videos fallback) or 'shorts' (Shorts tab)"
       }
     ],
     "columns": [

--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -12,17 +12,20 @@ cli({
     args: [
         { name: 'id', required: true, positional: true, help: 'Channel ID (UCxxxx) or handle (@name)' },
         { name: 'limit', type: 'int', default: 10, help: 'Max recent videos (max 30)' },
+        { name: 'type', default: '', help: "Tab to read: '' (default — Home tab + Videos fallback) or 'shorts' (Shorts tab)" },
     ],
     columns: ['field', 'value'],
     func: async (page, kwargs) => {
         const channelId = String(kwargs.id);
         const limit = Math.min(kwargs.limit || 10, 30);
+        const requestedType = String(kwargs.type || '').toLowerCase();
         await page.goto('https://www.youtube.com');
         await page.wait(2);
         const data = await page.evaluate(`
       (async () => {
         const channelId = ${JSON.stringify(channelId)};
         const limit = ${limit};
+        const requestedType = ${JSON.stringify(requestedType)};
         const cfg = window.ytcfg?.data_ || {};
         const apiKey = cfg.INNERTUBE_API_KEY;
         const context = cfg.INNERTUBE_CONTEXT;
@@ -71,10 +74,49 @@ cli({
           subscriberCount = header.subscriberCountText.simpleText;
         }
 
-        // Extract recent videos from Home tab
         const tabs = data.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
-        const homeTab = tabs.find(t => t.tabRenderer?.selected);
         const recentVideos = [];
+
+        // --type shorts: hit the Shorts tab via InnerTube and parse
+        // shortsLockupViewModel items. Returns at most \`limit\` Shorts.
+        if (requestedType === 'shorts') {
+          const shortsTab = tabs.find(t => {
+            const tab = t.tabRenderer;
+            const url = tab?.endpoint?.commandMetadata?.webCommandMetadata?.url || '';
+            return url.endsWith('/shorts') || tab?.title === 'Shorts';
+          });
+          const shortsTabParams = shortsTab?.tabRenderer?.endpoint?.browseEndpoint?.params;
+          if (shortsTabParams) {
+            const shortsResp = await fetch('/youtubei/v1/browse?key=' + apiKey + '&prettyPrint=false', {
+              method: 'POST', credentials: 'include',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({context, browseId, params: shortsTabParams})
+            });
+            if (shortsResp.ok) {
+              const shortsData = await shortsResp.json();
+              const respTabs = shortsData.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
+              const richGrid = respTabs.find(t => t.tabRenderer?.selected)?.tabRenderer?.content?.richGridRenderer?.contents || [];
+              for (const item of richGrid) {
+                if (recentVideos.length >= limit) break;
+                const lockup = item.richItemRenderer?.content?.shortsLockupViewModel;
+                if (!lockup) continue;
+                const videoId = lockup.onTap?.innertubeCommand?.reelWatchEndpoint?.videoId
+                              || (lockup.entityId || '').replace(/^shorts-shelf-item-/, '');
+                if (!videoId) continue;
+                const overlay = lockup.overlayMetadata || {};
+                recentVideos.push({
+                  title: overlay.primaryText?.content || '',
+                  duration: 'SHORT',
+                  views: overlay.secondaryText?.content || '',
+                  url: 'https://www.youtube.com/shorts/' + videoId,
+                });
+              }
+            }
+          }
+        }
+
+        // Extract recent videos from Home tab (default behaviour)
+        const homeTab = (requestedType === 'shorts') ? null : tabs.find(t => t.tabRenderer?.selected);
 
         if (homeTab) {
           const sections = homeTab.tabRenderer?.content?.sectionListRenderer?.contents || [];
@@ -115,8 +157,8 @@ cli({
           }
         }
 
-        // If Home tab has no videos, try Videos tab
-        if (recentVideos.length === 0) {
+        // If Home tab has no videos, try Videos tab (skip when caller asked for shorts)
+        if (recentVideos.length === 0 && requestedType !== 'shorts') {
           const videosTab = tabs.find(t => {
             const tab = t.tabRenderer;
             const url = tab?.endpoint?.commandMetadata?.webCommandMetadata?.url || '';


### PR DESCRIPTION
## Why

\`opencli youtube channel <id>\` only reads the Home tab (with a Videos-tab fallback after #1109). Channels whose primary output lives in the **Shorts** tab return little or nothing — there's no way to opt in to that tab today.

Concrete case: \`UCKz1652QrLR8mj2iF6ybCXg\` (惠姐日常工作HuiJie). The default \`opencli youtube channel\` returns the Home tab's long-form videos; the channel's eight Shorts (visible at /channel/.../shorts) are invisible.

## What

Add \`--type shorts\`. When set, the command:

1. Locates the Shorts tab in the initial channel page response (matched by URL ending in \`/shorts\` or \`title === 'Shorts'\`).
2. Issues a second InnerTube \`/youtubei/v1/browse\` request using the tab's \`browseEndpoint.params\`.
3. Walks \`richGridRenderer.contents\`, picking the tab with \`selected: true\` from the response (the response includes all tabs, only the requested one has content).
4. Parses each \`richItemRenderer.content.shortsLockupViewModel\` for videoId, title, view count, emitting rows shaped like:
   \`\`\`js
   { title, duration: 'SHORT', views, url: 'https://www.youtube.com/shorts/' + videoId }
   \`\`\`

The default behaviour (no \`--type\`) is unchanged — Home tab + Videos fallback. Other \`--type\` values are silently ignored (reserved for future expansion mirroring \`youtube search\`'s API).

## Verification

\`\`\`
$ opencli youtube channel UCKz1652QrLR8mj2iF6ybCXg --type shorts --limit 8
field                                                                value
Test the knife on the spot...                                        SHORT | 978 views    | youtube.com/shorts/s_32fiTS798
The Secrets of a Fish Sashimi Master...                              SHORT | 1K views     | youtube.com/shorts/sh2rE8k0B5A
A letter to my fans #Sashimi...                                      SHORT | 1.8K views   | youtube.com/shorts/wfd2r2oiwBI
这可能是你见过最震撼的起鱼鳞手法...                                      SHORT | 46K views    | youtube.com/shorts/eS0YVZK07uI
百万网红的秘密，杀鱼像雕花一样潇洒...                                    SHORT | 16K views    | youtube.com/shorts/MRRh3dbMmxA
网友的瞪大眼睛说不可能 全网最快的起鱼鳞手法...                              SHORT | 37K views    | youtube.com/shorts/3TR4YCK4FPY
这可能是你见过最惊讶的起鱼鳞手法...                                      SHORT | 2.1M views   | youtube.com/shorts/hH5U0-xwyf8
好大的鱼 这可能是你见过干活最利索的老板娘了...                              SHORT | 61K views    | youtube.com/shorts/0Ts9Pk4E1qM
\`\`\`

\`npm run typecheck\` clean. \`npm test\` passes (1952 / 1952). \`cli-manifest.json\` regenerated via \`npm run build\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)