### PR TITLE
feat(codex):卡比大佬：支持手机通过 OpenClaw 操作 Codex 项目对话

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -238,7 +238,7 @@ npm link
 | **hupu** | `hot` `search` `detail` `mentions` `reply` `like` `unlike` | 浏览器 |
 | **cursor** | `status` `send` `read` `new` `dump` `composer` `model` `extract-code` `ask` `screenshot` `history` `export` | 桌面端 |
 | **bilibili** | `hot` `search` `me` `favorite` `history` `feed` `subtitle` `video` `comments` `dynamic` `ranking` `following` `user-videos` `download` | 浏览器 |
-| **codex** | `status` `send` `read` `new` `dump` `extract-diff` `model` `ask` `screenshot` `history` `export` | 桌面端 |
+| **codex** | `status` `send` `read` `new` `dump` `extract-diff` `model` `ask` `screenshot` `projects` `history` `export` | 桌面端 |
 | **chatwise** | `status` `new` `send` `read` `ask` `model` `history` `export` `screenshot` | 桌面端 |
 | **doubao** | `status` `new` `send` `read` `ask` `history` `detail` `meeting-summary` `meeting-transcript` | 浏览器 |
 | **doubao-app** | `status` `new` `send` `read` `ask` `screenshot` `dump` | 桌面端 |

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4607,7 +4607,7 @@
   {
     "site": "codex",
     "name": "ask",
-    "description": "Send a prompt and wait for the AI response (send + wait + read)",
+    "description": "Send a prompt to the current or selected Codex conversation and wait for the AI response",
     "access": "write",
     "domain": "localhost",
     "strategy": "ui",
@@ -4626,10 +4626,36 @@
         "default": "60",
         "required": false,
         "help": "Max seconds to wait for response (default: 60)"
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
       }
     ],
     "columns": [
       "Role",
+      "Project",
+      "Conversation",
       "Text"
     ],
     "type": "js",
@@ -4684,15 +4710,31 @@
   {
     "site": "codex",
     "name": "history",
-    "description": "List recent conversation threads in Codex",
+    "description": "List visible Codex conversation threads grouped by project",
     "access": "read",
     "domain": "localhost",
     "strategy": "ui",
     "browser": true,
-    "args": [],
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Filter by project label or path"
+      },
+      {
+        "name": "limit",
+        "type": "str",
+        "required": false,
+        "help": "Max conversations per project"
+      }
+    ],
     "columns": [
+      "Project",
       "Index",
-      "Title"
+      "Title",
+      "Updated",
+      "Active"
     ],
     "type": "js",
     "modulePath": "codex/history.js",
@@ -4727,14 +4769,75 @@
   },
   {
     "site": "codex",
-    "name": "read",
-    "description": "Read the contents of the current Codex conversation thread",
+    "name": "projects",
+    "description": "List Codex projects and visible conversations from the sidebar",
     "access": "read",
     "domain": "localhost",
     "strategy": "ui",
     "browser": true,
-    "args": [],
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Filter by project label or path"
+      },
+      {
+        "name": "limit",
+        "type": "str",
+        "required": false,
+        "help": "Max conversations per project"
+      }
+    ],
     "columns": [
+      "Project",
+      "Index",
+      "Title",
+      "Updated",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "codex/projects.js",
+    "sourceFile": "codex/projects.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "codex",
+    "name": "read",
+    "description": "Read the contents of the current or selected Codex conversation thread",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
+      }
+    ],
+    "columns": [
+      "Project",
+      "Conversation",
       "Content"
     ],
     "type": "js",
@@ -4745,7 +4848,7 @@
   {
     "site": "codex",
     "name": "send",
-    "description": "Send text/commands to the Codex AI composer",
+    "description": "Send text/commands to the current or selected Codex AI composer",
     "access": "write",
     "domain": "localhost",
     "strategy": "ui",
@@ -4757,10 +4860,36 @@
         "required": true,
         "positional": true,
         "help": "Text, command (e.g. /review), or skill (e.g. $imagegen)"
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
       }
     ],
     "columns": [
       "Status",
+      "Project",
+      "Conversation",
       "InjectedText"
     ],
     "type": "js",

