### PR TITLE
chore(convention): retire listing↔detail id pairing CI gate, keep advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,6 @@ jobs:
             exit 1
           fi
 
-      # Guard: listing-class commands must surface an id-shaped column so their
-      # rows round-trip into the site's detail-class command. Without this, an
-      # agent has to re-search by title or scrape URLs to follow up on a row.
-      # See docs/conventions/listing-detail-id-pairing.md.
-      - name: Check listing↔detail id pairing
-        if: runner.os == 'Linux'
-        run: npm run check:listing-id-pairing
-
       # Guard: adapter rows must not silently emit keys omitted from `columns`.
       # Existing findings are tracked in scripts/silent-column-drop-baseline.json;
       # this gate rejects newly introduced drops while allowing incremental cleanup.

--- a/docs/conventions/listing-detail-id-pairing.md
+++ b/docs/conventions/listing-detail-id-pairing.md
@@ -1,19 +1,23 @@
-# Listing↔detail ID pairing
+# Listing↔detail ID pairing (advisory)
+
+> **Status:** advisory convention, not a CI gate. Use as guidance when
+> designing listing columns; an audit script (`npm run advise:listing-id-pairing`)
+> can surface candidate listings for human review.
 
 When a site exposes both a **listing-class command** (`search` / `hot` /
 `recent` / `top` / `feed` / ...) and a **detail-class command** (`read` /
-`paper` / `article` / `job` / `view` / ...), the listing rows MUST include
-an id-shaped column whose value can be passed directly into the detail
-command.
+`paper` / `article` / `job` / `view` / ...), it's usually nicer for agents
+if the listing rows include an id-shaped column whose value can be passed
+directly into the detail command.
 
-Without that, the agent has to either re-search by title, scrape a URL out
-of band, or guess — all of which break the agent-native contract.
+Without that, the agent has to either re-search by title or scrape a URL
+out of band to follow up on a listing row.
 
-## The rule
+## Soft convention
 
-> If `<site>` has both a listing command and a detail command, every
-> listing row MUST carry a column whose value round-trips into the detail
-> command's positional argument.
+> If `<site>` has both a listing command and a detail command, prefer
+> giving each listing row a column whose value round-trips into the
+> detail command's positional argument.
 
 That column is whatever the detail command expects:
 
@@ -48,13 +52,31 @@ and the detail command needs an id, the agent has three bad options:
    the failure mode silently downstream.
 
 Surfacing the id in the listing collapses all three into a single,
-unambiguous column. It is the cheapest and most durable way to keep the
-listing→detail call chain agent-native.
+unambiguous column.
+
+## Why this is advisory, not a gate
+
+Whether a listing should pair with a detail is a case-by-case product/UX
+call. Many legitimate listings genuinely don't pair:
+
+- **Topic-string listings** (`twitter trending`, `weibo hot`) — rows are
+  search keywords, not addressable entities.
+- **Profile-attribute listings** (`reddit user`, `lesswrong user`,
+  `weibo user`) — rows are `[field, value]` pairs of one profile.
+- **UI-only sessions** (`discord-app search`, `notion search` Quick Find)
+  — page ids aren't extractable from the rendered DOM.
+- **Comment / reply listings** — sub-resources of a parent thread; the
+  detail command fetches the parent, not the comment.
+
+A hard CI gate forced authors to either add an artificial id column or
+file an exemption with a reason — both of which were higher cognitive cost
+than the silent-loss bugs the rule actually catches. See PR #1311 thread
+for the broader "anti-pattern vs case-by-case" filter.
 
 ## What counts as an "id-shaped column"
 
-The validator (`scripts/check-listing-id-pairing.mjs`) considers any of
-these column names a valid round-trip handle:
+The advisory script (`scripts/check-listing-id-pairing.mjs`) considers any
+of these column names a valid round-trip handle:
 
 - Exact `id` / `short_id`
 - Anything ending in `_id` or `Id` (e.g. `offer_id`, `paperId`)
@@ -72,30 +94,7 @@ these column names a valid round-trip handle:
   Bluesky's `at://did:.../app.bsky.feed.post/...`).
 
 If the natural id for your site is a different shape, add the pattern to
-`ID_COLUMN_PATTERNS` in the validator and document it here.
-
-## What is intentionally exempt
-
-The rule does NOT fire on:
-
-- **Comment / review / reply listings** (`bilibili comments`,
-  `youtube comments`, `taobao reviews`, `weibo comments`, ...). The rows
-  are sub-resources within a parent thread; the detail command on those
-  sites fetches the parent post, not the comment. Keep the parent's id in
-  the *args* of the comments command, not in the rows.
-- **AI-chat / agent-session listings** (`chatgpt-app ask`, `claude new`,
-  `codex ask`, ...). The rows are conversation turns inside one session,
-  not separately fetchable.
-- **Topic / landing-page listings** (`tieba hot`, `weibo hot`). Their rows
-  point to a topic/search landing page, not to a post/thread entity accepted
-  by the detail command.
-- **Single-profile field listings** (`reddit user`, `lesswrong user`).
-  Their shape is `[field, value]` — every row is an attribute of the
-  same profile, addressed by the username arg. There is no per-row entity
-  to round-trip.
-
-These categories are encoded by their command name being absent from
-`LISTING_NAMES` in the validator.
+`ID_COLUMN_PATTERNS` in the script.
 
 ## How to add an id column to a listing
 
