### PR TITLE
refactor: simplify diagnostics and low-use errors

### DIFF
--- a/clis/band/mentions.js
+++ b/clis/band/mentions.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, EmptyResultError, SelectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, EmptyResultError, selectorError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 /**
  * band mentions — Show Band notifications where you were @mentioned.
@@ -52,7 +52,7 @@ cli({
             await page.wait(0.5);
         }
         if (!bellReady) {
-            throw new SelectorError('button._btnWidgetIcon', 'Notification bell not found. The Band.us UI may have changed.');
+            throw selectorError('button._btnWidgetIcon', 'Notification bell not found. The Band.us UI may have changed.');
         }
         // Poll until a capture containing result_data.news arrives, up to maxSecs seconds.
         // getInterceptedRequests() clears the array on each call, so captures are accumulated
@@ -80,7 +80,7 @@ cli({
       return true;
     }`);
         if (!bellClicked) {
-            throw new SelectorError('button._btnWidgetIcon', 'Notification bell disappeared before click. The Band.us UI may have changed.');
+            throw selectorError('button._btnWidgetIcon', 'Notification bell disappeared before click. The Band.us UI may have changed.');
         }
         const requests = await waitForOneCapture();
         // Find the get_news response (has result_data.news); get_news_count responses do not.

--- a/clis/bilibili/subtitle.js
+++ b/clis/bilibili/subtitle.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError, EmptyResultError, SelectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError, selectorError } from '@jackwener/opencli/errors';
 import { apiGet, resolveBvid } from './utils.js';
 cli({
     site: 'bilibili',
@@ -23,7 +23,7 @@ cli({
       return state?.videoData?.cid;
     })()`);
         if (!cid) {
-            throw new SelectorError('videoData.cid', '无法在页面中提取到当前视频的 CID，请检查页面是否正常加载。');
+            throw selectorError('videoData.cid', '无法在页面中提取到当前视频的 CID，请检查页面是否正常加载。');
         }
         // 3. 在 Node 端使用 apiGet 获取带 Wbi 签名的字幕列表
         // 之前纯靠 evaluate 里的 fetch 会失败，因为 B 站 /wbi/ 开头的接口强校验 w_rid，未签名直接被风控返回 403 HTML

--- a/clis/boss/send.js
+++ b/clis/boss/send.js
@@ -6,7 +6,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { requirePage, navigateToChat, findFriendByUid, clickCandidateInList, typeAndSendMessage, } from './utils.js';
-import { EmptyResultError, SelectorError } from '@jackwener/opencli/errors';
+import { EmptyResultError, selectorError } from '@jackwener/opencli/errors';
 cli({
     site: 'boss',
     name: 'send',
@@ -30,12 +30,12 @@ cli({
         const friendName = friend.name || '候选人';
         const clicked = await clickCandidateInList(page, numericUid);
         if (!clicked) {
-            throw new SelectorError('聊天列表中的用户', '请确认聊天列表中有此人');
+            throw selectorError('聊天列表中的用户', '请确认聊天列表中有此人');
         }
         await page.wait({ time: 2 });
         const sent = await typeAndSendMessage(page, kwargs.text);
         if (!sent) {
-            throw new SelectorError('消息输入框', '聊天页面 UI 可能已改变');
+            throw selectorError('消息输入框', '聊天页面 UI 可能已改变');
         }
         await page.wait({ time: 1 });
         return [{ status: '✅ 发送成功', detail: `已向 ${friendName} 发送: ${kwargs.text}` }];

--- a/clis/chatwise/ask.js
+++ b/clis/chatwise/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const askCommand = cli({
     site: 'chatwise',
     name: 'ask',
@@ -43,7 +43,7 @@ export const askCommand = cli({
       })(${JSON.stringify(text)})
     `);
         if (!injected)
-            throw new SelectorError('ChatWise input element');
+            throw selectorError('ChatWise input element');
         await page.wait(0.5);
         await page.pressKey('Enter');
         // Poll for response

--- a/clis/chatwise/model.js
+++ b/clis/chatwise/model.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const modelCommand = cli({
     site: 'chatwise',
     name: 'model',
@@ -58,7 +58,7 @@ export const modelCommand = cli({
         })(${JSON.stringify(desiredModel)})
       `);
             if (!opened)
-                throw new SelectorError('ChatWise model selector');
+                throw selectorError('ChatWise model selector');
             await page.wait(0.5);
             // Find and click the target model in the dropdown
             const found = await page.evaluate(`

--- a/clis/chatwise/send.js
+++ b/clis/chatwise/send.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const sendCommand = cli({
     site: 'chatwise',
     name: 'send',
@@ -36,7 +36,7 @@ export const sendCommand = cli({
       })(${JSON.stringify(text)})
     `);
         if (!injected)
-            throw new SelectorError('ChatWise input element');
+            throw selectorError('ChatWise input element');
         await page.wait(0.5);
         await page.pressKey('Enter');
         return [

--- a/clis/codex/ask.js
+++ b/clis/codex/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const askCommand = cli({
     site: 'codex',
     name: 'ask',
@@ -34,7 +34,7 @@ export const askCommand = cli({
       })(${JSON.stringify(text)})
     `);
         if (!injected)
-            throw new SelectorError('Codex input element');
+            throw selectorError('Codex input element');
         await page.wait(0.5);
         await page.pressKey('Enter');
         // Poll for new content

--- a/clis/codex/send.js
+++ b/clis/codex/send.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const sendCommand = cli({
     site: 'codex',
     name: 'send',
@@ -28,7 +28,7 @@ export const sendCommand = cli({
       })(${JSON.stringify(textToInsert)})
     `);
         if (!injected)
-            throw new SelectorError('Codex Composer input element');
+            throw selectorError('Codex Composer input element');
         // Wait for the UI to register the input
         await page.wait(0.5);
         // Simulate Enter key to submit

--- a/clis/cursor/ask.js
+++ b/clis/cursor/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const askCommand = cli({
     site: 'cursor',
     name: 'ask',
@@ -28,7 +28,7 @@ export const askCommand = cli({
         return true;
       })(${JSON.stringify(text)})`);
         if (!injected)
-            throw new SelectorError('Cursor input element');
+            throw selectorError('Cursor input element');
         await page.wait(0.5);
         await page.pressKey('Enter');
         // Poll until a new assistant message appears or timeout

--- a/clis/cursor/composer.js
+++ b/clis/cursor/composer.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const composerCommand = cli({
     site: 'cursor',
     name: 'composer',
@@ -27,7 +27,7 @@ export const composerCommand = cli({
         return true;
       })(${JSON.stringify(textToInsert)})`);
         if (!typed) {
-            throw new SelectorError('Cursor Composer input element', 'Could not find Cursor Composer input element after pressing Cmd+I.');
+            throw selectorError('Cursor Composer input element', 'Could not find Cursor Composer input element after pressing Cmd+I.');
         }
         await page.wait(0.5);
         await page.pressKey('Enter');

--- a/clis/cursor/send.js
+++ b/clis/cursor/send.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SelectorError } from '@jackwener/opencli/errors';
+import { selectorError } from '@jackwener/opencli/errors';
 export const sendCommand = cli({
     site: 'cursor',
     name: 'send',
@@ -24,7 +24,7 @@ export const sendCommand = cli({
         return true;
       })(${JSON.stringify(textToInsert)})`);
         if (!injected) {
-            throw new SelectorError('Cursor Composer input element');
+            throw selectorError('Cursor Composer input element');
         }
         // Submit the command. In Cursor, Enter usually submits the chat.
         await page.wait(0.5);

--- a/clis/twitter/followers.js
+++ b/clis/twitter/followers.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, SelectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, selectorError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 cli({
     site: 'twitter',
@@ -49,7 +49,7 @@ cli({
         return false;
     }`);
         if (!clicked) {
-            throw new SelectorError('Twitter followers link', 'Twitter may have changed the layout.');
+            throw selectorError('Twitter followers link', 'Twitter may have changed the layout.');
         }
         await page.waitForCapture(5);
         // 4. Scroll to trigger pagination API calls

--- a/clis/xianyu/chat.js
+++ b/clis/xianyu/chat.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, SelectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, selectorError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { normalizeNumericId } from './utils.js';
 function buildChatUrl(itemId, peerUserId) {
@@ -105,7 +105,7 @@ cli({
             throw new AuthRequiredError('www.goofish.com', 'Xianyu chat requires a logged-in browser session');
         }
         if (!state?.can_input) {
-            throw new SelectorError('闲鱼聊天输入框', '未找到可用的聊天输入框，请确认该会话页已正确加载');
+            throw selectorError('闲鱼聊天输入框', '未找到可用的聊天输入框，请确认该会话页已正确加载');
         }
         if (!text) {
             return [{
@@ -123,7 +123,7 @@ cli({
         }
         const sent = await page.evaluate(buildSendMessageEvaluate(text));
         if (!sent?.ok) {
-            throw new SelectorError('闲鱼发送按钮', `消息发送失败：${sent?.reason || 'unknown-reason'}`);
+            throw selectorError('闲鱼发送按钮', `消息发送失败：${sent?.reason || 'unknown-reason'}`);
         }
         await page.wait(1);
         return [{

--- a/clis/xianyu/item.js
+++ b/clis/xianyu/item.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, EmptyResultError, SelectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, EmptyResultError, selectorError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { normalizeNumericId } from './utils.js';
 function buildItemUrl(itemId) {
@@ -127,7 +127,7 @@ cli({
             throw new EmptyResultError('xianyu item', 'Xianyu item detail is blocked by verification or risk control');
         }
         if (result?.error === 'mtop-not-ready') {
-            throw new SelectorError('window.lib.mtop', '闲鱼页面未完成初始化，无法调用商品详情接口');
+            throw selectorError('window.lib.mtop', '闲鱼页面未完成初始化，无法调用商品详情接口');
         }
         if (!result || typeof result !== 'object') {
             throw new EmptyResultError('xianyu item', '闲鱼商品详情接口未返回有效数据');

--- a/clis/xianyu/item.test.js
+++ b/clis/xianyu/item.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AuthRequiredError, EmptyResultError, SelectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './item.js';
 import './item.js';
@@ -49,8 +49,8 @@ describe('xianyu item command', () => {
         const page = createPageMock({ error: 'blocked' });
         await expect(command.func(page, { item_id: '1040754408976' })).rejects.toBeInstanceOf(EmptyResultError);
     });
-    it('keeps SelectorError for true mtop initialization failures', async () => {
+    it('keeps SELECTOR code for true mtop initialization failures', async () => {
         const page = createPageMock({ error: 'mtop-not-ready' });
-        await expect(command.func(page, { item_id: '1040754408976' })).rejects.toBeInstanceOf(SelectorError);
+        await expect(command.func(page, { item_id: '1040754408976' })).rejects.toMatchObject({ code: 'SELECTOR' });
     });
 });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -187,9 +187,8 @@ type TargetLease = {
   lifecycle: LeaseLifecycle;
   surface: SurfacePolicy;
 };
-type AutomationSession = TargetLease;
 
-const automationSessions = new Map<string, AutomationSession>();
+const automationSessions = new Map<string, TargetLease>();
 let ownedContainerWindowId: number | null = null;
 const IDLE_TIMEOUT_DEFAULT = 30_000;      // 30s — adapter-driven automation
 const IDLE_TIMEOUT_INTERACTIVE = 600_000; // 10min — human-paced browser:* / operate:*
@@ -199,7 +198,7 @@ const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
 let leaseMutationQueue: Promise<void> = Promise.resolve();
 let ownedContainerWindowPromise: Promise<{ windowId: number; initialTabId?: number }> | null = null;
 
-type StoredLease = Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'> & {
+type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
   idleDeadlineAt: number;
   updatedAt: number;
 };
@@ -264,8 +263,8 @@ function withLeaseMutation<T>(fn: () => Promise<T>): Promise<T> {
 
 function makeSession(
   workspace: string,
-  session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
-): Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt'> {
+  session: Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
+): Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> {
   const ownership = session.owned ? 'owned' : 'borrowed';
   return {
     ...session,
@@ -790,7 +789,7 @@ function enumerateCrossOriginFrames(tree: any): Array<{ index: number; frameId: 
 
 function setWorkspaceSession(
   workspace: string,
-  session: Omit<AutomationSession, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
+  session: Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
 ): void {
   const existing = automationSessions.get(workspace);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Command } from 'commander';
 import type { CliCommand } from './registry.js';
-import { EmptyResultError, SelectorError } from './errors.js';
+import { EmptyResultError, selectorError } from './errors.js';
 
 const { mockExecuteCommand, mockRenderOutput } = vi.hoisted(() => ({
   mockExecuteCommand: vi.fn(),
@@ -356,7 +356,7 @@ describe('commanderAdapter error envelope output', () => {
 
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockExecuteCommand.mockRejectedValueOnce(
-      new SelectorError('.note-title', 'The note title selector no longer matches the current page.'),
+      selectorError('.note-title', 'The note title selector no longer matches the current page.'),
     );
 
     await program.parseAsync(['node', 'opencli', 'xiaohongshu', 'note', '69ca3927000000001a020fd5']);

--- a/src/diagnostic.test.ts
+++ b/src/diagnostic.test.ts
@@ -4,7 +4,7 @@ import {
   truncate, redactUrl, redactText, resolveAdapterSourcePath, MAX_DIAGNOSTIC_BYTES,
   type RepairContext,
 } from './diagnostic.js';
-import { SelectorError, CommandExecutionError } from './errors.js';
+import { selectorError, CommandExecutionError } from './errors.js';
 import type { InternalCliCommand } from './registry.js';
 import type { IPage } from './types.js';
 
@@ -130,7 +130,7 @@ describe('resolveAdapterSourcePath', () => {
 
 describe('buildRepairContext', () => {
   it('captures CliError fields', () => {
-    const err = new SelectorError('.missing-element', 'Element removed');
+    const err = selectorError('.missing-element', 'Element removed');
     const ctx = buildRepairContext(err, makeCmd());
 
     expect(ctx.error.code).toBe('SELECTOR');
@@ -170,9 +170,9 @@ describe('buildRepairContext', () => {
 
   it('truncates long stack traces', () => {
     const err = new Error('boom');
-    err.stack = 'x'.repeat(10_000);
+    err.stack = 'x'.repeat(60_000);
     const ctx = buildRepairContext(err, makeCmd());
-    expect(ctx.error.stack!.length).toBeLessThan(10_000);
+    expect(ctx.error.stack!.length).toBeLessThan(60_000);
     expect(ctx.error.stack).toContain('truncated');
   });
 
@@ -332,7 +332,7 @@ describe('collectDiagnostic', () => {
         token: 'token=abc123def456ghi789',
         nested: {
           cookie: 'cookie: session=super-secret-cookie-value',
-          body: 'x'.repeat(5000),
+          body: 'x'.repeat(60_000),
         },
       }]),
     });
@@ -352,6 +352,6 @@ describe('collectDiagnostic', () => {
       },
     });
     expect(body).toContain('[truncated,');
-    expect(body.length).toBeLessThan(5000);
+    expect(body.length).toBeLessThan(60_000);
   });
 });

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -23,22 +23,10 @@ import { fullName } from './registry.js';
 
 /** Maximum bytes for the entire diagnostic JSON output. */
 export const MAX_DIAGNOSTIC_BYTES = 256 * 1024; // 256 KB
