### PR TITLE
test(dianping): JSDOM-against-frozen-fixture tests for in-browser extractors

### DIFF
--- a/clis/dianping/__fixtures__/search.html
+++ b/clis/dianping/__fixtures__/search.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html><html class="trancy-und"><head>
+    
+    
+    <title>北京火锅相关搜索结果推荐-大众点评网</title>
+        
+        
+        
+        
+    
+
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+        
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+
+
+    
+</head>
+<body>
+    
+    
+    <div class="section Fix J-shop-search">
+        
+
+
+                            
+                        
+
+
+
+
+
+
+
+
+
+        
+        <div class="content-wrap">
+            <div class="shop-wrap">
+                <div class="content">
+                        
+                    
+<div class="shop-list J_shop-list shop-all-list" id="shop-all-list">
+  <ul>
+  <li class="">
+    <div class="pic">
+      <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu" data-shopid="H20FrTRI6kbXbgTu" title="">
+        <img title="芈重山老火锅(五道口店)" alt="芈重山老火锅(五道口店)" src="placeholder.png">
+      </a>
+    </div>
+
+    <div class="txt">
+      <div class="tit">
+        <a data-shopid="H20FrTRI6kbXbgTu" title="芈重山老火锅(五道口店)" href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu">
+            <h4>芈重山老火锅(五道口店)</h4>
+        </a>
+
+
+        <div class="promo-icon J_promo_icon">
+
+
+              <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu#promo=0" title="" class="ipromote icon-only" data-shopid="H20FrTRI6kbXbgTu"></a>
+
+
+
+
+
+
+        </div>
+
+
+
+      </div>
+
+      <div class="comment">
+
+        <div class="nebula_star">
+          <div class="star_icon">
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+          </div>
+        </div>
+
+          <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu#comment" class="review-num" data-shopid="H20FrTRI6kbXbgTu">
+              <b>21231</b>
+条评价</a>
+
+        <em class="sep">|</em>
+        <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu" class="mean-price" data-shopid="H20FrTRI6kbXbgTu">
+            人均
+            <b>￥109</b>
+            
+        </a>
+
+      </div>
+
+      <div class="tag-addr">
+        <a href="https://www.dianping.com/beijing/ch10/g32733" data-shopid="H20FrTRI6kbXbgTu"><span class="tag">重庆火锅</span></a>
+        <em class="sep">|</em>
+        <a href="https://www.dianping.com/beijing/ch0/r1489" data-shopid="H20FrTRI6kbXbgTu"><span class="tag">五道口</span></a>
+      </div>
+
+
+    </div>
+
+
+
+      <div class="svr-info">
+              <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu#promo=0" title="" data-shopid="H20FrTRI6kbXbgTu" class="tuan ">
+                <span class="tit">优惠：</span>此餐馆有优惠券
+              </a>
+      </div>
+
+    <div class="operate J_operate Hide">
+      <a href="javascript:void(0);" title="" class="o-nearby J_o-nearby" data-shopid="H20FrTRI6kbXbgTu">附近</a>
+    </div>
+
+    </li>
+  <li class="">
+    <div class="pic">
+      <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa" data-shopid="H6uJDRHtNUreCoBa" title="">
+        <img title="百年前门铜锅涮肉(前门总店)" alt="百年前门铜锅涮肉(前门总店)" src="placeholder.png">
+      </a>
+    </div>
+
+    <div class="txt">
+      <div class="tit">
+        <a data-shopid="H6uJDRHtNUreCoBa" title="百年前门铜锅涮肉(前门总店)" href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa">
+            <h4>百年前门铜锅涮肉(前门总店)</h4>
+        </a>
+
+
+        <div class="promo-icon J_promo_icon">
+
+              <a data-shopid="H6uJDRHtNUreCoBa" href="http://t.dianping.com/deal/671044080" title="百年前门铜锅涮肉!【春季新品】拔草必点超值 2-3人餐✨13店通用" class="igroup">
+              </a>
+
+              <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa#promo=0" title="" class="ipromote icon-only" data-shopid="H6uJDRHtNUreCoBa"></a>
+
+
+
+
+
+
+        </div>
+
+
+
+      </div>
+
+      <div class="comment">
+
+        <div class="nebula_star">
+          <div class="star_icon">
+              <span class="star star_45 star_sml"></span>
+              <span class="star star_45 star_sml"></span>
+              <span class="star star_45 star_sml"></span>
+              <span class="star star_45 star_sml"></span>
+              <span class="star star_45 star_sml"></span>
+          </div>
+        </div>
+
+          <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa#comment" class="review-num" data-shopid="H6uJDRHtNUreCoBa">
+              <b>15649</b>
+条评价</a>
+
+        <em class="sep">|</em>
+        <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa" class="mean-price" data-shopid="H6uJDRHtNUreCoBa">
+            人均
+            <b>￥81</b>
+            
+        </a>
+
+      </div>
+
+      <div class="tag-addr">
+        <a href="https://www.dianping.com/beijing/ch10/g34277" data-shopid="H6uJDRHtNUreCoBa"><span class="tag">老北京火锅</span></a>
+        <em class="sep">|</em>
+        <a href="https://www.dianping.com/beijing/ch0/r1503" data-shopid="H6uJDRHtNUreCoBa"><span class="tag">前门/大栅栏</span></a>
+      </div>
+
+
+    </div>
+
+
+
+      <div class="svr-info">
+              <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa#promo=0" title="" data-shopid="H6uJDRHtNUreCoBa" class="tuan privilege">
+                <span class="tit">优惠：</span>此餐馆有优惠券
+              </a>
+      </div>
+
+    <div class="operate J_operate Hide">
+      <a href="javascript:void(0);" title="" class="o-nearby J_o-nearby" data-shopid="H6uJDRHtNUreCoBa">附近</a>
+    </div>
+
+    </li>
+  <li class="">
+    <div class="pic">
+      <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs" data-shopid="H7gQoQ1L5p7CoUEs" title="">
+        <img title="东来顺饭庄(前门大街店)" alt="东来顺饭庄(前门大街店)" src="placeholder.png">
+      </a>
+    </div>
+
+    <div class="txt">
+      <div class="tit">
+        <a data-shopid="H7gQoQ1L5p7CoUEs" title="东来顺饭庄(前门大街店)" href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs">
+            <h4>东来顺饭庄(前门大街店)</h4>
+        </a>
+
+
+        <div class="promo-icon J_promo_icon">
+
+              <a data-shopid="H7gQoQ1L5p7CoUEs" href="http://t.dianping.com/deal/788879631" title="东来顺饭庄!仅售95元！价值100元的代金券1张，全场通用，可叠加使用10张，可免费使用包间。" class="igroup">
+              </a>
+
+              <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs#promo=0" title="" class="ipromote icon-only" data-shopid="H7gQoQ1L5p7CoUEs"></a>
+
+
+
+
+
+
+        </div>
+
+
+
+      </div>
+
+      <div class="comment">
+
+        <div class="nebula_star">
+          <div class="star_icon">
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+              <span class="star star_50 star_sml"></span>
+          </div>
+        </div>
+
+          <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs#comment" class="review-num" data-shopid="H7gQoQ1L5p7CoUEs">
+              <b>21537</b>
+条评价</a>
+
+        <em class="sep">|</em>
+        <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs" class="mean-price" data-shopid="H7gQoQ1L5p7CoUEs">
+            人均
+            <b>￥124</b>
+            
+        </a>
+
+      </div>
+
+      <div class="tag-addr">
+        <a href="https://www.dianping.com/beijing/ch10/g34277" data-shopid="H7gQoQ1L5p7CoUEs"><span class="tag">老北京火锅</span></a>
+        <em class="sep">|</em>
+        <a href="https://www.dianping.com/beijing/ch0/r1503" data-shopid="H7gQoQ1L5p7CoUEs"><span class="tag">前门/大栅栏</span></a>
+      </div>
+
+
+    </div>
+
+
+
+      <div class="svr-info">
+              <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs#promo=0" title="" data-shopid="H7gQoQ1L5p7CoUEs" class="tuan privilege">
+                <span class="tit">优惠：</span>此餐馆有优惠券
+              </a>
+      </div>
+
+    <div class="operate J_operate Hide">
+      <a href="javascript:void(0);" title="" class="o-nearby J_o-nearby" data-shopid="H7gQoQ1L5p7CoUEs">附近</a>
+    </div>
+
+    </li>
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  </ul>
+</div>
+                </div>
+                    
+
+
+
+	
+
+
+
+
+
+
+
+
+            </div>
+            
+        
+
+        </div>
+        
+    </div>
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</body></html>

