### PR TITLE
feat(openreview): public adapter — search/venue/paper/reviews

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -271,6 +271,7 @@ npm link
 | **devto** | `top` `tag` `user` | 公开 |
 | **dictionary** | `search` `synonyms` `examples` | 公开 |
 | **arxiv** | `search` `paper` | 公开 |
+| **openreview** | `search` `venue` `paper` `reviews` | 公开 |
 | **paperreview** | `submit` `review` `feedback` | 公开 |
 | **wikipedia** | `search` `summary` `random` `trending` | 公开 |
 | **hackernews** | `top` `new` `best` `ask` `show` `jobs` `search` `user` | 公共 API |

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -13266,6 +13266,154 @@
     "navigateBefore": false
   },
   {
+    "site": "openreview",
+    "name": "paper",
+    "description": "Show full metadata for a single OpenReview paper",
+    "domain": "openreview.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "OpenReview note id (e.g. \"5sRnsubyAK\")"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "authors",
+      "keywords",
+      "venue",
+      "venueid",
+      "primary_area",
+      "abstract",
+      "pdate",
+      "pdf",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openreview/paper.js",
+    "sourceFile": "openreview/paper.js"
+  },
+  {
+    "site": "openreview",
+    "name": "reviews",
+    "description": "Show full review thread (paper + reviews + decisions) for an OpenReview forum",
+    "domain": "openreview.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "forum",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "OpenReview forum id (same as paper id)"
+      },
+      {
+        "name": "max-length",
+        "type": "int",
+        "default": 4000,
+        "required": false,
+        "help": "Per-row text truncation (min 200)"
+      }
+    ],
+    "columns": [
+      "type",
+      "author",
+      "rating",
+      "confidence",
+      "text"
+    ],
+    "type": "js",
+    "modulePath": "openreview/reviews.js",
+    "sourceFile": "openreview/reviews.js"
+  },
+  {
+    "site": "openreview",
+    "name": "search",
+    "description": "Search OpenReview papers by free-text query",
+    "domain": "openreview.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (e.g. \"diffusion model\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Max results (max 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "authors",
+      "venue",
+      "pdate",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openreview/search.js",
+    "sourceFile": "openreview/search.js"
+  },
+  {
+    "site": "openreview",
+    "name": "venue",
+    "description": "List papers at an OpenReview venue (e.g. \"ICLR 2024 oral\" or full invitation id)",
+    "domain": "openreview.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "venue",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Venue name (\"ICLR 2024 oral\") or invitation (\"ICLR.cc/2025/Conference/-/Submission\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Max results (max 200)"
+      },
+      {
+        "name": "offset",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Pagination offset"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "authors",
+      "keywords",
+      "primary_area",
+      "pdate",
+      "pdf",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openreview/venue.js",
+    "sourceFile": "openreview/venue.js"
+  },
+  {
     "site": "paperreview",
     "name": "feedback",
     "description": "Submit feedback for a paperreview.ai review token",

--- a/clis/openreview/openreview.test.js
+++ b/clis/openreview/openreview.test.js
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    absolutePdf,
+    coerceInt,
+    formatDate,
+    noteToRow,
+    requireBoundedInt,
+    requireForumId,
+    requireNonNegativeInt,
+} from './utils.js';
+import './search.js';
+import './venue.js';
+import './paper.js';
+import './reviews.js';
+
+const SAMPLE_NOTE = {
+    id: 'abc123XYZ_',
+    forum: 'abc123XYZ_',
+    pdate: 1727524853394,
+    cdate: 1727524853394,
+    content: {
+        title: { value: 'Test Paper Title with   spaces' },
+        authors: { value: ['Alice Smith', 'Bob Jones'] },
+        authorids: { value: ['~Alice_Smith1', '~Bob_Jones2'] },
+        keywords: { value: ['transformer', 'attention'] },
+        abstract: { value: 'A long abstract\n  with newlines.' },
+        venue: { value: 'ICLR 2024 oral' },
+        venueid: { value: 'ICLR.cc/2024/Conference' },
+        primary_area: { value: 'foundation models' },
+        pdf: { value: '/pdf/abc.pdf' },
+    },
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('openreview adapter', () => {
+    it('registers all four commands with the expected columns', () => {
+        const search = getRegistry().get('openreview/search');
+        const venue = getRegistry().get('openreview/venue');
+        const paper = getRegistry().get('openreview/paper');
+        const reviews = getRegistry().get('openreview/reviews');
+
+        expect(search).toBeDefined();
+        expect(venue).toBeDefined();
+        expect(paper).toBeDefined();
+        expect(reviews).toBeDefined();
+
+        expect(search.columns).toEqual(['rank', 'id', 'title', 'authors', 'venue', 'pdate', 'url']);
+        expect(venue.columns).toEqual(['rank', 'id', 'title', 'authors', 'keywords', 'primary_area', 'pdate', 'pdf', 'url']);
+        expect(paper.columns).toEqual(['id', 'title', 'authors', 'keywords', 'venue', 'venueid', 'primary_area', 'abstract', 'pdate', 'pdf', 'url']);
+        expect(reviews.columns).toEqual(['type', 'author', 'rating', 'confidence', 'text']);
+    });
+
+    it('noteToRow extracts every wrapped v2 field, joins lists, and builds absolute URLs', () => {
+        const row = noteToRow(SAMPLE_NOTE);
+        expect(row.id).toBe('abc123XYZ_');
+        expect(row.title).toBe('Test Paper Title with spaces');
+        expect(row.authors).toBe('Alice Smith, Bob Jones');
+        expect(row.keywords).toBe('transformer, attention');
+        expect(row.abstract).toBe('A long abstract with newlines.');
+        expect(row.venue).toBe('ICLR 2024 oral');
+        expect(row.venueid).toBe('ICLR.cc/2024/Conference');
+        expect(row.primary_area).toBe('foundation models');
+        expect(row.pdf).toBe('https://openreview.net/pdf/abc.pdf');
+        expect(row.url).toBe('https://openreview.net/forum?id=abc123XYZ_');
+        expect(row.pdate).toBe('2024-09-28');
+    });
+
+    it('noteToRow falls back to author IDs when authors field is missing', () => {
+        const note = { ...SAMPLE_NOTE, content: { ...SAMPLE_NOTE.content, authors: undefined } };
+        expect(noteToRow(note).authors).toBe('Alice Smith, Bob Jones');
+    });
+
+    it('coerceInt accepts numeric strings, rejects floats and NaN', () => {
+        expect(coerceInt(10)).toBe(10);
+        expect(coerceInt('25')).toBe(25);
+        expect(Number.isNaN(coerceInt(1.5))).toBe(true);
+        expect(Number.isNaN(coerceInt('abc'))).toBe(true);
+        expect(Number.isNaN(coerceInt(undefined))).toBe(true);
+        expect(Number.isNaN(coerceInt(''))).toBe(true);
+    });
+
+    it('requireBoundedInt rejects non-positive, non-integer and over-cap values', () => {
+        expect(requireBoundedInt(10, 25, 50)).toBe(10);
+        expect(requireBoundedInt(undefined, 25, 50)).toBe(25);
+        expect(() => requireBoundedInt(0, 25, 50)).toThrow('positive integer');
+        expect(() => requireBoundedInt(1.5, 25, 50)).toThrow('positive integer');
+        expect(() => requireBoundedInt(51, 25, 50)).toThrow('<= 50');
+        expect(() => requireBoundedInt('abc', 25, 50)).toThrow('positive integer');
+    });
+
+    it('requireNonNegativeInt accepts 0 and rejects negatives', () => {
+        expect(requireNonNegativeInt(0, 0)).toBe(0);
+        expect(requireNonNegativeInt(50, 0)).toBe(50);
+        expect(() => requireNonNegativeInt(-1, 0)).toThrow('non-negative integer');
+        expect(() => requireNonNegativeInt(1.5, 0)).toThrow('non-negative integer');
+    });
+
+    it('requireForumId rejects empty and malformed ids', () => {
+        expect(requireForumId('5sRnsubyAK')).toBe('5sRnsubyAK');
+        expect(requireForumId('abc-def_12')).toBe('abc-def_12');
+        expect(() => requireForumId('')).toThrow('required');
+        expect(() => requireForumId('  ')).toThrow('required');
+        expect(() => requireForumId('has space')).toThrow('not a valid forum id');
+        expect(() => requireForumId('a/b')).toThrow('not a valid forum id');
+        expect(() => requireForumId('short')).toThrow('not a valid forum id');
+    });
+
+    it('formatDate handles ms-since-epoch and rejects invalid input', () => {
+        expect(formatDate(1727524853394)).toBe('2024-09-28');
+        expect(formatDate(0)).toBe('');
+        expect(formatDate(undefined)).toBe('');
+        expect(formatDate('abc')).toBe('');
+    });
+
+    it('absolutePdf prefixes relative paths and preserves absolute URLs', () => {
+        expect(absolutePdf('/pdf/abc.pdf')).toBe('https://openreview.net/pdf/abc.pdf');
+        expect(absolutePdf('http://arxiv.org/pdf/1.pdf')).toBe('http://arxiv.org/pdf/1.pdf');
+        expect(absolutePdf('https://example.com/x.pdf')).toBe('https://example.com/x.pdf');
+        expect(absolutePdf('')).toBe('');
+        expect(absolutePdf(undefined)).toBe('');
+    });
+
+    it('search throws ArgumentError on empty query', async () => {
+        const search = getRegistry().get('openreview/search');
+        await expect(search.func({ query: '', limit: 10 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+        await expect(search.func({ query: '   ', limit: 10 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    });
+
+    it('search throws EmptyResult when API returns no notes', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [] }), { status: 200 })));
+        const search = getRegistry().get('openreview/search');
+        await expect(search.func({ query: 'no-such-paper-xyz', limit: 5 })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+
+    it('search wraps non-200 responses as CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        const search = getRegistry().get('openreview/search');
+        await expect(search.func({ query: 'transformer', limit: 5 })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
+    it('search wraps fetch network errors', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')));
+        const search = getRegistry().get('openreview/search');
+        await expect(search.func({ query: 'transformer', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Network failure'),
+        });
+    });
+
+    it('search wraps malformed JSON', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not-json', { status: 200 })));
+        const search = getRegistry().get('openreview/search');
+        await expect(search.func({ query: 'transformer', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Malformed JSON'),
+        });
+    });
+
+    it('search returns rank-ordered rows with the expected shape', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [SAMPLE_NOTE, SAMPLE_NOTE] }), { status: 200 })));
+        const search = getRegistry().get('openreview/search');
+        const rows = await search.func({ query: 'transformer', limit: 5 });
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toEqual({
+            rank: 1,
+            id: 'abc123XYZ_',
+            title: 'Test Paper Title with spaces',
+            authors: 'Alice Smith, Bob Jones',
+            venue: 'ICLR 2024 oral',
+            pdate: '2024-09-28',
+            url: 'https://openreview.net/forum?id=abc123XYZ_',
+        });
+        expect(rows[1].rank).toBe(2);
+    });
+
+    it('venue dispatches invitation vs venue-text via /-/ heuristic', async () => {
+        // Each call must return a fresh Response — bodies can only be read once.
+        const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ notes: [SAMPLE_NOTE] }), { status: 200 })));
+        vi.stubGlobal('fetch', fetchMock);
+        const venue = getRegistry().get('openreview/venue');
+        await venue.func({ venue: 'ICLR.cc/2025/Conference/-/Submission', limit: 1, offset: 0 });
+        expect(fetchMock.mock.calls[0][0]).toContain('invitation=ICLR.cc');
+        await venue.func({ venue: 'ICLR 2024 oral', limit: 1, offset: 0 });
+        expect(fetchMock.mock.calls[1][0]).toContain('content.venue=ICLR%202024%20oral');
+    });
+
+    it('venue applies offset to the rank column so paginated results stay ordered', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [SAMPLE_NOTE, SAMPLE_NOTE] }), { status: 200 })));
+        const venue = getRegistry().get('openreview/venue');
+        const rows = await venue.func({ venue: 'ICLR 2024 oral', limit: 2, offset: 50 });
+        expect(rows[0].rank).toBe(51);
+        expect(rows[1].rank).toBe(52);
+    });
+
+    it('paper rejects invalid ids before calling the network', async () => {
+        const paper = getRegistry().get('openreview/paper');
+        await expect(paper.func({ id: '' })).rejects.toMatchObject({ code: 'ARGUMENT' });
+        await expect(paper.func({ id: 'has space' })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    });
+
+    it('paper throws EmptyResult when the note id is unknown', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [] }), { status: 200 })));
+        const paper = getRegistry().get('openreview/paper');
+        await expect(paper.func({ id: 'abc123XYZ_' })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+
+    it('paper returns a single row with the full abstract intact', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [SAMPLE_NOTE] }), { status: 200 })));
+        const paper = getRegistry().get('openreview/paper');
+        const rows = await paper.func({ id: 'abc123XYZ_' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].abstract).toBe('A long abstract with newlines.');
+        expect(rows[0].pdf).toBe('https://openreview.net/pdf/abc.pdf');
+    });
+
+    it('reviews rejects max-length below 200', async () => {
+        const reviews = getRegistry().get('openreview/reviews');
+        await expect(reviews.func({ forum: 'abc123XYZ_', 'max-length': 100 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    });
+
+    it('reviews emits PAPER first then sorts by cdate, classifies invitations, and joins sections', async () => {
+        const replyReview = {
+            id: 'review1aaa',
+            forum: 'abc123XYZ_',
+            replyto: 'abc123XYZ_',
+            cdate: 1727524900000,
+            invitations: ['ICLR.cc/2025/Conference/Submission1/-/Official_Review'],
+            signatures: ['ICLR.cc/2025/Conference/Submission1/Reviewer_uVwr'],
+            content: {
+                summary: { value: 'Short summary' },
+                strengths: { value: 'Solid baselines' },
+                weaknesses: { value: 'Limited novelty' },
+                rating: { value: 5 },
+                confidence: { value: 4 },
+            },
+        };
+        const replyDecision = {
+            id: 'decision01',
+            forum: 'abc123XYZ_',
+            replyto: 'abc123XYZ_',
+            cdate: 1727525000000,
+            invitations: ['ICLR.cc/2025/Conference/-/Decision'],
+            signatures: ['ICLR.cc/2025/Conference/Program_Chairs'],
+            content: {
+                decision: { value: 'Accept (poster)' },
+            },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [replyReview, SAMPLE_NOTE, replyDecision] }), { status: 200 })));
+        const reviews = getRegistry().get('openreview/reviews');
+        const rows = await reviews.func({ forum: 'abc123XYZ_', 'max-length': 4000 });
+        expect(rows[0].type).toBe('PAPER');
+        expect(rows[1].type).toBe('REVIEW');
+        expect(rows[1].author).toBe('Reviewer_uVwr');
+        expect(rows[1].rating).toBe('5');
+        expect(rows[1].confidence).toBe('4');
+        expect(rows[1].text).toContain('Summary: Short summary');
+        expect(rows[1].text).toContain('Strengths: Solid baselines');
+        expect(rows[2].type).toBe('DECISION');
+        expect(rows[2].author).toBe('Program_Chairs');
+        expect(rows[2].text).toContain('Decision: Accept (poster)');
+    });
+
+    it('reviews truncates long text to max-length with ellipsis', async () => {
+        const longReview = {
+            id: 'longreview1',
+            forum: 'abc123XYZ_',
+            replyto: 'abc123XYZ_',
+            cdate: 1727524900000,
+            invitations: ['ICLR.cc/2025/Conference/Submission1/-/Official_Review'],
+            signatures: ['ICLR.cc/2025/Conference/Submission1/Reviewer_xxxx'],
+            content: { summary: { value: 'x'.repeat(5000) } },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [SAMPLE_NOTE, longReview] }), { status: 200 })));
+        const reviews = getRegistry().get('openreview/reviews');
+        const rows = await reviews.func({ forum: 'abc123XYZ_', 'max-length': 500 });
+        expect(rows[1].text.length).toBe(500);
+        expect(rows[1].text.endsWith('...')).toBe(true);
+    });
+});

