### PR TITLE
fix(extension): prevent Chrome focus steal on macOS during automation

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -686,6 +686,13 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl) {
   });
   ownedContainerWindowId = win.id;
   console.log(`[opencli] Created owned automation container window ${ownedContainerWindowId} (start=${startUrl})`);
+  if (!windowFocused) {
+    try {
+      await chrome.windows.update(ownedContainerWindowId, { state: "minimized", focused: false });
+    } catch (e) {
+      console.warn("[opencli] minimize automation window failed:", e);
+    }
+  }
   const tabs = await chrome.tabs.query({ windowId: win.id });
   const initialTabId = tabs[0]?.id;
   if (initialTabId) {
@@ -742,7 +749,7 @@ async function createOwnedTabLeaseUnlocked(workspace, initialUrl) {
       tab = await chrome.tabs.get(initialTabId);
     }
   } else {
-    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
+    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: windowFocused });
   }
   if (!tab.id) throw new Error("Failed to create tab lease in automation container");
   setWorkspaceSession(workspace, {
@@ -1083,7 +1090,7 @@ async function resolveTab(tabId, workspace, initialUrl) {
     } catch {
     }
   }
-  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
+  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: windowFocused });
   if (!newTab.id) throw new Error("Failed to create tab in automation container");
   return { tabId: newTab.id, tab: newTab };
 }
@@ -1269,7 +1276,7 @@ async function handleTabs(cmd, workspace) {
         return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
       }
       const windowId = await getAutomationWindow(workspace);
-      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: windowFocused });
       if (!tab.id) return { id: cmd.id, ok: false, error: "Failed to create tab" };
       setWorkspaceSession(workspace, {
         windowId: tab.windowId,

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -282,7 +282,9 @@ describe('background tab isolation', () => {
     const result = await mod.__test__.handleTabs({ id: '2', action: 'tabs', op: 'new', url: 'https://new.example', workspace: 'site:twitter' }, 'site:twitter');
 
     expect(result.ok).toBe(true);
-    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'https://new.example', active: true });
+    // active follows windowFocused (false by default — keeps Chrome in the background
+    // so opencli automation doesn't steal focus from the user). Pass --focus to flip.
+    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'https://new.example', active: false });
   });
 
   it('reuses the initial container tab for first tab-new lease instead of leaving a blank tab', async () => {
@@ -500,7 +502,7 @@ describe('background tab isolation', () => {
     }));
     expect(maxInFlight).toBe(2);
     expect(chrome.windows.create).toHaveBeenCalledTimes(1);
-    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'about:blank', active: true });
+    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'about:blank', active: false });
   });
 
   it('releases owned workspaces as tab leases before closing the shared container', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -379,6 +379,18 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<
   ownedContainerWindowId = win.id!;
   console.log(`[opencli] Created owned automation container window ${ownedContainerWindowId} (start=${startUrl})`);
 
+  // macOS 15.x (and intermittently 26.x) ignore `focused: false` on windows.create
+  // and pull the new window to the foreground anyway. See issue #739. Counteract by
+  // minimizing the window right after creation. `state: 'minimized'` is rejected when
+  // combined with width/height in create(), but is fine on update().
+  if (!windowFocused) {
+    try {
+      await chrome.windows.update(ownedContainerWindowId, { state: 'minimized', focused: false });
+    } catch (e) {
+      console.warn('[opencli] minimize automation window failed:', e);
+    }
+  }
+
   // Wait for the initial tab to finish loading instead of a fixed 200ms sleep.
   const tabs = await chrome.tabs.query({ windowId: win.id! });
   const initialTabId = tabs[0]?.id;
@@ -444,7 +456,7 @@ async function createOwnedTabLeaseUnlocked(workspace: string, initialUrl?: strin
       tab = await chrome.tabs.get(initialTabId);
     }
   } else {
-    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
+    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: windowFocused });
   }
   if (!tab.id) throw new Error('Failed to create tab lease in automation container');
 
@@ -869,7 +881,7 @@ async function resolveTab(tabId: number | undefined, workspace: string, initialU
   }
 
   // Fallback: create a new tab
-  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
+  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: windowFocused });
   if (!newTab.id) throw new Error('Failed to create tab in automation container');
   return { tabId: newTab.id, tab: newTab };
 }
@@ -1092,7 +1104,7 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
         return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
       }
       const windowId = await getAutomationWindow(workspace);
