### PR TITLE
feat(lobsters): surface short_id + created_at on listings, add `read <short_id>`

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -307,7 +307,7 @@ npm link
 | **imdb** | `search` `title` `top` `trending` `person` `reviews` | 公开 |
 | **producthunt** | `posts` `today` `hot` `browse` | 公开 / 浏览器 |
 | **instagram** | `explore` `profile` `search` `user` `followers` `following` `follow` `unfollow` `like` `unlike` `comment` `save` `unsave` `saved` | 浏览器 |
-| **lobsters** | `hot` `newest` `active` `tag` | 公开 |
+| **lobsters** | `hot` `newest` `active` `tag` `read` | 公开 |
 | **medium** | `feed` `search` `user` | 浏览器 |
 | **sinablog** | `hot` `search` `article` `user` | 浏览器 |
 | **substack** | `feed` `search` `publication` | 浏览器 |

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11353,11 +11353,14 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "score",
       "author",
       "comments",
-      "tags"
+      "created_at",
+      "tags",
+      "url"
     ],
     "type": "js",
     "modulePath": "lobsters/active.js",
@@ -11381,11 +11384,14 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "score",
       "author",
       "comments",
-      "tags"
+      "created_at",
+      "tags",
+      "url"
     ],
     "type": "js",
     "modulePath": "lobsters/hot.js",
@@ -11409,15 +11415,72 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "score",
       "author",
       "comments",
-      "tags"
+      "created_at",
+      "tags",
+      "url"
     ],
     "type": "js",
     "modulePath": "lobsters/newest.js",
     "sourceFile": "lobsters/newest.js"
+  },
+  {
+    "site": "lobsters",
+    "name": "read",
+    "description": "Read a Lobste.rs story and its comment tree",
+    "domain": "lobste.rs",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Lobste.rs short_id (e.g. 6cmh6h)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Max top-level comments"
+      },
+      {
+        "name": "depth",
+        "type": "int",
+        "default": 2,
+        "required": false,
+        "help": "Max reply depth (1=no replies, 2=one level of replies, etc.)"
+      },
+      {
+        "name": "replies",
+        "type": "int",
+        "default": 5,
+        "required": false,
+        "help": "Max replies shown per comment at each level"
+      },
+      {
+        "name": "max-length",
+        "type": "int",
+        "default": 2000,
+        "required": false,
+        "help": "Max characters per comment body (min 100)"
+      }
+    ],
+    "columns": [
+      "type",
+      "author",
+      "score",
+      "text"
+    ],
+    "type": "js",
+    "modulePath": "lobsters/read.js",
+    "sourceFile": "lobsters/read.js"
   },
   {
     "site": "lobsters",
@@ -11444,11 +11507,14 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "score",
       "author",
       "comments",
-      "tags"
+      "created_at",
+      "tags",
+      "url"
     ],
     "type": "js",
     "modulePath": "lobsters/tag.js",

--- a/clis/lobsters/active.js
+++ b/clis/lobsters/active.js
@@ -9,15 +9,17 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of stories' },
     ],
-    columns: ['rank', 'title', 'score', 'author', 'comments', 'tags'],
+    columns: ['rank', 'id', 'title', 'score', 'author', 'comments', 'created_at', 'tags', 'url'],
     pipeline: [
         { fetch: { url: 'https://lobste.rs/active.json' } },
         { map: {
                 rank: '${{ index + 1 }}',
+                id: '${{ item.short_id }}',
                 title: '${{ item.title }}',
                 score: '${{ item.score }}',
                 author: '${{ item.submitter_user }}',
                 comments: '${{ item.comment_count }}',
+                created_at: '${{ item.created_at }}',
                 tags: `\${{ item.tags | join(', ') }}`,
                 url: '${{ item.comments_url }}',
             } },

--- a/clis/lobsters/hot.js
+++ b/clis/lobsters/hot.js
@@ -9,15 +9,17 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of stories' },
     ],
