### PR TITLE
docs(cli): unify adapter naming in --help (closes #1197 part 1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -425,7 +425,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   program
     .command('list')
-    .description('List all available CLI commands')
+    .description('List all available adapter and external commands')
     .option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table')
     .action((opts) => {
       const registry = getRegistry();
@@ -491,7 +491,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         console.log();
       }
 
-      console.log(styleText('dim', `  ${commands.length} built-in commands across ${sites.size} sites, ${externalClis.length} external CLIs`));
+      console.log(styleText('dim', `  ${commands.length} adapter commands across ${sites.size} sites, ${externalClis.length} external CLIs`));
       console.log();
     });
 
@@ -499,7 +499,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   program
     .command('validate')
-    .description('Validate CLI definitions')
+    .description('Validate adapter definitions')
     .argument('[target]', 'site or site/name')
     .action(async (target) => {
       const { validateClisWithTarget, renderValidationReport } = await import('./validate.js');
@@ -2095,7 +2095,7 @@ cli({
     });
 
   // ── Built-in: adapter management ─────────────────────────────────────────
-  const adapterCmd = program.command('adapter').description('Manage CLI adapters');
+  const adapterCmd = program.command('adapter').description('Manage adapters');
 
   adapterCmd
     .command('status')
@@ -2321,7 +2321,7 @@ cli({
   externalCmd
     .command('register')
     .description('Register an external CLI')
-    .argument('<name>', 'Name of the CLI')
+    .argument('<name>', 'Name of the external CLI')
     .option('--binary <bin>', 'Binary name if different from name')
     .option('--install <cmd>', 'Auto-install command')
     .option('--desc <text>', 'Description')


### PR DESCRIPTION
## Summary
Issue #1197 reported that `--help` conflates "adapter" (YAML/JS website wrapper) with generic "CLI" (the opencli binary). Standardize wording so users see "adapter" consistently for adapter-related descriptions and reserve "external CLI" for the docker/gh/vercel passthrough family.

| Where | Before | After |
|---|---|---|
| `list` description | List all available CLI commands | List all available adapter and external commands |
| `list` footer | … built-in commands … | … adapter commands … |
| `validate` description | Validate CLI definitions | Validate adapter definitions |
| `adapter` description | Manage CLI adapters | Manage adapters |
| `external register` arg desc | Name of the CLI | Name of the external CLI |

## Scope
Per maintainer's direction, this PR only addresses the naming half of #1197. The structural half (~100 adapter commands cluttering top-level `--help`) is deferred while we think through the right hide/group strategy without breaking `opencli weibo hot`-style invocation that scripts rely on.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/cli.test.ts` — 100/100 passing
- [x] `node dist/src/main.js --help` shows updated descriptions
- [x] `node dist/src/main.js external register --help` shows updated arg description