### PR TITLE
fix(jd): separate main and detail image extraction

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9114,7 +9114,7 @@
   {
     "site": "jd",
     "name": "item",
-    "description": "京东商品详情（价格、店铺、规格参数、AVIF 图片）",
+    "description": "京东商品详情（价格、店铺、规格参数、主图、详情图）",
     "domain": "item.jd.com",
     "strategy": "cookie",
     "browser": true,
@@ -9129,9 +9129,9 @@
       {
         "name": "images",
         "type": "int",
-        "default": 10,
+        "default": 200,
         "required": false,
-        "help": "AVIF 图片数量上限（默认10）"
+        "help": "图片数量上限（默认200）"
       }
     ],
     "columns": [
@@ -9139,7 +9139,8 @@
       "price",
       "shop",
       "specs",
-      "avifImages"
+      "mainImages",
+      "detailImages"
     ],
     "type": "js",
     "modulePath": "jd/item.js",

--- a/clis/jd/item.js
+++ b/clis/jd/item.js
@@ -5,16 +5,258 @@
  * 用法: opencli jd item 100291143898
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-function extractAvifImages(imageUrls, maxImages) {
-    const unique = [...new Set(imageUrls.filter(Boolean))];
-    return unique
-        .filter((url) => url.includes('.avif') && url.includes('pcpubliccms'))
+function normalizePositiveInt(value, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
+}
+function normalizeJdImageUrl(rawUrl) {
+    if (!rawUrl || typeof rawUrl !== 'string')
+        return '';
+    let url = rawUrl.trim();
+    if (!url)
+        return '';
+    if (url.startsWith('//'))
+        url = `https:${url}`;
+    if (!/^https?:\/\//.test(url))
+        return '';
+    return url;
+}
+function normalizeJdImageSize(url) {
+    return normalizeJdImageUrl(url)
+        .replace(/\/pcpubliccms\/s\d+x\d+_jfs\//, '/pcpubliccms/jfs/')
+        .replace(/\/(n\d+)\/s\d+x\d+_jfs\//, '/$1/jfs/')
+        .replace(/\/s\d+x\d+_jfs\//, '/jfs/');
+}
+function isJdMainImage(url) {
+    const normalized = normalizeJdImageSize(url);
+    return /360buyimg\.com\/(?:pcpubliccms|n\d+)\/jfs\//.test(normalized) &&
+        !/\/(?:s\d+x\d+_|n\d\/s\d+x\d+_)/.test(normalized) &&
+        !/\/(?:imgzone|sku|shaidan|popWaterMark|babel|jdcms|cms|ddimg|vc)\//.test(normalized);
+}
+function collectImageUrlsFrom(root) {
+    if (!root)
+        return [];
+    const urls = [];
+    const push = (value) => {
+        const url = normalizeJdImageUrl(value);
+        if (url && url.includes('360buyimg.com'))
+            urls.push(url);
+    };
+    for (const img of root.querySelectorAll?.('img') || []) {
+        push(img.currentSrc || img.src);
+        push(img.getAttribute('data-src'));
+        push(img.getAttribute('data-lazy-img'));
+        push(img.getAttribute('data-original'));
+    }
+    for (const el of root.querySelectorAll?.('[style*="360buyimg.com"]') || []) {
+        const style = el.getAttribute('style') || '';
+        for (const match of style.matchAll(/url\(["']?([^"')]+360buyimg\.com[^"')]+)["']?\)/g)) {
+            push(match[1]);
+        }
+    }
+    return [...new Set(urls)];
+}
+function isJdDetailImage(url) {
+    const normalized = normalizeJdImageSize(url);
+    return /360buyimg\.com\/(?:imgzone|skuimg|babel|jdcms|cms|popWaterMark|vc|ddimg)\//.test(normalized) &&
+        !/\/shaidan\//.test(normalized) &&
+        !/\/(?:s\d+x\d+_|n\d\/s\d+x\d+_|pcpubliccms|sku)\//.test(normalized);
+}
+function rankJdDetailImage(url) {
+    const normalized = normalizeJdImageSize(url);
+    if (/\.jpe?g(?:\.avif)?(?:$|[?#])/.test(normalized))
+        return 0;
+    if (/\.(?:png|webp)(?:\.avif)?(?:$|[?#])/.test(normalized))
+        return 1;
+    if (/\.gif(?:$|[?#])/.test(normalized))
+        return 3;
+    if (/\.avif(?:$|[?#])/.test(normalized))
+        return 2;
+    return 4;
+}
+function orderJdDetailImages(urls) {
+    return [...new Set(urls)]
+        .filter(isJdDetailImage)
+        .map((url, index) => ({ url, index, rank: rankJdDetailImage(url) }))
+        .sort((a, b) => a.rank - b.rank || a.index - b.index)
+        .map((item) => item.url);
+}
+function extractDetailImagesFromDom(maxImages) {
+    const detailTitleParent = document.querySelector('#SPXQ-title')?.parentElement;
+    const safeDetailTitleParent = detailTitleParent && detailTitleParent !== document.body && detailTitleParent !== document.documentElement
+        ? detailTitleParent
+        : null;
+    const roots = [
+        safeDetailTitleParent,
+        '#J-detail',
+        '#J-detail-content',
+        '#detail',
+        '.detail',
+        '.detail-content',
+        '.detail-content-wrap',
+        '.ssd-module-wrap',
+        '#SPXQ-title + *',
+    ];
+    const scopedRoots = roots
+        .map((selector) => typeof selector === 'string' ? document.querySelector(selector) : selector)
+        .filter(Boolean);
+    const scoped = scopedRoots.flatMap((root) => collectImageUrlsFrom(root));
+    return orderJdDetailImages(scoped).slice(0, maxImages);
+}
+function extractMainImages(maxImages) {
+    const roots = [
+        document.querySelector('._gallery_116km_1'),
+        ...Array.from(document.querySelectorAll('[class*="_gallery_"]')),
+        document.querySelector('.preview-wrap'),
+        document.querySelector('#spec-img')?.parentElement,
+    ].filter(Boolean);
+    const urls = roots.flatMap((root) => collectImageUrlsFrom(root).map(normalizeJdImageSize));
+    return [...new Set(urls)]
+        .filter(isJdMainImage)
         .slice(0, maxImages);
+}
+function extractAvifImages(imageUrls, maxImages) {
+    const unique = [...new Set(imageUrls.map(normalizeJdImageSize).filter(Boolean))];
+    return unique
+        .filter((url) => url.includes('.avif') && isJdDetailImage(url))
+        .slice(0, maxImages);
+}
+function extractPriceFromPayload(payload) {
+    const items = Array.isArray(payload) ? payload : [];
+    const item = items.find((entry) => entry && typeof entry === 'object');
+    for (const key of ['p', 'op', 'm']) {
+        const value = item?.[key];
+        if (value && value !== '-1.00')
+            return String(value);
+    }
+    return '';
+}
+function normalizePriceText(text) {
+    const match = String(text || '').replace(/\s+/g, '').match(/(?:¥|￥)?(\d{2,7}(?:\.\d{1,2})?)/);
+    return match ? match[1] : '';
+}
+function extractPriceFromDom(sku) {
+    const selectors = [
+        `.J-p-${sku}`,
+        '[class*="price"] [class*="num"]',
+        '[class*="price"]',
+        '.p-price strong',
+        '.price.jd-price',
+    ];
+    for (const selector of selectors) {
+        for (const el of document.querySelectorAll(selector)) {
+            const price = normalizePriceText(el.textContent || '');
+            if (price)
+                return price;
+        }
+    }
+    for (const el of document.querySelectorAll('span, strong, div')) {
+        const text = (el.textContent || '').trim();
+        if (!/预售价|到手价|秒杀价|京东价|¥|￥/.test(text))
+            continue;
+        const direct = normalizePriceText(text);
+        if (direct)
+            return direct;
+        const parentPrice = normalizePriceText(el.parentElement?.textContent || '');
+        if (parentPrice)
+            return parentPrice;
+    }
+    return '';
+}
+async function fetchJdPrice(sku) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    try {
+        const resp = await fetch(`https://p.3.cn/prices/mgets?skuIds=J_${encodeURIComponent(sku)}&type=1`, {
+            credentials: 'include',
+            signal: controller.signal,
+        });
+        if (!resp.ok)
+            return '';
+        return extractPriceFromPayload(await resp.json());
+    }
+    catch {
+        return '';
+    }
+    finally {
+        clearTimeout(timeout);
+    }
+}
+function extractSpecsFromText(text) {
+    const specs = {};
+    const lines = String(text || '').split('\n').map((line) => line.trim()).filter(Boolean);
+    const allowedKeys = new Set(['品牌', '商品名称', '商品编号', '商品毛重', '商品产地', '货号', '类型', '能效等级', '洗涤容量', '烘干容量', '排水方式', '颜色', '型号', '系列', '系列品', '款式', '版本', '规格', '容量']);
+    const setSpec = (key, val) => {
+        const normalizedKey = String(key || '').trim().replace(/[：:]+$/, '');
+        const normalizedVal = String(val || '').trim();
+        if (!allowedKeys.has(normalizedKey))
+            return;
+        if (!normalizedVal || normalizedVal.length > 120)
+            return;
+        if (/^(服务|支付定金|加入购物车|立即购买|首页|购物车|我的|客服|品牌闪购|以旧换新)$/.test(normalizedVal))
+            return;
+        if (!specs[normalizedKey])
+            specs[normalizedKey] = normalizedVal;
+    };
+    for (const line of lines) {
+        const compactMatch = line.match(/^([^：:]{1,12})[：:]\s*(.{1,120})$/);
+        if (compactMatch) {
+            setSpec(compactMatch[1], compactMatch[2]);
+            continue;
+        }
+    }
+    for (let i = 0; i < lines.length - 1; i++) {
+        const key = lines[i].replace(/[：:]+$/, '');
+        const val = lines[i + 1];
+        if (allowedKeys.has(key) && !allowedKeys.has(val)) {
+            setSpec(key, val);
+        }
+    }
+    return specs;
+}
+function extractSpecs() {
+    const specs = {};
+    for (const el of document.querySelectorAll('.specification-group')) {
+        const label = el.querySelector('.specification-label, .label')?.textContent?.trim();
+        const selected = el.querySelector('.specification-item-sku--selected, .selected, [class*="selected"]');
+        const value = selected?.textContent?.trim() || selected?.querySelector('img')?.getAttribute('alt')?.trim();
+        if (label && value)
+            specs[label] = value;
+    }
+    const attrsRoot = document.querySelector('#SPXQ-title')?.parentElement?.querySelector('.attrs') ||
+        document.querySelector('#parameter2') ||
+        document.querySelector('.Ptable');
+    if (attrsRoot) {
+        Object.assign(specs, extractSpecsFromText(attrsRoot.innerText || attrsRoot.textContent || ''));
+    }
+    return specs;
+}
+function detectJdPageState(expectedSku) {
+    const href = location.href;
+    const title = document.title || '';
+    const bodyText = document.body?.innerText || document.body?.textContent || '';
+    const hasProductMarker = Boolean(document.querySelector('.product-title, .sku-title, #spec-list, #J-detail, #SPXQ-title, [class*="_gallery_"]'));
+    const text = `${title}\n${bodyText}`;
+    const isLoginPage = /passport\.jd\.com|\/login\.aspx/.test(href) || /京东-欢迎登录|京东登录/.test(title);
+    const hasSecurityChallenge = /risk_handler|安全验证|安全校验|完成安全验证|滑块|captcha|访问过于频繁|验证中心|京东验证/.test(`${href}\n${text}`);
+    const loginOnlyWithoutProduct = /请登录|登录/.test(text) && !hasProductMarker;
+    const looksBlocked = isLoginPage || hasSecurityChallenge || loginOnlyWithoutProduct;
+    const onExpectedItemUrl = new RegExp(`item\.jd\.com/${expectedSku}\.html`).test(href);
+    return {
+        href,
+        title,
+        isProductPage: hasProductMarker && onExpectedItemUrl && !looksBlocked,
+        hasProductMarker,
+        onExpectedItemUrl,
+        looksBlocked,
+        isLoginPage,
+        hasSecurityChallenge,
+    };
 }
 cli({
     site: 'jd',
     name: 'item',
-    description: '京东商品详情（价格、店铺、规格参数、AVIF 图片）',
+    description: '京东商品详情（价格、店铺、规格参数、主图、详情图）',
     domain: 'item.jd.com',
     strategy: Strategy.COOKIE,
     args: [
@@ -27,71 +269,101 @@ cli({
         {
             name: 'images',
             type: 'int',
-            default: 10,
-            help: 'AVIF 图片数量上限（默认10）',
+            default: 200,
+            help: '图片数量上限（默认200）',
         },
     ],
-    columns: ['title', 'price', 'shop', 'specs', 'avifImages'],
+    columns: ['title', 'price', 'shop', 'specs', 'mainImages', 'detailImages'],
     func: async (page, kwargs) => {
-        const sku = kwargs.sku;
-        const maxImages = kwargs.images;
+        const sku = String(kwargs.sku);
+        const maxImages = normalizePositiveInt(kwargs.images, 200);
         const url = `https://item.jd.com/${sku}.html`;
-        await page.goto(url, { waitUntil: 'load' });
-        await page.wait(2);
-        // 滚动加载商品详情区域中的延迟图片
-        for (let i = 0; i < 6; i++) {
-            await page.evaluate(`window.scrollTo(0, ${i * 2500})`);
-            await page.wait(1);
+        const currentHref = await page.evaluate(`location.href`).catch(() => '');
+        if (!currentHref.includes(`item.jd.com/${sku}.html`)) {
+            await page.goto(url, { waitUntil: 'load' });
+            await page.wait(2);
         }
-        await page.evaluate(`window.scrollTo(0, document.body.scrollHeight)`);
-        await page.wait(2);
+        const initialState = await page.evaluate(`(() => {
+          const detectJdPageState = ${detectJdPageState.toString()};
+          return detectJdPageState(${JSON.stringify(sku)});
+        })()`).catch(() => null);
+        if (!initialState?.looksBlocked) {
+            await page.evaluate(`document.querySelector('#SPXQ-tab-column')?.click()`);
+            await page.wait(1);
+            // 少量滚动即可触发详情懒加载，避免每次全页深滚造成高频异常行为。
+            for (const y of [900, 1800, 3200]) {
+                await page.evaluate(`window.scrollTo(0, ${y})`);
+                await page.wait(0.8);
+            }
+        }
         const data = await page.evaluate(`
-      (() => {
+      (async () => {
         const maxImg = ${maxImages};
-        // 尝试多种价格选择器
-        const skuMatch = location.pathname.match(/(\\d+)\\.html/);
-        const sku = skuMatch ? skuMatch[1] : '';
-        const priceEl = document.querySelector('.J-p-' + sku) ||
-                        document.querySelector('[class*="price"] [class*="num"]') ||
-                        document.querySelector('.p-price strong') ||
-                        document.querySelector('.price.jd-price');
-        const price = priceEl?.textContent?.trim() || 'not found';
+        const normalizeJdImageUrl = ${normalizeJdImageUrl.toString()};
+        const normalizeJdImageSize = ${normalizeJdImageSize.toString()};
+        const isJdMainImage = ${isJdMainImage.toString()};
+        const collectImageUrlsFrom = ${collectImageUrlsFrom.toString()};
+        const isJdDetailImage = ${isJdDetailImage.toString()};
+        const rankJdDetailImage = ${rankJdDetailImage.toString()};
+        const orderJdDetailImages = ${orderJdDetailImages.toString()};
+        const extractMainImages = ${extractMainImages.toString()};
+        const extractDetailImagesFromDom = ${extractDetailImagesFromDom.toString()};
+        const extractPriceFromPayload = ${extractPriceFromPayload.toString()};
+        const fetchJdPrice = ${fetchJdPrice.toString()};
+        const extractSpecsFromText = ${extractSpecsFromText.toString()};
+        const extractSpecs = ${extractSpecs.toString()};
+        const detectJdPageState = ${detectJdPageState.toString()};
+        const pageState = detectJdPageState(${JSON.stringify(sku)});
+        const normalizePriceText = ${normalizePriceText.toString()};
+        const extractPriceFromDom = ${extractPriceFromDom.toString()};
+        const apiPrice = await fetchJdPrice(${JSON.stringify(sku)});
+        const domPrice = extractPriceFromDom(${JSON.stringify(sku)});
+        const price = apiPrice || domPrice || 'not found';
 
-        // 标题
         const title = document.querySelector('.product-title')?.textContent?.trim() ||
+                      document.querySelector('.sku-title')?.textContent?.trim() ||
                       document.title.split('-')[0].trim();
 
-        // 店铺
-        const shop = document.querySelector('.J-shop-name')?.textContent?.trim() || '京东自营';
+        const shop = document.querySelector('.J-shop-name')?.textContent?.trim() ||
+                     document.querySelector('.top-name')?.textContent?.trim() ||
+                     document.querySelector('[class*="shop"] [class*="name"]')?.textContent?.trim() ||
+                     '京东自营';
 
-        // 所有图片
         const allImgs = Array.from(document.querySelectorAll('img[src*="360buyimg.com"]'));
         const srcs = allImgs.map(img => img.src).filter(Boolean);
 
-        // 所有 avif 图片（去重，只保留 pcpubliccms CDN）
-        const avifImages = ${extractAvifImages.toString()}(srcs, maxImg);
+        const mainImages = extractMainImages(maxImg);
+        const detailImages = extractDetailImagesFromDom(maxImg);
+        const specs = extractSpecs();
 
-        // 规格参数：从页面文本提取
-        const text = document.body.innerText;
-        const specMatch = text.match(/商品编号[\\s\\S]*?(?=包装清单|\\n\\n|$)/);
-        let specs = {};
-        if (specMatch) {
-          const lines = specMatch[0].split('\\n').filter(l => l.trim());
-          for (let i = 0; i < lines.length - 1; i += 2) {
-            const key = lines[i].trim();
-            const val = lines[i + 1]?.trim() || '';
-            if (key && val && key !== '商品编号') {
-              specs[key] = val;
-            }
-          }
+        const result = { title, price, shop, specs, mainImages, detailImages, totalImages: new Set(srcs).size, pageState };
+        if (!pageState.isProductPage) {
+          result.error = pageState.looksBlocked
+            ? 'JD page is blocked by login/security verification'
+            : 'JD product page was not loaded';
+          result.pageState = pageState;
         }
-
-        return { title, price, shop, specs, avifImages, totalImages: new Set(srcs).size };
+        return result;
       })()
     `);
         return [data];
     },
 });
 export const __test__ = {
+    normalizePositiveInt,
+    normalizeJdImageUrl,
+    normalizeJdImageSize,
+    isJdMainImage,
+    collectImageUrlsFrom,
+    isJdDetailImage,
+    rankJdDetailImage,
+    orderJdDetailImages,
+    extractMainImages,
+    extractDetailImagesFromDom,
     extractAvifImages,
+    extractPriceFromPayload,
+    normalizePriceText,
+    extractPriceFromDom,
+    extractSpecsFromText,
+    detectJdPageState,
 };

--- a/clis/jd/item.js
+++ b/clis/jd/item.js
@@ -37,6 +37,11 @@ function collectImageUrlsFrom(root) {
     if (!root)
         return [];
     const urls = [];
+    const pushUrlsFromText = (text) => {
+        for (const match of String(text || '').matchAll(/url\(["']?([^"')]+360buyimg\.com[^"')]+)["']?\)/g)) {
+            push(match[1]);
+        }
+    };
     const push = (value) => {
         const url = normalizeJdImageUrl(value);
         if (url && url.includes('360buyimg.com'))
@@ -46,12 +51,30 @@ function collectImageUrlsFrom(root) {
         push(img.currentSrc || img.src);
         push(img.getAttribute('data-src'));
         push(img.getAttribute('data-lazy-img'));
+        push(img.getAttribute('data-lazyload'));
         push(img.getAttribute('data-original'));
+    }
+    for (const source of root.querySelectorAll?.('source') || []) {
+        push(source.getAttribute('src'));
+        push(source.getAttribute('srcset')?.split(/\s+/)[0]);
+        push(source.getAttribute('data-src'));
+        push(source.getAttribute('data-srcset')?.split(/\s+/)[0]);
     }
     for (const el of root.querySelectorAll?.('[style*="360buyimg.com"]') || []) {
         const style = el.getAttribute('style') || '';
-        for (const match of style.matchAll(/url\(["']?([^"')]+360buyimg\.com[^"')]+)["']?\)/g)) {
-            push(match[1]);
+        pushUrlsFromText(style);
+    }
+    if (typeof getComputedStyle === 'function') {
+        const elements = [root, ...Array.from(root.querySelectorAll?.('*') || [])];
+        for (const el of elements) {
+            try {
+                const style = getComputedStyle(el);
+                pushUrlsFromText(style?.backgroundImage);
+                pushUrlsFromText(style?.background);
+            }
+            catch {
+                // ignore inaccessible/computed-style edge cases in the page context
+            }
         }
     }
     return [...new Set(urls)];
@@ -86,8 +109,7 @@ function extractDetailImagesFromDom(maxImages) {
     const safeDetailTitleParent = detailTitleParent && detailTitleParent !== document.body && detailTitleParent !== document.documentElement
         ? detailTitleParent
         : null;
-    const roots = [
-        safeDetailTitleParent,
+    const selectorRoots = [
         '#J-detail',
         '#J-detail-content',
         '#detail',
@@ -97,11 +119,30 @@ function extractDetailImagesFromDom(maxImages) {
         '.ssd-module-wrap',
         '#SPXQ-title + *',
     ];
-    const scopedRoots = roots
-        .map((selector) => typeof selector === 'string' ? document.querySelector(selector) : selector)
-        .filter(Boolean);
+    const scopedRoots = [
+        safeDetailTitleParent,
+        ...selectorRoots.flatMap((selector) => Array.from(document.querySelectorAll(selector))),
+    ].filter((root) => root && root !== document.body && root !== document.documentElement);
     const scoped = scopedRoots.flatMap((root) => collectImageUrlsFrom(root));
     return orderJdDetailImages(scoped).slice(0, maxImages);
+}
+function getJdDetailScrollSnapshot(maxImages) {
+    const doc = document.scrollingElement || document.documentElement || document.body;
+    const scrollY = window.scrollY || window.pageYOffset || doc?.scrollTop || 0;
+    const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+    const scrollHeight = Math.max(doc?.scrollHeight || 0, document.documentElement?.scrollHeight || 0, document.body?.scrollHeight || 0);
+    return {
+        detailImageCount: extractDetailImagesFromDom(maxImages).length,
+        scrollY,
+        viewportHeight,
+        scrollHeight,
+        nearBottom: scrollY + viewportHeight >= scrollHeight - 120,
+    };
+}
+function scrollJdDetailStep() {
+    const step = Math.max(900, Math.floor((window.innerHeight || 900) * 0.9));
+    window.scrollBy(0, step);
+    return step;
 }
 function extractMainImages(maxImages) {
     const roots = [
@@ -288,11 +329,35 @@ cli({
           return detectJdPageState(${JSON.stringify(sku)});
         })()`).catch(() => null);
         if (!initialState?.looksBlocked) {
-            await page.evaluate(`document.querySelector('#SPXQ-tab-column')?.click()`);
+            await page.evaluate(`
+              document.querySelector('#SPXQ-tab-column')?.click();
+              document.querySelector('#SPXQ-title')?.scrollIntoView({ block: 'start' });
+            `);
             await page.wait(1);
-            // 少量滚动即可触发详情懒加载，避免每次全页深滚造成高频异常行为。
-            for (const y of [900, 1800, 3200]) {
-                await page.evaluate(`window.scrollTo(0, ${y})`);
+            let previousDetailImageCount = -1;
+            let stableRounds = 0;
+            for (let i = 0; i < 30; i++) {
+                const snapshot = await page.evaluate(`(() => {
+                  const normalizeJdImageUrl = ${normalizeJdImageUrl.toString()};
+                  const normalizeJdImageSize = ${normalizeJdImageSize.toString()};
+                  const collectImageUrlsFrom = ${collectImageUrlsFrom.toString()};
+                  const isJdDetailImage = ${isJdDetailImage.toString()};
+                  const rankJdDetailImage = ${rankJdDetailImage.toString()};
+                  const orderJdDetailImages = ${orderJdDetailImages.toString()};
+                  const extractDetailImagesFromDom = ${extractDetailImagesFromDom.toString()};
+                  const getJdDetailScrollSnapshot = ${getJdDetailScrollSnapshot.toString()};
+                  return getJdDetailScrollSnapshot(${maxImages});
+                })()`).catch(() => null);
+                if (!snapshot)
+                    break;
+                stableRounds = snapshot.detailImageCount === previousDetailImageCount ? stableRounds + 1 : 0;
+                previousDetailImageCount = snapshot.detailImageCount;
+                if (snapshot.nearBottom && stableRounds >= 2)
+                    break;
+                await page.evaluate(`(() => {
+                  const scrollJdDetailStep = ${scrollJdDetailStep.toString()};
+                  return scrollJdDetailStep();
+                })()`);
                 await page.wait(0.8);
             }
         }
@@ -358,6 +423,8 @@ export const __test__ = {
     isJdDetailImage,
     rankJdDetailImage,
     orderJdDetailImages,
+    getJdDetailScrollSnapshot,
+    scrollJdDetailStep,
     extractMainImages,
     extractDetailImagesFromDom,
     extractAvifImages,

--- a/clis/jd/item.js
+++ b/clis/jd/item.js
@@ -79,6 +79,48 @@ function collectImageUrlsFrom(root) {
     }
     return [...new Set(urls)];
 }
+function collectImageUrlsFromText(text) {
+    const urls = [];
+    const push = (value) => {
+        const url = normalizeJdImageUrl(value);
+        if (url && url.includes('360buyimg.com'))
+            urls.push(url);
+    };
+    for (const match of String(text || '').matchAll(/(?:https?:)?\/\/[^"'`\s<>]+360buyimg\.com[^"'`\s<>]*/g)) {
+        push(match[0]);
+    }
+    for (const match of String(text || '').matchAll(/url\(["']?([^"')]+360buyimg\.com[^"')]+)["']?\)/g)) {
+        push(match[1]);
+    }
+    return urls;
+}
+function collectImageUrlsFromFramesAndScripts() {
+    const urls = [];
+    for (const script of document.scripts || []) {
+        const text = script.textContent || '';
+        if (!/360buyimg\.com/.test(text))
+            continue;
+        urls.push(...collectImageUrlsFromText(text));
+    }
+    for (const iframe of document.querySelectorAll('iframe')) {
+        try {
+            const frameDoc = iframe.contentDocument || iframe.contentWindow?.document;
+            if (!frameDoc)
+                continue;
+            urls.push(...collectImageUrlsFrom(frameDoc.body || frameDoc.documentElement || frameDoc));
+            for (const script of frameDoc.scripts || []) {
+                const text = script.textContent || '';
+                if (!/360buyimg\.com/.test(text))
+                    continue;
+                urls.push(...collectImageUrlsFromText(text));
+            }
+        }
+        catch {
+            // ignore cross-origin or not-yet-loaded iframe content
+        }
+    }
+    return [...new Set(urls)];
+}
 function isJdDetailImage(url) {
     const normalized = normalizeJdImageSize(url);
     return /360buyimg\.com\/(?:imgzone|skuimg|babel|jdcms|cms|popWaterMark|vc|ddimg)\//.test(normalized) &&
@@ -123,7 +165,10 @@ function extractDetailImagesFromDom(maxImages) {
         safeDetailTitleParent,
         ...selectorRoots.flatMap((selector) => Array.from(document.querySelectorAll(selector))),
     ].filter((root) => root && root !== document.body && root !== document.documentElement);
-    const scoped = scopedRoots.flatMap((root) => collectImageUrlsFrom(root));
+    const scoped = [
+        ...scopedRoots.flatMap((root) => collectImageUrlsFrom(root)),
+        ...collectImageUrlsFromFramesAndScripts(),
+    ];
     return orderJdDetailImages(scoped).slice(0, maxImages);
 }
 function getJdDetailScrollSnapshot(maxImages) {

--- a/clis/jd/item.js
+++ b/clis/jd/item.js
@@ -5,6 +5,7 @@
  * 用法: opencli jd item 100291143898
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 function normalizePositiveInt(value, fallback) {
     const n = Number(value);
     return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
@@ -682,6 +683,15 @@ cli({
         return result;
       })()
     `);
+        if (data?.error) {
+            if (data?.pageState?.looksBlocked) {
+                throw new AuthRequiredError('item.jd.com', data.error);
+            }
+            throw new CommandExecutionError(data.error);
+        }
+        if (maxImages > 0 && data?.pageState?.isProductPage && (!Array.isArray(data.detailImages) || data.detailImages.length === 0)) {
+            throw new CommandExecutionError('JD item detail images were not found', 'The product page loaded, but no detail images were detected from DOM, scripts, frames, page data, or WareGraphic fallback.');
+        }
         return [data];
     },
 });

--- a/clis/jd/item.js
+++ b/clis/jd/item.js
@@ -9,6 +9,18 @@ function normalizePositiveInt(value, fallback) {
     const n = Number(value);
     return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
 }
+function normalizeJdSkuInput(input) {
+    const text = String(input || '').trim();
+    const itemMatch = text.match(/item\.jd\.com\/(\d+)\.html/i);
+    if (itemMatch)
+        return itemMatch[1];
+    if (/^\d+$/.test(text))
+        return text;
+    const paramMatch = text.match(/(?:skuId|sku|wareId|productId)[=:](\d+)/i);
+    if (paramMatch)
+        return paramMatch[1];
+    return text;
+}
 function normalizeJdImageUrl(rawUrl) {
     if (!rawUrl || typeof rawUrl !== 'string')
         return '';
@@ -33,10 +45,22 @@ function isJdMainImage(url) {
         !/\/(?:s\d+x\d+_|n\d\/s\d+x\d+_)/.test(normalized) &&
         !/\/(?:imgzone|sku|shaidan|popWaterMark|babel|jdcms|cms|ddimg|vc)\//.test(normalized);
 }
-function collectImageUrlsFrom(root) {
+function collectImageUrlsFrom(root, options = {}) {
     if (!root)
         return [];
     const urls = [];
+    const ignoredContexts = '#spec-list, [class*="spec-list"], [class*="recommend"], [id*="recommend"], [class*="shaidan"], [id*="shaidan"], [class*="review"], [id*="review"], [class*="comment"], [id*="comment"], [class*="thumb"], [id*="thumb"], [class*="related"], [id*="related"]';
+    const ignoreContexts = Boolean(options.ignoreContexts);
+    const isIgnoredContext = (el) => {
+        if (!ignoreContexts)
+            return false;
+        try {
+            return !!el?.closest?.(ignoredContexts);
+        }
+        catch {
+            return false;
+        }
+    };
     const pushUrlsFromText = (text) => {
         for (const match of String(text || '').matchAll(/url\(["']?([^"')]+360buyimg\.com[^"')]+)["']?\)/g)) {
             push(match[1]);
@@ -48,6 +72,8 @@ function collectImageUrlsFrom(root) {
             urls.push(url);
     };
     for (const img of root.querySelectorAll?.('img') || []) {
+        if (isIgnoredContext(img))
+            continue;
         push(img.currentSrc || img.src);
         push(img.getAttribute('data-src'));
         push(img.getAttribute('data-lazy-img'));
@@ -55,18 +81,24 @@ function collectImageUrlsFrom(root) {
         push(img.getAttribute('data-original'));
     }
     for (const source of root.querySelectorAll?.('source') || []) {
+        if (isIgnoredContext(source))
+            continue;
         push(source.getAttribute('src'));
         push(source.getAttribute('srcset')?.split(/\s+/)[0]);
         push(source.getAttribute('data-src'));
         push(source.getAttribute('data-srcset')?.split(/\s+/)[0]);
     }
     for (const el of root.querySelectorAll?.('[style*="360buyimg.com"]') || []) {
+        if (isIgnoredContext(el))
+            continue;
         const style = el.getAttribute('style') || '';
         pushUrlsFromText(style);
     }
     if (typeof getComputedStyle === 'function') {
         const elements = [root, ...Array.from(root.querySelectorAll?.('*') || [])];
         for (const el of elements) {
+            if (isIgnoredContext(el))
+                continue;
             try {
                 const style = getComputedStyle(el);
                 pushUrlsFromText(style?.backgroundImage);
@@ -86,7 +118,7 @@ function collectImageUrlsFromText(text) {
         if (url && url.includes('360buyimg.com'))
             urls.push(url);
     };
-    for (const match of String(text || '').matchAll(/(?:https?:)?\/\/[^"'`\s<>]+360buyimg\.com[^"'`\s<>]*/g)) {
+    for (const match of String(text || '').matchAll(/(?:https?:)?\/\/[^"'`\s<>)\\]+360buyimg\.com[^"'`\s<>)\\]*/g)) {
         push(match[0]);
     }
     for (const match of String(text || '').matchAll(/url\(["']?([^"')]+360buyimg\.com[^"')]+)["']?\)/g)) {
@@ -121,11 +153,141 @@ function collectImageUrlsFromFramesAndScripts() {
     }
     return [...new Set(urls)];
 }
+function collectImageUrlsFromPayload(payload, seen = new Set(), depth = 0) {
+    if (payload == null || depth > 4)
+        return [];
+    const urls = [];
+    const push = (value) => {
+        const url = normalizeJdImageUrl(value);
+        if (url && url.includes('360buyimg.com'))
+            urls.push(url);
+    };
+    if (typeof payload === 'string') {
+        urls.push(...collectImageUrlsFromText(payload));
+        return [...new Set(urls)];
+    }
+    if (typeof payload !== 'object')
+        return [];
+    if (seen.has(payload))
+        return [];
+    seen.add(payload);
+    if (Array.isArray(payload)) {
+        for (const item of payload)
+            urls.push(...collectImageUrlsFromPayload(item, seen, depth + 1));
+        return [...new Set(urls)];
+    }
+    for (const value of Object.values(payload)) {
+        if (typeof value === 'string') {
+            push(value);
+            urls.push(...collectImageUrlsFromText(value));
+            continue;
+        }
+        urls.push(...collectImageUrlsFromPayload(value, seen, depth + 1));
+    }
+    return [...new Set(urls)];
+}
+function collectImageUrlsFromPageDataObjects() {
+    const urls = [];
+    const keys = ['__NEXT_DATA__', '__NUXT__', '__INITIAL_STATE__', '__INITIAL_DATA__', '__APOLLO_STATE__', '__INITIAL_PROPS__', '__REDUX_STATE__', '__PAGE_DATA__', 'pageData', '__data__', 'detailData'];
+    for (const key of keys) {
+        try {
+            if (typeof globalThis !== 'undefined' && key in globalThis) {
+                urls.push(...collectImageUrlsFromPayload(globalThis[key]));
+            }
+        }
+        catch {
+            // ignore inaccessible globals
+        }
+    }
+    return [...new Set(urls)];
+}
+async function collectImageUrlsFromNetworkResources() {
+    const urls = [];
+    const entries = typeof performance !== 'undefined' && typeof performance.getEntriesByType === 'function'
+        ? performance.getEntriesByType('resource')
+        : [];
+    const candidates = [...new Set(entries
+            .map((entry) => entry?.name)
+            .filter((name) => typeof name === 'string' && /(?:jd\.com|360buyimg\.com)/.test(name) && /(?:detail|desc|ware|item|product|sku)/i.test(name) && !/pc_item_getWareGraphic/i.test(name)))].slice(0, 12);
+    for (const url of candidates) {
+        try {
+            const resp = await fetch(url, { credentials: 'include' });
+            if (!resp.ok)
+                continue;
+            const text = await resp.text();
+            const contentType = resp.headers.get('content-type') || '';
+            if (/json/i.test(contentType) || /^\s*[\[{]/.test(text)) {
+                try {
+                    urls.push(...collectImageUrlsFromPayload(JSON.parse(text)));
+                    continue;
+                }
+                catch {
+                    // fall back to text scanning
+                }
+            }
+            urls.push(...collectImageUrlsFromText(text));
+        }
+        catch {
+            // ignore request failures and cross-origin oddities
+        }
+    }
+    return [...new Set(urls)];
+}
+function collectImageUrlsFromWareGraphicText(text) {
+    let graphicContent = '';
+    try {
+        const payload = JSON.parse(String(text || ''));
+        graphicContent = payload?.data?.graphicContent || payload?.graphicContent || '';
+    }
+    catch {
+        graphicContent = String(text || '');
+    }
+    return [...new Set(collectImageUrlsFromText(graphicContent))];
+}
+async function collectImageUrlsFromWareGraphicResources(sku) {
+    const urls = [];
+    const entries = typeof performance !== 'undefined' && typeof performance.getEntriesByType === 'function'
+        ? performance.getEntriesByType('resource')
+        : [];
+    const candidates = [...new Set(entries
+            .map((entry) => entry?.name)
+            .filter((name) => typeof name === 'string' && /pc_item_getWareGraphic/i.test(name)))];
+    if (sku) {
+        const body = encodeURIComponent(JSON.stringify({ skuId: String(sku) }));
+        candidates.unshift(`https://api.m.jd.com/client.action?appid=item-v3&functionId=pc_item_getWareGraphic&client=pc&clientVersion=1.0.0&body=${body}`);
+    }
+    for (const url of candidates) {
+        try {
+            const resp = await fetch(url, { credentials: 'include' });
+            if (!resp.ok)
+                continue;
+            urls.push(...collectImageUrlsFromWareGraphicText(await resp.text()));
+        }
+        catch {
+            // ignore request failures and keep DOM/script fallbacks available
+        }
+    }
+    return [...new Set(urls)];
+}
+async function collectImageUrlsFromFallbackSources() {
+    return [
+        ...collectImageUrlsFromPageDataObjects(),
+        ...await collectImageUrlsFromNetworkResources(),
+    ];
+}
 function isJdDetailImage(url) {
     const normalized = normalizeJdImageSize(url);
     return /360buyimg\.com\/(?:imgzone|skuimg|babel|jdcms|cms|popWaterMark|vc|ddimg)\//.test(normalized) &&
         !/\/shaidan\//.test(normalized) &&
-        !/\/(?:s\d+x\d+_|n\d\/s\d+x\d+_|pcpubliccms|sku)\//.test(normalized);
+        !/\/(?:s\d+x\d+_|n\d\/s\d+x\d+_|sku)\//.test(normalized);
+}
+function isJdWareGraphicDetailImage(url) {
+    const raw = normalizeJdImageUrl(url);
+    if (/\/(?:s\d+x\d+_|n\d\/s\d+x\d+_|sku\/s\d+x\d+_)jfs\//.test(raw))
+        return false;
+    const normalized = normalizeJdImageSize(url);
+    return /360buyimg\.com\/sku\/jfs\//.test(normalized) &&
+        !/\/shaidan\//.test(normalized);
 }
 function rankJdDetailImage(url) {
     const normalized = normalizeJdImageSize(url);
@@ -139,9 +301,10 @@ function rankJdDetailImage(url) {
         return 2;
     return 4;
 }
-function orderJdDetailImages(urls) {
+function orderJdDetailImages(urls, options = {}) {
+    const allowWareGraphicSku = Boolean(options.allowWareGraphicSku);
     return [...new Set(urls)]
-        .filter(isJdDetailImage)
+        .filter((url) => isJdDetailImage(url) || (allowWareGraphicSku && isJdWareGraphicDetailImage(url)))
         .map((url, index) => ({ url, index, rank: rankJdDetailImage(url) }))
         .sort((a, b) => a.rank - b.rank || a.index - b.index)
         .map((item) => item.url);
@@ -166,10 +329,18 @@ function extractDetailImagesFromDom(maxImages) {
         ...selectorRoots.flatMap((selector) => Array.from(document.querySelectorAll(selector))),
     ].filter((root) => root && root !== document.body && root !== document.documentElement);
     const scoped = [
-        ...scopedRoots.flatMap((root) => collectImageUrlsFrom(root)),
+        ...scopedRoots.flatMap((root) => collectImageUrlsFrom(root, { ignoreContexts: true })),
         ...collectImageUrlsFromFramesAndScripts(),
     ];
     return orderJdDetailImages(scoped).slice(0, maxImages);
+}
+async function extractDetailImagesFromPage(maxImages, sku) {
+    const scoped = extractDetailImagesFromDom(maxImages);
+    const fallback = await collectImageUrlsFromFallbackSources();
+    const wareGraphic = await collectImageUrlsFromWareGraphicResources(sku);
+    const regularImages = orderJdDetailImages([...scoped, ...fallback]);
+    const wareGraphicImages = orderJdDetailImages(wareGraphic, { allowWareGraphicSku: true });
+    return orderJdDetailImages([...regularImages, ...wareGraphicImages], { allowWareGraphicSku: true }).slice(0, maxImages);
 }
 function getJdDetailScrollSnapshot(maxImages) {
     const doc = document.scrollingElement || document.documentElement || document.body;
@@ -188,6 +359,18 @@ function scrollJdDetailStep() {
     const step = Math.max(900, Math.floor((window.innerHeight || 900) * 0.9));
     window.scrollBy(0, step);
     return step;
+}
+async function scrollJdDetailIntoView() {
+    const tab = document.querySelector('#SPXQ-tab-column');
+    const title = document.querySelector('#SPXQ-title');
+    if (tab)
+        tab.click();
+    title?.scrollIntoView({ block: 'start' });
+    const step = Math.max(900, Math.floor((window.innerHeight || 900) * 0.9));
+    for (let i = 0; i < 2; i++) {
+        window.scrollBy(0, step);
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
 }
 function extractMainImages(maxImages) {
     const roots = [
@@ -302,12 +485,29 @@ function extractSpecsFromText(text) {
 }
 function extractSpecs() {
     const specs = {};
+    const setSpec = (label, value) => {
+        const normalizedLabel = String(label || '').trim().replace(/[：:]+$/, '');
+        const normalizedValue = String(value || '').replace(/\s+/g, ' ').trim();
+        if (!normalizedLabel || !normalizedValue)
+            return;
+        specs[normalizedLabel] = normalizedValue;
+    };
+    const selectedText = (root) => {
+        const selected = root.querySelector('.specification-item-sku--selected, .specification-series-item--selected, .selected, [class*="selected"]');
+        if (!selected)
+            return '';
+        return selected.querySelector('[class*="text"]')?.textContent?.trim() ||
+            selected.textContent?.trim() ||
+            selected.querySelector('img')?.getAttribute('alt')?.trim() ||
+            '';
+    };
+    for (const el of document.querySelectorAll('.specification-series-layout')) {
+        const label = el.querySelector('.layout-label')?.textContent?.trim();
+        setSpec(label, selectedText(el));
+    }
     for (const el of document.querySelectorAll('.specification-group')) {
-        const label = el.querySelector('.specification-label, .label')?.textContent?.trim();
-        const selected = el.querySelector('.specification-item-sku--selected, .selected, [class*="selected"]');
-        const value = selected?.textContent?.trim() || selected?.querySelector('img')?.getAttribute('alt')?.trim();
-        if (label && value)
-            specs[label] = value;
+        const label = el.querySelector('.specification-label, .specification-group-label, .label')?.textContent?.trim();
+        setSpec(label, selectedText(el));
     }
     const attrsRoot = document.querySelector('#SPXQ-title')?.parentElement?.querySelector('.attrs') ||
         document.querySelector('#parameter2') ||
@@ -361,7 +561,7 @@ cli({
     ],
     columns: ['title', 'price', 'shop', 'specs', 'mainImages', 'detailImages'],
     func: async (page, kwargs) => {
-        const sku = String(kwargs.sku);
+        const sku = normalizeJdSkuInput(kwargs.sku);
         const maxImages = normalizePositiveInt(kwargs.images, 200);
         const url = `https://item.jd.com/${sku}.html`;
         const currentHref = await page.evaluate(`location.href`).catch(() => '');
@@ -375,10 +575,12 @@ cli({
         })()`).catch(() => null);
         if (!initialState?.looksBlocked) {
             await page.evaluate(`
-              document.querySelector('#SPXQ-tab-column')?.click();
-              document.querySelector('#SPXQ-title')?.scrollIntoView({ block: 'start' });
+              (async () => {
+                const scrollJdDetailIntoView = ${scrollJdDetailIntoView.toString()};
+                return scrollJdDetailIntoView();
+              })()
             `);
-            await page.wait(1);
+            await page.wait(1.5);
             let previousDetailImageCount = -1;
             let stableRounds = 0;
             for (let i = 0; i < 30; i++) {
@@ -386,11 +588,25 @@ cli({
                   const normalizeJdImageUrl = ${normalizeJdImageUrl.toString()};
                   const normalizeJdImageSize = ${normalizeJdImageSize.toString()};
                   const collectImageUrlsFrom = ${collectImageUrlsFrom.toString()};
+                  const collectImageUrlsFromText = ${collectImageUrlsFromText.toString()};
+                  const collectImageUrlsFromFramesAndScripts = ${collectImageUrlsFromFramesAndScripts.toString()};
+                  const collectImageUrlsFromPayload = ${collectImageUrlsFromPayload.toString()};
+                  const collectImageUrlsFromPageDataObjects = ${collectImageUrlsFromPageDataObjects.toString()};
+                  const collectImageUrlsFromNetworkResources = ${collectImageUrlsFromNetworkResources.toString()};
+                  const collectImageUrlsFromWareGraphicText = ${collectImageUrlsFromWareGraphicText.toString()};
+                  const collectImageUrlsFromWareGraphicResources = ${collectImageUrlsFromWareGraphicResources.toString()};
+                  const collectImageUrlsFromFallbackSources = ${collectImageUrlsFromFallbackSources.toString()};
                   const isJdDetailImage = ${isJdDetailImage.toString()};
+                  const isJdWareGraphicDetailImage = ${isJdWareGraphicDetailImage.toString()};
                   const rankJdDetailImage = ${rankJdDetailImage.toString()};
                   const orderJdDetailImages = ${orderJdDetailImages.toString()};
                   const extractDetailImagesFromDom = ${extractDetailImagesFromDom.toString()};
+                  const extractDetailImagesFromPage = ${extractDetailImagesFromPage.toString()};
                   const getJdDetailScrollSnapshot = ${getJdDetailScrollSnapshot.toString()};
+                  const scrollJdDetailIntoView = ${scrollJdDetailIntoView.toString()};
+                  if (document.querySelector('#SPXQ-title') && window.scrollY < 1000) {
+                    return scrollJdDetailIntoView().then(() => getJdDetailScrollSnapshot(${maxImages}));
+                  }
                   return getJdDetailScrollSnapshot(${maxImages});
                 })()`).catch(() => null);
                 if (!snapshot)
@@ -413,11 +629,21 @@ cli({
         const normalizeJdImageSize = ${normalizeJdImageSize.toString()};
         const isJdMainImage = ${isJdMainImage.toString()};
         const collectImageUrlsFrom = ${collectImageUrlsFrom.toString()};
+        const collectImageUrlsFromText = ${collectImageUrlsFromText.toString()};
+        const collectImageUrlsFromFramesAndScripts = ${collectImageUrlsFromFramesAndScripts.toString()};
+        const collectImageUrlsFromPayload = ${collectImageUrlsFromPayload.toString()};
+        const collectImageUrlsFromPageDataObjects = ${collectImageUrlsFromPageDataObjects.toString()};
+        const collectImageUrlsFromNetworkResources = ${collectImageUrlsFromNetworkResources.toString()};
+        const collectImageUrlsFromWareGraphicText = ${collectImageUrlsFromWareGraphicText.toString()};
+        const collectImageUrlsFromWareGraphicResources = ${collectImageUrlsFromWareGraphicResources.toString()};
+        const collectImageUrlsFromFallbackSources = ${collectImageUrlsFromFallbackSources.toString()};
         const isJdDetailImage = ${isJdDetailImage.toString()};
+        const isJdWareGraphicDetailImage = ${isJdWareGraphicDetailImage.toString()};
         const rankJdDetailImage = ${rankJdDetailImage.toString()};
         const orderJdDetailImages = ${orderJdDetailImages.toString()};
         const extractMainImages = ${extractMainImages.toString()};
         const extractDetailImagesFromDom = ${extractDetailImagesFromDom.toString()};
+        const extractDetailImagesFromPage = ${extractDetailImagesFromPage.toString()};
         const extractPriceFromPayload = ${extractPriceFromPayload.toString()};
         const fetchJdPrice = ${fetchJdPrice.toString()};
         const extractSpecsFromText = ${extractSpecsFromText.toString()};
@@ -443,7 +669,7 @@ cli({
         const srcs = allImgs.map(img => img.src).filter(Boolean);
 
         const mainImages = extractMainImages(maxImg);
-        const detailImages = extractDetailImagesFromDom(maxImg);
+        const detailImages = await extractDetailImagesFromPage(maxImg, ${JSON.stringify(sku)});
         const specs = extractSpecs();
 
         const result = { title, price, shop, specs, mainImages, detailImages, totalImages: new Set(srcs).size, pageState };
@@ -461,21 +687,33 @@ cli({
 });
 export const __test__ = {
     normalizePositiveInt,
+    normalizeJdSkuInput,
     normalizeJdImageUrl,
     normalizeJdImageSize,
     isJdMainImage,
     collectImageUrlsFrom,
+    collectImageUrlsFromText,
+    collectImageUrlsFromFramesAndScripts,
+    collectImageUrlsFromPayload,
+    collectImageUrlsFromPageDataObjects,
+    collectImageUrlsFromNetworkResources,
+    collectImageUrlsFromWareGraphicText,
+    collectImageUrlsFromWareGraphicResources,
+    collectImageUrlsFromFallbackSources,
     isJdDetailImage,
+    isJdWareGraphicDetailImage,
     rankJdDetailImage,
     orderJdDetailImages,
     getJdDetailScrollSnapshot,
     scrollJdDetailStep,
     extractMainImages,
     extractDetailImagesFromDom,
+    extractDetailImagesFromPage,
     extractAvifImages,
     extractPriceFromPayload,
     normalizePriceText,
     extractPriceFromDom,
     extractSpecsFromText,
+    extractSpecs,
     detectJdPageState,
 };

--- a/clis/jd/item.test.js
+++ b/clis/jd/item.test.js
@@ -67,4 +67,54 @@ describe('jd item adapter', () => {
             globalThis.getComputedStyle = previousGetComputedStyle;
         }
     });
+    it('collects JD detail images from inline JSON-like script text', () => {
+        const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+      <script>
+        window.__DETAIL_DATA__ = {
+          images: [
+            "https://img10.360buyimg.com/imgzone/jfs/t1/script-detail-a.jpg.avif",
+            "//img11.360buyimg.com/imgzone/jfs/t1/script-detail-b.gif"
+          ]
+        };
+      </script>
+    `);
+        const previousDocument = globalThis.document;
+        globalThis.document = dom.window.document;
+        try {
+            expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+                'https://img10.360buyimg.com/imgzone/jfs/t1/script-detail-a.jpg.avif',
+                'https://img11.360buyimg.com/imgzone/jfs/t1/script-detail-b.gif',
+            ]);
+        }
+        finally {
+            globalThis.document = previousDocument;
+        }
+    });
+    it('collects JD detail images from same-origin iframe content', () => {
+        const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+      <iframe id="detail-frame"></iframe>
+    `, { url: 'https://item.jd.com/100328272886.html' });
+        const frameDom = new JSDOM(`
+      <div id="J-detail">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/frame-detail-a.jpg.avif" />
+        <div style="background-image:url(//img11.360buyimg.com/cms/jfs/t1/frame-detail-b.jpg.avif)"></div>
+      </div>
+    `, { url: 'https://item.jd.com/detail-frame.html' });
+        const iframe = dom.window.document.getElementById('detail-frame');
+        Object.defineProperty(iframe, 'contentDocument', { value: frameDom.window.document, configurable: true });
+        Object.defineProperty(iframe, 'contentWindow', { value: frameDom.window, configurable: true });
+        const previousDocument = globalThis.document;
+        globalThis.document = dom.window.document;
+        try {
+            expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+                'https://img10.360buyimg.com/imgzone/jfs/t1/frame-detail-a.jpg.avif',
+                'https://img11.360buyimg.com/cms/jfs/t1/frame-detail-b.jpg.avif',
+            ]);
+        }
+        finally {
+            globalThis.document = previousDocument;
+        }
+    });
 });

--- a/clis/jd/item.test.js
+++ b/clis/jd/item.test.js
@@ -18,15 +18,16 @@ describe('jd item adapter', () => {
         expect(skuArg.required).toBe(true);
         expect(skuArg.positional).toBe(true);
     });
-    it('has images arg with default 10', () => {
+    it('has images arg with default 200', () => {
         const imagesArg = command.args.find((a) => a.name === 'images');
         expect(imagesArg).toBeDefined();
-        expect(imagesArg.default).toBe(10);
+        expect(imagesArg.default).toBe(200);
     });
     it('includes expected columns', () => {
-        expect(command.columns).toEqual(expect.arrayContaining(['title', 'price', 'shop', 'specs', 'avifImages']));
+        expect(command.columns).toEqual(expect.arrayContaining(['title', 'price', 'shop', 'specs', 'mainImages', 'detailImages']));
+        expect(command.columns).not.toContain('avifImages');
     });
-    it('extracts only pcpubliccms avif images and respects the limit', () => {
+    it('extracts only detail avif images and respects the limit', () => {
         const result = __test__.extractAvifImages([
             'https://img14.360buyimg.com/n1/jfs/t1/normal.jpg',
             'https://img10.360buyimg.com/imgzone/jfs/t1/detail.avif',
@@ -36,8 +37,7 @@ describe('jd item adapter', () => {
             'https://example.com/not-jd.avif',
         ], 2);
         expect(result).toEqual([
-            'https://pcpubliccms.jd.com/image1.avif',
-            'https://pcpubliccms.jd.com/image2.avif?x=1',
+            'https://img10.360buyimg.com/imgzone/jfs/t1/detail.avif',
         ]);
     });
 });

--- a/clis/jd/item.test.js
+++ b/clis/jd/item.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './item.js';
 import './item.js';
@@ -39,5 +40,31 @@ describe('jd item adapter', () => {
         expect(result).toEqual([
             'https://img10.360buyimg.com/imgzone/jfs/t1/detail.avif',
         ]);
+    });
+    it('collects JD detail images from computed background images', () => {
+        const dom = new JSDOM(`
+      <div id="J-detail">
+        <div class="ssd-module computed-bg"></div>
+        <div class="ssd-module ignored-bg"></div>
+      </div>
+    `);
+        const previousDocument = globalThis.document;
+        const previousGetComputedStyle = globalThis.getComputedStyle;
+        globalThis.document = dom.window.document;
+        globalThis.getComputedStyle = ((element) => ({
+            background: '',
+            backgroundImage: element.classList.contains('computed-bg')
+                ? 'url("//img10.360buyimg.com/imgzone/jfs/t1/computed-detail.jpg.avif")'
+                : 'none',
+        }));
+        try {
+            expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+                'https://img10.360buyimg.com/imgzone/jfs/t1/computed-detail.jpg.avif',
+            ]);
+        }
+        finally {
+            globalThis.document = previousDocument;
+            globalThis.getComputedStyle = previousGetComputedStyle;
+        }
     });
 });

--- a/clis/jd/item.test.js
+++ b/clis/jd/item.test.js
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError } from '@jackwener/opencli/errors';
 import { __test__ } from './item.js';
 import './item.js';
 const originalPerformance = globalThis.performance;
@@ -31,6 +32,64 @@ describe('jd item adapter', () => {
         const imagesArg = command.args.find((a) => a.name === 'images');
         expect(imagesArg).toBeDefined();
         expect(imagesArg.default).toBe(200);
+    });
+    it('fails fast when JD blocks the item page', async () => {
+        const page = {
+            evaluate: vi.fn()
+                .mockResolvedValueOnce('https://item.jd.com/100328272886.html')
+                .mockResolvedValueOnce({ looksBlocked: true })
+                .mockResolvedValueOnce({
+                error: 'JD page is blocked by login/security verification',
+                pageState: { looksBlocked: true },
+            }),
+            goto: vi.fn(),
+            wait: vi.fn(),
+        };
+        await expect(command.func(page, { sku: '100328272886', images: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+    it('fails fast when a loaded product page has no detail images', async () => {
+        const page = {
+            evaluate: vi.fn()
+                .mockResolvedValueOnce('https://item.jd.com/100328272886.html')
+                .mockResolvedValueOnce({ looksBlocked: false })
+                .mockResolvedValueOnce(undefined)
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce({
+                title: 'JD product',
+                price: '100',
+                shop: '京东自营',
+                specs: {},
+                mainImages: ['https://img10.360buyimg.com/pcpubliccms/jfs/t1/main.jpg'],
+                detailImages: [],
+                pageState: { isProductPage: true, looksBlocked: false },
+            }),
+            goto: vi.fn(),
+            wait: vi.fn(),
+        };
+        await expect(command.func(page, { sku: '100328272886', images: 5 })).rejects.toThrow('JD item detail images were not found');
+    });
+    it('allows zero-image requests to skip detail image fail-fast', async () => {
+        const data = {
+            title: 'JD product',
+            price: '100',
+            shop: '京东自营',
+            specs: {},
+            mainImages: [],
+            detailImages: [],
+            pageState: { isProductPage: true, looksBlocked: false },
+        };
+        const page = {
+            evaluate: vi.fn()
+                .mockResolvedValueOnce('https://item.jd.com/100328272886.html')
+                .mockResolvedValueOnce({ looksBlocked: false })
+                .mockResolvedValueOnce(undefined)
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce(data),
+            goto: vi.fn(),
+            wait: vi.fn(),
+        };
+        await expect(command.func(page, { sku: '100328272886', images: 0 })).resolves.toEqual([data]);
     });
     it('normalizes JD item URL input to a SKU before building selectors', () => {
         expect(__test__.normalizeJdSkuInput('100328272886')).toBe('100328272886');

--- a/clis/jd/item.test.js
+++ b/clis/jd/item.test.js
@@ -3,6 +3,14 @@ import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './item.js';
 import './item.js';
+const originalPerformance = globalThis.performance;
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+function restoreGlobals() {
+    globalThis.performance = originalPerformance;
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+}
 describe('jd item adapter', () => {
     const command = getRegistry().get('jd/item');
     it('registers the command with correct shape', () => {
@@ -24,6 +32,11 @@ describe('jd item adapter', () => {
         expect(imagesArg).toBeDefined();
         expect(imagesArg.default).toBe(200);
     });
+    it('normalizes JD item URL input to a SKU before building selectors', () => {
+        expect(__test__.normalizeJdSkuInput('100328272886')).toBe('100328272886');
+        expect(__test__.normalizeJdSkuInput('https://item.jd.com/100328272886.html?purchasetab=gfgm')).toBe('100328272886');
+        expect(__test__.normalizeJdSkuInput('skuId=10218494560141')).toBe('10218494560141');
+    });
     it('includes expected columns', () => {
         expect(command.columns).toEqual(expect.arrayContaining(['title', 'price', 'shop', 'specs', 'mainImages', 'detailImages']));
         expect(command.columns).not.toContain('avifImages');
@@ -40,6 +53,39 @@ describe('jd item adapter', () => {
         expect(result).toEqual([
             'https://img10.360buyimg.com/imgzone/jfs/t1/detail.avif',
         ]);
+    });
+    it('treats WareGraphic sku images as detail images only for WareGraphic fallback', () => {
+        expect(__test__.isJdDetailImage('https://img10.360buyimg.com/sku/jfs/t1/color-option.gif')).toBe(false);
+        expect(__test__.isJdWareGraphicDetailImage('https://img10.360buyimg.com/sku/jfs/t1/ware-graphic.jpg')).toBe(true);
+        expect(__test__.isJdWareGraphicDetailImage('https://img10.360buyimg.com/sku/s228x228_jfs/t1/thumb.jpg')).toBe(false);
+    });
+    it('keeps main gallery images while ignoring unrelated contexts for detail images', () => {
+        const dom = new JSDOM(`
+      <div class="_gallery_116km_1">
+        <img src="https://img10.360buyimg.com/pcpubliccms/jfs/t1/main-a.jpg" />
+        <img data-src="//img10.360buyimg.com/n1/jfs/t1/main-b.jpg" />
+      </div>
+      <div class="recommend">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/recommend.jpg.avif" />
+      </div>
+      <div class="detail-content-wrap">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif" />
+      </div>
+    `);
+        const previousDocument = globalThis.document;
+        globalThis.document = dom.window.document;
+        try {
+            expect(__test__.extractMainImages(10)).toEqual([
+                'https://img10.360buyimg.com/pcpubliccms/jfs/t1/main-a.jpg',
+                'https://img10.360buyimg.com/n1/jfs/t1/main-b.jpg',
+            ]);
+            expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+                'https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif',
+            ]);
+        }
+        finally {
+            globalThis.document = previousDocument;
+        }
     });
     it('collects JD detail images from computed background images', () => {
         const dom = new JSDOM(`
@@ -115,6 +161,135 @@ describe('jd item adapter', () => {
         }
         finally {
             globalThis.document = previousDocument;
+        }
+    });
+    it('collects JD detail images from page data objects', async () => {
+        const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+    `);
+        globalThis.document = dom.window.document;
+        globalThis.window = dom.window;
+        globalThis.__PAGE_DATA__ = {
+            detail: {
+                images: [
+                    'https://img10.360buyimg.com/imgzone/jfs/t1/page-data-a.jpg.avif',
+                    { src: '//img11.360buyimg.com/imgzone/jfs/t1/page-data-b.webp' },
+                ],
+            },
+        };
+        try {
+            await expect(__test__.extractDetailImagesFromPage(10)).resolves.toEqual([
+                'https://img10.360buyimg.com/imgzone/jfs/t1/page-data-a.jpg.avif',
+                'https://img11.360buyimg.com/imgzone/jfs/t1/page-data-b.webp',
+            ]);
+        }
+        finally {
+            delete globalThis.__PAGE_DATA__;
+            restoreGlobals();
+        }
+    });
+    it('collects JD detail images from network resource text', async () => {
+        const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+    `);
+        const previousFetch = globalThis.fetch;
+        globalThis.document = dom.window.document;
+        globalThis.window = dom.window;
+        globalThis.performance = {
+            getEntriesByType: () => [{ name: 'https://cdn.jd.com/detail/data.json' }],
+            now: () => 0,
+        };
+        globalThis.fetch = (async () => ({
+            ok: true,
+            headers: { get: () => 'application/json' },
+            text: async () => JSON.stringify({
+                detail: {
+                    imgs: ['https://img10.360buyimg.com/imgzone/jfs/t1/network-detail-a.jpg.avif'],
+                },
+            }),
+        }));
+        try {
+            await expect(__test__.extractDetailImagesFromPage(10)).resolves.toEqual([
+                'https://img10.360buyimg.com/imgzone/jfs/t1/network-detail-a.jpg.avif',
+            ]);
+        }
+        finally {
+            globalThis.fetch = previousFetch;
+            restoreGlobals();
+        }
+    });
+    it('collects JD detail images from WareGraphic graphicContent', async () => {
+        const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+    `);
+        const previousFetch = globalThis.fetch;
+        globalThis.document = dom.window.document;
+        globalThis.window = dom.window;
+        globalThis.performance = {
+            getEntriesByType: () => [
+                { name: 'https://api.m.jd.com/client.action?functionId=pc_item_getWareGraphic&skuId=100328272886' },
+            ],
+            now: () => 0,
+        };
+        globalThis.fetch = (async () => ({
+            ok: true,
+            headers: { get: () => 'application/json' },
+            text: async () => JSON.stringify({
+                data: {
+                    graphicContent: `
+            <div style="background-image:url(//img30.360buyimg.com/sku/jfs/t1/ware-a.jpg)"></div>
+            <img src="https://img30.360buyimg.com/sku/jfs/t1/ware-b.png" />
+            <a href="https://item.jd.com/100328272886.html">not image</a>
+          `,
+                },
+            }),
+        }));
+        try {
+            await expect(__test__.extractDetailImagesFromPage(10)).resolves.toEqual([
+                'https://img30.360buyimg.com/sku/jfs/t1/ware-a.jpg',
+                'https://img30.360buyimg.com/sku/jfs/t1/ware-b.png',
+            ]);
+        }
+        finally {
+            globalThis.fetch = previousFetch;
+            restoreGlobals();
+        }
+    });
+    it('extracts selected specs from the newer JD spec-list DOM', () => {
+        const dom = new JSDOM(`
+      <div id="spec-list" class="page-right-spec">
+        <div class="horizontal-layout specification-series-layout">
+          <div class="layout-label">系列品</div>
+          <div class="layout-content">
+            <div class="specification-series-item specification-series-item--selected">
+              <span class="specification-series-item-text">【年度新品】玉兔3.0pro 12kg</span>
+            </div>
+            <div class="specification-series-item"><span class="specification-series-item-text">其他系列</span></div>
+          </div>
+        </div>
+        <div class="specifications-panel-content">
+          <div class="specification-group">
+            <div class="specification-group-label">款式</div>
+            <div class="specification-group-content">
+              <div class="specification-item-sku has-image specification-item-sku--selected" title="">
+                <img class="specification-item-sku-image" alt="洗烘套装" src="https://img13.360buyimg.com/pcpubliccms/s48x48_jfs/t1/spec.jpg.avif" />
+                <span class="specification-item-sku-text">洗烘套装</span>
+              </div>
+              <div class="specification-item-sku has-image"><span class="specification-item-sku-text">滚筒单洗</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+        globalThis.document = dom.window.document;
+        try {
+            expect(__test__.extractSpecs()).toEqual({
+                系列品: '【年度新品】玉兔3.0pro 12kg',
+                款式: '洗烘套装',
+            });
+        }
+        finally {
+            restoreGlobals();
         }
     });
 });

--- a/clis/jd/item.test.ts
+++ b/clis/jd/item.test.ts
@@ -153,6 +153,61 @@ describe('jd item image helpers', () => {
     }
   });
 
+  it('collects JD detail images from inline JSON-like script text', () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+      <script>
+        window.__DETAIL_DATA__ = {
+          images: [
+            "https://img10.360buyimg.com/imgzone/jfs/t1/script-detail-a.jpg.avif",
+            "//img11.360buyimg.com/imgzone/jfs/t1/script-detail-b.gif"
+          ]
+        };
+      </script>
+    `);
+    const previousDocument = globalThis.document;
+    globalThis.document = dom.window.document;
+
+    try {
+      expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/script-detail-a.jpg.avif',
+        'https://img11.360buyimg.com/imgzone/jfs/t1/script-detail-b.gif',
+      ]);
+    }
+    finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it('collects JD detail images from same-origin iframe content', () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+      <iframe id="detail-frame"></iframe>
+    `, { url: 'https://item.jd.com/100328272886.html' });
+    const frameDom = new JSDOM(`
+      <div id="J-detail">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/frame-detail-a.jpg.avif" />
+        <div style="background-image:url(//img11.360buyimg.com/cms/jfs/t1/frame-detail-b.jpg.avif)"></div>
+      </div>
+    `, { url: 'https://item.jd.com/detail-frame.html' });
+    const iframe = dom.window.document.getElementById('detail-frame') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentDocument', { value: frameDom.window.document, configurable: true });
+    Object.defineProperty(iframe, 'contentWindow', { value: frameDom.window, configurable: true });
+
+    const previousDocument = globalThis.document;
+    globalThis.document = dom.window.document;
+
+    try {
+      expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/frame-detail-a.jpg.avif',
+        'https://img11.360buyimg.com/cms/jfs/t1/frame-detail-b.jpg.avif',
+      ]);
+    }
+    finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
   it('collects images from every repeated JD detail module', () => {
     const dom = new JSDOM(`
       <h2 id="SPXQ-title">商品详情</h2>

--- a/clis/jd/item.test.ts
+++ b/clis/jd/item.test.ts
@@ -98,6 +98,7 @@ describe('jd item image helpers', () => {
       <div class="detail-content-wrap">
         <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-hero.gif" />
         <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif" />
+        <source srcset="https://img11.360buyimg.com/imgzone/jfs/t1/detail-source.jpg.avif 1x" />
         <img src="https://img10.360buyimg.com/pcpubliccms/jfs/t1/wrong-main-in-detail.jpg.avif" />
         <img src="https://img10.360buyimg.com/shaidan/jfs/t1/wrong-user.jpg.avif" />
       </div>
@@ -115,11 +116,99 @@ describe('jd item image helpers', () => {
       ]);
       expect(__test__.extractDetailImagesFromDom(10)).toEqual([
         'https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif',
+        'https://img11.360buyimg.com/imgzone/jfs/t1/detail-source.jpg.avif',
         'https://img10.360buyimg.com/imgzone/jfs/t1/detail-hero.gif',
       ]);
     }
     finally {
       globalThis.document = previousDocument;
+    }
+  });
+
+  it('collects JD detail images from computed background images', () => {
+    const dom = new JSDOM(`
+      <div id="J-detail">
+        <div class="ssd-module computed-bg"></div>
+        <div class="ssd-module ignored-bg"></div>
+      </div>
+    `);
+    const previousDocument = globalThis.document;
+    const previousGetComputedStyle = globalThis.getComputedStyle;
+    globalThis.document = dom.window.document;
+    globalThis.getComputedStyle = ((element: Element) => ({
+      background: '',
+      backgroundImage: element.classList.contains('computed-bg')
+        ? 'url("//img10.360buyimg.com/imgzone/jfs/t1/computed-detail.jpg.avif")'
+        : 'none',
+    })) as typeof getComputedStyle;
+
+    try {
+      expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/computed-detail.jpg.avif',
+      ]);
+    }
+    finally {
+      globalThis.document = previousDocument;
+      globalThis.getComputedStyle = previousGetComputedStyle;
+    }
+  });
+
+  it('collects images from every repeated JD detail module', () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+      <div class="ssd-module-wrap">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif" />
+      </div>
+      <div class="ssd-module-wrap">
+        <img src="https://img11.360buyimg.com/imgzone/jfs/t1/detail-b.jpg.avif" />
+      </div>
+      <div class="ssd-module-wrap">
+        <img src="https://img12.360buyimg.com/imgzone/jfs/t1/detail-c.gif" />
+      </div>
+    `);
+    const previousDocument = globalThis.document;
+    globalThis.document = dom.window.document;
+
+    try {
+      expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif',
+        'https://img11.360buyimg.com/imgzone/jfs/t1/detail-b.jpg.avif',
+        'https://img12.360buyimg.com/imgzone/jfs/t1/detail-c.gif',
+      ]);
+    }
+    finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it('reports detail scroll progress so lazy-loaded detail images can stabilize', () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+      <div class="detail-content-wrap">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif" />
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-b.jpg.avif" />
+      </div>
+    `);
+    const previousDocument = globalThis.document;
+    const previousWindow = globalThis.window;
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window as unknown as Window & typeof globalThis;
+    Object.defineProperty(dom.window, 'scrollY', { value: 1800, configurable: true });
+    Object.defineProperty(dom.window, 'innerHeight', { value: 900, configurable: true });
+    Object.defineProperty(dom.window.document.documentElement, 'scrollHeight', { value: 2600, configurable: true });
+
+    try {
+      expect(__test__.getJdDetailScrollSnapshot(10)).toMatchObject({
+        detailImageCount: 2,
+        scrollY: 1800,
+        viewportHeight: 900,
+        scrollHeight: 2600,
+        nearBottom: true,
+      });
+    }
+    finally {
+      globalThis.document = previousDocument;
+      globalThis.window = previousWindow;
     }
   });
 

--- a/clis/jd/item.test.ts
+++ b/clis/jd/item.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { __test__ } from './item.js';
+
+describe('jd item image helpers', () => {
+  it('normalizes protocol-relative and thumbnail-sized JD image URLs', () => {
+    expect(__test__.normalizeJdImageUrl('//img10.360buyimg.com/imgzone/jfs/a.jpg.avif')).toBe('https://img10.360buyimg.com/imgzone/jfs/a.jpg.avif');
+    expect(__test__.normalizeJdImageSize('https://img10.360buyimg.com/pcpubliccms/s228x228_jfs/t1/a.jpg.avif')).toBe('https://img10.360buyimg.com/pcpubliccms/jfs/t1/a.jpg.avif');
+    expect(__test__.normalizeJdImageSize('https://img10.360buyimg.com/n1/s450x450_jfs/t1/a.jpg.avif')).toBe('https://img10.360buyimg.com/n1/jfs/t1/a.jpg.avif');
+  });
+
+  it('accepts only product main images for mainImages', () => {
+    expect(__test__.isJdMainImage('https://img10.360buyimg.com/pcpubliccms/jfs/t1/main.jpg.avif')).toBe(true);
+    expect(__test__.isJdMainImage('https://img10.360buyimg.com/pcpubliccms/s228x228_jfs/t1/main.jpg.avif')).toBe(true);
+    expect(__test__.isJdMainImage('https://img10.360buyimg.com/n1/jfs/t1/main.jpg.avif')).toBe(true);
+
+    expect(__test__.isJdMainImage('https://img10.360buyimg.com/imgzone/jfs/t1/detail.jpg.avif')).toBe(false);
+    expect(__test__.isJdMainImage('https://img10.360buyimg.com/shaidan/jfs/t1/user.jpg.avif')).toBe(false);
+    expect(__test__.isJdMainImage('https://img10.360buyimg.com/babel/jfs/t1/recommend.jpg.avif')).toBe(false);
+  });
+
+  it('accepts only detail-area image CDN paths for detailImages', () => {
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/imgzone/jfs/t1/detail.jpg.avif')).toBe(true);
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/jdcms/jfs/t1/detail.jpg.avif')).toBe(true);
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/babel/jfs/t1/detail.jpg.avif')).toBe(true);
+
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/pcpubliccms/jfs/t1/main.jpg.avif')).toBe(false);
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/pcpubliccms/s228x228_jfs/t1/thumb.jpg.avif')).toBe(false);
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/n1/jfs/t1/main.jpg.avif')).toBe(false);
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/sku/jfs/t1/color-option.gif')).toBe(false);
+    expect(__test__.isJdDetailImage('https://img10.360buyimg.com/shaidan/jfs/t1/user.jpg.avif')).toBe(false);
+  });
+
+  it('keeps legacy avifImages restricted to detail images only', () => {
+    expect(__test__.extractAvifImages([
+      'https://img10.360buyimg.com/pcpubliccms/jfs/t1/main.jpg.avif',
+      'https://img10.360buyimg.com/imgzone/jfs/t1/detail.jpg.avif',
+      'https://img10.360buyimg.com/shaidan/jfs/t1/user.jpg.avif',
+      'https://img10.360buyimg.com/imgzone/jfs/t1/detail.gif',
+    ], 10)).toEqual([
+      'https://img10.360buyimg.com/imgzone/jfs/t1/detail.jpg.avif',
+    ]);
+  });
+
+  it('prioritizes JPG detail images before PNG banners and GIFs when limiting detailImages', () => {
+    expect(__test__.orderJdDetailImages([
+      'https://img10.360buyimg.com/imgzone/jfs/t1/hero-a.gif',
+      'https://img11.360buyimg.com/imgzone/jfs/t1/banner.png.avif',
+      'https://img12.360buyimg.com/imgzone/jfs/t1/326893/25/18592/117159/68c264f5F9a41addf/2c9ad60b7f390339.jpg.avif',
+      'https://img12.360buyimg.com/imgzone/jfs/t1/330152/17/11906/130964/68c264f2Ffcf6e5c1/c2ccb28722dc47ce.jpg.avif',
+      'https://img11.360buyimg.com/cms/jfs/t1/banner.gif',
+    ])).toEqual([
+      'https://img12.360buyimg.com/imgzone/jfs/t1/326893/25/18592/117159/68c264f5F9a41addf/2c9ad60b7f390339.jpg.avif',
+      'https://img12.360buyimg.com/imgzone/jfs/t1/330152/17/11906/130964/68c264f2Ffcf6e5c1/c2ccb28722dc47ce.jpg.avif',
+      'https://img11.360buyimg.com/imgzone/jfs/t1/banner.png.avif',
+      'https://img10.360buyimg.com/imgzone/jfs/t1/hero-a.gif',
+      'https://img11.360buyimg.com/cms/jfs/t1/banner.gif',
+    ]);
+  });
+
+  it('extracts valid JD price payload values', () => {
+    expect(__test__.extractPriceFromPayload([{ id: 'J_100291143898', p: '6999.00' }])).toBe('6999.00');
+    expect(__test__.extractPriceFromPayload([{ id: 'J_100291143898', p: '-1.00', op: '7299.00' }])).toBe('7299.00');
+    expect(__test__.extractPriceFromPayload([])).toBe('');
+  });
+
+  it('extracts visible JD price text from DOM', () => {
+    const dom = new JSDOM(`
+      <div>
+        <span>预售价</span>
+        <span><span>¥</span><span>12221</span></span>
+      </div>
+    `);
+    const previousDocument = globalThis.document;
+    globalThis.document = dom.window.document;
+
+    try {
+      expect(__test__.normalizePriceText('¥ 12221')).toBe('12221');
+      expect(__test__.extractPriceFromDom('100291143898')).toBe('12221');
+    }
+    finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it('extracts only gallery main images and detail-container images from DOM', () => {
+    const dom = new JSDOM(`
+      <div class="_gallery_116km_1">
+        <img src="https://img10.360buyimg.com/pcpubliccms/s228x228_jfs/t1/main-a.jpg.avif" />
+        <img data-src="//img10.360buyimg.com/n1/s450x450_jfs/t1/main-b.jpg.avif" />
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/wrong-detail-in-gallery.jpg.avif" />
+      </div>
+      <div class="recommend">
+        <img src="https://img10.360buyimg.com/babel/jfs/t1/recommend.jpg.avif" />
+        <img src="https://img10.360buyimg.com/pcpubliccms/jfs/t1/recommend-main-like.jpg.avif" />
+      </div>
+      <h2 id="SPXQ-title">商品详情</h2>
+      <div class="detail-content-wrap">
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-hero.gif" />
+        <img src="https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif" />
+        <img src="https://img10.360buyimg.com/pcpubliccms/jfs/t1/wrong-main-in-detail.jpg.avif" />
+        <img src="https://img10.360buyimg.com/shaidan/jfs/t1/wrong-user.jpg.avif" />
+      </div>
+      <div id="spec-list">
+        <img src="https://img10.360buyimg.com/pcpubliccms/s48x48_jfs/t1/wrong-sku-option.jpg.avif" />
+      </div>
+    `);
+    const previousDocument = globalThis.document;
+    globalThis.document = dom.window.document;
+
+    try {
+      expect(__test__.extractMainImages(10)).toEqual([
+        'https://img10.360buyimg.com/pcpubliccms/jfs/t1/main-a.jpg.avif',
+        'https://img10.360buyimg.com/n1/jfs/t1/main-b.jpg.avif',
+      ]);
+      expect(__test__.extractDetailImagesFromDom(10)).toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/detail-a.jpg.avif',
+        'https://img10.360buyimg.com/imgzone/jfs/t1/detail-hero.gif',
+      ]);
+    }
+    finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it('parses structured specs without pairing unrelated body text', () => {
+    expect(__test__.extractSpecsFromText([
+      '品牌：美的（Midea）',
+      '商品编号',
+      '100291143898',
+      '洗涤容量',
+      '能效等级',
+      '一级能效',
+      '类型',
+      '加入购物车',
+    ].join('\n'))).toEqual({
+      品牌: '美的（Midea）',
+      商品编号: '100291143898',
+      能效等级: '一级能效',
+    });
+  });
+
+  it('detects whether the loaded page is the expected JD product page', () => {
+    const dom = new JSDOM(`
+      <html>
+        <head><title>京东</title></head>
+        <body><div>请登录</div><div class="sku-title">商品标题</div><div id="spec-list"></div></body>
+      </html>
+    `, { url: 'https://item.jd.com/100291143898.html' });
+    const previousDocument = globalThis.document;
+    const previousLocation = globalThis.location;
+    globalThis.document = dom.window.document;
+    globalThis.location = dom.window.location;
+
+    try {
+      expect(__test__.detectJdPageState('100291143898')).toMatchObject({
+        isProductPage: true,
+        hasProductMarker: true,
+        onExpectedItemUrl: true,
+        looksBlocked: false,
+        isLoginPage: false,
+        hasSecurityChallenge: false,
+      });
+      document.body.innerHTML = '<div>请登录后完成安全验证</div>';
+      expect(__test__.detectJdPageState('100291143898')).toMatchObject({
+        isProductPage: false,
+        looksBlocked: true,
+        hasSecurityChallenge: true,
+      });
+      const riskDom = new JSDOM(`
+        <html>
+          <head><title>京东验证</title></head>
+          <body><div>京东验证</div></body>
+        </html>
+      `, { url: 'https://cfe.m.jd.com/privatedomain/risk_handler/03101900/?returnurl=https%3A%2F%2Fitem.jd.com%2F100291143898.html' });
+      globalThis.document = riskDom.window.document;
+      globalThis.location = riskDom.window.location;
+      expect(__test__.detectJdPageState('100291143898')).toMatchObject({
+        isProductPage: false,
+        looksBlocked: true,
+        hasSecurityChallenge: true,
+      });
+    }
+    finally {
+      globalThis.document = previousDocument;
+      globalThis.location = previousLocation;
+    }
+  });
+
+  it('does not treat JD login page as a product page', () => {
+    const dom = new JSDOM(`
+      <html>
+        <head><title>京东-欢迎登录</title></head>
+        <body><img src="https://img10.360buyimg.com/img/jfs/login.png" /></body>
+      </html>
+    `, { url: 'https://passport.jd.com/new/login.aspx?ReturnUrl=https%3A%2F%2Fitem.jd.com%2F100291143898.html' });
+    const previousDocument = globalThis.document;
+    const previousLocation = globalThis.location;
+    globalThis.document = dom.window.document;
+    globalThis.location = dom.window.location;
+
+    try {
+      expect(__test__.detectJdPageState('100291143898')).toMatchObject({
+        isProductPage: false,
+        hasProductMarker: false,
+        onExpectedItemUrl: false,
+        looksBlocked: true,
+        isLoginPage: true,
+      });
+    }
+    finally {
+      globalThis.document = previousDocument;
+      globalThis.location = previousLocation;
+    }
+  });
+});

--- a/clis/jd/item.test.ts
+++ b/clis/jd/item.test.ts
@@ -2,7 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { __test__ } from './item.js';
 
+const originalPerformance = globalThis.performance;
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+function restoreGlobals() {
+  globalThis.performance = originalPerformance;
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+}
+
 describe('jd item image helpers', () => {
+  it('normalizes JD item URL input to a SKU before building selectors', () => {
+    expect(__test__.normalizeJdSkuInput('100328272886')).toBe('100328272886');
+    expect(__test__.normalizeJdSkuInput('https://item.jd.com/100328272886.html?purchasetab=gfgm')).toBe('100328272886');
+    expect(__test__.normalizeJdSkuInput('skuId=10218494560141')).toBe('10218494560141');
+  });
+
   it('normalizes protocol-relative and thumbnail-sized JD image URLs', () => {
     expect(__test__.normalizeJdImageUrl('//img10.360buyimg.com/imgzone/jfs/a.jpg.avif')).toBe('https://img10.360buyimg.com/imgzone/jfs/a.jpg.avif');
     expect(__test__.normalizeJdImageSize('https://img10.360buyimg.com/pcpubliccms/s228x228_jfs/t1/a.jpg.avif')).toBe('https://img10.360buyimg.com/pcpubliccms/jfs/t1/a.jpg.avif');
@@ -28,6 +44,8 @@ describe('jd item image helpers', () => {
     expect(__test__.isJdDetailImage('https://img10.360buyimg.com/pcpubliccms/s228x228_jfs/t1/thumb.jpg.avif')).toBe(false);
     expect(__test__.isJdDetailImage('https://img10.360buyimg.com/n1/jfs/t1/main.jpg.avif')).toBe(false);
     expect(__test__.isJdDetailImage('https://img10.360buyimg.com/sku/jfs/t1/color-option.gif')).toBe(false);
+    expect(__test__.isJdWareGraphicDetailImage('https://img10.360buyimg.com/sku/jfs/t1/ware-graphic.jpg')).toBe(true);
+    expect(__test__.isJdWareGraphicDetailImage('https://img10.360buyimg.com/sku/s228x228_jfs/t1/thumb.jpg')).toBe(false);
     expect(__test__.isJdDetailImage('https://img10.360buyimg.com/shaidan/jfs/t1/user.jpg.avif')).toBe(false);
   });
 
@@ -208,6 +226,105 @@ describe('jd item image helpers', () => {
     }
   });
 
+  it('collects JD detail images from page data objects', async () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+    `);
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window as unknown as Window;
+    (globalThis as typeof globalThis & { __PAGE_DATA__?: unknown }).__PAGE_DATA__ = {
+      detail: {
+        images: [
+          'https://img10.360buyimg.com/imgzone/jfs/t1/page-data-a.jpg.avif',
+          { src: '//img11.360buyimg.com/imgzone/jfs/t1/page-data-b.webp' },
+        ],
+      },
+    };
+
+    try {
+      await expect(__test__.extractDetailImagesFromPage(10)).resolves.toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/page-data-a.jpg.avif',
+        'https://img11.360buyimg.com/imgzone/jfs/t1/page-data-b.webp',
+      ]);
+    }
+    finally {
+      delete (globalThis as typeof globalThis & { __PAGE_DATA__?: unknown }).__PAGE_DATA__;
+      restoreGlobals();
+    }
+  });
+
+  it('collects JD detail images from network resource text', async () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+    `);
+    const previousFetch = globalThis.fetch;
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window as unknown as Window;
+    const fakePerformance = {
+      getEntriesByType: () => [{ name: 'https://cdn.jd.com/detail/data.json' }],
+      now: () => 0,
+    } as Performance;
+    globalThis.performance = fakePerformance;
+    globalThis.fetch = (async () => ({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify({
+        detail: {
+          imgs: ['https://img10.360buyimg.com/imgzone/jfs/t1/network-detail-a.jpg.avif'],
+        },
+      }),
+    })) as typeof fetch;
+
+    try {
+      await expect(__test__.extractDetailImagesFromPage(10)).resolves.toEqual([
+        'https://img10.360buyimg.com/imgzone/jfs/t1/network-detail-a.jpg.avif',
+      ]);
+    }
+    finally {
+      globalThis.fetch = previousFetch;
+      restoreGlobals();
+    }
+  });
+
+  it('collects JD detail images from WareGraphic graphicContent', async () => {
+    const dom = new JSDOM(`
+      <h2 id="SPXQ-title">商品详情</h2>
+    `);
+    const previousFetch = globalThis.fetch;
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window as unknown as Window;
+    globalThis.performance = {
+      getEntriesByType: () => [
+        { name: 'https://api.m.jd.com/client.action?functionId=pc_item_getWareGraphic&skuId=100328272886' },
+      ],
+      now: () => 0,
+    } as Performance;
+    globalThis.fetch = (async () => ({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify({
+        data: {
+          graphicContent: `
+            <div style="background-image:url(//img30.360buyimg.com/sku/jfs/t1/ware-a.jpg)"></div>
+            <img src="https://img30.360buyimg.com/sku/jfs/t1/ware-b.png" />
+            <a href="https://item.jd.com/100328272886.html">not image</a>
+          `,
+        },
+      }),
+    })) as typeof fetch;
+
+    try {
+      await expect(__test__.extractDetailImagesFromPage(10)).resolves.toEqual([
+        'https://img30.360buyimg.com/sku/jfs/t1/ware-a.jpg',
+        'https://img30.360buyimg.com/sku/jfs/t1/ware-b.png',
+      ]);
+    }
+    finally {
+      globalThis.fetch = previousFetch;
+      restoreGlobals();
+    }
+  });
+
   it('collects images from every repeated JD detail module', () => {
     const dom = new JSDOM(`
       <h2 id="SPXQ-title">商品详情</h2>
@@ -282,6 +399,46 @@ describe('jd item image helpers', () => {
       商品编号: '100291143898',
       能效等级: '一级能效',
     });
+  });
+
+  it('extracts selected specs from the newer JD spec-list DOM', () => {
+    const dom = new JSDOM(`
+      <div id="spec-list" class="page-right-spec">
+        <div class="horizontal-layout specification-series-layout">
+          <div class="layout-label">系列品</div>
+          <div class="layout-content">
+            <div class="specification-series-item specification-series-item--selected">
+              <span class="specification-series-item-text">【年度新品】玉兔3.0pro 12kg</span>
+            </div>
+            <div class="specification-series-item"><span class="specification-series-item-text">其他系列</span></div>
+          </div>
+        </div>
+        <div class="specifications-panel-content">
+          <div class="specification-group">
+            <div class="specification-group-label">款式</div>
+            <div class="specification-group-content">
+              <div class="specification-item-sku has-image specification-item-sku--selected" title="">
+                <img class="specification-item-sku-image" alt="洗烘套装" src="https://img13.360buyimg.com/pcpubliccms/s48x48_jfs/t1/spec.jpg.avif" />
+                <span class="specification-item-sku-text">洗烘套装</span>
+              </div>
+              <div class="specification-item-sku has-image"><span class="specification-item-sku-text">滚筒单洗</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+    const previousDocument = globalThis.document;
+    globalThis.document = dom.window.document;
+
+    try {
+      expect(__test__.extractSpecs()).toEqual({
+        系列品: '【年度新品】玉兔3.0pro 12kg',
+        款式: '洗烘套装',
+      });
+    }
+    finally {
+      globalThis.document = previousDocument;
+    }
   });
 
   it('detects whether the loaded page is the expected JD product page', () => {


### PR DESCRIPTION
## Summary
- Split JD item image extraction into `mainImages` and `detailImages`, keeping product metadata fields (`title`, `price`, `shop`, `specs`, `totalImages`, `pageState`) and removing the noisy `avifImages` output.
- Recover lazy-loaded JD detail images from DOM images, computed CSS backgrounds, inline scripts/frames, page data objects, resource payloads, and the page-exposed `pc_item_getWareGraphic` fallback.
- Parse selected specs from the newer JD `#spec-list` DOM (`specification-series-layout`, `specification-group-label`, selected SKU items) without using full-page text pairing.
- Normalize full JD item URLs to SKU IDs before building selectors/API calls, so both `jd item 100328272886` and `jd item https://item.jd.com/100328272886.html?...` work.
- Extend JS and TS adapter tests for image-source separation, WareGraphic fallback, selected specs, blocked-page detection, and URL normalization.

## What changed
`jd item` previously mixed or missed JD product images because detail pages can render through several paths:

- product hero/gallery images under the top product area
- detail images lazy-loaded after scrolling into the detail section
- computed `background-image` on detail modules such as `.ssd-module`
- inline scripts, same-origin frames, or page data objects
- WareGraphic content from `pc_item_getWareGraphic`, where some SKUs expose real detail images under `/sku/jfs/`

This PR keeps `mainImages` restricted to the product gallery and collects `detailImages` only from detail-specific sources. Recommendation, thumbnail, review, related, and shaidan contexts are excluded from detail extraction. `/sku/jfs/` images remain rejected by normal detail scanning and are only accepted when they come from the WareGraphic fallback, which prevents SKU-option thumbnails from being treated as detail images.

The PR also updates specs extraction for the newer JD spec DOM. It reads only selected option text from visible structured spec groups, avoiding unreliable full-page regex/adjacent-line pairing.

## Live verification examples
Commands were run with the built local CLI against a logged-in browser session.

### SKU `100328272886`

```bash
node dist/src/main.js jd item "https://item.jd.com/100328272886.html?purchasetab=gfgm" --images 20 -f json
```

Selected output:

```json
{
  "price": "13332",
  "shop": "东芝京东自营旗舰店",
  "specs": {
    "款式": "洗烘套装",
    "系列品": "【年度新品】玉兔3.0pro 12kg"
  },
  "mainImages": [
    "https://img10.360buyimg.com/pcpubliccms/jfs/t1/423093/31/16996/359306/69ef2b5dFe06a44eb/00834655dcc9c494.jpg.avif"
  ],
  "detailImages": [
    "https://img30.360buyimg.com/sku/jfs/t1/411609/5/7648/255594/69cba754Ff03dae49/00d63168e69d5fdb.jpg",
    "https://img30.360buyimg.com/sku/jfs/t1/423495/22/16759/353686/69ef34f5Fdd416fc6/00d64387f4f87d4d.jpg"
  ],
  "totalImages": 71,
  "pageState": {
    "isProductPage": true,
    "looksBlocked": false,
    "onExpectedItemUrl": true
  }
}
```

This SKU's detail area can stay in a skeleton state, but `pc_item_getWareGraphic` returns `data.graphicContent`; the fallback now recovers the real detail images.

### SKU `10218494560141`

```bash
node dist/src/main.js jd item "https://item.jd.com/10218494560141.html" --images 20 -f json
```

Selected output:

```json
{
  "price": "8999",
  "shop": "七彩虹Colorful旗舰店",
  "specs": {
    "处理器或显卡": "白色I7-13650HX 16G 512G官标",
    "存储": "满血RTX5060电竞独显",
    "系列品": "P16 Pro 满血5060"
  },
  "mainImages": [
    "https://img10.360buyimg.com/pcpubliccms/jfs/t1/427383/40/1365/431945/69edea87F5056e1d7/008332032040c2fb.png.avif"
  ],
  "detailImages": [
    "https://img12.360buyimg.com/imgzone/jfs/t1/350056/6/2011/357093/68c264e3Fecf03a8d/b0107a5e4b3394a7.jpg",
    "https://img10.360buyimg.com/imgzone/jfs/t1/338007/13/9444/188842/68c264e5Fb6c5afde/075ad3fb7ff987ba.jpg",
    "https://img12.360buyimg.com/imgzone/jfs/t1/330152/17/11906/130964/68c264f2Ffcf6e5c1/c2ccb28722dc47ce.jpg",
    "https://img12.360buyimg.com/imgzone/jfs/t1/326893/25/18592/117159/68c264f5F9a41addf/2c9ad60b7f390339.jpg"
  ],
  "totalImages": 55,
  "pageState": {
    "isProductPage": true,
    "looksBlocked": false,
    "onExpectedItemUrl": true
  }
}
```

## Validation

```bash
npm run test:adapter
```

```text
Test Files  186 passed (186)
Tests       1126 passed (1126)
```

```bash
npm run typecheck
```

```text
> @jackwener/opencli@1.7.8 typecheck
> tsc --noEmit
```

```bash
npm run build
```

```text
✅ Manifest compiled: 630 entries → /home/xeron/Coding/temp/test/OpenCLI/cli-manifest.json
✅ Restored executable permission: dist/src/main.js
```