### PR TITLE
fix(browser): route type and keys through native input

### DIFF
--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { CliError } from '../errors.js';
 import { BasePage } from './base-page.js';
 
@@ -17,6 +17,26 @@ class TestPage extends BasePage {
   async tabs(): Promise<unknown[]> { return []; }
   async selectTab(): Promise<void> {}
 }
+
+class ActionPage extends BasePage {
+  results: unknown[] = [];
+  scripts: string[] = [];
+  nativeType?: (text: string) => Promise<void>;
+  insertText?: (text: string) => Promise<void>;
+  nativeKeyPress?: (key: string, modifiers?: string[]) => Promise<void>;
+
+  async goto(): Promise<void> {}
+  async evaluate(js: string): Promise<unknown> {
+    this.scripts.push(js);
+    return this.results.shift() ?? null;
+  }
+  async getCookies(): Promise<[]> { return []; }
+  async screenshot(): Promise<string> { return ''; }
+  async tabs(): Promise<unknown[]> { return []; }
+  async selectTab(): Promise<void> {}
+}
+
+const resolveOk = { ok: true, matches_n: 1, match_level: 'exact' };
 
 describe('BasePage.fetchJson', () => {
   it('passes a narrow browser-context JSON request and parses the response in Node', async () => {
@@ -79,5 +99,63 @@ describe('BasePage.fetchJson', () => {
       code: 'FETCH_ERROR',
       message: expect.stringContaining('The operation was aborted.'),
     });
+  });
+});
+
+describe('BasePage native input routing', () => {
+  it('types rich-editor text via native Input.insertText when available', async () => {
+    const page = new ActionPage();
+    page.nativeType = vi.fn().mockResolvedValue(undefined);
+    page.results = [resolveOk, { ok: true, mode: 'contenteditable' }];
+
+    await expect(page.typeText('#editor', 'hello')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+
+    expect(page.nativeType).toHaveBeenCalledWith('hello');
+    expect(page.scripts).toHaveLength(2);
+    expect(page.scripts[1]).toContain('nearestContentEditableHost');
+    expect(page.scripts.join('\n')).not.toContain("return 'typed'");
+  });
+
+  it('keeps the DOM setter fallback when native text insertion is unavailable', async () => {
+    const page = new ActionPage();
+    page.results = [resolveOk, 'typed'];
+
+    await page.typeText('#q', 'hello');
+
+    expect(page.scripts).toHaveLength(2);
+    expect(page.scripts[1]).toContain('document.execCommand');
+    expect(page.scripts[1]).toContain("return 'typed'");
+  });
+
+  it('falls back to DOM typing if native text insertion fails', async () => {
+    const page = new ActionPage();
+    page.nativeType = vi.fn().mockRejectedValue(new Error('native failed'));
+    page.results = [resolveOk, { ok: true, mode: 'input' }, 'typed'];
+
+    await page.typeText('#q', 'hello');
+
+    expect(page.nativeType).toHaveBeenCalledWith('hello');
+    expect(page.scripts).toHaveLength(3);
+    expect(page.scripts[2]).toContain("return 'typed'");
+  });
+
+  it('presses key chords through native CDP key events when available', async () => {
+    const page = new ActionPage();
+    page.nativeKeyPress = vi.fn().mockResolvedValue(undefined);
+
+    await page.pressKey('Control+a');
+
+    expect(page.nativeKeyPress).toHaveBeenCalledWith('a', ['Ctrl']);
+    expect(page.scripts).toHaveLength(0);
+  });
+
+  it('falls back to synthetic keyboard events with parsed modifiers', async () => {
+    const page = new ActionPage();
+
+    await page.pressKey('Meta+N');
+
+    expect(page.scripts).toHaveLength(1);
+    expect(page.scripts[0]).toContain('key: "N"');
+    expect(page.scripts[0]).toContain('metaKey: true');
   });
 });

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -25,6 +25,7 @@ import {
   resolveTargetJs,
   clickResolvedJs,
   typeResolvedJs,
+  prepareNativeTypeResolvedJs,
   scrollResolvedJs,
   type ResolveOptions,
   type TargetMatchLevel,
@@ -71,6 +72,24 @@ async function runResolve(
 function previewText(text: string | undefined): string | undefined {
   const preview = (text ?? '').replace(/\s+/g, ' ').trim().slice(0, 300);
   return preview ? `Response preview: ${preview}` : undefined;
+}
+
+function parseKeyChord(rawKey: string): { key: string; modifiers: string[] } {
+  const parts = rawKey.split('+').map(part => part.trim()).filter(Boolean);
+  if (parts.length <= 1) return { key: rawKey, modifiers: [] };
+
+  const modifiers: string[] = [];
+  for (const token of parts.slice(0, -1)) {
+    const normalized = token.toLowerCase();
+    if (normalized === 'ctrl' || normalized === 'control') modifiers.push('Ctrl');
+    else if (normalized === 'cmd' || normalized === 'command' || normalized === 'meta') modifiers.push('Meta');
+    else if (normalized === 'option' || normalized === 'alt') modifiers.push('Alt');
+    else if (normalized === 'shift') modifiers.push('Shift');
+    else return { key: rawKey, modifiers: [] };
+  }
+
+  const key = parts.at(-1);
+  return key ? { key, modifiers } : { key: rawKey, modifiers: [] };
 }
 
 export abstract class BasePage implements IPage {
@@ -225,19 +244,79 @@ export abstract class BasePage implements IPage {
     throw new Error(`Click failed: ${result.error ?? 'JS click and CDP fallback both failed'}`);
   }
 
-  /** Override in subclasses with CDP native click support */
-  protected async tryNativeClick(_x: number, _y: number): Promise<boolean> {
-    return false;
+  /** Uses native CDP click support when the concrete page exposes it. */
+  protected async tryNativeClick(x: number, y: number): Promise<boolean> {
+    const nativeClick = (this as IPage).nativeClick;
+    if (typeof nativeClick !== 'function') return false;
+    try {
+      await nativeClick.call(this, x, y);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Uses native CDP text insertion when the concrete page exposes it. */
+  protected async tryNativeType(text: string): Promise<boolean> {
+    const nativeType = (this as IPage).nativeType;
+    if (typeof nativeType === 'function') {
+      try {
+        await nativeType.call(this, text);
+        return true;
+      } catch {
+        // Fall through to the older dedicated insertText primitive if present.
+      }
+    }
+
+    const insertText = (this as IPage).insertText;
+    if (typeof insertText !== 'function') return false;
+    try {
+      await insertText.call(this, text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Uses native CDP key events when the concrete page exposes them. */
+  protected async tryNativeKeyPress(key: string, modifiers: string[]): Promise<boolean> {
+    const nativeKeyPress = (this as IPage).nativeKeyPress;
+    if (typeof nativeKeyPress !== 'function') return false;
+    try {
+      await nativeKeyPress.call(this, key, modifiers);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
     const resolved = await runResolve(this, ref, opts);
-    await this.evaluate(typeResolvedJs(text));
+    let typed = false;
+
+    if (typeof (this as IPage).nativeType === 'function' || typeof (this as IPage).insertText === 'function') {
+      try {
+        const preparation = await this.evaluate(prepareNativeTypeResolvedJs()) as
+          | { ok?: boolean; mode?: string; reason?: string }
+          | null;
+        typed = preparation?.ok === true && await this.tryNativeType(text);
+      } catch {
+        // Native input is a reliability upgrade, not the only path. Preserve
+        // the existing DOM setter fallback if preparation fails.
+      }
+    }
+
+    if (!typed) {
+      await this.evaluate(typeResolvedJs(text));
+    }
     return resolved;
   }
 
   async pressKey(key: string): Promise<void> {
-    await this.evaluate(pressKeyJs(key));
+    const parsed = parseKeyChord(key);
+    if (!await this.tryNativeKeyPress(parsed.key, parsed.modifiers)) {
+      await this.evaluate(pressKeyJs(parsed.key, parsed.modifiers));
+    }
   }
 
   async scrollTo(ref: string, opts: ResolveOptions = {}): Promise<unknown> {

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -63,4 +63,33 @@ describe('CDPBridge cookies', () => {
       { name: 'exact', value: '2', domain: 'example.com' },
     ]);
   });
+
+  it('exposes native input helpers on direct CDP pages', async () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'ws://127.0.0.1:9222/devtools/page/1');
+
+    const bridge = new CDPBridge();
+    const send = vi.spyOn(bridge, 'send').mockResolvedValue({});
+
+    const page = await bridge.connect();
+    send.mockClear();
+
+    expect(page.nativeType).toBeTypeOf('function');
+    expect(page.nativeKeyPress).toBeTypeOf('function');
+    expect(page.nativeClick).toBeTypeOf('function');
+    expect(page.cdp).toBeTypeOf('function');
+
+    await page.nativeType!('hello');
+    await page.nativeKeyPress!('a', ['Ctrl']);
+    await page.nativeClick!(10, 20);
+    await page.cdp!('Page.getLayoutMetrics', {});
+
+    expect(send.mock.calls).toEqual([
+      ['Input.insertText', { text: 'hello' }],
+      ['Input.dispatchKeyEvent', { type: 'keyDown', key: 'a', modifiers: 2 }],
+      ['Input.dispatchKeyEvent', { type: 'keyUp', key: 'a', modifiers: 2 }],
+      ['Input.dispatchMouseEvent', { type: 'mousePressed', x: 10, y: 20, button: 'left', clickCount: 1 }],
+      ['Input.dispatchMouseEvent', { type: 'mouseReleased', x: 10, y: 20, button: 'left', clickCount: 1 }],
+      ['Page.getLayoutMetrics', {}],
+    ]);
+  });
 });

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -365,6 +365,55 @@ class CDPPage extends BasePage {
   async selectTab(_target: number | string): Promise<void> {
     // Not supported in direct CDP mode
   }
+
+  async cdp(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    return this.bridge.send(method, params);
+  }
+
+  async nativeClick(x: number, y: number): Promise<void> {
+    await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mousePressed',
+      x,
+      y,
+      button: 'left',
+      clickCount: 1,
+    });
+    await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mouseReleased',
+      x,
+      y,
+      button: 'left',
+      clickCount: 1,
+    });
+  }
+
+  async nativeType(text: string): Promise<void> {
+    await this.cdp('Input.insertText', { text });
+  }
+
+  async insertText(text: string): Promise<void> {
+    await this.nativeType(text);
+  }
+
+  async nativeKeyPress(key: string, modifiers: string[] = []): Promise<void> {
+    let modifierFlags = 0;
+    for (const mod of modifiers) {
+      if (mod === 'Alt') modifierFlags |= 1;
+      if (mod === 'Ctrl' || mod === 'Control') modifierFlags |= 2;
+      if (mod === 'Meta') modifierFlags |= 4;
+      if (mod === 'Shift') modifierFlags |= 8;
+    }
+    await this.cdp('Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key,
+      modifiers: modifierFlags,
+    });
+    await this.cdp('Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key,
+      modifiers: modifierFlags,
+    });
+  }
 }
 
 function isCookie(value: unknown): value is BrowserCookie {

--- a/src/browser/dom-helpers.ts
+++ b/src/browser/dom-helpers.ts
@@ -84,12 +84,24 @@ export function typeTextJs(ref: string, text: string): string {
 }
 
 /** Generate JS to press a keyboard key */
-export function pressKeyJs(key: string): string {
+export function pressKeyJs(key: string, modifiers: string[] = []): string {
+  const hasCtrl = modifiers.includes('Ctrl') || modifiers.includes('Control');
+  const hasAlt = modifiers.includes('Alt');
+  const hasMeta = modifiers.includes('Meta');
+  const hasShift = modifiers.includes('Shift');
   return `
     (() => {
       const el = document.activeElement || document.body;
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: ${JSON.stringify(key)}, bubbles: true }));
-      el.dispatchEvent(new KeyboardEvent('keyup', { key: ${JSON.stringify(key)}, bubbles: true }));
+      const init = {
+        key: ${JSON.stringify(key)},
+        bubbles: true,
+        ctrlKey: ${hasCtrl},
+        altKey: ${hasAlt},
+        metaKey: ${hasMeta},
+        shiftKey: ${hasShift},
+      };
+      el.dispatchEvent(new KeyboardEvent('keydown', init));
+      el.dispatchEvent(new KeyboardEvent('keyup', init));
       return 'pressed';
     })()
   `;

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -390,7 +390,7 @@ export class Page extends BasePage {
     let modifierFlags = 0;
     for (const mod of modifiers) {
       if (mod === 'Alt') modifierFlags |= 1;
-      if (mod === 'Ctrl') modifierFlags |= 2;
+      if (mod === 'Ctrl' || mod === 'Control') modifierFlags |= 2;
       if (mod === 'Meta') modifierFlags |= 4;
       if (mod === 'Shift') modifierFlags |= 8;
     }

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -355,6 +355,82 @@ export function typeResolvedJs(text: string): string {
 }
 
 /**
+ * Prepare the resolved element for native CDP Input.insertText.
+ *
+ * This preserves `browser type`'s existing "replace current text" semantics:
+ * focus the editable target, select its current contents, then let CDP insert
+ * real browser text input so rich editors can update their internal state.
+ */
+export function prepareNativeTypeResolvedJs(): string {
+  return `
+    (() => {
+      const original = window.__resolved;
+      if (!original) throw new Error('No resolved element');
+
+      function nearestContentEditableHost(el) {
+        let current = el;
+        while (current && current.nodeType === 1) {
+          if (current.hasAttribute && current.hasAttribute('contenteditable')) return current;
+          current = current.parentElement;
+        }
+        return el.isContentEditable ? el : null;
+      }
+
+      const editableHost = original.isContentEditable ? nearestContentEditableHost(original) : null;
+      const inputTypes = new Set(['', 'text', 'search', 'url', 'tel', 'email', 'password']);
+      const isInput = original instanceof HTMLInputElement;
+      const isTextarea = original instanceof HTMLTextAreaElement;
+      const isTextControl = isTextarea || (isInput && inputTypes.has((original.getAttribute('type') || original.type || '').toLowerCase()));
+      const el = editableHost || (isTextControl ? original : null);
+
+      if (!el) {
+        return {
+          ok: false,
+          reason: 'not_editable',
+          tag: original.tagName ? original.tagName.toLowerCase() : '',
+        };
+      }
+
+      window.__resolved = el;
+      el.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'nearest' });
+      try {
+        el.focus({ preventScroll: true });
+      } catch (_) {
+        el.focus();
+      }
+
+      if (editableHost) {
+        const sel = window.getSelection();
+        if (!sel) return { ok: false, reason: 'selection_unavailable', mode: 'contenteditable' };
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        sel.removeAllRanges();
+        sel.addRange(range);
+        return { ok: true, mode: 'contenteditable' };
+      }
+
+      let selected = false;
+      try {
+        if (typeof el.setSelectionRange === 'function') {
+          el.setSelectionRange(0, String(el.value || '').length);
+          selected = true;
+        }
+      } catch (_) {}
+      try {
+        if (!selected && typeof el.select === 'function') {
+          el.select();
+          selected = true;
+        }
+      } catch (_) {}
+
+      return selected
+        ? { ok: true, mode: isTextarea ? 'textarea' : 'input' }
+        : { ok: false, reason: 'selection_unavailable', mode: isTextarea ? 'textarea' : 'input' };
+    })()
+  `;
+}
+
+/**
  * Generate JS for scrollTo that uses the unified resolver.
  * Assumes resolveTargetJs has been called and __resolved is set.
  */


### PR DESCRIPTION
## Summary
- Route `BasePage.typeText` through existing native `Input.insertText` when the resolved target can be focused and selected, then fall back to the existing DOM setter path if native input is unavailable or fails
- Route `BasePage.pressKey` through existing native `Input.dispatchKeyEvent` with basic chord parsing (`Control+a`, `Meta+N`, etc.), with synthetic DOM keyboard events as fallback
- Add direct `CDPPage` parity for `cdp`, `nativeType`, `insertText`, `nativeKeyPress`, and `nativeClick`

## Verification
- `npx vitest run src/browser/base-page.test.ts src/browser/cdp.test.ts src/browser/page.test.ts src/cli.test.ts --project unit` (131 passed)
- `npm run typecheck`
- `npm run build`

Fixes #1265.