### PR TITLE
feat(browser): support multiple Chrome profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It also works as a **CLI hub** for local tools such as `gh`, `docker`, and other
 
 - **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT, Notion, etc.) directly from the terminal via CDP.
 - **Browser Automation for AI Agents** — Install the `opencli-adapter-author` skill, and your AI agent can operate any website: navigate, click, type, extract, screenshot — all through your logged-in Chrome session.
+- **Multi-profile Browser Bridge** — Install the extension in each Chrome profile you want to use, then route commands with `--profile`, `OPENCLI_PROFILE`, or `opencli profile use`.
 - **Website → CLI** — Turn any website into a deterministic CLI: 90+ pre-built adapters, or write your own with the `opencli-adapter-author` skill + `opencli browser verify`.
 - **Account-safe** — Reuses Chrome/Chromium logged-in state; your credentials never leave the browser.
 - **AI Agent ready** — One skill takes you from site recon through API discovery, field decoding, adapter writing, and verification.
@@ -55,7 +56,20 @@ Install **OpenCLI** from the [Chrome Web Store](https://chromewebstore.google.co
 opencli doctor
 ```
 
-### 4. Run your first commands
+### 4. Optional: name your Chrome profile
+
+Each Chrome profile runs its own OpenCLI extension instance. If you use multiple Chrome profiles, list the connected profiles and assign local aliases:
+
+```bash
+opencli profile list
+opencli profile rename <contextId> work
+opencli profile use work
+opencli --profile work browser state
+```
+
+With only one connected profile, OpenCLI uses it automatically. With multiple connected profiles and no default, OpenCLI asks you to choose instead of guessing.
+
+### 5. Run your first commands
 
 ```bash
 opencli list
@@ -167,6 +181,7 @@ OpenCLI is not only for websites. It can also:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge |
+| `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
 | `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -420,6 +420,7 @@ let ws = null;
 let reconnectTimer = null;
 let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = "opencli_context_id_v1";
+const CONTEXT_ID_PATTERN = /^[23456789abcdefghjkmnpqrstuvwxyz]{8}$/;
 let currentContextId = "default";
 let contextIdPromise = null;
 async function getCurrentContextId() {
@@ -430,7 +431,7 @@ async function getCurrentContextId() {
       if (!local) return currentContextId;
       const raw = await local.get(CONTEXT_ID_KEY);
       const existing = raw[CONTEXT_ID_KEY];
-      if (typeof existing === "string" && existing.trim()) {
+      if (typeof existing === "string" && CONTEXT_ID_PATTERN.test(existing.trim())) {
         currentContextId = existing.trim();
         return currentContextId;
       }

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -420,7 +420,6 @@ let ws = null;
 let reconnectTimer = null;
 let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = "opencli_context_id_v1";
-const CONTEXT_ID_PATTERN = /^[23456789abcdefghjkmnpqrstuvwxyz]{8}$/;
 let currentContextId = "default";
 let contextIdPromise = null;
 async function getCurrentContextId() {
@@ -431,7 +430,7 @@ async function getCurrentContextId() {
       if (!local) return currentContextId;
       const raw = await local.get(CONTEXT_ID_KEY);
       const existing = raw[CONTEXT_ID_KEY];
-      if (typeof existing === "string" && CONTEXT_ID_PATTERN.test(existing.trim())) {
+      if (typeof existing === "string" && existing.trim()) {
         currentContextId = existing.trim();
         return currentContextId;
       }

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -419,6 +419,41 @@ async function refreshMappings() {
 let ws = null;
 let reconnectTimer = null;
 let reconnectAttempts = 0;
+const CONTEXT_ID_KEY = "opencli_context_id_v1";
+let currentContextId = "default";
+let contextIdPromise = null;
+async function getCurrentContextId() {
+  if (contextIdPromise) return contextIdPromise;
+  contextIdPromise = (async () => {
+    try {
+      const local = chrome.storage?.local;
+      if (!local) return currentContextId;
+      const raw = await local.get(CONTEXT_ID_KEY);
+      const existing = raw[CONTEXT_ID_KEY];
+      if (typeof existing === "string" && existing.trim()) {
+        currentContextId = existing.trim();
+        return currentContextId;
+      }
+      const generated = generateContextId();
+      await local.set({ [CONTEXT_ID_KEY]: generated });
+      currentContextId = generated;
+      return currentContextId;
+    } catch {
+      return currentContextId;
+    }
+  })();
+  return contextIdPromise;
+}
+function generateContextId() {
+  const alphabet = "23456789abcdefghjkmnpqrstuvwxyz";
+  const bytes = new Uint8Array(8);
+  try {
+    crypto.getRandomValues(bytes);
+  } catch {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join("");
+}
 const _origLog = console.log.bind(console);
 const _origWarn = console.warn.bind(console);
 const _origError = console.error.bind(console);
@@ -451,7 +486,9 @@ async function connect() {
     return;
   }
   try {
+    const contextId = await getCurrentContextId();
     ws = new WebSocket(DAEMON_WS_URL);
+    currentContextId = contextId;
   } catch {
     scheduleReconnect();
     return;
@@ -465,6 +502,7 @@ async function connect() {
     }
     ws?.send(JSON.stringify({
       type: "hello",
+      contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
       compatRange: ">=1.7.0"
     }));
@@ -554,7 +592,7 @@ function makeSession(workspace, session) {
   const ownership = session.owned ? "owned" : "borrowed";
   return {
     ...session,
-    contextId: "user-default",
+    contextId: currentContextId,
     ownership,
     lifecycle: getLeaseLifecycle(workspace),
     surface: ownership === "owned" ? "dedicated-container" : "borrowed-user-tab"
@@ -563,7 +601,7 @@ function makeSession(workspace, session) {
 function emptyRegistry() {
   return {
     version: 1,
-    contextId: "user-default",
+    contextId: currentContextId,
     ownedContainerWindowId,
     leases: {}
   };
@@ -577,7 +615,7 @@ async function readRegistry() {
     if (!stored || stored.version !== 1 || typeof stored.leases !== "object") return emptyRegistry();
     return {
       version: 1,
-      contextId: "user-default",
+      contextId: currentContextId,
       ownedContainerWindowId: typeof stored.ownedContainerWindowId === "number" ? stored.ownedContainerWindowId : null,
       leases: stored.leases
     };
@@ -608,7 +646,7 @@ async function persistRuntimeState() {
   }
   await writeRegistry({
     version: 1,
-    contextId: "user-default",
+    contextId: currentContextId,
     ownedContainerWindowId,
     leases
   });
@@ -827,8 +865,11 @@ function initialize() {
   chrome.alarms.create("keepalive", { periodInMinutes: 0.4 });
   registerListeners();
   registerFrameTracking();
-  void reconcileTargetLeaseRegistry();
-  void connect();
+  void (async () => {
+    await getCurrentContextId();
+    await reconcileTargetLeaseRegistry();
+    await connect();
+  })();
   console.log("[opencli] OpenCLI extension initialized");
 }
 chrome.runtime.onInstalled.addListener(() => {
@@ -846,7 +887,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "getStatus") {
     sendResponse({
       connected: ws?.readyState === WebSocket.OPEN,
-      reconnecting: reconnectTimer !== null
+      reconnecting: reconnectTimer !== null,
+      contextId: currentContextId
     });
   }
   return false;

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -446,13 +446,22 @@ async function getCurrentContextId() {
 }
 function generateContextId() {
   const alphabet = "23456789abcdefghjkmnpqrstuvwxyz";
-  const bytes = new Uint8Array(8);
-  try {
-    crypto.getRandomValues(bytes);
-  } catch {
-    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  const maxUnbiasedByte = Math.floor(256 / alphabet.length) * alphabet.length;
+  let id = "";
+  while (id.length < 8) {
+    const bytes = new Uint8Array(8);
+    try {
+      crypto.getRandomValues(bytes);
+    } catch {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+    }
+    for (const byte of bytes) {
+      if (byte >= maxUnbiasedByte) continue;
+      id += alphabet[byte % alphabet.length];
+      if (id.length === 8) break;
+    }
   }
-  return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join("");
+  return id;
 }
 const _origLog = console.log.bind(console);
 const _origWarn = console.warn.bind(console);
@@ -885,11 +894,15 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 });
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "getStatus") {
-    sendResponse({
-      connected: ws?.readyState === WebSocket.OPEN,
-      reconnecting: reconnectTimer !== null,
-      contextId: currentContextId
-    });
+    void (async () => {
+      const contextId = await getCurrentContextId();
+      sendResponse({
+        connected: ws?.readyState === WebSocket.OPEN,
+        reconnecting: reconnectTimer !== null,
+        contextId
+      });
+    })();
+    return true;
   }
   return false;
 });

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -38,6 +38,27 @@
     .dot.connecting { background: #ff9500; }
     .status-text { font-size: 13px; color: #555; }
     .status-text strong { color: #333; }
+    .profile-row {
+      margin-top: 10px;
+      padding: 9px 10px;
+      border-radius: 8px;
+      background: #fafafa;
+      border: 1px solid #ececec;
+      color: #666;
+      font-size: 11px;
+      line-height: 1.5;
+    }
+    .profile-row code {
+      display: block;
+      margin-top: 2px;
+      padding: 3px 5px;
+      border-radius: 4px;
+      background: #f0f0f0;
+      color: #333;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      word-break: break-all;
+      user-select: all;
+    }
     .hint {
       margin-top: 10px;
       padding: 8px 10px;
@@ -72,6 +93,10 @@
   <div class="status-row">
     <span class="dot disconnected" id="dot"></span>
     <span class="status-text" id="status">Checking...</span>
+  </div>
+  <div class="profile-row" id="profile" style="display: none;">
+    Chrome profile contextId
+    <code id="contextId"></code>
   </div>
   <div class="hint" id="hint">
     This is normal. The extension connects automatically when you run any <code>opencli</code> command.

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -3,11 +3,20 @@ chrome.runtime.sendMessage({ type: 'getStatus' }, (resp) => {
   const dot = document.getElementById('dot');
   const status = document.getElementById('status');
   const hint = document.getElementById('hint');
+  const profile = document.getElementById('profile');
+  const contextId = document.getElementById('contextId');
   if (chrome.runtime.lastError || !resp) {
     dot.className = 'dot disconnected';
     status.innerHTML = '<strong>No daemon connected</strong>';
+    profile.style.display = 'none';
     hint.style.display = 'block';
     return;
+  }
+  if (typeof resp.contextId === 'string' && resp.contextId.length > 0) {
+    contextId.textContent = resp.contextId;
+    profile.style.display = 'block';
+  } else {
+    profile.style.display = 'none';
   }
   if (resp.connected) {
     dot.className = 'dot connected';

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -418,7 +418,7 @@ describe('background tab isolation', () => {
 
   it('returns the persisted profile contextId from popup status', async () => {
     const { chrome } = createChromeMock();
-    await chrome.storage.local.set({ opencli_context_id_v1: 'abc123xy' });
+    await chrome.storage.local.set({ opencli_context_id_v1: 'abc234xy' });
     vi.stubGlobal('chrome', chrome);
 
     await import('./background');
@@ -430,7 +430,7 @@ describe('background tab isolation', () => {
     expect(keepAlive).toBe(true);
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({
-        contextId: 'abc123xy',
+        contextId: 'abc234xy',
       }));
     });
   });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -418,7 +418,7 @@ describe('background tab isolation', () => {
 
   it('returns the persisted profile contextId from popup status', async () => {
     const { chrome } = createChromeMock();
-    await chrome.storage.local.set({ opencli_context_id_v1: 'abc234xy' });
+    await chrome.storage.local.set({ opencli_context_id_v1: 'abc123xy' });
     vi.stubGlobal('chrome', chrome);
 
     await import('./background');
@@ -430,7 +430,7 @@ describe('background tab isolation', () => {
     expect(keepAlive).toBe(true);
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({
-        contextId: 'abc234xy',
+        contextId: 'abc123xy',
       }));
     });
   });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -416,6 +416,25 @@ describe('background tab isolation', () => {
     ]));
   });
 
+  it('returns the persisted profile contextId from popup status', async () => {
+    const { chrome } = createChromeMock();
+    await chrome.storage.local.set({ opencli_context_id_v1: 'abc123xy' });
+    vi.stubGlobal('chrome', chrome);
+
+    await import('./background');
+    const onMessageListener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const sendResponse = vi.fn();
+
+    const keepAlive = onMessageListener({ type: 'getStatus' }, {}, sendResponse);
+
+    expect(keepAlive).toBe(true);
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({
+        contextId: 'abc123xy',
+      }));
+    });
+  });
+
   it('can execute concurrently on two pages in the same workspace', async () => {
     const { chrome, tabs } = createChromeMock();
     tabs.push({

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -15,6 +15,43 @@ import * as identity from './identity';
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
+const CONTEXT_ID_KEY = 'opencli_context_id_v1';
+let currentContextId = 'default';
+let contextIdPromise: Promise<string> | null = null;
+
+async function getCurrentContextId(): Promise<string> {
+  if (contextIdPromise) return contextIdPromise;
+  contextIdPromise = (async () => {
+    try {
+      const local = chrome.storage?.local;
+      if (!local) return currentContextId;
+      const raw = await local.get(CONTEXT_ID_KEY) as Record<string, unknown>;
+      const existing = raw[CONTEXT_ID_KEY];
+      if (typeof existing === 'string' && existing.trim()) {
+        currentContextId = existing.trim();
+        return currentContextId;
+      }
+      const generated = generateContextId();
+      await local.set({ [CONTEXT_ID_KEY]: generated });
+      currentContextId = generated;
+      return currentContextId;
+    } catch {
+      return currentContextId;
+    }
+  })();
+  return contextIdPromise;
+}
+
+function generateContextId(): string {
+  const alphabet = '23456789abcdefghjkmnpqrstuvwxyz';
+  const bytes = new Uint8Array(8);
+  try {
+    crypto.getRandomValues(bytes);
+  } catch {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join('');
+}
 
 // ─── Console log forwarding ──────────────────────────────────────────
 // Hook console.log/warn/error to forward logs to daemon via WebSocket.
@@ -55,7 +92,9 @@ async function connect(): Promise<void> {
   }
 
   try {
+    const contextId = await getCurrentContextId();
     ws = new WebSocket(DAEMON_WS_URL);
+    currentContextId = contextId;
   } catch {
     scheduleReconnect();
     return;
@@ -71,6 +110,7 @@ async function connect(): Promise<void> {
     // Send version + compatibility range so the daemon can report mismatches to the CLI
     ws?.send(JSON.stringify({
       type: 'hello',
+      contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
       compatRange: __OPENCLI_COMPAT_RANGE__,
     }));
@@ -122,7 +162,7 @@ function scheduleReconnect(): void {
 // Interactive workspaces (browser:*, operate:*) get a longer timeout (10 min)
 // since users type commands manually; adapter workspaces keep a short 30s timeout.
 
-type BrowserContextId = 'user-default';
+type BrowserContextId = string;
 type LeaseOwnership = 'owned' | 'borrowed';
 type LeaseLifecycle = 'ephemeral' | 'persistent' | 'pinned';
 type SurfacePolicy = 'dedicated-container' | 'borrowed-user-tab';
@@ -220,7 +260,7 @@ function makeSession(
   const ownership = session.owned ? 'owned' : 'borrowed';
   return {
     ...session,
-    contextId: 'user-default',
+    contextId: currentContextId,
     ownership,
     lifecycle: getLeaseLifecycle(workspace),
     surface: ownership === 'owned' ? 'dedicated-container' : 'borrowed-user-tab',
@@ -230,7 +270,7 @@ function makeSession(
 function emptyRegistry(): StoredRegistry {
   return {
     version: 1,
-    contextId: 'user-default',
+    contextId: currentContextId,
     ownedContainerWindowId,
     leases: {},
   };
@@ -245,7 +285,7 @@ async function readRegistry(): Promise<StoredRegistry> {
     if (!stored || stored.version !== 1 || typeof stored.leases !== 'object') return emptyRegistry();
     return {
       version: 1,
-      contextId: 'user-default',
+      contextId: currentContextId,
       ownedContainerWindowId: typeof stored.ownedContainerWindowId === 'number' ? stored.ownedContainerWindowId : null,
       leases: stored.leases as Record<string, StoredLease>,
     };
@@ -279,7 +319,7 @@ async function persistRuntimeState(): Promise<void> {
   }
   await writeRegistry({
     version: 1,
-    contextId: 'user-default',
+    contextId: currentContextId,
     ownedContainerWindowId,
     leases,
   });
@@ -545,8 +585,11 @@ function initialize(): void {
   chrome.alarms.create('keepalive', { periodInMinutes: 0.4 }); // ~24 seconds
   executor.registerListeners();
   executor.registerFrameTracking();
-  void reconcileTargetLeaseRegistry();
-  void connect();
+  void (async () => {
+    await getCurrentContextId();
+    await reconcileTargetLeaseRegistry();
+    await connect();
+  })();
   console.log('[opencli] OpenCLI extension initialized');
 }
 
@@ -571,6 +614,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     sendResponse({
       connected: ws?.readyState === WebSocket.OPEN,
       reconnecting: reconnectTimer !== null,
+      contextId: currentContextId,
     });
   }
   return false;

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -16,6 +16,7 @@ let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = 'opencli_context_id_v1';
+const CONTEXT_ID_PATTERN = /^[23456789abcdefghjkmnpqrstuvwxyz]{8}$/;
 let currentContextId = 'default';
 let contextIdPromise: Promise<string> | null = null;
 
@@ -27,7 +28,7 @@ async function getCurrentContextId(): Promise<string> {
       if (!local) return currentContextId;
       const raw = await local.get(CONTEXT_ID_KEY) as Record<string, unknown>;
       const existing = raw[CONTEXT_ID_KEY];
-      if (typeof existing === 'string' && existing.trim()) {
+      if (typeof existing === 'string' && CONTEXT_ID_PATTERN.test(existing.trim())) {
         currentContextId = existing.trim();
         return currentContextId;
       }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -16,7 +16,6 @@ let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = 'opencli_context_id_v1';
-const CONTEXT_ID_PATTERN = /^[23456789abcdefghjkmnpqrstuvwxyz]{8}$/;
 let currentContextId = 'default';
 let contextIdPromise: Promise<string> | null = null;
 
@@ -28,7 +27,7 @@ async function getCurrentContextId(): Promise<string> {
       if (!local) return currentContextId;
       const raw = await local.get(CONTEXT_ID_KEY) as Record<string, unknown>;
       const existing = raw[CONTEXT_ID_KEY];
-      if (typeof existing === 'string' && CONTEXT_ID_PATTERN.test(existing.trim())) {
+      if (typeof existing === 'string' && existing.trim()) {
         currentContextId = existing.trim();
         return currentContextId;
       }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -44,13 +44,22 @@ async function getCurrentContextId(): Promise<string> {
 
 function generateContextId(): string {
   const alphabet = '23456789abcdefghjkmnpqrstuvwxyz';
-  const bytes = new Uint8Array(8);
-  try {
-    crypto.getRandomValues(bytes);
-  } catch {
-    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  const maxUnbiasedByte = Math.floor(256 / alphabet.length) * alphabet.length;
+  let id = '';
+  while (id.length < 8) {
+    const bytes = new Uint8Array(8);
+    try {
+      crypto.getRandomValues(bytes);
+    } catch {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+    }
+    for (const byte of bytes) {
+      if (byte >= maxUnbiasedByte) continue;
+      id += alphabet[byte % alphabet.length];
+      if (id.length === 8) break;
+    }
   }
-  return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join('');
+  return id;
 }
 
 // ─── Console log forwarding ──────────────────────────────────────────
@@ -611,11 +620,15 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === 'getStatus') {
-    sendResponse({
-      connected: ws?.readyState === WebSocket.OPEN,
-      reconnecting: reconnectTimer !== null,
-      contextId: currentContextId,
-    });
+    void (async () => {
+      const contextId = await getCurrentContextId();
+      sendResponse({
+        connected: ws?.readyState === WebSocket.OPEN,
+        reconnecting: reconnectTimer !== null,
+        contextId,
+      });
+    })();
+    return true;
   }
   return false;
 });

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -70,6 +70,8 @@ export interface Command {
   allowBoundNavigation?: boolean;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;
+  /** Browser profile/context selected by the CLI. Used by the daemon for routing. */
+  contextId?: string;
 }
 
 export interface Result {

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -13,6 +13,7 @@ import { getDaemonHealth, requestDaemonShutdown } from './daemon-client.js';
 import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import { BrowserConnectError } from '../errors.js';
 import { PKG_VERSION } from '../version.js';
+import { resolveProfileContextId } from './profile.js';
 
 const DAEMON_SPAWN_TIMEOUT = 10000; // 10s to wait for daemon + extension
 
@@ -30,7 +31,7 @@ export class BrowserBridge implements IBrowserFactory {
     return this._state;
   }
 
-  async connect(opts: { timeout?: number; workspace?: string; idleTimeout?: number } = {}): Promise<IPage> {
+  async connect(opts: { timeout?: number; workspace?: string; idleTimeout?: number; contextId?: string } = {}): Promise<IPage> {
     if (this._state === 'connected' && this._page) return this._page;
     if (this._state === 'connecting') throw new Error('Already connecting');
     if (this._state === 'closing') throw new Error('Session is closing');
@@ -39,8 +40,9 @@ export class BrowserBridge implements IBrowserFactory {
     this._state = 'connecting';
 
     try {
-      await this._ensureDaemon(opts.timeout);
-      this._page = new Page(opts.workspace, opts.idleTimeout);
+      const contextId = opts.contextId ?? resolveProfileContextId();
+      await this._ensureDaemon(opts.timeout, contextId);
+      this._page = new Page(opts.workspace, opts.idleTimeout, contextId);
       this._state = 'connected';
       return this._page;
     } catch (err) {
@@ -58,14 +60,32 @@ export class BrowserBridge implements IBrowserFactory {
     this._state = 'closed';
   }
 
-  private async _ensureDaemon(timeoutSeconds?: number): Promise<void> {
+  private async _ensureDaemon(timeoutSeconds?: number, contextId?: string): Promise<void> {
     const effectiveSeconds = (timeoutSeconds && timeoutSeconds > 0) ? timeoutSeconds : Math.ceil(DAEMON_SPAWN_TIMEOUT / 1000);
     const timeoutMs = effectiveSeconds * 1000;
 
-    const health = await getDaemonHealth();
+    const health = await getDaemonHealth({ contextId });
 
     // Fast path: everything ready
     if (health.state === 'ready') return;
+
+    if (health.state === 'profile-required') {
+      throw new BrowserConnectError(
+        'Multiple Browser Bridge profiles are connected',
+        'Select one with --profile <name>, OPENCLI_PROFILE=<name>, or opencli profile use <name>.\n' +
+        'Run opencli profile list to see connected profiles.',
+        'profile-required',
+      );
+    }
+
+    if (health.state === 'profile-disconnected') {
+      const label = contextId ?? health.status.contextId ?? 'unknown';
+      throw new BrowserConnectError(
+        `Browser profile "${label}" is not connected`,
+        'Open the matching Chrome profile and make sure the OpenCLI extension is enabled, or choose another profile with opencli profile use <name>.',
+        'profile-disconnected',
+      );
+    }
 
     // Daemon running but no extension
     if (health.state === 'no-extension') {
@@ -100,7 +120,24 @@ export class BrowserBridge implements IBrowserFactory {
           process.stderr.write('⏳ Waiting for Chrome/Chromium extension to connect...\n');
           process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
         }
-        if (await this._pollUntilReady(timeoutMs)) return;
+        if (await this._pollUntilReady(timeoutMs, contextId)) return;
+        const finalHealth = await getDaemonHealth({ contextId });
+        if (finalHealth.state === 'profile-required') {
+          throw new BrowserConnectError(
+            'Multiple Browser Bridge profiles are connected',
+            'Select one with --profile <name>, OPENCLI_PROFILE=<name>, or opencli profile use <name>.\n' +
+            'Run opencli profile list to see connected profiles.',
+            'profile-required',
+          );
+        }
+        if (finalHealth.state === 'profile-disconnected') {
+          const label = contextId ?? finalHealth.status.contextId ?? 'unknown';
+          throw new BrowserConnectError(
+            `Browser profile "${label}" is not connected`,
+            'Open the matching Chrome profile and make sure the OpenCLI extension is enabled, or choose another profile with opencli profile use <name>.',
+            'profile-disconnected',
+          );
+        }
         throw new BrowserConnectError(
           'Browser Bridge extension not connected',
           'Make sure Chrome/Chromium is open and the extension is enabled.\n' +
@@ -137,9 +174,25 @@ export class BrowserBridge implements IBrowserFactory {
     this._daemonProc.unref();
 
     // Wait for daemon + extension
-    if (await this._pollUntilReady(timeoutMs)) return;
+    if (await this._pollUntilReady(timeoutMs, contextId)) return;
 
-    const finalHealth = await getDaemonHealth();
+    const finalHealth = await getDaemonHealth({ contextId });
+    if (finalHealth.state === 'profile-required') {
+      throw new BrowserConnectError(
+        'Multiple Browser Bridge profiles are connected',
+        'Select one with --profile <name>, OPENCLI_PROFILE=<name>, or opencli profile use <name>.\n' +
+        'Run opencli profile list to see connected profiles.',
+        'profile-required',
+      );
+    }
+    if (finalHealth.state === 'profile-disconnected') {
+      const label = contextId ?? finalHealth.status.contextId ?? 'unknown';
+      throw new BrowserConnectError(
+        `Browser profile "${label}" is not connected`,
+        'Open the matching Chrome profile and make sure the OpenCLI extension is enabled, or choose another profile with opencli profile use <name>.',
+        'profile-disconnected',
+      );
+    }
     if (finalHealth.state === 'no-extension') {
       throw new BrowserConnectError(
         'Browser Bridge extension not connected',
@@ -171,11 +224,11 @@ export class BrowserBridge implements IBrowserFactory {
   }
 
   /** Poll getDaemonHealth() until state is 'ready' or deadline is reached. */
-  private async _pollUntilReady(timeoutMs: number): Promise<boolean> {
+  private async _pollUntilReady(timeoutMs: number, contextId?: string): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, 200));
-      const h = await getDaemonHealth();
+      const h = await getDaemonHealth({ contextId });
       if (h.state === 'ready') return true;
     }
     return false;

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -53,7 +53,7 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -14,6 +14,7 @@ describe('daemon-client', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('fetchDaemonStatus sends the shared status request and returns parsed data', async () => {
@@ -105,6 +106,48 @@ describe('daemon-client', () => {
     await expect(getDaemonHealth()).resolves.toEqual({ state: 'ready', status });
   });
 
+  it('getDaemonHealth returns profile-required when multiple profiles are connected without a selection', async () => {
+    const status = {
+      ok: true,
+      pid: 123,
+      uptime: 10,
+      extensionConnected: false,
+      profileRequired: true,
+      profiles: [
+        { contextId: 'work', extensionConnected: true, pending: 0 },
+        { contextId: 'personal', extensionConnected: true, pending: 0 },
+      ],
+      pending: 0,
+      memoryMB: 32,
+      port: 19825,
+    };
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(status),
+    } as Response);
+
+    await expect(getDaemonHealth()).resolves.toEqual({ state: 'profile-required', status });
+  });
+
+  it('fetchDaemonStatus includes contextId in the status query', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        ok: true,
+        pid: 1,
+        uptime: 0,
+        extensionConnected: true,
+        pending: 0,
+        memoryMB: 1,
+        port: 19825,
+      }),
+    } as Response);
+
+    await fetchDaemonStatus({ contextId: 'work' });
+
+    expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?contextId=work$/);
+  });
+
   it('sendCommand includes the current pid in generated command ids', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
     vi.mocked(fetch).mockResolvedValue({
@@ -124,6 +167,20 @@ describe('daemon-client', () => {
     expect(ids[0]).toMatch(new RegExp(`^cmd_${process.pid}_1763000000000_\\d+$`));
     expect(ids[1]).toMatch(new RegExp(`^cmd_${process.pid}_1763000000000_\\d+$`));
     expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('sendCommand forwards OPENCLI_PROFILE as command contextId', async () => {
+    vi.stubEnv('OPENCLI_PROFILE', 'work');
+    vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1 + 1' });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { contextId?: string };
+    expect(body.contextId).toBe('work');
   });
 
   it('sendCommand retries with a new id when daemon reports a duplicate pending id', async () => {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -8,6 +8,7 @@ import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import type { BrowserSessionInfo } from '../types.js';
 import { sleep } from '../utils.js';
 import { classifyBrowserError } from './errors.js';
+import { resolveProfileContextId } from './profile.js';
 
 const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
@@ -54,6 +55,8 @@ export interface DaemonCommand {
   allowBoundNavigation?: boolean;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;
+  /** Browser profile/context to route the command to. */
+  contextId?: string;
 }
 
 export interface DaemonResult {
@@ -82,9 +85,22 @@ export interface DaemonStatus {
   extensionConnected: boolean;
   extensionVersion?: string;
   extensionCompatRange?: string;
+  contextId?: string;
+  profileRequired?: boolean;
+  profileDisconnected?: boolean;
+  profiles?: BrowserProfileStatus[];
   pending: number;
   memoryMB: number;
   port: number;
+}
+
+export interface BrowserProfileStatus {
+  contextId: string;
+  extensionConnected: boolean;
+  extensionVersion?: string;
+  extensionCompatRange?: string;
+  pending: number;
+  lastSeenAt?: number;
 }
 
 async function requestDaemon(pathname: string, init?: RequestInit & { timeout?: number }): Promise<Response> {
@@ -102,9 +118,10 @@ async function requestDaemon(pathname: string, init?: RequestInit & { timeout?: 
   }
 }
 
-export async function fetchDaemonStatus(opts?: { timeout?: number }): Promise<DaemonStatus | null> {
+export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: string }): Promise<DaemonStatus | null> {
   try {
-    const res = await requestDaemon('/status', { timeout: opts?.timeout ?? 2000 });
+    const params = opts?.contextId ? `?contextId=${encodeURIComponent(opts.contextId)}` : '';
+    const res = await requestDaemon(`/status${params}`, { timeout: opts?.timeout ?? 2000 });
     if (!res.ok) return null;
     return await res.json() as DaemonStatus;
   } catch {
@@ -115,15 +132,19 @@ export async function fetchDaemonStatus(opts?: { timeout?: number }): Promise<Da
 export type DaemonHealth =
   | { state: 'stopped'; status: null }
   | { state: 'no-extension'; status: DaemonStatus }
+  | { state: 'profile-required'; status: DaemonStatus }
+  | { state: 'profile-disconnected'; status: DaemonStatus }
   | { state: 'ready'; status: DaemonStatus };
 
 /**
  * Unified daemon health check — single entry point for all status queries.
  * Replaces isDaemonRunning(), isExtensionConnected(), and checkDaemonStatus().
  */
-export async function getDaemonHealth(opts?: { timeout?: number }): Promise<DaemonHealth> {
+export async function getDaemonHealth(opts?: { timeout?: number; contextId?: string }): Promise<DaemonHealth> {
   const status = await fetchDaemonStatus(opts);
   if (!status) return { state: 'stopped', status: null };
+  if (status.profileRequired) return { state: 'profile-required', status };
+  if (status.profileDisconnected) return { state: 'profile-disconnected', status };
   if (!status.extensionConnected) return { state: 'no-extension', status };
   return { state: 'ready', status };
 }
@@ -156,7 +177,8 @@ async function sendCommandRaw(
     const id = generateId();
     const wf = process.env.OPENCLI_WINDOW_FOCUSED;
     const windowFocused = (wf === '1' || wf === 'true') ? true : undefined;
-    const command: DaemonCommand = { id, action, ...params, ...(windowFocused && { windowFocused }) };
+    const contextId = params.contextId ?? resolveProfileContextId();
+    const command: DaemonCommand = { id, action, ...params, ...(contextId && { contextId }), ...(windowFocused && { windowFocused }) };
     try {
       const res = await requestDaemon('/command', {
         method: 'POST',
@@ -218,11 +240,11 @@ export async function sendCommandFull(
   return { data: result.data, page: result.page };
 }
 
-export async function listSessions(): Promise<BrowserSessionInfo[]> {
-  const result = await sendCommand('sessions');
+export async function listSessions(opts?: { contextId?: string }): Promise<BrowserSessionInfo[]> {
+  const result = await sendCommand('sessions', { ...(opts?.contextId && { contextId: opts.contextId }) });
   return Array.isArray(result) ? result : [];
 }
 
-export async function bindTab(workspace: string, opts: { matchDomain?: string; matchPathPrefix?: string } = {}): Promise<unknown> {
+export async function bindTab(workspace: string, opts: { matchDomain?: string; matchPathPrefix?: string; contextId?: string } = {}): Promise<unknown> {
   return sendCommand('bind', { workspace, ...opts });
 }

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -32,7 +32,11 @@ function isUnsupportedNetworkCaptureError(err: unknown): boolean {
 export class Page extends BasePage {
   private readonly _idleTimeout: number | undefined;
 
-  constructor(private readonly workspace: string = 'default', idleTimeout?: number) {
+  constructor(
+    private readonly workspace: string = 'default',
+    idleTimeout?: number,
+    public readonly contextId?: string,
+  ) {
     super();
     this._idleTimeout = idleTimeout;
   }
@@ -43,14 +47,19 @@ export class Page extends BasePage {
   private _networkCaptureWarned = false;
 
   /** Helper: spread workspace into command params */
-  private _wsOpt(): { workspace: string; idleTimeout?: number } {
-    return { workspace: this.workspace, ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }) };
+  private _wsOpt(): { workspace: string; idleTimeout?: number; contextId?: string } {
+    return {
+      workspace: this.workspace,
+      ...(this.contextId && { contextId: this.contextId }),
+      ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
+    };
   }
 
   /** Helper: spread workspace + page identity into command params */
   private _cmdOpts(): Record<string, unknown> {
     return {
       workspace: this.workspace,
+      ...(this.contextId && { contextId: this.contextId }),
       ...(this._page !== undefined && { page: this._page }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
     };

--- a/src/browser/profile.ts
+++ b/src/browser/profile.ts
@@ -1,0 +1,96 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export const DEFAULT_CONTEXT_ID = 'default';
+
+export type ProfileConfig = {
+  version: 1;
+  defaultContextId?: string;
+  aliases: Record<string, string>;
+};
+
+function profileConfigPath(): string {
+  const baseDir = process.env.OPENCLI_CONFIG_DIR || path.join(os.homedir(), '.opencli');
+  return path.join(baseDir, 'browser-profiles.json');
+}
+
+export function normalizeContextId(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+export function emptyProfileConfig(): ProfileConfig {
+  return { version: 1, aliases: {} };
+}
+
+export function loadProfileConfig(): ProfileConfig {
+  try {
+    const raw = fs.readFileSync(profileConfigPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<ProfileConfig>;
+    const aliases = parsed.aliases && typeof parsed.aliases === 'object'
+      ? Object.fromEntries(Object.entries(parsed.aliases).filter((entry): entry is [string, string] => {
+        const [key, value] = entry;
+        return typeof key === 'string' && key.trim().length > 0
+          && typeof value === 'string' && value.trim().length > 0;
+      }))
+      : {};
+    return {
+      version: 1,
+      aliases,
+      ...(typeof parsed.defaultContextId === 'string' && parsed.defaultContextId.trim()
+        ? { defaultContextId: parsed.defaultContextId.trim() }
+        : {}),
+    };
+  } catch {
+    return emptyProfileConfig();
+  }
+}
+
+export function saveProfileConfig(config: ProfileConfig): void {
+  const target = profileConfigPath();
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+export function resolveProfileContextId(profile?: string): string | undefined {
+  const config = loadProfileConfig();
+  const requested = normalizeContextId(profile)
+    ?? normalizeContextId(process.env.OPENCLI_PROFILE)
+    ?? normalizeContextId(config.defaultContextId);
+  if (!requested) return undefined;
+  return config.aliases[requested] ?? requested;
+}
+
+export function aliasForContextId(config: ProfileConfig, contextId: string): string | undefined {
+  for (const [alias, id] of Object.entries(config.aliases)) {
+    if (id === contextId) return alias;
+  }
+  return undefined;
+}
+
+export function renameProfile(contextId: string, alias: string): ProfileConfig {
+  const normalizedContextId = normalizeContextId(contextId);
+  const normalizedAlias = normalizeContextId(alias);
+  if (!normalizedContextId) throw new Error('profile contextId is required');
+  if (!normalizedAlias) throw new Error('profile alias is required');
+
+  const config = loadProfileConfig();
+  for (const [existingAlias, existingContextId] of Object.entries(config.aliases)) {
+    if (existingAlias !== normalizedAlias && existingContextId === normalizedContextId) {
+      delete config.aliases[existingAlias];
+    }
+  }
+  config.aliases[normalizedAlias] = normalizedContextId;
+  saveProfileConfig(config);
+  return config;
+}
+
+export function setDefaultProfile(profile: string): ProfileConfig {
+  const contextId = resolveProfileContextId(profile) ?? normalizeContextId(profile);
+  if (!contextId) throw new Error('profile is required');
+  const config = loadProfileConfig();
+  config.defaultContextId = contextId;
+  saveProfileConfig(config);
+  return config;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,8 @@ import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
-import { bindTab, BrowserCommandError, sendCommand } from './browser/daemon-client.js';
+import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
+import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -313,6 +314,10 @@ async function resolveBrowserTargetInSession(
   );
 }
 
+function getBrowserScope(workspace: string, contextId?: string): string {
+  return contextId ? `${contextId}:${workspace}` : workspace;
+}
+
 async function resolveStoredBrowserTarget(page: import('./types.js').IPage, scope: string = DEFAULT_BROWSER_WORKSPACE): Promise<string | undefined> {
   const defaultPage = loadBrowserTargetState(scope)?.defaultPage?.trim();
   if (!defaultPage) return undefined;
@@ -320,7 +325,7 @@ async function resolveStoredBrowserTarget(page: import('./types.js').IPage, scop
 }
 
 /** Create a browser page for browser commands. Uses a dedicated browser workspace for session persistence. */
-async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_BROWSER_WORKSPACE): Promise<import('./types.js').IPage> {
+async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_BROWSER_WORKSPACE, contextId?: string): Promise<import('./types.js').IPage> {
   const { BrowserBridge } = await import('./browser/index.js');
   const bridge = new BrowserBridge();
   const envTimeout = process.env.OPENCLI_BROWSER_TIMEOUT;
@@ -328,11 +333,13 @@ async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_B
   const page = await bridge.connect({
     timeout: 30,
     workspace,
+    ...(contextId && { contextId }),
     ...(idleTimeout && idleTimeout > 0 && { idleTimeout }),
   });
+  const targetScope = getBrowserScope(workspace, contextId);
   const resolvedTargetPage = targetPage
-    ? await resolveBrowserTargetInSession(page, targetPage, { scope: workspace, source: 'explicit' })
-    : await resolveStoredBrowserTarget(page, workspace);
+    ? await resolveBrowserTargetInSession(page, targetPage, { scope: targetScope, source: 'explicit' })
+    : await resolveStoredBrowserTarget(page, targetScope);
   if (resolvedTargetPage) {
     if (!page.setActivePage) {
       throw new Error('This browser session does not support explicit tab targeting');
@@ -367,9 +374,19 @@ function getBrowserWorkspace(command?: Command): string {
   return typeof raw === 'string' && raw.trim() ? raw.trim() : DEFAULT_BROWSER_WORKSPACE;
 }
 
+function getBrowserContextId(command?: Command): string | undefined {
+  const raw = getCommandOption(command, 'profile');
+  return resolveProfileContextId(typeof raw === 'string' && raw.trim() ? raw.trim() : undefined);
+}
+
 function getPageWorkspace(page: import('./types.js').IPage): string {
   const workspace = (page as unknown as { workspace?: unknown }).workspace;
   return typeof workspace === 'string' && workspace.trim() ? workspace.trim() : DEFAULT_BROWSER_WORKSPACE;
+}
+
+function getPageScope(page: import('./types.js').IPage): string {
+  const contextId = (page as unknown as { contextId?: unknown }).contextId;
+  return getBrowserScope(getPageWorkspace(page), typeof contextId === 'string' && contextId.trim() ? contextId.trim() : undefined);
 }
 
 function resolveBrowserTabTarget(targetId?: string, opts?: { tab?: string } | Command): string | undefined {
@@ -401,6 +418,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .name('opencli')
     .description('Make any website your CLI. Zero setup. AI-powered.')
     .version(PKG_VERSION)
+    .option('--profile <name>', 'Chrome profile/context alias for Browser Bridge commands')
     .enablePositionalOptions();
 
   // ── Built-in: list ────────────────────────────────────────────────────────
@@ -571,7 +589,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         const command = args.at(-1) instanceof Command ? args.at(-1) as Command : undefined;
         const targetPage = getBrowserTargetId(command);
         const workspace = getBrowserWorkspace(command);
-        const page = await getBrowserPage(targetPage, workspace);
+        const contextId = getBrowserContextId(command);
+        const page = await getBrowserPage(targetPage, workspace, contextId);
         await fn(page, ...args);
       } catch (err) {
         if (err instanceof BrowserConnectError) {
@@ -633,12 +652,14 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       try {
         const { BrowserBridge } = await import('./browser/index.js');
         const bridge = new BrowserBridge();
-        await bridge.connect({ timeout: 30, workspace });
+        const contextId = getBrowserContextId(command);
+        await bridge.connect({ timeout: 30, workspace, ...(contextId && { contextId }) });
         const data = await bindTab(workspace, {
+          ...(contextId && { contextId }),
           ...(typeof opts.domain === 'string' && opts.domain.trim() ? { matchDomain: opts.domain.trim() } : {}),
           ...(typeof opts.pathPrefix === 'string' && opts.pathPrefix.trim() ? { matchPathPrefix: opts.pathPrefix.trim() } : {}),
         });
-        saveBrowserTargetState(undefined, workspace);
+        saveBrowserTargetState(undefined, getBrowserScope(workspace, contextId));
         console.log(JSON.stringify({ workspace, ...((data && typeof data === 'object') ? data as Record<string, unknown> : { data }) }, null, 2));
       } catch (err) {
         if (err instanceof BrowserCommandError && err.code) {
@@ -681,9 +702,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       try {
         const { BrowserBridge } = await import('./browser/index.js');
         const bridge = new BrowserBridge();
-        await bridge.connect({ timeout: 30, workspace });
-        await sendCommand('close-window', { workspace });
-        saveBrowserTargetState(undefined, workspace);
+        const contextId = getBrowserContextId(command);
+        await bridge.connect({ timeout: 30, workspace, ...(contextId && { contextId }) });
+        await sendCommand('close-window', { workspace, ...(contextId && { contextId }) });
+        saveBrowserTargetState(undefined, getBrowserScope(workspace, contextId));
         console.log(JSON.stringify({ unbound: true, workspace }, null, 2));
       } catch (err) {
         if (err instanceof BrowserCommandError && err.code) {
@@ -735,7 +757,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         throw new Error('Target tab required. Pass it as an argument or --tab <targetId>.');
       }
       await page.selectTab(resolvedTarget);
-      saveBrowserTargetState(resolvedTarget, getPageWorkspace(page));
+      saveBrowserTargetState(resolvedTarget, getPageScope(page));
       console.log(JSON.stringify({ selected: resolvedTarget }, null, 2));
     }));
 
@@ -751,16 +773,16 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         throw new Error('Target tab required. Pass it as an argument or --tab <targetId>.');
       }
       const validatedTarget = await resolveBrowserTargetInSession(page, resolvedTarget, {
-        scope: getPageWorkspace(page),
+        scope: getPageScope(page),
         source: 'explicit',
       });
       if (!validatedTarget) {
         throw new Error(`Target tab ${resolvedTarget} is not part of the current browser session.`);
       }
       await page.closeTab(validatedTarget);
-      const workspace = getPageWorkspace(page);
-      if (loadBrowserTargetState(workspace)?.defaultPage === validatedTarget) {
-        saveBrowserTargetState(undefined, workspace);
+      const scope = getPageScope(page);
+      if (loadBrowserTargetState(scope)?.defaultPage === validatedTarget) {
+        saveBrowserTargetState(undefined, scope);
       }
       console.log(JSON.stringify({ closed: validatedTarget }, null, 2));
     }));
@@ -2186,6 +2208,82 @@ cli({
       console.log(styleText('green', isOfficial
         ? `✅ Reset "${site}". Now using official baseline.`
         : `✅ Removed custom site "${site}".`));
+    });
+
+  // ── Built-in: browser profile selection ──────────────────────────────────
+  const profileCmd = program.command('profile').description('Manage Browser Bridge Chrome profiles');
+
+  profileCmd
+    .command('list')
+    .description('List Chrome profiles connected through the Browser Bridge extension')
+    .action(async () => {
+      const status = await fetchDaemonStatus();
+      const config = loadProfileConfig();
+      const profiles = status?.profiles ?? [];
+      if (!status) {
+        console.log(styleText('yellow', 'Daemon is not running. Run opencli doctor after opening Chrome.'));
+        return;
+      }
+      if (profiles.length === 0) {
+        console.log(styleText('yellow', 'No Browser Bridge profiles connected.'));
+        console.log(styleText('dim', 'Open a Chrome profile with the OpenCLI extension installed, then run opencli profile list again.'));
+        return;
+      }
+
+      const knownContextIds = new Set(profiles.map((profile) => profile.contextId));
+      console.log(styleText('bold', 'Connected Browser Bridge profiles'));
+      console.log();
+      for (const profile of profiles) {
+        const alias = aliasForContextId(config, profile.contextId);
+        const defaultMark = config.defaultContextId === profile.contextId ? styleText('green', ' default') : '';
+        const aliasText = alias ? ` ${styleText('cyan', alias)}` : '';
+        const version = profile.extensionVersion ? ` v${profile.extensionVersion}` : ' version unknown';
+        console.log(`  ${profile.contextId}${aliasText}${defaultMark} — connected${version}`);
+      }
+
+      const disconnectedAliases = Object.entries(config.aliases)
+        .filter(([, contextId]) => !knownContextIds.has(contextId));
+      if (disconnectedAliases.length > 0 || (config.defaultContextId && !knownContextIds.has(config.defaultContextId))) {
+        console.log();
+        console.log(styleText('dim', 'Disconnected saved profiles:'));
+        const shown = new Set<string>();
+        for (const [alias, contextId] of disconnectedAliases) {
+          shown.add(contextId);
+          console.log(styleText('dim', `  ${contextId} ${alias} — not connected`));
+        }
+        if (config.defaultContextId && !shown.has(config.defaultContextId) && !knownContextIds.has(config.defaultContextId)) {
+          console.log(styleText('dim', `  ${config.defaultContextId} — default, not connected`));
+        }
+      }
+    });
+
+  profileCmd
+    .command('rename')
+    .description('Assign a local alias to a connected Browser Bridge profile')
+    .argument('<contextId>', 'Profile contextId from opencli profile list')
+    .argument('<alias>', 'Local alias, e.g. work or personal')
+    .action((contextId: string, alias: string) => {
+      try {
+        renameProfile(contextId, alias);
+        console.log(`Profile ${contextId} is now aliased as ${styleText('cyan', alias)}.`);
+      } catch (err) {
+        console.error(styleText('red', `Error: ${getErrorMessage(err)}`));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+      }
+    });
+
+  profileCmd
+    .command('use')
+    .description('Set the default Browser Bridge profile for future commands')
+    .argument('<profile>', 'Profile alias or contextId')
+    .action((profile: string) => {
+      try {
+        const config = setDefaultProfile(profile);
+        console.log(`Default Browser Bridge profile: ${styleText('cyan', config.defaultContextId ?? profile)}`);
+      } catch (err) {
+        console.error(styleText('red', `Error: ${getErrorMessage(err)}`));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+      }
     });
 
   // ── Built-in: daemon ──────────────────────────────────────────────────────

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -96,7 +96,11 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         log.warn(`Deprecated: ${message}${replacement}`);
       }
 
-      const result = await executeCommand(cmd, kwargs, verbose, { prepared: true });
+      const globals = typeof subCmd.optsWithGlobals === 'function' ? subCmd.optsWithGlobals() as Record<string, unknown> : {};
+      const result = await executeCommand(cmd, kwargs, verbose, {
+        prepared: true,
+        ...(typeof globals.profile === 'string' && globals.profile.trim() ? { profile: globals.profile.trim() } : {}),
+      });
       if (result === null || result === undefined) {
         return;
       }

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -25,6 +25,12 @@ export async function daemonStatus(): Promise<void> {
   console.log(`Daemon: ${styleText('green', 'running')} (PID ${status.pid})`);
   console.log(`Uptime: ${formatDuration(Math.round(status.uptime * 1000))}`);
   console.log(`Extension: ${extensionLabel}`);
+  if (status.profiles && status.profiles.length > 0) {
+    console.log(`Profiles: ${status.profiles.map((profile) => {
+      const version = profile.extensionVersion ? ` v${profile.extensionVersion}` : '';
+      return `${profile.contextId}${version}`;
+    }).join(', ')}`);
+  }
   console.log(`Memory: ${status.memoryMB} MB`);
   console.log(`Port: ${status.port}`);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -26,15 +26,23 @@ import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { EXIT_CODES } from './errors.js';
 import { log } from './logger.js';
 import { PKG_VERSION } from './version.js';
+import { DEFAULT_CONTEXT_ID } from './browser/profile.js';
 
 const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
 
 // ─── State ───────────────────────────────────────────────────────────
 
-let extensionWs: WebSocket | null = null;
-let extensionVersion: string | null = null;
-let extensionCompatRange: string | null = null;
+type ExtensionProfileConnection = {
+  contextId: string;
+  ws: WebSocket;
+  extensionVersion: string | null;
+  extensionCompatRange: string | null;
+  lastSeenAt: number;
+};
+
+const extensionProfiles = new Map<string, ExtensionProfileConnection>();
 const pending = new Map<string, {
+  contextId: string;
   resolve: (data: unknown) => void;
   reject: (error: Error) => void;
   timer: ReturnType<typeof setTimeout>;
@@ -47,6 +55,78 @@ const logBuffer: LogEntry[] = [];
 function pushLog(entry: LogEntry): void {
   logBuffer.push(entry);
   if (logBuffer.length > LOG_BUFFER_SIZE) logBuffer.shift();
+}
+
+function activeProfiles(): ExtensionProfileConnection[] {
+  return [...extensionProfiles.values()].filter((entry) => entry.ws.readyState === WebSocket.OPEN);
+}
+
+function resolveExtensionConnection(contextId?: string): {
+  connection?: ExtensionProfileConnection;
+  errorCode?: 'extension_not_connected' | 'profile_required' | 'profile_disconnected';
+  error?: string;
+  errorHint?: string;
+} {
+  const requestedContextId = typeof contextId === 'string' && contextId.trim() ? contextId.trim() : undefined;
+  if (requestedContextId) {
+    const connection = extensionProfiles.get(requestedContextId);
+    if (connection?.ws.readyState === WebSocket.OPEN) return { connection };
+    return {
+      errorCode: 'profile_disconnected',
+      error: `Browser profile "${requestedContextId}" is not connected.`,
+      errorHint: 'Open that Chrome profile and make sure the OpenCLI extension is enabled, or choose another profile with opencli profile use <name>.',
+    };
+  }
+
+  const connected = activeProfiles();
+  if (connected.length === 1) return { connection: connected[0] };
+  if (connected.length > 1) {
+    return {
+      errorCode: 'profile_required',
+      error: 'Multiple Browser Bridge profiles are connected; choose one with --profile.',
+      errorHint: 'Run opencli profile list, then use opencli --profile <name> ... or opencli profile use <name>.',
+    };
+  }
+  return {
+    errorCode: 'extension_not_connected',
+    error: 'Extension not connected. Please install the opencli Browser Bridge extension.',
+  };
+}
+
+function registerExtensionConnection(ws: WebSocket, rawContextId: unknown): ExtensionProfileConnection {
+  const contextId = typeof rawContextId === 'string' && rawContextId.trim()
+    ? rawContextId.trim()
+    : DEFAULT_CONTEXT_ID;
+  const previous = extensionProfiles.get(contextId);
+  if (previous && previous.ws !== ws) {
+    previous.ws.close();
+  }
+  const existing = [...extensionProfiles.entries()].find(([, entry]) => entry.ws === ws);
+  if (existing && existing[0] !== contextId) extensionProfiles.delete(existing[0]);
+
+  const current = extensionProfiles.get(contextId);
+  const connection: ExtensionProfileConnection = {
+    contextId,
+    ws,
+    extensionVersion: current?.ws === ws ? current.extensionVersion : null,
+    extensionCompatRange: current?.ws === ws ? current.extensionCompatRange : null,
+    lastSeenAt: Date.now(),
+  };
+  extensionProfiles.set(contextId, connection);
+  return connection;
+}
+
+function unregisterExtensionConnection(ws: WebSocket): void {
+  for (const [contextId, connection] of extensionProfiles.entries()) {
+    if (connection.ws !== ws) continue;
+    extensionProfiles.delete(contextId);
+    for (const [id, p] of pending) {
+      if (p.contextId !== contextId) continue;
+      clearTimeout(p.timer);
+      p.reject(new Error(`Browser profile "${contextId}" disconnected`));
+      pending.delete(id);
+    }
+  }
 }
 
 // ─── HTTP Server ─────────────────────────────────────────────────────
@@ -135,14 +215,29 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   if (req.method === 'GET' && pathname === '/status') {
     const uptime = process.uptime();
     const mem = process.memoryUsage();
+    const params = new URL(url, `http://localhost:${PORT}`).searchParams;
+    const requestedContextId = params.get('contextId')?.trim() || undefined;
+    const route = resolveExtensionConnection(requestedContextId);
+    const profiles = activeProfiles().map((profile) => ({
+      contextId: profile.contextId,
+      extensionConnected: true,
+      extensionVersion: profile.extensionVersion ?? undefined,
+      extensionCompatRange: profile.extensionCompatRange ?? undefined,
+      pending: [...pending.values()].filter((entry) => entry.contextId === profile.contextId).length,
+      lastSeenAt: profile.lastSeenAt,
+    }));
     jsonResponse(res, 200, {
       ok: true,
       pid: process.pid,
       uptime,
       daemonVersion: PKG_VERSION,
-      extensionConnected: extensionWs?.readyState === WebSocket.OPEN,
-      extensionVersion,
-      extensionCompatRange,
+      extensionConnected: !!route.connection,
+      extensionVersion: route.connection?.extensionVersion ?? undefined,
+      extensionCompatRange: route.connection?.extensionCompatRange ?? undefined,
+      contextId: route.connection?.contextId ?? requestedContextId,
+      profileRequired: route.errorCode === 'profile_required',
+      profileDisconnected: route.errorCode === 'profile_disconnected',
+      profiles,
       pending: pending.size,
       memoryMB: Math.round(mem.rss / 1024 / 1024 * 10) / 10,
       port: PORT,
@@ -180,8 +275,15 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         return;
       }
 
-      if (!extensionWs || extensionWs.readyState !== WebSocket.OPEN) {
-        jsonResponse(res, 503, { id: body.id, ok: false, error: 'Extension not connected. Please install the opencli Browser Bridge extension.' });
+      const route = resolveExtensionConnection(typeof body.contextId === 'string' ? body.contextId : undefined);
+      if (!route.connection) {
+        jsonResponse(res, route.errorCode === 'profile_required' ? 409 : 503, {
+          id: body.id,
+          ok: false,
+          errorCode: route.errorCode,
+          error: route.error,
+          ...(route.errorHint ? { errorHint: route.errorHint } : {}),
+        });
         return;
       }
 
@@ -201,8 +303,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
           pending.delete(body.id);
           reject(new Error(`Command timeout (${timeoutMs / 1000}s)`));
         }, timeoutMs);
-        pending.set(body.id, { resolve, reject, timer });
-        extensionWs!.send(JSON.stringify(body));
+        pending.set(body.id, { contextId: route.connection!.contextId, resolve, reject, timer });
+        route.connection!.ws.send(JSON.stringify(body));
       });
 
       jsonResponse(res, 200, result);
@@ -236,9 +338,6 @@ const wss = new WebSocketServer({
 
 wss.on('connection', (ws: WebSocket) => {
   log.info('[daemon] Extension connected');
-  extensionWs = ws;
-  extensionVersion = null; // cleared until hello message arrives
-  extensionCompatRange = null;
 
   // ── Heartbeat: ping every 15s, close if 2 pongs missed ──
   let missedPongs = 0;
@@ -267,8 +366,11 @@ wss.on('connection', (ws: WebSocket) => {
 
       // Handle hello message from extension (version handshake)
       if (msg.type === 'hello') {
-        extensionVersion = typeof msg.version === 'string' ? msg.version : null;
-        extensionCompatRange = typeof msg.compatRange === 'string' ? msg.compatRange : null;
+        const connection = registerExtensionConnection(ws, msg.contextId);
+        connection.extensionVersion = typeof msg.version === 'string' ? msg.version : null;
+        connection.extensionCompatRange = typeof msg.compatRange === 'string' ? msg.compatRange : null;
+        connection.lastSeenAt = Date.now();
+        log.info(`[daemon] Extension profile connected: ${connection.contextId}`);
         return;
       }
 
@@ -296,32 +398,12 @@ wss.on('connection', (ws: WebSocket) => {
   ws.on('close', () => {
     log.info('[daemon] Extension disconnected');
     clearInterval(heartbeatInterval);
-    if (extensionWs === ws) {
-      extensionWs = null;
-      extensionVersion = null;
-      extensionCompatRange = null;
-      // Reject all pending requests since the extension is gone
-      for (const [id, p] of pending) {
-        clearTimeout(p.timer);
-        p.reject(new Error('Extension disconnected'));
-      }
-      pending.clear();
-    }
+    unregisterExtensionConnection(ws);
   });
 
   ws.on('error', () => {
     clearInterval(heartbeatInterval);
-    if (extensionWs === ws) {
-      extensionWs = null;
-      extensionVersion = null;
-      extensionCompatRange = null;
-      // Reject pending requests in case 'close' does not follow this 'error'
-      for (const [, p] of pending) {
-        clearTimeout(p.timer);
-        p.reject(new Error('Extension disconnected'));
-      }
-      pending.clear();
-    }
+    unregisterExtensionConnection(ws);
   });
 });
 
@@ -348,7 +430,7 @@ function shutdown(): void {
     p.reject(new Error('Daemon shutting down'));
   }
   pending.clear();
-  if (extensionWs) extensionWs.close();
+  for (const profile of extensionProfiles.values()) profile.ws.close();
   httpServer.close();
   process.exit(EXIT_CODES.SUCCESS);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,6 +52,18 @@ interface LogEntry { level: string; msg: string; ts: number; }
 const LOG_BUFFER_SIZE = 200;
 const logBuffer: LogEntry[] = [];
 
+class DaemonCommandFailure extends Error {
+  constructor(
+    message: string,
+    readonly errorCode?: string,
+    readonly errorHint?: string,
+    readonly status: number = 400,
+  ) {
+    super(message);
+    this.name = 'DaemonCommandFailure';
+  }
+}
+
 function pushLog(entry: LogEntry): void {
   logBuffer.push(entry);
   if (logBuffer.length > LOG_BUFFER_SIZE) logBuffer.shift();
@@ -123,7 +135,12 @@ function unregisterExtensionConnection(ws: WebSocket): void {
     for (const [id, p] of pending) {
       if (p.contextId !== contextId) continue;
       clearTimeout(p.timer);
-      p.reject(new Error(`Browser profile "${contextId}" disconnected`));
+      p.reject(new DaemonCommandFailure(
+        `Browser profile "${contextId}" disconnected`,
+        'profile_disconnected',
+        'Open that Chrome profile and make sure the OpenCLI extension is enabled, or choose another profile with opencli profile use <name>.',
+        503,
+      ));
       pending.delete(id);
     }
   }
@@ -309,9 +326,12 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
 
       jsonResponse(res, 200, result);
     } catch (err) {
-      jsonResponse(res, err instanceof Error && err.message.includes('timeout') ? 408 : 400, {
+      const commandFailure = err instanceof DaemonCommandFailure ? err : null;
+      jsonResponse(res, commandFailure?.status ?? (err instanceof Error && err.message.includes('timeout') ? 408 : 400), {
         ok: false,
         error: err instanceof Error ? err.message : 'Invalid request',
+        ...(commandFailure?.errorCode ? { errorCode: commandFailure.errorCode } : {}),
+        ...(commandFailure?.errorHint ? { errorHint: commandFailure.errorHint } : {}),
       });
     }
     return;

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -118,6 +118,47 @@ describe('doctor report rendering', () => {
     expect(text).toContain('bound:default → tab 42, mode=borrowed, surface=borrowed-user-tab, tabs=1, idle=none');
   });
 
+  it('renders connected profiles and groups sessions by profile', () => {
+    const text = strip(renderBrowserDoctorReport({
+      daemonRunning: true,
+      extensionConnected: false,
+      profiles: [
+        { contextId: 'work', extensionConnected: true, extensionVersion: '1.2.3', pending: 0 },
+        { contextId: 'personal', extensionConnected: true, extensionVersion: '1.2.3', pending: 0 },
+      ],
+      issues: [],
+      sessions: [
+        {
+          contextId: 'work',
+          workspace: 'bound:default',
+          windowId: 2,
+          preferredTabId: 42,
+          ownership: 'borrowed',
+          surface: 'borrowed-user-tab',
+          tabCount: 1,
+          idleMsRemaining: null,
+        },
+        {
+          contextId: 'personal',
+          workspace: 'site:foo',
+          windowId: 1,
+          preferredTabId: 10,
+          ownership: 'owned',
+          surface: 'dedicated-container',
+          tabCount: 1,
+          idleMsRemaining: 1000,
+        },
+      ],
+    }));
+
+    expect(text).toContain('Profiles:');
+    expect(text).toContain('work: connected v1.2.3');
+    expect(text).toContain('[profile: work]');
+    expect(text).toContain('[profile: personal]');
+    expect(text).toContain('bound:default → tab 42');
+    expect(text).toContain('site:foo → tab 10');
+  });
+
   it('renders unstable extension state when live connectivity and status disagree', () => {
     const text = strip(renderBrowserDoctorReport({
       daemonRunning: true,
@@ -239,6 +280,30 @@ describe('doctor report rendering', () => {
 
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('did not report a version'),
+    ]));
+  });
+
+  it('reports profile-required when multiple profiles are connected without a selection', async () => {
+    const status = {
+      state: 'profile-required' as const,
+      status: {
+        extensionConnected: false,
+        profileRequired: true,
+        profiles: [
+          { contextId: 'work', extensionConnected: true, pending: 0 },
+          { contextId: 'personal', extensionConnected: true, pending: 0 },
+        ],
+      },
+    };
+    mockGetDaemonHealth
+      .mockResolvedValueOnce(status)
+      .mockResolvedValueOnce(status);
+
+    const report = await runBrowserDoctor({ live: false });
+
+    expect(report.profiles).toHaveLength(2);
+    expect(report.issues).toEqual(expect.arrayContaining([
+      expect.stringContaining('Multiple Chrome profiles are connected'),
     ]));
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -12,6 +12,8 @@ import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
 import type { BrowserSessionInfo } from './types.js';
+import type { BrowserProfileStatus } from './browser/daemon-client.js';
+import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
 
@@ -68,6 +70,7 @@ export type DoctorReport = {
   latestExtensionVersion?: string;
   connectivity?: ConnectivityResult;
   sessions?: BrowserSessionInfo[];
+  profiles?: BrowserProfileStatus[];
   issues: string[];
 };
 
@@ -118,9 +121,19 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const extensionConnected = health.state === 'ready';
   const daemonFlaky = !!(connectivity?.ok && !daemonRunning);
   const extensionFlaky = !!(connectivity?.ok && daemonRunning && !extensionConnected);
-  const sessions = opts.sessions && health.state === 'ready'
-    ? await listSessions()
-    : undefined;
+  const profiles = health.status?.profiles;
+  let sessions: BrowserSessionInfo[] | undefined;
+  if (opts.sessions) {
+    if (profiles && profiles.length > 0) {
+      const grouped = await Promise.all(profiles.map(async (profile) => {
+        const rows = await listSessions({ contextId: profile.contextId }).catch(() => [] as BrowserSessionInfo[]);
+        return rows.map((row) => ({ ...row, contextId: row.contextId ?? profile.contextId }));
+      }));
+      sessions = grouped.flat();
+    } else if (health.state === 'ready') {
+      sessions = await listSessions();
+    }
+  }
   const extensionVersion = health.status?.extensionVersion;
 
   const issues: string[] = [];
@@ -138,6 +151,17 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
       'This usually means the Browser Bridge service worker is reconnecting slowly or Chrome suspended it.',
     );
   } else if (daemonRunning && !extensionConnected) {
+    if (health.state === 'profile-required') {
+      issues.push(
+        'Multiple Chrome profiles are connected to the daemon, but no default profile was selected.\n' +
+        '  Run opencli profile list, then opencli profile use <name>, or pass --profile <name>.',
+      );
+    } else if (health.state === 'profile-disconnected') {
+      issues.push(
+        `Selected browser profile is not connected: ${health.status?.contextId ?? 'unknown'}.\n` +
+        '  Open that Chrome profile and make sure the OpenCLI extension is enabled.',
+      );
+    } else {
     const daemonVersion = health.status?.daemonVersion;
     const isStale = opts.cliVersion && (!daemonVersion || daemonVersion !== opts.cliVersion);
     if (isStale) {
@@ -158,6 +182,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
         '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
         '  3. Click "Load unpacked" → select the extension folder',
       );
+    }
     }
   }
   if (extensionConnected && !extensionVersion) {
@@ -211,6 +236,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     latestExtensionVersion,
     connectivity,
     sessions,
+    profiles,
     issues,
   };
 }
@@ -244,6 +270,18 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
     : report.extensionConnected ? 'connected' : 'not connected';
   lines.push(`${extIcon} Extension: ${extLabel}${extVersion}`);
 
+  if (report.profiles && report.profiles.length > 0) {
+    const config = loadProfileConfig();
+    lines.push('', styleText('bold', 'Profiles:'));
+    for (const profile of report.profiles) {
+      const alias = aliasForContextId(config, profile.contextId);
+      const aliasText = alias ? ` (${alias})` : '';
+      const defaultText = config.defaultContextId === profile.contextId ? ', default' : '';
+      const version = profile.extensionVersion ? `v${profile.extensionVersion}` : 'version unknown';
+      lines.push(styleText('dim', `  • ${profile.contextId}${aliasText}: connected ${version}${defaultText}`));
+    }
+  }
+
   // Connectivity
   if (report.connectivity) {
     const connIcon = report.connectivity.ok ? styleText('green', '[OK]') : styleText('red', '[FAIL]');
@@ -260,7 +298,16 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
     if (report.sessions.length === 0) {
       lines.push(styleText('dim', '  • no active automation sessions'));
     } else {
+      const byContext = new Map<string, BrowserSessionInfo[]>();
       for (const session of report.sessions) {
+        const contextId = typeof session.contextId === 'string' && session.contextId ? session.contextId : 'default';
+        const rows = byContext.get(contextId) ?? [];
+        rows.push(session);
+        byContext.set(contextId, rows);
+      }
+      for (const [contextId, rows] of byContext) {
+        if (byContext.size > 1) lines.push(styleText('dim', `  [profile: ${contextId}]`));
+        for (const session of rows) {
         const idle = session.idleMsRemaining == null
           ? 'none'
           : `${Math.ceil(session.idleMsRemaining / 1000)}s`;
@@ -270,6 +317,7 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
         const mode = session.ownership ?? (session.owned === false ? 'borrowed' : 'owned');
         const surface = session.surface ? `, surface=${session.surface}` : '';
         lines.push(styleText('dim', `  • ${session.workspace ?? 'default'} → ${target}, mode=${mode}${surface}, tabs=${session.tabCount ?? 0}, idle=${idle}`));
+      }
       }
     }
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -57,7 +57,7 @@ export class CliError extends Error {
 
 // ── Typed subclasses ─────────────────────────────────────────────────────────
 
-export type BrowserConnectKind = 'daemon-not-running' | 'extension-not-connected' | 'command-failed' | 'unknown';
+export type BrowserConnectKind = 'daemon-not-running' | 'extension-not-connected' | 'profile-required' | 'profile-disconnected' | 'command-failed' | 'unknown';
 
 export class BrowserConnectError extends CliError {
   readonly kind: BrowserConnectKind;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -20,6 +20,7 @@ import { AdapterLoadError, ArgumentError, CommandExecutionError, getErrorMessage
 import { isDiagnosticEnabled, collectDiagnostic, emitDiagnostic } from './diagnostic.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT } from './runtime.js';
+import { resolveProfileContextId } from './browser/profile.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
@@ -156,7 +157,7 @@ export async function executeCommand(
   cmd: CliCommand,
   rawKwargs: CommandArgs,
   debug: boolean = false,
-  opts: { prepared?: boolean } = {},
+  opts: { prepared?: boolean; profile?: string } = {},
 ): Promise<unknown> {
   let kwargs: CommandArgs;
   try {
@@ -199,6 +200,7 @@ export async function executeCommand(
 
       ensureRequiredEnv(cmd);
       const BrowserFactory = getBrowserFactory(cmd.site);
+      const contextId = resolveProfileContextId(opts.profile);
       result = await browserSession(BrowserFactory, async (page) => {
         const preNavUrl = resolvePreNav(cmd);
         if (preNavUrl) {
@@ -242,7 +244,7 @@ export async function executeCommand(
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { workspace: `site:${cmd.site}`, cdpEndpoint });
+      }, { workspace: `site:${cmd.site}`, cdpEndpoint, contextId });
     } else {
       // Non-browser commands: apply timeout only when explicitly configured.
       const timeout = cmd.timeoutSeconds;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -64,14 +64,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string }): Promise<IPage>;
+  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { workspace?: string; cdpEndpoint?: string } = {},
+  opts: { workspace?: string; cdpEndpoint?: string; contextId?: string } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -79,6 +79,7 @@ export async function browserSession<T>(
       timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
       workspace: opts.workspace,
       cdpEndpoint: opts.cdpEndpoint,
+      contextId: opts.contextId,
     });
     return await fn(page);
   } finally {


### PR DESCRIPTION
## Summary
- add profile-aware Browser Bridge routing with extension-generated `contextId` handshake and daemon connection registry
- add CLI profile selection (`opencli profile list/rename/use`, global `--profile`, `OPENCLI_PROFILE`) and profile-scoped browser commands/sessions
- show connected profiles in doctor/daemon status and document multi-profile usage in README

## Verification
- `npm run typecheck`
- `cd extension && npm run typecheck`
- `npx vitest run src/browser/daemon-client.test.ts src/browser.test.ts src/doctor.test.ts src/commands/daemon.test.ts extension/src/background.test.ts`
- `npm run build`
- `cd extension && npm run build`
- `OPENCLI_DAEMON_PORT=29125 npm test`

Note: `npm test` without overriding `OPENCLI_DAEMON_PORT` hit a local 19825 port conflict from an existing daemon; rerunning with `OPENCLI_DAEMON_PORT=29125` passed.
