### PR TITLE
feat(browser): bind current tab to bound workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **browser** — `bind-current` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
+
 ## [1.7.8](https://github.com/jackwener/opencli/compare/v1.7.7...v1.7.8) (2026-04-25)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* **browser** — `bind-current` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
+* **browser** — `bind` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
 
 ## [1.7.8](https://github.com/jackwener/opencli/compare/v1.7.7...v1.7.8) (2026-04-25)
 

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1,1184 +1,1324 @@
-//#region src/protocol.ts
-/** Default daemon port */
-var DAEMON_PORT = 19825;
-var DAEMON_HOST = "localhost";
-var DAEMON_WS_URL = `ws://${DAEMON_HOST}:${DAEMON_PORT}/ext`;
-/** Lightweight health-check endpoint — probed before each WebSocket attempt. */
-var DAEMON_PING_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}/ping`;
-/** Base reconnect delay for extension WebSocket (ms) */
-var WS_RECONNECT_BASE_DELAY = 2e3;
-/** Max reconnect delay (ms) — kept short since daemon is long-lived */
-var WS_RECONNECT_MAX_DELAY = 5e3;
-//#endregion
-//#region src/cdp.ts
-/**
-* CDP execution via chrome.debugger API.
-*
-* chrome.debugger only needs the "debugger" permission — no host_permissions.
-* It can attach to any http/https tab. Avoid chrome:// and chrome-extension://
-* tabs (resolveTabId in background.ts filters them).
-*/
-var attached = /* @__PURE__ */ new Set();
-var networkCaptures = /* @__PURE__ */ new Map();
-/** Check if a URL can be attached via CDP — only allow http(s) and blank pages. */
+const DAEMON_PORT = 19825;
+const DAEMON_HOST = "localhost";
+const DAEMON_WS_URL = `ws://${DAEMON_HOST}:${DAEMON_PORT}/ext`;
+const DAEMON_PING_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}/ping`;
+const WS_RECONNECT_BASE_DELAY = 2e3;
+const WS_RECONNECT_MAX_DELAY = 5e3;
+
+const attached = /* @__PURE__ */ new Set();
+const tabFrameContexts = /* @__PURE__ */ new Map();
+const CDP_RESPONSE_BODY_CAPTURE_LIMIT = 8 * 1024 * 1024;
+const CDP_REQUEST_BODY_CAPTURE_LIMIT = 1 * 1024 * 1024;
+const networkCaptures = /* @__PURE__ */ new Map();
 function isDebuggableUrl$1(url) {
-	if (!url) return true;
-	return url.startsWith("http://") || url.startsWith("https://") || url === "about:blank" || url.startsWith("data:");
+  if (!url) return true;
+  return url.startsWith("http://") || url.startsWith("https://") || url === "about:blank" || url.startsWith("data:");
 }
 async function ensureAttached(tabId, aggressiveRetry = false) {
-	try {
-		const tab = await chrome.tabs.get(tabId);
-		if (!isDebuggableUrl$1(tab.url)) {
-			attached.delete(tabId);
-			throw new Error(`Cannot debug tab ${tabId}: URL is ${tab.url ?? "unknown"}`);
-		}
-	} catch (e) {
-		if (e instanceof Error && e.message.startsWith("Cannot debug tab")) throw e;
-		attached.delete(tabId);
-		throw new Error(`Tab ${tabId} no longer exists`);
-	}
-	if (attached.has(tabId)) try {
-		await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
-			expression: "1",
-			returnByValue: true
-		});
-		return;
-	} catch {
-		attached.delete(tabId);
-	}
-	const MAX_ATTACH_RETRIES = aggressiveRetry ? 5 : 2;
-	const RETRY_DELAY_MS = aggressiveRetry ? 1500 : 500;
-	let lastError = "";
-	for (let attempt = 1; attempt <= MAX_ATTACH_RETRIES; attempt++) try {
-		try {
-			await chrome.debugger.detach({ tabId });
-		} catch {}
-		await chrome.debugger.attach({ tabId }, "1.3");
-		lastError = "";
-		break;
-	} catch (e) {
-		lastError = e instanceof Error ? e.message : String(e);
-		if (attempt < MAX_ATTACH_RETRIES) {
-			console.warn(`[opencli] attach attempt ${attempt}/${MAX_ATTACH_RETRIES} failed: ${lastError}, retrying in ${RETRY_DELAY_MS}ms...`);
-			await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-			try {
-				const tab = await chrome.tabs.get(tabId);
-				if (!isDebuggableUrl$1(tab.url)) {
-					lastError = `Tab URL changed to ${tab.url} during retry`;
-					break;
-				}
-			} catch {
-				lastError = `Tab ${tabId} no longer exists`;
-			}
-		}
-	}
-	if (lastError) {
-		let finalUrl = "unknown";
-		let finalWindowId = "unknown";
-		try {
-			const tab = await chrome.tabs.get(tabId);
-			finalUrl = tab.url ?? "undefined";
-			finalWindowId = String(tab.windowId);
-		} catch {}
-		console.warn(`[opencli] attach failed for tab ${tabId}: url=${finalUrl}, windowId=${finalWindowId}, error=${lastError}`);
-		const hint = lastError.includes("chrome-extension://") ? ". Tip: another Chrome extension may be interfering — try disabling other extensions" : "";
-		throw new Error(`attach failed: ${lastError}${hint}`);
-	}
-	attached.add(tabId);
-	try {
-		await chrome.debugger.sendCommand({ tabId }, "Runtime.enable");
-	} catch {}
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (!isDebuggableUrl$1(tab.url)) {
+      attached.delete(tabId);
+      throw new Error(`Cannot debug tab ${tabId}: URL is ${tab.url ?? "unknown"}`);
+    }
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith("Cannot debug tab")) throw e;
+    attached.delete(tabId);
+    throw new Error(`Tab ${tabId} no longer exists`);
+  }
+  if (attached.has(tabId)) {
+    try {
+      await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+        expression: "1",
+        returnByValue: true
+      });
+      return;
+    } catch {
+      attached.delete(tabId);
+    }
+  }
+  const MAX_ATTACH_RETRIES = aggressiveRetry ? 5 : 2;
+  const RETRY_DELAY_MS = aggressiveRetry ? 1500 : 500;
+  let lastError = "";
+  for (let attempt = 1; attempt <= MAX_ATTACH_RETRIES; attempt++) {
+    try {
+      try {
+        await chrome.debugger.detach({ tabId });
+      } catch {
+      }
+      await chrome.debugger.attach({ tabId }, "1.3");
+      lastError = "";
+      break;
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      if (attempt < MAX_ATTACH_RETRIES) {
+        console.warn(`[opencli] attach attempt ${attempt}/${MAX_ATTACH_RETRIES} failed: ${lastError}, retrying in ${RETRY_DELAY_MS}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+        try {
+          const tab = await chrome.tabs.get(tabId);
+          if (!isDebuggableUrl$1(tab.url)) {
+            lastError = `Tab URL changed to ${tab.url} during retry`;
+            break;
+          }
+        } catch {
+          lastError = `Tab ${tabId} no longer exists`;
+        }
+      }
+    }
+  }
+  if (lastError) {
+    let finalUrl = "unknown";
+    let finalWindowId = "unknown";
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      finalUrl = tab.url ?? "undefined";
+      finalWindowId = String(tab.windowId);
+    } catch {
+    }
+    console.warn(`[opencli] attach failed for tab ${tabId}: url=${finalUrl}, windowId=${finalWindowId}, error=${lastError}`);
+    const hint = lastError.includes("chrome-extension://") ? ". Tip: another Chrome extension may be interfering — try disabling other extensions" : "";
+    throw new Error(`attach failed: ${lastError}${hint}`);
+  }
+  attached.add(tabId);
+  try {
+    await chrome.debugger.sendCommand({ tabId }, "Runtime.enable");
+  } catch {
+  }
 }
 async function evaluate(tabId, expression, aggressiveRetry = false) {
-	const MAX_EVAL_RETRIES = aggressiveRetry ? 3 : 2;
-	for (let attempt = 1; attempt <= MAX_EVAL_RETRIES; attempt++) try {
-		await ensureAttached(tabId, aggressiveRetry);
-		const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
-			expression,
-			returnByValue: true,
-			awaitPromise: true
-		});
-		if (result.exceptionDetails) {
-			const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
-			throw new Error(errMsg);
-		}
-		return result.result?.value;
-	} catch (e) {
-		const msg = e instanceof Error ? e.message : String(e);
-		const isNavigateError = msg.includes("Inspected target navigated") || msg.includes("Target closed");
-		if ((isNavigateError || msg.includes("attach failed") || msg.includes("Debugger is not attached") || msg.includes("chrome-extension://")) && attempt < MAX_EVAL_RETRIES) {
-			attached.delete(tabId);
-			const retryMs = isNavigateError ? 200 : 500;
-			await new Promise((resolve) => setTimeout(resolve, retryMs));
-			continue;
-		}
-		throw e;
-	}
-	throw new Error("evaluate: max retries exhausted");
+  const MAX_EVAL_RETRIES = aggressiveRetry ? 3 : 2;
+  for (let attempt = 1; attempt <= MAX_EVAL_RETRIES; attempt++) {
+    try {
+      await ensureAttached(tabId, aggressiveRetry);
+      const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+        expression,
+        returnByValue: true,
+        awaitPromise: true
+      });
+      if (result.exceptionDetails) {
+        const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
+        throw new Error(errMsg);
+      }
+      return result.result?.value;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const isNavigateError = msg.includes("Inspected target navigated") || msg.includes("Target closed");
+      const isAttachError = isNavigateError || msg.includes("attach failed") || msg.includes("Debugger is not attached") || msg.includes("chrome-extension://");
+      if (isAttachError && attempt < MAX_EVAL_RETRIES) {
+        attached.delete(tabId);
+        const retryMs = isNavigateError ? 200 : 500;
+        await new Promise((resolve) => setTimeout(resolve, retryMs));
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw new Error("evaluate: max retries exhausted");
 }
-var evaluateAsync = evaluate;
-/**
-* Capture a screenshot via CDP Page.captureScreenshot.
-* Returns base64-encoded image data.
-*/
+const evaluateAsync = evaluate;
 async function screenshot(tabId, options = {}) {
-	await ensureAttached(tabId);
-	const format = options.format ?? "png";
-	if (options.fullPage) {
-		const metrics = await chrome.debugger.sendCommand({ tabId }, "Page.getLayoutMetrics");
-		const size = metrics.cssContentSize || metrics.contentSize;
-		if (size) await chrome.debugger.sendCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
-			mobile: false,
-			width: Math.ceil(size.width),
-			height: Math.ceil(size.height),
-			deviceScaleFactor: 1
-		});
-	}
-	try {
-		const params = { format };
-		if (format === "jpeg" && options.quality !== void 0) params.quality = Math.max(0, Math.min(100, options.quality));
-		return (await chrome.debugger.sendCommand({ tabId }, "Page.captureScreenshot", params)).data;
-	} finally {
-		if (options.fullPage) await chrome.debugger.sendCommand({ tabId }, "Emulation.clearDeviceMetricsOverride").catch(() => {});
-	}
+  await ensureAttached(tabId);
+  const format = options.format ?? "png";
+  if (options.fullPage) {
+    const metrics = await chrome.debugger.sendCommand({ tabId }, "Page.getLayoutMetrics");
+    const size = metrics.cssContentSize || metrics.contentSize;
+    if (size) {
+      await chrome.debugger.sendCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
+        mobile: false,
+        width: Math.ceil(size.width),
+        height: Math.ceil(size.height),
+        deviceScaleFactor: 1
+      });
+    }
+  }
+  try {
+    const params = { format };
+    if (format === "jpeg" && options.quality !== void 0) {
+      params.quality = Math.max(0, Math.min(100, options.quality));
+    }
+    const result = await chrome.debugger.sendCommand({ tabId }, "Page.captureScreenshot", params);
+    return result.data;
+  } finally {
+    if (options.fullPage) {
+      await chrome.debugger.sendCommand({ tabId }, "Emulation.clearDeviceMetricsOverride").catch(() => {
+      });
+    }
+  }
 }
-/**
-* Set local file paths on a file input element via CDP DOM.setFileInputFiles.
-* This bypasses the need to send large base64 payloads through the message channel —
-* Chrome reads the files directly from the local filesystem.
-*
-* @param tabId - Target tab ID
-* @param files - Array of absolute local file paths
-* @param selector - CSS selector to find the file input (optional, defaults to first file input)
-*/
 async function setFileInputFiles(tabId, files, selector) {
-	await ensureAttached(tabId);
-	await chrome.debugger.sendCommand({ tabId }, "DOM.enable");
-	const doc = await chrome.debugger.sendCommand({ tabId }, "DOM.getDocument");
-	const query = selector || "input[type=\"file\"]";
-	const result = await chrome.debugger.sendCommand({ tabId }, "DOM.querySelector", {
-		nodeId: doc.root.nodeId,
-		selector: query
-	});
-	if (!result.nodeId) throw new Error(`No element found matching selector: ${query}`);
-	await chrome.debugger.sendCommand({ tabId }, "DOM.setFileInputFiles", {
-		files,
-		nodeId: result.nodeId
-	});
+  await ensureAttached(tabId);
+  await chrome.debugger.sendCommand({ tabId }, "DOM.enable");
+  const doc = await chrome.debugger.sendCommand({ tabId }, "DOM.getDocument");
+  const query = selector || 'input[type="file"]';
+  const result = await chrome.debugger.sendCommand({ tabId }, "DOM.querySelector", {
+    nodeId: doc.root.nodeId,
+    selector: query
+  });
+  if (!result.nodeId) {
+    throw new Error(`No element found matching selector: ${query}`);
+  }
+  await chrome.debugger.sendCommand({ tabId }, "DOM.setFileInputFiles", {
+    files,
+    nodeId: result.nodeId
+  });
 }
 async function insertText(tabId, text) {
-	await ensureAttached(tabId);
-	await chrome.debugger.sendCommand({ tabId }, "Input.insertText", { text });
+  await ensureAttached(tabId);
+  await chrome.debugger.sendCommand({ tabId }, "Input.insertText", { text });
+}
+function registerFrameTracking() {
+  chrome.debugger.onEvent.addListener((source, method, params) => {
+    const tabId = source.tabId;
+    if (!tabId) return;
+    if (method === "Runtime.executionContextCreated") {
+      const context = params.context;
+      if (!context?.auxData?.frameId || context.auxData.isDefault !== true) return;
+      const frameId = context.auxData.frameId;
+      if (!tabFrameContexts.has(tabId)) {
+        tabFrameContexts.set(tabId, /* @__PURE__ */ new Map());
+      }
+      tabFrameContexts.get(tabId).set(frameId, context.id);
+    }
+    if (method === "Runtime.executionContextDestroyed") {
+      const ctxId = params.executionContextId;
+      const contexts = tabFrameContexts.get(tabId);
+      if (contexts) {
+        for (const [fid, cid] of contexts) {
+          if (cid === ctxId) {
+            contexts.delete(fid);
+            break;
+          }
+        }
+      }
+    }
+    if (method === "Runtime.executionContextsCleared") {
+      tabFrameContexts.delete(tabId);
+    }
+  });
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    tabFrameContexts.delete(tabId);
+  });
+}
+async function getFrameTree(tabId) {
+  await ensureAttached(tabId);
+  return chrome.debugger.sendCommand({ tabId }, "Page.getFrameTree");
+}
+async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = false) {
+  await ensureAttached(tabId, aggressiveRetry);
+  await chrome.debugger.sendCommand({ tabId }, "Runtime.enable").catch(() => {
+  });
+  const contexts = tabFrameContexts.get(tabId);
+  const contextId = contexts?.get(frameId);
+  if (contextId === void 0) {
+    throw new Error(`No execution context found for frame ${frameId}. The frame may not be loaded yet.`);
+  }
+  const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+    expression,
+    contextId,
+    returnByValue: true,
+    awaitPromise: true
+  });
+  if (result.exceptionDetails) {
+    const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
+    throw new Error(errMsg);
+  }
+  return result.result?.value;
 }
 function normalizeCapturePatterns(pattern) {
-	return String(pattern || "").split("|").map((part) => part.trim()).filter(Boolean);
+  return String(pattern || "").split("|").map((part) => part.trim()).filter(Boolean);
 }
 function shouldCaptureUrl(url, patterns) {
-	if (!url) return false;
-	if (!patterns.length) return true;
-	return patterns.some((pattern) => url.includes(pattern));
+  if (!url) return false;
+  if (!patterns.length) return true;
+  return patterns.some((pattern) => url.includes(pattern));
 }
 function normalizeHeaders(headers) {
-	if (!headers || typeof headers !== "object") return {};
-	const out = {};
-	for (const [key, value] of Object.entries(headers)) out[String(key)] = String(value);
-	return out;
+  if (!headers || typeof headers !== "object") return {};
+  const out = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[String(key)] = String(value);
+  }
+  return out;
 }
 function getOrCreateNetworkCaptureEntry(tabId, requestId, fallback) {
-	const state = networkCaptures.get(tabId);
-	if (!state) return null;
-	const existingIndex = state.requestToIndex.get(requestId);
-	if (existingIndex !== void 0) return state.entries[existingIndex] || null;
-	const url = fallback?.url || "";
-	if (!shouldCaptureUrl(url, state.patterns)) return null;
-	const entry = {
-		kind: "cdp",
-		url,
-		method: fallback?.method || "GET",
-		requestHeaders: fallback?.requestHeaders || {},
-		timestamp: Date.now()
-	};
-	state.entries.push(entry);
-	state.requestToIndex.set(requestId, state.entries.length - 1);
-	return entry;
+  const state = networkCaptures.get(tabId);
+  if (!state) return null;
+  const existingIndex = state.requestToIndex.get(requestId);
+  if (existingIndex !== void 0) {
+    return state.entries[existingIndex] || null;
+  }
+  const url = fallback?.url || "";
+  if (!shouldCaptureUrl(url, state.patterns)) return null;
+  const entry = {
+    kind: "cdp",
+    url,
+    method: fallback?.method || "GET",
+    requestHeaders: fallback?.requestHeaders || {},
+    timestamp: Date.now()
+  };
+  state.entries.push(entry);
+  state.requestToIndex.set(requestId, state.entries.length - 1);
+  return entry;
 }
 async function startNetworkCapture(tabId, pattern) {
-	await ensureAttached(tabId);
-	await chrome.debugger.sendCommand({ tabId }, "Network.enable");
-	networkCaptures.set(tabId, {
-		patterns: normalizeCapturePatterns(pattern),
-		entries: [],
-		requestToIndex: /* @__PURE__ */ new Map()
-	});
+  await ensureAttached(tabId);
+  await chrome.debugger.sendCommand({ tabId }, "Network.enable");
+  networkCaptures.set(tabId, {
+    patterns: normalizeCapturePatterns(pattern),
+    entries: [],
+    requestToIndex: /* @__PURE__ */ new Map()
+  });
 }
 async function readNetworkCapture(tabId) {
-	const state = networkCaptures.get(tabId);
-	if (!state) return [];
-	const entries = state.entries.slice();
-	state.entries = [];
-	state.requestToIndex.clear();
-	return entries;
+  const state = networkCaptures.get(tabId);
+  if (!state) return [];
+  const entries = state.entries.slice();
+  state.entries = [];
+  state.requestToIndex.clear();
+  return entries;
 }
 function hasActiveNetworkCapture(tabId) {
-	return networkCaptures.has(tabId);
+  return networkCaptures.has(tabId);
 }
 async function detach(tabId) {
-	if (!attached.has(tabId)) return;
-	attached.delete(tabId);
-	networkCaptures.delete(tabId);
-	try {
-		await chrome.debugger.detach({ tabId });
-	} catch {}
+  if (!attached.has(tabId)) return;
+  attached.delete(tabId);
+  networkCaptures.delete(tabId);
+  tabFrameContexts.delete(tabId);
+  try {
+    await chrome.debugger.detach({ tabId });
+  } catch {
+  }
 }
 function registerListeners() {
-	chrome.tabs.onRemoved.addListener((tabId) => {
-		attached.delete(tabId);
-		networkCaptures.delete(tabId);
-	});
-	chrome.debugger.onDetach.addListener((source) => {
-		if (source.tabId) {
-			attached.delete(source.tabId);
-			networkCaptures.delete(source.tabId);
-		}
-	});
-	chrome.tabs.onUpdated.addListener(async (tabId, info) => {
-		if (info.url && !isDebuggableUrl$1(info.url)) await detach(tabId);
-	});
-	chrome.debugger.onEvent.addListener(async (source, method, params) => {
-		const tabId = source.tabId;
-		if (!tabId) return;
-		const state = networkCaptures.get(tabId);
-		if (!state) return;
-		if (method === "Network.requestWillBeSent") {
-			const requestId = String(params?.requestId || "");
-			const request = params?.request;
-			const entry = getOrCreateNetworkCaptureEntry(tabId, requestId, {
-				url: request?.url,
-				method: request?.method,
-				requestHeaders: normalizeHeaders(request?.headers)
-			});
-			if (!entry) return;
-			entry.requestBodyKind = request?.hasPostData ? "string" : "empty";
-			entry.requestBodyPreview = String(request?.postData || "").slice(0, 4e3);
-			try {
-				const postData = await chrome.debugger.sendCommand({ tabId }, "Network.getRequestPostData", { requestId });
-				if (postData?.postData) {
-					entry.requestBodyKind = "string";
-					entry.requestBodyPreview = postData.postData.slice(0, 4e3);
-				}
-			} catch {}
-			return;
-		}
-		if (method === "Network.responseReceived") {
-			const requestId = String(params?.requestId || "");
-			const response = params?.response;
-			const entry = getOrCreateNetworkCaptureEntry(tabId, requestId, { url: response?.url });
-			if (!entry) return;
-			entry.responseStatus = response?.status;
-			entry.responseContentType = response?.mimeType || "";
-			entry.responseHeaders = normalizeHeaders(response?.headers);
-			return;
-		}
-		if (method === "Network.loadingFinished") {
-			const requestId = String(params?.requestId || "");
-			const stateEntryIndex = state.requestToIndex.get(requestId);
-			if (stateEntryIndex === void 0) return;
-			const entry = state.entries[stateEntryIndex];
-			if (!entry) return;
-			try {
-				const body = await chrome.debugger.sendCommand({ tabId }, "Network.getResponseBody", { requestId });
-				if (typeof body?.body === "string") entry.responsePreview = body.base64Encoded ? `base64:${body.body.slice(0, 4e3)}` : body.body.slice(0, 4e3);
-			} catch {}
-		}
-	});
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    attached.delete(tabId);
+    networkCaptures.delete(tabId);
+    tabFrameContexts.delete(tabId);
+  });
+  chrome.debugger.onDetach.addListener((source) => {
+    if (source.tabId) {
+      attached.delete(source.tabId);
+      networkCaptures.delete(source.tabId);
+      tabFrameContexts.delete(source.tabId);
+    }
+  });
+  chrome.tabs.onUpdated.addListener(async (tabId, info) => {
+    if (info.url && !isDebuggableUrl$1(info.url)) {
+      await detach(tabId);
+    }
+  });
+  chrome.debugger.onEvent.addListener(async (source, method, params) => {
+    const tabId = source.tabId;
+    if (!tabId) return;
+    const state = networkCaptures.get(tabId);
+    if (!state) return;
+    const eventParams = params;
+    if (method === "Network.requestWillBeSent") {
+      const requestId = String(eventParams?.requestId || "");
+      const request = eventParams?.request;
+      const entry = getOrCreateNetworkCaptureEntry(tabId, requestId, {
+        url: request?.url,
+        method: request?.method,
+        requestHeaders: normalizeHeaders(request?.headers)
+      });
+      if (!entry) return;
+      entry.requestBodyKind = request?.hasPostData ? "string" : "empty";
+      {
+        const raw = String(request?.postData || "");
+        const fullSize = raw.length;
+        const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
+        entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
+        entry.requestBodyFullSize = fullSize;
+        entry.requestBodyTruncated = truncated;
+      }
+      try {
+        const postData = await chrome.debugger.sendCommand({ tabId }, "Network.getRequestPostData", { requestId });
+        if (postData?.postData) {
+          const raw = postData.postData;
+          const fullSize = raw.length;
+          const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
+          entry.requestBodyKind = "string";
+          entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
+          entry.requestBodyFullSize = fullSize;
+          entry.requestBodyTruncated = truncated;
+        }
+      } catch {
+      }
+      return;
+    }
+    if (method === "Network.responseReceived") {
+      const requestId = String(eventParams?.requestId || "");
+      const response = eventParams?.response;
+      const entry = getOrCreateNetworkCaptureEntry(tabId, requestId, {
+        url: response?.url
+      });
+      if (!entry) return;
+      entry.responseStatus = response?.status;
+      entry.responseContentType = response?.mimeType || "";
+      entry.responseHeaders = normalizeHeaders(response?.headers);
+      return;
+    }
+    if (method === "Network.loadingFinished") {
+      const requestId = String(eventParams?.requestId || "");
+      const stateEntryIndex = state.requestToIndex.get(requestId);
+      if (stateEntryIndex === void 0) return;
+      const entry = state.entries[stateEntryIndex];
+      if (!entry) return;
+      try {
+        const body = await chrome.debugger.sendCommand({ tabId }, "Network.getResponseBody", { requestId });
+        if (typeof body?.body === "string") {
+          const fullSize = body.body.length;
+          const truncated = fullSize > CDP_RESPONSE_BODY_CAPTURE_LIMIT;
+          const stored = truncated ? body.body.slice(0, CDP_RESPONSE_BODY_CAPTURE_LIMIT) : body.body;
+          entry.responsePreview = body.base64Encoded ? `base64:${stored}` : stored;
+          entry.responseBodyFullSize = fullSize;
+          entry.responseBodyTruncated = truncated;
+        }
+      } catch {
+      }
+    }
+  });
 }
