### PR TITLE
feat(browser): add dialog handling and CDP DOM primitives

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1444,9 +1444,12 @@ async function handleScreenshot(cmd, workspace) {
 const CDP_ALLOWLIST = /* @__PURE__ */ new Set([
   // Agent DOM context
   "Accessibility.getFullAXTree",
+  "DOM.enable",
   "DOM.getDocument",
   "DOM.getBoxModel",
   "DOM.getContentQuads",
+  "DOM.focus",
+  "DOM.querySelector",
   "DOM.querySelectorAll",
   "DOM.scrollIntoViewIfNeeded",
   "DOMSnapshot.captureSnapshot",
@@ -1458,6 +1461,7 @@ const CDP_ALLOWLIST = /* @__PURE__ */ new Set([
   "Page.getLayoutMetrics",
   "Page.captureScreenshot",
   "Page.getFrameTree",
+  "Page.handleJavaScriptDialog",
   // Runtime.enable needed for CDP attach setup (Runtime.evaluate goes through 'exec' action)
   "Runtime.enable",
   // Emulation (used by screenshot full-page)

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1278,9 +1278,12 @@ async function handleScreenshot(cmd: Command, workspace: string): Promise<Result
 const CDP_ALLOWLIST = new Set([
   // Agent DOM context
   'Accessibility.getFullAXTree',
+  'DOM.enable',
   'DOM.getDocument',
   'DOM.getBoxModel',
   'DOM.getContentQuads',
+  'DOM.focus',
+  'DOM.querySelector',
   'DOM.querySelectorAll',
   'DOM.scrollIntoViewIfNeeded',
   'DOMSnapshot.captureSnapshot',
@@ -1292,6 +1295,7 @@ const CDP_ALLOWLIST = new Set([
   'Page.getLayoutMetrics',
   'Page.captureScreenshot',
   'Page.getFrameTree',
+  'Page.handleJavaScriptDialog',
   // Runtime.enable needed for CDP attach setup (Runtime.evaluate goes through 'exec' action)
   'Runtime.enable',
   // Emulation (used by screenshot full-page)

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -20,15 +20,23 @@ class TestPage extends BasePage {
 
 class ActionPage extends BasePage {
   results: unknown[] = [];
+  withArgsResults: unknown[] = [];
   scripts: string[] = [];
+  withArgs: Record<string, unknown>[] = [];
   nativeType?: (text: string) => Promise<void>;
   insertText?: (text: string) => Promise<void>;
   nativeKeyPress?: (key: string, modifiers?: string[]) => Promise<void>;
+  cdp?: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
 
   async goto(): Promise<void> {}
   async evaluate(js: string): Promise<unknown> {
     this.scripts.push(js);
     return this.results.shift() ?? null;
+  }
+  override async evaluateWithArgs(js: string, args: Record<string, unknown>): Promise<unknown> {
+    this.scripts.push(js);
+    this.withArgs.push(args);
+    return this.withArgsResults.shift() ?? null;
   }
   async getCookies(): Promise<[]> { return []; }
   async screenshot(): Promise<string> { return ''; }
@@ -116,6 +124,30 @@ describe('BasePage native input routing', () => {
     expect(page.scripts.join('\n')).not.toContain("return 'typed'");
   });
 
+  it('uses CDP DOM focus and scroll before native text insertion when available', async () => {
+    const page = new ActionPage();
+    page.nativeType = vi.fn().mockResolvedValue(undefined);
+    page.cdp = vi.fn()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ root: { nodeId: 1 } })
+      .mockResolvedValueOnce({ nodeId: 7 })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ root: { nodeId: 1 } })
+      .mockResolvedValueOnce({ nodeId: 7 })
+      .mockResolvedValueOnce({});
+    page.results = [resolveOk, { ok: true, mode: 'input' }];
+    page.withArgsResults = [{ ok: true }, undefined, { ok: true }, undefined];
+
+    await page.typeText('#q', 'hello');
+
+    expect(page.cdp).toHaveBeenCalledWith('DOM.scrollIntoViewIfNeeded', { nodeId: 7 });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.focus', { nodeId: 7 });
+    expect(page.nativeType).toHaveBeenCalledWith('hello');
+    expect(page.scripts.at(-1)).toContain('if (false) el.scrollIntoView');
+    expect(page.scripts.at(-1)).toContain('if (false) {');
+  });
+
   it('keeps the DOM setter fallback when native text insertion is unavailable', async () => {
     const page = new ActionPage();
     page.results = [resolveOk, 'typed'];
@@ -137,6 +169,22 @@ describe('BasePage native input routing', () => {
     expect(page.nativeType).toHaveBeenCalledWith('hello');
     expect(page.scripts).toHaveLength(3);
     expect(page.scripts[2]).toContain("return 'typed'");
+  });
+
+  it('uses CDP DOM scrollIntoViewIfNeeded before JS click when available', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ root: { nodeId: 1 } })
+      .mockResolvedValueOnce({ nodeId: 9 })
+      .mockResolvedValueOnce({});
+    page.results = [resolveOk, { status: 'clicked', x: 1, y: 2 }];
+    page.withArgsResults = [{ ok: true }, undefined];
+
+    await page.click('#save');
+
+    expect(page.cdp).toHaveBeenCalledWith('DOM.scrollIntoViewIfNeeded', { nodeId: 9 });
+    expect(page.scripts.at(-1)).toContain('if (false) el.scrollIntoView');
   });
 
   it('presses key chords through native CDP key events when available', async () => {

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -96,6 +96,7 @@ export abstract class BasePage implements IPage {
   protected _lastUrl: string | null = null;
   /** Cached previous snapshot hashes for incremental diff marking */
   private _prevSnapshotHashes: string | null = null;
+  private _cdpTargetMarkerSeq = 0;
 
   // ── Transport-specific methods (must be implemented by subclasses) ──
 
@@ -224,9 +225,10 @@ export abstract class BasePage implements IPage {
   async click(ref: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
     // Phase 1: Resolve target with fingerprint verification
     const resolved = await runResolve(this, ref, opts);
+    const nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
 
     // Phase 2: Execute click on resolved element
-    const result = await this.evaluate(clickResolvedJs()) as
+    const result = await this.evaluate(clickResolvedJs({ skipScroll: nativeScrolled })) as
       | string
       | { status: string; x?: number; y?: number; w?: number; h?: number; error?: string }
       | null;
@@ -290,13 +292,79 @@ export abstract class BasePage implements IPage {
     }
   }
 
+  /**
+   * Run a DOM-domain CDP command against `window.__resolved`.
+   *
+   * CDP DOM.focus / DOM.scrollIntoViewIfNeeded need a nodeId, while our
+   * resolver stores the live Element in page JS. Bridge the two worlds with a
+   * short-lived marker attribute, then query it through CDP.
+   */
+  protected async tryCdpOnResolvedElement(method: 'DOM.focus' | 'DOM.scrollIntoViewIfNeeded'): Promise<boolean> {
+    const cdp = (this as IPage).cdp;
+    if (typeof cdp !== 'function') return false;
+
+    const markerAttr = 'data-opencli-cdp-target';
+    const markerValue = `${Date.now().toString(36)}-${++this._cdpTargetMarkerSeq}`;
+    const selector = `[${markerAttr}="${markerValue}"]`;
+    let marked = false;
+
+    try {
+      const marker = await this.evaluateWithArgs(`
+        (() => {
+          const el = window.__resolved;
+          if (!el || el.nodeType !== 1 || typeof el.setAttribute !== 'function') {
+            return { ok: false };
+          }
+          el.setAttribute(markerAttr, markerValue);
+          return { ok: true };
+        })()
+      `, { markerAttr, markerValue }) as { ok?: boolean } | null;
+      marked = marker?.ok === true;
+      if (!marked) return false;
+
+      await cdp.call(this, 'DOM.enable', {}).catch(() => undefined);
+      const doc = await cdp.call(this, 'DOM.getDocument', {}) as { root?: { nodeId?: unknown } } | null;
+      const rootNodeId = doc?.root?.nodeId;
+      if (typeof rootNodeId !== 'number') return false;
+
+      const query = await cdp.call(this, 'DOM.querySelector', {
+        nodeId: rootNodeId,
+        selector,
+      }) as { nodeId?: unknown } | null;
+      const nodeId = query?.nodeId;
+      if (typeof nodeId !== 'number' || nodeId <= 0) return false;
+
+      await cdp.call(this, method, { nodeId });
+      return true;
+    } catch {
+      return false;
+    } finally {
+      if (marked) {
+        await this.evaluateWithArgs(`
+          (() => {
+            for (const el of document.querySelectorAll(selector)) {
+              el.removeAttribute(markerAttr);
+            }
+          })()
+        `, { selector, markerAttr }).catch(() => undefined);
+      }
+    }
+  }
+
   async typeText(ref: string, text: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
     const resolved = await runResolve(this, ref, opts);
     let typed = false;
+    let nativeScrolled = false;
+    let nativeFocused = false;
 
     if (typeof (this as IPage).nativeType === 'function' || typeof (this as IPage).insertText === 'function') {
       try {
-        const preparation = await this.evaluate(prepareNativeTypeResolvedJs()) as
+        nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
+        nativeFocused = await this.tryCdpOnResolvedElement('DOM.focus');
+        const preparation = await this.evaluate(prepareNativeTypeResolvedJs({
+          skipScroll: nativeScrolled,
+          skipFocus: nativeFocused,
+        })) as
           | { ok?: boolean; mode?: string; reason?: string }
           | null;
         typed = preparation?.ok === true && await this.tryNativeType(text);
@@ -321,7 +389,8 @@ export abstract class BasePage implements IPage {
 
   async scrollTo(ref: string, opts: ResolveOptions = {}): Promise<unknown> {
     const resolved = await runResolve(this, ref, opts);
-    const result = (await this.evaluate(scrollResolvedJs())) as Record<string, unknown> | null;
+    const nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
+    const result = (await this.evaluate(scrollResolvedJs({ skipScroll: nativeScrolled }))) as Record<string, unknown> | null;
     // Fold match_level into the scroll payload so the user-facing envelope
     // carries it the same way click / type do.
     if (result && typeof result === 'object') {

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -76,11 +76,13 @@ describe('CDPBridge cookies', () => {
     expect(page.nativeType).toBeTypeOf('function');
     expect(page.nativeKeyPress).toBeTypeOf('function');
     expect(page.nativeClick).toBeTypeOf('function');
+    expect(page.handleJavaScriptDialog).toBeTypeOf('function');
     expect(page.cdp).toBeTypeOf('function');
 
     await page.nativeType!('hello');
     await page.nativeKeyPress!('a', ['Ctrl']);
     await page.nativeClick!(10, 20);
+    await page.handleJavaScriptDialog!(true, 'ok');
     await page.cdp!('Page.getLayoutMetrics', {});
 
     expect(send.mock.calls).toEqual([
@@ -89,6 +91,7 @@ describe('CDPBridge cookies', () => {
       ['Input.dispatchKeyEvent', { type: 'keyUp', key: 'a', modifiers: 2 }],
       ['Input.dispatchMouseEvent', { type: 'mousePressed', x: 10, y: 20, button: 'left', clickCount: 1 }],
       ['Input.dispatchMouseEvent', { type: 'mouseReleased', x: 10, y: 20, button: 'left', clickCount: 1 }],
+      ['Page.handleJavaScriptDialog', { accept: true, promptText: 'ok' }],
       ['Page.getLayoutMetrics', {}],
     ]);
   });

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -370,6 +370,13 @@ class CDPPage extends BasePage {
     return this.bridge.send(method, params);
   }
 
+  async handleJavaScriptDialog(accept: boolean, promptText?: string): Promise<void> {
+    await this.cdp('Page.handleJavaScriptDialog', {
+      accept,
+      ...(promptText !== undefined && { promptText }),
+    });
+  }
+
   async nativeClick(x: number, y: number): Promise<void> {
     await this.cdp('Input.dispatchMouseEvent', {
       type: 'mousePressed',

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -133,6 +133,27 @@ describe('Page network capture compatibility', () => {
   });
 });
 
+describe('Page CDP helpers', () => {
+  beforeEach(() => {
+    sendCommandMock.mockReset();
+    sendCommandFullMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it('handles JavaScript dialogs through the CDP passthrough', async () => {
+    sendCommandMock.mockResolvedValueOnce({});
+
+    const page = new Page('browser:default');
+    await page.handleJavaScriptDialog(true, 'confirm');
+
+    expect(sendCommandMock).toHaveBeenCalledWith('cdp', expect.objectContaining({
+      workspace: 'browser:default',
+      cdpMethod: 'Page.handleJavaScriptDialog',
+      cdpParams: { accept: true, promptText: 'confirm' },
+    }));
+  });
+});
+
 describe('Page active target tracking', () => {
   beforeEach(() => {
     sendCommandMock.mockReset();

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -294,6 +294,13 @@ export class Page extends BasePage {
     });
   }
 
+  async handleJavaScriptDialog(accept: boolean, promptText?: string): Promise<void> {
+    await this.cdp('Page.handleJavaScriptDialog', {
+      accept,
+      ...(promptText !== undefined && { promptText }),
+    });
+  }
+
   /** CDP native click fallback — called when JS el.click() fails */
   protected override async tryNativeClick(x: number, y: number): Promise<boolean> {
     try {

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -298,12 +298,13 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
  * Generate JS for click that uses the unified resolver.
  * Assumes resolveTargetJs has been called and __resolved is set.
  */
-export function clickResolvedJs(): string {
+export function clickResolvedJs(opts: { skipScroll?: boolean } = {}): string {
+  const shouldScroll = opts.skipScroll ? 'false' : 'true';
   return `
     (() => {
       const el = window.__resolved;
       if (!el) throw new Error('No resolved element');
-      el.scrollIntoView({ behavior: 'instant', block: 'center' });
+      if (${shouldScroll}) el.scrollIntoView({ behavior: 'instant', block: 'center' });
       const rect = el.getBoundingClientRect();
       const x = Math.round(rect.left + rect.width / 2);
       const y = Math.round(rect.top + rect.height / 2);
@@ -361,7 +362,9 @@ export function typeResolvedJs(text: string): string {
  * focus the editable target, select its current contents, then let CDP insert
  * real browser text input so rich editors can update their internal state.
  */
-export function prepareNativeTypeResolvedJs(): string {
+export function prepareNativeTypeResolvedJs(opts: { skipScroll?: boolean; skipFocus?: boolean } = {}): string {
+  const shouldScroll = opts.skipScroll ? 'false' : 'true';
+  const shouldFocus = opts.skipFocus ? 'false' : 'true';
   return `
     (() => {
       const original = window.__resolved;
@@ -392,11 +395,13 @@ export function prepareNativeTypeResolvedJs(): string {
       }
 
       window.__resolved = el;
-      el.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'nearest' });
-      try {
-        el.focus({ preventScroll: true });
-      } catch (_) {
-        el.focus();
+      if (${shouldScroll}) el.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'nearest' });
+      if (${shouldFocus}) {
+        try {
+          el.focus({ preventScroll: true });
+        } catch (_) {
+          el.focus();
+        }
       }
 
       if (editableHost) {
@@ -434,12 +439,13 @@ export function prepareNativeTypeResolvedJs(): string {
  * Generate JS for scrollTo that uses the unified resolver.
  * Assumes resolveTargetJs has been called and __resolved is set.
  */
-export function scrollResolvedJs(): string {
+export function scrollResolvedJs(opts: { skipScroll?: boolean } = {}): string {
+  const shouldScroll = opts.skipScroll ? 'false' : 'true';
   return `
     (() => {
       const el = window.__resolved;
       if (!el) throw new Error('No resolved element');
-      el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      if (${shouldScroll}) el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
       return { scrolled: true, tag: el.tagName.toLowerCase(), text: (el.textContent || '').trim().slice(0, 80) };
     })()
   `;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -358,6 +358,7 @@ describe('browser tab targeting commands', () => {
       selectTab: vi.fn().mockResolvedValue(undefined),
       newTab: vi.fn().mockResolvedValue('tab-3'),
       closeTab: vi.fn().mockResolvedValue(undefined),
+      handleJavaScriptDialog: vi.fn().mockResolvedValue(undefined),
       frames: vi.fn().mockResolvedValue([
         { index: 0, frameId: 'frame-1', url: 'https://x.example/embed', name: 'x-embed' },
       ]),
@@ -449,6 +450,31 @@ describe('browser tab targeting commands', () => {
 
     const out = lastJsonLog();
     expect(out.error.code).toBe('bound_session_missing');
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('accepts JavaScript dialogs through the browser dialog command', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'dialog', 'accept', '--text', 'ok']);
+
+    expect(browserState.page?.handleJavaScriptDialog).toHaveBeenCalledWith(true, 'ok');
+    const out = lastJsonLog();
+    expect(out).toEqual({ handled: true, action: 'accept', text: 'ok' });
+  });
+
+  it('emits a structured error when a browser action is blocked by a JavaScript dialog', async () => {
+    browserState.page = {
+      ...browserState.page,
+      evaluate: vi.fn().mockRejectedValue(new Error('JavaScript dialog showing')),
+    } as unknown as IPage;
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'eval', 'document.title']);
+
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('javascript_dialog_open');
+    expect(out.error.hint).toContain('browser dialog accept');
     expect(process.exitCode).toBeDefined();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -645,8 +645,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   function isJavaScriptDialogMessage(message: string): boolean {
     const normalized = message.toLowerCase();
-    return normalized.includes('javascript dialog')
-      || (normalized.includes('dialog') && (normalized.includes('showing') || normalized.includes('open')));
+    return normalized.includes('javascript dialog');
   }
 
   function emitJavaScriptDialogError(message: string): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -643,6 +643,22 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     }, null, 2));
   }
 
+  function isJavaScriptDialogMessage(message: string): boolean {
+    const normalized = message.toLowerCase();
+    return normalized.includes('javascript dialog')
+      || (normalized.includes('dialog') && (normalized.includes('showing') || normalized.includes('open')));
+  }
+
+  function emitJavaScriptDialogError(message: string): void {
+    console.log(JSON.stringify({
+      error: {
+        code: 'javascript_dialog_open',
+        message,
+        hint: 'Handle the modal first: opencli browser dialog accept (or dismiss). Use --text for prompt dialogs.',
+      },
+    }, null, 2));
+  }
+
   /** Wrap browser actions with error handling and optional --json output */
   function browserAction(fn: (page: Awaited<ReturnType<typeof getBrowserPage>>, ...args: any[]) => Promise<unknown>) {
     return async (...args: any[]) => {
@@ -658,7 +674,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           log.error(err.message);
           if (err.hint) log.error(`Hint: ${err.hint}`);
         } else if (err instanceof BrowserCommandError) {
-          if (err.code) {
+          if (isJavaScriptDialogMessage(err.message)) {
+            emitJavaScriptDialogError(err.message);
+          } else if (err.code) {
             console.log(JSON.stringify({
               error: {
                 code: err.code,
@@ -676,7 +694,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           if (err.hint) log.error(`Hint: ${err.hint}`);
         } else {
           const msg = getErrorMessage(err);
-          if (msg.includes('attach failed') || msg.includes('chrome-extension://')) {
+          if (isJavaScriptDialogMessage(msg)) {
+            emitJavaScriptDialogError(msg);
+            log.error(msg);
+          } else if (msg.includes('attach failed') || msg.includes('chrome-extension://')) {
             log.error(`Browser attach failed — another extension may be interfering. Try disabling 1Password.`);
           } else {
             log.error(msg);
@@ -1443,6 +1464,61 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .action(browserAction(async (page, key) => {
       await page.pressKey(key);
       console.log(`Pressed: ${key}`);
+    }));
+
+  const browserDialog = browser
+    .command('dialog')
+    .description('Handle a blocking JavaScript alert/confirm/prompt dialog');
+
+  addBrowserTabOption(browserDialog.command('accept')
+    .option('--text <text>', 'Prompt text to submit for prompt() dialogs')
+    .description('Accept the currently open JavaScript dialog'))
+    .action(browserAction(async (page, opts?: { text?: string }) => {
+      if (!page.handleJavaScriptDialog) {
+        throw new Error('This browser session does not support JavaScript dialog handling');
+      }
+      try {
+        await page.handleJavaScriptDialog(true, opts?.text);
+      } catch (err) {
+        const message = getErrorMessage(err);
+        if (message.toLowerCase().includes('no dialog')) {
+          console.log(JSON.stringify({
+            error: {
+              code: 'no_javascript_dialog',
+              message: 'No JavaScript dialog is currently open.',
+            },
+          }, null, 2));
+          process.exitCode = EXIT_CODES.USAGE_ERROR;
+          return;
+        }
+        throw err;
+      }
+      console.log(JSON.stringify({ handled: true, action: 'accept', ...(opts?.text !== undefined && { text: opts.text }) }, null, 2));
+    }));
+
+  addBrowserTabOption(browserDialog.command('dismiss')
+    .description('Dismiss the currently open JavaScript dialog'))
+    .action(browserAction(async (page) => {
+      if (!page.handleJavaScriptDialog) {
+        throw new Error('This browser session does not support JavaScript dialog handling');
+      }
+      try {
+        await page.handleJavaScriptDialog(false);
+      } catch (err) {
+        const message = getErrorMessage(err);
+        if (message.toLowerCase().includes('no dialog')) {
+          console.log(JSON.stringify({
+            error: {
+              code: 'no_javascript_dialog',
+              message: 'No JavaScript dialog is currently open.',
+            },
+          }, null, 2));
+          process.exitCode = EXIT_CODES.USAGE_ERROR;
+          return;
+        }
+        throw err;
+      }
+      console.log(JSON.stringify({ handled: true, action: 'dismiss' }, null, 2));
     }));
 
   // ── Wait commands ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,8 @@ export interface IPage {
   setActivePage?(page?: string): void;
   /** Send a raw CDP command via chrome.debugger passthrough. */
   cdp?(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  /** Accept or dismiss the currently open JavaScript alert/confirm/prompt dialog. */
+  handleJavaScriptDialog?(accept: boolean, promptText?: string): Promise<void>;
   /** List cross-origin iframe targets in snapshot order. */
   frames?(): Promise<Array<{ index: number; frameId: string; url: string; name: string }>>;
   /** Evaluate JavaScript inside a cross-origin iframe identified by its frame index. */


### PR DESCRIPTION
## Summary
- add `browser dialog accept|dismiss` for blocking JavaScript alert/confirm/prompt dialogs
- surface dialog-blocked automation failures as a structured `javascript_dialog_open` error with recovery hint
- use CDP `DOM.scrollIntoViewIfNeeded` / `DOM.focus` as internal reliability primitives before click/type/scroll, with JS fallback
- expose `Page.handleJavaScriptDialog` through Page/CDPPage parity and extension CDP allowlist

## Scope notes
- does not add `DOM.setAttributeValue`; we kept it out because it is a controlled-input footgun
- does not add Fetch-domain interception; defer until a concrete adapter needs it

## Verification
- `npx vitest run src/browser/base-page.test.ts src/browser/cdp.test.ts src/browser/page.test.ts src/cli.test.ts --project unit`
- `npm run typecheck`
- `npm run build`
- `extension/ npm run typecheck`
- `extension/ npm run build`
