### PR TITLE
fix(chatgpt-app): support Traditional Chinese UI labels

### DIFF
--- a/clis/chatgpt-app/ax.js
+++ b/clis/chatgpt-app/ax.js
@@ -380,5 +380,6 @@ export function getVisibleChatMessages() {
 }
 export const __test__ = {
     AX_SEND_SCRIPT,
+    AX_MODEL_SCRIPT,
     AX_GENERATING_SCRIPT,
 };

--- a/clis/chatgpt-app/ax.js
+++ b/clis/chatgpt-app/ax.js
@@ -156,7 +156,7 @@ guard s(input, kAXValueAttribute as String) == text else {
     exit(1)
 }
 
-guard let sendButton = findByDescriptions(win, ["发送", "Send"]) else {
+guard let sendButton = findByDescriptions(win, ["发送", "傳送", "Send"]) else {
     fputs("Could not find send button\\n", stderr)
     exit(1)
 }
@@ -240,10 +240,11 @@ let args = CommandLine.arguments
 let target = args.count > 1 ? args[1] : ""
 let needsLegacy = args.count > 2 && args[2] == "legacy"
 
-// Step 1: Click the "Options" button to open the popover (support both English and Chinese UI)
+// Step 1: Click the "Options" button to open the popover (support English, Simplified and Traditional Chinese UI)
 var optionsBtn: AXUIElement? = nil
 if let btn = findByDesc(win, "Options") { optionsBtn = btn }
 else if let btn = findByDesc(win, "选项") { optionsBtn = btn }
+else if let btn = findByDesc(win, "選項") { optionsBtn = btn }
 guard let options = optionsBtn else {
     fputs("Could not find Options button\\n", stderr); exit(1)
 }

--- a/clis/chatgpt-app/ax.test.js
+++ b/clis/chatgpt-app/ax.test.js
@@ -13,6 +13,18 @@ describe('chatgpt-app AX send script', () => {
     it('does not report success until the prompt leaves the composer after send', () => {
         expect(__test__.AX_SEND_SCRIPT).toContain('Prompt did not leave input after pressing send');
     });
+
+    it('supports english, zh-CN, and zh-TW send button labels', () => {
+        expect(__test__.AX_SEND_SCRIPT).toContain('["发送", "傳送", "Send"]');
+    });
+});
+
+describe('chatgpt-app AX model script', () => {
+    it('supports english, zh-CN, and zh-TW options button labels', () => {
+        expect(__test__.AX_MODEL_SCRIPT).toContain('findByDesc(win, "Options")');
+        expect(__test__.AX_MODEL_SCRIPT).toContain('findByDesc(win, "选项")');
+        expect(__test__.AX_MODEL_SCRIPT).toContain('findByDesc(win, "選項")');
+    });
 });
 
 describe('chatgpt-app generating detection', () => {


### PR DESCRIPTION
## Summary

`chatgpt-app send` and `chatgpt-app model` fail on macOS systems whose system language is Traditional Chinese (zh-TW / zh-HK), because the AX matchers in `clis/chatgpt-app/ax.js` only include Simplified Chinese strings.

| Button | Simplified | Traditional | English |
|---|---|---|---|
| Send | 发送 ✓ | **傳送** (missing) | Send ✓ |
| Options | 选项 ✓ | **選項** (missing) | Options ✓ |

## Repro (zh-TW user)

```
$ opencli chatgpt-app send "hi"
Could not find send button
- Status: |
    Error: Command failed: swift - hi
    Could not find send button
```

## Verification

Walked the AXUIElement tree of ChatGPT 1.2026.104 on macOS 26 with system language set to Traditional Chinese:

```
BUTTON desc='傳送' help='發送訊息 (⏎)'
BUTTON desc='選項' help='挑選模型或 GPT'
```

After this patch, full demo passes:

```
$ opencli chatgpt-app new
- Status: Success
$ opencli chatgpt-app send "請用一句話自我介紹（中文）"
- Status: Success
$ opencli chatgpt-app read
Role: Assistant
Text: 我是 ChatGPT，一個由 OpenAI 打造、能用自然語言幫助你解答問題與提供建議的人工智慧助手。
```

`npx vitest run clis/chatgpt-app/ax.test.js` — 4/4 passed.

## Notes

- `Stop generating` detection at line 314 already works for Traditional Chinese because `停止生成` uses identical glyphs in both writing systems.
- `Legacy models` at line 261 still lacks a Chinese variant; not addressed here because I haven't verified the Traditional Chinese translation against a live UI.

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run clis/chatgpt-app/ax.test.js` — 4/4 passed
- [x] End-to-end `new → send → read` against ChatGPT 1.2026.104 on macOS 26 (zh-TW) — works