### PR TITLE
feat(extension): polish popup UI — merged card, copy contextId, version surfacing

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -896,16 +896,35 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "getStatus") {
     void (async () => {
       const contextId = await getCurrentContextId();
+      const connected = ws?.readyState === WebSocket.OPEN;
+      const extensionVersion = chrome.runtime.getManifest().version;
+      const daemonVersion = connected ? await fetchDaemonVersion() : null;
       sendResponse({
-        connected: ws?.readyState === WebSocket.OPEN,
+        connected,
         reconnecting: reconnectTimer !== null,
-        contextId
+        contextId,
+        extensionVersion,
+        daemonVersion
       });
     })();
     return true;
   }
   return false;
 });
+async function fetchDaemonVersion() {
+  try {
+    const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/status`, {
+      method: "GET",
+      headers: { "X-OpenCLI": "1" },
+      signal: AbortSignal.timeout(1500)
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    return typeof body.daemonVersion === "string" ? body.daemonVersion : null;
+  } catch {
+    return null;
+  }
+}
 async function handleCommand(cmd) {
   const workspace = getWorkspaceKey(cmd.workspace);
   windowFocused = cmd.windowFocused === true;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -5,29 +5,41 @@
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      width: 280px;
+      width: 300px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       font-size: 13px;
-      color: #333;
+      color: #1d1d1f;
       background: #fff;
-      padding: 16px;
+      padding: 14px;
     }
     .header {
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 14px;
+      margin-bottom: 12px;
     }
-    .header img { width: 24px; height: 24px; }
-    .header h1 { font-size: 15px; font-weight: 600; }
-    .status-row {
+    .header img { width: 22px; height: 22px; }
+    .header h1 { font-size: 14px; font-weight: 600; flex: 1; }
+    .header .version-tag {
+      font-size: 11px;
+      color: #86868b;
+      font-variant-numeric: tabular-nums;
+    }
+    .card {
+      border: 1px solid #ececec;
+      border-radius: 10px;
+      overflow: hidden;
+    }
+    .card .status-row {
       display: flex;
       align-items: center;
       gap: 8px;
-      padding: 10px 12px;
-      border-radius: 8px;
-      background: #f5f5f5;
+      padding: 11px 12px;
+      background: #fafafa;
     }
+    .card.connected .status-row { border-left: 3px solid #34c759; padding-left: 9px; }
+    .card.disconnected .status-row { border-left: 3px solid #ff3b30; padding-left: 9px; }
+    .card.connecting .status-row { border-left: 3px solid #ff9500; padding-left: 9px; }
     .dot {
       width: 8px; height: 8px;
       border-radius: 50%;
@@ -36,50 +48,73 @@
     .dot.connected { background: #34c759; }
     .dot.disconnected { background: #ff3b30; }
     .dot.connecting { background: #ff9500; }
-    .status-text { font-size: 13px; color: #555; }
-    .status-text strong { color: #333; }
+    .status-text {
+      font-size: 13px;
+      font-weight: 600;
+      color: #1d1d1f;
+      flex: 1;
+    }
+    .daemon-version {
+      font-size: 11px;
+      color: #86868b;
+      font-variant-numeric: tabular-nums;
+    }
     .profile-row {
-      margin-top: 10px;
-      padding: 9px 10px;
-      border-radius: 8px;
-      background: #fafafa;
-      border: 1px solid #ececec;
-      color: #666;
-      font-size: 11px;
-      line-height: 1.5;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border-top: 1px solid #ececec;
+      background: #fff;
     }
-    .profile-row code {
-      display: block;
-      margin-top: 2px;
-      padding: 3px 5px;
-      border-radius: 4px;
-      background: #f0f0f0;
-      color: #333;
+    .profile-label {
+      font-size: 11px;
+      color: #86868b;
+      flex-shrink: 0;
+    }
+    .profile-id {
+      flex: 1;
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      word-break: break-all;
+      font-size: 12px;
+      color: #1d1d1f;
       user-select: all;
+      word-break: break-all;
     }
-    .hint {
-      margin-top: 10px;
-      padding: 8px 10px;
-      border-radius: 6px;
-      background: #f0f4ff;
+    .copy-btn {
+      flex-shrink: 0;
+      padding: 4px 9px;
       font-size: 11px;
-      color: #666;
+      font-family: inherit;
+      color: #007aff;
+      background: transparent;
+      border: 1px solid #d2d2d7;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background 0.12s, color 0.12s;
+    }
+    .copy-btn:hover { background: #f0f6ff; }
+    .copy-btn:active { background: #e1edff; }
+    .copy-btn.copied { color: #34c759; border-color: #34c759; background: #f0fdf4; }
+    .hint {
+      padding: 10px 12px;
+      border-top: 1px solid #ececec;
+      background: #f9fafc;
+      font-size: 11px;
+      color: #6e6e73;
       line-height: 1.5;
-      display: none;
     }
     .hint code {
-      background: #e8ecf1;
-      padding: 1px 4px;
+      background: #ececec;
+      padding: 1px 5px;
       border-radius: 3px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       font-size: 11px;
     }
     .footer {
-      margin-top: 14px;
+      margin-top: 12px;
       text-align: center;
       font-size: 11px;
-      color: #999;
+      color: #86868b;
     }
     .footer a { color: #007aff; text-decoration: none; }
     .footer a:hover { text-decoration: underline; }
@@ -89,17 +124,22 @@
   <div class="header">
     <img src="icons/icon-48.png" alt="OpenCLI">
     <h1>OpenCLI</h1>
+    <span class="version-tag" id="extVersion"></span>
   </div>
-  <div class="status-row">
-    <span class="dot disconnected" id="dot"></span>
-    <span class="status-text" id="status">Checking...</span>
-  </div>
-  <div class="profile-row" id="profile" style="display: none;">
-    Chrome profile contextId
-    <code id="contextId"></code>
-  </div>
-  <div class="hint" id="hint">
-    This is normal. The extension connects automatically when you run any <code>opencli</code> command.
+  <div class="card disconnected" id="card">
+    <div class="status-row">
+      <span class="dot disconnected" id="dot"></span>
+      <span class="status-text" id="status">Checking...</span>
+      <span class="daemon-version" id="daemonVersion"></span>
+    </div>
+    <div class="profile-row" id="profileRow" style="display: none;">
+      <span class="profile-label">Profile</span>
+      <span class="profile-id" id="contextId"></span>
+      <button type="button" class="copy-btn" id="copyBtn" title="Copy contextId">Copy</button>
+    </div>
+    <div class="hint" id="hint" style="display: none;">
+      The extension connects automatically when you run any <code>opencli</code> command.
+    </div>
   </div>
   <div class="footer">
     <a href="https://github.com/jackwener/opencli" target="_blank">Documentation</a>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,34 +1,77 @@
 // Query connection status from background service worker
 chrome.runtime.sendMessage({ type: 'getStatus' }, (resp) => {
+  const card = document.getElementById('card');
   const dot = document.getElementById('dot');
   const status = document.getElementById('status');
-  const hint = document.getElementById('hint');
-  const profile = document.getElementById('profile');
+  const daemonVersion = document.getElementById('daemonVersion');
+  const profileRow = document.getElementById('profileRow');
   const contextId = document.getElementById('contextId');
+  const copyBtn = document.getElementById('copyBtn');
+  const hint = document.getElementById('hint');
+  const extVersion = document.getElementById('extVersion');
+
+  if (resp && typeof resp.extensionVersion === 'string') {
+    extVersion.textContent = `v${resp.extensionVersion}`;
+  }
+
   if (chrome.runtime.lastError || !resp) {
-    dot.className = 'dot disconnected';
-    status.innerHTML = '<strong>No daemon connected</strong>';
-    profile.style.display = 'none';
+    setState(card, dot, 'disconnected');
+    status.textContent = 'No daemon connected';
+    daemonVersion.textContent = '';
+    profileRow.style.display = 'none';
     hint.style.display = 'block';
     return;
   }
+
   if (typeof resp.contextId === 'string' && resp.contextId.length > 0) {
     contextId.textContent = resp.contextId;
-    profile.style.display = 'block';
+    profileRow.style.display = 'flex';
+    copyBtn.addEventListener('click', () => copyToClipboard(resp.contextId, copyBtn));
   } else {
-    profile.style.display = 'none';
+    profileRow.style.display = 'none';
   }
+
   if (resp.connected) {
-    dot.className = 'dot connected';
-    status.innerHTML = '<strong>Connected to daemon</strong>';
+    setState(card, dot, 'connected');
+    status.textContent = 'Connected to daemon';
+    if (typeof resp.daemonVersion === 'string') {
+      daemonVersion.textContent = `daemon v${resp.daemonVersion}`;
+    }
     hint.style.display = 'none';
   } else if (resp.reconnecting) {
-    dot.className = 'dot connecting';
-    status.innerHTML = '<strong>Reconnecting...</strong>';
+    setState(card, dot, 'connecting');
+    status.textContent = 'Reconnecting...';
+    daemonVersion.textContent = '';
     hint.style.display = 'none';
   } else {
-    dot.className = 'dot disconnected';
-    status.innerHTML = '<strong>No daemon connected</strong>';
+    setState(card, dot, 'disconnected');
+    status.textContent = 'No daemon connected';
+    daemonVersion.textContent = '';
     hint.style.display = 'block';
   }
 });
+
+function setState(card, dot, state) {
+  card.classList.remove('connected', 'disconnected', 'connecting');
+  card.classList.add(state);
+  dot.classList.remove('connected', 'disconnected', 'connecting');
+  dot.classList.add(state);
+}
+
+function copyToClipboard(text, btn) {
+  navigator.clipboard.writeText(text).then(
+    () => {
+      const original = btn.textContent;
+      btn.textContent = 'Copied';
+      btn.classList.add('copied');
+      setTimeout(() => {
+        btn.textContent = original;
+        btn.classList.remove('copied');
+      }, 1200);
+    },
+    () => {
+      btn.textContent = 'Failed';
+      setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+    },
+  );
+}

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -8,7 +8,7 @@
 declare const __OPENCLI_COMPAT_RANGE__: string;
 
 import type { Command, Result } from './protocol';
-import { DAEMON_WS_URL, DAEMON_PING_URL, WS_RECONNECT_BASE_DELAY, WS_RECONNECT_MAX_DELAY } from './protocol';
+import { DAEMON_HOST, DAEMON_PORT, DAEMON_WS_URL, DAEMON_PING_URL, WS_RECONNECT_BASE_DELAY, WS_RECONNECT_MAX_DELAY } from './protocol';
 import * as executor from './cdp';
 import * as identity from './identity';
 
@@ -621,16 +621,41 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === 'getStatus') {
     void (async () => {
       const contextId = await getCurrentContextId();
+      const connected = ws?.readyState === WebSocket.OPEN;
+      const extensionVersion = chrome.runtime.getManifest().version;
+      const daemonVersion = connected ? await fetchDaemonVersion() : null;
       sendResponse({
-        connected: ws?.readyState === WebSocket.OPEN,
+        connected,
         reconnecting: reconnectTimer !== null,
         contextId,
+        extensionVersion,
+        daemonVersion,
       });
     })();
     return true;
   }
   return false;
 });
+
+/**
+ * Best-effort fetch of the daemon's reported version for the popup status panel.
+ * Resolves to null on any failure — the popup degrades to showing connection
+ * state without the version label.
+ */
+async function fetchDaemonVersion(): Promise<string | null> {
+  try {
+    const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/status`, {
+      method: 'GET',
+      headers: { 'X-OpenCLI': '1' },
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) return null;
+    const body = await res.json() as { daemonVersion?: unknown };
+    return typeof body.daemonVersion === 'string' ? body.daemonVersion : null;
+  } catch {
+    return null;
+  }
+}
 
 // ─── Command dispatcher ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Merge popup status row and profile row into a single rounded card with a brand-colored left border accent (green / red / orange) reflecting connection state — eliminates the visually split look of two stacked cards