@@ -107,20 +106,19 @@ These categories are encoded by their command name being absent from
 3. **Update the docs.** The site's `docs/adapters/browser/<site>.md`
    should list the new column under "Listing columns" and call out that
    it round-trips into the detail command.
-4. **Run the validator.**
+4. **Optional: run the advisory script** to confirm the manifest reflects
+   the new column.
 
    ```bash
-   node scripts/check-listing-id-pairing.mjs --strict
+   npm run advise:listing-id-pairing
    ```
 
-## Validator usage
+## Advisory script usage
 
 ```bash
-# Report-only (default): exit 0 even on violations
-node scripts/check-listing-id-pairing.mjs
-
-# Strict (CI): exit 1 if any listing is missing an id column
-node scripts/check-listing-id-pairing.mjs --strict
+# Print a report of listings that don't currently carry an id-shaped column.
+# Always exits 0 — does not fail CI.
+npm run advise:listing-id-pairing
 ```
 
 The script reads `cli-manifest.json`, so always rebuild the manifest

--- a/docs/developer/ts-adapter.md
+++ b/docs/developer/ts-adapter.md
@@ -59,19 +59,22 @@ Every adapter must declare `access: 'read' | 'write'`.
 
 Adapters may also declare `example` to override the canonical invocation shown in agent-facing help. Prefer YAML examples, e.g. `opencli mysite search <query> -f yaml`.
 
-## Listing↔Detail ID Pairing
+## Listing↔Detail ID Pairing (advisory)
 
 If your site exposes both a listing-class command (`search` / `hot` / `top` /
 `recent` / ...) and a detail-class command (`read` / `paper` / `article` /
-`post` / `view` / ...), every listing row MUST surface an id-shaped column
-that round-trips into the detail command's positional arg. Without that, an
-agent can't follow up on a row without re-searching by title or scraping a
-URL out of band.
+`post` / `view` / ...), it's usually nicer for agents if listing rows surface
+an id-shaped column that round-trips into the detail command's positional
+arg. Without that, an agent can't follow up on a row without re-searching by
+title or scraping a URL out of band.
 
-The CI gate `npm run check:listing-id-pairing` fails when a listing is
-missing its id column. See [Listing↔Detail ID Pairing](../conventions/listing-detail-id-pairing.md)
-for the full rule, exemption rationale, and how to add an id to an existing
-listing.
+This is a **soft convention**, not a CI gate. Many legitimate listings
+genuinely don't pair (topic-string trending, profile-attribute rows,
+UI-only sessions). Use judgment per command, not a checklist.
+
+Run `npm run advise:listing-id-pairing` to see candidate listings without an
+id column. See [Listing↔Detail ID Pairing](../conventions/listing-detail-id-pairing.md)
+for context, the full pattern table, and how to add an id to a listing.
 
 ## Strategy Types
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:adapter": "vitest run --project adapter",
     "test:all": "vitest run",
     "test:e2e": "vitest run --project e2e",
-    "check:listing-id-pairing": "node scripts/check-listing-id-pairing.mjs --strict",
+    "advise:listing-id-pairing": "node scripts/check-listing-id-pairing.mjs",
     "check:silent-column-drop": "node scripts/check-silent-column-drop.mjs",
     "check:typed-error-lint": "node scripts/check-typed-error-lint.mjs",
     "docs:dev": "vitepress dev docs",

