### PR TITLE
refactor(adapter): split browser command signatures

### DIFF
--- a/clis/36kr/news.js
+++ b/clis/36kr/news.js
@@ -12,7 +12,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Number of articles (max 50)' },
     ],
     columns: ['rank', 'title', 'summary', 'date', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const count = Math.min(kwargs.limit || 20, 50);
         const resp = await fetch('https://www.36kr.com/feed', {
             headers: { 'User-Agent': 'Mozilla/5.0 (compatible; opencli/1.0)' },

--- a/clis/apple-podcasts/commands.test.js
+++ b/clis/apple-podcasts/commands.test.js
@@ -24,7 +24,7 @@ describe('apple-podcasts search command', () => {
             }),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             query: 'machine learning',
             keyword: 'sports',
             limit: 5,
@@ -60,7 +60,7 @@ describe('apple-podcasts top command', () => {
             }),
         });
         vi.stubGlobal('fetch', fetchMock);
-        await cmd.func(null, { country: 'US', limit: 1 });
+        await cmd.func({ country: 'US', limit: 1 });
         const [, options] = fetchMock.mock.calls[0] ?? [];
         expect(options).toBeDefined();
         expect(options.signal).toBeDefined();
@@ -81,7 +81,7 @@ describe('apple-podcasts top command', () => {
             }),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await cmd.func(null, { country: 'US', limit: 2 });
+        const result = await cmd.func({ country: 'US', limit: 2 });
         expect(fetchMock).toHaveBeenCalledWith('https://rss.marketingtools.apple.com/api/v2/us/podcasts/top/2/podcasts.json', expect.objectContaining({
             signal: expect.any(Object),
         }));
@@ -94,6 +94,6 @@ describe('apple-podcasts top command', () => {
         const cmd = getRegistry().get('apple-podcasts/top');
         expect(cmd?.func).toBeTypeOf('function');
         vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('socket hang up')));
-        await expect(cmd.func(null, { country: 'us', limit: 3 })).rejects.toThrow('Unable to reach Apple Podcasts charts for US');
+        await expect(cmd.func({ country: 'us', limit: 3 })).rejects.toThrow('Unable to reach Apple Podcasts charts for US');
     });
 });

--- a/clis/apple-podcasts/episodes.js
+++ b/clis/apple-podcasts/episodes.js
@@ -12,7 +12,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Max episodes to show' },
     ],
     columns: ['title', 'duration', 'date'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 200));
         // results[0] is the podcast itself; the rest are episodes
         const data = await itunesFetch(`/lookup?id=${args.id}&entity=podcastEpisode&limit=${limit + 1}`);

