### PR TITLE
fix(update-check): inject --prefix into upgrade hint on silent prefix mismatch

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -10,7 +10,7 @@ import { BrowserBridge } from './browser/index.js';
 import { getDaemonHealth, listSessions } from './browser/daemon-client.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
-import { getCachedLatestExtensionVersion } from './update-check.js';
+import { getCachedLatestExtensionVersion, getUpgradeCommand } from './update-check.js';
 import type { BrowserSessionInfo } from './types.js';
 import type { BrowserProfileStatus } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
@@ -196,7 +196,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     if (!satisfiesRange(opts.cliVersion, extensionCompatRange)) {
       issues.push(
         `CLI version incompatible with extension: extension v${extensionVersion} requires CLI ${extensionCompatRange}, but CLI is v${opts.cliVersion}\n` +
-        '  Update the CLI: npm install -g @jackwener/opencli\n' +
+        `  Update the CLI: ${getUpgradeCommand()}\n` +
         '  Or download a compatible extension from: https://github.com/jackwener/opencli/releases',
       );
     }

--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   _extractLatestExtensionVersionFromReleases as extractLatestExtensionVersionFromReleases,
   _buildUpdateNotices as buildUpdateNotices,
+  _buildNpmInstallCommand as buildNpmInstallCommand,
+  _inferOwningGlobalPrefix as inferOwningGlobalPrefix,
+  _inferDefaultPrefixFromExecPath as inferDefaultPrefixFromExecPath,
   _EXTENSION_STALE_MS as EXTENSION_STALE_MS,
 } from './update-check.js';
 
@@ -133,5 +136,112 @@ describe('buildUpdateNotices', () => {
     });
     expect(lines.cli).toContain('v1.0.0 → v1.1.0');
     expect(lines.extension).toContain('v2.0.0 → v2.1.0');
+  });
+
+  it('uses the install-command override in the CLI hint when provided', () => {
+    const lines = buildUpdateNotices({
+      cliVersion: '1.0.0',
+      cache: { lastCheck: now, latestVersion: '1.0.1' },
+      now,
+      installCommand: 'npm install -g --prefix "/custom/prefix" @jackwener/opencli',
+    });
+    expect(lines.cli).toContain('--prefix "/custom/prefix"');
+  });
+});
+
+describe('buildNpmInstallCommand', () => {
+  it('emits a bare command when prefixes match', () => {
+    expect(
+      buildNpmInstallCommand({
+        owningPrefix: '/usr/local',
+        defaultPrefix: '/usr/local',
+      }),
+    ).toBe('npm install -g @jackwener/opencli');
+  });
+
+  it('emits a bare command when owning prefix cannot be inferred (dev / source)', () => {
+    expect(
+      buildNpmInstallCommand({
+        owningPrefix: null,
+        defaultPrefix: '/usr/local',
+      }),
+    ).toBe('npm install -g @jackwener/opencli');
+  });
+
+  it('emits a bare command when default prefix cannot be inferred', () => {
+    expect(
+      buildNpmInstallCommand({
+        owningPrefix: '/Users/me/.local/share/npm',
+        defaultPrefix: null,
+      }),
+    ).toBe('npm install -g @jackwener/opencli');
+  });
+
+  it('injects --prefix when owning prefix differs from default (the silent-mismatch case)', () => {
+    // Real-world reproduction: CLI installed under user-level prefix via
+    // ~/.npmrc, but env NPM_CONFIG_PREFIX points to the brew-managed node
+    // prefix, so a bare `npm install -g` would land somewhere PATH never
+    // looks. Hint must call out the owning prefix explicitly.
+    const cmd = buildNpmInstallCommand({
+      owningPrefix: '/Users/me/.local/share/npm',
+      defaultPrefix: '/opt/homebrew/Cellar/node@22/22.22.2_2',
+    });
+    expect(cmd).toBe('npm install -g --prefix "/Users/me/.local/share/npm" @jackwener/opencli');
+  });
+
+  it('treats prefixes that resolve to the same path as a match (trailing slash, dot)', () => {
+    expect(
+      buildNpmInstallCommand({
+        owningPrefix: '/usr/local/',
+        defaultPrefix: '/usr/local',
+      }),
+    ).toBe('npm install -g @jackwener/opencli');
+    expect(
+      buildNpmInstallCommand({
+        owningPrefix: '/usr/local/./',
+        defaultPrefix: '/usr/local',
+      }),
+    ).toBe('npm install -g @jackwener/opencli');
+  });
+});
+
+describe('inferOwningGlobalPrefix', () => {
+  it('returns the prefix above lib/node_modules for a standard POSIX npm global install', () => {
+    expect(
+      inferOwningGlobalPrefix(
+        '/Users/me/.local/share/npm/lib/node_modules/@jackwener/opencli/dist/src/update-check.js',
+      ),
+    ).toBe('/Users/me/.local/share/npm');
+  });
+
+  it('returns the prefix above node_modules when there is no lib/ segment (e.g. Windows)', () => {
+    expect(
+      inferOwningGlobalPrefix(
+        '/c/Users/me/AppData/Roaming/npm/node_modules/@jackwener/opencli/dist/src/update-check.js',
+      ),
+    ).toBe('/c/Users/me/AppData/Roaming/npm');
+  });
+
+  it('returns null when the module path is outside any node_modules/@jackwener/opencli (dev / source build)', () => {
+    expect(
+      inferOwningGlobalPrefix('/Users/me/code/opencli/src/update-check.ts'),
+    ).toBeNull();
+    expect(
+      inferOwningGlobalPrefix('/Users/me/code/opencli/dist/src/update-check.js'),
+    ).toBeNull();
+  });
+});
+
+describe('inferDefaultPrefixFromExecPath', () => {
+  it('strips the bin/ segment for a POSIX node binary', () => {
+    expect(
+      inferDefaultPrefixFromExecPath('/opt/homebrew/Cellar/node@22/22.22.2_2/bin/node'),
+    ).toBe('/opt/homebrew/Cellar/node@22/22.22.2_2');
+  });
+
+  it('returns null on POSIX when the layout is non-standard (no bin/ parent)', () => {
+    expect(
+      inferDefaultPrefixFromExecPath('/some/weird/place/node'),
+    ).toBeNull();
   });
 });

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -18,6 +18,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { styleText } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import { PKG_VERSION } from './version.js';
 
 const CACHE_DIR = path.join(os.homedir(), '.opencli');