--- a/scripts/check-listing-id-pairing.mjs
+++ b/scripts/check-listing-id-pairing.mjs
@@ -1,32 +1,32 @@
 #!/usr/bin/env node
 /**
- * check-listing-id-pairing.mjs — verify listing↔detail id round-tripping.
+ * check-listing-id-pairing.mjs — advisory report on listing↔detail id round-tripping.
  *
- * Agent-native rule: when a site exposes both a listing-class command
- * (search / hot / recent / trending / top / feed / popular / new / list)
- * AND a detail-class command (read / article / paper / post / detail /
+ * Soft convention (NOT a CI gate): when a site exposes both a listing-class
+ * command (search / hot / recent / trending / top / feed / popular / new /
+ * list) AND a detail-class command (read / article / paper / post / detail /
  * view / job / page / book / movie / show / chapter / question / answer /
- * tweet / video / track), every listing row must include an id-shaped
- * column whose value can be fed into the detail command's positional
- * argument. Without that, the agent has to re-search by title, scrape
- * a URL, or guess — all of which break the agent-native contract.
+ * tweet / video / track), it's usually nicer for agents if every listing row
+ * carries an id-shaped column whose value round-trips into the detail
+ * command. Without that, the agent has to re-search by title or scrape a URL
+ * to follow up.
+ *
+ * Why advisory and not a gate: whether a listing should pair with a detail
+ * is a case-by-case product/UX call (topic-string trending, profile-attribute
+ * key/value rows, UI-only sessions etc. legitimately don't pair). Forcing
+ * authors through an exempt list every PR was higher cognitive cost than the
+ * silent-loss bugs the rule actually catches. See PR #1311 thread for the
+ * "anti-pattern vs case-by-case" filter.
  *
  * What this script does:
  *  1. Group cli-manifest.json entries by site.
  *  2. For each site that has both classes, walk every listing entry and
  *     check `columns` for at least one id-shaped name.
- *  3. Fail (exit 1 in --strict) on any listing missing an id column.
- *
- * Heuristic, not perfect: the script only checks for the *presence* of an
- * id-shaped column on listings; it doesn't verify the id format actually
- * matches the detail command's positional arg. That stays a manual review
- * concern — the column shape gate alone catches the silent-loss class
- * (listings that emit only title/author/url and force the agent to scrape
- * the URL for an id).
+ *  3. Print a report. Always exits 0 — never fails CI.
  *
  * Usage:
- *   node scripts/check-listing-id-pairing.mjs           # report only
- *   node scripts/check-listing-id-pairing.mjs --strict  # exit 1 on violations
+ *   node scripts/check-listing-id-pairing.mjs   # print advisory report
+ *   npm run advise:listing-id-pairing
  */
 
 import { readFileSync } from 'node:fs';
@@ -69,25 +69,6 @@ const DETAIL_NAMES = new Set([
     'page', 'book', 'movie', 'show-detail', 'chapter', 'tweet',
     'video', 'track', 'note', 'review', 'item', 'product', 'episode',
     'thread', 'comment-detail', 'profile-detail', 'shop',
-]);
-
-/**
- * Listing/site pairs that are intentionally exempt because the listing
- * rows are a different entity type from what the detail command fetches.
- * Each exemption records WHY so future maintainers know what to verify
- * before removing the entry.
- */
-const EXEMPT = new Map([
-    ['nowcoder/hot', 'hot rows are search queries / topics, not posts; nowcoder/detail fetches a post by id'],
-    ['bluesky/trending', 'trending rows are topic strings, not threads; bluesky/thread fetches a single thread by url'],
-    ['twitter/trending', 'trending rows are topic strings, not tweets; twitter/post|thread|article fetch by tweet id or username/id'],
-    ['lesswrong/user', 'rows are profile-attribute key/value pairs; lesswrong/read fetches a post, addressed by post id'],
-    ['reddit/user', 'rows are profile-attribute key/value pairs; reddit/read fetches a post, addressed by post id'],
-    ['discord-app/search', 'desktop UI session — message ids are not extractable from the rendered DOM'],
-    ['notion/search', 'Strategy.UI Quick Find — page ids are not exposed in the rendered DOM; agents navigate via Notion UI (Cmd+P), not by id round-trip'],
-    ['tieba/hot', 'hot rows are topic landing pages, not thread rows; tieba/read fetches a thread by numeric id'],
-    ['weibo/hot', 'hot rows are search topics, not posts; weibo/post fetches a post by id or mblogid'],
-    ['weibo/user', 'rows are profile-attribute fields; weibo/post fetches a post, addressed by post id or mblogid'],
 ]);
 
 /** Columns whose name implies "this is an id you can pass to detail". */
