### PR TITLE
feat(help): group root --help adapters into External CLI / App / Site buckets

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -116,6 +116,93 @@ describe('createProgram root help descriptions', () => {
     }
   });
 
+  it('groups adapters into App / Site buckets by domain field', () => {
+    const registry = getRegistry();
+    const snapshot = new Map(registry);
+    registry.clear();
+    try {
+      cli({
+        site: 'bilibili',
+        name: 'hot',
+        access: 'read',
+        description: 'Bilibili hot videos',
+        domain: 'www.bilibili.com',
+        strategy: Strategy.PUBLIC,
+        browser: false,
+      });
+      cli({
+        site: 'chatwise',
+        name: 'ask',
+        access: 'write',
+        description: 'Ask Chatwise desktop app',
+        domain: 'localhost',
+        strategy: Strategy.UI,
+        browser: true,
+      });
+
+      const program = createProgram('', '');
+      const help = program.helpInformation();
+
+      // Two separate sections, each with own count
+      expect(help).toContain('App adapters (1):');
+      expect(help).toMatch(/App adapters \(1\):\n {2}chatwise/);
+      expect(help).toContain('Site adapters (1):');
+      expect(help).toMatch(/Site adapters \(1\):\n {2}bilibili/);
+
+      // App adapters appear before Site adapters (External CLIs are absent here)
+      expect(help.indexOf('App adapters')).toBeLessThan(help.indexOf('Site adapters'));
+    } finally {
+      registry.clear();
+      for (const [key, value] of snapshot) registry.set(key, value);
+    }
+  });
+
+  it('exposes external_clis / app_adapters / site_adapters in structured help', () => {
+    const registry = getRegistry();
+    const snapshot = new Map(registry);
+    const argv = process.argv;
+    registry.clear();
+    try {
+      cli({
+        site: 'bilibili',
+        name: 'hot',
+        access: 'read',
+        description: 'Bilibili hot videos',
+        domain: 'www.bilibili.com',
+        strategy: Strategy.PUBLIC,
+        browser: false,
+      });
+      cli({
+        site: 'chatwise',
+        name: 'ask',
+        access: 'write',
+        description: 'Ask Chatwise desktop app',
+        domain: 'localhost',
+        strategy: Strategy.UI,
+        browser: true,
+      });
+
+      const program = createProgram('', '');
+      process.argv = ['node', 'opencli', '--help', '-f', 'yaml'];
+      const data = yaml.load(program.helpInformation()) as any;
+
+      expect(data.app_adapters.count).toBe(1);
+      expect(data.app_adapters.apps).toEqual(['chatwise']);
+      expect(data.site_adapters.count).toBe(1);
+      expect(data.site_adapters.sites).toEqual(['bilibili']);
+      expect(data.external_clis.count).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(data.external_clis.clis)).toBe(true);
+      // Adapters must NOT leak into the core commands list
+      const commandNames = data.commands.map((cmd: any) => cmd.name);
+      expect(commandNames).not.toContain('bilibili');
+      expect(commandNames).not.toContain('chatwise');
+    } finally {
+      process.argv = argv;
+      registry.clear();
+      for (const [key, value] of snapshot) registry.set(key, value);
+    }
+  });
+
   it('renders root structured help with built-ins and site adapter names', () => {
     const registry = getRegistry();
     const snapshot = new Map(registry);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled } from './external.js';
 import { registerAllCommands } from './commanderAdapter.js';
-import { formatRootAdapterHelpText, installStructuredHelp, rootHelpData } from './help.js';
+import { classifyAdapter, formatRootAdapterHelpText, installStructuredHelp, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, clickResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
@@ -2713,11 +2713,27 @@ cli({
   siteGroups.set('antigravity', antigravityCmd);
   const siteNames = registerAllCommands(program, siteGroups);
   applyRootSubcommandSummaries(program);
-  const siteNameSet = new Set(siteNames);
+
+  // ── Help-text grouping: External CLIs / App adapters / Site adapters ──
+  // Classification derives from each adapter's `domain` field — see classifyAdapter.
+  // External CLIs are taken from the externalClis registry (passthrough binaries).
+  const externalNames = externalClis.map(ext => ext.name);
+  const siteDomains = new Map<string, string | undefined>();
+  for (const [, cmd] of getRegistry()) {
+    if (!siteDomains.has(cmd.site)) siteDomains.set(cmd.site, cmd.domain);
+  }
+  const apps: string[] = [];
+  const sites: string[] = [];
+  for (const site of siteNames) {
+    if (classifyAdapter(siteDomains.get(site)) === 'app') apps.push(site);
+    else sites.push(site);
+  }
+  const adapterGroups: RootAdapterGroups = { external: externalNames, apps, sites };
+  const adapterNameSet = new Set<string>([...externalNames, ...siteNames]);
   program.configureHelp({
-    visibleCommands: (command) => command.commands.filter(child => command !== program || !siteNameSet.has(child.name())),
+    visibleCommands: (command) => command.commands.filter(child => command !== program || !adapterNameSet.has(child.name())),
   });
-  installStructuredHelp(program, () => rootHelpData(program, siteNames), () => formatRootAdapterHelpText(siteNames));
+  installStructuredHelp(program, () => rootHelpData(program, adapterGroups), () => formatRootAdapterHelpText(adapterGroups));
 
   // ── Unknown command fallback ──────────────────────────────────────────────
   // Security: do NOT auto-discover and register arbitrary system binaries.

--- a/src/help.test.ts
+++ b/src/help.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { classifyAdapter, formatRootAdapterHelpText } from './help.js';
+
+describe('classifyAdapter', () => {
+  it('classifies DNS-style domains as site', () => {
+    expect(classifyAdapter('www.bilibili.com')).toBe('site');
+    expect(classifyAdapter('chatgpt.com')).toBe('site');
+    expect(classifyAdapter('claude.ai')).toBe('site');
+    expect(classifyAdapter('grok.com')).toBe('site');
+  });
+
+  it('classifies localhost as app (Electron / osascript desktop integrations)', () => {
+    expect(classifyAdapter('localhost')).toBe('app');
+  });
+
+  it('classifies non-DNS domain strings as app (e.g. literal "doubao-app")', () => {
+    expect(classifyAdapter('doubao-app')).toBe('app');
+  });
+
+  it('defaults missing domain to site (most adapters without explicit domain are public web scrapers)', () => {
+    expect(classifyAdapter(undefined)).toBe('site');
+  });
+});
+
+describe('formatRootAdapterHelpText', () => {
+  it('renders all three sections in External / App / Site order when populated', () => {
+    const text = formatRootAdapterHelpText({
+      external: ['gh', 'docker'],
+      apps: ['chatwise', 'codex'],
+      sites: ['bilibili'],
+    });
+    expect(text).toContain('External CLIs (2):');
+    expect(text).toContain('App adapters (2):');
+    expect(text).toContain('Site adapters (1):');
+    expect(text.indexOf('External CLIs')).toBeLessThan(text.indexOf('App adapters'));
+    expect(text.indexOf('App adapters')).toBeLessThan(text.indexOf('Site adapters'));
+  });
+
+  it('omits empty sections instead of rendering a (0) header', () => {
+    const text = formatRootAdapterHelpText({
+      external: [],
+      apps: [],
+      sites: ['bilibili'],
+    });
+    expect(text).not.toContain('External CLIs');
+    expect(text).not.toContain('App adapters');
+    expect(text).toContain('Site adapters (1):');
+  });
+
+  it('returns empty string when all groups are empty', () => {
+    expect(formatRootAdapterHelpText({ external: [], apps: [], sites: [] })).toBe('');
+  });
+
+  it('always renders the agent discovery hint when any section is populated', () => {
+    const text = formatRootAdapterHelpText({
+      external: [],
+      apps: [],
+      sites: ['bilibili'],
+    });
+    expect(text).toContain("'opencli <site> --help -f yaml'");
+  });
+});

--- a/src/help.ts
+++ b/src/help.ts
@@ -58,17 +58,53 @@ export function wrapCommaList(
   return lines.join('\n');
 }
 
-export function formatRootAdapterHelpText(siteNames: readonly string[]): string {
-  if (siteNames.length === 0) return '';
+/**
+ * Adapter category for help-text grouping.
+ *
+ * - `site`: web site adapter (real DNS-style domain, e.g. `www.bilibili.com`)
+ * - `app`: desktop app adapter (Electron/osascript, signaled by `domain: 'localhost'`
+ *   or other non-DNS string like `'doubao-app'`)
+ *
+ * Classification is derived from the adapter's `domain` field — no new schema
+ * required. Adapters without a `domain` field default to `site` (most are
+ * public web scrapers).
+ */
+export type AdapterKind = 'site' | 'app';
+
+export function classifyAdapter(domain: string | undefined): AdapterKind {
+  if (!domain) return 'site';
+  return domain.includes('.') ? 'site' : 'app';
+}
+
+export interface RootAdapterGroups {
+  /** Externally-registered CLIs (docker, gh, vercel, ...) — passthrough binaries */
+  external: readonly string[];
+  /** Desktop-app adapters (chatgpt-app, chatwise, codex, ...) */
+  apps: readonly string[];
+  /** Web-site adapters (bilibili, dianping, ...) */
+  sites: readonly string[];
+}
+
+function formatGroupSection(label: string, names: readonly string[]): string[] {
+  if (names.length === 0) return [];
   return [
+    `${label} (${names.length}):`,
+    wrapCommaList(names),
     '',
-    `Site adapters (${siteNames.length}):`,
-    wrapCommaList(siteNames),
-    '',
-    "Run 'opencli list' for full command details, or 'opencli <site> --help' to inspect one site.",
-    "Agent tip: use 'opencli <site> --help -f yaml' for structured commands, args, access, and examples.",
-    '',
-  ].join('\n');
+  ];
+}
+
+export function formatRootAdapterHelpText(groups: RootAdapterGroups): string {
+  const total = groups.external.length + groups.apps.length + groups.sites.length;
+  if (total === 0) return '';
+  const lines: string[] = [''];
+  lines.push(...formatGroupSection('External CLIs', groups.external));
+  lines.push(...formatGroupSection('App adapters', groups.apps));
+  lines.push(...formatGroupSection('Site adapters', groups.sites));
+  lines.push("Run 'opencli list' for full command details, or 'opencli <site> --help' to inspect one site.");
+  lines.push("Agent tip: use 'opencli <site> --help -f yaml' for structured commands, args, access, and examples.");
+  lines.push('');
+  return lines.join('\n');
 }
 
 function compactArg(arg: Arg): Record<string, unknown> {
@@ -99,22 +135,31 @@ function compactCommand(cmd: CliCommand, opts: { includeColumns?: boolean } = {}
   };
 }
 
-export function rootHelpData(program: Command, siteNames: readonly string[]): Record<string, unknown> {
-  const siteSet = new Set(siteNames);
+export function rootHelpData(program: Command, groups: RootAdapterGroups): Record<string, unknown> {
+  const adapterNames = new Set<string>([...groups.external, ...groups.apps, ...groups.sites]);
   const commands = program.commands
-    .filter(command => !siteSet.has(command.name()))
+    .filter(command => !adapterNames.has(command.name()))
     .map(command => ({
       name: command.name(),
       description: command.description(),
     }));
 
+  const sortLocale = (a: string, b: string) => a.localeCompare(b);
   return {
     name: program.name(),
     description: program.description(),
     commands,
+    external_clis: {
+      count: groups.external.length,
+      clis: [...groups.external].sort(sortLocale),
+    },
+    app_adapters: {
+      count: groups.apps.length,
+      apps: [...groups.apps].sort(sortLocale),
+    },
     site_adapters: {
-      count: siteNames.length,
-      sites: [...siteNames].sort((a, b) => a.localeCompare(b)),
+      count: groups.sites.length,
+      sites: [...groups.sites].sort(sortLocale),
     },
     next: [
       'opencli <site> --help -f yaml',


### PR DESCRIPTION
## Why

Per WAWQAQ in #OpenCLI thread on `opencli --help` output: the flat `Site adapters (112)` bucket conflates real web sites with desktop apps (chatgpt-app, chatwise, codex, cursor, discord-app, doubao-app, antigravity, notion). Agents that fall back to `--help` (the secondary discovery path — agent-user noted in another thread that the primary path is "guess command from site name") see one giant comma-list with no structure.

Spec from WAWQAQ:
```
External CLI:
    XXXX
App CLI:
    XXXX
Site adapter:
    XXXX
```

## What

Three sections in root `--help`, sourced from existing metadata only — **zero new adapter schema, zero new gate, zero new lint** (matches the 1-week soft freeze on new conventions).

Classifier: one line, derived from each adapter's existing `domain` field.

```ts
classifyAdapter(domain) = !domain ? 'site' : (domain.includes('.') ? 'site' : 'app');
```

- `'localhost'` → app (covers Electron + osascript desktop integrations)
- `'doubao-app'` (literal non-DNS string) → app
- `'www.bilibili.com'` / `'claude.ai'` → site
- `undefined` → site (default; most adapters without `domain` are public web scrapers like arxiv / wikipedia / spotify)

External CLIs come from `loadExternalClis()` (passthrough binaries: docker, gh, lark-cli, obsidian, vercel, wecom-cli, dws). They're now hidden from the default `Commands:` listing and surfaced in their own section.

## Sample output

```
Commands:
  list, validate, verify, convention-audit, browser, doctor, completion,
  plugin, adapter, profile, daemon, external

External CLIs (7):
  docker, dws, gh, lark-cli, obsidian, vercel, wecom-cli

App adapters (8):
  antigravity, chatgpt-app, chatwise, codex, cursor, discord-app, doubao-app, notion

Site adapters (104):
  1688, 1point3acres, 36kr, 51job, amazon, apple-podcasts, ...
```

Structured help (`-f yaml` / `-f json`) gains parallel keys:
- `external_clis: { count, clis: [] }`
- `app_adapters: { count, apps: [] }`
- `site_adapters: { count, sites: [] }` *(now contains only the 104 sites — apps moved out; see compat note)*
- `commands: []` no longer leaks adapter names

## Compat note

The structured-help YAML/JSON shape changes: previously `site_adapters.sites` contained ALL 112 adapters (apps + sites). Now it contains only the 104 sites; apps move to the new `app_adapters` key. Externals previously appeared in `commands`; now they have their own `external_clis` section.

This is a breaking change for `--help -f yaml/json` consumers, but the YAML help itself only shipped in v1.7.x (last 2 days, no real consumers yet), and per the project's "no backward-compat for unreleased features" convention this is the right time to fix the shape.

## Test

- `src/help.test.ts` (new): 4 `classifyAdapter` cases + 4 `formatRootAdapterHelpText` rendering cases
- `src/cli.test.ts` (added): 2 cases — text help shows separate App/Site sections; YAML help has all 3 keys correctly populated
- `src/cli.test.ts` (existing): the 5 root-help description tests still pass (bilibili+youtube without domain default to site)

Local checks all green:
- `npm run typecheck` — clean
- `npx vitest run src/help.test.ts src/cli.test.ts` — 126/126 pass
- `npm run check:silent-column-drop` — current=103, baseline=103, new=0
- `npm run check:typed-error-lint` — current=198, baseline=198, new=0

## Out of scope

- No changes to `cli-manifest.json` schema — consumers already have `domain` and can apply the same classifier.
- No changes to per-site `--help` output (only root `--help`).
- The "do agents actually use `opencli <site> --help`?" question (raised in a parallel thread) is orthogonal — even if the listing is rarely the primary discovery path, having it correctly bucketed is strictly better than flat 112.

Closes task #220.