-//#endregion
-//#region src/identity.ts
-/**
-* Page identity mapping — targetId ↔ tabId.
-*
-* targetId is the cross-layer page identity (CDP target UUID).
-* tabId is an internal Chrome Tabs API routing detail — never exposed outside the extension.
-*
-* Lifecycle:
-*   - Cache populated lazily via chrome.debugger.getTargets()
-*   - Evicted on tab close (chrome.tabs.onRemoved)
-*   - Miss triggers full refresh; refresh miss → hard error (no guessing)
-*/
-var targetToTab = /* @__PURE__ */ new Map();
-var tabToTarget = /* @__PURE__ */ new Map();
-/**
-* Resolve targetId for a given tabId.
-* Returns cached value if available; on miss, refreshes from chrome.debugger.getTargets().
-* Throws if no targetId can be found (page may have been destroyed).
-*/
+
+const targetToTab = /* @__PURE__ */ new Map();
+const tabToTarget = /* @__PURE__ */ new Map();
 async function resolveTargetId(tabId) {
-	const cached = tabToTarget.get(tabId);
-	if (cached) return cached;
-	await refreshMappings();
-	const result = tabToTarget.get(tabId);
-	if (!result) throw new Error(`No targetId for tab ${tabId} — page may have been closed`);
-	return result;
+  const cached = tabToTarget.get(tabId);
+  if (cached) return cached;
+  await refreshMappings();
+  const result = tabToTarget.get(tabId);
+  if (!result) throw new Error(`No targetId for tab ${tabId} — page may have been closed`);
+  return result;
 }
-/**
-* Resolve tabId for a given targetId.
-* Returns cached value if available; on miss, refreshes from chrome.debugger.getTargets().
-* Throws if no tabId can be found — never falls back to guessing.
-*/
 async function resolveTabId$1(targetId) {
-	const cached = targetToTab.get(targetId);
-	if (cached !== void 0) return cached;
-	await refreshMappings();
-	const result = targetToTab.get(targetId);
-	if (result === void 0) throw new Error(`Page not found: ${targetId} — stale page identity`);
-	return result;
+  const cached = targetToTab.get(targetId);
+  if (cached !== void 0) return cached;
+  await refreshMappings();
+  const result = targetToTab.get(targetId);
+  if (result === void 0) throw new Error(`Page not found: ${targetId} — stale page identity`);
+  return result;
 }
-/**
-* Remove mappings for a closed tab.
-* Called from chrome.tabs.onRemoved listener.
-*/
 function evictTab(tabId) {
-	const targetId = tabToTarget.get(tabId);
-	if (targetId) targetToTab.delete(targetId);
-	tabToTarget.delete(tabId);
+  const targetId = tabToTarget.get(tabId);
+  if (targetId) targetToTab.delete(targetId);
+  tabToTarget.delete(tabId);
 }
-/**
-* Full refresh of targetId ↔ tabId mappings from chrome.debugger.getTargets().
-*/
 async function refreshMappings() {
-	const targets = await chrome.debugger.getTargets();
-	targetToTab.clear();
-	tabToTarget.clear();
-	for (const t of targets) if (t.type === "page" && t.tabId !== void 0) {
-		targetToTab.set(t.id, t.tabId);
-		tabToTarget.set(t.tabId, t.id);
-	}
+  const targets = await chrome.debugger.getTargets();
+  targetToTab.clear();
+  tabToTarget.clear();
+  for (const t of targets) {
+    if (t.type === "page" && t.tabId !== void 0) {
+      targetToTab.set(t.id, t.tabId);
+      tabToTarget.set(t.tabId, t.id);
+    }
+  }
 }
-//#endregion
-//#region src/background.ts
-var ws = null;
-var reconnectTimer = null;
-var reconnectAttempts = 0;
-var _origLog = console.log.bind(console);
-var _origWarn = console.warn.bind(console);
-var _origError = console.error.bind(console);
+
+let ws = null;
+let reconnectTimer = null;
+let reconnectAttempts = 0;
+const _origLog = console.log.bind(console);
+const _origWarn = console.warn.bind(console);
+const _origError = console.error.bind(console);
 function forwardLog(level, args) {
-	if (!ws || ws.readyState !== WebSocket.OPEN) return;
-	try {
-		const msg = args.map((a) => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
-		ws.send(JSON.stringify({
-			type: "log",
-			level,
-			msg,
-			ts: Date.now()
-		}));
-	} catch {}
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  try {
+    const msg = args.map((a) => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
+    ws.send(JSON.stringify({ type: "log", level, msg, ts: Date.now() }));
+  } catch {
+  }
 }
 console.log = (...args) => {
-	_origLog(...args);
-	forwardLog("info", args);
+  _origLog(...args);
+  forwardLog("info", args);
 };
 console.warn = (...args) => {
-	_origWarn(...args);
-	forwardLog("warn", args);
+  _origWarn(...args);
+  forwardLog("warn", args);
 };
 console.error = (...args) => {
-	_origError(...args);
-	forwardLog("error", args);
+  _origError(...args);
+  forwardLog("error", args);
 };
-/**
-* Probe the daemon via its /ping HTTP endpoint before attempting a WebSocket
-* connection.  fetch() failures are silently catchable; new WebSocket() is not
-* — Chrome logs ERR_CONNECTION_REFUSED to the extension error page before any
-* JS handler can intercept it.  By keeping the probe inside connect() every
-* call site remains unchanged and the guard can never be accidentally skipped.
-*/
 async function connect() {
-	if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
-	try {
-		if (!(await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1e3) })).ok) return;
-	} catch {
-		return;
-	}
-	try {
-		ws = new WebSocket(DAEMON_WS_URL);
-	} catch {
-		scheduleReconnect();
-		return;
-	}
-	ws.onopen = () => {
-		console.log("[opencli] Connected to daemon");
-		reconnectAttempts = 0;
-		if (reconnectTimer) {
-			clearTimeout(reconnectTimer);
-			reconnectTimer = null;
-		}
-		ws?.send(JSON.stringify({
-			type: "hello",
-			version: chrome.runtime.getManifest().version,
-			compatRange: ">=1.7.0"
-		}));
-	};
-	ws.onmessage = async (event) => {
-		try {
-			const result = await handleCommand(JSON.parse(event.data));
-			ws?.send(JSON.stringify(result));
-		} catch (err) {
-			console.error("[opencli] Message handling error:", err);
-		}
-	};
-	ws.onclose = () => {
-		console.log("[opencli] Disconnected from daemon");
-		ws = null;
-		scheduleReconnect();
-	};
-	ws.onerror = () => {
-		ws?.close();
-	};
+  if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+  try {
+    const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1e3) });
+    if (!res.ok) return;
+  } catch {
+    return;
+  }
+  try {
+    ws = new WebSocket(DAEMON_WS_URL);
+  } catch {
+    scheduleReconnect();
+    return;
+  }
+  ws.onopen = () => {
+    console.log("[opencli] Connected to daemon");
+    reconnectAttempts = 0;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    ws?.send(JSON.stringify({
+      type: "hello",
+      version: chrome.runtime.getManifest().version,
+      compatRange: ">=1.7.0"
+    }));
+  };
+  ws.onmessage = async (event) => {
+    try {
+      const command = JSON.parse(event.data);
+      const result = await handleCommand(command);
+      ws?.send(JSON.stringify(result));
+    } catch (err) {
+      console.error("[opencli] Message handling error:", err);
+    }
+  };
+  ws.onclose = () => {
+    console.log("[opencli] Disconnected from daemon");
+    ws = null;
+    scheduleReconnect();
+  };
+  ws.onerror = () => {
+    ws?.close();
+  };
 }
-/**
-* After MAX_EAGER_ATTEMPTS (reaching 60s backoff), stop scheduling reconnects.
-* The keepalive alarm (~24s) will still call connect() periodically, but at a
-* much lower frequency — reducing console noise when the daemon is not running.
-*/
-var MAX_EAGER_ATTEMPTS = 6;
+const MAX_EAGER_ATTEMPTS = 6;
 function scheduleReconnect() {
-	if (reconnectTimer) return;
-	reconnectAttempts++;
-	if (reconnectAttempts > MAX_EAGER_ATTEMPTS) return;
-	const delay = Math.min(WS_RECONNECT_BASE_DELAY * Math.pow(2, reconnectAttempts - 1), WS_RECONNECT_MAX_DELAY);
-	reconnectTimer = setTimeout(() => {
-		reconnectTimer = null;
-		connect();
-	}, delay);
+  if (reconnectTimer) return;
+  reconnectAttempts++;
+  if (reconnectAttempts > MAX_EAGER_ATTEMPTS) return;
+  const delay = Math.min(WS_RECONNECT_BASE_DELAY * Math.pow(2, reconnectAttempts - 1), WS_RECONNECT_MAX_DELAY);
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void connect();
+  }, delay);
 }
-var automationSessions = /* @__PURE__ */ new Map();
-var IDLE_TIMEOUT_DEFAULT = 3e4;
-var IDLE_TIMEOUT_INTERACTIVE = 6e5;
-/** Per-workspace custom timeout overrides set via command.idleTimeout */
-var workspaceTimeoutOverrides = /* @__PURE__ */ new Map();
+const automationSessions = /* @__PURE__ */ new Map();
+const IDLE_TIMEOUT_DEFAULT = 3e4;
+const IDLE_TIMEOUT_INTERACTIVE = 6e5;
+const IDLE_TIMEOUT_NONE = -1;
+class CommandFailure extends Error {
+  constructor(code, message, hint) {
+    super(message);
+    this.code = code;
+    this.hint = hint;
+    this.name = "CommandFailure";
+  }
+}
+const workspaceTimeoutOverrides = /* @__PURE__ */ new Map();
 function getIdleTimeout(workspace) {
-	const override = workspaceTimeoutOverrides.get(workspace);
-	if (override !== void 0) return override;
-	if (workspace.startsWith("browser:") || workspace.startsWith("operate:")) return IDLE_TIMEOUT_INTERACTIVE;
-	return IDLE_TIMEOUT_DEFAULT;
+  if (workspace.startsWith("bound:")) return IDLE_TIMEOUT_NONE;
+  const override = workspaceTimeoutOverrides.get(workspace);
+  if (override !== void 0) return override;
+  if (workspace.startsWith("browser:") || workspace.startsWith("operate:")) {
+    return IDLE_TIMEOUT_INTERACTIVE;
+  }
+  return IDLE_TIMEOUT_DEFAULT;
 }
-var windowFocused = false;
+let windowFocused = false;
 function getWorkspaceKey(workspace) {
-	return workspace?.trim() || "default";
+  return workspace?.trim() || "default";
 }
 function resetWindowIdleTimer(workspace) {
-	const session = automationSessions.get(workspace);
-	if (!session) return;
-	if (session.idleTimer) clearTimeout(session.idleTimer);
-	const timeout = getIdleTimeout(workspace);
-	session.idleDeadlineAt = Date.now() + timeout;
-	session.idleTimer = setTimeout(async () => {
-		const current = automationSessions.get(workspace);
-		if (!current) return;
-		if (!current.owned) {
-			console.log(`[opencli] Borrowed workspace ${workspace} detached from window ${current.windowId} (idle timeout)`);
-			workspaceTimeoutOverrides.delete(workspace);
-			automationSessions.delete(workspace);
-			return;
-		}
-		try {
-			await chrome.windows.remove(current.windowId);
-			console.log(`[opencli] Automation window ${current.windowId} (${workspace}) closed (idle timeout, ${timeout / 1e3}s)`);
-		} catch {}
-		workspaceTimeoutOverrides.delete(workspace);
-		automationSessions.delete(workspace);
-	}, timeout);
+  const session = automationSessions.get(workspace);
+  if (!session) return;
+  if (session.idleTimer) clearTimeout(session.idleTimer);
+  const timeout = getIdleTimeout(workspace);
+  if (timeout <= 0) {
+    session.idleTimer = null;
+    session.idleDeadlineAt = 0;
+    return;
+  }
+  session.idleDeadlineAt = Date.now() + timeout;
+  session.idleTimer = setTimeout(async () => {
+    const current = automationSessions.get(workspace);
+    if (!current) return;
+    if (!current.owned) {
+      console.log(`[opencli] Borrowed workspace ${workspace} detached from window ${current.windowId} (idle timeout)`);
+      workspaceTimeoutOverrides.delete(workspace);
+      automationSessions.delete(workspace);
+      return;
+    }
+    try {
+      await chrome.windows.remove(current.windowId);
+      console.log(`[opencli] Automation window ${current.windowId} (${workspace}) closed (idle timeout, ${timeout / 1e3}s)`);
+    } catch {
+    }
+    workspaceTimeoutOverrides.delete(workspace);
+    automationSessions.delete(workspace);
+  }, timeout);
 }
