### PR TITLE
ci: gate new write/delete pair violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
         if: runner.os == 'Linux'
         run: npm run check:listing-id-pairing
 
+      # Guard: reversible write commands should expose their undo/delete pair.
+      # Existing findings are tracked in scripts/write-delete-pair-baseline.json.
+      - name: Check write/delete pair baseline
+        if: runner.os == 'Linux'
+        run: npm run check:write-delete-pair
+
   # ── Unit tests (vitest shard) ──
   # PR: ubuntu + Node 22 only (fast feedback, 2 jobs).
   # Push to main/dev: full matrix for cross-platform/cross-version coverage (12 jobs).

--- a/docs/conventions/convention-audit.md
+++ b/docs/conventions/convention-audit.md
@@ -37,3 +37,20 @@ The first version reports these categories:
 The scanners are heuristic. Treat reports as prioritized review input by
 default, then turn a specific rule into a strict CI gate only after the current
 violations and exemptions are understood.
+
+## CI Gates
+
+`npm run check:write-delete-pair` enforces `write-without-delete-pair` in
+baseline mode. The baseline file is
+`scripts/write-delete-pair-baseline.json`.
+
+The gate fails only on new violations beyond that baseline. This lets the repo
+adopt the invariant immediately while existing findings are cleaned up in
+separate sweep PRs.
+
+When a sweep fixes existing write/delete pair findings, update the baseline:
+
+```bash
+npm run build
+node scripts/check-write-delete-pair.mjs --update-baseline
+```

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:all": "vitest run",
     "test:e2e": "vitest run --project e2e",
     "check:listing-id-pairing": "node scripts/check-listing-id-pairing.mjs --strict",
+    "check:write-delete-pair": "node scripts/check-write-delete-pair.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/check-write-delete-pair.mjs
+++ b/scripts/check-write-delete-pair.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * check-write-delete-pair.mjs — CI gate for newly introduced write commands
+ * without an undo/delete counterpart.
+ *
+ * Baseline mode keeps adoption small: existing write-without-delete-pair
+ * findings are recorded in scripts/write-delete-pair-baseline.json, while CI
+ * rejects any new findings.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..');
+const DIST_AUDIT = resolve(PROJECT_ROOT, 'dist', 'src', 'convention-audit.js');
+const BASELINE_PATH = resolve(__dirname, 'write-delete-pair-baseline.json');
+const UPDATE = process.argv.includes('--update-baseline');
+const RULE = 'write-without-delete-pair';
+
+if (!existsSync(DIST_AUDIT)) {
+  console.error('dist/src/convention-audit.js not found. Run npm run build before this check.');
+  process.exit(1);
+}
+
+const { runConventionAudit } = await import(pathToFileURL(DIST_AUDIT).href);
+const report = runConventionAudit({ projectRoot: PROJECT_ROOT });
+const current = sortRecords(report.categories
+  .filter((category) => category.rule === RULE)
+  .flatMap((category) => category.violations.map(toBaselineRecord)));
+
+if (UPDATE) {
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(current, null, 2)}\n`);
+  console.log(`Updated ${relative(BASELINE_PATH)} with ${current.length} write/delete pair baseline entr${current.length === 1 ? 'y' : 'ies'}.`);
+  process.exit(0);
+}
+
+if (!existsSync(BASELINE_PATH)) {
+  console.error(`${relative(BASELINE_PATH)} not found. Run node scripts/check-write-delete-pair.mjs --update-baseline.`);
+  process.exit(1);
+}
+
+const baseline = sortRecords(JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')));
+const baselineSignatures = new Set(baseline.map(signature));
+const currentSignatures = new Set(current.map(signature));
+const added = current.filter((record) => !baselineSignatures.has(signature(record)));
+const resolved = baseline.filter((record) => !currentSignatures.has(signature(record)));
+
+console.log(`Write/delete pair gate: current=${current.length}, baseline=${baseline.length}, new=${added.length}, resolved=${resolved.length}`);
+
+if (resolved.length > 0) {
+  console.log('');
+  console.log('Resolved baseline entries detected. Consider shrinking the baseline:');
+  for (const record of resolved) {
+    console.log(`  - ${record.command} expected one of: ${record.expected_any_of.join(', ')}`);
+  }
+}
+
+if (added.length === 0) {
+  console.log('OK - no new write-without-delete-pair violations.');
+  process.exit(0);
+}
+
+console.log('');
+console.log('New write-without-delete-pair violations:');
+for (const record of added) {
+  console.log(`  - ${record.command}`);
+  console.log(`    expected one of: ${record.expected_any_of.join(', ')}`);
+}
+console.log('');
+console.log('Add the undo/delete command, add an explicit exemption in convention-audit if the site cannot support one,');
+console.log('or if this is an intentional baseline adoption, run:');
+console.log('  node scripts/check-write-delete-pair.mjs --update-baseline');
+process.exit(1);
+
+function toBaselineRecord(violation) {
+  const expected = Array.isArray(violation.details?.expected_any_of)
+    ? violation.details.expected_any_of.map(String)
+    : [];
+  return {
+    command: String(violation.command ?? ''),
+    expected_any_of: [...new Set(expected)].sort(),
+  };
+}
+
+function signature(record) {
+  return `${record.command}\0${record.expected_any_of.join('\0')}`;
+}
+
+function sortRecords(records) {
+  return records
+    .map((record) => ({
+      command: String(record.command),
+      expected_any_of: Array.isArray(record.expected_any_of)
+        ? [...new Set(record.expected_any_of.map(String))].sort()
+        : [],
+    }))
+    .sort((a, b) => signature(a).localeCompare(signature(b)));
+}
+
+function relative(file) {
+  return file.replace(`${PROJECT_ROOT}/`, '');
+}

--- a/scripts/write-delete-pair-baseline.json
+++ b/scripts/write-delete-pair-baseline.json
@@ -1,0 +1,67 @@
+[
+  {
+    "command": "instagram/post",
+    "expected_any_of": [
+      "delete",
+      "remove",
+      "rm"
+    ]
+  },
+  {
+    "command": "jike/create",
+    "expected_any_of": [
+      "delete",
+      "remove",
+      "rm"
+    ]
+  },
+  {
+    "command": "jike/like",
+    "expected_any_of": [
+      "unlike"
+    ]
+  },
+  {
+    "command": "reddit/save",
+    "expected_any_of": [
+      "delete",
+      "remove",
+      "rm",
+      "unsave"
+    ]
+  },
+  {
+    "command": "reddit/subscribe",
+    "expected_any_of": [
+      "unsubscribe"
+    ]
+  },
+  {
+    "command": "twitter/like",
+    "expected_any_of": [
+      "unlike"
+    ]
+  },
+  {
+    "command": "weixin/create-draft",
+    "expected_any_of": [
+      "delete",
+      "delete-draft",
+      "remove",
+      "remove-draft",
+      "rm"
+    ]
+  },
+  {
+    "command": "zhihu/follow",
+    "expected_any_of": [
+      "unfollow"
+    ]
+  },
+  {
+    "command": "zhihu/like",
+    "expected_any_of": [
+      "unlike"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a baseline CI gate for convention-audit write-without-delete-pair findings
- store the current 9 findings in scripts/write-delete-pair-baseline.json so CI rejects only new violations
- document the baseline update flow in convention-audit docs

## Verification
- npm run build
- npm run check:write-delete-pair
- npm run typecheck
- npm run docs:build
- npx vitest run src/convention-audit.test.ts src/cli.test.ts --project unit