### PR TITLE
chore(dianping/fixtures): strip whitespace-only lines from frozen HTML fixtures

### DIFF
--- a/clis/dianping/__fixtures__/search.html
+++ b/clis/dianping/__fixtures__/search.html
@@ -1,65 +1,11 @@
 <!DOCTYPE html><html class="trancy-und"><head>
-    
-    
     <title>北京火锅相关搜索结果推荐-大众点评网</title>
-        
-        
-        
-        
-    
-
-    
-
-    
-    
-    
-    
-    
-    
-    
-    
-        
-    
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-
-
-    
 </head>
 <body>
-    
-    
     <div class="section Fix J-shop-search">
-        
-
-
-                            
-                        
-
-
-
-
-
-
-
-
-
-        
         <div class="content-wrap">
             <div class="shop-wrap">
                 <div class="content">
-                        
-                    
 <div class="shop-list J_shop-list shop-all-list" id="shop-all-list">
   <ul>
   <li class="">
@@ -68,32 +14,16 @@
         <img title="芈重山老火锅(五道口店)" alt="芈重山老火锅(五道口店)" src="placeholder.png">
       </a>
     </div>
-
     <div class="txt">
       <div class="tit">
         <a data-shopid="H20FrTRI6kbXbgTu" title="芈重山老火锅(五道口店)" href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu">
             <h4>芈重山老火锅(五道口店)</h4>
         </a>
-
-
         <div class="promo-icon J_promo_icon">
-
-
               <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu#promo=0" title="" class="ipromote icon-only" data-shopid="H20FrTRI6kbXbgTu"></a>
-
-
-
-
-
-
         </div>
-
-
-
       </div>
-
       <div class="comment">
-
         <div class="nebula_star">
           <div class="star_icon">
               <span class="star star_50 star_sml"></span>
@@ -103,41 +33,29 @@
               <span class="star star_50 star_sml"></span>
           </div>
         </div>
-
           <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu#comment" class="review-num" data-shopid="H20FrTRI6kbXbgTu">
               <b>21231</b>
 条评价</a>
-
         <em class="sep">|</em>
         <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu" class="mean-price" data-shopid="H20FrTRI6kbXbgTu">
             人均
             <b>￥109</b>
-            
         </a>
-
       </div>
-
       <div class="tag-addr">
         <a href="https://www.dianping.com/beijing/ch10/g32733" data-shopid="H20FrTRI6kbXbgTu"><span class="tag">重庆火锅</span></a>
         <em class="sep">|</em>
         <a href="https://www.dianping.com/beijing/ch0/r1489" data-shopid="H20FrTRI6kbXbgTu"><span class="tag">五道口</span></a>
       </div>
-
-
     </div>
-
-
-
       <div class="svr-info">
               <a href="https://www.dianping.com/shop/H20FrTRI6kbXbgTu#promo=0" title="" data-shopid="H20FrTRI6kbXbgTu" class="tuan ">
                 <span class="tit">优惠：</span>此餐馆有优惠券
               </a>
       </div>
-
     <div class="operate J_operate Hide">
       <a href="javascript:void(0);" title="" class="o-nearby J_o-nearby" data-shopid="H20FrTRI6kbXbgTu">附近</a>
     </div>
-
     </li>
   <li class="">
     <div class="pic">
@@ -145,34 +63,18 @@
         <img title="百年前门铜锅涮肉(前门总店)" alt="百年前门铜锅涮肉(前门总店)" src="placeholder.png">
       </a>
     </div>
-
     <div class="txt">
       <div class="tit">
         <a data-shopid="H6uJDRHtNUreCoBa" title="百年前门铜锅涮肉(前门总店)" href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa">
             <h4>百年前门铜锅涮肉(前门总店)</h4>
         </a>
-
-
         <div class="promo-icon J_promo_icon">
-
               <a data-shopid="H6uJDRHtNUreCoBa" href="http://t.dianping.com/deal/671044080" title="百年前门铜锅涮肉!【春季新品】拔草必点超值 2-3人餐✨13店通用" class="igroup">
               </a>
-
               <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa#promo=0" title="" class="ipromote icon-only" data-shopid="H6uJDRHtNUreCoBa"></a>
-
-
-
-
-
-
         </div>
-
-
-
       </div>
-
       <div class="comment">
-
         <div class="nebula_star">
           <div class="star_icon">
               <span class="star star_45 star_sml"></span>
@@ -182,41 +84,29 @@
               <span class="star star_45 star_sml"></span>
           </div>
         </div>
-
           <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa#comment" class="review-num" data-shopid="H6uJDRHtNUreCoBa">
               <b>15649</b>
 条评价</a>
-
         <em class="sep">|</em>
         <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa" class="mean-price" data-shopid="H6uJDRHtNUreCoBa">
             人均
             <b>￥81</b>
