### PR TITLE
feat(browser): enforce verify row shape

### DIFF
--- a/docs/guide/extending-opencli.md
+++ b/docs/guide/extending-opencli.md
@@ -54,6 +54,10 @@ opencli browser verify example/detail --write-fixture --seed-args '["https://exa
 
 `--seed-args` is only used when the fixture has no `args`. Once the fixture is written, `opencli browser verify` reads args from `~/.opencli/sites/<site>/verify/<command>.json`.
 
+`browser verify` also enforces row shape before fixture checks: each row should
+stay compact (at most 12 top-level keys), avoid nesting deeper than one level,
+and keep id-shaped fields such as `id` / `user_id` at the top level.
+
 ## Local overrides for official adapters
 
 Use `adapter eject` when you want to customize an existing official adapter.

--- a/docs/zh/guide/extending-opencli.md
+++ b/docs/zh/guide/extending-opencli.md
@@ -54,6 +54,8 @@ opencli browser verify example/detail --write-fixture --seed-args '["https://exa
 
 `--seed-args` 只在 fixture 没有 `args` 时生效。fixture 写出后，`opencli browser verify` 会从 `~/.opencli/sites/<site>/verify/<command>.json` 读取 args。
 
+`browser verify` 也会先检查 row shape：每行保持紧凑（顶层 key 不超过 12 个）、嵌套深度不超过 1，并且 `id` / `user_id` 这类 id-shaped 字段必须在顶层。
+
 ## 本地覆盖官方 adapter
 
 如果你想改一个已有官方 adapter，用 `adapter eject`。

