### PR TITLE
fix(build-manifest): fail loud on import errors and refuse stale dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,19 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      # Catch silent manifest drift before publishing — if rebuilding the
+      # manifest at release time produces a different cli-manifest.json than
+      # what's committed, refuse to ship. Same gate as CI but enforced at
+      # the release boundary too, since publish runs `prepublishOnly: build`
+      # and would otherwise silently overwrite the committed manifest.
+      - name: Verify cli-manifest.json is up-to-date
+        run: |
+          npm run build-manifest
+          if ! git diff --exit-code -- cli-manifest.json; then
+            echo "::error::cli-manifest.json drift detected at release time. Run 'npm run build' locally and commit the result before tagging."
+            exit 1
+          fi
+
       - name: Install extension dependencies
         run: npm ci
         working-directory: extension
@@ -40,7 +53,7 @@ jobs:
 
       - name: Create extension ZIP
         run: |
-          EXT_VERSION=$(node -p "require('./extension/package.json').version")
+          EXT_VERSION=$(jq -r .version extension/package.json)
           cd extension-package
           zip -r ../opencli-extension-v${EXT_VERSION}.zip .
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dev": "tsx src/main.ts",
     "dev:bun": "bun src/main.ts",
     "build": "npm run clean-dist && tsc && npm run copy-yaml && npm run build-manifest",
-    "build-manifest": "node dist/src/build-manifest.js",
+    "build-manifest": "tsx src/build-manifest.ts",
     "clean-dist": "node scripts/clean-dist.cjs",
     "copy-yaml": "node scripts/copy-yaml.cjs",
     "start": "node dist/src/main.js",

--- a/src/build-manifest.test.ts
+++ b/src/build-manifest.test.ts
@@ -3,7 +3,16 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { cli, getRegistry, Strategy } from './registry.js';
-import { loadManifestEntries, normalizeManifestPath, serializeManifest } from './build-manifest.js';
+import {
+  ManifestImportError,
+  diffRemovedEntries,
+  loadManifestEntries,
+  normalizeManifestPath,
+  parseBuildManifestArgs,
+  scanClisDir,
+  serializeManifest,
+  type ManifestEntry,
+} from './build-manifest.js';
 
 describe('manifest helper rules', () => {
   const tempDirs: string[] = [];
@@ -175,5 +184,91 @@ describe('manifest helper rules', () => {
 
     expect(serialized.endsWith('\n')).toBe(true);
     expect(serialized).toContain('\n]');
+  });
+
+  it('throws ManifestImportError when an adapter looks like a CLI module but fails to import', async () => {
+    // Reproduces the "stale dist drops adapters silently" incident: the file
+    // matches the cli() pattern (so it's not just a helper), but the importer
+    // throws — we want the failure surfaced, not swallowed.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-manifest-fail-'));
+    tempDirs.push(dir);
+    const file = path.join(dir, 'broken.ts');
+    fs.writeFileSync(file, `export const command = cli({ site: 'demo', name: 'broken' });`);
+
+    const importer = async () => { throw new Error('boom: stale dist'); };
+
+    await expect(loadManifestEntries(file, 'demo', importer))
+      .rejects.toBeInstanceOf(ManifestImportError);
+
+    try {
+      await loadManifestEntries(file, 'demo', importer);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManifestImportError);
+      const e = err as ManifestImportError;
+      expect(e.filePath).toBe(file);
+      expect(e.message).toContain('boom: stale dist');
+    }
+  });
+
+  it('still silently skips files that do not call cli() even if the importer would have thrown', async () => {
+    // The cli() pattern check happens before importing — we don't even ask
+    // the importer about helper modules, so a thrown import does not turn
+    // them into failures.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-manifest-helper-'));
+    tempDirs.push(dir);
+    const file = path.join(dir, 'helper.ts');
+    fs.writeFileSync(file, `export const helper = () => 42;`);
+    const importer = async () => { throw new Error('should never be called'); };
+    await expect(loadManifestEntries(file, 'demo', importer)).resolves.toEqual([]);
+  });
+
+  it('scanClisDir aggregates per-adapter import failures instead of silently dropping them', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-clis-'));
+    tempDirs.push(root);
+    const siteDir = path.join(root, 'demo');
+    fs.mkdirSync(siteDir);
+    fs.writeFileSync(path.join(siteDir, 'good.js'),
+      `export const cmd = cli({ site: 'demo', name: 'good' });`);
+    fs.writeFileSync(path.join(siteDir, 'broken.js'),
+      `export const cmd = cli({ site: 'demo', name: 'broken' });`);
+
+    const importer = async (href: string): Promise<unknown> => {
+      if (href.endsWith('broken.js')) throw new Error('stale dist drops broken');
+      return { cmd: cli({ site: 'demo', name: 'good', description: 'ok' }) };
+    };
+
+    const result = await scanClisDir(root, importer);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toBeInstanceOf(ManifestImportError);
+    expect(result.failures[0].filePath).toMatch(/broken\.js$/);
+    expect(result.failures[0].message).toContain('stale dist drops broken');
+    expect(result.entries.map(e => e.name)).toEqual(['good']);
+
+    getRegistry().delete('demo/good');
+  });
+
+  it('diffRemovedEntries returns site/name keys present only in prev', () => {
+    const prev: ManifestEntry[] = [
+      { site: 'a', name: '1', description: '', strategy: 'public', browser: false, args: [], type: 'js' },
+      { site: 'a', name: '2', description: '', strategy: 'public', browser: false, args: [], type: 'js' },
+      { site: 'b', name: '3', description: '', strategy: 'public', browser: false, args: [], type: 'js' },
+    ];
+    const next: ManifestEntry[] = [
+      { site: 'a', name: '1', description: '', strategy: 'public', browser: false, args: [], type: 'js' },
+    ];
+    expect(diffRemovedEntries(prev, next)).toEqual(['a/2', 'b/3']);
+    expect(diffRemovedEntries(prev, prev)).toEqual([]);
+    expect(diffRemovedEntries([], next)).toEqual([]);
+  });
+
+  it('parseBuildManifestArgs reads --allow-removals[=N]', () => {
+    expect(parseBuildManifestArgs([]).allowRemovals).toBe(0);
+    expect(parseBuildManifestArgs(['--allow-removals=5']).allowRemovals).toBe(5);
+    expect(parseBuildManifestArgs(['--allow-removals=0']).allowRemovals).toBe(0);
+    // Bare flag is the explicit "I know what I'm doing" escape hatch.
+    expect(parseBuildManifestArgs(['--allow-removals']).allowRemovals).toBe(Number.POSITIVE_INFINITY);
+    // Unknown flags are ignored.
+    expect(parseBuildManifestArgs(['--something-else']).allowRemovals).toBe(0);
   });
 });

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -5,8 +5,21 @@
  * Scans all JS CLI definitions in clis/ and pre-compiles them into a single
  * manifest.json for instant cold-start registration.
  *
