### PR TITLE
fix(extension): remove popup status-row left border accent

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -37,9 +37,6 @@
       padding: 11px 12px;
       background: #fafafa;
     }
-    .card.connected .status-row { border-left: 3px solid #34c759; padding-left: 9px; }
-    .card.disconnected .status-row { border-left: 3px solid #ff3b30; padding-left: 9px; }
-    .card.connecting .status-row { border-left: 3px solid #ff9500; padding-left: 9px; }
     .dot {
       width: 8px; height: 8px;
       border-radius: 50%;


### PR DESCRIPTION
## Summary
- WAWQAQ 反馈：connected 状态下 status row 左侧的绿色 border 看起来割裂——它只覆盖卡片上半部分（status row），不延伸到 profile row 和 hint，像一个残缺的装饰条
- 连接状态已经由 dot（绿/红/橙）和文字（`Connected to daemon` / `Disconnected`）明确表达，左侧 border 是冗余装饰
- 删掉 `.card.connected/.disconnected/.connecting` 的 `border-left` 规则；不动 JS 和 layout

## Visual result
- Before: `■ ● Connected to daemon · daemon v1.7.9` 左侧带 3px 绿色竖条
- After: `● Connected to daemon · daemon v1.7.9` 干净的 status row

## Test plan
- [x] `npm run typecheck` (extension)
- [x] `npm run build` (extension)
- [ ] Load unpacked → 验证 connected/disconnected 两态都没有左侧竖条