### PR TITLE
feat(instagram): add collection-delete adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8721,6 +8721,32 @@
   },
   {
     "site": "instagram",
+    "name": "collection-delete",
+    "description": "Delete an Instagram saved-posts collection (folder) by name or id",
+    "domain": "www.instagram.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "target",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Collection name (case-insensitive) or numeric collection_id"
+      }
+    ],
+    "columns": [
+      "status",
+      "collectionId",
+      "collectionName"
+    ],
+    "type": "js",
+    "modulePath": "instagram/collection-delete.js",
+    "sourceFile": "instagram/collection-delete.js",
+    "navigateBefore": "https://www.instagram.com"
+  },
+  {
+    "site": "instagram",
     "name": "comment",
     "description": "Comment on an Instagram post",
     "domain": "www.instagram.com",

--- a/clis/instagram/collection-delete.js
+++ b/clis/instagram/collection-delete.js
@@ -1,0 +1,91 @@
+import { cli } from '@jackwener/opencli/registry';
+cli({
+    site: 'instagram',
+    name: 'collection-delete',
+    description: 'Delete an Instagram saved-posts collection (folder) by name or id',
+    domain: 'www.instagram.com',
+    args: [
+        {
+            name: 'target',
+            required: true,
+            positional: true,
+            help: 'Collection name (case-insensitive) or numeric collection_id',
+        },
+    ],
+    columns: ['status', 'collectionId', 'collectionName'],
+    pipeline: [
+        { navigate: 'https://www.instagram.com' },
+        { evaluate: `(async () => {
+  const target = \${{ args.target | json }};
+  if (!target || !String(target).trim()) {
+    throw new Error('Collection target (name or id) cannot be empty');
+  }
+  const raw = String(target).trim();
+  const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
+  if (!csrf) {
+    throw new Error('csrftoken cookie missing - make sure you are logged in to Instagram');
+  }
+  const headers = { 'X-IG-App-ID': '936619743392459' };
+
+  // Resolve name -> id via /collections/list/. Always go through this path so we can
+  // surface an explicit error on duplicate names or unknown names instead of relying
+  // on a 404.
+  const listRes = await fetch('https://www.instagram.com/api/v1/collections/list/?collection_types=%5B%22MEDIA%22%5D', {
+    credentials: 'include',
+    headers,
+  });
+  if (!listRes.ok) {
+    throw new Error('Failed to list collections: HTTP ' + listRes.status + ' - make sure you are logged in to Instagram');
+  }
+  const listData = await listRes.json();
+  const collections = listData?.items || [];
+  const isNumericId = /^\\d{6,}$/.test(raw);
+  let id = '';
+  let resolvedName = '';
+  if (isNumericId) {
+    const hit = collections.find((c) => String(c?.collection_id) === raw);
+    if (!hit) {
+      throw new Error('Collection id not found in your account: ' + raw);
+    }
+    id = String(hit.collection_id);
+    resolvedName = String(hit.collection_name || '');
+  } else {
+    const wanted = raw.toLowerCase();
+    const matches = collections.filter((c) => String(c?.collection_name || '').trim().toLowerCase() === wanted);
+    if (matches.length === 0) {
+      const names = collections.map((c) => c?.collection_name).filter(Boolean);
+      throw new Error('Collection not found: ' + raw + '. Available: ' + (names.length ? names.join(', ') : '(none)'));
+    }
+    if (matches.length > 1) {
+      const ids = matches.map((c) => c.collection_id).join(', ');
+      throw new Error('Multiple collections share the name "' + raw + '" (ids: ' + ids + '). Pass the numeric collection_id explicitly to disambiguate.');
+    }
+    id = String(matches[0].collection_id);
+    resolvedName = String(matches[0].collection_name || raw);
+  }
+
+  const fd = new FormData();
+  fd.append('module_name', 'collection_settings');
+  const res = await fetch('https://www.instagram.com/api/v1/collections/' + encodeURIComponent(id) + '/delete/', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { ...headers, 'X-CSRFToken': csrf },
+    body: fd,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error('Failed to delete collection: HTTP ' + res.status + (body ? ' - ' + body.slice(0, 200) : ''));
+  }
+  const d = await res.json().catch(() => ({}));
+  if (d?.status && d.status !== 'ok') {
+    throw new Error('Instagram returned non-ok status: ' + JSON.stringify(d).slice(0, 300));
+  }
+  return [{
+    status: 'Deleted',
+    collectionId: id,
+    collectionName: resolvedName,
+  }];
+})()
+` },
+    ],
+});

--- a/docs/adapters/browser/instagram.md
+++ b/docs/adapters/browser/instagram.md
@@ -14,6 +14,7 @@
 | `opencli instagram following` | List user's following |
 | `opencli instagram saved` | Get your saved posts (or one collection) |
 | `opencli instagram collection-create` | Create a new saved-posts collection |
+| `opencli instagram collection-delete` | Delete a saved-posts collection by name or id |
 
 ## Usage Examples
 
@@ -43,6 +44,9 @@ opencli instagram saved --collection inspiration --limit 10
 # Create a new saved-posts collection
 opencli instagram collection-create "design refs"
 
+# Delete a collection by name (or by numeric id, e.g. 17853899493659567)
+opencli instagram collection-delete "design refs"
+
 # JSON output
 opencli instagram profile nasa -f json
 ```
@@ -52,6 +56,7 @@ opencli instagram profile nasa -f json
 - `instagram saved` without `--collection` returns the unsegmented "All posts" bucket (same as the original behaviour).
 - With `--collection <name>` it resolves the name to an id via `/api/v1/collections/list/`, then fetches `/api/v1/feed/collection/{id}/posts/`. Match is case-insensitive after trimming. An unknown name throws an error that lists the available names.
 - `instagram collection-create <name>` calls `POST /api/v1/collections/create/` with a multipart `name` field. Instagram silently accepts duplicate names — the API just returns a new `collection_id` each time, so dedupe client-side if you care.
+- `instagram collection-delete <name-or-id>` calls `POST /api/v1/collections/{id}/delete/`. Pass either a case-insensitive collection name or a numeric `collection_id`. If the name resolves to multiple collections (e.g. duplicates from `collection-create`), the adapter throws and lists the candidate ids so you can disambiguate by passing the id explicitly. Unknown names list the available collections in the error message.
 - Saving an existing post directly into a named collection in one shot is not exposed by the web app's documented endpoints (`/api/v1/web/save/{pk}/save/` only writes to "All posts"). Use `instagram save` first, then move the post in the UI, or extend with the `/api/v1/collections/{id}/edit/` mutation.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

Adds `opencli instagram collection-delete <name-or-id>` to pair with `collection-create` (#1260). Users can now clean up saved-post collections from CLI without going to the IG web UI; this is also the first paired delete in line with the discussion in PR #1260's follow-up thread on write-adapter teardown.

- `POST /api/v1/collections/{id}/delete/` with multipart `module_name=collection_settings`
- Accepts either a case-insensitive collection name or a numeric `collection_id`
- Resolves name → id via `/collections/list/` first; explicit errors on:
  - **Unknown name** → lists available collections
  - **Duplicate names** (Instagram silently allows them) → lists candidate ids and asks the caller to pass the id explicitly
  - **Bogus numeric id** → "Collection id not found in your account"

## Verified manually

| Case | Result |
|---|---|
| Delete by name (unique) | ✓ `opencli-test` (id `18097240688034183`) deleted |
| Delete by numeric id | ✓ `18130945873498300` deleted |
| Duplicate name | ✓ throws with both ids listed |
| Unknown name | ✓ throws with available list |
| Probe endpoint with bogus id directly | ✓ returns `{message:'Collection does not exist', status:'fail'}` 404 |

(Did not add a `verify/<cmd>.json` fixture: the adapter is destructive and we have no `teardown`-aware fixture schema yet — the same gap WAWQAQ flagged in <https://github.com/jackwener/OpenCLI/pull/1260>'s thread. Once the fixture-teardown design lands, this delete adapter is exactly what `collection-create`'s teardown can reference.)

## Test plan

- [x] `opencli instagram collection-delete <name>` deletes a uniquely-named collection
- [x] `opencli instagram collection-delete <id>` deletes a collection by numeric id
- [x] Duplicate names error with both ids listed
- [x] Unknown name errors with available list
- [x] `cli-manifest.json` regenerated via `npx tsx src/build-manifest.ts` (+26 / -0, only adds the new entry)
- [x] `docs/adapters/browser/instagram.md` updated (commands table + usage example + Notes section)