### PR TITLE
feat(browser): add upload command and fix producthunt hot

### DIFF
--- a/clis/producthunt/hot.js
+++ b/clis/producthunt/hot.js
@@ -18,9 +18,8 @@ cli({
     columns: ['rank', 'name', 'votes', 'url'],
     func: async (page, args) => {
         const count = Math.min(Number(args.limit) || 20, 50);
-        await page.installInterceptor('producthunt.com');
         await page.goto('https://www.producthunt.com');
-        await page.waitForCapture(5);
+        await page.wait(3);
         const domItems = await page.evaluate(`
       (() => {
         const seen = new Set();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1139,6 +1139,83 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }, null, 2));
     }));
 
+  addBrowserTabOption(
+    browser.command('upload')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector of an <input type="file">')
+      .argument('<files...>', 'One or more local file paths to attach')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Set local file paths on a file input — JSON envelope {uploaded, files, target, matches_n}'),
+  )
+    .action(browserAction(async (page, target, files, opts) => {
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const paths = (Array.isArray(files) ? files : [files]).map((file) => path.resolve(String(file)));
+      const missing = paths.filter((file) => !fs.existsSync(file));
+      if (missing.length > 0) {
+        console.log(JSON.stringify({
+          error: {
+            code: 'file_not_found',
+            message: `File(s) not found: ${missing.join(', ')}`,
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const { matches_n, match_level } = await resolveRef(page, String(target), parsed.opts);
+      const inputCheck = await page.evaluate(`(() => {
+        const el = window.__resolved;
+        if (!el) return { ok: false, code: 'target_not_resolved', message: 'Resolved target is not available.' };
+        if (!(el instanceof HTMLInputElement) || el.type !== 'file') {
+          return { ok: false, code: 'not_file_input', message: 'Resolved target is not an <input type="file">.' };
+        }
+        return { ok: true, accept: el.accept || '', multiple: !!el.multiple };
+      })()` ) as { ok: true; accept: string; multiple: boolean } | { ok: false; code: string; message: string };
+      if (!inputCheck.ok) {
+        console.log(JSON.stringify({ error: { code: inputCheck.code, message: inputCheck.message, matches_n } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      if (paths.length > 1 && !inputCheck.multiple) {
+        console.log(JSON.stringify({
+          error: {
+            code: 'multiple_not_allowed',
+            message: 'Target file input does not allow multiple files.',
+            matches_n,
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      if (typeof (page as { setFileInput?: unknown }).setFileInput !== 'function') {
+        throw new Error('This browser session does not support file uploads');
+      }
+      const uploadToken = `opencli-upload-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const uploadSelector = `input[type="file"][data-opencli-upload-target="${uploadToken}"]`;
+      await page.evaluate(`(() => {
+        const el = window.__resolved;
+        if (el instanceof HTMLInputElement) {
+          el.setAttribute('data-opencli-upload-target', ${JSON.stringify(uploadToken)});
+        }
+      })()`);
+      await (page as { setFileInput: (files: string[], selector?: string) => Promise<void> }).setFileInput(paths, uploadSelector);
+      await page.evaluate(`(() => {
+        const el = document.querySelector(${JSON.stringify(uploadSelector)});
+        if (el) el.removeAttribute('data-opencli-upload-target');
+      })()`);
+      console.log(JSON.stringify({
+        uploaded: true,
+        files: paths,
+        target: String(target),
+        matches_n,
+        match_level,
+        accept: inputCheck.accept,
+      }, null, 2));
+    }));
+
   addBrowserTabOption(browser.command('keys').argument('<key>', 'Key to press (Enter, Escape, Tab, Control+a)'))
     .description('Press keyboard key')
     .action(browserAction(async (page, key) => {


### PR DESCRIPTION
## Summary
- Add a generic `opencli browser upload <target> <files...>` command for setting local files on resolved `<input type="file">` elements.
- Validate file existence, target type, multi-file support, and return structured JSON upload metadata.
- Fix `producthunt hot` by removing an unnecessary network-capture wait before DOM scraping.

## Why
The extension/page layer already supports file-input uploads, but the CLI did not expose a generic command. This makes media workflows for browser-backed adapters possible without platform-specific upload code.

`producthunt hot` could fail waiting for network capture even though the command only needs DOM data. A normal page wait is enough and avoids the brittle capture dependency.

## Test plan
- `npm run typecheck`
- `npm run build`
- `OPENCLI_DAEMON_PORT=19999 npm test`
- `node dist/src/main.js browser upload 2 /tmp/opencli-linkedin-test/transparent-1x1.png /tmp/opencli-linkedin-test/test-video.mp4`
- `node dist/src/main.js producthunt hot --limit 3`

## Manual validation
- Verified `browser upload` on a local file-input fixture.
- Verified LinkedIn image post flow with the new command using a real JPEG test image in Hanzi's logged-in browser session, after explicit approval for test posts.

