### PR TITLE
fix(twitter/following): limit>50 now works via cursor pagination

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -15044,7 +15044,7 @@
     "name": "following",
     "description": "Get accounts a Twitter/X user is following",
     "domain": "x.com",
-    "strategy": "intercept",
+    "strategy": "cookie",
     "browser": true,
     "args": [
       {
@@ -15071,7 +15071,7 @@
     "type": "js",
     "modulePath": "twitter/following.js",
     "sourceFile": "twitter/following.js",
-    "navigateBefore": true
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { resolveTwitterQueryId, sanitizeQueryId } from './shared.js';
 
 const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
@@ -127,6 +127,10 @@ function parseFollowing(data) {
     return { users, nextCursor };
 }
 
+function normalizeScreenName(value) {
+    return String(value || '').trim().replace(/^\/+/, '').replace(/^@+/, '');
+}
+
 cli({
     site: 'twitter',
     name: 'following',
@@ -140,8 +144,11 @@ cli({
     ],
     columns: ['screen_name', 'name', 'bio', 'followers'],
     func: async (page, kwargs) => {
-        const limit = kwargs.limit || 50;
-        let targetUser = kwargs.user;
+        const limit = kwargs.limit === undefined || kwargs.limit === null ? 50 : Number(kwargs.limit);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('twitter following --limit must be a positive integer', 'Example: opencli twitter following @elonmusk --limit 200');
+        }
+        let targetUser = normalizeScreenName(kwargs.user);
 
         await page.goto('https://x.com');
         await page.wait(3);
@@ -159,7 +166,10 @@ cli({
             }`);
             if (!href)
                 throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
-            targetUser = href.replace('/', '');
+            targetUser = normalizeScreenName(href.replace('/', ''));
+        }
+        if (!targetUser) {
+            throw new ArgumentError('twitter following user cannot be empty', 'Example: opencli twitter following @elonmusk --limit 200');
         }
 
         const followingQueryId = await resolveTwitterQueryId(page, 'Following', FOLLOWING_QUERY_ID);
@@ -172,13 +182,20 @@ cli({
         });
 
         // Get userId from screen_name
-        const userId = await page.evaluate(`async () => {
+        const userLookup = await page.evaluate(`async () => {
             const url = ${JSON.stringify(buildUserByScreenNameUrl(userByScreenNameQueryId, targetUser))};
             const resp = await fetch(url, { headers: ${headers}, credentials: 'include' });
-            if (!resp.ok) return null;
+            if (!resp.ok) return { error: resp.status };
             const d = await resp.json();
-            return d.data?.user?.result?.rest_id || null;
+            return { userId: d.data?.user?.result?.rest_id || null };
         }`);
+        if (userLookup?.error === 401 || userLookup?.error === 403) {
+            throw new AuthRequiredError('x.com', `Twitter user lookup failed (HTTP ${userLookup.error})`);
+        }
+        if (userLookup?.error) {
+            throw new CommandExecutionError(`HTTP ${userLookup.error}: Failed to resolve Twitter user @${targetUser}`);
+        }
+        const userId = userLookup?.userId || null;
         if (!userId)
             throw new CommandExecutionError(`Could not find user @${targetUser}`);
 
@@ -186,7 +203,8 @@ cli({
         const seen = new Set();
         let cursor = null;
 
-        for (let i = 0; i < 10 && allUsers.length < limit; i++) {
+        const maxPages = Math.ceil(limit / 50) + 2;
+        for (let i = 0; i < maxPages && allUsers.length < limit; i++) {
             const fetchCount = Math.min(50, limit - allUsers.length + 10);
             const apiUrl = buildFollowingUrl(followingQueryId, userId, fetchCount, cursor);
             const data = await page.evaluate(`async () => {
@@ -194,9 +212,9 @@ cli({
                 return r.ok ? await r.json() : { error: r.status };
             }`);
             if (data?.error) {
-                if (allUsers.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch following list. queryId may have expired.`);
-                break;
+                if (data.error === 401 || data.error === 403)
+                    throw new AuthRequiredError('x.com', `Twitter following request failed (HTTP ${data.error})`);
+                throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch following list. queryId may have expired.`);
             }
             const { users, nextCursor } = parseFollowing(data);
             for (const u of users) {
@@ -210,6 +228,10 @@ cli({
             cursor = nextCursor;
         }
 
+        if (allUsers.length === 0) {
+            throw new EmptyResultError('twitter following', `No following accounts found for @${targetUser}`);
+        }
+
         return allUsers.slice(0, limit);
     },
 });
@@ -219,5 +241,6 @@ export const __test__ = {
     buildFollowingUrl,
     buildUserByScreenNameUrl,
     extractUser,
+    normalizeScreenName,
     parseFollowing,
 };

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -1,11 +1,138 @@
-import { AuthRequiredError, SelectorError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { resolveTwitterQueryId, sanitizeQueryId } from './shared.js';
+
+const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+const FOLLOWING_QUERY_ID = 'zx6e-TLzRkeDO_a7p4b3JQ';  // Following fallback
+const USER_BY_SCREEN_NAME_QUERY_ID = 'qRednkZG-rn1P6b48NINmQ';
+
+const FEATURES = {
+    rweb_video_screen_enabled: false,
+    profile_label_improvements_pcf_label_in_post_enabled: true,
+    responsive_web_profile_redirect_enabled: false,
+    rweb_tipjar_consumption_enabled: false,
+    verified_phone_label_enabled: false,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    premium_content_api_read_enabled: false,
+    communities_web_enable_tweet_community_results_fetch: true,
+    c9s_tweet_anatomy_moderator_badge_enabled: true,
+    responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+    responsive_web_grok_analyze_post_followups_enabled: true,
+    responsive_web_jetfuel_frame: true,
+    responsive_web_grok_share_attachment_enabled: true,
+    responsive_web_grok_annotations_enabled: true,
+    articles_preview_enabled: true,
+    responsive_web_edit_tweet_api_enabled: true,
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+    view_counts_everywhere_api_enabled: true,
+    longform_notetweets_consumption_enabled: true,
+    responsive_web_twitter_article_tweet_consumption_enabled: true,
+    tweet_awards_web_tipping_enabled: false,
+    content_disclosure_indicator_enabled: true,
+    content_disclosure_ai_generated_indicator_enabled: true,
+    responsive_web_grok_show_grok_translated_post: false,
+    responsive_web_grok_analysis_button_from_backend: true,
+    post_ctas_fetch_enabled: false,
+    freedom_of_speech_not_reach_fetch_enabled: true,
+    standardized_nudges_misinfo: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    longform_notetweets_rich_text_read_enabled: true,
+    longform_notetweets_inline_media_enabled: false,
+    responsive_web_grok_image_annotation_enabled: true,
+    responsive_web_grok_imagine_annotation_enabled: true,
+    responsive_web_grok_community_note_auto_translation_is_enabled: false,
+    responsive_web_enhance_cards_enabled: false,
+};
+
+function buildFollowingUrl(queryId, userId, count, cursor) {
+    const vars = {
+        userId,
+        count,
+        includePromotedContent: false,
+        withClientEventToken: false,
+        withBirdwatchNotes: false,
+        withVoice: true,
+        withV2Timeline: true,
+    };
+    if (cursor)
+        vars.cursor = cursor;
+    return `/i/api/graphql/${queryId}/Following`
+        + `?variables=${encodeURIComponent(JSON.stringify(vars))}`
+        + `&features=${encodeURIComponent(JSON.stringify(FEATURES))}`;
+}
+
+function buildUserByScreenNameUrl(queryId, screenName) {
+    const vars = JSON.stringify({ screen_name: screenName, withSafetyModeUserFields: true });
+    const feats = JSON.stringify({
+        hidden_profile_subscriptions_enabled: true,
+        rweb_tipjar_consumption_enabled: true,
+        responsive_web_graphql_exclude_directive_enabled: true,
+        verified_phone_label_enabled: false,
+        subscriptions_verification_info_is_identity_verified_enabled: true,
+        subscriptions_verification_info_verified_since_enabled: true,
+        highlights_tweets_tab_ui_enabled: true,
+        responsive_web_twitter_article_notes_tab_enabled: true,
+        subscriptions_feature_can_gift_premium: true,
+        creator_subscriptions_tweet_preview_api_enabled: true,
+        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+        responsive_web_graphql_timeline_navigation_enabled: true,
+    });
+    return `/i/api/graphql/${queryId}/UserByScreenName`
+        + `?variables=${encodeURIComponent(vars)}`
+        + `&features=${encodeURIComponent(feats)}`;
+}
+
+function extractUser(result) {
+    if (!result || result.__typename !== 'User')
+        return null;
+    const core = result.core || {};
+    const legacy = result.legacy || {};
+    return {
+        screen_name: core.screen_name || legacy.screen_name || 'unknown',
+        name: core.name || legacy.name || 'unknown',
+        bio: legacy.description || result.profile_bio?.description || '',
+        followers: legacy.followers_count || legacy.normal_followers_count || 0,
+    };
+}
+
+function parseFollowing(data) {
+    const users = [];
+    let nextCursor = null;
+    const instructions = data?.data?.user?.result?.timeline_v2?.timeline?.instructions
+        || data?.data?.user?.result?.timeline?.timeline?.instructions
+        || [];
+    for (const inst of instructions) {
+        for (const entry of inst.entries || []) {
+            const content = entry.content;
+            // Extract cursor
+            if (content?.entryType === 'TimelineTimelineCursor' || content?.__typename === 'TimelineTimelineCursor') {
+                if (content.cursorType === 'Bottom' || content.cursorType === 'ShowMore')
+                    nextCursor = content.value;
+                continue;
+            }
+            if (entry.entryId?.startsWith('cursor-bottom-') || entry.entryId?.startsWith('cursor-showMore-')) {
+                nextCursor = content?.value || content?.itemContent?.value || nextCursor;
+                continue;
+            }
+            // Extract user
+            if (entry.entryId?.startsWith('user-')) {
+                const user = extractUser(content?.itemContent?.user_results?.result);
+                if (user)
+                    users.push(user);
+            }
+        }
+    }
+    return { users, nextCursor };
+}
+
 cli({
     site: 'twitter',
     name: 'following',
     description: 'Get accounts a Twitter/X user is following',
     domain: 'x.com',
-    strategy: Strategy.INTERCEPT,
+    strategy: Strategy.COOKIE,
     browser: true,
     args: [
         { name: 'user', positional: true, type: 'string', required: false },
@@ -13,83 +140,84 @@ cli({
     ],
     columns: ['screen_name', 'name', 'bio', 'followers'],
     func: async (page, kwargs) => {
+        const limit = kwargs.limit || 50;
         let targetUser = kwargs.user;
-        // If no user is specified, figure out the logged-in user's handle
-        if (!targetUser) {
-            await page.goto('https://x.com/home');
-            await page.wait({ selector: '[data-testid="primaryColumn"]' });
-            const href = await page.evaluate(`() => {
-            const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
-            return link ? link.getAttribute('href') : null;
+
+        await page.goto('https://x.com');
+        await page.wait(3);
+
+        const ct0 = await page.evaluate(`() => {
+            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
         }`);
-            if (!href) {
-                throw new AuthRequiredError('x.com', 'Could not find logged-in user profile link. Are you logged in?');
-            }
+        if (!ct0)
+            throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
+
+        if (!targetUser) {
+            const href = await page.evaluate(`() => {
+                const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
+                return link ? link.getAttribute('href') : null;
+            }`);
+            if (!href)
+                throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
             targetUser = href.replace('/', '');
         }
-        // 1. Navigate to profile page
-        await page.goto(`https://x.com/${targetUser}`);
-        await page.wait(3);
-        // 2. Install interceptor BEFORE SPA navigation.
-        //    goto() resets JS context, but SPA click preserves it.
-        await page.installInterceptor('Following');
-        // 3. Click the following link via SPA navigation (preserves interceptor)
-        const safeUser = JSON.stringify(targetUser);
-        const clicked = await page.evaluate(`() => {
-        const target = ${safeUser};
-        const link = document.querySelector('a[href="/' + target + '/following"]');
-        if (link) { link.click(); return true; }
-        return false;
-    }`);
-        if (!clicked) {
-            throw new SelectorError('Twitter following link', 'Twitter may have changed the layout.');
-        }
-        await page.waitForCapture(5);
-        // 4. Scroll to trigger pagination API calls
-        await page.autoScroll({ times: Math.ceil(kwargs.limit / 20), delayMs: 2000 });
-        // 5. Retrieve intercepted data
-        const requests = await page.getInterceptedRequests();
-        const requestList = Array.isArray(requests) ? requests : [];
-        if (requestList.length === 0) {
-            return [];
-        }
-        let results = [];
-        for (const req of requestList) {
-            try {
-                // GraphQL response: { data: { user: { result: { timeline: ... } } } }
-                let instructions = req.data?.user?.result?.timeline?.timeline?.instructions;
-                if (!instructions)
-                    continue;
-                let addEntries = instructions.find((i) => i.type === 'TimelineAddEntries');
-                if (!addEntries) {
-                    addEntries = instructions.find((i) => i.entries && Array.isArray(i.entries));
-                }
-                if (!addEntries)
-                    continue;
-                for (const entry of addEntries.entries) {
-                    if (!entry.entryId.startsWith('user-'))
-                        continue;
-                    const item = entry.content?.itemContent?.user_results?.result;
-                    if (!item || item.__typename !== 'User')
-                        continue;
-                    const core = item.core || {};
-                    const legacy = item.legacy || {};
-                    results.push({
-                        screen_name: core.screen_name || legacy.screen_name || 'unknown',
-                        name: core.name || legacy.name || 'unknown',
-                        bio: legacy.description || item.profile_bio?.description || '',
-                        followers: legacy.followers_count || legacy.normal_followers_count || 0
-                    });
+
+        const followingQueryId = await resolveTwitterQueryId(page, 'Following', FOLLOWING_QUERY_ID);
+        const userByScreenNameQueryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
+        const headers = JSON.stringify({
+            'Authorization': `Bearer ${decodeURIComponent(BEARER_TOKEN)}`,
+            'X-Csrf-Token': ct0,
+            'X-Twitter-Auth-Type': 'OAuth2Session',
+            'X-Twitter-Active-User': 'yes',
+        });
+
+        // Get userId from screen_name
+        const userId = await page.evaluate(`async () => {
+            const url = ${JSON.stringify(buildUserByScreenNameUrl(userByScreenNameQueryId, targetUser))};
+            const resp = await fetch(url, { headers: ${headers}, credentials: 'include' });
+            if (!resp.ok) return null;
+            const d = await resp.json();
+            return d.data?.user?.result?.rest_id || null;
+        }`);
+        if (!userId)
+            throw new CommandExecutionError(`Could not find user @${targetUser}`);
+
+        const allUsers = [];
+        const seen = new Set();
+        let cursor = null;
+
+        for (let i = 0; i < 10 && allUsers.length < limit; i++) {
+            const fetchCount = Math.min(50, limit - allUsers.length + 10);
+            const apiUrl = buildFollowingUrl(followingQueryId, userId, fetchCount, cursor);
+            const data = await page.evaluate(`async () => {
+                const r = await fetch("${apiUrl}", { headers: ${headers}, credentials: 'include' });
+                return r.ok ? await r.json() : { error: r.status };
+            }`);
+            if (data?.error) {
+                if (allUsers.length === 0)
+                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch following list. queryId may have expired.`);
+                break;
+            }
+            const { users, nextCursor } = parseFollowing(data);
+            for (const u of users) {
+                if (!seen.has(u.screen_name)) {
+                    seen.add(u.screen_name);
+                    allUsers.push(u);
                 }
             }
-            catch (e) {
-                // ignore parsing errors for individual payloads
-            }
+            if (!nextCursor || nextCursor === cursor)
+                break;
+            cursor = nextCursor;
         }
-        // Deduplicate by screen_name
-        const unique = new Map();
-        results.forEach(r => unique.set(r.screen_name, r));
-        const deduplicatedResults = Array.from(unique.values());
-        return deduplicatedResults.slice(0, kwargs.limit);
-    }
+
+        return allUsers.slice(0, limit);
+    },
 });
+
+export const __test__ = {
+    sanitizeQueryId,
+    buildFollowingUrl,
+    buildUserByScreenNameUrl,
+    extractUser,
+    parseFollowing,
+};

--- a/clis/twitter/following.test.js
+++ b/clis/twitter/following.test.js
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { __test__ } from './following.js';
 
 describe('twitter following helpers', () => {
@@ -149,5 +151,127 @@ describe('twitter following helpers', () => {
         const result = __test__.parseFollowing({});
         expect(result.users).toHaveLength(0);
         expect(result.nextCursor).toBeNull();
+    });
+
+    it('normalizes screen names for CLI and profile-link inputs', () => {
+        expect(__test__.normalizeScreenName('@elonmusk')).toBe('elonmusk');
+        expect(__test__.normalizeScreenName('/elonmusk')).toBe('elonmusk');
+        expect(__test__.normalizeScreenName('  @@alice  ')).toBe('alice');
+    });
+});
+
+function followingPayload(users, cursor) {
+    return {
+        data: {
+            user: {
+                result: {
+                    timeline_v2: {
+                        timeline: {
+                            instructions: [{
+                                entries: [
+                                    ...users.map((name) => ({
+                                        entryId: `user-${name}`,
+                                        content: {
+                                            itemContent: {
+                                                user_results: {
+                                                    result: {
+                                                        __typename: 'User',
+                                                        core: { screen_name: name, name: name.toUpperCase() },
+                                                        legacy: { description: `${name} bio`, followers_count: 10 },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    })),
+                                    ...(cursor ? [{
+                                        entryId: `cursor-bottom-${cursor}`,
+                                        content: {
+                                            entryType: 'TimelineTimelineCursor',
+                                            cursorType: 'Bottom',
+                                            value: cursor,
+                                        },
+                                    }] : []),
+                                ],
+                            }],
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+function createFollowingPage(followingResponses, { ct0 = 'token', userLookup = { userId: '42' } } = {}) {
+    const page = {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(async (script) => {
+            if (script.includes('document.cookie')) return ct0;
+            if (script.includes('operationName')) return null;
+            if (script.includes('/UserByScreenName')) return userLookup;
+            if (script.includes('/Following')) return followingResponses.shift() || followingPayload([], null);
+            if (script.includes('AppTabBar_Profile_Link')) return '/viewer';
+            throw new Error(`Unexpected evaluate script: ${script.slice(0, 80)}`);
+        }),
+    };
+    return page;
+}
+
+describe('twitter following command', () => {
+    it('paginates with cursor, deduplicates users, strips @, and respects limit', async () => {
+        const command = getRegistry().get('twitter/following');
+        const page = createFollowingPage([
+            followingPayload(['alice', 'bob'], 'cursor-1'),
+            followingPayload(['bob', 'carol', 'dave'], null),
+        ]);
+
+        const rows = await command.func(page, { user: '@elonmusk', limit: 3 });
+
+        expect(rows.map((row) => row.screen_name)).toEqual(['alice', 'bob', 'carol']);
+        const userLookupScript = page.evaluate.mock.calls.find(([script]) => script.includes('/UserByScreenName'))?.[0] || '';
+        expect(decodeURIComponent(userLookupScript)).toContain('"screen_name":"elonmusk"');
+        expect(decodeURIComponent(userLookupScript)).not.toContain('"screen_name":"@elonmusk"');
+        const followingCalls = page.evaluate.mock.calls.filter(([script]) => script.includes('/Following'));
+        expect(followingCalls).toHaveLength(2);
+        expect(decodeURIComponent(followingCalls[1][0])).toContain('"cursor":"cursor-1"');
+    });
+
+    it('rejects invalid limits before navigating', async () => {
+        const command = getRegistry().get('twitter/following');
+        const page = createFollowingPage([]);
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('maps first-page auth failures to AuthRequiredError', async () => {
+        const command = getRegistry().get('twitter/following');
+        const page = createFollowingPage([{ error: 401 }]);
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('does not silently return partial rows when a later page fails', async () => {
+        const command = getRegistry().get('twitter/following');
+        const page = createFollowingPage([
+            followingPayload(['alice'], 'cursor-1'),
+            { error: 429 },
+        ]);
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps user lookup auth failures to AuthRequiredError', async () => {
+        const command = getRegistry().get('twitter/following');
+        const page = createFollowingPage([], { userLookup: { error: 403 } });
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('fails fast when the following timeline is empty', async () => {
+        const command = getRegistry().get('twitter/following');
+        const page = createFollowingPage([followingPayload([], null)]);
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 })).rejects.toBeInstanceOf(EmptyResultError);
     });
 });

--- a/clis/twitter/following.test.js
+++ b/clis/twitter/following.test.js
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './following.js';
+
+describe('twitter following helpers', () => {
+    it('falls back when queryId contains unsafe characters', () => {
+        expect(__test__.sanitizeQueryId('safe_Query-123', 'fallback')).toBe('safe_Query-123');
+        expect(__test__.sanitizeQueryId('bad"id', 'fallback')).toBe('fallback');
+        expect(__test__.sanitizeQueryId('bad/id', 'fallback')).toBe('fallback');
+        expect(__test__.sanitizeQueryId(null, 'fallback')).toBe('fallback');
+    });
+
+    it('builds following url with cursor', () => {
+        const url = __test__.buildFollowingUrl('query123', '42', 20, 'cursor-1');
+        expect(url).toContain('/i/api/graphql/query123/Following');
+        expect(decodeURIComponent(url)).toContain('"userId":"42"');
+        expect(decodeURIComponent(url)).toContain('"count":20');
+        expect(decodeURIComponent(url)).toContain('"cursor":"cursor-1"');
+    });
+
+    it('builds following url without cursor', () => {
+        const url = __test__.buildFollowingUrl('query123', '42', 20);
+        expect(url).toContain('/i/api/graphql/query123/Following');
+        expect(decodeURIComponent(url)).not.toContain('"cursor"');
+    });
+
+    it('extracts user from result', () => {
+        const user = __test__.extractUser({
+            __typename: 'User',
+            core: { screen_name: 'alice', name: 'Alice' },
+            legacy: { description: 'bio text', followers_count: 100 },
+        });
+        expect(user).toMatchObject({
+            screen_name: 'alice',
+            name: 'Alice',
+            bio: 'bio text',
+            followers: 100,
+        });
+    });
+
+    it('returns null for non-User typename', () => {
+        expect(__test__.extractUser({ __typename: 'Tweet' })).toBeNull();
+        expect(__test__.extractUser(null)).toBeNull();
+        expect(__test__.extractUser(undefined)).toBeNull();
+    });
+
+    it('falls back to legacy screen_name if core is missing', () => {
+        const user = __test__.extractUser({
+            __typename: 'User',
+            legacy: { screen_name: 'bob', name: 'Bob', description: '', followers_count: 0 },
+        });
+        expect(user?.screen_name).toBe('bob');
+    });
+
+    it('parses following timeline with users and cursor', () => {
+        const payload = {
+            data: {
+                user: {
+                    result: {
+                        timeline_v2: {
+                            timeline: {
+                                instructions: [{
+                                    entries: [
+                                        {
+                                            entryId: 'user-1',
+                                            content: {
+                                                itemContent: {
+                                                    user_results: {
+                                                        result: {
+                                                            __typename: 'User',
+                                                            core: { screen_name: 'bob', name: 'Bob' },
+                                                            legacy: { description: 'hello', followers_count: 50 },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        {
+                                            entryId: 'user-2',
+                                            content: {
+                                                itemContent: {
+                                                    user_results: {
+                                                        result: {
+                                                            __typename: 'User',
+                                                            core: { screen_name: 'carol', name: 'Carol' },
+                                                            legacy: { description: 'world', followers_count: 200 },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        {
+                                            entryId: 'cursor-bottom-1',
+                                            content: {
+                                                entryType: 'TimelineTimelineCursor',
+                                                cursorType: 'Bottom',
+                                                value: 'next-cursor',
+                                            },
+                                        },
+                                    ],
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = __test__.parseFollowing(payload);
+        expect(result.users).toHaveLength(2);
+        expect(result.users[0]).toMatchObject({ screen_name: 'bob', name: 'Bob', followers: 50 });
+        expect(result.users[1]).toMatchObject({ screen_name: 'carol', name: 'Carol', followers: 200 });
+        expect(result.nextCursor).toBe('next-cursor');
+    });
+
+    it('handles cursor-bottom entryId pattern', () => {
+        const payload = {
+            data: {
+                user: {
+                    result: {
+                        timeline: {
+                            timeline: {
+                                instructions: [{
+                                    entries: [
+                                        {
+                                            entryId: 'cursor-bottom-0',
+                                            content: {
+                                                itemContent: { value: 'cursor-val' },
+                                            },
+                                        },
+                                    ],
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = __test__.parseFollowing(payload);
+        expect(result.nextCursor).toBe('cursor-val');
+        expect(result.users).toHaveLength(0);
+    });
+
+    it('returns empty users and null cursor for missing instructions', () => {
+        const result = __test__.parseFollowing({ data: { user: { result: {} } } });
+        expect(result.users).toHaveLength(0);
+        expect(result.nextCursor).toBeNull();
+    });
+
+    it('returns empty for completely empty payload', () => {
+        const result = __test__.parseFollowing({});
+        expect(result.users).toHaveLength(0);
+        expect(result.nextCursor).toBeNull();
+    });
+});

--- a/docs/adapters/browser/twitter.md
+++ b/docs/adapters/browser/twitter.md
@@ -45,6 +45,10 @@ opencli twitter search "react 19"
 # Search latest/live tweets
 opencli twitter search "react 19" --filter live
 
+# Get following/followers list (supports large limits)
+opencli twitter following @elonmusk --limit 200
+opencli twitter followers @elonmusk --limit 100
+
 # JSON output
 opencli twitter trending -f json
 


### PR DESCRIPTION
## Description

Fixes #1230

`twitter following` returned only ~50 results regardless of `limit` because the INTERCEPT+autoScroll strategy scrolled `document.body` and waited for `scrollHeight` to grow. Twitter's virtual list uses a fixed-height scroll container, so `document.body.scrollHeight` stops growing after the first few pages — subsequent scrolls don't trigger new API calls.

Switch to Strategy.COOKIE with explicit cursor-based GraphQL pagination (same proven pattern as `twitter/likes`).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```
# Before: limit=200 returned ~50
# After:
$ opencli twitter following @user --limit 200 -f json | jq length
200
```

## Notes

- `followers.js` left unchanged — same INTERCEPT bug exists but Followers GraphQL endpoint returns 404, separate issue to address