### PR TITLE
fix(deepseek): fix send button detection and file upload

### DIFF
--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -74,14 +74,18 @@ export async function sendMessage(page, prompt) {
         document.execCommand('insertText', false, ${promptJson});
         await new Promise(r => setTimeout(r, 800));
 
-        const btns = document.querySelectorAll('div[role="button"]');
-        for (const btn of btns) {
-            if (btn.getAttribute('aria-disabled') === 'false') {
-                const svgs = btn.querySelectorAll('svg');
-                if (svgs.length > 0 && btn.closest('div')?.querySelector('textarea')) {
-                    btn.click();
-                    return { ok: true };
-                }
+        // Find the send button: last non-toggle button in the textarea's container
+        var container = box.parentElement;
+        while (container && !container.querySelector('div[role="button"]')) {
+            container = container.parentElement;
+        }
+        if (container) {
+            var btns = container.querySelectorAll('div[role="button"]:not(.ds-toggle-button)');
+            var sendBtn = btns[btns.length - 1];
+            if (sendBtn && sendBtn.getAttribute('aria-disabled') === 'false'
+                && sendBtn.querySelectorAll('svg').length > 0) {
+                sendBtn.click();
+                return { ok: true };
             }
         }
 
@@ -341,7 +345,8 @@ export async function sendWithFile(page, filePath, prompt) {
             }
 
             inp.files = dt.files;
-            inp[propsKey].onChange({ target: { files: dt.files } });
+            // Use inp.files, not dt.files; assignment transfers ownership
+            inp[propsKey].onChange({ target: { files: inp.files } });
             return { ok: true };
         })()`);
         if (fallbackResult && !fallbackResult.ok) return fallbackResult;
@@ -349,6 +354,23 @@ export async function sendWithFile(page, filePath, prompt) {
 
     const ready = await waitForFilePreview(page, fileName);
     if (!ready) return { ok: false, reason: 'file preview did not appear' };
+
+    // File preview appears immediately but send button stays disabled until
+    // the server upload finishes. Wait for it.
+    for (let tick = 0; tick < 15; tick++) {
+        const enabled = await page.evaluate(`(() => {
+            var box = document.querySelector('${TEXTAREA_SELECTOR}');
+            if (!box) return false;
+            var c = box.parentElement;
+            while (c && !c.querySelector('div[role="button"]')) c = c.parentElement;
+            if (!c) return false;
+            var btns = c.querySelectorAll('div[role="button"]:not(.ds-toggle-button)');
+            var last = btns[btns.length - 1];
+            return last && last.getAttribute('aria-disabled') === 'false';
+        })()`);
+        if (enabled) break;
+        await page.wait(1);
+    }
 
     return sendMessage(page, prompt);
 }

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -357,6 +357,7 @@ export async function sendWithFile(page, filePath, prompt) {
 
     // File preview appears immediately but send button stays disabled until
     // the server upload finishes. Wait for it.
+    let sendEnabled = false;
     for (let tick = 0; tick < 15; tick++) {
         const enabled = await page.evaluate(`(() => {
             var box = document.querySelector('${TEXTAREA_SELECTOR}');
@@ -366,10 +367,16 @@ export async function sendWithFile(page, filePath, prompt) {
             if (!c) return false;
             var btns = c.querySelectorAll('div[role="button"]:not(.ds-toggle-button)');
             var last = btns[btns.length - 1];
-            return last && last.getAttribute('aria-disabled') === 'false';
+            return !!(last && last.getAttribute('aria-disabled') === 'false');
         })()`);
-        if (enabled) break;
+        if (enabled) {
+            sendEnabled = true;
+            break;
+        }
         await page.wait(1);
+    }
+    if (!sendEnabled) {
+        return { ok: false, reason: 'send button did not enable after upload' };
     }
 
     return sendMessage(page, prompt);

--- a/clis/deepseek/utils.test.js
+++ b/clis/deepseek/utils.test.js
@@ -107,9 +107,10 @@ describe('deepseek sendWithFile', () => {
       setFileInput: vi.fn().mockResolvedValue(undefined),
       wait: vi.fn().mockResolvedValue(undefined),
       evaluate: vi.fn()
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce({ ok: true }),
+        .mockResolvedValueOnce(undefined)    // sidebar collapse
+        .mockResolvedValueOnce(true)         // waitForFilePreview
+        .mockResolvedValueOnce(true)         // send button enabled check
+        .mockResolvedValueOnce({ ok: true }), // sendMessage
     };
 
     const result = await sendWithFile(page, filePath, 'summarize this');

--- a/clis/deepseek/utils.test.js
+++ b/clis/deepseek/utils.test.js
@@ -115,8 +115,28 @@ describe('deepseek sendWithFile', () => {
 
     const result = await sendWithFile(page, filePath, 'summarize this');
 
-    expect(result).toEqual({ ok: true });
-    expect(page.setFileInput).toHaveBeenCalledWith([filePath], 'input[type="file"]');
+    expect(result).toEqual({ ok: true });    expect(page.setFileInput).toHaveBeenCalledWith([filePath], 'input[type="file"]');
+  });
+
+  it('fails closed when upload preview appears but send button never enables', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-deepseek-'));
+    tempDirs.push(dir);
+    const filePath = path.join(dir, 'report.txt');
+    fs.writeFileSync(filePath, 'hello');
+
+    const page = {
+      setFileInput: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce(undefined) // sidebar collapse
+        .mockResolvedValueOnce(true)      // waitForFilePreview
+        .mockResolvedValue(false),        // send button never enables
+    };
+
+    const result = await sendWithFile(page, filePath, 'summarize this');
+
+    expect(result).toEqual({ ok: false, reason: 'send button did not enable after upload' });
+    expect(page.evaluate).toHaveBeenCalledTimes(17);
   });
 });
 


### PR DESCRIPTION
## Description

Three bugs in `sendMessage` and `sendWithFile` that caused `--file` upload to silently fail:

**1. sendMessage button detection always failed.** The selector `btn.closest('div')?.querySelector('textarea')` always returned null because the button itself is a `<div>`, so `closest('div')` returns the button, which has no textarea inside. This caused every send to use the Enter key fallback, and when the send button was disabled (during file upload), it would click the attachment button instead.

Fix: walk up from the textarea to find the input container, then click only the last non-toggle button (the actual send button).

**2. sendWithFile sent the message before the file upload finished.** DeepSeek shows the file preview chip immediately (optimistic UI), but the send button stays `aria-disabled="true"` until the PoW challenge + server upload completes (~2s). The old code sent the message as soon as the preview appeared, before the upload was done.

Fix: after `waitForFilePreview`, poll until the send button becomes enabled (up to 15s).

**3. DataTransfer ownership bug.** `inp.files = dt.files` transfers the FileList and empties `dt.files`. The old code then passed the now-empty `dt.files` to React's onChange.

Fix: pass `inp.files` instead of `dt.files` to onChange.

Fixes #1167

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A

## Screenshots / Output

**File upload now works:**
```
$ echo "The answer is 42." > /tmp/test.txt
$ opencli deepseek ask "what number is in this file" --new --file /tmp/test.txt
- response: The number in the file is 42.
```

All commands tested:
```
ask (instant)      OK
ask --think        OK
ask --model expert OK
ask --file         OK
ask --search       OK
history            OK
status             OK
new                OK
read               OK
```