### PR TITLE
fix(twitter): preserve text when posting images

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -2,10 +2,18 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+
 const MAX_IMAGES = 4;
 const UPLOAD_POLL_MS = 500;
 const UPLOAD_TIMEOUT_MS = 30_000;
+const COMPOSER_POLL_MS = 250;
+const COMPOSER_TIMEOUT_MS = 10_000;
+const SUBMIT_POLL_MS = 500;
+const SUBMIT_TIMEOUT_MS = 15_000;
+const COMPOSE_URL = 'https://x.com/compose/post';
+const FILE_INPUT_SELECTOR = 'input[type="file"][data-testid="fileInput"]';
 const SUPPORTED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+
 function validateImagePaths(raw) {
     const paths = raw.split(',').map(s => s.trim()).filter(Boolean);
     if (paths.length > MAX_IMAGES) {
@@ -24,6 +32,156 @@ function validateImagePaths(raw) {
         return absPath;
     });
 }
+
+function isUnsupportedInsertTextError(err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const lower = msg.toLowerCase();
+    return lower.includes('unknown action') || lower.includes('not supported') || lower.includes('inserttext returned no inserted flag');
+}
+
+async function focusComposer(page) {
+    return page.evaluate(`(() => {
+        const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+        const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]'));
+        const box = boxes.find(visible) || boxes[0];
+        if (!box) return { ok: false, message: 'Could not find the tweet composer text area. Are you logged in?' };
+        box.focus();
+        return { ok: true };
+    })()`);
+}
+
+async function verifyComposerText(page, text) {
+    const iterations = Math.ceil(COMPOSER_TIMEOUT_MS / COMPOSER_POLL_MS);
+    return page.evaluate(`(async () => {
+        const expected = ${JSON.stringify(text)};
+        const normalize = s => String(s || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        const normalizedExpected = normalize(expected);
+        for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
+            const box = document.querySelector('[data-testid="tweetTextarea_0"]');
+            const actual = box ? (box.innerText || box.textContent || '') : '';
+            if (box && normalize(actual).includes(normalizedExpected)) return { ok: true };
+            await new Promise(r => setTimeout(r, ${JSON.stringify(COMPOSER_POLL_MS)}));
+        }
+        const box = document.querySelector('[data-testid="tweetTextarea_0"]');
+        return {
+            ok: false,
+            message: 'Could not verify tweet text in the composer after typing.',
+            actualText: box ? (box.innerText || box.textContent || '') : ''
+        };
+    })()`);
+}
+
+async function insertComposerText(page, text) {
+    const focusResult = await focusComposer(page);
+    if (!focusResult?.ok) return focusResult;
+
+    const nativeInserters = [
+        page.nativeType?.bind(page),
+        page.insertText?.bind(page),
+    ].filter(Boolean);
+
+    for (const insert of nativeInserters) {
+        try {
+            // Native CDP Input.insertText updates Twitter/X's Draft.js editor much more
+            // reliably than synthetic paste/input events. Prefer the Page CDP helper
+            // when available because older Browser Bridge insert-text can report
+            // inserted while the editor state does not change after media upload.
+            await insert(text);
+            const verified = await verifyComposerText(page, text);
+            if (verified?.ok) return verified;
+        }
+        catch (err) {
+            if (!isUnsupportedInsertTextError(err)) throw err;
+            // Older Browser Bridge versions do not expose this insertion path; try the next one.
+        }
+    }
+
+    return page.evaluate(`(async () => {
+        try {
+            const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]'));
+            const box = boxes.find(visible) || boxes[0];
+            if (!box) return { ok: false, message: 'Could not find the tweet composer text area. Are you logged in?' };
+            const textToInsert = ${JSON.stringify(text)};
+            const normalize = s => String(s || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+            box.focus();
+            if (!document.execCommand('insertText', false, textToInsert)) {
+                const dt = new DataTransfer();
+                dt.setData('text/plain', textToInsert);
+                box.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+            }
+            await new Promise(r => setTimeout(r, 500));
+            const actual = box.innerText || box.textContent || '';
+            if (normalize(actual).includes(normalize(textToInsert))) return { ok: true };
+            return { ok: false, message: 'Could not verify tweet text in the composer after typing.', actualText: actual };
+        } catch (e) { return { ok: false, message: String(e) }; }
+    })()`);
+}
+
+async function waitForImageUpload(page, expectedCount) {
+    const iterations = Math.ceil(UPLOAD_TIMEOUT_MS / UPLOAD_POLL_MS);
+    return page.evaluate(`(async () => {
+        const expected = ${JSON.stringify(expectedCount)};
+        const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+        for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
+            await new Promise(r => setTimeout(r, ${JSON.stringify(UPLOAD_POLL_MS)}));
+            const attachments = document.querySelector('[data-testid="attachments"]');
+            const previewCount = Math.max(
+                attachments ? attachments.querySelectorAll('[role="group"], img, video').length : 0,
+                document.querySelectorAll('[data-testid="tweetPhoto"], img[src^="blob:"], video[src^="blob:"]').length,
+                Array.from(document.querySelectorAll('button,[role="button"]')).filter((el) =>
+                    /remove media|remove image|remove/i.test((el.getAttribute('aria-label') || '') + ' ' + (el.textContent || ''))
+                ).length
+            );
+            const button = Array.from(document.querySelectorAll('[data-testid="tweetButtonInline"], [data-testid="tweetButton"]'))
+                .find((el) => visible(el));
+            const buttonReady = !!button && !button.disabled && button.getAttribute('aria-disabled') !== 'true';
+            if (previewCount >= expected && buttonReady) return { ok: true, previewCount };
+        }
+        return { ok: false, message: 'Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).' };
+    })()`);
+}
+
+async function submitTweet(page, text) {
+    const clickResult = await page.evaluate(`(async () => {
+        try {
+            const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            const buttons = Array.from(document.querySelectorAll('[data-testid="tweetButtonInline"], [data-testid="tweetButton"]'));
+            const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
+            if (!btn) return { ok: false, message: 'Tweet button is disabled or not found.' };
+            btn.click();
+            return { ok: true };
+        } catch (e) { return { ok: false, message: String(e) }; }
+    })()`);
+    if (!clickResult?.ok) return clickResult;
+
+    const iterations = Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS);
+    return page.evaluate(`(async () => {
+        const expected = ${JSON.stringify(text)};
+        const normalize = s => String(s || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        const expectedText = normalize(expected);
+        const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+        for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
+            await new Promise(r => setTimeout(r, ${JSON.stringify(SUBMIT_POLL_MS)}));
+            const toasts = Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))
+                .filter((el) => visible(el));
+            const successToast = toasts.find((el) => /sent|posted|your post was sent|your tweet was sent/i.test(el.textContent || ''));
+            if (successToast) return { ok: true, message: 'Tweet posted successfully.' };
+            const alert = toasts.find((el) => /failed|error|try again|not sent|could not/i.test(el.textContent || ''));
+            if (alert) return { ok: false, message: (alert.textContent || 'Tweet failed to post.').trim() };
+
+            const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]')).filter(visible);
+            const composerStillHasText = boxes.some((box) => normalize(box.innerText || box.textContent || '').includes(expectedText));
+            const hasMedia = !!document.querySelector('[data-testid="attachments"], [data-testid="tweetPhoto"]')
+                || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0;
+            if (!composerStillHasText && !hasMedia) {
+                return { ok: true, message: 'Tweet posted successfully.' };
+            }
+        }
+        return { ok: false, message: 'Tweet submission did not complete before timeout.' };
+    })()`);
+}
+
 cli({
     site: 'twitter',
     name: 'post',
@@ -39,60 +197,39 @@ cli({
     func: async (page, kwargs) => {
         if (!page)
             throw new CommandExecutionError('Browser session required for twitter post');
-        // Validate images upfront before any browser interaction
+
+        // Validate images upfront before any browser interaction.
         const absPaths = kwargs.images ? validateImagePaths(String(kwargs.images)) : [];
-        // 1. Navigate to compose modal
-        await page.goto('https://x.com/compose/tweet');
-        await page.wait(3);
-        // 2. Type the text via clipboard paste (handles newlines in Draft.js)
-        const typeResult = await page.evaluate(`(async () => {
-        try {
-            const box = document.querySelector('[data-testid="tweetTextarea_0"]');
-            if (!box) return { ok: false, message: 'Could not find the tweet composer text area.' };
-            box.focus();
-            const dt = new DataTransfer();
-            dt.setData('text/plain', ${JSON.stringify(kwargs.text)});
-            box.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
-            return { ok: true };
-        } catch (e) { return { ok: false, message: String(e) }; }
-    })()`);
-        if (!typeResult.ok) {
-            return [{ status: 'failed', message: typeResult.message, text: kwargs.text }];
-        }
-        // 3. Attach images if provided
+        const text = String(kwargs.text ?? '');
+
+        // The current X standalone composer is /compose/post. It keeps a single,
+        // visible composer and is the same route used by the reply command.
+        await page.goto(COMPOSE_URL, { waitUntil: 'load', settleMs: 2500 });
+        await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
+
+        // Attach media before inserting text. Uploading media after Draft.js has
+        // text can re-render/reset the editor, causing image-only posts.
         if (absPaths.length > 0) {
             if (!page.setFileInput) {
                 throw new CommandExecutionError('Browser extension does not support file upload. Please update the extension.');
             }
-            await page.setFileInput(absPaths, 'input[data-testid="fileInput"]');
-            // Poll until attachments render and tweet button is enabled
-            const pollIterations = Math.ceil(UPLOAD_TIMEOUT_MS / UPLOAD_POLL_MS);
-            const uploaded = await page.evaluate(`(async () => {
-          for (let i = 0; i < ${JSON.stringify(pollIterations)}; i++) {
-              await new Promise(r => setTimeout(r, ${JSON.stringify(UPLOAD_POLL_MS)}));
-              const container = document.querySelector('[data-testid="attachments"]');
-              if (!container) continue;
-              if (container.querySelectorAll('[role="group"]').length !== ${JSON.stringify(absPaths.length)}) continue;
-              const btn = document.querySelector('[data-testid="tweetButton"]') || document.querySelector('[data-testid="tweetButtonInline"]');
-              if (btn && !btn.disabled) return true;
-          }
-          return false;
-      })()`);
-            if (!uploaded) {
-                return [{ status: 'failed', message: `Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).`, text: kwargs.text }];
+            await page.wait({ selector: FILE_INPUT_SELECTOR, timeout: 20 });
+            await page.setFileInput(absPaths, FILE_INPUT_SELECTOR);
+            const uploadState = await waitForImageUpload(page, absPaths.length);
+            if (!uploadState?.ok) {
+                return [{ status: 'failed', message: uploadState?.message ?? `Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).`, text }];
             }
         }
-        // 4. Click the post button
+
+        // Insert and verify the text after media upload so text + images are in
+        // the final Draft.js composer state immediately before clicking Post.
+        const typeResult = await insertComposerText(page, text);
+        if (!typeResult?.ok) {
+            return [{ status: 'failed', message: typeResult?.message ?? 'Could not type tweet text.', text }];
+        }
+
         await page.wait(1);
-        const result = await page.evaluate(`(async () => {
-        try {
-            const btn = document.querySelector('[data-testid="tweetButton"]') || document.querySelector('[data-testid="tweetButtonInline"]');
-            if (btn && !btn.disabled) { btn.click(); return { ok: true, message: 'Tweet posted successfully.' }; }
-            return { ok: false, message: 'Tweet button is disabled or not found.' };
-        } catch (e) { return { ok: false, message: String(e) }; }
-    })()`);
-        if (result.ok)
-            await page.wait(3);
-        return [{ status: result.ok ? 'success' : 'failed', message: result.message, text: kwargs.text }];
+        const result = await submitTweet(page, text);
+        return [{ status: result?.ok ? 'success' : 'failed', message: result?.message ?? 'Tweet failed to post.', text }];
     }
 });

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './post.js';
+
 vi.mock('node:fs', async (importOriginal) => {
     const actual = await importOriginal();
     return {
@@ -12,6 +13,7 @@ vi.mock('node:fs', async (importOriginal) => {
         }),
     };
 });
+
 vi.mock('node:path', async (importOriginal) => {
     const actual = await importOriginal();
     return {
@@ -23,92 +25,170 @@ vi.mock('node:path', async (importOriginal) => {
         }),
     };
 });
-function makePage(overrides = {}) {
+
+function makePage(evaluateResults = [], overrides = {}) {
+    const evaluate = vi.fn();
+    for (const result of evaluateResults) {
+        evaluate.mockResolvedValueOnce(result);
+    }
+    evaluate.mockResolvedValue({ ok: true });
+
     return {
         goto: vi.fn().mockResolvedValue(undefined),
         wait: vi.fn().mockResolvedValue(undefined),
-        evaluate: vi.fn().mockResolvedValue({ ok: true }),
+        evaluate,
         setFileInput: vi.fn().mockResolvedValue(undefined),
+        insertText: vi.fn().mockResolvedValue(undefined),
         ...overrides,
     };
 }
+
 describe('twitter post command', () => {
     const getCommand = () => getRegistry().get('twitter/post');
-    it('posts text-only tweet successfully', async () => {
+
+    it('posts text-only tweet successfully through the current compose route', async () => {
         const command = getCommand();
-        const page = makePage({
-            evaluate: vi.fn()
-                .mockResolvedValueOnce({ ok: true })
-                .mockResolvedValueOnce({ ok: true, message: 'Tweet posted successfully.' }),
-        });
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' }, // verify submit completed
+        ]);
+
         const result = await command.func(page, { text: 'hello world' });
+
         expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'hello world' }]);
-        expect(page.goto).toHaveBeenCalledWith('https://x.com/compose/tweet');
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/compose/post', { waitUntil: 'load', settleMs: 2500 });
+        expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
+        expect(page.insertText).toHaveBeenCalledWith('hello world');
     });
+
     it('returns failed when text area not found', async () => {
         const command = getCommand();
-        const page = makePage({
-            evaluate: vi.fn()
-                .mockResolvedValueOnce({ ok: false, message: 'Could not find the tweet composer text area.' }),
-        });
+        const page = makePage([
+            { ok: false, message: 'Could not find the tweet composer text area. Are you logged in?' },
+        ]);
+
         const result = await command.func(page, { text: 'hello' });
-        expect(result).toEqual([{ status: 'failed', message: 'Could not find the tweet composer text area.', text: 'hello' }]);
+
+        expect(result).toEqual([{ status: 'failed', message: 'Could not find the tweet composer text area. Are you logged in?', text: 'hello' }]);
+        expect(page.insertText).not.toHaveBeenCalled();
     });
+
     it('throws when more than 4 images', async () => {
         const command = getCommand();
         const page = makePage();
         await expect(command.func(page, { text: 'hi', images: 'a.png,b.png,c.png,d.png,e.png' })).rejects.toThrow('Too many images: 5 (max 4)');
     });
+
     it('throws when image file does not exist', async () => {
         const command = getCommand();
         const page = makePage();
         await expect(command.func(page, { text: 'hi', images: 'missing.png' })).rejects.toThrow('Not a valid file');
     });
+
     it('throws on unsupported image format', async () => {
         const command = getCommand();
         const page = makePage();
         await expect(command.func(page, { text: 'hi', images: 'photo.bmp' })).rejects.toThrow('Unsupported image format');
     });
+
     it('throws when page.setFileInput is not available', async () => {
         const command = getCommand();
-        const page = makePage({
-            evaluate: vi.fn().mockResolvedValueOnce({ ok: true }),
-            setFileInput: undefined,
-        });
+        const page = makePage([], { setFileInput: undefined });
         await expect(command.func(page, { text: 'hi', images: 'a.png' })).rejects.toThrow('Browser extension does not support file upload');
     });
-    it('posts with images when upload completes', async () => {
+
+    it('uploads images before inserting text so media re-renders cannot erase the tweet text', async () => {
         const command = getCommand();
-        const page = makePage({
-            evaluate: vi.fn()
-                .mockResolvedValueOnce({ ok: true }) // type text
-                .mockResolvedValueOnce(true) // upload polling returns true
-                .mockResolvedValueOnce({ ok: true, message: 'Tweet posted successfully.' }), // click post
-        });
+        const page = makePage([
+            { ok: true, previewCount: 2 }, // upload polling returns true
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' }, // verify submit completed
+        ]);
+
         const result = await command.func(page, { text: 'with images', images: 'a.png,b.png' });
+
         expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'with images' }]);
-        expect(page.setFileInput).toHaveBeenCalled();
-        const uploadScript = page.evaluate.mock.calls[1][0];
+        expect(page.wait).toHaveBeenNthCalledWith(2, { selector: 'input[type="file"][data-testid="fileInput"]', timeout: 20 });
+        expect(page.setFileInput).toHaveBeenCalledWith(['/abs/a.png', '/abs/b.png'], 'input[type="file"][data-testid="fileInput"]');
+        expect(page.insertText).toHaveBeenCalledWith('with images');
+        expect(page.setFileInput.mock.invocationCallOrder[0]).toBeLessThan(page.insertText.mock.invocationCallOrder[0]);
+
+        const uploadScript = page.evaluate.mock.calls[0][0];
         expect(uploadScript).toContain('[data-testid="attachments"]');
-        expect(uploadScript).toContain('[role="group"]');
+        expect(uploadScript).toContain('buttonReady');
     });
+
+    it('prefers nativeType when available because bridge insert-text can miss Draft.js after media upload', async () => {
+        const command = getCommand();
+        const nativeType = vi.fn().mockResolvedValue(undefined);
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify nativeType
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ], { nativeType });
+
+        const result = await command.func(page, { text: 'native type' });
+
+        expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'native type' }]);
+        expect(nativeType).toHaveBeenCalledWith('native type');
+        expect(page.insertText).not.toHaveBeenCalled();
+    });
+
+    it('treats X success toast as completed even if stale composer nodes remain', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' }, // verify submit completed
+        ]);
+
+        await command.func(page, { text: 'toast success' });
+
+        const submitScript = page.evaluate.mock.calls[3][0];
+        expect(submitScript).toContain('successToast');
+        expect(submitScript).toContain('your post was sent');
+    });
+
     it('returns failed when image upload times out', async () => {
         const command = getCommand();
-        const page = makePage({
-            evaluate: vi.fn()
-                .mockResolvedValueOnce({ ok: true })
-                .mockResolvedValueOnce(false),
-        });
+        const page = makePage([
+            { ok: false, message: 'Image upload timed out (30s).' },
+        ]);
+
         const result = await command.func(page, { text: 'timeout', images: 'a.png' });
+
         expect(result).toEqual([{ status: 'failed', message: 'Image upload timed out (30s).', text: 'timeout' }]);
+        expect(page.insertText).not.toHaveBeenCalled();
     });
