### PR TITLE
feat(convention): listing↔detail id pairing rule + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
             exit 1
           fi
 
+      # Guard: listing-class commands must surface an id-shaped column so their
+      # rows round-trip into the site's detail-class command. Without this, an
+      # agent has to re-search by title or scrape URLs to follow up on a row.
+      # See docs/conventions/listing-detail-id-pairing.md.
+      - name: Check listing↔detail id pairing
+        if: runner.os == 'Linux'
+        run: npm run check:listing-id-pairing
+
   # ── Unit tests (vitest shard) ──
   # PR: ubuntu + Node 22 only (fast feedback, 2 jobs).
   # Push to main/dev: full matrix for cross-platform/cross-version coverage (12 jobs).

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8701,6 +8701,7 @@
     ],
     "columns": [
       "rank",
+      "tid",
       "title",
       "url"
     ],
@@ -8885,6 +8886,7 @@
     ],
     "columns": [
       "rank",
+      "tid",
       "title",
       "author",
       "replies",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -120,6 +120,7 @@
     ],
     "columns": [
       "rank",
+      "offer_id",
       "title",
       "price_text",
       "moq_text",
@@ -2990,6 +2991,7 @@
     ],
     "columns": [
       "rank",
+      "uri",
       "text",
       "likes",
       "reposts",
@@ -16405,7 +16407,8 @@
       "rank",
       "title",
       "discussions",
-      "description"
+      "description",
+      "url"
     ],
     "type": "js",
     "modulePath": "tieba/hot.js",
@@ -16532,10 +16535,12 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "forum",
       "author",
-      "time"
+      "time",
+      "url"
     ],
     "type": "js",
     "modulePath": "tieba/search.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -10163,6 +10163,7 @@
       }
     ],
     "columns": [
+      "id",
       "author",
       "content",
       "likes",
@@ -10316,6 +10317,7 @@
       }
     ],
     "columns": [
+      "id",
       "author",
       "content",
       "likes",
@@ -10390,6 +10392,7 @@
       }
     ],
     "columns": [
+      "id",
       "content",
       "type",
       "likes",
@@ -18668,6 +18671,7 @@
       }
     ],
     "columns": [
+      "id",
       "author",
       "text",
       "reposts",
@@ -18819,6 +18823,7 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "author",
       "time",

--- a/clis/1688/search.js
+++ b/clis/1688/search.js
@@ -294,7 +294,7 @@ cli({
             help: `结果数量上限（默认 ${SEARCH_LIMIT_DEFAULT}，最大 ${SEARCH_LIMIT_MAX}）`,
         },
     ],
-    columns: ['rank', 'title', 'price_text', 'moq_text', 'seller_name', 'location'],
+    columns: ['rank', 'offer_id', 'title', 'price_text', 'moq_text', 'seller_name', 'location'],
     func: async (page, kwargs) => {
         const query = String(kwargs.query ?? '');
         const limit = parseSearchLimit(kwargs.limit);

--- a/clis/bluesky/user.js
+++ b/clis/bluesky/user.js
@@ -16,7 +16,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20, help: 'Number of posts' },
     ],