--- a/clis/codex/ask.js
+++ b/clis/codex/ask.js
@@ -1,21 +1,24 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { selectorError } from '@jackwener/opencli/errors';
+import { conversationSelectionArgs, openCodexConversation } from './sidebar.js';
 export const askCommand = cli({
     site: 'codex',
     name: 'ask',
     access: 'write',
-    description: 'Send a prompt and wait for the AI response (send + wait + read)',
+    description: 'Send a prompt to the current or selected Codex conversation and wait for the AI response',
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
         { name: 'timeout', required: false, help: 'Max seconds to wait for response (default: 60)', default: '60' },
+        ...conversationSelectionArgs,
     ],
-    columns: ['Role', 'Text'],
+    columns: ['Role', 'Project', 'Conversation', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
         const timeout = parseInt(kwargs.timeout, 10) || 60;
+        const selected = await openCodexConversation(page, kwargs);
         // Snapshot the current content length before sending
         const beforeLen = await page.evaluate(`
       (function() {
@@ -60,13 +63,13 @@ export const askCommand = cli({
         }
         if (!response) {
             return [
-                { Role: 'User', Text: text },
-                { Role: 'System', Text: `No response within ${timeout}s. The agent may still be working.` },
+                { Role: 'User', Project: selected?.project || '', Conversation: selected?.conversation || '', Text: text },
+                { Role: 'System', Project: selected?.project || '', Conversation: selected?.conversation || '', Text: `No response within ${timeout}s. The agent may still be working.` },
             ];
         }
         return [
-            { Role: 'User', Text: text },
-            { Role: 'Assistant', Text: response },
+            { Role: 'User', Project: selected?.project || '', Conversation: selected?.conversation || '', Text: text },
+            { Role: 'Assistant', Project: selected?.project || '', Conversation: selected?.conversation || '', Text: response },
         ];
     },
 });

--- a/clis/codex/ask.js
+++ b/clis/codex/ask.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { selectorError } from '@jackwener/opencli/errors';
-import { conversationSelectionArgs, openCodexConversation } from './sidebar.js';
+import { conversationSelectionArgs, openCodexConversation, parsePositiveIntegerOption } from './sidebar.js';
 export const askCommand = cli({
     site: 'codex',
     name: 'ask',
@@ -17,7 +17,7 @@ export const askCommand = cli({
     columns: ['Role', 'Project', 'Conversation', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const timeout = parseInt(kwargs.timeout, 10) || 60;
+        const timeout = parsePositiveIntegerOption(kwargs.timeout ?? '60', 'codex ask --timeout');
         const selected = await openCodexConversation(page, kwargs);
         // Snapshot the current content length before sending
         const beforeLen = await page.evaluate(`

--- a/clis/codex/history.js
+++ b/clis/codex/history.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { flattenCodexProjects, readCodexProjects } from './sidebar.js';
 export const historyCommand = cli({
     site: 'codex',
@@ -17,7 +18,9 @@ export const historyCommand = cli({
         const projects = await readCodexProjects(page);
         const rows = flattenCodexProjects(projects, kwargs);
         if (rows.length === 0) {
-            return [{ Project: kwargs.project || '', Index: 0, Title: 'No Codex threads found. Try opening the sidebar first.', Updated: '', Active: '' }];
+            throw new EmptyResultError('codex history', kwargs.project
+                ? `No Codex conversations were visible for project "${kwargs.project}".`
+                : 'No Codex conversations were visible. Open the Codex sidebar and retry.');
         }
         return rows;
     },

--- a/clis/codex/projects.js
+++ b/clis/codex/projects.js
@@ -1,10 +1,11 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { flattenCodexProjects, readCodexProjects } from './sidebar.js';
-export const historyCommand = cli({
+
+export const projectsCommand = cli({
     site: 'codex',
-    name: 'history',
+    name: 'projects',
     access: 'read',
-    description: 'List visible Codex conversation threads grouped by project',
+    description: 'List Codex projects and visible conversations from the sidebar',
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
@@ -17,7 +18,7 @@ export const historyCommand = cli({
         const projects = await readCodexProjects(page);
         const rows = flattenCodexProjects(projects, kwargs);
         if (rows.length === 0) {
-            return [{ Project: kwargs.project || '', Index: 0, Title: 'No Codex threads found. Try opening the sidebar first.', Updated: '', Active: '' }];
+            return [{ Project: kwargs.project || '', Index: 0, Title: 'No Codex projects found', Updated: '', Active: '' }];
         }
         return rows;
     },

--- a/clis/codex/projects.js
+++ b/clis/codex/projects.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { flattenCodexProjects, readCodexProjects } from './sidebar.js';
 
 export const projectsCommand = cli({
@@ -18,7 +19,9 @@ export const projectsCommand = cli({
         const projects = await readCodexProjects(page);
         const rows = flattenCodexProjects(projects, kwargs);
         if (rows.length === 0) {
-            return [{ Project: kwargs.project || '', Index: 0, Title: 'No Codex projects found', Updated: '', Active: '' }];
+            throw new EmptyResultError('codex projects', kwargs.project
+                ? `No Codex projects matched "${kwargs.project}".`
+                : 'No Codex projects were visible. Open the Codex sidebar and retry.');
         }
         return rows;
     },

--- a/clis/codex/read.js
+++ b/clis/codex/read.js
@@ -1,15 +1,19 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { conversationSelectionArgs, openCodexConversation } from './sidebar.js';
 export const readCommand = cli({
     site: 'codex',
     name: 'read',
     access: 'read',
-    description: 'Read the contents of the current Codex conversation thread',
+    description: 'Read the contents of the current or selected Codex conversation thread',
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
-    args: [],
-    columns: ['Content'],
-    func: async (page) => {
+    args: [
+        ...conversationSelectionArgs,
+    ],
+    columns: ['Project', 'Conversation', 'Content'],
+    func: async (page, kwargs) => {
+        const selected = await openCodexConversation(page, kwargs);
         const historyText = await page.evaluate(`
       (function() {
         const turns = Array.from(document.querySelectorAll('[data-content-search-turn-key]'));
@@ -28,6 +32,8 @@ export const readCommand = cli({
     `);
         return [
             {
+                Project: selected?.project || '',
+                Conversation: selected?.conversation || '',
                 Content: historyText,
             },
         ];

--- a/clis/codex/send.js
+++ b/clis/codex/send.js
@@ -1,17 +1,22 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { selectorError } from '@jackwener/opencli/errors';
+import { conversationSelectionArgs, openCodexConversation } from './sidebar.js';
 export const sendCommand = cli({
     site: 'codex',
     name: 'send',
     access: 'write',
-    description: 'Send text/commands to the Codex AI composer',
+    description: 'Send text/commands to the current or selected Codex AI composer',
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
-    args: [{ name: 'text', required: true, positional: true, help: 'Text, command (e.g. /review), or skill (e.g. $imagegen)' }],
-    columns: ['Status', 'InjectedText'],
+    args: [
+        { name: 'text', required: true, positional: true, help: 'Text, command (e.g. /review), or skill (e.g. $imagegen)' },
+        ...conversationSelectionArgs,
+    ],
+    columns: ['Status', 'Project', 'Conversation', 'InjectedText'],
     func: async (page, kwargs) => {
         const textToInsert = kwargs.text;
+        const selected = await openCodexConversation(page, kwargs);
         const injected = await page.evaluate(`
       (function(text) {
         let composer = document.querySelector('textarea, [contenteditable="true"]');
@@ -37,6 +42,8 @@ export const sendCommand = cli({
         return [
             {
                 Status: 'Success',
+                Project: selected?.project || '',
+                Conversation: selected?.conversation || '',
                 InjectedText: textToInsert,
             },
         ];

--- a/clis/codex/sidebar.js
+++ b/clis/codex/sidebar.js
@@ -1,0 +1,307 @@
+function cleanText(value) {
+    return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeMatch(value) {
+    return cleanText(value).toLowerCase();
+}
+
+function matchesProject(project, query) {
+    if (!query)
+        return true;
+    const label = normalizeMatch(project.project);
+    const projectPath = normalizeMatch(project.projectPath);
+    const needle = normalizeMatch(query);
+    if (!needle)
+        return true;
+    return label === needle
+        || label.includes(needle)
+        || projectPath === needle
+        || projectPath.endsWith(`/${needle}`);
+}
+
+export function hasConversationTarget(kwargs) {
+    return !!(kwargs?.project || kwargs?.conversation || kwargs?.index || kwargs?.['thread-id']);
+}
+
+export function collectCodexProjectsFromDocument(doc = document) {
+    const projectRowSelector = '[data-app-action-sidebar-project-row]';
+    const threadRowSelector = '[data-app-action-sidebar-thread-row]';
+
+    function visibleText(el) {
+        return (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function isRelativeTime(text) {
+        return /^(?:(?:\d+\s*)?(?:刚刚|秒|分钟|小时|天|周|个月|年|sec|min|hr|hour|day|week|month|year|s|m|h|d|w)|.*\bago)$/i.test(text.trim());
+    }
+
+    function getUpdatedText(row, title) {
+        const candidates = Array.from(row.querySelectorAll('.tabular-nums, [class*="tabular-nums"], [class*="description"]'))
+            .map(visibleText)
+            .filter(Boolean);
+        const direct = candidates.find(isRelativeTime);
+        if (direct)
+            return direct;
+        const fullText = visibleText(row);
+        const suffix = fullText.replace(title, '').trim();
+        return isRelativeTime(suffix) ? suffix : '';
+    }
+
+    return Array.from(doc.querySelectorAll(projectRowSelector)).map((projectRow, projectIndex) => {
+        const label = projectRow.getAttribute('data-app-action-sidebar-project-label')
+            || projectRow.getAttribute('aria-label')
+            || visibleText(projectRow);
+        const path = projectRow.getAttribute('data-app-action-sidebar-project-id') || '';
+        const projectItem = projectRow.closest('[role="listitem"][aria-label]') || projectRow.parentElement;
+        const threadRows = projectItem
+            ? Array.from(projectItem.querySelectorAll(threadRowSelector))
+            : [];
+        const conversations = threadRows.map((row, index) => {
+            const title = row.getAttribute('data-app-action-sidebar-thread-title') || visibleText(row);
+            return {
+                index: index + 1,
+                title,
+                updated: getUpdatedText(row, title),
+                active: row.getAttribute('data-app-action-sidebar-thread-active') === 'true',
+                pinned: row.getAttribute('data-app-action-sidebar-thread-pinned') === 'true',
+                threadId: row.getAttribute('data-app-action-sidebar-thread-id') || '',
+                hostId: row.getAttribute('data-app-action-sidebar-thread-host-id') || '',
+                kind: row.getAttribute('data-app-action-sidebar-thread-kind') || '',
+            };
+        });
+
+        return {
+            index: projectIndex + 1,
+            project: label,
+            projectPath: path,
+            collapsed: projectRow.getAttribute('data-app-action-sidebar-project-collapsed') === 'true'
+                || projectRow.getAttribute('aria-expanded') === 'false',
+            conversations,
+        };
+    });
+}
+
+export function selectCodexConversationInDocument(target, doc = document) {
+    const projectRowSelector = '[data-app-action-sidebar-project-row]';
+    const threadRowSelector = '[data-app-action-sidebar-thread-row]';
+
+    function clean(value) {
+        return String(value ?? '').replace(/\s+/g, ' ').trim();
+    }
+
+    function normalize(value) {
+        return clean(value).toLowerCase();
+    }
+
+    function matches(value, query) {
+        const haystack = normalize(value);
+        const needle = normalize(query);
+        return !!needle && (haystack === needle || haystack.includes(needle));
+    }
+
+    function projectLabel(row) {
+        return row.getAttribute('data-app-action-sidebar-project-label')
+            || row.getAttribute('aria-label')
+            || row.textContent
+            || '';
+    }
+
+    function projectPath(row) {
+        return row.getAttribute('data-app-action-sidebar-project-id') || '';
+    }
+
+    function threadTitle(row) {
+        return row.getAttribute('data-app-action-sidebar-thread-title')
+            || row.textContent
+            || '';
+    }
+
+    function centerPoint(row) {
+        const rect = row.getBoundingClientRect?.();
+        if (!rect || !Number.isFinite(rect.left) || !Number.isFinite(rect.top)) {
+            return {};
+        }
+        return {
+            x: rect.left + rect.width / 2,
+            y: rect.top + rect.height / 2,
+        };
+    }
+
+    const projectRows = Array.from(doc.querySelectorAll(projectRowSelector));
+    let projectRow = null;
+    if (target.project) {
+        projectRow = projectRows.find(row => matches(projectLabel(row), target.project))
+            || projectRows.find(row => matches(projectPath(row), target.project));
+        if (!projectRow) {
+            return {
+                ok: false,
+                error: `Project not found: ${target.project}`,
+                projects: projectRows.map(row => projectLabel(row)).filter(Boolean),
+            };
+        }
+    }
+
+    if (projectRow) {
+        const collapsed = projectRow.getAttribute('data-app-action-sidebar-project-collapsed') === 'true'
+            || projectRow.getAttribute('aria-expanded') === 'false';
+        if (collapsed) {
+            projectRow.scrollIntoView?.({ block: 'center' });
+            if (!target.preferNativeClick) {
+                projectRow.click();
+            }
+            return {
+                ok: true,
+                expanded: true,
+                selected: false,
+                project: projectLabel(projectRow),
+                projectPath: projectPath(projectRow),
+                ...centerPoint(projectRow),
+            };
+        }
+    }
+
+    const scope = projectRow
+        ? (projectRow.closest('[role="listitem"][aria-label]') || projectRow.parentElement || doc)
+        : doc;
+    const threadRows = Array.from(scope.querySelectorAll(threadRowSelector));
+    if (!threadRows.length) {
+        return {
+            ok: false,
+            error: projectRow
+                ? `No visible conversations under project: ${projectLabel(projectRow)}`
+                : 'No visible Codex conversations found',
+        };
+    }
+
+    let threadRow = null;
+    if (target.threadId) {
+        threadRow = threadRows.find(row => row.getAttribute('data-app-action-sidebar-thread-id') === target.threadId);
+    }
+    if (!threadRow && target.index != null) {
+        const index = Number(target.index);
+        if (!Number.isInteger(index) || index < 1) {
+            return { ok: false, error: `Invalid conversation index: ${target.index}` };
+        }
+        threadRow = threadRows[index - 1] || null;
+    }
+    if (!threadRow && target.conversation) {
+        const exact = threadRows.filter(row => normalize(threadTitle(row)) === normalize(target.conversation));
+        threadRow = exact[0] || threadRows.find(row => matches(threadTitle(row), target.conversation)) || null;
+        if (exact.length > 1 && !target.project) {
+            return {
+                ok: false,
+                error: `Multiple conversations matched "${target.conversation}". Pass --project to disambiguate.`,
+            };
+        }
+    }
+
+    if (!threadRow) {
+        return {
+            ok: false,
+            error: target.conversation
+                ? `Conversation not found: ${target.conversation}`
+                : 'Pass --conversation, --thread-id, or --index to select a Codex conversation',
+            conversations: threadRows.map((row, index) => ({ index: index + 1, title: threadTitle(row) })),
+        };
+    }
+
+    threadRow.scrollIntoView?.({ block: 'center' });
+    if (!target.preferNativeClick) {
+        threadRow.click();
+    }
+    return {
+        ok: true,
+        expanded: false,
+        selected: true,
+        project: projectRow ? projectLabel(projectRow) : '',
+        projectPath: projectRow ? projectPath(projectRow) : '',
+        conversation: threadTitle(threadRow),
+        threadId: threadRow.getAttribute('data-app-action-sidebar-thread-id') || '',
+        index: threadRows.indexOf(threadRow) + 1,
+        ...centerPoint(threadRow),
+    };
+}
+
+export function flattenCodexProjects(projects, opts = {}) {
+    const projectFilter = opts.project;
+    const limit = Number.parseInt(String(opts.limit ?? ''), 10);
+    const rows = [];
+    for (const project of projects) {
+        if (!matchesProject(project, projectFilter)) {
+            continue;
+        }
+        const conversations = Number.isInteger(limit) && limit > 0
+            ? project.conversations.slice(0, limit)
+            : project.conversations;
+        if (conversations.length === 0) {
+            rows.push({
+                Project: project.project,
+                Index: 0,
+                Title: project.collapsed ? '(collapsed)' : '(no visible conversations)',
+                Updated: '',
+                Active: '',
+                ProjectPath: project.projectPath,
+                ThreadId: '',
+            });
+            continue;
+        }
+        for (const conversation of conversations) {
+            rows.push({
+                Project: project.project,
+                Index: conversation.index,
+                Title: conversation.title,
+                Updated: conversation.updated,
+                Active: conversation.active ? 'yes' : '',
+                ProjectPath: project.projectPath,
+                ThreadId: conversation.threadId,
+            });
+        }
+    }
+    return rows;
+}
+
+export async function readCodexProjects(page) {
+    const projects = await page.evaluate(`(${collectCodexProjectsFromDocument.toString()})()`);
+    return Array.isArray(projects) ? projects : [];
+}
+
+export async function openCodexConversation(page, kwargs) {
+    if (!hasConversationTarget(kwargs))
+        return null;
+    const target = {
+        project: kwargs.project || '',
+        conversation: kwargs.conversation || '',
+        index: kwargs.index || '',
+        threadId: kwargs['thread-id'] || '',
+        preferNativeClick: typeof page.nativeClick === 'function',
+    };
+    let result = await page.evaluate(`(${selectCodexConversationInDocument.toString()})(${JSON.stringify(target)})`);
+    if (result?.expanded) {
+        if (typeof page.nativeClick === 'function' && Number.isFinite(result.x) && Number.isFinite(result.y)) {
+            await page.nativeClick(result.x, result.y);
+        }
+        await page.wait(0.75);
+        result = await page.evaluate(`(${selectCodexConversationInDocument.toString()})(${JSON.stringify(target)})`);
+    }
+    if (!result?.ok || !result?.selected) {
+        const detail = result?.conversations
+            ? ` Available: ${result.conversations.map(item => `${item.index}. ${item.title}`).join('; ')}`
+            : result?.projects
+                ? ` Available projects: ${result.projects.join(', ')}`
+                : '';
+        throw new Error(`${result?.error || 'Could not select Codex conversation'}${detail}`);
+    }
+    if (typeof page.nativeClick === 'function' && Number.isFinite(result.x) && Number.isFinite(result.y)) {
+        await page.nativeClick(result.x, result.y);
+    }
+    await page.wait(1);
+    return result;
+}
+
+export const conversationSelectionArgs = [
+    { name: 'project', required: false, help: 'Project label or path to select before running the command' },
+    { name: 'conversation', required: false, help: 'Conversation title to select within --project' },
+    { name: 'index', required: false, help: '1-based conversation index within --project' },
+    { name: 'thread-id', required: false, help: 'Exact Codex thread id to select' },
+];

--- a/clis/codex/sidebar.js
+++ b/clis/codex/sidebar.js
@@ -1,3 +1,5 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
 function cleanText(value) {
     return String(value ?? '').replace(/\s+/g, ' ').trim();
 }
@@ -22,6 +24,33 @@ function matchesProject(project, query) {
 
 export function hasConversationTarget(kwargs) {
     return !!(kwargs?.project || kwargs?.conversation || kwargs?.index || kwargs?.['thread-id']);
+}
+
+export function parsePositiveIntegerOption(raw, label) {
+    const value = cleanText(raw);
+    if (!/^\d+$/.test(value)) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    return parsed;
+}
+
+export function parseOptionalPositiveIntegerOption(raw, label) {
+    if (raw == null || cleanText(raw) === '') {
+        return null;
+    }
+    return parsePositiveIntegerOption(raw, label);
+}
+
+export function requireNonEmptyOption(raw, label) {
+    const value = cleanText(raw);
+    if (!value) {
+        throw new ArgumentError(`${label} cannot be empty`);
+    }
+    return value;
 }
 
 export function collectCodexProjectsFromDocument(doc = document) {
@@ -199,7 +228,9 @@ export function selectCodexConversationInDocument(target, doc = document) {
     if (!threadRow) {
         return {
             ok: false,
-            error: target.conversation
+            error: target.threadId
+                ? `Thread not found: ${target.threadId}`
+                : target.conversation
                 ? `Conversation not found: ${target.conversation}`
                 : 'Pass --conversation, --thread-id, or --index to select a Codex conversation',
             conversations: threadRows.map((row, index) => ({ index: index + 1, title: threadTitle(row) })),
@@ -225,13 +256,13 @@ export function selectCodexConversationInDocument(target, doc = document) {
 
 export function flattenCodexProjects(projects, opts = {}) {
     const projectFilter = opts.project;
-    const limit = Number.parseInt(String(opts.limit ?? ''), 10);
+    const limit = parseOptionalPositiveIntegerOption(opts.limit, 'codex --limit');
     const rows = [];
     for (const project of projects) {
         if (!matchesProject(project, projectFilter)) {
             continue;
         }
-        const conversations = Number.isInteger(limit) && limit > 0
+        const conversations = limit
             ? project.conversations.slice(0, limit)
             : project.conversations;
         if (conversations.length === 0) {
@@ -263,17 +294,22 @@ export function flattenCodexProjects(projects, opts = {}) {
 
 export async function readCodexProjects(page) {
     const projects = await page.evaluate(`(${collectCodexProjectsFromDocument.toString()})()`);
-    return Array.isArray(projects) ? projects : [];
+    if (!Array.isArray(projects)) {
+        throw new CommandExecutionError('Codex sidebar project extraction returned an invalid payload');
+    }
+    return projects;
 }
 
 export async function openCodexConversation(page, kwargs) {
     if (!hasConversationTarget(kwargs))
         return null;
+    const index = parseOptionalPositiveIntegerOption(kwargs.index, 'codex conversation --index');
+    const threadId = kwargs['thread-id'] ? requireNonEmptyOption(kwargs['thread-id'], 'codex conversation --thread-id') : '';
     const target = {
         project: kwargs.project || '',
         conversation: kwargs.conversation || '',
-        index: kwargs.index || '',
-        threadId: kwargs['thread-id'] || '',
+        index: index == null ? '' : String(index),
+        threadId,
         preferNativeClick: typeof page.nativeClick === 'function',
     };
     let result = await page.evaluate(`(${selectCodexConversationInDocument.toString()})(${JSON.stringify(target)})`);
@@ -290,7 +326,20 @@ export async function openCodexConversation(page, kwargs) {
             : result?.projects
                 ? ` Available projects: ${result.projects.join(', ')}`
                 : '';
-        throw new Error(`${result?.error || 'Could not select Codex conversation'}${detail}`);
+        const message = `${result?.error || 'Could not select Codex conversation'}${detail}`;
+        if (result?.error?.startsWith('Invalid conversation index:')) {
+            throw new ArgumentError(message);
+        }
+        if (result?.error?.startsWith('Multiple conversations matched')) {
+            throw new ArgumentError(message, 'Pass --project or --thread-id to disambiguate the target conversation.');
+        }
+        if (result?.error?.startsWith('Project not found:')
+            || result?.error?.startsWith('Conversation not found:')
+            || result?.error?.startsWith('Thread not found:')
+            || result?.error?.startsWith('No visible conversations under project:')) {
+            throw new EmptyResultError('codex conversation', message);
+        }
+        throw new CommandExecutionError(message, 'Open the Codex sidebar and verify project/conversation rows are visible.');
     }
     if (typeof page.nativeClick === 'function' && Number.isFinite(result.x) && Number.isFinite(result.y)) {
         await page.nativeClick(result.x, result.y);

--- a/clis/codex/sidebar.test.js
+++ b/clis/codex/sidebar.test.js
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import {
+    collectCodexProjectsFromDocument,
+    flattenCodexProjects,
+    selectCodexConversationInDocument,
+} from './sidebar.js';
+
+class FakeElement {
+    constructor(tagName = 'div', attrs = {}, children = [], text = '') {
+        this.tagName = tagName.toUpperCase();
+        this.attrs = attrs;
+        this.children = children;
+        this.parentElement = null;
+        this.textContent = text;
+        this.innerText = text;
+        this.className = attrs.class || '';
+        this.listeners = new Map();
+        for (const child of children) {
+            child.parentElement = this;
+        }
+    }
+
+    getAttribute(name) {
+        return this.attrs[name] ?? null;
+    }
+
+    addEventListener(name, fn) {
+        const listeners = this.listeners.get(name) || [];
+        listeners.push(fn);
+        this.listeners.set(name, listeners);
+    }
+
+    click() {
+        for (const listener of this.listeners.get('click') || []) {
+            listener();
+        }
+    }
+
+    scrollIntoView() {
+    }
+
+    closest(selector) {
+        let current = this;
+        while (current) {
+            if (matchesSelector(current, selector))
+                return current;
+            current = current.parentElement;
+        }
+        return null;
+    }
+
+    querySelectorAll(selector) {
+        const selectors = selector.split(',').map(part => part.trim());
+        const results = [];
+        const visit = (node) => {
+            if (selectors.some(part => matchesSelector(node, part))) {
+                results.push(node);
+            }
+            for (const child of node.children) {
+                visit(child);
+            }
+        };
+        for (const child of this.children) {
+            visit(child);
+        }
+        return results;
+    }
+}
+
+function matchesSelector(node, selector) {
+    if (selector === '[data-app-action-sidebar-project-row]') {
+        return node.getAttribute('data-app-action-sidebar-project-row') !== null;
+    }
+    if (selector === '[data-app-action-sidebar-thread-row]') {
+        return node.getAttribute('data-app-action-sidebar-thread-row') !== null;
+    }
+    if (selector === '[role="listitem"][aria-label]') {
+        return node.getAttribute('role') === 'listitem' && node.getAttribute('aria-label') !== null;
+    }
+    if (selector === '.tabular-nums') {
+        return String(node.className || '').split(/\s+/).includes('tabular-nums');
+    }
+    if (selector === '[class*="tabular-nums"]') {
+        return String(node.className || '').includes('tabular-nums');
+    }
+    if (selector === '[class*="description"]') {
+        return String(node.className || '').includes('description');
+    }
+    return false;
+}
+
+function el(tagName, attrs, children = [], text = '') {
+    return new FakeElement(tagName, attrs, children, text);
+}
+
+function thread(attrs, title, updated) {
+    return el('div', {
+        role: 'button',
+        'data-app-action-sidebar-thread-row': '',
+        'data-app-action-sidebar-thread-title': title,
+        'data-app-action-sidebar-thread-id': attrs.threadId,
+        'data-app-action-sidebar-thread-host-id': attrs.hostId || '',
+        'data-app-action-sidebar-thread-kind': attrs.kind || '',
+        'data-app-action-sidebar-thread-active': attrs.active ? 'true' : 'false',
+        'data-app-action-sidebar-thread-pinned': attrs.pinned ? 'true' : 'false',
+    }, [
+        el('span', { 'data-thread-title': '' }, [], title),
+        el('span', { class: 'tabular-nums' }, [], updated),
+    ], `${title} ${updated}`);
+}
+
+function project(label, projectPath, children) {
+    return el('div', { role: 'listitem', 'aria-label': label }, [
+        el('div', {
+            role: 'button',
+            'aria-expanded': 'true',
+            'data-app-action-sidebar-project-row': '',
+            'data-app-action-sidebar-project-label': label,
+            'data-app-action-sidebar-project-id': projectPath,
+        }, [], label),
+        ...children,
+    ]);
+}
+
+function fixtureDocument() {
+    return el('document', {}, [
+        project('stock', '/Users/youngcan/stock', [
+            thread({ threadId: 'local:stock-sync', hostId: 'local', kind: 'local', active: true }, '同步各仓库最新代码', '4 小时'),
+            thread({ threadId: 'local:trading-agents' }, '借鉴 TradingAgents', '2 小时'),
+        ]),
+        project('opencli', '/Users/youngcan/opencli', [
+            thread({ threadId: 'local:opencli-groups' }, '统一 opencli 二级命令分组', '1 天'),
+        ]),
+    ]);
+}
+
+describe('codex sidebar helpers', () => {
+    it('collects projects and visible conversations from Codex data attributes', () => {
+        const projects = collectCodexProjectsFromDocument(fixtureDocument());
+
+        expect(projects).toHaveLength(2);
+        expect(projects[0]).toMatchObject({
+            project: 'stock',
+            projectPath: '/Users/youngcan/stock',
+            collapsed: false,
+        });
+        expect(projects[0].conversations[0]).toMatchObject({
+            index: 1,
+            title: '同步各仓库最新代码',
+            updated: '4 小时',
+            active: true,
+            threadId: 'local:stock-sync',
+        });
+    });
+
+    it('flattens project rows with project filters', () => {
+        const projects = collectCodexProjectsFromDocument(fixtureDocument());
+        const rows = flattenCodexProjects(projects, { project: 'opencli' });
+
+        expect(rows).toEqual([
+            expect.objectContaining({
+                Project: 'opencli',
+                Index: 1,
+                Title: '统一 opencli 二级命令分组',
+                Updated: '1 天',
+            }),
+        ]);
+    });
+
+    it('does not match nested project paths when filtering by a parent label', () => {
+        const projects = collectCodexProjectsFromDocument(fixtureDocument());
+        projects.push({
+            index: 3,
+            project: 'nested',
+            projectPath: '/Users/youngcan/opencli/nested',
+            collapsed: false,
+            conversations: [
+                { index: 1, title: 'Nested thread', updated: '', active: false, threadId: 'local:nested' },
+            ],
+        });
+
+        const rows = flattenCodexProjects(projects, { project: 'opencli' });
+
+        expect(rows.map(row => row.Project)).toEqual(['opencli']);
+    });
+
+    it('selects a conversation by project and title', () => {
+        const doc = fixtureDocument();
+        const selected = [];
+        for (const row of doc.querySelectorAll('[data-app-action-sidebar-thread-row]')) {
+            row.addEventListener('click', () => selected.push(row.getAttribute('data-app-action-sidebar-thread-id')));
+        }
+
+        const result = selectCodexConversationInDocument({
+            project: 'stock',
+            conversation: 'TradingAgents',
+        }, doc);
+
+        expect(result).toMatchObject({
+            ok: true,
+            selected: true,
+            project: 'stock',
+            conversation: '借鉴 TradingAgents',
+            threadId: 'local:trading-agents',
+            index: 2,
+        });
+        expect(selected).toEqual(['local:trading-agents']);
+    });
+
+    it('does not dispatch DOM click when native click is preferred', () => {
+        const doc = fixtureDocument();
+        const selected = [];
+        for (const row of doc.querySelectorAll('[data-app-action-sidebar-thread-row]')) {
+            row.addEventListener('click', () => selected.push(row.getAttribute('data-app-action-sidebar-thread-id')));
+        }
+
+        const result = selectCodexConversationInDocument({
+            project: 'stock',
+            conversation: 'TradingAgents',
+            preferNativeClick: true,
+        }, doc);
+
+        expect(result).toMatchObject({
+            ok: true,
+            selected: true,
+            threadId: 'local:trading-agents',
+        });
+        expect(selected).toEqual([]);
+    });
+
+    it('selects a conversation by index within a project', () => {
+        const result = selectCodexConversationInDocument({
+            project: '/Users/youngcan/opencli',
+            index: '1',
+        }, fixtureDocument());
+
+        expect(result).toMatchObject({
+            ok: true,
+            project: 'opencli',
+            conversation: '统一 opencli 二级命令分组',
+            threadId: 'local:opencli-groups',
+        });
+    });
+});

--- a/clis/codex/sidebar.test.js
+++ b/clis/codex/sidebar.test.js
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { askCommand } from './ask.js';
+import { historyCommand } from './history.js';
+import { projectsCommand } from './projects.js';
 import {
     collectCodexProjectsFromDocument,
     flattenCodexProjects,
+    openCodexConversation,
     selectCodexConversationInDocument,
 } from './sidebar.js';
 
@@ -167,6 +172,14 @@ describe('codex sidebar helpers', () => {
         ]);
     });
 
+    it('rejects invalid project/history limits instead of silently ignoring them', () => {
+        const projects = collectCodexProjectsFromDocument(fixtureDocument());
+
+        expect(() => flattenCodexProjects(projects, { limit: '0' })).toThrowError(ArgumentError);
+        expect(() => flattenCodexProjects(projects, { limit: '1.5' })).toThrowError(ArgumentError);
+        expect(() => flattenCodexProjects(projects, { limit: 'abc' })).toThrowError(ArgumentError);
+    });
+
     it('does not match nested project paths when filtering by a parent label', () => {
         const projects = collectCodexProjectsFromDocument(fixtureDocument());
         projects.push({
@@ -240,5 +253,77 @@ describe('codex sidebar helpers', () => {
             conversation: '统一 opencli 二级命令分组',
             threadId: 'local:opencli-groups',
         });
+    });
+
+    it('reports exact thread-id misses as not found', () => {
+        const result = selectCodexConversationInDocument({
+            project: 'stock',
+            threadId: 'local:missing',
+        }, fixtureDocument());
+
+        expect(result).toMatchObject({
+            ok: false,
+            error: 'Thread not found: local:missing',
+        });
+    });
+
+    it('maps project/conversation misses to EmptyResultError in command selection', async () => {
+        const page = {
+            evaluate: async () => selectCodexConversationInDocument({ project: 'missing' }, fixtureDocument()),
+        };
+
+        await expect(openCodexConversation(page, { project: 'missing' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('maps missing sidebar DOM to CommandExecutionError instead of empty success', async () => {
+        const page = {
+            evaluate: async () => selectCodexConversationInDocument({ conversation: 'anything' }, el('document', {}, [])),
+        };
+
+        await expect(openCodexConversation(page, { conversation: 'anything' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps ambiguous conversation selection to ArgumentError', async () => {
+        const duplicateDoc = el('document', {}, [
+            project('alpha', '/tmp/alpha', [
+                thread({ threadId: 'local:one' }, 'Shared title', '1 小时'),
+            ]),
+            project('beta', '/tmp/beta', [
+                thread({ threadId: 'local:two' }, 'Shared title', '2 小时'),
+            ]),
+        ]);
+        const page = {
+            evaluate: async () => selectCodexConversationInDocument({ conversation: 'Shared title' }, duplicateDoc),
+        };
+
+        await expect(openCodexConversation(page, { conversation: 'Shared title' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+});
+
+describe('codex sidebar commands', () => {
+    it('projects fails empty result instead of returning a sentinel row', async () => {
+        const page = {
+            evaluate: async () => [],
+        };
+
+        await expect(projectsCommand.func(page, {})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('history fails empty result instead of returning a sentinel row', async () => {
+        const page = {
+            evaluate: async () => [],
+        };
+
+        await expect(historyCommand.func(page, {})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('ask rejects invalid timeout instead of falling back to the default', async () => {
+        const page = {
+            evaluate: async () => 0,
+        };
+
+        await expect(askCommand.func(page, { text: 'hello', timeout: 'bogus' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(askCommand.func(page, { text: 'hello', timeout: '0' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(askCommand.func(page, { text: 'hello', timeout: '1.5' })).rejects.toBeInstanceOf(ArgumentError);
     });
 });

--- a/docs/adapters/desktop/codex.md
+++ b/docs/adapters/desktop/codex.md
@@ -30,7 +30,21 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
   - *Pro-tip*: You can trigger internal shortcuts, e.g., `opencli codex send "/review"`.
 - `opencli codex ask "message"`: Send + wait + read in one shot.
 - `opencli codex read`: Extracts the entire current thread history and AI reasoning logs.
+- `opencli codex projects`: List visible sidebar projects and conversations.
+- `opencli codex history`: List visible conversation threads grouped by project.
 - `opencli codex extract-diff`: Automatically scrapes any visual Patch chunks and Code Diffs.
 - `opencli codex model`: Get the currently active AI model.
-- `opencli codex history`: List recent conversation threads from the sidebar.
 - `opencli codex export`: Export the current conversation as Markdown.
+
+### Selecting a Project Conversation
+
+`send`, `ask`, and `read` can select a visible sidebar conversation before acting:
+
+```bash
+opencli codex projects
+opencli codex send "Sync the repo and report blockers" --project stock --conversation "同步各仓库最新代码"
+opencli codex ask "Summarize current status" --project opencli --index 2 --timeout 120
+opencli codex read --project /Users/youngcan/stock --thread-id local:019df125-bf8b-77f0-ade5-de44670db82d
+```
+
+Project selection matches either the project label or path. Conversation selection accepts `--conversation`, `--index`, or `--thread-id`.


### PR DESCRIPTION
## 背景

想用手机给 OpenClaw 发消息，再让 OpenClaw 通过 OpenCLI 操作 Codex App。Codex 侧栏本身有项目和对话分组，但现有 `opencli codex` 命令只能操作当前会话，缺少结构化项目列表和指定项目对话后再执行的能力。

## 改动

- 新增 `opencli codex projects`，列出当前 Codex 侧栏可见的项目和对话。
- 调整 `opencli codex history`，按项目展示可见对话，并支持 `--project`、`--limit`。
- 给 `read`、`send`、`ask` 增加 `--project`、`--conversation`、`--index`、`--thread-id`，可以先选择指定项目下的对话再执行。
- 抽出 Codex sidebar helper，使用 Codex App 的 `data-app-action-sidebar-*` DOM 属性定位项目和对话，并优先使用 native click 进行真实选择。
- 补充 sidebar 单测和 Codex adapter 文档。

## 验证

- `npm run test:adapter -- clis/codex/sidebar.test.js`
- `npm run build`
- `node dist/src/main.js validate codex`
- `node dist/src/main.js codex projects --project stock -f json`
- `node dist/src/main.js codex read --project stock --index 1 -f json`

## 说明

当前实现读取的是 Codex 侧栏当前可见的项目和对话，适合手机端通过 OpenClaw 选择项目下的已有会话后发送消息。后续如果需要全量历史，可以再补滚动枚举或读取 Codex 内部数据源。
