### PR TITLE
[codex] fix(cli): allow dash-leading positional adapter args

### DIFF
--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -84,6 +84,23 @@ describe('commanderAdapter arg passing', () => {
     });
   });
 
+  it('accepts dash-leading positional arguments while still parsing later options', async () => {
+    const program = new Command();
+    program.exitOverride();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'submit', '-123456abdc', '-f', 'json']);
+
+    expect(mockExecuteCommand).toHaveBeenCalled();
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(kwargs.pdf).toBe('-123456abdc');
+    expect(mockRenderOutput).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ fmt: 'json' }),
+    );
+  });
+
   it('rejects invalid bool values before calling executeCommand', async () => {
     const program = new Command();
     const siteCmd = program.command('paperreview');

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -33,6 +33,11 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
   const deprecatedSuffix = cmd.deprecated ? ' [deprecated]' : '';
   const subCmd = siteCmd.command(cmd.name).description(`${cmd.description}${deprecatedSuffix}`);
   if (cmd.aliases?.length) subCmd.aliases(cmd.aliases);
+  const hasPositionalArgs = cmd.args.some((arg) => arg.positional);
+
+  // Commander treats dash-leading positional values as unknown options by default.
+  // Allow them through so our adapter layer can validate values like "-123456abdc".
+  if (hasPositionalArgs) subCmd.allowUnknownOption();
 
   // Register positional args first, then named options
   const positionalArgs: typeof cmd.args = [];


### PR DESCRIPTION
## Summary
- allow dynamic adapter commands with positional args to accept dash-leading values
- add a regression test for `opencli boss detail -123456abdc -f json`

## Root Cause
Commander treated values like `-123456abdc` as unknown options before OpenCLI's adapter argument preparation ran, so commands with positional IDs could fail before adapter-level validation had a chance to handle them.

## Impact
Commands such as `opencli boss detail -123456abdc -f json` now parse the positional `security-id` correctly instead of failing with `unknown option`.

## Validation
- `npm run typecheck`
- `npm test -- --runInBand src/commanderAdapter.test.ts`
- `npm run build`
- `npm test` (fails on this Windows environment due pre-existing unrelated symlink/path separator assertions in `src/plugin.test.ts`, `src/engine.test.ts`, and several adapter download/upload tests)

Fixes #1160
