### PR TITLE
feat(arxiv): full abstract/authors + surface pdf/categories/comment + new `recent <category>`

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1038,12 +1038,51 @@
       "title",
       "authors",
       "published",
+      "updated",
+      "primary_category",
+      "categories",
       "abstract",
+      "comment",
+      "pdf",
       "url"
     ],
     "type": "js",
     "modulePath": "arxiv/paper.js",
     "sourceFile": "arxiv/paper.js"
+  },
+  {
+    "site": "arxiv",
+    "name": "recent",
+    "description": "List recent arXiv submissions in a category",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "category",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "arXiv category (e.g. cs.CL, cs.LG, math.PR, q-bio.NC)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max results (max 50)"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "authors",
+      "published",
+      "primary_category",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "arxiv/recent.js",
+    "sourceFile": "arxiv/recent.js"
   },
   {
     "site": "arxiv",
@@ -1072,6 +1111,7 @@
       "title",
       "authors",
       "published",
+      "primary_category",
       "url"
     ],
     "type": "js",

--- a/clis/arxiv/arxiv.test.js
+++ b/clis/arxiv/arxiv.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { parseEntries } from './utils.js';
+import { normalizeArxivCategory, normalizeArxivLimit, parseEntries } from './utils.js';
 import './paper.js';
 import './search.js';
 import './recent.js';
@@ -88,5 +88,25 @@ describe('arxiv adapter', () => {
     await expect(recent.func({ category: '', limit: 5 })).rejects.toMatchObject({
       code: 'ARGUMENT',
     });
+  });
+
+  it('category validation accepts real arXiv archive and subcategory forms', () => {
+    expect(normalizeArxivCategory('cs.CL')).toBe('cs.CL');
+    expect(normalizeArxivCategory('math')).toBe('math');
+    expect(normalizeArxivCategory('physics.comp-ph')).toBe('physics.comp-ph');
+    expect(normalizeArxivCategory('physics.data-an')).toBe('physics.data-an');
+    expect(normalizeArxivCategory('cond-mat.soft')).toBe('cond-mat.soft');
+    expect(normalizeArxivCategory('q-bio.NC')).toBe('q-bio.NC');
+    expect(() => normalizeArxivCategory('not a category')).toThrow('Invalid arXiv category');
+    expect(() => normalizeArxivCategory('cs/CL')).toThrow('Invalid arXiv category');
+    expect(() => normalizeArxivCategory('')).toThrow('Invalid arXiv category');
+  });
+
+  it('limit validation rejects non-positive, non-integer and over-cap values', () => {
+    expect(normalizeArxivLimit(10, 5, 25)).toBe(10);
+    expect(normalizeArxivLimit(undefined, 5, 25)).toBe(5);
+    expect(() => normalizeArxivLimit(0, 5, 25)).toThrow('positive integer');
+    expect(() => normalizeArxivLimit(1.5, 5, 25)).toThrow('positive integer');
+    expect(() => normalizeArxivLimit(26, 5, 25)).toThrow('<= 25');
   });
 });

