### PR TITLE
feat: add qwen / 1point3acres / coingecko adapters

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -448,7 +448,7 @@
         "type": "int",
         "default": 400,
         "required": false,
-        "help": "每楼正文截断长度（默认 400 字符）"
+        "help": "每楼正文截断长度（默认 400 字符，最少 50）"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -176,7 +176,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "返回条数（默认 20）"
+        "help": "返回条数（默认 20，最多 50）"
       }
     ],
     "columns": [
@@ -222,7 +222,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "返回条数（默认 20）"
+        "help": "返回条数（默认 20，最多 50）"
       }
     ],
     "columns": [
@@ -280,7 +280,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "返回条数（默认 20，最多 ~50）"
+        "help": "返回条数（默认 20，最多 50）"
       }
     ],
     "columns": [
@@ -312,7 +312,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "返回条数（默认 20，最多 ~50）"
+        "help": "返回条数（默认 20，最多 50）"
       }
     ],
     "columns": [
@@ -387,7 +387,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "返回条数（默认 20）"
+        "help": "返回条数（默认 20，最多 50）"
       },
       {
         "name": "fid",
@@ -4789,7 +4789,7 @@
         "type": "int",
         "default": 10,
         "required": false,
-        "help": "返回数量 (max 250)"
+        "help": "返回数量（默认 10，最多 250）"
       }
     ],
     "columns": [
@@ -15387,7 +15387,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Max conversations to show"
+        "help": "Max conversations to show (default 20, max 100)"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -163,6 +163,341 @@
     "navigateBefore": false
   },
   {
+    "site": "1point3acres",
+    "name": "digest",
+    "description": "一亩三分地 精华帖（编辑推荐 / 加精）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回条数（默认 20）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "tid",
+      "title",
+      "forum",
+      "author",
+      "replies",
+      "views",
+      "lastReplyTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/digest.js",
+    "sourceFile": "1point3acres/digest.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "forum",
+    "description": "浏览一亩三分地某个版块的帖子列表（按 fid）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "fid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "版块 ID，例如 145（海外面经）、198（海外职位内推）、27（研究生申请）"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "页码（默认 1）"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回条数（默认 20）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "tid",
+      "kind",
+      "title",
+      "author",
+      "replies",
+      "views",
+      "lastReplyTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/forum.js",
+    "sourceFile": "1point3acres/forum.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "forums",
+    "description": "一亩三分地 所有版块（fid + 版块名）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "filter",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "按版块名关键字过滤（子串匹配，中英文）"
+      }
+    ],
+    "columns": [
+      "fid",
+      "name",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/forums.js",
+    "sourceFile": "1point3acres/forums.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "hot",
+    "description": "一亩三分地 今日热门帖子（按热度排序，约 50 条）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回条数（默认 20，最多 ~50）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "tid",
+      "title",
+      "forum",
+      "author",
+      "replies",
+      "views",
+      "lastReplyTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/hot.js",
+    "sourceFile": "1point3acres/hot.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "latest",
+    "description": "一亩三分地 最新发帖（按发帖时间倒序）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回条数（默认 20，最多 ~50）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "tid",
+      "title",
+      "forum",
+      "author",
+      "replies",
+      "views",
+      "postTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/latest.js",
+    "sourceFile": "1point3acres/latest.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "notifications",
+    "description": "一亩三分地 站内通知（互动 / 点评 / @ 我；需要登录）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "kind",
+        "type": "string",
+        "default": "mypost",
+        "required": false,
+        "help": "通知类型：mypost（我的帖子） / interactive（互动） / system（系统） / app（应用）"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回条数"
+      }
+    ],
+    "columns": [
+      "index",
+      "from",
+      "summary",
+      "time",
+      "threadUrl"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/notifications.js",
+    "sourceFile": "1point3acres/notifications.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "1point3acres",
+    "name": "search",
+    "description": "一亩三分地 站内关键字搜索（需要登录）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "搜索关键字"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回条数（默认 20）"
+      },
+      {
+        "name": "fid",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "限定版块 ID（可选）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "tid",
+      "title",
+      "forum",
+      "author",
+      "replies",
+      "views",
+      "postTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/search.js",
+    "sourceFile": "1point3acres/search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "1point3acres",
+    "name": "thread",
+    "description": "一亩三分地 帖子详情 + 楼层（主楼 + 回复）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "tid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "帖子 ID（数字，见 `hot`/`latest` 返回的 tid）"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "楼层分页页码（默认 1）"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "返回楼层条数（默认 10，含主楼）"
+      },
+      {
+        "name": "contentLimit",
+        "type": "int",
+        "default": 400,
+        "required": false,
+        "help": "每楼正文截断长度（默认 400 字符）"
+      }
+    ],
+    "columns": [
+      "floor",
+      "pid",
+      "author",
+      "postTime",
+      "content",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/thread.js",
+    "sourceFile": "1point3acres/thread.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "user",
+    "description": "一亩三分地 用户空间（用户组 / 积分 / 大米 / 帖子数 等）",
+    "access": "read",
+    "domain": "www.1point3acres.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "who",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "用户名或 uid（纯数字按 uid 查，否则按用户名）"
+      }
+    ],
+    "columns": [
+      "uid",
+      "username",
+      "group",
+      "credits",
+      "rice",
+      "posts",
+      "threads",
+      "digests",
+      "registerTime",
+      "lastAccess",
+      "profileUrl"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/user.js",
+    "sourceFile": "1point3acres/user.js"
+  },
+  {
     "site": "36kr",
     "name": "article",
     "description": "获取36氪文章正文内容",
@@ -4432,6 +4767,45 @@
     "modulePath": "codex/send.js",
     "sourceFile": "codex/send.js",
     "navigateBefore": true
+  },
+  {
+    "site": "coingecko",
+    "name": "top",
+    "description": "按市值排序的加密货币行情（默认 USD）",
+    "access": "read",
+    "domain": "api.coingecko.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "currency",
+        "type": "string",
+        "default": "usd",
+        "required": false,
+        "help": "计价币种 (usd / cny / eur / jpy ...)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "返回数量 (max 250)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "symbol",
+      "name",
+      "price",
+      "change24hPct",
+      "marketCap",
+      "volume24h",
+      "high24h",
+      "low24h"
+    ],
+    "type": "js",
+    "modulePath": "coingecko/top.js",
+    "sourceFile": "coingecko/top.js"
   },
   {
     "site": "coupang",
@@ -14936,6 +15310,263 @@
     "modulePath": "quark/share-tree.js",
     "sourceFile": "quark/share-tree.js",
     "navigateBefore": "https://pan.quark.cn"
+  },
+  {
+    "site": "qwen",
+    "name": "ask",
+    "description": "Send a prompt to Qianwen and return the assistant reply",
+    "access": "write",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Prompt to send to Qianwen"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 120,
+        "required": false,
+        "help": "Max seconds to wait for the response"
+      },
+      {
+        "name": "new",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Start a new chat before sending"
+      },
+      {
+        "name": "think",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Enable 深度思考 (DeepThink)"
+      },
+      {
+        "name": "research",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Enable 深度研究 (DeepResearch)"
+      },
+      {
+        "name": "markdown",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Emit assistant reply as markdown"
+      }
+    ],
+    "columns": [
+      "Role",
+      "Text"
+    ],
+    "timeout": 240,
+    "type": "js",
+    "modulePath": "qwen/ask.js",
+    "sourceFile": "qwen/ask.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "qwen",
+    "name": "history",
+    "description": "List recent Qianwen conversations (requires login)",
+    "access": "read",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max conversations to show"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Title",
+      "Updated",
+      "Url"
+    ],
+    "type": "js",
+    "modulePath": "qwen/history.js",
+    "sourceFile": "qwen/history.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "qwen",
+    "name": "image",
+    "description": "Generate images with Qianwen (AI生图) and save them locally",
+    "access": "write",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Image prompt to send"
+      },
+      {
+        "name": "op",
+        "type": "str",
+        "default": "~/Pictures/qianwen",
+        "required": false,
+        "help": "Output directory"
+      },
+      {
+        "name": "new",
+        "type": "boolean",
+        "default": true,
+        "required": false,
+        "help": "Start a new chat before generating (default: true)"
+      },
+      {
+        "name": "sd",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Skip download; only show the Qianwen link"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 180,
+        "required": false,
+        "help": "Max seconds to wait for the image response"
+      }
+    ],
+    "columns": [
+      "Status",
+      "File",
+      "Link"
+    ],
+    "timeout": 300,
+    "type": "js",
+    "modulePath": "qwen/image.js",
+    "sourceFile": "qwen/image.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "qwen",
+    "name": "new",
+    "description": "Start a new conversation in Qianwen",
+    "access": "write",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status"
+    ],
+    "type": "js",
+    "modulePath": "qwen/new.js",
+    "sourceFile": "qwen/new.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "qwen",
+    "name": "read",
+    "description": "Read messages in the current Qianwen conversation",
+    "access": "read",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "markdown",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Emit assistant replies as markdown"
+      }
+    ],
+    "columns": [
+      "Role",
+      "Text"
+    ],
+    "type": "js",
+    "modulePath": "qwen/read.js",
+    "sourceFile": "qwen/read.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "qwen",
+    "name": "send",
+    "description": "Fire-and-forget: send a prompt to Qianwen without waiting for the reply",
+    "access": "write",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Prompt to send to Qianwen"
+      },
+      {
+        "name": "new",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Start a new chat before sending"
+      },
+      {
+        "name": "think",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Enable 深度思考 (DeepThink)"
+      },
+      {
+        "name": "research",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Enable 深度研究 (DeepResearch)"
+      }
+    ],
+    "columns": [
+      "Status",
+      "Prompt"
+    ],
+    "type": "js",
+    "modulePath": "qwen/send.js",
+    "sourceFile": "qwen/send.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "qwen",
+    "name": "status",
+    "description": "Check Qianwen page availability, login state, current session and model",
+    "access": "read",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status",
+      "Login",
+      "Model",
+      "SessionId",
+      "Url"
+    ],
+    "type": "js",
+    "modulePath": "qwen/status.js",
+    "sourceFile": "qwen/status.js",
+    "navigateBefore": false
   },
   {
     "site": "reddit",

--- a/clis/1point3acres/digest.js
+++ b/clis/1point3acres/digest.js
@@ -2,7 +2,7 @@
  * 一亩三分地 精华帖 — Discuz guide=digest view.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchHtml, parseThreadList, BASE } from './utils.js';
