### PR TITLE
feat(daemon): surface stale versions and restart

### DIFF
--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -2,10 +2,7 @@
  * Browser session manager — auto-spawns daemon and provides IPage.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
+import type { ChildProcess } from 'node:child_process';
 import type { IPage } from '../types.js';
 import type { IBrowserFactory } from '../runtime.js';
 import { Page } from './page.js';
@@ -14,6 +11,7 @@ import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import { BrowserConnectError } from '../errors.js';
 import { PKG_VERSION } from '../version.js';
 import { resolveProfileContextId } from './profile.js';
+import { resolveDaemonLaunchSpec, spawnDaemonProcess, waitForDaemonStop } from './daemon-lifecycle.js';
 
 const DAEMON_SPAWN_TIMEOUT = 10000; // 10s to wait for daemon + extension
 
@@ -102,7 +100,7 @@ export class BrowserBridge implements IBrowserFactory {
           process.stderr.write(`⚠️  Stale daemon detected (${reason}). Restarting...\n`);
         }
         const shutdownAccepted = await requestDaemonShutdown();
-        const portReleased = shutdownAccepted && await this._waitForDaemonStop(3000);
+        const portReleased = shutdownAccepted && await waitForDaemonStop(3000);
 
         if (!portReleased) {
           // Stale daemon replacement failed — don't blindly spawn on an occupied port
@@ -151,27 +149,11 @@ export class BrowserBridge implements IBrowserFactory {
     }
 
     // No daemon — spawn one
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const parentDir = path.resolve(__dirname, '..');
-    const daemonTs = path.join(parentDir, 'daemon.ts');
-    const daemonJs = path.join(parentDir, 'daemon.js');
-    const isTs = fs.existsSync(daemonTs);
-    const daemonPath = isTs ? daemonTs : daemonJs;
-
     if (process.env.OPENCLI_VERBOSE || process.stderr.isTTY) {
       process.stderr.write('⏳ Starting daemon...\n');
     }
 
-    const spawnArgs = isTs
-      ? [process.execPath, '--import', 'tsx/esm', daemonPath]
-      : [process.execPath, daemonPath];
-
-    this._daemonProc = spawn(spawnArgs[0], spawnArgs.slice(1), {
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env },
-    });
-    this._daemonProc.unref();
+    this._daemonProc = spawnDaemonProcess();
 
     // Wait for daemon + extension
     if (await this._pollUntilReady(timeoutMs, contextId)) return;
@@ -207,20 +189,9 @@ export class BrowserBridge implements IBrowserFactory {
 
     throw new BrowserConnectError(
       'Failed to start opencli daemon',
-      `Try running manually:\n  node ${daemonPath}\nMake sure port ${DEFAULT_DAEMON_PORT} is available.`,
+      `Try running manually:\n  node ${resolveDaemonLaunchSpec().scriptPath}\nMake sure port ${DEFAULT_DAEMON_PORT} is available.`,
       'daemon-not-running',
     );
-  }
-
-  /** Poll until daemon is fully stopped (port released). */
-  private async _waitForDaemonStop(timeoutMs: number): Promise<boolean> {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      await new Promise(resolve => setTimeout(resolve, 200));
-      const h = await getDaemonHealth();
-      if (h.state === 'stopped') return true;
-    }
-    return false;
   }
 
   /** Poll getDaemonHealth() until state is 'ready' or deadline is reached. */

