### PR TITLE
fix(browser): keep text/javascript API responses in network output

### DIFF
--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -57,7 +57,7 @@ opencli browser network
 - `shape` — response body 的路径→类型映射（不含原 body，省 token）
 - `status / url / method / ct / size`
 
-静态资源 / 埋点 / 追踪默认已过滤；需要全量看用 `--all`。
+静态资源 / 埋点 / 追踪默认已过滤。默认会保留 JSON / XML / plain text / `text/javascript` 这类 API 响应；如果你确定浏览器 DevTools 里有目标请求但这里缺失，用 `--all` 查一遍是否被 content-type 或 URL 噪音过滤挡掉。
 
 ### 按 shape 初筛
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -159,6 +159,8 @@ browser network --ttl <ms>             # cache TTL (default 24h)
 
 List entries look like `{key, method, status, url, ct, size, shape, body_truncated?}`. Detail envelope is `{key, url, method, status, ct, size, shape, body, body_truncated?, body_full_size?, body_truncation_reason}`. Cache lives in `~/.opencli/cache/browser-network/` so you can re-inspect without re-triggering the request.
 
+Default output keeps JSON/XML/plain-text and JS-like API responses, then drops obvious static assets and telemetry by URL. If an expected endpoint is missing, run `browser network --all` once and check whether an unusual content type or URL filter hid it.
+
 ### Tabs & session
 
 | command | purpose |

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -587,6 +587,35 @@ describe('browser network command', () => {
     expect(out.entries.map((e: any) => e.key)).toContain('GET cdn.example.com/app.js');
   });
 
+  it('default output keeps text/javascript API responses while dropping static JS files', async () => {
+    browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+      {
+        url: 'https://hw.mail.163.com/js6/s?sid=abc&func=mbox:listMessages',
+        method: 'POST',
+        responseStatus: 200,
+        responseContentType: 'text/javascript',
+        responsePreview: JSON.stringify({ messages: [{ id: 'm1', subject: 'hello' }] }),
+      },
+      {
+        url: 'https://cdn.example.com/app.js',
+        method: 'GET',
+        responseStatus: 200,
+        responseContentType: 'application/javascript',
+        responsePreview: '// js',
+      },
+    ]);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(1);
+    expect(out.filtered_out).toBe(1);
+    expect(out.entries[0].key).toBe('POST hw.mail.163.com/js6/s');
+    expect(out.entries[0].ct).toBe('text/javascript');
+    expect(out.entries[0].shape['$.messages']).toBe('array(1)');
+  });
+
   it('--raw emits full bodies inline for every entry', async () => {
     const program = createProgram('', '');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,11 +95,14 @@ async function captureNetworkItems(page: import('./types.js').IPage): Promise<Br
 
 /** Drop static-resource / telemetry noise so agents see only API-shaped traffic. */
 function filterNetworkItems(items: BrowserNetworkItem[]): BrowserNetworkItem[] {
-  return items.filter((r) =>
-    (r.ct?.includes('json') || r.ct?.includes('xml') || r.ct?.includes('text/plain')) &&
-    !/\.(js|css|png|jpg|gif|svg|woff|ico|map)(\?|$)/i.test(r.url) &&
-    !/analytics|tracking|telemetry|beacon|pixel|gtag|fbevents/i.test(r.url),
-  );
+  return items.filter((r) => {
+    const ct = r.ct?.toLowerCase() ?? '';
+    return (
+      (ct.includes('json') || ct.includes('xml') || ct.includes('text/plain') || ct.includes('javascript')) &&
+      !/\.(js|css|png|jpg|gif|svg|woff|ico|map)(\?|$)/i.test(r.url) &&
+      !/analytics|tracking|telemetry|beacon|pixel|gtag|fbevents/i.test(r.url)
+    );
+  });
 }
 
 /** Exit codes by network error code — usage errors vs runtime failures. */


### PR DESCRIPTION
## Summary
- include JS-like API response content types in default `browser network` output
- keep static JS assets filtered by URL extension
- document when to use `browser network --all` for content-type / URL-filter diagnosis

Fixes #1172.

## Verification
- `npx vitest run src/cli.test.ts -t "browser network command"`
- `npm run typecheck`