### PR TITLE
feat(trace): prune retained artifacts

### DIFF
--- a/src/observation/artifact.test.ts
+++ b/src/observation/artifact.test.ts
@@ -56,6 +56,7 @@ describe('observation artifact', () => {
     const summary = fs.readFileSync(result.summaryPath, 'utf-8');
     expect(summary).toContain('schemaVersion: 1');
     expect(summary).toContain('opencliVersion:');
+    expect(summary).toContain('expiresAt:');
     expect(summary).toContain('status: failure');
     expect(summary).toContain('contextId: "work"');
     expect(summary).toContain('adapterSourcePath: "/tmp/clis/demo/run.js"');
@@ -73,6 +74,7 @@ describe('observation artifact', () => {
       summaryPath: result.summaryPath,
       receiptPath: result.receiptPath,
       status: 'failure',
+      expiresAt: expect.any(String),
       scope: {
         contextId: 'work',
         workspace: 'site:demo',
@@ -90,7 +92,10 @@ describe('observation artifact', () => {
       dir: '/tmp/opencli/profiles/work/traces/trace-1',
       summaryPath: '/tmp/opencli/profiles/work/traces/trace-1/summary.md',
       receiptPath: '/tmp/opencli/profiles/work/traces/trace-1/receipt.json',
-    }, 'failure', new Error('failed with token=secret'));
+    }, 'failure', new Error('failed with token=secret'), {
+      createdAt: '2026-05-03T00:00:00.000Z',
+      retentionPolicy: { maxAgeDays: 7 },
+    });
 
     expect(receipt).toMatchObject({
       schemaVersion: 1,
@@ -99,7 +104,32 @@ describe('observation artifact', () => {
       traceDir: '/tmp/opencli/profiles/work/traces/trace-1',
       receiptPath: '/tmp/opencli/profiles/work/traces/trace-1/receipt.json',
       status: 'failure',
+      expiresAt: '2026-05-10T00:00:00.000Z',
     });
     expect(receipt.error?.message).toContain('token=[REDACTED]');
+  });
+
+  it('prunes older traces after export while protecting the exported trace', () => {
+    const oldTraceDir = getTraceDirectory('work', 'old-trace', baseDir);
+    fs.mkdirSync(oldTraceDir, { recursive: true });
+    fs.writeFileSync(path.join(oldTraceDir, 'receipt.json'), JSON.stringify({
+      createdAt: '2026-04-01T00:00:00.000Z',
+    }), 'utf-8');
+    fs.writeFileSync(path.join(oldTraceDir, 'trace.jsonl'), '{}\n', 'utf-8');
+
+    const session = new ObservationSession({
+      id: 'new-trace',
+      scope: { contextId: 'work', workspace: 'site:demo' },
+      now: () => Date.parse('2026-05-03T00:00:00.000Z'),
+    });
+    session.record({ stream: 'action', name: 'command', phase: 'start' });
+
+    const result = exportObservationSession(session, {
+      baseDir,
+      retentionPolicy: { maxAgeDays: 365, maxCountPerProfile: 1, maxBytesPerProfile: '500MB' },
+    });
+
+    expect(fs.existsSync(oldTraceDir)).toBe(false);
+    expect(fs.existsSync(result.dir)).toBe(true);
   });
 });

--- a/src/observation/artifact.ts
+++ b/src/observation/artifact.ts
@@ -4,13 +4,16 @@ import * as path from 'node:path';
 import type { ObservationEvent, ObservationExportResult, ObservationExportStatus, ObservationTraceReceipt } from './events.js';
 import { ObservationSession } from './session.js';
 import { redactValue } from './redaction.js';
+import { pruneTraceArtifacts, traceExpiresAt, type TraceRetentionPolicyInput } from './retention.js';
 import { CliError, getErrorMessage } from '../errors.js';
+import { log } from '../logger.js';
 import { PKG_VERSION } from '../version.js';
 
 export interface ExportObservationOptions {
   baseDir?: string;
   error?: unknown;
   status?: ObservationExportStatus;
+  retentionPolicy?: TraceRetentionPolicyInput;
 }
 
 function baseOpenCliDir(): string {
@@ -75,14 +78,17 @@ export function exportObservationSession(session: ObservationSession, opts: Expo
     status,
     dir,
     createdAt,
+    retentionPolicy: opts.retentionPolicy,
   }), 'utf-8');
   const receiptPath = path.join(dir, 'receipt.json');
   const resultBase = { traceId: session.id, dir, summaryPath, receiptPath };
   const receipt = buildTraceReceipt(resultBase, status, opts.error, {
     createdAt,
     scope: session.scope,
+    retentionPolicy: opts.retentionPolicy,
   });
   fs.writeFileSync(receiptPath, JSON.stringify(receipt, null, 2), 'utf-8');
