### PR TITLE
fix(bilibili,reddit): add identifier and url columns to hot lists

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1787,7 +1787,9 @@
       "title",
       "author",
       "play",
-      "danmaku"
+      "danmaku",
+      "bvid",
+      "url"
     ],
     "type": "js",
     "modulePath": "bilibili/hot.js",
@@ -13950,7 +13952,10 @@
       "title",
       "subreddit",
       "score",
-      "comments"
+      "comments",
+      "postId",
+      "author",
+      "url"
     ],
     "type": "js",
     "modulePath": "reddit/hot.js",

--- a/clis/bilibili/hot.js
+++ b/clis/bilibili/hot.js
@@ -7,7 +7,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of videos' },
     ],
-    columns: ['rank', 'title', 'author', 'play', 'danmaku'],
+    columns: ['rank', 'title', 'author', 'play', 'danmaku', 'bvid', 'url'],
     pipeline: [
         { navigate: 'https://www.bilibili.com' },
         { evaluate: `(async () => {
@@ -20,6 +20,8 @@ cli({
     author: item.owner?.name,
     play: item.stat?.view,
     danmaku: item.stat?.danmaku,
+    bvid: item.bvid,
+    url: item.bvid ? 'https://www.bilibili.com/video/' + item.bvid : '',
   }));
 })()
 ` },
@@ -29,6 +31,8 @@ cli({
                 author: '${{ item.author }}',
                 play: '${{ item.play }}',
                 danmaku: '${{ item.danmaku }}',
+                bvid: '${{ item.bvid }}',
+                url: '${{ item.url }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/bilibili/hot.test.js
+++ b/clis/bilibili/hot.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot.js';
+
+describe('bilibili hot adapter', () => {
+  const command = getRegistry().get('bilibili/hot');
+
+  it('registers bvid and url columns in the public hot-list shape', () => {
+    expect(command?.columns).toEqual(['rank', 'title', 'author', 'play', 'danmaku', 'bvid', 'url']);
+    expect(command?.pipeline?.[1]?.evaluate).toContain('bvid: item.bvid');
+    expect(command?.pipeline?.[1]?.evaluate).toContain("'https://www.bilibili.com/video/' + item.bvid");
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      bvid: '${{ item.bvid }}',
+      url: '${{ item.url }}',
+    });
+  });
+});

--- a/clis/reddit/hot.js
+++ b/clis/reddit/hot.js
@@ -12,7 +12,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20, help: 'Number of posts' },
     ],
-    columns: ['rank', 'title', 'subreddit', 'score', 'comments'],
+    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
@@ -29,6 +29,7 @@ cli({
     score: c.data.score,
     comments: c.data.num_comments,
     author: c.data.author,
+    postId: c.data.id,
     url: 'https://www.reddit.com' + c.data.permalink,
   }));
 })()
@@ -39,6 +40,9 @@ cli({
                 subreddit: '${{ item.subreddit }}',
                 score: '${{ item.score }}',
                 comments: '${{ item.comments }}',
+                postId: '${{ item.postId }}',
+                author: '${{ item.author }}',
+                url: '${{ item.url }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/hot.test.js
+++ b/clis/reddit/hot.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot.js';
+
+describe('reddit hot adapter', () => {
+  const command = getRegistry().get('reddit/hot');
+
+  it('registers postId, author, and url columns in the hot-list shape', () => {
+    expect(command?.columns).toEqual(['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url']);
+    expect(command?.pipeline?.[1]?.evaluate).toContain('postId: c.data.id');
+    expect(command?.pipeline?.[1]?.evaluate).toContain("'https://www.reddit.com' + c.data.permalink");
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      postId: '${{ item.postId }}',
+      author: '${{ item.author }}',
+      url: '${{ item.url }}',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Both `bilibili hot` and `reddit hot` previously dropped their per-row identifier and URL on the way out, breaking the most common agent follow-up: take a row from the list, then call detail/comments with the id.

- **`bilibili hot`**: add `bvid` and `url` columns (URL constructed from `bvid`).
- **`reddit hot`**: surface `postId`, `author`, `url` — these were already produced inside the `evaluate` step but dropped in the final `map`.

Without these columns, the agent has to re-scrape the listing or open Chrome to copy a link, which defeats the point of having a `hot` listing adapter.

Discovered while exploring existing adapters end-to-end with `opencli browser` (per WAWQAQ's directive to play with what we have and surface gaps).

## Test plan

- [x] `opencli bilibili hot --limit 2 -f json` returns rows with non-empty `bvid` and `url`
- [x] `opencli reddit hot --limit 2 -f json` returns rows with non-empty `postId`, `author`, `url`
- [x] `opencli reddit hot --subreddit programming --limit 2 -f json` works the same way
- [x] `opencli bilibili video <bvid>` and `opencli reddit read <postId>` are the natural follow-ups (manual)

Tested via local `~/.opencli/clis/<site>/hot.js` overrides before committing.