### PR TITLE
fix: separate author name from date text in search results

### DIFF
--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -47,6 +47,11 @@ export function noteIdToDate(url) {
     // Offset by UTC+8 (China Standard Time) so the date matches what XHS users see
     return new Date((ts + 8 * 3600) * 1000).toISOString().slice(0, 10);
 }
+export function stripXhsAuthorDateSuffix(value) {
+    const text = (value || '').replace(/\s+/g, ' ').trim();
+    const stripped = text.replace(/\s*(?:\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2})$/u, '').trim();
+    return stripped || text;
+}
 cli({
     site: 'xiaohongshu',
     name: 'search',
@@ -81,6 +86,7 @@ cli({
         };
 
         const cleanText = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+        const stripXhsAuthorDateSuffix = ${stripXhsAuthorDateSuffix.toString()};
 
         const results = [];
         const seen = new Set();
@@ -95,7 +101,7 @@ cli({
           let author = cleanText(nameEl?.textContent || '');
           if (!author && authorWrapEl) {
             const nameChild = authorWrapEl.querySelector('.name');
-            author = nameChild ? cleanText(nameChild.textContent || '') : cleanText(authorWrapEl.textContent || '').replace(/\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2}$/g, '').trim();
+            author = nameChild ? cleanText(nameChild.textContent || '') : stripXhsAuthorDateSuffix(authorWrapEl.textContent || '');
           }
           const likesEl = el.querySelector('.count, .like-count, .like-wrapper .count');
           // Prefer search_result link (preserves xsec_token) over generic /explore/ link
@@ -136,3 +142,6 @@ cli({
         }));
     },
 });