--- a/src/browser/daemon-lifecycle.ts
+++ b/src/browser/daemon-lifecycle.ts
@@ -1,0 +1,86 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { DEFAULT_DAEMON_PORT } from '../constants.js';
+import { fetchDaemonStatus, getDaemonHealth, requestDaemonShutdown, type DaemonStatus } from './daemon-client.js';
+
+export interface DaemonLaunchSpec {
+  binary: string;
+  args: string[];
+  scriptPath: string;
+}
+
+export interface DaemonRestartResult {
+  previousStatus: DaemonStatus | null;
+  status: DaemonStatus | null;
+  stopped: boolean;
+  spawned: boolean;
+}
+
+export function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const parentDir = path.resolve(__dirname, '..');
+  const daemonTs = path.join(parentDir, 'daemon.ts');
+  const daemonJs = path.join(parentDir, 'daemon.js');
+  const isTs = fs.existsSync(daemonTs);
+  const scriptPath = isTs ? daemonTs : daemonJs;
+  return {
+    binary: process.execPath,
+    args: isTs ? ['--import', 'tsx/esm', scriptPath] : [scriptPath],
+    scriptPath,
+  };
+}
+
+export function spawnDaemonProcess(): ChildProcess {
+  const launch = resolveDaemonLaunchSpec();
+  const proc = spawn(launch.binary, launch.args, {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  });
+  proc.unref();
+  return proc;
+}
+
+export async function waitForDaemonStop(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await sleep(200);
+    const h = await getDaemonHealth();
+    if (h.state === 'stopped') return true;
+  }
+  return false;
+}
+
+export async function waitForDaemonStatus(timeoutMs: number): Promise<DaemonStatus | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = await fetchDaemonStatus({ timeout: Math.min(1000, Math.max(100, deadline - Date.now())) });
+    if (status) return status;
+    await sleep(200);
+  }
+  return null;
+}
+
+export async function restartDaemon(opts: { stopTimeoutMs?: number; startTimeoutMs?: number } = {}): Promise<DaemonRestartResult> {
+  const previousStatus = await fetchDaemonStatus();
+  let stopped = previousStatus === null;
+  if (previousStatus) {
+    const shutdownAccepted = await requestDaemonShutdown();
+    stopped = shutdownAccepted && await waitForDaemonStop(opts.stopTimeoutMs ?? 3000);
+    if (!stopped) {
+      return { previousStatus, status: previousStatus, stopped: false, spawned: false };
+    }
+  }
+
+  spawnDaemonProcess();
+  const status = await waitForDaemonStatus(opts.startTimeoutMs ?? 5000);
+  return { previousStatus, status, stopped, spawned: true };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export { DEFAULT_DAEMON_PORT };

--- a/src/browser/daemon-version.ts
+++ b/src/browser/daemon-version.ts
@@ -1,0 +1,15 @@
+import type { DaemonStatus } from './daemon-client.js';
+
+export function isDaemonStale(status: Pick<DaemonStatus, 'daemonVersion'> | null | undefined, cliVersion?: string): boolean {
+  if (!status || !cliVersion) return false;
+  return !status.daemonVersion || status.daemonVersion !== cliVersion;
+}
+
+export function formatDaemonVersion(status: Pick<DaemonStatus, 'daemonVersion'> | null | undefined): string {
+  return status?.daemonVersion ? `v${status.daemonVersion}` : 'version unknown';
+}
+
+export function staleDaemonIssue(status: Pick<DaemonStatus, 'daemonVersion'> | null | undefined, cliVersion: string): string {
+  return `Stale daemon detected: daemon ${formatDaemonVersion(status)} != CLI v${cliVersion}.\n` +
+    '  Run: opencli daemon restart';
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { BrowserCommandError } from './browser/daemon-client.js';
 import type { IPage } from './types.js';
 import { TargetError } from './browser/target-errors.js';
+import { PKG_VERSION } from './version.js';
 
 const {
   mockBrowserConnect,
@@ -128,6 +129,65 @@ describe('selectFreshByTimestamp', () => {
     ], first.lastSeenTs);
     expect(rolled.fresh.map((item) => item.text)).toEqual(['c']);
     expect(rolled.lastSeenTs).toBe(3);
+  });
+});
+
+describe('profile list', () => {
+  const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    stdoutSpy.mockClear();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('reports stale daemon instead of no profiles when status lacks profile support', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        pid: 123,
+        uptime: 1,
+        daemonVersion: '1.7.6',
+        extensionConnected: true,
+        extensionVersion: '1.0.3',
+        pending: 0,
+        memoryMB: 20,
+        port: 19825,
+      }),
+    } as Response);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'profile', 'list']);
+
+    const output = stdoutSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('stale');
+    expect(output).toContain('opencli daemon restart');
+    expect(output).not.toContain('No Browser Bridge profiles connected');
+  });
+
+  it('keeps the empty profile message for current daemon status with no profiles', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        pid: 123,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        extensionConnected: false,
+        profiles: [],
+        pending: 0,
+        memoryMB: 20,
+        port: 19825,
+      }),
+    } as Response);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'profile', 'list']);
+
+    const output = stdoutSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('No Browser Bridge profiles connected');
+    expect(output).not.toContain('opencli daemon restart');
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,10 +30,11 @@ import { parseFilter, shapeMatchesFilter } from './browser/shape-filter.js';
 import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
