### PR TITLE
feat(web): make read render-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **browser** — `bind` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
 * **browser lifecycle** — owned browser workspaces now lease tabs inside a shared dedicated automation container instead of owning one Chrome window per workspace; lease state is persisted for MV3 service-worker reconciliation and idle cleanup is backed by alarms.
+* **web read** — make page extraction render-aware: same-origin iframe content is merged into the Markdown source, `--wait-for` can wait inside main/iframe documents, `--wait-until networkidle` waits for captured requests to settle, and `--diagnose` reports frames, empty containers, and API-like XHRs for shell/AJAX pages.
 
 ## [1.7.8](https://github.com/jackwener/opencli/compare/v1.7.7...v1.7.8) (2026-04-25)
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17184,6 +17184,42 @@
         "help": "Seconds to wait after page load"
       },
       {
+        "name": "wait-for",
+        "type": "str",
+        "required": false,
+        "valueRequired": true,
+        "help": "CSS selector to wait for in the main document or same-origin iframes"
+      },
+      {
+        "name": "wait-until",
+        "type": "str",
+        "default": "domstable",
+        "required": false,
+        "help": "Readiness policy after navigation: domstable or networkidle",
+        "choices": [
+          "domstable",
+          "networkidle"
+        ]
+      },
+      {
+        "name": "frames",
+        "type": "str",
+        "default": "same-origin",
+        "required": false,
+        "help": "Iframe handling mode: same-origin or none",
+        "choices": [
+          "same-origin",
+          "none"
+        ]
+      },
+      {
+        "name": "diagnose",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Print render diagnostics (frames, empty containers, XHR/API-like requests) to stderr"
+      },
+      {
         "name": "stdout",
         "type": "boolean",
         "default": false,

--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -404,10 +404,12 @@ const command = cli({
             await page.wait(waitSeconds);
         }
         if (waitUntil === 'networkidle') {
-            if (captureSupported) {
-                await waitForNetworkIdle(page, waitSeconds, networkEntries);
-            } else {
-                await page.wait(waitSeconds);
+            if (!captureSupported) {
+                throw new Error('Network capture is unavailable, so --wait-until networkidle cannot be satisfied');
+            }
+            const idle = await waitForNetworkIdle(page, waitSeconds, networkEntries);
+            if (!idle?.ok) {
+                throw new Error(`Timed out waiting for network idle after ${waitSeconds}s`);
             }
         }
         // Extract article content using browser-side heuristics

--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -15,63 +15,204 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { downloadArticle } from '@jackwener/opencli/download/article-download';
-const command = cli({
-    site: 'web',
-    name: 'read',
-    description: 'Fetch any web page and export as Markdown',
-    strategy: Strategy.COOKIE,
-    navigateBefore: false, // we handle navigation ourselves
-    args: [
-        { name: 'url', required: true, help: 'Any web page URL' },
-        { name: 'output', default: './web-articles', help: 'Output directory' },
-        { name: 'download-images', type: 'boolean', default: true, help: 'Download images locally' },
-        { name: 'wait', type: 'int', default: 3, help: 'Seconds to wait after page load' },
-        { name: 'stdout', type: 'boolean', default: false, help: 'Print markdown to stdout instead of saving to a file' },
-    ],
-    columns: ['title', 'author', 'publish_time', 'status', 'size', 'saved'],
-    func: async (page, kwargs) => {
-        const url = kwargs.url;
-        const waitSeconds = kwargs.wait ?? 3;
-        // Navigate to the target URL
-        await page.goto(url);
-        await page.wait(waitSeconds);
-        // Extract article content using browser-side heuristics
-        const data = await page.evaluate(`
+
+const NETWORK_IDLE_QUIET_MS = 1000;
+const NETWORK_IDLE_POLL_MS = 500;
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function boolish(value) {
+    if (value === true) return true;
+    if (typeof value === 'string') return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+    return false;
+}
+
+function normalizeFrameMode(value) {
+    const mode = String(value || 'same-origin').toLowerCase();
+    if (['same-origin', 'none'].includes(mode)) return mode;
+    return 'same-origin';
+}
+
+function normalizeWaitUntil(value) {
+    const waitUntil = String(value || 'domstable').toLowerCase();
+    if (['domstable', 'networkidle'].includes(waitUntil)) return waitUntil;
+    return 'domstable';
+}
+
+function normalizeNetworkEntry(entry) {
+    const preview = typeof entry?.responsePreview === 'string' ? entry.responsePreview : '';
+    return {
+        method: typeof entry?.method === 'string' ? entry.method : 'GET',
+        url: typeof entry?.url === 'string' ? entry.url : '',
+        status: typeof entry?.responseStatus === 'number' ? entry.responseStatus : 0,
+        contentType: typeof entry?.responseContentType === 'string' ? entry.responseContentType : '',
+        size: typeof entry?.responseBodyFullSize === 'number' ? entry.responseBodyFullSize : preview.length,
+        bodyTruncated: entry?.responseBodyTruncated === true,
+    };
+}
+
+function isInterestingNetworkEntry(entry) {
+    const ct = (entry.contentType || '').toLowerCase();
+    const url = entry.url || '';
+    const method = (entry.method || 'GET').toUpperCase();
+    const staticAsset = /\.(js|css|png|jpg|jpeg|gif|svg|woff|woff2|ico|map)(\?|$)/i.test(url);
+    const noisy = /analytics|tracking|telemetry|beacon|pixel|gtag|fbevents/i.test(url);
+    const apiLikeUrl = /\/(api|ajax|graphql|rest|service|handler)(\/|[?._-]|$)|\.(ashx|aspx|asmx|php)(\?|$)/i.test(url);
+    const dataLikeContent = ct.includes('json')
+        || ct.includes('xml')
+        || ct.includes('text/plain')
+        || ct.includes('javascript')
+        || (apiLikeUrl && ct.includes('text/html'));
+    return (
+        !staticAsset
+        && !noisy
+        && (dataLikeContent || apiLikeUrl || method !== 'GET')
+    );
+}
+
+async function drainNetworkCapture(page, sink) {
+    if (!page.readNetworkCapture) return [];
+    const raw = await page.readNetworkCapture().catch(() => []);
+    const entries = Array.isArray(raw) ? raw.map(normalizeNetworkEntry).filter(entry => entry.url) : [];
+    sink.push(...entries);
+    return entries;
+}
+
+async function maybeStartNetworkCapture(page) {
+    if (!page.startNetworkCapture) return false;
+    try {
+        return await page.startNetworkCapture('');
+    } catch {
+        return false;
+    }
+}
+
+async function waitForNetworkIdle(page, maxSeconds, sink) {
+    const timeoutMs = Math.max(1, Number(maxSeconds) || 1) * 1000;
+    const deadline = Date.now() + timeoutMs;
+    let quietSince = Date.now();
+    while (Date.now() < deadline) {
+        const entries = await drainNetworkCapture(page, sink);
+        if (entries.length > 0) quietSince = Date.now();
+        if (Date.now() - quietSince >= NETWORK_IDLE_QUIET_MS) return { ok: true };
+        await sleep(NETWORK_IDLE_POLL_MS);
+    }
+    return { ok: false, timedOut: true };
+}
+
+function buildWaitForSelectorAcrossFramesJs(selector, timeoutMs) {
+    return `
+      (async () => {
+        const selector = ${JSON.stringify(selector)};
+        const timeoutAt = Date.now() + ${Number(timeoutMs) || 10000};
+        const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        const sameOriginFrameDocs = () => Array.from(document.querySelectorAll('iframe')).map((frame) => {
+          try {
+            const href = new URL(frame.getAttribute('src') || frame.src || '', window.location.href).href;
+            if (new URL(href).origin !== window.location.origin) return null;
+            return { href, doc: frame.contentDocument };
+          } catch {
+            return null;
+          }
+        }).filter(Boolean);
+        const findMatch = () => {
+          try {
+            if (document.querySelector(selector)) return { ok: true, scope: 'main', url: window.location.href };
+          } catch (err) {
+            return { ok: false, invalidSelector: true, error: String(err && err.message || err) };
+          }
+          for (const frame of sameOriginFrameDocs()) {
+            try {
+              if (frame.doc?.querySelector(selector)) return { ok: true, scope: 'iframe', url: frame.href };
+            } catch {}
+          }
+          return { ok: false };
+        };
+        while (Date.now() < timeoutAt) {
+          const found = findMatch();
+          if (found.ok || found.invalidSelector) return found;
+          await sleep(100);
+        }
+        return { ok: false, timedOut: true, selector };
+      })()
+    `;
+}
+
+function buildRenderAwareExtractorJs(options) {
+    return `
       (() => {
+        const frameMode = ${JSON.stringify(options.frames)};
         const result = {
           title: '',
           author: '',
           publishTime: '',
           contentHtml: '',
-          imageUrls: []
+          imageUrls: [],
+          diagnostics: {
+            url: window.location.href,
+            frames: [],
+            emptyContainers: [],
+            includedFrameCount: 0
+          }
         };
 
-        // --- Title extraction ---
-        // Priority: og:title > <title> > first <h1>
+        const absolutize = (value, base) => {
+          if (!value || value.startsWith('data:') || value.startsWith('javascript:') || value.startsWith('#')) return value || '';
+          try { return new URL(value, base).href; } catch { return value; }
+        };
+        const absolutizeTree = (root, base) => {
+          root.querySelectorAll?.('[href]').forEach(el => el.setAttribute('href', absolutize(el.getAttribute('href'), base)));
+          root.querySelectorAll?.('[src]').forEach(el => el.setAttribute('src', absolutize(el.getAttribute('src'), base)));
+          root.querySelectorAll?.('[poster]').forEach(el => el.setAttribute('poster', absolutize(el.getAttribute('poster'), base)));
+          root.querySelectorAll?.('[action]').forEach(el => el.setAttribute('action', absolutize(el.getAttribute('action'), base)));
+        };
+        const textLen = (node) => (node?.textContent || '').replace(/\\s+/g, ' ').trim().length;
+        const describeFrame = (frame, index) => {
+          const rawSrc = frame.getAttribute('src') || frame.src || '';
+          let href = '';
+          try { href = new URL(rawSrc, window.location.href).href; } catch { href = rawSrc; }
+          let sameOrigin = false;
+          try { sameOrigin = href ? new URL(href).origin === window.location.origin : false; } catch {}
+          let accessible = false;
+          let title = frame.getAttribute('title') || frame.getAttribute('name') || frame.id || '';
+          let length = 0;
+          try {
+            accessible = !!frame.contentDocument;
+            title = title || frame.contentDocument?.title || '';
+            length = textLen(frame.contentDocument?.body);
+          } catch {}
+          return { index, src: href, title, sameOrigin, accessible, textLength: length };
+        };
+        const collectEmptyContainers = (root, scope, baseUrl) => {
+          const likely = 'table, tbody, ul[id], ol[id], div[id], section[id], [class*="grid"], [class*="data"], [class*="list"], [id*="grid"], [id*="data"], [id*="list"]';
+          root.querySelectorAll?.(likely).forEach((el) => {
+            const id = el.getAttribute('id') || '';
+            const cls = el.getAttribute('class') || '';
+            const name = [id, cls].join(' ').toLowerCase();
+            if (!/(grid|data|list|table|content|result)/.test(name) && !['TABLE', 'TBODY', 'UL', 'OL'].includes(el.nodeName)) return;
+            if (textLen(el) > 20) return;
+            result.diagnostics.emptyContainers.push({
+              scope,
+              url: baseUrl,
+              tag: el.tagName.toLowerCase(),
+              id,
+              className: cls,
+            });
+          });
+        };
+
         const ogTitle = document.querySelector('meta[property="og:title"]');
-        if (ogTitle) {
-          result.title = ogTitle.getAttribute('content')?.trim() || '';
-        }
-        if (!result.title) {
-          result.title = document.title?.trim() || '';
-        }
-        if (!result.title) {
-          const h1 = document.querySelector('h1');
-          result.title = h1?.textContent?.trim() || 'untitled';
-        }
-        // Strip site suffix (e.g. " | Anthropic", " - Blog")
+        if (ogTitle) result.title = ogTitle.getAttribute('content')?.trim() || '';
+        if (!result.title) result.title = document.title?.trim() || '';
+        if (!result.title) result.title = document.querySelector('h1')?.textContent?.trim() || 'untitled';
         result.title = result.title.replace(/\\s*[|\\-–—]\\s*[^|\\-–—]{1,30}$/, '').trim();
 
-        // --- Author extraction ---
-        const authorMeta = document.querySelector(
-          'meta[name="author"], meta[property="article:author"], meta[name="twitter:creator"]'
-        );
+        const authorMeta = document.querySelector('meta[name="author"], meta[property="article:author"], meta[name="twitter:creator"]');
         result.author = authorMeta?.getAttribute('content')?.trim() || '';
 
-        // --- Publish time extraction ---
-        const timeMeta = document.querySelector(
-          'meta[property="article:published_time"], meta[name="date"], meta[name="publishdate"], time[datetime]'
-        );
+        const timeMeta = document.querySelector('meta[property="article:published_time"], meta[name="date"], meta[name="publishdate"], time[datetime]');
         if (timeMeta) {
           result.publishTime = timeMeta.getAttribute('content')
             || timeMeta.getAttribute('datetime')
@@ -79,34 +220,19 @@ const command = cli({
             || '';
         }
 
-        // --- Content extraction ---
-        // Strategy: try semantic elements first, then fall back to largest text block
         let contentEl = null;
-
-        // 1. <article>
         const articles = document.querySelectorAll('article');
         if (articles.length === 1) {
           contentEl = articles[0];
         } else if (articles.length > 1) {
-          // Pick the largest article by text length
           let maxLen = 0;
           articles.forEach(a => {
-            const len = a.textContent?.length || 0;
+            const len = textLen(a);
             if (len > maxLen) { maxLen = len; contentEl = a; }
           });
         }
-
-        // 2. [role="main"]
-        if (!contentEl) {
-          contentEl = document.querySelector('[role="main"]');
-        }
-
-        // 3. <main>
-        if (!contentEl) {
-          contentEl = document.querySelector('main');
-        }
-
-        // 4. Largest text-dense block fallback
+        if (!contentEl) contentEl = document.querySelector('[role="main"]');
+        if (!contentEl) contentEl = document.querySelector('main');
         if (!contentEl) {
           const candidates = document.querySelectorAll(
             'div[class*="content"], div[class*="article"], div[class*="post"], ' +
@@ -115,26 +241,51 @@ const command = cli({
           );
           let maxLen = 0;
           candidates.forEach(c => {
-            const len = c.textContent?.length || 0;
+            const len = textLen(c);
             if (len > maxLen) { maxLen = len; contentEl = c; }
           });
         }
+        if (!contentEl || textLen(contentEl) < 200) contentEl = document.body;
 
-        // 5. Last resort: document.body
-        if (!contentEl || (contentEl.textContent?.length || 0) < 200) {
-          contentEl = document.body;
+        const clone = contentEl.cloneNode(true);
+        absolutizeTree(clone, window.location.href);
+
+        const originalFrames = Array.from(contentEl.querySelectorAll('iframe'));
+        const clonedFrames = Array.from(clone.querySelectorAll('iframe'));
+        const allFrames = Array.from(document.querySelectorAll('iframe'));
+        result.diagnostics.frames = allFrames.map(describeFrame);
+
+        if (frameMode === 'same-origin') {
+          originalFrames.forEach((frame, index) => {
+            const cloned = clonedFrames[index];
+            if (!cloned) return;
+            const desc = describeFrame(frame, index);
+            if (!desc.sameOrigin || !desc.accessible) return;
+            try {
+              const doc = frame.contentDocument;
+              if (!doc?.body) return;
+              const frameBody = doc.body.cloneNode(true);
+              absolutizeTree(frameBody, desc.src || window.location.href);
+              collectEmptyContainers(frameBody, 'iframe', desc.src);
+              const section = document.createElement('section');
+              section.setAttribute('data-opencli-iframe-source', desc.src);
+              const heading = document.createElement('h2');
+              heading.textContent = '来自 iframe: ' + (desc.src || frame.getAttribute('src') || ('#' + index));
+              section.appendChild(heading);
+              Array.from(frameBody.childNodes).forEach(node => section.appendChild(node));
+              cloned.replaceWith(section);
+              result.diagnostics.includedFrameCount += 1;
+            } catch {}
+          });
         }
 
-        // Clean up noise elements before extraction
-        const clone = contentEl.cloneNode(true);
+        collectEmptyContainers(clone, 'main', window.location.href);
+
         const noise = 'nav, header, footer, aside, .sidebar, .nav, .menu, .footer, ' +
           '.header, .comments, .comment, .ad, .ads, .advertisement, .social-share, ' +
           '.related-posts, .newsletter, .cookie-banner, script, style, noscript, iframe';
         clone.querySelectorAll(noise).forEach(el => el.remove());
 
-        // Deduplicate: some sites (e.g. Anthropic) render each paragraph twice
-        // (a visible version + a line-broken animation version with missing spaces).
-        // Compare by stripping ALL whitespace so "Hello world" matches "Helloworld".
         const stripWS = (s) => (s || '').replace(/\\s+/g, '');
         const dedup = (parent) => {
           const children = Array.from(parent.children || []);
@@ -144,9 +295,7 @@ const command = cli({
             const cur = stripWS(curRaw);
             const prev = stripWS(prevRaw);
             if (cur.length < 20 || prev.length < 20) continue;
-            // Exact match after whitespace strip, or >90% overlap
             if (cur === prev) {
-              // Keep the one with more proper spacing (more spaces = better formatted)
               const curSpaces = (curRaw.match(/ /g) || []).length;
               const prevSpaces = (prevRaw.match(/ /g) || []).length;
               if (curSpaces >= prevSpaces) children[i - 1].remove();
@@ -163,10 +312,6 @@ const command = cli({
           if (el.children && el.children.length > 2) dedup(el);
         });
 
-        // --- Lazy-load image src rewrite ---
-        // Many sites render <img src="placeholder.gif" data-src="real.jpg">.
-        // Promote the real URL onto src so both the markdown body and the
-        // image download list reference the same URL.
         clone.querySelectorAll('img').forEach(img => {
           const srcset = img.getAttribute('data-srcset') || '';
           const srcsetFirst = srcset.split(',')[0]?.trim().split(' ')[0] || '';
@@ -174,12 +319,11 @@ const command = cli({
             || img.getAttribute('data-original')
             || img.getAttribute('data-lazy-src')
             || srcsetFirst;
-          if (real) img.setAttribute('src', real);
+          if (real) img.setAttribute('src', absolutize(real, window.location.href));
         });
 
         result.contentHtml = clone.innerHTML;
 
-        // --- Image extraction ---
         const seen = new Set();
         clone.querySelectorAll('img').forEach(img => {
           const src = img.getAttribute('src') || '';
@@ -191,7 +335,85 @@ const command = cli({
 
         return result;
       })()
-    `);
+    `;
+}
+
+function formatDiagnostics(data, networkEntries, captureSupported) {
+    const lines = [];
+    const diag = data?.diagnostics || {};
+    lines.push('[web-read diagnose]');
+    lines.push(`url: ${diag.url || '-'}`);
+    lines.push(`frames: ${Array.isArray(diag.frames) ? diag.frames.length : 0}, included_same_origin: ${diag.includedFrameCount || 0}`);
+    for (const frame of (diag.frames || []).slice(0, 20)) {
+        lines.push(`  [frame ${frame.index}] ${frame.sameOrigin ? 'same-origin' : 'cross-origin'} ${frame.accessible ? 'accessible' : 'blocked'} text=${frame.textLength || 0} ${frame.src || '-'}`);
+    }
+    if (Array.isArray(diag.emptyContainers) && diag.emptyContainers.length > 0) {
+        lines.push(`empty_containers: ${diag.emptyContainers.length}`);
+        for (const item of diag.emptyContainers.slice(0, 12)) {
+            const selector = `${item.tag}${item.id ? `#${item.id}` : ''}${item.className ? `.${String(item.className).trim().split(/\\s+/).filter(Boolean).join('.')}` : ''}`;
+            lines.push(`  ${item.scope}: ${selector} (${item.url || '-'})`);
+        }
+    }
+    const interesting = networkEntries.filter(isInterestingNetworkEntry);
+    lines.push(`network_capture: ${captureSupported ? 'enabled' : 'unavailable'}, entries=${networkEntries.length}, api_like=${interesting.length}`);
+    for (const entry of interesting.slice(0, 20)) {
+        lines.push(`  ${entry.method} ${entry.status || '-'} ${entry.contentType || '-'} ${entry.url}`);
+    }
+    return `${lines.join('\n')}\n`;
+}
+
+const command = cli({
+    site: 'web',
+    name: 'read',
+    description: 'Fetch any web page and export as Markdown',
+    strategy: Strategy.COOKIE,
+    navigateBefore: false, // we handle navigation ourselves
+    args: [
+        { name: 'url', required: true, help: 'Any web page URL' },
+        { name: 'output', default: './web-articles', help: 'Output directory' },
+        { name: 'download-images', type: 'boolean', default: true, help: 'Download images locally' },
+        { name: 'wait', type: 'int', default: 3, help: 'Seconds to wait after page load' },
+        { name: 'wait-for', valueRequired: true, help: 'CSS selector to wait for in the main document or same-origin iframes' },
+        { name: 'wait-until', default: 'domstable', choices: ['domstable', 'networkidle'], help: 'Readiness policy after navigation: domstable or networkidle' },
+        { name: 'frames', default: 'same-origin', choices: ['same-origin', 'none'], help: 'Iframe handling mode: same-origin or none' },
+        { name: 'diagnose', type: 'boolean', default: false, help: 'Print render diagnostics (frames, empty containers, XHR/API-like requests) to stderr' },
+        { name: 'stdout', type: 'boolean', default: false, help: 'Print markdown to stdout instead of saving to a file' },
+    ],
+    columns: ['title', 'author', 'publish_time', 'status', 'size', 'saved'],
+    func: async (page, kwargs, debug = false) => {
+        const url = kwargs.url;
+        const waitSeconds = kwargs.wait ?? 3;
+        const waitUntil = normalizeWaitUntil(kwargs['wait-until']);
+        const frameMode = normalizeFrameMode(kwargs.frames);
+        const shouldDiagnose = boolish(kwargs.diagnose) || debug || !!process.env.OPENCLI_VERBOSE;
+        const networkEntries = [];
+        const captureSupported = (waitUntil === 'networkidle' || shouldDiagnose)
+            ? await maybeStartNetworkCapture(page)
+            : false;
+        // Navigate to the target URL
+        await page.goto(url);
+        if (kwargs['wait-for']) {
+            const waitResult = await page.evaluate(buildWaitForSelectorAcrossFramesJs(String(kwargs['wait-for']), waitSeconds * 1000));
+            if (waitResult?.invalidSelector) {
+                throw new Error(`Invalid --wait-for selector "${kwargs['wait-for']}": ${waitResult.error || 'querySelector failed'}`);
+            }
+            if (!waitResult?.ok) {
+                throw new Error(`Timed out waiting for selector "${kwargs['wait-for']}" in main document or same-origin iframes`);
+            }
+        } else if (waitUntil !== 'networkidle') {
+            await page.wait(waitSeconds);
+        }
+        if (waitUntil === 'networkidle') {
+            if (captureSupported) {
+                await waitForNetworkIdle(page, waitSeconds, networkEntries);
+            } else {
+                await page.wait(waitSeconds);
+            }
+        }
+        // Extract article content using browser-side heuristics
+        const data = await page.evaluate(buildRenderAwareExtractorJs({ frames: frameMode }));
+        if (captureSupported) await drainNetworkCapture(page, networkEntries);
+        if (shouldDiagnose) process.stderr.write(formatDiagnostics(data, networkEntries, captureSupported));
         // Determine Referer from URL for image downloads
         let referer = '';
         try {
@@ -225,4 +447,12 @@ const command = cli({
         return kwargs.stdout ? null : result;
     },
 });
-export const __test__ = { command };
+export const __test__ = {
+    command,
+    buildRenderAwareExtractorJs,
+    buildWaitForSelectorAcrossFramesJs,
+    formatDiagnostics,
+    isInterestingNetworkEntry,
+    normalizeFrameMode,
+    normalizeWaitUntil,
+};

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 
 const { mockDownloadArticle } = vi.hoisted(() => ({
     mockDownloadArticle: vi.fn(),
@@ -12,19 +13,29 @@ const { __test__ } = await import('./read.js');
 
 describe('web/read stdout behavior', () => {
     const read = __test__.command;
-    const page = {
-        goto: vi.fn().mockResolvedValue(undefined),
-        wait: vi.fn().mockResolvedValue(undefined),
-        evaluate: vi.fn().mockResolvedValue({
+    const extractedArticle = {
             title: 'Example Article',
             author: 'Author',
             publishTime: '2026-04-22',
             contentHtml: '<p>hello</p>',
             imageUrls: ['https://example.com/a.jpg'],
-        }),
+            diagnostics: {
+                url: 'https://example.com/article',
+                frames: [],
+                emptyContainers: [],
+                includedFrameCount: 0,
+            },
+        };
+    const page = {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(extractedArticle),
+        startNetworkCapture: vi.fn().mockResolvedValue(true),
+        readNetworkCapture: vi.fn().mockResolvedValue([]),
     };
 
     beforeEach(() => {
+        vi.restoreAllMocks();
         mockDownloadArticle.mockReset();
         mockDownloadArticle.mockResolvedValue([{
             title: 'Example Article',
@@ -37,6 +48,11 @@ describe('web/read stdout behavior', () => {
         page.goto.mockClear();
         page.wait.mockClear();
         page.evaluate.mockClear();
+        page.evaluate.mockResolvedValue(extractedArticle);
+        page.startNetworkCapture.mockClear();
+        page.startNetworkCapture.mockResolvedValue(true);
+        page.readNetworkCapture.mockClear();
+        page.readNetworkCapture.mockResolvedValue([]);
     });
 
     it('returns null in --stdout mode so the CLI does not append result rows to stdout', async () => {
@@ -58,6 +74,7 @@ describe('web/read stdout behavior', () => {
                 stdout: true,
             }),
         );
+        expect(page.evaluate.mock.calls[0]?.[0]).toContain('const frameMode = "same-origin"');
     });
 
     it('still returns the saved-row payload when writing to disk', async () => {
@@ -72,5 +89,162 @@ describe('web/read stdout behavior', () => {
         });
 
         expect(result).toBe(rows);
+    });
+
+    it('waits for a selector in the main document or same-origin iframes before extracting', async () => {
+        page.evaluate
+            .mockResolvedValueOnce({ ok: true, scope: 'iframe', url: 'https://example.com/frame' })
+            .mockResolvedValueOnce(extractedArticle);
+
+        await read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            'wait-for': '#gridDatas li',
+            wait: 7,
+            stdout: false,
+        });
+
+        expect(page.wait).not.toHaveBeenCalled();
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+        expect(page.evaluate.mock.calls[0]?.[0]).toContain('"#gridDatas li"');
+        expect(page.evaluate.mock.calls[0]?.[0]).toContain('sameOriginFrameDocs');
+        expect(page.evaluate.mock.calls[1]?.[0]).toContain('const frameMode = "same-origin"');
+    });
+
+    it('throws a clear error when --wait-for times out', async () => {
+        page.evaluate.mockResolvedValueOnce({ ok: false, timedOut: true, selector: '#missing' });
+
+        await expect(read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            'wait-for': '#missing',
+            wait: 1,
+            stdout: false,
+        })).rejects.toThrow('Timed out waiting for selector "#missing"');
+
+        expect(mockDownloadArticle).not.toHaveBeenCalled();
+    });
+
+    it('starts network capture and writes diagnostics in diagnose mode', async () => {
+        const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        page.readNetworkCapture.mockResolvedValueOnce([{
+            method: 'POST',
+            url: 'https://example.com/api/data',
+            responseStatus: 200,
+            responseContentType: 'application/json',
+            responsePreview: '{"ok":true}',
+        }]);
+
+        await read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            diagnose: true,
+            wait: 0,
+            stdout: false,
+        });
+
+        expect(page.startNetworkCapture).toHaveBeenCalledWith('');
+        expect(page.readNetworkCapture).toHaveBeenCalledTimes(1);
+        expect(stderr).toHaveBeenCalledWith(expect.stringContaining('[web-read diagnose]'));
+        expect(stderr).toHaveBeenCalledWith(expect.stringContaining('POST 200 application/json https://example.com/api/data'));
+    });
+
+    it('passes --frames none into the extractor', async () => {
+        await read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            frames: 'none',
+            stdout: false,
+        });
+
+        expect(page.evaluate.mock.calls[0]?.[0]).toContain('const frameMode = "none"');
+    });
+});
+
+describe('web/read render-aware helpers', () => {
+    it('merges accessible same-origin iframe bodies into the extracted HTML', () => {
+        const dom = new JSDOM(`
+          <main>
+            <h1>Shell</h1>
+            <iframe id="MF" src="/frame.html"></iframe>
+          </main>
+        `, { url: 'https://example.com/main.html', runScripts: 'outside-only' });
+        const frame = dom.window.document.querySelector('iframe');
+        frame.contentDocument.open();
+        frame.contentDocument.write('<body><table id="gridHd"><tr><th>Name</th></tr></table><ul id="gridDatas"><li>Station A 42</li></ul></body>');
+        frame.contentDocument.close();
+
+        const result = dom.window.eval(__test__.buildRenderAwareExtractorJs({ frames: 'same-origin' }));
+
+        expect(result.diagnostics.includedFrameCount).toBe(1);
+        expect(result.contentHtml).toContain('data-opencli-iframe-source="https://example.com/frame.html"');
+        expect(result.contentHtml).toContain('来自 iframe: https://example.com/frame.html');
+        expect(result.contentHtml).toContain('Station A 42');
+    });
+
+    it('marks API-like network entries as interesting and ignores static assets', () => {
+        expect(__test__.isInterestingNetworkEntry({
+            method: 'POST',
+            url: 'https://example.com/GJZ/Ajax/Publish.ashx',
+            status: 200,
+            contentType: 'text/html',
+            size: 100,
+            bodyTruncated: false,
+        })).toBe(true);
+        expect(__test__.isInterestingNetworkEntry({
+            method: 'POST',
+            url: 'https://example.com/GJZ/Ajax/Publish.ashx',
+            status: 200,
+            contentType: 'application/json',
+            size: 100,
+            bodyTruncated: false,
+        })).toBe(true);
+        expect(__test__.isInterestingNetworkEntry({
+            method: 'GET',
+            url: 'https://example.com/app.js',
+            status: 200,
+            contentType: 'application/javascript',
+            size: 100,
+            bodyTruncated: false,
+        })).toBe(false);
+    });
+
+    it('formats frame and XHR diagnostics for shell pages', () => {
+        const output = __test__.formatDiagnostics({
+            diagnostics: {
+                url: 'https://example.com/main.html',
+                includedFrameCount: 1,
+                frames: [{
+                    index: 0,
+                    src: 'https://example.com/frame.html',
+                    sameOrigin: true,
+                    accessible: true,
+                    textLength: 42,
+                }],
+                emptyContainers: [{
+                    scope: 'iframe',
+                    url: 'https://example.com/frame.html',
+                    tag: 'ul',
+                    id: 'gridDatas',
+                    className: '',
+                }],
+            },
+        }, [{
+            method: 'POST',
+            url: 'https://example.com/GJZ/Ajax/Publish.ashx',
+            status: 200,
+            contentType: 'application/json',
+            size: 64,
+            bodyTruncated: false,
+        }], true);
+
+        expect(output).toContain('frames: 1, included_same_origin: 1');
+        expect(output).toContain('[frame 0] same-origin accessible text=42 https://example.com/frame.html');
+        expect(output).toContain('iframe: ul#gridDatas (https://example.com/frame.html)');
+        expect(output).toContain('POST 200 application/json https://example.com/GJZ/Ajax/Publish.ashx');
     });
 });

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -191,18 +191,18 @@ describe('web/read stdout behavior', () => {
             responsePreview: '{"ok":true}',
         }]);
 
-        const pending = read.func(page, {
+        const pending = expect(read.func(page, {
             url: 'https://example.com/article',
             output: '/tmp/out',
             'download-images': false,
             'wait-until': 'networkidle',
             wait: 1,
             stdout: false,
-        });
+        })).rejects.toThrow('Timed out waiting for network idle after 1s');
 
         await vi.advanceTimersByTimeAsync(2000);
 
-        await expect(pending).rejects.toThrow('Timed out waiting for network idle after 1s');
+        await pending;
         expect(mockDownloadArticle).not.toHaveBeenCalled();
     });
 });

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -36,6 +36,7 @@ describe('web/read stdout behavior', () => {
 
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.useRealTimers();
         mockDownloadArticle.mockReset();
         mockDownloadArticle.mockResolvedValue([{
             title: 'Example Article',
@@ -162,6 +163,47 @@ describe('web/read stdout behavior', () => {
         });
 
         expect(page.evaluate.mock.calls[0]?.[0]).toContain('const frameMode = "none"');
+    });
+
+    it('fails fast when --wait-until networkidle is requested but capture is unavailable', async () => {
+        page.startNetworkCapture.mockResolvedValue(false);
+
+        await expect(read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            'wait-until': 'networkidle',
+            wait: 2,
+            stdout: false,
+        })).rejects.toThrow('Network capture is unavailable');
+
+        expect(page.wait).not.toHaveBeenCalled();
+        expect(mockDownloadArticle).not.toHaveBeenCalled();
+    });
+
+    it('fails fast when network traffic never settles before the networkidle timeout', async () => {
+        vi.useFakeTimers();
+        page.readNetworkCapture.mockResolvedValue([{
+            method: 'POST',
+            url: 'https://example.com/api/data',
+            responseStatus: 200,
+            responseContentType: 'application/json',
+            responsePreview: '{"ok":true}',
+        }]);
+
+        const pending = read.func(page, {
+            url: 'https://example.com/article',
+            output: '/tmp/out',
+            'download-images': false,
+            'wait-until': 'networkidle',
+            wait: 1,
+            stdout: false,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+
+        await expect(pending).rejects.toThrow('Timed out waiting for network idle after 1s');
+        expect(mockDownloadArticle).not.toHaveBeenCalled();
     });
 });
 

--- a/docs/adapters/browser/web.md
+++ b/docs/adapters/browser/web.md
@@ -6,23 +6,44 @@
 
 | Command | Description |
 |---------|-------------|
-| `opencli web read <url>` | Fetch any web page and export as Markdown |
+| `opencli web read --url <url>` | Fetch any web page and export as Markdown |
 
 ## Usage Examples
 
 ```bash
 # Read a web page and save as Markdown
-opencli web read https://example.com/article
+opencli web read --url https://example.com/article
 
 # Custom output directory
-opencli web read https://example.com/article --output ./my-articles
+opencli web read --url https://example.com/article --output ./my-articles
 
 # Skip image download
-opencli web read https://example.com/article --download-images false
+opencli web read --url https://example.com/article --download-images false
 
 # JSON output
-opencli web read https://example.com/article -f json
+opencli web read --url https://example.com/article -f json
+
+# Iframe/AJAX shell page: wait for rendered data and print diagnostics
+opencli web read \
+  --url https://example.com/shell.html \
+  --wait-for "#gridDatas li" \
+  --wait-until networkidle \
+  --diagnose
 ```
+
+## Render-Aware Reading
+
+`web read` runs in Chrome, not in a raw HTTP fetcher. It now handles common shell pages where the top document only contains layout and the real content is rendered later.
+
+| Option | Purpose |
+|--------|---------|
+| `--frames same-origin` | Default. Merge accessible same-origin iframe bodies into the extracted HTML before Markdown conversion. |
+| `--frames none` | Disable iframe merging when the embedded content is noisy. |
+| `--wait-for <selector>` | Wait until a CSS selector appears in the main document or a same-origin iframe before extraction. |
+| `--wait-until networkidle` | Start network capture before navigation and wait until captured requests are quiet. |
+| `--diagnose` | Print frame tree, empty table/list containers, and API-like XHR/fetch requests to stderr. |
+
+Cross-origin iframes are listed in diagnostics but not merged. If diagnostics reveal that the page data comes from an API endpoint, prefer a dedicated adapter or `opencli browser network --detail <key>` for structured data instead of forcing table-like data into Markdown.
 
 ## Prerequisites
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -167,6 +167,7 @@ Default timeout `10000` ms. SPA routes, login redirects, and lazy-loaded lists n
 
 ### Extract
 
+- **`web read --url <url>`** — One-shot Markdown reader for arbitrary pages. It expands same-origin iframes by default, so old iframe-shell sites work better than with a top-document-only scrape. For AJAX shell pages use `opencli web read --url <url> --wait-for "<selector>" --wait-until networkidle --diagnose`; diagnostics show frame URLs, empty containers, and API-like XHRs. If the value you need is table/API data, switch to `browser network` or a dedicated adapter instead of relying on Markdown.
 - **`browser eval <js> [--frame N]`** — Run an expression in the page (or in a cross-origin frame via `--frame`). Wrap in an IIFE and return JSON. Read-only: no `document.forms[0].submit()`, no clicks, no navigations. If the result is a string, stdout is the raw string; otherwise it's JSON.
 - **`browser extract [--selector <css>] [--chunk-size N] [--start N]`** — Markdown extraction of long-form content with a continuation cursor. Returns `{url, title, selector, total_chars, chunk_size, start, end, next_start_char, content}`. Loop on `next_start_char` until it is `null`. Auto-scopes to `<main>`/`<article>`/`<body>` if you don't pass `--selector`.
 


### PR DESCRIPTION
## Summary

Implements the P0 Render-aware Reader scope for `opencli web read`:

- merges accessible same-origin iframe bodies into the extracted HTML before Markdown conversion
- adds `--wait-for <selector>` across the main document and same-origin iframes
- adds `--wait-until networkidle` using browser network capture when available
- adds `--frames same-origin|none` and `--diagnose` for shell/AJAX pages
- surfaces diagnostics for frame tree, empty containers, and API-like XHR/fetch endpoints
- updates docs, skill guidance, changelog, and regenerated `cli-manifest.json`

## Verification

- `npx vitest run --project adapter clis/web/read.test.js` (9/9)
- `npx vitest run --project unit src/commanderAdapter.test.ts src/execution.test.ts src/build-manifest.test.ts` (24/24)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `HOME=$(mktemp -d) node dist/src/main.js web read --help` shows new flags