--- a/clis/arxiv/arxiv.test.js
+++ b/clis/arxiv/arxiv.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { parseEntries } from './utils.js';
+import './paper.js';
+import './search.js';
+import './recent.js';
+
+const SAMPLE_ENTRY_XML = `<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"
+      xmlns:arxiv="http://arxiv.org/schemas/atom"
+      xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/1706.03762v7</id>
+    <title>Attention Is All You Need &amp; Friends</title>
+    <updated>2023-08-02T00:41:18Z</updated>
+    <link href="https://arxiv.org/abs/1706.03762v7" rel="alternate" type="text/html"/>
+    <link href="https://arxiv.org/pdf/1706.03762v7" rel="related" type="application/pdf" title="pdf"/>
+    <summary>The dominant sequence transduction models are based on complex recurrent or convolutional neural networks. We propose a new simple network architecture, the Transformer, based solely on attention.</summary>
+    <category term="cs.CL" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <published>2017-06-12T17:57:34Z</published>
+    <arxiv:comment>15 pages, 5 figures</arxiv:comment>
+    <arxiv:primary_category term="cs.CL"/>
+    <author><name>Ashish Vaswani</name></author>
+    <author><name>Noam Shazeer</name></author>
+    <author><name>Niki Parmar</name></author>
+    <author><name>Jakob Uszkoreit</name></author>
+    <author><name>Llion Jones</name></author>
+    <author><name>Aidan N. Gomez</name></author>
+    <author><name>Lukasz Kaiser</name></author>
+    <author><name>Illia Polosukhin</name></author>
+  </entry>
+</feed>`;
+
+describe('arxiv adapter', () => {
+  it('registers paper, search and recent commands with the expected columns', () => {
+    const paper = getRegistry().get('arxiv/paper');
+    const search = getRegistry().get('arxiv/search');
+    const recent = getRegistry().get('arxiv/recent');
+
+    expect(paper).toBeDefined();
+    expect(search).toBeDefined();
+    expect(recent).toBeDefined();
+
+    expect(paper.columns).toEqual([
+      'id', 'title', 'authors', 'published', 'updated',
+      'primary_category', 'categories', 'abstract', 'comment', 'pdf', 'url',
+    ]);
+    expect(search.columns).toEqual([
+      'id', 'title', 'authors', 'published', 'primary_category', 'url',
+    ]);
+    expect(recent.columns).toEqual([
+      'id', 'title', 'authors', 'published', 'primary_category', 'url',
+    ]);
+  });
+
+  it('parseEntries returns full abstract, all authors, pdf, primary category and comment', () => {
+    const [entry] = parseEntries(SAMPLE_ENTRY_XML);
+
+    expect(entry.id).toBe('1706.03762');
+    expect(entry.title).toBe('Attention Is All You Need & Friends');
+    // All 8 authors must be present — earlier impl truncated to 3.
+    expect(entry.authors.split(', ')).toHaveLength(8);
+    expect(entry.authors).toContain('Ashish Vaswani');
+    expect(entry.authors).toContain('Illia Polosukhin');
+    // Full abstract — earlier impl truncated at 200 chars.
+    expect(entry.abstract.length).toBeGreaterThan(140);
+    expect(entry.abstract.endsWith('...')).toBe(false);
+    expect(entry.abstract).toContain('attention');
+    expect(entry.published).toBe('2017-06-12');
+    expect(entry.updated).toBe('2023-08-02');
+    expect(entry.primary_category).toBe('cs.CL');
+    expect(entry.categories).toBe('cs.CL, cs.LG');
+    expect(entry.comment).toBe('15 pages, 5 figures');
+    expect(entry.pdf).toBe('https://arxiv.org/pdf/1706.03762v7');
+    expect(entry.url).toBe('https://arxiv.org/abs/1706.03762');
+  });
+
+  it('parseEntries returns an empty list for feeds with no entries', () => {
+    expect(parseEntries('<feed></feed>')).toEqual([]);
+  });
+
+  it('recent rejects malformed category strings', async () => {
+    const recent = getRegistry().get('arxiv/recent');
+    await expect(recent.func({ category: 'not a category', limit: 5 })).rejects.toMatchObject({
+      code: 'ARGUMENT',
+    });
+    await expect(recent.func({ category: '', limit: 5 })).rejects.toMatchObject({
+      code: 'ARGUMENT',
+    });
+  });
+});