-/** Get or create the dedicated automation window.
-*  @param initialUrl — if provided (http/https), used as the initial page instead of about:blank.
-*    This avoids an extra blank-page→target-domain navigation on first command.
-*/
 async function getAutomationWindow(workspace, initialUrl) {
-	const existing = automationSessions.get(workspace);
-	if (existing) try {
-		await chrome.windows.get(existing.windowId);
-		return existing.windowId;
-	} catch {
-		automationSessions.delete(workspace);
-	}
-	const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
-	const win = await chrome.windows.create({
-		url: startUrl,
-		focused: windowFocused,
-		width: 1280,
-		height: 900,
-		type: "normal"
-	});
-	const session = {
-		windowId: win.id,
-		idleTimer: null,
-		idleDeadlineAt: Date.now() + getIdleTimeout(workspace),
-		owned: true,
-		preferredTabId: null
-	};
-	automationSessions.set(workspace, session);
-	console.log(`[opencli] Created automation window ${session.windowId} (${workspace}, start=${startUrl})`);
-	resetWindowIdleTimer(workspace);
-	const tabs = await chrome.tabs.query({ windowId: win.id });
-	if (tabs[0]?.id) await new Promise((resolve) => {
-		const timeout = setTimeout(resolve, 500);
-		const listener = (tabId, info) => {
-			if (tabId === tabs[0].id && info.status === "complete") {
-				chrome.tabs.onUpdated.removeListener(listener);
-				clearTimeout(timeout);
-				resolve();
-			}
-		};
-		if (tabs[0].status === "complete") {
-			clearTimeout(timeout);
-			resolve();
-		} else chrome.tabs.onUpdated.addListener(listener);
-	});
-	return session.windowId;
+  if (workspace.startsWith("bound:") && !automationSessions.has(workspace)) {
+    throw new CommandFailure(
+      "bound_session_missing",
+      `Bound workspace "${workspace}" is not attached to a tab. Run "opencli browser bind-current --workspace ${workspace}" first.`,
+      "Run bind-current again, then retry the browser command."
+    );
+  }
+  const existing = automationSessions.get(workspace);
+  if (existing) {
+    if (!existing.owned) {
+      throw new CommandFailure(
+        "bound_window_operation_blocked",
+        `Workspace "${workspace}" is bound to a user tab and does not own an automation window.`,
+        "Use commands that operate on the bound tab, or unbind and use an automation workspace."
+      );
+    }
+    try {
+      await chrome.windows.get(existing.windowId);
+      return existing.windowId;
+    } catch {
+      automationSessions.delete(workspace);
+    }
+  }
+  const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
+  const win = await chrome.windows.create({
+    url: startUrl,
+    focused: windowFocused,
+    width: 1280,
+    height: 900,
+    type: "normal"
+  });
+  const session = {
+    windowId: win.id,
+    idleTimer: null,
+    idleDeadlineAt: Date.now() + getIdleTimeout(workspace),
+    owned: true,
+    preferredTabId: null
+  };
+  automationSessions.set(workspace, session);
+  console.log(`[opencli] Created automation window ${session.windowId} (${workspace}, start=${startUrl})`);
+  resetWindowIdleTimer(workspace);
+  const tabs = await chrome.tabs.query({ windowId: win.id });
+  if (tabs[0]?.id) {
+    await new Promise((resolve) => {
+      const timeout = setTimeout(resolve, 500);
+      const listener = (tabId, info) => {
+        if (tabId === tabs[0].id && info.status === "complete") {
+          chrome.tabs.onUpdated.removeListener(listener);
+          clearTimeout(timeout);
+          resolve();
+        }
+      };
+      if (tabs[0].status === "complete") {
+        clearTimeout(timeout);
+        resolve();
+      } else {
+        chrome.tabs.onUpdated.addListener(listener);
+      }
+    });
+  }
+  return session.windowId;
 }
 chrome.windows.onRemoved.addListener(async (windowId) => {
-	for (const [workspace, session] of automationSessions.entries()) if (session.windowId === windowId) {
-		console.log(`[opencli] Automation window closed (${workspace})`);
-		if (session.idleTimer) clearTimeout(session.idleTimer);
-		automationSessions.delete(workspace);
-		workspaceTimeoutOverrides.delete(workspace);
-	}
+  for (const [workspace, session] of automationSessions.entries()) {
+    if (session.windowId === windowId) {
+      console.log(`[opencli] Automation window closed (${workspace})`);
+      if (session.idleTimer) clearTimeout(session.idleTimer);
+      automationSessions.delete(workspace);
+      workspaceTimeoutOverrides.delete(workspace);
+    }
+  }
 });
 chrome.tabs.onRemoved.addListener((tabId) => {
-	evictTab(tabId);
+  evictTab(tabId);
+  for (const [workspace, session] of automationSessions.entries()) {
+    if (!session.owned && session.preferredTabId === tabId) {
+      if (session.idleTimer) clearTimeout(session.idleTimer);
+      automationSessions.delete(workspace);
+      workspaceTimeoutOverrides.delete(workspace);
+      console.log(`[opencli] Borrowed workspace ${workspace} detached from tab ${tabId} (tab closed)`);
+    }
+  }
 });
-var initialized = false;
+let initialized = false;
 function initialize() {
-	if (initialized) return;
-	initialized = true;
-	chrome.alarms.create("keepalive", { periodInMinutes: .4 });
-	registerListeners();
-	connect();
-	console.log("[opencli] OpenCLI extension initialized");
+  if (initialized) return;
+  initialized = true;
+  chrome.alarms.create("keepalive", { periodInMinutes: 0.4 });
+  registerListeners();
+  registerFrameTracking();
+  void connect();
+  console.log("[opencli] OpenCLI extension initialized");
 }
 chrome.runtime.onInstalled.addListener(() => {
-	initialize();
+  initialize();
 });
 chrome.runtime.onStartup.addListener(() => {
-	initialize();
+  initialize();
 });
 chrome.alarms.onAlarm.addListener((alarm) => {
-	if (alarm.name === "keepalive") connect();
+  if (alarm.name === "keepalive") void connect();
 });
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-	if (msg?.type === "getStatus") sendResponse({
-		connected: ws?.readyState === WebSocket.OPEN,
-		reconnecting: reconnectTimer !== null
-	});
-	return false;
+  if (msg?.type === "getStatus") {
+    sendResponse({
+      connected: ws?.readyState === WebSocket.OPEN,
+      reconnecting: reconnectTimer !== null
+    });
+  }
+  return false;
 });
 async function handleCommand(cmd) {
-	const workspace = getWorkspaceKey(cmd.workspace);
-	windowFocused = cmd.windowFocused === true;
-	if (cmd.idleTimeout != null && cmd.idleTimeout > 0) workspaceTimeoutOverrides.set(workspace, cmd.idleTimeout * 1e3);
-	resetWindowIdleTimer(workspace);
-	try {
-		switch (cmd.action) {
-			case "exec": return await handleExec(cmd, workspace);
-			case "navigate": return await handleNavigate(cmd, workspace);
-			case "tabs": return await handleTabs(cmd, workspace);
-			case "cookies": return await handleCookies(cmd);
-			case "screenshot": return await handleScreenshot(cmd, workspace);
-			case "close-window": return await handleCloseWindow(cmd, workspace);
-			case "cdp": return await handleCdp(cmd, workspace);
-			case "sessions": return await handleSessions(cmd);
-			case "set-file-input": return await handleSetFileInput(cmd, workspace);
-			case "insert-text": return await handleInsertText(cmd, workspace);
-			case "bind-current": return await handleBindCurrent(cmd, workspace);
-			case "network-capture-start": return await handleNetworkCaptureStart(cmd, workspace);
-			case "network-capture-read": return await handleNetworkCaptureRead(cmd, workspace);
-			default: return {
-				id: cmd.id,
-				ok: false,
-				error: `Unknown action: ${cmd.action}`
-			};
-		}
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  const workspace = getWorkspaceKey(cmd.workspace);
+  windowFocused = cmd.windowFocused === true;
+  if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
+    workspaceTimeoutOverrides.set(workspace, cmd.idleTimeout * 1e3);
+  }
+  resetWindowIdleTimer(workspace);
+  try {
+    switch (cmd.action) {
+      case "exec":
+        return await handleExec(cmd, workspace);
+      case "navigate":
+        return await handleNavigate(cmd, workspace);
+      case "tabs":
+        return await handleTabs(cmd, workspace);
+      case "cookies":
+        return await handleCookies(cmd);
+      case "screenshot":
+        return await handleScreenshot(cmd, workspace);
+      case "close-window":
+        return await handleCloseWindow(cmd, workspace);
+      case "cdp":
+        return await handleCdp(cmd, workspace);
+      case "sessions":
+        return await handleSessions(cmd);
+      case "set-file-input":
+        return await handleSetFileInput(cmd, workspace);
+      case "insert-text":
+        return await handleInsertText(cmd, workspace);
+      case "bind-current":
+        return await handleBindCurrent(cmd, workspace);
+      case "network-capture-start":
+        return await handleNetworkCaptureStart(cmd, workspace);
+      case "network-capture-read":
+        return await handleNetworkCaptureRead(cmd, workspace);
+      case "frames":
+        return await handleFrames(cmd, workspace);
+      default:
+        return { id: cmd.id, ok: false, error: `Unknown action: ${cmd.action}` };
+    }
+  } catch (err) {
+    return {
+      id: cmd.id,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      ...err instanceof CommandFailure ? { errorCode: err.code } : {},
+      ...err instanceof CommandFailure && err.hint ? { errorHint: err.hint } : {}
+    };
+  }
 }
-/** Internal blank page used when no user URL is provided. */
-var BLANK_PAGE = "about:blank";
-/** Check if a URL can be attached via CDP — only allow http(s) and blank pages. */
+const BLANK_PAGE = "about:blank";
 function isDebuggableUrl(url) {
-	if (!url) return true;
-	return url.startsWith("http://") || url.startsWith("https://") || url === "about:blank" || url.startsWith("data:");
+  if (!url) return true;
+  return url.startsWith("http://") || url.startsWith("https://") || url === "about:blank" || url.startsWith("data:");
 }
-/** Check if a URL is safe for user-facing navigation (http/https only). */
 function isSafeNavigationUrl(url) {
-	return url.startsWith("http://") || url.startsWith("https://");
+  return url.startsWith("http://") || url.startsWith("https://");
 }