-    columns: ['rank', 'title', 'score', 'author', 'comments', 'tags'],
+    columns: ['rank', 'id', 'title', 'score', 'author', 'comments', 'created_at', 'tags', 'url'],
     pipeline: [
         { fetch: { url: 'https://lobste.rs/hottest.json' } },
         { map: {
                 rank: '${{ index + 1 }}',
+                id: '${{ item.short_id }}',
                 title: '${{ item.title }}',
                 score: '${{ item.score }}',
                 author: '${{ item.submitter_user }}',
                 comments: '${{ item.comment_count }}',
+                created_at: '${{ item.created_at }}',
                 tags: `\${{ item.tags | join(', ') }}`,
                 url: '${{ item.comments_url }}',
             } },

--- a/clis/lobsters/lobsters.test.js
+++ b/clis/lobsters/lobsters.test.js
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './hot.js';
+import './active.js';
+import './newest.js';
+import './tag.js';
+import './read.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('lobsters listing adapters expose short_id and created_at', () => {
+    const listings = ['lobsters/hot', 'lobsters/active', 'lobsters/newest', 'lobsters/tag'];
+
+    listings.forEach((key) => {
+        it(`${key} surfaces id (short_id) and created_at on every row`, () => {
+            const cmd = getRegistry().get(key);
+            expect(cmd?.columns).toEqual(['rank', 'id', 'title', 'score', 'author', 'comments', 'created_at', 'tags', 'url']);
+            const mapStep = cmd?.pipeline?.find((step) => step.map);
+            expect(mapStep?.map).toMatchObject({
+                id: '${{ item.short_id }}',
+                created_at: '${{ item.created_at }}',
+                url: '${{ item.comments_url }}',
+            });
+        });
+    });
+});
+
+describe('lobsters/read adapter', () => {
+    const cmd = getRegistry().get('lobsters/read');
+
+    it('registers the comment-thread shape (type/author/score/text)', () => {
+        expect(cmd?.columns).toEqual(['type', 'author', 'score', 'text']);
+    });
+
+    it('takes a positional short_id plus tunable depth/limit/replies/max-length args', () => {
+        const argNames = (cmd?.args || []).map((a) => a.name);
+        expect(argNames).toEqual(['id', 'limit', 'depth', 'replies', 'max-length']);
+        const idArg = cmd?.args?.find((a) => a.name === 'id');
+        expect(idArg?.required).toBe(true);
+        expect(idArg?.positional).toBe(true);
+    });
+
+    it('uses the public lobste.rs JSON endpoint (no browser, public strategy)', () => {
+        expect(cmd?.browser).toBe(false);
+        expect(cmd?.strategy).toBe('public');
+    });
+
+    it('fails fast with ArgumentError for non-alphanumeric short_id before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ id: 'BAD!ID', limit: 5, depth: 2, replies: 5, 'max-length': 2000 }))
+            .rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails fast with EmptyResultError on 404', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Not found', { status: 404 })));
+
+        await expect(cmd.func({ id: 'missing', limit: 5, depth: 2, replies: 5, 'max-length': 2000 }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('builds a threaded tree from the flat comments[] using parent_comment', async () => {
+        const story = {
+            short_id: 'abc123',
+            title: 'Hello world',
+            url: 'https://example.com/post',
+            score: 42,
+            submitter_user: 'pg',
+            description_plain: 'Some intro text.',
+            comments_url: 'https://lobste.rs/s/abc123/hello_world',
+            comments: [
+                {
+                    short_id: 'top1',
+                    parent_comment: null,
+                    score: 5,
+                    commenting_user: 'alice',
+                    comment_plain: 'Top one',
+                    is_deleted: false,
+                },
+                {
+                    short_id: 'reply1',
+                    parent_comment: 'top1',
+                    score: 3,
+                    commenting_user: 'bob',
+                    comment_plain: 'A reply',
+                    is_deleted: false,
+                },
+                {
+                    short_id: 'reply2',
+                    parent_comment: 'top1',
+                    score: 1,
+                    commenting_user: 'carol',
+                    comment_plain: 'Another reply',
+                    is_deleted: false,
+                },
+                {
+                    short_id: 'top2',
+                    parent_comment: null,
+                    score: 4,
+                    commenting_user: 'dave',
+                    comment_plain: 'Top two',
+                    is_deleted: false,
+                },
+            ],
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(story), { status: 200 })));
+
+        const rows = await cmd.func({ id: 'abc123', limit: 5, depth: 2, replies: 5, 'max-length': 2000 });
+
+        expect(rows).toEqual([
+            {
+                type: 'POST',
+                author: 'pg',
+                score: 42,
+                text: 'Hello world\nSome intro text.\nhttps://example.com/post',
+            },
+            { type: 'L0', author: 'alice', score: 5, text: 'Top one' },
+            { type: 'L1', author: 'bob', score: 3, text: '  > A reply' },
+            { type: 'L1', author: 'carol', score: 1, text: '  > Another reply' },
+            { type: 'L0', author: 'dave', score: 4, text: 'Top two' },
+        ]);
+    });
+
+    it('emits a "+N more replies" stub when depth cutoff hides children', async () => {
+        const story = {
+            short_id: 'abc123',
+            title: 'Hi',
+            url: '',
+            score: 1,
+            submitter_user: 'u',
+            description_plain: '',
+            comments: [
+                { short_id: 't1', parent_comment: null, commenting_user: 'a', comment_plain: 'top', is_deleted: false },
+                { short_id: 'r1', parent_comment: 't1', commenting_user: 'b', comment_plain: 'r', is_deleted: false },
+            ],
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(story), { status: 200 })));
+
+        const rows = await cmd.func({ id: 'abc123', limit: 5, depth: 1, replies: 5, 'max-length': 2000 });
+
+        expect(rows).toEqual([
+            { type: 'POST', author: 'u', score: 1, text: 'Hi' },
+            { type: 'L0', author: 'a', score: '', text: 'top' },
+            { type: 'L1', author: '', score: '', text: '  [+1 more replies]' },
+        ]);
+    });
+});

