### PR TITLE
Allow direct CDP endpoint options for browser commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docs/.vitepress/cache
 .windsurf
 .claude
 .cortex
+.omx
 
 # Database files
 *.db

--- a/README.md
+++ b/README.md
@@ -207,6 +207,13 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
+You can also pass CDP settings per command:
+
+```bash
+opencli --cdp-endpoint http://127.0.0.1:9222 <site> <command>
+opencli browser --cdp-endpoint http://127.0.0.1:9222 state
+```
+
 `--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation lease open until you run `opencli browser close` or the idle timeout expires.
 
 ## Update

--- a/docs/advanced/remote-chrome.md
+++ b/docs/advanced/remote-chrome.md
@@ -37,6 +37,13 @@ Use `127.0.0.1` instead of `localhost` in the SSH command to avoid IPv6 resoluti
 export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
 ```
 
+For one-off browser automation commands, pass the endpoint directly:
+
+```bash
+opencli browser --cdp-endpoint http://127.0.0.1:9222 state
+opencli browser --cdp-endpoint http://127.0.0.1:9222 open https://example.com
+```
+
 ### 4. Verify
 
 ```bash

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -29,7 +29,14 @@ export class BrowserBridge implements IBrowserFactory {
     return this._state;
   }
 
-  async connect(opts: { timeout?: number; workspace?: string; idleTimeout?: number; contextId?: string } = {}): Promise<IPage> {
+  async connect(opts: {
+    timeout?: number;
+    workspace?: string;
+    idleTimeout?: number;
+    cdpEndpoint?: string;
+    cdpTarget?: string;
+    contextId?: string;
+  } = {}): Promise<IPage> {
     if (this._state === 'connected' && this._page) return this._page;
     if (this._state === 'connecting') throw new Error('Already connecting');
     if (this._state === 'closing') throw new Error('Session is closing');

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -53,7 +53,13 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage> {
+  async connect(opts?: {
+    timeout?: number;
+    workspace?: string;
+    cdpEndpoint?: string;
+    cdpTarget?: string;
+    contextId?: string;
+  }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
@@ -62,7 +68,7 @@ export class CDPBridge implements IBrowserFactory {
     let wsUrl = endpoint;
     if (endpoint.startsWith('http')) {
       const targets = await fetchJsonDirect(`${endpoint.replace(/\/$/, '')}/json`) as CDPTarget[];
-      const target = selectCDPTarget(targets);
+      const target = selectCDPTarget(targets, opts?.cdpTarget);
       if (!target || !target.webSocketDebuggerUrl) {
         throw new Error('No inspectable targets found at CDP endpoint');
       }
@@ -437,8 +443,8 @@ function matchesCookieDomain(cookieDomain: string, targetDomain: string): boolea
     || normalizedTargetDomain.endsWith(`.${normalizedCookieDomain}`);
 }
 
-function selectCDPTarget(targets: CDPTarget[]): CDPTarget | undefined {
-  const preferredPattern = compilePreferredPattern(process.env.OPENCLI_CDP_TARGET);
+function selectCDPTarget(targets: CDPTarget[], preferredTarget?: string): CDPTarget | undefined {
+  const preferredPattern = compilePreferredPattern(preferredTarget ?? process.env.OPENCLI_CDP_TARGET);
 
   const ranked = targets
     .map((target, index) => ({ target, index, score: scoreCDPTarget(target, preferredPattern) }))

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -12,6 +12,8 @@ import { PKG_VERSION } from './version.js';
 const {
   mockBrowserConnect,
   mockBrowserClose,
+  mockCdpConnect,
+  mockCdpClose,
   mockBindTab,
   mockSendCommand,
   mockExecFileSync,
@@ -19,6 +21,8 @@ const {
 } = vi.hoisted(() => ({
   mockBrowserConnect: vi.fn(),
   mockBrowserClose: vi.fn(),
+  mockCdpConnect: vi.fn(),
+  mockCdpClose: vi.fn(),
   mockBindTab: vi.fn(),
   mockSendCommand: vi.fn(),
   mockExecFileSync: vi.fn(),
@@ -27,10 +31,15 @@ const {
 
 vi.mock('./browser/index.js', () => {
   mockBrowserConnect.mockImplementation(async () => browserState.page as IPage);
+  mockCdpConnect.mockImplementation(async () => browserState.page as IPage);
   return {
     BrowserBridge: class {
       connect = mockBrowserConnect;
       close = mockBrowserClose;
+    },
+    CDPBridge: class {
+      connect = mockCdpConnect;
+      close = mockCdpClose;
     },
   };
 });
@@ -472,6 +481,8 @@ describe('browser tab targeting commands', () => {
     stderrSpy.mockClear();
     mockBrowserConnect.mockClear();
     mockBrowserClose.mockReset().mockResolvedValue(undefined);
+    mockCdpConnect.mockClear();
+    mockCdpClose.mockReset().mockResolvedValue(undefined);
     mockBindTab.mockReset().mockResolvedValue({
       workspace: 'bound:default',
       page: 'tab-2',
@@ -548,6 +559,30 @@ describe('browser tab targeting commands', () => {
 
     expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default' });
     expect(browserState.page?.snapshot).toHaveBeenCalled();
+  });
+
+  it('routes browser commands through CDP when an endpoint is provided', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync([
+      'node',
+      'opencli',
+      'browser',
+      '--cdp-endpoint',
+      'http://127.0.0.1:9222',
+      '--cdp-target',
+      'example',
+      'state',
+    ]);
+
+    expect(mockBrowserConnect).not.toHaveBeenCalled();
+    expect(mockCdpConnect).toHaveBeenCalledWith({
+      timeout: 30,
+      cdpEndpoint: 'http://127.0.0.1:9222',
+      cdpTarget: 'example',
+    });
+    expect(browserState.page?.snapshot).toHaveBeenCalled();
+    expect(mockCdpClose).toHaveBeenCalledTimes(1);
   });
 
   it('blocks history navigation on bound workspaces unless explicitly allowed', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
 const DEFAULT_BOUND_WORKSPACE = 'bound:default';
 const BROWSER_TAB_OPTION_DESCRIPTION = 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"';
 const FOLLOW_POLL_MS = 1_000;
+const BROWSER_PAGE_CLEANUP = Symbol('opencli.browserPageCleanup');
 
 type BrowserNetworkItem = {
   url: string;
@@ -56,6 +57,10 @@ type BrowserNetworkItem = {
   bodyTruncated?: boolean;
   /** Epoch milliseconds when the request was observed. */
   timestamp?: number;
+};
+
+type BrowserPageWithCleanup = import('./types.js').IPage & {
+  [BROWSER_PAGE_CLEANUP]?: () => Promise<void>;
 };
 
 function parseDurationMs(raw: unknown, flagName: string): number | null | { error: string } {
@@ -374,7 +379,31 @@ async function resolveStoredBrowserTarget(page: import('./types.js').IPage, scop
 }
 
 /** Create a browser page for browser commands. Uses a dedicated browser workspace for session persistence. */
-async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_BROWSER_WORKSPACE, contextId?: string): Promise<import('./types.js').IPage> {
+async function getBrowserPage(
+  targetPage?: string,
+  workspace: string = DEFAULT_BROWSER_WORKSPACE,
+  contextId?: string,
+  opts: { cdpEndpoint?: string; cdpTarget?: string } = {},
+): Promise<import('./types.js').IPage> {
+  const cdpEndpoint = opts.cdpEndpoint?.trim();
+  if (cdpEndpoint) {
+    if (targetPage) {
+      throw new Error('Direct CDP mode does not support --tab. Use --cdp-target/OPENCLI_CDP_TARGET or pass a page WebSocket URL as --cdp-endpoint.');
+    }
+    const { CDPBridge } = await import('./browser/index.js');
+    const bridge = new CDPBridge();
+    const page = await bridge.connect({
+      timeout: 30,
+      cdpEndpoint,
+      ...(opts.cdpTarget?.trim() ? { cdpTarget: opts.cdpTarget.trim() } : {}),
+    }) as BrowserPageWithCleanup;
+    Object.defineProperty(page, BROWSER_PAGE_CLEANUP, {
+      value: () => bridge.close(),
+      configurable: true,
+    });
+    return page;
+  }
+
   const { BrowserBridge } = await import('./browser/index.js');
   const bridge = new BrowserBridge();
   const envTimeout = process.env.OPENCLI_BROWSER_TIMEOUT;
@@ -428,6 +457,20 @@ function getBrowserContextId(command?: Command): string | undefined {
   return resolveProfileContextId(typeof raw === 'string' && raw.trim() ? raw.trim() : undefined);
 }
 
+function getBrowserCdpEndpoint(command?: Command): string | undefined {
+  const raw = getCommandOption(command, 'cdpEndpoint');
+  if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  const env = process.env.OPENCLI_CDP_ENDPOINT;
+  return typeof env === 'string' && env.trim() ? env.trim() : undefined;
+}
+
+function getBrowserCdpTarget(command?: Command): string | undefined {
+  const raw = getCommandOption(command, 'cdpTarget');
+  if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  const env = process.env.OPENCLI_CDP_TARGET;
+  return typeof env === 'string' && env.trim() ? env.trim() : undefined;
+}
+
 function getPageWorkspace(page: import('./types.js').IPage): string {
   const workspace = (page as unknown as { workspace?: unknown }).workspace;
   return typeof workspace === 'string' && workspace.trim() ? workspace.trim() : DEFAULT_BROWSER_WORKSPACE;
@@ -436,6 +479,10 @@ function getPageWorkspace(page: import('./types.js').IPage): string {
 function getPageScope(page: import('./types.js').IPage): string {
   const contextId = (page as unknown as { contextId?: unknown }).contextId;
   return getBrowserScope(getPageWorkspace(page), typeof contextId === 'string' && contextId.trim() ? contextId.trim() : undefined);
+}
+
+async function closeBrowserPageTransport(page: import('./types.js').IPage): Promise<void> {
+  await (page as BrowserPageWithCleanup)[BROWSER_PAGE_CLEANUP]?.().catch(() => {});
 }
 
 function resolveBrowserTabTarget(targetId?: string, opts?: { tab?: string } | Command): string | undefined {
@@ -482,6 +529,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .description('Make any website your CLI. Zero setup. AI-powered.')
     .version(PKG_VERSION)
     .option('--profile <name>', 'Chrome profile/context alias for Browser Bridge commands')
+    .option('--cdp-endpoint <url>', 'Chrome DevTools Protocol endpoint for direct browser automation')
+    .option('--cdp-target <pattern>', 'Filter CDP targets by title or URL substring')
     .enablePositionalOptions();
 
   // ── Built-in: list ────────────────────────────────────────────────────────
@@ -613,6 +662,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   const browser = program
     .command('browser')
     .option('--workspace <name>', 'Browser workspace to use (default: browser:default; bound tabs use bound:<name>)')
+    .option('--cdp-endpoint <url>', 'Chrome DevTools Protocol endpoint for direct browser automation')
+    .option('--cdp-target <pattern>', 'Filter CDP targets by title or URL substring')
     .description('Browser control — navigate, click, type, extract, wait (no LLM needed)');
 
   /**
@@ -691,8 +742,15 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         const targetPage = getBrowserTargetId(command);
         const workspace = getBrowserWorkspace(command);
         const contextId = getBrowserContextId(command);
-        const page = await getBrowserPage(targetPage, workspace, contextId);
-        await fn(page, ...args);
+        const page = await getBrowserPage(targetPage, workspace, contextId, {
+          cdpEndpoint: getBrowserCdpEndpoint(command),
+          cdpTarget: getBrowserCdpTarget(command),
+        });
+        try {
+          await fn(page, ...args);
+        } finally {
+          await closeBrowserPageTransport(page);
+        }
       } catch (err) {
         if (err instanceof BrowserConnectError) {
           log.error(err.message);

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -105,6 +105,8 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
       const result = await executeCommand(cmd, kwargs, verbose, {
         prepared: true,
         ...(typeof globals.profile === 'string' && globals.profile.trim() ? { profile: globals.profile.trim() } : {}),
+        ...(typeof globals.cdpEndpoint === 'string' && globals.cdpEndpoint.trim() ? { cdpEndpoint: globals.cdpEndpoint.trim() } : {}),
+        ...(typeof globals.cdpTarget === 'string' && globals.cdpTarget.trim() ? { cdpTarget: globals.cdpTarget.trim() } : {}),
         ...(typeof optionsRecord.trace === 'string' && optionsRecord.trace !== 'off' ? { trace: optionsRecord.trace } : {}),
       });
       if (result === null || result === undefined) {

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -78,6 +78,41 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('routes browser-backed adapters through CDP when OPENCLI_CDP_ENDPOINT is set', async () => {
+    const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+    let capturedFactoryName = '';
+    let capturedOpts: unknown;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (Factory, fn, opts) => {
+      capturedFactoryName = Factory.name;
+      capturedOpts = opts;
+      return fn(mockPage);
+    });
+
+    const prevEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
+    process.env.OPENCLI_CDP_ENDPOINT = 'http://127.0.0.1:9222';
+    try {
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'browser-cdp-endpoint', access: 'read',
+        description: 'test CDP endpoint routing',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => [{ ok: true }],
+      });
+
+      await executeCommand(cmd, {});
+
+      expect(capturedFactoryName).toBe('CDPBridge');
+      expect(capturedOpts).toMatchObject({ cdpEndpoint: 'http://127.0.0.1:9222' });
+    } finally {
+      if (prevEndpoint === undefined) delete process.env.OPENCLI_CDP_ENDPOINT;
+      else process.env.OPENCLI_CDP_ENDPOINT = prevEndpoint;
+      vi.restoreAllMocks();
+    }
+  });
+
   it('skips closeWindow when OPENCLI_LIVE=1 (success path)', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -26,12 +26,12 @@ import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
 import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceReceipt, getErrorMessage } from './errors.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
-import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT } from './runtime.js';
+import { getBrowserFactoryForEndpoint, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT } from './runtime.js';
 import { resolveProfileContextId } from './browser/profile.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
-import { probeCDP, resolveElectronEndpoint } from './launcher.js';
+import { resolveElectronEndpoint } from './launcher.js';
 import { ObservationSession, exportObservationSession, type ObservationExportResult, type ObservationExportStatus } from './observation/index.js';
 import { resolveAdapterSourcePath } from './adapter-source.js';
 
@@ -182,6 +182,8 @@ export async function executeCommand(
   opts: {
     prepared?: boolean;
     profile?: string;
+    cdpEndpoint?: string;
+    cdpTarget?: string;
     trace?: string;
     onTraceExport?: (trace: ObservationExportResult) => void;
   } = {},
@@ -207,27 +209,14 @@ export async function executeCommand(
   try {
     if (shouldUseBrowserSession(cmd)) {
       const electron = isElectronApp(cmd.site);
-      let cdpEndpoint: string | undefined;
+      let cdpEndpoint = opts.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
 
-      if (electron) {
-        // Electron apps: respect manual endpoint override, then try auto-detect
-        const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
-        if (manualEndpoint) {
-          const port = Number(new URL(manualEndpoint).port);
-          if (!await probeCDP(port)) {
-            throw new CommandExecutionError(
-              `CDP not reachable at ${manualEndpoint}`,
-              'Check that the app is running with --remote-debugging-port and the endpoint is correct.',
-            );
-          }
-          cdpEndpoint = manualEndpoint;
-        } else {
-          cdpEndpoint = await resolveElectronEndpoint(cmd.site);
-        }
+      if (electron && !cdpEndpoint) {
+        cdpEndpoint = await resolveElectronEndpoint(cmd.site);
       }
 
       ensureRequiredEnv(cmd);
-      const BrowserFactory = getBrowserFactory(cmd.site);
+      const BrowserFactory = getBrowserFactoryForEndpoint(cdpEndpoint, cmd.site);
       const contextId = resolveProfileContextId(opts.profile);
       const internal = cmd as InternalCliCommand;
       result = await browserSession(BrowserFactory, async (page) => {
@@ -343,7 +332,12 @@ export async function executeCommand(
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { workspace: `site:${cmd.site}:${crypto.randomUUID()}`, cdpEndpoint, contextId });
+      }, {
+        workspace: `site:${cmd.site}:${crypto.randomUUID()}`,
+        cdpEndpoint,
+        cdpTarget: opts.cdpTarget,
+        contextId,
+      });
     } else {
       // Non-browser commands: apply timeout only when explicitly configured.
       const timeout = cmd.timeoutSeconds;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,6 +13,11 @@ export function getBrowserFactory(site?: string): new () => IBrowserFactory {
   return BrowserBridge;
 }
 
+export function getBrowserFactoryForEndpoint(cdpEndpoint?: string, site?: string): new () => IBrowserFactory {
+  if (cdpEndpoint) return CDPBridge;
+  return getBrowserFactory(site);
+}
+
 function parseEnvTimeout(envVar: string, fallback: number): number {
   const raw = process.env[envVar];
   if (raw === undefined) return fallback;
@@ -64,14 +69,21 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage>;
+  connect(opts?: {
+    timeout?: number;
+    workspace?: string;
+    idleTimeout?: number;
+    cdpEndpoint?: string;
+    cdpTarget?: string;
+    contextId?: string;
+  }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { workspace?: string; cdpEndpoint?: string; contextId?: string } = {},
+  opts: { workspace?: string; cdpEndpoint?: string; cdpTarget?: string; contextId?: string } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -79,6 +91,7 @@ export async function browserSession<T>(
       timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
       workspace: opts.workspace,
       cdpEndpoint: opts.cdpEndpoint,
+      cdpTarget: opts.cdpTarget,
       contextId: opts.contextId,
     });
     return await fn(page);


### PR DESCRIPTION
## Summary
- add global and browser-level --cdp-endpoint / --cdp-target options
- route one-off browser commands and browser-backed adapters through CDPBridge when an endpoint is provided
- document direct CDP usage and cover CLI/runtime routing with unit tests

## Tests
- npm run typecheck
- npx vitest run --project unit src/cli.test.ts src/execution.test.ts