+export const __test__ = {
+    stripXhsAuthorDateSuffix,
+};

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -90,7 +90,13 @@ cli({
           if (el.classList.contains('query-note-item')) return;
 
           const titleEl = el.querySelector('.title, .note-title, a.title, .footer .title span');
-          const nameEl = el.querySelector('a.author .name, .name, .author-name, .nick-name, a.author');
+          const nameEl = el.querySelector('a.author .name, .author-name, .nick-name, .name');
+          const authorWrapEl = el.querySelector('a.author');
+          let author = cleanText(nameEl?.textContent || '');
+          if (!author && authorWrapEl) {
+            const nameChild = authorWrapEl.querySelector('.name');
+            author = nameChild ? cleanText(nameChild.textContent || '') : cleanText(authorWrapEl.textContent || '').replace(/\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2}$/g, '').trim();
+          }
           const likesEl = el.querySelector('.count, .like-count, .like-wrapper .count');
           // Prefer search_result link (preserves xsec_token) over generic /explore/ link
           const detailLinkEl =
@@ -109,7 +115,7 @@ cli({
 
           results.push({
             title: cleanText(titleEl?.textContent || ''),
-            author: cleanText(nameEl?.textContent || ''),
+            author,
             likes: cleanText(likesEl?.textContent || '0'),
             url,
             author_url: normalizeUrl(authorLinkEl?.getAttribute('href') || ''),

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { noteIdToDate } from './search.js';
+import { JSDOM } from 'jsdom';
+import { __test__, noteIdToDate } from './search.js';
 function createPageMock(evaluateResults) {
     const evaluate = vi.fn();
     for (const result of evaluateResults) {
@@ -126,6 +127,41 @@ describe('xiaohongshu search', () => {
         expect(page.goto).toHaveBeenCalledTimes(1);
         // Two evaluate calls: wait + extraction
         expect(page.evaluate).toHaveBeenCalledTimes(2);
+    });
+    it('separates fallback author text from appended relative date', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        expect(cmd?.func).toBeTypeOf('function');
+        const dom = new JSDOM(`
+          <section class="note-item">
+            <a class="cover mask" href="/search_result/68e90be80000000004022e66?xsec_token=test-token"></a>
+            <div class="title">数字作者测试</div>
+            <a class="author" href="/user/profile/author123">
+              <span>数字3天前端</span><span>3天前</span>
+            </a>
+            <span class="count">8</span>
+          </section>
+        `, { url: 'https://www.xiaohongshu.com/search_result?keyword=test' });
+        const page = createPageMock([]);
+        page.evaluate.mockImplementationOnce(async () => 'content');
+        page.evaluate.mockImplementationOnce(async (script) => Function('document', `return (${script})`)(dom.window.document));
+
+        const result = await cmd.func(page, { query: '测试', limit: 1 });
+
+        expect(result[0]).toMatchObject({
+            title: '数字作者测试',
+            author: '数字3天前端',
+            likes: '8',
+            author_url: 'https://www.xiaohongshu.com/user/profile/author123',
+        });
+    });
+});
+describe('stripXhsAuthorDateSuffix', () => {
+    it('only strips trailing date suffixes and preserves date-like author text', () => {
+        expect(__test__.stripXhsAuthorDateSuffix('作者名 3天前')).toBe('作者名');
+        expect(__test__.stripXhsAuthorDateSuffix('作者名2026-04-01')).toBe('作者名');
+        expect(__test__.stripXhsAuthorDateSuffix('3天前端工程师')).toBe('3天前端工程师');
+        expect(__test__.stripXhsAuthorDateSuffix('刚刚好')).toBe('刚刚好');
+        expect(__test__.stripXhsAuthorDateSuffix('刚刚')).toBe('刚刚');
     });
 });
 describe('noteIdToDate (ObjectID timestamp parsing)', () => {


### PR DESCRIPTION
## Description
The xiaohongshu search command returns author names concatenated with relative date text (e.g. Albert Zhang4天前 , 香煎小鸿猪🐷04-18 ) because the CSS selector a.author .name, .name, .author-name, .nick-name, a.author includes a.author as a fallback. Since querySelector returns the first match in document order and a.author (the parent element) appears before div.name (the child), the parent's textContent — which includes both the author name and the date — is used.

The XHS DOM structure for each search result's author block is:

```
<a class="author">
  <img class="author-avatar">
  <div class="name-time-wrapper">
    <div class="name">栗氪聊AI</div>
    <div class="time">1天前</div>
  </div>
</a>
```
This PR makes the following changes:

- Remove a.author from the primary selector list so querySelector no longer matches the parent element that contains both name and date text.
- Add a two-step fallback when the primary selector returns no match:
  1. Look for a .name child inside a.author and use its text content.
  2. If no .name child exists, strip common Chinese relative date suffixes (e.g. X天前 , X小时前 , MM-DD , YYYY-MM-DD ) from the parent's text content using a regex.
- Use the resolved author variable directly in the result object instead of re-reading nameEl.textContent .
Related issue: N/A

## Type of Change
- 🐛 Bug fix

## Checklist
- I ran the checks relevant to this PR
- I updated tests or docs if needed
- I included output or screenshots when useful

## Documentation (if adding/modifying an adapter)
- Added doc page under docs/adapters/ (if new adapter) — existing adapter, no new doc page needed
- Updated docs/adapters/index.md table (if new adapter) — no command discoverability change
- Updated sidebar in docs/.vitepress/config.mts (if new adapter) — no command discoverability change
- Updated README.md / README.zh-CN.md when command discoverability changed — no command discoverability change
- Used positional args for the command's primary subject unless a named flag is clearly better
- Normalized expected adapter failures to CliError subclasses instead of raw Error
## Screenshots / Output
Targeted tests:

Before fix:

```
- rank: 1
  author: Albert Zhang4天前
  title: Claude Design 又来抢设计师的饭碗了！
  published_at: '2026-04-21'
- rank: 2
  author: 凯莉彭3天前
  title: 实测Claude Design，设计门槛真的没
  了？
  published_at: '2026-04-22'
- rank: 3
  author: 香煎小鸿猪🐷04-18
  title: Claude Design真的颠覆设计行业了吗
  published_at: '2026-04-18'
```
After fix:

```
- rank: 1
  author: Albert Zhang
  title: Claude Design 又来抢设计师的饭碗了！
  published_at: '2026-04-21'
- rank: 2
  author: 凯莉彭
  title: 实测Claude Design，设计门槛真的没
  了？
  published_at: '2026-04-22'
- rank: 3
  author: 香煎小鸿猪🐷
  title: Claude Design真的颠覆设计行业了吗
  published_at: '2026-04-18'
```