### PR TITLE
feat(observation): add runtime trace capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* **observation** — add trace artifact primitives, `browser console`, `browser network --since/--follow/--failed`, and adapter `--trace=retain-on-failure` for failure-retained browser evidence.
 * **browser** — `bind` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
 * **browser lifecycle** — owned browser workspaces now lease tabs inside a shared dedicated automation container instead of owning one Chrome window per workspace; lease state is persisted for MV3 service-worker reconciliation and idle cleanup is backed by alarms.
 * **web read** — make page extraction render-aware: same-origin iframe content is merged into the Markdown source, `--wait-for` can wait inside main/iframe documents, `--wait-until networkidle` waits for captured requests to settle, and `--diagnose` reports frames, empty containers, and API-like XHRs for shell/AJAX pages.

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -274,7 +274,7 @@ class CDPPage extends BasePage {
           const idx = this._networkEntries.push({
             url: p.request.url,
             method: p.request.method,
-            timestamp: p.timestamp,
+            timestamp: Date.now(),
           }) - 1;
           this._pendingRequests.set(p.requestId, idx);
         }
@@ -340,14 +340,14 @@ class CDPPage extends BasePage {
       this.bridge.on('Runtime.consoleAPICalled', (params: unknown) => {
         const p = params as { type: string; args: Array<{ value?: unknown; description?: string }>; timestamp: number };
         const text = (p.args || []).map(a => a.value !== undefined ? String(a.value) : (a.description || '')).join(' ');
-        this._consoleMessages.push({ type: p.type, text, timestamp: p.timestamp });
+        this._consoleMessages.push({ type: p.type, text, timestamp: Date.now() });
         if (this._consoleMessages.length > 500) this._consoleMessages.shift();
       });
       // Capture uncaught exceptions as error-level messages
       this.bridge.on('Runtime.exceptionThrown', (params: unknown) => {
         const p = params as { timestamp: number; exceptionDetails?: { exception?: { description?: string }; text?: string } };
         const desc = p.exceptionDetails?.exception?.description || p.exceptionDetails?.text || 'Unknown exception';
-        this._consoleMessages.push({ type: 'error', text: desc, timestamp: p.timestamp });
+        this._consoleMessages.push({ type: 'error', text: desc, timestamp: Date.now() });
         if (this._consoleMessages.length > 500) this._consoleMessages.shift();
       });
       this._consoleCapturing = true;

--- a/src/browser/network-cache.ts
+++ b/src/browser/network-cache.ts
@@ -31,6 +31,7 @@ export interface CachedNetworkEntry {
      */
     body_truncated?: boolean;
     body_full_size?: number;
+    timestamp?: number;
 }
 
 export interface NetworkCacheFile {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -39,7 +39,7 @@ vi.mock('./browser/daemon-client.js', async () => {
   };
 });
 
-import { createProgram, findPackageRoot, normalizeVerifyRows, renderVerifyPreview, resolveBrowserVerifyInvocation } from './cli.js';
+import { createProgram, findPackageRoot, normalizeVerifyRows, renderVerifyPreview, resolveBrowserVerifyInvocation, selectFreshByTimestamp } from './cli.js';
 
 describe('resolveBrowserVerifyInvocation', () => {
   it('prefers the built entry declared in package metadata', () => {
@@ -110,6 +110,24 @@ describe('resolveBrowserVerifyInvocation', () => {
       args: ['tsx', path.join(projectRoot, 'src', 'main.ts')],
       cwd: projectRoot,
     });
+  });
+});
+
+describe('selectFreshByTimestamp', () => {
+  it('uses timestamp watermarks so rolled buffers still emit new messages', () => {
+    const first = selectFreshByTimestamp([
+      { timestamp: 1, text: 'a' },
+      { timestamp: 2, text: 'b' },
+    ], 0);
+    expect(first.fresh.map((item) => item.text)).toEqual(['a', 'b']);
+    expect(first.lastSeenTs).toBe(2);
+
+    const rolled = selectFreshByTimestamp([
+      { timestamp: 2, text: 'b' },
+      { timestamp: 3, text: 'c' },
+    ], first.lastSeenTs);
+    expect(rolled.fresh.map((item) => item.text)).toEqual(['c']);
+    expect(rolled.lastSeenTs).toBe(3);
   });
 });
 
@@ -653,6 +671,7 @@ describe('browser network command', () => {
           responseStatus: 200,
           responseContentType: 'application/json',
           responsePreview: JSON.stringify({ data: { user: { rest_id: '42' } } }),
+          timestamp: Date.now(),
         },
         {
           url: 'https://cdn.example.com/app.js',
@@ -707,6 +726,44 @@ describe('browser network command', () => {
     expect(out.entries.map((e: any) => e.key)).toContain('GET cdn.example.com/app.js');
   });
 
+  it('--failed and --since filter captured entries by status and time window', async () => {
+    const now = Date.now();
+    browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+      {
+        url: 'https://api.example.com/new-fail',
+        method: 'GET',
+        responseStatus: 500,
+        responseContentType: 'application/json',
+        responsePreview: JSON.stringify({ error: true }),
+        timestamp: now,
+      },
+      {
+        url: 'https://api.example.com/old-fail',
+        method: 'GET',
+        responseStatus: 500,
+        responseContentType: 'application/json',
+        responsePreview: JSON.stringify({ error: true }),
+        timestamp: now - 180_000,
+      },
+      {
+        url: 'https://api.example.com/new-ok',
+        method: 'GET',
+        responseStatus: 200,
+        responseContentType: 'application/json',
+        responsePreview: JSON.stringify({ ok: true }),
+        timestamp: now,
+      },
+    ]);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'network', '--since', '120s', '--failed']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(1);
+    expect(out.entries[0].url).toBe('https://api.example.com/new-fail');
+    expect(out.entries[0].timestamp).toMatch(/T/);
+  });
+
   it('default output keeps text/javascript API responses while dropping static JS files', async () => {
     browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
       {
@@ -743,6 +800,7 @@ describe('browser network command', () => {
 
     const out = lastJsonLog();
     expect(out.entries[0].body).toEqual({ data: { user: { rest_id: '42' } } });
+    expect(out.entries[0].timestamp).toMatch(/T/);
   });
 
   it('--detail <key> returns the full body for the requested entry', async () => {
@@ -756,6 +814,7 @@ describe('browser network command', () => {
     expect(out.key).toBe('UserTweets');
     expect(out.body).toEqual({ data: { user: { rest_id: '42' } } });
     expect(out.shape['$.data.user.rest_id']).toBe('string');
+    expect(out.timestamp).toMatch(/T/);
   });
 
   it('--detail reports key_not_found with the list of available keys', async () => {
@@ -1089,6 +1148,46 @@ describe('browser network command', () => {
       expect(entry).not.toHaveProperty('bodyTruncated');
       expect(entry).not.toHaveProperty('bodyFullSize');
     });
+  });
+});
+
+describe('browser console command', () => {
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    consoleLogSpy.mockClear();
+    mockBrowserConnect.mockClear();
+    mockBrowserClose.mockReset().mockResolvedValue(undefined);
+    const now = Date.now();
+    browserState.page = {
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      tabs: vi.fn().mockResolvedValue([{ page: 'tab-1', active: true }]),
+      consoleMessages: vi.fn().mockResolvedValue([
+        { type: 'error', text: 'boom', timestamp: now },
+        { type: 'log', text: 'ok', timestamp: now },
+        { type: 'warning', text: 'old warning', timestamp: now - 180_000 },
+      ]),
+    } as unknown as IPage;
+  });
+
+  function lastJsonLog(): any {
+    const calls = consoleLogSpy.mock.calls;
+    if (calls.length === 0) throw new Error('Expected at least one console.log call');
+    const last = calls[calls.length - 1][0];
+    if (typeof last !== 'string') throw new Error(`Expected string arg to console.log, got ${typeof last}`);
+    return JSON.parse(last);
+  }
+
+  it('filters console messages by level and time window', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'console', '--level', 'error', '--since', '120s']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(1);
+    expect(out.messages[0]).toMatchObject({ type: 'error', text: 'boom' });
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
 const DEFAULT_BOUND_WORKSPACE = 'bound:default';
 const BROWSER_TAB_OPTION_DESCRIPTION = 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"';
+const FOLLOW_POLL_MS = 1_000;
 
 type BrowserNetworkItem = {
   url: string;
@@ -51,7 +52,51 @@ type BrowserNetworkItem = {
   bodyFullSize?: number;
   /** True when the capture layer had to cap the stored body to protect memory. */
   bodyTruncated?: boolean;
+  /** Epoch milliseconds when the request was observed. */
+  timestamp?: number;
 };
+
+function parseDurationMs(raw: unknown, flagName: string): number | null | { error: string } {
+  if (raw === undefined || raw === null || raw === '') return null;
+  const str = String(raw).trim();
+  const match = /^(\d+(?:\.\d+)?)(ms|s|m|h)?$/.exec(str);
+  if (!match) return { error: `--${flagName} must be a duration like 500ms, 30s, 2m, got "${str}"` };
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2] ?? 'ms';
+  const multiplier = unit === 'h' ? 3_600_000 : unit === 'm' ? 60_000 : unit === 's' ? 1_000 : 1;
+  return Math.round(value * multiplier);
+}
+
+function timestampFromRaw(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : Date.now();
+}
+
+function toIsoTimestamp(timestamp: unknown): string | undefined {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return undefined;
+  return new Date(timestamp).toISOString();
+}
+
+function filterByTimeWindow<T extends { timestamp?: number }>(items: T[], opts: { sinceMs?: number | null; untilMs?: number | null }, now: number = Date.now()): T[] {
+  const sinceTs = opts.sinceMs != null ? now - opts.sinceMs : undefined;
+  const untilTs = opts.untilMs != null ? now - opts.untilMs : undefined;
+  return items.filter((item) => {
+    const ts = item.timestamp ?? now;
+    if (sinceTs !== undefined && ts < sinceTs) return false;
+    if (untilTs !== undefined && ts > untilTs) return false;
+    return true;
+  });
+}
+
+export function selectFreshByTimestamp<T extends { timestamp?: unknown }>(
+  items: T[],
+  lastSeenTs: number,
+): { fresh: T[]; lastSeenTs: number } {
+  const fresh = items.filter((item) => Number(item.timestamp ?? 0) > lastSeenTs);
+  const nextSeenTs = fresh.length > 0
+    ? Math.max(lastSeenTs, ...fresh.map((item) => Number(item.timestamp ?? 0)).filter(Number.isFinite))
+    : lastSeenTs;
+  return { fresh, lastSeenTs: nextSeenTs };
+}
 
 /**
  * Normalize raw capture entries (from daemon/CDP `readNetworkCapture` or
@@ -83,13 +128,15 @@ async function captureNetworkItems(page: import('./types.js').IPage): Promise<Br
           body,
           bodyFullSize: fullSize,
           bodyTruncated: truncated,
+          timestamp: timestampFromRaw(e.timestamp),
         };
       });
     }
   }
   const raw = await page.evaluate(`(function(){ var out = window.__opencli_net || []; window.__opencli_net = []; return JSON.stringify(out); })()`) as string;
   try {
-    return JSON.parse(raw) as BrowserNetworkItem[];
+    const parsed = JSON.parse(raw) as BrowserNetworkItem[];
+    return parsed.map((item) => ({ ...item, timestamp: timestampFromRaw(item.timestamp) }));
   } catch {
     if (process.env.OPENCLI_VERBOSE) log.warn(`[network] Failed to parse interceptor buffer: ${typeof raw === 'string' ? raw.slice(0, 200) : String(raw)}`);
     return [];
@@ -798,7 +845,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
    * silently dropping the body. Per-entry cap is 1 MiB and the ring is
    * capped at 200 entries, bounding worst-case in-page memory.
    */
-  const NETWORK_INTERCEPTOR_JS = `(function(){if(window.__opencli_net)return;window.__opencli_net=[];var M=200,B=1048576,F=window.fetch;function capture(url,method,status,text,ct){if(window.__opencli_net.length>=M)return;var full=text?text.length:0,trunc=full>B,stored=trunc?text.slice(0,B):text,body=null;if(stored){if(trunc){body=stored}else{try{body=JSON.parse(stored)}catch(e){body=stored}}}var e={url:url,method:method||'GET',status:status,size:full,ct:ct,body:body};if(trunc){e.bodyTruncated=true;e.bodyFullSize=full}window.__opencli_net.push(e)}window.fetch=async function(){var r=await F.apply(this,arguments);try{var ct=r.headers.get('content-type')||'';if(ct.includes('json')||ct.includes('text')){var c=r.clone(),t=await c.text();capture(r.url||(arguments[0]&&arguments[0].url)||String(arguments[0]),(arguments[1]&&arguments[1].method)||'GET',r.status,t,ct)}}catch(e){}return r};var X=XMLHttpRequest.prototype,O=X.open,S=X.send;X.open=function(m,u){this._om=m;this._ou=u;return O.apply(this,arguments)};X.send=function(){var x=this;x.addEventListener('load',function(){try{var ct=x.getResponseHeader('content-type')||'';if(ct.includes('json')||ct.includes('text')){capture(x._ou,x._om||'GET',x.status,x.responseText||'',ct)}}catch(e){}});return S.apply(this,arguments)}})()`;
+  const NETWORK_INTERCEPTOR_JS = `(function(){if(window.__opencli_net)return;window.__opencli_net=[];var M=200,B=1048576,F=window.fetch;function capture(url,method,status,text,ct){if(window.__opencli_net.length>=M)return;var full=text?text.length:0,trunc=full>B,stored=trunc?text.slice(0,B):text,body=null;if(stored){if(trunc){body=stored}else{try{body=JSON.parse(stored)}catch(e){body=stored}}}var e={url:url,method:method||'GET',status:status,size:full,ct:ct,body:body,timestamp:Date.now()};if(trunc){e.bodyTruncated=true;e.bodyFullSize=full}window.__opencli_net.push(e)}window.fetch=async function(){var r=await F.apply(this,arguments);try{var ct=r.headers.get('content-type')||'';if(ct.includes('json')||ct.includes('text')){var c=r.clone(),t=await c.text();capture(r.url||(arguments[0]&&arguments[0].url)||String(arguments[0]),(arguments[1]&&arguments[1].method)||'GET',r.status,t,ct)}}catch(e){}return r};var X=XMLHttpRequest.prototype,O=X.open,S=X.send;X.open=function(m,u){this._om=m;this._ou=u;return O.apply(this,arguments)};X.send=function(){var x=this;x.addEventListener('load',function(){try{var ct=x.getResponseHeader('content-type')||'';if(ct.includes('json')||ct.includes('text')){capture(x._ou,x._om||'GET',x.status,x.responseText||'',ct)}}catch(e){}});return S.apply(this,arguments)}})()`;
 
   addBrowserTabOption(browser.command('open').argument('<url>').option('--allow-navigate-bound', 'Allow navigating a bound user tab', false).description('Open URL in automation window'))
     .action(browserAction(async (page, url, opts) => {
@@ -875,6 +922,72 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       } else {
         console.log(await page.screenshot({ format: 'png' }));
       }
+    }));
+
+  addBrowserTabOption(browser.command('console'))
+    .option('--level <level>', 'Console level: all, error, warning, log, info, debug', 'all')
+    .option('--since <duration>', 'Only include messages from the last duration (for example: 30s, 2m)')
+    .option('--until <duration>', 'Only include messages older than the duration from now')
+    .option('--follow', 'Continuously print new console messages as JSON lines', false)
+    .description('Read recent browser console messages')
+    .action(browserAction(async (page, opts) => {
+      const sinceMs = parseDurationMs(opts.since, 'since');
+      const untilMs = parseDurationMs(opts.until, 'until');
+      if (sinceMs && typeof sinceMs === 'object') {
+        console.log(JSON.stringify({ error: { code: 'invalid_since', message: sinceMs.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      if (untilMs && typeof untilMs === 'object') {
+        console.log(JSON.stringify({ error: { code: 'invalid_until', message: untilMs.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const normalize = (messages: unknown[]): Array<Record<string, unknown>> => messages.map((message) => {
+        if (message && typeof message === 'object') {
+          const record = message as Record<string, unknown>;
+          return {
+            ...record,
+            timestamp: timestampFromRaw(record.timestamp),
+          };
+        }
+        return { type: 'log', text: String(message), timestamp: Date.now() };
+      });
+      const filter = (messages: Array<Record<string, unknown>>) =>
+        filterByTimeWindow(messages, { sinceMs, untilMs }).filter((message) => {
+          if (opts.level === 'all') return true;
+          const type = String(message.type ?? message.level ?? '').toLowerCase();
+          return opts.level === 'error'
+            ? type === 'error' || type === 'warning'
+            : type === String(opts.level).toLowerCase();
+        });
+
+      if (opts.follow) {
+        let lastSeenTs = 0;
+        while (true) {
+          const messages = filter(normalize(await page.consoleMessages('all')));
+          const next = selectFreshByTimestamp(messages, lastSeenTs);
+          for (const message of next.fresh) {
+            console.log(JSON.stringify({
+              ...message,
+              timestamp: toIsoTimestamp(message.timestamp),
+            }));
+          }
+          lastSeenTs = next.lastSeenTs;
+          await new Promise((resolve) => setTimeout(resolve, FOLLOW_POLL_MS));
+        }
+      }
+
+      const messages = filter(normalize(await page.consoleMessages(opts.level)));
+      console.log(JSON.stringify({
+        workspace: getPageWorkspace(page),
+        captured_at: new Date().toISOString(),
+        count: messages.length,
+        messages: messages.map((message) => ({
+          ...message,
+          timestamp: toIsoTimestamp(message.timestamp),
+        })),
+      }, null, 2));
     }));
 
   // ── Analyze (site recon, agent-native) ──
@@ -1487,6 +1600,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .option('--all', 'Include static resources (js/css/images/telemetry)')
     .option('--raw', 'Emit full bodies for every entry (skip shape preview)')
     .option('--filter <fields>', 'Comma-separated field names; keep only entries whose body shape has ALL names as path segments')
+    .option('--since <duration>', 'Only include entries from the last duration (for example: 30s, 2m)')
+    .option('--until <duration>', 'Only include entries older than the duration from now')
+    .option('--follow', 'Continuously print new matching entries as JSON lines', false)
+    .option('--failed', 'Only include failed HTTP requests (status 0 or >= 400)', false)
     .option('--max-body <chars>', 'With --detail: cap the emitted body at N chars (0 = unlimited, default)', '0')
     .option('--ttl <ms>', 'Cache TTL in ms for --detail lookups', String(DEFAULT_TTL_MS))
     .description('Capture network requests as shape previews; retrieve full bodies by key')
@@ -1495,6 +1612,16 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       const workspace = getPageWorkspace(page);
       const hasDetail = typeof opts.detail === 'string' && opts.detail.length > 0;
       const hasFilter = typeof opts.filter === 'string';
+      const sinceMs = parseDurationMs(opts.since, 'since');
+      const untilMs = parseDurationMs(opts.until, 'until');
+      if (sinceMs && typeof sinceMs === 'object') {
+        emitNetworkError('invalid_since', sinceMs.error);
+        return;
+      }
+      if (untilMs && typeof untilMs === 'object') {
+        emitNetworkError('invalid_until', untilMs.error);
+        return;
+      }
 
       // --detail and --filter do different things (one request by key vs. narrow
       // the list by shape), don't compose, and combining them has no sensible
@@ -1513,6 +1640,11 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           return;
         }
         filterFields = parsed.fields;
+      }
+
+      if (hasDetail && opts.follow) {
+        emitNetworkError('invalid_args', '--follow cannot be used with --detail.');
+        return;
       }
 
       // --detail short-circuits: read from cache only, no live capture needed.
@@ -1563,6 +1695,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           status: entry.status,
           ct: entry.ct,
           size: entry.size,
+          ...(typeof entry.timestamp === 'number' ? { timestamp: toIsoTimestamp(entry.timestamp) } : {}),
           shape: inferShape(entry.body),
           body: outputBody,
         };
@@ -1577,6 +1710,35 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         return;
       }
 
+      if (opts.follow) {
+        if (!await page.startNetworkCapture?.()) {
+          try { await page.evaluate(NETWORK_INTERCEPTOR_JS); } catch { /* non-fatal */ }
+        }
+        while (true) {
+          const rawItems = await captureNetworkItems(page).catch((err) => {
+            emitNetworkError('capture_failed', `Could not read network capture: ${(err as Error).message}`);
+            return [];
+          });
+          let items = opts.all ? rawItems : filterNetworkItems(rawItems);
+          items = filterByTimeWindow(items, { sinceMs, untilMs });
+          if (opts.failed) items = items.filter((item) => item.status === 0 || item.status >= 400);
+          const keyed = assignKeys(items);
+          for (const item of keyed) {
+            console.log(JSON.stringify({
+              key: item.key,
+              timestamp: toIsoTimestamp(item.timestamp),
+              method: item.method,
+              status: item.status,
+              url: item.url,
+              ct: item.ct,
+              size: item.size,
+              ...(item.bodyTruncated ? { body_truncated: true } : {}),
+            }));
+          }
+          await new Promise((resolve) => setTimeout(resolve, FOLLOW_POLL_MS));
+        }
+      }
+
       // Fresh capture path.
       let rawItems: BrowserNetworkItem[];
       try {
@@ -1586,7 +1748,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         return;
       }
 
-      const items = opts.all ? rawItems : filterNetworkItems(rawItems);
+      let items = opts.all ? rawItems : filterNetworkItems(rawItems);
+      items = filterByTimeWindow(items, { sinceMs, untilMs });
+      if (opts.failed) items = items.filter((item) => item.status === 0 || item.status >= 400);
       const filteredOut = rawItems.length - items.length;
 
       const keyed = assignKeys(items);
@@ -1598,6 +1762,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         size: it.size,
         ct: it.ct,
         body: it.body,
+        ...(typeof it.timestamp === 'number' ? { timestamp: it.timestamp } : {}),
         ...(it.bodyTruncated ? { body_truncated: true } : {}),
         ...(it.bodyTruncated && typeof it.bodyFullSize === 'number'
           ? { body_full_size: it.bodyFullSize }
@@ -1642,11 +1807,15 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
 
       if (opts.raw) {
-        envelope.entries = visible.map((s) => s.entry);
+        envelope.entries = visible.map((s) => ({
+          ...s.entry,
+          ...(typeof s.entry.timestamp === 'number' ? { timestamp: toIsoTimestamp(s.entry.timestamp) } : {}),
+        }));
       } else {
         envelope.entries = visible.map((s) => ({
           key: s.entry.key,
           method: s.entry.method,
+          ...(typeof s.entry.timestamp === 'number' ? { timestamp: toIsoTimestamp(s.entry.timestamp) } : {}),
           status: s.entry.status,
           url: s.entry.url,
           ct: s.entry.ct,

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -84,6 +84,21 @@ describe('commanderAdapter arg passing', () => {
     });
   });
 
+  it('passes explicit trace mode to executeCommand', async () => {
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'submit', './paper.pdf', '--trace', 'retain-on-failure']);
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ site: 'paperreview', name: 'submit' }),
+      expect.objectContaining({ pdf: './paper.pdf' }),
+      false,
+      { prepared: true, trace: 'retain-on-failure' },
+    );
+  });
+
   it('rejects invalid bool values before calling executeCommand', async () => {
     const program = new Command();
     const siteCmd = program.command('paperreview');

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -51,6 +51,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
   }
   subCmd
     .option('-f, --format <fmt>', 'Output format: table, plain, json, yaml, md, csv', 'table')
+    .option('--trace <mode>', 'Trace capture: off, on, retain-on-failure', 'off')
     .option('-v, --verbose', 'Debug output', false);
 
   subCmd.addHelpText('after', formatRegistryHelpText(cmd));
@@ -100,6 +101,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
       const result = await executeCommand(cmd, kwargs, verbose, {
         prepared: true,
         ...(typeof globals.profile === 'string' && globals.profile.trim() ? { profile: globals.profile.trim() } : {}),
+        ...(typeof optionsRecord.trace === 'string' && optionsRecord.trace !== 'off' ? { trace: optionsRecord.trace } : {}),
       });
       if (result === null || result === undefined) {
         return;

--- a/src/diagnostic.test.ts
+++ b/src/diagnostic.test.ts
@@ -163,6 +163,20 @@ describe('buildRepairContext', () => {
     expect(ctx.page).toEqual(pageState);
   });
 
+  it('includes trace artifact metadata when provided', () => {
+    const ctx = buildRepairContext(new CommandExecutionError('boom'), makeCmd(), undefined, {
+      traceId: 'trace-1',
+      dir: '/tmp/opencli/profiles/default/traces/trace-1',
+      summaryPath: '/tmp/opencli/profiles/default/traces/trace-1/summary.md',
+    });
+
+    expect(ctx.trace).toEqual({
+      traceId: 'trace-1',
+      dir: '/tmp/opencli/profiles/default/traces/trace-1',
+      summaryPath: '/tmp/opencli/profiles/default/traces/trace-1/summary.md',
+    });
+  });
+
   it('omits page when not provided', () => {
     const ctx = buildRepairContext(new Error('boom'), makeCmd());
     expect(ctx.page).toBeUndefined();
@@ -344,9 +358,9 @@ describe('collectDiagnostic', () => {
     expect(payload).toEqual({
       source: 'interceptor',
       responseBody: {
-        token: 'token=[REDACTED]',
+        token: '[REDACTED]',
         nested: {
-          cookie: 'cookie: [REDACTED]',
+          cookie: '[REDACTED]',
           body,
         },
       },

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -18,6 +18,13 @@ import type { IPage } from './types.js';
 import { CliError, getErrorMessage } from './errors.js';
 import type { InternalCliCommand } from './registry.js';
 import { fullName } from './registry.js';
+import type { ObservationExportResult } from './observation/index.js';
+import {
+  redactHeaders as redactObservationHeaders,
+  redactText as redactObservationText,
+  redactUrl as redactObservationUrl,
+  redactValue as redactObservationValue,
+} from './observation/redaction.js';
 
 // ── Size budgets ─────────────────────────────────────────────────────────────
 
@@ -27,33 +34,6 @@ export const MAX_DIAGNOSTIC_BYTES = 256 * 1024; // 256 KB
 const MAX_DIAGNOSTIC_FIELD_CHARS = 50_000;
 /** Maximum entries to keep from diagnostic collections. */
 const MAX_DIAGNOSTIC_COLLECTION_ITEMS = 50;
-
-// ── Sensitive data patterns ──────────────────────────────────────────────────
-
-const SENSITIVE_HEADERS = new Set([
-  'authorization',
-  'cookie',
-  'set-cookie',
-  'x-csrf-token',
-  'x-xsrf-token',
-  'proxy-authorization',
-  'x-api-key',
-  'x-auth-token',
-]);
-
-const SENSITIVE_URL_PARAMS = /([?&])(token|key|secret|password|auth|access_token|api_key|session_id|csrf)=[^&]*/gi;
-
-/** Patterns that match inline secrets in free-text strings (error messages, stack traces, console output, DOM). */
-const SENSITIVE_TEXT_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
-  // Bearer tokens
-  { pattern: /Bearer\s+[A-Za-z0-9\-._~+/]+=*/gi, replacement: 'Bearer [REDACTED]' },
-  // Generic "token=...", "key=...", etc. in non-URL text
-  { pattern: /(token|secret|password|api_key|apikey|access_token|session_id)[=:]\s*['"]?[A-Za-z0-9\-._~+/]{8,}['"]?/gi, replacement: '$1=[REDACTED]' },
-  // Cookie header values (key=value pairs)
-  { pattern: /(cookie[=:]\s*)[^\n;]{10,}/gi, replacement: '$1[REDACTED]' },
-  // JWT-like tokens (three base64 segments separated by dots)
-  { pattern: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, replacement: '[REDACTED_JWT]' },
-];
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -77,6 +57,11 @@ export interface RepairContext {
     capturedPayloads?: unknown[];
     consoleErrors: unknown[];
   };
+  trace?: {
+    traceId: string;
+    dir: string;
+    summaryPath: string;
+  };
   timestamp: string;
 }
 
@@ -90,63 +75,32 @@ export function truncate(str: string, maxLen: number): string {
 
 /** Redact sensitive query parameters from a URL. */
 export function redactUrl(url: string): string {
-  return url.replace(SENSITIVE_URL_PARAMS, '$1$2=[REDACTED]');
+  return redactObservationUrl(url);
 }
 
 /** Redact inline secrets from free-text strings (error messages, stack traces, console output, DOM). */
 export function redactText(text: string): string {
-  let result = text;
-  for (const { pattern, replacement } of SENSITIVE_TEXT_PATTERNS) {
-    // Reset lastIndex for global regexps
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, replacement);
-  }
-  return result;
+  return redactObservationText(text, { maxStringLength: MAX_DIAGNOSTIC_FIELD_CHARS });
 }
 
 /** Redact sensitive headers from a headers object. */
 function redactHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
   if (!headers || typeof headers !== 'object') return headers;
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    result[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? '[REDACTED]' : value;
-  }
-  return result;
+  return redactObservationHeaders(headers, {
+    maxStringLength: MAX_DIAGNOSTIC_FIELD_CHARS,
+    maxArrayItems: MAX_DIAGNOSTIC_COLLECTION_ITEMS,
+    maxObjectFields: MAX_DIAGNOSTIC_COLLECTION_ITEMS,
+  }) as Record<string, string>;
 }
 
 /** Recursively sanitize arbitrary captured response content for diagnostic output. */
-function sanitizeCapturedValue(value: unknown, depth: number = 0): unknown {
-  if (typeof value === 'string') {
-    return redactText(truncate(value, MAX_DIAGNOSTIC_FIELD_CHARS));
-  }
-  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
-    return value;
-  }
-  if (depth >= 4) {
-    return '[truncated: max depth reached]';
-  }
-  if (Array.isArray(value)) {
-    const items = value
-      .slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)
-      .map(item => sanitizeCapturedValue(item, depth + 1));
-    if (value.length > MAX_DIAGNOSTIC_COLLECTION_ITEMS) {
-      items.push(`[truncated, ${value.length - MAX_DIAGNOSTIC_COLLECTION_ITEMS} items omitted]`);
-    }
-    return items;
-  }
-  if (!value || typeof value !== 'object') {
-    return value;
-  }
-
-  const entries = Object.entries(value);
-  const result: Record<string, unknown> = {};
-  for (const [key, child] of entries.slice(0, MAX_DIAGNOSTIC_COLLECTION_ITEMS)) {
-    result[key] = sanitizeCapturedValue(child, depth + 1);
-  }
-  if (entries.length > MAX_DIAGNOSTIC_COLLECTION_ITEMS) {
-    result.__truncated__ = `[${entries.length - MAX_DIAGNOSTIC_COLLECTION_ITEMS} fields omitted]`;
-  }
-  return result;
+function sanitizeCapturedValue(value: unknown): unknown {
+  return redactObservationValue(value, {
+    maxStringLength: MAX_DIAGNOSTIC_FIELD_CHARS,
+    maxArrayItems: MAX_DIAGNOSTIC_COLLECTION_ITEMS,
+    maxObjectFields: MAX_DIAGNOSTIC_COLLECTION_ITEMS,
+    maxDepth: 4,
+  });
 }
 
 /** Redact sensitive data from a single network request entry. */
@@ -289,6 +243,7 @@ export function buildRepairContext(
   err: unknown,
   cmd: InternalCliCommand,
   pageState?: RepairContext['page'],
+  trace?: ObservationExportResult,
 ): RepairContext {
   const isCliError = err instanceof CliError;
   const sourcePath = resolveAdapterSourcePath(cmd);
@@ -306,6 +261,11 @@ export function buildRepairContext(
       source: readAdapterSource(sourcePath),
     },
     page: pageState,
+    trace: trace ? {
+      traceId: trace.traceId,
+      dir: trace.dir,
+      summaryPath: trace.summaryPath,
+    } : undefined,
     timestamp: new Date().toISOString(),
   };
 }
@@ -315,9 +275,10 @@ export async function collectDiagnostic(
   err: unknown,
   cmd: InternalCliCommand,
   page: IPage | null,
+  trace?: ObservationExportResult,
 ): Promise<RepairContext> {
   const pageState = page ? await collectPageState(page) : undefined;
-  return buildRepairContext(err, cmd, pageState);
+  return buildRepairContext(err, cmd, pageState, trace);
 }
 
 /** Emit diagnostic JSON to stderr, enforcing total size cap. */

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { CliCommand } from './registry.js';
 import { executeCommand, prepareCommandArgs } from './execution.js';
 import { TimeoutError } from './errors.js';
@@ -148,5 +151,108 @@ describe('executeCommand — non-browser timeout', () => {
     await executeCommand(cmd, kwargs, false, { prepared: true });
 
     expect(validateArgs).toHaveBeenCalledTimes(1);
+  });
+
+  it('exports a profile-scoped trace artifact on browser command failure when requested', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-'));
+    const prevConfigDir = process.env.OPENCLI_CONFIG_DIR;
+    process.env.OPENCLI_CONFIG_DIR = baseDir;
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = {
+      closeWindow,
+      startNetworkCapture: vi.fn().mockResolvedValue(true),
+      readNetworkCapture: vi.fn().mockResolvedValue([
+        {
+          url: 'https://api.example.com/data?token=secret',
+          method: 'GET',
+          responseStatus: 500,
+          responseContentType: 'application/json',
+          responsePreview: JSON.stringify({ password: 'secret', ok: false }),
+          requestHeaders: { authorization: 'Bearer secret' },
+          timestamp: Date.now(),
+        },
+      ]),
+      consoleMessages: vi.fn().mockResolvedValue([{ type: 'error', text: 'boom password=secret', timestamp: Date.now() }]),
+      snapshot: vi.fn().mockResolvedValue({ html: '<input type="password" value="secret">' }),
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('png').toString('base64')),
+      getCurrentUrl: vi.fn().mockResolvedValue('https://api.example.com/app'),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+    } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    try {
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'browser-trace-failure',
+        description: 'test trace export',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => { throw new Error('adapter failure'); },
+      });
+
+      await expect(executeCommand(cmd, {}, false, { trace: 'retain-on-failure' })).rejects.toThrow('adapter failure');
+
+      const tracesRoot = path.join(baseDir, 'profiles', 'default', 'traces');
+      const traceId = fs.readdirSync(tracesRoot)[0];
+      const traceDir = path.join(tracesRoot, traceId);
+      expect(fs.existsSync(path.join(traceDir, 'trace.jsonl'))).toBe(true);
+      const trace = fs.readFileSync(path.join(traceDir, 'trace.jsonl'), 'utf-8');
+      expect(trace).toContain('token=[REDACTED]');
+      expect(trace).toContain('"authorization":"[REDACTED]"');
+      expect(trace).not.toContain('password=secret');
+      expect(stderrSpy.mock.calls.flat().join('\n')).toContain('OpenCLI trace artifact:');
+      expect(closeWindow).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prevConfigDir === undefined) delete process.env.OPENCLI_CONFIG_DIR;
+      else process.env.OPENCLI_CONFIG_DIR = prevConfigDir;
+      stderrSpy.mockRestore();
+      fs.rmSync(baseDir, { recursive: true, force: true });
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('keeps the original adapter error when trace export fails', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-fail-'));
+    const blockedPath = path.join(baseDir, 'not-a-dir');
+    fs.writeFileSync(blockedPath, 'file');
+    const prevConfigDir = process.env.OPENCLI_CONFIG_DIR;
+    process.env.OPENCLI_CONFIG_DIR = blockedPath;
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const mockPage = {
+      closeWindow: vi.fn().mockResolvedValue(undefined),
+      startNetworkCapture: vi.fn().mockResolvedValue(true),
+      readNetworkCapture: vi.fn().mockResolvedValue([]),
+      consoleMessages: vi.fn().mockResolvedValue([]),
+      snapshot: vi.fn().mockResolvedValue('snapshot'),
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('png').toString('base64')),
+      getCurrentUrl: vi.fn().mockResolvedValue('https://example.com'),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+    } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    try {
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'browser-trace-export-fails',
+        description: 'test trace export failure handling',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => { throw new Error('adapter failure'); },
+      });
+
+      await expect(executeCommand(cmd, {}, false, { trace: 'retain-on-failure' })).rejects.toThrow('adapter failure');
+      expect(stderrSpy.mock.calls.flat().join('\n')).toContain('[trace] Failed to export trace artifact');
+    } finally {
+      if (prevConfigDir === undefined) delete process.env.OPENCLI_CONFIG_DIR;
+      else process.env.OPENCLI_CONFIG_DIR = prevConfigDir;
+      stderrSpy.mockRestore();
+      fs.rmSync(baseDir, { recursive: true, force: true });
+      vi.restoreAllMocks();
+    }
   });
 });

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -33,11 +33,20 @@ import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
 import { probeCDP, resolveElectronEndpoint } from './launcher.js';
+import { ObservationSession, exportObservationSession, type ObservationExportResult } from './observation/index.js';
 
 const _loadedModules = new Map<string, Promise<void>>();
 /** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
 const _moduleMtimes = new Map<string, number>();
 const _userClisDir = `${os.homedir()}/.opencli/clis/`;
+
+type TraceMode = 'off' | 'on' | 'retain-on-failure';
+
+function normalizeTraceMode(raw: unknown): TraceMode {
+  if (raw === undefined || raw === null || raw === '' || raw === 'off') return 'off';
+  if (raw === 'on' || raw === 'retain-on-failure') return raw;
+  throw new ArgumentError(`--trace must be one of: off, on, retain-on-failure. Received: "${String(raw)}"`);
+}
 
 export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: CommandArgs): CommandArgs {
   const result: CommandArgs = { ...kwargs };
@@ -170,7 +179,7 @@ export async function executeCommand(
   cmd: CliCommand,
   rawKwargs: CommandArgs,
   debug: boolean = false,
-  opts: { prepared?: boolean; profile?: string } = {},
+  opts: { prepared?: boolean; profile?: string; trace?: string } = {},
 ): Promise<unknown> {
   let kwargs: CommandArgs;
   try {
@@ -179,6 +188,8 @@ export async function executeCommand(
     if (err instanceof ArgumentError) throw err;
     throw new ArgumentError(getErrorMessage(err));
   }
+
+  const traceMode = normalizeTraceMode(opts.trace);
 
   const hookCtx: HookContext = {
     command: fullName(cmd),
@@ -215,8 +226,34 @@ export async function executeCommand(
       const BrowserFactory = getBrowserFactory(cmd.site);
       const contextId = resolveProfileContextId(opts.profile);
       result = await browserSession(BrowserFactory, async (page) => {
+        const observation = traceMode === 'off'
+          ? null
+          : new ObservationSession({
+            scope: {
+              contextId,
+              workspace: `site:${cmd.site}`,
+              target: page.getActivePage?.(),
+              site: cmd.site,
+              command: fullName(cmd),
+            },
+          });
+        if (observation) {
+          observation.record({
+            stream: 'action',
+            name: 'command',
+            phase: 'start',
+            data: { args: kwargs },
+          });
+          await page.startNetworkCapture?.().catch(() => false);
+        }
         const preNavUrl = resolvePreNav(cmd);
         if (preNavUrl) {
+          observation?.record({
+            stream: 'action',
+            name: 'pre_navigate',
+            phase: 'start',
+            data: { url: preNavUrl },
+          });
           // Navigate directly — the extension's handleNavigate already has a fast-path
           // that skips navigation if the tab is already at the target URL.
           // This avoids an extra exec round-trip (getCurrentUrl) on first command and
@@ -224,7 +261,19 @@ export async function executeCommand(
           // instead of about:blank.
           try {
             await page.goto(preNavUrl);
+            observation?.record({
+              stream: 'action',
+              name: 'pre_navigate',
+              phase: 'end',
+              data: { url: preNavUrl },
+            });
           } catch (err) {
+            observation?.record({
+              stream: 'action',
+              name: 'pre_navigate',
+              phase: 'error',
+              data: { url: preNavUrl, error: err instanceof Error ? err.message : String(err) },
+            });
             throw new CommandExecutionError(
               `Pre-navigation to ${preNavUrl} failed: ${err instanceof Error ? err.message : err}`,
               'Check that the site is reachable and the browser extension is running.',
@@ -239,15 +288,42 @@ export async function executeCommand(
             timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT,
             label: fullName(cmd),
           });
+          observation?.record({
+            stream: 'action',
+            name: 'command',
+            phase: 'end',
+          });
+          if (observation && traceMode === 'on') {
+            await collectObservationEvidence(observation, page).catch(() => {});
+            exportTraceArtifact(observation);
+          }
           // Adapter commands are one-shot — close the automation window immediately
           // instead of waiting for the 30s idle timeout.
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
+          let trace: ObservationExportResult | undefined;
+          if (observation) {
+            observation.record({
+              stream: 'action',
+              name: 'command',
+              phase: 'error',
+              data: { error: err instanceof Error ? err.message : String(err) },
+            });
+            observation.record({
+              stream: 'error',
+              message: err instanceof Error ? err.message : String(err),
+              stack: err instanceof Error ? err.stack : undefined,
+            });
+            if (traceMode === 'on' || traceMode === 'retain-on-failure') {
+              await collectObservationEvidence(observation, page).catch(() => {});
+              trace = exportTraceArtifact(observation, err);
+            }
+          }
           // Collect diagnostic while page is still alive (before closing the window).
           if (isDiagnosticEnabled()) {
             const internal = cmd as InternalCliCommand;
-            const ctx = await collectDiagnostic(err, internal, page);
+            const ctx = await collectDiagnostic(err, internal, page, trace);
             emitDiagnostic(ctx);
             diagnosticEmitted = true;
           }
@@ -288,6 +364,64 @@ export async function executeCommand(
   hookCtx.finishedAt = Date.now();
   await emitHook('onAfterExecute', hookCtx, result);
   return result;
+}
+
+async function collectObservationEvidence(session: ObservationSession, page: IPage): Promise<void> {
+  const target = page.getActivePage?.() ?? session.scope.target;
+  const [url, snapshot, networkEntries, consoleMessages, screenshot] = await Promise.all([
+    page.getCurrentUrl?.().catch(() => null) ?? Promise.resolve(null),
+    page.snapshot().catch(() => undefined),
+    page.readNetworkCapture?.().catch(() => []) ?? Promise.resolve([]),
+    page.consoleMessages('all').catch(() => []),
+    page.screenshot({ format: 'png' }).catch(() => undefined),
+  ]);
+
+  if (snapshot !== undefined || url !== undefined) {
+    session.record({ stream: 'state', url, target, snapshot, label: 'final' });
+  }
+  for (const entry of Array.isArray(networkEntries) ? networkEntries : []) {
+    const record = entry as Record<string, unknown>;
+    session.record({
+      stream: 'network',
+      url: String(record.url ?? ''),
+      method: typeof record.method === 'string' ? record.method : undefined,
+      status: typeof record.responseStatus === 'number' ? record.responseStatus : undefined,
+      contentType: typeof record.responseContentType === 'string' ? record.responseContentType : undefined,
+      size: typeof record.responseBodyFullSize === 'number' ? record.responseBodyFullSize : undefined,
+      requestHeaders: record.requestHeaders as Record<string, unknown> | undefined,
+      responseHeaders: record.responseHeaders as Record<string, unknown> | undefined,
+      requestBody: record.requestBodyPreview,
+      responseBody: record.responsePreview,
+      ts: typeof record.timestamp === 'number' ? record.timestamp : undefined,
+    });
+  }
+  for (const message of Array.isArray(consoleMessages) ? consoleMessages : []) {
+    if (message && typeof message === 'object') {
+      const record = message as Record<string, unknown>;
+      session.record({
+        stream: 'console',
+        level: String(record.type ?? record.level ?? 'log'),
+        text: String(record.text ?? record.message ?? ''),
+        ts: typeof record.timestamp === 'number' ? record.timestamp : undefined,
+      });
+    } else {
+      session.record({ stream: 'console', level: 'log', text: String(message) });
+    }
+  }
+  if (typeof screenshot === 'string' && screenshot) {
+    session.record({ stream: 'screenshot', format: 'png', data: screenshot, label: 'final' });
+  }
+}
+
+function exportTraceArtifact(session: ObservationSession, error?: unknown): ObservationExportResult | undefined {
+  try {
+    const trace = exportObservationSession(session, { error });
+    process.stderr.write(`OpenCLI trace artifact: ${trace.dir}\n`);
+    return trace;
+  } catch (err) {
+    log.warn(`[trace] Failed to export trace artifact: ${err instanceof Error ? err.message : String(err)}`);
+    return undefined;
+  }
 }
 
 export function prepareCommandArgs(

--- a/src/observation/artifact.test.ts
+++ b/src/observation/artifact.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { exportObservationSession, getTraceDirectory } from './artifact.js';
+import { ObservationSession } from './session.js';
+
+describe('observation artifact', () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-trace-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('writes artifacts under profile-scoped trace directory', () => {
+    const session = new ObservationSession({
+      id: 'trace-1',
+      scope: { contextId: 'work', workspace: 'site:demo', site: 'demo', command: 'demo/run' },
+      now: () => 1_700_000_000_000,
+    });
+    session.record({ stream: 'action', name: 'command', phase: 'start' });
+    session.record({ stream: 'screenshot', format: 'png', data: Buffer.from('png-bytes').toString('base64'), label: 'final' });
+    session.record({
+      stream: 'network',
+      url: 'https://api.test/data?token=secret',
+      method: 'GET',
+      status: 500,
+      requestHeaders: { authorization: 'Bearer secret' },
+      responseBody: { ok: false },
+    });
+    session.record({ stream: 'console', level: 'error', text: 'boom password=supersecret' });
+
+    const result = exportObservationSession(session, { baseDir, error: new Error('failed') });
+    expect(result.dir).toBe(getTraceDirectory('work', 'trace-1', baseDir));
+    expect(fs.existsSync(path.join(result.dir, 'trace.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(result.dir, 'network.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(result.dir, 'console.jsonl'))).toBe(true);
+    expect(fs.readFileSync(path.join(result.dir, 'screenshots', '0001.png'), 'utf-8')).toBe('png-bytes');
+
+    const trace = fs.readFileSync(path.join(result.dir, 'trace.jsonl'), 'utf-8');
+    expect(trace).toContain('token=[REDACTED]');
+    expect(trace).toContain('"authorization":"[REDACTED]"');
+    expect(trace).not.toContain('supersecret');
+
+    const summary = fs.readFileSync(result.summaryPath, 'utf-8');
+    expect(summary).toContain('contextId: work');
+    expect(summary).toContain('network: 1');
+  });
+});

--- a/src/observation/artifact.ts
+++ b/src/observation/artifact.ts
@@ -1,0 +1,101 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ObservationEvent, ObservationExportResult } from './events.js';
+import { ObservationSession } from './session.js';
+import { redactValue } from './redaction.js';
+
+export interface ExportObservationOptions {
+  baseDir?: string;
+  error?: unknown;
+}
+
+function baseOpenCliDir(): string {
+  return process.env.OPENCLI_CONFIG_DIR || path.join(os.homedir(), '.opencli');
+}
+
+function safeSegment(value: string | undefined): string {
+  const safe = (value || 'default').replace(/[^a-zA-Z0-9_-]+/g, '_');
+  return safe || 'default';
+}
+
+export function getTraceDirectory(contextId: string | undefined, traceId: string, baseDir: string = baseOpenCliDir()): string {
+  return path.join(baseDir, 'profiles', safeSegment(contextId), 'traces', safeSegment(traceId));
+}
+
+export function exportObservationSession(session: ObservationSession, opts: ExportObservationOptions = {}): ObservationExportResult {
+  const dir = getTraceDirectory(session.scope.contextId, session.id, opts.baseDir);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(path.join(dir, 'screenshots'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+
+  const originalEvents = session.events();
+  const sanitizedEvents = originalEvents.map((event) => redactObservationEvent(event));
+  const traceLines: string[] = [];
+  const networkLines: string[] = [];
+  const consoleLines: string[] = [];
+  let screenshotIndex = 0;
+  let stateIndex = 0;
+
+  for (let i = 0; i < sanitizedEvents.length; i++) {
+    const originalEvent = originalEvents[i];
+    const event = sanitizedEvents[i];
+    const serializable = { ...event } as Record<string, unknown>;
+    if (event.stream === 'screenshot' && originalEvent.stream === 'screenshot' && typeof originalEvent.data === 'string') {
+      const ext = event.format === 'jpeg' ? 'jpg' : 'png';
+      const file = `screenshots/${String(++screenshotIndex).padStart(4, '0')}.${ext}`;
+      fs.writeFileSync(path.join(dir, file), originalEvent.data, 'base64');
+      serializable.path = file;
+      delete serializable.data;
+    }
+    if (event.stream === 'state' && serializable.snapshot !== undefined) {
+      const file = `state/${String(++stateIndex).padStart(4, '0')}.json`;
+      fs.writeFileSync(path.join(dir, file), JSON.stringify(serializable.snapshot, null, 2), 'utf-8');
+      serializable.snapshotPath = file;
+      delete serializable.snapshot;
+    }
+    const line = JSON.stringify(serializable);
+    traceLines.push(line);
+    if (event.stream === 'network') networkLines.push(line);
+    if (event.stream === 'console') consoleLines.push(line);
+  }
+
+  fs.writeFileSync(path.join(dir, 'trace.jsonl'), traceLines.join('\n') + (traceLines.length ? '\n' : ''), 'utf-8');
+  fs.writeFileSync(path.join(dir, 'network.jsonl'), networkLines.join('\n') + (networkLines.length ? '\n' : ''), 'utf-8');
+  fs.writeFileSync(path.join(dir, 'console.jsonl'), consoleLines.join('\n') + (consoleLines.length ? '\n' : ''), 'utf-8');
+
+  const summaryPath = path.join(dir, 'summary.md');
+  fs.writeFileSync(summaryPath, renderSummary(session, sanitizedEvents, opts.error), 'utf-8');
+  return { traceId: session.id, dir, summaryPath };
+}
+
+function redactObservationEvent(event: ObservationEvent): ObservationEvent {
+  return redactValue(event) as ObservationEvent;
+}
+
+function renderSummary(session: ObservationSession, events: ObservationEvent[], error: unknown): string {
+  const counts = events.reduce<Record<string, number>>((acc, event) => {
+    acc[event.stream] = (acc[event.stream] ?? 0) + 1;
+    return acc;
+  }, {});
+  const errorMessage = error instanceof Error ? error.message : (error === undefined ? undefined : String(error));
+  const lines = [
+    '# OpenCLI Trace',
+    '',
+    `- traceId: ${session.id}`,
+    `- contextId: ${session.scope.contextId ?? 'default'}`,
+    `- workspace: ${session.scope.workspace}`,
+    ...(session.scope.target ? [`- target: ${session.scope.target}`] : []),
+    ...(session.scope.site ? [`- site: ${session.scope.site}`] : []),
+    ...(session.scope.command ? [`- command: ${session.scope.command}`] : []),
+    `- startedAt: ${new Date(session.startedAt).toISOString()}`,
+    `- exportedAt: ${new Date().toISOString()}`,
+    ...(errorMessage ? [`- error: ${String(redactValue(errorMessage))}`] : []),
+    '',
+    '## Event Counts',
+    '',
+    ...Object.entries(counts).map(([stream, count]) => `- ${stream}: ${count}`),
+    '',
+  ];
+  return lines.join('\n');
+}

--- a/src/observation/events.ts
+++ b/src/observation/events.ts
@@ -1,0 +1,86 @@
+export type ObservationStream = 'action' | 'network' | 'console' | 'screenshot' | 'state' | 'error';
+
+export interface ObservationScope {
+  contextId?: string;
+  workspace: string;
+  target?: string;
+  site?: string;
+  command?: string;
+}
+
+interface BaseObservationEvent {
+  id: string;
+  ts: number;
+  stream: ObservationStream;
+}
+
+export interface ActionObservationEvent extends BaseObservationEvent {
+  stream: 'action';
+  name: string;
+  phase?: 'start' | 'end' | 'error';
+  data?: Record<string, unknown>;
+}
+
+export interface NetworkObservationEvent extends BaseObservationEvent {
+  stream: 'network';
+  url: string;
+  method?: string;
+  status?: number;
+  contentType?: string;
+  size?: number;
+  requestHeaders?: Record<string, unknown>;
+  responseHeaders?: Record<string, unknown>;
+  requestBody?: unknown;
+  responseBody?: unknown;
+}
+
+export interface ConsoleObservationEvent extends BaseObservationEvent {
+  stream: 'console';
+  level: string;
+  text: string;
+  source?: string;
+}
+
+export interface ScreenshotObservationEvent extends BaseObservationEvent {
+  stream: 'screenshot';
+  format: 'png' | 'jpeg';
+  data: string;
+  label?: string;
+}
+
+export interface StateObservationEvent extends BaseObservationEvent {
+  stream: 'state';
+  url?: string | null;
+  target?: string;
+  snapshot?: unknown;
+  label?: string;
+}
+
+export interface ErrorObservationEvent extends BaseObservationEvent {
+  stream: 'error';
+  code?: string;
+  message: string;
+  stack?: string;
+  hint?: string;
+}
+
+export type ObservationEvent =
+  | ActionObservationEvent
+  | NetworkObservationEvent
+  | ConsoleObservationEvent
+  | ScreenshotObservationEvent
+  | StateObservationEvent
+  | ErrorObservationEvent;
+
+export type ObservationEventInput =
+  ObservationEvent extends infer T
+    ? T extends ObservationEvent
+      ? Omit<T, 'id' | 'ts'> & Partial<Pick<T, 'id' | 'ts'>>
+      : never
+    : never;
+
+export interface ObservationExportResult {
+  traceId: string;
+  dir: string;
+  summaryPath: string;
+}

--- a/src/observation/index.ts
+++ b/src/observation/index.ts
@@ -1,0 +1,6 @@
+export * from './events.js';
+export * from './ring-buffer.js';
+export * from './redaction.js';
+export * from './session.js';
+export * from './manager.js';
+export * from './artifact.js';

--- a/src/observation/manager.test.ts
+++ b/src/observation/manager.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { ObservationManager } from './manager.js';
+
+describe('ObservationManager', () => {
+  it('indexes sessions by id and scope', () => {
+    const manager = new ObservationManager();
+    const work = manager.start({ id: 'work-1', scope: { contextId: 'work', workspace: 'site:x', target: 'tab-1' } });
+    manager.start({ id: 'personal-1', scope: { contextId: 'personal', workspace: 'site:x', target: 'tab-2' } });
+
+    expect(manager.get('work-1')).toBe(work);
+    expect(manager.findByScope({ contextId: 'work', workspace: 'site:x' }).map((session) => session.id)).toEqual(['work-1']);
+    expect(manager.stop('work-1')).toBe(work);
+    expect(manager.get('work-1')).toBeUndefined();
+  });
+});

--- a/src/observation/manager.ts
+++ b/src/observation/manager.ts
@@ -1,0 +1,34 @@
+import { ObservationSession, type ObservationSessionOptions } from './session.js';
+import type { ObservationScope } from './events.js';
+
+export class ObservationManager {
+  private readonly sessions = new Map<string, ObservationSession>();
+
+  start(opts: ObservationSessionOptions): ObservationSession {
+    const session = new ObservationSession(opts);
+    this.sessions.set(session.id, session);
+    return session;
+  }
+
+  get(id: string): ObservationSession | undefined {
+    return this.sessions.get(id);
+  }
+
+  stop(id: string): ObservationSession | undefined {
+    const session = this.sessions.get(id);
+    this.sessions.delete(id);
+    return session;
+  }
+
+  findByScope(scope: ObservationScope): ObservationSession[] {
+    return [...this.sessions.values()].filter((session) => scopeMatches(session.scope, scope));
+  }
+}
+
+function scopeMatches(actual: ObservationScope, expected: ObservationScope): boolean {
+  return actual.workspace === expected.workspace
+    && (expected.contextId === undefined || actual.contextId === expected.contextId)
+    && (expected.target === undefined || actual.target === expected.target)
+    && (expected.site === undefined || actual.site === expected.site)
+    && (expected.command === undefined || actual.command === expected.command);
+}

--- a/src/observation/redaction.test.ts
+++ b/src/observation/redaction.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { redactHeaders, redactUrl, redactValue } from './redaction.js';
+
+describe('observation redaction', () => {
+  it('redacts sensitive headers by default', () => {
+    expect(redactHeaders({
+      authorization: 'Bearer secret-token',
+      cookie: 'sid=abc',
+      'set-cookie': 'sid=abc',
+      accept: 'application/json',
+    })).toEqual({
+      authorization: '[REDACTED]',
+      cookie: '[REDACTED]',
+      'set-cookie': '[REDACTED]',
+      accept: 'application/json',
+    });
+  });
+
+  it('redacts sensitive url query params', () => {
+    expect(redactUrl('https://x.test/api?token=abc&ok=1&password=secret'))
+      .toBe('https://x.test/api?token=[REDACTED]&ok=1&password=[REDACTED]');
+  });
+
+  it('redacts password and token fields recursively', () => {
+    expect(redactValue({
+      user: 'alice',
+      password: 'secret',
+      nested: { access_token: 'abc123456789', value: 'safe' },
+    })).toEqual({
+      user: 'alice',
+      password: '[REDACTED]',
+      nested: { access_token: '[REDACTED]', value: 'safe' },
+    });
+  });
+});

--- a/src/observation/redaction.ts
+++ b/src/observation/redaction.ts
@@ -1,0 +1,91 @@
+const DEFAULT_REDACTION = '[REDACTED]';
+
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'proxy-authorization',
+  'x-api-key',
+  'x-auth-token',
+  'x-csrf-token',
+  'x-xsrf-token',
+]);
+
+const SENSITIVE_FIELD_PATTERN = /(password|passwd|pwd|token|secret|authorization|cookie|set-cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?id|csrf|xsrf)/i;
+const SENSITIVE_URL_PARAMS = /([?&])(token|key|secret|password|auth|access_token|api_key|session_id|csrf|xsrf)=[^&]*/gi;
+
+export interface RedactionOptions {
+  allowlist?: string[];
+  maxStringLength?: number;
+  maxDepth?: number;
+  maxArrayItems?: number;
+  maxObjectFields?: number;
+}
+
+export function redactUrl(url: string): string {
+  return url.replace(SENSITIVE_URL_PARAMS, '$1$2=[REDACTED]');
+}
+
+export function redactHeaders(headers: Record<string, unknown> | undefined, opts: RedactionOptions = {}): Record<string, unknown> | undefined {
+  if (!headers) return headers;
+  const allow = new Set((opts.allowlist ?? []).map((key) => key.toLowerCase()));
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    out[key] = SENSITIVE_HEADER_NAMES.has(lower) && !allow.has(lower)
+      ? DEFAULT_REDACTION
+      : redactValue(value, opts, key);
+  }
+  return out;
+}
+
+export function redactText(text: string, opts: RedactionOptions = {}): string {
+  const max = opts.maxStringLength ?? 50_000;
+  let out = text
+    .replace(/Bearer\s+[A-Za-z0-9\-._~+/]+=*/gi, 'Bearer [REDACTED]')
+    .replace(/(["'])(password|passwd|pwd|token|secret|api_key|apikey|access_token|session_id)\1\s*:\s*(["'])(.*?)\3/gi, '$1$2$1:$3[REDACTED]$3')
+    .replace(/(token|secret|password|api_key|apikey|access_token|session_id)[=:]\s*['"]?[^'"\s,;}&]+['"]?/gi, '$1=[REDACTED]')
+    .replace(/(cookie[=:]\s*)[^\n;]{3,}/gi, '$1[REDACTED]')
+    .replace(/eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, '[REDACTED_JWT]');
+  if (out.length > max) out = out.slice(0, max) + `\n...[truncated, ${out.length - max} chars omitted]`;
+  return out;
+}
+
+export function redactValue(value: unknown, opts: RedactionOptions = {}, keyHint?: string, depth: number = 0): unknown {
+  const allow = new Set((opts.allowlist ?? []).map((key) => key.toLowerCase()));
+  if (keyHint && SENSITIVE_FIELD_PATTERN.test(keyHint) && !allow.has(keyHint.toLowerCase())) {
+    return DEFAULT_REDACTION;
+  }
+  if (typeof value === 'string') {
+    return keyHint === 'url' ? redactUrl(value) : redactText(value, opts);
+  }
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') return value;
+
+  const maxDepth = opts.maxDepth ?? 5;
+  if (depth >= maxDepth) return '[truncated: max depth reached]';
+
+  if (Array.isArray(value)) {
+    const max = opts.maxArrayItems ?? 100;
+    const items = value.slice(0, max).map((item) => redactValue(item, opts, undefined, depth + 1));
+    if (value.length > max) items.push(`[truncated, ${value.length - max} items omitted]`);
+    return items;
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const max = opts.maxObjectFields ?? 100;
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of entries.slice(0, max)) {
+      if (key.toLowerCase() === 'url' && typeof child === 'string') out[key] = redactUrl(child);
+      else if (key.toLowerCase().includes('headers') && child && typeof child === 'object' && !Array.isArray(child)) {
+        out[key] = redactHeaders(child as Record<string, unknown>, opts);
+      } else {
+        out[key] = redactValue(child, opts, key, depth + 1);
+      }
+    }
+    if (entries.length > max) out.__truncated__ = `[${entries.length - max} fields omitted]`;
+    return out;
+  }
+
+  return value;
+}

--- a/src/observation/ring-buffer.test.ts
+++ b/src/observation/ring-buffer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { RingBuffer } from './ring-buffer.js';
+
+describe('RingBuffer', () => {
+  it('keeps items in event order and filters by time window', () => {
+    let now = 10_000;
+    const buffer = new RingBuffer<{ ts: number; value: string }>({ maxAgeMs: 5_000, now: () => now });
+    buffer.push({ ts: 4_000, value: 'old' });
+    buffer.push({ ts: 7_000, value: 'kept' });
+    buffer.push({ ts: 9_000, value: 'new' });
+
+    expect(buffer.values().map((item) => item.value)).toEqual(['kept', 'new']);
+    expect(buffer.values({ since: 8_000 }).map((item) => item.value)).toEqual(['new']);
+    now = 13_000;
+    expect(buffer.values().map((item) => item.value)).toEqual(['new']);
+  });
+
+  it('caps by item count', () => {
+    const buffer = new RingBuffer<{ ts: number; value: number }>({ maxItems: 2, maxAgeMs: 100_000, now: () => 10 });
+    buffer.push({ ts: 1, value: 1 });
+    buffer.push({ ts: 2, value: 2 });
+    buffer.push({ ts: 3, value: 3 });
+    expect(buffer.values().map((item) => item.value)).toEqual([2, 3]);
+  });
+});

--- a/src/observation/ring-buffer.ts
+++ b/src/observation/ring-buffer.ts
@@ -1,0 +1,53 @@
+export interface RingBufferOptions {
+  maxAgeMs?: number;
+  maxItems?: number;
+  now?: () => number;
+}
+
+export class RingBuffer<T extends { ts: number }> {
+  private readonly maxAgeMs: number;
+  private readonly maxItems: number;
+  private readonly now: () => number;
+  private items: T[] = [];
+
+  constructor(opts: RingBufferOptions = {}) {
+    this.maxAgeMs = opts.maxAgeMs ?? 120_000;
+    this.maxItems = opts.maxItems ?? 1_000;
+    this.now = opts.now ?? Date.now;
+  }
+
+  push(item: T): void {
+    this.items.push(item);
+    this.prune();
+  }
+
+  values(opts: { since?: number; until?: number } = {}): T[] {
+    this.prune();
+    return this.items.filter((item) => {
+      if (opts.since !== undefined && item.ts < opts.since) return false;
+      if (opts.until !== undefined && item.ts > opts.until) return false;
+      return true;
+    });
+  }
+
+  clear(): void {
+    this.items = [];
+  }
+
+  get size(): number {
+    this.prune();
+    return this.items.length;
+  }
+
+  private prune(): void {
+    const minTs = this.now() - this.maxAgeMs;
+    if (this.items.length > this.maxItems) {
+      this.items = this.items.slice(this.items.length - this.maxItems);
+    }
+    if (this.maxAgeMs > 0) {
+      const firstKept = this.items.findIndex((item) => item.ts >= minTs);
+      if (firstKept > 0) this.items = this.items.slice(firstKept);
+      else if (firstKept === -1) this.items = [];
+    }
+  }
+}

--- a/src/observation/session.ts
+++ b/src/observation/session.ts
@@ -1,0 +1,66 @@
+import { RingBuffer } from './ring-buffer.js';
+import type { ObservationEvent, ObservationEventInput, ObservationScope, ObservationStream } from './events.js';
+import { randomBytes } from 'node:crypto';
+
+export const DEFAULT_OBSERVATION_WINDOW_MS = 120_000;
+
+export interface ObservationSessionOptions {
+  id?: string;
+  scope: ObservationScope;
+  windowMs?: number;
+  maxEventsPerStream?: number;
+  now?: () => number;
+}
+
+export class ObservationSession {
+  readonly id: string;
+  readonly scope: ObservationScope;
+  readonly startedAt: number;
+
+  private readonly now: () => number;
+  private counter = 0;
+  private readonly buffers: Record<ObservationStream, RingBuffer<ObservationEvent>>;
+
+  constructor(opts: ObservationSessionOptions) {
+    this.id = opts.id ?? createTraceId(opts.now?.() ?? Date.now());
+    this.scope = opts.scope;
+    this.now = opts.now ?? Date.now;
+    this.startedAt = this.now();
+    const bufferOpts = {
+      maxAgeMs: opts.windowMs ?? DEFAULT_OBSERVATION_WINDOW_MS,
+      maxItems: opts.maxEventsPerStream ?? 1_000,
+      now: this.now,
+    };
+    this.buffers = {
+      action: new RingBuffer<ObservationEvent>(bufferOpts),
+      network: new RingBuffer<ObservationEvent>(bufferOpts),
+      console: new RingBuffer<ObservationEvent>(bufferOpts),
+      screenshot: new RingBuffer<ObservationEvent>({ ...bufferOpts, maxItems: Math.min(opts.maxEventsPerStream ?? 50, 50) }),
+      state: new RingBuffer<ObservationEvent>({ ...bufferOpts, maxItems: Math.min(opts.maxEventsPerStream ?? 50, 50) }),
+      error: new RingBuffer<ObservationEvent>(bufferOpts),
+    };
+  }
+
+  record(input: ObservationEventInput): ObservationEvent {
+    const event = {
+      ...input,
+      id: input.id ?? `${this.id}-${++this.counter}`,
+      ts: input.ts ?? this.now(),
+    } as ObservationEvent;
+    this.buffers[event.stream].push(event);
+    return event;
+  }
+
+  events(opts: { stream?: ObservationStream; since?: number; until?: number } = {}): ObservationEvent[] {
+    const streams = opts.stream ? [opts.stream] : Object.keys(this.buffers) as ObservationStream[];
+    return streams
+      .flatMap((stream) => this.buffers[stream].values({ since: opts.since, until: opts.until }))
+      .sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
+  }
+}
+
+export function createTraceId(now: number | (() => number) = Date.now): string {
+  const ts = typeof now === 'function' ? now() : now;
+  const rand = randomBytes(4).toString('hex');
+  return `${new Date(ts).toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${rand}`;
+}


### PR DESCRIPTION
## Summary

- add `src/observation/` core primitives: event model, 120s ring buffer, profile-scoped artifact writer, manager, and shared redaction
- add `opencli browser console` and extend `browser network` with `--since`, `--until`, `--follow`, and `--failed`
- add adapter `--trace on|retain-on-failure|off`; failures export traces under `~/.opencli/profiles/<contextId>/traces/<traceId>/`
- include trace artifact metadata in `OPENCLI_DIAGNOSTIC=1` repair context

## Design Notes

- BrowserBridge does not add a new `chrome.debugger.attach` path; trace uses existing page/network/screenshot methods.
- Default trace window is 120s.
- Redaction defaults to strong mode for cookies, authorization, set-cookie, token-like fields, and password fields.
- Non-browser adapter commands accept `--trace` but effectively no-op because no browser evidence exists.

## Verification

- `npm run typecheck`
- `npx vitest run src/observation/*.test.ts src/cli.test.ts src/commanderAdapter.test.ts src/execution.test.ts src/diagnostic.test.ts --project unit`
- `npm run build`
- `OPENCLI_DAEMON_PORT=29125 npm test` -> 261 files, 2147 passed, 2 skipped