### PR TITLE
docs: refresh stale entry and developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It also works as a **CLI hub** for local tools such as `gh`, `docker`, and other
 - **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT, Notion, etc.) directly from the terminal via CDP.
 - **Browser Automation for AI Agents** — Install the `opencli-adapter-author` skill, and your AI agent can operate any website: navigate, click, type, extract, screenshot — all through your logged-in Chrome session.
 - **Multi-profile Browser Bridge** — Install the extension in each Chrome profile you want to use, then route commands with `--profile`, `OPENCLI_PROFILE`, or `opencli profile use`.
-- **Website → CLI** — Turn any website into a deterministic CLI: 90+ pre-built adapters, or write your own with the `opencli-adapter-author` skill + `opencli browser verify`.
+- **Website → CLI** — Turn any website into a deterministic CLI: 100+ site surfaces are already registered, or write your own with the `opencli-adapter-author` skill + `opencli browser verify`.
 - **Account-safe** — Reuses Chrome/Chromium logged-in state; your credentials never leave the browser.
 - **AI Agent ready** — One skill takes you from site recon through API discovery, field decoding, adapter writing, and verification.
 - **CLI Hub** — Discover, auto-install, and passthrough commands to any external CLI (gh, docker, obsidian, etc).
@@ -277,7 +277,7 @@ To load the source Browser Bridge extension:
 | **hackernews** | `top` `new` `best` `ask` `show` `jobs` `search` `user` |
 | **xiaoyuzhou** | `auth*` `podcast*` `podcast-episodes*` `episode*` `download*` `transcript*` |
 
-90+ adapters in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
+100+ site surfaces in total — **[→ see all supported sites & commands](./docs/adapters/index.md)**
 
 `*` `opencli xiaoyuzhou podcast`, `podcast-episodes`, `episode`, `download`, and `transcript` require local Xiaoyuzhou credentials in `~/.opencli/xiaoyuzhou.json`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 OpenCLI 可以用同一套 CLI 做三类事情：
 