--- a/clis/apple-podcasts/search.js
+++ b/clis/apple-podcasts/search.js
@@ -12,7 +12,7 @@ cli({
         { name: 'limit', type: 'int', default: 10, help: 'Max results' },
     ],
     columns: ['id', 'title', 'author', 'episodes', 'genre', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const term = encodeURIComponent(args.query);
         const limit = Math.max(1, Math.min(Number(args.limit), 25));
         const data = await itunesFetch(`/search?term=${term}&media=podcast&limit=${limit}`);

--- a/clis/apple-podcasts/top.js
+++ b/clis/apple-podcasts/top.js
@@ -14,7 +14,7 @@ cli({
         { name: 'country', default: 'us', help: 'Country code (e.g. us, cn, gb, jp)' },
     ],
     columns: ['rank', 'title', 'author', 'id'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 100));
         const country = String(args.country || 'us').trim().toLowerCase();
         const url = `${CHARTS_URL}/${country}/podcasts/top/${limit}/podcasts.json`;

--- a/clis/arxiv/paper.js
+++ b/clis/arxiv/paper.js
@@ -11,7 +11,7 @@ cli({
         { name: 'id', positional: true, required: true, help: 'arXiv paper ID (e.g. 1706.03762)' },
     ],
     columns: ['id', 'title', 'authors', 'published', 'abstract', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const xml = await arxivFetch(`id_list=${encodeURIComponent(args.id)}`);
         const entries = parseEntries(xml);
         if (!entries.length)

--- a/clis/arxiv/search.js
+++ b/clis/arxiv/search.js
@@ -12,7 +12,7 @@ cli({
         { name: 'limit', type: 'int', default: 10, help: 'Max results (max 25)' },
     ],
     columns: ['id', 'title', 'authors', 'published', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 25));
         const query = encodeURIComponent(`all:${args.query}`);
         const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=relevance`);

--- a/clis/bbc/news.js
+++ b/clis/bbc/news.js
@@ -12,7 +12,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Number of headlines (max 50)' },
     ],
     columns: ['rank', 'title', 'description', 'url'],
-    func: async (page, kwargs) => {
+    func: async (kwargs) => {
         const count = Math.min(kwargs.limit || 20, 50);
         const resp = await fetch('https://feeds.bbci.co.uk/news/rss.xml');
         if (!resp.ok)

--- a/clis/bloomberg/businessweek.js
+++ b/clis/bloomberg/businessweek.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('businessweek', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/economics.js
+++ b/clis/bloomberg/economics.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('economics', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/industries.js
+++ b/clis/bloomberg/industries.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('industries', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/main.js
+++ b/clis/bloomberg/main.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('main', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/markets.js
+++ b/clis/bloomberg/markets.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('markets', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/opinions.js
+++ b/clis/bloomberg/opinions.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('opinions', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/politics.js
+++ b/clis/bloomberg/politics.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('politics', kwargs.limit ?? 1);
     },
 });

--- a/clis/bloomberg/tech.js
+++ b/clis/bloomberg/tech.js
@@ -11,7 +11,7 @@ cli({
         { name: 'limit', type: 'int', default: 1, help: 'Number of feed items to return (max 20)' },
     ],
     columns: ['title', 'summary', 'link', 'mediaLinks'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         return fetchBloombergFeed('tech', kwargs.limit ?? 1);
     },
 });

--- a/clis/chatgpt-app/ask.js
+++ b/clis/chatgpt-app/ask.js
@@ -15,7 +15,7 @@ export const askCommand = cli({
         { name: 'timeout', required: false, help: 'Max seconds to wait for response (default: 30)', default: '30' },
     ],
     columns: ['Role', 'Text'],
-    func: async (page, kwargs) => {
+    func: async (kwargs) => {
         if (process.platform !== 'darwin') {
             throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
         }

--- a/clis/chatgpt-app/model.js
+++ b/clis/chatgpt-app/model.js
@@ -12,7 +12,7 @@ export const modelCommand = cli({
         { name: 'model', required: true, positional: true, help: 'Model to switch to', choices: MODEL_CHOICES },
     ],
     columns: ['Status', 'Model'],
-    func: async (page, kwargs) => {
+    func: async (kwargs) => {
         if (process.platform !== 'darwin') {
             throw new ConfigError('ChatGPT Desktop integration requires macOS');
         }

--- a/clis/chatgpt-app/new.js
+++ b/clis/chatgpt-app/new.js
@@ -10,7 +10,7 @@ export const newCommand = cli({
     browser: false,
     args: [],
     columns: ['Status'],
-    func: async (page) => {
+    func: async () => {
         if (process.platform !== 'darwin') {
             throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
         }

--- a/clis/chatgpt-app/read.js
+++ b/clis/chatgpt-app/read.js
@@ -11,7 +11,7 @@ export const readCommand = cli({
     browser: false,
     args: [],
     columns: ['Role', 'Text'],
-    func: async (page) => {
+    func: async () => {
         if (process.platform !== 'darwin') {
             throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
         }

--- a/clis/chatgpt-app/send.js
+++ b/clis/chatgpt-app/send.js
@@ -13,7 +13,7 @@ export const sendCommand = cli({
         { name: 'model', required: false, help: 'Model/mode to use: auto, instant, thinking, 5.2-instant, 5.2-thinking', choices: MODEL_CHOICES },
     ],
     columns: ['Status'],
-    func: async (page, kwargs) => {
+    func: async (kwargs) => {
         const text = kwargs.text;
         const model = kwargs.model;
         try {

--- a/clis/chatgpt-app/status.js
+++ b/clis/chatgpt-app/status.js
@@ -10,7 +10,7 @@ export const statusCommand = cli({
     browser: false,
     args: [],
     columns: ['Status'],
-    func: async (page) => {
+    func: async () => {
         if (process.platform !== 'darwin') {
             throw new ConfigError('ChatGPT Desktop integration requires macOS (osascript is not available on this platform)');
         }

--- a/clis/ctrip/search.js
+++ b/clis/ctrip/search.js
@@ -34,7 +34,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Number of results' },
     ],
     columns: ['rank', 'name', 'type', 'score', 'price', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const query = String(kwargs.query || '').trim();
         if (!query) {
             throw new ArgumentError('Search keyword cannot be empty');

--- a/clis/ctrip/search.test.js
+++ b/clis/ctrip/search.test.js
@@ -25,7 +25,7 @@ describe('ctrip search', () => {
                 ],
             },
         }), { status: 200 })));
-        const result = await command.func(null, { query: '苏州', limit: 3 });
+        const result = await command.func({ query: '苏州', limit: 3 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -46,11 +46,11 @@ describe('ctrip search', () => {
         ]);
     });
     it('rejects empty queries', async () => {
-        await expect(command.func(null, { query: '   ', limit: 3 })).rejects.toThrow('Search keyword cannot be empty');
+        await expect(command.func({ query: '   ', limit: 3 })).rejects.toThrow('Search keyword cannot be empty');
     });
     it('surfaces fetch failures as CliError', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 503 })));
-        await expect(command.func(null, { query: '苏州', limit: 3 })).rejects.toMatchObject({
+        await expect(command.func({ query: '苏州', limit: 3 })).rejects.toMatchObject({
             code: 'FETCH_ERROR',
             message: 'ctrip search failed with status 503',
         });
@@ -59,6 +59,6 @@ describe('ctrip search', () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
             Response: { searchResults: [] },
         }), { status: 200 })));
-        await expect(command.func(null, { query: '苏州', limit: 3 })).rejects.toThrow('ctrip search returned no data');
+        await expect(command.func({ query: '苏州', limit: 3 })).rejects.toThrow('ctrip search returned no data');
     });
 });

--- a/clis/eastmoney/announcement.js
+++ b/clis/eastmoney/announcement.js
@@ -18,7 +18,7 @@ cli({
     { name: 'limit',  type: 'int',    default: 20,            help: '返回数量 (max 100)' },
   ],
   columns: ['time', 'code', 'name', 'title', 'category', 'url'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const market = String(args.market ?? 'SHA,SZA,BJA').trim() || 'SHA,SZA,BJA';
     const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
 

--- a/clis/eastmoney/convertible.js
+++ b/clis/eastmoney/convertible.js
@@ -28,7 +28,7 @@ cli({
     { name: 'limit', type: 'int',    default: 20,         help: '返回数量 (max 100)' },
   ],
   columns: ['rank', 'bondCode', 'bondName', 'bondPrice', 'bondChangePct', 'stockCode', 'stockName', 'stockPrice', 'stockChangePct', 'convPrice', 'convValue', 'convPremiumPct', 'remainingYears', 'ytm', 'listDate'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const sortKey = String(args.sort ?? 'turnover').toLowerCase();
     const sort = SORTS[sortKey];
     if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);

--- a/clis/eastmoney/etf.js
+++ b/clis/eastmoney/etf.js
@@ -26,7 +26,7 @@ cli({
     { name: 'limit', type: 'int',   default: 20,         help: '返回数量 (max 100)' },
   ],
   columns: ['rank', 'code', 'name', 'price', 'changePercent', 'change', 'turnover', 'volume', 'turnoverRate'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const sortKey = String(args.sort ?? 'turnover').toLowerCase();
     const sort = SORTS[sortKey];
     if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);

--- a/clis/eastmoney/holders.js
+++ b/clis/eastmoney/holders.js
@@ -37,7 +37,7 @@ cli({
     { name: 'limit',  type: 'int',    default: 10,      help: '返回股东数（默认十大流通股东）' },
   ],
   columns: ['rank', 'reportDate', 'name', 'holdNum', 'floatRatio', 'change'],
-  func: async (_page, args) => {
+  func: async (args) => {
     /** @type {string} */
     let secucode;
     try { secucode = toSecucode(args.symbol); }

--- a/clis/eastmoney/index-board.js
+++ b/clis/eastmoney/index-board.js
@@ -47,7 +47,7 @@ cli({
     },
   ],
   columns: ['code', 'name', 'price', 'changePercent', 'change', 'open', 'high', 'low', 'prevClose'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const group = String(args.group ?? 'main').toLowerCase();
     /** @type {[string,string][]} */
     let entries;

--- a/clis/eastmoney/kline.js
+++ b/clis/eastmoney/kline.js
@@ -36,7 +36,7 @@ cli({
     { name: 'limit',  type: 'int',    default: 30,        help: '返回最近 N 根（末尾）' },
   ],
   columns: ['date', 'open', 'close', 'high', 'low', 'volume', 'turnover', 'amplitude', 'changePercent', 'change', 'turnoverRate'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const secid = resolveSecid(args.symbol);
     const periodKey = String(args.period ?? 'day').toLowerCase();
     const klt = PERIOD_MAP[periodKey];

--- a/clis/eastmoney/kuaixun.js
+++ b/clis/eastmoney/kuaixun.js
@@ -26,7 +26,7 @@ cli({
     { name: 'limit',  type: 'int',    default: 20,    help: '返回数量 (max 100)' },
   ],
   columns: ['time', 'title', 'summary', 'stocks'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const column = String(args.column ?? '102').trim();
     const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
 

--- a/clis/eastmoney/longhu.js
+++ b/clis/eastmoney/longhu.js
@@ -26,7 +26,7 @@ cli({
     { name: 'limit', type: 'int',    default: 20,  help: '返回数量 (max 100)' },
   ],
   columns: ['tradeDate', 'code', 'name', 'closePrice', 'changeRate', 'boardAmt', 'buyAmt', 'sellAmt', 'netAmt', 'turnover', 'dealRatio', 'market', 'reason'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const sinceDate = String(args.date || '').trim() || defaultTradeDate();
     const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
 

--- a/clis/eastmoney/money-flow.js
+++ b/clis/eastmoney/money-flow.js
@@ -28,7 +28,7 @@ cli({
     { name: 'limit', type: 'int', default: 20, help: '返回数量 (max 100)' },
   ],
   columns: ['rank', 'code', 'name', 'price', 'changePercent', 'mainNet', 'mainNetRatio', 'superNet', 'bigNet', 'mediumNet', 'smallNet'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const rangeKey = String(args.range ?? 'today').toLowerCase();
     const range = RANGES[rangeKey];
     if (!range) {

--- a/clis/eastmoney/northbound.js
+++ b/clis/eastmoney/northbound.js
@@ -19,7 +19,7 @@ cli({
     { name: 'limit',     type: 'int',    default: 10,      help: '返回最近 N 分钟' },
   ],
   columns: ['time', 'cumulativeNetYi', 'minuteNetYi', 'totalNetYi'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const dir = String(args.direction ?? 'north').toLowerCase();
     if (!['north', 'south', 'n', 's'].includes(dir)) {
       throw new CliError('INVALID_ARGUMENT', `Unknown direction "${dir}". Valid: north / south`);

--- a/clis/eastmoney/quote.js
+++ b/clis/eastmoney/quote.js
@@ -57,7 +57,7 @@ cli({
     'turnoverRate', 'amplitude', 'peDynamic', 'priceBook',
     'marketCap', 'floatMarketCap',
   ],
-  func: async (_page, args) => {
+  func: async (args) => {
     const raw = splitSymbols(args.symbols);
     if (raw.length === 0) {
       throw new CliError('INVALID_ARGUMENT', 'At least one symbol is required');

--- a/clis/eastmoney/rank.js
+++ b/clis/eastmoney/rank.js
@@ -43,7 +43,7 @@ cli({
     { name: 'limit',  type: 'int',    default: 20,       help: '返回数量 (max 100)' },
   ],
   columns: ['rank', 'code', 'name', 'price', 'changePercent', 'change', 'turnover', 'volume', 'turnoverRate', 'peDynamic', 'marketCap'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const market = String(args.market ?? 'hs-a').toLowerCase();
     const sortKey = String(args.sort ?? 'change').toLowerCase();
     const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));

--- a/clis/eastmoney/sectors.js
+++ b/clis/eastmoney/sectors.js
@@ -33,7 +33,7 @@ cli({
     { name: 'limit', type: 'int',   default: 20,         help: '返回数量 (max 100)' },
   ],
   columns: ['rank', 'code', 'name', 'price', 'changePercent', 'mainNet', 'leadStock', 'leadChangePercent', 'upCount', 'downCount'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const typeKey = String(args.type ?? 'industry').toLowerCase();
     const fs = SECTOR_TYPES[typeKey];
     if (!fs) throw new CliError('INVALID_ARGUMENT', `Unknown sector type "${typeKey}". Valid: ${Object.keys(SECTOR_TYPES).join(', ')}`);

--- a/clis/google/news.js
+++ b/clis/google/news.js
@@ -18,7 +18,7 @@ cli({
         { name: 'region', default: 'US', help: 'Region code (e.g. US, CN)' },
     ],
     columns: ['title', 'source', 'date', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 100));
         const lang = encodeURIComponent(args.lang);
         const region = encodeURIComponent(args.region);

--- a/clis/google/suggest.js
+++ b/clis/google/suggest.js
@@ -15,7 +15,7 @@ cli({
         { name: 'lang', default: 'zh-CN', help: 'Language code' },
     ],
     columns: ['suggestion'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const keyword = encodeURIComponent(args.keyword);
         const lang = encodeURIComponent(args.lang);
         const url = `https://suggestqueries.google.com/complete/search?client=firefox&q=${keyword}&hl=${lang}`;

--- a/clis/google/trends.js
+++ b/clis/google/trends.js
@@ -16,7 +16,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
     ],
     columns: ['title', 'traffic', 'date'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 100));
         const region = encodeURIComponent(args.region);
         const url = `https://trends.google.com/trending/rss?geo=${region}`;

--- a/clis/hf/top.js
+++ b/clis/hf/top.js
@@ -50,7 +50,7 @@ cli({
             return getWeekRange();
         return kwargs.date ?? new Date().toISOString().slice(0, 10);
     },
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const period = String(kwargs.period ?? 'daily');
         const all = Boolean(kwargs.all);
         const endpoint = process.env.HF_ENDPOINT?.replace(/\/+$/, '') || 'https://huggingface.co';

--- a/clis/lesswrong/comments.js
+++ b/clis/lesswrong/comments.js
@@ -19,7 +19,7 @@ cli({
         { name: 'limit', type: 'int', default: 5, help: 'Number of comments' },
     ],
     columns: ['rank', 'score', 'author', 'text'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const postId = gqlEscape(parsePostId(String(kwargs['url-or-id'])));
         const limit = Number(kwargs.limit ?? 5);
         // Fetch post title and comments in parallel

--- a/clis/lesswrong/curated.js
+++ b/clis/lesswrong/curated.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "curated", limit: ${limit}}}) {

--- a/clis/lesswrong/frontpage.js
+++ b/clis/lesswrong/frontpage.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "frontpage", limit: ${limit}}}) {

--- a/clis/lesswrong/new.js
+++ b/clis/lesswrong/new.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "new", limit: ${limit}}}) {

--- a/clis/lesswrong/read.js
+++ b/clis/lesswrong/read.js
@@ -18,7 +18,7 @@ cli({
         },
     ],
     columns: ['title', 'author', 'karma', 'comments', 'tags', 'content', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const postId = parsePostId(String(kwargs['url-or-id']));
         const query = `query PostsSingle {
       post(input: {selector: {documentId: "${gqlEscape(postId)}"}}) {

--- a/clis/lesswrong/sequences.js
+++ b/clis/lesswrong/sequences.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query Sequences {
       sequences(input: {terms: {view: "communitySequences", limit: ${limit}}}) {

--- a/clis/lesswrong/shortform.js
+++ b/clis/lesswrong/shortform.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "shortform", limit: ${limit}}}) {

--- a/clis/lesswrong/tag.js
+++ b/clis/lesswrong/tag.js
@@ -19,7 +19,7 @@ cli({
         { name: 'limit', type: 'int', default: 10, help: 'Number of results' },
     ],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const tagInput = String(kwargs.tag);
         const limit = Number(kwargs.limit ?? 10);
         const tag = await resolveTagId(tagInput);

--- a/clis/lesswrong/tags.js
+++ b/clis/lesswrong/tags.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 20, help: 'Number of results' }],
     columns: ['rank', 'name', 'posts'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 20);
         const query = `query Tags {
       tags(input: {terms: {view: "coreTags", limit: ${limit}}}) {

--- a/clis/lesswrong/top-month.js
+++ b/clis/lesswrong/top-month.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "top", after: "${daysAgo(30)}", limit: ${limit}}}) {

--- a/clis/lesswrong/top-week.js
+++ b/clis/lesswrong/top-week.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "top", after: "${daysAgo(7)}", limit: ${limit}}}) {

--- a/clis/lesswrong/top-year.js
+++ b/clis/lesswrong/top-year.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "top", after: "${daysAgo(365)}", limit: ${limit}}}) {

--- a/clis/lesswrong/top.js
+++ b/clis/lesswrong/top.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'limit', type: 'int', default: 10, help: 'Number of results' }],
     columns: ['rank', 'title', 'author', 'karma', 'comments', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Number(kwargs.limit ?? 10);
         const query = `query PostsList {
       posts(input: {terms: {view: "top", limit: ${limit}}}) {

--- a/clis/lesswrong/user-posts.js
+++ b/clis/lesswrong/user-posts.js
@@ -18,7 +18,7 @@ cli({
         { name: 'limit', type: 'int', default: 10, help: 'Number of results' },
     ],
     columns: ['rank', 'title', 'karma', 'comments', 'date', 'url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const username = String(kwargs.username);
         const limit = Number(kwargs.limit ?? 10);
         const user = await resolveUserId(username);

--- a/clis/lesswrong/user.js
+++ b/clis/lesswrong/user.js
@@ -18,7 +18,7 @@ cli({
         },
     ],
     columns: ['field', 'value'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const slug = gqlEscape(String(kwargs.username).toLowerCase());
         const query = `query UserProfile {
       user(input: {selector: {slug: "${slug}"}}) {

--- a/clis/paperreview/commands.test.js
+++ b/clis/paperreview/commands.test.js
@@ -38,7 +38,7 @@ describe('paperreview submit command', () => {
             resolvedPath: '/tmp/paper.pdf',
             sizeBytes: 4096,
         });
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             pdf: './paper.pdf',
             email: 'wang2629651228@gmail.com',
             venue: 'RAL',
@@ -80,7 +80,7 @@ describe('paperreview submit command', () => {
                 message: 'Submission accepted',
             },
         });
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             pdf: './paper.pdf',
             email: 'wang2629651228@gmail.com',
             venue: 'RAL',
@@ -112,7 +112,7 @@ describe('paperreview submit command', () => {
                 s3_key: 'uploads/paper.pdf',
             },
         });
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             pdf: './paper.pdf',
             email: 'wang2629651228@gmail.com',
             venue: 'RAL',
@@ -153,7 +153,7 @@ describe('paperreview submit command', () => {
                 message: 'Submission accepted',
             },
         });
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             pdf: './paper.pdf',
             email: 'wang2629651228@gmail.com',
             venue: 'RAL',
