### PR TITLE
feat(dianping): browser adapter — search + shop on www.dianping.com

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5124,6 +5124,81 @@
     "sourceFile": "devto/user.js"
   },
   {
+    "site": "dianping",
+    "name": "search",
+    "description": "大众点评店铺搜索（按关键词 + 城市）",
+    "access": "read",
+    "domain": "www.dianping.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "搜索关键词，例如 \"火锅\""
+      },
+      {
+        "name": "city",
+        "type": "str",
+        "required": false,
+        "help": "城市名（北京/上海/beijing/...）或 cityId 数字。不传则使用 cookie 默认城市"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 15,
+        "required": false,
+        "help": "返回的店铺数量（最多 15，dianping 单页固定 15 条）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "shop_id",
+      "name",
+      "rating",
+      "reviews",
+      "price",
+      "cuisine",
+      "district",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dianping/search.js",
+    "sourceFile": "dianping/search.js",
+    "navigateBefore": "https://www.dianping.com"
+  },
+  {
+    "site": "dianping",
+    "name": "shop",
+    "aliases": [
+      "detail"
+    ],
+    "description": "大众点评店铺详情（按 shop_id）",
+    "access": "read",
+    "domain": "www.dianping.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "shop_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "店铺 ID（来自 search 的 shop_id 列，或 https://www.dianping.com/shop/<id> URL 段）"
+      }
+    ],
+    "columns": [
+      "field",
+      "value"
+    ],
+    "type": "js",
+    "modulePath": "dianping/shop.js",
+    "sourceFile": "dianping/shop.js",
+    "navigateBefore": "https://www.dianping.com"
+  },
+  {
     "site": "dictionary",
     "name": "examples",
     "description": "Read real-world example sentences utilizing the word",

--- a/clis/dianping/dianping.test.js
+++ b/clis/dianping/dianping.test.js
@@ -172,6 +172,14 @@ describe('dianping adapter — search runtime', () => {
             ok: true,
             rows: [{ rank: 1, shop_id: '', name: '火锅店' }],
         }), { keyword: '火锅', city: 2 })).rejects.toThrow(CommandExecutionError);