--- a/clis/openreview/openreview.test.js
+++ b/clis/openreview/openreview.test.js
@@ -160,6 +160,17 @@ describe('openreview adapter', () => {
         });
     });
 
+    it('search wraps OpenReview in-band error envelopes as CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            errors: [{ message: 'bad term' }],
+        }), { status: 200 })));
+        const search = getRegistry().get('openreview/search');
+        await expect(search.func({ query: 'transformer', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('bad term'),
+        });
+    });
+
     it('search returns rank-ordered rows with the expected shape', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [SAMPLE_NOTE, SAMPLE_NOTE] }), { status: 200 })));
         const search = getRegistry().get('openreview/search');
@@ -249,7 +260,18 @@ describe('openreview adapter', () => {
                 decision: { value: 'Accept (poster)' },
             },
         };
-        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [replyReview, SAMPLE_NOTE, replyDecision] }), { status: 200 })));
+        const replyMetaReview = {
+            id: 'meta000001',
+            forum: 'abc123XYZ_',
+            replyto: 'abc123XYZ_',
+            cdate: 1727524950000,
+            invitations: ['ICLR.cc/2025/Conference/Submission1/-/Meta_Review'],
+            signatures: ['ICLR.cc/2025/Conference/Area_Chair_1'],
+            content: {
+                summary: { value: 'Meta summary' },
+            },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [replyReview, SAMPLE_NOTE, replyDecision, replyMetaReview] }), { status: 200 })));
         const reviews = getRegistry().get('openreview/reviews');
         const rows = await reviews.func({ forum: 'abc123XYZ_', 'max-length': 4000 });
         expect(rows[0].type).toBe('PAPER');