-      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: windowFocused });
       if (!tab.id) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
       setWorkspaceSession(workspace, {
         windowId: tab.windowId,

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -156,7 +156,21 @@ async function sendCommandRaw(
     const id = generateId();
     const wf = process.env.OPENCLI_WINDOW_FOCUSED;
     const windowFocused = (wf === '1' || wf === 'true') ? true : undefined;
-    const command: DaemonCommand = { id, action, ...params, ...(windowFocused && { windowFocused }) };
+    // OPENCLI_IDLE_TIMEOUT_MS lets callers (e.g. polling pipelines) keep the
+    // automation window alive longer than the 30s extension default, so successive
+    // commands reuse the same window instead of forcing a new windows.create() — the
+    // real focus-steal trigger on macOS 15.x. cmd.idleTimeout is in seconds; convert.
+    const itm = process.env.OPENCLI_IDLE_TIMEOUT_MS;
+    const idleTimeoutFromEnv = itm && /^\d+$/.test(itm)
+      ? Math.max(0, Math.floor(parseInt(itm, 10) / 1000))
+      : undefined;
+    const command: DaemonCommand = {
+      id,
+      action,
+      ...params,
+      ...(windowFocused && { windowFocused }),
+      ...(idleTimeoutFromEnv !== undefined && params.idleTimeout === undefined && { idleTimeout: idleTimeoutFromEnv }),
+    };
     try {
       const res = await requestDaemon('/command', {
         method: 'POST',


### PR DESCRIPTION
## Background

On macOS 15.x (and intermittently 26.x), `chrome.windows.create({ focused: false })` is **not honored** by the OS window server — the new automation window gets pulled to the foreground regardless. Combined with the default 30s `WINDOW_IDLE_TIMEOUT`, polling pipelines that call opencli every minute or so see the window destroyed → recreated on every cycle, stealing terminal focus each time.

Reported and discussed in: #739, #1071, #684, #721.

I'm running an ml-scout pipeline that bursts ~50 `opencli twitter list-tweets` calls during recall — every burst yanked Chrome to the foreground 5-10x. After this PR (and `OPENCLI_IDLE_TIMEOUT_MS=600000` on the caller side), zero focus steals across a full recall cycle.

## What's changed

Three independent layers, smallest blast radius first:

### 1. Tab activation follows window focus state (`extension/src/background.ts`)

Three `chrome.tabs.create({ active: true })` call sites unconditionally activated the new tab regardless of `windowFocused`:

- `createOwnedTabLeaseUnlocked` (L447) — first tab when starting a session
- Shared-tab fallback (L872)
- `tabs new` op (L1095)

Switched all three to `active: windowFocused`. When users pass `--focus`, behavior is unchanged. The two `chrome.tabs.update({ active: true })` calls in `tabs select` are kept as-is — `select` is explicitly an "activate this tab" command.

### 2. Force-minimize the automation window right after creation

`state: 'minimized'` is rejected by `windows.create` when combined with `width`/`height` (root cause of #545), but `windows.update` accepts it. After creating the automation window with `focused: false`, we immediately call:

```ts
await chrome.windows.update(ownedContainerWindowId, { state: 'minimized', focused: false });
```

Even if macOS briefly stole focus during `create`, the window is dumped to the dock within ~50ms. The catch wraps it so the existing flow isn't broken if the update ever fails.

### 3. New env var `OPENCLI_IDLE_TIMEOUT_MS` (`src/browser/daemon-client.ts`)

Polling pipelines hit the 30s default repeatedly. Setting `OPENCLI_IDLE_TIMEOUT_MS=600000` keeps the same automation window alive across calls — eliminating most `windows.create` invocations, which is the actual focus-steal trigger. Plumbing reuses the existing `cmd.idleTimeout` field; explicit per-command overrides still win over the env var.

## Risk / compatibility

- Default behavior unchanged for users not passing `--focus` and not setting the env var, except: tabs created during automation are no longer marked active. That's a behavior change but matches the `windowFocused: false` window contract — the only consumers that depended on `active: true` were the unit tests (updated below).
- `--focus` flag: behavior fully preserved.
- The minimize call adds one Chrome API roundtrip on `windows.create` (a few ms). Negligible vs. the existing initial-tab load wait.
- No new dependencies, no schema changes, no breaking API.

## Tests

- `extension` project: 37 pass / 1 skip (pre-existing).
- Updated 2 tests in `extension/src/background.test.ts` where the expected `active: true` argument changed to `active: false` (now matches the default `windowFocused: false`).
- Manual: real ml-scout multi-platform recall (X / XHS / YouTube / HN) over a full pipeline run — no focus steals; window stays minimized; daemon-side `OPENCLI_IDLE_TIMEOUT_MS=600000` confirmed honored.