- Render contextId inline next to a "Profile" label with a one-click **Copy** button so users can paste it directly into `opencli profile rename <id> <name>` without manual selection of an 8-character code block
- Surface daemon version inline in the status row (`Connected to daemon · daemon v1.7.9`) and the extension version as a small tag in the popup header (`OpenCLI · v1.0.3`) — both make protocol-version mismatches visible from the popup, complementing #197's stale-daemon diagnostics in `opencli doctor` / `opencli profile list`

## How it works

`popup.js` calls the existing `chrome.runtime.sendMessage({ type: 'getStatus' })` API. The background `getStatus` handler now also reads `chrome.runtime.getManifest().version` for the extension version and (when the WebSocket is open) does a best-effort `fetch('/status')` with a 1.5s timeout to read `daemonVersion` from the daemon. Failures return `null` so the popup degrades gracefully.

## Test plan

- [ ] Visual: load unpacked extension, click toolbar icon — popup shows single card with green left border, "Connected to daemon · daemon v1.7.x" status row, "Profile <contextId> [Copy]" row, and "v1.0.3" version tag in the header
- [ ] Click **Copy** — button shows "Copied" briefly with green styling, contextId appears in clipboard (verify via paste)
- [ ] Stop daemon (`opencli daemon stop`) and reopen popup — left border turns red, status reads "No daemon connected", hint about auto-reconnect appears, daemon version label hides
- [ ] During reconnect window — left border turns orange, status reads "Reconnecting..."
- [ ] `cd extension && npm run typecheck && npm run build` passes