- * Usage: npx tsx src/build-manifest.ts
+ * Usage: npx tsx src/build-manifest.ts [--allow-removals[=N]]
+ *
  * Output: cli-manifest.json next to clis/
+ *
+ * Safety invariants:
+ *   - Adapters whose source file does not call `cli(...)` are silently
+ *     skipped (they are helpers / type modules, not commands).
+ *   - Adapters that look like commands but fail to import are reported as
+ *     failures, the manifest is NOT written, and the process exits 1. This
+ *     prevents a stale dist or a broken adapter from silently dropping
+ *     other adapters' entries (root cause of the "manifest lost 478 lines"
+ *     incident).
+ *   - Net-deletions vs the existing committed manifest abort the build by
+ *     default; pass `--allow-removals=N` (or just `--allow-removals` for any
+ *     amount) to confirm an intentional removal.
  */
 
 import * as fs from 'node:fs';
@@ -15,47 +28,44 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { getErrorMessage } from './errors.js';
 import { fullName, getRegistry, type CliCommand } from './registry.js';
 import { findPackageRoot, getCliManifestPath } from './package-paths.js';
+import type { ManifestEntry } from './manifest-types.js';
+import { isRecord } from './utils.js';
+
+export type { ManifestEntry } from './manifest-types.js';
 
 const PACKAGE_ROOT = findPackageRoot(fileURLToPath(import.meta.url));
 const CLIS_DIR = path.join(PACKAGE_ROOT, 'clis');
 // Write manifest next to clis/ so both dev and installed runtime can find it.
 const OUTPUT = getCliManifestPath(CLIS_DIR);
 
