### PR TITLE
chore: bump version to 1.7.10 (extension 1.0.4)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump package.json to 1.7.10
- Bump extension/manifest.json and extension/package.json to 1.0.4

Since v1.7.9:
- feat(extension): polish popup UI (#1262)
- feat(browser): pass trace through verify (#1263)
- feat(daemon): surface stale versions and restart (#1261)
- feat(instagram): add collection-create + collection filter (#1260)