@@ -148,7 +129,6 @@ function classify(name) {
 }
 
 function main() {
-    const strict = process.argv.includes('--strict');
     const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
 
     const bySite = new Map();
@@ -158,8 +138,7 @@ function main() {
         bySite.get(entry.site).push(entry);
     }
 
-    const violations = [];
-    const exempted = [];
+    const findings = [];
     let scannedSites = 0;
     let scannedListings = 0;
 
@@ -177,14 +156,9 @@ function main() {
         for (const entry of entries) {
             if (classify(entry.name) !== 'listing') continue;
             scannedListings++;
-            const key = `${site}/${entry.name}`;
-            if (EXEMPT.has(key)) {
-                exempted.push({ key, reason: EXEMPT.get(key) });
-                continue;
-            }
             const columns = Array.isArray(entry.columns) ? entry.columns : [];
             if (!columns.some((col) => isIdColumn(col, readDetail))) {
-                violations.push({
+                findings.push({
                     site,
                     name: entry.name,
                     columns,
@@ -195,26 +169,25 @@ function main() {
     }
 
     console.log(`Scanned ${scannedSites} site(s) with both listing and read-detail commands.`);
-    console.log(`Checked ${scannedListings} listing command(s); ${exempted.length} exempted.`);
+    console.log(`Checked ${scannedListings} listing command(s).`);
 
-    if (violations.length === 0) {
+    if (findings.length === 0) {
         console.log('OK — every listing carries an id-shaped column.');
-        process.exit(0);
+        return;
     }
 
     console.log('');
-    console.log(`Found ${violations.length} listing(s) missing a round-trippable id column:`);
-    for (const v of violations) {
+    console.log(`Advisory: ${findings.length} listing(s) without a round-trippable id column.`);
+    console.log('Some of these are legitimate (topic strings, profile-attribute rows, UI-only');
+    console.log('sessions); others may be worth adding an id to. Use judgment, not a gate.');
+    console.log('');
+    for (const v of findings) {
         console.log(`  • ${v.site}/${v.name}`);
         console.log(`      columns: [${v.columns.join(', ')}]`);
         console.log(`      detail commands on this site: ${v.detail.join(', ')}`);
     }
     console.log('');
-    console.log('Add an id-shaped column (id / short_id / jk / bvid / asin / etc.)');
-    console.log('to each listing so its rows round-trip into the detail command.');
-    console.log('See docs/conventions/listing-detail-id-pairing.md for the full rule.');
-
-    if (strict) process.exit(1);
+    console.log('See docs/conventions/listing-detail-id-pairing.md for context and patterns.');
 }
 
 main();


### PR DESCRIPTION
## Summary

Retires the CI gate introduced by PR #1297 (listing↔detail id pairing) and downgrades the convention to advisory. Keeps the doc, the script, and the column-pattern table so agents/authors can still consult them; removes the gate failure path and the per-PR EXEMPT-list maintenance burden.

## Why

By the same filter that closed PR #1311 (write-without-delete-pair gate, see [#1311 thread](https://github.com/jackwener/OpenCLI/pull/1311)):

> Is "listing should pair with detail" a **permanent** anti-pattern, or **case-by-case** business judgment?

It's case-by-case. Topic-string listings (`twitter trending`, `weibo hot`), profile-attribute rows (`reddit user`, `lesswrong user`), UI-only sessions (`discord-app search`, `notion search`), and comment/reply listings genuinely don't pair with a detail command — they're different entity types.

The fact that #1297 shipped a 10-entry `EXEMPT` map with individual reason strings is the smell. Each exemption was the rule failing to capture a legitimate case, not the rule winning. Forcing every new adapter PR to either:
1. Add an id-shaped column whose value isn't actually round-trippable, OR
2. File an exemption with a "why this is OK" reason

was a higher cognitive cost than the silent-loss bugs the rule actually catches. Per WAWQAQ in [#OpenCLI:36d2f65a](https://github.com/jackwener/OpenCLI/pull/1311) discussion: *"我们不应该太过度设计，不应该加太多的包袱。不要引入太多的复杂的东西。"*

## What changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Drop the `Check listing↔detail id pairing` step. Other gates (silent-column-drop, typed-error-lint) untouched. |
| `package.json` | Rename script from `check:listing-id-pairing` to `advise:listing-id-pairing` to make advisory nature explicit. |
| `scripts/check-listing-id-pairing.mjs` | Remove `--strict` flag and the entire `EXEMPT` map. Script always exits 0 and prints an advisory report. |
| `docs/conventions/listing-detail-id-pairing.md` | Rewrite from "MUST" to "soft convention". Adds explicit "why advisory, not a gate" section documenting the legitimate non-pairing categories. |
| `docs/developer/ts-adapter.md` | Match the advisory tone. |

Net: **-34 lines** (gate + EXEMPT map removed; small advisory-rationale section added to the doc).

The 4 adapter fixes from #1297 (1688/bluesky/hupu/jike/tieba/weibo listings now carrying id columns) remain in place — they're real improvements regardless of gate status.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean (manifest still compiles)
- [x] `npm run advise:listing-id-pairing` — runs, exits 0, prints 10 candidate listings (matches the categories that were in the old `EXEMPT` map)
- [x] `npm run check:silent-column-drop` — still green (unchanged baseline)
- [x] `npm run check:typed-error-lint` — still green (unchanged baseline)
- [ ] CI confirms the listing↔detail step is gone but the rest of the gates still run

## Reviewer

cc @coding-claude-opus per the [#OpenCLI:36d2f65a](https://github.com/jackwener/OpenCLI/pull/1313) thread alignment ("A: opencli-user 自己的领域，他推的他撤；coding-claude-opus review").