+  pruneTraceArtifactsBestEffort(path.dirname(dir), dir, opts.retentionPolicy);
   return { ...resultBase, receipt };
 }
 
@@ -94,9 +100,10 @@ export function buildTraceReceipt(
   result: Pick<ObservationExportResult, 'traceId' | 'dir' | 'summaryPath' | 'receiptPath'>,
   status: ObservationExportStatus,
   error?: unknown,
-  opts: { createdAt?: string; scope?: ObservationSession['scope'] } = {},
+  opts: { createdAt?: string; scope?: ObservationSession['scope']; retentionPolicy?: TraceRetentionPolicyInput } = {},
 ): ObservationTraceReceipt {
   const maybeCliError = error instanceof CliError ? error : undefined;
+  const createdAt = opts.createdAt ?? new Date().toISOString();
   return {
     schemaVersion: 1,
     opencliVersion: PKG_VERSION,
@@ -105,7 +112,8 @@ export function buildTraceReceipt(
     summaryPath: result.summaryPath,
     receiptPath: result.receiptPath,
     status,
-    createdAt: opts.createdAt ?? new Date().toISOString(),
+    createdAt,
+    expiresAt: traceExpiresAt(createdAt, opts.retentionPolicy),
     ...(opts.scope ? { scope: opts.scope } : {}),
     ...(error === undefined ? {} : {
       error: {
@@ -117,10 +125,26 @@ export function buildTraceReceipt(
   };
 }
 
+function pruneTraceArtifactsBestEffort(
+  tracesDir: string,
+  protectedTraceDir: string,
+  retentionPolicy?: TraceRetentionPolicyInput,
+): void {
+  try {
+    pruneTraceArtifacts(tracesDir, {
+      policy: retentionPolicy,
+      protectedTraceDirs: [protectedTraceDir],
+      warn: (message) => log.warn(`[trace] ${message}`),
+    });
+  } catch (err) {
+    log.warn(`[trace] Failed to prune trace artifacts: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 function renderSummary(
   session: ObservationSession,
   events: ObservationEvent[],
-  opts: { error?: unknown; status: ObservationExportStatus; dir: string; createdAt: string },
+  opts: { error?: unknown; status: ObservationExportStatus; dir: string; createdAt: string; retentionPolicy?: TraceRetentionPolicyInput },
 ): string {
   const counts = events.reduce<Record<string, number>>((acc, event) => {
     acc[event.stream] = (acc[event.stream] ?? 0) + 1;
@@ -159,6 +183,7 @@ function renderSummary(
     `traceDir: ${yamlScalar(opts.dir)}`,
     `startedAt: ${yamlScalar(new Date(session.startedAt).toISOString())}`,
     `exportedAt: ${yamlScalar(opts.createdAt)}`,
+    `expiresAt: ${yamlScalar(traceExpiresAt(opts.createdAt, opts.retentionPolicy))}`,
     ...(error ? [
       `errorCode: ${yamlScalar(error.code ?? 'UNKNOWN')}`,
       `errorMessage: ${yamlScalar(error.message)}`,

--- a/src/observation/events.ts
+++ b/src/observation/events.ts
@@ -99,6 +99,8 @@ export interface ObservationTraceReceipt {
   receiptPath: string;
   status: ObservationExportStatus;
   createdAt: string;
+  /** Advisory only; actual deletion is governed by current trace retention budgets. */
+  expiresAt?: string;
   scope?: ObservationScope;
   error?: {
     name?: string;

--- a/src/observation/index.ts
+++ b/src/observation/index.ts
@@ -4,3 +4,4 @@ export * from './redaction.js';
 export * from './session.js';
 export * from './manager.js';
 export * from './artifact.js';
+export * from './retention.js';

--- a/src/observation/retention.test.ts
+++ b/src/observation/retention.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { parseByteSize, pruneTraceArtifacts } from './retention.js';
+
+describe('trace artifact retention', () => {
+  let tmpDir: string;
+  let tracesDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-trace-retention-'));
+    tracesDir = path.join(tmpDir, 'profiles', 'default', 'traces');
+    fs.mkdirSync(tracesDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses byte budgets with units', () => {
+    expect(parseByteSize(128)).toBe(128);
+    expect(parseByteSize('128')).toBe(128);
+    expect(parseByteSize('2KB')).toBe(2 * 1024);
+    expect(parseByteSize('1.5MB')).toBe(Math.floor(1.5 * 1024 * 1024));
+    expect(parseByteSize('1 GB')).toBe(1024 ** 3);
+    expect(() => parseByteSize('many')).toThrow('Invalid byte size');
+  });
+
+  it('prunes traces older than the age budget', () => {
+    const now = Date.parse('2026-05-03T00:00:00.000Z');
+    const old = createTraceDir('old', '2026-04-24T00:00:00.000Z');
+    const recent = createTraceDir('recent', '2026-05-02T00:00:00.000Z');
+
+    const result = pruneTraceArtifacts(tracesDir, {
+      now: () => now,
+      policy: { maxAgeDays: 7, maxCountPerProfile: 20, maxBytesPerProfile: '500MB' },
+      warn: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([old]);
+    expect(fs.existsSync(old)).toBe(false);
+    expect(fs.existsSync(recent)).toBe(true);
+  });
+
+  it('prunes oldest traces over the count budget', () => {
+    const oldest = createTraceDir('oldest', '2026-05-01T00:00:00.000Z');
+    const middle = createTraceDir('middle', '2026-05-02T00:00:00.000Z');
+    const newest = createTraceDir('newest', '2026-05-03T00:00:00.000Z');
+
+    const result = pruneTraceArtifacts(tracesDir, {
+      now: () => Date.parse('2026-05-03T12:00:00.000Z'),
+      policy: { maxAgeDays: 30, maxCountPerProfile: 2, maxBytesPerProfile: '500MB' },
+      warn: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([oldest]);
+    expect(fs.existsSync(oldest)).toBe(false);
+    expect(fs.existsSync(middle)).toBe(true);
+    expect(fs.existsSync(newest)).toBe(true);
+  });
+
+  it('prunes oldest traces over the byte budget', () => {
+    const oldest = createTraceDir('oldest', '2026-05-01T00:00:00.000Z', 512);
+    const middle = createTraceDir('middle', '2026-05-02T00:00:00.000Z', 64);
+    const newest = createTraceDir('newest', '2026-05-03T00:00:00.000Z', 64);
+    const budget = directorySize(middle) + directorySize(newest) + 1;
+
+    const result = pruneTraceArtifacts(tracesDir, {
+      now: () => Date.parse('2026-05-03T12:00:00.000Z'),
+      policy: { maxAgeDays: 30, maxCountPerProfile: 20, maxBytesPerProfile: budget },
+      warn: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([oldest]);
+    expect(fs.existsSync(oldest)).toBe(false);
+    expect(fs.existsSync(middle)).toBe(true);
+    expect(fs.existsSync(newest)).toBe(true);
+  });
+
+  it('falls back to directory mtime when receipt is missing', () => {
+    const now = Date.parse('2026-05-03T00:00:00.000Z');
+    const old = createTraceDir('old-no-receipt', undefined);
+    const recent = createTraceDir('recent', '2026-05-02T00:00:00.000Z');
+    const oldDate = new Date('2026-04-20T00:00:00.000Z');
+    fs.utimesSync(old, oldDate, oldDate);
+
+    const result = pruneTraceArtifacts(tracesDir, {
+      now: () => now,
+      policy: { maxAgeDays: 7, maxCountPerProfile: 20, maxBytesPerProfile: '500MB' },
+      warn: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([old]);
+    expect(fs.existsSync(old)).toBe(false);
+    expect(fs.existsSync(recent)).toBe(true);
+  });
+
+  it('does not delete the protected trace exported by the current run', () => {
+    const old = createTraceDir('oldest', '2026-05-01T00:00:00.000Z');
+    const current = createTraceDir('current', '2026-04-01T00:00:00.000Z', 1024);
+
+    const result = pruneTraceArtifacts(tracesDir, {
+      now: () => Date.parse('2026-05-03T12:00:00.000Z'),
+      policy: { maxAgeDays: 0, maxCountPerProfile: 0, maxBytesPerProfile: 1 },
+      protectedTraceDirs: [current],
+      warn: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([old]);
+    expect(fs.existsSync(old)).toBe(false);
+    expect(fs.existsSync(current)).toBe(true);
+  });
+
+  function createTraceDir(name: string, createdAt?: string, payloadBytes = 8): string {
+    const dir = path.join(tracesDir, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'trace.jsonl'), 'x'.repeat(payloadBytes), 'utf-8');
+    if (createdAt) {
+      fs.writeFileSync(path.join(dir, 'receipt.json'), JSON.stringify({ createdAt }, null, 2), 'utf-8');
+      const date = new Date(createdAt);
+      fs.utimesSync(dir, date, date);
+    }
+    return dir;
+  }
+});
+
+function directorySize(dir: string): number {
+  let total = 0;
+  for (const name of fs.readdirSync(dir)) {
+    const item = path.join(dir, name);
+    const stat = fs.lstatSync(item);
+    if (stat.isDirectory()) total += directorySize(item);
+    else total += stat.size;
+  }
+  return total;
+}

--- a/src/observation/retention.ts
+++ b/src/observation/retention.ts
@@ -1,0 +1,202 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { log } from '../logger.js';
+
+export interface TraceRetentionPolicyInput {
+  maxAgeDays?: number;
+  maxCountPerProfile?: number;
+  maxBytesPerProfile?: string | number;
+}
+
+export interface ResolvedTraceRetentionPolicy {
+  maxAgeDays: number;
+  maxAgeMs: number;
+  maxCountPerProfile: number;
+  maxBytesPerProfile: number;
+}
+
+export interface TraceRetentionPruneResult {
+  scanned: number;
+  deleted: string[];
+  kept: string[];
+  totalBytesBefore: number;
+  totalBytesAfter: number;
+}
+
+interface TraceEntry {
+  dir: string;
+  createdAtMs: number;
+  sizeBytes: number;
+  protected: boolean;
+}
+
+export const DEFAULT_TRACE_RETENTION_POLICY = {
+  maxAgeDays: 7,
+  maxCountPerProfile: 20,
+  maxBytesPerProfile: '500MB',
+} satisfies Required<TraceRetentionPolicyInput>;
+
+const BYTES_UNITS: Record<string, number> = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 ** 2,
+  GB: 1024 ** 3,
+};
+
+export function parseByteSize(value: string | number): number {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) throw new Error(`Invalid byte size: ${value}`);
+    return Math.floor(value);
+  }
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)?$/i);
+  if (!match) throw new Error(`Invalid byte size: ${value}`);
+  const amount = Number(match[1]);
+  const unit = (match[2] ?? 'B').toUpperCase();
+  return Math.floor(amount * BYTES_UNITS[unit]);
+}
+
+export function resolveTraceRetentionPolicy(input: TraceRetentionPolicyInput = {}): ResolvedTraceRetentionPolicy {
+  const maxAgeDays = input.maxAgeDays ?? DEFAULT_TRACE_RETENTION_POLICY.maxAgeDays;
+  const maxCountPerProfile = input.maxCountPerProfile ?? DEFAULT_TRACE_RETENTION_POLICY.maxCountPerProfile;
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays < 0) throw new Error(`Invalid trace maxAgeDays: ${maxAgeDays}`);
+  if (!Number.isInteger(maxCountPerProfile) || maxCountPerProfile < 0) {
+    throw new Error(`Invalid trace maxCountPerProfile: ${maxCountPerProfile}`);
+  }
+  return {
+    maxAgeDays,
+    maxAgeMs: maxAgeDays * 24 * 60 * 60 * 1000,
+    maxCountPerProfile,
+    maxBytesPerProfile: parseByteSize(input.maxBytesPerProfile ?? DEFAULT_TRACE_RETENTION_POLICY.maxBytesPerProfile),
+  };
+}
+
+export function traceExpiresAt(createdAt: string, policyInput: TraceRetentionPolicyInput = {}): string {
+  const policy = resolveTraceRetentionPolicy(policyInput);
+  const createdAtMs = Date.parse(createdAt);
+  const base = Number.isFinite(createdAtMs) ? createdAtMs : Date.now();
+  return new Date(base + policy.maxAgeMs).toISOString();
+}
+
+export function pruneTraceArtifacts(
+  tracesDir: string,
+  opts: {
+    policy?: TraceRetentionPolicyInput;
+    protectedTraceDirs?: string[];
+    now?: () => number;
+    warn?: (message: string) => void;
+  } = {},
+): TraceRetentionPruneResult {
+  const warn = opts.warn ?? ((message: string) => log.warn(`[trace] ${message}`));
+  const policy = resolveTraceRetentionPolicy(opts.policy);
+  const now = opts.now ?? Date.now;
+  const protectedDirs = new Set((opts.protectedTraceDirs ?? []).map((dir) => path.resolve(dir)));
+
+  const entries = readTraceEntries(tracesDir, protectedDirs, warn);
+  const totalBytesBefore = entries.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+  const deleted = new Set<string>();
+  const sorted = [...entries].sort((a, b) => a.createdAtMs - b.createdAtMs || a.dir.localeCompare(b.dir));
+  const cutoff = now() - policy.maxAgeMs;
+
+  for (const entry of sorted) {
+    if (!entry.protected && entry.createdAtMs < cutoff) deleted.add(entry.dir);
+  }
+
+  let remaining = sorted.filter((entry) => !deleted.has(entry.dir));
+  while (remaining.length > policy.maxCountPerProfile) {
+    const victim = remaining.find((entry) => !entry.protected);
+    if (!victim) break;
+    deleted.add(victim.dir);
+    remaining = remaining.filter((entry) => entry.dir !== victim.dir);
+  }
+
+  let remainingBytes = remaining.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+  while (remainingBytes > policy.maxBytesPerProfile) {
+    const victim = remaining.find((entry) => !entry.protected);
+    if (!victim) break;
+    deleted.add(victim.dir);
+    remaining = remaining.filter((entry) => entry.dir !== victim.dir);
+    remainingBytes -= victim.sizeBytes;
+  }
+
+  const deletedDirs: string[] = [];
+  for (const dir of sorted.map((entry) => entry.dir).filter((dir) => deleted.has(dir))) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+      deletedDirs.push(dir);
+    } catch (err) {
+      warn(`Failed to prune trace artifact ${dir}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const keptEntries = entries.filter((entry) => !deletedDirs.includes(entry.dir));
+  return {
+    scanned: entries.length,
+    deleted: deletedDirs,
+    kept: keptEntries.map((entry) => entry.dir),
+    totalBytesBefore,
+    totalBytesAfter: keptEntries.reduce((sum, entry) => sum + entry.sizeBytes, 0),
+  };
+}
+
+function readTraceEntries(
+  tracesDir: string,
+  protectedDirs: Set<string>,
+  warn: (message: string) => void,
+): TraceEntry[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(tracesDir);
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    warn(`Failed to list trace artifacts in ${tracesDir}: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+
+  const entries: TraceEntry[] = [];
+  for (const name of names) {
+    const dir = path.join(tracesDir, name);
+    try {
+      const stat = fs.statSync(dir);
+      if (!stat.isDirectory()) continue;
+      entries.push({
+        dir,
+        createdAtMs: readCreatedAtMs(dir, stat.mtimeMs),
+        sizeBytes: directorySize(dir),
+        protected: protectedDirs.has(path.resolve(dir)),
+      });
+    } catch (err) {
+      if (!isEnoent(err)) {
+        warn(`Failed to inspect trace artifact ${dir}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+  return entries;
+}
+
+function readCreatedAtMs(dir: string, fallbackMs: number): number {
+  try {
+    const receipt = JSON.parse(fs.readFileSync(path.join(dir, 'receipt.json'), 'utf-8')) as { createdAt?: unknown };
+    if (typeof receipt.createdAt === 'string') {
+      const parsed = Date.parse(receipt.createdAt);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  } catch {
+    // Older or hand-edited trace directories may not have a receipt.
+  }
+  return fallbackMs;
+}
+
+function directorySize(dir: string): number {
+  let total = 0;
+  for (const name of fs.readdirSync(dir)) {
+    const item = path.join(dir, name);
+    const stat = fs.lstatSync(item);
+    if (stat.isDirectory()) total += directorySize(item);
+    else total += stat.size;
+  }
+  return total;
+}
+
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === 'ENOENT';
+}


### PR DESCRIPTION
## Summary
- add trace retention policy helpers with defaults: 7 days / 20 traces / 500MB per profile
- prune the current profile trace directory after each artifact export, while protecting the just-exported trace
- add advisory `expiresAt` to receipt.json and summary front matter
- cover age, count, byte-budget, mtime fallback, protected trace, and byte parser behavior

## Tests
- `npx vitest run src/observation/*.test.ts --project unit`
- `npm run typecheck`
- `npm run build`
- `npx vitest run src/execution.test.ts src/commanderAdapter.test.ts --project unit`
- `OPENCLI_DAEMON_PORT=29125 npm test`
- `npm run docs:build`