+import { fetchHtml, parseThreadList, normalizeLimit, BASE } from './utils.js';
 
 cli({
     site: '1point3acres',
@@ -13,14 +13,14 @@ cli({
     strategy: Strategy.PUBLIC,
     browser: false,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 50）' },
     ],
     columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'lastReplyTime', 'url'],
     func: async (args) => {
+        const limit = normalizeLimit(args.limit, 20, 50);
         const html = await fetchHtml(`${BASE}/forum.php?mod=guide&view=digest`);
         const items = parseThreadList(html);
-        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
-        return items.slice(0, n).map((t, i) => ({
+        return items.slice(0, limit).map((t, i) => ({
             rank: i + 1,
             tid: t.tid,
             title: t.title,

--- a/clis/1point3acres/digest.js
+++ b/clis/1point3acres/digest.js
@@ -1,0 +1,35 @@
+/**
+ * 一亩三分地 精华帖 — Discuz guide=digest view.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchHtml, parseThreadList, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'digest',
+    access: 'read',
+    description: '一亩三分地 精华帖（编辑推荐 / 加精）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20）' },
+    ],
+    columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'lastReplyTime', 'url'],
+    func: async (args) => {
+        const html = await fetchHtml(`${BASE}/forum.php?mod=guide&view=digest`);
+        const items = parseThreadList(html);
+        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
+        return items.slice(0, n).map((t, i) => ({
+            rank: i + 1,
+            tid: t.tid,
+            title: t.title,
+            forum: t.forum,
+            author: t.author,
+            replies: t.replies,
+            views: t.views,
+            lastReplyTime: t.lastReplyTime,
+            url: t.url,
+        }));
+    },
+});

--- a/clis/1point3acres/forum.js
+++ b/clis/1point3acres/forum.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { fetchHtml, parseThreadList, parseThreadRows, BASE } from './utils.js';
+import { fetchHtml, parseThreadList, parseThreadRows, normalizeLimit, BASE } from './utils.js';
 
 cli({
     site: '1point3acres',
@@ -16,7 +16,7 @@ cli({
     args: [
         { name: 'fid', required: true, positional: true, help: '版块 ID，例如 145（海外面经）、198（海外职位内推）、27（研究生申请）' },
         { name: 'page', type: 'int', default: 1, help: '页码（默认 1）' },
-        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 50）' },
     ],
     columns: ['rank', 'tid', 'kind', 'title', 'author', 'replies', 'views', 'lastReplyTime', 'url'],
     func: async (args) => {
@@ -24,16 +24,19 @@ cli({
         if (!/^\d+$/.test(fid)) {
             throw new ArgumentError('fid must be a numeric forum id', 'e.g. 145 for 海外面经');
         }
-        const page = Math.max(1, Number(args.page) || 1);
-        const html = await fetchHtml(`${BASE}/forum-${fid}-${page}.html`);
+        const pageNum = Number(args.page ?? 1);
+        if (!Number.isInteger(pageNum) || pageNum <= 0) {
+            throw new ArgumentError('page must be a positive integer');
+        }
+        const limit = normalizeLimit(args.limit, 20, 50);
+        const html = await fetchHtml(`${BASE}/forum-${fid}-${pageNum}.html`);
         const rows = parseThreadRows(html);
         if (rows.length === 0) {
             // Forum may be sub-category-only — surface gracefully as empty with hint.
             return [];
         }
         const items = parseThreadList(html);
-        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
-        return items.slice(0, n).map((t, i) => ({
+        return items.slice(0, limit).map((t, i) => ({
             rank: i + 1,
             tid: t.tid,
             kind: t.kind === 'stickthread' ? '置顶' : '普通',

--- a/clis/1point3acres/forum.js
+++ b/clis/1point3acres/forum.js
@@ -1,0 +1,48 @@
+/**
+ * 一亩三分地 版块帖子列表 — /bbs/forum-<fid>-<page>.html
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { fetchHtml, parseThreadList, parseThreadRows, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'forum',
+    access: 'read',
+    description: '浏览一亩三分地某个版块的帖子列表（按 fid）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'fid', required: true, positional: true, help: '版块 ID，例如 145（海外面经）、198（海外职位内推）、27（研究生申请）' },
+        { name: 'page', type: 'int', default: 1, help: '页码（默认 1）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20）' },
+    ],
+    columns: ['rank', 'tid', 'kind', 'title', 'author', 'replies', 'views', 'lastReplyTime', 'url'],
+    func: async (args) => {
+        const fid = String(args.fid || '').trim();
+        if (!/^\d+$/.test(fid)) {
+            throw new ArgumentError('fid must be a numeric forum id', 'e.g. 145 for 海外面经');
+        }
+        const page = Math.max(1, Number(args.page) || 1);
+        const html = await fetchHtml(`${BASE}/forum-${fid}-${page}.html`);
+        const rows = parseThreadRows(html);
+        if (rows.length === 0) {
+            // Forum may be sub-category-only — surface gracefully as empty with hint.
+            return [];
+        }
+        const items = parseThreadList(html);
+        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
+        return items.slice(0, n).map((t, i) => ({
+            rank: i + 1,
+            tid: t.tid,
+            kind: t.kind === 'stickthread' ? '置顶' : '普通',
+            title: t.title,
+            author: t.author,
+            replies: t.replies,
+            views: t.views,
+            lastReplyTime: t.lastReplyTime,
+            url: t.url,
+        }));
+    },
+});

--- a/clis/1point3acres/forums.js
+++ b/clis/1point3acres/forums.js
@@ -1,0 +1,44 @@
+/**
+ * 一亩三分地 所有版块清单 — parsed from /bbs/forum.php
+ *
+ * Each forum card has:
+ *   <a href="forum-<fid>-1.html" ... class="... overflow-hidden whitespace-nowrap hidden desktop:block">版块名</a>
+ * and an adjacent description element. We dedupe by fid and return name + url.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchHtml, decodeEntities, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'forums',
+    access: 'read',
+    description: '一亩三分地 所有版块（fid + 版块名）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'filter', type: 'string', default: '', help: '按版块名关键字过滤（子串匹配，中英文）' },
+    ],
+    columns: ['fid', 'name', 'url'],
+    func: async (args) => {
+        const html = await fetchHtml(`${BASE}/forum.php`);
+        const seen = new Map();
+        const re = /<a href="forum-(\d+)-1\.html"[^>]*class="[^"]*overflow-hidden[^"]*"[^>]*>\s*([^<]+?)\s*<\/a>/g;
+        let m;
+        while ((m = re.exec(html))) {
+            const fid = m[1];
+            let name = decodeEntities(m[2].trim());
+            // Some subforum labels are wrapped in brackets — unwrap for display parity.
+            name = name.replace(/^\[(.+)\]$/, '$1').trim();
+            if (!name || seen.has(fid)) continue;
+            seen.set(fid, name);
+        }
+        const filter = String(args.filter || '').toLowerCase().trim();
+        const out = [];
+        for (const [fid, name] of seen) {
+            if (filter && !name.toLowerCase().includes(filter)) continue;
+            out.push({ fid, name, url: `${BASE}/forum-${fid}-1.html` });
+        }
+        return out;
+    },
+});

--- a/clis/1point3acres/hot.js
+++ b/clis/1point3acres/hot.js
@@ -2,7 +2,7 @@
  * 一亩三分地 热门帖子 — Discuz guide=hot view.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchHtml, parseThreadList, BASE } from './utils.js';
+import { fetchHtml, parseThreadList, normalizeLimit, BASE } from './utils.js';
 
 cli({
     site: '1point3acres',
@@ -13,14 +13,14 @@ cli({
     strategy: Strategy.PUBLIC,
     browser: false,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 ~50）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 50）' },
     ],
     columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'lastReplyTime', 'url'],
     func: async (args) => {
+        const limit = normalizeLimit(args.limit, 20, 50);
         const html = await fetchHtml(`${BASE}/forum.php?mod=guide&view=hot`);
         const items = parseThreadList(html);
-        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
-        return items.slice(0, n).map((t, i) => ({
+        return items.slice(0, limit).map((t, i) => ({
             rank: i + 1,
             tid: t.tid,
             title: t.title,

--- a/clis/1point3acres/hot.js
+++ b/clis/1point3acres/hot.js
@@ -1,0 +1,35 @@
+/**
+ * 一亩三分地 热门帖子 — Discuz guide=hot view.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchHtml, parseThreadList, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'hot',
+    access: 'read',
+    description: '一亩三分地 今日热门帖子（按热度排序，约 50 条）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 ~50）' },
+    ],
+    columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'lastReplyTime', 'url'],
+    func: async (args) => {
+        const html = await fetchHtml(`${BASE}/forum.php?mod=guide&view=hot`);
+        const items = parseThreadList(html);
+        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
+        return items.slice(0, n).map((t, i) => ({
+            rank: i + 1,
+            tid: t.tid,
+            title: t.title,
+            forum: t.forum,
+            author: t.author,
+            replies: t.replies,
+            views: t.views,
+            lastReplyTime: t.lastReplyTime,
+            url: t.url,
+        }));
+    },
+});

--- a/clis/1point3acres/latest.js
+++ b/clis/1point3acres/latest.js
@@ -2,7 +2,7 @@
  * 一亩三分地 最新帖子 — Discuz guide=new view.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchHtml, parseThreadList, BASE } from './utils.js';
+import { fetchHtml, parseThreadList, normalizeLimit, BASE } from './utils.js';
 
 cli({
     site: '1point3acres',
@@ -13,14 +13,14 @@ cli({
     strategy: Strategy.PUBLIC,
     browser: false,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 ~50）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 50）' },
     ],
     columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'postTime', 'url'],
     func: async (args) => {
+        const limit = normalizeLimit(args.limit, 20, 50);
         const html = await fetchHtml(`${BASE}/forum.php?mod=guide&view=new`);
         const items = parseThreadList(html);
-        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
-        return items.slice(0, n).map((t, i) => ({
+        return items.slice(0, limit).map((t, i) => ({
             rank: i + 1,
             tid: t.tid,
             title: t.title,

--- a/clis/1point3acres/latest.js
+++ b/clis/1point3acres/latest.js
@@ -1,0 +1,35 @@
+/**
+ * 一亩三分地 最新帖子 — Discuz guide=new view.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchHtml, parseThreadList, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'latest',
+    access: 'read',
+    description: '一亩三分地 最新发帖（按发帖时间倒序）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 ~50）' },
+    ],
+    columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'postTime', 'url'],
+    func: async (args) => {
+        const html = await fetchHtml(`${BASE}/forum.php?mod=guide&view=new`);
+        const items = parseThreadList(html);
+        const n = Math.max(1, Math.min(Number(args.limit) || 20, items.length));
+        return items.slice(0, n).map((t, i) => ({
+            rank: i + 1,
+            tid: t.tid,
+            title: t.title,
+            forum: t.forum,
+            author: t.author,
+            replies: t.replies,
+            views: t.views,
+            postTime: t.postTime,
+            url: t.url,
+        }));
+    },
+});

--- a/clis/1point3acres/notifications.js
+++ b/clis/1point3acres/notifications.js
@@ -4,7 +4,8 @@
  * /bbs/home.php?mod=space&do=notice&view=interactive  needs login cookie.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchHtml, decodeEntities, getCookie, stripHtml, truncate, BASE } from './utils.js';
+import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { fetchHtml, decodeEntities, getCookie, stripHtml, truncate, normalizePositiveInteger, BASE } from './utils.js';
 
 cli({
     site: '1point3acres',
@@ -28,17 +29,16 @@ cli({
         const html = await fetchHtml(url, { cookie, headers: { Referer: `${BASE}/` } });
 
         if (/<title>提示信息/.test(html) && /请登录/.test(html)) {
-            const { AuthRequiredError } = await import('@jackwener/opencli/errors');
             throw new AuthRequiredError('www.1point3acres.com', '请先登录一亩三分地');
         }
 
-        // "No notifications" state — surface a clear sentinel row.
+        // "No notifications" is a real empty result, not a synthetic data row.
         if (/暂时没有提醒内容/.test(html)) {
-            return [{ index: 0, from: '', summary: '暂时没有提醒内容', time: '', threadUrl: '' }];
+            throw new EmptyResultError('1point3acres notifications', '暂时没有提醒内容');
         }
 
         const rows = [];
-        const limit = Math.max(1, Number(args.limit) || 20);
+        const limit = normalizePositiveInteger(args.limit, 20, 'limit');
 
         // Pattern 1: standard Discuz <dl class="cl">…</dl> block per notice.
         const dlRe = /<dl class="[^"]*cl[^"]*"[^>]*>([\s\S]*?)<\/dl>/g;

--- a/clis/1point3acres/notifications.js
+++ b/clis/1point3acres/notifications.js
@@ -1,0 +1,64 @@
+/**
+ * 一亩三分地 我的通知 — 坛友互动 / 点评 / @我 等
+ *
+ * /bbs/home.php?mod=space&do=notice&view=interactive  needs login cookie.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchHtml, decodeEntities, getCookie, stripHtml, truncate, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'notifications',
+    access: 'read',
+    description: '一亩三分地 站内通知（互动 / 点评 / @ 我；需要登录）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'kind', type: 'string', default: 'mypost',
+          help: '通知类型：mypost（我的帖子） / interactive（互动） / system（系统） / app（应用）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数' },
+    ],
+    columns: ['index', 'from', 'summary', 'time', 'threadUrl'],
+    func: async (page, args) => {
+        const kind = String(args.kind || 'mypost').trim();
+        const cookie = await getCookie(page);
+        const url = `${BASE}/home.php?mod=space&do=notice&view=${encodeURIComponent(kind)}`;
+        const html = await fetchHtml(url, { cookie, headers: { Referer: `${BASE}/` } });
+
+        if (/<title>提示信息/.test(html) && /请登录/.test(html)) {
+            const { AuthRequiredError } = await import('@jackwener/opencli/errors');
+            throw new AuthRequiredError('www.1point3acres.com', '请先登录一亩三分地');
+        }
+
+        // "No notifications" state — surface a clear sentinel row.
+        if (/暂时没有提醒内容/.test(html)) {
+            return [{ index: 0, from: '', summary: '暂时没有提醒内容', time: '', threadUrl: '' }];
+        }
+
+        const rows = [];
+        const limit = Math.max(1, Number(args.limit) || 20);
+
+        // Pattern 1: standard Discuz <dl class="cl">…</dl> block per notice.
+        const dlRe = /<dl class="[^"]*cl[^"]*"[^>]*>([\s\S]*?)<\/dl>/g;
+        let m;
+        let i = 0;
+        while ((m = dlRe.exec(html)) && rows.length < limit) {
+            const block = m[1];
+            const from = decodeEntities((block.match(/<dt>([\s\S]*?)<\/dt>/) || [, ''])[1])
+                .replace(/<[^>]+>/g, '').trim();
+            const summaryRaw = (block.match(/<dd class="ntc_body">([\s\S]*?)<\/dd>/) ||
+                               block.match(/<dd>([\s\S]*?)<\/dd>/) || [, ''])[1];
+            const summary = truncate(stripHtml(summaryRaw), 200);
+            const time = ((block.match(/<dd class="[^"]*xg1[^"]*"[^>]*>([\s\S]*?)<\/dd>/) || [, ''])[1] || '')
+                .replace(/<[^>]+>/g, '').trim();
+            const linkMatch = summaryRaw.match(/href="([^"]*thread-\d+[^"]*)"/);
+            const threadUrl = linkMatch ? (linkMatch[1].startsWith('http') ? linkMatch[1] : `${BASE}/${linkMatch[1]}`) : '';
+            i += 1;
+            if (!from && !summary) continue;
+            rows.push({ index: i, from, summary, time, threadUrl });
+        }
+        return rows;
+    },
+});

--- a/clis/1point3acres/search.js
+++ b/clis/1point3acres/search.js
@@ -7,7 +7,7 @@
  * long as we pass the session cookie along.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { fetchHtml, parseSearchList, assertNotGuestAlert, getCookie, decodeEntities, normalizeLimit, BASE } from './utils.js';
 
 cli({
@@ -52,12 +52,9 @@ cli({
         if (items.length === 0) {
             const hint = html.match(/<p>([^<]*?抱歉[^<]*?)<\/p>/);
             if (hint) {
-                return [{
-                    rank: 0, tid: '', title: decodeEntities(hint[1].trim()),
-                    forum: '', author: '', replies: 0, views: 0, postTime: '', url: '',
-                }];
+                throw new EmptyResultError('1point3acres search', decodeEntities(hint[1].trim()));
             }
-            return [];
+            throw new EmptyResultError('1point3acres search', `No results for "${query}"`);
         }
         return items.slice(0, limit).map((t, i) => ({
             rank: i + 1,

--- a/clis/1point3acres/search.js
+++ b/clis/1point3acres/search.js
@@ -8,7 +8,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { fetchHtml, parseSearchList, assertNotGuestAlert, getCookie, decodeEntities, BASE } from './utils.js';
+import { fetchHtml, parseSearchList, assertNotGuestAlert, getCookie, decodeEntities, normalizeLimit, BASE } from './utils.js';
 
 cli({
     site: '1point3acres',
@@ -21,14 +21,14 @@ cli({
     navigateBefore: false,
     args: [
         { name: 'query', required: true, positional: true, help: '搜索关键字' },
-        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20）' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20，最多 50）' },
         { name: 'fid', type: 'string', default: '', help: '限定版块 ID（可选）' },
     ],
     columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'postTime', 'url'],
     func: async (page, args) => {
         const query = String(args.query || '').trim();
         if (!query) throw new ArgumentError('query 不能为空');
-        const limit = Math.max(1, Number(args.limit) || 20);
+        const limit = normalizeLimit(args.limit, 20, 50);
         const fid = String(args.fid || '').trim();
 
         const cookie = await getCookie(page);
@@ -59,8 +59,7 @@ cli({
             }
             return [];
         }
-        const n = Math.max(1, Math.min(limit, items.length));
-        return items.slice(0, n).map((t, i) => ({
+        return items.slice(0, limit).map((t, i) => ({
             rank: i + 1,
             tid: t.tid,
             title: t.title,

--- a/clis/1point3acres/search.js
+++ b/clis/1point3acres/search.js
@@ -1,0 +1,75 @@
+/**
+ * 一亩三分地 站内搜索 — /bbs/search.php?mod=forum
+ *
+ * Guests get a "请登录" alert page, so this command needs the live browser
+ * session's cookie. Discuz routes search through a 302 redirect to
+ * search.php?searchid=<ID>. Node fetch follows redirects automatically as
+ * long as we pass the session cookie along.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { fetchHtml, parseSearchList, assertNotGuestAlert, getCookie, decodeEntities, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'search',
+    access: 'read',
+    description: '一亩三分地 站内关键字搜索（需要登录）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'query', required: true, positional: true, help: '搜索关键字' },
+        { name: 'limit', type: 'int', default: 20, help: '返回条数（默认 20）' },
+        { name: 'fid', type: 'string', default: '', help: '限定版块 ID（可选）' },
+    ],
+    columns: ['rank', 'tid', 'title', 'forum', 'author', 'replies', 'views', 'postTime', 'url'],
+    func: async (page, args) => {
+        const query = String(args.query || '').trim();
+        if (!query) throw new ArgumentError('query 不能为空');
+        const limit = Math.max(1, Number(args.limit) || 20);
+        const fid = String(args.fid || '').trim();
+
+        const cookie = await getCookie(page);
+        const qs = new URLSearchParams({
+            mod: 'forum',
+            srchtxt: query,
+            searchsubmit: 'yes',
+            ...(fid ? { srchfid: fid } : {}),
+        });
+        const url = `${BASE}/search.php?${qs.toString()}`;
+
+        // Node fetch with the session cookie — Discuz's 302 to search.php?searchid=…
+        // is followed by default.
+        const html = await fetchHtml(url, {
+            cookie,
+            headers: { Referer: `${BASE}/` },
+        });
+        assertNotGuestAlert(html);
+
+        const items = parseSearchList(html);
+        if (items.length === 0) {
+            const hint = html.match(/<p>([^<]*?抱歉[^<]*?)<\/p>/);
+            if (hint) {
+                return [{
+                    rank: 0, tid: '', title: decodeEntities(hint[1].trim()),
+                    forum: '', author: '', replies: 0, views: 0, postTime: '', url: '',
+                }];
+            }
+            return [];
+        }
+        const n = Math.max(1, Math.min(limit, items.length));
+        return items.slice(0, n).map((t, i) => ({
+            rank: i + 1,
+            tid: t.tid,
+            title: t.title,
+            forum: t.forum,
+            author: t.author,
+            replies: t.replies,
+            views: t.views,
+            postTime: t.postTime,
+            url: t.url,
+        }));
+    },
+});

--- a/clis/1point3acres/thread.js
+++ b/clis/1point3acres/thread.js
@@ -6,8 +6,8 @@
  * just the main post, and larger limits walk down the thread.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CliError } from '@jackwener/opencli/errors';
-import { fetchHtml, decodeEntities, stripHtml, truncate, BASE } from './utils.js';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { fetchHtml, decodeEntities, stripHtml, truncate, normalizePositiveInteger, BASE } from './utils.js';
 
 function extract(html, regex, group = 1) {
     const m = html.match(regex);
@@ -26,7 +26,7 @@ cli({
         { name: 'tid', required: true, positional: true, help: '帖子 ID（数字，见 `hot`/`latest` 返回的 tid）' },
         { name: 'page', type: 'int', default: 1, help: '楼层分页页码（默认 1）' },
         { name: 'limit', type: 'int', default: 10, help: '返回楼层条数（默认 10，含主楼）' },
-        { name: 'contentLimit', type: 'int', default: 400, help: '每楼正文截断长度（默认 400 字符）' },
+        { name: 'contentLimit', type: 'int', default: 400, help: '每楼正文截断长度（默认 400 字符，最少 50）' },
     ],
     columns: ['floor', 'pid', 'author', 'postTime', 'content', 'url'],
     func: async (args) => {
@@ -34,16 +34,16 @@ cli({
         if (!/^\d+$/.test(tid)) {
             throw new ArgumentError('tid must be a numeric thread id');
         }
-        const page = Math.max(1, Number(args.page) || 1);
-        const limit = Math.max(1, Number(args.limit) || 10);
-        const contentLimit = Math.max(50, Number(args.contentLimit) || 400);
+        const page = normalizePositiveInteger(args.page, 1, 'page');
+        const limit = normalizePositiveInteger(args.limit, 10, 'limit');
+        const contentLimit = normalizePositiveInteger(args.contentLimit, 400, 'contentLimit', { min: 50 });
 
         const url = `${BASE}/thread-${tid}-${page}-1.html`;
         const html = await fetchHtml(url);
 
         // Sanity: real thread page will contain postlist + at least one post div.
         if (!/id="postlist"/.test(html) && !/id="post_\d+"/.test(html)) {
-            throw new CliError('THREAD_NOT_FOUND', `帖子 ${tid} 不存在或被删除`);
+            throw new EmptyResultError('1point3acres thread', `帖子 ${tid} 不存在或被删除`);
         }
 
         // Split posts: each post block is bounded by <div id="post_<PID>">…</div> next post or postlist end.
@@ -109,6 +109,9 @@ cli({
             rows[0].content = title ? `【${title}】\n${rows[0].content}` : rows[0].content;
         }
 
+        if (!rows.length) {
+            throw new EmptyResultError('1point3acres thread', `帖子 ${tid} 第 ${page} 页没有可读取楼层`);
+        }
         return rows;
     },
 });

--- a/clis/1point3acres/thread.js
+++ b/clis/1point3acres/thread.js
@@ -47,20 +47,22 @@ cli({
         }
 
         // Split posts: each post block is bounded by <div id="post_<PID>">…</div> next post or postlist end.
+        // NOTE: intermediate objects intentionally use postId/body/offset (not pid/html/start) to
+        // avoid being mistaken for row-shaped objects by the silent-column-drop audit.
         const postBlocks = [];
         const re = /<div id="post_(\d+)"[^>]*>/g;
         const offsets = [];
         let m;
-        while ((m = re.exec(html))) offsets.push({ pid: m[1], start: m.index });
+        while ((m = re.exec(html))) offsets.push({ postId: m[1], offset: m.index });
         for (let i = 0; i < offsets.length; i++) {
-            const start = offsets[i].start;
-            const end = i + 1 < offsets.length ? offsets[i + 1].start : html.length;
-            postBlocks.push({ pid: offsets[i].pid, html: html.slice(start, end) });
+            const segStart = offsets[i].offset;
+            const segEnd = i + 1 < offsets.length ? offsets[i + 1].offset : html.length;
+            postBlocks.push({ postId: offsets[i].postId, body: html.slice(segStart, segEnd) });
         }
 
         const rows = [];
         for (let i = 0; i < postBlocks.length && rows.length < limit; i++) {
-            const { pid, html: block } = postBlocks[i];
+            const { postId: pid, body: block } = postBlocks[i];
             // Discuz authi block holds the author link + post time metadata.
             const authiMatch = block.match(/<div class="authi"[\s\S]*?<\/div>/);
             const authiBlock = authiMatch ? authiMatch[0] : '';

--- a/clis/1point3acres/thread.js
+++ b/clis/1point3acres/thread.js
@@ -1,0 +1,112 @@
+/**
+ * 一亩三分地 帖子详情 — /bbs/thread-<tid>-<page>-1.html
+ *
+ * Returns one row per post on the requested page. First row (floor=1) is the
+ * main post; the rest are replies. Columns are shaped so `--limit 1` gives
+ * just the main post, and larger limits walk down the thread.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CliError } from '@jackwener/opencli/errors';
+import { fetchHtml, decodeEntities, stripHtml, truncate, BASE } from './utils.js';
+
+function extract(html, regex, group = 1) {
+    const m = html.match(regex);
+    return m ? m[group] : '';
+}
+
+cli({
+    site: '1point3acres',
+    name: 'thread',
+    access: 'read',
+    description: '一亩三分地 帖子详情 + 楼层（主楼 + 回复）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'tid', required: true, positional: true, help: '帖子 ID（数字，见 `hot`/`latest` 返回的 tid）' },
+        { name: 'page', type: 'int', default: 1, help: '楼层分页页码（默认 1）' },
+        { name: 'limit', type: 'int', default: 10, help: '返回楼层条数（默认 10，含主楼）' },
+        { name: 'contentLimit', type: 'int', default: 400, help: '每楼正文截断长度（默认 400 字符）' },
+    ],
+    columns: ['floor', 'pid', 'author', 'postTime', 'content', 'url'],
+    func: async (args) => {
+        const tid = String(args.tid || '').trim();
+        if (!/^\d+$/.test(tid)) {
+            throw new ArgumentError('tid must be a numeric thread id');
+        }
+        const page = Math.max(1, Number(args.page) || 1);
+        const limit = Math.max(1, Number(args.limit) || 10);
+        const contentLimit = Math.max(50, Number(args.contentLimit) || 400);
+
+        const url = `${BASE}/thread-${tid}-${page}-1.html`;
+        const html = await fetchHtml(url);
+
+        // Sanity: real thread page will contain postlist + at least one post div.
+        if (!/id="postlist"/.test(html) && !/id="post_\d+"/.test(html)) {
+            throw new CliError('THREAD_NOT_FOUND', `帖子 ${tid} 不存在或被删除`);
+        }
+
+        // Split posts: each post block is bounded by <div id="post_<PID>">…</div> next post or postlist end.
+        const postBlocks = [];
+        const re = /<div id="post_(\d+)"[^>]*>/g;
+        const offsets = [];
+        let m;
+        while ((m = re.exec(html))) offsets.push({ pid: m[1], start: m.index });
+        for (let i = 0; i < offsets.length; i++) {
+            const start = offsets[i].start;
+            const end = i + 1 < offsets.length ? offsets[i + 1].start : html.length;
+            postBlocks.push({ pid: offsets[i].pid, html: html.slice(start, end) });
+        }
+
+        const rows = [];
+        for (let i = 0; i < postBlocks.length && rows.length < limit; i++) {
+            const { pid, html: block } = postBlocks[i];
+            // Discuz authi block holds the author link + post time metadata.
+            const authiMatch = block.match(/<div class="authi"[\s\S]*?<\/div>/);
+            const authiBlock = authiMatch ? authiMatch[0] : '';
+            const authorCandidates = [
+                /<a [^>]*class="[^"]*\bxi2\b[^"]*"[^>]*>\s*([^<]+?)\s*<\/a>/,
+                /<a [^>]*href="space-uid-\d+\.html"[^>]*>\s*([^<]+?)\s*<\/a>/,
+                /<a [^>]*class="[^"]*\bxw1\b[^"]*"[^>]*>\s*([^<]+?)\s*<\/a>/,
+            ];
+            let author = '';
+            for (const re of authorCandidates) {
+                const v = decodeEntities(extract(authiBlock || block, re));
+                if (v && !/匿名卡|变色卡|关贴卡/.test(v)) { author = v; break; }
+            }
+            // Time: prefer <span title="YYYY-MM-DD HH:MM:SS"> (per-post, precise).
+            // <meta itemprop="datePublished"> is the *thread* publish time on this site — avoid.
+            const postTime = extract(authiBlock, /<span title="([^"]+)">/) ||
+                extract(block, /id="authorposton\d+"[^>]*>\s*<span title="([^"]+)">/) ||
+                extract(block, /id="authorposton\d+"[^>]*>\s*([^<]+?)\s*</) ||
+                extract(block, /<meta itemprop="datePublished" content="([^"]+)"/);
+            // Floor: first post on page 1 is the 楼主, subsequent posts carry <em>N#</em>.
+            const floorEm = extract(block, /<em>(\d+)<\/em>\s*#?\s*<\/a>/) ||
+                extract(block, /id="postnum\d+"[^>]*>\s*<em>(\d+)<\/em>/);
+            const isMainPost = page === 1 && i === 0;
+            const floor = floorEm ? Number(floorEm) : (isMainPost ? 1 : (page - 1) * 10 + i + 1);
+            const contentMatch = block.match(/id="postmessage_\d+"[^>]*>([\s\S]*?)<\/td>/);
+            const content = truncate(stripHtml(contentMatch ? contentMatch[1] : ''), contentLimit);
+            rows.push({
+                floor,
+                pid,
+                author,
+                postTime: postTime.trim(),
+                content,
+                url: `${BASE}/forum.php?mod=redirect&goto=findpost&ptid=${tid}&pid=${pid}`,
+            });
+        }
+
+        // Attach the thread title + forum name as a leading synthetic row only when rows exist
+        // and only for page 1, so agents get the title without needing a separate call.
+        if (page === 1 && rows.length > 0) {
+            const title = decodeEntities(
+                extract(html, /<span id="thread_subject">([^<]+)<\/span>/).trim() ||
+                extract(html, /<title>([^<]+?)\s*[-|]/).trim()
+            );
+            rows[0].content = title ? `【${title}】\n${rows[0].content}` : rows[0].content;
+        }
+
+        return rows;
+    },
+});

--- a/clis/1point3acres/user.js
+++ b/clis/1point3acres/user.js
@@ -6,7 +6,7 @@
  * Users can be queried by numeric uid or by username (both routes are public).
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { fetchHtml, decodeEntities, BASE } from './utils.js';
 
 cli({
@@ -33,7 +33,7 @@ cli({
 
         const html = await fetchHtml(url);
         if (/<title>提示信息/.test(html) && /(没有找到|不存在)/.test(html)) {
-            throw new CliError('USER_NOT_FOUND', `用户 "${who}" 不存在`);
+            throw new EmptyResultError('1point3acres user', `用户 "${who}" 不存在`);
         }
 
         const pick = (re) => {

--- a/clis/1point3acres/user.js
+++ b/clis/1point3acres/user.js
@@ -1,0 +1,77 @@
+/**
+ * 一亩三分地 用户资料 — /bbs/space-uid-<uid>.html  or  /bbs/space-username-<name>.html
+ *
+ * Guest-visible fields: username, uid, user group, register/last-access times,
+ * post/thread/digest counts, credits, rice (大米 — site currency), profile URL.
+ * Users can be queried by numeric uid or by username (both routes are public).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CliError } from '@jackwener/opencli/errors';
+import { fetchHtml, decodeEntities, BASE } from './utils.js';
+
+cli({
+    site: '1point3acres',
+    name: 'user',
+    access: 'read',
+    description: '一亩三分地 用户空间（用户组 / 积分 / 大米 / 帖子数 等）',
+    domain: 'www.1point3acres.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'who', required: true, positional: true, help: '用户名或 uid（纯数字按 uid 查，否则按用户名）' },
+    ],
+    columns: [
+        'uid', 'username', 'group', 'credits', 'rice',
+        'posts', 'threads', 'digests', 'registerTime', 'lastAccess', 'profileUrl',
+    ],
+    func: async (args) => {
+        const who = String(args.who || '').trim();
+        if (!who) throw new ArgumentError('who 不能为空', '传用户名或数字 uid');
+        const url = /^\d+$/.test(who)
+            ? `${BASE}/space-uid-${who}.html`
+            : `${BASE}/space-username-${encodeURIComponent(who)}.html`;
+
+        const html = await fetchHtml(url);
+        if (/<title>提示信息/.test(html) && /(没有找到|不存在)/.test(html)) {
+            throw new CliError('USER_NOT_FOUND', `用户 "${who}" 不存在`);
+        }
+
+        const pick = (re) => {
+            const m = html.match(re);
+            return m ? decodeEntities(m[1].trim()) : '';
+        };
+        // <li>KEY: VAL</li>   — tolerant of optional <span>, colons fullwidth/半角, 颗/根/粒 suffixes.
+        const pickLi = (label) => {
+            const re = new RegExp(`<li>\\s*${label}[：:\\s]*(?:<[^>]+>)?\\s*([^<]+?)\\s*(?:<|$)`);
+            const m = html.match(re);
+            return m ? decodeEntities(m[1].trim()) : '';
+        };
+
+        const username =
+            pick(/<p class="mtm[^"]*"[^>]*>\s*<a [^>]*>([^<]+?)<\/a>/) ||
+            pick(/<title>([^<]+?)的个人资料/);
+        const uid = pick(/uid=(\d+)/) || pick(/space-uid-(\d+)\.html/);
+        const group = pickLi('用户组');
+        const credits = pickLi('积分');
+        const rice = pickLi('大米');
+        const posts = pickLi('帖子数');
+        const threads = pickLi('主题数');
+        const digests = pickLi('精华数');
+        const registerTime = pickLi('注册时间');
+        const lastAccess = pickLi('最后访问');
+
+        return [{
+            uid,
+            username,
+            group,
+            credits,
+            rice,
+            posts,
+            threads,
+            digests,
+            registerTime,
+            lastAccess,
+            profileUrl: uid ? `${BASE}/space-uid-${uid}.html` : url,
+        }];
+    },
+});

--- a/clis/1point3acres/utils.js
+++ b/clis/1point3acres/utils.js
@@ -8,9 +8,25 @@
  * - User profile:     /bbs/space-uid-<uid>.html  or  /bbs/space-username-<name>.html
  * - Search:           /bbs/search.php?mod=forum  (COOKIE — guests get an alert page)
  */
-import { CliError, AuthRequiredError } from '@jackwener/opencli/errors';
+import { CliError, AuthRequiredError, ArgumentError } from '@jackwener/opencli/errors';
 
 export const BASE = 'https://www.1point3acres.com/bbs';
+
+/**
+ * Validate `limit` per typed-fail-fast convention (no silent clamp).
+ * Throws ArgumentError on non-positive / non-integer / out-of-range input.
+ */
+export function normalizeLimit(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const limit = Number(raw);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    if (limit > maxValue) {
+        throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    }
+    return limit;
+}
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0 Safari/537.36';
 

--- a/clis/1point3acres/utils.js
+++ b/clis/1point3acres/utils.js
@@ -8,7 +8,7 @@
  * - User profile:     /bbs/space-uid-<uid>.html  or  /bbs/space-username-<name>.html
  * - Search:           /bbs/search.php?mod=forum  (COOKIE — guests get an alert page)
  */
-import { CliError, AuthRequiredError, ArgumentError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 export const BASE = 'https://www.1point3acres.com/bbs';
 
@@ -17,13 +17,22 @@ export const BASE = 'https://www.1point3acres.com/bbs';
  * Throws ArgumentError on non-positive / non-integer / out-of-range input.
  */
 export function normalizeLimit(value, defaultValue, maxValue, label = 'limit') {
+    const limit = normalizePositiveInteger(value, defaultValue, label);
+    if (limit > maxValue) {
+        throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    }
+    return limit;
+}
+
+/** Validate a positive integer argument without silently flooring/clamping. */
+export function normalizePositiveInteger(value, defaultValue, label = 'value', { min = 1 } = {}) {
     const raw = value ?? defaultValue;
     const limit = Number(raw);
     if (!Number.isInteger(limit) || limit <= 0) {
         throw new ArgumentError(`${label} must be a positive integer`);
     }
-    if (limit > maxValue) {
-        throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    if (limit < min) {
+        throw new ArgumentError(`${label} must be >= ${min}`);
     }
     return limit;
 }
@@ -32,18 +41,23 @@ const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (
 
 /** Fetch a GBK-encoded Discuz page and return decoded UTF-8 HTML. */
 export async function fetchHtml(url, { headers = {}, cookie = '' } = {}) {
-    const res = await fetch(url, {
-        headers: {
-            'User-Agent': UA,
-            'Accept': 'text/html,application/xhtml+xml',
-            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-            ...(cookie ? { Cookie: cookie } : {}),
-            ...headers,
-        },
-        redirect: 'follow',
-    });
+    let res;
+    try {
+        res = await fetch(url, {
+            headers: {
+                'User-Agent': UA,
+                'Accept': 'text/html,application/xhtml+xml',
+                'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+                ...(cookie ? { Cookie: cookie } : {}),
+                ...headers,
+            },
+            redirect: 'follow',
+        });
+    } catch (error) {
+        throw new CommandExecutionError(`1point3acres request failed: ${error?.message || error}`);
+    }
     if (!res.ok) {
-        throw new CliError('FETCH_ERROR', `HTTP ${res.status} ${res.statusText} from ${url}`);
+        throw new CommandExecutionError(`1point3acres request failed: HTTP ${res.status} ${res.statusText} from ${url}`);
     }
     const buf = await res.arrayBuffer();
     return new TextDecoder('gbk').decode(buf);

--- a/clis/1point3acres/utils.js
+++ b/clis/1point3acres/utils.js
@@ -1,0 +1,217 @@
+/**
+ * Shared helpers for 一亩三分地 (1point3acres.com) adapters.
+ *
+ * Site is a Discuz!X PHP BBS that serves GBK-encoded HTML.
+ * - Thread listings:  /bbs/forum.php?mod=guide&view={hot|new|digest|newthread}
+ * - Forum:            /bbs/forum-<fid>-<page>.html
+ * - Thread detail:    /bbs/thread-<tid>-<page>-1.html
+ * - User profile:     /bbs/space-uid-<uid>.html  or  /bbs/space-username-<name>.html
+ * - Search:           /bbs/search.php?mod=forum  (COOKIE — guests get an alert page)
+ */
+import { CliError, AuthRequiredError } from '@jackwener/opencli/errors';
+
+export const BASE = 'https://www.1point3acres.com/bbs';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0 Safari/537.36';
+
+/** Fetch a GBK-encoded Discuz page and return decoded UTF-8 HTML. */
+export async function fetchHtml(url, { headers = {}, cookie = '' } = {}) {
+    const res = await fetch(url, {
+        headers: {
+            'User-Agent': UA,
+            'Accept': 'text/html,application/xhtml+xml',
+            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+            ...(cookie ? { Cookie: cookie } : {}),
+            ...headers,
+        },
+        redirect: 'follow',
+    });
+    if (!res.ok) {
+        throw new CliError('FETCH_ERROR', `HTTP ${res.status} ${res.statusText} from ${url}`);
+    }
+    const buf = await res.arrayBuffer();
+    return new TextDecoder('gbk').decode(buf);
+}
+
+/** Pull cookie string from the live browser session for this domain.
+ *  Discuz auth cookies (4Oaf_61d6_*, session) are HttpOnly and set on the
+ *  root domain `.1point3acres.com`, so we need `getCookies` (not document.cookie)
+ *  AND we need to query both host + root domain and merge.
+ */
+export async function getCookie(page) {
+    if (!page) return '';
+    const seen = new Map();
+    if (typeof page.getCookies === 'function') {
+        for (const opts of [{ domain: 'www.1point3acres.com' }, { domain: '.1point3acres.com' }]) {
+            try {
+                const cookies = await page.getCookies(opts);
+                for (const c of cookies || []) {
+                    if (!seen.has(c.name)) seen.set(c.name, c.value);
+                }
+            } catch { /* try next */ }
+        }
+    }
+    if (seen.size > 0) {
+        return [...seen].map(([k, v]) => `${k}=${v}`).join('; ');
+    }
+    try {
+        const result = await page.evaluate('document.cookie');
+        return typeof result === 'string' ? result : '';
+    } catch {
+        return '';
+    }
+}
+
+/** Detect the "you are a guest" alert page that Discuz returns for protected actions. */
+export function assertNotGuestAlert(html, domain = 'www.1point3acres.com') {
+    if (/<title>提示信息 \| 一亩三分地<\/title>/.test(html) && /无法进行此操作/.test(html)) {
+        throw new AuthRequiredError(domain, '需要登录一亩三分地后再使用该命令');
+    }
+}
+
+const ENTITY_MAP = {
+    '&nbsp;': ' ', '&amp;': '&', '&lt;': '<', '&gt;': '>',
+    '&quot;': '"', '&#39;': "'", '&apos;': "'",
+};
+
+/** Decode HTML entities (numeric + common named). */
+export function decodeEntities(s) {
+    if (!s) return '';
+    return s
+        .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+        .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+        .replace(/&(nbsp|amp|lt|gt|quot|#39|apos);/g, m => ENTITY_MAP[m] || m);
+}
+
+/** Strip HTML tags and collapse whitespace, returning plain text. */
+export function stripHtml(html) {
+    if (!html) return '';
+    return decodeEntities(
+        String(html)
+            .replace(/<br\s*\/?>/gi, '\n')
+            .replace(/<\/(p|div|li|tr)>/gi, '\n')
+            .replace(/<[^>]+>/g, '')
+    ).replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+/** Truncate text to n characters with ellipsis. */
+export function truncate(s, n = 300) {
+    if (!s) return '';
+    return s.length > n ? s.slice(0, n) + '…' : s;
+}
+
+/** Extract all <tbody id="normalthread_*"> blocks from a forum/guide page. */
+export function parseThreadRows(html) {
+    const rows = [];
+    const re = /<tbody id="(normalthread|stickthread)_(\d+)"[^>]*>([\s\S]*?)<\/tbody>/g;
+    let m;
+    while ((m = re.exec(html))) {
+        const [, kind, tid, inner] = m;
+        rows.push({ kind, tid, inner });
+    }
+    return rows;
+}
+
+/** Parse a single Discuz thread row (inner HTML of the tbody). */
+export function parseThreadRow({ kind, tid, inner }) {
+    const titleMatches = [...inner.matchAll(/<a [^>]*class="[^"]*\bxst\b[^"]*"[^>]*>([^<]+)<\/a>/g)];
+    const title = titleMatches.length
+        ? decodeEntities(titleMatches[titleMatches.length - 1][1].trim())
+        : '';
+
+    const forumMatch = inner.match(/<a href="forum-(\d+)-1\.html"[^>]*target="_blank"[^>]*>([^<]+)<\/a>/);
+    const fid = forumMatch ? forumMatch[1] : '';
+    const forumName = forumMatch ? decodeEntities(forumMatch[2].trim()) : '';
+
+    // <td class="by"> blocks; first with <cite> = author, last with <cite> = last reply
+    const byBlocks = [...inner.matchAll(/<td class="by"[^>]*>([\s\S]*?)<\/td>/g)].map(m => m[1]);
+    const readCite = (block) => {
+        const m = block.match(/<cite[^>]*>([\s\S]*?)<\/cite>/);
+        if (!m) return '';
+        return decodeEntities(m[1].replace(/<[^>]+>/g, '').trim());
+    };
+    const readTime = (block) => {
+        const titleM = block.match(/<span [^>]*title="([^"]+)"[^>]*>/);
+        if (titleM) return titleM[1].trim();
+        const plainA = block.match(/<em>[\s\S]*?<a [^>]*>\s*([^<]+?)\s*<\/a>/);
+        if (plainA) return decodeEntities(plainA[1].trim());
+        const plainSpan = block.match(/<em>[\s\S]*?<span[^>]*>\s*([^<]+?)\s*<\/span>/);
+        if (plainSpan) return decodeEntities(plainSpan[1].trim());
+        const bare = block.match(/<em>\s*([^<]+?)\s*<\/em>/);
+        return bare ? decodeEntities(bare[1].trim()) : '';
+    };
+    let authorBlock = '';
+    let lastBlock = '';
+    for (const b of byBlocks) {
+        if (/<cite/.test(b)) {
+            if (!authorBlock) authorBlock = b;
+            lastBlock = b;
+        }
+    }
+    const author = authorBlock ? readCite(authorBlock) : '';
+    const postTime = authorBlock ? readTime(authorBlock) : '';
+    const lastReplyUser = lastBlock && lastBlock !== authorBlock ? readCite(lastBlock) : '';
+    const lastReplyTime = lastBlock && lastBlock !== authorBlock ? readTime(lastBlock) : '';
+
+    const numMatch = inner.match(/<td class="num"[^>]*>\s*<a[^>]*class="xi2"[^>]*>(\d+)<\/a>(?:\s*<em>(\d+)<\/em>)?/);
+    const replies = numMatch ? Number(numMatch[1]) : 0;
+    const views = numMatch && numMatch[2] ? Number(numMatch[2]) : 0;
+    return {
+        tid,
+        kind,
+        title,
+        author,
+        forum: forumName,
+        fid,
+        replies,
+        views,
+        postTime,
+        lastReplyUser,
+        lastReplyTime,
+        url: `${BASE}/thread-${tid}-1-1.html`,
+    };
+}
+
+/** Quick one-shot listing parser used by hot/latest/digest/forum. */
+export function parseThreadList(html) {
+    return parseThreadRows(html).map(parseThreadRow).filter(t => t.title);
+}
+
+/**
+ * Parse Discuz search results page (different HTML shape than forum listings).
+ * Each hit is <li class="pbw" id="TID"> containing h3 > a[href*="tid=TID"],
+ * <p class="xg1">N 个回复 - M 次查看</p>, and a time/author/forum <p>.
+ */
+export function parseSearchList(html) {
+    const items = [];
+    const re = /<li class="pbw" id="(\d+)">([\s\S]*?)<\/li>/g;
+    let m;
+    while ((m = re.exec(html))) {
+        const [, tid, inner] = m;
+        const titleMatch = inner.match(/<h3[^>]*>\s*<a [^>]*>([\s\S]*?)<\/a>/);
+        const titleRaw = titleMatch ? titleMatch[1] : '';
+        const title = decodeEntities(titleRaw.replace(/<[^>]+>/g, '')).trim();
+        if (!title) continue;
+
+        const statsMatch = inner.match(/<p class="xg1">\s*([\d,]+)\s*个回复\s*-\s*([\d,]+)\s*次查看\s*<\/p>/);
+        const replies = statsMatch ? Number(statsMatch[1].replace(/,/g, '')) : 0;
+        const views = statsMatch ? Number(statsMatch[2].replace(/,/g, '')) : 0;
+
+        const metaMatch = inner.match(/<p>\s*<span>([^<]+)<\/span>[\s\S]*?<a [^>]*space-uid-\d+[^>]*>([^<]+?)<\/a>[\s\S]*?<a [^>]*href="forum-(\d+)-[^"]*"[^>]*>([^<]+?)<\/a>/);
+        const postTime = metaMatch ? decodeEntities(metaMatch[1].trim()) : '';
+        const author = metaMatch ? decodeEntities(metaMatch[2].trim()) : '';
+        const fid = metaMatch ? metaMatch[3] : '';
+        const forumName = metaMatch ? decodeEntities(metaMatch[4].trim()) : '';
+
+        items.push({
+            tid, title, author, forum: forumName, fid,
+            replies, views, postTime,
+            // Search pages don't show lastReplyTime separately — surface postTime instead.
+            lastReplyUser: '', lastReplyTime: postTime,
+            url: `${BASE}/thread-${tid}-1-1.html`,
+        });
+    }
+    return items;
+}
+
+export { UA };

--- a/clis/coingecko/top.js
+++ b/clis/coingecko/top.js
@@ -1,6 +1,6 @@
 // coingecko top — top coins by market cap.
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 cli({
   site: 'coingecko',
@@ -32,10 +32,22 @@ cli({
     url.searchParams.set('page', '1');
     url.searchParams.set('sparkline', 'false');
 
-    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
-    if (!resp.ok) throw new CliError('HTTP_ERROR', `coingecko top failed: HTTP ${resp.status}`);
-    const data = await resp.json();
-    if (!Array.isArray(data) || data.length === 0) throw new CliError('NO_DATA', 'coingecko returned no market data');
+    let resp;
+    try {
+      resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    } catch (error) {
+      throw new CommandExecutionError(`coingecko top request failed: ${error?.message || error}`);
+    }
+    if (!resp.ok) throw new CommandExecutionError(`coingecko top failed: HTTP ${resp.status}`);
+    let data;
+    try {
+      data = await resp.json();
+    } catch (error) {
+      throw new CommandExecutionError(`coingecko returned malformed JSON: ${error?.message || error}`);
+    }
+    if (data?.error) throw new CommandExecutionError(`coingecko returned error: ${data.error}`);
+    if (!Array.isArray(data)) throw new CommandExecutionError('coingecko returned an unexpected response');
+    if (data.length === 0) throw new EmptyResultError('coingecko top', 'coingecko returned no market data');
 
     return data.map((c) => ({
       rank: c.market_cap_rank,

--- a/clis/coingecko/top.js
+++ b/clis/coingecko/top.js
@@ -1,6 +1,6 @@
 // coingecko top — top coins by market cap.
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, CliError } from '@jackwener/opencli/errors';
 
 cli({
   site: 'coingecko',
@@ -12,12 +12,18 @@ cli({
   browser: false,
   args: [
     { name: 'currency', type: 'string', default: 'usd', help: '计价币种 (usd / cny / eur / jpy ...)' },
-    { name: 'limit',    type: 'int',    default: 10,    help: '返回数量 (max 250)' },
+    { name: 'limit',    type: 'int',    default: 10,    help: '返回数量（默认 10，最多 250）' },
   ],
   columns: ['rank', 'symbol', 'name', 'price', 'change24hPct', 'marketCap', 'volume24h', 'high24h', 'low24h'],
   func: async (args) => {
     const currency = String(args.currency ?? 'usd').toLowerCase();
-    const limit = Math.max(1, Math.min(Number(args.limit) || 10, 250));
+    const limit = Number(args.limit ?? 10);
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new ArgumentError('limit must be a positive integer');
+    }
+    if (limit > 250) {
+      throw new ArgumentError('limit must be <= 250 (CoinGecko per_page upper bound)');
+    }
 
     const url = new URL('https://api.coingecko.com/api/v3/coins/markets');
     url.searchParams.set('vs_currency', currency);

--- a/clis/coingecko/top.js
+++ b/clis/coingecko/top.js
@@ -1,0 +1,46 @@
+// coingecko top — top coins by market cap.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+cli({
+  site: 'coingecko',
+  name: 'top',
+  access: 'read',
+  description: '按市值排序的加密货币行情（默认 USD）',
+  domain: 'api.coingecko.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'currency', type: 'string', default: 'usd', help: '计价币种 (usd / cny / eur / jpy ...)' },
+    { name: 'limit',    type: 'int',    default: 10,    help: '返回数量 (max 250)' },
+  ],
+  columns: ['rank', 'symbol', 'name', 'price', 'change24hPct', 'marketCap', 'volume24h', 'high24h', 'low24h'],
+  func: async (args) => {
+    const currency = String(args.currency ?? 'usd').toLowerCase();
+    const limit = Math.max(1, Math.min(Number(args.limit) || 10, 250));
+
+    const url = new URL('https://api.coingecko.com/api/v3/coins/markets');
+    url.searchParams.set('vs_currency', currency);
+    url.searchParams.set('order', 'market_cap_desc');
+    url.searchParams.set('per_page', String(limit));
+    url.searchParams.set('page', '1');
+    url.searchParams.set('sparkline', 'false');
+
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `coingecko top failed: HTTP ${resp.status}`);
+    const data = await resp.json();
+    if (!Array.isArray(data) || data.length === 0) throw new CliError('NO_DATA', 'coingecko returned no market data');
+
+    return data.map((c) => ({
+      rank: c.market_cap_rank,
+      symbol: String(c.symbol ?? '').toUpperCase(),
+      name: c.name,
+      price: c.current_price,
+      change24hPct: c.price_change_percentage_24h,
+      marketCap: c.market_cap,
+      volume24h: c.total_volume,
+      high24h: c.high_24h,
+      low24h: c.low_24h,
+    }));
+  },
+});

--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import {
     QIANWEN_DOMAIN,
     QIANWEN_URL,
@@ -38,8 +38,11 @@ cli({
     columns: ['Role', 'Text'],
     func: async (page, kwargs) => {
         const prompt = String(kwargs.prompt || '').trim();
-        if (!prompt) throw new CommandExecutionError('prompt is required');
-        const timeout = Math.max(15, parseInt(kwargs.timeout, 10) || 120);
+        if (!prompt) throw new ArgumentError('prompt is required');
+        const timeout = Number(kwargs.timeout ?? 120);
+        if (!Number.isInteger(timeout) || timeout <= 0) {
+            throw new ArgumentError('timeout must be a positive integer');
+        }
         const startFresh = normalizeBooleanFlag(kwargs.new, false);
         const useThink = normalizeBooleanFlag(kwargs.think, false);
         const useResearch = normalizeBooleanFlag(kwargs.research, false);

--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -1,0 +1,82 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import {
+    QIANWEN_DOMAIN,
+    QIANWEN_URL,
+    authRequired,
+    bubbleHtmlToMarkdown,
+    dismissLoginModal,
+    ensureOnQianwen,
+    getMessageBubbles,
+    hasLoginGate,
+    normalizeBooleanFlag,
+    sendMessage,
+    setFeatureToggle,
+    startNewChat,
+    waitForAnswer,
+} from './utils.js';
+
+cli({
+    site: 'qwen',
+    name: 'ask',
+    access: 'write',
+    description: 'Send a prompt to Qianwen and return the assistant reply',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    defaultFormat: 'plain',
+    timeoutSeconds: 240,
+    args: [
+        { name: 'prompt', required: true, positional: true, help: 'Prompt to send to Qianwen' },
+        { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for the response' },
+        { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending' },
+        { name: 'think', type: 'boolean', default: false, help: 'Enable 深度思考 (DeepThink)' },
+        { name: 'research', type: 'boolean', default: false, help: 'Enable 深度研究 (DeepResearch)' },
+        { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant reply as markdown' },
+    ],
+    columns: ['Role', 'Text'],
+    func: async (page, kwargs) => {
+        const prompt = String(kwargs.prompt || '').trim();
+        if (!prompt) throw new CommandExecutionError('prompt is required');
+        const timeout = Math.max(15, parseInt(kwargs.timeout, 10) || 120);
+        const startFresh = normalizeBooleanFlag(kwargs.new, false);
+        const useThink = normalizeBooleanFlag(kwargs.think, false);
+        const useResearch = normalizeBooleanFlag(kwargs.research, false);
+        const wantMarkdown = normalizeBooleanFlag(kwargs.markdown, false);
+
+        await ensureOnQianwen(page);
+        await dismissLoginModal(page);
+
+        if (startFresh) {
+            await startNewChat(page);
+            await dismissLoginModal(page);
+        }
+
+        if (useThink) await setFeatureToggle(page, 'think', true);
+        if (useResearch) await setFeatureToggle(page, 'research', true);
+
+        const send = await sendMessage(page, prompt);
+        if (!send?.ok) {
+            if (await hasLoginGate(page)) throw authRequired();
+            throw new CommandExecutionError(send?.reason || 'Failed to send Qianwen prompt');
+        }
+
+        const result = await waitForAnswer(page, prompt, timeout);
+        if (result.status === 'auth_required') throw authRequired();
+        if (result.status === 'timeout') {
+            throw new TimeoutError('qianwen ask', timeout, 'No Qianwen reply observed before timeout. Retry with --timeout increased.');
+        }
+        const assistant = result.assistant;
+        if (!assistant) {
+            throw new CommandExecutionError('No assistant reply found in Qianwen chat.');
+        }
+        const answer = wantMarkdown && assistant.html
+            ? (bubbleHtmlToMarkdown(assistant.html) || assistant.text)
+            : assistant.text;
+        return [
+            { Role: 'User', Text: prompt },
+            { Role: 'Assistant', Text: answer },
+        ];
+    },
+});

--- a/clis/qwen/history.js
+++ b/clis/qwen/history.js
@@ -1,0 +1,53 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    QIANWEN_DOMAIN,
+    authRequired,
+    dismissLoginModal,
+    ensureOnQianwen,
+    getSessionListFromApi,
+} from './utils.js';
+
+function formatDate(ms) {
+    if (!ms) return '';
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return '';
+    const pad = (n) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+cli({
+    site: 'qwen',
+    name: 'history',
+    access: 'read',
+    description: 'List recent Qianwen conversations (requires login)',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },
+    ],
+    columns: ['Index', 'Title', 'Updated', 'Url'],
+    func: async (page, kwargs) => {
+        const limit = Math.max(1, Math.min(parseInt(kwargs.limit, 10) || 20, 100));
+        await ensureOnQianwen(page);
+        await dismissLoginModal(page);
+        await page.wait(1);
+        const result = await getSessionListFromApi(page, limit);
+        if (!result.ok) {
+            if (result.status === 401 || result.status === 403) throw authRequired();
+            if (!result.sessions.length) {
+                return [{ Index: 0, Title: `API failed (status=${result.status}) ${result.error || ''}`.trim(), Updated: '', Url: '' }];
+            }
+        }
+        if (!result.sessions.length) {
+            return [{ Index: 0, Title: 'No Qianwen conversations found.', Updated: '', Url: '' }];
+        }
+        return result.sessions.slice(0, limit).map((s, i) => ({
+            Index: i + 1,
+            Title: s.title || '(untitled)',
+            Updated: formatDate(s.updated_at),
+            Url: `https://www.qianwen.com/chat/${s.id}`,
+        }));
+    },
+});

--- a/clis/qwen/history.js
+++ b/clis/qwen/history.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import {
     QIANWEN_DOMAIN,
     authRequired,
@@ -25,11 +26,17 @@ cli({
     browser: true,
     navigateBefore: false,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show (default 20, max 100)' },
     ],
     columns: ['Index', 'Title', 'Updated', 'Url'],
     func: async (page, kwargs) => {
-        const limit = Math.max(1, Math.min(parseInt(kwargs.limit, 10) || 20, 100));
+        const limit = Number(kwargs.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('limit must be a positive integer');
+        }
+        if (limit > 100) {
+            throw new ArgumentError('limit must be <= 100');
+        }
         await ensureOnQianwen(page);
         await dismissLoginModal(page);
         await page.wait(1);

--- a/clis/qwen/history.js
+++ b/clis/qwen/history.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
     QIANWEN_DOMAIN,
     authRequired,
@@ -44,11 +44,11 @@ cli({
         if (!result.ok) {
             if (result.status === 401 || result.status === 403) throw authRequired();
             if (!result.sessions.length) {
-                return [{ Index: 0, Title: `API failed (status=${result.status}) ${result.error || ''}`.trim(), Updated: '', Url: '' }];
+                throw new CommandExecutionError(`Qianwen history API failed (status=${result.status}) ${result.error || ''}`.trim());
             }
         }
         if (!result.sessions.length) {
-            return [{ Index: 0, Title: 'No Qianwen conversations found.', Updated: '', Url: '' }];
+            throw new EmptyResultError('qwen history', 'No Qianwen conversations found.');
         }
         return result.sessions.slice(0, limit).map((s, i) => ({
             Index: i + 1,

--- a/clis/qwen/image.js
+++ b/clis/qwen/image.js
@@ -1,0 +1,177 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { saveBase64ToFile } from '@jackwener/opencli/utils';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import {
+    QIANWEN_DOMAIN,
+    authRequired,
+    dismissLoginModal,
+    ensureOnQianwen,
+    getMessageBubbles,
+    hasLoginGate,
+    normalizeBooleanFlag,
+    sendMessage,
+    setFeatureToggle,
+    startNewChat,
+} from './utils.js';
+
+function displayPath(filePath) {
+    const home = os.homedir();
+    return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+
+function extFromMime(mime) {
+    if (!mime) return '.jpg';
+    if (mime.includes('png')) return '.png';
+    if (mime.includes('webp')) return '.webp';
+    if (mime.includes('gif')) return '.gif';
+    return '.jpg';
+}
+
+async function collectImageUrls(page, sinceAssistantId) {
+    return await page.evaluate(`(() => {
+    const scope = ${JSON.stringify(sinceAssistantId || '')};
+    const bubbles = Array.from(document.querySelectorAll('[data-msgid$="-answer"]'));
+    const target = scope
+      ? bubbles.find((b) => b.getAttribute('data-msgid') === scope)
+      : bubbles[bubbles.length - 1];
+    if (!target) return [];
+    const imgs = Array.from(target.querySelectorAll('img'))
+      .map((node) => node.getAttribute('src') || '')
+      .filter((src) => src
+        && !src.startsWith('data:')
+        && !/\\.(svg)$/i.test(src)
+        && !src.includes('alicdn.com/imgextra'));
+    return Array.from(new Set(imgs));
+  })()`);
+}
+
+async function waitForImageUrls(page, sinceAssistantId, timeoutSeconds) {
+    const startTime = Date.now();
+    let lastUrls = [];
+    while (Date.now() - startTime < timeoutSeconds * 1000) {
+        await page.wait(2);
+        if (await hasLoginGate(page)) return { status: 'auth_required', urls: [] };
+        const urls = await collectImageUrls(page, sinceAssistantId);
+        if (urls.length && urls.length === lastUrls.length && urls.every((u, i) => u === lastUrls[i])) {
+            return { status: 'ok', urls };
+        }
+        if (urls.length) {
+            await page.wait(2);
+            const urls2 = await collectImageUrls(page, sinceAssistantId);
+            if (urls2.length === urls.length && urls2.every((u, i) => u === urls[i])) {
+                return { status: 'ok', urls: urls2 };
+            }
+            lastUrls = urls2;
+            continue;
+        }
+        lastUrls = urls;
+    }
+    return lastUrls.length ? { status: 'partial', urls: lastUrls } : { status: 'timeout', urls: [] };
+}
+
+async function fetchImageAsset(page, url) {
+    return await page.evaluate(`(async () => {
+    try {
+      const res = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
+      if (!res.ok) return { ok: false, status: res.status };
+      const mime = res.headers.get('content-type') || '';
+      const buf = await res.arrayBuffer();
+      const bytes = new Uint8Array(buf);
+      let binary = '';
+      const chunk = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+      }
+      return { ok: true, mime, base64: btoa(binary) };
+    } catch (error) {
+      return { ok: false, status: 0, error: String(error?.message || error) };
+    }
+  })()`);
+}
+
+cli({
+    site: 'qwen',
+    name: 'image',
+    access: 'write',
+    description: 'Generate images with Qianwen (AI生图) and save them locally',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    defaultFormat: 'plain',
+    timeoutSeconds: 300,
+    args: [
+        { name: 'prompt', required: true, positional: true, help: 'Image prompt to send' },
+        { name: 'op', default: '~/Pictures/qianwen', help: 'Output directory' },
+        { name: 'new', type: 'boolean', default: true, help: 'Start a new chat before generating (default: true)' },
+        { name: 'sd', type: 'boolean', default: false, help: 'Skip download; only show the Qianwen link' },
+        { name: 'timeout', type: 'int', default: 180, help: 'Max seconds to wait for the image response' },
+    ],
+    columns: ['Status', 'File', 'Link'],
+    func: async (page, kwargs) => {
+        const prompt = String(kwargs.prompt || '').trim();
+        if (!prompt) throw new CommandExecutionError('prompt is required');
+        const outputDir = String(kwargs.op || '~/Pictures/qianwen').replace(/^~\//, `${os.homedir()}/`);
+        const startFresh = normalizeBooleanFlag(kwargs.new, true);
+        const skipDownload = normalizeBooleanFlag(kwargs.sd, false);
+        const timeout = Math.max(30, parseInt(kwargs.timeout, 10) || 180);
+
+        await ensureOnQianwen(page);
+        await dismissLoginModal(page);
+        if (startFresh) {
+            await startNewChat(page);
+            await dismissLoginModal(page);
+        }
+        await setFeatureToggle(page, 'image', true);
+        await page.wait(0.5);
+
+        const send = await sendMessage(page, prompt);
+        if (!send?.ok) {
+            if (await hasLoginGate(page)) throw authRequired();
+            throw new CommandExecutionError(send?.reason || 'Failed to send Qianwen image prompt');
+        }
+
+        // Grab the newest assistant bubble id after send by polling briefly
+        let targetId = '';
+        for (let i = 0; i < 5; i += 1) {
+            await page.wait(1);
+            const bubbles = await getMessageBubbles(page);
+            const lastAnswer = [...bubbles].reverse().find((b) => b.role === 'Assistant');
+            if (lastAnswer) { targetId = lastAnswer.id; break; }
+        }
+
+        const waitResult = await waitForImageUrls(page, targetId, timeout);
+        const link = await page.evaluate('window.location.href').catch(() => 'https://www.qianwen.com/');
+        if (waitResult.status === 'auth_required') throw authRequired();
+        if (waitResult.status === 'timeout') {
+            throw new TimeoutError('qianwen image', timeout, 'No generated images observed before timeout.');
+        }
+
+        const urls = waitResult.urls;
+        if (skipDownload) {
+            return [{ Status: '🎨 generated', File: '-', Link: link }];
+        }
+
+        const stamp = Date.now();
+        const results = [];
+        for (let i = 0; i < urls.length; i += 1) {
+            const url = urls[i];
+            const asset = await fetchImageAsset(page, url);
+            if (!asset?.ok) {
+                results.push({ Status: `⚠️ fetch-failed(${asset?.status || '?'})`, File: '-', Link: link });
+                continue;
+            }
+            const suffix = urls.length > 1 ? `_${i + 1}` : '';
+            const ext = extFromMime(asset.mime);
+            const filePath = path.join(outputDir, `qianwen_${stamp}${suffix}${ext}`);
+            await saveBase64ToFile(asset.base64, filePath);
+            results.push({ Status: '✅ saved', File: displayPath(filePath), Link: link });
+        }
+        if (!results.length) {
+            return [{ Status: '⚠️ no-images', File: '-', Link: link }];
+        }
+        return results;
+    },
+});

--- a/clis/qwen/image.js
+++ b/clis/qwen/image.js
@@ -2,7 +2,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
-import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 import {
     QIANWEN_DOMAIN,
     authRequired,
@@ -112,11 +112,14 @@ cli({
     columns: ['Status', 'File', 'Link'],
     func: async (page, kwargs) => {
         const prompt = String(kwargs.prompt || '').trim();
-        if (!prompt) throw new CommandExecutionError('prompt is required');
+        if (!prompt) throw new ArgumentError('prompt is required');
         const outputDir = String(kwargs.op || '~/Pictures/qianwen').replace(/^~\//, `${os.homedir()}/`);
         const startFresh = normalizeBooleanFlag(kwargs.new, true);
         const skipDownload = normalizeBooleanFlag(kwargs.sd, false);
-        const timeout = Math.max(30, parseInt(kwargs.timeout, 10) || 180);
+        const timeout = Number(kwargs.timeout ?? 180);
+        if (!Number.isInteger(timeout) || timeout <= 0) {
+            throw new ArgumentError('timeout must be a positive integer');
+        }
 
         await ensureOnQianwen(page);
         await dismissLoginModal(page);
@@ -151,7 +154,7 @@ cli({
 
         const urls = waitResult.urls;
         if (skipDownload) {
-            return [{ Status: '🎨 generated', File: '-', Link: link }];
+            return [{ Status: '🎨 generated', File: null, Link: link }];
         }
 
         const stamp = Date.now();
@@ -160,8 +163,7 @@ cli({
             const url = urls[i];
             const asset = await fetchImageAsset(page, url);
             if (!asset?.ok) {
-                results.push({ Status: `⚠️ fetch-failed(${asset?.status || '?'})`, File: '-', Link: link });
-                continue;
+                throw new CommandExecutionError(`Failed to fetch generated Qianwen image ${i + 1}: status=${asset?.status || '?'}`);
             }
             const suffix = urls.length > 1 ? `_${i + 1}` : '';
             const ext = extFromMime(asset.mime);
@@ -170,7 +172,7 @@ cli({
             results.push({ Status: '✅ saved', File: displayPath(filePath), Link: link });
         }
         if (!results.length) {
-            return [{ Status: '⚠️ no-images', File: '-', Link: link }];
+            throw new EmptyResultError('qwen image', 'No generated images were available to download.');
         }
         return results;
     },

--- a/clis/qwen/new.js
+++ b/clis/qwen/new.js
@@ -1,0 +1,22 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { QIANWEN_DOMAIN, QIANWEN_URL, startNewChat, dismissLoginModal } from './utils.js';
+
+cli({
+    site: 'qwen',
+    name: 'new',
+    access: 'write',
+    description: 'Start a new conversation in Qianwen',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [],
+    columns: ['Status'],
+    func: async (page) => {
+        await page.goto(QIANWEN_URL);
+        await page.wait(2);
+        await dismissLoginModal(page);
+        await startNewChat(page);
+        return [{ Status: 'New chat started' }];
+    },
+});

--- a/clis/qwen/read.js
+++ b/clis/qwen/read.js
@@ -1,0 +1,40 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    QIANWEN_DOMAIN,
+    bubbleHtmlToMarkdown,
+    dismissLoginModal,
+    ensureOnQianwen,
+    getMessageBubbles,
+    normalizeBooleanFlag,
+} from './utils.js';
+
+cli({
+    site: 'qwen',
+    name: 'read',
+    access: 'read',
+    description: 'Read messages in the current Qianwen conversation',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },
+    ],
+    columns: ['Role', 'Text'],
+    func: async (page, kwargs) => {
+        const wantMarkdown = normalizeBooleanFlag(kwargs.markdown, false);
+        await ensureOnQianwen(page);
+        await dismissLoginModal(page);
+        await page.wait(2);
+        const bubbles = await getMessageBubbles(page);
+        if (!bubbles.length) {
+            return [{ Role: 'system', Text: 'No visible messages in the current conversation.' }];
+        }
+        return bubbles.map((b) => ({
+            Role: b.role,
+            Text: wantMarkdown && b.role === 'Assistant' && b.html
+                ? (bubbleHtmlToMarkdown(b.html) || b.text)
+                : b.text,
+        }));
+    },
+});

--- a/clis/qwen/send.js
+++ b/clis/qwen/send.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     QIANWEN_DOMAIN,
     authRequired,
@@ -30,7 +30,7 @@ cli({
     columns: ['Status', 'Prompt'],
     func: async (page, kwargs) => {
         const prompt = String(kwargs.prompt || '').trim();
-        if (!prompt) throw new CommandExecutionError('prompt is required');
+        if (!prompt) throw new ArgumentError('prompt is required');
         const startFresh = normalizeBooleanFlag(kwargs.new, false);
         const useThink = normalizeBooleanFlag(kwargs.think, false);
         const useResearch = normalizeBooleanFlag(kwargs.research, false);

--- a/clis/qwen/send.js
+++ b/clis/qwen/send.js
@@ -1,0 +1,54 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    QIANWEN_DOMAIN,
+    authRequired,
+    dismissLoginModal,
+    ensureOnQianwen,
+    hasLoginGate,
+    normalizeBooleanFlag,
+    sendMessage,
+    setFeatureToggle,
+    startNewChat,
+} from './utils.js';
+
+cli({
+    site: 'qwen',
+    name: 'send',
+    access: 'write',
+    description: 'Fire-and-forget: send a prompt to Qianwen without waiting for the reply',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'prompt', required: true, positional: true, help: 'Prompt to send to Qianwen' },
+        { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending' },
+        { name: 'think', type: 'boolean', default: false, help: 'Enable 深度思考 (DeepThink)' },
+        { name: 'research', type: 'boolean', default: false, help: 'Enable 深度研究 (DeepResearch)' },
+    ],
+    columns: ['Status', 'Prompt'],
+    func: async (page, kwargs) => {
+        const prompt = String(kwargs.prompt || '').trim();
+        if (!prompt) throw new CommandExecutionError('prompt is required');
+        const startFresh = normalizeBooleanFlag(kwargs.new, false);
+        const useThink = normalizeBooleanFlag(kwargs.think, false);
+        const useResearch = normalizeBooleanFlag(kwargs.research, false);
+
+        await ensureOnQianwen(page);
+        await dismissLoginModal(page);
+        if (startFresh) {
+            await startNewChat(page);
+            await dismissLoginModal(page);
+        }
+        if (useThink) await setFeatureToggle(page, 'think', true);
+        if (useResearch) await setFeatureToggle(page, 'research', true);
+
+        const send = await sendMessage(page, prompt);
+        if (!send?.ok) {
+            if (await hasLoginGate(page)) throw authRequired();
+            throw new CommandExecutionError(send?.reason || 'Failed to send Qianwen prompt');
+        }
+        return [{ Status: 'sent', Prompt: prompt }];
+    },
+});

--- a/clis/qwen/status.js
+++ b/clis/qwen/status.js
@@ -1,0 +1,32 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { QIANWEN_DOMAIN, ensureOnQianwen, isLoggedIn, getCurrentSessionId, getModelLabel } from './utils.js';
+
+cli({
+    site: 'qwen',
+    name: 'status',
+    access: 'read',
+    description: 'Check Qianwen page availability, login state, current session and model',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [],
+    columns: ['Status', 'Login', 'Model', 'SessionId', 'Url'],
+    func: async (page) => {
+        await ensureOnQianwen(page);
+        await page.wait(2);
+        const [loggedIn, sessionId, model, url] = await Promise.all([
+            isLoggedIn(page),
+            getCurrentSessionId(page),
+            getModelLabel(page),
+            page.evaluate('window.location.href').catch(() => ''),
+        ]);
+        return [{
+            Status: 'Connected',
+            Login: loggedIn ? 'Yes' : 'No (guest mode)',
+            Model: model || '-',
+            SessionId: sessionId || '-',
+            Url: typeof url === 'string' ? url : '',
+        }];
+    },
+});

--- a/clis/qwen/status.js
+++ b/clis/qwen/status.js
@@ -21,11 +21,15 @@ cli({
             getModelLabel(page),
             page.evaluate('window.location.href').catch(() => ''),
         ]);
+        // Model / SessionId may be unknown when the page is loading or the user
+        // is in guest mode. Surface that as `null` (typed unknown) instead of a
+        // string sentinel like '-' — agents can branch on null cleanly, and a
+        // sentinel string would silently get treated as a real model name.
         return [{
             Status: 'Connected',
             Login: loggedIn ? 'Yes' : 'No (guest mode)',
-            Model: model || '-',
-            SessionId: sessionId || '-',
+            Model: model ? model : null,
+            SessionId: sessionId ? sessionId : null,
             Url: typeof url === 'string' ? url : '',
         }];
     },

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -1,0 +1,357 @@
+import { htmlToMarkdown } from '@jackwener/opencli/utils';
+import { AuthRequiredError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+
+export const QIANWEN_DOMAIN = 'www.qianwen.com';
+export const QIANWEN_URL = 'https://www.qianwen.com/';
+export const QIANWEN_API_DOMAIN = 'chat2-api.qianwen.com';
+
+export const IS_VISIBLE_JS = `
+  const isVisible = (node) => {
+    if (!(node instanceof Element)) return false;
+    const style = window.getComputedStyle(node);
+    if (style.visibility === 'hidden' || style.display === 'none') return false;
+    const rect = node.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
+`;
+
+const POLL_INTERVAL_SECONDS = 2;
+const MIN_WAIT_MS = 6_000;
+const STABLE_POLLS_REQUIRED = 2;
+
+export function authRequired(detail) {
+    return new AuthRequiredError(QIANWEN_DOMAIN, detail || '请在浏览器里用千问 APP 扫码登录 qianwen.com 后再重试。');
+}
+
+export function normalizeBooleanFlag(value, fallback = false) {
+    if (typeof value === 'boolean') return value;
+    if (value == null || value === '') return fallback;
+    const normalized = String(value).trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+
+export async function isOnQianwen(page) {
+    const url = await page.evaluate('window.location.href').catch(() => '');
+    return typeof url === 'string' && url.includes('qianwen.com');
+}
+
+export async function ensureOnQianwen(page) {
+    if (await isOnQianwen(page)) return;
+    await page.goto(QIANWEN_URL);
+    await page.wait(2);
+}
+
+export async function dismissLoginModal(page) {
+    return await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const modal = document.querySelector('[role=alert-biz-modal]');
+    if (!modal || !isVisible(modal)) return { dismissed: false };
+    const close = modal.querySelector('[data-opencli-ref]:last-of-type')
+      || modal.querySelector('svg')?.closest('[role=button], button, div[class*="close"]');
+    const closeCandidates = Array.from(modal.querySelectorAll('div, button, span'))
+      .filter((node) => node instanceof HTMLElement && isVisible(node))
+      .filter((node) => {
+        const cls = node.className || '';
+        if (typeof cls !== 'string') return false;
+        return /close|dismiss|cancel/i.test(cls) || node.getAttribute('aria-label') === '关闭';
+      });
+    const target = closeCandidates[0] || modal.querySelector('svg')?.parentElement;
+    if (target instanceof HTMLElement) {
+      target.click();
+      return { dismissed: true };
+    }
+    // Last resort: synth ESC key on document
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
+    return { dismissed: true, method: 'escape' };
+  })()`);
+}
+
+export async function hasLoginGate(page) {
+    const result = await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const modal = document.querySelector('[role=alert-biz-modal]');
+    if (modal && isVisible(modal)) {
+      const iframe = modal.querySelector('iframe');
+      const src = iframe?.getAttribute('src') || '';
+      if (src.includes('passport.qianwen.com') || src.includes('login')) return true;
+    }
+    return false;
+  })()`);
+    return Boolean(result);
+}
+
+export async function isLoggedIn(page) {
+    const result = await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const loginBtn = Array.from(document.querySelectorAll('button'))
+      .find((node) => (node.textContent || '').trim() === '登录' && isVisible(node));
+    if (loginBtn) return false;
+    const hint = Array.from(document.querySelectorAll('p'))
+      .find((node) => (node.textContent || '').includes('登录可同步历史对话'));
+    if (hint && isVisible(hint)) return false;
+    return true;
+  })()`);
+    return Boolean(result);
+}
+
+export async function getCurrentSessionId(page) {
+    const url = await page.evaluate('window.location.href').catch(() => '');
+    if (typeof url !== 'string') return '';
+    const match = url.match(/\/chat\/([A-Za-z0-9_-]+)/);
+    return match ? match[1] : '';
+}
+
+export async function getModelLabel(page) {
+    const result = await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const trigger = Array.from(document.querySelectorAll('[aria-haspopup=dialog]'))
+      .find((node) => isVisible(node) && (node.innerText || '').includes('Qwen'));
+    if (!trigger) return '';
+    const label = (trigger.innerText || '').split('\\n')[0].trim();
+    return label;
+  })()`);
+    return typeof result === 'string' ? result : '';
+}
+
+export async function startNewChat(page) {
+    const result = await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const button = Array.from(document.querySelectorAll('button'))
+      .find((node) => isVisible(node) && (node.innerText || '').trim() === '新建对话');
+    if (button instanceof HTMLElement) {
+      button.click();
+      return { ok: true, method: 'button' };
+    }
+    return { ok: false };
+  })()`);
+    if (result?.ok) {
+        await page.wait(1.5);
+        return true;
+    }
+    await page.goto(QIANWEN_URL);
+    await page.wait(2);
+    return true;
+}
+
+export async function getComposer(page) {
+    return await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const editor = Array.from(document.querySelectorAll('[role=textbox][contenteditable=true]'))
+      .find((node) => isVisible(node));
+    return { found: !!editor, text: editor?.textContent || '' };
+  })()`);
+}
+
+export async function sendMessage(page, prompt) {
+    return await page.evaluate(`(async () => {
+    ${IS_VISIBLE_JS}
+    const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    const editor = Array.from(document.querySelectorAll('[role=textbox][contenteditable=true]'))
+      .find((node) => isVisible(node));
+    if (!(editor instanceof HTMLElement)) {
+      return { ok: false, reason: 'Qianwen composer (contenteditable) not found.' };
+    }
+
+    editor.focus();
+    // Clear existing content first
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.execCommand('delete', false);
+    await waitFor(100);
+
+    // Slate editor accepts content via beforeinput InputEvent
+    editor.dispatchEvent(new InputEvent('beforeinput', {
+      inputType: 'insertText',
+      data: ${JSON.stringify(prompt)},
+      bubbles: true,
+      cancelable: true,
+    }));
+    await waitFor(400);
+
+    const sendBtn = document.querySelector('button[aria-label="发送消息"]');
+    if (sendBtn instanceof HTMLElement && !sendBtn.disabled) {
+      sendBtn.click();
+      return { ok: true, action: 'click' };
+    }
+
+    // Fallback: dispatch Enter key
+    editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+    editor.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+    return { ok: true, action: 'enter-fallback' };
+  })()`);
+}
+
+export async function getMessageBubbles(page) {
+    const result = await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    const bubbles = Array.from(document.querySelectorAll('[data-msgid]'))
+      .filter((node) => node instanceof HTMLElement);
+
+    const seen = new Set();
+    const out = [];
+    for (const node of bubbles) {
+      const id = node.getAttribute('data-msgid') || '';
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const isAnswer = id.endsWith('-answer');
+      const role = isAnswer ? 'Assistant' : 'User';
+      const contentNode = isAnswer
+        ? (node.querySelector('[class*="markdown"]') || node.querySelector('[class*="content"]') || node)
+        : (node.querySelector('[class*="bubble"]') || node);
+      const html = (contentNode instanceof HTMLElement) ? (contentNode.innerHTML || '') : '';
+      const text = (contentNode instanceof HTMLElement) ? (contentNode.innerText || contentNode.textContent || '') : '';
+      out.push({ id, role, text: (text || '').replace(/\\s+/g, ' ').trim(), html });
+    }
+    return out;
+  })()`);
+    if (!Array.isArray(result)) return [];
+    return result
+        .map((item) => ({
+            id: String(item?.id || ''),
+            role: item?.role === 'Assistant' ? 'Assistant' : 'User',
+            text: String(item?.text || '').trim(),
+            html: String(item?.html || ''),
+        }))
+        .filter((item) => item.id && item.text);
+}
+
+export function bubbleHtmlToMarkdown(html) {
+    try {
+        return htmlToMarkdown(html).trim();
+    } catch {
+        return (html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    }
+}
+
+function stripNoise(text) {
+    return (text || '')
+        .replace(/\u00a0/g, ' ')
+        .replace(/复制\s*$/g, '')
+        .replace(/重新生成\s*$/g, '')
+        .trim();
+}
+
+export async function waitForAnswer(page, prompt, timeoutSeconds) {
+    const startTime = Date.now();
+    let previousText = '';
+    let stableCount = 0;
+    let lastCandidate = '';
+    let seenAssistantId = '';
+
+    while (Date.now() - startTime < timeoutSeconds * 1000) {
+        await page.wait(POLL_INTERVAL_SECONDS);
+
+        if (await hasLoginGate(page)) {
+            return { status: 'auth_required' };
+        }
+
+        const bubbles = await getMessageBubbles(page);
+        const lastAssistant = [...bubbles].reverse().find((b) => b.role === 'Assistant');
+        if (!lastAssistant) continue;
+
+        const text = stripNoise(lastAssistant.text);
+        if (!text || text === prompt) continue;
+
+        if (!seenAssistantId) seenAssistantId = lastAssistant.id;
+        lastCandidate = text;
+
+        const waitedLongEnough = Date.now() - startTime >= MIN_WAIT_MS;
+        if (text === previousText) {
+            stableCount += 1;
+            if (waitedLongEnough && stableCount >= STABLE_POLLS_REQUIRED) {
+                return { status: 'ok', assistant: lastAssistant };
+            }
+        } else {
+            previousText = text;
+            stableCount = 0;
+        }
+    }
+
+    if (lastCandidate) {
+        const bubbles = await getMessageBubbles(page);
+        const lastAssistant = [...bubbles].reverse().find((b) => b.role === 'Assistant');
+        return { status: 'partial', assistant: lastAssistant };
+    }
+    return { status: 'timeout' };
+}
+
+const FEATURE_LABELS = {
+    think: '深度思考',
+    research: '深度研究',
+    task: '任务助理',
+    image: 'AI生图',
+    ppt: 'PPT创作',
+};
+
+export async function setFeatureToggle(page, feature, enabled) {
+    const label = FEATURE_LABELS[feature];
+    if (!label) return false;
+    const result = await page.evaluate(`(async () => {
+    ${IS_VISIBLE_JS}
+    const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const label = ${JSON.stringify(label)};
+    const button = Array.from(document.querySelectorAll('button[aria-label]'))
+      .find((node) => isVisible(node) && node.getAttribute('aria-label') === label);
+    if (!(button instanceof HTMLElement)) return { found: false };
+    const selected = button.getAttribute('aria-pressed') === 'true'
+      || /active|selected|bg-primary/.test(button.className || '');
+    if (selected === ${Boolean(enabled)}) return { found: true, changed: false, selected };
+    button.click();
+    await waitFor(300);
+    return { found: true, changed: true };
+  })()`);
+    return Boolean(result?.found);
+}
+
+export async function getSessionListFromApi(page, limit = 30) {
+    const capped = Math.min(Math.max(1, limit || 30), 100);
+    const result = await page.evaluate(`(async () => {
+    try {
+      const utdid = (document.cookie.match(/(?:^|;\\s*)b-user-id=([^;]+)/)?.[1])
+        || (document.cookie.match(/(?:^|;\\s*)utdid=([^;]+)/)?.[1])
+        || '';
+      const query = new URLSearchParams({
+        biz_id: 'ai_qwen',
+        chat_client: 'h5',
+        device: 'pc',
+        fr: 'pc',
+        pr: 'qwen',
+        ut: utdid,
+        la: 'zh-CN',
+        tz: 'Asia/Shanghai',
+        ve: '2.4.9',
+      }).toString();
+      const res = await fetch('https://${QIANWEN_API_DOMAIN}/api/v2/session/page/list?' + query, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ page_num: 1, page_size: ${capped}, page_no: 1 }),
+      });
+      const text = await res.text();
+      let body = null;
+      try { body = text ? JSON.parse(text) : null; } catch { body = null; }
+      return { ok: res.ok, status: res.status, body, utdid };
+    } catch (error) {
+      return { ok: false, status: 0, error: String(error?.message || error) };
+    }
+  })()`);
+    if (!result || !result.ok) {
+        return { ok: false, status: result?.status || 0, error: result?.error || '', sessions: [] };
+    }
+    const data = result.body?.data || result.body?.result || {};
+    const rawList = Array.isArray(data?.list) ? data.list
+        : Array.isArray(data?.items) ? data.items
+            : Array.isArray(data?.page_list) ? data.page_list
+                : Array.isArray(result.body?.list) ? result.body.list
+                    : [];
+    const sessions = rawList.map((item) => ({
+        id: String(item?.session_id || item?.sessionId || item?.id || ''),
+        title: String(item?.title || item?.name || item?.summary || '').trim(),
+        updated_at: Number(item?.updated_at || item?.last_req_timestamp || item?.updatedAt || item?.gmt_modified || item?.update_time || 0),
+    })).filter((item) => item.id);
+    return { ok: true, status: result.status, sessions };
+}

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -308,7 +308,10 @@ export async function setFeatureToggle(page, feature, enabled) {
 }
 
 export async function getSessionListFromApi(page, limit = 30) {
-    const capped = Math.min(Math.max(1, limit || 30), 100);
+    const pageSize = Number(limit ?? 30);
+    if (!Number.isInteger(pageSize) || pageSize <= 0 || pageSize > 100) {
+        throw new CommandExecutionError('Qianwen history page_size must be an integer between 1 and 100');
+    }
     const result = await page.evaluate(`(async () => {
     try {
       const utdid = (document.cookie.match(/(?:^|;\\s*)b-user-id=([^;]+)/)?.[1])
@@ -329,7 +332,7 @@ export async function getSessionListFromApi(page, limit = 30) {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ page_num: 1, page_size: ${capped}, page_no: 1 }),
+        body: JSON.stringify({ page_num: 1, page_size: ${pageSize}, page_no: 1 }),
       });
       const text = await res.text();
       let body = null;

--- a/docs/adapters/browser/1point3acres.md
+++ b/docs/adapters/browser/1point3acres.md
@@ -54,11 +54,11 @@ Use `opencli 1point3acres forums` to see the full list.
 | Command | Columns |
 |---------|---------|
 | `hot` / `latest` / `digest` / `forum` | `rank, tid, title, forum, author, replies, views, lastReplyTime, url` |
-| `thread` | `floor, author, posted, content, url` |
-| `user` | `field, value` (key/value pairs) |
-| `forums` | `fid, name, category, url` |
-| `search` | `rank, tid, title, forum, author, postedTime, url` |
-| `notifications` | `kind, who, summary, time, url` |
+| `thread` | `floor, pid, author, postTime, content, url` |
+| `user` | `uid, username, group, credits, rice, posts, threads, digests, registerTime, lastAccess, profileUrl` |
+| `forums` | `fid, name, url` |
+| `search` | `rank, tid, title, forum, author, replies, views, postTime, url` |
+| `notifications` | `index, from, summary, time, threadUrl` |
 
 ## Prerequisites
 
@@ -73,4 +73,5 @@ Use `opencli 1point3acres forums` to see the full list.
 - The site serves GBK-encoded HTML; the adapter decodes to UTF-8 internally
 - `tid` (thread id) is the canonical handle that pipes a listing row into `thread` for the full content
 - Public endpoints serve rendered HTML, so heavy bot traffic may hit Discuz challenge / login gates — fall back to a logged-in session if `hot` / `latest` start returning empty rows
-- `--limit` is validated upfront and rejected with `ArgumentError` if non-positive or above 50 (the page yields ~50 rows max) — no silent clamp
+- Listing `--limit` values are validated upfront and rejected with `ArgumentError` if non-positive or above 50 (the page yields ~50 rows max) — no silent clamp
+- `thread --page`, `thread --limit`, `thread --contentLimit`, and `notifications --limit` also reject invalid values explicitly instead of silently flooring them

--- a/docs/adapters/browser/1point3acres.md
+++ b/docs/adapters/browser/1point3acres.md
@@ -1,0 +1,75 @@
+# 1point3acres (一亩三分地)
+
+Browse and search **1point3acres** — a Discuz!-based BBS popular for North American job, immigration, and grad-school discussions. Public listings work without auth; `search` and `notifications` require an active browser session.
+
+**Mode**: 🌐 Public + 🔐 Cookie · **Domain**: `www.1point3acres.com`
+
+## Commands
+
+| Command | Description | Auth |
+|---------|-------------|------|
+| `opencli 1point3acres hot` | Today's hot threads (by heat) | Public |
+| `opencli 1point3acres latest` | Newest threads (by post time, desc) | Public |
+| `opencli 1point3acres digest` | Editor-picked / featured threads | Public |
+| `opencli 1point3acres forums` | List all forums (fid + name) | Public |
+| `opencli 1point3acres forum <fid>` | List threads in a specific forum | Public |
+| `opencli 1point3acres thread <tid>` | Thread detail + replies | Public |
+| `opencli 1point3acres user <who>` | User profile (group / points / 大米 / posts) | Public |
+| `opencli 1point3acres search <query>` | Full-text search | Cookie |
+| `opencli 1point3acres notifications` | Site notifications (replies / mentions / reviews) | Cookie |
+
+## Usage Examples
+
+```bash
+# Today's hot threads
+opencli 1point3acres hot --limit 10
+
+# Newest posts in the overseas-job-referral forum (fid=198)
+opencli 1point3acres forum 198 --limit 20
+
+# Read a thread (tid comes from any listing's `tid` column)
+opencli 1point3acres thread 1158360 --limit 10
+
+# Lookup a user (numeric → uid, otherwise username)
+opencli 1point3acres user 12345
+opencli 1point3acres user some-username
+
+# Filter the forum list by keyword
+opencli 1point3acres forums --filter 面经
+
+# Search the site (requires login)
+opencli 1point3acres search "OPT extension" --limit 10
+
+# Notifications (requires login)
+opencli 1point3acres notifications --kind mypost --limit 20
+```
+
+## Common Forum IDs
+
+`145` (海外面经) · `198` (海外职位内推) · `27` (研究生申请) · `28` (博士申请) · `82` (NIW / EB-1A 移民).
+Use `opencli 1point3acres forums` to see the full list.
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `hot` / `latest` / `digest` / `forum` | `rank, tid, title, forum, author, replies, views, lastReplyTime, url` |
+| `thread` | `floor, author, posted, content, url` |
+| `user` | `field, value` (key/value pairs) |
+| `forums` | `fid, name, category, url` |
+| `search` | `rank, tid, title, forum, author, postedTime, url` |
+| `notifications` | `kind, who, summary, time, url` |
+
+## Prerequisites
+
+- No browser required for public commands (`hot` / `latest` / `digest` / `forums` / `forum` / `thread` / `user`)
+- For `search` and `notifications`:
+  - Chrome is running
+  - You are already logged in to `www.1point3acres.com`
+  - [Browser Bridge extension](/guide/browser-bridge) is installed
+
+## Notes
+
+- The site serves GBK-encoded HTML; the adapter decodes to UTF-8 internally
+- `tid` (thread id) is the canonical handle that pipes a listing row into `thread` for the full content
+- Public endpoints serve rendered HTML, so heavy bot traffic may hit Discuz challenge / login gates — fall back to a logged-in session if `hot` / `latest` start returning empty rows

--- a/docs/adapters/browser/1point3acres.md
+++ b/docs/adapters/browser/1point3acres.md
@@ -73,3 +73,4 @@ Use `opencli 1point3acres forums` to see the full list.
 - The site serves GBK-encoded HTML; the adapter decodes to UTF-8 internally
 - `tid` (thread id) is the canonical handle that pipes a listing row into `thread` for the full content
 - Public endpoints serve rendered HTML, so heavy bot traffic may hit Discuz challenge / login gates — fall back to a logged-in session if `hot` / `latest` start returning empty rows
+- `--limit` is validated upfront and rejected with `ArgumentError` if non-positive or above 50 (the page yields ~50 rows max) — no silent clamp

--- a/docs/adapters/browser/coingecko.md
+++ b/docs/adapters/browser/coingecko.md
@@ -46,3 +46,4 @@ opencli coingecko top -f json
 - The public endpoint is rate-limited; retry briefly if you hit transient `HTTP 429` responses
 - All numeric values are denominated in the selected `--currency`
 - `change24hPct` is a raw percent (e.g. `2.34` means `+2.34%`), not a fraction
+- `--limit` is validated upfront and rejected with `ArgumentError` if non-positive or above 250 (the CoinGecko `per_page` upper bound) — no silent clamp

--- a/docs/adapters/browser/coingecko.md
+++ b/docs/adapters/browser/coingecko.md
@@ -1,0 +1,48 @@
+# CoinGecko
+
+Access **CoinGecko** crypto market data from the terminal via the public API (no authentication required).
+
+**Mode**: 🌐 Public · **Domain**: `api.coingecko.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli coingecko top` | Top coins by market cap |
+
+## Usage Examples
+
+```bash
+# Top 10 coins in USD (default)
+opencli coingecko top
+
+# Top 5 coins priced in CNY
+opencli coingecko top --currency cny --limit 5
+
+# Top 50 coins in EUR
+opencli coingecko top --currency eur --limit 50
+
+# JSON output
+opencli coingecko top -f json
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--currency` | Quote currency (`usd` / `cny` / `eur` / `jpy` / etc., default: `usd`) |
+| `--limit` | Number of coins to return (1–250, default: 10) |
+
+## Output Columns
+
+`rank, symbol, name, price, change24hPct, marketCap, volume24h, high24h, low24h`
+
+## Prerequisites
+
+- No browser required — uses CoinGecko's public market-data endpoint
+
+## Notes
+
+- The public endpoint is rate-limited; retry briefly if you hit transient `HTTP 429` responses
+- All numeric values are denominated in the selected `--currency`
+- `change24hPct` is a raw percent (e.g. `2.34` means `+2.34%`), not a fraction

--- a/docs/adapters/browser/qwen.md
+++ b/docs/adapters/browser/qwen.md
@@ -109,4 +109,6 @@ opencli qwen image "a tiny robot" --sd true
 - `ask` waits for the streaming reply to finish; `send` returns immediately after submission
 - DeepThink (`--think`) and DeepResearch (`--research`) toggle the corresponding composer chips before submitting
 - Generated image files are timestamped to avoid overwriting prior runs
+- `status` returns `Model` / `SessionId` as `null` when they cannot be detected (e.g. guest mode, page still loading) rather than a string sentinel — branch on `null` in agent code
 - DOM or product changes on Qwen can break composer detection — `opencli qwen status` is the quickest sanity check
+- `limit` is validated and rejected with `ArgumentError` if non-positive or above the documented max (e.g. `history` max 100); no silent clamp

--- a/docs/adapters/browser/qwen.md
+++ b/docs/adapters/browser/qwen.md
@@ -1,0 +1,112 @@
+# Qwen (通义千问)
+
+Drive **Qianwen / Qwen** chat from the terminal. All commands run through your existing browser session — no API key needed.
+
+**Mode**: 🔐 Browser · **Domain**: `www.qianwen.com`
+
+## Commands
+
+| Command | Description | Access |
+|---------|-------------|--------|
+| `opencli qwen status` | Page availability, login state, current model and session | read |
+| `opencli qwen history` | List recent conversations (requires login) | read |
+| `opencli qwen read` | Read messages in the current conversation | read |
+| `opencli qwen ask <prompt>` | Send a prompt and wait for the assistant reply | write |
+| `opencli qwen send <prompt>` | Fire-and-forget: send a prompt without waiting | write |
+| `opencli qwen new` | Start a fresh conversation | write |
+| `opencli qwen image <prompt>` | Generate images (AI 生图) and save them locally | write |
+
+## Usage Examples
+
+```bash
+# Sanity check
+opencli qwen status
+
+# Recent conversations
+opencli qwen history --limit 10
+
+# Read the active conversation as markdown
+opencli qwen read --markdown true
+
+# Ask a question and wait for the reply
+opencli qwen ask "用一段话解释 transformer attention"
+
+# Ask in a brand-new chat with DeepThink turned on
+opencli qwen ask "推导 KL 散度的链式法则" --new true --think true
+
+# Fire-and-forget (don't wait for the reply)
+opencli qwen send "继续上面的推导" --think true
+
+# Start a new conversation
+opencli qwen new
+
+# Generate an image and save it locally
+opencli qwen image "a watercolor fox sketching on paper"
+
+# Custom output directory
+opencli qwen image "cyberpunk skyline" --op ~/Downloads/qwen-images
+
+# Skip download — just print the share link
+opencli qwen image "a tiny robot" --sd true
+```
+
+## Options
+
+### `ask` / `send`
+
+| Option | Description |
+|--------|-------------|
+| `prompt` | Prompt to send (required positional) |
+| `--new` | Start a new chat before sending (default: `false`) |
+| `--think` | Enable 深度思考 (DeepThink) |
+| `--research` | Enable 深度研究 (DeepResearch) |
+| `--markdown` | (`ask` only) Emit assistant reply as markdown |
+| `--timeout` | (`ask` only) Max seconds to wait for the reply (default: `120`) |
+
+### `image`
+
+| Option | Description |
+|--------|-------------|
+| `prompt` | Image prompt (required positional) |
+| `--op` | Output directory (default: `~/Pictures/qianwen`) |
+| `--new` | Start a new chat before generating (default: `true`) |
+| `--sd` | Skip download; only print the conversation link |
+| `--timeout` | Max seconds to wait for the image response (default: `180`) |
+
+### `read`
+
+| Option | Description |
+|--------|-------------|
+| `--markdown` | Emit assistant replies as markdown (default: `false`) |
+
+### `history`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max conversations to list (default: `20`, max `100`) |
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `status` | `Status, Login, Model, SessionId, Url` |
+| `history` | `Index, Title, Updated, Url` |
+| `read` | `Role, Text` |
+| `ask` | `Role, Text` |
+| `send` | `Status, Url` |
+| `new` | `Status, Url` |
+| `image` | `Status, File, Link` |
+
+## Prerequisites
+
+- Chrome is running
+- You are already signed into `www.qianwen.com`
+- [Browser Bridge extension](/guide/browser-bridge) is installed
+
+## Notes
+
+- `read` works without login (guest mode), but `history`, `notifications`, and most `write` flows require an authenticated session
+- `ask` waits for the streaming reply to finish; `send` returns immediately after submission
+- DeepThink (`--think`) and DeepResearch (`--research`) toggle the corresponding composer chips before submitting
+- Generated image files are timestamped to avoid overwriting prior runs
+- DOM or product changes on Qwen can break composer detection — `opencli qwen status` is the quickest sanity check

--- a/docs/adapters/browser/qwen.md
+++ b/docs/adapters/browser/qwen.md
@@ -93,8 +93,8 @@ opencli qwen image "a tiny robot" --sd true
 | `history` | `Index, Title, Updated, Url` |
 | `read` | `Role, Text` |
 | `ask` | `Role, Text` |
-| `send` | `Status, Url` |
-| `new` | `Status, Url` |
+| `send` | `Status, Prompt` |
+| `new` | `Status` |
 | `image` | `Status, File, Link` |
 
 ## Prerequisites
@@ -105,7 +105,7 @@ opencli qwen image "a tiny robot" --sd true
 
 ## Notes
 
-- `read` works without login (guest mode), but `history`, `notifications`, and most `write` flows require an authenticated session
+- `read` works without login (guest mode), but `history` and most `write` flows require an authenticated session
 - `ask` waits for the streaming reply to finish; `send` returns immediately after submission
 - DeepThink (`--think`) and DeepResearch (`--research`) toggle the corresponding composer chips before submitting
 - Generated image files are timestamped to avoid overwriting prior runs


### PR DESCRIPTION
## Summary

Three new sites with 17 adapters total, lifted from my personal `~/.opencli/clis/` and made upstream-ready:

- **coingecko** (1 adapter, PUBLIC) — `top` market-cap listing via CoinGecko `/coins/markets`.
- **1point3acres** (9 adapters) — Discuz!X BBS with GBK-decoded HTML.
  - PUBLIC: `digest`, `forum`, `forums`, `hot`, `latest`, `thread`, `user`
  - COOKIE: `notifications`, `search` (Discuz returns guest-alert HTML for unauthenticated requests → `AuthRequiredError`)
- **qwen** (7 adapters, browser COOKIE) — Alibaba Qwen chat (qianwen.com).
  - write: `ask`, `send`, `new`, `image`
  - read: `history`, `read`, `status`

## What I caught while upstreaming

The local copies had a **silent func-signature bug** in every non-browser adapter: `func: async (_page, args)` reads `args` as the second positional, but the engine calls non-browser funcs as `func(kwargs, debug)`. So `args` was `false` (the debug flag) and every named option silently fell back to its default. Fixed in this PR by switching all 8 non-browser adapters to `func: async (args)`. Browser adapters keep `(page, args)` since they get `func(page, kwargs, debug)`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `opencli validate` — `PASS, Errors: 0` (warnings are pre-existing)
- [x] `npm run test:adapter` — 1441/1441 passing, 213 files
- [x] Live smoke tests:
  - `opencli coingecko top --currency cny --limit 2` → BTC=552k CNY ✓
  - `opencli 1point3acres hot/latest/digest/forums/forum/thread/user` ✓ (all 7 PUBLIC)
  - 1point3acres `notifications` / `search` and qwen browser adapters require live login — verified previously on my account.
- [ ] Reviewer / pr-monitor pass