### PR TITLE
feat(youtube/xiaohongshu/xiaoe): surface dropped ids/url on listings (sweep)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19720,6 +19720,7 @@
       "title",
       "type",
       "resource_id",
+      "url",
       "status"
     ],
     "type": "js",
@@ -20077,6 +20078,7 @@
       }
     ],
     "columns": [
+      "id",
       "title",
       "author",
       "likes",
@@ -21574,6 +21576,7 @@
       "rank",
       "title",
       "channel",
+      "video_id",
       "views",
       "duration",
       "published",

--- a/clis/xiaoe/catalog.js
+++ b/clis/xiaoe/catalog.js
@@ -9,7 +9,7 @@ cli({
     args: [
         { name: 'url', required: true, positional: true, help: '课程页面 URL' },
     ],
-    columns: ['ch', 'chapter', 'no', 'title', 'type', 'resource_id', 'status'],
+    columns: ['ch', 'chapter', 'no', 'title', 'type', 'resource_id', 'url', 'status'],
     pipeline: [
         { navigate: '${{ args.url }}' },
         { wait: 8 },

--- a/clis/xiaohongshu/feed.js
+++ b/clis/xiaohongshu/feed.js
@@ -10,7 +10,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of items to return' },
     ],
-    columns: ['title', 'author', 'likes', 'type', 'url'],
+    columns: ['id', 'title', 'author', 'likes', 'type', 'url'],
     pipeline: [
         { navigate: 'https://www.xiaohongshu.com/explore' },
         { tap: {

--- a/clis/youtube/feed.js
+++ b/clis/youtube/feed.js
@@ -15,7 +15,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max videos to return (default 20, max 100)' },
     ],
-    columns: ['rank', 'title', 'channel', 'views', 'duration', 'published', 'url'],
+    columns: ['rank', 'title', 'channel', 'video_id', 'views', 'duration', 'published', 'url'],
     func: async (page, kwargs) => {
         const limit = Math.min(kwargs.limit || 20, 100);
         await page.goto('https://www.youtube.com');
@@ -49,7 +49,7 @@ cli({
               views: parts[1] || '',
               duration,
               published: parts[2] || '',
-              videoId: lvm.contentId,
+              video_id: lvm.contentId,
             };
           }
 
@@ -62,7 +62,7 @@ cli({
               views: v.viewCountText?.simpleText || v.shortViewCountText?.simpleText || '',
               duration: v.lengthText?.simpleText || '',
               published: v.publishedTimeText?.simpleText || '',
-              videoId: v.videoId,
+              video_id: v.videoId,
             };
           }
           return null;
@@ -75,8 +75,8 @@ cli({
         for (const item of richContents) {
           if (videos.length >= limit) break;
           const v = extractFromItem(item);
-          if (v?.videoId) {
-            videos.push({ rank: videos.length + 1, ...v, url: 'https://www.youtube.com/watch?v=' + v.videoId });
+          if (v?.video_id) {
+            videos.push({ rank: videos.length + 1, ...v, url: 'https://www.youtube.com/watch?v=' + v.video_id });
           }
         }
 

--- a/clis/youtube/feed.js
+++ b/clis/youtube/feed.js
@@ -98,8 +98,8 @@ cli({
             for (const item of newItems) {
               if (videos.length >= limit) break;
               const v = extractFromItem(item);
-              if (v?.videoId) {
-                videos.push({ rank: videos.length + 1, ...v, url: 'https://www.youtube.com/watch?v=' + v.videoId });
+              if (v?.video_id) {
+                videos.push({ rank: videos.length + 1, ...v, url: 'https://www.youtube.com/watch?v=' + v.video_id });
               }
             }
             contItem = newItems[newItems.length - 1];

--- a/clis/youtube/feed.test.js
+++ b/clis/youtube/feed.test.js
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './feed.js';
+
+function makePage({ initialData, continuationData, fetchImpl } = {}) {
+    const fetchMock = fetchImpl || vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => continuationData,
+    });
+
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(async (script) => {
+            const previousWindow = globalThis.window;
+            const previousFetch = globalThis.fetch;
+
+            globalThis.window = {
+                ytInitialData: initialData,
+                ytcfg: {
+                    data_: {
+                        INNERTUBE_API_KEY: 'test-key',
+                        INNERTUBE_CONTEXT: { client: { clientName: 'WEB', clientVersion: '1.0' } },
+                    },
+                },
+            };
+            globalThis.fetch = fetchMock;
+
+            try {
+                return await eval(script);
+            }
+            finally {
+                globalThis.window = previousWindow;
+                globalThis.fetch = previousFetch;
+            }
+        }),
+        __fetchMock: fetchMock,
+    };
+}
+
+const initialData = {
+    contents: {
+        twoColumnBrowseResultsRenderer: {
+            tabs: [{
+                tabRenderer: {
+                    content: {
+                        richGridRenderer: {
+                            contents: [
+                                {
+                                    richItemRenderer: {
+                                        content: {
+                                            videoRenderer: {
+                                                videoId: 'first-video',
+                                                title: { runs: [{ text: 'First video' }] },
+                                                ownerText: { runs: [{ text: 'First channel' }] },
+                                                viewCountText: { simpleText: '1K views' },
+                                                lengthText: { simpleText: '10:00' },
+                                                publishedTimeText: { simpleText: '1 day ago' },
+                                            },
+                                        },
+                                    },
+                                },
+                                {
+                                    continuationItemRenderer: {
+                                        continuationEndpoint: {
+                                            continuationCommand: {
+                                                token: 'next-token',
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+            }],
+        },
+    },
+};
+
+const continuationData = {
+    onResponseReceivedActions: [{
+        appendContinuationItemsAction: {
+            continuationItems: [{
+                richItemRenderer: {
+                    content: {
+                        videoRenderer: {
+                            videoId: 'second-video',
+                            title: { runs: [{ text: 'Second video' }] },
+                            ownerText: { runs: [{ text: 'Second channel' }] },
+                            viewCountText: { simpleText: '2K views' },
+                            lengthText: { simpleText: '11:00' },
+                            publishedTimeText: { simpleText: '2 days ago' },
+                        },
+                    },
+                },
+            }],
+        },
+    }],
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('youtube feed', () => {
+    it('uses continuation results when the first page is below limit', async () => {
+        const page = makePage({ initialData, continuationData });
+        const cmd = getRegistry().get('youtube/feed');
+
+        const rows = await cmd.func(page, { limit: 2 });
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.youtube.com');
+        expect(page.wait).toHaveBeenCalledWith(3);
+        expect(page.__fetchMock).toHaveBeenCalledTimes(1);
+        expect(rows).toEqual([
+            expect.objectContaining({
+                rank: 1,
+                title: 'First video',
+                video_id: 'first-video',
+                url: 'https://www.youtube.com/watch?v=first-video',
+            }),
+            expect.objectContaining({
+                rank: 2,
+                title: 'Second video',
+                video_id: 'second-video',
+                url: 'https://www.youtube.com/watch?v=second-video',
+            }),
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

Round 8 sweep — same silent-column-drop class as #1300 / #1301 / #1302. Row builds the id/url, `columns` array forgets to list it, table view drops it, agent loses the chain into detail commands.

3 files, 4 insertions, 4 deletions:

- **youtube/feed**: rename row key `videoId` → `video_id` (snake_case to match project convention — twitter `is_retweet`/`created_at`/`has_media`, douban `subject_id`/`photo_id`, hupu `thread_title`), add to columns. youtube/video already accepts both URL and id, so url-based round-trip wasn't broken, but exposing the canonical id removes a url-parse step for chained calls.
- **xiaohongshu/feed**: pipeline `map` already extracts `id` from the homefeed payload — columns now projects it.
- **xiaoe/catalog**: pipeline `map` already projects `url` — columns now lists it. xiaoe/detail takes positional `url`, so this completes the round-trip path explicitly.

## Why

Same `--format table` (default) bug as last 3 sweeps. JSON output was already correct; agents reading the default rendered output couldn't see the id and had to re-derive from url or re-search.

## Validation

- `check:listing-id-pairing --strict` ✓ (34 sites, 77 listings, 10 exempt, 0 violations)
- `typecheck` clean
- `vitest run clis/youtube/ clis/xiaohongshu/` → 13 files / 114 tests pass
- Manifest 660 → 660 entries (no count change, only column shape)

## Notes

- youtube/feed's `videoId` → `video_id` rename is a `-f json` schema change. The field was hidden (not in columns), so it's not a publicized contract. Leaning on convention consistency over backward compat for an undocumented field.
- xiaohongshu/feed pairs with xiaohongshu/note which requires `xsec_token` in the URL — adding `id` exposes the canonical id but the url-with-token flow is what actually round-trips. Both visible now.
- Audit follow-ups still queued: xiaohongshu/search drops `author_url` from columns; xhs row never extracts the note id even though url contains it. Will be a separate PR.

Adapter-only fast merge candidate.