### PR TITLE
fix(#1184): preserve button text in web read; remove button from STRIPPED_TAGS

### DIFF
--- a/src/download/article-download.test.ts
+++ b/src/download/article-download.test.ts
@@ -87,15 +87,41 @@ describe('downloadArticle', () => {
         '<style>.x{color:red}</style>' +
         '<noscript>nojs</noscript>' +
         '<iframe src="https://www.youtube.com/embed/abc" title="Demo video"></iframe>' +
-        '<form><button>click</button></form>',
+        '<form><button>click-in-form</button></form>',
       );
       expect(md).toContain('keep');
       expect(md).not.toContain('alert');
       expect(md).not.toContain('color:red');
       expect(md).not.toContain('nojs');
-      expect(md).not.toContain('click');
+      // Button inside <form> is stripped because the parent <form> is in STRIPPED_TAGS.
+      expect(md).not.toContain('click-in-form');
       // Iframe degrades to a link preserving the embedded URL.
       expect(md).toContain('[Demo video](https://www.youtube.com/embed/abc)');
+    });
+
+    it('preserves standalone button text content as inline Markdown', async () => {
+      const md = await runAndRead(
+        '<h2>2023</h2>' +
+        '<button>Download All</button>' +
+        '<p>Some article text.</p>' +
+        '<button>Copy</button>',
+      );
+      expect(md).toContain('Download All');
+      expect(md).toContain('Copy');
+      expect(md).toContain('Some article text.');
+    });
+
+    it('drops icon-only buttons that have no visible text', async () => {
+      const md = await runAndRead(
+        '<p>content</p>' +
+        '<button></button>' +
+        '<button>   </button>' +
+        '<p>after</p>',
+      );
+      expect(md).toContain('content');
+      expect(md).toContain('after');
+      // No stray empty button artefacts
+      expect(md).not.toMatch(/<button/);
     });
 
     it('strips SVG nodes entirely', async () => {

--- a/src/download/article-download.ts
+++ b/src/download/article-download.ts
@@ -92,10 +92,14 @@ const DEFAULT_LABELS: Required<FrontmatterLabels> = {
 // `iframe` is NOT in this set — it's handled by a dedicated rule below that
 // degrades to a link so embedded content (YouTube, Twitter, CodePen …) keeps
 // a reachable URL in the exported markdown.
+// `button` is NOT in this set — buttons inside <form> are already removed when
+// the parent <form> is stripped; standalone buttons may carry meaningful labels
+// (e.g. "Download All") and are handled by the dedicated `buttonElement` rule
+// below which preserves their text content as inline Markdown.
 const STRIPPED_TAGS: Array<keyof HTMLElementTagNameMap> = [
   'script', 'style', 'noscript',
   'canvas',
-  'form', 'button', 'dialog',
+  'form', 'dialog',
   'header', 'footer', 'nav', 'aside',
 ];
 
@@ -160,6 +164,19 @@ function createTurndown(
         || el.querySelector('source')?.getAttribute('src')
         || '';
       return src ? `\n<audio src="${src}" controls></audio>\n` : '';
+    },
+  });
+  // Buttons may carry meaningful labels on content pages (e.g. "Download All",
+  // "Copy"). Rather than stripping them wholesale, preserve the trimmed text
+  // content as inline Markdown. Buttons that contain no visible text (icon-only
+  // or purely decorative) are silently dropped. Buttons inside <form> elements
+  // are never reached here because the parent <form> is already removed by
+  // STRIPPED_TAGS before Turndown processes children.
+  td.addRule('buttonElement', {
+    filter: (node) => node.nodeName === 'BUTTON',
+    replacement: (_content, node) => {
+      const text = (node as Element).textContent?.trim() ?? '';
+      return text ? text : '';
     },
   });
   // Iframes (YouTube, Twitter, CodePen …) degrade to a markdown link so the


### PR DESCRIPTION
## Summary

Fixes #1184

`opencli web read` was silently stripping all `<button>` elements because `'button'` was listed in the `STRIPPED_TAGS` array, which is fed to `TurndownService.remove()` before HTML?Markdown conversion. On many real-world pages (exam archives, dashboards, e-commerce sites) buttons carry meaningful labels such as **Download All** that both humans and AI agents need to see in the output. This also made `web read` inconsistent with `opencli browser state`, which does surface button text.

## Root Cause

`src/download/article-download.ts` lines 95-100:

`	s
const STRIPPED_TAGS = [
  'script', 'style', 'noscript',
  'canvas',
  'form', 'button', 'dialog', // ? unconditionally removes ALL buttons
  'header', 'footer', 'nav', 'aside',
];
`	s

## Changes

### `src/download/article-download.ts`  
- Removed `'button'` from `STRIPPED_TAGS`  
- Added a dedicated `buttonElement` Turndown rule that:
  - Preserves the trimmed `textContent` of every `<button>` as inline Markdown text
  - Silently drops icon-only / decorative buttons whose trimmed text is empty
  - Buttons inside `<form>` are unaffected - the parent `<form>` is still stripped, so children are never visited

### `src/download/article-download.test.ts`  
- Updated the existing form-stripping test to use a clearer button label (`click-in-form`) to make the assertion unambiguous
- Added: **preserves standalone button text content as inline Markdown** - covers the exact `Download All` scenario from the issue
- Added: **drops icon-only buttons that have no visible text** - covers the empty-button edge case

## Testing

All new and existing tests in `src/download/article-download.test.ts` cover the fix. The test environment on this machine runs Node 20 which cannot load `undici` (requires Node ? 22); this is a pre-existing environment limitation unrelated to this change - confirmed identical error on `main` before any changes.