### PR TITLE
feat(browser): pass trace through verify

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -12,12 +12,14 @@ const {
   mockBrowserClose,
   mockBindTab,
   mockSendCommand,
+  mockExecFileSync,
   browserState,
 } = vi.hoisted(() => ({
   mockBrowserConnect: vi.fn(),
   mockBrowserClose: vi.fn(),
   mockBindTab: vi.fn(),
   mockSendCommand: vi.fn(),
+  mockExecFileSync: vi.fn(),
   browserState: { page: null as IPage | null },
 }));
 
@@ -37,6 +39,14 @@ vi.mock('./browser/daemon-client.js', async () => {
     ...actual,
     bindTab: mockBindTab,
     sendCommand: mockSendCommand,
+  };
+});
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFileSync: mockExecFileSync,
   };
 });
 
@@ -129,6 +139,40 @@ describe('selectFreshByTimestamp', () => {
     ], first.lastSeenTs);
     expect(rolled.fresh.map((item) => item.text)).toEqual(['c']);
     expect(rolled.lastSeenTs).toBe(3);
+  });
+});
+
+describe('browser verify', () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+    mockExecFileSync.mockReset().mockReturnValue('[]');
+  });
+
+  it('passes --trace through to the adapter subprocess', async () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-verify-trace-'));
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+
+    try {
+      const adapterDir = path.join(fakeHome, '.opencli', 'clis', 'hn');
+      fs.mkdirSync(adapterDir, { recursive: true });
+      fs.writeFileSync(path.join(adapterDir, 'top.js'), 'export default {};\n', 'utf-8');
+
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'verify', 'hn/top', '--no-fixture', '--trace', 'retain-on-failure']);
+
+      expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+      const [, execArgs] = mockExecFileSync.mock.calls[0] as [string, string[]];
+      expect(execArgs.slice(-6)).toEqual(['hn', 'top', '--trace', 'retain-on-failure', '--format', 'json']);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1907,8 +1907,9 @@ cli({
     .option('--update-fixture', 'Overwrite an existing fixture with one derived from current output')
     .option('--no-fixture', 'Ignore any fixture file for this run (no value-level validation)')
     .option('--strict-memory', 'Fail (not just warn) when ~/.opencli/sites/<site>/endpoints.json or notes.md is missing')
+    .option('--trace <mode>', 'Trace capture for the adapter subprocess: off, on, retain-on-failure', 'off')
     .description('Execute an adapter and validate output; uses fixture at ~/.opencli/sites/<site>/verify/<cmd>.json when present')
-    .action(async (name: string, opts: { fixture?: boolean; writeFixture?: boolean; updateFixture?: boolean; strictMemory?: boolean } = {}) => {
+    .action(async (name: string, opts: { fixture?: boolean; writeFixture?: boolean; updateFixture?: boolean; strictMemory?: boolean; trace?: string } = {}) => {
       try {
         const parts = name.split('/');
         if (parts.length !== 2) { console.error('Name must be site/command format'); process.exitCode = EXIT_CODES.USAGE_ERROR; return; }
@@ -1944,11 +1945,12 @@ cli({
         const cliArgs: string[] = expandFixtureArgs(fixtureArgs);
         if (cliArgs.length === 0 && hasLimitArg) cliArgs.push('--limit', '3');
 
-        const argDisplay = cliArgs.join(' ');
+        const traceArgs = opts.trace && opts.trace !== 'off' ? ['--trace', opts.trace] : [];
+        const argDisplay = [...cliArgs, ...traceArgs].join(' ');
         const invocation = resolveBrowserVerifyInvocation();
 
         // Always request JSON so we can validate structurally.
-        const execArgs = [...invocation.args, site, command, ...cliArgs, '--format', 'json'];
+        const execArgs = [...invocation.args, site, command, ...cliArgs, ...traceArgs, '--format', 'json'];
 
         let rawJson: string;
         try {


### PR DESCRIPTION
## Summary
- add `--trace <mode>` to `opencli browser verify`
- pass non-off trace mode through to the adapter subprocess before `--format json`
- cover the subprocess argv with a focused unit test

## Verification
- `npx vitest run src/cli.test.ts -t "browser verify" --project unit`
- `npx vitest run src/cli.test.ts --project unit`
- `npm run typecheck`
- `npm run build`