@@ -86,10 +87,104 @@ function isCI(): boolean {
   return !!(process.env.CI || process.env.CONTINUOUS_INTEGRATION);
 }
 
+/**
+ * Infer the npm global prefix that owns the currently-running CLI binary.
+ *
+ * Returns null when this CLI is being executed from source (dev / vitest) or
+ * from a layout that doesn't match the standard npm global install
+ * (`<prefix>/lib/node_modules/@jackwener/opencli/...` on POSIX, no `lib/`
+ * segment on Windows).
+ *
+ * The point: if this returns a string, that string is the prefix you must
+ * `npm install -g --prefix <here>` against to actually overwrite this CLI.
+ */
+function inferOwningGlobalPrefix(modulePath: string): string | null {
+  try {
+    const marker = `${path.sep}node_modules${path.sep}@jackwener${path.sep}opencli${path.sep}`;
+    const idx = modulePath.indexOf(marker);
+    if (idx === -1) return null;
+    const beforeNodeModules = modulePath.slice(0, idx);
+    // POSIX npm global layout: `<prefix>/lib/node_modules/...`. Windows: no `lib/`.
+    if (path.basename(beforeNodeModules) === 'lib') return path.dirname(beforeNodeModules);
+    return beforeNodeModules;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute the npm global prefix that `npm install -g` *would* default to,
+ * derived from the running node binary (`<prefix>/bin/node` on POSIX,
+ * `<prefix>/node.exe` on Windows). Returns null if the layout is unfamiliar.
+ *
+ * Note: this is a heuristic — the actual default can be overridden by
+ * `~/.npmrc`, `NPM_CONFIG_PREFIX`, etc. We only use it as a tiebreaker against
+ * `inferOwningGlobalPrefix` to decide whether the upgrade hint needs an
+ * explicit `--prefix` flag.
+ */
+function inferDefaultPrefixFromExecPath(execPath: string): string | null {
+  try {
+    const dir = path.dirname(execPath);
+    if (path.basename(dir) === 'bin') return path.dirname(dir);
+    // Windows: `<prefix>/node.exe` — exec path's dir IS the prefix.
+    if (process.platform === 'win32') return dir;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the `npm install -g` command suggested in upgrade hints.
+ *
+ * If the prefix that owns the running CLI binary differs from the prefix
+ * `npm install -g` would default to (e.g. CLI installed under
+ * `~/.local/share/npm` via `~/.npmrc`, but `NPM_CONFIG_PREFIX` env points
+ * at the brew node prefix), emit `--prefix <owning>` so the upgrade lands
+ * on the same binary the user is already running.
+ *
+ * This silent prefix mismatch is the most common cause of "I ran the
+ * upgrade command and `opencli --version` didn't change."
+ */
+function buildNpmInstallCommand({
+  owningPrefix,
+  defaultPrefix,
+}: {
+  owningPrefix: string | null;
+  defaultPrefix: string | null;
+}): string {
+  if (
+    owningPrefix &&
+    defaultPrefix &&
+    path.resolve(owningPrefix) !== path.resolve(defaultPrefix)
+  ) {
+    // Quote the path defensively in case it contains spaces.
+    return `npm install -g --prefix "${owningPrefix}" @jackwener/opencli`;
+  }
+  return 'npm install -g @jackwener/opencli';
+}
+
+/**
+ * Public: returns the current upgrade command for this runtime, with
+ * `--prefix` injected when the running binary's prefix differs from npm's
+ * default.
+ */
+export function getUpgradeCommand(): string {
+  return buildNpmInstallCommand({
+    owningPrefix: inferOwningGlobalPrefix(fileURLToPath(import.meta.url)),
+    defaultPrefix: inferDefaultPrefixFromExecPath(process.execPath),
+  });
+}
+
 interface NoticeInputs {
   cliVersion: string;
   cache: UpdateCache | null;
   now: number;
+  /**
+   * Optional override of the install command (test seam). Defaults to the
+   * runtime-inferred command via `getUpgradeCommand()`.
+   */
+  installCommand?: string;
 }
 
 interface NoticeLines {
@@ -98,13 +193,14 @@ interface NoticeLines {
 }
 
 /** Pure function: derive notice text from cache state. Exported for tests. */
-function buildUpdateNotices({ cliVersion, cache, now }: NoticeInputs): NoticeLines {
+function buildUpdateNotices({ cliVersion, cache, now, installCommand }: NoticeInputs): NoticeLines {
   if (!cache) return {};
   const lines: NoticeLines = {};
+  const cmd = installCommand ?? getUpgradeCommand();
   if (cache.latestVersion && isNewer(cache.latestVersion, cliVersion)) {
     lines.cli =
       styleText('yellow', `\n  Update available: v${cliVersion} → v${cache.latestVersion}\n`) +
-      styleText('dim', `  Run: npm install -g @jackwener/opencli\n`);
+      styleText('dim', `  Run: ${cmd}\n`);
   }
   const { currentExtensionVersion, latestExtensionVersion, extensionLastSeenAt } = cache;
   if (
@@ -233,5 +329,8 @@ export function getCachedLatestExtensionVersion(): string | undefined {
 export {
   extractLatestExtensionVersionFromReleases as _extractLatestExtensionVersionFromReleases,
   buildUpdateNotices as _buildUpdateNotices,
+  buildNpmInstallCommand as _buildNpmInstallCommand,
+  inferOwningGlobalPrefix as _inferOwningGlobalPrefix,
+  inferDefaultPrefixFromExecPath as _inferDefaultPrefixFromExecPath,
   EXTENSION_STALE_MS as _EXTENSION_STALE_MS,
 };


### PR DESCRIPTION
## Why

Hit this myself today going `1.7.11 → 1.7.12`:

```
$ npm install -g @jackwener/opencli@latest
changed 17 packages in 10s
$ opencli --version
1.7.11   # ← still the old one
```

Cause: `~/.npmrc` puts the user-level prefix at `~/.local/share/npm`
(which is what PATH's `opencli` symlink points into), but the env var
`npm_config_prefix=/opt/homebrew/Cellar/node@22/...` overrides it. So
`npm install -g` runs against the brew prefix, the user-level prefix
stays on 1.7.11, and `opencli --version` keeps lying.

The `Run: npm install -g @jackwener/opencli` exit-time hint is exactly
what walked me into this trap. Same hint shows up in `opencli doctor`
when an incompatible-extension issue fires.

## What

Make both upgrade hints emit `--prefix "<owning>"` when they detect
the prefix that owns the running CLI binary differs from the prefix
`npm install -g` would default to.

- `inferOwningGlobalPrefix(modulePath)` — walks up from the CLI module
  through `node_modules/@jackwener/opencli/...` to find the npm global
  prefix that owns this binary. Handles POSIX `<prefix>/lib/node_modules`
  + Windows-style `<prefix>/node_modules`. Returns `null` for dev /
  source builds.
- `inferDefaultPrefixFromExecPath(execPath)` — derives the prefix
  `npm install -g` would default to, from `<prefix>/bin/node` (POSIX)
  or `<prefix>/node.exe` (Windows). Returns `null` on weird layouts.
- `buildNpmInstallCommand({owningPrefix, defaultPrefix})` — pure
  function:
  - both resolve to the same path → `npm install -g @jackwener/opencli`
  - either is `null` (dev / source build / unknown layout) →
    same bare command (don't make up a prefix we can't verify)
  - they differ → `npm install -g --prefix "<owning>" @jackwener/opencli`
- `getUpgradeCommand()` — runtime-resolved command shared by both call
  sites:
  - `src/update-check.ts` exit-time CLI update notice
  - `src/doctor.ts` extension-incompat hint

## Test plan

- [x] `npx vitest run src/update-check.test.ts` (21/21 pass — added 9
      new cases covering match / null / mismatch / trailing-slash /
      dev / POSIX / Windows layouts)
- [x] `npx vitest run src/doctor.test.ts` (20/20 pass)
- [x] `npx tsc --noEmit` clean
- [x] `npm run check:silent-column-drop` 103=103, new=0
- [x] `npm run check:typed-error-lint` 198=198, new=0
- [ ] CI green

Conservative by design: when the inferer can't figure out the layout
(dev / source / vitest / unfamiliar packaging), it falls back to the
existing bare command. So the only behavior change is: when the
exact silent-mismatch case is detectable, we now emit the working
`--prefix` form.