### PR TITLE
docs(adapter-author): add jsdom-fixture-pattern reference for in-browser DOM extractors

### DIFF
--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -187,6 +187,7 @@ DONE
 | `references/site-memory.md` | 总览：in-repo 种子 + 本地 `~/.opencli/sites/` 的两层结构 |
 | `references/site-memory/<site>.md` | Step 2 读站点公共知识（eastmoney / xueqiu / bilibili / tonghuashun 已铺） |
 | `references/success-rate-pitfalls.md` | Step 7 / 11 踩坑前翻：10 种"verify 能过但数据是错的"静默失败 |
+| `references/jsdom-fixture-pattern.md` | 当 adapter 走 `page.evaluate` 内 DOM 抽取、且 mocked-evaluate 单测漏 silent bug 时——把 HTML 冻进 `clis/<site>/__fixtures__/` 用 JSDOM 跑（含 fixture 创建 mandatory `awk 'NF>0'` 收紧 + reverse-validate 纪律） |
 
 ---
 
@@ -198,6 +199,7 @@ DONE
 - 写私人 adapter 用 `~/.opencli/clis/<site>/<name>.js`（免 build）；要提 PR 才 copy 到 `clis/<site>/<name>.js`
 - 站点记忆每轮回写：没记忆 → 用 skill → 产生记忆 → 下次变 5 分钟
 - **调试过程中的原始 dump / 抓包 / HTML 样本只能落在 `~/.opencli/sites/<site>/fixtures/` 或 `/tmp/`。严禁在 repo 根目录、`clis/<site>/` 或当前工作目录留 `.dbg-*.html / raw-*.json / sample.*` 这类临时文件**（PR diff 会带上去，别人 review 时很烦）。
+- **JSDOM unit-test fixture（`clis/<site>/__fixtures__/<command>.html`）是上面那条的例外**——它是有意 commit 进 repo 的 review artifact，不是临时 dump。但因此 quality bar 要更高：必须按 `references/jsdom-fixture-pattern.md` 的 5 步做完（含 mandatory `awk 'NF>0'` 空白行收紧），并 reverse-validate 一道证明 regression guard 真能挂。
 
 ---
 

