### PR TITLE
chore: bump version to 1.7.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump package.json to 1.7.11
- Extension stays at 1.0.4 (no change)

Since v1.7.10:
- fix(browser): native type/keys input + CDPPage parity (#1274)
- feat(instagram): collection-delete adapter (#1271)
- feat(browser): verify workflow polish (#1270)
- fix(release): build before manifest drift check (#1269)
- fix(build-manifest): fail loud on import errors (#1268)
- fix(extension): remove status-row left border accent (#1267)