+
+    it('falls back to DOM insertion when native insertText is unavailable', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // fallback DOM insertion
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ], { insertText: undefined });
+
+        const result = await command.func(page, { text: 'fallback text' });
+
+        expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'fallback text' }]);
+        expect(page.evaluate.mock.calls[1][0]).toContain("execCommand('insertText'");
+    });
+
     it('validates images before navigating to compose page', async () => {
         const command = getCommand();
         const page = makePage();
         await expect(command.func(page, { text: 'hi', images: 'missing.png' })).rejects.toThrow('Not a valid file');
-        // Should NOT have navigated since validation happens first
         expect(page.goto).not.toHaveBeenCalled();
     });
+
     it('throws when no browser session', async () => {
         const command = getCommand();
         await expect(command.func(null, { text: 'hi' })).rejects.toThrow('Browser session required for twitter post');


### PR DESCRIPTION
## Summary
- upload images before inserting tweet text so X's composer re-render cannot erase Draft.js content
- use the current `/compose/post` route and explicit composer/file input readiness checks
- insert text with native browser input when available, fall back to DOM events, and verify text before clicking Post
- wait for submission completion instead of reporting success immediately after click
- add adapter regression coverage for image posting order, upload timeout, fallback text insertion, and validation paths

## Test Plan
- [x] `npx vitest run --project adapter clis/twitter/post.test.js clis/twitter/reply.test.js`
- [x] `npm run build`
- [x] `git diff --check`

## Background
While using `opencli twitter post "text" --images image.jpg`, the command could report success while the resulting tweet was missing text/media. X's composer can reset the Draft.js editor while media is attaching, so the command now attaches media first and verifies the final composer state before posting.