--- a/clis/dianping/__fixtures__/shop.html
+++ b/clis/dianping/__fixtures__/shop.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><html class="trancy-und"><head>
+  
+  
+  
+   
+  
+  <title>【芈重山老火锅(五道口店)】电话_地址_价格_营业时间_五道口重庆火锅团购 - [undefined] - 大众点评网</title>
+  
+
+
+
+
+
+
+
+  
+  
+  
+  
+  
+  
+  
+
+
+ 
+</head>
+
+<body>
+
+  
+  
+
+
+<div id="cocktail-root" class="cocktail-root"><div id="shop-head" class="shop-head shop-head-pc wx-view"><div id="pc-shop-head" class="wx-view"><div class="pc-shopInfo wx-view"><div class="leftPanel wx-view"><span class="shopName wx-text">芈重山老火锅(五道口店)</span><div class="smallPanel iconPanelPc wx-view"><div class="component-star"><div class="star-container star-50 wx-view"><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="star-score score-50 wx-view">4.8</div></div></div><div class="smallPanel wx-view"><span class="reviews wx-text">21241条</span><span class="price wx-text">¥109/人</span></div></div><div class="bottomPanel wx-view"><div class="wx-view"><span class="region wx-text">五道口</span><span class="category wx-text">重庆火锅</span></div></div><div class="middlePanel no-float wx-view"><span class="scoreText wx-text">口味:4.8 环境:4.8 服务:4.8 食材:4.9 </span></div><div class="rankPanel wx-view"><div class="rank-left wx-view"><img src="placeholder.png" class="rank-icon"><div class="rank-text wx-view">海淀区重庆火锅口味榜 · 第1名</div></div><div class="rank-right wx-view"><div class="rank-entry wx-view"></div></div></div><div class="shop-info wx-view"><div class="shopinfo wx-view"><div class="shopinf-wrap wx-view"><div class="key-services retina-boder-top  wx-view"><div class="left-service wx-view"><div class="biz-title  wx-view"><span class="biz-txt wx-text">营业中</span><span class="biz-time wx-text">11:00-次日02:00</span></div><div class="shop-tag-title wx-view"><div class="shop-feature wx-view"><span class="feature-txt wx-text">有包厢</span></div><div class="shop-feature wx-view"><span class="feature-txt wx-text">有大桌</span></div><div class="shop-feature wx-view"><span class="feature-txt wx-text">付费停车</span></div></div></div><div class="wx-view"><div class="entry wx-view"></div></div></div></div></div></div><div class="wx-view"><div id="shop-map" class="shopmap wx-view"><div class="shopmap-wrap wx-view"><div class="desc-content wx-view"><div class="desc-left wx-view"><div class="desc-info wx-view"><div class="iconAddress wx-view"></div><span class="addressText wx-text"> 成府路35号东源大厦2层东侧</span></div><div class="desc-addr wx-view"><span class="desc-addr-txt wx-text">距地铁13号线五道口站A北口步行90m</span></div></div><div class="desc-right wx-view"><div class="desc-car wx-view"><span class="tips wx-text">到店</span></div><div class="desc-phone wx-view"></div></div></div></div></div></div></div><div class="rightPanel wx-view"><img src="placeholder.png" class="shopPic fetchImgStart fecthImgEnd"><div class="picCount wx-view">7万+</div></div></div></div></div><div class="component-review-list-v2" id="review-list-new-pc"><div class="review-list-container wx-view"><div class="component-review-header"><div class="review-header wx-view"><div class="review-title wx-view"><span class="count-text wx-text">评价(21241)</span><span class="tip-text wx-text">1小时前有新增评价</span></div></div></div></div></div></div>
+
+
+
+
+</body></html>

