### PR TITLE
fix(xianyu): fix chat send button detection and textarea activation

### DIFF
--- a/clis/xianyu/chat.js
+++ b/clis/xianyu/chat.js
@@ -12,8 +12,9 @@ function buildExtractChatStateEvaluate() {
       const requiresAuth = /请先登录|登录后/.test(bodyText);
 
       const textarea = document.querySelector('textarea');
+      const normalizeBtn = (s) => (s || '').replace(/\\s+/g, '').trim();
       const sendButton = Array.from(document.querySelectorAll('button'))
-        .find((btn) => clean(btn.textContent || '') === '发送');
+        .find((btn) => normalizeBtn(btn.textContent || '') === '发送');
       const topbar = document.querySelector('[class*="message-topbar"]');
       const itemCard = Array.from(document.querySelectorAll('a[href*="/item?id="]'))
         .find((el) => el.closest('main'));
@@ -51,7 +52,7 @@ function buildExtractChatStateEvaluate() {
 }
 function buildSendMessageEvaluate(text) {
     return `
-    (() => {
+    (async () => {
       const clean = (value) => (value || '').replace(/\\s+/g, ' ').trim();
       const textarea = document.querySelector('textarea');
       if (!textarea || textarea.disabled) {
@@ -63,13 +64,22 @@ function buildSendMessageEvaluate(text) {
         return { ok: false, reason: 'textarea-setter-not-found' };
       }
 
+      // Click textarea first to activate chat and trigger send button to appear
+      textarea.click();
       textarea.focus();
       setter.call(textarea, ${JSON.stringify(text)});
       textarea.dispatchEvent(new Event('input', { bubbles: true }));
       textarea.dispatchEvent(new Event('change', { bubbles: true }));
 
-      const sendButton = Array.from(document.querySelectorAll('button'))
-        .find((btn) => clean(btn.textContent || '') === '发送');
+      // Poll up to 3s for send button (may appear after textarea interaction)
+      const normalizeBtn = (s) => (s || '').replace(/\\s+/g, '').trim();
+      let sendButton = null;
+      for (let i = 0; i < 30; i++) {
+        sendButton = Array.from(document.querySelectorAll('button'))
+          .find((btn) => normalizeBtn(btn.textContent || '') === '发送');
+        if (sendButton) break;
+        await new Promise(r => setTimeout(r, 100));
+      }
       if (!sendButton) {
         return { ok: false, reason: 'send-button-not-found' };
       }

--- a/clis/xianyu/chat.js
+++ b/clis/xianyu/chat.js
@@ -154,4 +154,6 @@ cli({
 export const __test__ = {
     normalizeNumericId,
     buildChatUrl,
+    buildExtractChatStateEvaluate,
+    buildSendMessageEvaluate,
 };

--- a/clis/xianyu/chat.test.js
+++ b/clis/xianyu/chat.test.js
@@ -1,5 +1,13 @@
+import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
 import { __test__ } from './chat.js';
+
+async function runBrowserScript(html, script, { url = 'https://www.goofish.com/im', beforeEval } = {}) {
+    const dom = new JSDOM(html, { url, runScripts: 'outside-only' });
+    beforeEval?.(dom.window);
+    return dom.window.eval(script);
+}
+
 describe('xianyu chat helpers', () => {
     it('builds goofish im urls from ids', () => {
         expect(__test__.buildChatUrl('1038951278192', '3650092411')).toBe('https://www.goofish.com/im?itemId=1038951278192&peerUserId=3650092411');
@@ -11,5 +19,61 @@ describe('xianyu chat helpers', () => {
     it('rejects non-numeric ids', () => {
         expect(() => __test__.normalizeNumericId('abc', 'item_id', '1038951278192')).toThrow();
         expect(() => __test__.normalizeNumericId('3650092411x', 'user_id', '3650092411')).toThrow();
+    });
+
+    it('detects send buttons with whitespace-split text in the in-browser state extractor', async () => {
+        const state = await runBrowserScript(`
+            <main>
+              <textarea></textarea>
+              <button>发 送</button>
+              <div id="message-list-scrollable"><div class="bubble">你好</div></div>
+            </main>
+        `, __test__.buildExtractChatStateEvaluate());
+
+        expect(state.can_input).toBe(true);
+        expect(state.can_send).toBe(true);
+        expect(state.visible_messages).toEqual(['你好']);
+    });
+
+    it('activates the textarea and waits for a whitespace-split send button before clicking it', async () => {
+        let inputValue = '';
+        let sendClicked = false;
+        const result = await runBrowserScript(`
+            <main>
+              <textarea></textarea>
+            </main>
+        `, __test__.buildSendMessageEvaluate('还在吗？'), {
+            beforeEval(window) {
+                const textarea = window.document.querySelector('textarea');
+                textarea.addEventListener('input', () => {
+                    inputValue = textarea.value;
+                });
+                textarea.addEventListener('click', () => {
+                    const button = window.document.createElement('button');
+                    button.textContent = '发 送';
+                    button.addEventListener('click', () => {
+                        sendClicked = true;
+                    });
+                    window.document.body.append(button);
+                });
+            },
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(inputValue).toBe('还在吗？');
+        expect(sendClicked).toBe(true);
+    });
+
+    it('returns a typed failure reason when activation still does not reveal the send button', async () => {
+        const result = await runBrowserScript('<textarea></textarea>', __test__.buildSendMessageEvaluate('ping'), {
+            beforeEval(window) {
+                window.setTimeout = (fn) => {
+                    fn();
+                    return 0;
+                };
+            },
+        });
+
+        expect(result).toEqual({ ok: false, reason: 'send-button-not-found' });
     });
 });


### PR DESCRIPTION
## Problem

`opencli xianyu chat <item_id> <user_id> --text "..."` silently fails to send messages on newly opened chat tabs.

## Root Cause (3 stacked bugs)

### 1. Button text contains whitespace
Xianyu renders the send button as `发 送` (with a space), but the original code compared against `'发送'` after calling `clean()` which only collapses whitespace. Added `normalizeBtn()` that removes **all** whitespace before comparing.

### 2. Template literal escaping error
`\s` inside a JS template literal is eaten by the string parser, producing `/s+/g` instead of `/\s+/g`. Used `\\s+` to produce the correct regex in the browser context.

### 3. Send button not present on initial load
When the page opens in a new tab, the input area isn't rendered yet. Added a `textarea.click()` to activate the chat UI, then polls up to 3 seconds (30 × 100 ms) for the send button to appear before giving up.

## Changes
- `clis/xianyu/chat.js`: `buildExtractChatStateEvaluate` and `buildSendMessageEvaluate`
  - Add `normalizeBtn()` for whitespace-stripped button matching
  - Convert IIFE to async, add `textarea.click()` activation
  - Poll for send button with 3s timeout