### PR TITLE
fix: default access to 'read' for local adapters missing the field

### DIFF
--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -102,11 +102,14 @@ describe('cli() registration', () => {
     expect(getRegistry().get('test-registry/plain-default')?.defaultFormat).toBe('plain');
   });
 
-  it('rejects commands without explicit access metadata', () => {
-    expect(() => cli({
+  it('defaults access to read when not specified (backward compat)', () => {
+    const cmd = cli({
       site: 'test-registry',
       name: 'missing-access',
-    } as any)).toThrow("Command test-registry/missing-access must declare access: 'read' | 'write'");
+      description: 'no access field',
+      args: [],
+    } as any);
+    expect(cmd.access).toBe('read');
   });
 });
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -205,8 +205,9 @@ function normalizeCommand(cmd: RawCliCommand): CliCommand {
 
 function assertCommandAccess(cmd: Pick<RawCliCommand, 'site' | 'name'> & { access?: unknown }): asserts cmd is RawCliCommand {
   if (cmd.access === 'read' || cmd.access === 'write') return;
-  const key = `${cmd.site}/${cmd.name}`;
-  throw new Error(`Command ${key} must declare access: 'read' | 'write'`);
+  // Backward compatibility: local/user-written adapters created before access
+  // was mandatory may omit the field. Default to 'read' instead of crashing.
+  (cmd as Record<string, unknown>).access = 'read';
 }
 
 export function registerCommand(cmd: RawCliCommand): void {


### PR DESCRIPTION
## Summary
- Local/user-written adapters created before `access` was mandatory (PR #1296) would crash on load with "must declare access: 'read' | 'write'"
- Instead of throwing, default missing `access` to `'read'` for backward compatibility
- Built-in adapters are unaffected (all already have `access` set via build-manifest validation)

## Test plan
- Updated test in `src/registry.test.ts` passes
- Fixes the "17 local adapter loading failures" reported by @opencli-user