@@ -190,7 +190,7 @@ describe('paperreview review command', () => {
             response: { status: 202 },
             payload: { detail: 'Review is still processing.' },
         });
-        const result = await cmd.func(null, { token: 'tok_123' });
+        const result = await cmd.func({ token: 'tok_123' });
         expect(result).toMatchObject({
             status: 'processing',
             token: 'tok_123',
@@ -214,7 +214,7 @@ describe('paperreview feedback command', () => {
             response: { ok: true, status: 200 },
             payload: { message: 'Thanks for the feedback.' },
         });
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             token: 'tok_123',
             helpfulness: 4,
             'critical-error': 'yes',

--- a/clis/paperreview/feedback.js
+++ b/clis/paperreview/feedback.js
@@ -17,7 +17,7 @@ cli({
         { name: 'additional-comments', help: 'Optional free-text feedback' },
     ],
     columns: ['status', 'token', 'helpfulness', 'critical_error', 'actionable_suggestions', 'message'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const token = String(kwargs.token ?? '').trim();
         if (!token) {
             throw new CliError('ARGUMENT', 'A review token is required.');

--- a/clis/paperreview/review.js
+++ b/clis/paperreview/review.js
@@ -13,7 +13,7 @@ cli({
         { name: 'token', positional: true, required: true, help: 'Review token returned by paperreview.ai' },
     ],
     columns: ['status', 'title', 'venue', 'numerical_score', 'has_feedback', 'review_url'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const token = String(kwargs.token ?? '').trim();
         if (!token) {
             throw new CliError('ARGUMENT', 'A review token is required.');

--- a/clis/paperreview/submit.js
+++ b/clis/paperreview/submit.js
@@ -24,7 +24,7 @@ cli({
             return 'prepared only';
         return undefined;
     },
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const pdfFile = await readPdfFile(kwargs.pdf);
         const email = String(kwargs.email ?? '').trim();
         const venue = normalizeVenue(kwargs.venue);

--- a/clis/producthunt/posts.js
+++ b/clis/producthunt/posts.js
@@ -19,7 +19,7 @@ cli({
         },
     ],
     columns: ['rank', 'name', 'tagline', 'author', 'date', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const count = Math.min(Number(args.limit) || 20, 50);
         const category = String(args.category ?? '').trim() || undefined;
         const posts = await fetchFeed(category);

--- a/clis/producthunt/today.js
+++ b/clis/producthunt/today.js
@@ -16,7 +16,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max results' },
     ],
     columns: ['rank', 'name', 'tagline', 'author', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const count = Math.min(Number(args.limit) || 20, 50);
         const posts = await fetchFeed();
         if (posts.length === 0)

--- a/clis/sinablog/search.js
+++ b/clis/sinablog/search.js
@@ -47,5 +47,5 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: '返回的文章数量' },
     ],
     columns: ['rank', 'title', 'author', 'date', 'description', 'url'],
-    func: async (_page, args) => searchSinaBlog(args.keyword, Math.max(1, Math.min(Number(args.limit) || 20, 50))),
+    func: async (args) => searchSinaBlog(args.keyword, Math.max(1, Math.min(Number(args.limit) || 20, 50))),
 });

--- a/clis/sinafinance/news.js
+++ b/clis/sinafinance/news.js
@@ -34,7 +34,7 @@ cli({
         { name: 'type', type: 'int', default: 0, help: 'News type: 0=全部 1=A股 2=宏观 3=公司 4=数据 5=市场 6=国际 7=观点 8=央行 9=其它' },
     ],
     columns: ['id', 'time', 'content', 'views'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 50));
         const apiTag = TYPE_MAP[args.type] ?? 0;
         const params = new URLSearchParams({

--- a/clis/sinafinance/stock.js
+++ b/clis/sinafinance/stock.js
@@ -62,7 +62,7 @@ cli({
         { name: 'market', type: 'string', default: 'auto', help: 'Market: cn, hk, us, auto (default: auto searches cn → hk → us)' },
     ],
     columns: ['Symbol', 'Name', 'Price', 'Change', 'ChangePercent', 'Open', 'High', 'Low', 'Volume', 'MarketCap'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const key = String(args.key);
         const market = String(args.market);
         const marketMap = {

--- a/clis/sinafinance/stock.test.js
+++ b/clis/sinafinance/stock.test.js
@@ -28,7 +28,7 @@ describe('sinafinance stock command', () => {
             .mockResolvedValueOnce(textResponse('var hq_str_gb_AAPL="Apple Inc,189.98,1.23,0,1.56,0,188.50,180.00,195.00,175.00,1200000,0,3000000000000";'));
         vi.stubGlobal('fetch', fetchMock);
 
-        const result = await cmd.func(null, { key: 'AAPL', market: 'auto' });
+        const result = await cmd.func({ key: 'AAPL', market: 'auto' });
 
         expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://suggest3.sinajs.cn/suggest/type=11,31,41&key=AAPL', expect.any(Object));
         expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://hq.sinajs.cn/list=gb_AAPL', expect.any(Object));
@@ -48,7 +48,7 @@ describe('sinafinance stock command', () => {
             .mockResolvedValueOnce(textResponse('var hq_str_gb_AAPL="苹果公司,189.98,1.23,0,1.56,0,188.50,180.00,195.00,175.00,1200000,0,3000000000000";'));
         vi.stubGlobal('fetch', fetchMock);
 
-        const result = await cmd.func(null, { key: '苹果', market: 'auto' });
+        const result = await cmd.func({ key: '苹果', market: 'auto' });
 
         expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://hq.sinajs.cn/list=gb_AAPL', expect.any(Object));
         expect(result[0]).toMatchObject({

--- a/clis/spotify/spotify.js
+++ b/clis/spotify/spotify.js
@@ -198,7 +198,7 @@ cli({
     browser: false,
     args: [{ name: 'query', type: 'str', default: '', positional: true, help: 'Track or artist to play (optional)' }],
     columns: ['track', 'artist', 'status'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         if (kwargs.query) {
             const { uri, name, artist } = await findTrackUri(kwargs.query);
             await api('PUT', '/me/player/play', { uris: [uri] });
@@ -246,7 +246,7 @@ cli({
     browser: false,
     args: [{ name: 'level', type: 'int', default: 50, positional: true, required: true, help: 'Volume 0–100' }],
     columns: ['volume'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const level = Math.round(kwargs.level);
         if (level < 0 || level > 100)
             throw new CliError('INVALID_ARGS', 'Volume must be between 0 and 100');
@@ -265,7 +265,7 @@ cli({
         { name: 'limit', type: 'int', default: 10, help: 'Number of results (default: 10)' },
     ],
     columns: ['track', 'artist', 'album', 'uri'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const limit = Math.min(50, Math.max(1, Math.round(kwargs.limit)));
         const data = await api('GET', `/search?q=${encodeURIComponent(kwargs.query)}&type=track&limit=${limit}`);
         const results = mapSpotifyTrackResults(data);
@@ -282,7 +282,7 @@ cli({
     browser: false,
     args: [{ name: 'query', type: 'str', required: true, positional: true, help: 'Track to add to queue' }],
     columns: ['track', 'artist', 'status'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const { uri, name, artist } = await findTrackUri(kwargs.query);
         await api('POST', `/me/player/queue?uri=${encodeURIComponent(uri)}`);
         return [{ track: name, artist, status: 'added to queue' }];
@@ -296,7 +296,7 @@ cli({
     browser: false,
     args: [{ name: 'state', type: 'str', default: 'on', positional: true, choices: ['on', 'off'], help: 'on or off' }],
     columns: ['shuffle'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         await api('PUT', `/me/player/shuffle?state=${kwargs.state === 'on'}`);
         return [{ shuffle: kwargs.state }];
     },
@@ -309,7 +309,7 @@ cli({
     browser: false,
     args: [{ name: 'mode', type: 'str', default: 'context', positional: true, choices: ['off', 'track', 'context'], help: 'off / track / context' }],
     columns: ['repeat'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         await api('PUT', `/me/player/repeat?state=${kwargs.mode}`);
         return [{ repeat: kwargs.mode }];
     },

--- a/clis/substack/search.js
+++ b/clis/substack/search.js
@@ -69,7 +69,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: '返回结果数量' },
     ],
     columns: ['rank', 'title', 'author', 'date', 'description', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit) || 20, 50));
         return args.type === 'publications'
             ? searchPublications(args.keyword, limit)

--- a/clis/weread/ranking.js
+++ b/clis/weread/ranking.js
@@ -12,7 +12,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max results' },
     ],
     columns: ['rank', 'title', 'author', 'category', 'readingCount', 'bookId'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const cat = encodeURIComponent(args.category ?? 'all');
         const data = await fetchWebApi(`/bookListInCategory/${cat}`, { rank: '1' });
         const books = data?.books ?? [];

--- a/clis/weread/search-regression.test.js
+++ b/clis/weread/search-regression.test.js
@@ -35,7 +35,7 @@ describe('weread/search regression', () => {
         `),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: 'deep work', limit: 5 });
+        const result = await command.func({ query: 'deep work', limit: 5 });
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(String(fetchMock.mock.calls[0][0])).toContain('keyword=deep+work');
         expect(String(fetchMock.mock.calls[1][0])).toContain('/web/search/books?keyword=deep+work');
@@ -72,7 +72,7 @@ describe('weread/search regression', () => {
             text: () => Promise.resolve('<html><body><p>no search cards</p></body></html>'),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: 'deep work', limit: 5 });
+        const result = await command.func({ query: 'deep work', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -128,7 +128,7 @@ describe('weread/search regression', () => {
         `),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: 'cal newport', limit: 5 });
+        const result = await command.func({ query: 'cal newport', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -166,7 +166,7 @@ describe('weread/search regression', () => {
         })
             .mockRejectedValueOnce(new Error('network timeout'));
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: 'deep work', limit: 5 });
+        const result = await command.func({ query: 'deep work', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -220,7 +220,7 @@ describe('weread/search regression', () => {
         `),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: '文明', limit: 5 });
+        const result = await command.func({ query: '文明', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -279,7 +279,7 @@ describe('weread/search regression', () => {
         `),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: '文明', limit: 5 });
+        const result = await command.func({ query: '文明', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -332,7 +332,7 @@ describe('weread/search regression', () => {
         `),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: '文明', limit: 5 });
+        const result = await command.func({ query: '文明', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,
@@ -386,7 +386,7 @@ describe('weread/search regression', () => {
         `),
         });
         vi.stubGlobal('fetch', fetchMock);
-        const result = await command.func(null, { query: '文明', limit: 5 });
+        const result = await command.func({ query: '文明', limit: 5 });
         expect(result).toEqual([
             {
                 rank: 1,

--- a/clis/weread/search.js
+++ b/clis/weread/search.js
@@ -124,7 +124,7 @@ cli({
         { name: 'limit', type: 'int', default: 10, help: 'Max results' },
     ],
     columns: ['rank', 'title', 'author', 'bookId', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const [data, htmlEntries] = await Promise.all([
             fetchWebApi('/search/global', { keyword: args.query }),
             loadSearchHtmlEntries(String(args.query ?? '')),

--- a/clis/wikipedia/random.js
+++ b/clis/wikipedia/random.js
@@ -9,7 +9,7 @@ cli({
     browser: false,
     args: [{ name: 'lang', default: 'en', help: 'Language code (e.g. en, zh, ja)' }],
     columns: ['title', 'description', 'extract', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const lang = args.lang || 'en';
         const data = (await wikiFetch(lang, '/api/rest_v1/page/random/summary'));
         if (!data?.title)

--- a/clis/wikipedia/search.js
+++ b/clis/wikipedia/search.js
@@ -13,7 +13,7 @@ cli({
         { name: 'lang', default: 'en', help: 'Language code (e.g. en, zh, ja)' },
     ],
     columns: ['title', 'snippet', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 50));
         const lang = args.lang || 'en';
         const q = encodeURIComponent(args.query);

--- a/clis/wikipedia/summary.js
+++ b/clis/wikipedia/summary.js
@@ -12,7 +12,7 @@ cli({
         { name: 'lang', default: 'en', help: 'Language code (e.g. en, zh, ja)' },
     ],
     columns: ['title', 'description', 'extract', 'url'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const lang = args.lang || 'en';
         const title = encodeURIComponent(args.title.replace(/ /g, '_'));
         const data = (await wikiFetch(lang, `/api/rest_v1/page/summary/${title}`));

--- a/clis/wikipedia/trending.js
+++ b/clis/wikipedia/trending.js
@@ -12,7 +12,7 @@ cli({
         { name: 'lang', default: 'en', help: 'Language code (e.g. en, zh, ja)' },
     ],
     columns: ['rank', 'title', 'description', 'views'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const lang = args.lang || 'en';
         const limit = Math.max(1, Math.min(Number(args.limit), 50));
         // Use yesterday's UTC date — Wikipedia API expects UTC and yesterday

--- a/clis/xiaoyuzhou/download.js
+++ b/clis/xiaoyuzhou/download.js
@@ -18,7 +18,7 @@ cli({
         { name: 'output', default: './xiaoyuzhou-downloads', help: 'Output directory' },
     ],
     columns: ['title', 'podcast', 'status', 'size', 'file'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const credentials = loadXiaoyuzhouCredentials();
         const response = await requestXiaoyuzhouJson('/v1/episode/get', {
             query: { eid: args.id },

--- a/clis/xiaoyuzhou/download.test.js
+++ b/clis/xiaoyuzhou/download.test.js
@@ -68,7 +68,7 @@ describe('xiaoyuzhou download', () => {
         });
         mockHttpDownload.mockResolvedValue({ success: true, size: 1234 });
 
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             id: 'ep123',
             output: '/tmp/xiaoyuzhou-test',
         });
@@ -106,7 +106,7 @@ describe('xiaoyuzhou download', () => {
         });
         mockHttpDownload.mockResolvedValue({ success: true, size: 2048 });
 
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             id: 'ep456',
             output: '/tmp/xiaoyuzhou-test',
         });
@@ -125,7 +125,7 @@ describe('xiaoyuzhou download', () => {
             },
         });
 
-        await expect(cmd.func(null, { id: 'ep789', output: '/tmp/xiaoyuzhou-test' })).rejects.toMatchObject({
+        await expect(cmd.func({ id: 'ep789', output: '/tmp/xiaoyuzhou-test' })).rejects.toMatchObject({
             code: 'PARSE_ERROR',
             message: 'Audio URL not found in episode payload',
             hint: 'Episode payload does not expose media.source.url',

--- a/clis/xiaoyuzhou/episode.js
+++ b/clis/xiaoyuzhou/episode.js
@@ -11,7 +11,7 @@ cli({
     browser: false,
     args: [{ name: 'id', positional: true, required: true, help: 'Episode ID (eid from podcast-episodes output)' }],
     columns: ['title', 'podcast', 'duration', 'plays', 'comments', 'likes', 'date'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const credentials = loadXiaoyuzhouCredentials();
         const response = await requestXiaoyuzhouJson('/v1/episode/get', {
             query: { eid: args.id },

--- a/clis/xiaoyuzhou/podcast-episodes.js
+++ b/clis/xiaoyuzhou/podcast-episodes.js
@@ -14,7 +14,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max episodes to show' },
     ],
     columns: ['eid', 'title', 'duration', 'plays', 'date'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const requestedLimit = Number(args.limit);
         if (!Number.isInteger(requestedLimit) || requestedLimit < 1) {
             throw new CliError('INVALID_ARGUMENT', 'limit must be a positive integer', 'Example: --limit 5');

--- a/clis/xiaoyuzhou/podcast-episodes.test.js
+++ b/clis/xiaoyuzhou/podcast-episodes.test.js
@@ -44,7 +44,7 @@ describe('xiaoyuzhou podcast-episodes', () => {
             ],
         });
 
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             id: 'podcast-1',
             limit: 3,
         });
@@ -66,7 +66,7 @@ describe('xiaoyuzhou podcast-episodes', () => {
     });
 
     it('rejects non-positive limits before hitting the API', async () => {
-        await expect(cmd.func(null, {
+        await expect(cmd.func({
             id: 'podcast-1',
             limit: 0,
         })).rejects.toMatchObject({

--- a/clis/xiaoyuzhou/podcast.js
+++ b/clis/xiaoyuzhou/podcast.js
@@ -11,7 +11,7 @@ cli({
     browser: false,
     args: [{ name: 'id', positional: true, required: true, help: 'Podcast ID (from xiaoyuzhoufm.com URL)' }],
     columns: ['title', 'author', 'description', 'subscribers', 'episodes', 'updated'],
-    func: async (_page, args) => {
+    func: async (args) => {
         const credentials = loadXiaoyuzhouCredentials();
         const response = await requestXiaoyuzhouJson('/v1/podcast/get', {
             query: { pid: args.id },

--- a/clis/xiaoyuzhou/transcript.js
+++ b/clis/xiaoyuzhou/transcript.js
@@ -18,7 +18,7 @@ cli({
         { name: 'text', type: 'boolean', default: true, help: 'Save extracted transcript text file' },
     ],
     columns: ['title', 'podcast', 'status', 'segments', 'json_file', 'text_file'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         if (kwargs.json === false && kwargs.text === false) {
             throw new ArgumentError('At least one of --json or --text must be enabled', 'Example: opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 --text true');
         }

--- a/clis/xiaoyuzhou/transcript.test.js
+++ b/clis/xiaoyuzhou/transcript.test.js
@@ -67,7 +67,7 @@ describe('xiaoyuzhou transcript', () => {
         mockFetchTranscriptBody.mockResolvedValue(JSON.stringify({
             segments: [{ text: 'hello' }, { text: 'world' }],
         }));
-        const result = await cmd.func(null, {
+        const result = await cmd.func({
             id: 'ep123',
             output: '/tmp/xiaoyuzhou-transcripts',
             json: true,
@@ -112,7 +112,7 @@ describe('xiaoyuzhou transcript', () => {
             },
         });
         mockFetchTranscriptBody.mockResolvedValue(JSON.stringify({ text: 'hello' }));
-        await cmd.func(null, {
+        await cmd.func({
             id: 'ep456',
             output: '/tmp/xiaoyuzhou-transcripts',
             json: false,
@@ -137,7 +137,7 @@ describe('xiaoyuzhou transcript', () => {
             credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
             data: {},
         });
-        await expect(cmd.func(null, {
+        await expect(cmd.func({
             id: 'ep123',
             output: '/tmp/xiaoyuzhou-transcripts',
             json: true,
@@ -168,7 +168,7 @@ describe('xiaoyuzhou transcript', () => {
         mockFetchTranscriptBody.mockResolvedValue(JSON.stringify({
             segments: [{ startAt: 0, endAt: 1 }],
         }));
-        await expect(cmd.func(null, {
+        await expect(cmd.func({
             id: 'ep123',
             output: '/tmp/xiaoyuzhou-transcripts',
             json: true,
@@ -181,7 +181,7 @@ describe('xiaoyuzhou transcript', () => {
     });
 
     it('rejects disabling both json and text outputs', async () => {
-        await expect(cmd.func(null, {
+        await expect(cmd.func({
             id: 'ep123',
             output: '/tmp/xiaoyuzhou-transcripts',
             json: false,

--- a/clis/yollomi/models.js
+++ b/clis/yollomi/models.js
@@ -10,7 +10,7 @@ cli({
         { name: 'type', default: 'all', choices: ['all', 'image', 'video', 'tool'], help: 'Filter by model type' },
     ],
     columns: ['type', 'model', 'credits', 'description'],
-    func: async (_page, kwargs) => {
+    func: async (kwargs) => {
         const filter = kwargs.type;
         const rows = [];
         if (filter === 'all' || filter === 'image') {

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -177,7 +177,7 @@ cli({
     { name: 'limit', type: 'int', default: 10, help: 'Number of items' },
   ],
   columns: ['title', 'score'],
-  func: async (_page, kwargs) => {
+  func: async (kwargs) => {
     const res = await fetch('https://api.example.com/data');
     const data = await res.json();
     return data.items.slice(0, kwargs.limit).map((item: any, i: number) => ({

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -37,7 +37,7 @@ cli({
   columns: ['rank', 'bondCode', 'bondName', 'bondPrice', 'bondChangePct',
             'stockCode', 'stockName', 'stockPrice', 'stockChangePct',
             'convPrice', 'convValue', 'convPremiumPct', 'remainingYears', 'ytm', 'listDate'],
-  func: async (_page, args) => {
+  func: async (args) => {
     const sortKey = String(args.sort ?? 'turnover').toLowerCase();
     const sort = SORTS[sortKey];
     if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
@@ -120,7 +120,7 @@ columns: ['rank', 'bondCode', 'bondName', /* ... */ ],
 ### 3. func — 主体
 
 ```javascript
-func: async (_page, args) => {
+func: async (args) => {
   // 1. 解析参数
   const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
 
@@ -148,8 +148,9 @@ func: async (_page, args) => {
 
 **参数形态**：
 
-- `page` — 仅当 `browser: true` 时有用；`PUBLIC` 模式传一个 no-op 占位
-- `args` — 所有 `args[]` 声明的参数解析后的 object
+- `browser: false`：`func: async (args, debug?) => { ... }`，不会收到 `page`
+- `browser: true`：`func: async (page, args, debug?) => { ... }`，`page` 是浏览器上下文
+- `args`：所有 `args[]` 声明的参数解析后的 object
 
 **错误处理**：
 
@@ -234,7 +235,21 @@ cli({
 });
 ```
 
-### 为什么不走 `page.evaluate(fetch(...))`
+### JSON API 用 `page.fetchJson()`，不要手写 `page.evaluate(fetch(...))`
+
+如果接口必须在浏览器上下文里请求（依赖当前页面 cookie / CORS / origin），用内置 primitive：
+
+```javascript
+const data = await page.fetchJson(`${BASE}/api/list`, {
+  method: 'POST',
+  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  body: { page: 1, size: Number(args.limit) || 20 },
+});
+```
+
+它固定 `credentials: 'include'`，带 timeout，HTTP 非 2xx / 非 JSON 会抛统一 `CliError`。
+
+### HTML 不走 browser fetch
 
 三个坑，踩一个就重写：
 
@@ -242,7 +257,7 @@ cli({
 - **`navigateBefore: false` 时当前 tab 不在目标站**：页面 origin 可能是 `about:blank` 或上一条命令留下的别处，从那儿发 fetch 到目标域就是 cross-origin，浏览器 CORS 一挡就是 "Failed to fetch"。
 - **非 UTF-8 编码解码麻烦**：GBK / Big5 / Shift-JIS 的站（Discuz / phpBB 老版 / 日站）在 `page.evaluate` 里用 `response.text()` 拿到的是乱码，`TextDecoder('gbk').decode(buf)` 的写法只在 Node 侧干净。
 
-**规则**：HTML 型 COOKIE adapter 一律 Node 侧 `fetch`，浏览器只当 cookie jar 用。
+**规则**：JSON 型浏览器接口用 `page.fetchJson()`；HTML 型 COOKIE adapter 一律 Node 侧 `fetch`，浏览器只当 cookie jar 用。
 
 ### Cookie 域的双查
 

--- a/skills/opencli-adapter-author/references/field-conventions.md
+++ b/skills/opencli-adapter-author/references/field-conventions.md
@@ -137,7 +137,7 @@ B 站接口字段也大多人类可读。关键坑是 **wbi 签名**：
 - 凡 URL 含 `/wbi/` 的接口都需要 `w_rid + wts` 签名
 - 签名算法依赖每日轮换的 `img_key + sub_key`（从 `nav` 接口拿）
 - 平台 SDK 在 `clis/bilibili/utils.js`：`apiGet(page, path, { signed: true, params })` 自动签
-- 普通 cookie 接口用 `fetchJson(page, url)`
+- 普通 cookie JSON 接口优先用 `page.fetchJson(url)`
 
 | 字段 | 含义 |
 |------|------|

--- a/skills/opencli-adapter-author/references/site-memory/bilibili.md
+++ b/skills/opencli-adapter-author/references/site-memory/bilibili.md
@@ -21,7 +21,7 @@
 - 凡 URL 含 `/wbi/` 的接口都要 `w_rid + wts` 签名
 - 签名算法依赖每日轮换的 `img_key / sub_key`，从 `api.bilibili.com/x/web-interface/nav` 的 `wbi_img` 字段拿
 - **不要自己重新实现**：`clis/bilibili/utils.js` 里的 `apiGet(page, path, { signed: true, params })` 已经封装好
-- 普通 cookie 接口用 `fetchJson(page, url)`（也在 utils.js）
+- 普通 cookie JSON 接口优先用 `page.fetchJson(url)`；站点级签名逻辑仍复用 `utils.js`
 
 ## 已知 endpoint
 

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { CliError } from '../errors.js';
+import { BasePage } from './base-page.js';
+
+class TestPage extends BasePage {
+  result: unknown;
+  args: Record<string, unknown> | undefined;
+
+  async goto(): Promise<void> {}
+  async evaluate(): Promise<unknown> { return null; }
+  override async evaluateWithArgs(_js: string, args: Record<string, unknown>): Promise<unknown> {
+    this.args = args;
+    return this.result;
+  }
+  async getCookies(): Promise<[]> { return []; }
+  async screenshot(): Promise<string> { return ''; }
+  async tabs(): Promise<unknown[]> { return []; }
+  async selectTab(): Promise<void> {}
+}
+
+describe('BasePage.fetchJson', () => {
+  it('passes a narrow browser-context JSON request and parses the response in Node', async () => {
+    const page = new TestPage();
+    page.result = {
+      ok: true,
+      status: 200,
+      url: 'https://api.example.com/items',
+      contentType: 'application/json',
+      text: '{"items":[1]}',
+    };
+
+    await expect(page.fetchJson('https://api.example.com/items', {
+      method: 'POST',
+      headers: { 'X-Test': '1' },
+      body: { q: 'opencli' },
+      timeoutMs: 1234,
+    })).resolves.toEqual({ items: [1] });
+
+    expect(page.args).toEqual({
+      request: {
+        url: 'https://api.example.com/items',
+        method: 'POST',
+        headers: { 'X-Test': '1' },
+        body: { q: 'opencli' },
+        hasBody: true,
+        timeoutMs: 1234,
+      },
+    });
+  });
+
+  it('throws a CliError for non-JSON responses', async () => {
+    const page = new TestPage();
+    page.result = {
+      ok: true,
+      status: 200,
+      url: 'https://api.example.com/items',
+      contentType: 'text/html',
+      text: '<html>blocked</html>',
+    };
+
+    const err = await page.fetchJson('https://api.example.com/items').catch((error: unknown) => error);
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).code).toBe('FETCH_ERROR');
+    expect((err as CliError).message).toContain('Expected JSON');
+    expect((err as CliError).hint).toContain('blocked');
+  });
+
+  it('throws a CliError for browser fetch transport errors', async () => {
+    const page = new TestPage();
+    page.result = {
+      ok: false,
+      status: 0,
+      url: 'https://api.example.com/items',
+      text: '',
+      error: 'The operation was aborted.',
+    };
+
+    await expect(page.fetchJson('https://api.example.com/items')).rejects.toMatchObject({
+      code: 'FETCH_ERROR',
+      message: expect.stringContaining('The operation was aborted.'),
+    });
+  });
+});

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -9,7 +9,7 @@
  * getCookies, screenshot, tabs, etc.
  */
 
-import type { BrowserCookie, IPage, ScreenshotOptions, SnapshotOptions, WaitOptions } from '../types.js';
+import type { BrowserCookie, FetchJsonOptions, IPage, ScreenshotOptions, SnapshotOptions, WaitOptions } from '../types.js';
 import { generateSnapshotJs, getFormStateJs } from './dom-snapshot.js';
 import {
   pressKeyJs,
@@ -30,6 +30,8 @@ import {
   type TargetMatchLevel,
 } from './target-resolver.js';
 import { TargetError, type TargetErrorCode } from './target-errors.js';
+import { CliError } from '../errors.js';
+import { formatSnapshot } from '../snapshotFormatter.js';
 
 export interface ResolveSuccess {
   matches_n: number;
@@ -65,7 +67,12 @@ async function runResolve(
   }
   return { matches_n: resolution.matches_n, match_level: resolution.match_level };
 }
-import { formatSnapshot } from '../snapshotFormatter.js';
+
+function previewText(text: string | undefined): string | undefined {
+  const preview = (text ?? '').replace(/\s+/g, ' ').trim().slice(0, 300);
+  return preview ? `Response preview: ${preview}` : undefined;
+}
+
 export abstract class BasePage implements IPage {
   protected _lastUrl: string | null = null;
   /** Cached previous snapshot hashes for incremental diff marking */
@@ -94,6 +101,98 @@ export abstract class BasePage implements IPage {
       })
       .join('\n');
     return this.evaluate(`${declarations}\n${js}`);
+  }
+
+  async fetchJson(url: string, opts: FetchJsonOptions = {}): Promise<unknown> {
+    const request = {
+      url,
+      method: opts.method ?? 'GET',
+      headers: opts.headers ?? {},
+      body: opts.body,
+      hasBody: opts.body !== undefined,
+      timeoutMs: opts.timeoutMs ?? 15_000,
+    };
+
+    const result = await this.evaluateWithArgs(`
+      (async () => {
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), request.timeoutMs);
+        try {
+          const headers = { Accept: 'application/json', ...request.headers };
+          const init = {
+            method: request.method,
+            credentials: 'include',
+            headers,
+            signal: ctrl.signal,
+          };
+          if (request.hasBody) {
+            if (!Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
+              headers['Content-Type'] = 'application/json';
+            }
+            init.body = JSON.stringify(request.body);
+          }
+          const resp = await fetch(request.url, init);
+          const text = await resp.text();
+          return {
+            ok: resp.ok,
+            status: resp.status,
+            statusText: resp.statusText,
+            url: resp.url,
+            contentType: resp.headers.get('content-type') || '',
+            text,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            status: 0,
+            statusText: '',
+            url: request.url,
+            contentType: '',
+            text: '',
+            error: error instanceof Error ? error.message : String(error),
+          };
+        } finally {
+          clearTimeout(timer);
+        }
+      })()
+    `, { request }) as {
+      ok?: boolean;
+      status?: number;
+      statusText?: string;
+      url?: string;
+      contentType?: string;
+      text?: string;
+      error?: string;
+    };
+
+    const targetUrl = result.url || url;
+    if (result.error) {
+      throw new CliError(
+        'FETCH_ERROR',
+        `Browser fetch failed for ${targetUrl}: ${result.error}`,
+        'Check that the page is reachable and the current browser profile has access.',
+      );
+    }
+    if (!result.ok) {
+      throw new CliError(
+        'FETCH_ERROR',
+        `HTTP ${result.status ?? 0}${result.statusText ? ` ${result.statusText}` : ''} from ${targetUrl}`,
+        previewText(result.text),
+      );
+    }
+
+    const text = result.text ?? '';
+    if (!text.trim()) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      const contentType = result.contentType ? ` (${result.contentType})` : '';
+      throw new CliError(
+        'FETCH_ERROR',
+        `Expected JSON from ${targetUrl}${contentType}`,
+        previewText(text),
+      );
+    }
   }
 
   abstract getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;

--- a/src/capabilityRouting.test.ts
+++ b/src/capabilityRouting.test.ts
@@ -9,7 +9,7 @@ function makeCmd(partial: Partial<CliCommand>): CliCommand {
     description: '',
     args: [],
     ...partial,
-  };
+  } as CliCommand;
 }
 
 describe('shouldUseBrowserSession', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1712,10 +1712,10 @@ cli({
     { name: 'limit', type: 'int', default: 10, help: 'Number of items' },
   ],
   columns: [], // TODO: field names for table output (e.g. ['title', 'score', 'url'])
-  func: async (page, kwargs) => {
+  func: async (kwargs) => {
     // TODO: implement data fetching
     // Prefer API calls (fetch) over browser automation
-    // page is available if browser: true
+    // If you set browser: true, change this to: async (page, kwargs) => { ... }
     return [];
   },
 });

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -221,7 +221,7 @@ describe('executeCommand', () => {
       args: [
         { name: 'note-id', required: true, help: 'Note ID' },
       ],
-      func: async (_page, kwargs) => [{ noteId: kwargs['note-id'] }],
+      func: async (kwargs) => [{ noteId: kwargs['note-id'] }],
     });
 
     const result = await executeCommand(cmd, { 'note-id': 'abc123' });
@@ -235,7 +235,7 @@ describe('executeCommand', () => {
       description: 'test command with func',
       browser: false,
       strategy: Strategy.PUBLIC,
-      func: async (_page, kwargs) => {
+      func: async (kwargs) => {
         return [{ title: kwargs.query ?? 'default' }];
       },
     });
@@ -279,7 +279,7 @@ describe('executeCommand', () => {
       name: 'debug-test',
       description: 'debug test',
       browser: false,
-      func: async (_page, _kwargs, debug) => {
+      func: async (_kwargs, debug) => {
         receivedDebug = debug ?? false;
         return [];
       },

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -10,7 +10,15 @@
  * 6. Lifecycle hooks (onBeforeExecute / onAfterExecute)
  */
 
-import { type CliCommand, type InternalCliCommand, type Arg, type CommandArgs, getRegistry, fullName } from './registry.js';
+import {
+  type BrowserCliCommand,
+  type CliCommand,
+  type InternalCliCommand,
+  type Arg,
+  type CommandArgs,
+  getRegistry,
+  fullName,
+} from './registry.js';
 import type { IPage } from './types.js';
 import { pathToFileURL } from 'node:url';
 import * as fs from 'node:fs';
@@ -117,20 +125,25 @@ async function runCommand(
 
     const updated = getRegistry().get(fullName(cmd));
     if (updated?.func) {
-      if (!page && updated.browser !== false) {
-        throw new CommandExecutionError(`Command ${fullName(cmd)} requires a browser session but none was provided`);
-      }
-      return updated.func(page as IPage, kwargs, debug);
+      return runCommandFunc(updated, page, kwargs, debug);
     }
     if (updated?.pipeline) return executePipeline(page, updated.pipeline, { args: kwargs, debug });
   }
 
-  if (cmd.func) return cmd.func(page as IPage, kwargs, debug);
+  if (cmd.func) return runCommandFunc(cmd, page, kwargs, debug);
   if (cmd.pipeline) return executePipeline(page, cmd.pipeline, { args: kwargs, debug });
   throw new CommandExecutionError(
     `Command ${fullName(cmd)} has no func or pipeline`,
     'This is likely a bug in the adapter definition. Please report this issue.',
   );
+}
+
+function runCommandFunc(cmd: CliCommand, page: IPage | null, kwargs: CommandArgs, debug: boolean): Promise<unknown> {
+  if (cmd.browser === false) return cmd.func!(kwargs, debug);
+  if (!page) {
+    throw new CommandExecutionError(`Command ${fullName(cmd)} requires a browser session but none was provided`);
+  }
+  return (cmd as BrowserCliCommand).func!(page, kwargs, debug);
 }
 
 function resolvePreNav(cmd: CliCommand): string | null {

--- a/src/pipeline/executor.test.ts
+++ b/src/pipeline/executor.test.ts
@@ -12,6 +12,7 @@ function createMockPage(overrides: Partial<IPage> = {}): IPage {
   return {
     goto: vi.fn(),
     evaluate: vi.fn().mockResolvedValue(null),
+    fetchJson: vi.fn().mockResolvedValue(null),
     getCookies: vi.fn().mockResolvedValue([]),
     snapshot: vi.fn().mockResolvedValue(''),
     click: vi.fn(),

--- a/src/pipeline/steps/download.test.ts
+++ b/src/pipeline/steps/download.test.ts
@@ -25,6 +25,7 @@ function createMockPage(getCookies: IPage['getCookies']): IPage {
   return {
     goto: vi.fn(),
     evaluate: vi.fn().mockResolvedValue(null),
+    fetchJson: vi.fn().mockResolvedValue(null),
     getCookies,
     snapshot: vi.fn().mockResolvedValue(''),
     click: vi.fn(),

--- a/src/pipeline/steps/fetch.test.ts
+++ b/src/pipeline/steps/fetch.test.ts
@@ -27,27 +27,23 @@ describe('stepFetch', () => {
     expect(jsonMock).not.toHaveBeenCalled();
   });
 
-  // W1 + W3: browser single fetch returns error status from evaluate, outer code throws CliError
+  // W1 + W3: browser single fetch delegates to page.fetchJson, which owns browser-context fetch errors
   it('throws CliError with FETCH_ERROR code on non-ok responses inside the browser session', async () => {
-    const jsonMock = vi.fn().mockResolvedValue({ error: 'auth required' });
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      statusText: 'Unauthorized',
-      json: jsonMock,
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    // Simulate real CDP behavior: evaluate returns a value, errors are thrown outside
     const page = {
-      evaluate: vi.fn(async (js: string) => Function(`return (${js})`)()()),
+      fetchJson: vi.fn().mockRejectedValue(new CliError(
+        'FETCH_ERROR',
+        'HTTP 401 Unauthorized from https://api.example.com/items',
+      )),
     } as unknown as IPage;
 
     const err = await stepFetch(page, { url: 'https://api.example.com/items' }, null, {}).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(CliError);
     expect((err as CliError).code).toBe('FETCH_ERROR');
     expect((err as CliError).message).toBe('HTTP 401 Unauthorized from https://api.example.com/items');
-    expect(jsonMock).not.toHaveBeenCalled();
+    expect(page.fetchJson).toHaveBeenCalledWith('https://api.example.com/items', {
+      method: 'GET',
+      headers: {},
+    });
   });
 
   it('returns per-item HTTP errors for batch fetches without a browser session', async () => {

--- a/src/pipeline/steps/fetch.ts
+++ b/src/pipeline/steps/fetch.ts
@@ -36,27 +36,7 @@ async function fetchSingle(
     return resp.json();
   }
 
-  const headersJs = JSON.stringify(renderedHeaders);
-  const urlJs = JSON.stringify(finalUrl);
-  const methodJs = JSON.stringify(method.toUpperCase());
-  // Return error status instead of throwing inside evaluate to avoid CDP wrapper
-  // rewriting the message (CDP prepends "Evaluate error: " to thrown errors).
-  const result = await page.evaluate(`
-    async () => {
-      const resp = await fetch(${urlJs}, {
-        method: ${methodJs}, headers: ${headersJs}, credentials: "include"
-      });
-      if (!resp.ok) {
-        return { __httpError: resp.status, statusText: resp.statusText };
-      }
-      return await resp.json();
-    }
-  `);
-  if (result && typeof result === 'object' && '__httpError' in result) {
-    const { __httpError: status, statusText } = result as { __httpError: number; statusText: string };
-    throw new CliError('FETCH_ERROR', `HTTP ${status} ${statusText} from ${finalUrl}`);
-  }
-  return result;
+  return page.fetchJson(finalUrl, { method: method.toUpperCase(), headers: renderedHeaders });
 }
 
 /**

--- a/src/plugin-scaffold.test.ts
+++ b/src/plugin-scaffold.test.ts
@@ -69,7 +69,7 @@ describe('createPluginScaffold', () => {
     expect(tsSample).toContain(`import { cli, Strategy } from '@jackwener/opencli/registry';`);
     expect(tsSample).toContain(`strategy: Strategy.PUBLIC`);
     expect(tsSample).toContain(`help: 'Name to greet'`);
-    expect(tsSample).toContain(`func: async (_page, kwargs)`);
+    expect(tsSample).toContain(`func: async (kwargs)`);
     expect(tsSample).not.toContain('async run(');
   });
 

--- a/src/plugin-scaffold.ts
+++ b/src/plugin-scaffold.ts
@@ -118,7 +118,7 @@ cli({
     { name: 'name', positional: true, required: true, help: 'Name to greet' },
   ],
   columns: ['greeting'],
-  func: async (_page, kwargs) => [{ greeting: \`Hello, \${String(kwargs.name ?? 'World')}!\` }],
+  func: async (kwargs) => [{ greeting: \`Hello, \${String(kwargs.name ?? 'World')}!\` }],
 });
 `;
   writeFile(targetDir, 'greet.ts', tsContent);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -30,18 +30,18 @@ export interface RequiredEnv {
 }
 
 export type CommandArgs = Record<string, any>;
+export type BrowserCommandFunc = (page: IPage, kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
+export type NonBrowserCommandFunc = (kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
 
-export interface CliCommand {
+interface BaseCliCommand {
   site: string;
   name: string;
   aliases?: string[];
   description: string;
   domain?: string;
   strategy?: Strategy;
-  browser?: boolean;
   args: Arg[];
   columns?: string[];
-  func?: (page: IPage, kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
   pipeline?: Record<string, unknown>[];
   timeoutSeconds?: number;
   /** Origin of this command: 'yaml', 'ts', or plugin name. */
@@ -73,17 +73,48 @@ export interface CliCommand {
   defaultFormat?: 'table' | 'plain' | 'json' | 'yaml' | 'yml' | 'md' | 'markdown' | 'csv';
 }
 
+export interface BrowserCliCommand extends BaseCliCommand {
+  /** Browser commands receive an IPage. Omitted means true after normalization. */
+  browser?: true;
+  func?: BrowserCommandFunc;
+}
+
+export interface NonBrowserCliCommand extends BaseCliCommand {
+  /** Non-browser commands do not receive a page argument. */
+  browser: false;
+  func?: NonBrowserCommandFunc;
+}
+
+export type CliCommand = BrowserCliCommand | NonBrowserCliCommand;
+type RawCliCommand = BaseCliCommand & {
+  browser?: boolean;
+  func?: BrowserCommandFunc | NonBrowserCommandFunc;
+};
+
 /** Internal extension for lazy-loaded TS modules (not exposed in public API) */
-export interface InternalCliCommand extends CliCommand {
+export type InternalCliCommand = CliCommand & {
   _lazy?: boolean;
   _modulePath?: string;
-}
-export interface CliOptions extends Partial<Omit<CliCommand, 'args' | 'description'>> {
+};
+
+type RequiredCliOptions = {
   site: string;
   name: string;
   description?: string;
   args?: Arg[];
-}
+};
+
+type BrowserStrategy = Exclude<Strategy, Strategy.PUBLIC | Strategy.LOCAL>;
+type BrowserCliOptions = Partial<Omit<BrowserCliCommand, 'args' | 'description' | 'browser' | 'strategy'>> & RequiredCliOptions & (
+  | { browser: true; strategy?: Strategy }
+  | { browser?: true; strategy?: BrowserStrategy }
+);
+type NonBrowserCliOptions = Partial<Omit<NonBrowserCliCommand, 'args' | 'description'>> & RequiredCliOptions & (
+  | { browser: false }
+  | { strategy: Strategy.PUBLIC | Strategy.LOCAL; browser?: false }
+);
+
+export type CliOptions = BrowserCliOptions | NonBrowserCliOptions;
 
 // Use globalThis to ensure a single shared registry across all module instances.
 // This is critical for TS plugins loaded via npm link / peerDependency — without
@@ -93,7 +124,7 @@ const _registry: Map<string, CliCommand> =
   globalThis.__opencli_registry__ ??= new Map<string, CliCommand>();
 
 export function cli(opts: CliOptions): CliCommand {
-  const cmd: CliCommand = {
+  const cmd: RawCliCommand = {
     site: opts.site,
     name: opts.name,
     aliases: opts.aliases,
@@ -122,7 +153,7 @@ export function getRegistry(): Map<string, CliCommand> {
   return _registry;
 }
 
-export function fullName(cmd: CliCommand): string {
+export function fullName(cmd: Pick<BaseCliCommand, 'site' | 'name'>): string {
   return `${cmd.site}/${cmd.name}`;
 }
 
@@ -143,7 +174,7 @@ export function strategyLabel(cmd: CliCommand): string {
  *   1. Explicit field on the command (`browser: false`, `navigateBefore: false`)
  *   2. Derived from strategy + domain (the defaults below)
  */
-function normalizeCommand(cmd: CliCommand): CliCommand {
+function normalizeCommand(cmd: RawCliCommand): CliCommand {
   const strategy = cmd.strategy ?? (cmd.browser === false ? Strategy.PUBLIC : Strategy.COOKIE);
   const browser = cmd.browser ?? (strategy !== Strategy.PUBLIC && strategy !== Strategy.LOCAL);
 
@@ -159,10 +190,12 @@ function normalizeCommand(cmd: CliCommand): CliCommand {
     }
   }
 
-  return { ...cmd, strategy, browser, navigateBefore };
+  return browser
+    ? { ...cmd, strategy, browser: true, navigateBefore } as BrowserCliCommand
+    : { ...cmd, strategy, browser: false, navigateBefore } as NonBrowserCliCommand;
 }
 
-export function registerCommand(cmd: CliCommand): void {
+export function registerCommand(cmd: RawCliCommand): void {
   const normalized = normalizeCommand(cmd);
   const canonicalKey = fullName(normalized);
   const existing = _registry.get(canonicalKey);

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,13 @@ export interface ScreenshotOptions {
   path?: string;
 }
 
+export interface FetchJsonOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  timeoutMs?: number;
+}
+
 export interface BrowserSessionInfo {
   workspace?: string;
   connected?: boolean;
@@ -58,6 +65,12 @@ export interface IPage {
   evaluate(js: string): Promise<any>;
   /** Safely evaluate JS with pre-serialized arguments — prevents injection. */
   evaluateWithArgs?(js: string, args: Record<string, unknown>): Promise<any>;
+  /**
+   * Fetch JSON from inside the browser context, carrying the page's cookies.
+   * This is intentionally narrow: browser-context JSON fetch, not a generic
+   * HTTP client.
+   */
+  fetchJson(url: string, opts?: FetchJsonOptions): Promise<unknown>;
   getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   snapshot(opts?: SnapshotOptions): Promise<any>;
   click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;


### PR DESCRIPTION
## Summary
- split adapter func typing by browser runtime: browser commands receive page, non-browser commands receive args directly
- remove dead _page parameters from non-browser adapters, scaffold, docs, and direct adapter tests
- add BasePage.fetchJson() as the narrow browser-context JSON fetch primitive and route pipeline single browser fetches through it

## Verification
- npm run typecheck
- npm run build
- OPENCLI_DAEMON_PORT=29125 npm test