### PR TITLE
fix(twitter): skip "Discover new Lists" + inline user bio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docs/.vitepress/cache
 .windsurf
 .claude
 .cortex
+.gstack
 
 # Database files
 *.db

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -59,11 +59,13 @@ export function extractTimelineTweet(result, seen) {
     const user = tw.core?.user_results?.result;
     const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';
     const displayName = user?.legacy?.name || user?.core?.name || '';
+    const bio = user?.legacy?.description || '';
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     return {
         id: tw.rest_id,
         author: screenName,
         name: displayName,
+        bio,
         text: noteText || legacy.full_text || '',
         likes: legacy.favorite_count || 0,
         retweets: legacy.retweet_count || 0,
@@ -115,7 +117,7 @@ cli({
         { name: 'listId', positional: true, type: 'string', required: true },
         { name: 'limit', type: 'int', default: 50 },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -24,6 +24,7 @@ describe('twitter list-tweets parser', () => {
             id: '99',
             author: 'bob',
             name: 'Bob',
+            bio: '',
             text: 'hello list',
             likes: 3,
             retweets: 1,

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -62,6 +62,19 @@ export function extractListEntry(entry, seen) {
     };
 }
 
+// X 的 ListsManagementPageTimeline 把 /<user>/lists 整个页面的所有 section
+// 都塞在同一个 TimelineAddEntries instruction 里，靠 entry.entryId 前缀区分：
+//   - `owned-subscribed-list-module-*`  → 用户的 owned + subscribed list（要保留）
+//   - `list-to-follow-module-*`         → "Discover new Lists" 算法推荐（要剔除）
+//   - `cursor-*`                         → 分页游标（无 list 数据）
+// 旧版 parser 忽略 entryId 一律下钻，导致推荐 list 被当成自建/订阅泄漏出来。
+const OWNED_SUBSCRIBED_ENTRY_PREFIX = 'owned-subscribed-list-module-';
+
+export function isOwnedSubscribedEntry(entry) {
+    return typeof entry?.entryId === 'string'
+        && entry.entryId.startsWith(OWNED_SUBSCRIBED_ENTRY_PREFIX);
+}
+
 export function parseListsManagement(data, seen) {
     const lists = [];
     const instructions = data?.data?.viewer?.list_management_timeline?.timeline?.instructions
@@ -70,6 +83,7 @@ export function parseListsManagement(data, seen) {
         || [];
     for (const inst of instructions) {
         for (const entry of inst.entries || []) {
+            if (!isOwnedSubscribedEntry(entry)) continue;
             const direct = extractListEntry(entry, seen);
             if (direct) {
                 lists.push(direct);

--- a/clis/twitter/lists.test.js
+++ b/clis/twitter/lists.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractListEntry, parseListsManagement } from './lists.js';
+import { extractListEntry, isOwnedSubscribedEntry, parseListsManagement } from './lists.js';
 
 describe('twitter lists parser', () => {
     it('extracts a list entry with full metadata', () => {
@@ -56,7 +56,7 @@ describe('twitter lists parser', () => {
         expect(extractListEntry({ content: { itemContent: {} } }, new Set())).toBeNull();
     });
 
-    it('parses ListsManagementPageTimeline payload instructions', () => {
+    it('parses ListsManagementPageTimeline payload instructions (real shape: nested module items)', () => {
         const payload = {
             data: {
                 viewer: {
@@ -64,21 +64,32 @@ describe('twitter lists parser', () => {
                         timeline: {
                             instructions: [
                                 {
+                                    type: 'TimelineAddEntries',
                                     entries: [
                                         {
-                                            entryId: 'owned-list-1',
+                                            entryId: 'owned-subscribed-list-module-0',
                                             content: {
-                                                itemContent: {
-                                                    list: { id_str: '1', name: 'Crypto', member_count: 44, subscriber_count: 8747, mode: 'Public' },
-                                                },
-                                            },
-                                        },
-                                        {
-                                            entryId: 'subscribed-list-2',
-                                            content: {
-                                                itemContent: {
-                                                    list: { id_str: '2', name: 'AI', member_count: 15, subscriber_count: 0, mode: 'Private' },
-                                                },
+                                                entryType: 'TimelineTimelineModule',
+                                                items: [
+                                                    {
+                                                        entryId: 'owned-subscribed-list-module-0-list-1',
+                                                        item: {
+                                                            itemContent: {
+                                                                itemType: 'TimelineTwitterList',
+                                                                list: { id_str: '1', name: 'AI & Agents', member_count: 33, subscriber_count: 0, mode: 'Private' },
+                                                            },
+                                                        },
+                                                    },
+                                                    {
+                                                        entryId: 'owned-subscribed-list-module-0-list-2',
+                                                        item: {
+                                                            itemContent: {
+                                                                itemType: 'TimelineTwitterList',
+                                                                list: { id_str: '2', name: 'Anthropic Team', member_count: 10, subscriber_count: 0, mode: 'Public' },
+                                                            },
+                                                        },
+                                                    },
+                                                ],
                                             },
                                         },
                                     ],
@@ -91,8 +102,76 @@ describe('twitter lists parser', () => {
         };
         const result = parseListsManagement(payload, new Set());
         expect(result).toHaveLength(2);
-        expect(result[0]).toMatchObject({ id: '1', name: 'Crypto', mode: 'public' });
-        expect(result[1]).toMatchObject({ id: '2', name: 'AI', mode: 'private' });
+        expect(result[0]).toMatchObject({ id: '1', name: 'AI & Agents', mode: 'private' });
+        expect(result[1]).toMatchObject({ id: '2', name: 'Anthropic Team', mode: 'public' });
+    });
+
+    it('skips "Discover new Lists" recommendations (list-to-follow-module-*)', () => {
+        // 真实 X.com /<user>/lists 响应：Discover 推荐 + Your Lists 同 instruction，
+        // 区别只在 entry.entryId 前缀。Parser 必须按前缀剔除推荐。
+        const payload = {
+            data: {
+                viewer: {
+                    list_management_timeline: {
+                        timeline: {
+                            instructions: [
+                                {
+                                    type: 'TimelineAddEntries',
+                                    entries: [
+                                        {
+                                            entryId: 'list-to-follow-module-2050754937725386752',
+                                            content: {
+                                                entryType: 'TimelineTimelineModule',
+                                                items: [
+                                                    {
+                                                        entryId: 'list-to-follow-module-XYZ-list-1597593475389984769',
+                                                        item: { itemContent: { itemType: 'TimelineTwitterList', list: { id_str: '1597593475389984769', name: 'Crypto', member_count: 44, subscriber_count: 8947, mode: 'Public' } } },
+                                                    },
+                                                    {
+                                                        entryId: 'list-to-follow-module-XYZ-list-1499395616262217730',
+                                                        item: { itemContent: { itemType: 'TimelineTwitterList', list: { id_str: '1499395616262217730', name: 'Crypto Blockchain', member_count: 24, subscriber_count: 1166, mode: 'Public' } } },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                        {
+                                            entryId: 'owned-subscribed-list-module-0',
+                                            content: {
+                                                entryType: 'TimelineTimelineModule',
+                                                items: [
+                                                    {
+                                                        entryId: 'owned-subscribed-list-module-0-list-2044679538156912976',
+                                                        item: { itemContent: { itemType: 'TimelineTwitterList', list: { id_str: '2044679538156912976', name: 'AI & Agents', member_count: 33, subscriber_count: 0, mode: 'Private' } } },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                        {
+                                            entryId: 'cursor-bottom-2050754937725386750',
+                                            content: { entryType: 'TimelineTimelineCursor' },
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        const result = parseListsManagement(payload, new Set());
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ id: '2044679538156912976', name: 'AI & Agents' });
+        // No Crypto/Blockchain leakage
+        expect(result.find(l => l.name === 'Crypto')).toBeUndefined();
+        expect(result.find(l => l.name === 'Crypto Blockchain')).toBeUndefined();
+    });
+
+    it('isOwnedSubscribedEntry classifies entryIds', () => {
+        expect(isOwnedSubscribedEntry({ entryId: 'owned-subscribed-list-module-0' })).toBe(true);
+        expect(isOwnedSubscribedEntry({ entryId: 'list-to-follow-module-2050754937725386752' })).toBe(false);
+        expect(isOwnedSubscribedEntry({ entryId: 'cursor-bottom-XYZ' })).toBe(false);
+        expect(isOwnedSubscribedEntry({})).toBe(false);
+        expect(isOwnedSubscribedEntry({ entryId: null })).toBe(false);
     });
 
     it('returns empty list for malformed payload', () => {
@@ -100,13 +179,23 @@ describe('twitter lists parser', () => {
         expect(parseListsManagement({ data: {} }, new Set())).toEqual([]);
     });
 
-    it('dedupes across repeated entries', () => {
-        const entryA = { content: { itemContent: { list: { id_str: '1', name: 'A' } } } };
+    it('dedupes across repeated entries within owned-subscribed module', () => {
+        const itemA = {
+            entryId: 'owned-subscribed-list-module-0-list-1',
+            item: { itemContent: { list: { id_str: '1', name: 'A' } } },
+        };
         const payload = {
             data: {
                 viewer: {
                     list_management_timeline: {
-                        timeline: { instructions: [{ entries: [entryA, entryA] }] },
+                        timeline: {
+                            instructions: [{
+                                entries: [{
+                                    entryId: 'owned-subscribed-list-module-0',
+                                    content: { items: [itemA, itemA] },
+                                }],
+                            }],
+                        },
                     },
                 },
             },

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -103,7 +103,7 @@ cli({
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'] },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const query = kwargs.query;
         const filter = kwargs.filter === 'live' ? 'live' : 'top';
@@ -150,9 +150,11 @@ cli({
                     seen.add(tweet.rest_id);
                     // Twitter moved screen_name from legacy to core
                     const tweetUser = tweet.core?.user_results?.result;
+                    const bio = tweetUser?.legacy?.description || '';
                     results.push({
                         id: tweet.rest_id,
                         author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown',
+                        bio,
                         text: tweet.note_tweet?.note_tweet_results?.result?.text || tweet.legacy?.full_text || '',
                         created_at: tweet.legacy?.created_at || '',
                         likes: tweet.legacy?.favorite_count || 0,

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -70,6 +70,7 @@ describe('twitter search command', () => {
             {
                 id: '1',
                 author: 'alice',
+                bio: '',
                 text: 'hello world',
                 created_at: 'Thu Mar 26 10:30:00 +0000 2026',
                 likes: 7,
@@ -200,6 +201,7 @@ describe('twitter search command', () => {
             {
                 id: '99',
                 author: 'bob',
+                bio: '',
                 text: 'fallback works',
                 created_at: 'Wed Apr 02 12:00:00 +0000 2026',
                 likes: 3,

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -73,11 +73,13 @@ function extractTweet(result, seen) {
     seen.add(tw.rest_id);
     const u = tw.core?.user_results?.result;
     const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';
+    const bio = u?.legacy?.description || '';
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     const views = tw.views?.count ? parseInt(tw.views.count, 10) : 0;
     return {
         id: tw.rest_id,
         author: screenName,
+        bio,
         text: noteText || l.full_text || '',
         likes: l.favorite_count || 0,
         retweets: l.retweet_count || 0,
@@ -149,7 +151,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';


### PR DESCRIPTION
## Description

Three independent fixes/enhancements on the X.com adapter, all verified against live accounts.

### 1. Skip "Discover new Lists" in `twitter lists` (the namesake fix)

The X.com `/<user>/lists` page powers two sections from a single `ListsManagementPageTimeline` GraphQL response:

- **Your Lists** (owned + subscribed) — what users actually want
- **Discover new Lists** — algorithmic recommendations

The previous parser ignored `entry.entryId` entirely and returned **everything**, so recommendations leaked through and downstream consumers treated them as the user's own lists.

X distinguishes the sections by `entry.entryId` prefix:

| prefix | meaning | action |
|---|---|---|
| `owned-subscribed-list-module-*` | owned + subscribed | keep |
| `list-to-follow-module-*` | Discover recommendations | drop |
| `cursor-*` | pagination | drop (no list payload) |

`parseListsManagement` now filters on the `owned-subscribed` prefix; `isOwnedSubscribedEntry` is exposed for testing. The existing test fixture used a fictional `entryId` shape that no longer matches real responses — updated it to the real nested-module shape and added two new tests (Discover-skipped + entryId classifier).

**Verified end-to-end**: 10 raw entries (3 Discover + 7 owned/subscribed) → 7 owned/subscribed lists, zero leakage.

### 2. Inline user bio in `list-tweets` / `timeline` / `search`

Each tweet response now carries a `bio` field (extracted from `user.legacy.description`), matching the existing field in `profile`. Lets downstream consumers display author profiles without an extra API roundtrip per author. Defaults to `''` when the user object is missing. `columns` arrays updated so `--format table` renders bio when asked.

### 3. Ignore `.gstack/` tool directory

Internal tooling artifact, no reason to track it.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature (bio inlining)
- [x] 🔧 CI / build / tooling (.gitignore)

## Checklist

- [x] I ran the checks relevant to this PR (twitter test suite green)
- [x] I updated tests (new lists.test.js cases for Discover filtering and entryId classifier)
- [x] I included output (see "Verified end-to-end" above)

## Screenshots / Output

```
$ opencli twitter lists <user>
# before: 10 entries (3 Discover + 7 real)
# after:  7 entries (only owned + subscribed)
```