### PR TITLE
fix(doubao): use ID selector for send button

### DIFF
--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -420,84 +420,15 @@ function detectDoubaoVerificationScript() {
 function clickSendButtonScript() {
     return `
     (() => {
-      ${buildDoubaoComposerLocatorScript()}
-      const composer = findComposer();
-      if (!(composer instanceof HTMLElement)) return false;
+      const sendBtn = document.querySelector('button#flow-end-msg-send');
+      if (!sendBtn) return false;
 
-      const composerRect = composer.getBoundingClientRect();
-      const rootCandidates = [
-        composer.closest('form'),
-        composer.closest('[role="form"]'),
-        composer.closest('[data-testid="chat_input"]'),
-        composer.closest('.chat-input'),
-        composer.parentElement,
-        composer.parentElement?.parentElement,
-      ].filter(Boolean);
+      const disabled = sendBtn.getAttribute('disabled') !== null
+        || sendBtn.getAttribute('aria-disabled') === 'true';
+      if (disabled) return false;
 
-      const seen = new Set();
-      const buttons = [];
-      for (const root of rootCandidates) {
-        root.querySelectorAll('button, [role="button"]').forEach((node) => {
-          if (!(node instanceof HTMLElement)) return;
-          if (seen.has(node)) return;
-          seen.add(node);
-          buttons.push(node);
-        });
-      }
-
-      const submitPattern = /send|发送|提交|发消息/i;
-      const excludedPattern = /新对话|new chat|快速|视频生成|深入研究|图像生成|帮我写作|音乐生成|更多|上传|upload|麦克风|microphone|模式|mode|工具|tools|设置|settings|云盘|history|历史/i;
-      let bestButton = null;
-      let bestScore = -Infinity;
-
-      for (const button of buttons) {
-        if (!isVisible(button)) continue;
-        const disabled = button.getAttribute('disabled') !== null
-          || button.getAttribute('aria-disabled') === 'true';
-        if (disabled) continue;
-
-        const text = (button.innerText || button.textContent || '').trim();
-        const aria = (button.getAttribute('aria-label') || '').trim();
-        const title = (button.getAttribute('title') || '').trim();
-        const className = String(button.className || '');
-        const haystack = [text, aria, title].join(' ').trim();
-        if (excludedPattern.test(haystack)) continue;
-
-        const rect = button.getBoundingClientRect();
-        const dx = rect.left - composerRect.right;
-        const dy = Math.abs((rect.top + rect.height / 2) - (composerRect.top + composerRect.height / 2));
-        const distancePenalty = Math.abs(dx) + dy;
-        const isSubmitLike = submitPattern.test(haystack)
-          || button.getAttribute('type') === 'submit'
-          || className.includes('bg-dbx-text-highlight')
-          || className.includes('bg-dbx-fill-highlight')
-          || className.includes('text-dbx-text-static-white-primary');
-        if (!isSubmitLike) continue;
-        if (dx < -80 || dx > 280) continue;
-        if (dy > 140) continue;
-
-        let score = -distancePenalty;
-        if (submitPattern.test(haystack)) score += 5000;
-        if (button.getAttribute('type') === 'submit') score += 1200;
-        if (button.closest('.chat-input-button')) score += 1200;
-        if (className.includes('bg-dbx-text-highlight')) score += 600;
-        if (className.includes('bg-dbx-fill-highlight')) score += 600;
-        if (className.includes('text-dbx-text-static-white-primary')) score += 400;
-        if (dx >= -40 && dx <= 240) score += 120;
-        if (rect.left >= composerRect.left - 40) score += 40;
-
-        if (score > bestScore) {
-          bestScore = score;
-          bestButton = button;
-        }
-      }
-
-      if (bestButton && bestScore >= 200) {
-        bestButton.click();
-        return true;
-      }
-
-      return false;
+      sendBtn.click();
+      return true;
     })()
   `;
 }

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -420,15 +420,94 @@ function detectDoubaoVerificationScript() {
 function clickSendButtonScript() {
     return `
     (() => {
-      const sendBtn = document.querySelector('button#flow-end-msg-send');
-      if (!sendBtn) return false;
+      ${buildDoubaoComposerLocatorScript()}
+      const directSendButton = document.querySelector('button#flow-end-msg-send');
+      if (directSendButton instanceof HTMLElement && isVisible(directSendButton)) {
+        const disabled = directSendButton.getAttribute('disabled') !== null
+          || directSendButton.getAttribute('aria-disabled') === 'true';
+        if (!disabled) {
+          directSendButton.click();
+          return true;
+        }
+      }
 
-      const disabled = sendBtn.getAttribute('disabled') !== null
-        || sendBtn.getAttribute('aria-disabled') === 'true';
-      if (disabled) return false;
+      const composer = findComposer();
+      if (!(composer instanceof HTMLElement)) return false;
 
-      sendBtn.click();
-      return true;
+      const composerRect = composer.getBoundingClientRect();
+      const rootCandidates = [
+        composer.closest('form'),
+        composer.closest('[role="form"]'),
+        composer.closest('[data-testid="chat_input"]'),
+        composer.closest('.chat-input'),
+        composer.parentElement,
+        composer.parentElement?.parentElement,
+      ].filter(Boolean);
+
+      const seen = new Set();
+      const buttons = [];
+      for (const root of rootCandidates) {
+        root.querySelectorAll('button, [role="button"]').forEach((node) => {
+          if (!(node instanceof HTMLElement)) return;
+          if (seen.has(node)) return;
+          seen.add(node);
+          buttons.push(node);
+        });
+      }
+
+      const submitPattern = /send|发送|提交|发消息/i;
+      const excludedPattern = /新对话|new chat|快速|视频生成|深入研究|图像生成|帮我写作|音乐生成|更多|上传|upload|麦克风|microphone|模式|mode|工具|tools|设置|settings|云盘|history|历史/i;
+      let bestButton = null;
+      let bestScore = -Infinity;
+
+      for (const button of buttons) {
+        if (!isVisible(button)) continue;
+        const disabled = button.getAttribute('disabled') !== null
+          || button.getAttribute('aria-disabled') === 'true';
+        if (disabled) continue;
+
+        const text = (button.innerText || button.textContent || '').trim();
+        const aria = (button.getAttribute('aria-label') || '').trim();
+        const title = (button.getAttribute('title') || '').trim();
+        const className = String(button.className || '');
+        const haystack = [text, aria, title].join(' ').trim();
+        if (excludedPattern.test(haystack)) continue;
+
+        const rect = button.getBoundingClientRect();
+        const dx = rect.left - composerRect.right;
+        const dy = Math.abs((rect.top + rect.height / 2) - (composerRect.top + composerRect.height / 2));
+        const distancePenalty = Math.abs(dx) + dy;
+        const isSubmitLike = submitPattern.test(haystack)
+          || button.getAttribute('type') === 'submit'
+          || className.includes('bg-dbx-text-highlight')
+          || className.includes('bg-dbx-fill-highlight')
+          || className.includes('text-dbx-text-static-white-primary');
+        if (!isSubmitLike) continue;
+        if (dx < -80 || dx > 280) continue;
+        if (dy > 140) continue;
+
+        let score = -distancePenalty;
+        if (submitPattern.test(haystack)) score += 5000;
+        if (button.getAttribute('type') === 'submit') score += 1200;
+        if (button.closest('.chat-input-button')) score += 1200;
+        if (className.includes('bg-dbx-text-highlight')) score += 600;
+        if (className.includes('bg-dbx-fill-highlight')) score += 600;
+        if (className.includes('text-dbx-text-static-white-primary')) score += 400;
+        if (dx >= -40 && dx <= 240) score += 120;
+        if (rect.left >= composerRect.left - 40) score += 40;
+
+        if (score > bestScore) {
+          bestScore = score;
+          bestButton = button;
+        }
+      }
+
+      if (bestButton && bestScore >= 200) {
+        bestButton.click();
+        return true;
+      }
+
+      return false;
     })()
   `;
 }

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -205,7 +205,8 @@ describe('collectDoubaoTranscriptAdditions', () => {
         expect(__test__.clickSendButtonScript()).toContain("button#flow-end-msg-send");
         expect(__test__.clickSendButtonScript()).toContain("getAttribute('disabled') !== null");
         expect(__test__.clickSendButtonScript()).toContain("getAttribute('aria-disabled') === 'true'");
-        expect(__test__.clickSendButtonScript()).not.toContain('bestScore >= 200');
+        expect(__test__.clickSendButtonScript()).toContain('bestScore >= 200');
+        expect(__test__.clickSendButtonScript()).toContain("button.getAttribute('type') === 'submit') score += 1200");
         expect(__test__.composerStateScript()).toContain("(composer.innerText || '').trim() || (composer.textContent || '').trim()");
         expect(__test__.detectDoubaoVerificationScript()).not.toContain('document.body?.innerText');
         expect(__test__.detectDoubaoVerificationScript()).not.toContain('[class*=\"verify\"]');

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -202,10 +202,10 @@ describe('collectDoubaoTranscriptAdditions', () => {
         expect(collectDoubaoTranscriptAdditions(before, current, '测试一下，只回复OK', (value) => value.replace('测试一下，只回复OK', '').trim())).toBe('');
     });
     it('treats only the exact landing-page chip string as UI noise', () => {
-        expect(__test__.clickSendButtonScript()).not.toContain('document,');
-        expect(__test__.clickSendButtonScript()).toContain('bestScore >= 200');
-        expect(__test__.clickSendButtonScript()).not.toContain("|| !!button.closest('.chat-input-button')");
-        expect(__test__.clickSendButtonScript()).toContain("button.getAttribute('type') === 'submit') score += 1200");
+        expect(__test__.clickSendButtonScript()).toContain("button#flow-end-msg-send");
+        expect(__test__.clickSendButtonScript()).toContain("getAttribute('disabled') !== null");
+        expect(__test__.clickSendButtonScript()).toContain("getAttribute('aria-disabled') === 'true'");
+        expect(__test__.clickSendButtonScript()).not.toContain('bestScore >= 200');
         expect(__test__.composerStateScript()).toContain("(composer.innerText || '').trim() || (composer.textContent || '').trim()");
         expect(__test__.detectDoubaoVerificationScript()).not.toContain('document.body?.innerText');
         expect(__test__.detectDoubaoVerificationScript()).not.toContain('[class*=\"verify\"]');


### PR DESCRIPTION
## Summary
- Fixed Doubao adapter `clickSendButtonScript` that was failing to find the send button

## Problem
The original code searched for the send button by walking up only 2 DOM levels from the textarea, but the actual send button `button#flow-end-msg-send` is at level 5. This caused `opencli doubao ask` to fail with "发送失败" (send failed).

## Fix
Replaced complex DOM traversal logic with a direct ID selector `button#flow-end-msg-send`, which is more reliable and simpler.

## Verification
Tested with `opencli doubao ask "1+1等于几"` - returns correct response.

## Related Issue
Fixes #1183