-            
         </a>
-
       </div>
-
       <div class="tag-addr">
         <a href="https://www.dianping.com/beijing/ch10/g34277" data-shopid="H6uJDRHtNUreCoBa"><span class="tag">老北京火锅</span></a>
         <em class="sep">|</em>
         <a href="https://www.dianping.com/beijing/ch0/r1503" data-shopid="H6uJDRHtNUreCoBa"><span class="tag">前门/大栅栏</span></a>
       </div>
-
-
     </div>
-
-
-
       <div class="svr-info">
               <a href="https://www.dianping.com/shop/H6uJDRHtNUreCoBa#promo=0" title="" data-shopid="H6uJDRHtNUreCoBa" class="tuan privilege">
                 <span class="tit">优惠：</span>此餐馆有优惠券
               </a>
       </div>
-
     <div class="operate J_operate Hide">
       <a href="javascript:void(0);" title="" class="o-nearby J_o-nearby" data-shopid="H6uJDRHtNUreCoBa">附近</a>
     </div>
-
     </li>
   <li class="">
     <div class="pic">
@@ -224,34 +114,18 @@
         <img title="东来顺饭庄(前门大街店)" alt="东来顺饭庄(前门大街店)" src="placeholder.png">
       </a>
     </div>
-
     <div class="txt">
       <div class="tit">
         <a data-shopid="H7gQoQ1L5p7CoUEs" title="东来顺饭庄(前门大街店)" href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs">
             <h4>东来顺饭庄(前门大街店)</h4>
         </a>
-
-
         <div class="promo-icon J_promo_icon">
-
               <a data-shopid="H7gQoQ1L5p7CoUEs" href="http://t.dianping.com/deal/788879631" title="东来顺饭庄!仅售95元！价值100元的代金券1张，全场通用，可叠加使用10张，可免费使用包间。" class="igroup">
               </a>
-
               <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs#promo=0" title="" class="ipromote icon-only" data-shopid="H7gQoQ1L5p7CoUEs"></a>
-
-
-
-
-
-
         </div>
-
-
-
       </div>
-
       <div class="comment">
-
         <div class="nebula_star">
           <div class="star_icon">
               <span class="star star_50 star_sml"></span>
@@ -261,112 +135,34 @@
               <span class="star star_50 star_sml"></span>
           </div>
         </div>
-
           <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs#comment" class="review-num" data-shopid="H7gQoQ1L5p7CoUEs">
               <b>21537</b>
 条评价</a>
-
         <em class="sep">|</em>
         <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs" class="mean-price" data-shopid="H7gQoQ1L5p7CoUEs">
             人均
             <b>￥124</b>
-            
         </a>
-
       </div>
-
       <div class="tag-addr">
         <a href="https://www.dianping.com/beijing/ch10/g34277" data-shopid="H7gQoQ1L5p7CoUEs"><span class="tag">老北京火锅</span></a>
         <em class="sep">|</em>
         <a href="https://www.dianping.com/beijing/ch0/r1503" data-shopid="H7gQoQ1L5p7CoUEs"><span class="tag">前门/大栅栏</span></a>
       </div>
-
-
     </div>
-
-
-
       <div class="svr-info">
               <a href="https://www.dianping.com/shop/H7gQoQ1L5p7CoUEs#promo=0" title="" data-shopid="H7gQoQ1L5p7CoUEs" class="tuan privilege">
                 <span class="tit">优惠：</span>此餐馆有优惠券
               </a>
       </div>
-
     <div class="operate J_operate Hide">
       <a href="javascript:void(0);" title="" class="o-nearby J_o-nearby" data-shopid="H7gQoQ1L5p7CoUEs">附近</a>
     </div>
-
     </li>
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
   </ul>
 </div>
                 </div>
-                    
-
-
-
-	
-
-
-
-
-
-
-
-
             </div>
-            
-        
-
         </div>
-        
     </div>
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 </body></html>

--- a/clis/dianping/__fixtures__/shop.html
+++ b/clis/dianping/__fixtures__/shop.html
@@ -1,39 +1,6 @@
 <!DOCTYPE html><html class="trancy-und"><head>
-  
-  
-  
-   
-  
   <title>【芈重山老火锅(五道口店)】电话_地址_价格_营业时间_五道口重庆火锅团购 - [undefined] - 大众点评网</title>
-  
-
-
-
-
-
-
-
-  
-  
-  
-  
-  
-  
-  
-
-
- 
 </head>
-
 <body>