--- a/src/browser/verify-fixture.test.ts
+++ b/src/browser/verify-fixture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveFixture, expandFixtureArgs, parseSeedArgs, validateRows, type Fixture } from './verify-fixture.js';
+import { deriveFixture, expandFixtureArgs, parseSeedArgs, validateRows, validateRowShape, type Fixture } from './verify-fixture.js';
 
 describe('validateRows', () => {
     it('passes when rows meet all expectations', () => {
@@ -147,6 +147,53 @@ describe('validateRows', () => {
         expect(failures).toHaveLength(4);
         expect(failures.every((f) => f.rule === 'mustBeTruthy')).toBe(true);
         expect(failures.map((f) => f.rowIndex)).toEqual([1, 2, 3, 4]);
+    });
+});
+
+describe('validateRowShape', () => {
+    it('passes flat rows with a compact key set', () => {
+        const failures = validateRowShape([
+            { id: '1', title: 'A', author: { name: 'Ada' }, tags: ['ai', 'web'] },
+        ]);
+        expect(failures).toEqual([]);
+    });
+
+    it('reports rows with too many top-level keys', () => {
+        const row = Object.fromEntries(Array.from({ length: 13 }, (_, i) => [`k${i}`, i]));
+        const failures = validateRowShape([row]);
+        expect(failures).toEqual([
+            {
+                rule: 'shapeKeyCount',
+                detail: 'row has 13 top-level keys, expected at most 12',
+                rowIndex: 0,
+            },
+        ]);
+    });
+
+    it('reports nesting deeper than one level', () => {
+        const failures = validateRowShape([
+            { title: 'A', stats: { author: { name: 'Ada' } } },
+        ]);
+        expect(failures).toEqual([
+            {
+                rule: 'shapeDepth',
+                detail: '"stats" nesting depth is 2, expected at most 1',
+                rowIndex: 0,
+            },
+        ]);
+    });
+
+    it('reports nested id-shaped fields even when one-level nesting is otherwise allowed', () => {
+        const failures = validateRowShape([
+            { title: 'A', author: { user_id: 'u1', name: 'Ada' } },
+        ]);
+        expect(failures).toEqual([
+            {
+                rule: 'shapeNestedId',
+                detail: 'id-shaped field "author.user_id" must be a top-level row key',
+                rowIndex: 0,
+            },
+        ]);
     });
 });
 

--- a/src/browser/verify-fixture.ts
+++ b/src/browser/verify-fixture.ts
@@ -64,12 +64,48 @@ export type Fixture = {
 };
 
 export type ValidationFailure = {
-  rule: 'rowCount' | 'column' | 'type' | 'pattern' | 'notEmpty' | 'mustNotContain' | 'mustBeTruthy';
+  rule:
+    | 'rowCount'
+    | 'column'
+    | 'type'
+    | 'pattern'
+    | 'notEmpty'
+    | 'mustNotContain'
+    | 'mustBeTruthy'
+    | 'shapeKeyCount'
+    | 'shapeDepth'
+    | 'shapeNestedId';
   detail: string;
   rowIndex?: number;
 };
 
 export type Row = Record<string, unknown>;
+
+export type RowShapeOptions = {
+  maxTopLevelKeys?: number;
+  maxNestedDepth?: number;
+};
+
+const DEFAULT_MAX_TOP_LEVEL_KEYS = 12;
+const DEFAULT_MAX_NESTED_DEPTH = 1;
+const ID_SHAPED_KEY_PATTERNS = [
+  /^id$/i,
+  /_id$/i,
+  /Id$/,
+  /^short_id$/i,
+  /^bvid$/i,
+  /^aid$/i,
+  /^tid$/i,
+  /^asin$/i,
+  /^sku$/i,
+  /^isbn$/i,
+  /^doi$/i,
+  /^slug$/i,
+  /^hn_id$/i,
+  /^username$/i,
+  /^handle$/i,
+  /^uri$/i,
+];
 
 export function fixturePath(site: string, command: string): string {
   return path.join(os.homedir(), '.opencli', 'sites', site, 'verify', `${command}.json`);
@@ -224,6 +260,44 @@ export function validateRows(rows: Row[], fixture: Fixture): ValidationFailure[]
   return failures;
 }
 
+export function validateRowShape(rows: Row[], opts: RowShapeOptions = {}): ValidationFailure[] {
+  const failures: ValidationFailure[] = [];
+  const maxTopLevelKeys = opts.maxTopLevelKeys ?? DEFAULT_MAX_TOP_LEVEL_KEYS;
+  const maxNestedDepth = opts.maxNestedDepth ?? DEFAULT_MAX_NESTED_DEPTH;
+
+  rows.forEach((row, i) => {
+    const keys = Object.keys(row);
+    if (keys.length > maxTopLevelKeys) {
+      failures.push({
+        rule: 'shapeKeyCount',
+        detail: `row has ${keys.length} top-level keys, expected at most ${maxTopLevelKeys}`,
+        rowIndex: i,
+      });
+    }
+
+    for (const [key, value] of Object.entries(row)) {
+      const depth = nestedDepth(value);
+      if (depth > maxNestedDepth) {
+        failures.push({
+          rule: 'shapeDepth',
+          detail: `"${key}" nesting depth is ${depth}, expected at most ${maxNestedDepth}`,
+          rowIndex: i,
+        });
+      }
+
+      for (const path of nestedIdPaths(value, key)) {
+        failures.push({
+          rule: 'shapeNestedId',
+          detail: `id-shaped field "${path}" must be a top-level row key`,
+          rowIndex: i,
+        });
+      }
+    }
+  });
+
+  return failures;
+}
+
 /**
  * Convert fixture args into argv tokens appended after the command name.
  * - Array form is passed through verbatim (stringified), supporting positional subjects.
@@ -258,6 +332,39 @@ function jsType(v: unknown): string {
   if (v === null) return 'null';
   if (Array.isArray(v)) return 'array';
   return typeof v;
+}
+
+function nestedDepth(value: unknown): number {
+  if (value === null || value === undefined || typeof value !== 'object') return 0;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 1;
+    return 1 + Math.max(...value.map(nestedDepth));
+  }
+  const values = Object.values(value as Record<string, unknown>);
+  if (values.length === 0) return 1;
+  return 1 + Math.max(...values.map(nestedDepth));
+}
+
+function nestedIdPaths(value: unknown, prefix: string): string[] {
+  if (value === null || value === undefined || typeof value !== 'object') return [];
+  const paths: string[] = [];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      paths.push(...nestedIdPaths(item, `${prefix}[${index}]`));
+    });
+    return paths;
+  }
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const childPath = `${prefix}.${key}`;
+    if (isIdShapedKey(key)) paths.push(childPath);
+    paths.push(...nestedIdPaths(nested, childPath));
+  }
+  return paths;
+}
+
+function isIdShapedKey(key: string): boolean {
+  return ID_SHAPED_KEY_PATTERNS.some((pattern) => pattern.test(key));
 }
 
 function typeMatches(actual: string, declared: string): boolean {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -364,6 +364,38 @@ describe('browser verify', () => {
       fs.rmSync(fakeHome, { recursive: true, force: true });
     }
   });
+
+  it('fails before fixture handling when output row shape is not agent-native', async () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-verify-shape-'));
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    mockExecFileSync.mockReturnValue(JSON.stringify([{ title: 'ok', author: { user_id: 'u1' } }]));
+    const consoleLogSpy = vi.mocked(console.log);
+    consoleLogSpy.mockClear();
+
+    try {
+      const adapterDir = path.join(fakeHome, '.opencli', 'clis', 'hn');
+      fs.mkdirSync(adapterDir, { recursive: true });
+      fs.writeFileSync(path.join(adapterDir, 'top.js'), 'export default {};\n', 'utf-8');
+
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'browser', 'verify', 'hn/top', '--no-fixture']);
+
+      expect(process.exitCode).toBe(1);
+      const output = consoleLogSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(output).toContain('Adapter output violates row shape conventions');
+      expect(output).toContain('author.user_id');
+    } finally {
+      consoleLogSpy.mockClear();
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('profile list', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2039,7 +2039,7 @@ cli({
         }
 
         const { execFileSync } = await import('node:child_process');
-        const { loadFixture, writeFixture, deriveFixture, validateRows, fixturePath, expandFixtureArgs, parseSeedArgs } = await import('./browser/verify-fixture.js');
+        const { loadFixture, writeFixture, deriveFixture, validateRows, validateRowShape, fixturePath, expandFixtureArgs, parseSeedArgs } = await import('./browser/verify-fixture.js');
         const filePath = path.join(os.homedir(), '.opencli', 'clis', site, `${command}.js`);
         if (!fs.existsSync(filePath)) {
           console.error(`Adapter not found: ${filePath}`);
@@ -2105,6 +2105,21 @@ cli({
 
         console.log(renderVerifyPreview(rows));
         console.log(`\n  → ${rows.length} row${rows.length === 1 ? '' : 's'}`);
+
+        const shapeFailures = validateRowShape(rows);
+        if (shapeFailures.length > 0) {
+          console.log(`\n  ✗ Adapter output violates row shape conventions:`);
+          for (const f of shapeFailures.slice(0, 20)) {
+            const where = f.rowIndex !== undefined ? `row[${f.rowIndex}] ` : '';
+            console.log(`    - [${f.rule}] ${where}${f.detail}`);
+          }
+          if (shapeFailures.length > 20) {
+            console.log(`    ... and ${shapeFailures.length - 20} more failure(s)`);
+          }
+          console.log(`\n  Keep rows agent-native: <=12 top-level keys, nesting depth <=1, and id-shaped fields at top level.`);
+          process.exitCode = EXIT_CODES.GENERIC_ERROR;
+          return;
+        }
 
         // ── Fixture handling ───────────────────────────────────────────
         if (opts.writeFixture || opts.updateFixture) {


### PR DESCRIPTION
## Summary
- add verify row-shape validation for compact agent-native rows
- fail browser verify before fixture handling when rows exceed 12 top-level keys, nest deeper than one level, or hide id-shaped fields under nested objects
- document the shape rules in English and Chinese extending guides

## Verification
- npm run typecheck
- npx vitest run src/browser/verify-fixture.test.ts src/cli.test.ts --project unit
- npm run build
- npm run check:silent-column-drop
- npm run check:typed-error-lint
- npm run docs:build