### PR TITLE
feat(twitter): surface tweet id on bookmarks/likes/tweets listings

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17349,11 +17349,13 @@
       }
     ],
     "columns": [
+      "id",
       "author",
       "text",
       "likes",
       "retweets",
       "bookmarks",
+      "created_at",
       "url"
     ],
     "type": "js",
@@ -17608,10 +17610,13 @@
       }
     ],
     "columns": [
+      "id",
       "author",
       "name",
       "text",
       "likes",
+      "retweets",
+      "created_at",
       "url",
       "has_media",
       "media_urls"
@@ -18135,6 +18140,7 @@
       }
     ],
     "columns": [
+      "id",
       "author",
       "created_at",
       "is_retweet",

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -108,7 +108,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['author', 'text', 'likes', 'retweets', 'bookmarks', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         await page.goto('https://x.com');

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -146,7 +146,7 @@ cli({
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (without @). Defaults to logged-in user.' },
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['author', 'name', 'text', 'likes', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         let username = (kwargs.username || '').replace(/^@/, '');

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -153,7 +153,7 @@ cli({
         { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (with or without @)' },
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },
     ],
-    columns: ['author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = Math.max(1, Math.min(200, kwargs.limit || 20));
         const username = String(kwargs.username || '').replace(/^@/, '').trim();

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -3,9 +3,9 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './tweets.js';
 
 describe('twitter tweets helpers', () => {
-    it('registers is_retweet in the default columns', () => {
+    it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
-        expect(cmd?.columns).toEqual(['author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls']);
+        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls']);
     });
 
     it('falls back when queryId contains unsafe characters', () => {


### PR DESCRIPTION
## Summary

Round 6 silent-drop audit follow-up. The canonical tweet `id` (rest_id) is inconsistent across twitter listings:

| Listing | `id` exposed in columns? |
|---------|---------|
| `timeline` | ✓ |
| `search` | ✓ |
| `list-tweets` | ✓ |
| `notifications` | ✓ |
| `bookmarks` | ✗ → fixed |
| `likes` | ✗ → fixed |
| `tweets` | ✗ → fixed |

Each row object already contained `id` — only the `columns` projection was missing, so JSON output (`-f json`) already had it but the table view didn't. Same bug class as PRs #1284 / #1285 / #1288 / #1289 / #1291 / #1293 / #1300.

With the listing↔detail id-pairing CI gate from #1297 now active on main, surfacing `id` lets the table view round-trip into `twitter thread <id>` / `twitter like <id>` / `twitter delete <id>` etc., not just `-f json`.

## Changes per file

- `bookmarks`: `columns` ← `[id, author, text, likes, retweets, bookmarks, created_at, url]`
- `likes`:     `columns` ← `[id, author, name, text, likes, retweets, created_at, url, has_media, media_urls]`
- `tweets`:    `columns` ← `[id, author, created_at, is_retweet, text, likes, retweets, replies, views, url, has_media, media_urls]`

While at it, aligned `created_at` / `retweets` / `name` projections with sibling adapters where those values were already emitted but dropped from columns.

## Test plan

- [x] `npx vitest run clis/twitter/` — 81/81 pass
- [x] `tweets.test.js` had a strict `toEqual` on the columns array — updated it to match new shape
- [x] `npm run check:listing-id-pairing` — passes (no longer relies on URL fallback for these listings)
- [x] `npx tsx src/build-manifest.ts` — 660 entries, columns delta only

## Audit context

This PR is one fix from a wider silent-drop audit run earlier today (15 listings across 8 sites). Other findings (1688/search dropping `offer_id`, hupu/mentions dropping `tid`/`pid`, douban/photos dropping `photo_id`, etc.) will follow as separate focused PRs after this one lands.