### PR TITLE
feat(instagram): add collection-create + collection filter for saved (#1192)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8694,6 +8694,33 @@
   },
   {
     "site": "instagram",
+    "name": "collection-create",
+    "description": "Create a new Instagram saved-posts collection (folder)",
+    "domain": "www.instagram.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Name of the collection to create"
+      }
+    ],
+    "columns": [
+      "status",
+      "collectionId",
+      "collectionName",
+      "mediaCount"
+    ],
+    "type": "js",
+    "modulePath": "instagram/collection-create.js",
+    "sourceFile": "instagram/collection-create.js",
+    "navigateBefore": "https://www.instagram.com"
+  },
+  {
+    "site": "instagram",
     "name": "comment",
     "description": "Comment on an Instagram post",
     "domain": "www.instagram.com",
@@ -9078,7 +9105,7 @@
   {
     "site": "instagram",
     "name": "saved",
-    "description": "Get your saved Instagram posts",
+    "description": "Get your saved Instagram posts (optionally from a specific collection)",
     "domain": "www.instagram.com",
     "strategy": "cookie",
     "browser": true,
@@ -9089,6 +9116,12 @@
         "default": 20,
         "required": false,
         "help": "Number of saved posts"
+      },
+      {
+        "name": "collection",
+        "type": "str",
+        "required": false,
+        "help": "Collection name (case-insensitive). Omit for the default \"All posts\" feed."
       }
     ],
     "columns": [

--- a/clis/instagram/collection-create.js
+++ b/clis/instagram/collection-create.js
@@ -1,0 +1,57 @@
+import { cli } from '@jackwener/opencli/registry';
+cli({
+    site: 'instagram',
+    name: 'collection-create',
+    description: 'Create a new Instagram saved-posts collection (folder)',
+    domain: 'www.instagram.com',
+    args: [
+        {
+            name: 'name',
+            required: true,
+            positional: true,
+            help: 'Name of the collection to create',
+        },
+    ],
+    columns: ['status', 'collectionId', 'collectionName', 'mediaCount'],
+    pipeline: [
+        { navigate: 'https://www.instagram.com' },
+        { evaluate: `(async () => {
+  const name = \${{ args.name | json }};
+  if (!name || !String(name).trim()) {
+    throw new Error('Collection name cannot be empty');
+  }
+  const trimmed = String(name).trim();
+  const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
+  if (!csrf) {
+    throw new Error('csrftoken cookie missing - make sure you are logged in to Instagram');
+  }
+  const fd = new FormData();
+  fd.append('name', trimmed);
+  fd.append('module_name', 'collection_create');
+  const res = await fetch('https://www.instagram.com/api/v1/collections/create/', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'X-IG-App-ID': '936619743392459',
+      'X-CSRFToken': csrf,
+    },
+    body: fd,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error('Failed to create collection: HTTP ' + res.status + (body ? ' - ' + body.slice(0, 200) : ''));
+  }
+  const d = await res.json();
+  if (d?.status && d.status !== 'ok') {
+    throw new Error('Instagram returned non-ok status: ' + JSON.stringify(d).slice(0, 300));
+  }
+  return [{
+    status: 'Created',
+    collectionId: String(d?.collection_id ?? ''),
+    collectionName: String(d?.collection_name ?? trimmed),
+    mediaCount: d?.collection_media_count ?? 0,
+  }];
+})()
+` },
+    ],
+});

--- a/clis/instagram/saved.js
+++ b/clis/instagram/saved.js
@@ -2,23 +2,37 @@ import { cli } from '@jackwener/opencli/registry';
 cli({
     site: 'instagram',
     name: 'saved',
-    description: 'Get your saved Instagram posts',
+    description: 'Get your saved Instagram posts (optionally from a specific collection)',
     domain: 'www.instagram.com',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of saved posts' },
+        { name: 'collection', help: 'Collection name (case-insensitive). Omit for the default "All posts" feed.' },
     ],
     columns: ['index', 'user', 'caption', 'likes', 'comments', 'type'],
     pipeline: [
         { navigate: 'https://www.instagram.com' },
         { evaluate: `(async () => {
   const limit = \${{ args.limit }};
-  const res = await fetch(
-    'https://www.instagram.com/api/v1/feed/saved/posts/',
-    {
-      credentials: 'include',
-      headers: { 'X-IG-App-ID': '936619743392459' }
+  const collectionArg = \${{ args.collection | json }};
+  const headers = { 'X-IG-App-ID': '936619743392459' };
+  const opts = { credentials: 'include', headers };
+
+  let endpoint = 'https://www.instagram.com/api/v1/feed/saved/posts/';
+  if (collectionArg && String(collectionArg).trim()) {
+    const wanted = String(collectionArg).trim().toLowerCase();
+    const listRes = await fetch('https://www.instagram.com/api/v1/collections/list/?collection_types=%5B%22MEDIA%22%2C%22ALL_MEDIA_AUTO_COLLECTION%22%5D', opts);
+    if (!listRes.ok) throw new Error('Failed to list collections: HTTP ' + listRes.status + ' - make sure you are logged in to Instagram');
+    const listData = await listRes.json();
+    const collections = listData?.items || [];
+    const match = collections.find((c) => String(c?.collection_name || '').trim().toLowerCase() === wanted);
+    if (!match) {
+      const names = collections.map((c) => c?.collection_name).filter(Boolean);
+      throw new Error('Collection not found: ' + collectionArg + '. Available: ' + (names.length ? names.join(', ') : '(none)'));
     }
-  );
+    endpoint = 'https://www.instagram.com/api/v1/feed/collection/' + encodeURIComponent(match.collection_id) + '/posts/';
+  }
+
+  const res = await fetch(endpoint, opts);
   if (!res.ok) throw new Error('HTTP ' + res.status + ' - make sure you are logged in to Instagram');
   const data = await res.json();
   return (data?.items || []).slice(0, limit).map((item, i) => {

--- a/docs/adapters/browser/instagram.md
+++ b/docs/adapters/browser/instagram.md
@@ -12,7 +12,8 @@
 | `opencli instagram explore` | Discover trending posts |
 | `opencli instagram followers` | List user's followers |
 | `opencli instagram following` | List user's following |
-| `opencli instagram saved` | Get your saved posts |
+| `opencli instagram saved` | Get your saved posts (or one collection) |
+| `opencli instagram collection-create` | Create a new saved-posts collection |
 
 ## Usage Examples
 
@@ -33,12 +34,25 @@ opencli instagram explore --limit 20
 opencli instagram followers nasa --limit 20
 opencli instagram following nasa --limit 20
 
-# Get your saved posts
+# Get your saved posts (default "All posts" feed)
 opencli instagram saved --limit 10
+
+# Get posts from a specific collection (case-insensitive name match)
+opencli instagram saved --collection inspiration --limit 10
+
+# Create a new saved-posts collection
+opencli instagram collection-create "design refs"
 
 # JSON output
 opencli instagram profile nasa -f json
 ```
+
+### Notes on collections
+
+- `instagram saved` without `--collection` returns the unsegmented "All posts" bucket (same as the original behaviour).
+- With `--collection <name>` it resolves the name to an id via `/api/v1/collections/list/`, then fetches `/api/v1/feed/collection/{id}/posts/`. Match is case-insensitive after trimming. An unknown name throws an error that lists the available names.
+- `instagram collection-create <name>` calls `POST /api/v1/collections/create/` with a multipart `name` field. Instagram silently accepts duplicate names — the API just returns a new `collection_id` each time, so dedupe client-side if you care.
+- Saving an existing post directly into a named collection in one shot is not exposed by the web app's documented endpoints (`/api/v1/web/save/{pk}/save/` only writes to "All posts"). Use `instagram save` first, then move the post in the UI, or extend with the `/api/v1/collections/{id}/edit/` mutation.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Closes #1192. The reporter asked for `instagram saved` to support specific collections instead of dumping the unsegmented "All posts" feed. Two changes:

- **New `instagram collection-create <name>`** adapter wraps `POST /api/v1/collections/create/`. Multipart body (`name` + `module_name=collection_create`), X-IG-App-ID + X-CSRFToken from cookie. Returns one row: `{status, collectionId, collectionName, mediaCount}`.
- **`instagram saved` gains `--collection <name>`** (optional). When set, the adapter calls `/api/v1/collections/list/?collection_types=["MEDIA","ALL_MEDIA_AUTO_COLLECTION"]`, case-insensitive trim-matches the name against `collection_name`, then fetches `/api/v1/feed/collection/{id}/posts/`. Item shape is the same as the existing saved feed so the row mapping is unchanged. Unknown collection name throws an error that lists available names so callers can self-correct.

Out of scope: saving an existing post directly into a named collection in one shot. The web app does this with a separate `/api/v1/collections/{id}/edit/` mutation; left for a follow-up if anyone wants it.

## Verify status

Both adapters were exercised end-to-end against a real Instagram account (cookie-based) and both pass `opencli browser verify` with hand-tuned fixtures that include `patterns`, `notEmpty`, `mustBeTruthy`, and `mustNotContain` guards (per `success-rate-pitfalls.md` §1 / §4 / §8). Fixtures live under `~/.opencli/sites/instagram/verify/{collection-create,saved}.json` (per-user; not in repo by design).

```
✓ Adapter matches fixture (~/.opencli/sites/instagram/verify/collection-create.json)
✓ Adapter matches fixture (~/.opencli/sites/instagram/verify/saved.json)
```

`opencli browser analyze` confirms the path: pattern A (cookie REST), no anti-bot vendor, 20 sibling adapters under `clis/instagram/`.

## Known sharp edge

`POST /api/v1/collections/create/` accepts duplicate names — Instagram returns a fresh `collection_id` per call. Adapter does not dedupe; document this so a no-op double-call does not silently duplicate.

## Test plan

- [x] `opencli instagram collection-create "<name>"` creates a collection and returns its id
- [x] `opencli instagram saved` with no args returns the existing "All posts" feed (no behaviour regression)
- [x] `opencli instagram saved --collection <name>` returns the named collection's feed
- [x] `opencli instagram saved --collection unknown-name` errors with the available-names list
- [x] `opencli browser verify instagram/{collection-create,saved}` both ✓
- [x] `npx vitest run src/build-manifest.test.ts` passes
- [ ] CI green