### PR TITLE
feat(1688/hupu/douban/linux-do): surface dropped ids on listings (sweep)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -122,9 +122,11 @@
       "rank",
       "offer_id",
       "title",
+      "item_url",
       "price_text",
       "moq_text",
       "seller_name",
+      "member_id",
       "location"
     ],
     "type": "js",
@@ -5579,6 +5581,8 @@
     ],
     "columns": [
       "index",
+      "photo_id",
+      "subject_id",
       "title",
       "image_url",
       "detail_url"
@@ -8862,8 +8866,11 @@
       "time",
       "username",
       "thread_title",
+      "tid",
+      "pid",
       "post_content",
       "quote_content",
+      "url",
       "reply_url"
     ],
     "type": "js",
@@ -11774,6 +11781,7 @@
     "columns": [
       "rank",
       "name",
+      "slug",
       "count",
       "url"
     ],

--- a/clis/1688/search.js
+++ b/clis/1688/search.js
@@ -294,7 +294,7 @@ cli({
             help: `结果数量上限（默认 ${SEARCH_LIMIT_DEFAULT}，最大 ${SEARCH_LIMIT_MAX}）`,
         },
     ],
-    columns: ['rank', 'offer_id', 'title', 'price_text', 'moq_text', 'seller_name', 'location'],
+    columns: ['rank', 'offer_id', 'title', 'item_url', 'price_text', 'moq_text', 'seller_name', 'member_id', 'location'],
     func: async (page, kwargs) => {
         const query = String(kwargs.query ?? '');
         const limit = parseSearchLimit(kwargs.limit);

--- a/clis/douban/photos.js
+++ b/clis/douban/photos.js
@@ -12,7 +12,7 @@ cli({
         { name: 'type', default: 'Rb', help: '豆瓣 photos 的 type 参数，默认 Rb（海报）' },
         { name: 'limit', type: 'int', default: 120, help: '最多返回多少张图片' },
     ],
-    columns: ['index', 'title', 'image_url', 'detail_url'],
+    columns: ['index', 'photo_id', 'subject_id', 'title', 'image_url', 'detail_url'],
     func: async (page, kwargs) => {
         const subjectId = normalizeDoubanSubjectId(String(kwargs.id || ''));
         const data = await loadDoubanSubjectPhotos(page, subjectId, {

--- a/clis/hupu/mentions.js
+++ b/clis/hupu/mentions.js
@@ -28,7 +28,7 @@ cli({
             help: '分页游标；不传时从第一页开始'
         }
     ],
-    columns: ['time', 'username', 'thread_title', 'post_content', 'quote_content', 'reply_url'],
+    columns: ['time', 'username', 'thread_title', 'tid', 'pid', 'post_content', 'quote_content', 'url', 'reply_url'],
     func: async (page, kwargs) => {
         const plate = '1';
         const limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 100));

--- a/clis/linux-do/tags.js
+++ b/clis/linux-do/tags.js
@@ -11,7 +11,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 30, help: 'Number of tags' },
     ],
-    columns: ['rank', 'name', 'count', 'url'],
+    columns: ['rank', 'name', 'slug', 'count', 'url'],
     func: async (page, kwargs) => {
         const data = await fetchLinuxDoJson(page, '/tags.json');
         const tags = (data?.tags || []);


### PR DESCRIPTION
## Summary

Round 7 — silent-drop sweep across four adapters surfaced by an audit run after PR #1297 (listing↔detail id-pairing convention) shipped. Each row already carries the ids internally — only the `columns` projection was missing, so the data was visible in `-f json` but never on the table view.

| Adapter | Added columns | Round-trip win |
|---------|---------------|----------------|
| `1688 search` | `item_url`, `member_id` | → `1688 item <item_url>`, `1688 store <member_id>` |
| `hupu mentions` | `tid`, `pid`, `url` | → `hupu detail <tid>` (pid for deep link) |
| `douban photos` | `photo_id`, `subject_id` | photo_id is the canonical id; subject_id ties photos back to the parent movie |
| `linux-do tags` | `slug` | → `linux-do feed --tag <slug>` |

This is the same bug class as PRs #1284 / #1285 / #1288 / #1289 / #1291 / #1293 / #1300 / #1301 — the row builder extracts the canonical id then drops it from columns. Each fix is one line.

## What was NOT changed

Audit also flagged `tieba/search`, `tieba/hot`, `youtube/feed`, `xiaohongshu/feed`, `xiaoe/catalog`, plus a few twitter listings (already covered by #1301). On re-verification:

- `tieba/search`, `tieba/hot` — already expose `id`/`url` on main; audit was stale.
- `youtube/feed`, `xiaohongshu/feed`, `xiaoe/catalog` — kept for a follow-up PR; need slightly more thought (rename `videoId` → `video_id` for snake_case consistency, etc.).

## Test plan

- [x] `npx vitest run clis/1688/ clis/hupu/ clis/douban/ clis/linux-do/` — 45/45 pass
- [x] `npm run check:listing-id-pairing` — passes (the new id-pairing CI gate from #1297)
- [x] `npx tsx src/build-manifest.ts` — 660 entries, columns delta only