### PR TITLE
fix(douban): drop unparseable fields from movie-hot, add id/votes

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5196,12 +5196,11 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "rating",
-      "quote",
-      "director",
+      "votes",
       "year",
-      "region",
       "url"
     ],
     "type": "js",

--- a/clis/douban/movie-hot.js
+++ b/clis/douban/movie-hot.js
@@ -9,6 +9,6 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: '返回的电影数量' },
     ],
-    columns: ['rank', 'title', 'rating', 'quote', 'director', 'year', 'region', 'url'],
+    columns: ['rank', 'id', 'title', 'rating', 'votes', 'year', 'url'],
     func: async (page, args) => loadDoubanMovieHot(page, Number(args.limit) || 20),
 });

--- a/clis/douban/movie-hot.test.js
+++ b/clis/douban/movie-hot.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './movie-hot.js';
+
+describe('douban movie-hot command', () => {
+    it('exposes only fields available from the chart page', () => {
+        const command = getRegistry().get('douban/movie-hot');
+
+        expect(command?.columns).toEqual(['rank', 'id', 'title', 'rating', 'votes', 'year', 'url']);
+        expect(command?.columns).not.toContain('director');
+        expect(command?.columns).not.toContain('region');
+        expect(command?.columns).not.toContain('quote');
+    });
+});