@@ -259,9 +281,12 @@ describe('openreview adapter', () => {
         expect(rows[1].confidence).toBe('4');
         expect(rows[1].text).toContain('Summary: Short summary');
         expect(rows[1].text).toContain('Strengths: Solid baselines');
-        expect(rows[2].type).toBe('DECISION');
-        expect(rows[2].author).toBe('Program_Chairs');
-        expect(rows[2].text).toContain('Decision: Accept (poster)');
+        expect(rows[2].type).toBe('META_REVIEW');
+        expect(rows[2].author).toBe('Area_Chair_1');
+        expect(rows[2].text).toContain('Summary: Meta summary');
+        expect(rows[3].type).toBe('DECISION');
+        expect(rows[3].author).toBe('Program_Chairs');
+        expect(rows[3].text).toContain('Decision: Accept (poster)');
     });
 
     it('reviews truncates long text to max-length with ellipsis', async () => {

--- a/clis/openreview/openreview.test.js
+++ b/clis/openreview/openreview.test.js
@@ -271,10 +271,17 @@ describe('openreview adapter', () => {
                 summary: { value: 'Meta summary' },
             },
         };
-        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [replyReview, SAMPLE_NOTE, replyDecision, replyMetaReview] }), { status: 200 })));
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url) => {
+            const href = String(url);
+            if (href.includes('/notes?id=')) {
+                return new Response(JSON.stringify({ notes: [SAMPLE_NOTE] }), { status: 200 });
+            }
+            return new Response(JSON.stringify({ notes: [replyDecision, replyReview, { ...SAMPLE_NOTE }, replyMetaReview] }), { status: 200 });
+        }));
         const reviews = getRegistry().get('openreview/reviews');
         const rows = await reviews.func({ forum: 'abc123XYZ_', 'max-length': 4000 });
         expect(rows[0].type).toBe('PAPER');
