### PR TITLE
ci: gate new silent column drops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
         if: runner.os == 'Linux'
         run: npm run check:listing-id-pairing
 
+      # Guard: adapter rows must not silently emit keys omitted from `columns`.
+      # Existing findings are tracked in scripts/silent-column-drop-baseline.json;
+      # this gate rejects newly introduced drops while allowing incremental cleanup.
+      - name: Check silent column drops
+        if: runner.os == 'Linux'
+        run: npm run check:silent-column-drop
+
   # ── Unit tests (vitest shard) ──
   # PR: ubuntu + Node 22 only (fast feedback, 2 jobs).
   # Push to main/dev: full matrix for cross-platform/cross-version coverage (12 jobs).

--- a/docs/conventions/convention-audit.md
+++ b/docs/conventions/convention-audit.md
@@ -37,3 +37,20 @@ The first version reports these categories:
 The scanners are heuristic. Treat reports as prioritized review input by
 default, then turn a specific rule into a strict CI gate only after the current
 violations and exemptions are understood.
+
+## CI Gates
+
+`npm run check:silent-column-drop` enforces the `silent-column-drop` rule in
+baseline mode. The baseline file is
+`scripts/silent-column-drop-baseline.json`.
+
+The gate fails only on new violations beyond that baseline. This lets the repo
+adopt the invariant immediately while existing findings are cleaned up in
+separate sweep PRs.
+
+When a sweep fixes existing entries, update the baseline:
+
+```bash
+npm run build
+node scripts/check-silent-column-drop.mjs --update-baseline
+```

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:all": "vitest run",
     "test:e2e": "vitest run --project e2e",
     "check:listing-id-pairing": "node scripts/check-listing-id-pairing.mjs --strict",