--- a/clis/douban/utils.js
+++ b/clis/douban/utils.js
@@ -524,7 +524,11 @@ export async function loadDoubanMovieHot(page, limit) {
       return results;
     })()
   `);
-    return Array.isArray(data) ? data : [];
+    const results = Array.isArray(data) ? data : [];
+    if (!results.length) {
+        throw new EmptyResultError('douban movie-hot', 'No movie chart rows were parsed from movie.douban.com/chart.');
+    }
+    return results;
 }
 export function inferDoubanSearchResultType(searchType, item = {}) {
     const fallbackType = String(searchType || '').trim() || 'movie';

--- a/clis/douban/utils.js
+++ b/clis/douban/utils.js
@@ -502,26 +502,20 @@ export async function loadDoubanMovieHot(page, limit) {
         let url = titleEl?.getAttribute('href') || '';
         if (!title || !url) continue;
         if (!url.startsWith('http')) url = 'https://movie.douban.com' + url;
+        const id = url.match(/subject\\/(\\d+)/)?.[1] || '';
 
         const info = normalize(el.querySelector('.pl2 p')?.textContent);
-        const infoParts = info.split('/').map((part) => part.trim()).filter(Boolean);
-        const releaseIndex = (() => {
-          for (let i = infoParts.length - 1; i >= 0; i -= 1) {
-            if (/\\d{4}-\\d{2}-\\d{2}|\\d{4}\\/\\d{2}\\/\\d{2}/.test(infoParts[i])) return i;
-          }
-          return -1;
-        })();
-        const directorPart = releaseIndex >= 1 ? infoParts[releaseIndex - 1] : '';
-        const regionPart = releaseIndex >= 2 ? infoParts[releaseIndex - 2] : '';
         const yearMatch = info.match(/\\b(19|20)\\d{2}\\b/);
+        const votesText = normalize(el.querySelector('.star .pl')?.textContent);
+        const votes = parseInt(votesText.replace(/[^0-9]/g, ''), 10) || 0;
+
         results.push({
           rank: results.length + 1,
+          id,
           title,
           rating: parseFloat(normalize(el.querySelector('.rating_nums')?.textContent)) || 0,
-          quote: normalize(el.querySelector('.inq')?.textContent),
-          director: directorPart.replace(/^导演:\\s*/, ''),
+          votes,
           year: yearMatch?.[0] || '',
-          region: regionPart,
           url,
           cover: el.querySelector('img')?.getAttribute('src') || '',
         });

--- a/clis/douban/utils.test.js
+++ b/clis/douban/utils.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
     getDoubanPhotoExtension,
     inferDoubanSearchResultType,
+    loadDoubanMovieHot,
     loadDoubanSubjectDetail,
     loadDoubanSubjectPhotos,
     normalizeDoubanBookSubject,
@@ -42,6 +43,39 @@ function createFakeSearchItem({ title, url, rating, abstract, cover }) {
             return null;
         },
     };
+}
+
+function createFakeMovieHotItem({ title, url, info, rating, votes, cover }) {
+    return {
+        querySelector(selector) {
+            if (selector === '.pl2 a') {
+                return createFakeNode(title, { href: url });
+            }
+            if (selector === '.pl2 p') {
+                return createFakeNode(info);
+            }
+            if (selector === '.star .pl') {
+                return createFakeNode(votes);
+            }
+            if (selector === '.rating_nums') {
+                return createFakeNode(rating);
+            }
+            if (selector === 'img') {
+                return createFakeNode('', { src: cover });
+            }
+            return null;
+        },
+    };
+}
+
+function runMovieHotEvaluate(script, items) {
+    const document = {
+        querySelectorAll(selector) {
+            return selector === '.item' ? items : [];
+        },
+    };
+
+    return vm.runInNewContext(script, { document, URL });
 }
 
 async function runSearchEvaluate(script, rawItems, domItems) {
@@ -240,6 +274,51 @@ ISBN: 9787544270871
             cover: 'https://img9.doubanio.com/view/subject/l/public/s29618581.jpg',
             url: 'https://book.douban.com/subject/2567698/',
         });
+    });
+
+    it('parses movie-hot rows with real chart fields only', async () => {
+        const items = [
+            createFakeMovieHotItem({
+                title: ' 少年与犬 ',
+                url: '/subject/36840171/',
+                info: '2025-03-20 / 日本 / 剧情',
+                rating: '6.8',
+                votes: '(12345人评价)',
+                cover: 'https://img1.doubanio.com/view/photo/s_ratio_poster/public/p1.jpg',
+            }),
+        ];
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ blocked: false, title: '豆瓣电影排行榜', href: 'https://movie.douban.com/chart' })
+                .mockImplementationOnce((script) => runMovieHotEvaluate(script, items)),
+        };
+
+        await expect(loadDoubanMovieHot(page, 20)).resolves.toEqual([
+            {
+                rank: 1,
+                id: '36840171',
+                title: '少年与犬',
+                rating: 6.8,
+                votes: 12345,
+                year: '2025',
+                url: 'https://movie.douban.com/subject/36840171/',
+                cover: 'https://img1.doubanio.com/view/photo/s_ratio_poster/public/p1.jpg',
+            },
+        ]);
+    });
+
+    it('throws EmptyResultError when movie-hot parses no chart rows', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ blocked: false, title: '豆瓣电影排行榜', href: 'https://movie.douban.com/chart' })
+                .mockResolvedValueOnce([]),
+        };
+
+        await expect(loadDoubanMovieHot(page, 20)).rejects.toThrow('douban movie-hot returned no data');
     });
 
     it('loads book subject details from book.douban.com when type=book', async () => {


### PR DESCRIPTION
## Summary

`opencli douban movie-hot` silently produces wrong data: the `director` column contains release dates like `'2025-09-07(多伦多电影节)'`, and `region` / `quote` are always empty.

Root cause: the chart page only exposes a single comma-joined dump in `.pl2 p`:

```
<release_dates...> / <actors...> / <regions...> / <director_zh> /
<runtime>分钟 / <other_titles> / <genres> / <director with English> /
<languages>
```

The old code anchored on the release-date regex and took `parts[releaseIndex - 1]` as director, `parts[releaseIndex - 2]` as region. With multiple back-to-back release dates (the common case), `releaseIndex - 1` is itself a date, so director output is the date and region is empty. With a single release date, the offsets land on actor names.

This is the canonical "verify passes but data is wrong" failure (success-rate-pitfalls §2 sibling DOM contamination). Trying to reconstruct director / region from this scrambled string is not reliable — that data is only clean on the subject detail page.

## Fix

Drop `director`, `region`, `quote` from the listing. Surface what the chart page actually provides reliably:

- `id`     — extracted from the subject URL, ready for `opencli douban subject <id>`
- `votes`  — from `.star .pl` (`(62484人评价)`), useful as popularity signal
- existing `rank`, `title`, `rating`, `year`, `url`

Agents that need director / region should follow up with `opencli douban subject <id>`, which already pulls full metadata.

## Before

```
$ opencli douban movie-hot --limit 1 -f json
[{
  "rank": 1,
  "title": "世界的主人 / ...",
  "rating": 9.2,
  "quote": "",
  "director": "2025-09-07(多伦多电影节)",   // wrong
  "year": "2025",
  "region": "",                               // empty
  "url": "https://movie.douban.com/subject/37116612/"
}]
```

## After

```
$ opencli douban movie-hot --limit 1 -f json
[{
  "rank": 1,
  "id": "37116612",
  "title": "世界的主人 / ...",
  "rating": 9.2,
  "votes": 62514,
  "year": "2025",
  "url": "https://movie.douban.com/subject/37116612/"
}]
```

## Test plan

- [x] `opencli douban movie-hot --limit 5 -f json` — id / votes / year / url all present, no director/region/quote columns
- [x] `opencli douban movie-hot --limit 3 -f table` — column order matches columns array
- [x] `opencli douban subject 37116612` still works for full metadata follow-up