+        expect(rows.filter((row) => row.type === 'PAPER')).toHaveLength(1);
         expect(rows[1].type).toBe('REVIEW');
         expect(rows[1].author).toBe('Reviewer_uVwr');
         expect(rows[1].rating).toBe('5');
@@ -289,6 +296,30 @@ describe('openreview adapter', () => {
         expect(rows[3].text).toContain('Decision: Accept (poster)');
     });
 
+    it('reviews still emits PAPER row 0 when forum replies response omits the root note', async () => {
+        const replyReview = {
+            id: 'review1aaa',
+            forum: 'abc123XYZ_',
+            replyto: 'abc123XYZ_',
+            cdate: 1727524900000,
+            invitations: ['ICLR.cc/2025/Conference/Submission1/-/Official_Review'],
+            signatures: ['ICLR.cc/2025/Conference/Submission1/Reviewer_uVwr'],
+            content: { summary: { value: 'Short summary' } },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url) => {
+            const href = String(url);
+            if (href.includes('/notes?id=')) {
+                return new Response(JSON.stringify({ notes: [SAMPLE_NOTE] }), { status: 200 });
+            }
+            return new Response(JSON.stringify({ notes: [replyReview] }), { status: 200 });
+        }));
+        const reviews = getRegistry().get('openreview/reviews');
+        const rows = await reviews.func({ forum: 'abc123XYZ_', 'max-length': 4000 });
+        expect(rows[0].type).toBe('PAPER');
+        expect(rows[0].author).toBe('');
+        expect(rows[1].type).toBe('REVIEW');
+    });
+
     it('reviews truncates long text to max-length with ellipsis', async () => {
         const longReview = {
             id: 'longreview1',
@@ -299,7 +330,13 @@ describe('openreview adapter', () => {
             signatures: ['ICLR.cc/2025/Conference/Submission1/Reviewer_xxxx'],
             content: { summary: { value: 'x'.repeat(5000) } },
         };
-        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ notes: [SAMPLE_NOTE, longReview] }), { status: 200 })));
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url) => {
+            const href = String(url);
+            if (href.includes('/notes?id=')) {
+                return new Response(JSON.stringify({ notes: [SAMPLE_NOTE] }), { status: 200 });
+            }
+            return new Response(JSON.stringify({ notes: [longReview] }), { status: 200 });
+        }));
         const reviews = getRegistry().get('openreview/reviews');
         const rows = await reviews.func({ forum: 'abc123XYZ_', 'max-length': 500 });
         expect(rows[1].text.length).toBe(500);