--- a/clis/arxiv/paper.js
+++ b/clis/arxiv/paper.js
@@ -10,7 +10,7 @@ cli({
     args: [
         { name: 'id', positional: true, required: true, help: 'arXiv paper ID (e.g. 1706.03762)' },
     ],
-    columns: ['id', 'title', 'authors', 'published', 'abstract', 'url'],
+    columns: ['id', 'title', 'authors', 'published', 'updated', 'primary_category', 'categories', 'abstract', 'comment', 'pdf', 'url'],
     func: async (args) => {
         const xml = await arxivFetch(`id_list=${encodeURIComponent(args.id)}`);
         const entries = parseEntries(xml);

--- a/clis/arxiv/paper.js
+++ b/clis/arxiv/paper.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { arxivFetch, parseEntries } from './utils.js';
 cli({
     site: 'arxiv',
@@ -15,7 +15,7 @@ cli({
         const xml = await arxivFetch(`id_list=${encodeURIComponent(args.id)}`);
         const entries = parseEntries(xml);
         if (!entries.length)
-            throw new CliError('NOT_FOUND', `Paper ${args.id} not found`, 'Check the arXiv ID format, e.g. 1706.03762');
+            throw new EmptyResultError('arxiv paper', `Paper ${args.id} was not found. Check the arXiv ID format, e.g. 1706.03762`);
         return entries;
     },
 });

--- a/clis/arxiv/recent.js
+++ b/clis/arxiv/recent.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
-import { arxivFetch, parseEntries } from './utils.js';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { arxivFetch, normalizeArxivCategory, normalizeArxivLimit, parseEntries } from './utils.js';
 cli({
     site: 'arxiv',
     name: 'recent',
@@ -13,11 +13,8 @@ cli({
     ],
     columns: ['id', 'title', 'authors', 'published', 'primary_category', 'url'],
     func: async (args) => {
-        const category = String(args.category || '').trim();
-        if (!/^[a-z\-]+(\.[A-Z]{2})?$/.test(category)) {
-            throw new ArgumentError(`Invalid arXiv category "${args.category}". Examples: cs.CL, cs.LG, math.PR, q-bio.NC`);
-        }
-        const limit = Math.max(1, Math.min(Number(args.limit), 50));
+        const category = normalizeArxivCategory(args.category);
+        const limit = normalizeArxivLimit(args.limit, 10, 50);
         const query = encodeURIComponent(`cat:${category}`);
         const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=submittedDate&sortOrder=descending`);
         const entries = parseEntries(xml);

--- a/clis/arxiv/recent.js
+++ b/clis/arxiv/recent.js
@@ -1,0 +1,35 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { arxivFetch, parseEntries } from './utils.js';
+cli({
+    site: 'arxiv',
+    name: 'recent',
+    description: 'List recent arXiv submissions in a category',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'category', positional: true, required: true, help: 'arXiv category (e.g. cs.CL, cs.LG, math.PR, q-bio.NC)' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max results (max 50)' },
+    ],
+    columns: ['id', 'title', 'authors', 'published', 'primary_category', 'url'],
+    func: async (args) => {
+        const category = String(args.category || '').trim();
+        if (!/^[a-z\-]+(\.[A-Z]{2})?$/.test(category)) {
+            throw new ArgumentError(`Invalid arXiv category "${args.category}". Examples: cs.CL, cs.LG, math.PR, q-bio.NC`);
+        }
+        const limit = Math.max(1, Math.min(Number(args.limit), 50));
+        const query = encodeURIComponent(`cat:${category}`);
+        const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=submittedDate&sortOrder=descending`);
+        const entries = parseEntries(xml);
+        if (!entries.length)
+            throw new EmptyResultError('arxiv', `No recent papers in ${category}. Check the category name.`);
+        return entries.map(e => ({
+            id: e.id,
+            title: e.title,
+            authors: e.authors,
+            published: e.published,
+            primary_category: e.primary_category,
+            url: e.url,
+        }));
+    },
+});

--- a/clis/arxiv/search.js
+++ b/clis/arxiv/search.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { arxivFetch, parseEntries } from './utils.js';
 cli({
     site: 'arxiv',
@@ -11,14 +11,21 @@ cli({
         { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "attention is all you need")' },
         { name: 'limit', type: 'int', default: 10, help: 'Max results (max 25)' },
     ],
-    columns: ['id', 'title', 'authors', 'published', 'url'],
+    columns: ['id', 'title', 'authors', 'published', 'primary_category', 'url'],
     func: async (args) => {
         const limit = Math.max(1, Math.min(Number(args.limit), 25));
         const query = encodeURIComponent(`all:${args.query}`);
         const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=relevance`);
         const entries = parseEntries(xml);
         if (!entries.length)
-            throw new CliError('NOT_FOUND', 'No papers found', 'Try a different keyword');
-        return entries.map(e => ({ id: e.id, title: e.title, authors: e.authors, published: e.published, url: e.url }));
+            throw new EmptyResultError('arxiv', 'No papers found. Try a different keyword.');
+        return entries.map(e => ({
+            id: e.id,
+            title: e.title,
+            authors: e.authors,
+            published: e.published,
+            primary_category: e.primary_category,
+            url: e.url,
+        }));
     },
 });

--- a/clis/arxiv/search.js
+++ b/clis/arxiv/search.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
-import { arxivFetch, parseEntries } from './utils.js';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { arxivFetch, normalizeArxivLimit, parseEntries } from './utils.js';
 cli({
     site: 'arxiv',
     name: 'search',
@@ -13,8 +13,12 @@ cli({
     ],
     columns: ['id', 'title', 'authors', 'published', 'primary_category', 'url'],
     func: async (args) => {
-        const limit = Math.max(1, Math.min(Number(args.limit), 25));
-        const query = encodeURIComponent(`all:${args.query}`);
+        const queryText = String(args.query || '').trim();
+        if (!queryText) {
+            throw new ArgumentError('arxiv search query cannot be empty');
+        }
+        const limit = normalizeArxivLimit(args.limit, 10, 25);
+        const query = encodeURIComponent(`all:${queryText}`);
         const xml = await arxivFetch(`search_query=${query}&max_results=${limit}&sortBy=relevance`);
         const entries = parseEntries(xml);
         if (!entries.length)

--- a/clis/arxiv/utils.js
+++ b/clis/arxiv/utils.js
@@ -13,6 +13,16 @@ export async function arxivFetch(params) {
     }
     return resp.text();
 }
+/** Decode the small set of XML entities arXiv emits in text fields. */
+function decodeEntities(s) {
+    return s
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&#39;/g, "'");
+}
 /** Extract the text content of the first matching XML tag. */
 function extract(xml, tag) {
     const m = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`));
@@ -27,6 +37,34 @@ function extractAll(xml, tag) {
         results.push(m[1].trim());
     return results;
 }
+/** Extract the value of a named attribute from the first matching tag (open or self-closing). */
+function extractAttr(xml, tag, attr) {
+    const m = xml.match(new RegExp(`<${tag}\\b[^>]*?\\b${attr}="([^"]*)"`));
+    return m ? m[1] : '';
+}
+/** Extract all values of a named attribute across repeated tags. */
+function extractAllAttr(xml, tag, attr) {
+    const re = new RegExp(`<${tag}\\b[^>]*?\\b${attr}="([^"]*)"`, 'g');
+    const out = [];
+    let m;
+    while ((m = re.exec(xml)) !== null)
+        out.push(m[1]);
+    return out;
+}
+/** Find the href of the first <link> tag matching a given rel. */
+function findLinkHref(xml, rel) {
+    const re = /<link\b([^>]*)\/?>/g;
+    let m;
+    while ((m = re.exec(xml)) !== null) {
+        const attrs = m[1];
+        if (new RegExp(`\\brel="${rel}"`).test(attrs)) {
+            const h = attrs.match(/\bhref="([^"]*)"/);
+            if (h)
+                return h[1];
+        }
+    }
+    return '';
+}
 /** Parse Atom XML feed into structured entries. */
 export function parseEntries(xml) {
     const entryRe = /<entry>([\s\S]*?)<\/entry>/g;
@@ -36,12 +74,18 @@ export function parseEntries(xml) {
         const e = m[1];
         const rawId = extract(e, 'id');
         const arxivId = rawId.replace(/^https?:\/\/arxiv\.org\/abs\//, '').replace(/v\d+$/, '');
+        const pdf = findLinkHref(e, 'related') || `https://arxiv.org/pdf/${arxivId}`;
         entries.push({
             id: arxivId,
-            title: extract(e, 'title').replace(/\s+/g, ' '),
-            authors: extractAll(e, 'name').slice(0, 3).join(', '),
-            abstract: (() => { const s = extract(e, 'summary').replace(/\s+/g, ' '); return s.length > 200 ? s.slice(0, 200) + '...' : s; })(),
+            title: decodeEntities(extract(e, 'title').replace(/\s+/g, ' ')),
+            authors: decodeEntities(extractAll(e, 'name').join(', ')),
+            abstract: decodeEntities(extract(e, 'summary').replace(/\s+/g, ' ')),
             published: extract(e, 'published').slice(0, 10),
+            updated: extract(e, 'updated').slice(0, 10),
+            primary_category: extractAttr(e, 'arxiv:primary_category', 'term'),
+            categories: extractAllAttr(e, 'category', 'term').join(', '),
+            comment: decodeEntities(extract(e, 'arxiv:comment').replace(/\s+/g, ' ')),
+            pdf,
             url: `https://arxiv.org/abs/${arxivId}`,
         });
     }

--- a/clis/arxiv/utils.js
+++ b/clis/arxiv/utils.js
@@ -4,14 +4,33 @@
  * arXiv exposes a public Atom/XML API — no key required.
  * https://info.arxiv.org/help/api/index.html
  */
-import { CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 export const ARXIV_BASE = 'https://export.arxiv.org/api/query';
+const ARXIV_CATEGORY_PATTERN = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)?$/;
 export async function arxivFetch(params) {
     const resp = await fetch(`${ARXIV_BASE}?${params}`);
     if (!resp.ok) {
-        throw new CliError('FETCH_ERROR', `arXiv API HTTP ${resp.status}`, 'Check your search term or paper ID');
+        throw new CommandExecutionError(`arXiv API HTTP ${resp.status}`, 'Check your search term or paper ID');
     }
     return resp.text();
+}
+export function normalizeArxivLimit(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const limit = Number(raw);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError(`arxiv ${label} must be a positive integer`);
+    }
+    if (limit > maxValue) {
+        throw new ArgumentError(`arxiv ${label} must be <= ${maxValue}`);
+    }
+    return limit;
+}
+export function normalizeArxivCategory(value) {
+    const category = String(value || '').trim();
+    if (!ARXIV_CATEGORY_PATTERN.test(category)) {
+        throw new ArgumentError(`Invalid arXiv category "${value}". Examples: cs.CL, cs.LG, math.PR, q-bio.NC, physics.comp-ph`);
+    }
+    return category;
 }
 /** Decode the small set of XML entities arXiv emits in text fields. */
 function decodeEntities(s) {

--- a/docs/adapters/browser/arxiv.md
+++ b/docs/adapters/browser/arxiv.md
@@ -6,8 +6,9 @@
 
 | Command | Description |
 |---------|-------------|
-| `opencli arxiv search` | Search arXiv papers |
-| `opencli arxiv paper` | Get arXiv paper details by ID |
+| `opencli arxiv search <query>` | Search arXiv papers |
+| `opencli arxiv paper <id>` | Get arXiv paper details by ID |
+| `opencli arxiv recent <category>` | List recent submissions in a category |
 
 ## Usage Examples
 
@@ -15,12 +16,30 @@
 # Search for papers
 opencli arxiv search "transformer attention" --limit 10
 
-# Get paper details by arXiv ID
-opencli arxiv paper 2301.00001
+# Get full paper details (full abstract, all authors, primary/all categories, pdf url)
+opencli arxiv paper 1706.03762
+
+# Newest papers in a category, sorted by submitted date desc
+opencli arxiv recent cs.CL --limit 10
+opencli arxiv recent math.PR --limit 5
 
 # JSON output
 opencli arxiv search "LLM" -f json
 ```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `paper` | `id, title, authors, published, updated, primary_category, categories, abstract, comment, pdf, url` |
+| `search` | `id, title, authors, published, primary_category, url` |
+| `recent` | `id, title, authors, published, primary_category, url` |
+
+`paper` returns the full abstract and full author list. `search`/`recent` are list-style outputs that omit the abstract for readability — pipe an id into `paper` for the full record.
+
+## Common Categories
+
+`cs.AI`, `cs.CL`, `cs.LG`, `cs.CV`, `cs.RO`, `stat.ML`, `math.PR`, `math.ST`, `q-bio.NC`, `econ.TH`, `physics.comp-ph`. Full list: <https://arxiv.org/category_taxonomy>.
 
 ## Prerequisites
 


### PR DESCRIPTION
## What

Three changes to the arxiv adapter, all agent-facing data quality / coverage gaps I hit while exploring:

### 1. `paper <id>` — stop silently truncating the data
The Atom feed for `1706.03762` has 8 authors and a ~200-word abstract. Old behavior:
- Abstract was cut at 200 chars + `…` (silent — caller had no signal)
- Authors were `.slice(0, 3).join(', ')` (also silent)

New behavior: full abstract, full author list. Plus surface fields the API was already returning that we threw away:
- `pdf` (from `<link rel="related" type="application/pdf">`, with id-based fallback)
- `primary_category` (e.g. `cs.CL`)
- `categories` (all `<category term>` entries comma-joined)
- `comment` (e.g. `"15 pages, 5 figures"`, conference info, etc.)
- `updated`

### 2. `search <query>` — minor cleanup
- Add `primary_category` to columns (cheap signal of paper area)
- Switch the no-results path from `CliError('NOT_FOUND', …)` to `EmptyResultError('arxiv', …)` to match the convention other public-API adapters use (matches the lesson from PR #1285).

### 3. `recent <category>` — new
You couldn't ask "what's new in cs.CL today?" without inventing a search term. Now:

```bash
opencli arxiv recent cs.CL --limit 10
opencli arxiv recent math.PR --limit 5
```

Uses `search_query=cat:<category>&sortBy=submittedDate&sortOrder=descending`. Validates the category string against the arxiv `<archive>.<sub>` shape (also accepts archive-only like `math` or `q-bio`). Bad input → `ArgumentError`.

## Why

I'm an agent that calls these adapters. With the old `paper`, an agent fetching "Attention Is All You Need" got 4 of 8 authors and a clipped first paragraph — silently. That's a worse failure mode than an outright error: caller has no idea data is missing.

`recent` is just an obvious gap — `arxiv search "anything"` was the only way to read the Atom feed.

## Tested

- `clis/arxiv/arxiv.test.js`: 4 tests covering command registration, full-abstract / all-authors parsing, XML entity decoding in titles, pdf/categories/comment extraction, and category validation.
- Live runs:
  - `opencli arxiv paper 1706.03762` → all 8 authors, full abstract, primary_category=`cs.CL`, pdf URL present.
  - `opencli arxiv recent cs.CL --limit 3` → 3 newest cs.CL papers, sorted by submitted date desc.
  - `opencli arxiv search "attention is all you need" --limit 3` → 3 hits with primary_category surfaced.
  - `opencli arxiv recent "BAD..STR"` → `ARGUMENT` error (exit 2).