-
-  
-  
-
-
 <div id="cocktail-root" class="cocktail-root"><div id="shop-head" class="shop-head shop-head-pc wx-view"><div id="pc-shop-head" class="wx-view"><div class="pc-shopInfo wx-view"><div class="leftPanel wx-view"><span class="shopName wx-text">芈重山老火锅(五道口店)</span><div class="smallPanel iconPanelPc wx-view"><div class="component-star"><div class="star-container star-50 wx-view"><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="light wx-view">★</div><div class="star-score score-50 wx-view">4.8</div></div></div><div class="smallPanel wx-view"><span class="reviews wx-text">21241条</span><span class="price wx-text">¥109/人</span></div></div><div class="bottomPanel wx-view"><div class="wx-view"><span class="region wx-text">五道口</span><span class="category wx-text">重庆火锅</span></div></div><div class="middlePanel no-float wx-view"><span class="scoreText wx-text">口味:4.8 环境:4.8 服务:4.8 食材:4.9 </span></div><div class="rankPanel wx-view"><div class="rank-left wx-view"><img src="placeholder.png" class="rank-icon"><div class="rank-text wx-view">海淀区重庆火锅口味榜 · 第1名</div></div><div class="rank-right wx-view"><div class="rank-entry wx-view"></div></div></div><div class="shop-info wx-view"><div class="shopinfo wx-view"><div class="shopinf-wrap wx-view"><div class="key-services retina-boder-top  wx-view"><div class="left-service wx-view"><div class="biz-title  wx-view"><span class="biz-txt wx-text">营业中</span><span class="biz-time wx-text">11:00-次日02:00</span></div><div class="shop-tag-title wx-view"><div class="shop-feature wx-view"><span class="feature-txt wx-text">有包厢</span></div><div class="shop-feature wx-view"><span class="feature-txt wx-text">有大桌</span></div><div class="shop-feature wx-view"><span class="feature-txt wx-text">付费停车</span></div></div></div><div class="wx-view"><div class="entry wx-view"></div></div></div></div></div></div><div class="wx-view"><div id="shop-map" class="shopmap wx-view"><div class="shopmap-wrap wx-view"><div class="desc-content wx-view"><div class="desc-left wx-view"><div class="desc-info wx-view"><div class="iconAddress wx-view"></div><span class="addressText wx-text"> 成府路35号东源大厦2层东侧</span></div><div class="desc-addr wx-view"><span class="desc-addr-txt wx-text">距地铁13号线五道口站A北口步行90m</span></div></div><div class="desc-right wx-view"><div class="desc-car wx-view"><span class="tips wx-text">到店</span></div><div class="desc-phone wx-view"></div></div></div></div></div></div></div><div class="rightPanel wx-view"><img src="placeholder.png" class="shopPic fetchImgStart fecthImgEnd"><div class="picCount wx-view">7万+</div></div></div></div></div><div class="component-review-list-v2" id="review-list-new-pc"><div class="review-list-container wx-view"><div class="component-review-header"><div class="review-header wx-view"><div class="review-title wx-view"><span class="count-text wx-text">评价(21241)</span><span class="tip-text wx-text">1小时前有新增评价</span></div></div></div></div></div></div>
-
-
-
-
 </body></html>


### PR DESCRIPTION
## Summary

Per @WAWQAQ feedback in #1313 thread (`#OpenCLI:36d2f65a`):

> 我发现 fixtures 怎么这么多空白行，我觉得这个点有值得提升的地方。

The two dianping fixtures came out of `page.content()` with hundreds of blank lines that JSDOM ignores during parsing — pure visual / disk noise that bloats reviewer diff and obscures the meaningful DOM subtree the fixture freezes.

| File | Before | After | Δ lines | Δ bytes |
|------|--------|-------|---------|---------|
| `clis/dianping/__fixtures__/search.html` | 372 lines | 168 lines | −204 | −572 |
| `clis/dianping/__fixtures__/shop.html`   |  39 lines |   6 lines |  −33 |  −64 |

## Approach

`awk 'NF>0'` keeps every line that has any non-whitespace character. The minified mega-line in `shop.html` (where the rating-vs-reviews adjacency that triggers #1312 silent fusion lives) is preserved verbatim — only purely-blank lines disappear.

## Test plan

- [x] `npx vitest run clis/dianping/dianping.test.js` → 18/18 pass after strip
- [x] **Regression-guard discipline:** temporarily reintroduce the buggy `headText.match(/(\d+)条/)` reviews extractor (the #1312 bug variant). Test fails with `expected '821241条' to be '21241条'` — confirming the fusion-bug detection power is intact after the strip, then revert to clean.
- [x] `npm run build && npm run check:silent-column-drop` → 103/103 0 new
- [x] `npm run check:typed-error-lint` → 198/198 0 new
- [x] `npm run typecheck` clean

cc @coding-claude-opus (independently validated the same `awk 'NF>0'` approach in #1313 thread before this cleanup).