### PR TITLE
fix(doctor): remove adapter analyze tip

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -52,7 +52,7 @@ describe('doctor report rendering', () => {
     expect(text).toContain('(v1.7.9)');
     expect(text).toContain('[OK] Extension: connected (v1.6.8)');
     expect(text).toContain('Everything looks good!');
-    expect(text).toContain('opencli browser analyze <url>');
+    expect(text).not.toContain('opencli browser analyze <url>');
   });
 
   it('renders a warning when daemon version is stale', () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -336,7 +336,6 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
     }
   } else if (report.daemonRunning && report.extensionConnected) {
     lines.push('', styleText('green', 'Everything looks good!'));
-    lines.push(styleText('dim', 'Tip: writing a new adapter? Run `opencli browser analyze <url>` for one-shot site recon.'));
   }
 
   return lines.join('\n');


### PR DESCRIPTION
## Summary
- remove the adapter-authoring analyze tip from successful doctor output
- keep the doctor report focused on environment/connectivity diagnostics
- update the doctor rendering test to prevent the tip from returning

## Tests
- npx vitest run src/doctor.test.ts --project unit
- npm run typecheck