--- a/clis/dianping/dianping.test.js
+++ b/clis/dianping/dianping.test.js
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     ArgumentError,
     AuthRequiredError,
@@ -16,8 +20,12 @@ import {
     requireSearchLimit,
     resolveCityId,
 } from './utils.js';
-import './search.js';
-import './shop.js';
+import { extractSearchRows } from './search.js';
+import { extractShopFields } from './shop.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHOP_FIXTURE = readFileSync(join(__dirname, '__fixtures__/shop.html'), 'utf8');
+const SEARCH_FIXTURE = readFileSync(join(__dirname, '__fixtures__/search.html'), 'utf8');
 
 function createPageMock(evaluateResult, overrides = {}) {
     const evaluate = typeof evaluateResult === 'function'
@@ -265,5 +273,152 @@ describe('dianping adapter — shop runtime', () => {
         await expect(command.func(createPageMock(() => {
             throw new Error('evaluate failed');
         }), { shop_id: 'GxJZ4urc9TnKE3kY' })).rejects.toThrow(CommandExecutionError);
+    });
+});
+
+/**
+ * In-browser DOM extractors against frozen sanitized HTML fixtures.
+ *
+ * The mocked-page.evaluate tests above can't catch silent bugs that live
+ * inside the IIFE — they feed pre-baked results to the func and the real
+ * DOM walk never runs. PR #1312 found two such bugs only on live verify:
+ *
+ *   1. shop title fallback split on ASCII `[]` while dianping renders
+ *      full-width `【】`, so `name` was always empty.
+ *   2. headText `\s+` collapse fused rating "4.8" with "21241条", so a
+ *      head-wide /\d+条/ regex captured "4.821241" → 5.
+ *
+ * These tests replay the real (sanitized) HTML through JSDOM so changes
+ * to the extractor logic that re-introduce either bug fail in CI.
+ */
+describe('dianping adapter — extractors against frozen HTML fixtures', () => {
+    let originalDocument;
+    let originalLocation;
+
+    beforeEach(() => {
+        originalDocument = globalThis.document;
+        originalLocation = globalThis.location;
+    });
+
+    afterEach(() => {
+        globalThis.document = originalDocument;
+        globalThis.location = originalLocation;
+    });
+
+    function loadFixture(html, url) {
+        const dom = new JSDOM(html, { url });
+        globalThis.document = dom.window.document;
+        globalThis.location = dom.window.location;
+        return dom;
+    }
+
+    it('extractShopFields recovers name from full-width 【】 title and avoids rating/reviews fusion', () => {
+        loadFixture(SHOP_FIXTURE, 'https://www.dianping.com/shop/H20FrTRI6kbXbgTu');
+
+        const data = extractShopFields();
+
+        expect(data.ok).toBe(true);
+        // Regression guard for #1312 bug #1: title is "【芈重山老火锅(五道口店)】..."
+        // (full-width brackets); ASCII `[]` split would leave name empty here.
+        expect(data.name).toBe('芈重山老火锅(五道口店)');
+        // Regression guard for #1312 bug #2: .reviews selector returns "21241条" cleanly,
+        // while a head-wide /\d+条/ on the whitespace-collapsed headText would catch
+        // "4.821241条" → 5. Asserting the raw string excludes both regressions.
+        expect(data.reviewsRaw).toBe('21241条');
+        expect(data.rating).toBe('4.8');
+        expect(data.priceRaw).toBe('¥109');
+        expect(data.breakdown).toEqual({
+            '口味': 4.8,
+            '环境': 4.8,
+            '服务': 4.8,
+            '食材': 4.9,
+        });
+        expect(data.hours).toBe('营业中11:00-次日02:00');
+        expect(data.rank).toBe('海淀区重庆火锅口味榜 · 第1名');
+        expect(data.subway).toBe('距地铁13号线五道口站A北口步行90m');
+        expect(data.url).toBe('https://www.dianping.com/shop/H20FrTRI6kbXbgTu');
+    });
+
+    it('extractSearchRows returns three result-shaped rows with shop_id, name, reviews, price, star, tags', () => {
+        loadFixture(SEARCH_FIXTURE, 'https://www.dianping.com/search/keyword/2/0_%E7%81%AB%E9%94%85');
+
+        const result = extractSearchRows();
+
+        expect(result.ok).toBe(true);
+        expect(result.rows).toHaveLength(3);
+
+        // First row carries the rating + review fusion bug for shop fixture too;
+        // here we lock in the per-card breakdown to prove every row has its own
+        // identity (no silent fall-through to row[0] data).
+        expect(result.rows[0]).toMatchObject({
+            rank: 1,
+            shop_id: 'H20FrTRI6kbXbgTu',
+            name: '芈重山老火锅(五道口店)',
+            starClass: '50',
+            reviewsRaw: '21231',
+            priceRaw: '￥109',
+            cuisine: '重庆火锅',
+            district: '五道口',
+            url: 'https://www.dianping.com/shop/H20FrTRI6kbXbgTu',
+        });
+        expect(result.rows[1]).toMatchObject({
+            rank: 2,
+            shop_id: 'H6uJDRHtNUreCoBa',
+            name: '百年前门铜锅涮肉(前门总店)',
+            starClass: '45',
+            reviewsRaw: '15649',
+            priceRaw: '￥81',
+            cuisine: '老北京火锅',
+            district: '前门/大栅栏',
+        });
+        expect(result.rows[2]).toMatchObject({
+            rank: 3,
+            shop_id: 'H7gQoQ1L5p7CoUEs',
+            name: '东来顺饭庄(前门大街店)',
+            starClass: '50',
+            reviewsRaw: '21537',
+            priceRaw: '￥124',
+        });
+
+        // Round-trip through the public adapter mappers (parseReviewCount /
+        // parsePrice / star → rating) — this is what the live func does after
+        // the extractor returns. Catches drift between extractor + post-process.
+        const finalRows = result.rows.map((r) => ({
+            shop_id: r.shop_id,
+            rating: r.starClass ? Number((Number(r.starClass) / 10).toFixed(1)) : null,
+            reviews: parseReviewCount(r.reviewsRaw),
+            price: parsePrice(r.priceRaw),
+        }));
+        expect(finalRows).toEqual([
+            { shop_id: 'H20FrTRI6kbXbgTu', rating: 5.0, reviews: 21231, price: 109 },
+            { shop_id: 'H6uJDRHtNUreCoBa', rating: 4.5, reviews: 15649, price: 81 },
+            { shop_id: 'H7gQoQ1L5p7CoUEs', rating: 5.0, reviews: 21537, price: 124 },
+        ]);
+    });
+
+    it('extractShopFields signals ok:false with a sample when shop-head is missing', () => {
+        loadFixture(
+            '<html><head><title>blocked</title></head><body><main>验证码</main></body></html>',
+            'https://verify.meituan.com/v2/web/general_page',
+        );
+
+        const data = extractShopFields();
+
+        expect(data.ok).toBe(false);
+        expect(data.url).toBe('https://verify.meituan.com/v2/web/general_page');
+        expect(data.sample).toContain('验证码');
+    });
+
+    it('extractSearchRows signals ok:false with a sample when shop-all-list is empty', () => {
+        loadFixture(
+            '<html><head><title>blocked</title></head><body><main>没有找到相关</main><ul id="shop-all-list"></ul></body></html>',
+            'https://www.dianping.com/search/keyword/2/0_zzz',
+        );
+
+        const result = extractSearchRows();
+
+        expect(result.ok).toBe(false);
+        expect(result.sample).toContain('没有找到相关');
+        expect(result.url).toBe('https://www.dianping.com/search/keyword/2/0_zzz');
     });
 });

