### PR TITLE
fix(toutiao): fix NON_TITLE_LINES scope error in articles parser

### DIFF
--- a/clis/toutiao/articles.js
+++ b/clis/toutiao/articles.js
@@ -1,12 +1,11 @@
 import { cli } from '@jackwener/opencli/registry';
 
-const NON_TITLE_LINES = new Set([
-    '展现', '阅读', '点赞', '评论',
-    '查看数据', '查看评论', '修改', '更多', '首发',
-    '已发布', '定时发布', '定时发布中', '由文章生成', '审核中',
-]);
-
 export function parseToutiaoArticlesText(text) {
+    const NON_TITLE_LINES = new Set([
+        '展现', '阅读', '点赞', '评论',
+        '查看数据', '查看评论', '修改', '更多', '首发',
+        '已发布', '定时发布', '定时发布中', '由文章生成', '审核中',
+    ]);
     const lines = String(text || '').split('\n').map((line) => line.trim()).filter(Boolean);
     const results = [];
 

--- a/clis/toutiao/articles.test.js
+++ b/clis/toutiao/articles.test.js
@@ -2,22 +2,29 @@ import { describe, expect, it } from 'vitest';
 import { __test__ } from './articles.js';
 
 describe('toutiao articles parser', () => {
-    it('keeps short chinese titles instead of silently dropping the row', () => {
-        const text = [
-            '短标题',
-            '04-20 20:30',
-            '已发布',
-            '展现 8 阅读 0 点赞 0 评论 0',
-        ].join('\n');
+    const articleText = [
+        '短标题',
+        '04-20 20:30',
+        '已发布',
+        '展现 8 阅读 0 点赞 0 评论 0',
+    ].join('\n');
+    const parsedArticle = {
+        title: '短标题',
+        date: '04-20 20:30',
+        status: '已发布',
+        '展现': '8',
+        '阅读': '0',
+        '点赞': '0',
+        '评论': '0',
+    };
 
-        expect(__test__.parseToutiaoArticlesText(text)).toEqual([{
-            title: '短标题',
-            date: '04-20 20:30',
-            status: '已发布',
-            '展现': '8',
-            '阅读': '0',
-            '点赞': '0',
-            '评论': '0',
-        }]);
+    it('keeps short chinese titles instead of silently dropping the row', () => {
+        expect(__test__.parseToutiaoArticlesText(articleText)).toEqual([parsedArticle]);
+    });
+
+    it('keeps parsing when serialized into the browser evaluate context', () => {
+        const parse = Function(`return (${__test__.parseToutiaoArticlesText.toString()})`)();
+
+        expect(parse(articleText)).toEqual([parsedArticle]);
     });
 });


### PR DESCRIPTION
## Bug Description

When running `opencli toutiao articles`, the command fails with:

```
ReferenceError: NON_TITLE_LINES is not defined
    at parseToutiaoArticlesText (<anonymous>:19:70)
```

## Root Cause

`NON_TITLE_LINES` is defined as a module-level `const` **outside** `parseToutiaoArticlesText()`. The function is serialized via `.toString()` and injected into the browser's `evaluate` context for DOM parsing. Outer scope variables are not available in the injected execution context, causing the ReferenceError.

## Fix

Move `NON_TITLE_LINES` inside the `parseToutiaoArticlesText` function so it's included in the serialized string.

```diff
-import { cli } from '@jackwener/opencli/registry';
-
-const NON_TITLE_LINES = new Set([...]);
-
 export function parseToutiaoArticlesText(text) {
+    const NON_TITLE_LINES = new Set([...]);
     const lines = String(text || '').split('\n').map(...);
```

## Verification

```
$ opencli toutiao articles -f table
┌───────┬─────────────┬────────┬──────┬──────┬──────┬──────┐
│ Title │ Date        │ Status │ 展现 │ 阅读 │ 点赞 │ 评论 │
├───────┼─────────────┼────────┼──────┼──────┼──────┼──────┤
│ 高    │ 03-19 10:28 │ 已发布 │ 18   │ 1    │ 0    │ 0    │
└───────┴─────────────┴────────┴──────┴──────┴──────┴──────┘
```

Works correctly after the fix. Command was completely broken before.
