### PR TITLE
feat(browser): manage owned workspaces as tab leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **browser** — `bind` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
+* **browser lifecycle** — owned browser workspaces now lease tabs inside a shared dedicated automation container instead of owning one Chrome window per workspace; lease state is persisted for MV3 service-worker reconciliation and idle cleanup is backed by alarms.
 
 ## [1.7.8](https://github.com/jackwener/opencli/compare/v1.7.7...v1.7.8) (2026-04-25)
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ OpenCLI is not only for websites. It can also:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge |
-| `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open automation windows in the foreground (useful for debugging). The `--focus` flag sets this. |
-| `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation window open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
+| `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
+| `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |
@@ -177,7 +177,7 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_DIAGNOSTIC` | `false` | Set to `1` to capture structured diagnostic context on failures |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
-`--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation window open until you run `opencli browser close` or the idle timeout expires.
+`--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation lease open until you run `opencli browser close` or the idle timeout expires.
 
 ## Update
 

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -506,6 +506,7 @@ const IDLE_TIMEOUT_NONE = -1;
 const REGISTRY_KEY = "opencli_target_lease_registry_v1";
 const LEASE_IDLE_ALARM_PREFIX = "opencli:lease-idle:";
 let leaseMutationQueue = Promise.resolve();
+let ownedContainerWindowPromise = null;
 class CommandFailure extends Error {
   constructor(code, message, hint) {
     super(message);
@@ -657,6 +658,13 @@ function resetWindowIdleTimer(workspace) {
   }, timeout);
 }
 async function ensureOwnedContainerWindow(initialUrl) {
+  if (ownedContainerWindowPromise) return ownedContainerWindowPromise;
+  ownedContainerWindowPromise = ensureOwnedContainerWindowUnlocked(initialUrl).finally(() => {
+    ownedContainerWindowPromise = null;
+  });
+  return ownedContainerWindowPromise;
+}
+async function ensureOwnedContainerWindowUnlocked(initialUrl) {
   if (ownedContainerWindowId !== null) {
     try {
       await chrome.windows.get(ownedContainerWindowId);
@@ -829,10 +837,10 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.runtime.onStartup.addListener(() => {
   initialize();
 });
-chrome.alarms.onAlarm.addListener((alarm) => {
+chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === "keepalive") void connect();
   const workspace = workspaceFromAlarmName(alarm.name);
-  if (workspace) void releaseWorkspaceLease(workspace, "idle alarm");
+  if (workspace) await releaseWorkspaceLease(workspace, "idle alarm");
 });
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "getStatus") {

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -499,9 +499,13 @@ function scheduleReconnect() {
   }, delay);
 }
 const automationSessions = /* @__PURE__ */ new Map();
+let ownedContainerWindowId = null;
 const IDLE_TIMEOUT_DEFAULT = 3e4;
 const IDLE_TIMEOUT_INTERACTIVE = 6e5;
 const IDLE_TIMEOUT_NONE = -1;
+const REGISTRY_KEY = "opencli_target_lease_registry_v1";
+const LEASE_IDLE_ALARM_PREFIX = "opencli:lease-idle:";
+let leaseMutationQueue = Promise.resolve();
 class CommandFailure extends Error {
   constructor(code, message, hint) {
     super(message);
@@ -524,34 +528,222 @@ let windowFocused = false;
 function getWorkspaceKey(workspace) {
   return workspace?.trim() || "default";
 }
+function getLeaseLifecycle(workspace) {
+  if (workspace.startsWith("bound:")) return "pinned";
+  if (workspace.startsWith("browser:") || workspace.startsWith("operate:")) return "persistent";
+  return "ephemeral";
+}
+function makeAlarmName(workspace) {
+  return `${LEASE_IDLE_ALARM_PREFIX}${encodeURIComponent(workspace)}`;
+}
+function workspaceFromAlarmName(name) {
+  if (!name.startsWith(LEASE_IDLE_ALARM_PREFIX)) return null;
+  try {
+    return decodeURIComponent(name.slice(LEASE_IDLE_ALARM_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+function withLeaseMutation(fn) {
+  const run = leaseMutationQueue.then(fn, fn);
+  leaseMutationQueue = run.then(() => void 0, () => void 0);
+  return run;
+}
+function makeSession(workspace, session) {
+  const ownership = session.owned ? "owned" : "borrowed";
+  return {
+    ...session,
+    contextId: "user-default",
+    ownership,
+    lifecycle: getLeaseLifecycle(workspace),
+    surface: ownership === "owned" ? "dedicated-container" : "borrowed-user-tab"
+  };
+}
+function emptyRegistry() {
+  return {
+    version: 1,
+    contextId: "user-default",
+    ownedContainerWindowId,
+    leases: {}
+  };
+}
+async function readRegistry() {
+  try {
+    const local = chrome.storage?.local;
+    if (!local) return emptyRegistry();
+    const raw = await local.get(REGISTRY_KEY);
+    const stored = raw[REGISTRY_KEY];
+    if (!stored || stored.version !== 1 || typeof stored.leases !== "object") return emptyRegistry();
+    return {
+      version: 1,
+      contextId: "user-default",
+      ownedContainerWindowId: typeof stored.ownedContainerWindowId === "number" ? stored.ownedContainerWindowId : null,
+      leases: stored.leases
+    };
+  } catch {
+    return emptyRegistry();
+  }
+}
+async function writeRegistry(registry) {
+  try {
+    await chrome.storage?.local?.set({ [REGISTRY_KEY]: registry });
+  } catch {
+  }
+}
+async function persistRuntimeState() {
+  const leases = {};
+  for (const [workspace, session] of automationSessions.entries()) {
+    leases[workspace] = {
+      windowId: session.windowId,
+      owned: session.owned,
+      preferredTabId: session.preferredTabId,
+      contextId: session.contextId,
+      ownership: session.ownership,
+      lifecycle: session.lifecycle,
+      surface: session.surface,
+      idleDeadlineAt: session.idleDeadlineAt,
+      updatedAt: Date.now()
+    };
+  }
+  await writeRegistry({
+    version: 1,
+    contextId: "user-default",
+    ownedContainerWindowId,
+    leases
+  });
+}
+function scheduleIdleAlarm(workspace, timeout) {
+  const alarmName = makeAlarmName(workspace);
+  try {
+    if (timeout > 0) {
+      chrome.alarms?.create?.(alarmName, { when: Date.now() + timeout });
+    } else {
+      chrome.alarms?.clear?.(alarmName);
+    }
+  } catch {
+  }
+}
+async function safeDetach(tabId) {
+  try {
+    const detach$1 = detach;
+    if (typeof detach$1 === "function") await detach$1(tabId);
+  } catch {
+  }
+}
+async function removeWorkspaceSession(workspace) {
+  const existing = automationSessions.get(workspace);
+  if (existing?.idleTimer) clearTimeout(existing.idleTimer);
+  automationSessions.delete(workspace);
+  workspaceTimeoutOverrides.delete(workspace);
+  scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+  await persistRuntimeState();
+}
 function resetWindowIdleTimer(workspace) {
   const session = automationSessions.get(workspace);
   if (!session) return;
   if (session.idleTimer) clearTimeout(session.idleTimer);
   const timeout = getIdleTimeout(workspace);
+  scheduleIdleAlarm(workspace, timeout);
   if (timeout <= 0) {
     session.idleTimer = null;
     session.idleDeadlineAt = 0;
+    void persistRuntimeState();
     return;
   }
   session.idleDeadlineAt = Date.now() + timeout;
+  void persistRuntimeState();
   session.idleTimer = setTimeout(async () => {
-    const current = automationSessions.get(workspace);
-    if (!current) return;
-    if (!current.owned) {
-      console.log(`[opencli] Borrowed workspace ${workspace} detached from window ${current.windowId} (idle timeout)`);
-      workspaceTimeoutOverrides.delete(workspace);
-      automationSessions.delete(workspace);
-      return;
-    }
-    try {
-      await chrome.windows.remove(current.windowId);
-      console.log(`[opencli] Automation window ${current.windowId} (${workspace}) closed (idle timeout, ${timeout / 1e3}s)`);
-    } catch {
-    }
-    workspaceTimeoutOverrides.delete(workspace);
-    automationSessions.delete(workspace);
+    await releaseWorkspaceLease(workspace, "idle timeout");
   }, timeout);
+}
+async function ensureOwnedContainerWindow(initialUrl) {
+  if (ownedContainerWindowId !== null) {
+    try {
+      await chrome.windows.get(ownedContainerWindowId);
+      return {
+        windowId: ownedContainerWindowId,
+        initialTabId: await findReusableOwnedContainerTab(ownedContainerWindowId)
+      };
+    } catch {
+      ownedContainerWindowId = null;
+    }
+  }
+  const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
+  const win = await chrome.windows.create({
+    url: startUrl,
+    focused: windowFocused,
+    width: 1280,
+    height: 900,
+    type: "normal"
+  });
+  ownedContainerWindowId = win.id;
+  console.log(`[opencli] Created owned automation container window ${ownedContainerWindowId} (start=${startUrl})`);
+  const tabs = await chrome.tabs.query({ windowId: win.id });
+  const initialTabId = tabs[0]?.id;
+  if (initialTabId) {
+    await new Promise((resolve) => {
+      const timeout = setTimeout(resolve, 500);
+      const listener = (tabId, info) => {
+        if (tabId === initialTabId && info.status === "complete") {
+          chrome.tabs.onUpdated.removeListener(listener);
+          clearTimeout(timeout);
+          resolve();
+        }
+      };
+      if (tabs[0].status === "complete") {
+        clearTimeout(timeout);
+        resolve();
+      } else {
+        chrome.tabs.onUpdated.addListener(listener);
+      }
+    });
+  }
+  await persistRuntimeState();
+  return { windowId: ownedContainerWindowId, initialTabId };
+}
+async function findReusableOwnedContainerTab(windowId) {
+  try {
+    const tabs = await chrome.tabs.query({ windowId });
+    const reusable = tabs.find(
+      (tab) => tab.id !== void 0 && initialTabIsAvailable(tab.id) && isDebuggableUrl(tab.url)
+    );
+    return reusable?.id;
+  } catch {
+    return void 0;
+  }
+}
+function initialTabIsAvailable(tabId) {
+  if (tabId === void 0) return false;
+  for (const session of automationSessions.values()) {
+    if (session.owned && session.preferredTabId === tabId) return false;
+  }
+  return true;
+}
+async function createOwnedTabLease(workspace, initialUrl) {
+  return withLeaseMutation(() => createOwnedTabLeaseUnlocked(workspace, initialUrl));
+}
+async function createOwnedTabLeaseUnlocked(workspace, initialUrl) {
+  const targetUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
+  const { windowId, initialTabId } = await ensureOwnedContainerWindow(targetUrl);
+  let tab;
+  if (initialTabIsAvailable(initialTabId)) {
+    tab = await chrome.tabs.get(initialTabId);
+    if (!isTargetUrl(tab.url, targetUrl)) {
+      tab = await chrome.tabs.update(initialTabId, { url: targetUrl });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      tab = await chrome.tabs.get(initialTabId);
+    }
+  } else {
+    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
+  }
+  if (!tab.id) throw new Error("Failed to create tab lease in automation container");
+  setWorkspaceSession(workspace, {
+    windowId,
+    owned: true,
+    preferredTabId: tab.id
+  });
+  resetWindowIdleTimer(workspace);
+  return { tabId: tab.id, tab };
 }
 async function getAutomationWindow(workspace, initialUrl) {
   if (workspace.startsWith("bound:") && !automationSessions.has(workspace)) {
@@ -566,76 +758,59 @@ async function getAutomationWindow(workspace, initialUrl) {
     if (!existing.owned) {
       throw new CommandFailure(
         "bound_window_operation_blocked",
-        `Workspace "${workspace}" is bound to a user tab and does not own an automation window.`,
+        `Workspace "${workspace}" is bound to a user tab and does not own an automation tab lease.`,
         "Use commands that operate on the bound tab, or unbind and use an automation workspace."
       );
     }
     try {
+      const tabId = existing.preferredTabId;
+      if (tabId !== null) {
+        const tab = await chrome.tabs.get(tabId);
+        if (isDebuggableUrl(tab.url)) return tab.windowId;
+      }
       await chrome.windows.get(existing.windowId);
       return existing.windowId;
     } catch {
-      automationSessions.delete(workspace);
+      await removeWorkspaceSession(workspace);
     }
   }
-  const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
-  const win = await chrome.windows.create({
-    url: startUrl,
-    focused: windowFocused,
-    width: 1280,
-    height: 900,
-    type: "normal"
-  });
-  const session = {
-    windowId: win.id,
-    idleTimer: null,
-    idleDeadlineAt: Date.now() + getIdleTimeout(workspace),
-    owned: true,
-    preferredTabId: null
-  };
-  automationSessions.set(workspace, session);
-  console.log(`[opencli] Created automation window ${session.windowId} (${workspace}, start=${startUrl})`);
-  resetWindowIdleTimer(workspace);
-  const tabs = await chrome.tabs.query({ windowId: win.id });
-  if (tabs[0]?.id) {
-    await new Promise((resolve) => {
-      const timeout = setTimeout(resolve, 500);
-      const listener = (tabId, info) => {
-        if (tabId === tabs[0].id && info.status === "complete") {
-          chrome.tabs.onUpdated.removeListener(listener);
-          clearTimeout(timeout);
-          resolve();
-        }
-      };
-      if (tabs[0].status === "complete") {
-        clearTimeout(timeout);
-        resolve();
-      } else {
-        chrome.tabs.onUpdated.addListener(listener);
-      }
-    });
-  }
-  return session.windowId;
+  return (await ensureOwnedContainerWindow(initialUrl)).windowId;
 }
 chrome.windows.onRemoved.addListener(async (windowId) => {
+  if (ownedContainerWindowId === windowId) {
+    ownedContainerWindowId = null;
+  }
   for (const [workspace, session] of automationSessions.entries()) {
     if (session.windowId === windowId) {
-      console.log(`[opencli] Automation window closed (${workspace})`);
+      console.log(`[opencli] Automation container closed (${workspace})`);
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(workspace);
       workspaceTimeoutOverrides.delete(workspace);
+      scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
     }
   }
+  await persistRuntimeState();
 });
-chrome.tabs.onRemoved.addListener((tabId) => {
+chrome.tabs.onRemoved.addListener(async (tabId) => {
   evictTab(tabId);
   for (const [workspace, session] of automationSessions.entries()) {
-    if (!session.owned && session.preferredTabId === tabId) {
+    if (session.preferredTabId === tabId) {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(workspace);
       workspaceTimeoutOverrides.delete(workspace);
-      console.log(`[opencli] Borrowed workspace ${workspace} detached from tab ${tabId} (tab closed)`);
+      scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+      console.log(`[opencli] Workspace ${workspace} lease detached from tab ${tabId} (tab closed)`);
     }
   }
+  if (ownedContainerWindowId !== null) {
+    const hasOwnedLease = [...automationSessions.values()].some((s) => s.owned && s.windowId === ownedContainerWindowId);
+    if (!hasOwnedLease) {
+      await chrome.windows.remove(ownedContainerWindowId).catch(() => {
+      });
+      ownedContainerWindowId = null;
+    }
+  }
+  await persistRuntimeState();
 });
 let initialized = false;
 function initialize() {
@@ -644,6 +819,7 @@ function initialize() {
   chrome.alarms.create("keepalive", { periodInMinutes: 0.4 });
   registerListeners();
   registerFrameTracking();
+  void reconcileTargetLeaseRegistry();
   void connect();
   console.log("[opencli] OpenCLI extension initialized");
 }
@@ -655,6 +831,8 @@ chrome.runtime.onStartup.addListener(() => {
 });
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === "keepalive") void connect();
+  const workspace = workspaceFromAlarmName(alarm.name);
+  if (workspace) void releaseWorkspaceLease(workspace, "idle alarm");
 });
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "getStatus") {
@@ -798,10 +976,11 @@ function setWorkspaceSession(workspace, session) {
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
   const timeout = getIdleTimeout(workspace);
   automationSessions.set(workspace, {
-    ...session,
+    ...makeSession(workspace, session),
     idleTimer: null,
     idleDeadlineAt: timeout <= 0 ? 0 : Date.now() + timeout
   });
+  void persistRuntimeState();
 }
 async function resolveCommandTabId(cmd) {
   if (cmd.page) return resolveTabId$1(cmd.page);
@@ -864,7 +1043,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
       }
     } catch (err) {
       if (err instanceof CommandFailure) throw err;
-      automationSessions.delete(workspace);
+      await removeWorkspaceSession(workspace);
       if (!session.owned) {
         throw new CommandFailure(
           "bound_tab_gone",
@@ -872,7 +1051,14 @@ async function resolveTab(tabId, workspace, initialUrl) {
           'Run "opencli browser bind" again, then retry the command.'
         );
       }
+      return createOwnedTabLease(workspace, initialUrl);
     }
+  }
+  if (!existingSession && workspace.startsWith("bound:")) {
+    await getAutomationWindow(workspace, initialUrl);
+  }
+  if (!existingSession || existingSession.owned && existingSession.preferredTabId === null) {
+    return createOwnedTabLease(workspace, initialUrl);
   }
   const windowId = await getAutomationWindow(workspace, initialUrl);
   const tabs = await chrome.tabs.query({ windowId });
@@ -890,7 +1076,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
     }
   }
   const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
-  if (!newTab.id) throw new Error("Failed to create tab in automation window");
+  if (!newTab.id) throw new Error("Failed to create tab in automation container");
   return { tabId: newTab.id, tab: newTab };
 }
 async function pageScopedResult(id, tabId, data) {
@@ -1070,9 +1256,19 @@ async function handleTabs(cmd, workspace) {
       if (cmd.url && !isSafeNavigationUrl(cmd.url)) {
         return { id: cmd.id, ok: false, error: "Blocked URL scheme -- only http:// and https:// are allowed" };
       }
+      if (!automationSessions.has(workspace)) {
+        const created = await createOwnedTabLease(workspace, cmd.url);
+        return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
+      }
       const windowId = await getAutomationWindow(workspace);
       const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
       if (!tab.id) return { id: cmd.id, ok: false, error: "Failed to create tab" };
+      setWorkspaceSession(workspace, {
+        windowId: tab.windowId,
+        owned: true,
+        preferredTabId: tab.id
+      });
+      resetWindowIdleTimer(workspace);
       return pageScopedResult(cmd.id, tab.id, { url: tab.url });
     }
     case "close": {
@@ -1081,15 +1277,25 @@ async function handleTabs(cmd, workspace) {
         const target = tabs[cmd.index];
         if (!target?.id) return { id: cmd.id, ok: false, error: `Tab index ${cmd.index} not found` };
         const closedPage2 = await resolveTargetId(target.id).catch(() => void 0);
-        await chrome.tabs.remove(target.id);
-        await detach(target.id);
+        const currentSession2 = automationSessions.get(workspace);
+        if (currentSession2?.preferredTabId === target.id) {
+          await releaseWorkspaceLease(workspace, "tab close");
+        } else {
+          await safeDetach(target.id);
+          await chrome.tabs.remove(target.id);
+        }
         return { id: cmd.id, ok: true, data: { closed: closedPage2 } };
       }
       const cmdTabId = await resolveCommandTabId(cmd);
       const tabId = await resolveTabId(cmdTabId, workspace);
       const closedPage = await resolveTargetId(tabId).catch(() => void 0);
-      await chrome.tabs.remove(tabId);
-      await detach(tabId);
+      const currentSession = automationSessions.get(workspace);
+      if (currentSession?.preferredTabId === tabId) {
+        await releaseWorkspaceLease(workspace, "tab close");
+      } else {
+        await safeDetach(tabId);
+        await chrome.tabs.remove(tabId);
+      }
       return { id: cmd.id, ok: true, data: { closed: closedPage } };
     }
     case "select": {
@@ -1105,7 +1311,7 @@ async function handleTabs(cmd, workspace) {
           return { id: cmd.id, ok: false, error: `Page no longer exists` };
         }
         if (!session2 || tab.windowId !== session2.windowId) {
-          return { id: cmd.id, ok: false, error: `Page is not in the automation window` };
+          return { id: cmd.id, ok: false, error: `Page is not in the automation container` };
         }
         await chrome.tabs.update(cmdTabId, { active: true });
         return pageScopedResult(cmd.id, cmdTabId, { selected: true });
@@ -1197,22 +1403,8 @@ async function handleCdp(cmd, workspace) {
   }
 }
 async function handleCloseWindow(cmd, workspace) {
-  const session = automationSessions.get(workspace);
-  if (session) {
-    if (session.owned) {
-      try {
-        await chrome.windows.remove(session.windowId);
-      } catch {
-      }
-    } else if (session.preferredTabId !== null) {
-      await detach(session.preferredTabId).catch(() => {
-      });
-    }
-    if (session.idleTimer) clearTimeout(session.idleTimer);
-    workspaceTimeoutOverrides.delete(workspace);
-    automationSessions.delete(workspace);
-  }
-  return { id: cmd.id, ok: true, data: { closed: true } };
+  await releaseWorkspaceLease(workspace, "explicit close");
+  return { id: cmd.id, ok: true, data: { closed: true, workspace } };
 }
 async function handleSetFileInput(cmd, workspace) {
   if (!cmd.files || !Array.isArray(cmd.files) || cmd.files.length === 0) {
@@ -1260,6 +1452,95 @@ async function handleNetworkCaptureRead(cmd, workspace) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
+async function releaseWorkspaceLease(workspace, reason = "released") {
+  const session = automationSessions.get(workspace);
+  if (!session) {
+    workspaceTimeoutOverrides.delete(workspace);
+    scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+    await persistRuntimeState();
+    return;
+  }
+  if (session.idleTimer) clearTimeout(session.idleTimer);
+  scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+  if (session.owned) {
+    const tabId = session.preferredTabId;
+    if (tabId !== null) {
+      await safeDetach(tabId);
+      await chrome.tabs.remove(tabId).catch(() => {
+      });
+      console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+    } else {
+      await chrome.windows.remove(session.windowId).catch(() => {
+      });
+      if (ownedContainerWindowId === session.windowId) ownedContainerWindowId = null;
+      console.log(`[opencli] Released legacy owned window lease ${session.windowId} (${workspace}, ${reason})`);
+    }
+  } else if (session.preferredTabId !== null) {
+    await safeDetach(session.preferredTabId);
+    console.log(`[opencli] Detached borrowed tab lease ${session.preferredTabId} (${workspace}, ${reason})`);
+  }
+  automationSessions.delete(workspace);
+  workspaceTimeoutOverrides.delete(workspace);
+  if (ownedContainerWindowId !== null) {
+    const stillHasOwnedLeases = [...automationSessions.values()].some((s) => s.owned && s.windowId === ownedContainerWindowId);
+    if (!stillHasOwnedLeases) {
+      await chrome.windows.remove(ownedContainerWindowId).catch(() => {
+      });
+      ownedContainerWindowId = null;
+    }
+  }
+  await persistRuntimeState();
+}
+async function reconcileTargetLeaseRegistry() {
+  const registry = await readRegistry();
+  ownedContainerWindowId = registry.ownedContainerWindowId;
+  if (ownedContainerWindowId !== null) {
+    try {
+      await chrome.windows.get(ownedContainerWindowId);
+    } catch {
+      ownedContainerWindowId = null;
+    }
+  }
+  automationSessions.clear();
+  for (const [workspace, stored] of Object.entries(registry.leases)) {
+    const tabId = stored.preferredTabId;
+    if (tabId === null) continue;
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (!isDebuggableUrl(tab.url)) continue;
+      const session = makeSession(workspace, {
+        windowId: tab.windowId,
+        owned: stored.owned,
+        preferredTabId: tabId
+      });
+      const timeout = getIdleTimeout(workspace);
+      automationSessions.set(workspace, {
+        ...session,
+        idleTimer: null,
+        idleDeadlineAt: stored.idleDeadlineAt
+      });
+      if (session.owned && ownedContainerWindowId === null) ownedContainerWindowId = tab.windowId;
+      const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
+      if (timeout > 0) {
+        if (remaining <= 0) {
+          await releaseWorkspaceLease(workspace, "reconciled idle expiry");
+        } else {
+          resetWindowIdleTimer(workspace);
+        }
+      }
+    } catch {
+    }
+  }
+  if (ownedContainerWindowId !== null) {
+    const hasOwnedLease = [...automationSessions.values()].some((s) => s.owned && s.windowId === ownedContainerWindowId);
+    if (!hasOwnedLease) {
+      await chrome.windows.remove(ownedContainerWindowId).catch(() => {
+      });
+      ownedContainerWindowId = null;
+    }
+  }
+  await persistRuntimeState();
+}
 async function handleSessions(cmd) {
   const now = Date.now();
   const data = await Promise.all([...automationSessions.entries()].map(async ([workspace, session]) => ({
@@ -1267,6 +1548,10 @@ async function handleSessions(cmd) {
     windowId: session.windowId,
     owned: session.owned,
     preferredTabId: session.preferredTabId,
+    contextId: session.contextId,
+    ownership: session.ownership,
+    lifecycle: session.lifecycle,
+    surface: session.surface,
     tabCount: session.preferredTabId !== null ? await chrome.tabs.get(session.preferredTabId).then((tab) => isDebuggableUrl(tab.url) ? 1 : 0).catch(() => 0) : (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
     idleMsRemaining: session.idleDeadlineAt <= 0 ? null : Math.max(0, session.idleDeadlineAt - now)
   })));
@@ -1288,21 +1573,20 @@ async function handleBind(cmd, workspace) {
       id: cmd.id,
       ok: false,
       errorCode: "invalid_bind_workspace",
-      error: `Workspace "${workspace}" already owns an automation window and cannot be rebound to a user tab.`,
+      error: `Workspace "${workspace}" already owns an automation tab lease and cannot be rebound to a user tab.`,
       errorHint: "Use a fresh bound:<name> workspace, or close/unbind the existing session first."
     };
   }
   const activeTabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   const fallbackTabs = await chrome.tabs.query({ lastFocusedWindow: true });
-  const allTabs = await chrome.tabs.query({});
-  const boundTab = activeTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? fallbackTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? allTabs.find((tab) => matchesBindCriteria(tab, cmd));
+  const boundTab = activeTabs.find((tab) => matchesBindCriteria(tab, cmd)) ?? fallbackTabs.find((tab) => matchesBindCriteria(tab, cmd));
   if (!boundTab?.id) {
     return {
       id: cmd.id,
       ok: false,
       errorCode: "bound_tab_not_found",
-      error: cmd.matchDomain || cmd.matchPathPrefix ? `No visible tab matching ${cmd.matchDomain ?? "domain"}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ""}` : "No active debuggable tab found",
-      errorHint: "Focus the target Chrome tab or relax --domain / --path-prefix, then retry bind."
+      error: cmd.matchDomain || cmd.matchPathPrefix ? `No visible tab in the current window matching ${cmd.matchDomain ?? "domain"}${cmd.matchPathPrefix ? ` ${cmd.matchPathPrefix}` : ""}` : "No debuggable tab found in the current window",
+      errorHint: "Focus the target Chrome tab/window or relax --domain / --path-prefix, then retry bind."
     };
   }
   if (existing && !existing.owned && existing.preferredTabId !== null && existing.preferredTabId !== boundTab.id) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,13 +2,14 @@
   "manifest_version": 3,
   "name": "OpenCLI",
   "version": "1.0.2",
-  "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in isolated Chrome windows via a local daemon.",
+  "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",
     "tabs",
     "cookies",
     "activeTab",
-    "alarms"
+    "alarms",
+    "storage"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -564,6 +564,105 @@ describe('background tab isolation', () => {
     expect(chrome.windows.remove).toHaveBeenCalledWith(1);
   });
 
+  it('restores owned and borrowed leases from the registry', async () => {
+    const { chrome } = createChromeMock();
+    const deadline = Date.now() + 30_000;
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v1: {
+        version: 1,
+        contextId: 'user-default',
+        ownedContainerWindowId: 1,
+        leases: {
+          'site:restored': {
+            windowId: 1,
+            owned: true,
+            preferredTabId: 1,
+            contextId: 'user-default',
+            ownership: 'owned',
+            lifecycle: 'ephemeral',
+            surface: 'dedicated-container',
+            idleDeadlineAt: deadline,
+            updatedAt: Date.now(),
+          },
+          'bound:restored': {
+            windowId: 2,
+            owned: false,
+            preferredTabId: 2,
+            contextId: 'user-default',
+            ownership: 'borrowed',
+            lifecycle: 'pinned',
+            surface: 'borrowed-user-tab',
+            idleDeadlineAt: 0,
+            updatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(mod.__test__.getSession('site:restored')).toEqual(expect.objectContaining({
+      owned: true,
+      ownership: 'owned',
+      lifecycle: 'ephemeral',
+      surface: 'dedicated-container',
+      preferredTabId: 1,
+    }));
+    expect(mod.__test__.getSession('bound:restored')).toEqual(expect.objectContaining({
+      owned: false,
+      ownership: 'borrowed',
+      lifecycle: 'pinned',
+      surface: 'borrowed-user-tab',
+      preferredTabId: 2,
+      idleTimer: null,
+      idleDeadlineAt: 0,
+    }));
+    expect(chrome.alarms.create).toHaveBeenCalledWith(
+      'opencli:lease-idle:site%3Arestored',
+      expect.objectContaining({ when: expect.any(Number) }),
+    );
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+  });
+
+  it('releases owned leases from the idle alarm path', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await mod.__test__.resolveTabId(undefined, 'site:alarm');
+
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    await onAlarmListener({ name: 'opencli:lease-idle:site%3Aalarm' });
+
+    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
+    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(mod.__test__.getSession('site:alarm')).toBeNull();
+  });
+
+  it('deduplicates concurrent automation container creation', async () => {
+    const { chrome } = createChromeMock();
+    chrome.windows.get = vi.fn(async (windowId: number) => {
+      if (windowId === 90 || windowId === 91) throw new Error(`stale window ${windowId}`);
+      return { id: windowId };
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('site:stale-a', { windowId: 90, owned: true, preferredTabId: null });
+    mod.__test__.setSession('site:stale-b', { windowId: 91, owned: true, preferredTabId: null });
+
+    const [first, second] = await Promise.all([
+      mod.__test__.handleTabs({ id: 'new-a', action: 'tabs', op: 'new', workspace: 'site:stale-a', url: 'https://a.example' }, 'site:stale-a'),
+      mod.__test__.handleTabs({ id: 'new-b', action: 'tabs', op: 'new', workspace: 'site:stale-b', url: 'https://b.example' }, 'site:stale-b'),
+    ]);
+
+    expect(first).toEqual(expect.objectContaining({ ok: true }));
+    expect(second).toEqual(expect.objectContaining({ ok: true }));
+    expect(chrome.windows.create).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps site:notebooklm inside its owned automation lease instead of rebinding to a user tab', async () => {
     const { chrome, tabs } = createChromeMock();
     tabs[0].url = 'https://notebooklm.google.com/';

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -32,6 +32,7 @@ class MockWebSocket {
 
 function createChromeMock() {
   let nextTabId = 10;
+  const storageState: Record<string, unknown> = {};
   const tabs: MockTab[] = [
     { id: 1, windowId: 1, url: 'https://automation.example', title: 'automation', active: true, status: 'complete' },
     { id: 2, windowId: 2, url: 'https://user.example', title: 'user', active: true, status: 'complete' },
@@ -110,7 +111,16 @@ function createChromeMock() {
     },
     alarms: {
       create: vi.fn(),
+      clear: vi.fn(),
       onAlarm: { addListener: vi.fn() } as Listener<(alarm: { name: string }) => void>,
+    },
+    storage: {
+      local: {
+        get: vi.fn(async (key: string) => ({ [key]: storageState[key] })),
+        set: vi.fn(async (items: Record<string, unknown>) => {
+          Object.assign(storageState, items);
+        }),
+      },
     },
     runtime: {
       onInstalled: { addListener: vi.fn() } as Listener<() => void>,
@@ -262,7 +272,7 @@ describe('background tab isolation', () => {
     expect(evaluateInFrame).toHaveBeenCalledWith(1, 'document.title', 'cross-origin-nested', false);
   });
 
-  it('creates new tabs inside the automation window', async () => {
+  it('creates new tabs inside the automation container', async () => {
     const { chrome, create } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -273,6 +283,22 @@ describe('background tab isolation', () => {
 
     expect(result.ok).toBe(true);
     expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'https://new.example', active: true });
+  });
+
+  it('reuses the initial container tab for first tab-new lease instead of leaving a blank tab', async () => {
+    const { chrome, create, update } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const result = await mod.__test__.handleTabs(
+      { id: 'first-new', action: 'tabs', op: 'new', url: 'https://first.example', workspace: 'browser:first-new' },
+      'browser:first-new',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(chrome.windows.create).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://first.example' }));
+    expect(update).toHaveBeenCalledWith(1, { url: 'https://first.example' });
+    expect(create).not.toHaveBeenCalled();
   });
 
   it('closes a tab by page identity', async () => {
@@ -436,8 +462,8 @@ describe('background tab isolation', () => {
     expect(maxInFlight).toBe(2);
   });
 
-  it('can execute concurrently across two workspaces/windows', async () => {
-    const { chrome } = createChromeMock();
+  it('can execute concurrently across two workspaces in the shared container window', async () => {
+    const { chrome, create } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
     let inFlight = 0;
@@ -469,13 +495,76 @@ describe('background tab isolation', () => {
     }));
     expect(second).toEqual(expect.objectContaining({
       ok: true,
-      page: 'target-2',
-      data: { tabId: 2, code: 'window.__window = 2' },
+      page: 'target-10',
+      data: { tabId: 10, code: 'window.__window = 2' },
     }));
     expect(maxInFlight).toBe(2);
+    expect(chrome.windows.create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'about:blank', active: true });
   });
 
-  it('keeps site:notebooklm inside its owned automation window instead of rebinding to a user tab', async () => {
+  it('releases owned workspaces as tab leases before closing the shared container', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await mod.__test__.resolveTabId(undefined, 'site:first');
+    await mod.__test__.resolveTabId(undefined, 'site:second');
+    expect(mod.__test__.getSession('site:second')).toEqual(expect.objectContaining({ preferredTabId: 10 }));
+
+    const closeSecond = await mod.__test__.handleCommand({ id: 'close-second', action: 'close-window', workspace: 'site:second' });
+    expect(closeSecond).toEqual(expect.objectContaining({ ok: true }));
+    expect(chrome.tabs.remove).toHaveBeenCalledWith(10);
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+    expect(mod.__test__.getSession('site:first')).not.toBeNull();
+    expect(mod.__test__.getSession('site:second')).toBeNull();
+
+    await mod.__test__.handleCommand({ id: 'close-first', action: 'close-window', workspace: 'site:first' });
+    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
+    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+  });
+
+  it('releases the current owned tab lease when tabs close targets it', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await mod.__test__.resolveTabId(undefined, 'site:closetab');
+
+    const result = await mod.__test__.handleTabs(
+      { id: 'close-current-lease', action: 'tabs', op: 'close', workspace: 'site:closetab' },
+      'site:closetab',
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      id: 'close-current-lease',
+      ok: true,
+      data: { closed: 'target-1' },
+    }));
+    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
+    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(mod.__test__.getSession('site:closetab')).toBeNull();
+  });
+
+  it('reconciles an owned container with no stored leases by closing it', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v1: {
+        version: 1,
+        contextId: 'user-default',
+        ownedContainerWindowId: 1,
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+  });
+
+  it('keeps site:notebooklm inside its owned automation lease instead of rebinding to a user tab', async () => {
     const { chrome, tabs } = createChromeMock();
     tabs[0].url = 'https://notebooklm.google.com/';
     tabs[0].title = 'NotebookLM Home';
@@ -494,9 +583,9 @@ describe('background tab isolation', () => {
     }));
   });
 
-  it('moves drifted tab back to automation window instead of creating a new one', async () => {
+  it('moves drifted legacy tab back to its automation container instead of creating a new one', async () => {
     const { chrome, tabs } = createChromeMock();
-    // Tab 1 belongs to automation window 1 but drifted to window 2
+    // Tab 1 belongs to automation container 1 but drifted to window 2
     tabs[0].windowId = 2;
     tabs[0].url = 'https://twitter.com/home';
     vi.stubGlobal('chrome', chrome);
@@ -527,7 +616,7 @@ describe('background tab isolation', () => {
     expect(typeof tabId).toBe('number');
   });
 
-  it('idle timeout closes the automation window for site:notebooklm', async () => {
+  it('idle timeout releases the automation lease for site:notebooklm', async () => {
     const { chrome, tabs } = createChromeMock();
     tabs[0].url = 'https://notebooklm.google.com/';
     tabs[0].title = 'NotebookLM Home';
@@ -628,7 +717,7 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getIdleTimeout('browser:custom')).toBe(120_000);
   });
 
-  it('clears workspaceTimeoutOverrides when user manually closes automation window', async () => {
+  it('clears workspaceTimeoutOverrides when user manually closes the automation container', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -712,7 +801,7 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).not.toHaveBeenCalled();
   });
 
-  it('refuses bind when the bound workspace already owns an automation window', async () => {
+  it('refuses bind when the bound workspace already owns an automation lease', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -767,7 +856,7 @@ describe('background tab isolation', () => {
     expect(chrome.windows.remove).not.toHaveBeenCalled();
   });
 
-  it('fails closed when a borrowed bound tab is gone instead of creating an automation window', async () => {
+  it('fails closed when a borrowed bound tab is gone instead of creating an automation lease', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -115,25 +115,51 @@ function scheduleReconnect(): void {
   }, delay);
 }
 
-// ─── Automation window isolation ─────────────────────────────────────
-// All opencli operations happen in a dedicated Chrome window so the
-// user's active browsing session is never touched.
-// The window auto-closes after a period of idle (no commands).
+// ─── Browser target leases ───────────────────────────────────────────
+// OpenCLI does not model workspace identity as a Chrome window. A workspace
+// owns or borrows a tab lease; owned leases share a dedicated container surface
+// and borrowed leases point at user-owned tabs.
 // Interactive workspaces (browser:*, operate:*) get a longer timeout (10 min)
 // since users type commands manually; adapter workspaces keep a short 30s timeout.
 
-type AutomationSession = {
+type BrowserContextId = 'user-default';
+type LeaseOwnership = 'owned' | 'borrowed';
+type LeaseLifecycle = 'ephemeral' | 'persistent' | 'pinned';
+type SurfacePolicy = 'dedicated-container' | 'borrowed-user-tab';
+
+type TargetLease = {
   windowId: number;
   idleTimer: ReturnType<typeof setTimeout> | null;
   idleDeadlineAt: number;
   owned: boolean;
   preferredTabId: number | null;
+  contextId: BrowserContextId;
+  ownership: LeaseOwnership;
+  lifecycle: LeaseLifecycle;
+  surface: SurfacePolicy;
 };
+type AutomationSession = TargetLease;
 
 const automationSessions = new Map<string, AutomationSession>();
+let ownedContainerWindowId: number | null = null;
 const IDLE_TIMEOUT_DEFAULT = 30_000;      // 30s — adapter-driven automation
 const IDLE_TIMEOUT_INTERACTIVE = 600_000; // 10min — human-paced browser:* / operate:*
-const IDLE_TIMEOUT_NONE = -1;             // borrowed bound-current tabs stay bound until unbound/closed
+const IDLE_TIMEOUT_NONE = -1;             // borrowed bound tabs stay bound until unbound/closed
+const REGISTRY_KEY = 'opencli_target_lease_registry_v1';
+const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
+let leaseMutationQueue: Promise<void> = Promise.resolve();
+
+type StoredLease = Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'> & {
+  idleDeadlineAt: number;
+  updatedAt: number;
+};
+
+type StoredRegistry = {
+  version: 1;
+  contextId: BrowserContextId;
+  ownedContainerWindowId: number | null;
+  leases: Record<string, StoredLease>;
+};
 
 class CommandFailure extends Error {
   constructor(readonly code: string, message: string, readonly hint?: string) {
@@ -161,40 +187,269 @@ function getWorkspaceKey(workspace?: string): string {
   return workspace?.trim() || 'default';
 }
 
+function getLeaseLifecycle(workspace: string): LeaseLifecycle {
+  if (workspace.startsWith('bound:')) return 'pinned';
+  if (workspace.startsWith('browser:') || workspace.startsWith('operate:')) return 'persistent';
+  return 'ephemeral';
+}
+
+function makeAlarmName(workspace: string): string {
+  return `${LEASE_IDLE_ALARM_PREFIX}${encodeURIComponent(workspace)}`;
+}
+
+function workspaceFromAlarmName(name: string): string | null {
+  if (!name.startsWith(LEASE_IDLE_ALARM_PREFIX)) return null;
+  try {
+    return decodeURIComponent(name.slice(LEASE_IDLE_ALARM_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+function withLeaseMutation<T>(fn: () => Promise<T>): Promise<T> {
+  const run = leaseMutationQueue.then(fn, fn);
+  leaseMutationQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+function makeSession(
+  workspace: string,
+  session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
+): Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'> {
+  const ownership = session.owned ? 'owned' : 'borrowed';
+  return {
+    ...session,
+    contextId: 'user-default',
+    ownership,
+    lifecycle: getLeaseLifecycle(workspace),
+    surface: ownership === 'owned' ? 'dedicated-container' : 'borrowed-user-tab',
+  };
+}
+
+function emptyRegistry(): StoredRegistry {
+  return {
+    version: 1,
+    contextId: 'user-default',
+    ownedContainerWindowId,
+    leases: {},
+  };
+}
+
+async function readRegistry(): Promise<StoredRegistry> {
+  try {
+    const local = chrome.storage?.local;
+    if (!local) return emptyRegistry();
+    const raw = await local.get(REGISTRY_KEY) as Record<string, unknown>;
+    const stored = raw[REGISTRY_KEY] as Partial<StoredRegistry> | undefined;
+    if (!stored || stored.version !== 1 || typeof stored.leases !== 'object') return emptyRegistry();
+    return {
+      version: 1,
+      contextId: 'user-default',
+      ownedContainerWindowId: typeof stored.ownedContainerWindowId === 'number' ? stored.ownedContainerWindowId : null,
+      leases: stored.leases as Record<string, StoredLease>,
+    };
+  } catch {
+    return emptyRegistry();
+  }
+}
+
+async function writeRegistry(registry: StoredRegistry): Promise<void> {
+  try {
+    await chrome.storage?.local?.set({ [REGISTRY_KEY]: registry });
+  } catch {
+    // Registry persistence is a recovery aid; command execution should not fail on storage errors.
+  }
+}
+
+async function persistRuntimeState(): Promise<void> {
+  const leases: Record<string, StoredLease> = {};
+  for (const [workspace, session] of automationSessions.entries()) {
+    leases[workspace] = {
+      windowId: session.windowId,
+      owned: session.owned,
+      preferredTabId: session.preferredTabId,
+      contextId: session.contextId,
+      ownership: session.ownership,
+      lifecycle: session.lifecycle,
+      surface: session.surface,
+      idleDeadlineAt: session.idleDeadlineAt,
+      updatedAt: Date.now(),
+    };
+  }
+  await writeRegistry({
+    version: 1,
+    contextId: 'user-default',
+    ownedContainerWindowId,
+    leases,
+  });
+}
+
+function scheduleIdleAlarm(workspace: string, timeout: number): void {
+  const alarmName = makeAlarmName(workspace);
+  try {
+    if (timeout > 0) {
+      chrome.alarms?.create?.(alarmName, { when: Date.now() + timeout });
+    } else {
+      chrome.alarms?.clear?.(alarmName);
+    }
+  } catch {
+    // setTimeout remains the in-process fast path; alarms are the MV3 restart recovery path.
+  }
+}
+
+async function safeDetach(tabId: number): Promise<void> {
+  try {
+    const detach = (executor as unknown as { detach?: (tabId: number) => Promise<void> }).detach;
+    if (typeof detach === 'function') await detach(tabId);
+  } catch {
+    // Detach is best-effort during cleanup.
+  }
+}
+
+async function removeWorkspaceSession(workspace: string): Promise<void> {
+  const existing = automationSessions.get(workspace);
+  if (existing?.idleTimer) clearTimeout(existing.idleTimer);
+  automationSessions.delete(workspace);
+  workspaceTimeoutOverrides.delete(workspace);
+  scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+  await persistRuntimeState();
+}
+
 function resetWindowIdleTimer(workspace: string): void {
   const session = automationSessions.get(workspace);
   if (!session) return;
   if (session.idleTimer) clearTimeout(session.idleTimer);
   const timeout = getIdleTimeout(workspace);
+  scheduleIdleAlarm(workspace, timeout);
   if (timeout <= 0) {
     session.idleTimer = null;
     session.idleDeadlineAt = 0;
+    void persistRuntimeState();
     return;
   }
   session.idleDeadlineAt = Date.now() + timeout;
+  void persistRuntimeState();
   session.idleTimer = setTimeout(async () => {
-    const current = automationSessions.get(workspace);
-    if (!current) return;
-    if (!current.owned) {
-      console.log(`[opencli] Borrowed workspace ${workspace} detached from window ${current.windowId} (idle timeout)`);
-      workspaceTimeoutOverrides.delete(workspace);
-      automationSessions.delete(workspace);
-      return;
-    }
-    try {
-      await chrome.windows.remove(current.windowId);
-      console.log(`[opencli] Automation window ${current.windowId} (${workspace}) closed (idle timeout, ${timeout / 1000}s)`);
-    } catch {
-      // Already gone
-    }
-    workspaceTimeoutOverrides.delete(workspace);
-    automationSessions.delete(workspace);
+    await releaseWorkspaceLease(workspace, 'idle timeout');
   }, timeout);
 }
 
-/** Get or create the dedicated automation window.
- *  @param initialUrl — if provided (http/https), used as the initial page instead of about:blank.
- *    This avoids an extra blank-page→target-domain navigation on first command.
+/**
+ * Ensure the shared owned automation surface exists.
+ *
+ * First-principles model:
+ * - BrowserContext is the user's default Chrome profile.
+ * - Workspace identity maps to a TargetLease (usually a tab), not a window.
+ * - Owned TargetLeases are placed in the default dedicated-container surface.
+ */
+async function ensureOwnedContainerWindow(initialUrl?: string): Promise<{ windowId: number; initialTabId?: number }> {
+  if (ownedContainerWindowId !== null) {
+    try {
+      await chrome.windows.get(ownedContainerWindowId);
+      return {
+        windowId: ownedContainerWindowId,
+        initialTabId: await findReusableOwnedContainerTab(ownedContainerWindowId),
+      };
+    } catch {
+      ownedContainerWindowId = null;
+    }
+  }
+
+  const startUrl = (initialUrl && isSafeNavigationUrl(initialUrl)) ? initialUrl : BLANK_PAGE;
+
+  // Note: Do NOT set `state` parameter here. Chrome 146+ rejects 'normal' as an invalid
+  // state value for windows.create(). The window defaults to 'normal' state anyway.
+  const win = await chrome.windows.create({
+    url: startUrl,
+    focused: windowFocused,
+    width: 1280,
+    height: 900,
+    type: 'normal',
+  });
+  ownedContainerWindowId = win.id!;
+  console.log(`[opencli] Created owned automation container window ${ownedContainerWindowId} (start=${startUrl})`);
+
+  // Wait for the initial tab to finish loading instead of a fixed 200ms sleep.
+  const tabs = await chrome.tabs.query({ windowId: win.id! });
+  const initialTabId = tabs[0]?.id;
+  if (initialTabId) {
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 500); // fallback cap
+      const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+        if (tabId === initialTabId && info.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(listener);
+          clearTimeout(timeout);
+          resolve();
+        }
+      };
+      // Check if already complete before listening
+      if (tabs[0].status === 'complete') {
+        clearTimeout(timeout);
+        resolve();
+      } else {
+        chrome.tabs.onUpdated.addListener(listener);
+      }
+    });
+  }
+  await persistRuntimeState();
+  return { windowId: ownedContainerWindowId, initialTabId };
+}
+
+async function findReusableOwnedContainerTab(windowId: number): Promise<number | undefined> {
+  try {
+    const tabs = await chrome.tabs.query({ windowId });
+    const reusable = tabs.find(tab =>
+      tab.id !== undefined &&
+      initialTabIsAvailable(tab.id) &&
+      isDebuggableUrl(tab.url),
+    );
+    return reusable?.id;
+  } catch {
+    return undefined;
+  }
+}
+
+function initialTabIsAvailable(tabId: number | undefined): tabId is number {
+  if (tabId === undefined) return false;
+  for (const session of automationSessions.values()) {
+    if (session.owned && session.preferredTabId === tabId) return false;
+  }
+  return true;
+}
+
+async function createOwnedTabLease(workspace: string, initialUrl?: string): Promise<ResolvedTab> {
+  return withLeaseMutation(() => createOwnedTabLeaseUnlocked(workspace, initialUrl));
+}
+
+async function createOwnedTabLeaseUnlocked(workspace: string, initialUrl?: string): Promise<ResolvedTab> {
+  const targetUrl = (initialUrl && isSafeNavigationUrl(initialUrl)) ? initialUrl : BLANK_PAGE;
+  const { windowId, initialTabId } = await ensureOwnedContainerWindow(targetUrl);
+  let tab: chrome.tabs.Tab;
+
+  if (initialTabIsAvailable(initialTabId)) {
+    tab = await chrome.tabs.get(initialTabId);
+    if (!isTargetUrl(tab.url, targetUrl)) {
+      tab = await chrome.tabs.update(initialTabId, { url: targetUrl });
+      await new Promise(resolve => setTimeout(resolve, 300));
+      tab = await chrome.tabs.get(initialTabId);
+    }
+  } else {
+    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
+  }
+  if (!tab.id) throw new Error('Failed to create tab lease in automation container');
+
+  setWorkspaceSession(workspace, {
+    windowId,
+    owned: true,
+    preferredTabId: tab.id,
+  });
+  resetWindowIdleTimer(workspace);
+  return { tabId: tab.id, tab };
+}
+
+/** Get or create the dedicated automation container window.
+ *  This compatibility helper returns the shared owned container. Workspaces
+ *  lease tabs inside it instead of owning separate windows.
  */
 async function getAutomationWindow(workspace: string, initialUrl?: string): Promise<number> {
   if (workspace.startsWith('bound:') && !automationSessions.has(workspace)) {
@@ -210,88 +465,64 @@ async function getAutomationWindow(workspace: string, initialUrl?: string): Prom
     if (!existing.owned) {
       throw new CommandFailure(
         'bound_window_operation_blocked',
-        `Workspace "${workspace}" is bound to a user tab and does not own an automation window.`,
+        `Workspace "${workspace}" is bound to a user tab and does not own an automation tab lease.`,
         'Use commands that operate on the bound tab, or unbind and use an automation workspace.',
       );
     }
     try {
+      const tabId = existing.preferredTabId;
+      if (tabId !== null) {
+        const tab = await chrome.tabs.get(tabId);
+        if (isDebuggableUrl(tab.url)) return tab.windowId;
+      }
       await chrome.windows.get(existing.windowId);
       return existing.windowId;
     } catch {
-      // Window was closed by user
-      automationSessions.delete(workspace);
+      // Tab/window was closed by user
+      await removeWorkspaceSession(workspace);
     }
   }
 
-  // Use the target URL directly if it's a safe navigation URL, otherwise fall back to about:blank.
-  const startUrl = (initialUrl && isSafeNavigationUrl(initialUrl)) ? initialUrl : BLANK_PAGE;
-
-  // Note: Do NOT set `state` parameter here. Chrome 146+ rejects 'normal' as an invalid
-  // state value for windows.create(). The window defaults to 'normal' state anyway.
-  const win = await chrome.windows.create({
-    url: startUrl,
-    focused: windowFocused,
-    width: 1280,
-    height: 900,
-    type: 'normal',
-  });
-  const session: AutomationSession = {
-    windowId: win.id!,
-    idleTimer: null,
-    idleDeadlineAt: Date.now() + getIdleTimeout(workspace),
-    owned: true,
-    preferredTabId: null,
-  };
-  automationSessions.set(workspace, session);
-  console.log(`[opencli] Created automation window ${session.windowId} (${workspace}, start=${startUrl})`);
-  resetWindowIdleTimer(workspace);
-  // Wait for the initial tab to finish loading instead of a fixed 200ms sleep.
-  const tabs = await chrome.tabs.query({ windowId: win.id! });
-  if (tabs[0]?.id) {
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, 500); // fallback cap
-      const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
-        if (tabId === tabs[0].id && info.status === 'complete') {
-          chrome.tabs.onUpdated.removeListener(listener);
-          clearTimeout(timeout);
-          resolve();
-        }
-      };
-      // Check if already complete before listening
-      if (tabs[0].status === 'complete') {
-        clearTimeout(timeout);
-        resolve();
-      } else {
-        chrome.tabs.onUpdated.addListener(listener);
-      }
-    });
-  }
-  return session.windowId;
+  return (await ensureOwnedContainerWindow(initialUrl)).windowId;
 }
 
-// Clean up when the automation window is closed
+// Clean up when the shared automation container window is closed
 chrome.windows.onRemoved.addListener(async (windowId) => {
+  if (ownedContainerWindowId === windowId) {
+    ownedContainerWindowId = null;
+  }
   for (const [workspace, session] of automationSessions.entries()) {
     if (session.windowId === windowId) {
-      console.log(`[opencli] Automation window closed (${workspace})`);
+      console.log(`[opencli] Automation container closed (${workspace})`);
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(workspace);
       workspaceTimeoutOverrides.delete(workspace);
+      scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
     }
   }
+  await persistRuntimeState();
 });
 
 // Evict identity mappings when tabs are closed
-chrome.tabs.onRemoved.addListener((tabId) => {
+chrome.tabs.onRemoved.addListener(async (tabId) => {
   identity.evictTab(tabId);
   for (const [workspace, session] of automationSessions.entries()) {
-    if (!session.owned && session.preferredTabId === tabId) {
+    if (session.preferredTabId === tabId) {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(workspace);
       workspaceTimeoutOverrides.delete(workspace);
-      console.log(`[opencli] Borrowed workspace ${workspace} detached from tab ${tabId} (tab closed)`);
+      scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+      console.log(`[opencli] Workspace ${workspace} lease detached from tab ${tabId} (tab closed)`);
     }
   }
+  if (ownedContainerWindowId !== null) {
+    const hasOwnedLease = [...automationSessions.values()].some(s => s.owned && s.windowId === ownedContainerWindowId);
+    if (!hasOwnedLease) {
+      await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
+      ownedContainerWindowId = null;
+    }
+  }
+  await persistRuntimeState();
 });
 
 // ─── Lifecycle events ────────────────────────────────────────────────
@@ -304,6 +535,7 @@ function initialize(): void {
   chrome.alarms.create('keepalive', { periodInMinutes: 0.4 }); // ~24 seconds
   executor.registerListeners();
   executor.registerFrameTracking();
+  void reconcileTargetLeaseRegistry();
   void connect();
   console.log('[opencli] OpenCLI extension initialized');
 }
@@ -318,6 +550,8 @@ chrome.runtime.onStartup.addListener(() => {
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === 'keepalive') void connect();
+  const workspace = workspaceFromAlarmName(alarm.name);
+  if (workspace) void releaseWorkspaceLease(workspace, 'idle alarm');
 });
 
 // ─── Popup status API ───────────────────────────────────────────────
@@ -487,15 +721,19 @@ function enumerateCrossOriginFrames(tree: any): Array<{ index: number; frameId: 
   return frames;
 }
 
-function setWorkspaceSession(workspace: string, session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'>): void {
+function setWorkspaceSession(
+  workspace: string,
+  session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
+): void {
   const existing = automationSessions.get(workspace);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
   const timeout = getIdleTimeout(workspace);
   automationSessions.set(workspace, {
-    ...session,
+    ...makeSession(workspace, session),
     idleTimer: null,
     idleDeadlineAt: timeout <= 0 ? 0 : Date.now() + timeout,
   });
+  void persistRuntimeState();
 }
 
 /**
@@ -510,7 +748,7 @@ async function resolveCommandTabId(cmd: Command): Promise<number | undefined> {
 type ResolvedTab = { tabId: number; tab: chrome.tabs.Tab | null };
 
 /**
- * Resolve target tab in the automation window, returning both the tabId and
+ * Resolve target tab for the workspace lease, returning both the tabId and
  * the Tab object (when available) so callers can skip a redundant chrome.tabs.get().
  */
 async function resolveTab(tabId: number | undefined, workspace: string, initialUrl?: string): Promise<ResolvedTab> {
@@ -578,7 +816,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
       }
     } catch (err) {
       if (err instanceof CommandFailure) throw err;
-      automationSessions.delete(workspace);
+      await removeWorkspaceSession(workspace);
       if (!session.owned) {
         throw new CommandFailure(
           'bound_tab_gone',
@@ -586,10 +824,19 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
           'Run "opencli browser bind" again, then retry the command.',
         );
       }
+      return createOwnedTabLease(workspace, initialUrl);
     }
   }
 
-  // Get (or create) the automation window
+  if (!existingSession && workspace.startsWith('bound:')) {
+    await getAutomationWindow(workspace, initialUrl); // throws bound_session_missing
+  }
+
+  if (!existingSession || (existingSession.owned && existingSession.preferredTabId === null)) {
+    return createOwnedTabLease(workspace, initialUrl);
+  }
+
+  // Get (or create) the dedicated automation container
   const windowId = await getAutomationWindow(workspace, initialUrl);
 
   // Prefer an existing debuggable tab
@@ -613,7 +860,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
 
   // Fallback: create a new tab
   const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
-  if (!newTab.id) throw new Error('Failed to create tab in automation window');
+  if (!newTab.id) throw new Error('Failed to create tab in automation container');
   return { tabId: newTab.id, tab: newTab };
 }
 
@@ -830,9 +1077,19 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
       if (cmd.url && !isSafeNavigationUrl(cmd.url)) {
         return { id: cmd.id, ok: false, error: 'Blocked URL scheme -- only http:// and https:// are allowed' };
       }
+      if (!automationSessions.has(workspace)) {
+        const created = await createOwnedTabLease(workspace, cmd.url);
+        return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
+      }
       const windowId = await getAutomationWindow(workspace);
       const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
       if (!tab.id) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
+      setWorkspaceSession(workspace, {
+        windowId: tab.windowId,
+        owned: true,
+        preferredTabId: tab.id,
+      });
+      resetWindowIdleTimer(workspace);
       return pageScopedResult(cmd.id, tab.id, { url: tab.url });
     }
     case 'close': {
@@ -841,15 +1098,25 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
         const target = tabs[cmd.index];
         if (!target?.id) return { id: cmd.id, ok: false, error: `Tab index ${cmd.index} not found` };
         const closedPage = await identity.resolveTargetId(target.id).catch(() => undefined);
-        await chrome.tabs.remove(target.id);
-        await executor.detach(target.id);
+        const currentSession = automationSessions.get(workspace);
+        if (currentSession?.preferredTabId === target.id) {
+          await releaseWorkspaceLease(workspace, 'tab close');
+        } else {
+          await safeDetach(target.id);
+          await chrome.tabs.remove(target.id);
+        }
         return { id: cmd.id, ok: true, data: { closed: closedPage } };
       }
       const cmdTabId = await resolveCommandTabId(cmd);
       const tabId = await resolveTabId(cmdTabId, workspace);
       const closedPage = await identity.resolveTargetId(tabId).catch(() => undefined);
-      await chrome.tabs.remove(tabId);
-      await executor.detach(tabId);
+      const currentSession = automationSessions.get(workspace);
+      if (currentSession?.preferredTabId === tabId) {
+        await releaseWorkspaceLease(workspace, 'tab close');
+      } else {
+        await safeDetach(tabId);
+        await chrome.tabs.remove(tabId);
+      }
       return { id: cmd.id, ok: true, data: { closed: closedPage } };
     }
     case 'select': {
@@ -865,7 +1132,7 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
           return { id: cmd.id, ok: false, error: `Page no longer exists` };
         }
         if (!session || tab.windowId !== session.windowId) {
-          return { id: cmd.id, ok: false, error: `Page is not in the automation window` };
+          return { id: cmd.id, ok: false, error: `Page is not in the automation container` };
         }
         await chrome.tabs.update(cmdTabId, { active: true });
         return pageScopedResult(cmd.id, cmdTabId, { selected: true });
@@ -963,22 +1230,8 @@ async function handleCdp(cmd: Command, workspace: string): Promise<Result> {
 }
 
 async function handleCloseWindow(cmd: Command, workspace: string): Promise<Result> {
-  const session = automationSessions.get(workspace);
-  if (session) {
-    if (session.owned) {
-      try {
-        await chrome.windows.remove(session.windowId);
-      } catch {
-        // Window may already be closed
-      }
-    } else if (session.preferredTabId !== null) {
-      await executor.detach(session.preferredTabId).catch(() => {});
-    }
-    if (session.idleTimer) clearTimeout(session.idleTimer);
-    workspaceTimeoutOverrides.delete(workspace);
-    automationSessions.delete(workspace);
-  }
-  return { id: cmd.id, ok: true, data: { closed: true } };
+  await releaseWorkspaceLease(workspace, 'explicit close');
+  return { id: cmd.id, ok: true, data: { closed: true, workspace } };
 }
 
 async function handleSetFileInput(cmd: Command, workspace: string): Promise<Result> {
@@ -1031,6 +1284,105 @@ async function handleNetworkCaptureRead(cmd: Command, workspace: string): Promis
   }
 }
 
+async function releaseWorkspaceLease(workspace: string, reason: string = 'released'): Promise<void> {
+  const session = automationSessions.get(workspace);
+  if (!session) {
+    workspaceTimeoutOverrides.delete(workspace);
+    scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+    await persistRuntimeState();
+    return;
+  }
+
+  if (session.idleTimer) clearTimeout(session.idleTimer);
+  scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
+
+  if (session.owned) {
+    const tabId = session.preferredTabId;
+    if (tabId !== null) {
+      await safeDetach(tabId);
+      await chrome.tabs.remove(tabId).catch(() => {});
+      console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+    } else {
+      // Legacy fallback for sessions created before tab leases existed.
+      await chrome.windows.remove(session.windowId).catch(() => {});
+      if (ownedContainerWindowId === session.windowId) ownedContainerWindowId = null;
+      console.log(`[opencli] Released legacy owned window lease ${session.windowId} (${workspace}, ${reason})`);
+    }
+  } else if (session.preferredTabId !== null) {
+    await safeDetach(session.preferredTabId);
+    console.log(`[opencli] Detached borrowed tab lease ${session.preferredTabId} (${workspace}, ${reason})`);
+  }
+
+  automationSessions.delete(workspace);
+  workspaceTimeoutOverrides.delete(workspace);
+
+  if (ownedContainerWindowId !== null) {
+    const stillHasOwnedLeases = [...automationSessions.values()].some(s => s.owned && s.windowId === ownedContainerWindowId);
+    if (!stillHasOwnedLeases) {
+      await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
+      ownedContainerWindowId = null;
+    }
+  }
+
+  await persistRuntimeState();
+}
+
+async function reconcileTargetLeaseRegistry(): Promise<void> {
+  const registry = await readRegistry();
+  ownedContainerWindowId = registry.ownedContainerWindowId;
+
+  if (ownedContainerWindowId !== null) {
+    try {
+      await chrome.windows.get(ownedContainerWindowId);
+    } catch {
+      ownedContainerWindowId = null;
+    }
+  }
+
+  automationSessions.clear();
+  for (const [workspace, stored] of Object.entries(registry.leases)) {
+    const tabId = stored.preferredTabId;
+    if (tabId === null) continue;
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (!isDebuggableUrl(tab.url)) continue;
+      const session = makeSession(workspace, {
+        windowId: tab.windowId,
+        owned: stored.owned,
+        preferredTabId: tabId,
+      });
+      const timeout = getIdleTimeout(workspace);
+      automationSessions.set(workspace, {
+        ...session,
+        idleTimer: null,
+        idleDeadlineAt: stored.idleDeadlineAt,
+      });
+      if (session.owned && ownedContainerWindowId === null) ownedContainerWindowId = tab.windowId;
+      const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
+      if (timeout > 0) {
+        if (remaining <= 0) {
+          await releaseWorkspaceLease(workspace, 'reconciled idle expiry');
+        } else {
+          resetWindowIdleTimer(workspace);
+        }
+      }
+    } catch {
+      // Registry is semantic state, not truth. If Chrome no longer has the tab,
+      // drop the lease record and never close unrelated user resources.
+    }
+  }
+
+  if (ownedContainerWindowId !== null) {
+    const hasOwnedLease = [...automationSessions.values()].some(s => s.owned && s.windowId === ownedContainerWindowId);
+    if (!hasOwnedLease) {
+      await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
+      ownedContainerWindowId = null;
+    }
+  }
+
+  await persistRuntimeState();
+}
+
 async function handleSessions(cmd: Command): Promise<Result> {
   const now = Date.now();
   const data = await Promise.all([...automationSessions.entries()].map(async ([workspace, session]) => ({
@@ -1038,6 +1390,10 @@ async function handleSessions(cmd: Command): Promise<Result> {
     windowId: session.windowId,
     owned: session.owned,
     preferredTabId: session.preferredTabId,
+    contextId: session.contextId,
+    ownership: session.ownership,
+    lifecycle: session.lifecycle,
+    surface: session.surface,
     tabCount: session.preferredTabId !== null
       ? (await chrome.tabs.get(session.preferredTabId).then((tab) => isDebuggableUrl(tab.url) ? 1 : 0).catch(() => 0))
       : (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
@@ -1062,7 +1418,7 @@ async function handleBind(cmd: Command, workspace: string): Promise<Result> {
       id: cmd.id,
       ok: false,
       errorCode: 'invalid_bind_workspace',
-      error: `Workspace "${workspace}" already owns an automation window and cannot be rebound to a user tab.`,
+      error: `Workspace "${workspace}" already owns an automation tab lease and cannot be rebound to a user tab.`,
       errorHint: 'Use a fresh bound:<name> workspace, or close/unbind the existing session first.',
     };
   }
@@ -1112,6 +1468,7 @@ export const __test__ = {
   handleCommand,
   getIdleTimeout,
   workspaceTimeoutOverrides,
+  reconcileTargetLeaseRegistry,
   getSession: (workspace: string = 'default') => automationSessions.get(workspace) ?? null,
   getAutomationWindowId: (workspace: string = 'default') => automationSessions.get(workspace)?.windowId ?? null,
   setAutomationWindowId: (workspace: string, windowId: number | null) => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -148,6 +148,7 @@ const IDLE_TIMEOUT_NONE = -1;             // borrowed bound tabs stay bound unti
 const REGISTRY_KEY = 'opencli_target_lease_registry_v1';
 const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
 let leaseMutationQueue: Promise<void> = Promise.resolve();
+let ownedContainerWindowPromise: Promise<{ windowId: number; initialTabId?: number }> | null = null;
 
 type StoredLease = Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'> & {
   idleDeadlineAt: number;
@@ -343,6 +344,15 @@ function resetWindowIdleTimer(workspace: string): void {
  * - Owned TargetLeases are placed in the default dedicated-container surface.
  */
 async function ensureOwnedContainerWindow(initialUrl?: string): Promise<{ windowId: number; initialTabId?: number }> {
+  if (ownedContainerWindowPromise) return ownedContainerWindowPromise;
+  ownedContainerWindowPromise = ensureOwnedContainerWindowUnlocked(initialUrl)
+    .finally(() => {
+      ownedContainerWindowPromise = null;
+    });
+  return ownedContainerWindowPromise;
+}
+
+async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<{ windowId: number; initialTabId?: number }> {
   if (ownedContainerWindowId !== null) {
     try {
       await chrome.windows.get(ownedContainerWindowId);
@@ -548,10 +558,10 @@ chrome.runtime.onStartup.addListener(() => {
   initialize();
 });
 
-chrome.alarms.onAlarm.addListener((alarm) => {
+chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === 'keepalive') void connect();
   const workspace = workspaceFromAlarmName(alarm.name);
-  if (workspace) void releaseWorkspaceLease(workspace, 'idle alarm');
+  if (workspace) await releaseWorkspaceLease(workspace, 'idle alarm');
 });
 
 // ─── Popup status API ───────────────────────────────────────────────

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -62,11 +62,11 @@ export interface Command {
   cdpMethod?: string;
   /** CDP method params for 'cdp' action */
   cdpParams?: Record<string, unknown>;
-  /** When true, automation windows are created in the foreground (focused) */
+  /** When true, the owned automation container is created in the foreground (focused) */
   windowFocused?: boolean;
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
-  /** Explicitly allow navigation inside a borrowed bound-current tab. */
+  /** Explicitly allow navigation inside a borrowed bound tab. */
   allowBoundNavigation?: boolean;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;

--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash(opencli:*), Read, Edit, Write, Grep
 
 全程用现有工具：`opencli browser *` / `opencli doctor` / `opencli browser init` / `opencli browser verify`。没有新命令。
 
-调试浏览器型 adapter 时，优先直接带上 `--live --focus`。这样命令跑完后 automation window 还在，而且在前台，方便你核对最终页面状态，而不是猜是抓数错了还是页面走偏了。
+调试浏览器型 adapter 时，优先直接带上 `--live --focus`。这样命令跑完后 automation lease 还在，而且容器在前台，方便你核对最终页面状态，而不是猜是抓数错了还是页面走偏了。
 
 ---
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -22,12 +22,12 @@ Until `doctor` is green, nothing else will work. Typical failures: Chrome not ru
 
 ---
 
-## Window lifecycle
+## Lease lifecycle
 
-- `opencli browser *` commands already keep the automation session alive between calls. The window stays open until you run `opencli browser close` or the idle timeout expires.
+- `opencli browser *` commands keep an owned tab lease alive between calls. Owned leases share a dedicated automation container and are released with `opencli browser close` or when the idle timeout expires.
 - `opencli browser bind` binds a `bound:*` workspace to the Chrome tab you already have open. Use this for logged-in pages, SSO flows, or pages you manually positioned before handing control to the agent.
-- `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation window in the foreground. Use it when you want to watch the page live.
-- `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation window open after the command returns so you can inspect the final page state.
+- `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation container in the foreground. Use it when you want to watch the page live.
+- `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation lease open after the command returns so you can inspect the final page state.
 
 ### Bind Tab
 
@@ -48,7 +48,7 @@ opencli browser bind --workspace bound:gmail --domain mail.google.com --path-pre
 opencli browser --workspace bound:gmail state
 ```
 