+    "check:silent-column-drop": "node scripts/check-silent-column-drop.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/check-silent-column-drop.mjs
+++ b/scripts/check-silent-column-drop.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * check-silent-column-drop.mjs — CI gate for newly introduced table-output loss.
+ *
+ * This gate intentionally uses a baseline. The repo currently has known
+ * silent-column-drop findings, and blocking every existing violation would make
+ * the first CI adoption PR too large. The invariant enforced here is:
+ *
+ *   no new silent-column-drop signatures beyond scripts/silent-column-drop-baseline.json
+ *
+ * When a follow-up sweep fixes existing violations, run:
+ *
+ *   node scripts/check-silent-column-drop.mjs --update-baseline
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..');
+const DIST_AUDIT = resolve(PROJECT_ROOT, 'dist', 'src', 'convention-audit.js');
+const BASELINE_PATH = resolve(__dirname, 'silent-column-drop-baseline.json');
+const UPDATE = process.argv.includes('--update-baseline');
+
+if (!existsSync(DIST_AUDIT)) {
+  console.error('dist/src/convention-audit.js not found. Run npm run build before this check.');
+  process.exit(1);
+}
+
+const { runConventionAudit } = await import(pathToFileURL(DIST_AUDIT).href);
+const report = runConventionAudit({ projectRoot: PROJECT_ROOT });
+const category = report.categories.find((item) => item.rule === 'silent-column-drop');
+const current = sortRecords((category?.violations ?? []).map(toBaselineRecord));
+
+if (UPDATE) {
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(current, null, 2)}\n`);
+  console.log(`Updated ${relative(BASELINE_PATH)} with ${current.length} silent-column-drop baseline entr${current.length === 1 ? 'y' : 'ies'}.`);
+  process.exit(0);
+}
+
+if (!existsSync(BASELINE_PATH)) {
+  console.error(`${relative(BASELINE_PATH)} not found. Run node scripts/check-silent-column-drop.mjs --update-baseline.`);
+  process.exit(1);
+}
+
+const baseline = sortRecords(JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')));
+const baselineSignatures = new Set(baseline.map(signature));
+const currentSignatures = new Set(current.map(signature));
+const added = current.filter((record) => !baselineSignatures.has(signature(record)));
+const resolved = baseline.filter((record) => !currentSignatures.has(signature(record)));
+
+console.log(`Silent-column-drop gate: current=${current.length}, baseline=${baseline.length}, new=${added.length}, resolved=${resolved.length}`);
+
+if (resolved.length > 0) {
+  console.log('');
+  console.log('Resolved baseline entries detected. Consider shrinking the baseline:');
+  for (const record of resolved) {
+    console.log(`  - ${record.command} ${record.file} missing=[${record.missing.join(', ')}]`);
+  }
+}
+
+if (added.length === 0) {
+  console.log('OK - no new silent-column-drop violations.');
+  process.exit(0);
+}
+
+console.log('');
+console.log('New silent-column-drop violations:');
+for (const record of added) {
+  console.log(`  - ${record.command} ${record.file} missing=[${record.missing.join(', ')}]`);
+}
+console.log('');
+console.log('Fix the adapter columns, or if this is an intentional baseline adoption, run:');
+console.log('  node scripts/check-silent-column-drop.mjs --update-baseline');
+process.exit(1);
+
+function toBaselineRecord(violation) {
+  const missing = Array.isArray(violation.details?.missing)
+    ? violation.details.missing.map(String).sort()
+    : [];
+  return {
+    command: String(violation.command ?? ''),
+    file: String(violation.file ?? ''),
+    missing,
+  };
+}
+
+function signature(record) {
+  return `${record.command}\0${record.file}\0${record.missing.join('\0')}`;
+}
+
+function sortRecords(records) {
+  return records
+    .map((record) => ({
+      command: String(record.command),
+      file: String(record.file),
+      missing: Array.isArray(record.missing) ? record.missing.map(String).sort() : [],
+    }))
+    .sort((a, b) => signature(a).localeCompare(signature(b)));
+}
+
+function relative(file) {
+  return file.replace(`${PROJECT_ROOT}/`, '');
+}

--- a/scripts/silent-column-drop-baseline.json
+++ b/scripts/silent-column-drop-baseline.json
@@ -1,0 +1,969 @@
+[
+  {
+    "command": "1688/assets",
+    "file": "clis/1688/assets.js",
+    "missing": [
+      "detail_images",
+      "item_url",
+      "main_images",
+      "other_images",
+      "raw_assets",
+      "sku_images",
+      "source",
+      "videos"
+    ]
+  },
+  {
+    "command": "1688/assets",
+    "file": "clis/1688/assets.js",
+    "missing": [
+      "gallery",
+      "href",
+      "offerId",
+      "offerTitle",
+      "scannedAssets"
+    ]
+  },
+  {
+    "command": "1688/download",
+    "file": "clis/1688/download.js",
+    "missing": [
+      "filename",
+      "url"
+    ]
+  },
+  {
+    "command": "1688/item",
+    "file": "clis/1688/item.js",
+    "missing": [
+      "bodyText",
+      "gallery",
+      "href",
+      "offerId",
+      "offerTitle",
+      "seller",
+      "services",
+      "shipping",
+      "trade"
+    ]
+  },
+  {
+    "command": "1688/item",
+    "file": "clis/1688/item.js",
+    "missing": [
+      "currency",
+      "customization_text",
+      "delivery_days_text",
+      "item_url",
+      "main_images",
+      "member_id",
+      "moq_value",
+      "price_tiers",
+      "private_label_text",
+      "sales_text",
+      "seller_url",
+      "service_badges",
+      "shop_id",
+      "shop_name",
+      "stock_quantity",
+      "visible_attributes"
+    ]
+  },
+  {
+    "command": "1688/search",
+    "file": "clis/1688/search.js",
+    "missing": [
+      "badges",
+      "currency",
+      "fetched_at",
+      "moq_value",
+      "price_max",
+      "price_min",
+      "return_rate_text",
+      "sales_text",
+      "seller_url",
+      "shop_id",
+      "source_url",
+      "strategy"
+    ]
+  },
+  {
+    "command": "1688/search",
+    "file": "clis/1688/search.js",
+    "missing": [
+      "bodyText",
+      "candidates",
+      "href",
+      "next_url"
+    ]
+  },
+  {
+    "command": "1688/search",
+    "file": "clis/1688/search.js",
+    "missing": [
+      "container_text",
+      "desc_rows",
+      "hover_items",
+      "hover_price_text",
+      "sales_text",
+      "seller_url",
+      "tag_items"
+    ]
+  },
+  {
+    "command": "1688/store",
+    "file": "clis/1688/store.js",
+    "missing": [
+      "business_model_text",
+      "company_name",
+      "company_url",
+      "factory_badges",
+      "member_id",
+      "mobile_text",
+      "phone_text",
+      "response_rate_text",
+      "service_badges",
+      "shop_id",
+      "staff_size_text",
+      "store_url",
+      "top_categories"
+    ]
+  },
+  {
+    "command": "51job/company",
+    "file": "clis/51job/company.js",
+    "missing": [
+      "cInfoParts",
+      "links",
+      "sidebarText"
+    ]
+  },
+  {
+    "command": "51job/detail",
+    "file": "clis/51job/detail.js",
+    "missing": [
+      "companyTag",
+      "finalUrl",
+      "meta"
+    ]
+  },
+  {
+    "command": "amazon/discussion",
+    "file": "clis/amazon/discussion.js",
+    "missing": [
+      "average_rating_text",
+      "discussion_url",
+      "product_url",
+      "qa_urls",
+      "review_samples",
+      "total_review_count_text"
+    ]
+  },
+  {
+    "command": "amazon/offer",
+    "file": "clis/amazon/offer.js",
+    "missing": [
+      "buybox_text",
+      "href",
+      "merchant_info",
+      "offer_link",
+      "qa_url",
+      "review_url",
+      "ships_from_text",
+      "title"
+    ]
+  },
+  {
+    "command": "amazon/offer",
+    "file": "clis/amazon/offer.js",
+    "missing": [
+      "currency",
+      "merchant_info_text",
+      "offer_listing_url",
+      "price_value",
+      "product_url",
+      "qa_url",
+      "review_url"
+    ]
+  },
+  {
+    "command": "amazon/product",
+    "file": "clis/amazon/product.js",
+    "missing": [
+      "brand_text",
+      "breadcrumbs",
+      "bullet_points",
+      "currency",
+      "price_value",
+      "product_url",
+      "qa_url",
+      "rating_text",
+      "review_count_text",
+      "review_url"
+    ]
+  },
+  {
+    "command": "amazon/product",
+    "file": "clis/amazon/product.js",
+    "missing": [
+      "breadcrumbs",
+      "bullets",
+      "byline",
+      "href",
+      "product_title",
+      "qa_url",
+      "rating_text",
+      "review_count_text",
+      "review_url"
+    ]
+  },
+  {
+    "command": "amazon/search",
+    "file": "clis/amazon/search.js",
+    "missing": [
+      "badge_texts",
+      "href",
+      "rating_text",
+      "review_count_text",
+      "sponsored"
+    ]
+  },
+  {
+    "command": "amazon/search",
+    "file": "clis/amazon/search.js",
+    "missing": [
+      "badges",
+      "currency",
+      "is_sponsored",
+      "price_value",
+      "product_url",
+      "rating_text",
+      "review_count_text"
+    ]
+  },
+  {
+    "command": "band/post",
+    "file": "clis/band/post.js",
+    "missing": [
+      "comments",
+      "photos"
+    ]
+  },
+  {
+    "command": "band/post",
+    "file": "clis/band/post.js",
+    "missing": [
+      "depth"
+    ]
+  },
+  {
+    "command": "band/post",
+    "file": "clis/band/post.js",
+    "missing": [
+      "filename",
+      "url"
+    ]
+  },
+  {
+    "command": "bilibili/download",
+    "file": "clis/bilibili/download.js",
+    "missing": [
+      "author"
+    ]
+  },
+  {
+    "command": "bilibili/feed",
+    "file": "clis/bilibili/feed.js",
+    "missing": [
+      "comments",
+      "itemType"
+    ]
+  },
+  {
+    "command": "binance/depth",
+    "file": "clis/binance/depth.js",
+    "missing": [
+      "select"
+    ]
+  },
+  {
+    "command": "binance/gainers",
+    "file": "clis/binance/gainers.js",
+    "missing": [
+      "sort_change"
+    ]
+  },
+  {
+    "command": "binance/losers",
+    "file": "clis/binance/losers.js",
+    "missing": [
+      "sort_change"
+    ]
+  },
+  {
+    "command": "binance/ticker",
+    "file": "clis/binance/ticker.js",
+    "missing": [
+      "sort_volume"
+    ]
+  },
+  {
+    "command": "binance/top",
+    "file": "clis/binance/top.js",
+    "missing": [
+      "sort_volume"
+    ]
+  },
+  {
+    "command": "bloomberg/news",
+    "file": "clis/bloomberg/news.js",
+    "missing": [
+      "errorCode",
+      "message",
+      "preview"
+    ]
+  },
+  {
+    "command": "bloomberg/news",
+    "file": "clis/bloomberg/news.js",
+    "missing": [
+      "errorCode",
+      "preview"
+    ]
+  },
+  {
+    "command": "boss/resume",
+    "file": "clis/boss/resume.js",
+    "missing": [
+      "activeTime",
+      "jobChatting",
+      "workHistory"
+    ]
+  },
+  {
+    "command": "coupang/search",
+    "file": "clis/coupang/search.js",
+    "missing": [
+      "badge",
+      "category",
+      "deliveryPromise",
+      "deliveryType",
+      "discountRate",
+      "originalPrice",
+      "productId",
+      "reviewCount",
+      "seller",
+      "unitPrice"
+    ]
+  },
+  {
+    "command": "coupang/search",
+    "file": "clis/coupang/search.js",
+    "missing": [
+      "originalPrice",
+      "unitPrice"
+    ]
+  },
+  {
+    "command": "douban/download",
+    "file": "clis/douban/download.js",
+    "missing": [
+      "detail_url",
+      "image_url",
+      "photo_id"
+    ]
+  },
+  {
+    "command": "douban/marks",
+    "file": "clis/douban/marks.js",
+    "missing": [
+      "movieId"
+    ]
+  },
+  {
+    "command": "douban/photos",
+    "file": "clis/douban/photos.js",
+    "missing": [
+      "page",
+      "subject_title",
+      "thumb_url",
+      "type"
+    ]
+  },
+  {
+    "command": "douban/reviews",
+    "file": "clis/douban/reviews.js",
+    "missing": [
+      "createdAt",
+      "movieId",
+      "reviewId"
+    ]
+  },
+  {
+    "command": "hupu/mentions",
+    "file": "clis/hupu/mentions.js",
+    "missing": [
+      "has_next_page",
+      "msg_type",
+      "next_page_str",
+      "topic_id"
+    ]
+  },
+  {
+    "command": "indeed/job",
+    "file": "clis/indeed/job.js",
+    "missing": [
+      "challenge",
+      "jobType",
+      "notFound",
+      "ready"
+    ]
+  },
+  {
+    "command": "indeed/search",
+    "file": "clis/indeed/search.js",
+    "missing": [
+      "jk"
+    ]
+  },
+  {
+    "command": "instagram/note",
+    "file": "clis/instagram/note.js",
+    "missing": [
+      "stage",
+      "text"
+    ]
+  },
+  {
+    "command": "instagram/post",
+    "file": "clis/instagram/post.js",
+    "missing": [
+      "failed",
+      "settled"
+    ]
+  },
+  {
+    "command": "instagram/post",
+    "file": "clis/instagram/post.js",
+    "missing": [
+      "state"
+    ]
+  },
+  {
+    "command": "instagram/reel",
+    "file": "clis/instagram/reel.js",
+    "missing": [
+      "failed",
+      "settled"
+    ]
+  },
+  {
+    "command": "instagram/reel",
+    "file": "clis/instagram/reel.js",
+    "missing": [
+      "state"
+    ]
+  },
+  {
+    "command": "jd/item",
+    "file": "clis/jd/item.js",
+    "missing": [
+      "hasProductMarker",
+      "hasSecurityChallenge",
+      "href",
+      "isLoginPage",
+      "isProductPage",
+      "looksBlocked",
+      "onExpectedItemUrl"
+    ]
+  },
+  {
+    "command": "jianyu/search",
+    "file": "clis/jianyu/search.js",
+    "missing": [
+      "contextText",
+      "date"
+    ]
+  },
+  {
+    "command": "jianyu/search",
+    "file": "clis/jianyu/search.js",
+    "missing": [
+      "detail_reason"
+    ]
+  },
+  {
+    "command": "jianyu/search",
+    "file": "clis/jianyu/search.js",
+    "missing": [
+      "detail_reason",
+      "notice_id",
+      "source_id"
+    ]
+  },
+  {
+    "command": "jike/notifications",
+    "file": "clis/jike/notifications.js",
+    "missing": [
+      "actionType",
+      "fromUser"
+    ]
+  },
+  {
+    "command": "jike/topic",
+    "file": "clis/jike/topic.js",
+    "missing": [
+      "id"
+    ]
+  },
+  {
+    "command": "ke/chengjiao",
+    "file": "clis/ke/chengjiao.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "ke/xiaoqu",
+    "file": "clis/ke/xiaoqu.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "linkedin/timeline",
+    "file": "clis/linkedin/timeline.js",
+    "missing": [
+      "authorUrl",
+      "postedAt"
+    ]
+  },
+  {
+    "command": "linkedin/timeline",
+    "file": "clis/linkedin/timeline.js",
+    "missing": [
+      "id"
+    ]
+  },
+  {
+    "command": "linkedin/timeline",
+    "file": "clis/linkedin/timeline.js",
+    "missing": [
+      "postedAt"
+    ]
+  },
+  {
+    "command": "linux-do/tags",
+    "file": "clis/linux-do/tags.js",
+    "missing": [
+      "id"
+    ]
+  },
+  {
+    "command": "paperreview/review",
+    "file": "clis/paperreview/review.js",
+    "missing": [
+      "message",
+      "token"
+    ]
+  },
+  {
+    "command": "powerchina/search",
+    "file": "clis/powerchina/search.js",
+    "missing": [
+      "contextText",
+      "date"
+    ]
+  },
+  {
+    "command": "producthunt/hot",
+    "file": "clis/producthunt/hot.js",
+    "missing": [
+      "voteCandidates"
+    ]
+  },
+  {
+    "command": "reddit/popular",
+    "file": "clis/reddit/popular.js",
+    "missing": [
+      "author"
+    ]
+  },
+  {
+    "command": "tieba/search",
+    "file": "clis/tieba/search.js",
+    "missing": [
+      "snippet"
+    ]
+  },
+  {
+    "command": "twitter/accept",
+    "file": "clis/twitter/accept.js",
+    "missing": [
+      "href",
+      "idx",
+      "text"
+    ]
+  },
+  {
+    "command": "twitter/bookmarks",
+    "file": "clis/twitter/bookmarks.js",
+    "missing": [
+      "name"
+    ]
+  },
+  {
+    "command": "twitter/download",
+    "file": "clis/twitter/download.js",
+    "missing": [
+      "poster",
+      "url"
+    ]
+  },
+  {
+    "command": "twitter/download",
+    "file": "clis/twitter/download.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "twitter/list-add",
+    "file": "clis/twitter/list-add.js",
+    "missing": [
+      "method",
+      "ts",
+      "url",
+      "via"
+    ]
+  },
+  {
+    "command": "twitter/list-remove",
+    "file": "clis/twitter/list-remove.js",
+    "missing": [
+      "method",
+      "ts",
+      "url"
+    ]
+  },
+  {
+    "command": "twitter/list-tweets",
+    "file": "clis/twitter/list-tweets.js",
+    "missing": [
+      "name"
+    ]
+  },
+  {
+    "command": "twitter/post",
+    "file": "clis/twitter/post.js",
+    "missing": [
+      "actualText"
+    ]
+  },
+  {
+    "command": "twitter/reply-dm",
+    "file": "clis/twitter/reply-dm.js",
+    "missing": [
+      "convId",
+      "href",
+      "idx",
+      "preview"
+    ]
+  },
+  {
+    "command": "twitter/thread",
+    "file": "clis/twitter/thread.js",
+    "missing": [
+      "created_at",
+      "in_reply_to"
+    ]
+  },
+  {
+    "command": "twitter/tweets",
+    "file": "clis/twitter/tweets.js",
+    "missing": [
+      "name"
+    ]
+  },
+  {
+    "command": "uiverse/code",
+    "file": "clis/uiverse/code.js",
+    "missing": [
+      "code",
+      "isTailwind",
+      "postId",
+      "type",
+      "url"
+    ]
+  },
+  {
+    "command": "uiverse/preview",
+    "file": "clis/uiverse/preview.js",
+    "missing": [
+      "matchedClassName",
+      "matchedTag",
+      "postId",
+      "selectorSource",
+      "url",
+      "x",
+      "y"
+    ]
+  },
+  {
+    "command": "v2ex/daily",
+    "file": "clis/v2ex/daily.js",
+    "missing": [
+      "claimed"
+    ]
+  },
+  {
+    "command": "v2ex/daily",
+    "file": "clis/v2ex/daily.js",
+    "missing": [
+      "claimed",
+      "once"
+    ]
+  },
+  {
+    "command": "web/read",
+    "file": "clis/web/read.js",
+    "missing": [
+      "accessible",
+      "index",
+      "sameOrigin",
+      "src",
+      "textLength"
+    ]
+  },
+  {
+    "command": "web/read",
+    "file": "clis/web/read.js",
+    "missing": [
+      "bodyTruncated",
+      "contentType",
+      "method",
+      "url"
+    ]
+  },
+  {
+    "command": "weibo/me",
+    "file": "clis/weibo/me.js",
+    "missing": [
+      "avatar",
+      "description",
+      "profile_url"
+    ]
+  },
+  {
+    "command": "weibo/user",
+    "file": "clis/weibo/user.js",
+    "missing": [
+      "avatar",
+      "birthday",
+      "created_at",
+      "gender",
+      "ip_location",
+      "verified_reason"
+    ]
+  },
+  {
+    "command": "weread/book",
+    "file": "clis/weread/book.js",
+    "missing": [
+      "metadataReady"
+    ]
+  },
+  {
+    "command": "weread/book",
+    "file": "clis/weread/book.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "xianyu/chat",
+    "file": "clis/xianyu/chat.js",
+    "missing": [
+      "can_input",
+      "can_send",
+      "item_url",
+      "peer_masked_id",
+      "requiresAuth",
+      "title",
+      "visible_messages"
+    ]
+  },
+  {
+    "command": "xianyu/item",
+    "file": "clis/xianyu/item.js",
+    "missing": [
+      "browse_count",
+      "category",
+      "collect_count",
+      "description",
+      "image_count",
+      "image_urls",
+      "item_url",
+      "original_price",
+      "reply_interval",
+      "reply_ratio_24h",
+      "seller_id",
+      "seller_score",
+      "seller_url",
+      "status"
+    ]
+  },
+  {
+    "command": "xianyu/search",
+    "file": "clis/xianyu/search.js",
+    "missing": [
+      "extra",
+      "original_price"
+    ]
+  },
+  {
+    "command": "xiaohongshu/creator-note-detail",
+    "file": "clis/xiaohongshu/creator-note-detail.js",
+    "missing": [
+      "label"
+    ]
+  },
+  {
+    "command": "xiaohongshu/creator-notes-summary",
+    "file": "clis/xiaohongshu/creator-notes-summary.js",
+    "missing": [
+      "published_at",
+      "top_interest_pct",
+      "top_source_pct"
+    ]
+  },
+  {
+    "command": "xiaohongshu/creator-notes",
+    "file": "clis/xiaohongshu/creator-notes-summary.js",
+    "missing": [
+      "avg_view_time",
+      "published_at",
+      "rise_fans",
+      "shares",
+      "top_interest",
+      "top_interest_pct",
+      "top_source",
+      "top_source_pct"
+    ]
+  },
+  {
+    "command": "xiaohongshu/download",
+    "file": "clis/xiaohongshu/download.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "xiaohongshu/search",
+    "file": "clis/xiaohongshu/search.js",
+    "missing": [
+      "author_url"
+    ]
+  },
+  {
+    "command": "xueqiu/comments",
+    "file": "clis/xueqiu/comments.js",
+    "missing": [
+      "id"
+    ]
+  },
+  {
+    "command": "xueqiu/earnings-date",
+    "file": "clis/xueqiu/earnings-date.js",
+    "missing": [
+      "_future",
+      "_ts"
+    ]
+  },
+  {
+    "command": "xueqiu/hot-stock",
+    "file": "clis/xueqiu/hot-stock.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "xueqiu/kline",
+    "file": "clis/xueqiu/kline.js",
+    "missing": [
+      "percent",
+      "symbol"
+    ]
+  },
+  {
+    "command": "xueqiu/watchlist",
+    "file": "clis/xueqiu/watchlist.js",
+    "missing": [
+      "change",
+      "url",
+      "volume"
+    ]
+  },
+  {
+    "command": "yahoo-finance/quote",
+    "file": "clis/yahoo-finance/quote.js",
+    "missing": [
+      "currency",
+      "exchange"
+    ]
+  },
+  {
+    "command": "yollomi/upload",
+    "file": "clis/yollomi/upload.js",
+    "missing": [
+      "data"
+    ]
+  },
+  {
+    "command": "youtube/playlist",
+    "file": "clis/youtube/playlist.js",
+    "missing": [
+      "channelName",
+      "stats",
+      "videos"
+    ]
+  },
+  {
+    "command": "youtube/watch-later",
+    "file": "clis/youtube/watch-later.js",
+    "missing": [
+      "stats",
+      "videos"
+    ]
+  },
+  {
+    "command": "zhihu/hot",
+    "file": "clis/zhihu/hot.js",
+    "missing": [
+      "answer_count",
+      "follower_count",
+      "url"
+    ]
+  },
+  {
+    "command": "zhihu/hot",
+    "file": "clis/zhihu/hot.js",
+    "missing": [
+      "url"
+    ]
+  },
+  {
+    "command": "zhihu/search",
+    "file": "clis/zhihu/search.js",
+    "missing": [
+      "excerpt"
+    ]
+  },
+  {
+    "command": "zsxq/groups",
+    "file": "clis/zsxq/groups.js",
+    "missing": [
+      "valid_until"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add `scripts/check-silent-column-drop.mjs` as a baseline-mode CI gate for new silent-column-drop findings
- add `scripts/silent-column-drop-baseline.json` from the current convention-audit output so existing findings do not block adoption
- wire `npm run check:silent-column-drop` into the Linux build job after manifest/listing gates
- document baseline update flow in the convention-audit docs

## Verification
- `npm run build`
- `npm run typecheck`
- `npx vitest run src/convention-audit.test.ts src/cli.test.ts --project unit`
- `npm run docs:build`
- `npm run check:silent-column-drop`
- `npm run check:listing-id-pairing`

## Stack
This PR is stacked on #1306 / `feat/convention-audit` because it reuses `dist/src/convention-audit.js`. After #1306 merges, rebase/retarget this PR onto `main`.