-import { daemonStatus, daemonStop } from './commands/daemon.js';
+import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
+import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -2392,6 +2393,11 @@ cli({
         console.log(styleText('yellow', 'Daemon is not running. Run opencli doctor after opening Chrome.'));
         return;
       }
+      if (isDaemonStale(status, PKG_VERSION) || !Array.isArray(status.profiles)) {
+        console.log(styleText('yellow', `Daemon ${formatDaemonVersion(status)} is stale for CLI v${PKG_VERSION}.`));
+        console.log(styleText('dim', 'Run: opencli daemon restart'));
+        return;
+      }
       if (profiles.length === 0) {
         console.log(styleText('yellow', 'No Browser Bridge profiles connected.'));
         console.log(styleText('dim', 'Open a Chrome profile with the OpenCLI extension installed, then run opencli profile list again.'));
@@ -2464,6 +2470,10 @@ cli({
     .command('stop')
     .description('Stop the daemon')
     .action(async () => { await daemonStop(); });
+  daemonCmd
+    .command('restart')
+    .description('Restart the daemon')
+    .action(async () => { await daemonRestart(); });
 
   // ── External CLIs ─────────────────────────────────────────────────────────
 

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   fetchDaemonStatusMock,
   requestDaemonShutdownMock,
+  restartDaemonMock,
 } = vi.hoisted(() => ({
   fetchDaemonStatusMock: vi.fn(),
   requestDaemonShutdownMock: vi.fn(),
+  restartDaemonMock: vi.fn(),
 }));
 
 vi.mock('../browser/daemon-client.js', () => ({
@@ -13,7 +15,12 @@ vi.mock('../browser/daemon-client.js', () => ({
   requestDaemonShutdown: requestDaemonShutdownMock,
 }));
 
-import { daemonStatus, daemonStop } from './daemon.js';
+vi.mock('../browser/daemon-lifecycle.js', () => ({
+  restartDaemon: restartDaemonMock,
+}));
+
+import { daemonRestart, daemonStatus, daemonStop } from './daemon.js';
+import { PKG_VERSION } from '../version.js';
 
 describe('daemonStatus', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
@@ -41,6 +48,7 @@ describe('daemonStatus', () => {
       ok: true,
       pid: 12345,
       uptime: 3661,
+      daemonVersion: PKG_VERSION,
       extensionConnected: true,
       extensionVersion: '1.6.8',
       pending: 0,
@@ -52,6 +60,7 @@ describe('daemonStatus', () => {
 
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('running'));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('PID 12345'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`v${PKG_VERSION}`));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1h 1m'));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('connected'));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('v1.6.8'));
@@ -64,6 +73,7 @@ describe('daemonStatus', () => {
       ok: true,
       pid: 99,
       uptime: 120,
+      daemonVersion: PKG_VERSION,
       extensionConnected: false,
       pending: 0,
       memoryMB: 32,
@@ -80,6 +90,7 @@ describe('daemonStatus', () => {
       ok: true,
       pid: 99,
       uptime: 120,
+      daemonVersion: PKG_VERSION,
       extensionConnected: true,
       extensionVersion: undefined,
       pending: 0,
@@ -119,6 +130,7 @@ describe('daemonStop', () => {
       ok: true,
       pid: 12345,
       uptime: 100,
+      daemonVersion: PKG_VERSION,
       extensionConnected: true,
       pending: 0,
       memoryMB: 50,
@@ -137,6 +149,7 @@ describe('daemonStop', () => {
       ok: true,
       pid: 12345,
       uptime: 100,
+      daemonVersion: PKG_VERSION,
       extensionConnected: true,
       pending: 0,
       memoryMB: 50,
@@ -147,5 +160,107 @@ describe('daemonStop', () => {
     await daemonStop();
 
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to stop daemon'));
+  });
+});
+
+describe('daemonRestart', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    fetchDaemonStatusMock.mockReset();
+    requestDaemonShutdownMock.mockReset();
+    restartDaemonMock.mockReset();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it('restarts a running daemon and reports the new version', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 12345,
+      uptime: 100,
+      daemonVersion: '1.7.6',
+      extensionConnected: true,
+      profiles: [{ contextId: 'work', extensionConnected: true, pending: 0 }],
+      pending: 0,
+      memoryMB: 50,
+      port: 19825,
+    });
+    restartDaemonMock.mockResolvedValue({
+      previousStatus: { daemonVersion: '1.7.6' },
+      stopped: true,
+      spawned: true,
+      status: {
+        ok: true,
+        pid: 12346,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        extensionConnected: true,
+        profiles: [{ contextId: 'work', extensionConnected: true, pending: 0 }],
+        pending: 0,
+        memoryMB: 51,
+        port: 19825,
+      },
+    });
+
+    await daemonRestart();
+
+    expect(restartDaemonMock).toHaveBeenCalledTimes(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('will disconnect 1 browser profile'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`Daemon restarted on port 19825 (v${PKG_VERSION})`));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Extension connected; profiles connected: 1'));
+  });
+
+  it('starts a new daemon when none was running', async () => {
+    fetchDaemonStatusMock.mockResolvedValue(null);
+    restartDaemonMock.mockResolvedValue({
+      previousStatus: null,
+      stopped: true,
+      spawned: true,
+      status: {
+        ok: true,
+        pid: 12346,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        extensionConnected: false,
+        pending: 0,
+        memoryMB: 51,
+        port: 19825,
+      },
+    });
+
+    await daemonRestart();
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`Daemon started on port 19825 (v${PKG_VERSION})`));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('extension has not connected yet'));
+  });
+
+  it('reports failure when the daemon cannot stop', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 12345,
+      uptime: 100,
+      daemonVersion: '1.7.6',
+      extensionConnected: true,
+      pending: 0,
+      memoryMB: 50,
+      port: 19825,
+    });
+    restartDaemonMock.mockResolvedValue({
+      previousStatus: { daemonVersion: '1.7.6' },
+      status: { daemonVersion: '1.7.6' },
+      stopped: false,
+      spawned: false,
+    });
+
+    await daemonRestart();
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to stop daemon before restart'));
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -2,12 +2,16 @@
  * CLI commands for daemon lifecycle:
  *   opencli daemon status — show daemon state
  *   opencli daemon stop   — graceful shutdown
+ *   opencli daemon restart — graceful shutdown, then start a fresh daemon
  */
 
 import { styleText } from 'node:util';
 import { fetchDaemonStatus, requestDaemonShutdown } from '../browser/daemon-client.js';
+import { restartDaemon } from '../browser/daemon-lifecycle.js';
 import { formatDuration } from '../download/progress.js';
 import { log } from '../logger.js';
+import { PKG_VERSION } from '../version.js';
+import { formatDaemonVersion, isDaemonStale } from '../browser/daemon-version.js';
 
 export async function daemonStatus(): Promise<void> {
   const status = await fetchDaemonStatus();
@@ -22,7 +26,10 @@ export async function daemonStatus(): Promise<void> {
       ? `${styleText('green', 'connected')} ${styleText('dim', `(v${status.extensionVersion})`)}`
       : `${styleText('yellow', 'connected')} ${styleText('dim', '(version unknown)')}`;
 
-  console.log(`Daemon: ${styleText('green', 'running')} (PID ${status.pid})`);
+  const daemonVersion = formatDaemonVersion(status);
+  const stale = isDaemonStale(status, PKG_VERSION);
+  console.log(`Daemon: ${stale ? styleText('yellow', 'stale') : styleText('green', 'running')} (PID ${status.pid})`);
+  console.log(`Version: ${daemonVersion}${stale ? styleText('yellow', ` (CLI v${PKG_VERSION}; run: opencli daemon restart)`) : ''}`);
   console.log(`Uptime: ${formatDuration(Math.round(status.uptime * 1000))}`);
   console.log(`Extension: ${extensionLabel}`);
   if (status.profiles && status.profiles.length > 0) {
@@ -48,5 +55,35 @@ export async function daemonStop(): Promise<void> {
   } else {
     log.error('Failed to stop daemon.');
     process.exitCode = 1;
+  }
+}
+
+export async function daemonRestart(): Promise<void> {
+  const before = await fetchDaemonStatus();
+  if (before?.profiles && before.profiles.length > 0) {
+    log.warn(`Restarting daemon will disconnect ${before.profiles.length} browser profile(s); the extension should reconnect automatically.`);
+  }
+
+  const result = await restartDaemon();
+  if (!result.stopped) {
+    log.error('Failed to stop daemon before restart.');
+    process.exitCode = 1;
+    return;
+  }
+  if (!result.status) {
+    log.error('Daemon restart timed out before the new daemon reported status.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const action = result.previousStatus ? 'restarted' : 'started';
+  const version = formatDaemonVersion(result.status);
+  log.success(`Daemon ${action} on port ${result.status.port} (${version}).`);
+  if (result.status.extensionConnected) {
+    const profiles = result.status.profiles?.length ?? 0;
+    const profileText = profiles > 0 ? `; profiles connected: ${profiles}` : '';
+    log.status(`Extension connected${profileText}.`);
+  } else {
+    log.warn('Daemon is running, but the Browser Bridge extension has not connected yet.');
   }
 }

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -30,15 +30,34 @@ describe('doctor report rendering', () => {
 
   it('renders OK-style report when daemon and extension connected', () => {
     const text = strip(renderBrowserDoctorReport({
+      cliVersion: '1.7.9',
       daemonRunning: true,
+      daemonVersion: '1.7.9',
       extensionConnected: true,
       extensionVersion: '1.6.8',
       issues: [],
     }));
 
     expect(text).toContain('[OK] Daemon: running on port 19825');
+    expect(text).toContain('(v1.7.9)');
     expect(text).toContain('[OK] Extension: connected (v1.6.8)');
     expect(text).toContain('Everything looks good!');
+  });
+
+  it('renders a warning when daemon version is stale', () => {
+    const text = strip(renderBrowserDoctorReport({
+      cliVersion: '1.7.9',
+      daemonRunning: true,
+      daemonVersion: '1.7.6',
+      daemonStale: true,
+      extensionConnected: true,
+      extensionVersion: '1.0.3',
+      issues: ['Stale daemon detected: daemon v1.7.6 != CLI v1.7.9.\n  Run: opencli daemon restart'],
+    }));
+
+    expect(text).toContain('[WARN] Daemon: running on port 19825 (v1.7.6, stale; CLI v1.7.9)');
+    expect(text).toContain('Run: opencli daemon restart');
+    expect(text).not.toContain('Everything looks good!');
   });
 
   it('renders MISSING when daemon not running', () => {
@@ -280,6 +299,27 @@ describe('doctor report rendering', () => {
 
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('did not report a version'),
+    ]));
+  });
+
+  it('reports an issue when daemon version differs from CLI version', async () => {
+    const status = {
+      state: 'ready' as const,
+      status: {
+        daemonVersion: '1.7.6',
+        extensionConnected: true,
+        extensionVersion: '1.0.3',
+      },
+    };
+    mockGetDaemonHealth
+      .mockResolvedValueOnce(status)
+      .mockResolvedValueOnce(status);
+
+    const report = await runBrowserDoctor({ live: false, cliVersion: '1.7.9' });
+
+    expect(report.daemonStale).toBe(true);
+    expect(report.issues).toEqual(expect.arrayContaining([
+      expect.stringContaining('Stale daemon detected: daemon v1.7.6 != CLI v1.7.9'),
     ]));
   });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -14,6 +14,7 @@ import { getCachedLatestExtensionVersion } from './update-check.js';
 import type { BrowserSessionInfo } from './types.js';
 import type { BrowserProfileStatus } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
+import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
 
@@ -63,6 +64,7 @@ export type DoctorReport = {
   cliVersion?: string;
   daemonRunning: boolean;
   daemonFlaky?: boolean;
+  daemonStale?: boolean;
   daemonVersion?: string;
   extensionConnected: boolean;
   extensionFlaky?: boolean;
@@ -121,6 +123,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const extensionConnected = health.state === 'ready';
   const daemonFlaky = !!(connectivity?.ok && !daemonRunning);
   const extensionFlaky = !!(connectivity?.ok && daemonRunning && !extensionConnected);
+  const daemonStale = isDaemonStale(health.status, opts.cliVersion);
   const profiles = health.status?.profiles;
   let sessions: BrowserSessionInfo[] | undefined;
   if (opts.sessions) {
@@ -145,6 +148,9 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   } else if (!daemonRunning) {
     issues.push('Daemon is not running. It should start automatically when you run an opencli browser command.');
   }
+  if (daemonStale && opts.cliVersion) {
+    issues.push(staleDaemonIssue(health.status, opts.cliVersion));
+  }
   if (extensionFlaky) {
     issues.push(
       'Extension connection is unstable. The live browser test succeeded, but the daemon reported the extension disconnected immediately afterward.\n' +
@@ -162,27 +168,14 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
         '  Open that Chrome profile and make sure the OpenCLI extension is enabled.',
       );
     } else {
-    const daemonVersion = health.status?.daemonVersion;
-    const isStale = opts.cliVersion && (!daemonVersion || daemonVersion !== opts.cliVersion);
-    if (isStale) {
-      const reason = daemonVersion
-        ? `daemon v${daemonVersion} ≠ CLI v${opts.cliVersion}`
-        : `daemon predates version reporting, CLI is v${opts.cliVersion}`;
-      issues.push(
-        `Stale daemon detected: ${reason}.\n` +
-        'The daemon was started by an older CLI version and may have missed the extension registration.\n' +
-        '  Quick fix: opencli daemon stop && opencli doctor',
-      );
-    } else {
       issues.push(
         'Daemon is running but the Chrome/Chromium extension is not connected.\n' +
-        'If the extension is already installed, try: opencli daemon stop && opencli doctor\n' +
+        'If the extension is already installed, try: opencli daemon restart\n' +
         'If the extension is not installed:\n' +
         '  1. Download from https://github.com/jackwener/opencli/releases\n' +
         '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
         '  3. Click "Load unpacked" → select the extension folder',
       );
-    }
     }
   }
   if (extensionConnected && !extensionVersion) {
@@ -229,6 +222,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     cliVersion: opts.cliVersion,
     daemonRunning,
     daemonFlaky,
+    daemonStale,
     daemonVersion: health.status?.daemonVersion,
     extensionConnected,
     extensionFlaky,
@@ -247,10 +241,16 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
   // Daemon status
   const daemonIcon = report.daemonFlaky
     ? styleText('yellow', '[WARN]')
-    : report.daemonRunning ? styleText('green', '[OK]') : styleText('red', '[MISSING]');
+    : report.daemonStale
+      ? styleText('yellow', '[WARN]')
+      : report.daemonRunning ? styleText('green', '[OK]') : styleText('red', '[MISSING]');
   const daemonLabel = report.daemonFlaky
     ? 'unstable (running during live check, then stopped)'
-    : report.daemonRunning ? `running on port ${DEFAULT_DAEMON_PORT}` + (report.daemonVersion ? ` (v${report.daemonVersion})` : '') : 'not running';
+    : report.daemonRunning
+      ? `running on port ${DEFAULT_DAEMON_PORT} (${report.daemonStale
+        ? `${formatDaemonVersion(report)}, stale; CLI v${report.cliVersion ?? 'unknown'}`
+        : formatDaemonVersion(report)})`
+      : 'not running';
   lines.push(`${daemonIcon} Daemon: ${daemonLabel}`);
 
   // Extension status


### PR DESCRIPTION
## Summary
- add shared daemon stale-version helpers and lifecycle restart utilities
- add `opencli daemon restart` for explicit stop/start with status feedback
- make `opencli doctor` print daemon version and warn when daemon version is missing or differs from CLI
- make `opencli profile list` detect stale/old daemon protocol instead of misleadingly saying no profiles are connected
- reuse daemon spawn/stop helpers from BrowserBridge without changing the connected-daemon auto-restart behavior

## Scope notes
- does not add profile rename UI/hints
- does not add extension identity/email permissions
- does not auto-kill a connected daemon from ordinary BrowserBridge commands

## Tests
- `npx vitest run src/commands/daemon.test.ts src/doctor.test.ts src/cli.test.ts --project unit`
- `npm run typecheck`
- `npm run build`
- `npm run docs:build`
- `OPENCLI_DAEMON_PORT=29125 npm test`