+
+        await expect(command.func(createPageMock({
+            ok: true,
+            rows: [
+                { rank: 1, shop_id: 'GxJZ4urc9TnKE3kY', name: '火锅店' },
+                { rank: 2, shop_id: '', name: '缺 id 火锅店' },
+            ],
+        }), { keyword: '火锅', city: 2, limit: 2 })).rejects.toThrow(CommandExecutionError);
     });
 
     it('wraps browser navigation and evaluate failures as CommandExecutionError', async () => {

--- a/clis/dianping/dianping.test.js
+++ b/clis/dianping/dianping.test.js
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    SEARCH_COLUMNS,
+    SHOP_COLUMNS,
+    detectAuthOrPageFailure,
+    normalizeShopId,
+    parsePrice,
+    parseReviewCount,
+    requireSearchLimit,
+    resolveCityId,
+} from './utils.js';
+import './search.js';
+import './shop.js';
+
+function createPageMock(evaluateResult, overrides = {}) {
+    const evaluate = typeof evaluateResult === 'function'
+        ? vi.fn(evaluateResult)
+        : vi.fn().mockResolvedValue(evaluateResult);
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate,
+        ...overrides,
+    };
+}
+
+describe('dianping adapter — registration', () => {
+    it('registers search and shop as cookie-browser read commands', () => {
+        const search = getRegistry().get('dianping/search');
+        const shop = getRegistry().get('dianping/shop');
+        const detail = getRegistry().get('dianping/detail');
+
+        expect(search).toBeDefined();
+        expect(search.browser).toBe(true);
+        expect(search.strategy).toBe('cookie');
+        expect(search.columns).toEqual(SEARCH_COLUMNS);
+
+        expect(shop).toBeDefined();
+        expect(shop.browser).toBe(true);
+        expect(shop.strategy).toBe('cookie');
+        expect(shop.columns).toEqual(SHOP_COLUMNS);
+        expect(detail).toBe(shop);
+    });
+});
+
+describe('dianping adapter — helpers', () => {
+    it('validates search limit for direct func callers', () => {
+        expect(requireSearchLimit(undefined)).toBe(15);
+        expect(requireSearchLimit('5')).toBe(5);
+        expect(requireSearchLimit(15)).toBe(15);
+        expect(() => requireSearchLimit('abc')).toThrow(ArgumentError);
+        expect(() => requireSearchLimit('1.5')).toThrow(ArgumentError);
+        expect(() => requireSearchLimit(0)).toThrow(ArgumentError);
+        expect(() => requireSearchLimit(16)).toThrow(ArgumentError);
+    });
+
+    it('normalizes city, shop id, review count, and price inputs', () => {
+        expect(resolveCityId('北京')).toBe(2);
+        expect(resolveCityId('shanghai')).toBe(1);
+        expect(resolveCityId('dalian')).toBe(19);
+        expect(resolveCityId('shenyang')).toBe(18);
+        expect(resolveCityId('123')).toBe(123);
+        expect(resolveCityId('')).toBeNull();
+        expect(() => resolveCityId('not-a-city')).toThrow(ArgumentError);
+
+        expect(normalizeShopId('https://www.dianping.com/shop/GxJZ4urc9TnKE3kY?foo=1')).toBe('GxJZ4urc9TnKE3kY');
+        expect(normalizeShopId('GxJZ4urc9TnKE3kY')).toBe('GxJZ4urc9TnKE3kY');
+        expect(() => normalizeShopId('bad/id')).toThrow(ArgumentError);
+
+        expect(parseReviewCount('1.2万条')).toBe(12000);
+        expect(parseReviewCount('213 条评价')).toBe(213);
+        expect(parseReviewCount('暂无')).toBeNull();
+        expect(parsePrice('人均￥109')).toBe(109);
+        expect(parsePrice('暂无')).toBeNull();
+    });
+
+    it('classifies captcha, login, explicit empty, and unknown no-data pages', () => {
+        expect(() => detectAuthOrPageFailure({ url: 'https://verify.meituan.com/captcha' }, 'search'))
+            .toThrow(AuthRequiredError);
+        expect(() => detectAuthOrPageFailure({ text: '请先登录后继续访问' }, 'search'))
+            .toThrow(AuthRequiredError);
+        expect(() => detectAuthOrPageFailure(
+            { text: '没有找到相关商户' },
+            'search',
+            { emptyPatterns: [/没有找到相关商户/] },
+        )).toThrow(EmptyResultError);
+        expect(() => detectAuthOrPageFailure({ text: '<html>unexpected shell</html>' }, 'search'))
+            .toThrow(CommandExecutionError);
+    });
+});
+
+describe('dianping adapter — search runtime', () => {
+    const command = getRegistry().get('dianping/search');
+
+    it('fails fast on invalid args before browser work', async () => {
+        const page = createPageMock({ ok: true, rows: [] });
+
+        await expect(command.func(page, { keyword: '   ', limit: 5 })).rejects.toThrow(ArgumentError);
+        await expect(command.func(page, { keyword: '火锅', limit: 'abc' })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('returns normalized rows for happy search results', async () => {
+        const page = createPageMock({
+            ok: true,
+            rows: [{
+                rank: 1,
+                shop_id: 'GxJZ4urc9TnKE3kY',
+                name: '  火锅店  ',
+                starClass: '45',
+                reviewsRaw: '1.2万条',
+                priceRaw: '人均￥109',
+                cuisine: '重庆火锅',
+                district: '海淀区',
+                url: 'https://www.dianping.com/shop/GxJZ4urc9TnKE3kY',
+            }],
+        });
+
+        const rows = await command.func(page, { keyword: '火锅', city: '北京', limit: '1' });
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.dianping.com/search/keyword/2/0_%E7%81%AB%E9%94%85');
+        expect(page.wait).toHaveBeenCalledWith(2);
+        expect(rows).toEqual([{
+            rank: 1,
+            shop_id: 'GxJZ4urc9TnKE3kY',
+            name: '  火锅店  ',
+            rating: 4.5,
+            reviews: 12000,
+            price: 109,
+            cuisine: '重庆火锅',
+            district: '海淀区',
+            url: 'https://www.dianping.com/shop/GxJZ4urc9TnKE3kY',
+        }]);
+    });
+
+    it('maps explicit zero-result pages to EmptyResultError', async () => {
+        const page = createPageMock({
+            ok: false,
+            sample: '没有找到相关商户，换个关键词试试',
+            url: 'https://www.dianping.com/search/keyword/2/0_x',
+        });
+
+        await expect(command.func(page, { keyword: 'zzzxxyy', city: '北京' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps captcha pages to AuthRequiredError', async () => {
+        const page = createPageMock({
+            ok: false,
+            sample: '请依次点击图中图标完成身份核实',
+            url: 'https://verify.meituan.com/v2/web/general_page',
+        });
+
+        await expect(command.func(page, { keyword: '火锅' })).rejects.toThrow(AuthRequiredError);
+    });
+
+    it('maps selector drift and missing shop ids to CommandExecutionError', async () => {
+        await expect(command.func(createPageMock({
+            ok: false,
+            sample: '<main>unexpected dianping layout</main>',
+            url: 'https://www.dianping.com/search/keyword/2/0_x',
+        }), { keyword: '火锅', city: 2 })).rejects.toThrow(CommandExecutionError);
+
+        await expect(command.func(createPageMock({
+            ok: true,
+            rows: [{ rank: 1, shop_id: '', name: '火锅店' }],
+        }), { keyword: '火锅', city: 2 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('wraps browser navigation and evaluate failures as CommandExecutionError', async () => {
+        await expect(command.func(createPageMock(
+            { ok: true, rows: [] },
+            { goto: vi.fn().mockRejectedValue(new Error('browser disconnected')) },
+        ), { keyword: '火锅' })).rejects.toThrow(CommandExecutionError);
+
+        await expect(command.func(createPageMock(() => {
+            throw new Error('evaluate failed');
+        }), { keyword: '火锅' })).rejects.toThrow(CommandExecutionError);
+    });
+});
+
+describe('dianping adapter — shop runtime', () => {
+    const command = getRegistry().get('dianping/shop');
+
+    it('fails fast on invalid shop id before browser work', async () => {
+        const page = createPageMock({ ok: true });
+
+        await expect(command.func(page, { shop_id: '' })).rejects.toThrow(ArgumentError);
+        await expect(command.func(page, { shop_id: 'bad/id' })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('returns a field/value sheet and accepts a full shop URL', async () => {
+        const page = createPageMock({
+            ok: true,
+            name: '火锅店',
+            rating: '4.8',
+            reviewsRaw: '321条',
+            priceRaw: '￥109',
+            breakdown: { '口味': 4.9, '环境': 4.7, '服务': 4.6 },
+            features: ['可停车', '有包间'],
+            address: '北京市海淀区',
+            subway: '距地铁步行300m',
+            hours: '营业中 11:00-22:00',
+            rank: '海淀区 口味榜 · 第1名',
+            url: 'https://www.dianping.com/shop/GxJZ4urc9TnKE3kY',
+        });
+
+        const rows = await command.func(page, {
+            shop_id: 'https://www.dianping.com/shop/GxJZ4urc9TnKE3kY?foo=1',
+        });
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.dianping.com/shop/GxJZ4urc9TnKE3kY');
+        expect(rows).toContainEqual({ field: 'shop_id', value: 'GxJZ4urc9TnKE3kY' });
+        expect(rows).toContainEqual({ field: 'rating', value: 4.8 });
+        expect(rows).toContainEqual({ field: 'reviews', value: 321 });
+        expect(rows).toContainEqual({ field: 'price', value: 109 });
+        expect(rows).toContainEqual({ field: 'taste', value: 4.9 });
+        expect(rows).toContainEqual({ field: 'ingredients', value: null });
+        expect(rows).toContainEqual({ field: 'features', value: '可停车, 有包间' });
+    });
+
+    it('maps captcha, not-found, and selector drift to distinct typed errors', async () => {
+        await expect(command.func(createPageMock({
+            ok: false,
+            sample: '身份核实 请依次点击',
+            url: 'https://verify.meituan.com/v2/web/general_page',
+        }), { shop_id: 'GxJZ4urc9TnKE3kY' })).rejects.toThrow(AuthRequiredError);
+
+        await expect(command.func(createPageMock({
+            ok: false,
+            sample: '商户不存在或店铺已关闭',
+            url: 'https://www.dianping.com/shop/missing',
+        }), { shop_id: 'missing' })).rejects.toThrow(EmptyResultError);
+
+        await expect(command.func(createPageMock({
+            ok: false,
+            sample: '<main>new shop shell without expected selectors</main>',
+            url: 'https://www.dianping.com/shop/GxJZ4urc9TnKE3kY',
+        }), { shop_id: 'GxJZ4urc9TnKE3kY' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('wraps browser navigation and evaluate failures as CommandExecutionError', async () => {
+        await expect(command.func(createPageMock(
+            { ok: true },
+            { goto: vi.fn().mockRejectedValue(new Error('browser disconnected')) },
+        ), { shop_id: 'GxJZ4urc9TnKE3kY' })).rejects.toThrow(CommandExecutionError);
+
+        await expect(command.func(createPageMock(() => {
+            throw new Error('evaluate failed');
+        }), { shop_id: 'GxJZ4urc9TnKE3kY' })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/dianping/search.js
+++ b/clis/dianping/search.js
@@ -62,6 +62,10 @@ cli({
                 }
                 const rows = [];
                 items.forEach((el, i) => {
+                    const resultShape = el.querySelector('.tit h4, .review-num, .mean-price, .tag-addr')
+                        || el.querySelector('.tit a, a[data-shopid], a[href*="/shop/"]');
+                    if (!resultShape) return;
+
                     const link = el.querySelector('.tit a[href*="/shop/"]')
                         || el.querySelector('a[data-shopid]')
                         || el.querySelector('a[href*="/shop/"]');
@@ -110,11 +114,12 @@ cli({
             );
         }
 
-        const rows = (result.rows || [])
-            .filter((row) => row?.shop_id)
-            .slice(0, limit);
+        const rows = (result.rows || []).slice(0, limit);
         if (rows.length === 0) {
-            throw new CommandExecutionError('dianping search parser found result cards but no shop_id values');
+            throw new CommandExecutionError('dianping search parser found no result-shaped shop cards');
+        }
+        if (rows.some((row) => !row?.shop_id)) {
+            throw new CommandExecutionError('dianping search parser found result cards without shop_id values');
         }
         return rows.map((r) => ({
             rank: r.rank,

--- a/clis/dianping/search.js
+++ b/clis/dianping/search.js
@@ -1,0 +1,121 @@
+/**
+ * dianping search — search shops/restaurants by keyword on a given city.
+ *
+ * Targets www.dianping.com (PC site). The PC site renders search results
+ * server-side, so the func only needs to parse the SSR DOM after navigate.
+ * m.dianping.com (mobile) is intentionally crippled for non-mobile UAs and
+ * does not return data without app installation, so it's not used.
+ */
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { detectAuthOrEmpty, parsePrice, parseReviewCount, resolveCityId } from './utils.js';
+
+cli({
+    site: 'dianping',
+    name: 'search',
+    access: 'read',
+    description: '大众点评店铺搜索（按关键词 + 城市）',
+    domain: 'www.dianping.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'keyword', required: true, positional: true, help: '搜索关键词，例如 "火锅"' },
+        { name: 'city', help: '城市名（北京/上海/beijing/...）或 cityId 数字。不传则使用 cookie 默认城市' },
+        { name: 'limit', type: 'int', default: 15, help: '返回的店铺数量（最多 15，dianping 单页固定 15 条）' },
+    ],
+    columns: ['rank', 'shop_id', 'name', 'rating', 'reviews', 'price', 'cuisine', 'district', 'url'],
+    func: async (page, kwargs) => {
+        const keyword = String(kwargs.keyword || '').trim();
+        if (!keyword) throw new ArgumentError('keyword', 'must be a non-empty string');
+
+        const limit = Number(kwargs.limit) || 15;
+        if (limit < 1 || limit > 15) {
+            throw new ArgumentError('limit', 'must be between 1 and 15 (dianping single page)');
+        }
+
+        const cityId = resolveCityId(kwargs.city);
+        const path = cityId
+            ? `/search/keyword/${cityId}/0_${encodeURIComponent(keyword)}`
+            : `/search/keyword/0/0_${encodeURIComponent(keyword)}`;
+        const url = `https://www.dianping.com${path}`;
+
+        await page.goto(url);
+        await page.wait(2);
+
+        const result = await page.evaluate(`
+            (() => {
+                const items = document.querySelectorAll('#shop-all-list li');
+                if (items.length === 0) {
+                    return {
+                        ok: false,
+                        bodyLen: document.body.innerText.length,
+                        sample: document.body.innerText.slice(0, 800),
+                        url: location.href,
+                    };
+                }
+                const rows = [];
+                items.forEach((el, i) => {
+                    const link = el.querySelector('.tit a[href*="/shop/"]')
+                        || el.querySelector('a[data-shopid]')
+                        || el.querySelector('a[href*="/shop/"]');
+                    const shopId = link?.getAttribute('data-shopid')
+                        || (link?.getAttribute('href') || '').match(/\\/shop\\/([^?#/]+)/)?.[1]
+                        || '';
+                    const name = el.querySelector('.tit h4')?.textContent?.trim()
+                        || link?.getAttribute('title')
+                        || '';
+                    const reviewsRaw = el.querySelector('.review-num b')?.textContent?.trim() || '';
+                    const priceRaw = el.querySelector('.mean-price b')?.textContent?.trim() || '';
+                    const tagAddr = Array.from(el.querySelectorAll('.tag-addr .tag'))
+                        .map((t) => t.textContent.trim())
+                        .filter(Boolean);
+                    let starClass = '';
+                    const starWrap = el.querySelector('.nebula_star');
+                    if (starWrap) {
+                        const m = starWrap.outerHTML.match(/star_(\\d{2})/g);
+                        if (m && m.length) {
+                            const last = m[m.length - 1];
+                            const lastDigits = last.match(/star_(\\d{2})/)[1];
+                            starClass = lastDigits;
+                        }
+                    }
+                    rows.push({
+                        rank: i + 1,
+                        shop_id: shopId,
+                        name,
+                        starClass,
+                        reviewsRaw,
+                        priceRaw,
+                        cuisine: tagAddr[0] || '',
+                        district: tagAddr[1] || '',
+                        url: shopId ? 'https://www.dianping.com/shop/' + shopId : '',
+                    });
+                });
+                return { ok: true, rows };
+            })()
+        `);
+
+        if (!result || !result.ok) {
+            detectAuthOrEmpty(
+                { text: String(result?.sample || ''), url: String(result?.url || url) },
+                `search "${keyword}"`,
+            );
+        }
+
+        const rows = (result.rows || []).slice(0, limit);
+        if (rows.length === 0) {
+            detectAuthOrEmpty({ text: '', url }, `search "${keyword}"`);
+        }
+        return rows.map((r) => ({
+            rank: r.rank,
+            shop_id: r.shop_id,
+            name: r.name,
+            rating: r.starClass ? Number((Number(r.starClass) / 10).toFixed(1)) : null,
+            reviews: parseReviewCount(r.reviewsRaw),
+            price: parsePrice(r.priceRaw),
+            cuisine: r.cuisine,
+            district: r.district,
+            url: r.url,
+        }));
+    },
+});

--- a/clis/dianping/search.js
+++ b/clis/dianping/search.js
@@ -8,8 +8,16 @@
  */
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError } from '@jackwener/opencli/errors';
-import { detectAuthOrEmpty, parsePrice, parseReviewCount, resolveCityId } from './utils.js';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    SEARCH_COLUMNS,
+    detectAuthOrPageFailure,
+    parsePrice,
+    parseReviewCount,
+    requireSearchLimit,
+    resolveCityId,
+    wrapDianpingStep,
+} from './utils.js';
 
 cli({
     site: 'dianping',
@@ -23,15 +31,12 @@ cli({
         { name: 'city', help: '城市名（北京/上海/beijing/...）或 cityId 数字。不传则使用 cookie 默认城市' },
         { name: 'limit', type: 'int', default: 15, help: '返回的店铺数量（最多 15，dianping 单页固定 15 条）' },
     ],
-    columns: ['rank', 'shop_id', 'name', 'rating', 'reviews', 'price', 'cuisine', 'district', 'url'],
+    columns: SEARCH_COLUMNS,
     func: async (page, kwargs) => {
         const keyword = String(kwargs.keyword || '').trim();
         if (!keyword) throw new ArgumentError('keyword', 'must be a non-empty string');
 
-        const limit = Number(kwargs.limit) || 15;
-        if (limit < 1 || limit > 15) {
-            throw new ArgumentError('limit', 'must be between 1 and 15 (dianping single page)');
-        }
+        const limit = requireSearchLimit(kwargs.limit);
 
         const cityId = resolveCityId(kwargs.city);
         const path = cityId
@@ -39,10 +44,12 @@ cli({
             : `/search/keyword/0/0_${encodeURIComponent(keyword)}`;
         const url = `https://www.dianping.com${path}`;
 
-        await page.goto(url);
-        await page.wait(2);
+        await wrapDianpingStep(`search "${keyword}" navigation`, async () => {
+            await page.goto(url);
+            await page.wait(2);
+        });
 
-        const result = await page.evaluate(`
+        const result = await wrapDianpingStep(`search "${keyword}" extraction`, () => page.evaluate(`
             (() => {
                 const items = document.querySelectorAll('#shop-all-list li');
                 if (items.length === 0) {
@@ -93,18 +100,21 @@ cli({
                 });
                 return { ok: true, rows };
             })()
-        `);
+        `));
 
         if (!result || !result.ok) {
-            detectAuthOrEmpty(
+            detectAuthOrPageFailure(
                 { text: String(result?.sample || ''), url: String(result?.url || url) },
                 `search "${keyword}"`,
+                { emptyPatterns: [/没有找到|暂无结果|暂无商户|换个关键词|未找到相关/i] },
             );
         }
 
-        const rows = (result.rows || []).slice(0, limit);
+        const rows = (result.rows || [])
+            .filter((row) => row?.shop_id)
+            .slice(0, limit);
         if (rows.length === 0) {
-            detectAuthOrEmpty({ text: '', url }, `search "${keyword}"`);
+            throw new CommandExecutionError('dianping search parser found result cards but no shop_id values');
         }
         return rows.map((r) => ({
             rank: r.rank,

--- a/clis/dianping/shop.js
+++ b/clis/dianping/shop.js
@@ -1,0 +1,127 @@
+/**
+ * dianping shop — read shop detail by shop ID (the alphanumeric handle in
+ * `https://www.dianping.com/shop/<shop_id>`).
+ *
+ * Returns a key/value sheet so the table view stays readable when fields
+ * are absent (phone is hidden on PC web — only shows in app — so the row
+ * surfaces it as `null` rather than fabricating).
+ */
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { detectAuthOrEmpty, parsePrice, parseReviewCount } from './utils.js';
+
+cli({
+    site: 'dianping',
+    name: 'shop',
+    access: 'read',
+    aliases: ['detail'],
+    description: '大众点评店铺详情（按 shop_id）',
+    domain: 'www.dianping.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'shop_id', required: true, positional: true, help: '店铺 ID（来自 search 的 shop_id 列，或 https://www.dianping.com/shop/<id> URL 段）' },
+    ],
+    columns: ['field', 'value'],
+    func: async (page, kwargs) => {
+        const raw = String(kwargs.shop_id || '').trim();
+        if (!raw) throw new ArgumentError('shop_id', 'must be a non-empty string');
+
+        const idMatch = raw.match(/\/shop\/([^?#/]+)/);
+        const shopId = idMatch ? idMatch[1] : raw;
+        if (!/^[A-Za-z0-9_-]+$/.test(shopId)) {
+            throw new ArgumentError('shop_id', `'${raw}' does not look like a dianping shop id`);
+        }
+
+        const url = `https://www.dianping.com/shop/${shopId}`;
+        await page.goto(url);
+        await page.wait(3);
+
+        const data = await page.evaluate(`
+            (() => {
+                const head = document.querySelector('.shop-head');
+                if (!head) {
+                    return {
+                        ok: false,
+                        bodyLen: document.body.innerText.length,
+                        sample: document.body.innerText.slice(0, 800),
+                        url: location.href,
+                    };
+                }
+                const headText = head.textContent.trim().replace(/\\s+/g, ' ');
+                const titleEl = document.querySelector('.shop-name, .shop-head h2, .shop-head h1');
+                const name = titleEl?.textContent?.trim() || (document.title || '').split(/[\\[\\]]/)[1] || '';
+                const ratingText = document.querySelector('.star-score')?.textContent?.trim() || '';
+                const features = Array.from(document.querySelectorAll('.shop-feature')).map((f) => f.textContent.trim()).filter(Boolean);
+                const address = document.querySelector('.desc-info')?.textContent?.trim() || '';
+                const subwayMatch = headText.match(/距(?:地铁)?[^\\s]+?步行\\d+m/);
+                const subway = subwayMatch ? subwayMatch[0] : '';
+
+                // Shop-head text holds price + cuisine + district + rank.
+                const priceMatch = headText.match(/[¥￥]\\s*\\d+(?:\\.\\d+)?/);
+                const reviewsMatch = headText.match(/(\\d+(?:[\\.,]\\d+)?(?:万)?)\\s*条/);
+
+                // Try to read score breakdown ("口味:4.8 环境:4.8 服务:4.8 食材:4.9").
+                const breakdown = {};
+                const breakKeys = ['口味', '环境', '服务', '食材'];
+                for (const key of breakKeys) {
+                    const m = headText.match(new RegExp(key + '[:：]\\\\s*([0-9.]+)'));
+                    if (m) breakdown[key] = Number(m[1]);
+                }
+
+                // Hours: "营业中 11:00-次日02:00" / "今日休息".
+                const hoursMatch = headText.match(/营业中[^\\s]*\\d{1,2}:\\d{2}-(?:次日)?\\d{1,2}:\\d{2}|今日休息|暂停营业/);
+
+                // Rank line: "海淀区 重庆火锅 口味榜 · 第1名".
+                const rankMatch = headText.match(/[^\\s]+?(?:口味|人气|环境|服务)榜\\s*[·•]\\s*第\\d+名/);
+
+                return {
+                    ok: true,
+                    name,
+                    rating: ratingText,
+                    reviewsRaw: reviewsMatch?.[1] || '',
+                    priceRaw: priceMatch?.[0] || '',
+                    breakdown,
+                    features,
+                    address,
+                    subway,
+                    hours: hoursMatch?.[0] || '',
+                    rank: rankMatch?.[0] || '',
+                    url: location.href,
+                };
+            })()
+        `);
+
+        if (!data || !data.ok) {
+            detectAuthOrEmpty(
+                { text: String(data?.sample || ''), url: String(data?.url || url) },
+                `shop ${shopId}`,
+            );
+        }
+
+        const rating = data.rating ? Number(data.rating) : null;
+        const reviews = parseReviewCount(data.reviewsRaw);
+        const price = parsePrice(data.priceRaw);
+        const breakdown = data.breakdown || {};
+
+        const fields = [
+            ['shop_id', shopId],
+            ['name', data.name || ''],
+            ['rating', Number.isFinite(rating) ? rating : null],
+            ['reviews', reviews],
+            ['price', price],
+            ['rank', data.rank || ''],
+            ['taste', Number.isFinite(breakdown['口味']) ? breakdown['口味'] : null],
+            ['environment', Number.isFinite(breakdown['环境']) ? breakdown['环境'] : null],
+            ['service', Number.isFinite(breakdown['服务']) ? breakdown['服务'] : null],
+            ['ingredients', Number.isFinite(breakdown['食材']) ? breakdown['食材'] : null],
+            ['hours', data.hours || ''],
+            ['address', data.address || ''],
+            ['subway', data.subway || ''],
+            ['features', (data.features || []).join(', ')],
+            ['url', data.url || url],
+        ];
+
+        return fields.map(([field, value]) => ({ field, value }));
+    },
+});

--- a/clis/dianping/shop.js
+++ b/clis/dianping/shop.js
@@ -8,8 +8,14 @@
  */
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError } from '@jackwener/opencli/errors';
-import { detectAuthOrEmpty, parsePrice, parseReviewCount } from './utils.js';
+import {
+    SHOP_COLUMNS,
+    detectAuthOrPageFailure,
+    normalizeShopId,
+    parsePrice,
+    parseReviewCount,
+    wrapDianpingStep,
+} from './utils.js';
 
 cli({
     site: 'dianping',
@@ -22,22 +28,17 @@ cli({
     args: [
         { name: 'shop_id', required: true, positional: true, help: '店铺 ID（来自 search 的 shop_id 列，或 https://www.dianping.com/shop/<id> URL 段）' },
     ],
-    columns: ['field', 'value'],
+    columns: SHOP_COLUMNS,
     func: async (page, kwargs) => {
-        const raw = String(kwargs.shop_id || '').trim();
-        if (!raw) throw new ArgumentError('shop_id', 'must be a non-empty string');
-
-        const idMatch = raw.match(/\/shop\/([^?#/]+)/);
-        const shopId = idMatch ? idMatch[1] : raw;
-        if (!/^[A-Za-z0-9_-]+$/.test(shopId)) {
-            throw new ArgumentError('shop_id', `'${raw}' does not look like a dianping shop id`);
-        }
+        const shopId = normalizeShopId(kwargs.shop_id);
 
         const url = `https://www.dianping.com/shop/${shopId}`;
-        await page.goto(url);
-        await page.wait(3);
+        await wrapDianpingStep(`shop ${shopId} navigation`, async () => {
+            await page.goto(url);
+            await page.wait(3);
+        });
 
-        const data = await page.evaluate(`
+        const data = await wrapDianpingStep(`shop ${shopId} extraction`, () => page.evaluate(`
             (() => {
                 const head = document.querySelector('.shop-head');
                 if (!head) {
@@ -90,12 +91,13 @@ cli({
                     url: location.href,
                 };
             })()
-        `);
+        `));
 
         if (!data || !data.ok) {
-            detectAuthOrEmpty(
+            detectAuthOrPageFailure(
                 { text: String(data?.sample || ''), url: String(data?.url || url) },
                 `shop ${shopId}`,
+                { emptyPatterns: [/商户不存在|店铺不存在|店铺已关闭|页面不存在|404|已下线|没有找到相关商户/i] },
             );
         }
 

--- a/clis/dianping/utils.js
+++ b/clis/dianping/utils.js
@@ -1,0 +1,110 @@
+/**
+ * Shared helpers for dianping (大众点评) adapters.
+ *
+ * Mobile m.dianping.com is intentionally crippled to push users to the
+ * native app — body renders as 2 chars when probed from desktop UA.
+ * www.dianping.com (PC site) returns the full search HTML server-side
+ * and does NOT require JS hydration, so adapters target it directly.
+ */
+
+import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+
+/**
+ * Common Chinese cities → dianping cityId.
+ * Source: dianping.com /citylist URL structure (cityId is the integer in
+ * the search path: /search/keyword/{cityId}/0_keyword).
+ */
+export const CITY_ID = {
+    beijing: 2, '北京': 2,
+    shanghai: 1, '上海': 1,
+    guangzhou: 4, '广州': 4,
+    shenzhen: 7, '深圳': 7,
+    hangzhou: 3, '杭州': 3,
+    chengdu: 8, '成都': 8,
+    chongqing: 9, '重庆': 9,
+    nanjing: 5, '南京': 5,
+    suzhou: 6, '苏州': 6,
+    xian: 17, '西安': 17,
+    wuhan: 16, '武汉': 16,
+    tianjin: 10, '天津': 10,
+    qingdao: 21, '青岛': 21,
+    changsha: 344, '长沙': 344,
+    dalian: 18, '大连': 18,
+    shenyang: 18, '沈阳': 18,
+    kunming: 25, '昆明': 25,
+    fuzhou: 110, '福州': 110,
+    xiamen: 14, '厦门': 14,
+    hefei: 26, '合肥': 26,
+};
+
+/**
+ * Resolve a city argument (name or id) to a numeric cityId.
+ * Returns null when the cookie's default city should be used.
+ */
+export function resolveCityId(cityArg) {
+    if (cityArg == null || cityArg === '') return null;
+    const raw = String(cityArg).trim().toLowerCase();
+    if (/^\d+$/.test(raw)) return Number(raw);
+    const id = CITY_ID[raw];
+    if (!id) {
+        const names = Object.keys(CITY_ID).filter((k) => /^[a-z]+$/.test(k)).join(', ');
+        throw new ArgumentError(
+            'city',
+            `unknown city '${cityArg}'. pass a numeric cityId or one of: ${names}`,
+        );
+    }
+    return id;
+}
+
+/**
+ * Throw the right typed error for a dianping page that didn't render data.
+ * The site short-circuits HTML when bot/login checks trip — typically
+ * redirects to verify.meituan.com (Yoda icon-tap captcha) or to a login
+ * page when the cookie is missing.
+ */
+export function detectAuthOrEmpty({ text = '', url = '' }, contextHint) {
+    if (/verify\.meituan\.com|verifyimg|身份核实|请依次点击/.test(url + ' ' + text)) {
+        throw new AuthRequiredError(
+            'dianping.com',
+            `dianping ${contextHint} blocked by captcha — open ${url || 'www.dianping.com'} manually in this profile and solve the captcha, then retry`,
+        );
+    }
+    if (/login\.dianping\.com|account\.dianping\.com|请先登录|未登录|请登录/.test(url + ' ' + text)) {
+        throw new AuthRequiredError(
+            'dianping.com',
+            `dianping ${contextHint} requires login — sign in to dianping.com in this profile, then retry`,
+        );
+    }
+    throw new EmptyResultError(`dianping ${contextHint}`);
+}
+
+/**
+ * Parse "21231" / "1.2万" review-count strings into integers.
+ * Returns null when the input has no parseable digits.
+ */
+export function parseReviewCount(raw) {
+    if (raw == null) return null;
+    const s = String(raw).trim();
+    if (!s) return null;
+    const wanMatch = s.match(/^([\d.]+)\s*万/);
+    if (wanMatch) {
+        const n = Number(wanMatch[1]);
+        return Number.isFinite(n) ? Math.round(n * 10000) : null;
+    }
+    const plainMatch = s.match(/(\d+(?:\.\d+)?)/);
+    if (!plainMatch) return null;
+    const n = Number(plainMatch[1]);
+    return Number.isFinite(n) ? Math.round(n) : null;
+}
+
+/**
+ * Parse "￥109" / "¥109" / "人均￥109" into a numeric yuan value.
+ * Returns null when no price is present (some shops omit price entirely).
+ */
+export function parsePrice(raw) {
+    if (!raw) return null;
+    const m = String(raw).match(/[¥￥]\s*(\d+(?:\.\d+)?)/);
+    if (!m) return null;
+    const n = Number(m[1]);
+    return Number.isFinite(n) ? n : null;
+}

--- a/clis/dianping/utils.js
+++ b/clis/dianping/utils.js
@@ -7,7 +7,12 @@
  * and does NOT require JS hydration, so adapters target it directly.
  */
 
-import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
 
 /**
  * Common Chinese cities → dianping cityId.
@@ -29,13 +34,16 @@ export const CITY_ID = {
     tianjin: 10, '天津': 10,
     qingdao: 21, '青岛': 21,
     changsha: 344, '长沙': 344,
-    dalian: 18, '大连': 18,
+    dalian: 19, '大连': 19,
     shenyang: 18, '沈阳': 18,
     kunming: 25, '昆明': 25,
     fuzhou: 110, '福州': 110,
     xiamen: 14, '厦门': 14,
     hefei: 26, '合肥': 26,
 };
+
+export const SEARCH_COLUMNS = ['rank', 'shop_id', 'name', 'rating', 'reviews', 'price', 'cuisine', 'district', 'url'];
+export const SHOP_COLUMNS = ['field', 'value'];
 
 /**
  * Resolve a city argument (name or id) to a numeric cityId.
@@ -56,26 +64,65 @@ export function resolveCityId(cityArg) {
     return id;
 }
 
+export function requireSearchLimit(value) {
+    const raw = value == null || value === '' ? 15 : value;
+    const limit = typeof raw === 'number' ? raw : Number(String(raw).trim());
+    if (!Number.isInteger(limit) || limit < 1 || limit > 15) {
+        throw new ArgumentError('limit must be an integer between 1 and 15 (dianping single page)');
+    }
+    return limit;
+}
+
+export function normalizeShopId(rawInput) {
+    const raw = String(rawInput || '').trim();
+    if (!raw) throw new ArgumentError('shop_id must be a non-empty string');
+
+    const idMatch = raw.match(/\/shop\/([^?#/]+)/);
+    const shopId = idMatch ? idMatch[1] : raw;
+    if (!/^[A-Za-z0-9_-]+$/.test(shopId)) {
+        throw new ArgumentError(`'${raw}' does not look like a dianping shop id`);
+    }
+    return shopId;
+}
+
+export function wrapDianpingStep(label, fn) {
+    return Promise.resolve()
+        .then(fn)
+        .catch((err) => {
+            if (err?.code) throw err;
+            const message = err?.message || String(err);
+            throw new CommandExecutionError(`dianping ${label} failed: ${message}`);
+        });
+}
+
 /**
  * Throw the right typed error for a dianping page that didn't render data.
  * The site short-circuits HTML when bot/login checks trip — typically
  * redirects to verify.meituan.com (Yoda icon-tap captcha) or to a login
  * page when the cookie is missing.
  */
-export function detectAuthOrEmpty({ text = '', url = '' }, contextHint) {
-    if (/verify\.meituan\.com|verifyimg|身份核实|请依次点击/.test(url + ' ' + text)) {
+export function detectAuthOrPageFailure({ text = '', url = '' }, contextHint, { emptyPatterns = [] } = {}) {
+    const signal = `${url} ${text}`;
+    if (/verify\.meituan\.com|verifyimg|身份核实|请依次点击|美团安全验证|Yoda/i.test(signal)) {
         throw new AuthRequiredError(
             'dianping.com',
             `dianping ${contextHint} blocked by captcha — open ${url || 'www.dianping.com'} manually in this profile and solve the captcha, then retry`,
         );
     }
-    if (/login\.dianping\.com|account\.dianping\.com|请先登录|未登录|请登录/.test(url + ' ' + text)) {
+    if (/login\.dianping\.com|account\.dianping\.com|请先登录|未登录|请登录/.test(signal)) {
         throw new AuthRequiredError(
             'dianping.com',
             `dianping ${contextHint} requires login — sign in to dianping.com in this profile, then retry`,
         );
     }
-    throw new EmptyResultError(`dianping ${contextHint}`);
+    if (emptyPatterns.some((pattern) => pattern.test(signal))) {
+        throw new EmptyResultError(`dianping ${contextHint}`);
+    }
+    const sample = text ? `; sample: ${String(text).slice(0, 160)}` : '';
+    throw new CommandExecutionError(
+        `dianping ${contextHint} did not render expected data${sample}`,
+        'This usually means dianping changed its HTML, returned an unexpected error page, or the browser profile hit an unrecognized anti-bot state.',
+    );
 }
 
 /**

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,6 +108,7 @@ export default defineConfig({
                 { text: 'Eastmoney', link: '/adapters/browser/eastmoney' },
                 { text: 'TDX', link: '/adapters/browser/tdx' },
                 { text: 'THS', link: '/adapters/browser/ths' },
+                { text: 'Dianping', link: '/adapters/browser/dianping' },
               ],
             },
             {

--- a/docs/adapters/browser/dianping.md
+++ b/docs/adapters/browser/dianping.md
@@ -1,0 +1,66 @@
+# dianping
+
+**Mode**: 🔐 Browser · **Domain**: `www.dianping.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli dianping search "<keyword>" --city <name-or-id> --limit <n>` | Search shops/restaurants on `www.dianping.com` |
+| `opencli dianping shop <shop_id>` | Read shop detail by shop id (alias: `detail`) |
+
+## Usage Examples
+
+```bash
+# Search "火锅" in 北京 (top 5 results, table view)
+opencli dianping search 火锅 --city beijing --limit 5
+
+# JSON output
+opencli dianping search 火锅 --city 北京 --limit 5 -f json
+
+# Search using a numeric cityId (path segment in dianping URLs)
+opencli dianping search 火锅 --city 2
+
+# Search using the cookie's currently-selected city (omit --city)
+opencli dianping search 火锅
+
+# Read a shop detail by id
+opencli dianping shop GxJZ4urc9TnKE3kY
+
+# `detail` alias works the same way
+opencli dianping detail GxJZ4urc9TnKE3kY -f json
+
+# Pass a full /shop/<id> URL — the id segment is auto-extracted
+opencli dianping shop https://www.dianping.com/shop/GxJZ4urc9TnKE3kY
+```
+
+## Prerequisites
+
+- Chrome running and **logged into** `dianping.com`
+- [Browser Bridge extension](/guide/browser-bridge) installed
+- The PC site (`www.dianping.com`) is the primary target. The mobile site
+  (`m.dianping.com`) is intentionally crippled for non-mobile UAs and is not
+  used by these adapters.
+
+## Notes
+
+- `search --limit` is between 1 and 15 (dianping fixed page size). Default is 15.
+- `--city` accepts a Chinese name (`北京`/`上海`), pinyin (`beijing`/`shanghai`),
+  or a numeric `cityId`. When omitted, the cookie's currently-selected city is
+  used.
+- `search` columns: `rank, shop_id, name, rating, reviews, price, cuisine, district, url`.
+  `shop_id` round-trips into `dianping shop`.
+- `shop` returns a `field, value` sheet so missing fields surface as `null`
+  rather than fabricated values. The phone number is intentionally hidden on
+  the PC web (only revealed in the native app), so it is not included.
+
+## Troubleshooting
+
+- If you hit a captcha redirect to `verify.meituan.com` (icon-tap challenge),
+  the adapter will throw `AUTH_REQUIRED` with the captcha URL. Open the URL
+  manually in the same Chrome profile, solve the captcha, then retry.
+- If `dianping shop` fails with `EMPTY_RESULT`, the shop may have been removed
+  or relocated; verify the id by visiting `https://www.dianping.com/shop/<id>`
+  in the browser.
+- If `dianping search` returns zero rows, try a more specific keyword or a
+  different city — dianping's search is keyword-coverage dependent.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -80,6 +80,7 @@ Run `opencli list` for the live registry.
 | **[eastmoney](./browser/eastmoney.md)**     | `hot-rank`                                                                                                                                                                                                                                                        | 🔐 Browser                          |
 | **[tdx](./browser/tdx.md)**                 | `hot-rank`                                                                                                                                                                                                                                                        | 🔐 Browser                          |
 | **[ths](./browser/ths.md)**                 | `hot-rank`                                                                                                                                                                                                                                                        | 🔐 Browser                          |
+| **[dianping](./browser/dianping.md)**       | `search` `shop`                                                                                                                                                                                                                                                   | 🔐 Browser                          |
 
 ## Public API Adapters
 

--- a/scripts/check-listing-id-pairing.mjs
+++ b/scripts/check-listing-id-pairing.mjs
@@ -68,7 +68,7 @@ const DETAIL_NAMES = new Set([
     'read', 'article', 'paper', 'post', 'detail', 'view', 'job',
     'page', 'book', 'movie', 'show-detail', 'chapter', 'tweet',
     'video', 'track', 'note', 'review', 'item', 'product', 'episode',
-    'thread', 'comment-detail', 'profile-detail',
+    'thread', 'comment-detail', 'profile-detail', 'shop',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Adds two new browser-mode adapters for **大众点评 (dianping)** on `www.dianping.com`:

- `dianping search "<keyword>" --city <name|id> --limit <n>` — keyword shop/restaurant search.
  Columns: `rank, shop_id, name, rating, reviews, price, cuisine, district, url`.
- `dianping shop <shop_id>` (alias `detail`) — shop detail field/value sheet
  (name, rating, breakdown 口味/环境/服务/食材, reviews, price, rank, hours, address,
  subway, features, url).

`search.shop_id` round-trips into `shop`, so listing→detail pairing is satisfied.

## Why www.dianping.com (PC site)

`m.dianping.com` is intentionally crippled for non-mobile UAs — body renders as 2 chars
to push users into the native app. The PC site renders search results SSR and does not
require JS hydration, so adapters target it directly with `Strategy.COOKIE`.

## Auth handling

`utils.detectAuthOrEmpty({text, url}, hint)` inspects both response text **and** the
final URL for:
- Meituan Yoda captcha redirect → `verify.meituan.com` → `AuthRequiredError`
  (message embeds the captcha URL so the user can click and clear it in the same profile)
- Login redirect → `login.dianping.com` / `account.dianping.com` → `AuthRequiredError`
- Otherwise → `EmptyResultError`

Verified live with `opencli dianping search 火锅 --city beijing --trace on`:
the request hit the Yoda captcha and the adapter raised
`AUTH_REQUIRED: dianping search "火锅" blocked by captcha — open https://verify.meituan.com/...`
with the actual `requestCode`. Trace artifact at
`~/.opencli/profiles/default/traces/20260504142805-4accf89f/`.

> Live happy-path verification requires clearing the captcha first in the
> `site:dianping` browser profile. Once cleared, `opencli browser verify dianping/search`
> can be run with `--write-fixture` to seed the verify fixture.

## Listing↔detail ID pairing

Adds `'shop'` to `DETAIL_NAMES` in `scripts/check-listing-id-pairing.mjs` so the
convention gate now covers this site. After the change:
`Scanned 35 site(s) / 78 listings ✓ — every listing carries an id-shaped column`.

## Files

- `clis/dianping/utils.js` — CITY_ID map (20 cities), `resolveCityId`,
  `detectAuthOrEmpty({text, url}, hint)`, `parseReviewCount`, `parsePrice`
- `clis/dianping/search.js` — keyword search, parses `#shop-all-list li` SSR DOM
- `clis/dianping/shop.js` — detail sheet, parses `.shop-head` + breakdown + features
- `docs/adapters/browser/dianping.md` — adapter docs (commands, examples, troubleshooting)
- `docs/.vitepress/config.mts` + `docs/adapters/index.md` — sidebar/index entries
- `scripts/check-listing-id-pairing.mjs` — `'shop'` added to DETAIL_NAMES
- `cli-manifest.json` — rebuilt (662 → 664 entries)

## Test plan

- [x] `pnpm build-manifest` — 664 entries
- [x] `pnpm typecheck` — clean
- [x] `node scripts/check-listing-id-pairing.mjs --strict` — 35/78 ✓
- [x] `pnpm docs:build` — clean
- [x] Live captcha-path verified (AuthRequiredError + captcha URL in trace)
- [ ] Live happy-path verify (requires manual captcha clearance, blocking on profile auth)