### PR TITLE
chore: enforce Node 21 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ It also works as a **CLI hub** for local tools such as `gh`, `docker`, and other
 
 ### 1. Install OpenCLI
 
+OpenCLI requires **Node.js >= 21**.
+
 ```bash
+node --version
 npm install -g @jackwener/opencli
 ```
 
@@ -171,7 +174,8 @@ OpenCLI is not only for websites. It can also:
 
 ## Prerequisites
 
-- **Node.js**: >= 21.0.0 (or **Bun** >= 1.0)
+- **Node.js**: >= 21.0.0 (required for the standard npm install path)
+- **Bun**: >= 1.0 (optional alternative runtime)
 - **Chrome or Chromium** running and logged into the target site for browser-backed commands
 
 > **Important**: Browser-backed commands reuse your Chrome/Chromium login session. If you get empty data or permission-like failures, first confirm the site is already open and authenticated in Chrome/Chromium.
@@ -405,7 +409,7 @@ See **[TESTING.md](./TESTING.md)** for how to run and write tests.
 - **"Extension not connected"** — Ensure the Browser Bridge extension is installed from the [Chrome Web Store](https://chromewebstore.google.com/detail/opencli/ildkmabpimmkaediidaifkhjpohdnifk) and **enabled** in `chrome://extensions`.
 - **"attach failed: Cannot access a chrome-extension:// URL"** — Another extension may be interfering. Try disabling other extensions temporarily.
 - **Empty data or 'Unauthorized' error** — Your Chrome/Chromium login session may have expired. Navigate to the target site and log in again.
-- **Node API errors** — Ensure Node.js >= 21. Some features require `node:util` styleText (stable in Node 21+).
+- **Node API errors / missing `fetch` / startup crash on old Node** — OpenCLI requires **Node.js >= 21**. Run `node --version`, upgrade Node if needed, then retry.
 - **Daemon issues** — Check status: `curl localhost:19825/status` · View logs: `curl localhost:19825/logs`
 
 ## Star History

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,10 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 
 ### 1. 安装 OpenCLI
 
+OpenCLI 要求 **Node.js >= 21**。
+
 ```bash
+node --version
 npm install -g @jackwener/opencli
 ```
 
@@ -155,7 +158,8 @@ OpenCLI 不只是网站 CLI，还可以：
 
 ## 前置要求
 
-- **Node.js**: >= 21.0.0
+- **Node.js**: >= 21.0.0（标准 npm 安装路径要求）
+- **Bun**: >= 1.0（可选替代运行时）
 - 浏览器型命令需要 Chrome 或 Chromium 处于运行中，并已登录目标网站
 
 > **重要**：浏览器型命令直接复用你的 Chrome/Chromium 登录态。如果拿到空数据或出现权限类失败，先确认目标站点已经在浏览器里打开并完成登录。
@@ -502,8 +506,8 @@ opencli plugin uninstall my-tool                            # 卸载
   - 其他 Chrome/Chromium 扩展（如 youmind、New Tab Override 或 AI 助手类扩展）可能产生冲突。请尝试**暂时禁用其他扩展**后重试。
 - **返回空数据，或者报错 "Unauthorized"**
   - Chrome/Chromium 里的登录态可能已经过期。请打开当前页面，在新标签页重新手工登录或刷新该页面。
-- **Node API 错误 (如 parseArgs, fs 等)**
-  - 确保 Node.js 版本 `>= 21`（`node:util` 的 `styleText` 需要 Node 21+）。
+- **Node API 错误 / 缺少 `fetch` / 旧 Node 启动即崩**
+  - OpenCLI 要求 **Node.js >= 21**。先执行 `node --version`，如果版本过低先升级，再重试命令。
 - **Daemon 问题**
   - 检查 daemon 状态：`curl localhost:19825/status`
   - 查看扩展日志：`curl localhost:19825/logs`

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { getCompletionsFromManifest, hasAllManifests, printCompletionScriptFast 
 import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
+import { isSupportedNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './runtime-detect.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -49,6 +50,18 @@ const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.
 const argv = process.argv.slice(2);
+
+if (typeof (globalThis as { Bun?: unknown }).Bun === 'undefined' && !isSupportedNodeVersion(process.version)) {
+  process.stderr.write(
+    [
+      `OpenCLI requires Node.js >= ${MIN_SUPPORTED_NODE_MAJOR}.0.0.`,
+      `Current runtime: ${process.version}`,
+      'Upgrade Node.js, then retry the same command.',
+      '',
+    ].join('\n'),
+  );
+  process.exit(EXIT_CODES.CONFIG_ERROR);
+}
 
 // Fast path: --version (only when it's the top-level intent, not passed to a subcommand)
 // e.g. `opencli --version` or `opencli -V`, but NOT `opencli gh --version`

--- a/src/runtime-detect.test.ts
+++ b/src/runtime-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectRuntime, getRuntimeVersion, getRuntimeLabel } from './runtime-detect.js';
+import { detectRuntime, getRuntimeVersion, getRuntimeLabel, parseNodeMajor, isSupportedNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './runtime-detect.js';
 
 describe('runtime-detect', () => {
   it('detectRuntime returns a valid runtime string', () => {
@@ -26,5 +26,18 @@ describe('runtime-detect', () => {
     } else {
       expect(rt).toBe('node');
     }
+  });
+
+  it('parses Node major versions from standard version strings', () => {
+    expect(parseNodeMajor('v21.0.0')).toBe(21);
+    expect(parseNodeMajor('22.13.1')).toBe(22);
+    expect(parseNodeMajor('bun-1.2.0')).toBeNull();
+  });
+
+  it('checks the current minimum supported Node major version', () => {
+    expect(MIN_SUPPORTED_NODE_MAJOR).toBe(21);
+    expect(isSupportedNodeVersion('v20.18.0')).toBe(false);
+    expect(isSupportedNodeVersion('v21.0.0')).toBe(true);
+    expect(isSupportedNodeVersion('v25.0.0')).toBe(true);
   });
 });

--- a/src/runtime-detect.ts
+++ b/src/runtime-detect.ts
@@ -7,6 +7,7 @@
  */
 
 export type Runtime = 'bun' | 'node';
+export const MIN_SUPPORTED_NODE_MAJOR = 21;
 
 /** Shape of `globalThis` when running under Bun. */
 interface BunGlobal {
@@ -35,4 +36,23 @@ export function getRuntimeVersion(): string {
  */
 export function getRuntimeLabel(): string {
   return `${detectRuntime()} ${getRuntimeVersion()}`;
+}
+
+/**
+ * Parse a Node.js version string like "v22.13.0" and return its major version.
+ * Returns null for non-Node or malformed inputs.
+ */
+export function parseNodeMajor(version: string): number | null {
+  const match = /^v?(\d+)\./.exec(String(version).trim());
+  if (!match) return null;
+  const major = Number(match[1]);
+  return Number.isInteger(major) ? major : null;
+}
+
+/**
+ * Whether the given Node.js version satisfies the current minimum support policy.
+ */
+export function isSupportedNodeVersion(version: string = process.version): boolean {
+  const major = parseNodeMajor(version);
+  return major !== null && major >= MIN_SUPPORTED_NODE_MAJOR;
 }


### PR DESCRIPTION
## Summary
- document `Node.js >= 21` explicitly in English and Chinese install/troubleshooting docs
- fail fast at startup when running under Node < 21, while leaving Bun unchanged
- add focused runtime-detect coverage for the minimum supported Node major version

## Validation
- `git diff --check`
- `node --check src/main.ts src/runtime-detect.ts src/runtime-detect.test.ts`
- `node node_modules/vitest/vitest.mjs run src/runtime-detect.test.ts`
- `npm run typecheck`
- `npm run build`
