### PR TITLE
twitter: inline user bio in list-tweets/timeline/search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docs/.vitepress/cache
 .windsurf
 .claude
 .cortex
+.gstack
 
 # Database files
 *.db

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -59,11 +59,13 @@ export function extractTimelineTweet(result, seen) {
     const user = tw.core?.user_results?.result;
     const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';
     const displayName = user?.legacy?.name || user?.core?.name || '';
+    const bio = user?.legacy?.description || '';
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     return {
         id: tw.rest_id,
         author: screenName,
         name: displayName,
+        bio,
         text: noteText || legacy.full_text || '',
         likes: legacy.favorite_count || 0,
         retweets: legacy.retweet_count || 0,
@@ -115,7 +117,7 @@ cli({
         { name: 'listId', positional: true, type: 'string', required: true },
         { name: 'limit', type: 'int', default: 50 },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -24,6 +24,7 @@ describe('twitter list-tweets parser', () => {
             id: '99',
             author: 'bob',
             name: 'Bob',
+            bio: '',
             text: 'hello list',
             likes: 3,
             retweets: 1,

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -103,7 +103,7 @@ cli({
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'] },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const query = kwargs.query;
         const filter = kwargs.filter === 'live' ? 'live' : 'top';
@@ -150,9 +150,11 @@ cli({
                     seen.add(tweet.rest_id);
                     // Twitter moved screen_name from legacy to core
                     const tweetUser = tweet.core?.user_results?.result;
+                    const bio = tweetUser?.legacy?.description || '';
                     results.push({
                         id: tweet.rest_id,
                         author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown',
+                        bio,
                         text: tweet.note_tweet?.note_tweet_results?.result?.text || tweet.legacy?.full_text || '',
                         created_at: tweet.legacy?.created_at || '',
                         likes: tweet.legacy?.favorite_count || 0,

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -70,6 +70,7 @@ describe('twitter search command', () => {
             {
                 id: '1',
                 author: 'alice',
+                bio: '',
                 text: 'hello world',
                 created_at: 'Thu Mar 26 10:30:00 +0000 2026',
                 likes: 7,
@@ -200,6 +201,7 @@ describe('twitter search command', () => {
             {
                 id: '99',
                 author: 'bob',
+                bio: '',
                 text: 'fallback works',
                 created_at: 'Wed Apr 02 12:00:00 +0000 2026',
                 likes: 3,

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -73,11 +73,13 @@ function extractTweet(result, seen) {
     seen.add(tw.rest_id);
     const u = tw.core?.user_results?.result;
     const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';
+    const bio = u?.legacy?.description || '';
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     const views = tw.views?.count ? parseInt(tw.views.count, 10) : 0;
     return {
         id: tw.rest_id,
         author: screenName,
+        bio,
         text: noteText || l.full_text || '',
         likes: l.favorite_count || 0,
         retweets: l.retweet_count || 0,
@@ -149,7 +151,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';


### PR DESCRIPTION
## Summary

- Inline `bio` (from `user.legacy.description`) on each tweet returned by `twitter list-tweets`, `twitter timeline`, and `twitter search`, matching the field already exposed by `twitter profile`.
- Add `.gstack` to `.gitignore` alongside the existing agent tool dirs (`.windsurf`, `.claude`, `.cortex`).

## Why

The bio is already present in the GraphQL response under `tweet.core.user_results.result.legacy.description` — we were dropping it on the floor. Surfacing it lets downstream consumers (agents, table views) see who the author is without making a separate `twitter profile <screen_name>` call per unique author. On a 50-tweet list with ~30 distinct authors, that saves ~30 API roundtrips and the matching rate-limit budget.

`bio` defaults to `''` when the user object is missing, so existing callers are unaffected. The `columns` arrays are updated so `--format table` renders bio when asked.

## Test plan

- [x] `clis/twitter/list-tweets.test.js` — bio assertion added
- [x] `clis/twitter/search.test.js` — bio assertion added
- [ ] Manual: `opencli twitter list-tweets <listId> --format json` shows non-empty `bio` for accounts with a description
- [ ] Manual: `opencli twitter search "<query>" --format table --columns bio,author,text` renders the bio column

🤖 Generated with [Claude Code](https://claude.com/claude-code)