### PR TITLE
feat(boss): add --jobType filter, fix experience codes, surface bossOnline

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3275,7 +3275,7 @@
   {
     "site": "boss",
     "name": "search",
-    "description": "BOSS直聘搜索职位",
+    "description": "BOSS直聘搜索职位（不带关键词时返回为你推荐职位）",
     "domain": "www.zhipin.com",
     "strategy": "cookie",
     "browser": true,
@@ -3283,9 +3283,9 @@
       {
         "name": "query",
         "type": "str",
-        "required": true,
+        "required": false,
         "positional": true,
-        "help": "Search keyword (e.g. AI agent, 前端)"
+        "help": "Search keyword (optional, empty = recommended jobs)"
       },
       {
         "name": "city",
@@ -3299,7 +3299,7 @@
         "type": "str",
         "default": "",
         "required": false,
-        "help": "Experience: 应届/1年以内/1-3年/3-5年/5-10年/10年以上"
+        "help": "Experience: 在校生(实习)/应届生(校招)/经验不限/1年以内/1-3年/3-5年/5-10年/10年以上"
       },
       {
         "name": "degree",
@@ -3321,6 +3321,13 @@
         "default": "",
         "required": false,
         "help": "Industry code or name (e.g. 100020, 互联网)"
+      },
+      {
+        "name": "jobType",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "Job type: 全职/兼职/实习（不传=不限，混合校招与实习）"
       },
       {
         "name": "page",
@@ -3346,6 +3353,7 @@
       "degree",
       "skills",
       "boss",
+      "bossOnline",
       "security_id",
       "url"
     ],

--- a/clis/boss/search.js
+++ b/clis/boss/search.js
@@ -38,6 +38,9 @@ const INDUSTRY_MAP = {
     '人工智能': '100901', '大数据': '100902', '金融': '100101',
     '教育培训': '100200', '医疗健康': '100300',
 };
+const JOB_TYPE_MAP = {
+    '不限': '0', '全职': '1901', '实习': '1902', '兼职': '1903',
+};
 function resolveCity(input) {
     if (!input)
         return '101010100';
@@ -65,22 +68,23 @@ function resolveMap(input, map) {
 cli({
     site: 'boss',
     name: 'search',
-    description: 'BOSS直聘搜索职位',
+    description: 'BOSS直聘搜索职位（不带关键词时返回为你推荐职位）',
     domain: 'www.zhipin.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
     browser: true,
     args: [
-        { name: 'query', required: true, positional: true, help: 'Search keyword (e.g. AI agent, 前端)' },
+        { name: 'query', positional: true, help: 'Search keyword (optional, empty = recommended jobs)' },
         { name: 'city', default: '北京', help: 'City name or code (e.g. 杭州, 上海, 101010100)' },
         { name: 'experience', default: '', help: 'Experience: 应届/1年以内/1-3年/3-5年/5-10年/10年以上' },
         { name: 'degree', default: '', help: 'Degree: 大专/本科/硕士/博士' },
         { name: 'salary', default: '', help: 'Salary: 3K以下/3-5K/5-10K/10-15K/15-20K/20-30K/30-50K/50K以上' },
         { name: 'industry', default: '', help: 'Industry code or name (e.g. 100020, 互联网)' },
+        { name: 'jobType', default: '', help: 'Job type: 全职/兼职/实习（不传=不限，混合校招与实习）' },
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
         { name: 'limit', type: 'int', default: 15, help: 'Number of results' },
     ],
-    columns: ['name', 'salary', 'company', 'area', 'experience', 'degree', 'skills', 'boss', 'security_id', 'url'],
+    columns: ['name', 'salary', 'company', 'area', 'experience', 'degree', 'skills', 'boss', 'bossOnline', 'security_id', 'url'],
     func: async (page, kwargs) => {
         requirePage(page);
         const cityCode = resolveCity(kwargs.city);
@@ -91,6 +95,7 @@ cli({
         const degreeVal = resolveMap(kwargs.degree, DEGREE_MAP);
         const salaryVal = resolveMap(kwargs.salary, SALARY_MAP);
         const industryVal = resolveMap(kwargs.industry, INDUSTRY_MAP);
+        const jobTypeVal = resolveMap(kwargs.jobType, JOB_TYPE_MAP);
         const limit = kwargs.limit || 15;
         let currentPage = kwargs.page || 1;
         let allJobs = [];
@@ -114,6 +119,8 @@ cli({
                 qs.set('salary', salaryVal);
             if (industryVal)
                 qs.set('industry', industryVal);
+            if (jobTypeVal)
+                qs.set('jobType', jobTypeVal);
             const targetUrl = `https://www.zhipin.com/wapi/zpgeek/search/joblist.json?${qs.toString()}`;
             verbose(`Fetching page ${currentPage}... (current jobs: ${allJobs.length})`);
             const data = await bossFetch(page, targetUrl);
@@ -135,6 +142,7 @@ cli({
                     degree: j.jobDegree,
                     skills: (j.skills || []).join(','),
                     boss: j.bossName + ' · ' + j.bossTitle,
+                    bossOnline: j.bossOnline ? 'Y' : '',
                     security_id: j.securityId || '',
                     url: 'https://www.zhipin.com/job_detail/' + j.encryptJobId + '.html',
                 });

--- a/clis/boss/search.js
+++ b/clis/boss/search.js
@@ -22,8 +22,15 @@ const CITY_CODES = {
     '香港': '101320100',
 };
 const EXP_MAP = {
-    '不限': '0', '在校/应届': '108', '应届': '108', '1年以内': '101',
-    '1-3年': '102', '3-5年': '103', '5-10年': '104', '10年以上': '105',
+    '不限': '0',
+    '在校生': '108', '在校': '108',
+    '应届生': '102', '应届': '102',
+    '经验不限': '101',
+    '1年以内': '103',
+    '1-3年': '104',
+    '3-5年': '105',
+    '5-10年': '106',
+    '10年以上': '107',
 };
 const DEGREE_MAP = {
     '不限': '0', '初中及以下': '209', '中专/中技': '208', '高中': '206',
@@ -76,7 +83,7 @@ cli({
     args: [
         { name: 'query', positional: true, help: 'Search keyword (optional, empty = recommended jobs)' },
         { name: 'city', default: '北京', help: 'City name or code (e.g. 杭州, 上海, 101010100)' },
-        { name: 'experience', default: '', help: 'Experience: 应届/1年以内/1-3年/3-5年/5-10年/10年以上' },
+        { name: 'experience', default: '', help: 'Experience: 在校生(实习)/应届生(校招)/经验不限/1年以内/1-3年/3-5年/5-10年/10年以上' },
         { name: 'degree', default: '', help: 'Degree: 大专/本科/硕士/博士' },
         { name: 'salary', default: '', help: 'Salary: 3K以下/3-5K/5-10K/10-15K/15-20K/20-30K/30-50K/50K以上' },
         { name: 'industry', default: '', help: 'Industry code or name (e.g. 100020, 互联网)' },

--- a/clis/boss/search.js
+++ b/clis/boss/search.js
@@ -24,6 +24,7 @@ const CITY_CODES = {
 };
 const EXP_MAP = {
     '不限': '0',
+    '在校/应届': '108',
     '在校生': '108', '在校': '108',
     '应届生': '102', '应届': '102',
     '经验不限': '101',
@@ -188,6 +189,8 @@ cli({
     },
 });
 export const __test__ = {
+    EXP_MAP,
+    resolveMap,
     resolveJobType,
     formatBossOnline,
 };

--- a/clis/boss/search.js
+++ b/clis/boss/search.js
@@ -2,6 +2,7 @@
  * BOSS直聘 job search — browser cookie API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { requirePage, navigateTo, bossFetch, verbose } from './utils.js';
 /** City name → BOSS Zhipin city code mapping */
 const CITY_CODES = {
@@ -48,6 +49,7 @@ const INDUSTRY_MAP = {
 const JOB_TYPE_MAP = {
     '不限': '0', '全职': '1901', '实习': '1902', '兼职': '1903',
 };
+const JOB_TYPE_CODES = new Set(Object.values(JOB_TYPE_MAP));
 function resolveCity(input) {
     if (!input)
         return '101010100';
@@ -72,6 +74,22 @@ function resolveMap(input, map) {
     }
     return input;
 }
+function resolveJobType(input) {
+    if (!input)
+        return '';
+    if (JOB_TYPE_MAP[input] !== undefined)
+        return JOB_TYPE_MAP[input];
+    if (JOB_TYPE_CODES.has(input))
+        return input;
+    throw new ArgumentError(`Invalid jobType: ${input}`, 'Use one of: 全职, 兼职, 实习, 不限');
+}
+function formatBossOnline(value) {
+    if (value === true)
+        return 'Y';
+    if (value === false)
+        return 'N';
+    return '';
+}
 cli({
     site: 'boss',
     name: 'search',
@@ -94,15 +112,16 @@ cli({
     columns: ['name', 'salary', 'company', 'area', 'experience', 'degree', 'skills', 'boss', 'bossOnline', 'security_id', 'url'],
     func: async (page, kwargs) => {
         requirePage(page);
+        const query = String(kwargs.query ?? '').trim();
         const cityCode = resolveCity(kwargs.city);
         verbose('Navigating to set referrer context...');
-        await navigateTo(page, `https://www.zhipin.com/web/geek/job?query=${encodeURIComponent(kwargs.query)}&city=${cityCode}`);
+        await navigateTo(page, `https://www.zhipin.com/web/geek/job?query=${encodeURIComponent(query)}&city=${cityCode}`);
         await new Promise(r => setTimeout(r, 1000));
         const expVal = resolveMap(kwargs.experience, EXP_MAP);
         const degreeVal = resolveMap(kwargs.degree, DEGREE_MAP);
         const salaryVal = resolveMap(kwargs.salary, SALARY_MAP);
         const industryVal = resolveMap(kwargs.industry, INDUSTRY_MAP);
-        const jobTypeVal = resolveMap(kwargs.jobType, JOB_TYPE_MAP);
+        const jobTypeVal = resolveJobType(kwargs.jobType);
         const limit = kwargs.limit || 15;
         let currentPage = kwargs.page || 1;
         let allJobs = [];
@@ -113,7 +132,7 @@ cli({
             }
             const qs = new URLSearchParams({
                 scene: '1',
-                query: kwargs.query,
+                query,
                 city: cityCode,
                 page: String(currentPage),
                 pageSize: '15',
@@ -149,7 +168,7 @@ cli({
                     degree: j.jobDegree,
                     skills: (j.skills || []).join(','),
                     boss: j.bossName + ' · ' + j.bossTitle,
-                    bossOnline: j.bossOnline ? 'Y' : '',
+                    bossOnline: formatBossOnline(j.bossOnline),
                     security_id: j.securityId || '',
                     url: 'https://www.zhipin.com/job_detail/' + j.encryptJobId + '.html',
                 });
@@ -168,3 +187,7 @@ cli({
         return allJobs;
     },
 });
+export const __test__ = {
+    resolveJobType,
+    formatBossOnline,
+};

--- a/clis/boss/search.test.js
+++ b/clis/boss/search.test.js
@@ -15,6 +15,11 @@ function createPageMock(response) {
 describe('boss search', () => {
     const command = getRegistry().get('boss/search');
 
+    it('keeps legacy 在校/应届 experience input compatible', () => {
+        expect(__test__.resolveMap('在校/应届', __test__.EXP_MAP)).toBe('108');
+        expect(__test__.resolveMap('应届', __test__.EXP_MAP)).toBe('102');
+    });
+
     it('fails fast on invalid jobType values', async () => {
         expect(() => __test__.resolveJobType('外包')).toThrow(ArgumentError);
     });

--- a/clis/boss/search.test.js
+++ b/clis/boss/search.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './search.js';
+import './search.js';
+
+function createPageMock(response) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(response),
+    };
+}
+
+describe('boss search', () => {
+    const command = getRegistry().get('boss/search');
+
+    it('fails fast on invalid jobType values', async () => {
+        expect(() => __test__.resolveJobType('外包')).toThrow(ArgumentError);
+    });
+
+    it('accepts supported jobType labels and raw codes', () => {
+        expect(__test__.resolveJobType('全职')).toBe('1901');
+        expect(__test__.resolveJobType('实习')).toBe('1902');
+        expect(__test__.resolveJobType('兼职')).toBe('1903');
+        expect(__test__.resolveJobType('1902')).toBe('1902');
+    });
+
+    it('keeps empty query empty and sends jobType filter to the API', async () => {
+        const page = createPageMock({
+            code: 0,
+            zpData: {
+                hasMore: false,
+                jobList: [
+                    {
+                        encryptJobId: 'abc',
+                        securityId: 'sec',
+                        jobName: '前端开发实习生',
+                        salaryDesc: '150-200/天',
+                        brandName: 'OpenCLI',
+                        cityName: '北京',
+                        areaDistrict: '海淀区',
+                        businessDistrict: '',
+                        jobExperience: '在校/应届',
+                        jobDegree: '本科',
+                        skills: ['JavaScript'],
+                        bossName: '张三',
+                        bossTitle: '技术负责人',
+                        bossOnline: false,
+                    },
+                ],
+            },
+        });
+
+        const rows = await command.func(page, {
+            query: undefined,
+            city: '北京',
+            jobType: '实习',
+            limit: 1,
+            page: 1,
+        });
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.zhipin.com/web/geek/job?query=&city=101010100');
+        const fetchScript = page.evaluate.mock.calls.at(-1)[0];
+        expect(fetchScript).toContain('query=');
+        expect(fetchScript).not.toContain('query=undefined');
+        expect(fetchScript).toContain('jobType=1902');
+        expect(rows[0]).toMatchObject({
+            name: '前端开发实习生',
+            bossOnline: 'N',
+        });
+    });
+});


### PR DESCRIPTION
## Description

Three changes to `boss search`, all driven by debugging why `--experience 应届 --degree 硕士` returned mostly internships instead of new-grad full-time roles. Verified all codes by clicking each filter in BOSS web UI and reading the URL parameter (`window.location.href`).

### 1. `fix(boss):` experience codes were off-by-N

Every value below `应届` in `EXP_MAP` was wrong. Verified live against BOSS web filter:

| Label | Was | Should be |
|---|---|---|
| 应届 (应届生) | `108` | `102` |
| 1年以内 | `101` | `103` |
| 1-3年 | `102` | `104` |
| 3-5年 | `103` | `105` |
| 5-10年 | `104` | `106` |
| 10年以上 | `105` | `107` |

`108` is actually 在校生 (interns), so `--experience 应届` was secretly querying internships. Same shift for the rest. Also added `经验不限 = 101`, `在校生 = 108` (with `在校` alias), and renamed primary key from `应届` to `应届生 = 102` (kept `应届` as alias for backward compat).

### 2. `feat(boss):` add `--jobType` filter

BOSS web UI has a 求职类型 (job type) filter not exposed in the CLI. Verified codes by clicking each option and reading the URL:

- `1901` = 全职
- `1902` = 实习
- `1903` = 兼职

Added `--jobType 全职/兼职/实习`. This is independent from `--experience`: e.g. you can query 应届生 + 全职 to get校招 only, or 在校生 + 实习 to get only internships.

### 3. `feat(boss):` surface `bossOnline` in output

The API already returns `bossOnline: bool` per job. Now exposed as a `Y` / empty column so callers can prioritize HRs currently online. (BOSS web API does **not** support recently-active / new-posted filters — those are mobile-only — so this is the only activity signal available.)

### Also (minor, unrelated)

The diff also includes two small pre-existing changes I picked up: `query` is no longer `required: true`, and the description gained a note that empty query returns recommended jobs. The BOSS API does support empty-query mode and returns recommendations, so this matches actual behavior. Happy to split these out if you'd prefer a narrower PR.

Related issue: none

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed (no boss tests exist; help strings updated)
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter) — N/A, not a new adapter
- [ ] Updated `docs/adapters/index.md` table (if new adapter) — N/A
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter) — N/A
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error` (no new error paths)

## Screenshots / Output

### Bug fix: `--experience 应届` before vs after

**Before** (`应届 = 108`, secretly = 在校生):

```bash
$ opencli boss search "AI Agent" --city 杭州 --experience 应届 --degree 硕士 --limit 3 -f json
# All results are interns at 200-500 元/天:
[
  { "name": "AI Agent开发工程师-27实习", "salary": "300-400元/天", "company": "华为云", ... },
  { "name": "AI agent全栈实习生", "salary": "400-450元/天", "company": "滴滴", ... },
  { "name": "AI agent实习生", "salary": "150-300元/天", ... }
]
```

**After** (`应届 = 102` = 应届生):

```bash
$ opencli boss search "AI Agent" --city 杭州 --experience 应届 --degree 硕士 --limit 3 -f json
# Real校招 positions at K-level salaries:
[
  { "name": "AI agent 优化工程师（训练、数据、评测）", "salary": "5-10K", "company": "阿里巴巴集团", ... },
  { "name": "【27年应届实习】AI Agent 开发工程师", "salary": "11-15K", "company": "阿里云", ... },
  { "name": "淘天-AI Agent优化工程师-训练/数据/评测", "salary": "25-50K·16薪", "company": "阿里巴巴集团", ... }
]
```

### Feature: `--jobType 全职`

```bash
$ opencli boss search "AI Agent" --city 杭州 --degree 硕士 --jobType 全职 --limit 3 -f json
[
  { "name": "高级AI Agent算法专家", "salary": "80-110K·16薪", "experience": "5-10年", ... },
  { "name": "AI agent工程师", "salary": "12-20K", "experience": "1-3年", ... },
  { "name": "天猫技术-AI Agent应用开发工程师", "salary": "25-50K·16薪", "experience": "1-3年", ... }
]
```

All results are full-time with K-level salaries — no `元/天` internship entries.

### Feature: `bossOnline` column

```bash
$ opencli boss search "Java" --city 杭州 --jobType 全职 --limit 5 -f table
┌──────────────────────┬────────────┬───────────────┬──────────────────┬───────────┐
│ name                 │ salary     │ company       │ boss             │ bossOnline│
├──────────────────────┼────────────┼───────────────┼──────────────────┼───────────┤
│ Java开发工程师       │ 25-40K·16薪│ 阿里巴巴集团  │ 张三 · 后端开发  │ Y         │
│ ...                  │ ...        │ ...           │ ...              │           │
└──────────────────────┴────────────┴───────────────┴──────────────────┴───────────┘
```

### Validation

- `npx tsc --noEmit` → pass
- `npm run test:adapter` → 1132 passed; 9 failures are pre-existing in unrelated adapters (instagram/twitter/xiaoyuzhou), not touched by this PR
- `npm run build-manifest` → `Manifest compiled: 632 entries`
- Manifest regeneration (boss/search entry) is included in this PR