-/** Maximum characters for DOM snapshot. */
-const MAX_SNAPSHOT_CHARS = 100_000;
-/** Maximum characters for adapter source. */
-const MAX_SOURCE_CHARS = 50_000;
-/** Maximum number of network requests to include. */
-const MAX_NETWORK_REQUESTS = 50;
-/** Maximum number of captured interceptor payloads to include. */
-const MAX_CAPTURED_PAYLOADS = 20;
-/** Maximum characters for a single network request body. */
-const MAX_REQUEST_BODY_CHARS = 4_000;
-/** Maximum characters for error stack trace. */
-const MAX_STACK_CHARS = 5_000;
-/** Maximum nesting depth for arbitrary captured payloads. */
-const MAX_CAPTURED_DEPTH = 4;
-/** Maximum object keys or array items to keep per nesting level. */
-const MAX_CAPTURED_CHILDREN = 20;
+/** Maximum characters for any single diagnostic text field. */
+const MAX_DIAGNOSTIC_FIELD_CHARS = 50_000;
+/** Maximum entries to keep from diagnostic collections. */
+const MAX_DIAGNOSTIC_COLLECTION_ITEMS = 50;
 
 // ── Sensitive data patterns ──────────────────────────────────────────────────
 
@@ -129,20 +117,20 @@ function redactHeaders(headers: Record<string, string> | undefined): Record<stri
 /** Recursively sanitize arbitrary captured response content for diagnostic output. */
 function sanitizeCapturedValue(value: unknown, depth: number = 0): unknown {
   if (typeof value === 'string') {
-    return redactText(truncate(value, MAX_REQUEST_BODY_CHARS));
+    return redactText(truncate(value, MAX_DIAGNOSTIC_FIELD_CHARS));
   }
   if (value === null || typeof value === 'number' || typeof value === 'boolean') {
     return value;
   }
-  if (depth >= MAX_CAPTURED_DEPTH) {
+  if (depth >= 4) {
     return '[truncated: max depth reached]';
   }
   if (Array.isArray(value)) {
     const items = value
-      .slice(0, MAX_CAPTURED_CHILDREN)
+      .slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)
       .map(item => sanitizeCapturedValue(item, depth + 1));
-    if (value.length > MAX_CAPTURED_CHILDREN) {
-      items.push(`[truncated, ${value.length - MAX_CAPTURED_CHILDREN} items omitted]`);
+    if (value.length > MAX_DIAGNOSTIC_COLLECTION_ITEMS) {
+      items.push(`[truncated, ${value.length - MAX_DIAGNOSTIC_COLLECTION_ITEMS} items omitted]`);
     }
     return items;
   }
@@ -152,11 +140,11 @@ function sanitizeCapturedValue(value: unknown, depth: number = 0): unknown {
 
   const entries = Object.entries(value);
   const result: Record<string, unknown> = {};
-  for (const [key, child] of entries.slice(0, MAX_CAPTURED_CHILDREN)) {
+  for (const [key, child] of entries.slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)) {
     result[key] = sanitizeCapturedValue(child, depth + 1);
   }
-  if (entries.length > MAX_CAPTURED_CHILDREN) {
-    result.__truncated__ = `[${entries.length - MAX_CAPTURED_CHILDREN} fields omitted]`;
+  if (entries.length > MAX_DIAGNOSTIC_COLLECTION_ITEMS) {
+    result.__truncated__ = `[${entries.length - MAX_DIAGNOSTIC_COLLECTION_ITEMS} fields omitted]`;
   }
   return result;
 }
@@ -185,7 +173,7 @@ function redactNetworkRequest(req: unknown): unknown {
 
   // Redact and truncate response body
   if (typeof redacted.body === 'string') {
-    redacted.body = redactText(truncate(redacted.body, MAX_REQUEST_BODY_CHARS));
+    redacted.body = redactText(truncate(redacted.body, MAX_DIAGNOSTIC_FIELD_CHARS));
   }
   if ('responseBody' in redacted) {
     redacted.responseBody = sanitizeCapturedValue(redacted.responseBody);
@@ -246,7 +234,7 @@ export function isDiagnosticEnabled(): boolean {
 }
 
 function normalizeInterceptedRequests(interceptedRequests: unknown[]): unknown[] {
-  return interceptedRequests.slice(0, MAX_CAPTURED_PAYLOADS).map(responseBody => ({
+  return interceptedRequests.slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS).map(responseBody => ({
     source: 'interceptor',
     responseBody: sanitizeCapturedValue(responseBody),
   }));
@@ -268,13 +256,13 @@ async function collectPageState(page: IPage): Promise<RepairContext['page'] | un
       const capturedResponses = normalizeInterceptedRequests(interceptedRequests as unknown[]);
       return {
         url: redactUrl(rawUrl),
-        snapshot: redactText(truncate(snapshot, MAX_SNAPSHOT_CHARS)),
+        snapshot: redactText(truncate(snapshot, MAX_DIAGNOSTIC_FIELD_CHARS)),
         networkRequests: (networkRequests as unknown[])
-          .slice(0, MAX_NETWORK_REQUESTS)
+          .slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)
           .map(redactNetworkRequest),
         capturedPayloads: capturedResponses,
         consoleErrors: (consoleErrors as unknown[])
-          .slice(0, 50)
+          .slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)
           .map(e => typeof e === 'string' ? redactText(e) : e),
       };
     } catch {
@@ -290,7 +278,7 @@ function readAdapterSource(sourcePath: string | undefined): string | undefined {
   if (!sourcePath) return undefined;
   try {
     const content = fs.readFileSync(sourcePath, 'utf-8');
-    return truncate(content, MAX_SOURCE_CHARS);
+    return truncate(content, MAX_DIAGNOSTIC_FIELD_CHARS);
   } catch {
     return undefined;
   }
@@ -309,7 +297,7 @@ export function buildRepairContext(
       code: isCliError ? err.code : 'UNKNOWN',
       message: redactText(getErrorMessage(err)),
       hint: isCliError && err.hint ? redactText(err.hint) : undefined,
-      stack: err instanceof Error ? redactText(truncate(err.stack ?? '', MAX_STACK_CHARS)) : undefined,
+      stack: err instanceof Error ? redactText(truncate(err.stack ?? '', MAX_DIAGNOSTIC_FIELD_CHARS)) : undefined,
     },
     adapter: {
       site: cmd.site,

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import {
   CliError,
   BrowserConnectError,
-  AdapterLoadError,
+  adapterLoadError,
   CommandExecutionError,
   ConfigError,
   AuthRequiredError,
   TimeoutError,
   ArgumentError,
   EmptyResultError,
-  SelectorError,
+  selectorError,
   toEnvelope,
 } from './errors.js';
 
@@ -17,14 +17,14 @@ describe('Error type hierarchy', () => {
   it('all error types extend CliError', () => {
     const errors = [
       new BrowserConnectError('test'),
-      new AdapterLoadError('test'),
+      adapterLoadError('test'),
       new CommandExecutionError('test'),
       new ConfigError('test'),
       new AuthRequiredError('example.com'),
       new TimeoutError('test', 30),
       new ArgumentError('test'),
       new EmptyResultError('test/cmd'),
-      new SelectorError('.btn'),
+      selectorError('.btn'),
     ];
 
     for (const err of errors) {
@@ -66,8 +66,8 @@ describe('Error type hierarchy', () => {
     expect(err.hint).toBeTruthy();
   });
 
-  it('SelectorError has default hint about page changes', () => {
-    const err = new SelectorError('.submit-btn');
+  it('selectorError has default hint about page changes', () => {
+    const err = selectorError('.submit-btn');
     expect(err.code).toBe('SELECTOR');
     expect(err.message).toContain('.submit-btn');
     expect(err.hint).toContain('report');

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,7 +13,7 @@
  *   1   Generic / unexpected error
  *   2   Argument / usage error          (ArgumentError)
  *  66   No input / empty result         (EmptyResultError)
- *  69   Service unavailable             (BrowserConnectError, AdapterLoadError)
+ *  69   Service unavailable             (BrowserConnectError, adapter load failures)
  *  75   Temporary failure, retry later  (TimeoutError)   EX_TEMPFAIL
  *  77   Permission denied / auth needed (AuthRequiredError)
  *  78   Configuration error             (ConfigError)
@@ -64,12 +64,6 @@ export class BrowserConnectError extends CliError {
   constructor(message: string, hint?: string, kind: BrowserConnectKind = 'unknown') {
     super('BROWSER_CONNECT', message, hint, EXIT_CODES.SERVICE_UNAVAIL);
     this.kind = kind;
-  }
-}
-
-export class AdapterLoadError extends CliError {
-  constructor(message: string, hint?: string) {
-    super('ADAPTER_LOAD', message, hint, EXIT_CODES.SERVICE_UNAVAIL);
   }
 }
 
@@ -126,15 +120,17 @@ export class EmptyResultError extends CliError {
   }
 }
 
-export class SelectorError extends CliError {
-  constructor(selector: string, hint?: string) {
-    super(
-      'SELECTOR',
-      `Could not find element: ${selector}`,
-      hint ?? 'The page UI may have changed. Please report this issue.',
-      EXIT_CODES.GENERIC_ERROR,
-    );
-  }
+export function adapterLoadError(message: string, hint?: string): CliError {
+  return new CliError('ADAPTER_LOAD', message, hint, EXIT_CODES.SERVICE_UNAVAIL);
+}
+
+export function selectorError(selector: string, hint?: string): CliError {
+  return new CliError(
+    'SELECTOR',
+    `Could not find element: ${selector}`,
+    hint ?? 'The page UI may have changed. Please report this issue.',
+    EXIT_CODES.GENERIC_ERROR,
+  );
 }
 
 export class PluginError extends CliError {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -24,7 +24,7 @@ import { pathToFileURL } from 'node:url';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
-import { AdapterLoadError, ArgumentError, CommandExecutionError, getErrorMessage } from './errors.js';
+import { adapterLoadError, ArgumentError, CommandExecutionError, getErrorMessage } from './errors.js';
 import { isDiagnosticEnabled, collectDiagnostic, emitDiagnostic } from './diagnostic.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT } from './runtime.js';
@@ -113,7 +113,7 @@ async function runCommand(
         },
         (err) => {
           _loadedModules.delete(modulePath);
-          throw new AdapterLoadError(
+          throw adapterLoadError(
             `Failed to load adapter module ${modulePath}: ${getErrorMessage(err)}`,
             'Check that the adapter file exists and has no syntax errors.',
           );


### PR DESCRIPTION
## Summary
- remove the `AutomationSession` alias and use `TargetLease` directly in the extension background runtime
- collapse diagnostic size knobs into total bytes, per-field chars, and collection item caps
- replace low-value `AdapterLoadError` / `SelectorError` subclasses with plain `CliError` factories while preserving `ADAPTER_LOAD` and `SELECTOR` error codes
- update adapter/test call sites to use `selectorError()` and code-based assertions

## Notes
- `SelectorError` was used by multiple adapters, so this keeps a `selectorError()` helper instead of scattering repeated `new CliError("SELECTOR", ...)` construction everywhere.
- `AdapterLoadError` was only a code/exit-code wrapper, so `adapterLoadError()` returns a plain `CliError`.

## Verification
- `npm run typecheck`
- `npx vitest run src/errors.test.ts src/diagnostic.test.ts src/commanderAdapter.test.ts src/execution.test.ts clis/xianyu/item.test.js --project unit`
- `cd extension && npm run typecheck && npm run build`
- `npx vitest run extension/src/background.test.ts --project extension`
- `npm run build`
- `git diff --check`
- `OPENCLI_DAEMON_PORT=29125 npm test`