### PR TITLE
errors: classify CDP debugger-detach as transient (retry-able)

### DIFF
--- a/src/browser/errors.test.ts
+++ b/src/browser/errors.test.ts
@@ -12,6 +12,9 @@ describe('classifyBrowserError', () => {
       'CDP connection reset',
       'Daemon command failed',
       'No window with id: 123',
+      'Detached while handling command id=cmd_42',
+      'No tab with id: 456',
+      'Debugger is not attached to the tab',
     ]) {
       const advice = classifyBrowserError(new Error(msg));
       expect(advice.kind, `expected "${msg}" → extension-transient`).toBe('extension-transient');

--- a/src/browser/errors.ts
+++ b/src/browser/errors.ts
@@ -45,6 +45,14 @@ const EXTENSION_TRANSIENT_PATTERNS = [
   'CDP connection',
   'Daemon command failed',
   'No window with id',
+  // CDP debugger detach race — daemon detaches a command while still serving
+  // it under concurrent load. Already treated as transient in the e2e
+  // test harness (tests/e2e/browser-public.test.ts isTransientBrowserDetach),
+  // but classifyBrowserError did not list it, so CLI runtime would surface
+  // it as a hard 500 to callers instead of retrying.
+  'Detached while handling command',
+  'No tab with id',
+  'Debugger is not attached to the tab',
 ] as const;
 
 /**


### PR DESCRIPTION
## Problem

`classifyBrowserError` does not list the `Detached while handling command` pattern (or the related `No tab with id` / `Debugger is not attached to the tab`), so when the daemon emits one of them under concurrent load, the CLI surfaces it to callers as a hard failure instead of going through the existing retry loop in `sendCommandRaw`.

The e2e test harness `tests/e2e/browser-public.test.ts` already treats these three patterns as transient and retries:
```ts
function isTransientBrowserDetach(result: CliResult): boolean {
  const text = `${result.stderr}\n${result.stdout}`;
  return /Detached while handling command|No tab with id|Debugger is not attached to the tab/i.test(text);
}
```

So the "transient" judgement is already established — it just was not reflected in the runtime classifier.

## Real-world impact

A news collector pipeline that calls `web read --url …` for ~20 BBC RSS items in parallel (workers=3) hit ~30-50 % spurious 500 failures even though re-running the failed items individually succeeds instantly. With this patch, daemon-client retries them automatically and end-to-end success is ~100 %.

## Change

- Add three patterns to `EXTENSION_TRANSIENT_PATTERNS` in `src/browser/errors.ts`.
- Add the same patterns to the existing positive case in `src/browser/errors.test.ts`. Vitest passes (7/7).

No behavioural change for callers that were already reaching the e2e helper; this just brings the runtime classifier into agreement with the e2e helper.