--- a/skills/opencli-adapter-author/references/jsdom-fixture-pattern.md
+++ b/skills/opencli-adapter-author/references/jsdom-fixture-pattern.md
@@ -1,0 +1,196 @@
+# JSDOM-against-frozen-fixture pattern (for in-browser DOM extractors)
+
+## When this pattern applies
+
+You're writing an adapter where the data extraction happens **inside the
+live browser** via `page.evaluate(...)` — not in Node-side post-processing.
+Typical signal: the adapter has a function literal stringified into
+`page.evaluate('(' + fn.toString() + ')()')`, walking `document.querySelector`
+and other DOM APIs.
+
+These extractors are invisible to mocked `page.evaluate` unit tests — those
+tests feed pre-baked results to the func, so the real DOM walk never runs.
+PR #1312 found two such silent in-browser bugs in dianping that only
+surfaced on live verify:
+
+1. shop title fallback split on ASCII `[]` while the page renders
+   full-width `【】`, so `name` was always empty.
+2. `headText.replace(/\s+/g, ' ')` collapsed rating "4.8" with reviews
+   "21241条", and a head-wide `/\d+条/` regex captured `4.821241` → 5.
+
+If either category looks plausible for your site, freeze a representative
+HTML snapshot and replay it through JSDOM in a unit test.
+
+## File layout
+
+- Test file: `clis/<site>/<site>.test.js` (alongside the adapter file)
+- Fixture file: `clis/<site>/__fixtures__/<command>.html`
+
+Reference implementation: `clis/dianping/__fixtures__/{shop,search}.html`
+(see PR #1313 for the original test + PR #1318 for the whitespace-strip
+follow-up that this doc grew out of).
+
+## Creating the HTML fixture
+
+The whole point is to commit a **representative snapshot of the live
+page's DOM** — so the JSDOM unit test exercises the real selector paths
+the live extractor walks.
+
+### Mandatory steps (in order)
+
+1. **Capture** the page's HTML from a live verify run:
+   ```bash
+   opencli browser open https://www.example.com/<page>
+   # In another shell, dump page.content():
+   opencli browser eval 'document.documentElement.outerHTML' \
+     > /tmp/raw-<command>.html
+   ```
+
+2. **Strip noise blocks** that JSDOM doesn't need and that change every
+   page load (so committed fixtures wouldn't survive a re-capture diff
+   anyway):
+   - All `<script>...</script>` content
+   - All `<style>...</style>` content
+   - All `<iframe>...</iframe>` content
+   - All `<!-- ... -->` HTML comments
+   - All `<link rel="preload" ...>` / tracking pixels
+
+3. **Replace `<img src="...">`** with a placeholder
+   (`src="placeholder.png"`) — real CDN URLs leak account-scoped tokens
+   and are noise.
+
+4. **Trim to the minimum subtree** that exercises the extractor and
+   triggers the bug you're guarding against. For dianping shop, that
+   was `.shop-head` + `.desc-info` + `.review-title`; for search,
+   3 of 15 result `<li>` cards (rank 1, 2, 3).
+
+5. **MANDATORY whitespace normalization step** — strip all
+   whitespace-only lines:
+   ```bash
+   awk 'NF>0' /tmp/raw-<command>.html > clis/<site>/__fixtures__/<command>.html
+   ```
+   JSDOM's HTML parser is whitespace-tolerant; blank lines have zero
+   semantic effect on the test, but they bloat the committed diff and
+   obscure the meaningful DOM subtree from reviewers.
+   **Skipping this step is the most common silent quality regression
+   in fixture creation.** PR #1318 cleaned 239 leftover blank lines
+   from dianping's two fixtures (84.6% / 54.8% of file content) and
+   the JSDOM tests still passed unchanged.
+
+6. **Commit** at `clis/<site>/__fixtures__/<command>.html`.
+
+### Anti-patterns to avoid
+
+- ❌ "Strip script/style content" but leave the surrounding newlines.
+  Removing inline script body without collapsing the now-blank line is
+  the source of the noise — Step 5 exists specifically to clean this up.
+- ❌ Trim to minimum subtree, skip Step 5. The fixture works for the
+  test but reviewers see hundreds of blank lines.
+- ❌ Pretty-print the **mega-line** (e.g. `<div>...</div>` collapsed
+  onto one giant line by the source page). Some bugs depend on
+  text-node adjacency without intervening whitespace (e.g. `4.8` and
+  `21241条` immediately adjacent → `headText` fusion bug). Pretty-print
+  inserts whitespace that masks the very condition you're testing for.
+  Step 5 only deletes empty lines — never re-flow content.
+- ❌ Re-capture from live and overwrite the committed fixture without
+  re-running Steps 2-5. The fixture is a **frozen** snapshot; if the
+  page layout changes, that's a separate decision (update test
+  expectations + re-trim + re-strip).
+
+## Writing the JSDOM unit test
+
+```js
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { extractShopFields } from './shop.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHOP_FIXTURE = readFileSync(join(__dirname, '__fixtures__/shop.html'), 'utf8');
+
+describe('shop adapter — extractor against frozen HTML fixture', () => {
+    let originalDocument;
+    let originalLocation;
+
+    beforeEach(() => {
+        originalDocument = globalThis.document;
+        originalLocation = globalThis.location;
+    });
+
+    afterEach(() => {
+        globalThis.document = originalDocument;
+        globalThis.location = originalLocation;
+    });
+
+    function loadFixture(html, url) {
+        const dom = new JSDOM(html, { url });
+        globalThis.document = dom.window.document;
+        globalThis.location = dom.window.location;
+        return dom;
+    }
+
+    it('extracts the canonical fields and avoids known silent bugs', () => {
+        loadFixture(SHOP_FIXTURE, 'https://www.example.com/shop/123');
+
+        const data = extractShopFields();
+
+        expect(data.ok).toBe(true);
+        expect(data.name).toBe('...');
+        // Add explicit regression guards for each known silent bug.
+        expect(data.reviewsRaw).toBe('...');  // not the fused "<rating><reviews>" form
+    });
+});
+```
+
+For this to work, the adapter's extractor must be a **top-level
+function** that uses bare `document` / `location` (not `window.document`),
+so the same code is exercised by:
+
+- live browser: injected via `${extractFn.toString()}` into
+  `page.evaluate`
+- JSDOM unit test: with `globalThis.document` swapped
+
+If your adapter currently has the extractor as an IIFE inside a
+template literal, refactor to a top-level `export function` first.
+Reference: `clis/dianping/{shop,search}.js` extracts `extractShopFields()`
+and `extractSearchRows()` with bare `document`/`location`.
+
+## Reverse-validation (mandatory before claiming the test catches the bug)
+
+A test that "passes 18/18" doesn't prove it would have caught the original
+bug — only that it agrees with the current implementation. Before
+trusting a regression guard:
+
+1. Make a backup of the adapter source.
+2. Reintroduce the buggy variant of the relevant extractor.
+3. Run the test. It MUST fail with an assertion that points at the
+   silent bug.
+4. Restore from backup.
+
+For dianping bug #2 (rating/reviews fusion):
+```js
+// BUGGY VARIANT — replaces the .reviews selector path
+const buggyMatch = headText.match(/(\d+)条/);
+let reviewsRaw = buggyMatch ? buggyMatch[0] : '';
+```
+
+If after Step 5 of fixture creation the test still fails on this buggy
+variant with `expected '21241条' to be '21241条'` actually receiving
+`'821241条'` (the fused digits), the regression guard is intact. If the
+test still passes with the buggy variant, the fixture is too stripped /
+normalization went too far / the assertion is too loose — go back and
+tighten.
+
+This is the same discipline as `--write-fixture` Step 10 in the main
+runbook (verify fixture catches what it should), applied to the JSDOM
+HTML fixture instead of the response JSON fixture.
+
+## See also
+
+- `references/adapter-template.md` — basic adapter file structure
+- `references/output-design.md` — column naming for the post-extract mapping
+- `references/success-rate-pitfalls.md` — broader "verify can pass while
+  data is silently wrong" catalog; the mocked-page.evaluate gap that
+  motivates this whole pattern is one entry there