-/** Minimal URL normalization for same-page comparison: root slash + default port only. */
 function normalizeUrlForComparison(url) {
-	if (!url) return "";
-	try {
-		const parsed = new URL(url);
-		if (parsed.protocol === "https:" && parsed.port === "443" || parsed.protocol === "http:" && parsed.port === "80") parsed.port = "";
-		const pathname = parsed.pathname === "/" ? "" : parsed.pathname;
-		return `${parsed.protocol}//${parsed.host}${pathname}${parsed.search}${parsed.hash}`;
-	} catch {
-		return url;
-	}
+  if (!url) return "";
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:" && parsed.port === "443" || parsed.protocol === "http:" && parsed.port === "80") {
+      parsed.port = "";
+    }
+    const pathname = parsed.pathname === "/" ? "" : parsed.pathname;
+    return `${parsed.protocol}//${parsed.host}${pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
 }
 function isTargetUrl(currentUrl, targetUrl) {
-	return normalizeUrlForComparison(currentUrl) === normalizeUrlForComparison(targetUrl);
+  return normalizeUrlForComparison(currentUrl) === normalizeUrlForComparison(targetUrl);
 }
 function matchesDomain(url, domain) {
-	if (!url) return false;
-	try {
-		const parsed = new URL(url);
-		return parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`);
-	} catch {
-		return false;
-	}
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`);
+  } catch {
+    return false;
+  }
 }
 function matchesBindCriteria(tab, cmd) {
-	if (!tab.id || !isDebuggableUrl(tab.url)) return false;
-	if (cmd.matchDomain && !matchesDomain(tab.url, cmd.matchDomain)) return false;
-	if (cmd.matchPathPrefix) try {
-		if (!new URL(tab.url).pathname.startsWith(cmd.matchPathPrefix)) return false;
-	} catch {
-		return false;
-	}
-	return true;
+  if (!tab.id || !isDebuggableUrl(tab.url)) return false;
+  if (cmd.matchDomain && !matchesDomain(tab.url, cmd.matchDomain)) return false;
+  if (cmd.matchPathPrefix) {
+    try {
+      const parsed = new URL(tab.url);
+      if (!parsed.pathname.startsWith(cmd.matchPathPrefix)) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+function getUrlOrigin(url) {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+function enumerateCrossOriginFrames(tree) {
+  const frames = [];
+  function collect(node, accessibleOrigin) {
+    for (const child of node.childFrames || []) {
+      const frame = child.frame;
+      const frameUrl = frame.url || frame.unreachableUrl || "";
+      const frameOrigin = getUrlOrigin(frameUrl);
+      if (accessibleOrigin && frameOrigin && frameOrigin === accessibleOrigin) {
+        collect(child, frameOrigin);
+        continue;
+      }
+      frames.push({
+        index: frames.length,
+        frameId: frame.id,
+        url: frameUrl,
+        name: frame.name || ""
+      });
+    }
+  }
+  const rootFrame = tree?.frameTree?.frame;
+  const rootUrl = rootFrame?.url || rootFrame?.unreachableUrl || "";
+  collect(tree.frameTree, getUrlOrigin(rootUrl));
+  return frames;
 }
 function setWorkspaceSession(workspace, session) {
-	const existing = automationSessions.get(workspace);
-	if (existing?.idleTimer) clearTimeout(existing.idleTimer);
-	automationSessions.set(workspace, {
-		...session,
-		idleTimer: null,
-		idleDeadlineAt: Date.now() + getIdleTimeout(workspace)
-	});
+  const existing = automationSessions.get(workspace);
+  if (existing?.idleTimer) clearTimeout(existing.idleTimer);
+  const timeout = getIdleTimeout(workspace);
+  automationSessions.set(workspace, {
+    ...session,
+    idleTimer: null,
+    idleDeadlineAt: timeout <= 0 ? 0 : Date.now() + timeout
+  });
 }
-/**
-* Resolve tabId from command's page (targetId).
-* Returns undefined if no page identity is provided.
-*/
 async function resolveCommandTabId(cmd) {
-	if (cmd.page) return resolveTabId$1(cmd.page);
+  if (cmd.page) return resolveTabId$1(cmd.page);
+  return void 0;
 }
-/**
-* Resolve target tab in the automation window, returning both the tabId and
-* the Tab object (when available) so callers can skip a redundant chrome.tabs.get().
-*/
 async function resolveTab(tabId, workspace, initialUrl) {
-	if (tabId !== void 0) try {
-		const tab = await chrome.tabs.get(tabId);
-		const session = automationSessions.get(workspace);
-		const matchesSession = session ? session.preferredTabId !== null ? session.preferredTabId === tabId : tab.windowId === session.windowId : false;
-		if (isDebuggableUrl(tab.url) && matchesSession) return {
-			tabId,
-			tab
-		};
-		if (session && !matchesSession && session.preferredTabId === null && isDebuggableUrl(tab.url)) {
-			console.warn(`[opencli] Tab ${tabId} drifted to window ${tab.windowId}, moving back to ${session.windowId}`);
-			try {
-				await chrome.tabs.move(tabId, {
-					windowId: session.windowId,
-					index: -1
-				});
-				const moved = await chrome.tabs.get(tabId);
-				if (moved.windowId === session.windowId && isDebuggableUrl(moved.url)) return {
-					tabId,
-					tab: moved
-				};
-			} catch (moveErr) {
-				console.warn(`[opencli] Failed to move tab back: ${moveErr}`);
-			}
-		} else if (!isDebuggableUrl(tab.url)) console.warn(`[opencli] Tab ${tabId} URL is not debuggable (${tab.url}), re-resolving`);
-	} catch {
-		console.warn(`[opencli] Tab ${tabId} no longer exists, re-resolving`);
-	}
-	const existingSession = automationSessions.get(workspace);
-	if (existingSession?.preferredTabId !== null) try {
-		const preferredTab = await chrome.tabs.get(existingSession.preferredTabId);
-		if (isDebuggableUrl(preferredTab.url)) return {
-			tabId: preferredTab.id,
-			tab: preferredTab
-		};
-	} catch {
-		automationSessions.delete(workspace);
-	}
-	const windowId = await getAutomationWindow(workspace, initialUrl);
-	const tabs = await chrome.tabs.query({ windowId });
-	const debuggableTab = tabs.find((t) => t.id && isDebuggableUrl(t.url));
-	if (debuggableTab?.id) return {
-		tabId: debuggableTab.id,
-		tab: debuggableTab
-	};
-	const reuseTab = tabs.find((t) => t.id);
-	if (reuseTab?.id) {
-		await chrome.tabs.update(reuseTab.id, { url: BLANK_PAGE });
-		await new Promise((resolve) => setTimeout(resolve, 300));
-		try {
-			const updated = await chrome.tabs.get(reuseTab.id);
-			if (isDebuggableUrl(updated.url)) return {
-				tabId: reuseTab.id,
-				tab: updated
-			};
-			console.warn(`[opencli] data: URI was intercepted (${updated.url}), creating fresh tab`);
-		} catch {}
-	}
-	const newTab = await chrome.tabs.create({
-		windowId,
-		url: BLANK_PAGE,
-		active: true
-	});
-	if (!newTab.id) throw new Error("Failed to create tab in automation window");
-	return {
-		tabId: newTab.id,
-		tab: newTab
-	};
+  const existingSession = automationSessions.get(workspace);
+  if (tabId !== void 0) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      const session = existingSession;
+      const matchesSession = session ? session.preferredTabId !== null ? session.preferredTabId === tabId : tab.windowId === session.windowId : false;
+      if (isDebuggableUrl(tab.url) && matchesSession) return { tabId, tab };
+      if (session && !session.owned) {
+        throw new CommandFailure(
+          matchesSession ? "bound_tab_not_debuggable" : "bound_tab_mismatch",
+          matchesSession ? `Bound tab for workspace "${workspace}" is not debuggable (${tab.url ?? "unknown URL"}).` : `Target tab is not the tab bound to workspace "${workspace}".`,
+          'Run "opencli browser bind-current" again on a debuggable http(s) tab.'
+        );
+      }
+      if (session && !matchesSession && session.preferredTabId === null && isDebuggableUrl(tab.url)) {
+        console.warn(`[opencli] Tab ${tabId} drifted to window ${tab.windowId}, moving back to ${session.windowId}`);
+        try {
+          await chrome.tabs.move(tabId, { windowId: session.windowId, index: -1 });
+          const moved = await chrome.tabs.get(tabId);
+          if (moved.windowId === session.windowId && isDebuggableUrl(moved.url)) {
+            return { tabId, tab: moved };
+          }
+        } catch (moveErr) {
+          console.warn(`[opencli] Failed to move tab back: ${moveErr}`);
+        }
+      } else if (!isDebuggableUrl(tab.url)) {
+        console.warn(`[opencli] Tab ${tabId} URL is not debuggable (${tab.url}), re-resolving`);
+      }
+    } catch (err) {
+      if (err instanceof CommandFailure) throw err;
+      if (existingSession && !existingSession.owned) {
+        automationSessions.delete(workspace);
+        throw new CommandFailure(
+          "bound_tab_gone",
+          `Bound tab for workspace "${workspace}" no longer exists.`,
+          'Run "opencli browser bind-current" again, then retry the command.'
+        );
+      }
+      console.warn(`[opencli] Tab ${tabId} no longer exists, re-resolving`);
+    }
+  }
+  const existingPreferredTabId = existingSession?.preferredTabId ?? null;
+  if (existingSession && existingPreferredTabId !== null) {
+    const session = existingSession;
+    try {
+      const preferredTab = await chrome.tabs.get(existingPreferredTabId);
+      if (isDebuggableUrl(preferredTab.url)) return { tabId: preferredTab.id, tab: preferredTab };
+      if (!session.owned) {
+        throw new CommandFailure(
+          "bound_tab_not_debuggable",
+          `Bound tab for workspace "${workspace}" is not debuggable (${preferredTab.url ?? "unknown URL"}).`,
+          'Switch the tab to an http(s) page or run "opencli browser bind-current" on another tab.'
+        );
+      }
+    } catch (err) {
+      if (err instanceof CommandFailure) throw err;
+      automationSessions.delete(workspace);
+      if (!session.owned) {
+        throw new CommandFailure(
+          "bound_tab_gone",
+          `Bound tab for workspace "${workspace}" no longer exists.`,
+          'Run "opencli browser bind-current" again, then retry the command.'
+        );
+      }
+    }
+  }
+  const windowId = await getAutomationWindow(workspace, initialUrl);
+  const tabs = await chrome.tabs.query({ windowId });
+  const debuggableTab = tabs.find((t) => t.id && isDebuggableUrl(t.url));
+  if (debuggableTab?.id) return { tabId: debuggableTab.id, tab: debuggableTab };
+  const reuseTab = tabs.find((t) => t.id);
+  if (reuseTab?.id) {
+    await chrome.tabs.update(reuseTab.id, { url: BLANK_PAGE });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    try {
+      const updated = await chrome.tabs.get(reuseTab.id);
+      if (isDebuggableUrl(updated.url)) return { tabId: reuseTab.id, tab: updated };
+      console.warn(`[opencli] data: URI was intercepted (${updated.url}), creating fresh tab`);
+    } catch {
+    }
+  }
+  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
+  if (!newTab.id) throw new Error("Failed to create tab in automation window");
+  return { tabId: newTab.id, tab: newTab };
 }
-/** Build a page-scoped success result with targetId resolved from tabId */
 async function pageScopedResult(id, tabId, data) {
-	return {
-		id,
-		ok: true,
-		data,
-		page: await resolveTargetId(tabId)
-	};
+  const page = await resolveTargetId(tabId);
+  return { id, ok: true, data, page };
 }
-/** Convenience wrapper returning just the tabId (used by most handlers) */
 async function resolveTabId(tabId, workspace, initialUrl) {
-	return (await resolveTab(tabId, workspace, initialUrl)).tabId;
+  const resolved = await resolveTab(tabId, workspace, initialUrl);
+  return resolved.tabId;
 }
 async function listAutomationTabs(workspace) {
-	const session = automationSessions.get(workspace);
-	if (!session) return [];
-	if (session.preferredTabId !== null) try {
-		return [await chrome.tabs.get(session.preferredTabId)];
-	} catch {
-		automationSessions.delete(workspace);
-		return [];
-	}
-	try {
-		return await chrome.tabs.query({ windowId: session.windowId });
-	} catch {
-		automationSessions.delete(workspace);
-		return [];
-	}
+  const session = automationSessions.get(workspace);
+  if (!session) return [];
+  if (session.preferredTabId !== null) {
+    try {
+      return [await chrome.tabs.get(session.preferredTabId)];
+    } catch {
+      automationSessions.delete(workspace);
+      return [];
+    }
+  }
+  try {
+    return await chrome.tabs.query({ windowId: session.windowId });
+  } catch {
+    automationSessions.delete(workspace);
+    return [];
+  }
 }
 async function listAutomationWebTabs(workspace) {
-	return (await listAutomationTabs(workspace)).filter((tab) => isDebuggableUrl(tab.url));
+  const tabs = await listAutomationTabs(workspace);
+  return tabs.filter((tab) => isDebuggableUrl(tab.url));
 }
 async function handleExec(cmd, workspace) {
-	if (!cmd.code) return {
-		id: cmd.id,
-		ok: false,
-		error: "Missing code"
-	};
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		const aggressive = workspace.startsWith("browser:") || workspace.startsWith("operate:");
-		const data = await evaluateAsync(tabId, cmd.code, aggressive);
-		return pageScopedResult(cmd.id, tabId, data);
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  if (!cmd.code) return { id: cmd.id, ok: false, error: "Missing code" };
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    const aggressive = workspace.startsWith("browser:") || workspace.startsWith("operate:");
+    if (cmd.frameIndex != null) {
+      const tree = await getFrameTree(tabId);
+      const frames = enumerateCrossOriginFrames(tree);
+      if (cmd.frameIndex < 0 || cmd.frameIndex >= frames.length) {
+        return { id: cmd.id, ok: false, error: `Frame index ${cmd.frameIndex} out of range (${frames.length} cross-origin frames available)` };
+      }
+      const data2 = await evaluateInFrame(tabId, cmd.code, frames[cmd.frameIndex].frameId, aggressive);
+      return pageScopedResult(cmd.id, tabId, data2);
+    }
+    const data = await evaluateAsync(tabId, cmd.code, aggressive);
+    return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+async function handleFrames(cmd, workspace) {
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    const tree = await getFrameTree(tabId);
+    return { id: cmd.id, ok: true, data: enumerateCrossOriginFrames(tree) };
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 async function handleNavigate(cmd, workspace) {
-	if (!cmd.url) return {
-		id: cmd.id,
-		ok: false,
-		error: "Missing url"
-	};
-	if (!isSafeNavigationUrl(cmd.url)) return {
-		id: cmd.id,
-		ok: false,
-		error: "Blocked URL scheme -- only http:// and https:// are allowed"
-	};
-	const resolved = await resolveTab(await resolveCommandTabId(cmd), workspace, cmd.url);
-	const tabId = resolved.tabId;
-	const beforeTab = resolved.tab ?? await chrome.tabs.get(tabId);
-	const beforeNormalized = normalizeUrlForComparison(beforeTab.url);
-	const targetUrl = cmd.url;
-	if (beforeTab.status === "complete" && isTargetUrl(beforeTab.url, targetUrl)) return pageScopedResult(cmd.id, tabId, {
-		title: beforeTab.title,
-		url: beforeTab.url,
-		timedOut: false
-	});
-	if (!hasActiveNetworkCapture(tabId)) await detach(tabId);
-	await chrome.tabs.update(tabId, { url: targetUrl });
-	let timedOut = false;
-	await new Promise((resolve) => {
-		let settled = false;
-		let checkTimer = null;
-		let timeoutTimer = null;
-		const finish = () => {
-			if (settled) return;
-			settled = true;
-			chrome.tabs.onUpdated.removeListener(listener);
-			if (checkTimer) clearTimeout(checkTimer);
-			if (timeoutTimer) clearTimeout(timeoutTimer);
-			resolve();
-		};
-		const isNavigationDone = (url) => {
-			return isTargetUrl(url, targetUrl) || normalizeUrlForComparison(url) !== beforeNormalized;
-		};
-		const listener = (id, info, tab) => {
-			if (id !== tabId) return;
-			if (info.status === "complete" && isNavigationDone(tab.url ?? info.url)) finish();
-		};
-		chrome.tabs.onUpdated.addListener(listener);
-		checkTimer = setTimeout(async () => {
-			try {
-				const currentTab = await chrome.tabs.get(tabId);
-				if (currentTab.status === "complete" && isNavigationDone(currentTab.url)) finish();
-			} catch {}
-		}, 100);
-		timeoutTimer = setTimeout(() => {
-			timedOut = true;
-			console.warn(`[opencli] Navigate to ${targetUrl} timed out after 15s`);
-			finish();
-		}, 15e3);
-	});
-	let tab = await chrome.tabs.get(tabId);
-	const session = automationSessions.get(workspace);
-	if (session && tab.windowId !== session.windowId) {
-		console.warn(`[opencli] Tab ${tabId} drifted to window ${tab.windowId} during navigation, moving back to ${session.windowId}`);
-		try {
-			await chrome.tabs.move(tabId, {
-				windowId: session.windowId,
-				index: -1
-			});
-			tab = await chrome.tabs.get(tabId);
-		} catch (moveErr) {
-			console.warn(`[opencli] Failed to recover drifted tab: ${moveErr}`);
-		}
-	}
-	return pageScopedResult(cmd.id, tabId, {
-		title: tab.title,
-		url: tab.url,
-		timedOut
-	});
+  if (!cmd.url) return { id: cmd.id, ok: false, error: "Missing url" };
+  if (!isSafeNavigationUrl(cmd.url)) {
+    return { id: cmd.id, ok: false, error: "Blocked URL scheme -- only http:// and https:// are allowed" };
+  }
+  const session = automationSessions.get(workspace);
+  if (session && !session.owned && cmd.allowBoundNavigation !== true) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: "bound_navigation_blocked",
+      error: `Workspace "${workspace}" is bound to a user tab; navigation is blocked by default.`,
+      errorHint: "Pass --allow-navigate-bound only if you intentionally want to navigate the bound tab."
+    };
+  }
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const resolved = await resolveTab(cmdTabId, workspace, cmd.url);
+  const tabId = resolved.tabId;
+  const beforeTab = resolved.tab ?? await chrome.tabs.get(tabId);
+  const beforeNormalized = normalizeUrlForComparison(beforeTab.url);
+  const targetUrl = cmd.url;
+  if (beforeTab.status === "complete" && isTargetUrl(beforeTab.url, targetUrl)) {
+    return pageScopedResult(cmd.id, tabId, { title: beforeTab.title, url: beforeTab.url, timedOut: false });
+  }
+  if (!hasActiveNetworkCapture(tabId)) {
+    await detach(tabId);
+  }
+  await chrome.tabs.update(tabId, { url: targetUrl });
+  let timedOut = false;
+  await new Promise((resolve) => {
+    let settled = false;
+    let checkTimer = null;
+    let timeoutTimer = null;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      chrome.tabs.onUpdated.removeListener(listener);
+      if (checkTimer) clearTimeout(checkTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      resolve();
+    };
+    const isNavigationDone = (url) => {
+      return isTargetUrl(url, targetUrl) || normalizeUrlForComparison(url) !== beforeNormalized;
+    };
+    const listener = (id, info, tab2) => {
+      if (id !== tabId) return;
+      if (info.status === "complete" && isNavigationDone(tab2.url ?? info.url)) {
+        finish();
+      }
+    };
+    chrome.tabs.onUpdated.addListener(listener);
+    checkTimer = setTimeout(async () => {
+      try {
+        const currentTab = await chrome.tabs.get(tabId);
+        if (currentTab.status === "complete" && isNavigationDone(currentTab.url)) {
+          finish();
+        }
+      } catch {
+      }
+    }, 100);
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      console.warn(`[opencli] Navigate to ${targetUrl} timed out after 15s`);
+      finish();
+    }, 15e3);
+  });
+  let tab = await chrome.tabs.get(tabId);
+  const postNavigationSession = automationSessions.get(workspace);
+  if (postNavigationSession?.owned === false && tab.windowId !== postNavigationSession.windowId) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: "bound_tab_moved",
+      error: `Bound tab for workspace "${workspace}" moved to another window during navigation.`,
+      errorHint: 'Run "opencli browser bind-current" again on the intended tab.'
+    };
+  }
+  if (postNavigationSession && tab.windowId !== postNavigationSession.windowId) {
+    console.warn(`[opencli] Tab ${tabId} drifted to window ${tab.windowId} during navigation, moving back to ${postNavigationSession.windowId}`);
+    try {
+      await chrome.tabs.move(tabId, { windowId: postNavigationSession.windowId, index: -1 });
+      tab = await chrome.tabs.get(tabId);
+    } catch (moveErr) {
+      console.warn(`[opencli] Failed to recover drifted tab: ${moveErr}`);
+    }
+  }
+  return pageScopedResult(cmd.id, tabId, { title: tab.title, url: tab.url, timedOut });
 }
 async function handleTabs(cmd, workspace) {
-	switch (cmd.op) {
-		case "list": {
-			const tabs = await listAutomationWebTabs(workspace);
-			const data = await Promise.all(tabs.map(async (t, i) => {
-				let page;
-				try {
-					page = t.id ? await resolveTargetId(t.id) : void 0;
-				} catch {}
-				return {
-					index: i,
-					page,
-					url: t.url,
-					title: t.title,
-					active: t.active
-				};
-			}));
-			return {
-				id: cmd.id,
-				ok: true,
-				data
-			};
-		}
-		case "new": {
-			if (cmd.url && !isSafeNavigationUrl(cmd.url)) return {
-				id: cmd.id,
-				ok: false,
-				error: "Blocked URL scheme -- only http:// and https:// are allowed"
-			};
-			const windowId = await getAutomationWindow(workspace);
-			const tab = await chrome.tabs.create({
-				windowId,
-				url: cmd.url ?? BLANK_PAGE,
-				active: true
-			});
-			if (!tab.id) return {
-				id: cmd.id,
-				ok: false,
-				error: "Failed to create tab"
-			};
-			return pageScopedResult(cmd.id, tab.id, { url: tab.url });
-		}
-		case "close": {
-			if (cmd.index !== void 0) {
-				const target = (await listAutomationWebTabs(workspace))[cmd.index];
-				if (!target?.id) return {
-					id: cmd.id,
-					ok: false,
-					error: `Tab index ${cmd.index} not found`
-				};
-				const closedPage = await resolveTargetId(target.id).catch(() => void 0);
-				await chrome.tabs.remove(target.id);
-				await detach(target.id);
-				return {
-					id: cmd.id,
-					ok: true,
-					data: { closed: closedPage }
-				};
-			}
-			const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-			const closedPage = await resolveTargetId(tabId).catch(() => void 0);
-			await chrome.tabs.remove(tabId);
-			await detach(tabId);
-			return {
-				id: cmd.id,
-				ok: true,
-				data: { closed: closedPage }
-			};
-		}
-		case "select": {
-			if (cmd.index === void 0 && cmd.page === void 0) return {
-				id: cmd.id,
-				ok: false,
-				error: "Missing index or page"
-			};
-			const cmdTabId = await resolveCommandTabId(cmd);
-			if (cmdTabId !== void 0) {
-				const session = automationSessions.get(workspace);
-				let tab;
-				try {
-					tab = await chrome.tabs.get(cmdTabId);
-				} catch {
-					return {
-						id: cmd.id,
-						ok: false,
-						error: `Page no longer exists`
-					};
-				}
-				if (!session || tab.windowId !== session.windowId) return {
-					id: cmd.id,
-					ok: false,
-					error: `Page is not in the automation window`
-				};
-				await chrome.tabs.update(cmdTabId, { active: true });
-				return pageScopedResult(cmd.id, cmdTabId, { selected: true });
-			}
-			const target = (await listAutomationWebTabs(workspace))[cmd.index];
-			if (!target?.id) return {
-				id: cmd.id,
-				ok: false,
-				error: `Tab index ${cmd.index} not found`
-			};
-			await chrome.tabs.update(target.id, { active: true });
-			return pageScopedResult(cmd.id, target.id, { selected: true });
-		}
-		default: return {
-			id: cmd.id,
-			ok: false,
-			error: `Unknown tabs op: ${cmd.op}`
-		};
-	}
+  const session = automationSessions.get(workspace);
+  if (session && !session.owned && cmd.op !== "list") {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: "bound_tab_mutation_blocked",
+      error: `Workspace "${workspace}" is bound to a user tab; tab mutation is blocked by default.`,
+      errorHint: "Use an automation workspace for tab new/select/close, or unbind first."
+    };
+  }
+  switch (cmd.op) {
+    case "list": {
+      const tabs = await listAutomationWebTabs(workspace);
+      const data = await Promise.all(tabs.map(async (t, i) => {
+        let page;
+        try {
+          page = t.id ? await resolveTargetId(t.id) : void 0;
+        } catch {
+        }
+        return { index: i, page, url: t.url, title: t.title, active: t.active };
+      }));
+      return { id: cmd.id, ok: true, data };
+    }
+    case "new": {
+      if (cmd.url && !isSafeNavigationUrl(cmd.url)) {
+        return { id: cmd.id, ok: false, error: "Blocked URL scheme -- only http:// and https:// are allowed" };
+      }
+      const windowId = await getAutomationWindow(workspace);
+      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      if (!tab.id) return { id: cmd.id, ok: false, error: "Failed to create tab" };
+      return pageScopedResult(cmd.id, tab.id, { url: tab.url });
+    }
+    case "close": {
+      if (cmd.index !== void 0) {
+        const tabs = await listAutomationWebTabs(workspace);
+        const target = tabs[cmd.index];
+        if (!target?.id) return { id: cmd.id, ok: false, error: `Tab index ${cmd.index} not found` };
+        const closedPage2 = await resolveTargetId(target.id).catch(() => void 0);
+        await chrome.tabs.remove(target.id);
+        await detach(target.id);
+        return { id: cmd.id, ok: true, data: { closed: closedPage2 } };
+      }
+      const cmdTabId = await resolveCommandTabId(cmd);
+      const tabId = await resolveTabId(cmdTabId, workspace);
+      const closedPage = await resolveTargetId(tabId).catch(() => void 0);
+      await chrome.tabs.remove(tabId);
+      await detach(tabId);
+      return { id: cmd.id, ok: true, data: { closed: closedPage } };
+    }
+    case "select": {
+      if (cmd.index === void 0 && cmd.page === void 0)
+        return { id: cmd.id, ok: false, error: "Missing index or page" };
+      const cmdTabId = await resolveCommandTabId(cmd);
+      if (cmdTabId !== void 0) {
+        const session2 = automationSessions.get(workspace);
+        let tab;
+        try {
+          tab = await chrome.tabs.get(cmdTabId);
+        } catch {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        if (!session2 || tab.windowId !== session2.windowId) {
+          return { id: cmd.id, ok: false, error: `Page is not in the automation window` };
+        }
+        await chrome.tabs.update(cmdTabId, { active: true });
+        return pageScopedResult(cmd.id, cmdTabId, { selected: true });
+      }
+      const tabs = await listAutomationWebTabs(workspace);
+      const target = tabs[cmd.index];
+      if (!target?.id) return { id: cmd.id, ok: false, error: `Tab index ${cmd.index} not found` };
+      await chrome.tabs.update(target.id, { active: true });
+      return pageScopedResult(cmd.id, target.id, { selected: true });
+    }
+    default:
+      return { id: cmd.id, ok: false, error: `Unknown tabs op: ${cmd.op}` };
+  }
 }
 async function handleCookies(cmd) {
-	if (!cmd.domain && !cmd.url) return {
-		id: cmd.id,
-		ok: false,
-		error: "Cookie scope required: provide domain or url to avoid dumping all cookies"
-	};
-	const details = {};
-	if (cmd.domain) details.domain = cmd.domain;
-	if (cmd.url) details.url = cmd.url;
-	const data = (await chrome.cookies.getAll(details)).map((c) => ({
-		name: c.name,
-		value: c.value,
-		domain: c.domain,
-		path: c.path,
-		secure: c.secure,
-		httpOnly: c.httpOnly,
-		expirationDate: c.expirationDate
-	}));
-	return {
-		id: cmd.id,
-		ok: true,
-		data
-	};
+  if (!cmd.domain && !cmd.url) {
+    return { id: cmd.id, ok: false, error: "Cookie scope required: provide domain or url to avoid dumping all cookies" };
+  }
+  const details = {};
+  if (cmd.domain) details.domain = cmd.domain;
+  if (cmd.url) details.url = cmd.url;
+  const cookies = await chrome.cookies.getAll(details);
+  const data = cookies.map((c) => ({
+    name: c.name,
+    value: c.value,
+    domain: c.domain,
+    path: c.path,
+    secure: c.secure,
+    httpOnly: c.httpOnly,
+    expirationDate: c.expirationDate
+  }));
+  return { id: cmd.id, ok: true, data };
 }
 async function handleScreenshot(cmd, workspace) {
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		const data = await screenshot(tabId, {
-			format: cmd.format,
-			quality: cmd.quality,
-			fullPage: cmd.fullPage
-		});
-		return pageScopedResult(cmd.id, tabId, data);
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    const data = await screenshot(tabId, {
+      format: cmd.format,
+      quality: cmd.quality,
+      fullPage: cmd.fullPage
+    });
+    return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
-/** CDP methods permitted via the 'cdp' passthrough action. */
-var CDP_ALLOWLIST = new Set([
-	"Accessibility.getFullAXTree",
-	"DOM.getDocument",
-	"DOM.getBoxModel",
-	"DOM.getContentQuads",
-	"DOM.querySelectorAll",
-	"DOM.scrollIntoViewIfNeeded",
-	"DOMSnapshot.captureSnapshot",
-	"Input.dispatchMouseEvent",
-	"Input.dispatchKeyEvent",
-	"Input.insertText",
-	"Page.getLayoutMetrics",
-	"Page.captureScreenshot",
-	"Runtime.enable",
-	"Emulation.setDeviceMetricsOverride",
-	"Emulation.clearDeviceMetricsOverride"
+const CDP_ALLOWLIST = /* @__PURE__ */ new Set([
+  // Agent DOM context
+  "Accessibility.getFullAXTree",
+  "DOM.getDocument",
+  "DOM.getBoxModel",
+  "DOM.getContentQuads",
+  "DOM.querySelectorAll",
+  "DOM.scrollIntoViewIfNeeded",
+  "DOMSnapshot.captureSnapshot",
+  // Native input events
+  "Input.dispatchMouseEvent",
+  "Input.dispatchKeyEvent",
+  "Input.insertText",
+  // Page metrics & screenshots
+  "Page.getLayoutMetrics",
+  "Page.captureScreenshot",
+  "Page.getFrameTree",
+  // Runtime.enable needed for CDP attach setup (Runtime.evaluate goes through 'exec' action)
+  "Runtime.enable",
+  // Emulation (used by screenshot full-page)
+  "Emulation.setDeviceMetricsOverride",
+  "Emulation.clearDeviceMetricsOverride"
 ]);
 async function handleCdp(cmd, workspace) {
-	if (!cmd.cdpMethod) return {
-		id: cmd.id,
-		ok: false,
-		error: "Missing cdpMethod"
-	};
-	if (!CDP_ALLOWLIST.has(cmd.cdpMethod)) return {
-		id: cmd.id,
-		ok: false,
-		error: `CDP method not permitted: ${cmd.cdpMethod}`
-	};
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		await ensureAttached(tabId, workspace.startsWith("browser:") || workspace.startsWith("operate:"));
-		const data = await chrome.debugger.sendCommand({ tabId }, cmd.cdpMethod, cmd.cdpParams ?? {});
-		return pageScopedResult(cmd.id, tabId, data);
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  if (!cmd.cdpMethod) return { id: cmd.id, ok: false, error: "Missing cdpMethod" };
+  if (!CDP_ALLOWLIST.has(cmd.cdpMethod)) {
+    return { id: cmd.id, ok: false, error: `CDP method not permitted: ${cmd.cdpMethod}` };
+  }
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    const aggressive = workspace.startsWith("browser:") || workspace.startsWith("operate:");
+    await ensureAttached(tabId, aggressive);
+    const data = await chrome.debugger.sendCommand(
+      { tabId },
+      cmd.cdpMethod,
+      cmd.cdpParams ?? {}
+    );
+    return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 async function handleCloseWindow(cmd, workspace) {
-	const session = automationSessions.get(workspace);
-	if (session) {
-		if (session.owned) try {
-			await chrome.windows.remove(session.windowId);
-		} catch {}
-		if (session.idleTimer) clearTimeout(session.idleTimer);
-		workspaceTimeoutOverrides.delete(workspace);
-		automationSessions.delete(workspace);
-	}
-	return {
-		id: cmd.id,
-		ok: true,
-		data: { closed: true }
-	};
+  const session = automationSessions.get(workspace);
+  if (session) {
+    if (session.owned) {
+      try {
+        await chrome.windows.remove(session.windowId);
+      } catch {
+      }
+    } else if (session.preferredTabId !== null) {
+      await detach(session.preferredTabId).catch(() => {
+      });
+    }
+    if (session.idleTimer) clearTimeout(session.idleTimer);
+    workspaceTimeoutOverrides.delete(workspace);
+    automationSessions.delete(workspace);
+  }
+  return { id: cmd.id, ok: true, data: { closed: true } };
 }
 async function handleSetFileInput(cmd, workspace) {
-	if (!cmd.files || !Array.isArray(cmd.files) || cmd.files.length === 0) return {
-		id: cmd.id,
-		ok: false,
-		error: "Missing or empty files array"
-	};
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		await setFileInputFiles(tabId, cmd.files, cmd.selector);
-		return pageScopedResult(cmd.id, tabId, { count: cmd.files.length });
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  if (!cmd.files || !Array.isArray(cmd.files) || cmd.files.length === 0) {
+    return { id: cmd.id, ok: false, error: "Missing or empty files array" };
+  }
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    await setFileInputFiles(tabId, cmd.files, cmd.selector);
+    return pageScopedResult(cmd.id, tabId, { count: cmd.files.length });
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 async function handleInsertText(cmd, workspace) {
-	if (typeof cmd.text !== "string") return {
-		id: cmd.id,
-		ok: false,
-		error: "Missing text payload"
-	};
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		await insertText(tabId, cmd.text);
-		return pageScopedResult(cmd.id, tabId, { inserted: true });
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  if (typeof cmd.text !== "string") {
+    return { id: cmd.id, ok: false, error: "Missing text payload" };
+  }
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    await insertText(tabId, cmd.text);
+    return pageScopedResult(cmd.id, tabId, { inserted: true });
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 async function handleNetworkCaptureStart(cmd, workspace) {
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		await startNetworkCapture(tabId, cmd.pattern);
-		return pageScopedResult(cmd.id, tabId, { started: true });
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    await startNetworkCapture(tabId, cmd.pattern);
+    return pageScopedResult(cmd.id, tabId, { started: true });
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 async function handleNetworkCaptureRead(cmd, workspace) {
-	const tabId = await resolveTabId(await resolveCommandTabId(cmd), workspace);
-	try {
-		const data = await readNetworkCapture(tabId);
-		return pageScopedResult(cmd.id, tabId, data);
-	} catch (err) {
-		return {
-			id: cmd.id,
-			ok: false,
-			error: err instanceof Error ? err.message : String(err)
-		};
-	}
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, workspace);
+  try {
+    const data = await readNetworkCapture(tabId);
+    return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 async function handleSessions(cmd) {
-	const now = Date.now();
-	const data = await Promise.all([...automationSessions.entries()].map(async ([workspace, session]) => ({
-		workspace,
-		windowId: session.windowId,
-		tabCount: (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
-		idleMsRemaining: Math.max(0, session.idleDeadlineAt - now)
-	})));
-	return {
-		id: cmd.id,
-		ok: true,
-		data
-	};
+  const now = Date.now();
+  const data = await Promise.all([...automationSessions.entries()].map(async ([workspace, session]) => ({
+    workspace,
+    windowId: session.windowId,
+    owned: session.owned,
+    preferredTabId: session.preferredTabId,
+    tabCount: session.preferredTabId !== null ? await chrome.tabs.get(session.preferredTabId).then((tab) => isDebuggableUrl(tab.url) ? 1 : 0).catch(() => 0) : (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
+    idleMsRemaining: session.idleDeadlineAt <= 0 ? null : Math.max(0, session.idleDeadlineAt - now)
+  })));
+  return { id: cmd.id, ok: true, data };
 }
 async function handleBindCurrent(cmd, workspace) {
-	const activeTabs = await chrome.tabs.query({
-		active: true,
-		lastFocusedWindow: true
-	});
-	const fallbackTabs = await chrome.tabs.query({ lastFocusedWindow: true });
-	const allTabs = await chrome.tabs.query({});
-	const boundTab = activeTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? fallbackTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? allTabs.find((tab) => matchesBindCriteria(tab, cmd));
-	if (!boundTab?.id) return {
-		id: cmd.id,
-		ok: false,
-		error: cmd.matchDomain || cmd.matchPathPrefix ? `No visible tab matching ${cmd.matchDomain ?? "domain"}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ""}` : "No active debuggable tab found"
-	};
-	setWorkspaceSession(workspace, {
-		windowId: boundTab.windowId,
-		owned: false,
-		preferredTabId: boundTab.id
-	});
-	resetWindowIdleTimer(workspace);
-	console.log(`[opencli] Workspace ${workspace} explicitly bound to tab ${boundTab.id} (${boundTab.url})`);
-	return pageScopedResult(cmd.id, boundTab.id, {
-		url: boundTab.url,
-		title: boundTab.title,
-		workspace
-	});
+  if (!workspace.startsWith("bound:")) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: "invalid_bind_workspace",
+      error: `bind-current workspace must start with "bound:", got "${workspace}".`,
+      errorHint: 'Use the default "bound:default" or pass --workspace bound:<name>.'
+    };
+  }
+  const existing = automationSessions.get(workspace);
+  if (existing?.owned) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: "invalid_bind_workspace",
+      error: `Workspace "${workspace}" already owns an automation window and cannot be rebound to a user tab.`,
+      errorHint: "Use a fresh bound:<name> workspace, or close/unbind the existing session first."
+    };
+  }
+  const activeTabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  const fallbackTabs = await chrome.tabs.query({ lastFocusedWindow: true });
+  const allTabs = await chrome.tabs.query({});
+  const boundTab = activeTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? fallbackTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? allTabs.find((tab) => matchesBindCriteria(tab, cmd));
+  if (!boundTab?.id) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: "bound_tab_not_found",
+      error: cmd.matchDomain || cmd.matchPathPrefix ? `No visible tab matching ${cmd.matchDomain ?? "domain"}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ""}` : "No active debuggable tab found",
+      errorHint: "Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind-current."
+    };
+  }
+  if (existing && !existing.owned && existing.preferredTabId !== null && existing.preferredTabId !== boundTab.id) {
+    await detach(existing.preferredTabId).catch(() => {
+    });
+  }
+  setWorkspaceSession(workspace, {
+    windowId: boundTab.windowId,
+    owned: false,
+    preferredTabId: boundTab.id
+  });
+  resetWindowIdleTimer(workspace);
+  console.log(`[opencli] Workspace ${workspace} explicitly bound to tab ${boundTab.id} (${boundTab.url})`);
+  return pageScopedResult(cmd.id, boundTab.id, {
+    url: boundTab.url,
+    title: boundTab.title,
+    workspace
+  });
 }
-//#endregion

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -557,8 +557,8 @@ async function getAutomationWindow(workspace, initialUrl) {
   if (workspace.startsWith("bound:") && !automationSessions.has(workspace)) {
     throw new CommandFailure(
       "bound_session_missing",
-      `Bound workspace "${workspace}" is not attached to a tab. Run "opencli browser bind-current --workspace ${workspace}" first.`,
-      "Run bind-current again, then retry the browser command."
+      `Bound workspace "${workspace}" is not attached to a tab. Run "opencli browser bind --workspace ${workspace}" first.`,
+      "Run bind again, then retry the browser command."
     );
   }
   const existing = automationSessions.get(workspace);
@@ -694,8 +694,8 @@ async function handleCommand(cmd) {
         return await handleSetFileInput(cmd, workspace);
       case "insert-text":
         return await handleInsertText(cmd, workspace);
-      case "bind-current":
-        return await handleBindCurrent(cmd, workspace);
+      case "bind":
+        return await handleBind(cmd, workspace);
       case "network-capture-start":
         return await handleNetworkCaptureStart(cmd, workspace);
       case "network-capture-read":
@@ -819,7 +819,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
         throw new CommandFailure(
           matchesSession ? "bound_tab_not_debuggable" : "bound_tab_mismatch",
           matchesSession ? `Bound tab for workspace "${workspace}" is not debuggable (${tab.url ?? "unknown URL"}).` : `Target tab is not the tab bound to workspace "${workspace}".`,
-          'Run "opencli browser bind-current" again on a debuggable http(s) tab.'
+          'Run "opencli browser bind" again on a debuggable http(s) tab.'
         );
       }
       if (session && !matchesSession && session.preferredTabId === null && isDebuggableUrl(tab.url)) {
@@ -843,7 +843,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
         throw new CommandFailure(
           "bound_tab_gone",
           `Bound tab for workspace "${workspace}" no longer exists.`,
-          'Run "opencli browser bind-current" again, then retry the command.'
+          'Run "opencli browser bind" again, then retry the command.'
         );
       }
       console.warn(`[opencli] Tab ${tabId} no longer exists, re-resolving`);
@@ -859,7 +859,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
         throw new CommandFailure(
           "bound_tab_not_debuggable",
           `Bound tab for workspace "${workspace}" is not debuggable (${preferredTab.url ?? "unknown URL"}).`,
-          'Switch the tab to an http(s) page or run "opencli browser bind-current" on another tab.'
+          'Switch the tab to an http(s) page or run "opencli browser bind" on another tab.'
         );
       }
     } catch (err) {
@@ -869,7 +869,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
         throw new CommandFailure(
           "bound_tab_gone",
           `Bound tab for workspace "${workspace}" no longer exists.`,
-          'Run "opencli browser bind-current" again, then retry the command.'
+          'Run "opencli browser bind" again, then retry the command.'
         );
       }
     }
@@ -1028,7 +1028,7 @@ async function handleNavigate(cmd, workspace) {
       ok: false,
       errorCode: "bound_tab_moved",
       error: `Bound tab for workspace "${workspace}" moved to another window during navigation.`,
-      errorHint: 'Run "opencli browser bind-current" again on the intended tab.'
+      errorHint: 'Run "opencli browser bind" again on the intended tab.'
     };
   }
   if (postNavigationSession && tab.windowId !== postNavigationSession.windowId) {
@@ -1272,13 +1272,13 @@ async function handleSessions(cmd) {
   })));
   return { id: cmd.id, ok: true, data };
 }
-async function handleBindCurrent(cmd, workspace) {
+async function handleBind(cmd, workspace) {
   if (!workspace.startsWith("bound:")) {
     return {
       id: cmd.id,
       ok: false,
       errorCode: "invalid_bind_workspace",
-      error: `bind-current workspace must start with "bound:", got "${workspace}".`,
+      error: `bind workspace must start with "bound:", got "${workspace}".`,
       errorHint: 'Use the default "bound:default" or pass --workspace bound:<name>.'
     };
   }
@@ -1302,7 +1302,7 @@ async function handleBindCurrent(cmd, workspace) {
       ok: false,
       errorCode: "bound_tab_not_found",
       error: cmd.matchDomain || cmd.matchPathPrefix ? `No visible tab matching ${cmd.matchDomain ?? "domain"}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ""}` : "No active debuggable tab found",
-      errorHint: "Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind-current."
+      errorHint: "Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind."
     };
   }
   if (existing && !existing.owned && existing.preferredTabId !== null && existing.preferredTabId !== boundTab.id) {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -37,10 +37,12 @@ function createChromeMock() {
     { id: 2, windowId: 2, url: 'https://user.example', title: 'user', active: true, status: 'complete' },
     { id: 3, windowId: 1, url: 'chrome://extensions', title: 'chrome', active: false, status: 'complete' },
   ];
+  let lastFocusedWindowId = 2;
 
-  const query = vi.fn(async (queryInfo: { windowId?: number; active?: boolean } = {}) => {
+  const query = vi.fn(async (queryInfo: { windowId?: number; active?: boolean; lastFocusedWindow?: boolean } = {}) => {
     return tabs.filter((tab) => {
       if (queryInfo.windowId !== undefined && tab.windowId !== queryInfo.windowId) return false;
+      if (queryInfo.lastFocusedWindow && tab.windowId !== lastFocusedWindowId) return false;
       if (queryInfo.active !== undefined && !!tab.active !== queryInfo.active) return false;
       return true;
     });
@@ -646,6 +648,30 @@ describe('background tab isolation', () => {
     expect(mod.__test__.workspaceTimeoutOverrides.has('browser:manual')).toBe(false);
     // Should fall back to default interactive timeout
     expect(mod.__test__.getIdleTimeout('browser:manual')).toBe(600_000);
+  });
+
+
+  it('bind does not reach into background windows when the current window has no match', async () => {
+    const { chrome, tabs } = createChromeMock();
+    tabs[1].active = false;
+    tabs[1].windowId = 3;
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+
+    const result = await mod.__test__.handleBind({
+      id: 'bind-current-window-only',
+      action: 'bind',
+      workspace: 'bound:default',
+      matchDomain: 'user.example',
+    }, 'bound:default');
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'bound_tab_not_found',
+      error: expect.stringContaining('current window'),
+    }));
+    expect(mod.__test__.getSession('bound:default')).toBeNull();
   });
 
   it('bind attaches only bound:* workspaces to the matching current tab', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-type Listener<T extends (...args: any[]) => void> = { addListener: (fn: T) => void };
+type Listener<T extends (...args: any[]) => void> = {
+  addListener: any;
+  removeListener?: any;
+};
 
 type MockTab = {
   id: number;
@@ -643,5 +646,149 @@ describe('background tab isolation', () => {
     expect(mod.__test__.workspaceTimeoutOverrides.has('browser:manual')).toBe(false);
     // Should fall back to default interactive timeout
     expect(mod.__test__.getIdleTimeout('browser:manual')).toBe(600_000);
+  });
+
+  it('bind-current attaches only bound:* workspaces to the matching current tab', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+
+    const rejected = await mod.__test__.handleBindCurrent({
+      id: 'bind-bad',
+      action: 'bind-current',
+      workspace: 'browser:default',
+      matchDomain: 'user.example',
+    }, 'browser:default');
+    expect(rejected).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'invalid_bind_workspace',
+    }));
+
+    const bound = await mod.__test__.handleBindCurrent({
+      id: 'bind-good',
+      action: 'bind-current',
+      workspace: 'bound:default',
+      matchDomain: 'user.example',
+    }, 'bound:default');
+
+    expect(bound).toEqual(expect.objectContaining({
+      ok: true,
+      data: expect.objectContaining({ workspace: 'bound:default', url: 'https://user.example' }),
+    }));
+    expect(mod.__test__.getSession('bound:default')).toEqual(expect.objectContaining({
+      windowId: 2,
+      owned: false,
+      preferredTabId: 2,
+      idleTimer: null,
+      idleDeadlineAt: 0,
+    }));
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps borrowed bound sessions alive without closing the user window on idle', async () => {
+    const { chrome } = createChromeMock();
+    vi.useFakeTimers();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('bound:default', { windowId: 2, owned: false, preferredTabId: 2 });
+
+    expect(mod.__test__.getIdleTimeout('bound:default')).toBe(-1);
+    mod.__test__.resetWindowIdleTimer('bound:default');
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+    expect(mod.__test__.getSession('bound:default')).not.toBeNull();
+  });
+
+  it('cleans borrowed sessions when the bound tab is closed', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('bound:default', { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const onRemovedListener = chrome.tabs.onRemoved.addListener.mock.calls[0][0];
+    onRemovedListener(2);
+
+    expect(mod.__test__.getSession('bound:default')).toBeNull();
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a borrowed bound tab is gone instead of creating an automation window', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('bound:default', { windowId: 2, owned: false, preferredTabId: 999 });
+
+    const result = await mod.__test__.handleCommand({
+      id: 'bound-exec-gone',
+      action: 'exec',
+      workspace: 'bound:default',
+      code: 'document.title',
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'bound_tab_gone',
+    }));
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a borrowed bound tab is no longer debuggable', async () => {
+    const { chrome, tabs } = createChromeMock();
+    tabs[1].url = 'chrome://settings';
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('bound:default', { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const result = await mod.__test__.handleCommand({
+      id: 'bound-exec-undebuggable',
+      action: 'exec',
+      workspace: 'bound:default',
+      code: 'document.title',
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'bound_tab_not_debuggable',
+    }));
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+  });
+
+  it('blocks navigation and tab mutation on borrowed bound sessions by default', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('bound:default', { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const nav = await mod.__test__.handleCommand({
+      id: 'bound-nav',
+      action: 'navigate',
+      workspace: 'bound:default',
+      url: 'https://other.example',
+    });
+    const tabNew = await mod.__test__.handleCommand({
+      id: 'bound-tab-new',
+      action: 'tabs',
+      workspace: 'bound:default',
+      op: 'new',
+      url: 'https://other.example',
+    });
+
+    expect(nav).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'bound_navigation_blocked',
+    }));
+    expect(tabNew).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'bound_tab_mutation_blocked',
+    }));
+    expect(chrome.tabs.update).not.toHaveBeenCalledWith(2, expect.objectContaining({ url: 'https://other.example' }));
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
   });
 });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -648,15 +648,15 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getIdleTimeout('browser:manual')).toBe(600_000);
   });
 
-  it('bind-current attaches only bound:* workspaces to the matching current tab', async () => {
+  it('bind attaches only bound:* workspaces to the matching current tab', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
     const mod = await import('./background');
 
-    const rejected = await mod.__test__.handleBindCurrent({
+    const rejected = await mod.__test__.handleBind({
       id: 'bind-bad',
-      action: 'bind-current',
+      action: 'bind',
       workspace: 'browser:default',
       matchDomain: 'user.example',
     }, 'browser:default');
@@ -665,9 +665,9 @@ describe('background tab isolation', () => {
       errorCode: 'invalid_bind_workspace',
     }));
 
-    const bound = await mod.__test__.handleBindCurrent({
+    const bound = await mod.__test__.handleBind({
       id: 'bind-good',
-      action: 'bind-current',
+      action: 'bind',
       workspace: 'bound:default',
       matchDomain: 'user.example',
     }, 'bound:default');
@@ -686,16 +686,16 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).not.toHaveBeenCalled();
   });
 
-  it('refuses bind-current when the bound workspace already owns an automation window', async () => {
+  it('refuses bind when the bound workspace already owns an automation window', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
     const mod = await import('./background');
     mod.__test__.setAutomationWindowId('bound:default', 1);
 
-    const result = await mod.__test__.handleBindCurrent({
+    const result = await mod.__test__.handleBind({
       id: 'bind-overwrite',
-      action: 'bind-current',
+      action: 'bind',
       workspace: 'bound:default',
       matchDomain: 'user.example',
     }, 'bound:default');

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -686,6 +686,31 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).not.toHaveBeenCalled();
   });
 
+  it('refuses bind-current when the bound workspace already owns an automation window', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId('bound:default', 1);
+
+    const result = await mod.__test__.handleBindCurrent({
+      id: 'bind-overwrite',
+      action: 'bind-current',
+      workspace: 'bound:default',
+      matchDomain: 'user.example',
+    }, 'bound:default');
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      errorCode: 'invalid_bind_workspace',
+    }));
+    expect(chrome.tabs.query).not.toHaveBeenCalled();
+    expect(mod.__test__.getSession('bound:default')).toEqual(expect.objectContaining({
+      windowId: 1,
+      owned: true,
+    }));
+  });
+
   it('keeps borrowed bound sessions alive without closing the user window on idle', async () => {
     const { chrome } = createChromeMock();
     vi.useFakeTimers();

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -133,11 +133,20 @@ type AutomationSession = {
 const automationSessions = new Map<string, AutomationSession>();
 const IDLE_TIMEOUT_DEFAULT = 30_000;      // 30s — adapter-driven automation
 const IDLE_TIMEOUT_INTERACTIVE = 600_000; // 10min — human-paced browser:* / operate:*
+const IDLE_TIMEOUT_NONE = -1;             // borrowed bound-current tabs stay bound until unbound/closed
+
+class CommandFailure extends Error {
+  constructor(readonly code: string, message: string, readonly hint?: string) {
+    super(message);
+    this.name = 'CommandFailure';
+  }
+}
 
 /** Per-workspace custom timeout overrides set via command.idleTimeout */
 const workspaceTimeoutOverrides = new Map<string, number>();
 
 function getIdleTimeout(workspace: string): number {
+  if (workspace.startsWith('bound:')) return IDLE_TIMEOUT_NONE;
   const override = workspaceTimeoutOverrides.get(workspace);
   if (override !== undefined) return override;
   if (workspace.startsWith('browser:') || workspace.startsWith('operate:')) {
@@ -157,6 +166,11 @@ function resetWindowIdleTimer(workspace: string): void {
   if (!session) return;
   if (session.idleTimer) clearTimeout(session.idleTimer);
   const timeout = getIdleTimeout(workspace);
+  if (timeout <= 0) {
+    session.idleTimer = null;
+    session.idleDeadlineAt = 0;
+    return;
+  }
   session.idleDeadlineAt = Date.now() + timeout;
   session.idleTimer = setTimeout(async () => {
     const current = automationSessions.get(workspace);
@@ -183,9 +197,23 @@ function resetWindowIdleTimer(workspace: string): void {
  *    This avoids an extra blank-page→target-domain navigation on first command.
  */
 async function getAutomationWindow(workspace: string, initialUrl?: string): Promise<number> {
+  if (workspace.startsWith('bound:') && !automationSessions.has(workspace)) {
+    throw new CommandFailure(
+      'bound_session_missing',
+      `Bound workspace "${workspace}" is not attached to a tab. Run "opencli browser bind-current --workspace ${workspace}" first.`,
+      'Run bind-current again, then retry the browser command.',
+    );
+  }
   // Check if our window is still alive
   const existing = automationSessions.get(workspace);
   if (existing) {
+    if (!existing.owned) {
+      throw new CommandFailure(
+        'bound_window_operation_blocked',
+        `Workspace "${workspace}" is bound to a user tab and does not own an automation window.`,
+        'Use commands that operate on the bound tab, or unbind and use an automation workspace.',
+      );
+    }
     try {
       await chrome.windows.get(existing.windowId);
       return existing.windowId;
@@ -256,6 +284,14 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
 // Evict identity mappings when tabs are closed
 chrome.tabs.onRemoved.addListener((tabId) => {
   identity.evictTab(tabId);
+  for (const [workspace, session] of automationSessions.entries()) {
+    if (!session.owned && session.preferredTabId === tabId) {
+      if (session.idleTimer) clearTimeout(session.idleTimer);
+      automationSessions.delete(workspace);
+      workspaceTimeoutOverrides.delete(workspace);
+      console.log(`[opencli] Borrowed workspace ${workspace} detached from tab ${tabId} (tab closed)`);
+    }
+  }
 });
 
 // ─── Lifecycle events ────────────────────────────────────────────────
@@ -345,6 +381,8 @@ async function handleCommand(cmd: Command): Promise<Result> {
       id: cmd.id,
       ok: false,
       error: err instanceof Error ? err.message : String(err),
+      ...(err instanceof CommandFailure ? { errorCode: err.code } : {}),
+      ...(err instanceof CommandFailure && err.hint ? { errorHint: err.hint } : {}),
     };
   }
 }
@@ -452,10 +490,11 @@ function enumerateCrossOriginFrames(tree: any): Array<{ index: number; frameId: 
 function setWorkspaceSession(workspace: string, session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'>): void {
   const existing = automationSessions.get(workspace);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
+  const timeout = getIdleTimeout(workspace);
   automationSessions.set(workspace, {
     ...session,
     idleTimer: null,
-    idleDeadlineAt: Date.now() + getIdleTimeout(workspace),
+    idleDeadlineAt: timeout <= 0 ? 0 : Date.now() + timeout,
   });
 }
 
@@ -475,15 +514,25 @@ type ResolvedTab = { tabId: number; tab: chrome.tabs.Tab | null };
  * the Tab object (when available) so callers can skip a redundant chrome.tabs.get().
  */
 async function resolveTab(tabId: number | undefined, workspace: string, initialUrl?: string): Promise<ResolvedTab> {
+  const existingSession = automationSessions.get(workspace);
   // Even when an explicit tabId is provided, validate it is still debuggable.
   if (tabId !== undefined) {
     try {
       const tab = await chrome.tabs.get(tabId);
-      const session = automationSessions.get(workspace);
+      const session = existingSession;
       const matchesSession = session
         ? (session.preferredTabId !== null ? session.preferredTabId === tabId : tab.windowId === session.windowId)
         : false;
       if (isDebuggableUrl(tab.url) && matchesSession) return { tabId, tab };
+      if (session && !session.owned) {
+        throw new CommandFailure(
+          matchesSession ? 'bound_tab_not_debuggable' : 'bound_tab_mismatch',
+          matchesSession
+            ? `Bound tab for workspace "${workspace}" is not debuggable (${tab.url ?? 'unknown URL'}).`
+            : `Target tab is not the tab bound to workspace "${workspace}".`,
+          'Run "opencli browser bind-current" again on a debuggable http(s) tab.',
+        );
+      }
       if (session && !matchesSession && session.preferredTabId === null && isDebuggableUrl(tab.url)) {
         // Tab drifted to another window but content is still valid.
         // Try to move it back instead of abandoning it.
@@ -500,18 +549,43 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
       } else if (!isDebuggableUrl(tab.url)) {
         console.warn(`[opencli] Tab ${tabId} URL is not debuggable (${tab.url}), re-resolving`);
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof CommandFailure) throw err;
+      if (existingSession && !existingSession.owned) {
+        automationSessions.delete(workspace);
+        throw new CommandFailure(
+          'bound_tab_gone',
+          `Bound tab for workspace "${workspace}" no longer exists.`,
+          'Run "opencli browser bind-current" again, then retry the command.',
+        );
+      }
       console.warn(`[opencli] Tab ${tabId} no longer exists, re-resolving`);
     }
   }
 
-  const existingSession = automationSessions.get(workspace);
-  if (existingSession?.preferredTabId !== null) {
+  const existingPreferredTabId = existingSession?.preferredTabId ?? null;
+  if (existingSession && existingPreferredTabId !== null) {
+    const session = existingSession;
     try {
-      const preferredTab = await chrome.tabs.get(existingSession.preferredTabId);
+      const preferredTab = await chrome.tabs.get(existingPreferredTabId);
       if (isDebuggableUrl(preferredTab.url)) return { tabId: preferredTab.id!, tab: preferredTab };
-    } catch {
+      if (!session.owned) {
+        throw new CommandFailure(
+          'bound_tab_not_debuggable',
+          `Bound tab for workspace "${workspace}" is not debuggable (${preferredTab.url ?? 'unknown URL'}).`,
+          'Switch the tab to an http(s) page or run "opencli browser bind-current" on another tab.',
+        );
+      }
+    } catch (err) {
+      if (err instanceof CommandFailure) throw err;
       automationSessions.delete(workspace);
+      if (!session.owned) {
+        throw new CommandFailure(
+          'bound_tab_gone',
+          `Bound tab for workspace "${workspace}" no longer exists.`,
+          'Run "opencli browser bind-current" again, then retry the command.',
+        );
+      }
     }
   }
 
@@ -617,6 +691,16 @@ async function handleNavigate(cmd: Command, workspace: string): Promise<Result> 
   if (!isSafeNavigationUrl(cmd.url)) {
     return { id: cmd.id, ok: false, error: 'Blocked URL scheme -- only http:// and https:// are allowed' };
   }
+  const session = automationSessions.get(workspace);
+  if (session && !session.owned && cmd.allowBoundNavigation !== true) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: 'bound_navigation_blocked',
+      error: `Workspace "${workspace}" is bound to a user tab; navigation is blocked by default.`,
+      errorHint: 'Pass --allow-navigate-bound only if you intentionally want to navigate the bound tab.',
+    };
+  }
   // Pass target URL so that first-time window creation can start on the right domain
   const cmdTabId = await resolveCommandTabId(cmd);
   const resolved = await resolveTab(cmdTabId, workspace, cmd.url);
@@ -698,11 +782,20 @@ async function handleNavigate(cmd: Command, workspace: string): Promise<Result> 
   // Post-navigation drift detection: if the tab moved to another window
   // during navigation (e.g. a tab-management extension regrouped it),
   // try to move it back to maintain session isolation.
-  const session = automationSessions.get(workspace);
-  if (session && tab.windowId !== session.windowId) {
-    console.warn(`[opencli] Tab ${tabId} drifted to window ${tab.windowId} during navigation, moving back to ${session.windowId}`);
+  const postNavigationSession = automationSessions.get(workspace);
+  if (postNavigationSession?.owned === false && tab.windowId !== postNavigationSession.windowId) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: 'bound_tab_moved',
+      error: `Bound tab for workspace "${workspace}" moved to another window during navigation.`,
+      errorHint: 'Run "opencli browser bind-current" again on the intended tab.',
+    };
+  }
+  if (postNavigationSession && tab.windowId !== postNavigationSession.windowId) {
+    console.warn(`[opencli] Tab ${tabId} drifted to window ${tab.windowId} during navigation, moving back to ${postNavigationSession.windowId}`);
     try {
-      await chrome.tabs.move(tabId, { windowId: session.windowId, index: -1 });
+      await chrome.tabs.move(tabId, { windowId: postNavigationSession.windowId, index: -1 });
       tab = await chrome.tabs.get(tabId);
     } catch (moveErr) {
       console.warn(`[opencli] Failed to recover drifted tab: ${moveErr}`);
@@ -713,6 +806,16 @@ async function handleNavigate(cmd: Command, workspace: string): Promise<Result> 
 }
 
 async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
+  const session = automationSessions.get(workspace);
+  if (session && !session.owned && cmd.op !== 'list') {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: 'bound_tab_mutation_blocked',
+      error: `Workspace "${workspace}" is bound to a user tab; tab mutation is blocked by default.`,
+      errorHint: 'Use an automation workspace for tab new/select/close, or unbind first.',
+    };
+  }
   switch (cmd.op) {
     case 'list': {
       const tabs = await listAutomationWebTabs(workspace);
@@ -868,6 +971,8 @@ async function handleCloseWindow(cmd: Command, workspace: string): Promise<Resul
       } catch {
         // Window may already be closed
       }
+    } else if (session.preferredTabId !== null) {
+      await executor.detach(session.preferredTabId).catch(() => {});
     }
     if (session.idleTimer) clearTimeout(session.idleTimer);
     workspaceTimeoutOverrides.delete(workspace);
@@ -931,13 +1036,36 @@ async function handleSessions(cmd: Command): Promise<Result> {
   const data = await Promise.all([...automationSessions.entries()].map(async ([workspace, session]) => ({
     workspace,
     windowId: session.windowId,
-    tabCount: (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
-    idleMsRemaining: Math.max(0, session.idleDeadlineAt - now),
+    owned: session.owned,
+    preferredTabId: session.preferredTabId,
+    tabCount: session.preferredTabId !== null
+      ? (await chrome.tabs.get(session.preferredTabId).then((tab) => isDebuggableUrl(tab.url) ? 1 : 0).catch(() => 0))
+      : (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
+    idleMsRemaining: session.idleDeadlineAt <= 0 ? null : Math.max(0, session.idleDeadlineAt - now),
   })));
   return { id: cmd.id, ok: true, data };
 }
 
 async function handleBindCurrent(cmd: Command, workspace: string): Promise<Result> {
+  if (!workspace.startsWith('bound:')) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: 'invalid_bind_workspace',
+      error: `bind-current workspace must start with "bound:", got "${workspace}".`,
+      errorHint: 'Use the default "bound:default" or pass --workspace bound:<name>.',
+    };
+  }
+  const existing = automationSessions.get(workspace);
+  if (existing?.owned) {
+    return {
+      id: cmd.id,
+      ok: false,
+      errorCode: 'invalid_bind_workspace',
+      error: `Workspace "${workspace}" already owns an automation window and cannot be rebound to a user tab.`,
+      errorHint: 'Use a fresh bound:<name> workspace, or close/unbind the existing session first.',
+    };
+  }
   const activeTabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   const fallbackTabs = await chrome.tabs.query({ lastFocusedWindow: true });
   const allTabs = await chrome.tabs.query({});
@@ -948,10 +1076,16 @@ async function handleBindCurrent(cmd: Command, workspace: string): Promise<Resul
     return {
       id: cmd.id,
       ok: false,
+      errorCode: 'bound_tab_not_found',
       error: cmd.matchDomain || cmd.matchPathPrefix
         ? `No visible tab matching ${cmd.matchDomain ?? 'domain'}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ''}`
         : 'No active debuggable tab found',
+      errorHint: 'Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind-current.',
     };
+  }
+
+  if (existing && !existing.owned && existing.preferredTabId !== null && existing.preferredTabId !== boundTab.id) {
+    await executor.detach(existing.preferredTabId).catch(() => {});
   }
 
   setWorkspaceSession(workspace, {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1068,19 +1068,17 @@ async function handleBind(cmd: Command, workspace: string): Promise<Result> {
   }
   const activeTabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   const fallbackTabs = await chrome.tabs.query({ lastFocusedWindow: true });
-  const allTabs = await chrome.tabs.query({});
   const boundTab = activeTabs.find((tab) => matchesBindCriteria(tab, cmd))
-    ?? fallbackTabs.find((tab) => matchesBindCriteria(tab, cmd))
-    ?? allTabs.find((tab) => matchesBindCriteria(tab, cmd));
+    ?? fallbackTabs.find((tab) => matchesBindCriteria(tab, cmd));
   if (!boundTab?.id) {
     return {
       id: cmd.id,
       ok: false,
       errorCode: 'bound_tab_not_found',
       error: cmd.matchDomain || cmd.matchPathPrefix
-        ? `No visible tab matching ${cmd.matchDomain ?? 'domain'}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ''}`
-        : 'No active debuggable tab found',
-      errorHint: 'Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind.',
+        ? `No visible tab in the current window matching ${cmd.matchDomain ?? 'domain'}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ''}`
+        : 'No debuggable tab found in the current window',
+      errorHint: 'Focus the target Chrome tab/window or relax --domain / --path-prefix, then retry bind.',
     };
   }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -200,8 +200,8 @@ async function getAutomationWindow(workspace: string, initialUrl?: string): Prom
   if (workspace.startsWith('bound:') && !automationSessions.has(workspace)) {
     throw new CommandFailure(
       'bound_session_missing',
-      `Bound workspace "${workspace}" is not attached to a tab. Run "opencli browser bind-current --workspace ${workspace}" first.`,
-      'Run bind-current again, then retry the browser command.',
+      `Bound workspace "${workspace}" is not attached to a tab. Run "opencli browser bind --workspace ${workspace}" first.`,
+      'Run bind again, then retry the browser command.',
     );
   }
   // Check if our window is still alive
@@ -365,8 +365,8 @@ async function handleCommand(cmd: Command): Promise<Result> {
         return await handleSetFileInput(cmd, workspace);
       case 'insert-text':
         return await handleInsertText(cmd, workspace);
-      case 'bind-current':
-        return await handleBindCurrent(cmd, workspace);
+      case 'bind':
+        return await handleBind(cmd, workspace);
       case 'network-capture-start':
         return await handleNetworkCaptureStart(cmd, workspace);
       case 'network-capture-read':
@@ -530,7 +530,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
           matchesSession
             ? `Bound tab for workspace "${workspace}" is not debuggable (${tab.url ?? 'unknown URL'}).`
             : `Target tab is not the tab bound to workspace "${workspace}".`,
-          'Run "opencli browser bind-current" again on a debuggable http(s) tab.',
+          'Run "opencli browser bind" again on a debuggable http(s) tab.',
         );
       }
       if (session && !matchesSession && session.preferredTabId === null && isDebuggableUrl(tab.url)) {
@@ -556,7 +556,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
         throw new CommandFailure(
           'bound_tab_gone',
           `Bound tab for workspace "${workspace}" no longer exists.`,
-          'Run "opencli browser bind-current" again, then retry the command.',
+          'Run "opencli browser bind" again, then retry the command.',
         );
       }
       console.warn(`[opencli] Tab ${tabId} no longer exists, re-resolving`);
@@ -573,7 +573,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
         throw new CommandFailure(
           'bound_tab_not_debuggable',
           `Bound tab for workspace "${workspace}" is not debuggable (${preferredTab.url ?? 'unknown URL'}).`,
-          'Switch the tab to an http(s) page or run "opencli browser bind-current" on another tab.',
+          'Switch the tab to an http(s) page or run "opencli browser bind" on another tab.',
         );
       }
     } catch (err) {
@@ -583,7 +583,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
         throw new CommandFailure(
           'bound_tab_gone',
           `Bound tab for workspace "${workspace}" no longer exists.`,
-          'Run "opencli browser bind-current" again, then retry the command.',
+          'Run "opencli browser bind" again, then retry the command.',
         );
       }
     }
@@ -789,7 +789,7 @@ async function handleNavigate(cmd: Command, workspace: string): Promise<Result> 
       ok: false,
       errorCode: 'bound_tab_moved',
       error: `Bound tab for workspace "${workspace}" moved to another window during navigation.`,
-      errorHint: 'Run "opencli browser bind-current" again on the intended tab.',
+      errorHint: 'Run "opencli browser bind" again on the intended tab.',
     };
   }
   if (postNavigationSession && tab.windowId !== postNavigationSession.windowId) {
@@ -1046,13 +1046,13 @@ async function handleSessions(cmd: Command): Promise<Result> {
   return { id: cmd.id, ok: true, data };
 }
 
-async function handleBindCurrent(cmd: Command, workspace: string): Promise<Result> {
+async function handleBind(cmd: Command, workspace: string): Promise<Result> {
   if (!workspace.startsWith('bound:')) {
     return {
       id: cmd.id,
       ok: false,
       errorCode: 'invalid_bind_workspace',
-      error: `bind-current workspace must start with "bound:", got "${workspace}".`,
+      error: `bind workspace must start with "bound:", got "${workspace}".`,
       errorHint: 'Use the default "bound:default" or pass --workspace bound:<name>.',
     };
   }
@@ -1080,7 +1080,7 @@ async function handleBindCurrent(cmd: Command, workspace: string): Promise<Resul
       error: cmd.matchDomain || cmd.matchPathPrefix
         ? `No visible tab matching ${cmd.matchDomain ?? 'domain'}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ''}`
         : 'No active debuggable tab found',
-      errorHint: 'Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind-current.',
+      errorHint: 'Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind.',
     };
   }
 
@@ -1108,7 +1108,7 @@ export const __test__ = {
   isTargetUrl,
   handleTabs,
   handleSessions,
-  handleBindCurrent,
+  handleBind,
   resolveTabId,
   resetWindowIdleTimer,
   handleCommand,

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -466,10 +466,11 @@ export function registerListeners(): void {
     if (!tabId) return;
     const state = networkCaptures.get(tabId);
     if (!state) return;
+    const eventParams = params as Record<string, any> | undefined;
 
     if (method === 'Network.requestWillBeSent') {
-      const requestId = String(params?.requestId || '');
-      const request = params?.request as {
+      const requestId = String(eventParams?.requestId || '');
+      const request = eventParams?.request as {
         url?: string;
         method?: string;
         headers?: Record<string, unknown>;
@@ -509,8 +510,8 @@ export function registerListeners(): void {
     }
 
     if (method === 'Network.responseReceived') {
-      const requestId = String(params?.requestId || '');
-      const response = params?.response as {
+      const requestId = String(eventParams?.requestId || '');
+      const response = eventParams?.response as {
         url?: string;
         mimeType?: string;
         status?: number;
@@ -527,7 +528,7 @@ export function registerListeners(): void {
     }
 
     if (method === 'Network.loadingFinished') {
-      const requestId = String(params?.requestId || '');
+      const requestId = String(eventParams?.requestId || '');
       const stateEntryIndex = state.requestToIndex.get(requestId);
       if (stateEntryIndex === undefined) return;
       const entry = state.entries[stateEntryIndex];

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -66,6 +66,8 @@ export interface Command {
   windowFocused?: boolean;
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
+  /** Explicitly allow navigation inside a borrowed bound-current tab. */
+  allowBoundNavigation?: boolean;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;
 }
@@ -79,6 +81,10 @@ export interface Result {
   data?: unknown;
   /** Error message on failure */
   error?: string;
+  /** Stable machine-readable error code on failure */
+  errorCode?: string;
+  /** Optional recovery hint for agent-facing CLI output */
+  errorHint?: string;
   /** Page identity (targetId) — present only on page-scoped command responses */
   page?: string;
 }

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -15,7 +15,7 @@ export type Action =
   | 'sessions'
   | 'set-file-input'
   | 'insert-text'
-  | 'bind-current'
+  | 'bind'
   | 'network-capture-start'
   | 'network-capture-read'
   | 'cdp'

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -50,6 +50,8 @@ opencli browser --workspace bound:gmail state
 
 Navigation is blocked by default on bound workspaces because it can destroy the logged-in/positioned state you wanted to preserve. `browser open` and `browser back` require `--allow-navigate-bound`; tab mutation (`tab new`, `tab select`, `tab close`) is blocked for bound workspaces. Use a normal `browser:*` automation workspace when you want OpenCLI to own tab/window lifecycle.
 
+`opencli browser sessions` returns `idleMsRemaining: null` for bound workspaces. That means there is no OpenCLI idle-close timer; the binding lasts until `unbind`, tab close, window close, or daemon restart.
+
 ---
 
 ## Mental model

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -25,8 +25,30 @@ Until `doctor` is green, nothing else will work. Typical failures: Chrome not ru
 ## Window lifecycle
 
 - `opencli browser *` commands already keep the automation session alive between calls. The window stays open until you run `opencli browser close` or the idle timeout expires.
+- `opencli browser bind-current` binds a `bound:*` workspace to the Chrome tab you already have open. Use this for logged-in pages, SSO flows, or pages you manually positioned before handing control to the agent.
 - `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation window in the foreground. Use it when you want to watch the page live.
 - `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation window open after the command returns so you can inspect the final page state.
+
+### Bind Current Tab
+
+```bash
+opencli browser bind-current --domain example.com
+opencli browser --workspace bound:default state
+opencli browser --workspace bound:default click "Search"
+opencli browser --workspace bound:default network
+opencli browser unbind
+```
+
+Binding uses a separate `bound:*` workspace. It never owns the user window, never closes the user tab, and fails closed if the tab is closed or becomes non-debuggable. Re-run `bind-current` when you switch to a different real tab.
+
+Use `--domain <host>` and `--path-prefix <path>` to avoid binding the wrong tab:
+
+```bash
+opencli browser bind-current --workspace bound:gmail --domain mail.google.com --path-prefix /mail
+opencli browser --workspace bound:gmail state
+```
+
+Navigation is blocked by default on bound workspaces because it can destroy the logged-in/positioned state you wanted to preserve. `browser open` and `browser back` require `--allow-navigate-bound`; tab mutation (`tab new`, `tab select`, `tab close`) is blocked for bound workspaces. Use a normal `browser:*` automation workspace when you want OpenCLI to own tab/window lifecycle.
 
 ---
 
@@ -171,6 +193,8 @@ Default output keeps JSON/XML/plain-text and JS-like API responses, then drops o
 | `browser tab close [targetId]` | Close by `page`. |
 | `browser back` | History back on the active tab. |
 | `browser close` | Close the automation window when done. |
+| `browser bind-current` | Bind `bound:default` (or `--workspace bound:<name>`) to the current Chrome tab. |
+| `browser unbind` | Detach a bound workspace without closing the user tab/window. |
 
 ---
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -25,26 +25,26 @@ Until `doctor` is green, nothing else will work. Typical failures: Chrome not ru
 ## Window lifecycle
 
 - `opencli browser *` commands already keep the automation session alive between calls. The window stays open until you run `opencli browser close` or the idle timeout expires.
-- `opencli browser bind-current` binds a `bound:*` workspace to the Chrome tab you already have open. Use this for logged-in pages, SSO flows, or pages you manually positioned before handing control to the agent.
+- `opencli browser bind` binds a `bound:*` workspace to the Chrome tab you already have open. Use this for logged-in pages, SSO flows, or pages you manually positioned before handing control to the agent.
 - `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation window in the foreground. Use it when you want to watch the page live.
 - `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation window open after the command returns so you can inspect the final page state.
 
-### Bind Current Tab
+### Bind Tab
 
 ```bash
