### PR TITLE
fix(web): preserve button text in web read output

### DIFF
--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -211,6 +211,12 @@ const command = cli({
             downloadImages: kwargs['download-images'],
             imageHeaders: referer ? { Referer: referer } : undefined,
             stdout: kwargs.stdout,
+            configureTurndown: (td) => {
+                td.addRule('preserveButtons', {
+                    filter: (node) => node.nodeName === 'BUTTON',
+                    replacement: (content) => content,
+                });
+            },
         });
         // `--stdout` is a content-streaming mode. The markdown body already went
         // to process.stdout inside downloadArticle(), so returning rows here


### PR DESCRIPTION
## Description

`opencli web read` silently strips all `<button>` elements because the shared article-download pipeline includes `'button'` in `STRIPPED_TAGS`. This is correct for article adapters (zhihu, weixin) where buttons are UI noise, but `web read` is a generic page reader where buttons often carry meaningful content (e.g. "Download All", "Buy Now").

The fix adds a `configureTurndown` callback in `web/read.js` that overrides the button stripping rule, converting `<button>` elements to their text content instead of removing them. The core `article-download.ts` is not modified, so all other adapters keep their existing behavior.

Fixes #1184

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A

## Screenshots / Output

**Before:**
```
$ opencli web read --url "https://www.wehuster.com/cet6" --stdout true | grep -i "download"
# (empty)
```

**After:**
```
$ opencli web read --url "https://www.wehuster.com/cet6" --stdout true | grep -i "download"
Download All
Download All
Download All
Download All
Download All
```