### PR DESCRIPTION
## Summary

Follow-up to #1313 (introduced the dianping JSDOM-against-frozen-fixture pattern) and #1318 (cleaned 239 leftover blank lines from those fixtures).

The skill had no reference doc for this whole category of test, so the next adapter author who hits silent-in-browser-DOM bugs would either reinvent the pattern or skip it. This PR codifies it.

## What's in the new doc

`skills/opencli-adapter-author/references/jsdom-fixture-pattern.md` — when/how to use the pattern, with these key conventions made explicit:

- **MANDATORY `awk 'NF>0'` as the final step of fixture creation.** The blank-line noise PR #1318 removed (84.6% / 54.8% of dianping fixture content) came from manually stripping `<script>`/`<style>` without collapsing surrounding newlines. Skipping this step is the silent quality regression the next fixture author will also hit.

- **Trim-to-minimum but never re-flow content.** Some bugs depend on text-node adjacency without intervening whitespace (#1312 bug #2: `4.8` + `21241条` fused as `4.821241条`). Pretty-printing the meaningful mega-line would mask the very condition under test.

- **Reverse-validate the regression guard.** "18/18 tests pass" only proves agreement with the current implementation. Reintroducing the buggy variant must make the test fail. Same discipline `--write-fixture` Step 10 already mandates for verify response fixtures.

- **`__fixtures__/` is the documented exception** to "no committed HTML dumps" in `关键约定`. Calling it out explicitly because the rule otherwise reads as "all HTML in repo is bad," which the dianping fixture pattern intentionally violates for a real reason.

## SKILL.md changes

- Added the new reference to the references table (line 190 area)
- Added a `关键约定` line clarifying that `__fixtures__/` HTML is the deliberate exception to the "no `.dbg-*.html` in repo" rule, and pointing at the new doc for the discipline that earns the exception

## Why now (and what's NOT in scope)

- WAWQAQ in #1313 thread (`#OpenCLI:36d2f65a`) asked twice — first about visible blank-line noise (→ #1318 cleanup), then about root cause / workflow improvement. This PR is the workflow improvement.
- **No new tooling / CI gate / lint** — B 1-week new-gate freeze still applies. `opencli browser fixture-snapshot` automation can be revisited when a 5th fixture site adopts this pattern (current count: 4 — dianping x2, article-extract x2). Until then, runbook discipline is the right scope.
- **article-extract fixture cleanup** intentionally skipped — blank ratios there (8% / 16%) are an order of magnitude lower than dianping (85% / 55%); ROI doesn't clear B-freeze bar.

## Test plan

- [x] `npm run docs:build` — VitePress build still succeeds (skill doc isn't part of VitePress site, but checking nothing else regressed)
- [x] `npm run typecheck` clean (no code changed)
- [x] No CI gates affected (silent-column-drop / typed-error-lint baselines unchanged)

cc @coding-claude-opus (in #1313 thread you said you'd review the skill follow-up).