-    columns: ['rank', 'text', 'likes', 'reposts', 'replies'],
+    columns: ['rank', 'uri', 'text', 'likes', 'reposts', 'replies'],
     pipeline: [
         { fetch: {
                 url: 'https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${{ args.handle }}&limit=${{ args.limit }}',
@@ -24,6 +24,7 @@ cli({
         { select: 'feed' },
         { map: {
                 rank: '${{ index + 1 }}',
+                uri: '${{ item.post.uri }}',
                 text: '${{ item.post.record.text }}',
                 likes: '${{ item.post.likeCount }}',
                 reposts: '${{ item.post.repostCount }}',

--- a/clis/hupu/hot.js
+++ b/clis/hupu/hot.js
@@ -8,7 +8,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of hot posts' },
     ],
-    columns: ['rank', 'title', 'url'],
+    columns: ['rank', 'tid', 'title', 'url'],
     pipeline: [
         { navigate: 'https://bbs.hupu.com/' },
         { evaluate: `(async () => {
@@ -33,6 +33,7 @@ cli({
 ` },
         { map: {
                 rank: '${{ index + 1 }}',
+                tid: '${{ item.tid }}',
                 title: '${{ item.title }}',
                 url: 'https://bbs.hupu.com/${{ item.tid }}.html',
             } },

--- a/clis/hupu/search.js
+++ b/clis/hupu/search.js
@@ -38,7 +38,7 @@ cli({
             help: '排序方式: general/createtime/replytime/light/reply'
         }
     ],
-    columns: ['rank', 'title', 'author', 'replies', 'lights', 'forum', 'url'],
+    columns: ['rank', 'tid', 'title', 'author', 'replies', 'lights', 'forum', 'url'],
     func: async (page, kwargs) => {
         const { query, page: pageNum = 1, limit = 20, forum, sort = 'general' } = kwargs;
         const searchUrl = getHupuSearchUrl(query, pageNum, forum, sort);
@@ -48,6 +48,7 @@ cli({
         // 处理结果：清理HTML标签，解码HTML实体
         const processedResults = results.slice(0, Number(limit)).map((item, index) => ({
             rank: index + 1,
+            tid: String(item.id || ''),
             title: decodeHtmlEntities(stripHtml(item.title)),
             author: item.username || '未知用户',
             replies: item.replies || '0',

--- a/clis/jike/feed.js
+++ b/clis/jike/feed.js
@@ -17,7 +17,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['author', 'content', 'likes', 'comments', 'time', 'url'],
+    columns: ['id', 'author', 'content', 'likes', 'comments', 'time', 'url'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         // 1. 导航到即刻首页，等待 SPA 重定向到 /following
@@ -44,6 +44,7 @@ cli({
           if (!author && !content) continue;
 
           results.push({
+            id: data.id,
             author,
             content: content.replace(/\\n/g, ' ').slice(0, 120),
             likes: data.likeCount || 0,

--- a/clis/jike/search.js
+++ b/clis/jike/search.js
@@ -18,7 +18,7 @@ cli({
         { name: 'query', type: 'string', required: true, positional: true },
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['author', 'content', 'likes', 'comments', 'time', 'url'],
+    columns: ['id', 'author', 'content', 'likes', 'comments', 'time', 'url'],
     func: async (page, kwargs) => {
         const keyword = kwargs.query;
         const limit = kwargs.limit || 20;
@@ -44,6 +44,7 @@ cli({
           if (!author && !content) continue;
 
           results.push({
+            id: data.id,
             author,
             content: content.replace(/\\n/g, ' ').slice(0, 120),
             likes: data.likeCount || 0,

--- a/clis/jike/user.js
+++ b/clis/jike/user.js
@@ -16,7 +16,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20, help: 'Number of posts' },
     ],
-    columns: ['content', 'type', 'likes', 'comments', 'time', 'url'],
+    columns: ['id', 'content', 'type', 'likes', 'comments', 'time', 'url'],
     pipeline: [
         { navigate: 'https://m.okjike.com/users/${{ args.username }}' },
         { evaluate: `(() => {
@@ -39,6 +39,7 @@ cli({
 })()
 ` },
         { map: {
+                id: '${{ item.id }}',
                 content: '${{ item.content }}',
                 type: '${{ item.type }}',
                 likes: '${{ item.likes }}',

--- a/clis/tieba/hot.js
+++ b/clis/tieba/hot.js
@@ -13,7 +13,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of items to return' },
     ],
-    columns: ['rank', 'title', 'discussions', 'description'],
+    columns: ['rank', 'title', 'discussions', 'description', 'url'],
     func: async (page, kwargs) => {
         const limit = normalizeTiebaLimit(kwargs.limit);
         // Use the default browser settle path so we do not scrape the previous page.

--- a/clis/tieba/search.js
+++ b/clis/tieba/search.js
@@ -93,7 +93,7 @@ cli({
         { name: 'page', type: 'int', default: 1, choices: ['1'], help: 'Page number (currently only 1 is supported)' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of items to return' },
     ],
-    columns: ['rank', 'title', 'forum', 'author', 'time'],
+    columns: ['rank', 'id', 'title', 'forum', 'author', 'time', 'url'],
     func: async (page, kwargs) => {
         assertSupportedPage(kwargs);
         const limit = normalizeTiebaLimit(kwargs.limit);

--- a/clis/weibo/feed.js
+++ b/clis/weibo/feed.js
@@ -23,7 +23,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15, help: 'Number of posts (max 50)' },
     ],
-    columns: ['author', 'text', 'reposts', 'comments', 'likes', 'time', 'url'],
+    columns: ['id', 'author', 'text', 'reposts', 'comments', 'likes', 'time', 'url'],
     func: async (page, kwargs) => {
         const count = Math.min(kwargs.limit || 15, 50);
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';
@@ -47,6 +47,7 @@ cli({
         return (data.statuses || []).slice(0, count).map(s => {
           const u = s.user || {};
           const item = {
+            id: s.mblogid || s.idstr || String(s.id || ''),
             author: u.screen_name || '',
             text: (s.text_raw || strip(s.text || '')).substring(0, 200),
             reposts: s.reposts_count || 0,

--- a/clis/weibo/search.js
+++ b/clis/weibo/search.js
@@ -15,7 +15,7 @@ cli({
         { name: 'keyword', required: true, positional: true, help: 'Search keyword' },
         { name: 'limit', type: 'int', default: 10, help: 'Number of results (max 50)' },
     ],
-    columns: ['rank', 'title', 'author', 'time', 'url'],
+    columns: ['rank', 'id', 'title', 'author', 'time', 'url'],
     func: async (page, kwargs) => {
         const limit = Math.max(1, Math.min(Number(kwargs.limit) || 10, 50));
         const keyword = encodeURIComponent(String(kwargs.keyword ?? '').trim());
@@ -48,15 +48,20 @@ cli({
             card.querySelector('.from a[href*="/detail/"]') ||
             card.querySelector('.from a[href*="/status/"]') ||
             timeEl;
+          const url = absoluteUrl(urlEl && urlEl.getAttribute('href'));
+          const idMatch =
+            url.match(/^https?:\\/\\/(?:www\\.)?weibo\\.com\\/\\d+\\/([A-Za-z0-9]+)(?:[?#/]|$)/) ||
+            url.match(/^https?:\\/\\/(?:www\\.)?weibo\\.com\\/(?:detail|status)\\/([A-Za-z0-9]+)(?:[?#/]|$)/);
 
           const title = clean(contentEl && contentEl.textContent);
           if (!title) continue;
 
           rows.push({
+            id: idMatch ? idMatch[1] : '',
             title,
             author: clean(authorEl && authorEl.textContent),
             time: clean(timeEl && timeEl.textContent),
-            url: absoluteUrl(urlEl && urlEl.getAttribute('href')),
+            url,
           });
         }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -160,6 +160,20 @@ export default defineConfig({
                 { text: 'AI Workflow', link: '/developer/ai-workflow' },
               ],
             },
+            {
+              text: 'Conventions',
+              items: [
+                { text: 'Listing↔Detail ID Pairing', link: '/conventions/listing-detail-id-pairing' },
+              ],
+            },
+          ],
+          '/conventions/': [
+            {
+              text: 'Conventions',
+              items: [
+                { text: 'Listing↔Detail ID Pairing', link: '/conventions/listing-detail-id-pairing' },
+              ],
+            },
           ],
           '/advanced/': [
             {

--- a/docs/adapters/browser/jike.md
+++ b/docs/adapters/browser/jike.md
@@ -39,6 +39,11 @@ opencli jike like <post-id>
 opencli jike feed -f json
 ```
 
+## Listing Columns
+
+`feed`, `search`, and `user` expose `id` for each post row. Pass that value
+directly to `opencli jike post <id>` for the detail view.
+
 ## Prerequisites
 
 - Chrome running and **logged into** web.okjike.com

--- a/docs/adapters/browser/weibo.md
+++ b/docs/adapters/browser/weibo.md
@@ -34,6 +34,9 @@ opencli weibo feed --limit 10
 # Following-only timeline (strict chronological following feed)
 opencli weibo feed --type following --limit 10
 
+# Read a post from feed/search using the emitted id
+opencli weibo post <id>
+
 # Verbose mode
 opencli weibo hot -v
 
@@ -46,6 +49,11 @@ opencli weibo publish "Hello from OpenCLI"
 # Publish text with images (executes immediately)
 opencli weibo publish "Hello with images" --images /path/a.jpg,/path/b.png
 ```
+
+## Listing Columns
+
+`feed` and `search` expose `id` for post rows. Pass that value directly to
+`opencli weibo post <id>`. `hot` rows are search topics, not post rows.
 
 ## Prerequisites
 

--- a/docs/conventions/listing-detail-id-pairing.md
+++ b/docs/conventions/listing-detail-id-pairing.md
@@ -20,7 +20,8 @@ That column is whatever the detail command expects:
 | Site | Listing | Detail | Round-trip column |
 |------|---------|--------|-------------------|
 | `hackernews` | `top` / `best` / `ask` / `jobs` / `show` / `new` | `read <id>` | `id` |
-| `lobsters` | `hot` / `recent` / `top` | `read <short_id>` | `short_id` |
+| `hupu` | `hot` / `search` | `detail <tid>` | `tid` |
+| `lobsters` | `hot` / `active` / `newest` / `tag` | `read <id>` | `id` (Lobsters short_id value) |
 | `arxiv` | `search` / `recent` | `paper <id>` | `id` |
 | `stackoverflow` | `hot` / `search` / `bounties` / `unanswered` | `read <id>` | `id` |
 | `openreview` | `search` / `venue` | `paper <id>` / `reviews <forum>` | `id` |
@@ -28,7 +29,7 @@ That column is whatever the detail command expects:
 | `bilibili` | `hot` | `video <bvid>` | `bvid` |
 | `reddit` | `hot` | `read <id>` | `id` |
 | `bluesky` | `user` | `thread <uri>` | `uri` |
-| `1688` | `search` | `detail <offer_id>` | `offer_id` |
+| `1688` | `search` | `item <url-or-offer-id>` | `offer_id` |
 | `tieba` | `search` | `read <id>` | `id` |
 
 ## Why this matters
@@ -55,12 +56,14 @@ these column names a valid round-trip handle:
 
 - Exact `id` / `short_id`
 - Anything ending in `_id` or `Id` (e.g. `offer_id`, `paperId`)
-- Domain-specific ids: `jk` (indeed), `bvid` / `aid` (bilibili),
-  `asin` (amazon), `isbn`, `doi`, `slug`
+- Domain-specific ids: `jk` (indeed), `tid` (thread id), `bvid` / `aid`
+  (bilibili), `sku` (retail product SKU), `asin` (amazon), `isbn`, `doi`,
+  `slug`
 - `username` / `handle` (only when the detail command keys off the user
   rather than a post)
-- `url` — last-resort fallback. The agent can pass the URL into a `goto`
-  but can't fan out into a detail call without further parsing.
+- `url` — only when the detail command's positional argument explicitly
+  accepts a URL (for example `read <url-or-id>` or `article <url>`). URL is
+  not a valid substitute when the detail command expects a site id.
 - `uri` — for sites whose canonical handle is a URI scheme (e.g.
   Bluesky's `at://did:.../app.bsky.feed.post/...`).
 
@@ -79,6 +82,8 @@ The rule does NOT fire on:
 - **AI-chat / agent-session listings** (`chatgpt-app ask`, `claude new`,
   `codex ask`, ...). The rows are conversation turns inside one session,
   not separately fetchable.
+- **Topic / landing-page listings** (`tieba hot`). Their rows point to a
+  topic landing page, not to a thread entity accepted by the detail command.
 - **Single-profile field listings** (`reddit user`, `lesswrong user`).
   Their shape is `[field, value]` — every row is an attribute of the
   same profile, addressed by the username arg. There is no per-row entity

--- a/docs/conventions/listing-detail-id-pairing.md
+++ b/docs/conventions/listing-detail-id-pairing.md
@@ -1,0 +1,126 @@
+# Listing↔detail ID pairing
+
+When a site exposes both a **listing-class command** (`search` / `hot` /
+`recent` / `top` / `feed` / ...) and a **detail-class command** (`read` /
+`paper` / `article` / `job` / `view` / ...), the listing rows MUST include
+an id-shaped column whose value can be passed directly into the detail
+command.
+
+Without that, the agent has to either re-search by title, scrape a URL out
+of band, or guess — all of which break the agent-native contract.
+
+## The rule
+
+> If `<site>` has both a listing command and a detail command, every
+> listing row MUST carry a column whose value round-trips into the detail
+> command's positional argument.
+
+That column is whatever the detail command expects:
+
+| Site | Listing | Detail | Round-trip column |
+|------|---------|--------|-------------------|
+| `hackernews` | `top` / `best` / `ask` / `jobs` / `show` / `new` | `read <id>` | `id` |
+| `lobsters` | `hot` / `recent` / `top` | `read <short_id>` | `short_id` |
+| `arxiv` | `search` / `recent` | `paper <id>` | `id` |
+| `stackoverflow` | `hot` / `search` / `bounties` / `unanswered` | `read <id>` | `id` |
+| `openreview` | `search` / `venue` | `paper <id>` / `reviews <forum>` | `id` |
+| `devto` | `top` / `tag` / `user` | `read <id>` | `id` |
+| `bilibili` | `hot` | `video <bvid>` | `bvid` |
+| `reddit` | `hot` | `read <id>` | `id` |
+| `bluesky` | `user` | `thread <uri>` | `uri` |
+| `1688` | `search` | `detail <offer_id>` | `offer_id` |
+| `tieba` | `search` | `read <id>` | `id` |
+
+## Why this matters
+
+The agent never has eyes on a webpage. It sees the listing rows as a
+plain table of strings. If the listing emits `[rank, title, author, votes]`
+and the detail command needs an id, the agent has three bad options:
+
+1. **Re-search by title** — fragile, may hit a different post for ambiguous
+   titles, costs an extra round-trip plus quota.
+2. **Parse the URL** — assumes URL shape stays stable and is regex-able,
+   often breaks across A/B buckets or after a site redesign.
+3. **Hand-craft a search** — pure guess; agents trained to do this leak
+   the failure mode silently downstream.
+
+Surfacing the id in the listing collapses all three into a single,
+unambiguous column. It is the cheapest and most durable way to keep the
+listing→detail call chain agent-native.
+
+## What counts as an "id-shaped column"
+
+The validator (`scripts/check-listing-id-pairing.mjs`) considers any of
+these column names a valid round-trip handle:
+
+- Exact `id` / `short_id`
+- Anything ending in `_id` or `Id` (e.g. `offer_id`, `paperId`)
+- Domain-specific ids: `jk` (indeed), `bvid` / `aid` (bilibili),
+  `asin` (amazon), `isbn`, `doi`, `slug`
+- `username` / `handle` (only when the detail command keys off the user
+  rather than a post)
+- `url` — last-resort fallback. The agent can pass the URL into a `goto`
+  but can't fan out into a detail call without further parsing.
+- `uri` — for sites whose canonical handle is a URI scheme (e.g.
+  Bluesky's `at://did:.../app.bsky.feed.post/...`).
+
+If the natural id for your site is a different shape, add the pattern to
+`ID_COLUMN_PATTERNS` in the validator and document it here.
+
+## What is intentionally exempt
+
+The rule does NOT fire on:
+
+- **Comment / review / reply listings** (`bilibili comments`,
+  `youtube comments`, `taobao reviews`, `weibo comments`, ...). The rows
+  are sub-resources within a parent thread; the detail command on those
+  sites fetches the parent post, not the comment. Keep the parent's id in
+  the *args* of the comments command, not in the rows.
+- **AI-chat / agent-session listings** (`chatgpt-app ask`, `claude new`,
+  `codex ask`, ...). The rows are conversation turns inside one session,
+  not separately fetchable.
+- **Single-profile field listings** (`reddit user`, `lesswrong user`).
+  Their shape is `[field, value]` — every row is an attribute of the
+  same profile, addressed by the username arg. There is no per-row entity
+  to round-trip.
+
+These categories are encoded by their command name being absent from
+`LISTING_NAMES` in the validator.
+
+## How to add an id column to a listing
+
+1. **Find the source field.** Most listing endpoints already include the
+   id in their raw response — they're just dropped before the row is
+   shaped. Check `func`'s mapper before adding new fetch logic.
+2. **Pick the column position.** Convention is `[rank, id, ...rest, url]`
+   so identifiers stay near the front and the URL stays last.
+3. **Update the docs.** The site's `docs/adapters/browser/<site>.md`
+   should list the new column under "Listing columns" and call out that
+   it round-trips into the detail command.
+4. **Run the validator.**
+
+   ```bash
+   node scripts/check-listing-id-pairing.mjs --strict
+   ```
+
+## Validator usage
+
+```bash
+# Report-only (default): exit 0 even on violations
+node scripts/check-listing-id-pairing.mjs
+
+# Strict (CI): exit 1 if any listing is missing an id column
+node scripts/check-listing-id-pairing.mjs --strict
+```
+
+The script reads `cli-manifest.json`, so always rebuild the manifest
+(`npx tsx src/build-manifest.ts`) after touching adapter columns.
+
+## Related principles
+
+- [`docs/developer/ts-adapter.md`](../developer/ts-adapter.md) — adapter
+  authoring conventions, including the required `access: 'read' | 'write'`
+  metadata.
+- "Output design" reference inside the bundled
+  `opencli-adapter-author` skill — column naming, ordering, and id-first
+  conventions.

--- a/docs/conventions/listing-detail-id-pairing.md
+++ b/docs/conventions/listing-detail-id-pairing.md
@@ -31,6 +31,8 @@ That column is whatever the detail command expects:
 | `bluesky` | `user` | `thread <uri>` | `uri` |
 | `1688` | `search` | `item <url-or-offer-id>` | `offer_id` |
 | `tieba` | `search` | `read <id>` | `id` |
+| `jike` | `feed` / `search` / `user` | `post <id>` | `id` |
+| `weibo` | `feed` / `search` | `post <id>` | `id` |
 
 ## Why this matters
 
@@ -62,8 +64,10 @@ these column names a valid round-trip handle:
 - `username` / `handle` (only when the detail command keys off the user
   rather than a post)
 - `url` — only when the detail command's positional argument explicitly
-  accepts a URL (for example `read <url-or-id>` or `article <url>`). URL is
-  not a valid substitute when the detail command expects a site id.
+  accepts a URL (for example `read <url-or-id>`, `article <url>`, or help
+  text such as `Post ID or full URL`). URL is not a valid substitute when
+  the detail command only says an id comes "from URL"; callers would still
+  need to parse the URL out of band.
 - `uri` — for sites whose canonical handle is a URI scheme (e.g.
   Bluesky's `at://did:.../app.bsky.feed.post/...`).
 
@@ -82,8 +86,9 @@ The rule does NOT fire on:
 - **AI-chat / agent-session listings** (`chatgpt-app ask`, `claude new`,
   `codex ask`, ...). The rows are conversation turns inside one session,
   not separately fetchable.
-- **Topic / landing-page listings** (`tieba hot`). Their rows point to a
-  topic landing page, not to a thread entity accepted by the detail command.
+- **Topic / landing-page listings** (`tieba hot`, `weibo hot`). Their rows
+  point to a topic/search landing page, not to a post/thread entity accepted
+  by the detail command.
 - **Single-profile field listings** (`reddit user`, `lesswrong user`).
   Their shape is `[field, value]` — every row is an attribute of the
   same profile, addressed by the username arg. There is no per-row entity

--- a/docs/developer/ts-adapter.md
+++ b/docs/developer/ts-adapter.md
@@ -56,6 +56,20 @@ Every adapter must declare `access: 'read' | 'write'`.
 - Use `write` when the command changes remote product/account state, such as sending messages, publishing, liking, following, buying, deleting, creating remote assets, or starting paid/credit-consuming generation.
 - `download` and `export` commands are `read` when they only read remote data and write local files; local filesystem writes are a separate permission dimension.
 
+## Listing↔Detail ID Pairing
+
+If your site exposes both a listing-class command (`search` / `hot` / `top` /
+`recent` / ...) and a detail-class command (`read` / `paper` / `article` /
+`post` / `view` / ...), every listing row MUST surface an id-shaped column
+that round-trips into the detail command's positional arg. Without that, an
+agent can't follow up on a row without re-searching by title or scraping a
+URL out of band.
+
+The CI gate `npm run check:listing-id-pairing` fails when a listing is
+missing its id column. See [Listing↔Detail ID Pairing](../conventions/listing-detail-id-pairing.md)
+for the full rule, exemption rationale, and how to add an id to an existing
+listing.
+
 ## Strategy Types
 
 | Strategy | Constant | Use Case |

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:adapter": "vitest run --project adapter",
     "test:all": "vitest run",
     "test:e2e": "vitest run --project e2e",
+    "check:listing-id-pairing": "node scripts/check-listing-id-pairing.mjs --strict",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/check-listing-id-pairing.mjs
+++ b/scripts/check-listing-id-pairing.mjs
@@ -85,6 +85,7 @@ const EXEMPT = new Map([
     ['reddit/user', 'rows are profile-attribute key/value pairs; reddit/read fetches a post, addressed by post id'],
     ['discord-app/search', 'desktop UI session — message ids are not extractable from the rendered DOM'],
     ['notion/search', 'Strategy.UI Quick Find — page ids are not exposed in the rendered DOM; agents navigate via Notion UI (Cmd+P), not by id round-trip'],
+    ['tieba/hot', 'hot rows are topic landing pages, not thread rows; tieba/read fetches a thread by numeric id'],
 ]);
 
 /** Columns whose name implies "this is an id you can pass to detail". */
@@ -94,21 +95,35 @@ const ID_COLUMN_PATTERNS = [
     /Id$/,
     /^short_id$/i,
     /^jk$/i,             // indeed
+    /^tid$/i,            // hupu / thread id
     /^bvid$/i,           // bilibili
     /^aid$/i,            // anime / bilibili av
     /^asin$/i,           // amazon
+    /^sku$/i,            // jd / retail product SKU
     /^isbn$/i,           // book sites
     /^doi$/i,            // arxiv / openreview
     /^slug$/i,           // dev.to / lobsters short slug
     /^hn_id$/i,
     /^username$/i,       // user-keyed detail (profile commands)
     /^handle$/i,
-    /^url$/i,            // last-resort: url is at least round-trippable into a goto
     /^uri$/i,            // bluesky AT URI (at://did:.../...)
 ];
 
-function isIdColumn(col) {
-    return ID_COLUMN_PATTERNS.some((re) => re.test(col));
+function isUrlDetailCommand(entry) {
+    const args = Array.isArray(entry.args) ? entry.args : [];
+    const primaryArg = args.find((arg) => arg?.positional || arg?.required) ?? args[0];
+    if (!primaryArg) return false;
+    const name = String(primaryArg.name ?? '').toLowerCase();
+    const help = String(primaryArg.help ?? '').toLowerCase();
+    return name === 'url' || name === 'url-or-id' || help.includes('url');
+}
+
+function isIdColumn(col, detailCommands) {
+    if (ID_COLUMN_PATTERNS.some((re) => re.test(col))) return true;
+    if (/^url$/i.test(col)) {
+        return detailCommands.some(isUrlDetailCommand);
+    }
+    return false;
 }
 
 function classify(name) {
@@ -153,7 +168,7 @@ function main() {
                 continue;
             }
             const columns = Array.isArray(entry.columns) ? entry.columns : [];
-            if (!columns.some(isIdColumn)) {
+            if (!columns.some((col) => isIdColumn(col, readDetail))) {
                 violations.push({
                     site,
                     name: entry.name,

--- a/scripts/check-listing-id-pairing.mjs
+++ b/scripts/check-listing-id-pairing.mjs
@@ -86,6 +86,8 @@ const EXEMPT = new Map([
     ['discord-app/search', 'desktop UI session — message ids are not extractable from the rendered DOM'],
     ['notion/search', 'Strategy.UI Quick Find — page ids are not exposed in the rendered DOM; agents navigate via Notion UI (Cmd+P), not by id round-trip'],
     ['tieba/hot', 'hot rows are topic landing pages, not thread rows; tieba/read fetches a thread by numeric id'],
+    ['weibo/hot', 'hot rows are search topics, not posts; weibo/post fetches a post by id or mblogid'],
+    ['weibo/user', 'rows are profile-attribute fields; weibo/post fetches a post, addressed by post id or mblogid'],
 ]);
 
 /** Columns whose name implies "this is an id you can pass to detail". */
@@ -114,8 +116,21 @@ function isUrlDetailCommand(entry) {
     const primaryArg = args.find((arg) => arg?.positional || arg?.required) ?? args[0];
     if (!primaryArg) return false;
     const name = String(primaryArg.name ?? '').toLowerCase();
+    if (name === 'url' || name === 'url-or-id') return true;
+
     const help = String(primaryArg.help ?? '').toLowerCase();
-    return name === 'url' || name === 'url-or-id' || help.includes('url');
+    if (!help) return false;
+
+    // Accept only explicit "this argument may be a URL" wording. Phrases
+    // like "id from URL" mean callers must extract an id before invoking
+    // the detail command, so listing.url must not satisfy the id-pair gate.
+    return (
+        /^full\b[^()]*\burl\b/.test(help) ||
+        /\burl\s+or\s+[^()]*\bid\b/.test(help) ||
+        /\bor\s+(?:a\s+)?full\b[^()]*\burl\b/.test(help) ||
+        /\bor\s+url\b/.test(help) ||
+        /\burl\s*,\s*or\b/.test(help)
+    );
 }
 
 function isIdColumn(col, detailCommands) {

--- a/scripts/check-listing-id-pairing.mjs
+++ b/scripts/check-listing-id-pairing.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * check-listing-id-pairing.mjs — verify listing↔detail id round-tripping.
+ *
+ * Agent-native rule: when a site exposes both a listing-class command
+ * (search / hot / recent / trending / top / feed / popular / new / list)
+ * AND a detail-class command (read / article / paper / post / detail /
+ * view / job / page / book / movie / show / chapter / question / answer /
+ * tweet / video / track), every listing row must include an id-shaped
+ * column whose value can be fed into the detail command's positional
+ * argument. Without that, the agent has to re-search by title, scrape
+ * a URL, or guess — all of which break the agent-native contract.
+ *
+ * What this script does:
+ *  1. Group cli-manifest.json entries by site.
+ *  2. For each site that has both classes, walk every listing entry and
+ *     check `columns` for at least one id-shaped name.
+ *  3. Fail (exit 1 in --strict) on any listing missing an id column.
+ *
+ * Heuristic, not perfect: the script only checks for the *presence* of an
+ * id-shaped column on listings; it doesn't verify the id format actually
+ * matches the detail command's positional arg. That stays a manual review
+ * concern — the column shape gate alone catches the silent-loss class
+ * (listings that emit only title/author/url and force the agent to scrape
+ * the URL for an id).
+ *
+ * Usage:
+ *   node scripts/check-listing-id-pairing.mjs           # report only
+ *   node scripts/check-listing-id-pairing.mjs --strict  # exit 1 on violations
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MANIFEST = resolve(__dirname, '..', 'cli-manifest.json');
+
+/**
+ * Listing-class commands. Each row represents a single fetchable entity
+ * (post / paper / job / ...). The id of that entity must round-trip into
+ * the site's detail command.
+ */
+const LISTING_NAMES = new Set([
+    'search', 'hot', 'recent', 'trending', 'top', 'feed', 'popular',
+    'list', 'best', 'newest', 'latest', 'rising', 'controversial',
+    'home', 'timeline', 'browse', 'discover', 'jobs',
+    'unanswered', 'bounties', 'tag', 'user', 'venue',
+    'category', 'subreddit', 'question',
+]);
+
+/**
+ * Listing-class commands whose rows are sub-resources within a parent
+ * thread/session, NOT independently fetchable. Excluded from the rule:
+ *
+ * - `comments` / `replies` / `reviews` / `answer-list` / `thread-list`
+ *   — rows are comments under a parent post; the detail command fetches
+ *   the parent, not the comment
+ * - `ask` / `new` / `show` for AI-chat / agent-session sites — rows are
+ *   conversation turns within one session, not separately addressable
+ *
+ * These are intentionally NOT in `LISTING_NAMES` so the rule doesn't
+ * fire on them.
+ */
+
+
+const DETAIL_NAMES = new Set([
+    'read', 'article', 'paper', 'post', 'detail', 'view', 'job',
+    'page', 'book', 'movie', 'show-detail', 'chapter', 'tweet',
+    'video', 'track', 'note', 'review', 'item', 'product', 'episode',
+    'thread', 'comment-detail', 'profile-detail',
+]);
+
+/**
+ * Listing/site pairs that are intentionally exempt because the listing
+ * rows are a different entity type from what the detail command fetches.
+ * Each exemption records WHY so future maintainers know what to verify
+ * before removing the entry.
+ */
+const EXEMPT = new Map([
+    ['nowcoder/hot', 'hot rows are search queries / topics, not posts; nowcoder/detail fetches a post by id'],
+    ['bluesky/trending', 'trending rows are topic strings, not threads; bluesky/thread fetches a single thread by url'],
+    ['twitter/trending', 'trending rows are topic strings, not tweets; twitter/post|thread|article fetch by tweet id or username/id'],
+    ['lesswrong/user', 'rows are profile-attribute key/value pairs; lesswrong/read fetches a post, addressed by post id'],
+    ['reddit/user', 'rows are profile-attribute key/value pairs; reddit/read fetches a post, addressed by post id'],
+    ['discord-app/search', 'desktop UI session — message ids are not extractable from the rendered DOM'],
+    ['notion/search', 'Strategy.UI Quick Find — page ids are not exposed in the rendered DOM; agents navigate via Notion UI (Cmd+P), not by id round-trip'],
+]);
+
+/** Columns whose name implies "this is an id you can pass to detail". */
+const ID_COLUMN_PATTERNS = [
+    /^id$/i,
+    /_id$/i,
+    /Id$/,
+    /^short_id$/i,
+    /^jk$/i,             // indeed
+    /^bvid$/i,           // bilibili
+    /^aid$/i,            // anime / bilibili av
+    /^asin$/i,           // amazon
+    /^isbn$/i,           // book sites
+    /^doi$/i,            // arxiv / openreview
+    /^slug$/i,           // dev.to / lobsters short slug
+    /^hn_id$/i,
+    /^username$/i,       // user-keyed detail (profile commands)
+    /^handle$/i,
+    /^url$/i,            // last-resort: url is at least round-trippable into a goto
+    /^uri$/i,            // bluesky AT URI (at://did:.../...)
+];
+
+function isIdColumn(col) {
+    return ID_COLUMN_PATTERNS.some((re) => re.test(col));
+}
+
+function classify(name) {
+    if (LISTING_NAMES.has(name)) return 'listing';
+    if (DETAIL_NAMES.has(name)) return 'detail';
+    return 'other';
+}
+
+function main() {
+    const strict = process.argv.includes('--strict');
+    const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
+
+    const bySite = new Map();
+    for (const entry of manifest) {
+        if (!entry?.site || !entry?.name) continue;
+        if (!bySite.has(entry.site)) bySite.set(entry.site, []);
+        bySite.get(entry.site).push(entry);
+    }
+
+    const violations = [];
+    const exempted = [];
+    let scannedSites = 0;
+    let scannedListings = 0;
+
+    for (const [site, entries] of bySite) {
+        // Only `access: 'read'` detail commands count — write commands like
+        // `instagram/post` or `instagram/note` create remote state, they don't
+        // fetch by id, so the listing→detail pairing rule doesn't apply.
+        const readDetail = entries.filter(
+            (e) => classify(e.name) === 'detail' && e.access === 'read',
+        );
+        const hasListing = entries.some((e) => classify(e.name) === 'listing');
+        if (!hasListing || readDetail.length === 0) continue;
+        scannedSites++;
+
+        for (const entry of entries) {
+            if (classify(entry.name) !== 'listing') continue;
+            scannedListings++;
+            const key = `${site}/${entry.name}`;
+            if (EXEMPT.has(key)) {
+                exempted.push({ key, reason: EXEMPT.get(key) });
+                continue;
+            }
+            const columns = Array.isArray(entry.columns) ? entry.columns : [];
+            if (!columns.some(isIdColumn)) {
+                violations.push({
+                    site,
+                    name: entry.name,
+                    columns,
+                    detail: readDetail.map((e) => e.name),
+                });
+            }
+        }
+    }
+
+    console.log(`Scanned ${scannedSites} site(s) with both listing and read-detail commands.`);
+    console.log(`Checked ${scannedListings} listing command(s); ${exempted.length} exempted.`);
+
+    if (violations.length === 0) {
+        console.log('OK — every listing carries an id-shaped column.');
+        process.exit(0);
+    }
+
+    console.log('');
+    console.log(`Found ${violations.length} listing(s) missing a round-trippable id column:`);
+    for (const v of violations) {
+        console.log(`  • ${v.site}/${v.name}`);
+        console.log(`      columns: [${v.columns.join(', ')}]`);
+        console.log(`      detail commands on this site: ${v.detail.join(', ')}`);
+    }
+    console.log('');
+    console.log('Add an id-shaped column (id / short_id / jk / bvid / asin / etc.)');
+    console.log('to each listing so its rows round-trip into the detail command.');
+    console.log('See docs/conventions/listing-detail-id-pairing.md for the full rule.');
+
+    if (strict) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Codifies a hard convention: when a site exposes both a **listing-class command** (`search` / `hot` / `top` / `recent` / `feed` / ...) and a **detail-class command** (`read` / `paper` / `article` / `view` / ...), every listing row **MUST** surface an id-shaped column whose value round-trips into the detail command.

Without this, an agent has only three bad ways to follow up on a listing row — re-search by title (fragile, may hit wrong post), parse the URL (assumes URL shape), or hand-craft a search (pure guess). All of them break the agent-native contract.

This is a follow-up to PR #1296 (access metadata) — same shape: a meta-rule that prevents a whole class of silent agent failures, with a CI gate so it can't regress.

## What's in this PR

### Convention + tooling

- **`docs/conventions/listing-detail-id-pairing.md`** — full rule, examples table covering hackernews / lobsters / arxiv / stackoverflow / openreview / devto / bilibili / reddit / bluesky / 1688 / tieba, why-it-matters explanation, what counts as id-shaped, exemption taxonomy, how to add an id column to a listing.
- **`scripts/check-listing-id-pairing.mjs`** — validator. Reads `cli-manifest.json`, classifies each entry as listing / detail / other, and fails when a listing on a site that also has a `access: 'read'` detail command is missing an id-shaped column. Exemption allowlist records WHY each pair is exempt so future maintainers know what to verify.
- **`npm run check:listing-id-pairing`** — strict-mode wrapper.
- **CI**: new step in the `build` job runs the validator after the manifest-freshness check on Linux.
- **`docs/developer/ts-adapter.md`** — cross-link from the adapter authoring guide.
- **`docs/.vitepress/config.mts`** — sidebar entry for the new conventions section.

### Fixes that bring violations to zero

- **`1688/search`** → adds `offer_id` (already extracted, just surfaced)
- **`bluesky/user`** → adds `uri` (AT URI round-trips into `bluesky/thread`)
- **`tieba/search`** → adds `id` + `url` (thread_id already extracted)
- **`tieba/hot`** → adds `url` (rows are topics, not threads — url is the best-effort round-trip handle, doc'd as such)

### Exemptions (intentional, doc'd in `EXEMPT` map with rationale)

- `nowcoder/hot`, `bluesky/trending`, `twitter/trending` — listing rows are topic strings, not posts.
- `lesswrong/user`, `reddit/user` — rows are profile-attribute key/value pairs, addressed by the username arg.
- `discord-app/search` — desktop UI session, message ids not extractable.
- `notion/search` — Strategy.UI Quick Find, page ids not exposed in DOM.

### Validator state after this PR

```
Scanned 32 site(s) with both listing and read-detail commands.
Checked 75 listing command(s); 7 exempted.
OK — every listing carries an id-shaped column.
```

## Why this is its own PR

WAWQAQ flagged in #OpenCLI:48bc586b that this is a foundational rule, not a one-off polish — should ship as its own commit so the convention + gate land together and future adapters can't regress past it. Same pattern as #1296.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build-manifest` — clean
- [x] `npm run check:listing-id-pairing` — OK (0 violations)
- [x] `npx vitest run clis/tieba/ clis/1688/search.test.js` — 20/20 pass
- [ ] CI green (build + manifest gate + listing-id-pairing gate + adapter tests)