-- **直接使用现成适配器**：B站、知乎、小红书、Twitter/X、Reddit、HackerNews 等 [90+ 站点](#内置命令) 开箱即用。
+- **直接使用现成适配器**：B站、知乎、小红书、Twitter/X、Reddit、HackerNews 等 [100+ 站点](#内置命令) 开箱即用。
 - **让 AI Agent 操作任意网站**：在你的 AI Agent（Claude Code、Cursor 等）中安装 `opencli-adapter-author` skill，Agent 就能用你的已登录浏览器导航、点击、输入、提取任意网页内容。
 - **把新网站写成 CLI**：用 `opencli browser` 原语 + `opencli-adapter-author` skill，从站点侦察、API 发现、字段解码到 `opencli browser verify` 一条龙。
 
@@ -20,7 +20,7 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 
 - **桌面应用控制** — 通过 CDP 直接在终端驱动 Electron 应用（Cursor、Codex、ChatGPT、Notion 等）。
 - **AI Agent 浏览器自动化** — 安装 `opencli-adapter-author` skill，你的 AI Agent 就能操作任意网站：导航、点击、输入、提取、截图——全部通过你的已登录 Chrome 会话完成。
-- **网站 → CLI** — 把任何网站变成确定性 CLI：90+ 内置适配器，或用 `opencli-adapter-author` skill + `opencli browser verify` 自己写。
+- **网站 → CLI** — 把任何网站变成确定性 CLI：100+ 站点能力已注册，或用 `opencli-adapter-author` skill + `opencli browser verify` 自己写。
 - **账号安全** — 复用 Chrome/Chromium 登录态，凭证永远不会离开浏览器。
 - **面向 AI Agent** — 一个 skill 带你走完站点侦察、API 发现、字段解码、适配器编写、验证的全流程。
 - **CLI 枢纽** — 统一发现、自动安装、纯透传任何外部 CLI（gh、docker、obsidian 等）。
@@ -318,7 +318,7 @@ npm link
 | **douyin** | `videos` `publish` `drafts` `draft` `delete` `stats` `profile` `update` `hashtag` `location` `activities` `collections` | 浏览器 |
 | **yuanbao** | `new` `ask` | 浏览器 |
 
-90+ 适配器 — **[→ 查看完整命令列表](./docs/adapters/index.md)**
+100+ 站点能力 — **[→ 查看完整命令列表](./docs/adapters/index.md)**
 
 `*` `opencli xiaoyuzhou podcast`、`podcast-episodes`、`episode`、`download`、`transcript` 需要本地小宇宙凭证：`~/.opencli/xiaoyuzhou.json`。
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -87,7 +87,7 @@ OpenCLI occupies a specific niche in the browser automation ecosystem. This guid
 - **Zero LLM cost** — No tokens consumed at runtime. Run 10,000 times for free.
 - **Deterministic output** — Same command always returns the same schema. Pipeable, scriptable, CI-friendly.
 - **Speed** — Adapter commands return in seconds, not minutes.
-- **Broad platform coverage** — 87+ sites spanning global platforms (Reddit, HackerNews, Twitter, YouTube) and Chinese platforms (Bilibili, Zhihu, Xiaohongshu, Douban, Weibo) with adapters that understand local anti-bot patterns.
+- **Broad platform coverage** — 100+ registered site surfaces spanning global platforms (Reddit, HackerNews, Twitter, YouTube) and Chinese platforms (Bilibili, Zhihu, Xiaohongshu, Douban, Weibo) with adapters that understand local anti-bot patterns.
 - **Desktop app control** — CDP adapters for Cursor, Codex, Notion, ChatGPT, Discord, and more.
 - **Easy to extend** — Drop a `.js` adapter into the `clis/` folder for auto-registration. Contributing a new site adapter is straightforward.
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -1,103 +1,164 @@
 # Architecture
 
-OpenCLI is built on a **Dual-Engine Architecture** that supports both declarative pipelines and programmatic TypeScript adapters.
+OpenCLI is a command surface that sits on top of four major subsystems:
 
-## High-Level Architecture
+1. command discovery and registry
+2. execution and formatting
+3. browser / daemon / CDP connectivity
+4. adapter, plugin, and external CLI integration
 
-```
-┌─────────────────────────────────────────────────────┐
-│                     opencli CLI                      │
-│              (Commander.js entry point)               │
-├─────────────────────────────────────────────────────┤
-│                   Engine Layer                        │
-│  ┌──────────────┐  ┌──────────────┐  ┌────────────┐ │
-│  │   Registry   │  │   Dynamic    │  │   Output   │ │
-│  │  (commands)  │  │   Loader     │  │ Formatter  │ │
-│  └──────────────┘  └──────────────┘  └────────────┘ │
-├─────────────────────────────────────────────────────┤
-│                 Adapter Layer                         │
-│  ┌─────────────────┐  ┌──────────────────────────┐  │
-│  │    Pipeline     │  │  TypeScript Adapters     │  │
-│  │  (declarative)  │  │  (browser/desktop/AI)    │  │
-│  └─────────────────┘  └──────────────────────────┘  │
-├─────────────────────────────────────────────────────┤
-│              Connection Layer                         │
-│  ┌─────────────────┐  ┌──────────────────────────┐  │
-│  │ Browser Bridge  │  │  CDP (Chrome DevTools)   │  │
-│  │ (Extension+WS)  │  │  (Electron apps)         │  │
-│  └─────────────────┘  └──────────────────────────┘  │
-└─────────────────────────────────────────────────────┘
+## Runtime Shape
+
+```text
+opencli CLI
+  ├─ command discovery / registry
+  ├─ execution / output
+  ├─ browser runtime
+  │   ├─ Browser Bridge extension
+  │   ├─ local daemon
+  │   └─ direct CDP path
+  ├─ adapter loading
+  │   ├─ built-in site adapters
+  │   ├─ generated adapters
+  │   └─ pipeline-backed adapters
+  ├─ plugin loading
+  └─ external CLI passthrough
 ```
 
 ## Core Modules
 
-### Registry (`src/registry.ts`)
-Central command registry. All adapters register their commands via the `cli()` function with metadata: site, name, description, domain, strategy, args, columns.
+### CLI Surface
 
-### Discovery (`src/discovery.ts`)
-CLI discovery and manifest loading. Discovers commands from TypeScript adapter files, parses pipelines, and registers them into the central registry.
+- `src/main.ts` — process entrypoint
+- `src/cli.ts` — top-level command tree and built-in command groups
+- `src/completion.ts` / `src/completion-fast.ts` — shell completion
 
-### Execution (`src/execution.ts`)
-Command execution: argument validation, lazy loading of adapter modules, and executing the appropriate handler function.
+### Discovery, Registry, Execution
 
-### Commander Adapter (`src/commanderAdapter.ts`)
-Bridges the Registry commands to Commander.js subcommands. Handles positional args, named options, browser session wiring, and output formatting. Isolates all Commander-specific logic so the core is framework-agnostic.
+- `src/discovery.ts` — discovers built-in adapters, generated adapters, plugins, and manifests
+- `src/registry.ts` — central command registry
+- `src/registry-api.ts` — adapter-facing registration helpers
+- `src/execution.ts` — argument validation, lazy loading, and command execution
+- `src/commanderAdapter.ts` — bridges registry metadata into Commander subcommands
+- `src/output.ts` — `table`, `json`, `yaml`, `md`, `csv` formatting
+- `src/serialization.ts` — registry and manifest serialization helpers
 
-### Browser (`src/browser.ts`)
-Manages connections to Chrome via the Browser Bridge WebSocket daemon. Handles JSON-RPC messaging, tab management, and extension/standalone mode switching.
+### Browser and Runtime
 
-### Pipeline (`src/pipeline/`)
-The pipeline engine. Processes declarative steps:
-- **fetch** — HTTP requests with cookie/header strategies
-- **map** — Data transformation with template expressions
-- **limit** — Result truncation
-- **filter** — Conditional filtering
-- **download** — Media download support
+- `src/runtime.ts` — shared command runtime and target resolution
+- `src/daemon.ts` — lifecycle and bridge behavior for the local daemon
+- `src/doctor.ts` — browser bridge diagnostics
+- `src/diagnostic.ts` — structured failure context
+- `src/interceptor.ts` — interception helpers for browser-backed strategies
+- `src/browser/` — Browser Bridge connection and browser-side primitives
 
-### Output (`src/output.ts`)
-Unified output formatting: `table`, `json`, `yaml`, `md`, `csv`.
+### Pipeline Engine
 
-## Authentication Strategies
+- `src/pipeline/executor.ts` — pipeline execution
+- `src/pipeline/template.ts` — template expansion
+- `src/pipeline/transform.ts` — transform helpers
+- `src/pipeline/steps/` — concrete steps such as:
+  - `fetch`
+  - `download`
+  - `browser`
+  - `intercept`
+  - `tap`
+  - `transform`
 
-OpenCLI uses a 3-tier authentication strategy:
+### Adapter and Extension Surfaces
 
-| Strategy | How It Works | When to Use |
-|----------|-------------|-------------|
-| `public` | Direct HTTP fetch, no auth | Public APIs (HackerNews, BBC) |
-| `cookie` | Reuse Chrome cookies via Browser Bridge | Logged-in sites (Bilibili, Zhihu) |
-| `header` | Custom auth headers | API-key based services |
-| `intercept` | Network request interception | GraphQL/XHR capture (Twitter) |
-| `ui` | DOM interaction via accessibility snapshot | Desktop apps, write operations |
+- `clis/` — built-in site adapters
+- `src/plugin.ts` / `src/plugin-manifest.ts` / `src/plugin-scaffold.ts` — plugin install, metadata, scaffold
+- `src/external.ts` / `src/external-clis.yaml` — external CLI passthrough and installable tools
+- `src/electron-apps.ts` — desktop / Electron app support
 
-## Directory Structure
+## Command Sources
 
+OpenCLI merges commands from multiple places into one registry:
+
+| Source | Location | Examples |
+|---|---|---|
+| Built-in adapters | `clis/` | `twitter`, `bilibili`, `reddit`, `chatgpt-app` |
+| Generated / local adapters | `~/.opencli/clis/` | user-authored adapters |
+| Plugins | `~/.opencli/plugins/` | community-contributed commands |
+| External CLIs | `src/external-clis.yaml` + local registrations | `gh`, `docker`, `vercel` |
+
+The user sees one unified command tree through `opencli list`.
+
+## Connectivity Modes
+
+### Browser Bridge mode
+
+Primary path for browser-backed commands:
+
+```text
+opencli process
+  ↔ local daemon
+  ↔ Browser Bridge extension
+  ↔ logged-in Chrome / Chromium
 ```
-src/
-├── main.ts              # Entry point
-├── cli.ts               # Commander.js CLI setup + built-in commands
-├── commanderAdapter.ts  # Registry → Commander bridge
-├── discovery.ts         # CLI discovery, manifest loading
-├── execution.ts         # Arg validation, command execution
-├── registry.ts          # Command registry
-├── serialization.ts     # Command serialization helpers
-├── runtime.ts           # Browser session & timeout management
-├── browser/             # Browser Bridge connection
-├── output.ts            # Output formatting
-├── doctor.ts            # Diagnostic tool
-├── pipeline/            # Pipeline engine
-│   ├── runner.ts
-│   ├── template.ts
-│   ├── transform.ts
-│   └── steps/
-│       ├── fetch.ts
-│       ├── map.ts
-│       ├── limit.ts
-│       ├── filter.ts
-│       └── download.ts
-└── clis/                # Site adapters
-    ├── twitter/
-    ├── reddit/
-    ├── bilibili/
-    ├── cursor/
-    └── ...
-```
+
+This path is used for:
+
+- cookie-backed websites
+- browser automation primitives
+- interactive browser verification
+
+### Direct CDP mode
+
+Used when OpenCLI talks directly to a Chrome or Electron debugging endpoint through `OPENCLI_CDP_ENDPOINT`.
+
+Typical uses:
+
+- remote Chrome
+- headless Chrome
+- Electron desktop adapters
+
+## Authentication / Access Strategies
+
+OpenCLI currently uses these access strategies:
+
+| Strategy | Purpose |
+|---|---|
+| `public` | direct fetch with no login |
+| `cookie` | reuse browser session cookies |
+| `header` | custom authenticated headers |
+| `intercept` | capture the app's own network responses |
+| `ui` | DOM / accessibility driven interaction |
+
+The key distinction is operational:
+
+- `public`, `header` favor direct network access
+- `cookie`, `intercept`, `ui` depend on a live browser or desktop surface
+
+## High-Risk Change Zones
+
+Changes in these files usually affect broad command behavior:
+
+- `src/cli.ts`
+- `src/commanderAdapter.ts`
+- `src/discovery.ts`
+- `src/execution.ts`
+- `src/runtime.ts`
+- `src/daemon.ts`
+- `src/plugin.ts`
+- `src/external.ts`
+- `src/pipeline/**`
+
+These areas deserve targeted tests first, then broader validation when the change crosses module boundaries.
+
+## Mental Model
+
+The simplest accurate model is:
+
+1. OpenCLI discovers command definitions.
+2. It registers them into one command registry.
+3. It resolves each invocation through execution + runtime.
+4. It reaches the target through one of:
+   - network fetch
+   - Browser Bridge
+   - direct CDP
+   - external CLI passthrough
+5. It formats the result into a stable output surface.
+
+That is the architecture to preserve when refactoring.

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -17,7 +17,7 @@ npm run build
 
 # 4. Run a few checks
 npx tsc --noEmit
-npm test
+npm run build
 
 # 5. Link globally (optional, for testing `opencli` command)
 npm link
@@ -98,11 +98,12 @@ chore: bump vitest to v4
 
 1. Create a feature branch: `git checkout -b feat/mysite-trending`
 2. Make your changes and add tests when relevant
-3. Run the checks:
+3. Run the smallest check set that matches your change:
    ```bash
    npx tsc --noEmit           # Type check
-   npm test                   # Default local gate: unit + extension + adapter
-   npm run test:adapter       # Adapter-only project (optional while iterating on adapters)
+   npm run build              # Ensure dist stays healthy
+   npx vitest run src/<target>.test.ts
+   npm test                   # Broader local gate when shared runtime changes justify it
    ```
 4. Commit using conventional commit format
 5. Push and open a PR

--- a/docs/developer/documentation-audit-2026-05.md
+++ b/docs/developer/documentation-audit-2026-05.md
@@ -1,0 +1,368 @@
+# Documentation Audit — 2026-05
+
+This document reviews the current long-form docs, README surfaces, and developer guides in `opencli`. It focuses on stale facts, internal contradictions, and documentation structure that now causes drift.
+
+## Scope
+
+- `README.md`
+- `README.zh-CN.md`
+- `docs/`
+- `skills/` references that are linked from user-facing docs
+
+## Executive View
+
+The docs are usable, but they are drifting in four visible ways:
+
+1. **Hard-coded counts and feature claims are stale.**
+2. **Developer docs describe an older architecture and older test layout.**
+3. **English and Chinese docs are no longer updated with the same rigor.**
+4. **Some pages still describe deleted concepts or old workflows.**
+
+The highest-value work is:
+
+1. Fix the stale facts in `README*`, `docs/index.md`, `docs/zh/index.md`, and `docs/guide/getting-started.md`.
+2. Rewrite `docs/developer/testing.md` and `docs/developer/architecture.md` against current `main`.
+3. Make English and Chinese entry docs derive from the same source-of-truth checklist.
+4. Stop writing command/adapters counts by hand unless they are generated.
+
+## Priority 0 — Clearly stale or incorrect
+
+### 1. Adapter / site counts are stale across multiple entry points
+
+Affected files:
+
+- `README.md`
+- `README.zh-CN.md`
+- `docs/guide/getting-started.md`
+- `docs/comparison.md`
+
+Current problems:
+
+- `README.md` and `README.zh-CN.md` still say `90+` adapters.
+- `docs/guide/getting-started.md` still says `87+` pre-built adapters.
+- `docs/comparison.md` still says `87+` sites.
+
+Current reality:
+
+- `node dist/src/main.js list --format json | jq 'map(.site) | unique | length'` returns `106`.
+
+Why this matters:
+
+- These are the first pages people read.
+- The mismatch is easy to notice and weakens trust in the rest of the docs.
+- These values will keep drifting if we maintain them manually.
+
+Recommended fix:
+
+- Replace all hard-coded counts with one of:
+  - `100+`
+  - `100+ sites`
+  - `over 100 registered sites`
+- Best option: generate this number into docs at release time or avoid explicit counts entirely.
+
+### 2. `docs/developer/testing.md` is materially out of date
+
+Affected file:
+
+- `docs/developer/testing.md`
+
+Current problems:
+
+- It says adapter tests live in `clis/**/*.test.{ts,js}`.
+- The file examples name adapter tests such as:
+  - `clis/zhihu/download.test.ts`
+  - `clis/twitter/timeline.test.ts`
+  - `clis/reddit/read.test.ts`
+  - `clis/bilibili/dynamic.test.ts`
+- Those files do not exist.
+- It says E2E coverage is `5` files.
+- Current reality is `11` E2E files.
+- It presents `npm test` as the main local gate, while current team rule is to prefer the smallest sufficient test set instead of default full-suite runs.
+
+Current reality from the repo:
+
+- `find src -name '*.test.ts' | wc -l` → `60`
+- `find clis -iregex '.*\\.test\\.(ts|js)$' | wc -l` → `0`
+- `find tests/e2e -name '*.test.ts' | wc -l` → `11`
+- `find tests/smoke -name '*.test.ts' | wc -l` → `1`
+
+Why this matters:
+
+- This page is the main developer testing contract.
+- A new contributor following it will get the wrong mental model of the test layout.
+- It encourages a heavier default test habit than the team currently wants.
+
+Recommended fix:
+
+- Rewrite the page from current files, not from remembered structure.
+- Separate:
+  - `fast local checks`
+  - `targeted validation`
+  - `full CI coverage`
+- Remove nonexistent adapter test examples.
+- Add a short rule:
+  - local default = smallest sufficient validation
+  - full-suite = broader refactor, shared runtime changes, or CI
+
+### 3. `docs/developer/architecture.md` describes an older system shape
+
+Affected file:
+
+- `docs/developer/architecture.md`
+
+Current problems:
+
+- It refers to `src/browser.ts`, but that file does not exist.
+- The directory structure block says `src/clis/`, but adapters live at top-level `clis/`.
+- The architecture diagram is too simplified for the current system and omits important pieces such as:
+  - `daemon.ts`
+  - `external.ts`
+  - `plugin.ts`
+  - `electron-apps.ts`
+  - update check / diagnostics / runtime detection paths
+- It says “3-tier authentication strategy” but lists `5` strategies.
+
+Why this matters:
+
+- This is the page people read to understand the project.
+- Once architecture docs are stale, all deeper docs become harder to trust.
+
+Recommended fix:
+
+- Rewrite this page around current modules:
+  - command discovery and registry
+  - execution
+  - browser / daemon bridge
+  - external CLI integration
+  - plugin system
+  - desktop / CDP path
+  - pipeline engine
+- Replace the static tree with a curated module map that matches current filenames.
+- Change “3-tier” to a neutral label like `authentication strategies`.
+
+### 4. Home pages still mention deleted concepts
+
+Affected files:
+
+- `docs/index.md`
+- `docs/zh/index.md`
+
+Current problems:
+
+- Both home pages say:
+  - `explore`
+  - `synthesize`
+  - `cascade`
+- `docs/developer/ai-workflow.md` explicitly says those commands do not exist and that the skill drives the loop.
+
+Why this matters:
+
+- The home page is currently teaching a product vocabulary that the actual CLI does not have.
+- This creates immediate confusion for users who go from docs to terminal.
+
+Recommended fix:
+
+- Replace those phrases with current concepts:
+  - `browser primitives`
+  - `adapter-authoring skill`
+  - `verify loop`
+- Keep the homepage aligned with `docs/developer/ai-workflow.md`.
+
+### 5. Chinese getting-started page lists a deleted built-in command
+
+Affected file:
+
+- `docs/zh/guide/getting-started.md`
+
+Current problem:
+
+- It says built-in commands include `list、explore、validate...`
+- `explore` is not a current built-in command.
+
+Why this matters:
+
+- This is a hard user-facing error.
+
+Recommended fix:
+
+- Replace the example list with current built-ins such as:
+  - `list`
+  - `validate`
+  - `verify`
+  - `browser`
+  - `doctor`
+  - `plugin`
+  - `adapter`
+
+## Priority 1 — Inconsistent or incomplete
+
+### 6. Installation pages are inconsistent about runtime support and update flow
+
+Affected files:
+
+- `README.md`
+- `README.zh-CN.md`
+- `docs/guide/installation.md`
+- `docs/zh/guide/installation.md`
+
+Current problems:
+
+- `README.md` says Node `>= 21` or Bun `>= 1.0`.
+- `docs/guide/installation.md` and `docs/zh/guide/installation.md` only mention Node.
+- `README.md` documents skill refresh on update.
+- `docs/zh/guide/installation.md` only documents package update and omits skills refresh.
+
+Why this matters:
+
+- Entry docs should agree on install prerequisites and upgrade procedure.
+
+Recommended fix:
+
+- Pick one official runtime support statement and reuse it everywhere.
+- If Bun is supported, add it consistently to guide pages.
+- Mirror the post-update skill refresh guidance in the install/update guides.
+
+### 7. README and docs still use top-level tables and examples that will drift by hand
+
+Affected files:
+
+- `README.md`
+- `README.zh-CN.md`
+
+Current problems:
+
+- The “Built-in Commands” section is manually curated and already partially selective.
+- The surrounding copy still frames it like a broad current snapshot.
+
+Why this matters:
+
+- Manual command snapshots go stale quickly in a repo with active adapter growth.
+
+Recommended fix:
+
+- Reframe the section as:
+  - “Representative built-in commands”
+  - “Sample sites”
+- Keep `opencli list` and `docs/adapters/index.md` as the full registry surface.
+
+### 8. `docs/comparison.md` contains stale scale claims
+
+Affected file:
+
+- `docs/comparison.md`
+
+Current problem:
+
+- It still says `87+` sites.
+
+Why this matters:
+
+- Comparison pages shape market positioning.
+- Stale numbers make the project look less maintained than it is.
+
+Recommended fix:
+
+- Remove exact numbers from comparison copy unless they are generated.
+
+## Priority 2 — Structural drift risks
+
+### 9. English and Chinese docs are drifting independently
+
+Most visible examples:
+
+- `docs/index.md` and `docs/zh/index.md` both kept the deleted `explore / synthesize / cascade` language.
+- `docs/zh/guide/getting-started.md` contains a stale built-in command example that should have been caught by parity review.
+- `README.md` and `README.zh-CN.md` both carry the same stale adapter count.
+
+Why this keeps happening:
+
+- We have mirrored content with no explicit parity checklist.
+- Updates land in one place and rely on memory for the rest.
+
+Recommended fix:
+
+- Introduce a small doc parity checklist for any change that touches:
+  - `README.md`
+  - `README.zh-CN.md`
+  - `docs/index.md`
+  - `docs/zh/index.md`
+  - `docs/guide/*`
+  - `docs/zh/guide/*`
+- Add one PR checklist item:
+  - “Did this change require an English/Chinese mirror update?”
+
+### 10. Core product pages mix generated facts with narrative copy
+
+Examples:
+
+- command counts
+- site counts
+- test counts
+- lists of built-in commands
+
+Why this matters:
+
+- Numbers and command inventories drift faster than narrative guidance.
+
+Recommended fix:
+
+- For fast-changing facts:
+  - generate them
+  - or generalize them
+- Reserve hand-written docs for:
+  - mental models
+  - workflows
+  - constraints
+  - trade-offs
+
+## Suggested rewrite order
+
+### Pass 1 — Fix trust-breaking errors
+
+1. `README.md`
+2. `README.zh-CN.md`
+3. `docs/index.md`
+4. `docs/zh/index.md`
+5. `docs/guide/getting-started.md`
+6. `docs/zh/guide/getting-started.md`
+7. `docs/comparison.md`
+
+### Pass 2 — Rebuild the technical source-of-truth pages
+
+1. `docs/developer/testing.md`
+2. `docs/developer/architecture.md`
+3. `docs/guide/installation.md`
+4. `docs/zh/guide/installation.md`
+
+### Pass 3 — Prevent the next round of drift
+
+1. Add a docs parity checklist to PR workflow.
+2. Remove exact counts from hand-written copy unless generated.
+3. Decide which pages are authoritative for:
+   - install
+   - browser bridge
+   - testing
+   - architecture
+   - AI workflow
+
+## Concrete edits I would make next
+
+### Small fast edits
+
+- Replace all `87+` / `90+` claims with `100+`.
+- Remove `explore / synthesize / cascade` from both home pages.
+- Remove `explore` from `docs/zh/guide/getting-started.md`.
+- Align install docs on Node/Bun support and skill refresh.
+
+### Medium rewrites
+
+- Rewrite `docs/developer/testing.md` from current filesystem state.
+- Rewrite `docs/developer/architecture.md` from current module boundaries.
+
+### Process fix
+
+- Add a lightweight “doc drift” checklist to PRs that touch command surface, runtime support, testing strategy, or adapter discovery.
+
+## Bottom line
+
+The docs do not need a ground-up rewrite. They need a focused trust repair pass on entry pages, then a source-of-truth rebuild for testing and architecture, then a small process change so counts and mirrored pages stop drifting.

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -1,255 +1,157 @@
 # Testing Guide
 
-> 面向开发者和 AI Agent 的测试参考手册。
+> 面向开发者和 AI Agent 的当前测试参考手册。
 
-## 目录
+## 测试结构
 
-- [测试架构](#测试架构)
-- [当前覆盖范围](#当前覆盖范围)
-- [本地运行测试](#本地运行测试)
-- [如何添加新测试](#如何添加新测试)
-- [CI/CD 流水线](#cicd-流水线)
-- [浏览器模式](#浏览器模式)
-- [站点兼容性](#站点兼容性)
+OpenCLI 当前测试主要分成四类：
 
----
+| 类别 | 位置 | 当前规模 | 主要用途 |
+|---|---|---:|---|
+| 单元测试 | `src/**/*.test.ts` | 60 | 核心运行时、命令层、浏览器桥、输出、插件、诊断 |
+| E2E 测试 | `tests/e2e/*.test.ts` | 11 | 真实 CLI 入口、公开站点、浏览器命令、管理命令、输出格式 |
+| 烟雾测试 | `tests/smoke/*.test.ts` | 1 | 外部 API 与注册完整性健康检查 |
+| 步骤级测试 | `src/pipeline/steps/*.test.ts` | 已包含在单元测试内 | pipeline step 行为与边界情况 |
 
-## 测试架构
+当前仓库里没有独立的 `clis/**/*.test.{ts,js}` adapter 测试树。adapter 相关验证主要分布在：
 
-测试分为三层，全部使用 **vitest** 运行：
+- `tests/e2e/`
+- `src/commanderAdapter.test.ts`
+- `src/registry.test.ts`
+- `src/execution.test.ts`
+- `src/validate.ts` / `opencli validate`
 
-```text
-tests/
-├── e2e/                           # E2E 集成测试（子进程运行真实 CLI）
-│   ├── helpers.ts                 # runCli() / parseJsonOutput() 共享工具
-│   ├── public-commands.test.ts    # 公开 API 命令
-│   ├── browser-public.test.ts     # 浏览器命令（公开数据）
-│   ├── browser-auth.test.ts       # 需登录命令（graceful failure）
-│   ├── management.test.ts         # 管理命令（list / validate / verify / help）
-│   └── output-formats.test.ts     # 输出格式校验
-├── smoke/
-│   └── api-health.test.ts         # 外部 API、adapter 定义、命令注册健康检查
-src/
-├── **/*.test.ts                   # 核心单元测试（`unit` project）
-clis/
-└── **/*.test.{ts,js}              # adapter tests（`adapter` project）
-```
+## 本地默认策略
 
-| 层 | 位置 | 当前文件数 | 运行方式 | 用途 |
-|---|---|---:|---|---|
-| 单元测试 | `src/**/*.test.ts`（排除 `clis/**`） | - | `npm test` | 内部模块、pipeline、runtime |
-| Adapter 测试 | `clis/**/*.test.{ts,js}` | - | `npm test` / `npm run test:adapter` | adapter 命令与数据归一化 |
-| E2E 测试 | `tests/e2e/*.test.ts` | 5 | `npx vitest run tests/e2e/` | 真实 CLI 命令执行 |
-| 烟雾测试 | `tests/smoke/*.test.ts` | 1 | `npx vitest run tests/smoke/` | 外部 API 与注册完整性 |
+本地默认跑最小充分验证，不要先跑全量。
 
----
+推荐顺序：
 
-## 当前覆盖范围
+1. 改动命令文案、输出格式、参数解析：
+   - 跑对应单元测试
+   - 跑一条真实 CLI 命令做 spot check
+2. 改动 adapter 发现、注册、验证逻辑：
+   - 跑 `src/registry.test.ts`
+   - 跑 `src/execution.test.ts`
+   - 跑 `opencli validate`
+3. 改动 browser / daemon / runtime：
+   - 跑对应 `src/*test.ts`
+   - 必要时补一条 `tests/e2e/*` 或手动 `opencli browser ...` 验证
+4. 改动共享底层、跨多个模块、或 merge 前需要更高信心：
+   - 再扩大到 `npm test`
 
-### 单元测试与 Adapter 测试
-
-| 领域 | 文件 |
-|---|---|
-| 核心运行时与输出 | `src/browser.test.ts`, `src/browser/dom-snapshot.test.ts`, `src/build-manifest.test.ts`, `src/capabilityRouting.test.ts`, `src/doctor.test.ts`, `src/engine.test.ts`, `src/interceptor.test.ts`, `src/output.test.ts`, `src/plugin.test.ts`, `src/registry.test.ts`, `src/snapshotFormatter.test.ts` |
-| pipeline 与下载 | `src/download/index.test.ts`, `src/pipeline/executor.test.ts`, `src/pipeline/template.test.ts`, `src/pipeline/transform.test.ts` |
-| 聚焦 adapter 逻辑 | `clis/zhihu/download.test.ts`, `clis/twitter/timeline.test.ts`, `clis/reddit/read.test.ts`, `clis/bilibili/dynamic.test.ts` |
-
-这些测试覆盖的重点包括：
-
-- Browser Bridge、DOM snapshot、interceptor、capability routing
-- manifest 生成、命令发现、插件安装与注册表
-- 输出格式渲染与 snapshot formatting
-- pipeline 模板求值、执行器与变换步骤
-- 各站点 adapter 的数据归一化、参数处理与容错逻辑
-
-### E2E 测试（5 个文件）
-
-| 文件 | 当前覆盖范围 |
-|---|---|
-| `tests/e2e/public-commands.test.ts` | `bloomberg`、`apple-podcasts`、`hackernews`、`v2ex`、`xiaoyuzhou`、`google suggest` 等公开命令 |
-| `tests/e2e/browser-public.test.ts` | `bbc`、`bloomberg`、`bilibili`、`weibo`、`zhihu`、`reddit`、`twitter`、`xueqiu`、`reuters`、`youtube`、`smzdm`、`boss`、`ctrip`、`coupang`、`xiaohongshu`、`google`、`yahoo-finance`、`v2ex daily` |
-| `tests/e2e/browser-auth.test.ts` | `bilibili`、`twitter`、`v2ex`、`xueqiu`、`linux-do`、`xiaohongshu` 的需登录命令 graceful failure |
-| `tests/e2e/management.test.ts` | `list`、`validate`、`verify`、`--version`、`--help`、unknown command |
-| `tests/e2e/output-formats.test.ts` | `json` / `yaml` / `csv` / `md` 输出格式校验 |
-
-### 烟雾测试（1 个文件）
-
-| 文件 | 当前覆盖范围 |
-|---|---|
-| `tests/smoke/api-health.test.ts` | `hackernews`、`v2ex` 公开 API 可用性，`validate` 全量 adapter 校验，以及命令注册表基础完整性 |
-
-### 快速核对命令
-
-需要刷新测试清单时，直接以仓库文件为准：
+## 常用命令
 
 ```bash
-find src -name '*.test.ts' | sort
-find tests/e2e -name '*.test.ts' | sort
-find tests/smoke -name '*.test.ts' | sort
+# 类型检查
+npx tsc --noEmit
+
+# 编译产物
+npm run build
+
+# 跑一个目标测试文件
+npx vitest run src/<target>.test.ts
+
+# 全量 vitest projects
+npm run test:all
+
+# E2E
+npm run test:e2e
+
+# 适配器注册 / schema 校验
+node dist/src/main.js validate
 ```
 
----
-
-## 本地运行测试
-
-### 前置条件
+如果你明确要跑 adapter project，也可以执行：
 
 ```bash
-npm ci                # 安装依赖
-npm run build         # 编译（E2E / smoke 测试需要 dist/src/main.js）
-```
-
-### 运行命令
-
-```bash
-# 默认本地测试口径（unit + extension + adapter）
-npm test
-
-# 只跑 adapter project
 npm run test:adapter
-
-# 全部 E2E 测试（会真实调用外部 API / 浏览器）
-npx vitest run tests/e2e/
-
-# 全部 smoke 测试
-npx vitest run tests/smoke/
-
-# 单个测试文件
-npx vitest run clis/apple-podcasts/commands.test.ts
-npx vitest run tests/e2e/management.test.ts
-
-# 全部测试
-npx vitest run
-
-# watch 模式（开发时推荐）
-npx vitest src/
 ```
 
-### 浏览器命令本地测试须知
+## 当前 E2E 文件
 
-- opencli 通过 Browser Bridge 扩展连接已运行的 Chrome 浏览器
-- E2E 测试通过 `tests/e2e/helpers.ts` 里的 `runCli()` 调用已构建的 `dist/src/main.js`
-- `browser-public.test.ts` 使用 `tryBrowserCommand()`，站点反爬或地域限制导致空数据时会 warn + pass
-- `browser-auth.test.ts` 验证 **graceful failure**，重点是不 crash、不 hang、错误信息可控
-- 如需测试完整登录态，保持 Chrome 登录态并安装 Browser Bridge 扩展，再手动运行对应测试
-- 对依赖具体 host 页面上下文的 browser adapter，除了单测外，还应手动验证真实命令，并把必要的 target host 约束写进 adapter docs / troubleshooting
-- 对会主动导航页面的 browser commands，手动验证时优先串行执行；多个 CLI 进程同时连到同一个 CDP target 可能互相覆盖导航，制造假的 adapter 故障
+当前 `tests/e2e/` 包含：
 
----
+- `browser-auth.test.ts`
+- `browser-public.test.ts`
+- `cli.test.ts`
+- `extension-bridge.test.ts`
+- `formats.test.ts`
+- `list.test.ts`
+- `management.test.ts`
+- `public-commands.test.ts`
+- `recovery.test.ts`
+- `remote-chrome.test.ts`
+- `tab-targeting.test.ts`
 
-## 如何添加新测试
+如果这个列表变化，以仓库文件为准：
 
-### 新增 Adapter（如 `clis/producthunt/trending.ts`）
-
-1. 根据 adapter 类型，在对应测试文件补一个 `it()` block
-
-```typescript
-// 如果 browser: false（公开 API）→ tests/e2e/public-commands.test.ts
-it('producthunt trending returns data', async () => {
-  const { stdout, code } = await runCli(['producthunt', 'trending', '--limit', '3', '-f', 'json']);
-  expect(code).toBe(0);
-  const data = parseJsonOutput(stdout);
-  expect(Array.isArray(data)).toBe(true);
-  expect(data.length).toBeGreaterThanOrEqual(1);
-  expect(data[0]).toHaveProperty('title');
-}, 30_000);
+```bash
+find tests/e2e -name '*.test.ts' | sort
 ```
 
-```typescript
-// 如果 browser: true 但可公开访问 → tests/e2e/browser-public.test.ts
-it('producthunt trending returns data', async () => {
-  const data = await tryBrowserCommand(['producthunt', 'trending', '--limit', '3', '-f', 'json']);
-  expectDataOrSkip(data, 'producthunt trending');
-}, 60_000);
+## 当前值得优先覆盖的区域
+
+以下改动最容易引入回归：
+
+- `src/cli.ts`
+- `src/commanderAdapter.ts`
+- `src/discovery.ts`
+- `src/execution.ts`
+- `src/runtime.ts`
+- `src/daemon.ts`
+- `src/plugin.ts`
+- `src/external.ts`
+- `src/pipeline/**`
+
+这类改动优先补：
+
+- 精准单元测试
+- 一条真实 CLI 验证路径
+- 必要时再扩大到 `npm test`
+
+## 手动验证建议
+
+文档或命令面改动后，优先做 2 到 4 条真实命令 spot check，例如：
+
+```bash
+node dist/src/main.js --help
+node dist/src/main.js list --format json
+node dist/src/main.js plugin --help
+node dist/src/main.js doctor --help
 ```
 
-```typescript
-// 如果 browser: true 且需登录 → tests/e2e/browser-auth.test.ts
-it('producthunt me fails gracefully without login', async () => {
-  await expectGracefulAuthFailure(['producthunt', 'me', '-f', 'json'], 'producthunt me');
-}, 60_000);
+浏览器相关改动再补：
+
+```bash
+node dist/src/main.js browser --help
+node dist/src/main.js browser tab list
 ```
 
-### 新增管理命令（如 `opencli export`）
+## CI 角色
 
-在 `tests/e2e/management.test.ts` 添加测试；如果新命令会影响输出格式，也同步补 `tests/e2e/output-formats.test.ts`。
+CI 负责更大范围的回归信心，本地负责最快闭环。
 
-### 新增内部模块
+适合交给 CI 的内容：
 
-在对应源码旁创建 `*.test.ts`，优先和被测模块放在同一目录下，便于发现与维护。
+- 更大的命令面回归
+- 多环境差异
+- E2E 稳定性
+- smoke 检查
 
-### 决策流程图
+适合本地优先做的内容：
 
-```text
-新增功能 → 是内部模块？ → 是 → src/ 下加 *.test.ts
-                ↓ 否
-         是 CLI 命令？ → browser: false? → tests/e2e/public-commands.test.ts
-                              ↓ true
-                        公开数据？ → tests/e2e/browser-public.test.ts
-                              ↓ 需登录
-                        tests/e2e/browser-auth.test.ts
-```
+- 参数解析
+- 输出格式
+- 注册与发现
+- 文档相关命令行为
+- 共享模块的小范围回归
 
----
+## 更新这份文档的规则
 
-## CI/CD 流水线
+当以下任一项变化时，顺手更新此页：
 
-### `ci.yml`
-
-| Job | 触发条件 | 内容 |
-|---|---|---|
-| `build` | push/PR 到 `main`,`dev` | `tsc --noEmit` + `npm run build` |
-| `unit-test` | push/PR 到 `main`,`dev` | Node `22` 运行 `unit + extension` tests，按 `2` shard 并行 |
-| `adapter-test` | push/PR 到 `main`,`dev` | Node `22` 单独运行 `adapter` project |
-| `smoke-test` | `schedule` 或 `workflow_dispatch` | 安装真实 Chrome，`xvfb-run` 执行 `tests/smoke/` |
-
-### `e2e-headed.yml`
-
-| Job | 触发条件 | 内容 |
-|---|---|---|
-| `e2e-headed` | push/PR 到 `main`,`dev`，或手动触发 | 安装真实 Chrome，`xvfb-run` 执行 `tests/e2e/` |
-
-E2E 与 smoke 都使用 `./.github/actions/setup-chrome` 准备真实 Chrome。
-
-### Sharding
-
-CI 里的 `unit-test` job 使用 vitest shard，只切 `unit + extension`，避免和独立的 `adapter-test` job 重复：
-
-::: v-pre
-```yaml
-strategy:
-  matrix:
-    shard: [1, 2]
-steps:
-  - run: npx vitest run --project unit --project extension --reporter=verbose --shard=${{ matrix.shard }}/2
-```
-:::
-
----
-
-## 浏览器模式
-
-opencli 通过 Browser Bridge 扩展连接浏览器：
-
-| 条件 | 模式 | 使用场景 |
-|---|---|---|
-| 扩展已安装 / 已连接 | Extension 模式 | 本地用户，连接已登录的 Chrome |
-| 无扩展 token | CLI 自行拉起浏览器 | CI、无登录态或纯自动化场景 |
-
-CI 通过 `./.github/actions/setup-chrome` 准备真实 Chrome，再直接执行测试。
-
----
-
-## 站点兼容性
-
-GitHub Actions 的美国 runner 上，部分站点会因为地域限制、登录要求或反爬而返回空数据。当前 E2E 对这些场景采用 warn + pass 策略，避免偶发站点限制把整条 CI 打红。
-
-| 站点 | CI 表现 | 常见原因 |
-|---|---|---|
-| `hackernews`、`bbc`、`v2ex`、`bloomberg` | 通常返回数据 | 公开接口或公开页面 |
-| `yahoo-finance`、`google` | 通常返回数据 | 页面公开，但仍可能受限流影响 |
-| `bilibili`、`zhihu`、`weibo`、`xiaohongshu`、`xueqiu` | 容易空数据 | 地域限制、反爬、登录要求 |
-| `reddit`、`twitter`、`youtube` | 容易空数据 | 登录态、cookie、机器人检测 |
-| `smzdm`、`boss`、`ctrip`、`coupang`、`linux-do` | 结果波动较大 | 地域限制、风控或页面结构变动 |
-
-> 如果需要更稳定的浏览器 E2E 结果，优先使用具备目标站点网络可达性的 self-hosted runner。
+- `tests/e2e/` 文件列表
+- 默认本地测试命令
+- `package.json` 测试脚本
+- 共享运行时的高风险模块

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,7 +13,7 @@ OpenCLI turns **any website** or **Electron app** into a command-line interface 
 
 - **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT, Notion, etc.) directly from the terminal via CDP.
 - **Browser Automation** — `browser` gives AI agents direct browser control: click, type, extract, screenshot — fully scriptable.
-- **Website → CLI** — Turn any website into a deterministic CLI: 87+ pre-built adapters, or author your own with the `opencli-adapter-author` skill.
+- **Website → CLI** — Turn any website into a deterministic CLI: 100+ site surfaces are already registered, or author your own with the `opencli-adapter-author` skill.
 - **Account-safe** — Reuses Chrome's logged-in state; your credentials never leave the browser.
 - **AI Agent ready** — `opencli browser *` primitives (`open` / `network` / `state` / `eval` / `init` / `verify`) drive the adapter-authoring loop.
 - **Zero LLM cost** — No tokens consumed at runtime. Run 10,000 times and pay nothing.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- **Node.js**: >= 21.0.0
+- **Node.js**: >= 21.0.0, or **Bun** >= 1.0
 - **Chrome** running and logged into the target site (for browser commands)
 
 ## Install via npm (Recommended)
@@ -29,6 +29,16 @@ npm install -g @jackwener/opencli@latest
 
 # If you use the packaged OpenCLI skills, refresh them too
 npx skills add jackwener/opencli
+```
+
+Or refresh only the skills you actually use:
+
+```bash
+npx skills add jackwener/opencli --skill opencli-adapter-author
+npx skills add jackwener/opencli --skill opencli-autofix
+npx skills add jackwener/opencli --skill opencli-browser
+npx skills add jackwener/opencli --skill opencli-usage
+npx skills add jackwener/opencli --skill smart-search
 ```
 
 ## Verify Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
     details: Reuses Chrome's logged-in state. Your credentials never leave the browser — no tokens, no exposed passwords.
   - icon: 🤖
     title: AI Agent Ready
-    details: "explore discovers APIs, synthesize generates adapters, cascade finds auth strategies. Built for AI-first workflows."
+    details: "Browser primitives plus adapter-authoring skills give AI agents a repeatable loop for recon, extraction, verification, and adapter writing."
   - icon: 💰
     title: Zero LLM Cost
     details: No tokens consumed at runtime. Run 10,000 times and pay nothing.

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -49,7 +49,7 @@ opencli bilibili [Tab] # 补全命令（hot、search、me、download...）
 
 补全功能包含：
 - 所有可用的站点和适配器
-- 内置命令（list、explore、validate...）
+- 内置命令（list、validate、verify、browser、doctor、plugin、adapter...）
 - 命令别名
 - 新增适配器时的实时更新
 

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -2,7 +2,7 @@
 
 ## 系统要求
 
-- **Node.js**: >= 21.0.0
+- **Node.js**: >= 21.0.0，或 **Bun** >= 1.0
 - **Chrome** 已运行并登录目标网站（浏览器命令需要）
 
 ## 通过 npm 安装（推荐）
@@ -26,6 +26,19 @@ opencli list
 
 ```bash
 npm install -g @jackwener/opencli@latest
+
+# 如果你在用打包发布的 OpenCLI skills，也一起刷新
+npx skills add jackwener/opencli
+```
+
+如果你只装了部分 skill，也可以只刷新自己在用的：
+
+```bash
+npx skills add jackwener/opencli --skill opencli-adapter-author
+npx skills add jackwener/opencli --skill opencli-autofix
+npx skills add jackwener/opencli --skill opencli-browser
+npx skills add jackwener/opencli --skill opencli-usage
+npx skills add jackwener/opencli --skill smart-search
 ```
 
 ## 验证安装

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -25,7 +25,7 @@ features:
     details: 复用 Chrome 登录态，凭证永远不会离开浏览器 — 无 token，无密码泄露。
   - icon: 🤖
     title: AI Agent 就绪
-    details: explore 发现 API，synthesize 生成适配器，cascade 查找认证策略。为 AI 优先工作流而生。
+    details: Browser 原语加上适配器编写 skill，让 AI Agent 可以稳定完成侦察、提取、验证和适配器落地。
   - icon: 💰
     title: 零 LLM 成本
     details: 运行时不消耗模型 token。跑 10,000 次也不花一分钱。


### PR DESCRIPTION
## Summary
- refresh entry docs and mirrored Chinese pages with current product language and counts
- rewrite developer testing and architecture docs against current main
- align installation and contributing guidance with current runtime support and testing expectations
- add a documentation audit note for the stale-doc cleanup pass

## Validation
- npm run docs:build
- node dist/src/main.js completion zsh | head -n 3
- node dist/src/main.js plugin --help | head -n 20
- node dist/src/main.js list --format json | jq 'length'