--- a/clis/dianping/search.js
+++ b/clis/dianping/search.js
@@ -5,6 +5,10 @@
  * server-side, so the func only needs to parse the SSR DOM after navigate.
  * m.dianping.com (mobile) is intentionally crippled for non-mobile UAs and
  * does not return data without app installation, so it's not used.
+ *
+ * The DOM extractor is defined as a plain top-level function and injected
+ * into `page.evaluate` via `.toString()`, so the same code is exercised by
+ * a JSDOM-against-frozen-fixture unit test (see dianping.test.js).
  */
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
@@ -18,6 +22,72 @@ import {
     resolveCityId,
     wrapDianpingStep,
 } from './utils.js';
+
+/**
+ * Pure DOM extractor for the dianping search-results page.
+ *
+ * Uses bare `document` / `location` so it runs identically in:
+ *   - the live browser (injected via `${extractSearchRows.toString()}`)
+ *   - JSDOM unit tests (which swap `globalThis.document` / `globalThis.location`)
+ */
+export function extractSearchRows() {
+    const items = document.querySelectorAll('#shop-all-list li');
+    if (items.length === 0) {
+        const body = document.body;
+        const sampleText = (body && (body.innerText || body.textContent)) || '';
+        return {
+            ok: false,
+            sample: sampleText.slice(0, 800),
+            url: location.href,
+        };
+    }
+    const rows = [];
+    items.forEach((el, i) => {
+        const resultShape = el.querySelector('.tit h4, .review-num, .mean-price, .tag-addr')
+            || el.querySelector('.tit a, a[data-shopid], a[href*="/shop/"]');
+        if (!resultShape) return;
+
+        const link = el.querySelector('.tit a[href*="/shop/"]')
+            || el.querySelector('a[data-shopid]')
+            || el.querySelector('a[href*="/shop/"]');
+        const shopId = (link && link.getAttribute('data-shopid'))
+            || (link && (link.getAttribute('href') || '').match(/\/shop\/([^?#/]+)/)?.[1])
+            || '';
+        const titleEl = el.querySelector('.tit h4');
+        const name = (titleEl && titleEl.textContent && titleEl.textContent.trim())
+            || (link && link.getAttribute('title'))
+            || '';
+        const reviewEl = el.querySelector('.review-num b');
+        const reviewsRaw = (reviewEl && reviewEl.textContent && reviewEl.textContent.trim()) || '';
+        const priceEl = el.querySelector('.mean-price b');
+        const priceRaw = (priceEl && priceEl.textContent && priceEl.textContent.trim()) || '';
+        const tagAddr = Array.from(el.querySelectorAll('.tag-addr .tag'))
+            .map((t) => t.textContent.trim())
+            .filter(Boolean);
+        let starClass = '';
+        const starWrap = el.querySelector('.nebula_star');
+        if (starWrap) {
+            const m = starWrap.outerHTML.match(/star_(\d{2})/g);
+            if (m && m.length) {
+                const last = m[m.length - 1];
+                const lastDigits = last.match(/star_(\d{2})/)[1];
+                starClass = lastDigits;
+            }
+        }
+        rows.push({
+            rank: i + 1,
+            shop_id: shopId,
+            name,
+            starClass,
+            reviewsRaw,
+            priceRaw,
+            cuisine: tagAddr[0] || '',
+            district: tagAddr[1] || '',
+            url: shopId ? 'https://www.dianping.com/shop/' + shopId : '',
+        });
+    });
+    return { ok: true, rows };
+}
 
 cli({
     site: 'dianping',
@@ -49,62 +119,10 @@ cli({
             await page.wait(2);
         });
 
-        const result = await wrapDianpingStep(`search "${keyword}" extraction`, () => page.evaluate(`
-            (() => {
-                const items = document.querySelectorAll('#shop-all-list li');
-                if (items.length === 0) {
-                    return {
-                        ok: false,
-                        bodyLen: document.body.innerText.length,
-                        sample: document.body.innerText.slice(0, 800),
-                        url: location.href,
-                    };
-                }
-                const rows = [];
-                items.forEach((el, i) => {
-                    const resultShape = el.querySelector('.tit h4, .review-num, .mean-price, .tag-addr')
-                        || el.querySelector('.tit a, a[data-shopid], a[href*="/shop/"]');
-                    if (!resultShape) return;
-
-                    const link = el.querySelector('.tit a[href*="/shop/"]')
-                        || el.querySelector('a[data-shopid]')
-                        || el.querySelector('a[href*="/shop/"]');
-                    const shopId = link?.getAttribute('data-shopid')
-                        || (link?.getAttribute('href') || '').match(/\\/shop\\/([^?#/]+)/)?.[1]
-                        || '';
-                    const name = el.querySelector('.tit h4')?.textContent?.trim()
-                        || link?.getAttribute('title')
-                        || '';
-                    const reviewsRaw = el.querySelector('.review-num b')?.textContent?.trim() || '';
-                    const priceRaw = el.querySelector('.mean-price b')?.textContent?.trim() || '';
-                    const tagAddr = Array.from(el.querySelectorAll('.tag-addr .tag'))
-                        .map((t) => t.textContent.trim())
-                        .filter(Boolean);
-                    let starClass = '';
-                    const starWrap = el.querySelector('.nebula_star');
-                    if (starWrap) {
-                        const m = starWrap.outerHTML.match(/star_(\\d{2})/g);
-                        if (m && m.length) {
-                            const last = m[m.length - 1];
-                            const lastDigits = last.match(/star_(\\d{2})/)[1];
-                            starClass = lastDigits;
-                        }
-                    }
-                    rows.push({
-                        rank: i + 1,
-                        shop_id: shopId,
-                        name,
-                        starClass,
-                        reviewsRaw,
-                        priceRaw,
-                        cuisine: tagAddr[0] || '',
-                        district: tagAddr[1] || '',
-                        url: shopId ? 'https://www.dianping.com/shop/' + shopId : '',
-                    });
-                });
-                return { ok: true, rows };
-            })()
-        `));
+        const result = await wrapDianpingStep(
+            `search "${keyword}" extraction`,
+            () => page.evaluate(`(${extractSearchRows.toString()})()`),
+        );
 
         if (!result || !result.ok) {
             detectAuthOrPageFailure(

--- a/clis/dianping/shop.js
+++ b/clis/dianping/shop.js
@@ -5,6 +5,12 @@
  * Returns a key/value sheet so the table view stays readable when fields
  * are absent (phone is hidden on PC web — only shows in app — so the row
  * surfaces it as `null` rather than fabricating).
+ *
+ * The DOM extractor is defined as a plain top-level function and injected
+ * into `page.evaluate` via `.toString()`, so the same code is exercised by
+ * a JSDOM-against-frozen-fixture unit test (see dianping.test.js). Mocked
+ * `page.evaluate` tests can't catch in-browser bugs like the original
+ * full-width `【】` vs ASCII `[]` mismatch — fixture tests can.
  */
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
@@ -16,6 +22,94 @@ import {
     parseReviewCount,
     wrapDianpingStep,
 } from './utils.js';
+
+/**
+ * Pure DOM extractor for the dianping shop page.
+ *
+ * Uses bare `document` / `location` so it runs identically in:
+ *   - the live browser (injected via `${extractShopFields.toString()}`)
+ *   - JSDOM unit tests (which swap `globalThis.document` / `globalThis.location`)
+ *
+ * Returns either `{ ok: true, ...fields }` on success or
+ * `{ ok: false, sample, url }` so the caller can classify the failure.
+ */
+export function extractShopFields() {
+    const head = document.querySelector('.shop-head');
+    if (!head) {
+        const body = document.body;
+        const sampleText = (body && (body.innerText || body.textContent)) || '';
+        return {
+            ok: false,
+            sample: sampleText.slice(0, 800),
+            url: location.href,
+        };
+    }
+    const headText = head.textContent.trim().replace(/\s+/g, ' ');
+    // Shop name: dianping puts it as "【芈重山老火锅(五道口店)】" at
+    // the head of document.title (full-width 【】, not ASCII []).
+    // Try selectors first, then fall back to title parsing.
+    const titleEl = document.querySelector('.shop-name, .shop-head h2, .shop-head h1');
+    let name = (titleEl && titleEl.textContent && titleEl.textContent.trim()) || '';
+    if (!name) {
+        const t = document.title || '';
+        const m = t.match(/【([^】]+)】/);
+        if (m) name = m[1].trim();
+    }
+    const ratingEl = document.querySelector('.star-score');
+    const ratingText = (ratingEl && ratingEl.textContent && ratingEl.textContent.trim()) || '';
+    const features = Array.from(document.querySelectorAll('.shop-feature'))
+        .map((f) => f.textContent.trim())
+        .filter(Boolean);
+    const addressEl = document.querySelector('.desc-info');
+    const address = (addressEl && addressEl.textContent && addressEl.textContent.trim()) || '';
+    const subwayMatch = headText.match(/距(?:地铁)?[^\s]+?步行\d+m/);
+    const subway = subwayMatch ? subwayMatch[0] : '';
+
+    // Reviews: prefer .reviews / .review-num selector — its text is
+    // "21241条" cleanly. Whitespace-collapsed headText fuses the
+    // rating "4.8" with review digits ("4.821241条"), so a
+    // head-wide /\d+条/ regex captures "4.821241" and rounds to 5.
+    const reviewEl = document.querySelector('.reviews, .review-num, .reviewCount, .reviewCountSentence');
+    let reviewsRaw = (reviewEl && reviewEl.textContent && reviewEl.textContent.trim()) || '';
+    if (!reviewsRaw) {
+        const titleReviewEl = document.querySelector('.review-title');
+        const titleText = titleReviewEl && titleReviewEl.textContent;
+        const titleM = titleText && titleText.match(/评价\(([\d.,万]+)\)/);
+        if (titleM) reviewsRaw = titleM[1];
+    }
+
+    // Shop-head text holds price + cuisine + district + rank.
+    const priceMatch = headText.match(/[¥￥]\s*\d+(?:\.\d+)?/);
+
+    // Try to read score breakdown ("口味:4.8 环境:4.8 服务:4.8 食材:4.9").
+    const breakdown = {};
+    const breakKeys = ['口味', '环境', '服务', '食材'];
+    for (const key of breakKeys) {
+        const m = headText.match(new RegExp(key + '[:：]\\s*([0-9.]+)'));
+        if (m) breakdown[key] = Number(m[1]);
+    }
+
+    // Hours: "营业中 11:00-次日02:00" / "今日休息".
+    const hoursMatch = headText.match(/营业中[^\s]*\d{1,2}:\d{2}-(?:次日)?\d{1,2}:\d{2}|今日休息|暂停营业/);
+
+    // Rank line: "海淀区 重庆火锅 口味榜 · 第1名".
+    const rankMatch = headText.match(/[^\s]+?(?:口味|人气|环境|服务)榜\s*[·•]\s*第\d+名/);
+
+    return {
+        ok: true,
+        name,
+        rating: ratingText,
+        reviewsRaw,
+        priceRaw: (priceMatch && priceMatch[0]) || '',
+        breakdown,
+        features,
+        address,
+        subway,
+        hours: (hoursMatch && hoursMatch[0]) || '',
+        rank: (rankMatch && rankMatch[0]) || '',
+        url: location.href,
+    };
+}
 
 cli({
     site: 'dianping',
@@ -38,79 +132,10 @@ cli({
             await page.wait(3);
         });
 
-        const data = await wrapDianpingStep(`shop ${shopId} extraction`, () => page.evaluate(`
-            (() => {
-                const head = document.querySelector('.shop-head');
-                if (!head) {
-                    return {
-                        ok: false,
-                        bodyLen: document.body.innerText.length,
-                        sample: document.body.innerText.slice(0, 800),
-                        url: location.href,
-                    };
-                }
-                const headText = head.textContent.trim().replace(/\\s+/g, ' ');
-                // Shop name: dianping puts it as "【芈重山老火锅(五道口店)】" at
-                // the head of document.title (full-width 【】, not ASCII []).
-                // Try selectors first, then fall back to title parsing.
-                const titleEl = document.querySelector('.shop-name, .shop-head h2, .shop-head h1');
-                let name = titleEl?.textContent?.trim() || '';
-                if (!name) {
-                    const t = document.title || '';
-                    const m = t.match(/【([^】]+)】/);
-                    if (m) name = m[1].trim();
-                }
-                const ratingText = document.querySelector('.star-score')?.textContent?.trim() || '';
-                const features = Array.from(document.querySelectorAll('.shop-feature')).map((f) => f.textContent.trim()).filter(Boolean);
-                const address = document.querySelector('.desc-info')?.textContent?.trim() || '';
-                const subwayMatch = headText.match(/距(?:地铁)?[^\\s]+?步行\\d+m/);
-                const subway = subwayMatch ? subwayMatch[0] : '';
-
-                // Reviews: prefer .reviews / .review-num selector — its text is
-                // "21241条" cleanly. Whitespace-collapsed headText fuses the
-                // rating "4.8" with review digits ("4.821241条"), so a
-                // head-wide /\\d+条/ regex captures "4.821241" and rounds to 5.
-                const reviewEl = document.querySelector('.reviews, .review-num, .reviewCount, .reviewCountSentence');
-                let reviewsRaw = reviewEl?.textContent?.trim() || '';
-                if (!reviewsRaw) {
-                    const titleReviewEl = document.querySelector('.review-title');
-                    const titleM = titleReviewEl?.textContent?.match(/评价\\(([\\d.,万]+)\\)/);
-                    if (titleM) reviewsRaw = titleM[1];
-                }
-
-                // Shop-head text holds price + cuisine + district + rank.
-                const priceMatch = headText.match(/[¥￥]\\s*\\d+(?:\\.\\d+)?/);
-
-                // Try to read score breakdown ("口味:4.8 环境:4.8 服务:4.8 食材:4.9").
-                const breakdown = {};
-                const breakKeys = ['口味', '环境', '服务', '食材'];
-                for (const key of breakKeys) {
-                    const m = headText.match(new RegExp(key + '[:：]\\\\s*([0-9.]+)'));
-                    if (m) breakdown[key] = Number(m[1]);
-                }
-
-                // Hours: "营业中 11:00-次日02:00" / "今日休息".
-                const hoursMatch = headText.match(/营业中[^\\s]*\\d{1,2}:\\d{2}-(?:次日)?\\d{1,2}:\\d{2}|今日休息|暂停营业/);
-
-                // Rank line: "海淀区 重庆火锅 口味榜 · 第1名".
-                const rankMatch = headText.match(/[^\\s]+?(?:口味|人气|环境|服务)榜\\s*[·•]\\s*第\\d+名/);
-
-                return {
-                    ok: true,
-                    name,
-                    rating: ratingText,
-                    reviewsRaw,
-                    priceRaw: priceMatch?.[0] || '',
-                    breakdown,
-                    features,
-                    address,
-                    subway,
-                    hours: hoursMatch?.[0] || '',
-                    rank: rankMatch?.[0] || '',
-                    url: location.href,
-                };
-            })()
-        `));
+        const data = await wrapDianpingStep(
+            `shop ${shopId} extraction`,
+            () => page.evaluate(`(${extractShopFields.toString()})()`),
+        );
 
         if (!data || !data.ok) {
             detectAuthOrPageFailure(


### PR DESCRIPTION
## Summary

Follow-up to PR #1309 / #1312. Add CI-time coverage for the dianping in-browser extractors so silent DOM bugs (like the full-width 【】 vs ASCII [] mismatch fixed in #1312) fail in CI rather than only on live verify.

PR #1312 fixed two silent bugs that mocked `page.evaluate` tests could not catch:
1. shop title fallback split on ASCII `[]` while dianping renders full-width `【】`, so `name` was always empty.
2. headText `\s+` collapse fused rating `4.8` with reviews `21241条`, so a head-wide `/\d+条/` regex captured `4.821241` → 5.

Both surfaced only on live verify. Existing tests fed pre-baked results to the func; the real DOM walk never ran.

## Changes

- `clis/dianping/shop.js` / `search.js`: extract the IIFE bodies into top-level `extractShopFields()` / `extractSearchRows()` using bare `document` / `location`. The live adapters inject these via `page.evaluate(\`(${fn.toString()})()\`)`, so behavior is unchanged. Both commands re-verified end-to-end against live dianping post-refactor.
- `clis/dianping/__fixtures__/shop.html` (3.4KB), `search.html` (8.4KB): sanitized HTML snapshots. Scripts/styles/iframes/comments stripped, images placeholdered, only structural attrs kept. Trimmed to minimum subtree needed to exercise the extractors (search keeps 3 of 15 li cards; shop keeps `.shop-head` + `.desc-info` + `.review-title` plus full-width 【】 title and the rating/reviews fusion preserved).
- `clis/dianping/dianping.test.js`: new "extractors against frozen HTML fixtures" describe block. Loads fixtures via JSDOM, swaps `globalThis.document` / `globalThis.location`, asserts post-fix behavior on shop (`name=芈重山老火锅(五道口店)`, `reviewsRaw=21241条`, `rating=4.8`, breakdown, hours, rank, subway), search (3 rows with shop_ids / names / reviewsRaw / priceRaw / starClass + post-process round-trip), and `ok:false` branches.

## Verification

Manually verified the fixtures would catch the original bugs by running buggy extractor variants against `shop.html`:
- ASCII-bracket fallback → `name = "undefined"` (fails new assertion).
- Head-wide `/\d+条/` regex → `reviewsRaw = "821241条"` (fails new assertion).

Test suite grows 14 → 18 passing.

Live verify after refactor:
- `opencli browser verify dianping/shop H20FrTRI6kbXbgTu` → `name=芈重山老火锅(五道口店), rating=4.8, reviews=21241, price=109, ...` ✓
- `opencli browser verify dianping/search 火锅 --city beijing --limit 3` → 3 rows with correct ids ✓

## Scope intentionally limited to dianping

Pattern intentionally not pushed across sites yet. If other in-browser DOM adapters encounter similar silent bugs, this JSDOM-against-frozen-fixture pattern can be adopted per-site.

## Test plan

- [x] `pnpm vitest run clis/dianping/dianping.test.js` — 18/18 passing
- [x] Live verify dianping/shop with refactored extractor
- [x] Live verify dianping/search with refactored extractor
- [x] Confirm fixtures would catch the original PR #1312 bugs