### PR TITLE
[codex] Improve browser bridge connection errors

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -162,7 +162,11 @@ describe('BrowserBridge state', () => {
 
     const bridge = new BrowserBridge();
 
-    await expect(bridge.connect({ timeout: 0.1 })).rejects.toThrow('Browser Bridge extension not connected');
+    await expect(bridge.connect({ timeout: 0.1 })).rejects.toMatchObject({
+      message: 'Browser Bridge extension not connected',
+      kind: 'extension-not-connected',
+      hint: expect.stringContaining('Try running the command again'),
+    });
   });
 
   it('attempts stale daemon replacement when daemonVersion is missing', async () => {

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -139,7 +139,8 @@ export class BrowserBridge implements IBrowserFactory {
         throw new BrowserConnectError(
           'Browser Bridge extension not connected',
           'Make sure Chrome/Chromium is open and the extension is enabled.\n' +
-          'If the extension is installed, try: opencli daemon stop && opencli doctor\n' +
+          'Try running the command again — the extension may need a moment to reconnect.\n' +
+          'If it still fails, reload OpenCLI in chrome://extensions and run: opencli doctor\n' +
           'If not installed:\n' +
           '  1. Download: https://github.com/jackwener/opencli/releases\n' +
           '  2. Open chrome://extensions → Developer Mode → Load unpacked',
@@ -179,7 +180,8 @@ export class BrowserBridge implements IBrowserFactory {
       throw new BrowserConnectError(
         'Browser Bridge extension not connected',
         'Make sure Chrome/Chromium is open and the extension is enabled.\n' +
-        'If the extension is installed, try: opencli daemon stop && opencli doctor\n' +
+        'Try running the command again — the extension may need a moment to reconnect.\n' +
+        'If it still fails, reload OpenCLI in chrome://extensions and run: opencli doctor\n' +
         'If not installed:\n' +
         '  1. Download: https://github.com/jackwener/opencli/releases\n' +
         '  2. Open chrome://extensions → Developer Mode → Load unpacked',

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -87,11 +87,13 @@ describe('doctor report rendering', () => {
     const text = strip(renderBrowserDoctorReport({
       daemonRunning: true,
       extensionConnected: false,
-      issues: ['Daemon is running but the Chrome extension is not connected.'],
+      issues: ['Daemon is running but the Chrome extension is not connected.\nTry running the command again — the extension may need a moment to reconnect.\nIf it still fails, reload OpenCLI in chrome://extensions and run: opencli daemon restart'],
     }));
 
     expect(text).toContain('[OK] Daemon: running on port 19825');
     expect(text).toContain('[MISSING] Extension: not connected');
+    expect(text).toContain('Try running the command again');
+    expect(text).toContain('reload OpenCLI in chrome://extensions');
   });
 
   it('renders a warning when the extension version is unknown', () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -173,7 +173,8 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     } else {
       issues.push(
         'Daemon is running but the Chrome/Chromium extension is not connected.\n' +
-        'If the extension is already installed, try: opencli daemon restart\n' +
+        'Try running the command again — the extension may need a moment to reconnect.\n' +
+        'If it still fails, reload OpenCLI in chrome://extensions and run: opencli daemon restart\n' +
         'If the extension is not installed:\n' +
         '  1. Download from https://github.com/jackwener/opencli/releases\n' +
         '  2. Open chrome://extensions/ → Enable Developer Mode\n' +

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -11,6 +11,7 @@ import {
   EmptyResultError,
   selectorError,
   toEnvelope,
+  attachTraceReceipt,
 } from './errors.js';
 
 describe('Error type hierarchy', () => {
@@ -77,6 +78,45 @@ describe('Error type hierarchy', () => {
     const err = new BrowserConnectError('Cannot connect');
     expect(err.code).toBe('BROWSER_CONNECT');
   });
+
+  it('BrowserConnectError envelope includes machine-readable layer and recovery advice', () => {
+    const err = new BrowserConnectError(
+      'Browser Bridge extension not connected',
+      'Reload the extension and retry',
+      'extension-not-connected',
+    );
+    const envelope = toEnvelope(err);
+
+    expect(envelope.error).toMatchObject({
+      code: 'BROWSER_CONNECT',
+      kind: 'extension-not-connected',
+      layer: 'browser_bridge',
+      recovery: {
+        safe: ['retry the command once'],
+        manual: expect.arrayContaining([
+          'reload the OpenCLI extension in chrome://extensions if it still fails',
+          'run opencli doctor',
+        ]),
+      },
+    });
+  });
+
+  it('BrowserConnectError envelope maps profile errors to the browser bridge layer', () => {
+    const envelope = toEnvelope(new BrowserConnectError(
+      'Multiple Browser Bridge profiles are connected',
+      undefined,
+      'profile-required',
+    ));
+
+    expect(envelope.error).toMatchObject({
+      code: 'BROWSER_CONNECT',
+      kind: 'profile-required',
+      layer: 'browser_bridge',
+      recovery: {
+        safe: expect.arrayContaining(['run opencli profile list']),
+      },
+    });
+  });
 });
 
 describe('toEnvelope', () => {
@@ -99,6 +139,28 @@ describe('toEnvelope', () => {
     const envelope = toEnvelope(err);
     expect(envelope.error.code).toBe('COMMAND_EXEC');
     expect(envelope.error).not.toHaveProperty('help');
+  });
+
+  it('preserves trace metadata on BrowserConnectError envelopes', () => {
+    const err = new BrowserConnectError('Browser Bridge extension not connected');
+    attachTraceReceipt(err, {
+      schemaVersion: 1,
+      opencliVersion: 'test',
+      traceId: 'trace-1',
+      traceDir: '/tmp/trace-1',
+      summaryPath: '/tmp/trace-1/summary.md',
+      receiptPath: '/tmp/trace-1/receipt.json',
+      status: 'failure',
+      createdAt: '2026-05-03T00:00:00.000Z',
+    });
+
+    expect(toEnvelope(err).trace).toEqual({
+      traceId: 'trace-1',
+      dir: '/tmp/trace-1',
+      summaryPath: '/tmp/trace-1/summary.md',
+      receiptPath: '/tmp/trace-1/receipt.json',
+      status: 'failure',
+    });
   });
 
   it('converts unknown Error to UNKNOWN envelope', () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -89,6 +89,76 @@ export class BrowserConnectError extends CliError {
   }
 }
 
+type BrowserConnectLayer = 'daemon' | 'browser_bridge' | 'browser_command' | 'unknown';
+
+type BrowserConnectRecovery = {
+  safe: string[];
+  manual: string[];
+};
+
+function browserConnectLayer(kind: BrowserConnectKind): BrowserConnectLayer {
+  switch (kind) {
+    case 'daemon-not-running':
+      return 'daemon';
+    case 'extension-not-connected':
+    case 'profile-required':
+    case 'profile-disconnected':
+      return 'browser_bridge';
+    case 'command-failed':
+      return 'browser_command';
+    default:
+      return 'unknown';
+  }
+}
+
+function browserConnectRecovery(kind: BrowserConnectKind): BrowserConnectRecovery {
+  switch (kind) {
+    case 'daemon-not-running':
+      return {
+        safe: ['run opencli doctor'],
+        manual: [
+          'make sure the daemon port is available',
+          'run opencli daemon stop && opencli doctor if a stale daemon is suspected',
+        ],
+      };
+    case 'extension-not-connected':
+      return {
+        safe: ['retry the command once'],
+        manual: [
+          'reload the OpenCLI extension in chrome://extensions if it still fails',
+          'run opencli doctor',
+          'run opencli daemon stop && opencli doctor if the bridge still does not reconnect',
+        ],
+      };
+    case 'profile-required':
+      return {
+        safe: [
+          'run opencli profile list',
+          'select a profile with opencli profile use <name> or pass --profile <name>',
+        ],
+        manual: ['disconnect unused Chrome profiles if profile selection is not intended'],
+      };
+    case 'profile-disconnected':
+      return {
+        safe: [
+          'open the selected Chrome profile',
+          'make sure the OpenCLI extension is enabled in that profile',
+        ],
+        manual: ['choose another connected profile with opencli profile use <name>'],
+      };
+    case 'command-failed':
+      return {
+        safe: ['retry the command once'],
+        manual: ['run opencli doctor if browser commands keep failing'],
+      };
+    default:
+      return {
+        safe: ['run opencli doctor'],
+        manual: [],
+      };
+  }
+}
+
 export class CommandExecutionError extends CliError {
   constructor(message: string, hint?: string) {
     super('COMMAND_EXEC', message, hint, EXIT_CODES.GENERIC_ERROR);
@@ -170,6 +240,9 @@ export interface ErrorEnvelope {
     code: string;
     message: string;
     help?: string;
+    kind?: string;
+    layer?: string;
+    recovery?: BrowserConnectRecovery;
     exitCode: number;
     stack?: string;
     cause?: string;
@@ -212,6 +285,22 @@ export function toEnvelope(err: unknown): ErrorEnvelope {
     receiptPath: traceReceipt.receiptPath,
     status: traceReceipt.status,
   } : undefined;
+  if (err instanceof BrowserConnectError) {
+    return {
+      ok: false,
+      error: {
+        code: err.code,
+        message: err.message,
+        ...(err.hint ? { help: err.hint } : {}),
+        kind: err.kind,
+        layer: browserConnectLayer(err.kind),
+        recovery: browserConnectRecovery(err.kind),
+        exitCode: err.exitCode,
+        ...(cause ? { cause } : {}),
+      },
+      ...(trace ? { trace } : {}),
+    };
+  }
   if (err instanceof CliError) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

Improve `BROWSER_CONNECT` failures for Browser Bridge extension disconnects.

This change makes browser connection failures easier for both humans and automation to diagnose by surfacing the existing connection kind in structured error output and by recommending the lower-risk recovery path first.

## What changed

- Add machine-readable `kind`, `layer`, and `recovery` fields to `BrowserConnectError` envelopes.
- Classify extension disconnects as the `browser_bridge` layer.
- Prefer extension reload guidance before daemon restart guidance when the daemon is running but the extension is disconnected.
- Update `doctor` messaging for extension-disconnected states.
- Add unit coverage for the structured error fields and updated recovery hint.

## Root cause

`BrowserConnectError` already tracked a coarse failure kind internally, but the CLI error envelope only exposed the generic `BROWSER_CONNECT` code. As a result, agents and scripts had to infer whether the failure was in daemon startup, extension connection, or command execution.

The human hint also jumped too quickly to daemon restart guidance, even when the lower-risk fix is reloading the already-installed OpenCLI extension in `chrome://extensions`.

## User impact

Normal successful commands remain unchanged.

On failure, users and agents get clearer, more actionable information:

- `kind: extension-not-connected`
- `layer: browser_bridge`
- safe recovery steps such as reloading the OpenCLI extension and retrying once
- manual recovery steps such as running `opencli doctor`

## Validation

- `npm test -- src/errors.test.ts src/browser.test.ts src/doctor.test.ts`
- `npm run typecheck`
