### PR TITLE
fix(release): build before manifest drift check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,12 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      # Catch silent manifest drift before publishing — if rebuilding the
-      # manifest at release time produces a different cli-manifest.json than
-      # what's committed, refuse to ship. Same gate as CI but enforced at
-      # the release boundary too, since publish runs `prepublishOnly: build`
-      # and would otherwise silently overwrite the committed manifest.
-      - name: Verify cli-manifest.json is up-to-date
+      # Build before the manifest drift gate: adapter modules import
+      # @jackwener/opencli/* through package exports, which resolve to dist/.
+      # A fresh release checkout has no dist/ until the full build runs.
+      - name: Build package and verify cli-manifest.json is up-to-date
         run: |
-          npm run build-manifest
+          npm run build
           if ! git diff --exit-code -- cli-manifest.json; then
             echo "::error::cli-manifest.json drift detected at release time. Run 'npm run build' locally and commit the result before tagging."
             exit 1


### PR DESCRIPTION
## Summary
- move the release manifest drift gate to run the full package build first
- rely on `npm run build` to produce dist and regenerate cli-manifest.json
- keep the release guard as `git diff --exit-code -- cli-manifest.json`

## Why
In a fresh release checkout there is no `dist/`. Adapter modules import `@jackwener/opencli/*` through package exports, which resolve to `dist/src/*`. Running `npm run build-manifest` before a full build fails with hundreds of adapter import errors.

## Verification
- `npm run clean-dist && npm run build && git diff --exit-code -- cli-manifest.json`
- `npx vitest run src/build-manifest.test.ts --project unit`