--- a/clis/openreview/paper.js
+++ b/clis/openreview/paper.js
@@ -1,0 +1,42 @@
+/**
+ * OpenReview single paper detail (full abstract + metadata).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { noteToRow, openreviewFetch, requireForumId } from './utils.js';
+
+cli({
+    site: 'openreview',
+    name: 'paper',
+    description: 'Show full metadata for a single OpenReview paper',
+    domain: 'openreview.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'OpenReview note id (e.g. "5sRnsubyAK")' },
+    ],
+    columns: ['id', 'title', 'authors', 'keywords', 'venue', 'venueid', 'primary_area', 'abstract', 'pdate', 'pdf', 'url'],
+    func: async (args) => {
+        const id = requireForumId(args.id);
+        const path = `/notes?id=${encodeURIComponent(id)}`;
+        const json = await openreviewFetch(path, `openreview paper ${id}`);
+        const notes = Array.isArray(json?.notes) ? json.notes : [];
+        if (!notes.length) {
+            throw new EmptyResultError('openreview', `No paper found with id "${id}". Confirm the forum/note id from openreview.net.`);
+        }
+        const row = noteToRow(notes[0]);
+        return [{
+            id: row.id,
+            title: row.title,
+            authors: row.authors,
+            keywords: row.keywords,
+            venue: row.venue,
+            venueid: row.venueid,
+            primary_area: row.primary_area,
+            abstract: row.abstract,
+            pdate: row.pdate,
+            pdf: row.pdf,
+            url: row.url,
+        }];
+    },
+});

--- a/clis/openreview/reviews.js
+++ b/clis/openreview/reviews.js
@@ -41,9 +41,9 @@ function classifyNote(note, isRoot) {
     if (tail.includes('decision')) return 'DECISION';
     if (tail.includes('withdrawal')) return 'WITHDRAWAL';
     if (tail.includes('rebuttal')) return 'REBUTTAL';
+    if (tail.includes('meta')) return 'META_REVIEW';
     if (tail.includes('review')) return 'REVIEW';
     if (tail.includes('comment')) return 'COMMENT';
-    if (tail.includes('meta')) return 'META_REVIEW';
     return tail ? tail.toUpperCase() : 'NOTE';
 }
 

--- a/clis/openreview/reviews.js
+++ b/clis/openreview/reviews.js
@@ -1,0 +1,132 @@
+/**
+ * OpenReview paper + threaded reviews/decisions/comments.
+ *
+ * Walks the forum tree once and emits one row per note in chronological order:
+ *   PAPER → REVIEW (one per reviewer) → REBUTTAL/COMMENT → DECISION → WITHDRAWAL.
+ *
+ * Each row carries `rating` / `confidence` so reviewers stand out at a glance.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { coerceInt, openreviewFetch, readContent, requireForumId } from './utils.js';
+
+const SECTION_FIELDS = [
+    ['summary', 'Summary'],
+    ['strengths', 'Strengths'],
+    ['weaknesses', 'Weaknesses'],
+    ['questions', 'Questions'],
+    ['comment', 'Comment'],
+    ['rebuttal', 'Rebuttal'],
+    ['decision', 'Decision'],
+    ['recommendation', 'Recommendation'],
+    ['title', 'Title'],
+    ['abstract', 'Abstract'],
+    ['withdrawal_confirmation', 'Withdrawal confirmation'],
+];
+
+/** Pull the trailing segment of an invitation id (e.g. ".../-/Official_Review" → "Official_Review"). */
+function invitationTail(invitations) {
+    if (!Array.isArray(invitations)) return '';
+    for (const inv of invitations) {
+        const m = String(inv).match(/\/-\/([^/]+)$/);
+        if (m) return m[1];
+    }
+    return '';
+}
+
+/** Map a note's invitation tail to a row type label. */
+function classifyNote(note, isRoot) {
+    if (isRoot) return 'PAPER';
+    const tail = invitationTail(note?.invitations).toLowerCase();
+    if (tail.includes('decision')) return 'DECISION';
+    if (tail.includes('withdrawal')) return 'WITHDRAWAL';
+    if (tail.includes('rebuttal')) return 'REBUTTAL';
+    if (tail.includes('review')) return 'REVIEW';
+    if (tail.includes('comment')) return 'COMMENT';
+    if (tail.includes('meta')) return 'META_REVIEW';
+    return tail ? tail.toUpperCase() : 'NOTE';
+}
+
+/**
+ * Pick the most informative signature segment, e.g.:
+ *   "ICLR.cc/2025/Conference/Submission14296/Reviewer_uVwr" → "Reviewer_uVwr"
+ *   "ICLR.cc/2025/Conference/Program_Chairs"               → "Program_Chairs"
+ *   "~Pedro_Jose_Moreno_Mengibar1"                          → "Pedro Jose Moreno Mengibar"
+ */
+function authorFromSignatures(signatures) {
+    if (!Array.isArray(signatures) || !signatures.length) return '';
+    const sig = String(signatures[0]);
+    if (sig.startsWith('~')) {
+        return sig.replace(/^~/, '').replace(/\d+$/, '').replace(/_/g, ' ').trim();
+    }
+    const parts = sig.split('/');
+    return parts[parts.length - 1] || sig;
+}
+
+function joinSections(content) {
+    const parts = [];
+    for (const [key, label] of SECTION_FIELDS) {
+        const value = readContent(content, key);
+        if (value === undefined || value === null) continue;
+        const text = Array.isArray(value) ? value.join(', ') : String(value);
+        const trimmed = text.replace(/\r\n/g, '\n').trim();
+        if (!trimmed) continue;
+        parts.push(`${label}: ${trimmed}`);
+    }
+    return parts.join('\n\n');
+}
+
+function truncate(text, maxLength) {
+    if (text.length <= maxLength) return text;
+    return `${text.slice(0, maxLength - 3)}...`;
+}
+
+cli({
+    site: 'openreview',
+    name: 'reviews',
+    description: 'Show full review thread (paper + reviews + decisions) for an OpenReview forum',
+    domain: 'openreview.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'forum', positional: true, required: true, help: 'OpenReview forum id (same as paper id)' },
+        { name: 'max-length', type: 'int', default: 4000, help: 'Per-row text truncation (min 200)' },
+    ],
+    columns: ['type', 'author', 'rating', 'confidence', 'text'],
+    func: async (args) => {
+        const forum = requireForumId(args.forum, 'forum');
+        const rawMax = args['max-length'] ?? args.maxLength ?? 4000;
+        const maxLength = coerceInt(rawMax);
+        if (!Number.isInteger(maxLength) || maxLength < 200) {
+            throw new ArgumentError('openreview reviews max-length must be an integer >= 200');
+        }
+        const path = `/notes?forum=${encodeURIComponent(forum)}&details=replies&limit=1000`;
+        const json = await openreviewFetch(path, `openreview reviews ${forum}`);
+        const notes = Array.isArray(json?.notes) ? json.notes : [];
+        if (!notes.length) {
+            throw new EmptyResultError('openreview', `No forum found with id "${forum}". Confirm the forum id from openreview.net.`);
+        }
+        // Sort by cdate (creation time) so ordering is deterministic regardless of API order.
+        const sorted = [...notes].sort((a, b) => (a?.cdate ?? 0) - (b?.cdate ?? 0));
+        // Lift the root submission (id === forum) to the top — readers want the paper first.
+        const rootIdx = sorted.findIndex(n => n?.id === forum);
+        const ordered = rootIdx > 0
+            ? [sorted[rootIdx], ...sorted.slice(0, rootIdx), ...sorted.slice(rootIdx + 1)]
+            : sorted;
+        return ordered.map((note) => {
+            const isRoot = note?.id === forum;
+            const type = classifyNote(note, isRoot);
+            const author = authorFromSignatures(note?.signatures);
+            const rating = readContent(note?.content, 'rating');
+            const confidence = readContent(note?.content, 'confidence');
+            const text = truncate(joinSections(note?.content), maxLength);
+            return {
+                type,
+                author,
+                rating: rating === undefined || rating === null ? '' : String(rating),
+                confidence: confidence === undefined || confidence === null ? '' : String(confidence),
+                text,
+            };
+        });
+    },
+});

