### PR TITLE
fix(twitter): drop permanently-N/A `tweets` column from trending

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -16935,7 +16935,6 @@
     "columns": [
       "rank",
       "topic",
-      "tweets",
       "category"
     ],
     "type": "js",

--- a/clis/twitter/trending.js
+++ b/clis/twitter/trending.js
@@ -1,6 +1,14 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
 // ── CLI definition ────────────────────────────────────────────────────
+//
+// X (Twitter) removed the post-count caption from each trend cell on the
+// /explore/tabs/trending page in 2024-2025. The DOM now only carries:
+//   divs[0] = rank + category (e.g. "1 · Trending in United States")
+//   divs[1] = topic
+//   divs[2..] = caret menu button (no post-count text)
+// We previously surfaced a `tweets` column whose value was permanently
+// "N/A" on every row — that's silent-wrong data, drop it.
 cli({
     site: 'twitter',
     name: 'trending',
@@ -11,7 +19,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of trends to show' },
     ],
-    columns: ['rank', 'topic', 'tweets', 'category'],
+    columns: ['rank', 'topic', 'category'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         // Navigate to trending page
@@ -23,9 +31,6 @@ cli({
     })()`);
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
-        // Scrape trends from DOM (consistent with what the user sees on the page)
-        // DOM children: [0] rank + category, [1] topic, optional post count,
-        // and a caret menu button identified by [data-testid="caret"].
         await page.wait(2);
         const trends = await page.evaluate(`(() => {
       const items = [];
@@ -41,14 +46,7 @@ cli({
         if (!topic) return;
         const catText = divs[0].textContent.trim();
         const category = catText.replace(/^\\d+\\s*/, '').replace(/^\\xB7\\s*/, '').trim();
-        // Find post count: skip rank, topic, and the caret menu button
-        let tweets = 'N/A';
-        for (let j = 2; j < divs.length; j++) {
-          if (divs[j].matches('[data-testid="caret"]') || divs[j].querySelector('[data-testid="caret"]')) continue;
-          const t = divs[j].textContent.trim();
-          if (t && /\\d/.test(t)) { tweets = t; break; }
-        }
-        items.push({ rank: items.length + 1, topic, tweets, category });
+        items.push({ rank: items.length + 1, topic, category });
       });
       return items;
     })()`);

--- a/clis/twitter/trending.test.js
+++ b/clis/twitter/trending.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './trending.js';
+
+describe('twitter trending', () => {
+    it('registers the trending command with rank/topic/category columns only', () => {
+        const cmd = getRegistry().get('twitter/trending');
+        expect(cmd).toBeDefined();
+        // The `tweets` column was permanently "N/A" because X removed the post-count
+        // caption from the trend cell; we drop it rather than keep returning a
+        // silent-wrong sentinel for every row. Guard against re-introduction.
+        expect(cmd.columns).toEqual(['rank', 'topic', 'category']);
+        expect(cmd.columns).not.toContain('tweets');
+    });
+});


### PR DESCRIPTION
## What

X removed the post-count caption from each cell on `/explore/tabs/trending`. The adapter still iterated `divs[2..]` looking for a numeric text node and fell back to the literal string `"N/A"` when none was found — which was every row, on every call.

We were emitting a silent-wrong column for every trending result.

## Change

- Drop `tweets` from `columns`.
- Drop the no-longer-relevant scan loop in the page-evaluate.
- Add `trending.test.js` asserting the column shape (incl. negative assertion that `tweets` is gone), so it doesn't slip back in.

## Why

First-principles agent-native: silent N/A on every row is worse than no column at all — caller can't tell the count is structurally missing vs. a transient outage. (Same lesson as PR #1285's "drop > silent-wrong" call on douban movie-hot.)

## Tested

- `npx vitest run clis/twitter/trending.test.js` — 1 passed.
- The `func` itself wasn't structurally changed; the only delta is removing the inner loop that always returned "N/A". The DOM extraction for `rank`, `topic`, `category` is untouched.