--- a/clis/lobsters/lobsters.test.js
+++ b/clis/lobsters/lobsters.test.js
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './hot.js';
 import './active.js';
 import './newest.js';
@@ -63,6 +63,22 @@ describe('lobsters/read adapter', () => {
 
         await expect(cmd.func({ id: 'missing', limit: 5, depth: 2, replies: 5, 'max-length': 2000 }))
             .rejects.toThrow(EmptyResultError);
+    });
+
+    it('fails fast with ArgumentError when max-length is below the minimum before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ id: 'abc123', limit: 5, depth: 2, replies: 5, 'max-length': 99 }))
+            .rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails fast with CommandExecutionError on non-404 HTTP failures', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('oops', { status: 503 })));
+
+        await expect(cmd.func({ id: 'abc123', limit: 5, depth: 2, replies: 5, 'max-length': 2000 }))
+            .rejects.toThrow(CommandExecutionError);
     });
 
     it('builds a threaded tree from the flat comments[] using parent_comment', async () => {

--- a/clis/lobsters/newest.js
+++ b/clis/lobsters/newest.js
@@ -9,15 +9,17 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of stories' },
     ],
-    columns: ['rank', 'title', 'score', 'author', 'comments', 'tags'],
+    columns: ['rank', 'id', 'title', 'score', 'author', 'comments', 'created_at', 'tags', 'url'],
     pipeline: [
         { fetch: { url: 'https://lobste.rs/newest.json' } },
         { map: {
                 rank: '${{ index + 1 }}',
+                id: '${{ item.short_id }}',
                 title: '${{ item.title }}',
                 score: '${{ item.score }}',
                 author: '${{ item.submitter_user }}',
                 comments: '${{ item.comment_count }}',
+                created_at: '${{ item.created_at }}',
                 tags: `\${{ item.tags | join(', ') }}`,
                 url: '${{ item.comments_url }}',
             } },

--- a/clis/lobsters/read.js
+++ b/clis/lobsters/read.js
@@ -1,0 +1,195 @@
+/**
+ * Lobste.rs story reader with threaded comment tree.
+ *
+ * Mirrors `hackernews read` semantics. The lobsters JSON endpoint:
+ *   https://lobste.rs/s/<short_id>.json
+ * already returns the story plus a flat `comments[]` array where each entry
+ * carries `parent_comment` (short_id of parent or null) and `depth` — so we
+ * just need one HTTP call, then build a children map and DFS.
+ *
+ * Output rows:
+ *   - first row is the story itself (`type=POST`)
+ *   - each subsequent row is a comment, indented by depth (`L0`, `L1`, …)
+ *   - `[+N more replies]` summary rows whenever depth/limit cuts in
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const LOBSTERS_STORY_BASE = 'https://lobste.rs/s';
+
+async function fetchStory(shortId) {
+    const res = await fetch(`${LOBSTERS_STORY_BASE}/${shortId}.json`);
+    if (res.status === 404) {
+        throw new EmptyResultError(`lobsters/${shortId}`, 'Story not found');
+    }
+    if (!res.ok) {
+        throw new CommandExecutionError(`Lobsters API HTTP ${res.status} for story ${shortId}`, 'Check the short id');
+    }
+    return res.json();
+}
+
+function requirePositiveInt(value, label) {
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    return value;
+}
+
+function requireMinInt(value, min, label) {
+    if (!Number.isInteger(value) || value < min) {
+        throw new ArgumentError(`${label} must be an integer >= ${min}`);
+    }
+    return value;
+}
+
+/** Lobsters returns comment text as a small HTML subset — convert to plain text. */
+function htmlToText(html) {
+    if (!html) return '';
+    return String(html)
+        .replace(/<p>/gi, '\n\n')
+        .replace(/<\/p>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<i>(.*?)<\/i>/gi, '$1')
+        .replace(/<em>(.*?)<\/em>/gi, '$1')
+        .replace(/<strong>(.*?)<\/strong>/gi, '$1')
+        .replace(/<a[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/gi, '$2 ($1)')
+        .replace(/<pre><code>([\s\S]*?)<\/code><\/pre>/gi, '\n$1\n')
+        .replace(/<code>(.*?)<\/code>/gi, '`$1`')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&#x27;/g, "'")
+        .replace(/&apos;/g, "'")
+        .replace(/&quot;/g, '"')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&#x2F;/g, '/')
+        .trim();
+}
+
+function indentLines(text, depth) {
+    if (depth === 0) return text;
+    const indent = '  '.repeat(depth);
+    const prefix = `${indent}> `;
+    return text.split('\n').map((line) => prefix + line).join('\n');
+}
+
+function moreRepliesIndent(depth) {
+    return '  '.repeat(depth + 1);
+}
+
+cli({
+    site: 'lobsters',
+    name: 'read',
+    description: 'Read a Lobste.rs story and its comment tree',
+    domain: 'lobste.rs',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', required: true, positional: true, help: 'Lobste.rs short_id (e.g. 6cmh6h)' },
+        { name: 'limit', type: 'int', default: 25, help: 'Max top-level comments' },
+        { name: 'depth', type: 'int', default: 2, help: 'Max reply depth (1=no replies, 2=one level of replies, etc.)' },
+        { name: 'replies', type: 'int', default: 5, help: 'Max replies shown per comment at each level' },
+        { name: 'max-length', type: 'int', default: 2000, help: 'Max characters per comment body (min 100)' },
+    ],
+    columns: ['type', 'author', 'score', 'text'],
+    func: async (args) => {
+        const shortId = String(args.id || '').trim();
+        if (!/^[a-z0-9]+$/.test(shortId)) {
+            throw new ArgumentError(`Invalid Lobsters short_id: ${args.id}`, 'Pass a lowercase alphanumeric id like 6cmh6h');
+        }
+        const limit = requirePositiveInt(args.limit ?? 25, 'lobsters read --limit');
+        const maxDepth = requirePositiveInt(args.depth ?? 2, 'lobsters read --depth');
+        const maxReplies = requirePositiveInt(args.replies ?? 5, 'lobsters read --replies');
+        const maxLength = requireMinInt(args['max-length'] ?? 2000, 100, 'lobsters read --max-length');
+
+        const story = await fetchStory(shortId);
+        if (!story || !story.short_id) {
+            throw new EmptyResultError(`lobsters/${shortId}`, 'Story not found');
+        }
+
+        const results = [];
+
+        // Story header — title, body (description_plain, often empty for link posts), then external url.
+        const storyBodyRaw = (story.description_plain || htmlToText(story.description || '')).trim();
+        const storyBody = storyBodyRaw.length > maxLength
+            ? storyBodyRaw.slice(0, maxLength) + '\n... [truncated]'
+            : storyBodyRaw;
+        const storyParts = [story.title || ''];
+        if (storyBody) storyParts.push('\n' + storyBody);
+        if (story.url) storyParts.push('\n' + story.url);
+        results.push({
+            type: 'POST',
+            author: story.submitter_user || '[deleted]',
+            score: story.score ?? 0,
+            text: storyParts.join('').trim(),
+        });
+
+        // Build a map: parent_comment -> [child comments in order]. Top-level keyed by null.
+        const allComments = Array.isArray(story.comments) ? story.comments : [];
+        const childrenMap = new Map();
+        for (const c of allComments) {
+            const parent = c.parent_comment || null;
+            if (!childrenMap.has(parent)) childrenMap.set(parent, []);
+            childrenMap.get(parent).push(c);
+        }
+
+        function emit(comment, depth) {
+            if (!comment || comment.is_deleted || comment.is_moderated) return;
+            const bodyRaw = (comment.comment_plain || htmlToText(comment.comment || '')).trim();
+            const truncated = bodyRaw.length > maxLength
+                ? bodyRaw.slice(0, maxLength) + '...'
+                : bodyRaw;
+
+            results.push({
+                type: depth === 0 ? 'L0' : `L${depth}`,
+                author: comment.commenting_user || '[deleted]',
+                score: comment.score ?? '',
+                text: indentLines(truncated, depth),
+            });
+
+            const kids = childrenMap.get(comment.short_id) || [];
+            // At depth cutoff: don't recurse, but show a "+N more replies" stub if any.
+            if (depth + 1 >= maxDepth) {
+                if (kids.length > 0) {
+                    results.push({
+                        type: `L${depth + 1}`,
+                        author: '',
+                        score: '',
+                        text: `${moreRepliesIndent(depth)}[+${kids.length} more replies]`,
+                    });
+                }
+                return;
+            }
+
+            const toShow = kids.slice(0, maxReplies);
+            for (const kid of toShow) emit(kid, depth + 1);
+
+            const hidden = kids.length - toShow.length;
+            if (hidden > 0) {
+                results.push({
+                    type: `L${depth + 1}`,
+                    author: '',
+                    score: '',
+                    text: `${moreRepliesIndent(depth)}[+${hidden} more replies]`,
+                });
+            }
+        }
+
+        const topLevel = childrenMap.get(null) || [];
+        const topToShow = topLevel.slice(0, limit);
+        for (const top of topToShow) emit(top, 0);
+
+        const hiddenTopLevel = topLevel.length - topToShow.length;
+        if (hiddenTopLevel > 0) {
+            results.push({
+                type: '',
+                author: '',
+                score: '',
+                text: `[+${hiddenTopLevel} more top-level comments]`,
+            });
+        }
+
+        return results;
+    },
+});

--- a/clis/lobsters/tag.js
+++ b/clis/lobsters/tag.js
@@ -15,15 +15,17 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20, help: 'Number of stories' },
     ],