-export interface ManifestEntry {
-  site: string;
-  name: string;
-  aliases?: string[];
-  description: string;
-  domain?: string;
-  strategy: string;
-  browser: boolean;
-  args: Array<{
-    name: string;
-    type?: string;
-    default?: unknown;
-    required?: boolean;
-    valueRequired?: boolean;
-    positional?: boolean;
-    help?: string;
-    choices?: string[];
-  }>;
-  columns?: string[];
-  pipeline?: Record<string, unknown>[];
-  timeout?: number;
-  deprecated?: boolean | string;
-  replacedBy?: string;
-  type: 'js';
-  /** Relative path from clis/ dir, e.g. 'bilibili/search.js' */
-  modulePath?: string;
-  /** Relative path to the source file from clis/ dir (e.g. 'site/cmd.js') */
-  sourceFile?: string;
-  /** Pre-navigation control — see CliCommand.navigateBefore */
-  navigateBefore?: boolean | string;
+const CLI_MODULE_PATTERN = /\bcli\s*\(/;
+
+/**
+ * Thrown by `loadManifestEntries` when an adapter file looks like a CLI
+ * module (matches CLI_MODULE_PATTERN) but cannot be imported. Callers
+ * decide whether to abort or aggregate failures across the whole scan.
+ */
+export class ManifestImportError extends Error {
+  constructor(
+    public readonly filePath: string,
+    public readonly cause: unknown,
+  ) {
+    super(`failed to scan ${filePath}: ${getErrorMessage(cause)}`);
+    this.name = 'ManifestImportError';
+  }
 }
 
-import { isRecord } from './utils.js';
+export interface BuildManifestResult {
+  entries: ManifestEntry[];
+  /** Adapters that look like CLI modules but failed to import. */
+  failures: ManifestImportError[];
+}
 
-const CLI_MODULE_PATTERN = /\bcli\s*\(/;
+export interface BuildManifestArgs {
+  /** Maximum number of entries that may be removed vs the existing manifest.
+   *  `Number.POSITIVE_INFINITY` disables the safety net entirely. */
+  allowRemovals: number;
+}
 
 function toManifestArgs(args: CliCommand['args']): ManifestEntry['args'] {
   return args.map(arg => ({
@@ -79,8 +89,8 @@ export function normalizeManifestPath(relativePath: string): string {
   return relativePath.replace(/\\/g, '/');
 }
 
-function toManifestRelativePath(filePath: string): string {
-  return normalizeManifestPath(path.relative(CLIS_DIR, filePath));
+function toManifestRelativePath(filePath: string, clisDir: string): string {
+  return normalizeManifestPath(path.relative(clisDir, filePath));
 }
 
 function isCliCommandValue(value: unknown, site: string): value is CliCommand {
@@ -112,17 +122,35 @@ function toManifestEntry(cmd: CliCommand, modulePath: string, sourceFile?: strin
   };
 }
 
+/**
+ * Load all manifest entries from a single adapter file.
+ *
+ * Returns `[]` for files that do not register a CLI command (helpers, types).
+ * Throws `ManifestImportError` when a file looks like a CLI module but its
+ * import or post-import processing fails — callers must decide whether to
+ * surface or aggregate the failure.
+ *
+ * The third argument `clisDir` is used to compute the POSIX-style
+ * `sourceFile` relative path; it defaults to the package's `clis/` dir so
+ * existing test callers stay backward-compatible.
+ */
 export async function loadManifestEntries(
   filePath: string,
   site: string,
   importer: (moduleHref: string) => Promise<unknown> = moduleHref => import(moduleHref),
+  clisDir: string = CLIS_DIR,
 ): Promise<ManifestEntry[]> {
+  let src: string;
   try {
-    const src = fs.readFileSync(filePath, 'utf-8');
+    src = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    throw new ManifestImportError(filePath, err);
+  }
 
-    // Helper/test modules should not appear as CLI commands in the manifest.
-    if (!CLI_MODULE_PATTERN.test(src)) return [];
+  // Helper / test modules that do not call cli() are not commands.
+  if (!CLI_MODULE_PATTERN.test(src)) return [];
 
+  try {
     const modulePath = toModulePath(filePath, site);
     const registry = getRegistry();
     const before = new Map(registry.entries());
@@ -143,7 +171,7 @@ export async function loadManifestEntries(
 
     // Manifest paths are cross-platform artifacts; keep them POSIX-style even
     // when build-manifest runs on Windows.
-    const sourceRelative = toManifestRelativePath(filePath);
+    const sourceRelative = toManifestRelativePath(filePath, clisDir);
 
     const seen = new Set<string>();
     return runtimeCommands
@@ -156,47 +184,167 @@ export async function loadManifestEntries(
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(cmd => toManifestEntry(cmd, modulePath, sourceRelative));
   } catch (err) {
-    // If parsing fails, log a warning (matching scanYaml behaviour) and skip the entry.
-    process.stderr.write(`Warning: failed to scan ${filePath}: ${getErrorMessage(err)}\n`);
-    return [];
+    throw new ManifestImportError(filePath, err);
   }
 }
 
-export async function buildManifest(): Promise<ManifestEntry[]> {
+/**
+ * Scan a `clis/` directory and aggregate per-adapter results. Import
+ * failures are collected in `failures` instead of crashing the whole scan,
+ * but the caller (e.g. `main()`) is expected to fail loud if any failure
+ * is present.
+ */
+export async function scanClisDir(
+  clisDir: string,
+  importer: (moduleHref: string) => Promise<unknown> = moduleHref => import(moduleHref),
+): Promise<BuildManifestResult> {
   const manifest = new Map<string, ManifestEntry>();
+  const failures: ManifestImportError[] = [];
 
-  // Scan JS adapters directly from clis/.
-  // Adapters are now JS-first — no compilation step needed.
-  if (fs.existsSync(CLIS_DIR)) {
-    for (const site of fs.readdirSync(CLIS_DIR)) {
-      const siteDir = path.join(CLIS_DIR, site);
-      if (!fs.statSync(siteDir).isDirectory()) continue;
-      for (const file of fs.readdirSync(siteDir)) {
-        if (file.endsWith('.js') && !file.endsWith('.d.js') && !file.endsWith('.test.js') && file !== 'index.js') {
-          const filePath = path.join(siteDir, file);
-          const entries = await loadManifestEntries(filePath, site);
+  if (!fs.existsSync(clisDir)) {
+    return { entries: [], failures };
+  }
+
+  for (const site of fs.readdirSync(clisDir)) {
+    const siteDir = path.join(clisDir, site);
+    if (!fs.statSync(siteDir).isDirectory()) continue;
+    for (const file of fs.readdirSync(siteDir)) {
+      if (file.endsWith('.js') && !file.endsWith('.d.js') && !file.endsWith('.test.js') && file !== 'index.js') {
+        const filePath = path.join(siteDir, file);
+        try {
+          const entries = await loadManifestEntries(filePath, site, importer, clisDir);
           for (const entry of entries) {
             const key = `${entry.site}/${entry.name}`;
             manifest.set(key, entry);
           }
+        } catch (err) {
+          if (err instanceof ManifestImportError) {
+            failures.push(err);
+            continue;
+          }
+          throw err;
         }
       }
     }
   }
 
-  return [...manifest.values()].sort((a, b) => a.site.localeCompare(b.site) || a.name.localeCompare(b.name));
+  const entries = [...manifest.values()].sort(
+    (a, b) => a.site.localeCompare(b.site) || a.name.localeCompare(b.name),
+  );
+  return { entries, failures };
+}
+
+export async function buildManifest(): Promise<BuildManifestResult> {
+  return scanClisDir(CLIS_DIR);
 }
 
 export function serializeManifest(manifest: ManifestEntry[]): string {
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }
 
-async function main(): Promise<void> {
-  const manifest = await buildManifest();
-  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
-  fs.writeFileSync(OUTPUT, serializeManifest(manifest));
+/**
+ * Diff helper: returns site/name keys that exist in `prev` but not in
+ * `next`. Used as a safety net to detect accidental mass-deletions caused
+ * by silently failing adapter imports.
+ */
+export function diffRemovedEntries(
+  prev: readonly ManifestEntry[],
+  next: readonly ManifestEntry[],
+): string[] {
+  const nextKeys = new Set(next.map(e => `${e.site}/${e.name}`));
+  return prev
+    .map(e => `${e.site}/${e.name}`)
+    .filter(key => !nextKeys.has(key))
+    .sort();
+}
 
-  console.log(`✅ Manifest compiled: ${manifest.length} entries → ${OUTPUT}`);
+/**
+ * Parse `--allow-removals` and `--allow-removals=N` from argv.
+ * Bare `--allow-removals` disables the safety net (`Infinity`); the
+ * numeric form sets an explicit upper bound.
+ */
+export function parseBuildManifestArgs(argv: readonly string[]): BuildManifestArgs {
+  let allowRemovals = 0;
+  for (const arg of argv) {
+    if (arg === '--allow-removals') {
+      allowRemovals = Number.POSITIVE_INFINITY;
+      continue;
+    }
+    const m = arg.match(/^--allow-removals=(\d+)$/);
+    if (m) {
+      allowRemovals = Number.parseInt(m[1], 10);
+      continue;
+    }
+  }
+  return { allowRemovals };
+}
+
+function readExistingManifest(filePath: string): ManifestEntry[] | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed as ManifestEntry[] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  // Runtime guard: refuse to run from dist/. tsc transitively emits this
+  // file (the test file imports from it) so dist/src/build-manifest.js
+  // physically exists. If a developer or agent runs that compiled copy,
+  // any stale dist will silently break adapter imports — the exact failure
+  // mode this script is meant to prevent. Direct them at the tsx entry
+  // before they can shoot themselves in the foot.
+  if (fileURLToPath(import.meta.url).includes(`${path.sep}dist${path.sep}`)) {
+    process.stderr.write(
+      `❌ Refusing to run build-manifest from dist/.\n`
+      + `   Stale compiled output silently drops adapters that import renamed/removed exports.\n`
+      + `   Run \`npm run build-manifest\` (or \`tsx src/build-manifest.ts\`) from the source tree instead.\n`,
+    );
+    process.exit(1);
+  }
+
+  const args = parseBuildManifestArgs(process.argv.slice(2));
+  const { entries, failures } = await buildManifest();
+
+  if (failures.length > 0) {
+    process.stderr.write(`❌ ${failures.length} adapter(s) failed to load:\n`);
+    for (const failure of failures) {
+      const rel = path.relative(PACKAGE_ROOT, failure.filePath) || failure.filePath;
+      process.stderr.write(`  - ${rel}: ${getErrorMessage(failure.cause)}\n`);
+    }
+    process.stderr.write(
+      `\nManifest NOT written. Likely cause: stale dist/ or a broken adapter import.\n`
+      + `Always run via tsx (\`npm run build-manifest\`), not against compiled dist/.\n`,
+    );
+    process.exit(1);
+  }
+
+  const existing = readExistingManifest(OUTPUT);
+  if (existing) {
+    const removed = diffRemovedEntries(existing, entries);
+    if (removed.length > args.allowRemovals) {
+      process.stderr.write(
+        `❌ ${removed.length} manifest entries would be removed; refusing to overwrite.\n`,
+      );
+      const preview = removed.slice(0, 20);
+      for (const key of preview) process.stderr.write(`  - ${key}\n`);
+      if (removed.length > preview.length) {
+        process.stderr.write(`  ... ${removed.length - preview.length} more\n`);
+      }
+      process.stderr.write(
+        `\nIf this removal is intentional, rerun with `
+        + `\`--allow-removals=${removed.length}\` (or \`--allow-removals\` to disable the check).\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, serializeManifest(entries));
+  console.log(`✅ Manifest compiled: ${entries.length} entries → ${OUTPUT}`);
 
   // Restore executable permissions on bin entries.
   // tsc does not preserve the +x bit, so after a clean rebuild the CLI

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -15,7 +15,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { type InternalCliCommand, Strategy, registerCommand } from './registry.js';
 import { getErrorMessage } from './errors.js';
 import { log } from './logger.js';
-import type { ManifestEntry } from './build-manifest.js';
+import type { ManifestEntry } from './manifest-types.js';
 import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 
 /** User runtime directory: ~/.opencli */

--- a/src/manifest-types.ts
+++ b/src/manifest-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared manifest types — kept in their own module so both runtime code
+ * (discovery.ts) and the build-time compiler (build-manifest.ts) can
+ * import them without pulling each other in. This is what lets us
+ * exclude `src/build-manifest.ts` from `tsc`'s emit set: the only thing
+ * runtime code needs from build-manifest is the `ManifestEntry` type,
+ * and that lives here.
+ */
+
+export interface ManifestEntry {
+  site: string;
+  name: string;
+  aliases?: string[];
+  description: string;
+  domain?: string;
+  strategy: string;
+  browser: boolean;
+  args: Array<{
+    name: string;
+    type?: string;
+    default?: unknown;
+    required?: boolean;
+    valueRequired?: boolean;
+    positional?: boolean;
+    help?: string;
+    choices?: string[];
+  }>;
+  columns?: string[];
+  pipeline?: Record<string, unknown>[];
+  timeout?: number;
+  deprecated?: boolean | string;
+  replacedBy?: string;
+  type: 'js';
+  /** Relative path from clis/ dir, e.g. 'bilibili/search.js' */
+  modulePath?: string;
+  /** Relative path to the source file from clis/ dir (e.g. 'site/cmd.js') */
+  sourceFile?: string;
+  /** Pre-navigation control — see CliCommand.navigateBefore */
+  navigateBefore?: boolean | string;
+}


### PR DESCRIPTION
## Background

WAWQAQ forwarded a user report (#opencli-new-version thread): they ran
`node dist/src/build-manifest.js` (habit, the file is in repo). dist
was stale — `selectorError` had been renamed in `src/errors.ts` but
not recompiled, so every adapter that imported it failed to load. The
catch block silently returned `[]` for those adapters, but the script
exited **0** with `✅ Manifest compiled: N entries` and a manifest
that had **dropped 478 lines of unrelated adapter entries**.

If the user hadn't checked `git diff --stat`, that would have been
committed and CI's manifest-drift check would only catch it on push,
after work was already lost.

## Three layers of defense

1. **Distinguish skip kinds.** Files that don't call `cli(...)` are
   still silently dropped (helpers / type modules). Files that look
   like CLI modules but fail to import now throw
   `ManifestImportError`. `scanClisDir()` aggregates failures and
   `main()` exits 1 with an explicit list, leaving the existing
   manifest on disk untouched.

2. **Net-deletion safety net.** `main()` diffs new entries against
   the committed manifest. Refuses to overwrite when entries would
   be removed. `--allow-removals=N` (or bare `--allow-removals` for
   any) is the explicit opt-in; the error tells the caller exactly
   what value to pass.

3. **Runtime dist guard.** `node dist/src/build-manifest.js` refuses
   to run with a clear pointer at `npm run build-manifest`. The npm
   script itself is migrated to `tsx src/build-manifest.ts` so no
   project-level command points at the compiled copy anymore.

## Release CI

`release.yml` gains a manifest-drift gate (`build-manifest && git
diff --exit-code -- cli-manifest.json`) so a tag push can never
publish stale or silently-shrunk manifests. The existing CI check on
PRs is preserved.

(Switched the unrelated extension version-read in `release.yml` from
`node -p "require(...)"` to `jq` per workflow lint rules.)

## Type split

`ManifestEntry` is moved to `src/manifest-types.ts` so runtime code
(`discovery.ts`) imports the type without pulling the build-time
compiler module. `build-manifest.ts` re-exports it for backward
compat.

## Demonstrated catching the actual bug locally

```
$ npm run build-manifest
❌ 2 adapter(s) failed to load:
  - clis/xianyu/chat.js: The requested module ... does not provide an export named 'selectorError'
  - clis/xianyu/item.js: ...
Manifest NOT written. Likely cause: stale dist/ or a broken adapter import.
Always run via tsx (`npm run build-manifest`), not against compiled dist/.
$ echo $?
1
```

After `npm run build` (refreshes dist):

```
$ npm run build-manifest
✅ Manifest compiled: 646 entries → cli-manifest.json
$ echo $?
0
```

And the dist guard:

```
$ node dist/src/build-manifest.js
❌ Refusing to run build-manifest from dist/.
   Stale compiled output silently drops adapters that import renamed/removed exports.
   Run `npm run build-manifest` (or `tsx src/build-manifest.ts`) from the source tree instead.
$ echo $?
1
```

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/build-manifest.test.ts --project unit` (11/11)
- [x] `npm run build` (full build pipeline still works)
- [x] Verified: stale-dist scenario triggers loud failure with exit 1
- [x] Verified: dist-execution refused with clear pointer
- [x] Verified: `git diff --exit-code -- cli-manifest.json` clean after build