### PR TITLE
fix(browser): typeText prefers CDP Input.insertText for React composers

### DIFF
--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -232,8 +232,20 @@ export abstract class BasePage implements IPage {
 
   async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
     const resolved = await runResolve(this, ref, opts);
-    await this.evaluate(typeResolvedJs(text));
+    // Prefer CDP Input.insertText: fires React's controlled-input synthetic
+    // events, which document.execCommand('insertText') does not. Required for
+    // DraftJS / ProseMirror / contenteditable composers (Twitter, Notion,
+    // Discord, etc.) that otherwise accept the text into the DOM but leave
+    // application state empty, producing silent submit failures. Falls back
+    // to the legacy JS path on backends without nativeType (e.g. CDPPage).
+    const nativeOk = await this.tryNativeType(text);
+    if (!nativeOk) await this.evaluate(typeResolvedJs(text));
     return resolved;
+  }
+
+  /** Override in subclasses with CDP Input.insertText support */
+  protected async tryNativeType(_text: string): Promise<boolean> {
+    return false;
   }
 
   async pressKey(key: string): Promise<void> {

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -232,12 +232,9 @@ export abstract class BasePage implements IPage {
 
   async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
     const resolved = await runResolve(this, ref, opts);
-    // Prefer CDP Input.insertText: fires React's controlled-input synthetic
-    // events, which document.execCommand('insertText') does not. Required for
-    // DraftJS / ProseMirror / contenteditable composers (Twitter, Notion,
-    // Discord, etc.) that otherwise accept the text into the DOM but leave
-    // application state empty, producing silent submit failures. Falls back
-    // to the legacy JS path on backends without nativeType (e.g. CDPPage).
+    // CDP Input.insertText fires React's controlled-input onChange (DraftJS,
+    // ProseMirror, Twitter, Notion); execCommand does not. Falls back to the
+    // JS path on backends without nativeType.
     const nativeOk = await this.tryNativeType(text);
     if (!nativeOk) await this.evaluate(typeResolvedJs(text));
     return resolved;

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -304,6 +304,16 @@ export class Page extends BasePage {
     }
   }
 
+  /** CDP Input.insertText path — fires React synthetic events (closes #1265) */
+  protected override async tryNativeType(text: string): Promise<boolean> {
+    try {
+      await this.nativeType(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /** Precise click using DOM.getContentQuads/getBoxModel for inline elements */
   async clickWithQuads(ref: string): Promise<void> {
     const safeRef = JSON.stringify(ref);


### PR DESCRIPTION
## Description

`browser type` currently routes through `document.execCommand('insertText', ...)`, which does not fire React's controlled-input synthetic onChange event. DraftJS / ProseMirror / contenteditable composers used by Twitter / X, Notion, Discord, and similar React apps accept the text into the DOM but leave application state untouched. The next submit then silently posts nothing.

This PR routes `BasePage.typeText` through `page.nativeType` (CDP `Input.insertText`) when the backend supports it, falling back to the existing `evaluate(typeResolvedJs(...))` path for backends without nativeType (e.g. `CDPPage`). The escalation mirrors the existing `tryNativeClick` pattern at `src/browser/base-page.ts:228`.

Closes #1265

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

(`Bug fix`)

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

A/B on the same Twitter / X compose page, fresh stack (opencli v1.7.10, extension v1.0.4):

| Path | tweetBtnDisabled | ariaDisabled |
| --- | --- | --- |
| Global `opencli` v1.7.10 (`document.execCommand('insertText')`) | `true` | `"true"` |
| `node dist/src/main.js` (this PR, CDP `Input.insertText`) | `false` | `null` |

Same composer, same prompt content, only the typeText path differs. The Post button moves from disabled to enabled because DraftJS finally receives the controlled-input onChange that the new path fires.

Tests:

- `npx tsc --noEmit` clean
- `npm run build` clean
- `npx vitest run src/browser/` -> 275/275 pass (no regressions)

Backward compatibility: `tryNativeType` defaults to `false` in `BasePage`, so `CDPPage` and any other backend without `nativeType` continues to use the existing `execCommand` path unchanged. Only `Page` (daemon-backed, where `nativeType` exists) takes the new path. CDP `Input.insertText` is the standard Chrome input path; for plain `<textarea>` / `<input>` elements it behaves the same as a keystroke, and for React-controlled composers it adds the missing onChange dispatch.

No new unit tests added: `BasePage.typeText` calls `runResolve()` first, which requires deep mocking of the resolver chain to exercise the new branch in isolation. Coverage is the live Twitter / X reproducer above plus the existing `src/browser/` regression suite.