--- a/clis/openreview/reviews.js
+++ b/clis/openreview/reviews.js
@@ -100,19 +100,17 @@ cli({
         if (!Number.isInteger(maxLength) || maxLength < 200) {
             throw new ArgumentError('openreview reviews max-length must be an integer >= 200');
         }
-        const path = `/notes?forum=${encodeURIComponent(forum)}&details=replies&limit=1000`;
-        const json = await openreviewFetch(path, `openreview reviews ${forum}`);
-        const notes = Array.isArray(json?.notes) ? json.notes : [];
-        if (!notes.length) {
+        const rootJson = await openreviewFetch(`/notes?id=${encodeURIComponent(forum)}`, `openreview paper ${forum}`);
+        const rootNotes = Array.isArray(rootJson?.notes) ? rootJson.notes : [];
+        const root = rootNotes[0];
+        if (!root) {
             throw new EmptyResultError('openreview', `No forum found with id "${forum}". Confirm the forum id from openreview.net.`);
         }
+        const repliesJson = await openreviewFetch(`/notes?forum=${encodeURIComponent(forum)}&details=replies&limit=1000`, `openreview reviews ${forum}`);
+        const replies = Array.isArray(repliesJson?.notes) ? repliesJson.notes.filter(note => note?.id !== forum) : [];
         // Sort by cdate (creation time) so ordering is deterministic regardless of API order.
-        const sorted = [...notes].sort((a, b) => (a?.cdate ?? 0) - (b?.cdate ?? 0));
-        // Lift the root submission (id === forum) to the top — readers want the paper first.
-        const rootIdx = sorted.findIndex(n => n?.id === forum);
-        const ordered = rootIdx > 0
-            ? [sorted[rootIdx], ...sorted.slice(0, rootIdx), ...sorted.slice(rootIdx + 1)]
-            : sorted;
+        const sorted = [...replies].sort((a, b) => (a?.cdate ?? 0) - (b?.cdate ?? 0));
+        const ordered = [root, ...sorted];
         return ordered.map((note) => {
             const isRoot = note?.id === forum;
             const type = classifyNote(note, isRoot);

--- a/clis/openreview/search.js
+++ b/clis/openreview/search.js
@@ -1,0 +1,45 @@
+/**
+ * OpenReview full-text search.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { noteToRow, openreviewFetch, requireBoundedInt } from './utils.js';
+
+cli({
+    site: 'openreview',
+    name: 'search',
+    description: 'Search OpenReview papers by free-text query',
+    domain: 'openreview.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "diffusion model")' },
+        { name: 'limit', type: 'int', default: 25, help: 'Max results (max 50)' },
+    ],
+    columns: ['rank', 'id', 'title', 'authors', 'venue', 'pdate', 'url'],
+    func: async (args) => {
+        const term = String(args.query ?? '').trim();
+        if (!term) {
+            throw new ArgumentError('openreview search query cannot be empty');
+        }
+        const limit = requireBoundedInt(args.limit, 25, 50);
+        const path = `/notes/search?term=${encodeURIComponent(term)}&type=terms&limit=${limit}`;
+        const json = await openreviewFetch(path, 'openreview search');
+        const notes = Array.isArray(json?.notes) ? json.notes : [];
+        if (!notes.length) {
+            throw new EmptyResultError('openreview', `No papers found for "${term}". Try a different keyword.`);
+        }
+        return notes.slice(0, limit).map((note, i) => {
+            const row = noteToRow(note);
+            return {
+                rank: i + 1,
+                id: row.id,
+                title: row.title,
+                authors: row.authors,
+                venue: row.venue,
+                pdate: row.pdate,
+                url: row.url,
+            };
+        });
+    },
+});

--- a/clis/openreview/utils.js
+++ b/clis/openreview/utils.js
@@ -1,0 +1,148 @@
+/**
+ * OpenReview adapter utilities.
+ *
+ * Public OpenReview v2 API — no key required for everyone-readable notes.
+ * https://docs.openreview.net/reference/api-v2
+ */
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const OPENREVIEW_API = 'https://api2.openreview.net';
+export const OPENREVIEW_BASE = 'https://openreview.net';
+
+/** Forum / note IDs on OpenReview are short URL-safe slugs (typically 10 chars). */
+const ID_PATTERN = /^[A-Za-z0-9_-]{6,20}$/;
+
+/**
+ * Coerce a value to a strict integer (accepts numeric strings, rejects
+ * floats / non-numeric / NaN). Returns NaN on invalid input so callers can
+ * decide on the right typed error.
+ */
+export function coerceInt(value) {
+    if (value === undefined || value === null || value === '') return NaN;
+    const n = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(n) && Number.isInteger(n) ? n : NaN;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = coerceInt(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`openreview ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`openreview ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireNonNegativeInt(value, defaultValue, label = 'offset') {
+    const raw = value ?? defaultValue;
+    const n = coerceInt(raw);
+    if (!Number.isInteger(n) || n < 0) {
+        throw new ArgumentError(`openreview ${label} must be a non-negative integer`);
+    }
+    return n;
+}
+
+export function requireForumId(value, label = 'id') {
+    const id = String(value ?? '').trim();
+    if (!id) {
+        throw new ArgumentError(`openreview ${label} is required`);
+    }
+    if (!ID_PATTERN.test(id)) {
+        throw new ArgumentError(`openreview ${label} "${value}" is not a valid forum id (expected 6-20 chars of [A-Za-z0-9_-])`);
+    }
+    return id;
+}
+
+/** Wrap fetch + json with typed errors so failures never look like empty results. */
+export async function openreviewFetch(path, label) {
+    const url = `${OPENREVIEW_API}${path}`;
+    let resp;
+    try {
+        resp = await fetch(url);
+    }
+    catch (e) {
+        throw new CommandExecutionError(`Network failure fetching ${label}: ${e?.message ?? e}`, 'Check your network connection and try again.');
+    }
+    if (resp.status === 404) {
+        return null;
+    }
+    if (!resp.ok) {
+        let body = '';
+        try { body = (await resp.text()).slice(0, 200); } catch {}
+        throw new CommandExecutionError(`OpenReview API HTTP ${resp.status} for ${label}${body ? ` (${body})` : ''}`, 'The OpenReview API may be down or rate-limiting.');
+    }
+    let json;
+    try {
+        json = await resp.json();
+    }
+    catch (e) {
+        throw new CommandExecutionError(`Malformed JSON from OpenReview for ${label}: ${e?.message ?? e}`, 'Try again or report this as an OpenReview API bug.');
+    }
+    return json;
+}
+
+/** Format ms-since-epoch as YYYY-MM-DD; empty string for invalid input. */
+export function formatDate(ms) {
+    if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) return '';
+    return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** Read a v2 content field, which is wrapped as `{ value: ... }`. */
+export function readContent(content, key) {
+    const v = content?.[key]?.value;
+    if (v === undefined || v === null) return undefined;
+    return v;
+}
+
+/** Build an absolute PDF URL from the `content.pdf` value, which may be a relative `/pdf/<hash>.pdf`. */
+export function absolutePdf(pdfValue) {
+    const v = String(pdfValue ?? '').trim();
+    if (!v) return '';
+    if (/^https?:\/\//.test(v)) return v;
+    if (v.startsWith('/')) return `${OPENREVIEW_BASE}${v}`;
+    return `${OPENREVIEW_BASE}/${v}`;
+}
+
+/** Strip `~` markers and trailing digits from author IDs (e.g. `~John_Doe1` → `John Doe`). */
+function authorIdToName(authorid) {
+    return String(authorid || '')
+        .replace(/^~/, '')
+        .replace(/\d+$/, '')
+        .replace(/_/g, ' ')
+        .trim();
+}
+
+/**
+ * Map a v2 note (submission or paper) to a flat row.
+ * `content.authors` is preferred; falls back to author IDs if missing.
+ */
+export function noteToRow(note) {
+    const c = note?.content ?? {};
+    const id = note?.id ?? '';
+    const authors = readContent(c, 'authors');
+    const authorIds = readContent(c, 'authorids');
+    let authorList = '';
+    if (Array.isArray(authors) && authors.length) {
+        authorList = authors.join(', ');
+    }
+    else if (Array.isArray(authorIds) && authorIds.length) {
+        authorList = authorIds.map(authorIdToName).join(', ');
+    }
+    const keywords = readContent(c, 'keywords');
+    const keywordList = Array.isArray(keywords) ? keywords.join(', ') : String(keywords ?? '');
+    return {
+        id,
+        title: String(readContent(c, 'title') ?? '').replace(/\s+/g, ' ').trim(),
+        authors: authorList,
+        keywords: keywordList,
+        venue: String(readContent(c, 'venue') ?? '').trim(),
+        venueid: String(readContent(c, 'venueid') ?? '').trim(),
+        primary_area: String(readContent(c, 'primary_area') ?? '').trim(),
+        abstract: String(readContent(c, 'abstract') ?? '').replace(/\s+/g, ' ').trim(),
+        pdate: formatDate(note?.pdate ?? note?.cdate),
+        pdf: absolutePdf(readContent(c, 'pdf')),
+        url: id ? `${OPENREVIEW_BASE}/forum?id=${id}` : '',
+    };
+}

--- a/clis/openreview/utils.js
+++ b/clis/openreview/utils.js
@@ -80,6 +80,16 @@ export async function openreviewFetch(path, label) {
     catch (e) {
         throw new CommandExecutionError(`Malformed JSON from OpenReview for ${label}: ${e?.message ?? e}`, 'Try again or report this as an OpenReview API bug.');
     }
+    const envelopeErrors = Array.isArray(json?.errors) ? json.errors.filter(Boolean) : [];
+    const envelopeError = typeof json?.error === 'string' ? json.error.trim() : '';
+    if (envelopeErrors.length || envelopeError) {
+        const detail = envelopeError || envelopeErrors.map((entry) => {
+            if (typeof entry === 'string') return entry;
+            if (entry?.message) return String(entry.message);
+            return JSON.stringify(entry);
+        }).join('; ');
+        throw new CommandExecutionError(`OpenReview API error for ${label}: ${detail}`, 'The OpenReview API returned an application-level error.');
+    }
     return json;
 }
 

--- a/clis/openreview/venue.js
+++ b/clis/openreview/venue.js
@@ -1,0 +1,62 @@
+/**
+ * OpenReview venue listing.
+ *
+ * Accepts either:
+ *   • a venue name (matched against `content.venue`, e.g. "ICLR 2024 oral"), or
+ *   • a full invitation id (e.g. "ICLR.cc/2025/Conference/-/Submission").
+ *
+ * Invitations contain the literal `/-/` segment, so we use that to disambiguate.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { noteToRow, openreviewFetch, requireBoundedInt, requireNonNegativeInt } from './utils.js';
+
+cli({
+    site: 'openreview',
+    name: 'venue',
+    description: 'List papers at an OpenReview venue (e.g. "ICLR 2024 oral" or full invitation id)',
+    domain: 'openreview.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'venue', positional: true, required: true, help: 'Venue name ("ICLR 2024 oral") or invitation ("ICLR.cc/2025/Conference/-/Submission")' },
+        { name: 'limit', type: 'int', default: 25, help: 'Max results (max 200)' },
+        { name: 'offset', type: 'int', default: 0, help: 'Pagination offset' },
+    ],
+    columns: ['rank', 'id', 'title', 'authors', 'keywords', 'primary_area', 'pdate', 'pdf', 'url'],
+    func: async (args) => {
+        const value = String(args.venue ?? '').trim();
+        if (!value) {
+            throw new ArgumentError('openreview venue cannot be empty');
+        }
+        const limit = requireBoundedInt(args.limit, 25, 200);
+        const offset = requireNonNegativeInt(args.offset, 0);
+        const isInvitation = value.includes('/-/');
+        const filter = isInvitation
+            ? `invitation=${encodeURIComponent(value)}`
+            : `content.venue=${encodeURIComponent(value)}`;
+        const path = `/notes?${filter}&limit=${limit}&offset=${offset}`;
+        const json = await openreviewFetch(path, `openreview venue ${value}`);
+        const notes = Array.isArray(json?.notes) ? json.notes : [];
+        if (!notes.length) {
+            const hint = isInvitation
+                ? 'Check the invitation id (e.g. "ICLR.cc/2025/Conference/-/Submission").'
+                : 'Try a venue text like "ICLR 2024 oral" or pass a full invitation id.';
+            throw new EmptyResultError('openreview', `No papers found at venue "${value}". ${hint}`);
+        }
+        return notes.slice(0, limit).map((note, i) => {
+            const row = noteToRow(note);
+            return {
+                rank: offset + i + 1,
+                id: row.id,
+                title: row.title,
+                authors: row.authors,
+                keywords: row.keywords,
+                primary_area: row.primary_area,
+                pdate: row.pdate,
+                pdf: row.pdf,
+                url: row.url,
+            };
+        });
+    },
+});

--- a/docs/adapters/browser/openreview.md
+++ b/docs/adapters/browser/openreview.md
@@ -1,0 +1,74 @@
+# OpenReview
+
+**Mode**: 🌐 Public · **Domain**: `openreview.net`
+
+OpenReview is the open peer-review platform used by ICLR, COLM, NeurIPS workshops, TMLR, and many other ML venues. The v2 API exposes everyone-readable submissions, reviews, and decisions without authentication, so all four commands run without a browser.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli openreview search <query>` | Full-text search across all OpenReview papers |
+| `opencli openreview venue <venue>` | List papers at a venue (e.g. `"ICLR 2024 oral"` or full invitation id) |
+| `opencli openreview paper <id>` | Show full metadata (incl. abstract) for a single paper |
+| `opencli openreview reviews <forum>` | Show paper + threaded reviews/decisions/comments |
+
+## Usage Examples
+
+```bash
+# Full-text search
+opencli openreview search "diffusion model" --limit 10
+
+# Browse a venue by display name (matched against content.venue)
+opencli openreview venue "ICLR 2024 oral" --limit 20
+
+# Browse a venue by full invitation id (use this when display names overlap)
+opencli openreview venue "ICLR.cc/2025/Conference/-/Submission" --limit 50 --offset 0
+
+# Single-paper detail (full abstract)
+opencli openreview paper KS8mIvetg2
+
+# Full review thread — paper + reviews + decision + author rebuttal
+opencli openreview reviews KS8mIvetg2 --max-length 4000
+
+# JSON output
+opencli openreview search "LLM" -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, id, title, authors, venue, pdate, url` |
+| `venue` | `rank, id, title, authors, keywords, primary_area, pdate, pdf, url` |
+| `paper` | `id, title, authors, keywords, venue, venueid, primary_area, abstract, pdate, pdf, url` |
+| `reviews` | `type, author, rating, confidence, text` |
+
+The `id` returned by `search`/`venue` round-trips into `paper`/`reviews` — it is the OpenReview note id (also the `forum` id for top-level submissions). `pdf` is normalized to an absolute `https://openreview.net/pdf/...` URL.
+
+## `reviews` Output
+
+`reviews` walks the forum's reply tree once and emits one row per note in chronological order, with the original submission lifted to the top:
+
+| `type` | When emitted |
+|--------|--------------|
+| `PAPER` | The submission itself (always row 0) |
+| `REVIEW` | An `Official_Review` reply |
+| `META_REVIEW` | A meta-review by Area Chairs |
+| `DECISION` | The final decision note |
+| `REBUTTAL` | An author rebuttal note |
+| `COMMENT` | An `Official_Comment` reply |
+| `WITHDRAWAL` | A withdrawal confirmation |
+
+`rating` and `confidence` are the raw OpenReview enum strings (e.g. `"6: marginally above the acceptance threshold"`). `text` joins together the standard sections — Summary, Strengths, Weaknesses, Questions, Comment, Rebuttal, Decision, Recommendation — and is per-row truncated to `--max-length` (default 4000, min 200).
+
+## Caveats
+
+- OpenReview indexes a lot of DBLP-mirrored entries (CoRR / journal records). Search results may include those alongside actual OpenReview submissions; only OpenReview-hosted papers have full review threads available via `reviews`.
+- The default sort for `search` is the API's relevance-by-term ranking. For a chronological view, use `venue` against the relevant invitation.
+- `pdate` (publication date) falls back to `cdate` (creation date) when missing, formatted as `YYYY-MM-DD`.
+- `venue` accepts either a display name (`"ICLR 2024 oral"`, matched against `content.venue`) or a full invitation id (`"ICLR.cc/2025/Conference/-/Submission"`). The presence of the literal `/-/` segment is what disambiguates the two modes.
+
+## Prerequisites
+
+- No browser required — uses the public OpenReview v2 API at `https://api2.openreview.net`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -92,6 +92,7 @@ Run `opencli list` for the live registry.
 | **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download` `transcript` (local credentials required)                                                   | 🔑 Local API |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
+| **[openreview](./browser/openreview.md)**         | `search` `venue` `paper` `reviews`                                                                                                             | 🌐 Public    |
 | **[paperreview](./browser/paperreview.md)**       | `submit` `review` `feedback`                                                                                                                   | 🌐 Public    |
 | **[barchart](./browser/barchart.md)**             | `quote` `options` `greeks` `flow`                                                                                                              | 🌐 Public    |
 | **[binance](./browser/binance.md)**               | `price` `prices` `ticker` `pairs` `trades` `depth` `asks` `klines` `top` `gainers` `losers`                                                 | 🌐 Public    |


### PR DESCRIPTION
## Summary

OpenReview is the open peer-review platform used by ICLR / TMLR / COLM and many ML workshops. Its v2 API (`api2.openreview.net`) exposes everyone-readable submissions, reviews, and decisions without auth, so all four commands run with `browser: false`.

- `openreview search <query>` — full-text search via `/notes/search?term=...&type=terms`
- `openreview venue <venue>` — list venue submissions; accepts either a display name (matched against `content.venue`, e.g. `"ICLR 2024 oral"`) or a full invitation id (e.g. `"ICLR.cc/2025/Conference/-/Submission"`); offset pagination
- `openreview paper <id>` — single-paper detail with full abstract
- `openreview reviews <forum>` — paper + threaded reviews/decisions/comments, ordered chronologically with paper lifted to row 0; classifies notes via invitation tail (`REVIEW` / `DECISION` / `REBUTTAL` / `COMMENT` / `META_REVIEW` / `WITHDRAWAL`)

Listing IDs round-trip into `paper` / `reviews` (id === forum for top-level submissions). PDF URLs normalized to absolute `https://openreview.net/pdf/...`. `pdate` falls back to `cdate` when missing, formatted as `YYYY-MM-DD`.

## Agent-native contract (lessons applied from #1292 / #1293)

- All limits/offsets/ids fail-fast with typed errors (`ArgumentError` / `EmptyResultError` / `CommandExecutionError`) — no silent clamping, no `Math.min/max`, no empty-array fallbacks.
- `coerceInt` accepts numeric strings but rejects floats / NaN / `'abc'` so CLI argv coercions don't silently drift.
- `openreviewFetch` wraps `fetch` rejection, non-2xx, 404 (mapped to `null` so callers throw a contextual `EmptyResultError`), and `res.json()` parse failures all into `CommandExecutionError`. Network/API failures never look like empty results.
- `requireForumId` validates `[A-Za-z0-9_-]{6,20}` so bad ids fail before any network call.
- `noteToRow` falls back from `content.authors` → `authorIds` (with `~` / trailing-digit cleanup) only when the primary field is missing — never silently masks a partial response.
- `reviews` per-row truncation has a 200-char floor (no `Math.max`).

## Output Columns

| Command | Columns |
|---------|---------|
| `search` | `rank, id, title, authors, venue, pdate, url` |
| `venue` | `rank, id, title, authors, keywords, primary_area, pdate, pdf, url` |
| `paper` | `id, title, authors, keywords, venue, venueid, primary_area, abstract, pdate, pdf, url` |
| `reviews` | `type, author, rating, confidence, text` |

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run clis/openreview/` — 1 file / 23 tests passing
- [x] `npm run build` — manifest regenerated, 655 entries, 4 new openreview entries
- [x] `bash scripts/check-doc-coverage.sh --strict` — 106/106
- [x] Live: `openreview search "diffusion model" --limit 3` — returns ranked papers with venue + pdate
- [x] Live: `openreview venue "ICLR 2024 oral" --limit 3` — returns ICLR 2024 orals with keywords/primary_area/pdf
- [x] Live: `openreview paper KS8mIvetg2` — full abstract intact
- [x] Live: `openreview reviews KS8mIvetg2 --max-length 800` — PAPER row first, then 3 REVIEW rows with rating/confidence
- [x] Live: `openreview paper notarealid` → `EMPTY_RESULT`; `openreview venue "ICLR 2099 oral"` → `EMPTY_RESULT`; empty `search ""` → `ARGUMENT`