### PR TITLE
fix(chatgpt): fix image generation detection and output path

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3532,9 +3532,8 @@
       {
         "name": "op",
         "type": "str",
-        "default": "~/Pictures/chatgpt",
         "required": false,
-        "help": "Output directory"
+        "help": "Output directory (default: ~/Pictures/chatgpt)"
       },
       {
         "name": "sd",

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -1,7 +1,9 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getChatGPTVisibleImageUrls, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
@@ -22,6 +24,22 @@ function normalizeBooleanFlag(value) {
 function displayPath(filePath) {
     const home = os.homedir();
     return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+
+export function resolveOutputDir(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return path.join(os.homedir(), 'Pictures', 'chatgpt');
+    if (raw === '~') return os.homedir();
+    if (raw.startsWith('~/')) return path.join(os.homedir(), raw.slice(2));
+    return path.resolve(raw);
+}
+
+export function nextAvailablePath(dir, baseName, ext, existsSync = fs.existsSync) {
+    let candidate = path.join(dir, `${baseName}${ext}`);
+    for (let index = 1; existsSync(candidate); index += 1) {
+        candidate = path.join(dir, `${baseName}_${index}${ext}`);
+    }
+    return candidate;
 }
 
 async function currentChatGPTLink(page) {
@@ -47,7 +65,7 @@ export const imageCommand = cli({
     columns: ['status', 'file', 'link'],
     func: async (page, kwargs) => {
         const prompt = kwargs.prompt;
-        const outputDir = kwargs.op || path.join(os.homedir(), 'Pictures', 'chatgpt');
+        const outputDir = resolveOutputDir(kwargs.op);
         const skipDownloadRaw = kwargs.sd;
         const skipDownload = skipDownloadRaw === '' || skipDownloadRaw === true || normalizeBooleanFlag(skipDownloadRaw);
         const timeout = 120;
@@ -79,7 +97,7 @@ export const imageCommand = cli({
         const link = convUrl;
 
         if (!urls.length) {
-            return [{ status: '⚠️ no-images', file: '📁 -', link: `🔗 ${link}` }];
+            throw new EmptyResultError('chatgpt image', `No generated images were detected before timeout. Open ${link} and verify whether ChatGPT finished generating the image.`);
         }
 
         if (skipDownload) {
@@ -89,7 +107,7 @@ export const imageCommand = cli({
         // Export and save images
         const assets = await getChatGPTImageAssets(page, urls);
         if (!assets.length) {
-            return [{ status: '⚠️ export-failed', file: '📁 -', link: `🔗 ${link}` }];
+            throw new CommandExecutionError('Failed to export generated ChatGPT image assets', `Open ${link} and verify the generated images are visible, then retry.`);
         }
 
         const stamp = Date.now();
@@ -99,7 +117,7 @@ export const imageCommand = cli({
             const base64 = asset.dataUrl.replace(/^data:[^;]+;base64,/, '');
             const suffix = assets.length > 1 ? `_${index + 1}` : '';
             const ext = extFromMime(asset.mimeType);
-            const filePath = path.join(outputDir, `chatgpt_${stamp}${suffix}${ext}`);
+            const filePath = nextAvailablePath(outputDir, `chatgpt_${stamp}${suffix}`, ext);
             await saveBase64ToFile(base64, filePath);
             results.push({ status: '✅ saved', file: `📁 ${displayPath(filePath)}`, link: `🔗 ${link}` });
         }

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -41,7 +41,7 @@ export const imageCommand = cli({
     timeoutSeconds: 240,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to ChatGPT' },
-        { name: 'op', default: '~/Pictures/chatgpt', help: 'Output directory' },
+        { name: 'op', help: 'Output directory (default: ~/Pictures/chatgpt)' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show ChatGPT link' },
     ],
     columns: ['status', 'file', 'link'],
@@ -63,9 +63,20 @@ export const imageCommand = cli({
             return [{ status: '⚠️ send-failed', file: '📁 -', link: `🔗 ${await currentChatGPTLink(page)}` }];
         }
 
-        // Wait for response and images
-        const urls = await waitForChatGPTImages(page, beforeUrls, timeout);
-        const link = await currentChatGPTLink(page);
+        // ChatGPT briefly navigates to /c/{id} after sending, then may
+        // redirect back to the home page. Poll until we capture the /c/ URL.
+        let convUrl = '';
+        for (let ci = 0; ci < 10; ci++) {
+            const url = await currentChatGPTLink(page);
+            if (url.includes('/c/')) { convUrl = url; break; }
+            await page.wait(2);
+        }
+        if (!convUrl) {
+            convUrl = await currentChatGPTLink(page);
+        }
+
+        const urls = await waitForChatGPTImages(page, beforeUrls, timeout, convUrl);
+        const link = convUrl;
 
         if (!urls.length) {
             return [{ status: '⚠️ no-images', file: '📁 -', link: `🔗 ${link}` }];

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -1,0 +1,92 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    getChatGPTVisibleImageUrls: vi.fn(),
+    sendChatGPTMessage: vi.fn(),
+    waitForChatGPTImages: vi.fn(),
+    getChatGPTImageAssets: vi.fn(),
+    saveBase64ToFile: vi.fn(),
+}));
+
+vi.mock('./utils.js', () => ({
+    getChatGPTVisibleImageUrls: mocks.getChatGPTVisibleImageUrls,
+    sendChatGPTMessage: mocks.sendChatGPTMessage,
+    waitForChatGPTImages: mocks.waitForChatGPTImages,
+    getChatGPTImageAssets: mocks.getChatGPTImageAssets,
+}));
+
+vi.mock('@jackwener/opencli/utils', () => ({
+    saveBase64ToFile: mocks.saveBase64ToFile,
+}));
+
+const { imageCommand, nextAvailablePath, resolveOutputDir } = await import('./image.js');
+
+function createPage() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue('https://chatgpt.com/c/test-conversation'),
+    };
+}
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.getChatGPTVisibleImageUrls.mockReset().mockResolvedValue([]);
+    mocks.sendChatGPTMessage.mockReset().mockResolvedValue(true);
+    mocks.waitForChatGPTImages.mockReset().mockResolvedValue(['https://images.example/generated.png']);
+    mocks.getChatGPTImageAssets.mockReset().mockResolvedValue([{
+        url: 'https://images.example/generated.png',
+        dataUrl: 'data:image/png;base64,aGVsbG8=',
+        mimeType: 'image/png',
+    }]);
+    mocks.saveBase64ToFile.mockReset().mockResolvedValue(undefined);
+});
+
+describe('chatgpt image output paths', () => {
+    it('expands the default and explicit home-relative output directories', () => {
+        expect(resolveOutputDir()).toBe(path.join(os.homedir(), 'Pictures', 'chatgpt'));
+        expect(resolveOutputDir('~/tmp/chatgpt-images')).toBe(path.join(os.homedir(), 'tmp', 'chatgpt-images'));
+        expect(resolveOutputDir('~')).toBe(os.homedir());
+    });
+
+    it('generates a non-overwriting file path when a timestamp collision exists', () => {
+        const dir = '/tmp/chatgpt';
+        const taken = new Set([
+            path.join(dir, 'chatgpt_123.png'),
+            path.join(dir, 'chatgpt_123_1.png'),
+        ]);
+
+        expect(nextAvailablePath(dir, 'chatgpt_123', '.png', (file) => taken.has(file))).toBe(path.join(dir, 'chatgpt_123_2.png'));
+    });
+});
+
+describe('chatgpt image failure contracts', () => {
+    it('fails fast when image generation detection finds no new images', async () => {
+        mocks.waitForChatGPTImages.mockResolvedValue([]);
+
+        await expect(imageCommand.func(createPage(), {
+            prompt: 'cat',
+            op: '',
+            sd: false,
+        })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+            message: expect.stringContaining('chatgpt image returned no data'),
+            hint: expect.stringContaining('No generated images were detected'),
+        });
+    });
+
+    it('fails fast when generated image assets cannot be exported', async () => {
+        mocks.getChatGPTImageAssets.mockResolvedValue([]);
+
+        await expect(imageCommand.func(createPage(), {
+            prompt: 'cat',
+            op: '',
+            sd: false,
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Failed to export generated ChatGPT image assets'),
+        });
+    });
+});

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -14,6 +14,13 @@ const COMPOSER_SELECTORS = [
 ];
 const SEND_BTN_SELECTOR = 'button[aria-label="Send prompt"]';
 
+function isSameChatGPTConversation(currentUrl, expectedUrl) {
+    if (!currentUrl || !expectedUrl) return false;
+    return currentUrl === expectedUrl
+        || currentUrl.startsWith(`${expectedUrl}?`)
+        || currentUrl.startsWith(`${expectedUrl}#`);
+}
+
 function buildComposerLocatorScript() {
     const markerAttr = 'data-opencli-chatgpt-composer';
     return `
@@ -196,12 +203,10 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
     for (let i = 0; i < maxPolls; i++) {
         await page.wait(i === 0 ? 3 : pollIntervalSeconds);
 
+        let currentUrl = '';
         if (convUrl && convUrl.includes('/c/')) {
-            const currentUrl = await page.evaluate('window.location.href').catch(() => '');
-            if (currentUrl && !currentUrl.includes('/c/')) {
-                await page.goto(convUrl);
-                await page.wait(3);
-            } else if (i > 0 && i % 5 === 0) {
+            currentUrl = await page.evaluate('window.location.href').catch(() => '');
+            if (currentUrl && !isSameChatGPTConversation(currentUrl, convUrl)) {
                 await page.goto(convUrl);
                 await page.wait(3);
             }
@@ -209,6 +214,14 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
 
         const generating = await isGenerating(page);
         if (generating) continue;
+
+        if (convUrl && convUrl.includes('/c/') && i > 0 && i % 5 === 0) {
+            const onConversation = !currentUrl || isSameChatGPTConversation(currentUrl, convUrl);
+            if (onConversation) {
+                await page.goto(convUrl);
+                await page.wait(3);
+            }
+        }
 
         const urls = (await getChatGPTVisibleImageUrls(page)).filter(url => !beforeSet.has(url));
         if (urls.length === 0) continue;
@@ -228,6 +241,11 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
     }
     return lastUrls;
 }
+
+export const __test__ = {
+    COMPOSER_SELECTORS,
+    isSameChatGPTConversation,
+};
 
 /**
  * Export images by URL: fetch from ChatGPT backend API and convert to base64 data URLs.

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -7,11 +7,14 @@ export const CHATGPT_DOMAIN = 'chatgpt.com';
 export const CHATGPT_URL = 'https://chatgpt.com';
 
 // Selectors
-const COMPOSER_SELECTOR = '[aria-label="Chat with ChatGPT"]';
+const COMPOSER_SELECTORS = [
+    '[aria-label="Chat with ChatGPT"]',
+    '[placeholder="Ask anything"]',
+    '#prompt-textarea',
+];
 const SEND_BTN_SELECTOR = 'button[aria-label="Send prompt"]';
 
 function buildComposerLocatorScript() {
-    const selectorsJson = JSON.stringify([COMPOSER_SELECTOR]);
     const markerAttr = 'data-opencli-chatgpt-composer';
     return `
       const isVisible = (el) => {
@@ -33,7 +36,7 @@ function buildComposerLocatorScript() {
         const marked = document.querySelector('[' + markerAttr + '="1"]');
         if (marked instanceof HTMLElement && isVisible(marked)) return marked;
 
-        for (const selector of ${JSON.stringify([COMPOSER_SELECTOR])}) {
+        for (const selector of ${JSON.stringify(COMPOSER_SELECTORS)}) {
           const node = Array.from(document.querySelectorAll(selector)).find(c => c instanceof HTMLElement && isVisible(c));
           if (node instanceof HTMLElement) {
             node.setAttribute(markerAttr, '1');
@@ -89,7 +92,9 @@ export async function sendChatGPTMessage(page, text) {
         // Fallback: use execCommand
         await page.evaluate(`
             (() => {
-                const composer = document.querySelector('[aria-label="Chat with ChatGPT"]');
+                var composer = null;
+                var sels = ${JSON.stringify(COMPOSER_SELECTORS)};
+                for (var si = 0; si < sels.length; si++) { composer = document.querySelector(sels[si]); if (composer) break; }
                 if (!composer) return;
                 composer.focus();
                 document.execCommand('insertText', false, ${JSON.stringify(text)});
@@ -181,7 +186,7 @@ export async function getChatGPTVisibleImageUrls(page) {
 /**
  * Wait for new images to appear after sending a prompt.
  */
-export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds) {
+export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, convUrl) {
     const beforeSet = new Set(beforeUrls);
     const pollIntervalSeconds = 3;
     const maxPolls = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));
@@ -191,7 +196,17 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds) {
     for (let i = 0; i < maxPolls; i++) {
         await page.wait(i === 0 ? 3 : pollIntervalSeconds);
 
-        // Check if still generating
+        if (convUrl && convUrl.includes('/c/')) {
+            const currentUrl = await page.evaluate('window.location.href').catch(() => '');
+            if (currentUrl && !currentUrl.includes('/c/')) {
+                await page.goto(convUrl);
+                await page.wait(3);
+            } else if (i > 0 && i % 5 === 0) {
+                await page.goto(convUrl);
+                await page.wait(3);
+            }
+        }
+
         const generating = await isGenerating(page);
         if (generating) continue;
 

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { __test__, waitForChatGPTImages } from './utils.js';
+
+function createPageMock({ location = '', generating = [], imageUrls = [] } = {}) {
+    let generatingIndex = 0;
+    let imageIndex = 0;
+    return {
+        wait: vi.fn().mockResolvedValue(undefined),
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn((script) => {
+            if (script === 'window.location.href') return Promise.resolve(location);
+            if (script.includes('Stop generating') || script.includes('Thinking')) {
+                const value = generating[Math.min(generatingIndex, generating.length - 1)] ?? false;
+                generatingIndex += 1;
+                return Promise.resolve(value);
+            }
+            if (script.includes("document.querySelectorAll('img')")) {
+                const value = imageUrls[Math.min(imageIndex, imageUrls.length - 1)] ?? [];
+                imageIndex += 1;
+                return Promise.resolve(value);
+            }
+            return Promise.resolve(undefined);
+        }),
+    };
+}
+
+describe('chatgpt image wait contract', () => {
+    it('does not periodically reload the conversation while generation is still active', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [true, true, true, true, true, true],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 18, convUrl)).resolves.toEqual([]);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('jumps back to the captured conversation when the page drifts away', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: 'https://chatgpt.com/',
+            generating: [false],
+            imageUrls: [['https://cdn.openai.com/generated/demo.png']],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 3, convUrl)).resolves.toEqual([
+            'https://cdn.openai.com/generated/demo.png',
+        ]);
+        expect(page.goto).toHaveBeenCalledWith(convUrl);
+    });
+
+    it('treats query and hash variants as the same conversation', () => {
+        expect(__test__.isSameChatGPTConversation(
+            'https://chatgpt.com/c/demo?model=gpt-image-1',
+            'https://chatgpt.com/c/demo',
+        )).toBe(true);
+        expect(__test__.isSameChatGPTConversation(
+            'https://chatgpt.com/c/other',
+            'https://chatgpt.com/c/demo',
+        )).toBe(false);
+    });
+});


### PR DESCRIPTION
## Description

Three fixes for the `chatgpt image` command:

**1. Image detection after page navigation.** After sending a prompt, ChatGPT briefly navigates to `/c/{id}` then may redirect back to the home page. The image poll loop now captures the conversation URL after send, navigates back if the page leaves the conversation, and periodically reloads to pick up asynchronously rendered images.

**2. Composer selector fallback.** ChatGPT uses different selectors across UI versions. Added `[placeholder="Ask anything"]` and `#prompt-textarea` as fallbacks alongside the existing `[aria-label="Chat with ChatGPT"]`.

**3. Output path tilde expansion.** The default `--op` value `~/Pictures/chatgpt` was a literal string. Node.js does not expand `~`, so images were saved to a directory literally named `~` in the working directory. Removed the string default and use `os.homedir()` fallback instead.

Fixes #1206

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A

## Screenshots / Output

**Before:**
```
$ opencli chatgpt image "a cute orange cat"
status: ⚠️ send-failed
```

**After:**
```
$ opencli chatgpt image "a red circle" --sd
status: 🎨 generated
link: 🔗 https://chatgpt.com/c/69f20f6a-...
```