-opencli browser bind-current --domain example.com
+opencli browser bind --domain example.com
 opencli browser --workspace bound:default state
 opencli browser --workspace bound:default click "Search"
 opencli browser --workspace bound:default network
 opencli browser unbind
 ```
 
-Binding uses a separate `bound:*` workspace. It never owns the user window, never closes the user tab, and fails closed if the tab is closed or becomes non-debuggable. Re-run `bind-current` when you switch to a different real tab.
+Binding uses a separate `bound:*` workspace. It never owns the user window, never closes the user tab, and fails closed if the tab is closed or becomes non-debuggable. Re-run `bind` when you switch to a different real tab.
 
 Use `--domain <host>` and `--path-prefix <path>` to avoid binding the wrong tab:
 
 ```bash
-opencli browser bind-current --workspace bound:gmail --domain mail.google.com --path-prefix /mail
+opencli browser bind --workspace bound:gmail --domain mail.google.com --path-prefix /mail
 opencli browser --workspace bound:gmail state
 ```
 
@@ -195,7 +195,7 @@ Default output keeps JSON/XML/plain-text and JS-like API responses, then drops o
 | `browser tab close [targetId]` | Close by `page`. |
 | `browser back` | History back on the active tab. |
 | `browser close` | Close the automation window when done. |
-| `browser bind-current` | Bind `bound:default` (or `--workspace bound:<name>`) to the current Chrome tab. |
+| `browser bind` | Bind `bound:default` (or `--workspace bound:<name>`) to the current Chrome tab. |
 | `browser unbind` | Detach a bound workspace without closing the user tab/window. |
 
 ---

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -12,6 +12,7 @@ OpenCLI turns any website, Electron desktop app, or external CLI into a uniform 
 
 - **Adapter commands** — `opencli <site> <command> [...]`. Built-in adapters live in `clis/`, user adapters in `~/.opencli/clis/`. Each is backed by a strategy (`PUBLIC | COOKIE | HEADER | INTERCEPT | UI | LOCAL`) that tells you whether a Chrome session is needed.
 - **Browser driving** — `opencli browser *` subcommands (`open`, `state`, `click`, `type`, `select`, `find`, `extract`, `network`, …) for ad-hoc interaction and scraping when no adapter covers the task. See `opencli-browser`.
+- **Current-tab binding** — `opencli browser bind-current --domain <host>` attaches a `bound:*` workspace to the Chrome tab the user already opened/logged into. Follow-up commands use `opencli browser --workspace bound:default ...`. See `opencli-browser` before using it; bound workspaces have stricter navigation/tab-mutation safety rules.
 - **External CLI passthrough** — `opencli gh`, `opencli docker`, `opencli vercel`, etc. Registered via `opencli install <name>` (auto-install from `external-clis.yaml`) or `opencli register <name>` (bring your own).
 
 ## Install

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -12,7 +12,7 @@ OpenCLI turns any website, Electron desktop app, or external CLI into a uniform 
 
 - **Adapter commands** — `opencli <site> <command> [...]`. Built-in adapters live in `clis/`, user adapters in `~/.opencli/clis/`. Each is backed by a strategy (`PUBLIC | COOKIE | HEADER | INTERCEPT | UI | LOCAL`) that tells you whether a Chrome session is needed.
 - **Browser driving** — `opencli browser *` subcommands (`open`, `state`, `click`, `type`, `select`, `find`, `extract`, `network`, …) for ad-hoc interaction and scraping when no adapter covers the task. See `opencli-browser`.
-- **Current-tab binding** — `opencli browser bind-current --domain <host>` attaches a `bound:*` workspace to the Chrome tab the user already opened/logged into. Follow-up commands use `opencli browser --workspace bound:default ...`. See `opencli-browser` before using it; bound workspaces have stricter navigation/tab-mutation safety rules.
+- **Current-tab binding** — `opencli browser bind --domain <host>` attaches a `bound:*` workspace to the Chrome tab the user already opened/logged into. Follow-up commands use `opencli browser --workspace bound:default ...`. See `opencli-browser` before using it; bound workspaces have stricter navigation/tab-mutation safety rules.
 - **External CLI passthrough** — `opencli gh`, `opencli docker`, `opencli vercel`, etc. Registered via `opencli install <name>` (auto-install from `external-clis.yaml`) or `opencli register <name>` (bring your own).
 
 ## Install

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -73,7 +73,7 @@ export abstract class BasePage implements IPage {
 
   // ── Transport-specific methods (must be implemented by subclasses) ──
 
-  abstract goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void>;
+  abstract goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number; allowBoundNavigation?: boolean }): Promise<void>;
   abstract evaluate(js: string): Promise<unknown>;
 
   /**

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -206,7 +206,7 @@ class CDPPage extends BasePage {
     super();
   }
 
-  async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void> {
+  async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number; allowBoundNavigation?: boolean }): Promise<void> {
     if (!this._pageEnabled) {
       await this.bridge.send('Page.enable');
       this._pageEnabled = true;

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -50,6 +50,8 @@ export interface DaemonCommand {
   windowFocused?: boolean;
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
+  /** Explicitly allow navigation inside a borrowed bound-current tab. */
+  allowBoundNavigation?: boolean;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;
 }
@@ -59,8 +61,17 @@ export interface DaemonResult {
   ok: boolean;
   data?: unknown;
   error?: string;
+  errorCode?: string;
+  errorHint?: string;
   /** Page identity (targetId) — present on page-scoped command responses */
   page?: string;
+}
+
+export class BrowserCommandError extends Error {
+  constructor(message: string, readonly code?: string, readonly hint?: string) {
+    super(message);
+    this.name = 'BrowserCommandError';
+  }
 }
 
 export interface DaemonStatus {
@@ -167,7 +178,7 @@ async function sendCommandRaw(
           await sleep(advice.delayMs);
           continue;
         }
-        throw new Error(result.error ?? 'Daemon command failed');
+        throw new BrowserCommandError(result.error ?? 'Daemon command failed', result.errorCode, result.errorHint);
       }
 
       return result;

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -21,7 +21,7 @@ function generateId(): string {
 
 export interface DaemonCommand {
   id: string;
-  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'sessions' | 'set-file-input' | 'insert-text' | 'bind-current' | 'network-capture-start' | 'network-capture-read' | 'cdp' | 'frames';
+  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'sessions' | 'set-file-input' | 'insert-text' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'cdp' | 'frames';
   /** Target page identity (targetId). Cross-layer contract with the extension. */
   page?: string;
   code?: string;
@@ -223,6 +223,6 @@ export async function listSessions(): Promise<BrowserSessionInfo[]> {
   return Array.isArray(result) ? result : [];
 }
 
-export async function bindCurrentTab(workspace: string, opts: { matchDomain?: string; matchPathPrefix?: string } = {}): Promise<unknown> {
-  return sendCommand('bind-current', { workspace, ...opts });
+export async function bindTab(workspace: string, opts: { matchDomain?: string; matchPathPrefix?: string } = {}): Promise<unknown> {
+  return sendCommand('bind', { workspace, ...opts });
 }

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -56,10 +56,11 @@ export class Page extends BasePage {
     };
   }
 
-  async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void> {
+  async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number; allowBoundNavigation?: boolean }): Promise<void> {
     const result = await sendCommandFull('navigate', {
       url,
       ...this._cmdOpts(),
+      ...(options?.allowBoundNavigation === true && { allowBoundNavigation: true }),
     });
     // Remember the page identity (targetId) for subsequent calls
     if (result.page) {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -8,10 +8,12 @@ import { TargetError } from './browser/target-errors.js';
 const {
   mockBrowserConnect,
   mockBrowserClose,
+  mockBindCurrentTab,
   browserState,
 } = vi.hoisted(() => ({
   mockBrowserConnect: vi.fn(),
   mockBrowserClose: vi.fn(),
+  mockBindCurrentTab: vi.fn(),
   browserState: { page: null as IPage | null },
 }));
 
@@ -22,6 +24,14 @@ vi.mock('./browser/index.js', () => {
       connect = mockBrowserConnect;
       close = mockBrowserClose;
     },
+  };
+});
+
+vi.mock('./browser/daemon-client.js', async () => {
+  const actual = await vi.importActual<typeof import('./browser/daemon-client.js')>('./browser/daemon-client.js');
+  return {
+    ...actual,
+    bindCurrentTab: mockBindCurrentTab,
   };
 });
 
@@ -114,6 +124,12 @@ describe('browser tab targeting commands', () => {
     stderrSpy.mockClear();
     mockBrowserConnect.mockClear();
     mockBrowserClose.mockReset().mockResolvedValue(undefined);
+    mockBindCurrentTab.mockReset().mockResolvedValue({
+      workspace: 'bound:default',
+      page: 'tab-2',
+      url: 'https://user.example/inbox',
+      title: 'Inbox',
+    });
 
     browserState.page = {
       goto: vi.fn().mockResolvedValue(undefined),
@@ -124,6 +140,7 @@ describe('browser tab targeting commands', () => {
       startNetworkCapture: vi.fn().mockResolvedValue(true),
       getCookies: vi.fn().mockResolvedValue([]),
       evaluate: vi.fn().mockResolvedValue({ ok: true }),
+      snapshot: vi.fn().mockResolvedValue('snapshot'),
       tabs: vi.fn().mockResolvedValue([
         { index: 0, page: 'tab-1', url: 'https://one.example', title: 'one', active: true },
         { index: 1, page: 'tab-2', url: 'https://two.example', title: 'two', active: false },
@@ -146,6 +163,58 @@ describe('browser tab targeting commands', () => {
     if (typeof last !== 'string') throw new Error(`Expected string arg to console.log, got ${typeof last}`);
     return JSON.parse(last);
   }
+
+  it('binds the current Chrome tab into a bound workspace', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'bind-current', '--domain', 'user.example', '--path-prefix', '/inbox']);
+
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default' });
+    expect(mockBindCurrentTab).toHaveBeenCalledWith('bound:default', {
+      matchDomain: 'user.example',
+      matchPathPrefix: '/inbox',
+    });
+    const out = lastJsonLog();
+    expect(out.workspace).toBe('bound:default');
+    expect(out.url).toBe('https://user.example/inbox');
+  });
+
+  it('rejects bind-current workspaces outside the bound namespace', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'bind-current', '--workspace', 'browser:default']);
+
+    expect(mockBrowserConnect).not.toHaveBeenCalled();
+    expect(mockBindCurrentTab).not.toHaveBeenCalled();
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('invalid_bind_workspace');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('runs browser commands against an explicit bound workspace', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--workspace', 'bound:default', 'state']);
+
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default' });
+    expect(browserState.page?.snapshot).toHaveBeenCalled();
+  });
+
+  it('blocks history navigation on bound workspaces unless explicitly allowed', async () => {
+    browserState.page = {
+      ...browserState.page,
+      workspace: 'bound:default',
+      evaluate: vi.fn(),
+      wait: vi.fn(),
+    } as unknown as IPage;
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--workspace', 'bound:default', 'back']);
+
+    expect(browserState.page?.evaluate).not.toHaveBeenCalled();
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('bound_navigation_blocked');
+  });
 
   it('binds browser commands to an explicit target tab via --tab', async () => {
     const program = createProgram('', '');
@@ -522,6 +591,10 @@ describe('browser network command', () => {
     return path.join(cacheDir, 'browser-network', 'browser_default.json');
   }
 
+  function getBoundNetworkCachePath(cacheDir: string): string {
+    return path.join(cacheDir, 'browser-network', 'bound_default.json');
+  }
+
   function lastJsonLog(): any {
     const calls = consoleLogSpy.mock.calls;
     if (calls.length === 0) throw new Error('Expected at least one console.log call');
@@ -574,6 +647,22 @@ describe('browser network command', () => {
     expect(out.entries[0].shape['$.data.user.rest_id']).toBe('string');
     expect(out.entries[0]).not.toHaveProperty('body');
     expect(fs.existsSync(getNetworkCachePath(cacheDir))).toBe(true);
+  });
+
+  it('uses the selected browser workspace for network cache scope', async () => {
+    const cacheDir = String(process.env.OPENCLI_CACHE_DIR);
+    browserState.page = {
+      ...browserState.page,
+      workspace: 'bound:default',
+    } as unknown as IPage;
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--workspace', 'bound:default', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.workspace).toBe('bound:default');
+    expect(fs.existsSync(getBoundNetworkCachePath(cacheDir))).toBe(true);
+    expect(fs.existsSync(getNetworkCachePath(cacheDir))).toBe(false);
   });
 
   it('--all includes static resources that the default filter drops', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -8,12 +8,12 @@ import { TargetError } from './browser/target-errors.js';
 const {
   mockBrowserConnect,
   mockBrowserClose,
-  mockBindCurrentTab,
+  mockBindTab,
   browserState,
 } = vi.hoisted(() => ({
   mockBrowserConnect: vi.fn(),
   mockBrowserClose: vi.fn(),
-  mockBindCurrentTab: vi.fn(),
+  mockBindTab: vi.fn(),
   browserState: { page: null as IPage | null },
 }));
 
@@ -31,7 +31,7 @@ vi.mock('./browser/daemon-client.js', async () => {
   const actual = await vi.importActual<typeof import('./browser/daemon-client.js')>('./browser/daemon-client.js');
   return {
     ...actual,
-    bindCurrentTab: mockBindCurrentTab,
+    bindTab: mockBindTab,
   };
 });
 
@@ -124,7 +124,7 @@ describe('browser tab targeting commands', () => {
     stderrSpy.mockClear();
     mockBrowserConnect.mockClear();
     mockBrowserClose.mockReset().mockResolvedValue(undefined);
-    mockBindCurrentTab.mockReset().mockResolvedValue({
+    mockBindTab.mockReset().mockResolvedValue({
       workspace: 'bound:default',
       page: 'tab-2',
       url: 'https://user.example/inbox',
@@ -167,10 +167,10 @@ describe('browser tab targeting commands', () => {
   it('binds the current Chrome tab into a bound workspace', async () => {
     const program = createProgram('', '');
 
-    await program.parseAsync(['node', 'opencli', 'browser', 'bind-current', '--domain', 'user.example', '--path-prefix', '/inbox']);
+    await program.parseAsync(['node', 'opencli', 'browser', 'bind', '--domain', 'user.example', '--path-prefix', '/inbox']);
 
     expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default' });
-    expect(mockBindCurrentTab).toHaveBeenCalledWith('bound:default', {
+    expect(mockBindTab).toHaveBeenCalledWith('bound:default', {
       matchDomain: 'user.example',
       matchPathPrefix: '/inbox',
     });
@@ -179,13 +179,13 @@ describe('browser tab targeting commands', () => {
     expect(out.url).toBe('https://user.example/inbox');
   });
 
-  it('rejects bind-current workspaces outside the bound namespace', async () => {
+  it('rejects bind workspaces outside the bound namespace', async () => {
     const program = createProgram('', '');
 
-    await program.parseAsync(['node', 'opencli', 'browser', 'bind-current', '--workspace', 'browser:default']);
+    await program.parseAsync(['node', 'opencli', 'browser', 'bind', '--workspace', 'browser:default']);
 
     expect(mockBrowserConnect).not.toHaveBeenCalled();
-    expect(mockBindCurrentTab).not.toHaveBeenCalled();
+    expect(mockBindTab).not.toHaveBeenCalled();
     const out = lastJsonLog();
     expect(out.error.code).toBe('invalid_bind_workspace');
     expect(process.exitCode).toBeDefined();

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { BrowserCommandError } from './browser/daemon-client.js';
 import type { IPage } from './types.js';
 import { TargetError } from './browser/target-errors.js';
 
@@ -9,11 +10,13 @@ const {
   mockBrowserConnect,
   mockBrowserClose,
   mockBindTab,
+  mockSendCommand,
   browserState,
 } = vi.hoisted(() => ({
   mockBrowserConnect: vi.fn(),
   mockBrowserClose: vi.fn(),
   mockBindTab: vi.fn(),
+  mockSendCommand: vi.fn(),
   browserState: { page: null as IPage | null },
 }));
 
@@ -32,6 +35,7 @@ vi.mock('./browser/daemon-client.js', async () => {
   return {
     ...actual,
     bindTab: mockBindTab,
+    sendCommand: mockSendCommand,
   };
 });
 
@@ -130,6 +134,7 @@ describe('browser tab targeting commands', () => {
       url: 'https://user.example/inbox',
       title: 'Inbox',
     });
+    mockSendCommand.mockReset().mockResolvedValue({ closed: true });
 
     browserState.page = {
       goto: vi.fn().mockResolvedValue(undefined),
@@ -214,6 +219,32 @@ describe('browser tab targeting commands', () => {
     expect(browserState.page?.evaluate).not.toHaveBeenCalled();
     const out = lastJsonLog();
     expect(out.error.code).toBe('bound_navigation_blocked');
+  });
+
+  it('unbinds a bound workspace through the daemon close-window command', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'unbind', '--workspace', 'bound:default']);
+
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default' });
+    expect(mockSendCommand).toHaveBeenCalledWith('close-window', { workspace: 'bound:default' });
+    const out = lastJsonLog();
+    expect(out).toEqual({ unbound: true, workspace: 'bound:default' });
+  });
+
+  it('does not print false success when unbind fails', async () => {
+    mockSendCommand.mockRejectedValueOnce(new BrowserCommandError(
+      'Workspace "bound:default" is not attached to a tab.',
+      'bound_session_missing',
+      'Run bind again, then retry the browser command.',
+    ));
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'unbind', '--workspace', 'bound:default']);
+
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('bound_session_missing');
+    expect(process.exitCode).toBeDefined();
   });
 
   it('binds browser commands to an explicit target tab via --tab', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,9 +32,11 @@ import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
+import { bindCurrentTab, BrowserCommandError } from './browser/daemon-client.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
+const DEFAULT_BOUND_WORKSPACE = 'bound:default';
 const BROWSER_TAB_OPTION_DESCRIPTION = 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"';
 
 type BrowserNetworkItem = {
@@ -318,19 +320,19 @@ async function resolveStoredBrowserTarget(page: import('./types.js').IPage, scop
 }
 
 /** Create a browser page for browser commands. Uses a dedicated browser workspace for session persistence. */
-async function getBrowserPage(targetPage?: string): Promise<import('./types.js').IPage> {
+async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_BROWSER_WORKSPACE): Promise<import('./types.js').IPage> {
   const { BrowserBridge } = await import('./browser/index.js');
   const bridge = new BrowserBridge();
   const envTimeout = process.env.OPENCLI_BROWSER_TIMEOUT;
   const idleTimeout = envTimeout ? parseInt(envTimeout, 10) : undefined;
   const page = await bridge.connect({
     timeout: 30,
-    workspace: DEFAULT_BROWSER_WORKSPACE,
+    workspace,
     ...(idleTimeout && idleTimeout > 0 && { idleTimeout }),
   });
   const resolvedTargetPage = targetPage
-    ? await resolveBrowserTargetInSession(page, targetPage, { scope: DEFAULT_BROWSER_WORKSPACE, source: 'explicit' })
-    : await resolveStoredBrowserTarget(page, DEFAULT_BROWSER_WORKSPACE);
+    ? await resolveBrowserTargetInSession(page, targetPage, { scope: workspace, source: 'explicit' })
+    : await resolveStoredBrowserTarget(page, workspace);
   if (resolvedTargetPage) {
     if (!page.setActivePage) {
       throw new Error('This browser session does not support explicit tab targeting');
@@ -350,9 +352,30 @@ function getBrowserTargetId(command?: Command): string | undefined {
   return typeof opts.tab === 'string' && opts.tab.trim() ? opts.tab.trim() : undefined;
 }
 
-function resolveBrowserTabTarget(targetId?: string, opts?: { tab?: string }): string | undefined {
+function getCommandOption(command: Command | undefined, option: string): unknown {
+  let current: Command | undefined = command;
+  while (current) {
+    const opts = current.opts();
+    if (Object.prototype.hasOwnProperty.call(opts, option) && opts[option] !== undefined) return opts[option];
+    current = current.parent as Command | undefined;
+  }
+  return undefined;
+}
+
+function getBrowserWorkspace(command?: Command): string {
+  const raw = getCommandOption(command, 'workspace');
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : DEFAULT_BROWSER_WORKSPACE;
+}
+
+function getPageWorkspace(page: import('./types.js').IPage): string {
+  const workspace = (page as unknown as { workspace?: unknown }).workspace;
+  return typeof workspace === 'string' && workspace.trim() ? workspace.trim() : DEFAULT_BROWSER_WORKSPACE;
+}
+
+function resolveBrowserTabTarget(targetId?: string, opts?: { tab?: string } | Command): string | undefined {
   if (typeof targetId === 'string' && targetId.trim()) return targetId.trim();
-  if (typeof opts?.tab === 'string' && opts.tab.trim()) return opts.tab.trim();
+  const tab = opts instanceof Command ? opts.opts().tab : opts?.tab;
+  if (typeof tab === 'string' && tab.trim()) return tab.trim();
   return undefined;
 }
 
@@ -485,6 +508,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   const browser = program
     .command('browser')
+    .option('--workspace <name>', 'Browser workspace to use (default: browser:default; bound tabs use bound:<name>)')
     .description('Browser control — navigate, click, type, extract, wait (no LLM needed)');
 
   /**
@@ -546,10 +570,23 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       try {
         const command = args.at(-1) instanceof Command ? args.at(-1) as Command : undefined;
         const targetPage = getBrowserTargetId(command);
-        const page = await getBrowserPage(targetPage);
+        const workspace = getBrowserWorkspace(command);
+        const page = await getBrowserPage(targetPage, workspace);
         await fn(page, ...args);
       } catch (err) {
         if (err instanceof BrowserConnectError) {
+          log.error(err.message);
+          if (err.hint) log.error(`Hint: ${err.hint}`);
+        } else if (err instanceof BrowserCommandError) {
+          if (err.code) {
+            console.log(JSON.stringify({
+              error: {
+                code: err.code,
+                message: err.message,
+                ...(err.hint ? { hint: err.hint } : {}),
+              },
+            }, null, 2));
+          }
           log.error(err.message);
           if (err.hint) log.error(`Hint: ${err.hint}`);
         } else if (err instanceof TargetError) {
@@ -569,6 +606,90 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
     };
   }
+
+  browser.command('bind-current')
+    .option('--domain <host>', 'Only bind a current/visible tab whose hostname matches this domain')
+    .option('--path-prefix <path>', 'Only bind a current/visible tab whose pathname starts with this prefix')
+    .option('--workspace <name>', 'Bound workspace name (must start with bound:)')
+    .description('Bind a bound:* workspace to the current Chrome tab/window')
+    .action(async (optsOrCommand, maybeCommand?: Command) => {
+      const command = optsOrCommand instanceof Command ? optsOrCommand : maybeCommand;
+      const opts = command?.opts() ?? optsOrCommand ?? {};
+      const rawWorkspace = getCommandOption(command, 'workspace');
+      const workspace = typeof rawWorkspace === 'string' && rawWorkspace.trim()
+        ? rawWorkspace.trim()
+        : DEFAULT_BOUND_WORKSPACE;
+      if (!workspace.startsWith('bound:')) {
+        console.log(JSON.stringify({
+          error: {
+            code: 'invalid_bind_workspace',
+            message: `--workspace must start with "bound:", got "${workspace}"`,
+            hint: 'Use the default bound:default or pass --workspace bound:<name>.',
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      try {
+        const { BrowserBridge } = await import('./browser/index.js');
+        const bridge = new BrowserBridge();
+        await bridge.connect({ timeout: 30, workspace });
+        const data = await bindCurrentTab(workspace, {
+          ...(typeof opts.domain === 'string' && opts.domain.trim() ? { matchDomain: opts.domain.trim() } : {}),
+          ...(typeof opts.pathPrefix === 'string' && opts.pathPrefix.trim() ? { matchPathPrefix: opts.pathPrefix.trim() } : {}),
+        });
+        saveBrowserTargetState(undefined, workspace);
+        console.log(JSON.stringify({ workspace, ...((data && typeof data === 'object') ? data as Record<string, unknown> : { data }) }, null, 2));
+      } catch (err) {
+        if (err instanceof BrowserCommandError && err.code) {
+          console.log(JSON.stringify({
+            error: {
+              code: err.code,
+              message: err.message,
+              ...(err.hint ? { hint: err.hint } : {}),
+            },
+          }, null, 2));
+        }
+        log.error(err instanceof Error ? err.message : String(err));
+        if (err instanceof BrowserCommandError && err.hint) log.error(`Hint: ${err.hint}`);
+        process.exitCode = err instanceof BrowserCommandError && err.code === 'invalid_bind_workspace'
+          ? EXIT_CODES.USAGE_ERROR
+          : EXIT_CODES.GENERIC_ERROR;
+      }
+    });
+
+  browser.command('unbind')
+    .option('--workspace <name>', 'Bound workspace name to detach')
+    .description('Detach a bound:* workspace without closing the user tab/window')
+    .action(async (optsOrCommand, maybeCommand?: Command) => {
+      const command = optsOrCommand instanceof Command ? optsOrCommand : maybeCommand;
+      const rawWorkspace = getCommandOption(command, 'workspace');
+      const workspace = typeof rawWorkspace === 'string' && rawWorkspace.trim()
+        ? rawWorkspace.trim()
+        : DEFAULT_BOUND_WORKSPACE;
+      if (!workspace.startsWith('bound:')) {
+        console.log(JSON.stringify({
+          error: {
+            code: 'invalid_bind_workspace',
+            message: `--workspace must start with "bound:", got "${workspace}"`,
+            hint: 'Use the default bound:default or pass --workspace bound:<name>.',
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      try {
+        const { BrowserBridge } = await import('./browser/index.js');
+        const bridge = new BrowserBridge();
+        const page = await bridge.connect({ timeout: 30, workspace });
+        await page.closeWindow?.();
+        saveBrowserTargetState(undefined, workspace);
+        console.log(JSON.stringify({ unbound: true, workspace }, null, 2));
+      } catch (err) {
+        log.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      }
+    });
 
   const browserTab = browser
     .command('tab')
@@ -598,20 +719,20 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   addBrowserTabOption(browserTab.command('select')
     .argument('[targetId]', 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"')
     .description('Select a tab by target ID and make it the default browser tab'))
-    .action(browserAction(async (page, targetId?: string, opts?: { tab?: string }) => {
+    .action(browserAction(async (page, targetId?: string, opts?: { tab?: string } | Command) => {
       const resolvedTarget = resolveBrowserTabTarget(targetId, opts);
       if (!resolvedTarget) {
         throw new Error('Target tab required. Pass it as an argument or --tab <targetId>.');
       }
       await page.selectTab(resolvedTarget);
-      saveBrowserTargetState(resolvedTarget, DEFAULT_BROWSER_WORKSPACE);
+      saveBrowserTargetState(resolvedTarget, getPageWorkspace(page));
       console.log(JSON.stringify({ selected: resolvedTarget }, null, 2));
     }));
 
   addBrowserTabOption(browserTab.command('close')
     .argument('[targetId]', 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"')
     .description('Close a tab by target ID'))
-    .action(browserAction(async (page, targetId?: string, opts?: { tab?: string }) => {
+    .action(browserAction(async (page, targetId?: string, opts?: { tab?: string } | Command) => {
       const resolvedTarget = resolveBrowserTabTarget(targetId, opts);
       if (!page.closeTab) {
         throw new Error('This browser session does not support closing tabs');
@@ -620,15 +741,16 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         throw new Error('Target tab required. Pass it as an argument or --tab <targetId>.');
       }
       const validatedTarget = await resolveBrowserTargetInSession(page, resolvedTarget, {
-        scope: DEFAULT_BROWSER_WORKSPACE,
+        scope: getPageWorkspace(page),
         source: 'explicit',
       });
       if (!validatedTarget) {
         throw new Error(`Target tab ${resolvedTarget} is not part of the current browser session.`);
       }
       await page.closeTab(validatedTarget);
-      if (loadBrowserTargetState(DEFAULT_BROWSER_WORKSPACE)?.defaultPage === validatedTarget) {
-        saveBrowserTargetState(undefined, DEFAULT_BROWSER_WORKSPACE);
+      const workspace = getPageWorkspace(page);
+      if (loadBrowserTargetState(workspace)?.defaultPage === validatedTarget) {
+        saveBrowserTargetState(undefined, workspace);
       }
       console.log(JSON.stringify({ closed: validatedTarget }, null, 2));
     }));
@@ -647,11 +769,15 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
    */
   const NETWORK_INTERCEPTOR_JS = `(function(){if(window.__opencli_net)return;window.__opencli_net=[];var M=200,B=1048576,F=window.fetch;function capture(url,method,status,text,ct){if(window.__opencli_net.length>=M)return;var full=text?text.length:0,trunc=full>B,stored=trunc?text.slice(0,B):text,body=null;if(stored){if(trunc){body=stored}else{try{body=JSON.parse(stored)}catch(e){body=stored}}}var e={url:url,method:method||'GET',status:status,size:full,ct:ct,body:body};if(trunc){e.bodyTruncated=true;e.bodyFullSize=full}window.__opencli_net.push(e)}window.fetch=async function(){var r=await F.apply(this,arguments);try{var ct=r.headers.get('content-type')||'';if(ct.includes('json')||ct.includes('text')){var c=r.clone(),t=await c.text();capture(r.url||(arguments[0]&&arguments[0].url)||String(arguments[0]),(arguments[1]&&arguments[1].method)||'GET',r.status,t,ct)}}catch(e){}return r};var X=XMLHttpRequest.prototype,O=X.open,S=X.send;X.open=function(m,u){this._om=m;this._ou=u;return O.apply(this,arguments)};X.send=function(){var x=this;x.addEventListener('load',function(){try{var ct=x.getResponseHeader('content-type')||'';if(ct.includes('json')||ct.includes('text')){capture(x._ou,x._om||'GET',x.status,x.responseText||'',ct)}}catch(e){}});return S.apply(this,arguments)}})()`;
 
-  addBrowserTabOption(browser.command('open').argument('<url>').description('Open URL in automation window'))
-    .action(browserAction(async (page, url) => {
+  addBrowserTabOption(browser.command('open').argument('<url>').option('--allow-navigate-bound', 'Allow navigating a bound user tab', false).description('Open URL in automation window'))
+    .action(browserAction(async (page, url, opts) => {
       // Start session-level capture before navigation (catches initial requests)
       const hasSessionCapture = await page.startNetworkCapture?.() ?? false;
-      await page.goto(url);
+      if (opts.allowNavigateBound === true) {
+        await page.goto(url, { allowBoundNavigation: true });
+      } else {
+        await page.goto(url);
+      }
       await page.wait(2);
       // Fallback: inject JS interceptor when session capture is unavailable
       if (!hasSessionCapture) {
@@ -663,8 +789,19 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }, null, 2));
     }));
 
-  addBrowserTabOption(browser.command('back').description('Go back in browser history'))
-    .action(browserAction(async (page) => {
+  addBrowserTabOption(browser.command('back').option('--allow-navigate-bound', 'Allow history navigation in a bound user tab', false).description('Go back in browser history'))
+    .action(browserAction(async (page, opts) => {
+      if (getPageWorkspace(page).startsWith('bound:') && opts.allowNavigateBound !== true) {
+        console.log(JSON.stringify({
+          error: {
+            code: 'bound_navigation_blocked',
+            message: `Workspace "${getPageWorkspace(page)}" is bound to a user tab; history navigation is blocked by default.`,
+            hint: 'Pass --allow-navigate-bound only if you intentionally want to navigate the bound tab.',
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+        return;
+      }
       await page.evaluate('history.back()');
       await page.wait(2);
       console.log('Navigated back');
@@ -1324,7 +1461,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .description('Capture network requests as shape previews; retrieve full bodies by key')
     .action(browserAction(async (page, opts) => {
       const ttlMs = parsePositiveIntOption(opts.ttl, 'ttl', DEFAULT_TTL_MS);
-      const workspace = DEFAULT_BROWSER_WORKSPACE;
+      const workspace = getPageWorkspace(page);
       const hasDetail = typeof opts.detail === 'string' && opts.detail.length > 0;
       const hasFilter = typeof opts.filter === 'string';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
-import { bindTab, BrowserCommandError } from './browser/daemon-client.js';
+import { bindTab, BrowserCommandError, sendCommand } from './browser/daemon-client.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -681,12 +681,22 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       try {
         const { BrowserBridge } = await import('./browser/index.js');
         const bridge = new BrowserBridge();
-        const page = await bridge.connect({ timeout: 30, workspace });
-        await page.closeWindow?.();
+        await bridge.connect({ timeout: 30, workspace });
+        await sendCommand('close-window', { workspace });
         saveBrowserTargetState(undefined, workspace);
         console.log(JSON.stringify({ unbound: true, workspace }, null, 2));
       } catch (err) {
+        if (err instanceof BrowserCommandError && err.code) {
+          console.log(JSON.stringify({
+            error: {
+              code: err.code,
+              message: err.message,
+              ...(err.hint ? { hint: err.hint } : {}),
+            },
+          }, null, 2));
+        }
         log.error(err instanceof Error ? err.message : String(err));
+        if (err instanceof BrowserCommandError && err.hint) log.error(`Hint: ${err.hint}`);
         process.exitCode = EXIT_CODES.GENERIC_ERROR;
       }
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
-import { bindCurrentTab, BrowserCommandError } from './browser/daemon-client.js';
+import { bindTab, BrowserCommandError } from './browser/daemon-client.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -607,7 +607,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     };
   }
 
-  browser.command('bind-current')
+  browser.command('bind')
     .option('--domain <host>', 'Only bind a current/visible tab whose hostname matches this domain')
     .option('--path-prefix <path>', 'Only bind a current/visible tab whose pathname starts with this prefix')
     .option('--workspace <name>', 'Bound workspace name (must start with bound:)')
@@ -634,7 +634,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         const { BrowserBridge } = await import('./browser/index.js');
         const bridge = new BrowserBridge();
         await bridge.connect({ timeout: 30, workspace });
-        const data = await bindCurrentTab(workspace, {
+        const data = await bindTab(workspace, {
           ...(typeof opts.domain === 'string' && opts.domain.trim() ? { matchDomain: opts.domain.trim() } : {}),
           ...(typeof opts.pathPrefix === 'string' && opts.pathPrefix.trim() ? { matchPathPrefix: opts.pathPrefix.trim() } : {}),
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface BrowserSessionInfo {
 }
 
 export interface IPage {
-  goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void>;
+  goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number; allowBoundNavigation?: boolean }): Promise<void>;
   evaluate(js: string): Promise<any>;
   /** Safely evaluate JS with pre-serialized arguments — prevents injection. */
   evaluateWithArgs?(js: string, args: Record<string, unknown>): Promise<any>;


### PR DESCRIPTION
## Summary

Closes #1169. Partially addresses #929 (browser commands; adapter --bind-current tracked separately).

- Adds `opencli browser bind-current` / `opencli browser unbind`, with `bound:default` as the default borrowed workspace.
- Lets browser commands target bound tabs via `opencli browser --workspace bound:default ...` without creating or owning a new automation window.
- Enforces `bound:*` workspace isolation in the extension, including fail-closed resolver errors for closed, mismatched, or non-debuggable bound tabs.
- Keeps borrowed sessions out of idle close behavior, clears them on tab/window close, and detaches debugger state on unbind/rebind.
- Blocks `browser open` / `browser back` on bound workspaces unless explicitly allowed, and blocks tab mutation on borrowed sessions.
- Scopes browser target state and network cache by selected workspace; documents the bound workspace contract in skills.

## Verification

- `npx vitest run src/cli.test.ts extension/src/background.test.ts src/browser/page.test.ts src/browser/daemon-client.test.ts src/browser/cdp.test.ts`
- `npm run typecheck`
- `cd extension && npm run typecheck`
- `npm run build`
- `cd extension && npm run build`
- `git diff --check`
