### PR TITLE
feat(pixiv): surface user_id + url on listings (id-pairing polish)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14258,7 +14258,8 @@
       "pages",
       "bookmarks",
       "tags",
-      "created"
+      "created",
+      "url"
     ],
     "type": "js",
     "modulePath": "pixiv/illusts.js",
@@ -14311,9 +14312,11 @@
       "rank",
       "title",
       "author",
+      "user_id",
       "illust_id",
       "pages",
-      "bookmarks"
+      "bookmarks",
+      "url"
     ],
     "type": "js",
     "modulePath": "pixiv/ranking.js",
@@ -14381,10 +14384,12 @@
       "rank",
       "title",
       "author",
+      "user_id",
       "illust_id",
       "pages",
       "bookmarks",
-      "tags"
+      "tags",
+      "url"
     ],
     "type": "js",
     "modulePath": "pixiv/search.js",
@@ -14416,7 +14421,8 @@
       "illusts",
       "manga",
       "novels",
-      "comment"
+      "comment",
+      "url"
     ],
     "type": "js",
     "modulePath": "pixiv/user.js",

--- a/clis/pixiv/illusts.js
+++ b/clis/pixiv/illusts.js
@@ -19,7 +19,7 @@ cli({
         { name: 'user-id', positional: true, required: true, help: 'Pixiv user ID' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
     ],
-    columns: ['rank', 'title', 'illust_id', 'pages', 'bookmarks', 'tags', 'created'],
+    columns: ['rank', 'title', 'illust_id', 'pages', 'bookmarks', 'tags', 'created', 'url'],
     func: async (page, kwargs) => {
         const userId = String(kwargs['user-id'] ?? '');
         const limit = Number(kwargs.limit) || 20;

--- a/clis/pixiv/ranking.js
+++ b/clis/pixiv/ranking.js
@@ -27,7 +27,7 @@ cli({
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
     ],
-    columns: ['rank', 'title', 'author', 'illust_id', 'pages', 'bookmarks'],
+    columns: ['rank', 'title', 'author', 'user_id', 'illust_id', 'pages', 'bookmarks', 'url'],
     pipeline: [
         { navigate: 'https://www.pixiv.net' },
         { evaluate: `(async () => {

--- a/clis/pixiv/search.js
+++ b/clis/pixiv/search.js
@@ -19,7 +19,7 @@ cli({
         { name: 'mode', type: 'str', default: 'all', help: 'Search mode', choices: ['all', 'safe', 'r18'] },
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
     ],
-    columns: ['rank', 'title', 'author', 'illust_id', 'pages', 'bookmarks', 'tags'],
+    columns: ['rank', 'title', 'author', 'user_id', 'illust_id', 'pages', 'bookmarks', 'tags', 'url'],
     func: async (page, kwargs) => {
         const { query, limit = 20, order = 'date_d', mode = 'all', page: pageNum = 1 } = kwargs;
         const encoded = encodeURIComponent(query);

--- a/clis/pixiv/user.js
+++ b/clis/pixiv/user.js
@@ -19,6 +19,7 @@ cli({
         'manga',
         'novels',
         'comment',
+        'url',
     ],
     pipeline: [
         { navigate: 'https://www.pixiv.net' },

--- a/docs/adapters/browser/pixiv.md
+++ b/docs/adapters/browser/pixiv.md
@@ -13,6 +13,18 @@
 | `opencli pixiv detail <id>` | View illustration details |
 | `opencli pixiv download <illust-id>` | Download original-quality images |
 
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `ranking` | `rank, title, author, user_id, illust_id, pages, bookmarks, url` |
+| `search` | `rank, title, author, user_id, illust_id, pages, bookmarks, tags, url` |
+| `illusts` | `rank, title, illust_id, pages, bookmarks, tags, created, url` |
+| `user` | `user_id, name, premium, following, illusts, manga, novels, comment, url` |
+| `detail` | `illust_id, title, author, type, pages, bookmarks, likes, views, tags, created, url` |
+
+`illust_id` round-trips from `ranking` / `search` / `illusts` into `detail` / `download`. `user_id` round-trips from `ranking` / `search` into `user` / `illusts`.
+
 ## Usage Examples
 
 ### Ranking


### PR DESCRIPTION
## Summary

While doing instagram/facebook/pixiv coverage gap analysis, I found that pixiv listings already **extract** `user_id` and **construct** `url` per row but **drop both from the column list** — so `opencli pixiv ranking` and `opencli pixiv search` show table output without the IDs that would let an agent chain the result into `pixiv user` / `pixiv illusts` / `pixiv detail`.

This is the same class of bug as PR #1284 / #1285 / #1288 / #1289 / #1291 / #1293 — listing emits the id internally but doesn't surface it. Per the listing↔detail id pairing convention (#1297), the `id` columns should be visible on listings so they round-trip cleanly.

## Changes

| Adapter | Added columns |
|---------|---------------|
| `pixiv ranking` | `user_id`, `url` |
| `pixiv search` | `user_id`, `url` |
| `pixiv illusts` | `url` (user_id is the arg) |
| `pixiv user` | `url` |

The row objects already contained these fields — only the `columns` array projection was missing. JSON output (`-f json`) already exposed them, so existing scripts keep working.

## Round-trip examples (after this PR)

```bash
# Pick a top-ranked artist from the daily ranking, then explore their work
opencli pixiv ranking --limit 5
# → user_id column visible
opencli pixiv user 11
opencli pixiv illusts 11

# Search → drill down into a single illust
opencli pixiv search "風景" --limit 10
# → illust_id + user_id columns both visible
opencli pixiv detail 12345678
```

## Test plan

- [x] `npx vitest run clis/pixiv` — 18/18 pass (existing tests use `toMatchObject`, unchanged)
- [x] `npx tsx src/build-manifest.ts` — 658 entries, columns delta only
- [x] Doc updated with explicit Output Columns table for all five pixiv commands