-Navigation is blocked by default on bound workspaces because it can destroy the logged-in/positioned state you wanted to preserve. `browser open` and `browser back` require `--allow-navigate-bound`; tab mutation (`tab new`, `tab select`, `tab close`) is blocked for bound workspaces. Use a normal `browser:*` automation workspace when you want OpenCLI to own tab/window lifecycle.
+Navigation is blocked by default on bound workspaces because it can destroy the logged-in/positioned state you wanted to preserve. `browser open` and `browser back` require `--allow-navigate-bound`; tab mutation (`tab new`, `tab select`, `tab close`) is blocked for bound workspaces. Use a normal `browser:*` automation workspace when you want OpenCLI to own tab lifecycle.
 
 `opencli browser sessions` returns `idleMsRemaining: null` for bound workspaces. That means there is no OpenCLI idle-close timer; the binding lasts until `unbind`, tab close, window close, or daemon restart.
 
@@ -194,7 +194,7 @@ Default output keeps JSON/XML/plain-text and JS-like API responses, then drops o
 | `browser tab select [targetId]` | Make a tab the default. All subcommands accept `--tab <targetId>` to target one without changing the default. |
 | `browser tab close [targetId]` | Close by `page`. |
 | `browser back` | History back on the active tab. |
-| `browser close` | Close the automation window when done. |
+| `browser close` | Release the current automation tab lease when done. |
 | `browser bind` | Bind `bound:default` (or `--workspace bound:<name>`) to the current Chrome tab. |
 | `browser unbind` | Detach a bound workspace without closing the user tab/window. |
 

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -46,11 +46,11 @@ export interface DaemonCommand {
   pattern?: string;
   cdpMethod?: string;
   cdpParams?: Record<string, unknown>;
-  /** When true, automation windows are created in the foreground */
+  /** When true, the owned automation container is created in the foreground */
   windowFocused?: boolean;
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
-  /** Explicitly allow navigation inside a borrowed bound-current tab. */
+  /** Explicitly allow navigation inside a borrowed bound tab. */
   allowBoundNavigation?: boolean;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -97,6 +97,27 @@ describe('doctor report rendering', () => {
     expect(text).toContain('[SKIP] Connectivity: skipped (--no-live)');
   });
 
+  it('renders sessions with tab leases and no idle timer', () => {
+    const text = strip(renderBrowserDoctorReport({
+      daemonRunning: true,
+      extensionConnected: true,
+      issues: [],
+      sessions: [
+        {
+          workspace: 'bound:default',
+          windowId: 2,
+          preferredTabId: 42,
+          ownership: 'borrowed',
+          surface: 'borrowed-user-tab',
+          tabCount: 1,
+          idleMsRemaining: null,
+        },
+      ],
+    }));
+
+    expect(text).toContain('bound:default → tab 42, mode=borrowed, surface=borrowed-user-tab, tabs=1, idle=none');
+  });
+
   it('renders unstable extension state when live connectivity and status disagree', () => {
     const text = strip(renderBrowserDoctorReport({
       daemonRunning: true,
@@ -174,10 +195,12 @@ describe('doctor report rendering', () => {
 
   it('uses the fast default timeout for live connectivity checks', async () => {
     let timeoutSeen: number | undefined;
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
     mockConnect.mockImplementationOnce(async (opts?: { timeout?: number }) => {
       timeoutSeen = opts?.timeout;
       return {
         evaluate: vi.fn().mockResolvedValue(2),
+        closeWindow,
       };
     });
     mockClose.mockResolvedValueOnce(undefined);
@@ -186,6 +209,7 @@ describe('doctor report rendering', () => {
     await runBrowserDoctor({ live: true });
 
     expect(timeoutSeen).toBe(8);
+    expect(closeWindow).toHaveBeenCalledTimes(1);
   });
 
   it('skips auto-start in no-live mode when daemon is already running', async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -11,6 +11,7 @@ import { getDaemonHealth, listSessions } from './browser/daemon-client.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
+import type { BrowserSessionInfo } from './types.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
 
@@ -66,7 +67,7 @@ export type DoctorReport = {
   extensionVersion?: string;
   latestExtensionVersion?: string;
   connectivity?: ConnectivityResult;
-  sessions?: Array<{ workspace: string; windowId: number; tabCount: number; idleMsRemaining: number }>;
+  sessions?: BrowserSessionInfo[];
   issues: string[];
 };
 
@@ -78,9 +79,13 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   try {
     const bridge = new BrowserBridge();
     const page = await bridge.connect({ timeout: opts?.timeout ?? DOCTOR_LIVE_TIMEOUT_SECONDS });
-    // Try a simple eval to verify end-to-end connectivity
-    await page.evaluate('1 + 1');
-    await bridge.close();
+    try {
+      // Try a simple eval to verify end-to-end connectivity.
+      await page.evaluate('1 + 1');
+      await page.closeWindow?.();
+    } finally {
+      await bridge.close();
+    }
     return { ok: true, durationMs: Date.now() - start };
   } catch (err) {
     return { ok: false, error: getErrorMessage(err), durationMs: Date.now() - start };
@@ -114,7 +119,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const daemonFlaky = !!(connectivity?.ok && !daemonRunning);
   const extensionFlaky = !!(connectivity?.ok && daemonRunning && !extensionConnected);
   const sessions = opts.sessions && health.state === 'ready'
-    ? await listSessions() as Array<{ workspace: string; windowId: number; tabCount: number; idleMsRemaining: number }>
+    ? await listSessions()
     : undefined;
   const extensionVersion = health.status?.extensionVersion;
 
@@ -256,7 +261,15 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
       lines.push(styleText('dim', '  • no active automation sessions'));
     } else {
       for (const session of report.sessions) {
-        lines.push(styleText('dim', `  • ${session.workspace} → window ${session.windowId}, tabs=${session.tabCount}, idle=${Math.ceil(session.idleMsRemaining / 1000)}s`));
+        const idle = session.idleMsRemaining == null
+          ? 'none'
+          : `${Math.ceil(session.idleMsRemaining / 1000)}s`;
+        const target = session.preferredTabId != null
+          ? `tab ${session.preferredTabId}`
+          : `window ${session.windowId ?? 'unknown'}`;
+        const mode = session.ownership ?? (session.owned === false ? 'borrowed' : 'owned');
+        const surface = session.surface ? `, surface=${session.surface}` : '';
+        lines.push(styleText('dim', `  • ${session.workspace ?? 'default'} → ${target}, mode=${mode}${surface}, tabs=${session.tabCount ?? 0}, idle=${idle}`));
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,15 @@ export interface ScreenshotOptions {
 export interface BrowserSessionInfo {
   workspace?: string;
   connected?: boolean;
+  windowId?: number;
+  preferredTabId?: number | null;
+  owned?: boolean;
+  ownership?: 'owned' | 'borrowed';
+  lifecycle?: 'ephemeral' | 'persistent' | 'pinned';
+  surface?: 'dedicated-container' | 'borrowed-user-tab';
+  contextId?: string;
+  tabCount?: number;
+  idleMsRemaining?: number | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Implements the first-principles browser target model for owned automation workspaces:

- replaces `workspace = window` with `workspace = target lease` for owned browser workspaces
- keeps owned leases as tabs inside one shared dedicated automation container
- persists lease registry in `chrome.storage.local` and reconciles it on MV3 service-worker startup
- backs idle cleanup with `chrome.alarms` so cleanup survives service-worker suspension
- makes `browser close`, `tab close`, idle expiry, tab/window removal, and doctor live probes release leases instead of leaking blank windows
- keeps `bound:*` as borrowed tab leases that are detached/fail-closed and never cleaned up as owned resources

## Verification

- `npm run typecheck`
- `npx vitest run extension/src/background.test.ts src/cli.test.ts src/execution.test.ts src/browser/page.test.ts src/doctor.test.ts` (166 tests)
- `npm run build`
- `cd extension && npm run typecheck`
- `cd extension && npm run build`
- `git diff --check`