-    columns: ['rank', 'title', 'score', 'author', 'comments', 'tags'],
+    columns: ['rank', 'id', 'title', 'score', 'author', 'comments', 'created_at', 'tags', 'url'],
     pipeline: [
         { fetch: { url: 'https://lobste.rs/t/${{ args.tag }}.json' } },
         { map: {
                 rank: '${{ index + 1 }}',
+                id: '${{ item.short_id }}',
                 title: '${{ item.title }}',
                 score: '${{ item.score }}',
                 author: '${{ item.submitter_user }}',
                 comments: '${{ item.comment_count }}',
+                created_at: '${{ item.created_at }}',
                 tags: `\${{ item.tags | join(', ') }}`,
                 url: '${{ item.comments_url }}',
             } },

--- a/docs/adapters/browser/lobsters.md
+++ b/docs/adapters/browser/lobsters.md
@@ -9,7 +9,8 @@
 | `opencli lobsters hot` | Hottest stories |
 | `opencli lobsters newest` | Latest stories |
 | `opencli lobsters active` | Most active discussions |
-| `opencli lobsters tag` | Stories by tag |
+| `opencli lobsters tag <tag>` | Stories by tag |
+| `opencli lobsters read <short_id>` | Read a story and its comment tree |
 
 ## Usage Examples
 
@@ -18,14 +19,23 @@
 opencli lobsters hot --limit 10
 
 # Filter by tag
-opencli lobsters tag --tag rust --limit 5
+opencli lobsters tag rust --limit 5
+
+# Read a specific story (use the short_id surfaced as `id` in any listing)
+opencli lobsters read 6cmh6h --limit 25 --depth 2
 
 # JSON output
 opencli lobsters hot -f json
-
-# Verbose mode
-opencli lobsters hot -v
 ```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `hot` / `newest` / `active` / `tag` | `rank, id, title, score, author, comments, created_at, tags, url` |
+| `read` | `type, author, score, text` (POST + L0/L1/… comments, with `[+N more replies]` stubs) |
+
+`id` is the lobste.rs `short_id` — pipe it into `read` to drill into the discussion.
 
 ## Prerequisites
 

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -101,7 +101,7 @@ Run `opencli list` for the live registry.
 | **[stackoverflow](./browser/stackoverflow.md)**   | `hot` `search` `bounties` `unanswered`                                                                                                         | 🌐 Public    |
 | **[wikipedia](./browser/wikipedia.md)**           | `search` `summary` `random` `trending`                                                                                                         | 🌐 Public    |
 | **[lesswrong](./browser/lesswrong.md)**           | `curated` `frontpage` `new` `top` `top-week` `top-month` `top-year` `read` `comments` `user` `user-posts` `tag` `tags` `sequences` `shortform` | 🌐 Public    |
-| **[lobsters](./browser/lobsters.md)**             | `hot` `newest` `active` `tag`                                                                                                                  | 🌐 Public    |
+| **[lobsters](./browser/lobsters.md)**             | `hot` `newest` `active` `tag` `read`                                                                                                           | 🌐 Public    |
 | **[steam](./browser/steam.md)**                   | `top-sellers`                                                                                                                                  | 🌐 Public    |
 
 ## Desktop Adapters


### PR DESCRIPTION
## What

Same agent-native gap as the just-merged hackernews PR (#1288), applied to lobsters:

1. **All 4 listings** (`hot` / `newest` / `active` / `tag`) didn't surface each story's `short_id`. Agents could see the title and a `comments_url` but couldn't pass the id back into a follow-up command. Add `id` (= `short_id`) and `created_at` columns.

2. **New `lobsters read <short_id>`** — there was no way to read a story + comment tree from the CLI. Lobsters' API is even nicer than HN's: `https://lobste.rs/s/<short_id>.json` returns the story plus a **flat** `comments[]` array where each entry already carries `parent_comment` and `depth`, so we get the full thread in one HTTP call.

`read` mirrors `hackernews read`'s shape (POST row + `L0`/`L1`/… indented comments, `[+N more replies]` stubs) so agents that learned one don't have to relearn the other.

## Typed fail-fast (per #1289 lessons)

- `ArgumentError` — bad `short_id` (must match `/^[a-z0-9]+$/`), non-positive `limit`/`depth`/`replies`, `max-length < 100`
- `EmptyResultError` — 404 from the JSON endpoint or empty body
- `CommandExecutionError` — any other non-2xx HTTP

No silent clamps anywhere; `id` validation runs before fetch (verified by an explicit "no fetch on bad input" test).

## Tests

11 vitest cases:
- All 4 listings: `columns` shape + the pipeline map step actually wires `short_id` and `created_at`
- `read`: registration / column shape / arg shape (positional id + limit/depth/replies/max-length) / strategy=public + browser=false
- `read` fail-fast: ArgumentError on `BAD!ID` (no fetch), EmptyResultError on 404
- `read` happy path: builds threaded tree from a flat `comments[]` (top1 → reply1, reply2 → top2)
- `read` depth cutoff: emits `[+N more replies]` stub when child comments exceed `--depth`

## Live verification

```
$ opencli lobsters hot --limit 3
  rank: 1
  id: 6cmh6h            ← previously missing
  title: 'Reminder: You Can Stitch Together Lots of Little HTML Pages...'
  ...
  created_at: '2026-05-04T01:36:50.000-05:00'   ← previously missing

$ opencli lobsters read 6cmh6h --limit 3 --depth 2
[ POST → L0 → L1 → L2 (more-replies stub) → L1 → L0 ... ]
```