### PR TITLE
Release v1.7.12 / Extension v1.0.5

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump CLI version to 1.7.12
- Bump extension version to 1.0.5 (new CDP allowlist methods: DOM.enable, DOM.focus, DOM.querySelector, Page.handleJavaScriptDialog)

## Test plan
- CI green
- Tag after merge triggers npm publish + GitHub Release + extension zip