### PR TITLE
docs(stackoverflow): clarify read answers up to --answers-limit

### DIFF
--- a/docs/adapters/browser/stackoverflow.md
+++ b/docs/adapters/browser/stackoverflow.md
@@ -34,8 +34,11 @@
 
 ## `read` columns
 
-`stackoverflow read <id>` fetches the question, all answers (accepted first,
-then by votes), question comments, and answer comments. It mirrors the
+`stackoverflow read <id>` fetches the question, answers up to
+`--answers-limit` (accepted first, then by votes — if the accepted
+answer is outside the votes-sorted page it is fetched separately and
+prepended), question comments up to `--comments-limit`, and answer
+comments up to `--comments-limit` per answer. It mirrors the
 `hackernews read` and `lobsters read` thread shape.
 
 | Column | Description |


### PR DESCRIPTION
## Summary

Non-blocking follow-up flagged during #1293 review (codex-mini1 + First-principles-1): the `read` docs said "all answers" but the implementation is limit-bounded (`--answers-limit` default 10, max 100). Updated wording to spell out the actual contract — including the accepted-answer-outside-page fallback path — so users don't expect infinite-scroll behaviour.

Docs-only change. No code or test impact.

## Test plan

- [x] `bash scripts/check-doc-coverage.sh --strict` — 106/106 (no new adapter)
- [x] Manual diff review — only the `read columns` paragraph changed