### PR TITLE
feat(dblp): public bibliography adapter — search + paper

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4743,6 +4743,82 @@
     "navigateBefore": true
   },
   {
+    "site": "dblp",
+    "name": "paper",
+    "aliases": [
+      "detail",
+      "view"
+    ],
+    "description": "Fetch a dblp record by canonical key (e.g. conf/nips/VaswaniSPUJGKP17)",
+    "access": "read",
+    "domain": "dblp.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "dblp record key (round-tripped from the `key` column of `dblp search`)"
+      }
+    ],
+    "columns": [
+      "key",
+      "type",
+      "title",
+      "authors",
+      "venue",
+      "year",
+      "pages",
+      "doi",
+      "open_access_url",
+      "dblp_url"
+    ],
+    "type": "js",
+    "modulePath": "dblp/paper.js",
+    "sourceFile": "dblp/paper.js"
+  },
+  {
+    "site": "dblp",
+    "name": "search",
+    "description": "Search dblp computer-science bibliography by free-text query",
+    "access": "read",
+    "domain": "dblp.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (title / author / venue, e.g. \"attention is all you need\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-100, single dblp page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "key",
+      "title",
+      "authors",
+      "venue",
+      "year",
+      "type",
+      "doi",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dblp/search.js",
+    "sourceFile": "dblp/search.js"
+  },
+  {
     "site": "deepseek",
     "name": "ask",
     "description": "Send a prompt to DeepSeek and get the response",

--- a/clis/dblp/dblp.test.js
+++ b/clis/dblp/dblp.test.js
@@ -1,0 +1,340 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    PAPER_COLUMNS,
+    SEARCH_COLUMNS,
+    coerceInt,
+    decodeXmlEntities,
+    extractAll,
+    extractFirst,
+    extractOpenAccessLink,
+    extractRecordKey,
+    extractRecordType,
+    normalizeAuthors,
+    recordXmlToRow,
+    requireBoundedInt,
+    requireQuery,
+    requireRecordKey,
+    searchHitToRow,
+} from './utils.js';
+import './search.js';
+import './paper.js';
+
+const SEARCH_HIT = {
+    '@score': '9',
+    '@id': '2578896',
+    info: {
+        authors: {
+            author: [
+                { '@pid': '167/1261-9', text: 'Xiaopeng Zhang 0009' },
+                { '@pid': '17/8386', text: 'Haoyu Yang' },
+                { '@pid': 'y/EFYYoung', text: 'Evangeline F. Y. Young' },
+            ],
+        },
+        title: 'Attentional Transfer is All You Need: Technology-aware Layout Pattern Generation.',
+        venue: 'DAC',
+        pages: '169-174',
+        year: '2021',
+        type: 'Conference and Workshop Papers',
+        access: 'closed',
+        key: 'conf/dac/ZhangYY21',
+        doi: '10.1109/DAC18074.2021.9586227',
+        ee: 'https://doi.org/10.1109/DAC18074.2021.9586227',
+        url: 'https://dblp.org/rec/conf/dac/ZhangYY21',
+    },
+};
+
+const RECORD_XML = `<?xml version="1.0" encoding="US-ASCII"?>
+<dblp>
+<inproceedings key="conf/nips/VaswaniSPUJGKP17" mdate="2021-01-21">
+<author>Ashish Vaswani</author>
+<author>Noam Shazeer</author>
+<author>Niki Parmar</author>
+<author>Jakob Uszkoreit</author>
+<author>Llion Jones</author>
+<author>Aidan N. Gomez</author>
+<author>Lukasz Kaiser</author>
+<author>Illia Polosukhin</author>
+<title>Attention is All you Need.</title>
+<pages>5998-6008</pages>
+<year>2017</year>
+<booktitle>NIPS</booktitle>
+<ee type="oa">https://proceedings.neurips.cc/paper/2017/hash/3f5ee243547dee91fbd053c1c4a845aa-Abstract.html</ee>
+<ee type="oa">http://papers.nips.cc/paper/7181-attention-is-all-you-need</ee>
+<crossref>conf/nips/2017</crossref>
+<url>db/conf/nips/nips2017.html#VaswaniSPUJGKP17</url>
+</inproceedings></dblp>`;
+
+const ARTICLE_XML = `<dblp>
+<article key="journals/corr/abs-2509-05821" publtype="informal" mdate="2025-10-21">
+<author>Mohsen Asghari Ilani</author>
+<author>Yaser Mohammadi Banadaki</author>
+<title>Brain Tumor Detection Through Diverse CNN Architectures.</title>
+<year>2025</year>
+<volume>abs/2509.05821</volume>
+<journal>CoRR</journal>
+<ee type="oa">https://doi.org/10.48550/arXiv.2509.05821</ee>
+</article></dblp>`;
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('dblp adapter', () => {
+    it('registers search and paper with the expected columns', () => {
+        const search = getRegistry().get('dblp/search');
+        const paper = getRegistry().get('dblp/paper');
+        expect(search).toBeDefined();
+        expect(paper).toBeDefined();
+        expect(search.columns).toEqual(SEARCH_COLUMNS);
+        expect(paper.columns).toEqual(PAPER_COLUMNS);
+        expect(search.access).toBe('read');
+        expect(paper.access).toBe('read');
+    });
+
+    it('paper aliases include detail / view', () => {
+        const paper = getRegistry().get('dblp/paper');
+        expect(paper.aliases).toEqual(expect.arrayContaining(['detail', 'view']));
+    });
+
+    describe('coerceInt', () => {
+        it.each([
+            [42, 42],
+            ['42', 42],
+            [' 7 ', 7],
+            [3.14, NaN],
+            ['x', NaN],
+            ['', NaN],
+            [null, NaN],
+        ])('coerceInt(%j) → %j', (input, expected) => {
+            const got = coerceInt(input);
+            if (Number.isNaN(expected)) expect(Number.isNaN(got)).toBe(true);
+            else expect(got).toBe(expected);
+        });
+    });
+
+    describe('requireBoundedInt', () => {
+        it('uses the default when value is undefined', () => {
+            expect(requireBoundedInt(undefined, 20, 100)).toBe(20);
+        });
+        it('rejects 0 / negative / float', () => {
+            expect(() => requireBoundedInt(0, 20, 100)).toThrow(ArgumentError);
+            expect(() => requireBoundedInt(-1, 20, 100)).toThrow(ArgumentError);
+            expect(() => requireBoundedInt(1.5, 20, 100)).toThrow(ArgumentError);
+        });
+        it('rejects values above the cap', () => {
+            expect(() => requireBoundedInt(101, 20, 100)).toThrow(/<= 100/);
+        });
+        it('accepts the boundary', () => {
+            expect(requireBoundedInt(100, 20, 100)).toBe(100);
+            expect(requireBoundedInt(1, 20, 100)).toBe(1);
+        });
+    });
+
+    describe('requireQuery', () => {
+        it('rejects empty / whitespace-only', () => {
+            expect(() => requireQuery('')).toThrow(ArgumentError);
+            expect(() => requireQuery('   ')).toThrow(ArgumentError);
+            expect(() => requireQuery(undefined)).toThrow(ArgumentError);
+        });
+        it('trims surrounding whitespace', () => {
+            expect(requireQuery('  bert  ')).toBe('bert');
+        });
+    });
+
+    describe('requireRecordKey', () => {
+        it('accepts known dblp keys', () => {
+            expect(requireRecordKey('conf/nips/VaswaniSPUJGKP17')).toBe('conf/nips/VaswaniSPUJGKP17');
+            expect(requireRecordKey('journals/corr/abs-2509-05821')).toBe('journals/corr/abs-2509-05821');
+            expect(requireRecordKey('phd/Smith2020')).toBe('phd/Smith2020');
+        });
+        it('rejects bad shapes', () => {
+            expect(() => requireRecordKey('')).toThrow(ArgumentError);
+            expect(() => requireRecordKey('NoSlashes')).toThrow(ArgumentError);
+            expect(() => requireRecordKey('conf//Empty')).toThrow(ArgumentError);
+            expect(() => requireRecordKey('Conf/nips/x')).toThrow(ArgumentError);
+            expect(() => requireRecordKey('https://dblp.org/rec/conf/x/y')).toThrow(ArgumentError);
+        });
+    });
+
+    describe('decodeXmlEntities', () => {
+        it('decodes common entities', () => {
+            expect(decodeXmlEntities('a &amp; b')).toBe('a & b');
+            expect(decodeXmlEntities('don&apos;t')).toBe("don't");
+            expect(decodeXmlEntities('a &lt; b &gt; c')).toBe('a < b > c');
+            expect(decodeXmlEntities('&quot;x&quot;')).toBe('"x"');
+            expect(decodeXmlEntities('&#x4E2D;')).toBe('中');
+            expect(decodeXmlEntities('&#65;')).toBe('A');
+        });
+        it('returns empty string for null/undefined', () => {
+            expect(decodeXmlEntities(undefined)).toBe('');
+            expect(decodeXmlEntities(null)).toBe('');
+        });
+    });
+
+    describe('normalizeAuthors', () => {
+        it('handles array of {@pid, text}', () => {
+            const authors = normalizeAuthors({
+                author: [
+                    { '@pid': 'a/1', text: 'Alice' },
+                    { '@pid': 'b/2', text: 'Bob' },
+                ],
+            });
+            expect(authors).toEqual(['Alice', 'Bob']);
+        });
+        it('handles single-object form', () => {
+            expect(normalizeAuthors({ author: { '@pid': 'a/1', text: 'Alice' } })).toEqual(['Alice']);
+        });
+        it('strips trailing 4+ digit homonym suffixes', () => {
+            expect(normalizeAuthors({ author: { text: 'Xiaopeng Zhang 0009' } })).toEqual(['Xiaopeng Zhang']);
+        });
+        it('handles empty / missing', () => {
+            expect(normalizeAuthors(null)).toEqual([]);
+            expect(normalizeAuthors({})).toEqual([]);
+            expect(normalizeAuthors({ author: [] })).toEqual([]);
+        });
+    });
+
+    describe('searchHitToRow', () => {
+        it('projects a complete hit', () => {
+            const row = searchHitToRow(SEARCH_HIT, 1);
+            expect(row).toEqual({
+                rank: 1,
+                key: 'conf/dac/ZhangYY21',
+                title: 'Attentional Transfer is All You Need: Technology-aware Layout Pattern Generation',
+                authors: 'Xiaopeng Zhang, Haoyu Yang, Evangeline F. Y. Young',
+                venue: 'DAC',
+                year: '2021',
+                type: 'conf',
+                doi: '10.1109/DAC18074.2021.9586227',
+                url: 'https://doi.org/10.1109/DAC18074.2021.9586227',
+            });
+        });
+        it('falls back to dblp url when ee is missing', () => {
+            const hit = { info: { ...SEARCH_HIT.info, ee: undefined } };
+            expect(searchHitToRow(hit, 1).url).toBe('https://dblp.org/rec/conf/dac/ZhangYY21');
+        });
+        it('decodes HTML entities in titles / venue', () => {
+            const hit = { info: { ...SEARCH_HIT.info, title: 'Don&apos;t Panic.', venue: 'A &amp; B' } };
+            const row = searchHitToRow(hit, 1);
+            expect(row.title).toBe("Don't Panic");
+            expect(row.venue).toBe('A & B');
+        });
+        it('compresses long type strings', () => {
+            const hit = { info: { ...SEARCH_HIT.info, type: 'Journal Articles' } };
+            expect(searchHitToRow(hit, 1).type).toBe('journal');
+        });
+    });
+
+    describe('XML record extraction', () => {
+        it('extractFirst / extractAll handle multi-line content', () => {
+            expect(extractFirst(RECORD_XML, 'title')).toBe('Attention is All you Need.');
+            expect(extractAll(RECORD_XML, 'author')).toEqual([
+                'Ashish Vaswani', 'Noam Shazeer', 'Niki Parmar', 'Jakob Uszkoreit',
+                'Llion Jones', 'Aidan N. Gomez', 'Lukasz Kaiser', 'Illia Polosukhin',
+            ]);
+        });
+        it('extractRecordKey reads the wrapper attr', () => {
+            expect(extractRecordKey(RECORD_XML)).toBe('conf/nips/VaswaniSPUJGKP17');
+            expect(extractRecordKey(ARTICLE_XML)).toBe('journals/corr/abs-2509-05821');
+        });
+        it('extractRecordType maps wrapper element to canonical tag', () => {
+            expect(extractRecordType(RECORD_XML)).toBe('conf');
+            expect(extractRecordType(ARTICLE_XML)).toBe('journal');
+        });
+        it('extractOpenAccessLink prefers type=oa', () => {
+            expect(extractOpenAccessLink(RECORD_XML)).toBe('https://proceedings.neurips.cc/paper/2017/hash/3f5ee243547dee91fbd053c1c4a845aa-Abstract.html');
+        });
+    });
+
+    describe('recordXmlToRow', () => {
+        it('builds a complete row for an inproceedings record', () => {
+            const row = recordXmlToRow(RECORD_XML);
+            expect(row.key).toBe('conf/nips/VaswaniSPUJGKP17');
+            expect(row.type).toBe('conf');
+            expect(row.title).toBe('Attention is All you Need');
+            expect(row.authors).toBe('Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin');
+            expect(row.venue).toBe('NIPS');
+            expect(row.year).toBe('2017');
+            expect(row.pages).toBe('5998-6008');
+            expect(row.open_access_url).toContain('proceedings.neurips.cc');
+            expect(row.dblp_url).toBe('https://dblp.org/rec/conf/nips/VaswaniSPUJGKP17.html');
+        });
+        it('reads `journal` for an article record', () => {
+            const row = recordXmlToRow(ARTICLE_XML);
+            expect(row.venue).toBe('CoRR');
+            expect(row.type).toBe('journal');
+            expect(row.doi).toBe('10.48550/arXiv.2509.05821');
+        });
+    });
+});
+
+describe('dblp search command', () => {
+    it('calls the JSON search endpoint and projects hits', async () => {
+        const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response(
+            JSON.stringify({ result: { hits: { hit: [SEARCH_HIT] } } }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+        )));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = getRegistry().get('dblp/search');
+        const rows = await search.func({ query: 'attention', limit: 5 });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const calledUrl = fetchMock.mock.calls[0][0];
+        expect(calledUrl).toContain('/search/publ/api?q=attention&format=json&h=5');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].rank).toBe(1);
+        expect(rows[0].key).toBe('conf/dac/ZhangYY21');
+    });
+
+    it('throws EmptyResultError when dblp returns no hits', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(
+            JSON.stringify({ result: { hits: {} } }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+        ))));
+        const search = getRegistry().get('dblp/search');
+        await expect(search.func({ query: 'aljkasdf', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('rate-limit (429) surfaces as a typed CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response('', { status: 429 }))));
+        const search = getRegistry().get('dblp/search');
+        await expect(search.func({ query: 'bert', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+});
+
+describe('dblp paper command', () => {
+    it('fetches XML and projects a single row', async () => {
+        const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response(
+            RECORD_XML,
+            { status: 200, headers: { 'content-type': 'application/xml' } },
+        )));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const paper = getRegistry().get('dblp/paper');
+        const rows = await paper.func({ key: 'conf/nips/VaswaniSPUJGKP17' });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const calledUrl = fetchMock.mock.calls[0][0];
+        expect(calledUrl).toContain('/rec/conf/nips/VaswaniSPUJGKP17.xml');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].title).toBe('Attention is All you Need');
+        expect(rows[0].dblp_url).toContain('VaswaniSPUJGKP17.html');
+    });
+
+    it('404 surfaces as EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response('', { status: 404 }))));
+        const paper = getRegistry().get('dblp/paper');
+        await expect(paper.func({ key: 'conf/x/never' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('rejects malformed keys before any network call', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const paper = getRegistry().get('dblp/paper');
+        await expect(paper.func({ key: 'NotARealKey' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/clis/dblp/dblp.test.js
+++ b/clis/dblp/dblp.test.js
@@ -89,8 +89,10 @@ describe('dblp adapter', () => {
         expect(paper).toBeDefined();
         expect(search.columns).toEqual(SEARCH_COLUMNS);
         expect(paper.columns).toEqual(PAPER_COLUMNS);
-        expect(search.access).toBe('read');
-        expect(paper.access).toBe('read');
+        expect(search.strategy).toBe('public');
+        expect(paper.strategy).toBe('public');
+        expect(search.browser).toBe(false);
+        expect(paper.browser).toBe(false);
     });
 
     it('paper aliases include detail / view', () => {
@@ -271,9 +273,23 @@ describe('dblp adapter', () => {
 });
 
 describe('dblp search command', () => {
+    it('rejects invalid query before any network call', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = getRegistry().get('dblp/search');
+        await expect(search.func({ query: '   ', limit: 5 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('calls the JSON search endpoint and projects hits', async () => {
         const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response(
-            JSON.stringify({ result: { hits: { hit: [SEARCH_HIT] } } }),
+            JSON.stringify({
+                result: {
+                    status: { '@code': '200', text: 'OK' },
+                    hits: { hit: [SEARCH_HIT] },
+                },
+            }),
             { status: 200, headers: { 'content-type': 'application/json' } },
         )));
         vi.stubGlobal('fetch', fetchMock);
@@ -291,7 +307,12 @@ describe('dblp search command', () => {
 
     it('throws EmptyResultError when dblp returns no hits', async () => {
         vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(
-            JSON.stringify({ result: { hits: {} } }),
+            JSON.stringify({
+                result: {
+                    status: { '@code': '200', text: 'OK' },
+                    hits: {},
+                },
+            }),
             { status: 200, headers: { 'content-type': 'application/json' } },
         ))));
         const search = getRegistry().get('dblp/search');
@@ -300,6 +321,42 @@ describe('dblp search command', () => {
 
     it('rate-limit (429) surfaces as a typed CommandExecutionError', async () => {
         vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response('', { status: 429 }))));
+        const search = getRegistry().get('dblp/search');
+        await expect(search.func({ query: 'bert', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('in-band API status envelope surfaces as CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(
+            JSON.stringify({
+                result: {
+                    status: { '@code': '500', text: 'Backend error' },
+                    hits: {},
+                },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+        ))));
+        const search = getRegistry().get('dblp/search');
+        await expect(search.func({ query: 'bert', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('missing in-band API status code surfaces as CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(
+            JSON.stringify({
+                result: {
+                    hits: {},
+                },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+        ))));
+        const search = getRegistry().get('dblp/search');
+        await expect(search.func({ query: 'bert', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('malformed JSON surfaces as CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(
+            'not json',
+            { status: 200, headers: { 'content-type': 'application/json' } },
+        ))));
         const search = getRegistry().get('dblp/search');
         await expect(search.func({ query: 'bert', limit: 5 })).rejects.toThrow(CommandExecutionError);
     });

--- a/clis/dblp/paper.js
+++ b/clis/dblp/paper.js
@@ -1,0 +1,40 @@
+/**
+ * dblp record detail.
+ *
+ * Fetches a single record's XML metadata at `/rec/<key>.xml` and projects
+ * it into a one-row table. The XML payload is small (<1KB typical) and
+ * uses a stable, narrow schema, so we parse it with conservative regexes
+ * — same approach as the arxiv adapter.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    PAPER_COLUMNS,
+    dblpFetchXml,
+    recordXmlToRow,
+    requireRecordKey,
+} from './utils.js';
+
+cli({
+    site: 'dblp',
+    name: 'paper',
+    aliases: ['detail', 'view'],
+    access: 'read',
+    description: 'Fetch a dblp record by canonical key (e.g. conf/nips/VaswaniSPUJGKP17)',
+    domain: 'dblp.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'dblp record key (round-tripped from the `key` column of `dblp search`)' },
+    ],
+    columns: PAPER_COLUMNS,
+    func: async (args) => {
+        const key = requireRecordKey(args.key);
+        const xml = await dblpFetchXml(`/rec/${encodeURI(key)}.xml`, 'dblp paper');
+        const row = recordXmlToRow(xml);
+        if (!row.key && !row.title) {
+            throw new EmptyResultError('dblp paper', `dblp returned an empty record for key "${key}".`);
+        }
+        return [row];
+    },
+});

--- a/clis/dblp/search.js
+++ b/clis/dblp/search.js
@@ -1,0 +1,45 @@
+/**
+ * dblp publication search.
+ *
+ * Calls the public `search/publ/api?q=&format=json&h=` endpoint. dblp
+ * doesn't expose abstracts via the search API, so the row schema mirrors
+ * what's actually addressable: canonical record `key`, title, authors,
+ * venue / year / type, DOI, and the open-access landing page when one
+ * exists.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    SEARCH_COLUMNS,
+    dblpFetchJson,
+    requireBoundedInt,
+    requireQuery,
+    searchHitToRow,
+} from './utils.js';
+
+cli({
+    site: 'dblp',
+    name: 'search',
+    access: 'read',
+    description: 'Search dblp computer-science bibliography by free-text query',
+    domain: 'dblp.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (title / author / venue, e.g. "attention is all you need")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-100, single dblp page)' },
+    ],
+    columns: SEARCH_COLUMNS,
+    func: async (args) => {
+        const query = requireQuery(args.query);
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const path = `/search/publ/api?q=${encodeURIComponent(query)}&format=json&h=${limit}`;
+        const json = await dblpFetchJson(path, 'dblp search');
+        const hits = json?.result?.hits?.hit;
+        const list = Array.isArray(hits) ? hits : [];
+        if (list.length === 0) {
+            throw new EmptyResultError('dblp search', `No publications matched "${query}".`);
+        }
+        return list.slice(0, limit).map((hit, i) => searchHitToRow(hit, i + 1));
+    },
+});

--- a/clis/dblp/utils.js
+++ b/clis/dblp/utils.js
@@ -1,0 +1,276 @@
+/**
+ * DBLP adapter utilities.
+ *
+ * dblp serves a public, unauthenticated API:
+ *   - Publication search (JSON):
+ *     `https://dblp.org/search/publ/api?q=<query>&format=json&h=<limit>`
+ *   - Per-record metadata (XML):
+ *     `https://dblp.org/rec/<key>.xml`
+ *
+ * The search response is well-shaped JSON, but the per-record endpoint is
+ * XML. We parse it with conservative regexes (same pattern as the arxiv
+ * adapter) to avoid pulling in an XML lib for this single endpoint.
+ */
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const DBLP_ORIGIN = 'https://dblp.org';
+
+/**
+ * dblp record keys look like `<type>/<venue>/<short>` (e.g.
+ * `conf/nips/VaswaniSPUJGKP17`, `journals/corr/abs-2509-05821`,
+ * `phd/Smith20`). Allow lowercase letter prefixes plus 1+ slash-segments
+ * containing letters / digits / `_` / `.` / `-`.
+ */
+const KEY_PATTERN = /^[a-z]+(?:\/[A-Za-z0-9_.-]+)+$/;
+
+/**
+ * Wraps `fetch` with typed errors. We always set a UA per dblp's
+ * polite-fetch guidance (https://dblp.org/faq/How+to+use+the+dblp+search+API.html).
+ */
+async function dblpFetch(url, label, accept) {
+    let res;
+    try {
+        res = await fetch(url, {
+            headers: {
+                accept,
+                'user-agent': 'opencli-dblp/1.0 (+https://github.com/jackwener/opencli)',
+            },
+        });
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err?.message ?? err}`, 'Check that dblp.org is reachable from this network.');
+    }
+    if (!res.ok) {
+        if (res.status === 429) {
+            throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`, 'dblp throttles clients that fetch too aggressively. Wait a few seconds and retry, or lower --limit.');
+        }
+        if (res.status === 404) {
+            throw new EmptyResultError(label, 'dblp returned 404 — the requested record may not exist.');
+        }
+        throw new CommandExecutionError(`${label} returned HTTP ${res.status}`, 'Inspect the response in a browser at the same URL for more context.');
+    }
+    return res;
+}
+
+export async function dblpFetchJson(path, label) {
+    const res = await dblpFetch(`${DBLP_ORIGIN}${path}`, label, 'application/json');
+    let body;
+    try {
+        body = await res.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+export async function dblpFetchXml(path, label) {
+    const res = await dblpFetch(`${DBLP_ORIGIN}${path}`, label, 'application/xml');
+    return res.text();
+}
+
+export function coerceInt(value) {
+    if (value === undefined || value === null || value === '') return NaN;
+    const n = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(n) && Number.isInteger(n) ? n : NaN;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = coerceInt(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`dblp ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`dblp ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireQuery(value, label = 'query') {
+    const q = String(value ?? '').trim();
+    if (!q) {
+        throw new ArgumentError(`dblp ${label} cannot be empty`);
+    }
+    return q;
+}
+
+export function requireRecordKey(value) {
+    const key = String(value ?? '').trim();
+    if (!key) {
+        throw new ArgumentError('dblp paper key is required');
+    }
+    if (!KEY_PATTERN.test(key)) {
+        throw new ArgumentError(`dblp paper key "${value}" is not a valid record key`, 'Expected something like "conf/nips/VaswaniSPUJGKP17" — copy the `key` column from `dblp search`.');
+    }
+    return key;
+}
+
+/** Decode the small set of XML entities dblp emits in record bodies. */
+export function decodeXmlEntities(text) {
+    if (!text) return '';
+    return String(text)
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&apos;/g, "'")
+        .replace(/&quot;/g, '"')
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+        .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(parseInt(d, 10)));
+}
+
+/** Strip dblp's per-author homonym suffixes (`Smith 0001`) → `Smith`. */
+function trimAuthorHomonym(name) {
+    return String(name || '').replace(/\s+\d{4,}$/, '').trim();
+}
+
+/**
+ * Normalize the `info.authors.author` field from a dblp search hit. dblp
+ * collapses single authors into one object instead of a 1-element array.
+ */
+export function normalizeAuthors(authorsField) {
+    if (!authorsField) return [];
+    const raw = authorsField?.author;
+    if (!raw) return [];
+    const list = Array.isArray(raw) ? raw : [raw];
+    return list.map((a) => {
+        if (a && typeof a === 'object') return trimAuthorHomonym(a.text || a['#text'] || '');
+        return trimAuthorHomonym(String(a));
+    }).filter(Boolean);
+}
+
+/**
+ * Project a dblp publication search hit into one row. Drops only the most
+ * volatile fields (e.g. abstract, which dblp does not expose) and keeps
+ * the canonical key as the round-trip handle.
+ */
+export function searchHitToRow(hit, rank) {
+    const info = hit?.info ?? {};
+    const authors = normalizeAuthors(info.authors);
+    const key = String(info.key ?? '').trim();
+    return {
+        rank,
+        key,
+        title: stripTrailingDot(decodeXmlEntities(info.title ?? '')).trim(),
+        authors: authors.join(', '),
+        venue: decodeXmlEntities(info.venue ?? ''),
+        year: String(info.year ?? '').trim(),
+        type: simplifyHitType(info.type),
+        doi: String(info.doi ?? '').trim(),
+        url: String(info.ee ?? info.url ?? '').trim(),
+    };
+}
+
+/** Title strings from dblp end with a period — strip it for cleaner display. */
+function stripTrailingDot(s) {
+    return String(s || '').replace(/\.\s*$/, '');
+}
+
+/** Compress dblp's verbose `type` strings into single-token tags. */
+function simplifyHitType(type) {
+    if (!type) return '';
+    const t = String(type);
+    if (/Conference and Workshop/i.test(t)) return 'conf';
+    if (/Journal Articles/i.test(t)) return 'journal';
+    if (/Books and Theses/i.test(t)) return 'book';
+    if (/Editorship/i.test(t)) return 'editorship';
+    if (/Reference Works/i.test(t)) return 'reference';
+    if (/Informal/i.test(t)) return 'preprint';
+    return t.toLowerCase().split(/\s+/)[0];
+}
+
+/**
+ * Extract a single tag from a dblp record XML blob (regex-based, same
+ * approach as arxiv/utils.js — keeps the dependency surface flat).
+ */
+export function extractFirst(xml, tag) {
+    const m = String(xml || '').match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+    return m ? m[1] : '';
+}
+
+export function extractAll(xml, tag) {
+    const out = [];
+    const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'g');
+    let m;
+    while ((m = re.exec(String(xml || ''))) !== null) out.push(m[1]);
+    return out;
+}
+
+/**
+ * Pick the first `<ee type="oa">` (open-access link) if present, otherwise
+ * fall back to the first `<ee>`.
+ */
+export function extractOpenAccessLink(xml) {
+    const oa = String(xml || '').match(/<ee\b[^>]*type=["']oa["'][^>]*>([\s\S]*?)<\/ee>/);
+    if (oa) return oa[1].trim();
+    const any = String(xml || '').match(/<ee\b[^>]*>([\s\S]*?)<\/ee>/);
+    return any ? any[1].trim() : '';
+}
+
+/** Pull the `key` attribute off the wrapper element regardless of record type. */
+export function extractRecordKey(xml) {
+    const m = String(xml || '').match(/<(?:article|inproceedings|incollection|proceedings|book|phdthesis|mastersthesis)\b[^>]*\bkey="([^"]+)"/);
+    return m ? m[1] : '';
+}
+
+/**
+ * Identify the record type from the wrapper element name. Maps to the
+ * same simplified tag set the search rows use.
+ */
+export function extractRecordType(xml) {
+    const m = String(xml || '').match(/<(article|inproceedings|incollection|proceedings|book|phdthesis|mastersthesis)\b/);
+    if (!m) return '';
+    switch (m[1]) {
+        case 'inproceedings': return 'conf';
+        case 'article': return 'journal';
+        case 'incollection': return 'incollection';
+        case 'proceedings': return 'editorship';
+        case 'book': return 'book';
+        case 'phdthesis': return 'phdthesis';
+        case 'mastersthesis': return 'mastersthesis';
+        default: return m[1];
+    }
+}
+
+/**
+ * Parse a single dblp record XML into the row shape used by `dblp paper`.
+ * Treats every field as optional; throws upstream when the record body
+ * is missing entirely (404 already handled at fetch level).
+ */
+export function recordXmlToRow(xml) {
+    const key = extractRecordKey(xml);
+    const type = extractRecordType(xml);
+    const title = stripTrailingDot(decodeXmlEntities(extractFirst(xml, 'title')));
+    const authors = extractAll(xml, 'author').map((a) => trimAuthorHomonym(decodeXmlEntities(a)));
+    const year = decodeXmlEntities(extractFirst(xml, 'year'));
+    const pages = decodeXmlEntities(extractFirst(xml, 'pages'));
+    const venueRaw = type === 'conf'
+        ? decodeXmlEntities(extractFirst(xml, 'booktitle'))
+        : decodeXmlEntities(extractFirst(xml, 'journal'));
+    const doi = (() => {
+        const m = String(xml || '').match(/<ee\b[^>]*>([^<]*?(?:doi\.org\/|10\.[^"<]+))<\/ee>/i);
+        if (!m) return '';
+        const v = m[1].replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '');
+        return v.startsWith('10.') ? v : '';
+    })();
+    return {
+        key,
+        type,
+        title,
+        authors: authors.join(', '),
+        venue: venueRaw,
+        year,
+        pages,
+        doi,
+        open_access_url: extractOpenAccessLink(xml),
+        dblp_url: key ? `${DBLP_ORIGIN}/rec/${key}.html` : '',
+    };
+}
+
+export const SEARCH_COLUMNS = [
+    'rank', 'key', 'title', 'authors', 'venue', 'year', 'type', 'doi', 'url',
+];
+
+export const PAPER_COLUMNS = [
+    'key', 'type', 'title', 'authors', 'venue', 'year', 'pages', 'doi', 'open_access_url', 'dblp_url',
+];

--- a/clis/dblp/utils.js
+++ b/clis/dblp/utils.js
@@ -61,6 +61,20 @@ export async function dblpFetchJson(path, label) {
     catch (err) {
         throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
     }
+    const statusCode = String(body?.result?.status?.['@code'] ?? '').trim();
+    if (!statusCode) {
+        throw new CommandExecutionError(
+            `${label} returned JSON without result.status.@code`,
+            'dblp changed its JSON envelope or returned a partial error payload; inspect the raw response in a browser.',
+        );
+    }
+    if (statusCode !== '200') {
+        const statusText = String(body?.result?.status?.text ?? '').trim();
+        throw new CommandExecutionError(
+            `${label} returned API status ${statusCode}${statusText ? ` (${statusText})` : ''}`,
+            'dblp accepted the HTTP request but reported an API-level failure. Retry later or inspect the same query in a browser.',
+        );
+    }
     return body;
 }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -121,6 +121,7 @@ export default defineConfig({
                 { text: 'Xiaoyuzhou', link: '/adapters/browser/xiaoyuzhou' },
                 { text: 'Yahoo Finance', link: '/adapters/browser/yahoo-finance' },
                 { text: 'arXiv', link: '/adapters/browser/arxiv' },
+                { text: 'dblp', link: '/adapters/browser/dblp' },
                 { text: 'paperreview.ai', link: '/adapters/browser/paperreview' },
                 { text: 'Barchart', link: '/adapters/browser/barchart' },
                 { text: 'Hugging Face', link: '/adapters/browser/hf' },

--- a/docs/adapters/browser/dblp.md
+++ b/docs/adapters/browser/dblp.md
@@ -1,0 +1,69 @@
+# dblp
+
+**Mode**: 🌐 Public · **Domain**: `dblp.org`
+
+[dblp](https://dblp.org) is the comprehensive computer-science bibliography maintained by Schloss Dagstuhl, indexing 7M+ publications across conferences, journals, books, and theses. Both commands hit the public API directly — no auth, no browser.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli dblp search <query>` | Free-text search across titles, authors, and venues |
+| `opencli dblp paper <key>` | Fetch a single record's full metadata by canonical dblp key |
+
+## Usage Examples
+
+```bash
+# Free-text search (matches title / author / venue)
+opencli dblp search "attention is all you need" --limit 5
+
+# Author search
+opencli dblp search "Yoshua Bengio" --limit 20
+
+# Venue search
+opencli dblp search "ICLR 2024" --limit 30
+
+# Single-record detail (round-trip from search.key)
+opencli dblp paper conf/nips/VaswaniSPUJGKP17
+
+# arXiv mirror records use the journals/corr/abs-* form
+opencli dblp paper journals/corr/abs-2509-05821
+
+# JSON output
+opencli dblp search "graph neural network" -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, key, title, authors, venue, year, type, doi, url` |
+| `paper` | `key, type, title, authors, venue, year, pages, doi, open_access_url, dblp_url` |
+
+The `key` column from `search` round-trips into `paper` — it is dblp's canonical record identifier (e.g. `conf/nips/VaswaniSPUJGKP17`, `journals/corr/abs-2509-05821`, `phd/Smith20`).
+
+## Type Tag
+
+The `type` column is a single-token simplification of dblp's verbose type strings:
+
+| Tag | Source |
+|-----|--------|
+| `conf` | Conference and Workshop Papers (`<inproceedings>`) |
+| `journal` | Journal Articles (`<article>`) |
+| `book` | Books and Theses |
+| `editorship` | Proceedings volumes |
+| `reference` | Reference Works |
+| `preprint` | Informal / Other Publications (CoRR, etc.) |
+| `incollection` / `phdthesis` / `mastersthesis` | (paper command only — kept distinct in the XML record) |
+
+## Caveats
+
+- dblp does **not** expose abstracts via either endpoint. For the abstract, follow `open_access_url` (when present), `doi`, or pipe the title into `arxiv search` / `openreview search`.
+- Author names occasionally carry dblp's per-author homonym suffix (`"Smith 0001"`). The adapter strips trailing 4+ digit groups so you get clean `Author, Author` strings.
+- Search results include CoRR / arXiv mirror entries. These have keys like `journals/corr/abs-2509-05821` and round-trip cleanly into `paper`.
+- dblp throttles aggressive clients. If you hit HTTP 429, wait a few seconds and lower `--limit` (max 100 per page).
+
+## Prerequisites
+
+- No browser required — uses the public dblp API at `https://dblp.org`.
+- The adapter sets a polite `User-Agent` per [dblp's API guidance](https://dblp.org/faq/How+to+use+the+dblp+search+API.html).

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -92,6 +92,7 @@ Run `opencli list` for the live registry.
 | **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download` `transcript` (local credentials required)                                                   | 🔑 Local API |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
+| **[dblp](./browser/dblp.md)**                     | `search` `paper`                                                                                                                               | 🌐 Public    |
 | **[openreview](./browser/openreview.md)**         | `search` `venue` `paper` `reviews`                                                                                                             | 🌐 Public    |
 | **[paperreview](./browser/paperreview.md)**       | `submit` `review` `feedback`                                                                                                                   | 🌐 Public    |
 | **[barchart](./browser/barchart.md)**             | `quote` `options` `greeks` `flow`                                                                                                              | 🌐 Public    |


### PR DESCRIPTION
## Summary

New public adapter for [dblp.org](https://dblp.org), the largest computer-science bibliography (~7M entries). Two commands, no auth, no browser:

- `opencli dblp search <query>` — free-text search across titles / authors / venues
- `opencli dblp paper <key>` — fetch a single record's full metadata by canonical dblp key

The `key` column from `search` round-trips into `paper` per the listing↔detail convention.

### Why dblp on top of arxiv / openreview

I started Round 4 aiming at Web of Science, then pivoted: WoS is institutional-walled (no public API, IP-gated landing pages), making it a poor agent verification target. Tried Semantic Scholar next — anonymous API hits get rate-limited (HTTP 429) within a handful of requests. dblp is the only major scholarly index that's both fully public and broader than what we already cover:

- Indexes pre-arXiv literature (decades of conferences before 1991)
- Covers journal articles, books, and theses arxiv doesn't touch
- Provides a canonical, stable record key — perfect listing/detail round-trip target

### Live verification

```
$ opencli dblp search "attention is all you need" --limit 3 -f json
[
  {"rank": 1, "key": "conf/dac/ZhangYY21", ...},
  {"rank": 2, "key": "journals/corr/abs-2407-15516", ...},
  {"rank": 3, "key": "journals/access/HouichimeA25", ...}
]

$ opencli dblp paper conf/nips/VaswaniSPUJGKP17 -f json
[{
  "key": "conf/nips/VaswaniSPUJGKP17",
  "type": "conf",
  "title": "Attention is All you Need",
  "authors": "Ashish Vaswani, Noam Shazeer, ...",
  "venue": "NIPS",
  "year": "2017",
  "pages": "5998-6008",
  "open_access_url": "https://proceedings.neurips.cc/paper/2017/...",
  "dblp_url": "https://dblp.org/rec/conf/nips/VaswaniSPUJGKP17.html"
}]
```

### Implementation

- No new deps — XML parsed with conservative regexes (same pattern as arxiv adapter)
- Polite User-Agent per dblp's [API guidance](https://dblp.org/faq/How+to+use+the+dblp+search+API.html)
- HTTP 429 → `CommandExecutionError` with "lower --limit" hint
- HTTP 404 → `EmptyResultError`
- Author homonym suffixes (`"Smith 0001"`) trimmed
- Both commands declare `access: 'read'` (per #1296)
- 39 unit tests covering validators, XML extraction, and both command handlers (mocked fetch + EmptyResult / 429 / 404 paths)

## Test plan

- [x] `npx vitest run clis/dblp/dblp.test.js` — 39/39 pass
- [x] `npx tsx src/build-manifest.ts` — 658 entries, +2 dblp
- [x] Live `dblp search "attention is all you need"` returns real hits
- [x] Live `dblp paper conf/nips/VaswaniSPUJGKP17` returns the original Vaswani paper with full metadata
- [x] Live `dblp search "graph neural network"` returns CS papers across multiple venues
- [x] CoRR (arXiv mirror) keys like `journals/corr/abs-2509-05821` round-trip cleanly