### PR TITLE
feat(extension): allow configuring Browser Bridge daemon port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 * **daemon** — removed `OPENCLI_DAEMON_PORT`; use `opencli config set daemon.port <port>` and set the same port in the Browser Bridge extension popup.
+* **browser** — removed `OPENCLI_BROWSER_CONNECT_TIMEOUT` / `OPENCLI_BROWSER_COMMAND_TIMEOUT` / `OPENCLI_CDP_ENDPOINT`; use `opencli config set browser.connect_timeout|command_timeout|cdp_endpoint <value>`.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **daemon** — removed `OPENCLI_DAEMON_PORT`; use `opencli config set daemon.port <port>` and set the same port in the Browser Bridge extension popup.
 * **browser** — removed `OPENCLI_BROWSER_CONNECT_TIMEOUT` / `OPENCLI_BROWSER_COMMAND_TIMEOUT` / `OPENCLI_CDP_ENDPOINT`; use `opencli config set browser.connect_timeout|command_timeout|cdp_endpoint <value>`.
+* **flags** — renamed `OPENCLI_LIVE` to `OPENCLI_WINDOW_LIVE` for parity with `OPENCLI_WINDOW_FOCUSED`. The `--live` flag is unchanged.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+* **daemon** — removed `OPENCLI_DAEMON_PORT`; use `opencli config set daemon.port <port>` and set the same port in the Browser Bridge extension popup.
+
 ### Features
 
 * **observation** — add trace artifact primitives, `browser console`, `browser network --since/--follow/--failed`, and adapter `--trace=retain-on-failure` for failure-retained browser evidence.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ OpenCLI is not only for websites. It can also:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge. The CLI/daemon read this at runtime; the extension uses the same value when built from source, and packaged extensions can override it from the popup Port field. |
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
 | `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
@@ -206,6 +205,15 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
+
+Persistent OpenCLI config is stored in `~/.opencli/config.json`. To change the Browser Bridge daemon port:
+
+```bash
+opencli config set daemon.port 23456
+opencli daemon restart
+```
+
+Set the same port in the Browser Bridge extension popup.
 
 `--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation lease open until you run `opencli browser close` or the idle timeout expires.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ OpenCLI is not only for websites. It can also:
 |----------|---------|-------------|
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
-| `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
+| `OPENCLI_WINDOW_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ OpenCLI is not only for websites. It can also:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge |
+| `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge. The CLI/daemon read this at runtime; the extension uses the same value when built from source, and packaged extensions can override it from the popup Port field. |
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
 | `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |

--- a/README.md
+++ b/README.md
@@ -199,14 +199,19 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
 | `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
-| `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |
-| `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
-| `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
-Persistent OpenCLI config is stored in `~/.opencli/config.toml`. To change the Browser Bridge daemon port:
+Persistent OpenCLI config is stored in `~/.opencli/config.yaml`.
+
+```bash
+opencli config set browser.connect_timeout 45
+opencli config set browser.command_timeout 90
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
+```
+
+To change the Browser Bridge daemon port:
 
 ```bash
 opencli config set daemon.port 23456

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
-Persistent OpenCLI config is stored in `~/.opencli/config.json`. To change the Browser Bridge daemon port:
+Persistent OpenCLI config is stored in `~/.opencli/config.toml`. To change the Browser Bridge daemon port:
 
 ```bash
 opencli config set daemon.port 23456

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -186,7 +186,7 @@ OpenCLI 不只是网站 CLI，还可以：
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |
 
-持久化 OpenCLI 配置位于 `~/.opencli/config.json`。修改 Browser Bridge daemon 端口：
+持久化 OpenCLI 配置位于 `~/.opencli/config.toml`。修改 Browser Bridge daemon 端口：
 
 ```bash
 opencli config set daemon.port 23456

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,7 +181,7 @@ OpenCLI 不只是网站 CLI，还可以：
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `OPENCLI_WINDOW_FOCUSED` | `false` | 设为 `1` 时 automation 窗口在前台打开（适合调试）。`--focus` 标志会设置此变量 |
-| `OPENCLI_LIVE` | `false` | 设为 `1` 时 adapter 命令执行完后保留 automation 窗口不关闭（适合检查页面）。`--live` 标志会设置此变量 |
+| `OPENCLI_WINDOW_LIVE` | `false` | 设为 `1` 时 adapter 命令执行完后保留 automation 窗口不关闭（适合检查页面）。`--live` 标志会设置此变量 |
 | `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
 | `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -182,11 +182,19 @@ OpenCLI 不只是网站 CLI，还可以：
 |------|--------|------|
 | `OPENCLI_WINDOW_FOCUSED` | `false` | 设为 `1` 时 automation 窗口在前台打开（适合调试）。`--focus` 标志会设置此变量 |
 | `OPENCLI_LIVE` | `false` | 设为 `1` 时 adapter 命令执行完后保留 automation 窗口不关闭（适合检查页面）。`--live` 标志会设置此变量 |
-| `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | 浏览器连接超时（秒） |
-| `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
-| `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |
+| `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
+| `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
+| `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |
 
-持久化 OpenCLI 配置位于 `~/.opencli/config.toml`。修改 Browser Bridge daemon 端口：
+持久化 OpenCLI 配置位于 `~/.opencli/config.yaml`。
+
+```bash
+opencli config set browser.connect_timeout 45
+opencli config set browser.command_timeout 90
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
+```
+
+修改 Browser Bridge daemon 端口：
 
 ```bash
 opencli config set daemon.port 23456
@@ -194,9 +202,6 @@ opencli daemon restart
 ```
 
 同时在 Browser Bridge 扩展 popup 里设置相同端口。
-| `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
-| `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
-| `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |
 
 `--focus` 同时适用于 `opencli browser *` 和浏览器型 adapter 命令。`--live` 主要是给 adapter 命令用的：`browser` 子命令本来就会一直保留 automation window，直到你手动执行 `opencli browser close` 或等空闲超时。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -180,12 +180,20 @@ OpenCLI 不只是网站 CLI，还可以：
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `OPENCLI_DAEMON_PORT` | `19825` | daemon-extension 通信端口 |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | 设为 `1` 时 automation 窗口在前台打开（适合调试）。`--focus` 标志会设置此变量 |
 | `OPENCLI_LIVE` | `false` | 设为 `1` 时 adapter 命令执行完后保留 automation 窗口不关闭（适合检查页面）。`--live` 标志会设置此变量 |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | 浏览器连接超时（秒） |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |
+
+持久化 OpenCLI 配置位于 `~/.opencli/config.json`。修改 Browser Bridge daemon 端口：
+
+```bash
+opencli config set daemon.port 23456
+opencli daemon restart
+```
+
+同时在 Browser Bridge 扩展 popup 里设置相同端口。
 | `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
 | `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |

--- a/docs/adapters/desktop/antigravity.md
+++ b/docs/adapters/desktop/antigravity.md
@@ -19,7 +19,7 @@ Start the Antigravity desktop app with the Chrome DevTools `remote-debugging-por
 Then set the target port:
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9224
 ```
 
 ## Commands

--- a/docs/adapters/desktop/chatgpt-app.md
+++ b/docs/adapters/desktop/chatgpt-app.md
@@ -32,10 +32,10 @@ ChatGPT Desktop is also an Electron app and can be launched with a remote debugg
 ```
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9224"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9224
 ```
 
-> The CDP approach is primarily for advanced automation and future desktop-only commands. The built-in command set above still works in the default AppleScript path unless you explicitly route through `OPENCLI_CDP_ENDPOINT`.
+> The CDP approach is primarily for advanced automation and future desktop-only commands. The built-in command set above still works in the default AppleScript path unless you explicitly route through `browser.cdp_endpoint`.
 
 ## How It Works
 

--- a/docs/adapters/desktop/chatwise.md
+++ b/docs/adapters/desktop/chatwise.md
@@ -14,7 +14,7 @@ Control the **ChatWise Desktop App** from the terminal via Chrome DevTools Proto
 ## Setup
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9228"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9228
 ```
 
 ## Commands

--- a/docs/adapters/desktop/codex.md
+++ b/docs/adapters/desktop/codex.md
@@ -14,7 +14,7 @@ Control the **OpenAI Codex Desktop App** headless or headfully via Chrome DevToo
 ## Setup
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
 ```
 
 ## Commands

--- a/docs/adapters/desktop/cursor.md
+++ b/docs/adapters/desktop/cursor.md
@@ -13,7 +13,7 @@ Control the **Cursor IDE** from the terminal via Chrome DevTools Protocol (CDP).
 ## Setup
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9226"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9226
 ```
 
 ## Commands

--- a/docs/adapters/desktop/discord.md
+++ b/docs/adapters/desktop/discord.md
@@ -12,7 +12,7 @@ Launch with remote debugging port:
 ## Setup
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9232"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9232
 ```
 
 ## Commands

--- a/docs/adapters/desktop/doubao-app.md
+++ b/docs/adapters/desktop/doubao-app.md
@@ -10,7 +10,7 @@ Control the **Doubao AI Desktop App** via Chrome DevTools Protocol (CDP).
    ```
 2. Set the CDP endpoint:
    ```bash
-   export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9225"
+   opencli config set browser.cdp_endpoint http://127.0.0.1:9225
    ```
 
 ## Commands

--- a/docs/adapters/desktop/notion.md
+++ b/docs/adapters/desktop/notion.md
@@ -12,7 +12,7 @@ Launch with remote debugging port:
 ## Setup
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9230"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9230
 ```
 
 ## Commands

--- a/docs/advanced/android-chrome.md
+++ b/docs/advanced/android-chrome.md
@@ -80,7 +80,7 @@ A successful response lists the open tabs:
 ### 4. Run any OpenCLI command
 
 ```bash
-export OPENCLI_CDP_ENDPOINT=http://localhost:9222
+opencli config set browser.cdp_endpoint http://localhost:9222
 opencli hackernews top --limit 5
 ```
 
@@ -97,7 +97,8 @@ OPENCLI_CDP_TARGET="twitter" opencli twitter trending
 You can also connect directly to a specific tab's WebSocket URL (from `/json`):
 
 ```bash
-OPENCLI_CDP_ENDPOINT=ws://localhost:9222/devtools/page/3941 opencli ...
+opencli config set browser.cdp_endpoint ws://localhost:9222/devtools/page/3941
+opencli ...
 ```
 
 ---
@@ -154,8 +155,10 @@ adb -s <device1-serial> forward tcp:9222 localabstract:chrome_devtools_remote
 adb -s <device2-serial> forward tcp:9223 localabstract:chrome_devtools_remote
 
 # Run commands targeting each device
-OPENCLI_CDP_ENDPOINT=http://localhost:9222 opencli twitter trending
-OPENCLI_CDP_ENDPOINT=http://localhost:9223 opencli twitter trending
+opencli config set browser.cdp_endpoint http://localhost:9222
+opencli twitter trending
+opencli config set browser.cdp_endpoint http://localhost:9223
+opencli twitter trending
 ```
 
 ---

--- a/docs/advanced/cdp.md
+++ b/docs/advanced/cdp.md
@@ -79,12 +79,12 @@ This will print a forwarding URL, such as `https://abcdef.ngrok.app`. **Copy thi
 
 Now switch to your **Remote Server** where OpenCLI is installed. 
 
-Depending on the network tunnel method you chose in Phase 2, set the `OPENCLI_CDP_ENDPOINT` environment variable and run your commands.
+Depending on the network tunnel method you chose in Phase 2, set `browser.cdp_endpoint` in OpenCLI config and run your commands.
 
 ### If you used Method A (SSH Tunnel):
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://localhost:9222"
+opencli config set browser.cdp_endpoint http://localhost:9222
 opencli doctor                    # Verify connection
 opencli bilibili hot --limit 5    # Test a command
 ```
@@ -93,11 +93,11 @@ opencli bilibili hot --limit 5    # Test a command
 
 ```bash
 # Use the URL you copied from ngrok earlier
-export OPENCLI_CDP_ENDPOINT="https://abcdef.ngrok.app"
+opencli config set browser.cdp_endpoint https://abcdef.ngrok.app
 opencli doctor                    # Verify connection
 opencli bilibili hot --limit 5    # Test a command
 ```
 
 > *Tip: If you provide a standard HTTP/HTTPS CDP endpoint, OpenCLI requests the `/json` target list and picks the most likely inspectable app/page target automatically. If multiple app targets exist, you can further narrow selection with `OPENCLI_CDP_TARGET` (for example `antigravity` or `codex`).*
 
-If you plan to use this setup frequently, you can persist the environment variable by adding the `export` line to your `~/.bashrc` or `~/.zshrc` on the server.
+If you need to change back to Browser Bridge mode, run `opencli config unset browser.cdp_endpoint`.

--- a/docs/advanced/electron.md
+++ b/docs/advanced/electron.md
@@ -82,7 +82,7 @@ await page.wait(1); // Wait for re-render
 
 ## Environment Variable
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
 ```
 
 ## Non-Electron Pattern (AppleScript)

--- a/docs/advanced/remote-chrome.md
+++ b/docs/advanced/remote-chrome.md
@@ -34,7 +34,7 @@ Use `127.0.0.1` instead of `localhost` in the SSH command to avoid IPv6 resoluti
 ### 3. Configure OpenCLI
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
 ```
 
 ### 4. Verify

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -106,7 +106,7 @@ This path is used for:
 
 ### Direct CDP mode
 
-Used when OpenCLI talks directly to a Chrome or Electron debugging endpoint through `OPENCLI_CDP_ENDPOINT`.
+Used when OpenCLI talks directly to a Chrome or Electron debugging endpoint through `browser.cdp_endpoint` config.
 
 Typical uses:
 

--- a/docs/guide/browser-bridge.md
+++ b/docs/guide/browser-bridge.md
@@ -25,6 +25,20 @@ That's it! The daemon auto-starts when you run any browser command. No tokens, n
 opencli doctor            # Check extension + daemon connectivity
 ```
 
+## Custom Daemon Port
+
+The default Browser Bridge port is `19825`.
+
+For source builds, set `OPENCLI_DAEMON_PORT` before building the extension so the generated background service worker uses the same port as the CLI/daemon:
+
+```bash
+cd extension
+OPENCLI_DAEMON_PORT=21350 npm run build
+OPENCLI_DAEMON_PORT=21350 opencli doctor
+```
+
+For an already installed extension, open the OpenCLI extension popup, edit the **Port** field, and click **Save**. The saved extension port overrides the build-time value. Click **Reset** to fall back to the build-time value, or to `19825` when no build-time value is configured.
+
 ## Tab Targeting
 
 Browser commands run inside the shared `browser:default` workspace unless you explicitly choose another tab target.

--- a/docs/guide/browser-bridge.md
+++ b/docs/guide/browser-bridge.md
@@ -29,15 +29,14 @@ opencli doctor            # Check extension + daemon connectivity
 
 The default Browser Bridge port is `19825`.
 
-For source builds, set `OPENCLI_DAEMON_PORT` before building the extension so the generated background service worker uses the same port as the CLI/daemon:
+If another local service occupies that port, set a persistent OpenCLI daemon port:
 
 ```bash
-cd extension
-OPENCLI_DAEMON_PORT=21350 npm run build
-OPENCLI_DAEMON_PORT=21350 opencli doctor
+opencli config set daemon.port 23456
+opencli daemon restart
 ```
 
-For an already installed extension, open the OpenCLI extension popup, edit the **Port** field, and click **Save**. The saved extension port overrides the build-time value. Click **Reset** to fall back to the build-time value, or to `19825` when no build-time value is configured.
+Then open the OpenCLI extension popup, edit the **Port** field to the same value, and click **Save**. Click **Reset** to return the extension to `19825`.
 
 ## Tab Targeting
 

--- a/docs/guide/electron-app-cli.md
+++ b/docs/guide/electron-app-cli.md
@@ -41,7 +41,7 @@ If Electron is present, the next step is usually to launch the app with a debugg
 Then point OpenCLI at that CDP endpoint:
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
 ```
 
 ### 3. Start with the 5-command pattern

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -48,7 +48,7 @@ opencli doctor
 For Electron/CDP-based adapters (Cursor, Codex, etc.):
 
 1. Make sure the app is launched with `--remote-debugging-port=XXXX`
-2. Verify the endpoint is set: `echo $OPENCLI_CDP_ENDPOINT`
+2. Verify the endpoint is set: `opencli config get browser.cdp_endpoint`
 3. Test the endpoint: `curl http://127.0.0.1:XXXX/json/version`
 
 ### Build errors

--- a/docs/superpowers/plans/2026-03-31-daemon-lifecycle-redesign.md
+++ b/docs/superpowers/plans/2026-03-31-daemon-lifecycle-redesign.md
@@ -171,9 +171,10 @@ In `src/daemon.ts`, replace the idle timeout section (lines 27, 29-57) with:
 
 Replace the `IDLE_TIMEOUT` constant (line 27):
 ```typescript
-import { DEFAULT_DAEMON_PORT, DEFAULT_DAEMON_IDLE_TIMEOUT } from './constants.js';
+import { DEFAULT_DAEMON_IDLE_TIMEOUT } from './constants.js';
+import { getConfiguredDaemonPort } from './config.js';
 
-const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
+const PORT = getConfiguredDaemonPort();
 const IDLE_TIMEOUT = DEFAULT_DAEMON_IDLE_TIMEOUT;
 ```
 
@@ -423,10 +424,9 @@ Create `src/commands/daemon.ts`:
  */
 
 import chalk from 'chalk';
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
+import { getConfiguredDaemonPort } from '../config.js';
 
-const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
-const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
+const DAEMON_URL = `http://127.0.0.1:${getConfiguredDaemonPort()}`;
 
 interface DaemonStatus {
   ok: boolean;
@@ -793,7 +793,7 @@ private async _ensureDaemon(timeoutSeconds?: number): Promise<void> {
   throw new Error(
     'Failed to start opencli daemon. Try running manually:\n' +
     `  node ${daemonPath}\n` +
-    `Make sure port ${DEFAULT_DAEMON_PORT} is available.`,
+    `Make sure the configured daemon port is available.`,
   );
 }
 ```

--- a/docs/superpowers/specs/2026-03-31-daemon-lifecycle-redesign.md
+++ b/docs/superpowers/specs/2026-03-31-daemon-lifecycle-redesign.md
@@ -184,7 +184,7 @@ and shows:
 ## Backward Compatibility
 
 - No breaking changes to CLI commands or Extension protocol
-- Existing `OPENCLI_DAEMON_PORT` environment variable continues to work
+- Daemon port configuration is handled by `opencli config set daemon.port <port>`
 - The only observable behavior change: daemon stays alive longer
 - New `daemon` subcommands are additive
 

--- a/docs/zh/advanced/android-chrome.md
+++ b/docs/zh/advanced/android-chrome.md
@@ -80,7 +80,7 @@ curl http://localhost:9222/json
 ### 第四步：执行 OpenCLI 命令
 
 ```bash
-export OPENCLI_CDP_ENDPOINT=http://localhost:9222
+opencli config set browser.cdp_endpoint http://localhost:9222
 opencli hackernews top --limit 5
 ```
 
@@ -97,7 +97,8 @@ OPENCLI_CDP_TARGET="twitter" opencli twitter trending
 也可直接使用 `/json` 返回的 WebSocket 地址精确连接某个标签页：
 
 ```bash
-OPENCLI_CDP_ENDPOINT=ws://localhost:9222/devtools/page/3941 opencli ...
+opencli config set browser.cdp_endpoint ws://localhost:9222/devtools/page/3941
+opencli ...
 ```
 
 ---
@@ -154,8 +155,10 @@ adb -s <设备1序列号> forward tcp:9222 localabstract:chrome_devtools_remote
 adb -s <设备2序列号> forward tcp:9223 localabstract:chrome_devtools_remote
 
 # 分别执行命令
-OPENCLI_CDP_ENDPOINT=http://localhost:9222 opencli twitter trending
-OPENCLI_CDP_ENDPOINT=http://localhost:9223 opencli twitter trending
+opencli config set browser.cdp_endpoint http://localhost:9222
+opencli twitter trending
+opencli config set browser.cdp_endpoint http://localhost:9223
+opencli twitter trending
 ```
 
 ---

--- a/docs/zh/guide/electron-app-cli.md
+++ b/docs/zh/guide/electron-app-cli.md
@@ -37,7 +37,7 @@ ls /Applications/AppName.app/Contents/Frameworks/Electron\ Framework.framework
 然后把 OpenCLI 指到这个端口：
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+opencli config set browser.cdp_endpoint http://127.0.0.1:9222
 ```
 
 ### 3. 先做 5 个基础命令

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1,14 +1,13 @@
 const DEFAULT_DAEMON_PORT = 19825;
 const DAEMON_PORT_STORAGE_KEY = "opencli_daemon_port_v1";
 const DAEMON_HOST = "localhost";
-const BUILD_DAEMON_PORT = "" ;
 function parseDaemonPort(value) {
   const port = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value.trim()) : NaN;
   if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
   return port;
 }
-function resolveDaemonPort(storedValue, buildValue = BUILD_DAEMON_PORT) {
-  return parseDaemonPort(storedValue) ?? parseDaemonPort(buildValue) ?? DEFAULT_DAEMON_PORT;
+function resolveDaemonPort(storedValue) {
+  return parseDaemonPort(storedValue) ?? DEFAULT_DAEMON_PORT;
 }
 function daemonWsUrl(port) {
   return `ws://${DAEMON_HOST}:${port}/ext`;
@@ -994,7 +993,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         contextId,
         daemonPort,
         defaultDaemonPort: DEFAULT_DAEMON_PORT,
-        buildDaemonPort: parseDaemonPort(BUILD_DAEMON_PORT) ?? void 0,
         extensionVersion,
         daemonVersion
       });

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -436,23 +436,33 @@ async function refreshMappings() {
 let ws = null;
 let reconnectTimer = null;
 let reconnectAttempts = 0;
+let currentDaemonPort = resolveDaemonPort(void 0);
+let daemonPortLoaded = false;
+let daemonPortLoadPromise = null;
 const CONTEXT_ID_KEY = "opencli_context_id_v1";
 let currentContextId = "default";
 let contextIdPromise = null;
 async function getConfiguredDaemonPort() {
+  if (daemonPortLoaded) return currentDaemonPort;
+  if (daemonPortLoadPromise) return daemonPortLoadPromise;
+  daemonPortLoadPromise = loadConfiguredDaemonPort();
+  return daemonPortLoadPromise;
+}
+async function loadConfiguredDaemonPort() {
   try {
     const local = chrome.storage?.local;
-    if (!local) return resolveDaemonPort(void 0);
+    if (!local) return setDaemonPortCache(resolveDaemonPort(void 0));
     const raw = await local.get(DAEMON_PORT_STORAGE_KEY);
-    return resolveDaemonPort(raw[DAEMON_PORT_STORAGE_KEY]);
+    return setDaemonPortCache(resolveDaemonPort(raw[DAEMON_PORT_STORAGE_KEY]));
   } catch {
-    return resolveDaemonPort(void 0);
+    return setDaemonPortCache(resolveDaemonPort(void 0));
   }
 }
 async function setConfiguredDaemonPort(value) {
   const port = parseDaemonPort(value);
   if (!port) throw new Error("daemon port must be an integer between 1 and 65535");
   await chrome.storage?.local?.set({ [DAEMON_PORT_STORAGE_KEY]: port });
+  setDaemonPortCache(port);
   return port;
 }
 async function resetConfiguredDaemonPort() {
@@ -462,7 +472,20 @@ async function resetConfiguredDaemonPort() {
   } else {
     await local?.set?.({ [DAEMON_PORT_STORAGE_KEY]: void 0 });
   }
-  return resolveDaemonPort(void 0);
+  return setDaemonPortCache(resolveDaemonPort(void 0));
+}
+function setDaemonPortCache(port) {
+  currentDaemonPort = port;
+  daemonPortLoaded = true;
+  daemonPortLoadPromise = null;
+  return currentDaemonPort;
+}
+function handleDaemonPortStorageChange(changes, areaName) {
+  if (areaName !== "local" || !(DAEMON_PORT_STORAGE_KEY in changes)) return;
+  const daemonPort = resolveDaemonPort(changes[DAEMON_PORT_STORAGE_KEY]?.newValue);
+  const unchanged = daemonPortLoaded && daemonPort === currentDaemonPort;
+  setDaemonPortCache(daemonPort);
+  if (!unchanged) reconnectDaemon();
 }
 function reconnectDaemon() {
   if (reconnectTimer) {
@@ -472,8 +495,13 @@ function reconnectDaemon() {
   reconnectAttempts = 0;
   const existing = ws;
   ws = null;
-  if (existing && existing.readyState !== WebSocket.CLOSED) {
-    existing.close();
+  if (existing) {
+    existing.onclose = null;
+    existing.onerror = null;
+    try {
+      existing.close();
+    } catch {
+    }
   }
   void connect();
 }
@@ -554,6 +582,7 @@ async function connect() {
   }
   try {
     const contextId = await getCurrentContextId();
+    if (daemonPort !== currentDaemonPort) return;
     ws = new WebSocket(wsUrl);
     currentContextId = contextId;
   } catch {
@@ -945,6 +974,7 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.runtime.onStartup.addListener(() => {
   initialize();
 });
+chrome.storage?.onChanged?.addListener(handleDaemonPortStorageChange);
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === "keepalive") void connect();
   const workspace = workspaceFromAlarmName(alarm.name);
@@ -957,7 +987,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       const connected = ws?.readyState === WebSocket.OPEN;
       const daemonPort = await getConfiguredDaemonPort();
       const extensionVersion = chrome.runtime.getManifest().version;
-      const daemonVersion = connected ? await fetchDaemonVersion() : null;
+      const daemonVersion = connected ? await fetchDaemonVersion(daemonPort) : null;
       sendResponse({
         connected,
         reconnecting: reconnectTimer !== null,
@@ -993,9 +1023,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
   return false;
 });
-async function fetchDaemonVersion() {
+async function fetchDaemonVersion(daemonPort) {
   try {
-    const daemonPort = await getConfiguredDaemonPort();
     const res = await fetch(daemonStatusUrl(daemonPort), {
       method: "GET",
       headers: { "X-OpenCLI": "1" },

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1,7 +1,24 @@
-const DAEMON_PORT = 19825;
+const DEFAULT_DAEMON_PORT = 19825;
+const DAEMON_PORT_STORAGE_KEY = "opencli_daemon_port_v1";
 const DAEMON_HOST = "localhost";
-const DAEMON_WS_URL = `ws://${DAEMON_HOST}:${DAEMON_PORT}/ext`;
-const DAEMON_PING_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}/ping`;
+const BUILD_DAEMON_PORT = "" ;
+function parseDaemonPort(value) {
+  const port = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value.trim()) : NaN;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  return port;
+}
+function resolveDaemonPort(storedValue, buildValue = BUILD_DAEMON_PORT) {
+  return parseDaemonPort(storedValue) ?? parseDaemonPort(buildValue) ?? DEFAULT_DAEMON_PORT;
+}
+function daemonWsUrl(port) {
+  return `ws://${DAEMON_HOST}:${port}/ext`;
+}
+function daemonPingUrl(port) {
+  return `http://${DAEMON_HOST}:${port}/ping`;
+}
+function daemonStatusUrl(port) {
+  return `http://${DAEMON_HOST}:${port}/status`;
+}
 const WS_RECONNECT_BASE_DELAY = 2e3;
 const WS_RECONNECT_MAX_DELAY = 5e3;
 
@@ -422,6 +439,44 @@ let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = "opencli_context_id_v1";
 let currentContextId = "default";
 let contextIdPromise = null;
+async function getConfiguredDaemonPort() {
+  try {
+    const local = chrome.storage?.local;
+    if (!local) return resolveDaemonPort(void 0);
+    const raw = await local.get(DAEMON_PORT_STORAGE_KEY);
+    return resolveDaemonPort(raw[DAEMON_PORT_STORAGE_KEY]);
+  } catch {
+    return resolveDaemonPort(void 0);
+  }
+}
+async function setConfiguredDaemonPort(value) {
+  const port = parseDaemonPort(value);
+  if (!port) throw new Error("daemon port must be an integer between 1 and 65535");
+  await chrome.storage?.local?.set({ [DAEMON_PORT_STORAGE_KEY]: port });
+  return port;
+}
+async function resetConfiguredDaemonPort() {
+  const local = chrome.storage?.local;
+  if (typeof local?.remove === "function") {
+    await local.remove(DAEMON_PORT_STORAGE_KEY);
+  } else {
+    await local?.set?.({ [DAEMON_PORT_STORAGE_KEY]: void 0 });
+  }
+  return resolveDaemonPort(void 0);
+}
+function reconnectDaemon() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  reconnectAttempts = 0;
+  const existing = ws;
+  ws = null;
+  if (existing && existing.readyState !== WebSocket.CLOSED) {
+    existing.close();
+  }
+  void connect();
+}
 async function getCurrentContextId() {
   if (contextIdPromise) return contextIdPromise;
   contextIdPromise = (async () => {
@@ -488,15 +543,18 @@ console.error = (...args) => {
 };
 async function connect() {
   if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+  const daemonPort = await getConfiguredDaemonPort();
+  const pingUrl = daemonPingUrl(daemonPort);
+  const wsUrl = daemonWsUrl(daemonPort);
   try {
-    const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1e3) });
+    const res = await fetch(pingUrl, { signal: AbortSignal.timeout(1e3) });
     if (!res.ok) return;
   } catch {
     return;
   }
   try {
     const contextId = await getCurrentContextId();
-    ws = new WebSocket(DAEMON_WS_URL);
+    ws = new WebSocket(wsUrl);
     currentContextId = contextId;
   } catch {
     scheduleReconnect();
@@ -897,15 +955,39 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     void (async () => {
       const contextId = await getCurrentContextId();
       const connected = ws?.readyState === WebSocket.OPEN;
+      const daemonPort = await getConfiguredDaemonPort();
       const extensionVersion = chrome.runtime.getManifest().version;
       const daemonVersion = connected ? await fetchDaemonVersion() : null;
       sendResponse({
         connected,
         reconnecting: reconnectTimer !== null,
         contextId,
+        daemonPort,
+        defaultDaemonPort: DEFAULT_DAEMON_PORT,
+        buildDaemonPort: parseDaemonPort(BUILD_DAEMON_PORT) ?? void 0,
         extensionVersion,
         daemonVersion
       });
+    })();
+    return true;
+  }
+  if (msg?.type === "setDaemonPort") {
+    void (async () => {
+      try {
+        const daemonPort = await setConfiguredDaemonPort(msg.port);
+        sendResponse({ ok: true, daemonPort });
+        reconnectDaemon();
+      } catch (err) {
+        sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });
+      }
+    })();
+    return true;
+  }
+  if (msg?.type === "resetDaemonPort") {
+    void (async () => {
+      const daemonPort = await resetConfiguredDaemonPort();
+      sendResponse({ ok: true, daemonPort });
+      reconnectDaemon();
     })();
     return true;
   }
@@ -913,7 +995,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 });
 async function fetchDaemonVersion() {
   try {
-    const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/status`, {
+    const daemonPort = await getConfiguredDaemonPort();
+    const res = await fetch(daemonStatusUrl(daemonPort), {
       method: "GET",
       headers: { "X-OpenCLI": "1" },
       signal: AbortSignal.timeout(1500)

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -92,6 +92,26 @@
     .copy-btn:hover { background: #f0f6ff; }
     .copy-btn:active { background: #e1edff; }
     .copy-btn.copied { color: #34c759; border-color: #34c759; background: #f0fdf4; }
+    .settings-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border-top: 1px solid #ececec;
+      background: #fff;
+    }
+    .settings-row input {
+      flex: 1;
+      min-width: 0;
+      padding: 5px 7px;
+      font: inherit;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      border: 1px solid #d2d2d7;
+      border-radius: 6px;
+    }
+    .settings-row .copy-btn {
+      padding-inline: 7px;
+    }
     .hint {
       padding: 10px 12px;
       border-top: 1px solid #ececec;
@@ -133,6 +153,12 @@
       <span class="profile-label">Profile</span>
       <span class="profile-id" id="contextId"></span>
       <button type="button" class="copy-btn" id="copyBtn" title="Copy contextId">Copy</button>
+    </div>
+    <div class="settings-row">
+      <span class="profile-label">Port</span>
+      <input id="daemonPort" inputmode="numeric" pattern="[0-9]*" aria-label="Daemon port">
+      <button type="button" class="copy-btn" id="savePortBtn">Save</button>
+      <button type="button" class="copy-btn" id="resetPortBtn">Reset</button>
     </div>
     <div class="hint" id="hint" style="display: none;">
       The extension connects automatically when you run any <code>opencli</code> command.

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -7,6 +7,9 @@ chrome.runtime.sendMessage({ type: 'getStatus' }, (resp) => {
   const profileRow = document.getElementById('profileRow');
   const contextId = document.getElementById('contextId');
   const copyBtn = document.getElementById('copyBtn');
+  const daemonPortInput = document.getElementById('daemonPort');
+  const savePortBtn = document.getElementById('savePortBtn');
+  const resetPortBtn = document.getElementById('resetPortBtn');
   const hint = document.getElementById('hint');
   const extVersion = document.getElementById('extVersion');
 
@@ -30,6 +33,12 @@ chrome.runtime.sendMessage({ type: 'getStatus' }, (resp) => {
   } else {
     profileRow.style.display = 'none';
   }
+
+  if (typeof resp.daemonPort === 'number') {
+    daemonPortInput.value = String(resp.daemonPort);
+  }
+  savePortBtn.addEventListener('click', () => saveDaemonPort(daemonPortInput, savePortBtn));
+  resetPortBtn.addEventListener('click', () => resetDaemonPort(daemonPortInput, resetPortBtn));
 
   if (resp.connected) {
     setState(card, dot, 'connected');
@@ -74,4 +83,41 @@ function copyToClipboard(text, btn) {
       setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
     },
   );
+}
+
+function saveDaemonPort(input, btn) {
+  const port = Number(input.value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    flashButton(btn, 'Invalid');
+    return;
+  }
+  chrome.runtime.sendMessage({ type: 'setDaemonPort', port }, (resp) => {
+    if (resp && resp.ok && typeof resp.daemonPort === 'number') {
+      input.value = String(resp.daemonPort);
+      flashButton(btn, 'Saved');
+    } else {
+      flashButton(btn, 'Failed');
+    }
+  });
+}
+
+function resetDaemonPort(input, btn) {
+  chrome.runtime.sendMessage({ type: 'resetDaemonPort' }, (resp) => {
+    if (resp && resp.ok && typeof resp.daemonPort === 'number') {
+      input.value = String(resp.daemonPort);
+      flashButton(btn, 'Reset');
+    } else {
+      flashButton(btn, 'Failed');
+    }
+  });
+}
+
+function flashButton(btn, text) {
+  const original = btn.textContent;
+  btn.textContent = text;
+  btn.classList.add('copied');
+  setTimeout(() => {
+    btn.textContent = original;
+    btn.classList.remove('copied');
+  }, 1200);
 }

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -120,6 +120,9 @@ function createChromeMock() {
         set: vi.fn(async (items: Record<string, unknown>) => {
           Object.assign(storageState, items);
         }),
+        remove: vi.fn(async (key: string) => {
+          delete storageState[key];
+        }),
       },
     },
     runtime: {
@@ -146,6 +149,18 @@ describe('background tab isolation', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it('resolves daemon port from stored value, build value, then default', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+
+    expect(mod.__test__.resolveDaemonPort('24567', '23456')).toBe(24567);
+    expect(mod.__test__.resolveDaemonPort('', '23456')).toBe(23456);
+    expect(mod.__test__.resolveDaemonPort('not-a-port', 'also-bad')).toBe(19825);
+    expect(mod.__test__.parseDaemonPort(65536)).toBeNull();
   });
 
   it('lists only automation-window web tabs', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -17,13 +17,16 @@ type MockTab = {
 class MockWebSocket {
   static OPEN = 1;
   static CONNECTING = 0;
+  static urls: string[] = [];
   readyState = MockWebSocket.CONNECTING;
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
-  constructor(_url: string) {}
+  constructor(url: string) {
+    MockWebSocket.urls.push(url);
+  }
   send(_data: string): void {}
   close(): void {
     this.onclose?.();
@@ -124,6 +127,7 @@ function createChromeMock() {
           delete storageState[key];
         }),
       },
+      onChanged: { addListener: vi.fn(), removeListener: vi.fn() } as Listener<(changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void>,
     },
     runtime: {
       onInstalled: { addListener: vi.fn() } as Listener<() => void>,
@@ -142,7 +146,9 @@ function createChromeMock() {
 describe('background tab isolation', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.doUnmock('./cdp');
     vi.useRealTimers();
+    MockWebSocket.urls = [];
     vi.stubGlobal('WebSocket', MockWebSocket);
   });
 
@@ -161,6 +167,141 @@ describe('background tab isolation', () => {
     expect(mod.__test__.resolveDaemonPort('', '23456')).toBe(23456);
     expect(mod.__test__.resolveDaemonPort('not-a-port', 'also-bad')).toBe(19825);
     expect(mod.__test__.parseDaemonPort(65536)).toBeNull();
+  });
+
+  it('returns the configured daemon port from popup status', async () => {
+    const { chrome } = createChromeMock();
+    await chrome.storage.local.set({ opencli_daemon_port_v1: 23456 });
+    vi.stubGlobal('chrome', chrome);
+
+    await import('./background');
+    const onMessageListener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const sendResponse = vi.fn();
+
+    const keepAlive = onMessageListener({ type: 'getStatus' }, {}, sendResponse);
+
+    expect(keepAlive).toBe(true);
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({
+        daemonPort: 23456,
+      }));
+    });
+    expect(chrome.storage.local.get).toHaveBeenCalledTimes(2); // contextId + daemon port
+  });
+
+  it('persists daemon port updates and reconnects against the new port', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    const fetchMock = vi.fn(async () => {
+      throw new Error('offline');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('./background');
+    const onMessageListener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const sendResponse = vi.fn();
+
+    const keepAlive = onMessageListener({ type: 'setDaemonPort', port: '24567' }, {}, sendResponse);
+
+    expect(keepAlive).toBe(true);
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ ok: true, daemonPort: 24567 });
+    });
+    await expect(chrome.storage.local.get('opencli_daemon_port_v1')).resolves.toEqual({
+      opencli_daemon_port_v1: 24567,
+    });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:24567/ping', expect.any(Object));
+    });
+  });
+
+  it('rejects invalid daemon port updates', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    await import('./background');
+    const onMessageListener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const sendResponse = vi.fn();
+
+    const keepAlive = onMessageListener({ type: 'setDaemonPort', port: '65536' }, {}, sendResponse);
+
+    expect(keepAlive).toBe(true);
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({
+        ok: false,
+        error: 'daemon port must be an integer between 1 and 65535',
+      });
+    });
+  });
+
+  it('connects to the daemon port stored by the extension', async () => {
+    const { chrome } = createChromeMock();
+    await chrome.storage.local.set({ opencli_daemon_port_v1: 24567 });
+    vi.stubGlobal('chrome', chrome);
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('./background');
+    const onStartupListener = chrome.runtime.onStartup.addListener.mock.calls[0][0];
+    onStartupListener();
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:24567/ping', expect.any(Object));
+      expect(MockWebSocket.urls).toContain('ws://localhost:24567/ext');
+    });
+  });
+
+  it('updates the cached daemon port from storage changes without re-reading storage', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('./background');
+    const onStartupListener = chrome.runtime.onStartup.addListener.mock.calls[0][0];
+    onStartupListener();
+    await vi.waitFor(() => {
+      expect(MockWebSocket.urls).toContain('ws://localhost:19825/ext');
+    });
+
+    chrome.storage.local.get.mockClear();
+    const onChangedListener = chrome.storage.onChanged.addListener.mock.calls[0][0];
+    onChangedListener({
+      opencli_daemon_port_v1: { oldValue: undefined, newValue: 24567 },
+    }, 'local');
+
+    await vi.waitFor(() => {
+      expect(MockWebSocket.urls).toContain('ws://localhost:24567/ext');
+    });
+    expect(chrome.storage.local.get).not.toHaveBeenCalledWith('opencli_daemon_port_v1');
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:24567/ping', expect.any(Object));
+  });
+
+  it('resets the cached daemon port on storage removal', async () => {
+    const { chrome } = createChromeMock();
+    await chrome.storage.local.set({ opencli_daemon_port_v1: 24567 });
+    vi.stubGlobal('chrome', chrome);
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('./background');
+    const onStartupListener = chrome.runtime.onStartup.addListener.mock.calls[0][0];
+    onStartupListener();
+    await vi.waitFor(() => {
+      expect(MockWebSocket.urls).toContain('ws://localhost:24567/ext');
+    });
+
+    chrome.storage.local.get.mockClear();
+    const onChangedListener = chrome.storage.onChanged.addListener.mock.calls[0][0];
+    onChangedListener({
+      opencli_daemon_port_v1: { oldValue: 24567, newValue: undefined },
+    }, 'local');
+
+    await vi.waitFor(() => {
+      expect(MockWebSocket.urls).toContain('ws://localhost:19825/ext');
+    });
+    expect(chrome.storage.local.get).not.toHaveBeenCalledWith('opencli_daemon_port_v1');
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:19825/ping', expect.any(Object));
   });
 
   it('lists only automation-window web tabs', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -157,15 +157,15 @@ describe('background tab isolation', () => {
     vi.unstubAllGlobals();
   });
 
-  it('resolves daemon port from stored value, build value, then default', async () => {
+  it('resolves daemon port from stored value then default', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
     const mod = await import('./background');
 
-    expect(mod.__test__.resolveDaemonPort('24567', '23456')).toBe(24567);
-    expect(mod.__test__.resolveDaemonPort('', '23456')).toBe(23456);
-    expect(mod.__test__.resolveDaemonPort('not-a-port', 'also-bad')).toBe(19825);
+    expect(mod.__test__.resolveDaemonPort('24567')).toBe(24567);
+    expect(mod.__test__.resolveDaemonPort('')).toBe(19825);
+    expect(mod.__test__.resolveDaemonPort('not-a-port')).toBe(19825);
     expect(mod.__test__.parseDaemonPort(65536)).toBeNull();
   });
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -26,18 +26,29 @@ import * as identity from './identity';
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
+let currentDaemonPort = resolveDaemonPort(undefined);
+let daemonPortLoaded = false;
+let daemonPortLoadPromise: Promise<number> | null = null;
 const CONTEXT_ID_KEY = 'opencli_context_id_v1';
 let currentContextId = 'default';
 let contextIdPromise: Promise<string> | null = null;
 
 async function getConfiguredDaemonPort(): Promise<number> {
+  if (daemonPortLoaded) return currentDaemonPort;
+  if (daemonPortLoadPromise) return daemonPortLoadPromise;
+
+  daemonPortLoadPromise = loadConfiguredDaemonPort();
+  return daemonPortLoadPromise;
+}
+
+async function loadConfiguredDaemonPort(): Promise<number> {
   try {
     const local = chrome.storage?.local;
-    if (!local) return resolveDaemonPort(undefined);
+    if (!local) return setDaemonPortCache(resolveDaemonPort(undefined));
     const raw = await local.get(DAEMON_PORT_STORAGE_KEY) as Record<string, unknown>;
-    return resolveDaemonPort(raw[DAEMON_PORT_STORAGE_KEY]);
+    return setDaemonPortCache(resolveDaemonPort(raw[DAEMON_PORT_STORAGE_KEY]));
   } catch {
-    return resolveDaemonPort(undefined);
+    return setDaemonPortCache(resolveDaemonPort(undefined));
   }
 }
 
@@ -45,6 +56,7 @@ async function setConfiguredDaemonPort(value: unknown): Promise<number> {
   const port = parseDaemonPort(value);
   if (!port) throw new Error('daemon port must be an integer between 1 and 65535');
   await chrome.storage?.local?.set({ [DAEMON_PORT_STORAGE_KEY]: port });
+  setDaemonPortCache(port);
   return port;
 }
 
@@ -55,7 +67,22 @@ async function resetConfiguredDaemonPort(): Promise<number> {
   } else {
     await local?.set?.({ [DAEMON_PORT_STORAGE_KEY]: undefined });
   }
-  return resolveDaemonPort(undefined);
+  return setDaemonPortCache(resolveDaemonPort(undefined));
+}
+
+function setDaemonPortCache(port: number): number {
+  currentDaemonPort = port;
+  daemonPortLoaded = true;
+  daemonPortLoadPromise = null;
+  return currentDaemonPort;
+}
+
+function handleDaemonPortStorageChange(changes: Record<string, chrome.storage.StorageChange>, areaName: string): void {
+  if (areaName !== 'local' || !(DAEMON_PORT_STORAGE_KEY in changes)) return;
+  const daemonPort = resolveDaemonPort(changes[DAEMON_PORT_STORAGE_KEY]?.newValue);
+  const unchanged = daemonPortLoaded && daemonPort === currentDaemonPort;
+  setDaemonPortCache(daemonPort);
+  if (!unchanged) reconnectDaemon();
 }
 
 function reconnectDaemon(): void {
@@ -66,8 +93,14 @@ function reconnectDaemon(): void {
   reconnectAttempts = 0;
   const existing = ws;
   ws = null;
-  if (existing && existing.readyState !== WebSocket.CLOSED) {
-    existing.close();
+  if (existing) {
+    existing.onclose = null;
+    existing.onerror = null;
+    try {
+      existing.close();
+    } catch {
+      // Closing is best-effort; the next connect() call uses the updated port.
+    }
   }
   void connect();
 }
@@ -159,6 +192,7 @@ async function connect(): Promise<void> {
 
   try {
     const contextId = await getCurrentContextId();
+    if (daemonPort !== currentDaemonPort) return; // Port changed while /ping was in flight.
     ws = new WebSocket(wsUrl);
     currentContextId = contextId;
   } catch {
@@ -666,6 +700,8 @@ chrome.runtime.onStartup.addListener(() => {
   initialize();
 });
 
+chrome.storage?.onChanged?.addListener(handleDaemonPortStorageChange);
+
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === 'keepalive') void connect();
   const workspace = workspaceFromAlarmName(alarm.name);
@@ -681,7 +717,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       const connected = ws?.readyState === WebSocket.OPEN;
       const daemonPort = await getConfiguredDaemonPort();
       const extensionVersion = chrome.runtime.getManifest().version;
-      const daemonVersion = connected ? await fetchDaemonVersion() : null;
+      const daemonVersion = connected ? await fetchDaemonVersion(daemonPort) : null;
       sendResponse({
         connected,
         reconnecting: reconnectTimer !== null,
@@ -723,9 +759,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
  * Resolves to null on any failure — the popup degrades to showing connection
  * state without the version label.
  */
-async function fetchDaemonVersion(): Promise<string | null> {
+async function fetchDaemonVersion(daemonPort: number): Promise<string | null> {
   try {
-    const daemonPort = await getConfiguredDaemonPort();
     const res = await fetch(daemonStatusUrl(daemonPort), {
       method: 'GET',
       headers: { 'X-OpenCLI': '1' },

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -9,7 +9,6 @@ declare const __OPENCLI_COMPAT_RANGE__: string;
 
 import type { Command, Result } from './protocol';
 import {
-  BUILD_DAEMON_PORT,
   DAEMON_PORT_STORAGE_KEY,
   DEFAULT_DAEMON_PORT,
   daemonPingUrl,
@@ -724,7 +723,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         contextId,
         daemonPort,
         defaultDaemonPort: DEFAULT_DAEMON_PORT,
-        buildDaemonPort: parseDaemonPort(BUILD_DAEMON_PORT) ?? undefined,
         extensionVersion,
         daemonVersion,
       });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -8,7 +8,18 @@
 declare const __OPENCLI_COMPAT_RANGE__: string;
 
 import type { Command, Result } from './protocol';
-import { DAEMON_HOST, DAEMON_PORT, DAEMON_WS_URL, DAEMON_PING_URL, WS_RECONNECT_BASE_DELAY, WS_RECONNECT_MAX_DELAY } from './protocol';
+import {
+  BUILD_DAEMON_PORT,
+  DAEMON_PORT_STORAGE_KEY,
+  DEFAULT_DAEMON_PORT,
+  daemonPingUrl,
+  daemonStatusUrl,
+  daemonWsUrl,
+  parseDaemonPort,
+  resolveDaemonPort,
+  WS_RECONNECT_BASE_DELAY,
+  WS_RECONNECT_MAX_DELAY,
+} from './protocol';
 import * as executor from './cdp';
 import * as identity from './identity';
 
@@ -18,6 +29,48 @@ let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = 'opencli_context_id_v1';
 let currentContextId = 'default';
 let contextIdPromise: Promise<string> | null = null;
+
+async function getConfiguredDaemonPort(): Promise<number> {
+  try {
+    const local = chrome.storage?.local;
+    if (!local) return resolveDaemonPort(undefined);
+    const raw = await local.get(DAEMON_PORT_STORAGE_KEY) as Record<string, unknown>;
+    return resolveDaemonPort(raw[DAEMON_PORT_STORAGE_KEY]);
+  } catch {
+    return resolveDaemonPort(undefined);
+  }
+}
+
+async function setConfiguredDaemonPort(value: unknown): Promise<number> {
+  const port = parseDaemonPort(value);
+  if (!port) throw new Error('daemon port must be an integer between 1 and 65535');
+  await chrome.storage?.local?.set({ [DAEMON_PORT_STORAGE_KEY]: port });
+  return port;
+}
+
+async function resetConfiguredDaemonPort(): Promise<number> {
+  const local = chrome.storage?.local;
+  if (typeof local?.remove === 'function') {
+    await local.remove(DAEMON_PORT_STORAGE_KEY);
+  } else {
+    await local?.set?.({ [DAEMON_PORT_STORAGE_KEY]: undefined });
+  }
+  return resolveDaemonPort(undefined);
+}
+
+function reconnectDaemon(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  reconnectAttempts = 0;
+  const existing = ws;
+  ws = null;
+  if (existing && existing.readyState !== WebSocket.CLOSED) {
+    existing.close();
+  }
+  void connect();
+}
 
 async function getCurrentContextId(): Promise<string> {
   if (contextIdPromise) return contextIdPromise;
@@ -93,8 +146,12 @@ console.error = (...args: unknown[]) => { _origError(...args); forwardLog('error
 async function connect(): Promise<void> {
   if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
 
+  const daemonPort = await getConfiguredDaemonPort();
+  const pingUrl = daemonPingUrl(daemonPort);
+  const wsUrl = daemonWsUrl(daemonPort);
+
   try {
-    const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1000) });
+    const res = await fetch(pingUrl, { signal: AbortSignal.timeout(1000) });
     if (!res.ok) return; // unexpected response — not our daemon
   } catch {
     return; // daemon not running — skip WebSocket to avoid console noise
@@ -102,7 +159,7 @@ async function connect(): Promise<void> {
 
   try {
     const contextId = await getCurrentContextId();
-    ws = new WebSocket(DAEMON_WS_URL);
+    ws = new WebSocket(wsUrl);
     currentContextId = contextId;
   } catch {
     scheduleReconnect();
@@ -622,15 +679,39 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     void (async () => {
       const contextId = await getCurrentContextId();
       const connected = ws?.readyState === WebSocket.OPEN;
+      const daemonPort = await getConfiguredDaemonPort();
       const extensionVersion = chrome.runtime.getManifest().version;
       const daemonVersion = connected ? await fetchDaemonVersion() : null;
       sendResponse({
         connected,
         reconnecting: reconnectTimer !== null,
         contextId,
+        daemonPort,
+        defaultDaemonPort: DEFAULT_DAEMON_PORT,
+        buildDaemonPort: parseDaemonPort(BUILD_DAEMON_PORT) ?? undefined,
         extensionVersion,
         daemonVersion,
       });
+    })();
+    return true;
+  }
+  if (msg?.type === 'setDaemonPort') {
+    void (async () => {
+      try {
+        const daemonPort = await setConfiguredDaemonPort((msg as { port?: unknown }).port);
+        sendResponse({ ok: true, daemonPort });
+        reconnectDaemon();
+      } catch (err) {
+        sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });
+      }
+    })();
+    return true;
+  }
+  if (msg?.type === 'resetDaemonPort') {
+    void (async () => {
+      const daemonPort = await resetConfiguredDaemonPort();
+      sendResponse({ ok: true, daemonPort });
+      reconnectDaemon();
     })();
     return true;
   }
@@ -644,7 +725,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
  */
 async function fetchDaemonVersion(): Promise<string | null> {
   try {
-    const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/status`, {
+    const daemonPort = await getConfiguredDaemonPort();
+    const res = await fetch(daemonStatusUrl(daemonPort), {
       method: 'GET',
       headers: { 'X-OpenCLI': '1' },
       signal: AbortSignal.timeout(1500),
@@ -1552,6 +1634,9 @@ async function handleBind(cmd: Command, workspace: string): Promise<Result> {
 }
 
 export const __test__ = {
+  parseDaemonPort,
+  resolveDaemonPort,
+  getConfiguredDaemonPort,
   handleExec,
   handleNavigate,
   isTargetUrl,

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -91,15 +91,10 @@ export interface Result {
   page?: string;
 }
 
-declare const __OPENCLI_DAEMON_PORT__: string | number | undefined;
-
 /** Default daemon port */
 export const DEFAULT_DAEMON_PORT = 19825;
 export const DAEMON_PORT_STORAGE_KEY = 'opencli_daemon_port_v1';
 export const DAEMON_HOST = 'localhost';
-export const BUILD_DAEMON_PORT = typeof __OPENCLI_DAEMON_PORT__ !== 'undefined'
-  ? __OPENCLI_DAEMON_PORT__
-  : undefined;
 
 export function parseDaemonPort(value: unknown): number | null {
   const port = typeof value === 'number'
@@ -111,9 +106,8 @@ export function parseDaemonPort(value: unknown): number | null {
   return port;
 }
 
-export function resolveDaemonPort(storedValue: unknown, buildValue: unknown = BUILD_DAEMON_PORT): number {
+export function resolveDaemonPort(storedValue: unknown): number {
   return parseDaemonPort(storedValue)
-    ?? parseDaemonPort(buildValue)
     ?? DEFAULT_DAEMON_PORT;
 }
 

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -91,12 +91,44 @@ export interface Result {
   page?: string;
 }
 
+declare const __OPENCLI_DAEMON_PORT__: string | number | undefined;
+
 /** Default daemon port */
-export const DAEMON_PORT = 19825;
+export const DEFAULT_DAEMON_PORT = 19825;
+export const DAEMON_PORT_STORAGE_KEY = 'opencli_daemon_port_v1';
 export const DAEMON_HOST = 'localhost';
-export const DAEMON_WS_URL = `ws://${DAEMON_HOST}:${DAEMON_PORT}/ext`;
+export const BUILD_DAEMON_PORT = typeof __OPENCLI_DAEMON_PORT__ !== 'undefined'
+  ? __OPENCLI_DAEMON_PORT__
+  : undefined;
+
+export function parseDaemonPort(value: unknown): number | null {
+  const port = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value.trim()
+      ? Number(value.trim())
+      : NaN;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  return port;
+}
+
+export function resolveDaemonPort(storedValue: unknown, buildValue: unknown = BUILD_DAEMON_PORT): number {
+  return parseDaemonPort(storedValue)
+    ?? parseDaemonPort(buildValue)
+    ?? DEFAULT_DAEMON_PORT;
+}
+
+export function daemonWsUrl(port: number): string {
+  return `ws://${DAEMON_HOST}:${port}/ext`;
+}
+
 /** Lightweight health-check endpoint — probed before each WebSocket attempt. */
-export const DAEMON_PING_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}/ping`;
+export function daemonPingUrl(port: number): string {
+  return `http://${DAEMON_HOST}:${port}/ping`;
+}
+
+export function daemonStatusUrl(port: number): string {
+  return `http://${DAEMON_HOST}:${port}/status`;
+}
 
 /** Base reconnect delay for extension WebSocket (ms) */
 export const WS_RECONNECT_BASE_DELAY = 2000;

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -4,12 +4,10 @@ import { readFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 const compatRange: string = pkg.opencli?.compatRange ?? '>=0.0.0';
-const daemonPort = process.env.OPENCLI_DAEMON_PORT ?? '';
 
 export default defineConfig({
   define: {
     __OPENCLI_COMPAT_RANGE__: JSON.stringify(compatRange),
-    __OPENCLI_DAEMON_PORT__: JSON.stringify(daemonPort),
   },
   build: {
     outDir: 'dist',

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -4,10 +4,12 @@ import { readFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 const compatRange: string = pkg.opencli?.compatRange ?? '>=0.0.0';
+const daemonPort = process.env.OPENCLI_DAEMON_PORT ?? '';
 
 export default defineConfig({
   define: {
     __OPENCLI_COMPAT_RANGE__: JSON.stringify(compatRange),
+    __OPENCLI_DAEMON_PORT__: JSON.stringify(daemonPort),
   },
   build: {
     outDir: 'dist',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "copy-yaml": "node scripts/copy-yaml.cjs",
     "start": "node dist/src/main.js",
     "start:bun": "bun dist/src/main.js",
-    "preuninstall": "node -e \"fetch('http://127.0.0.1:'+(process.env.OPENCLI_DAEMON_PORT||'19825')+'/shutdown',{method:'POST',headers:{'X-OpenCLI':'1'},signal:AbortSignal.timeout(3000)}).catch(()=>{})\" || true",
+    "preuninstall": "node scripts/preuninstall.cjs || true",
     "postinstall": "node scripts/postinstall.js || true; node scripts/fetch-adapters.js || true",
     "typecheck": "tsc --noEmit",
     "prepare": "[ -d src ] && npm run build || true",

--- a/scripts/preuninstall.cjs
+++ b/scripts/preuninstall.cjs
@@ -1,25 +1,13 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const yaml = require('js-yaml');
 
 function readDaemonPort() {
   const configDir = path.join(os.homedir(), '.opencli');
   try {
-    const raw = fs.readFileSync(path.join(configDir, 'config.toml'), 'utf8');
-    let inDaemon = false;
-    let port = NaN;
-    for (const line of raw.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) continue;
-      const section = trimmed.match(/^\[([A-Za-z0-9_.-]+)\]$/);
-      if (section) {
-        inDaemon = section[1] === 'daemon';
-        continue;
-      }
-      if (!inDaemon) continue;
-      const value = trimmed.match(/^port\s*=\s*(\d+)\s*(?:#.*)?$/)?.[1];
-      if (value) port = Number(value);
-    }
+    const raw = fs.readFileSync(path.join(configDir, 'config.yaml'), 'utf8');
+    const port = Number(yaml.load(raw)?.daemon?.port);
     return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : 19825;
   } catch {
     return 19825;

--- a/scripts/preuninstall.cjs
+++ b/scripts/preuninstall.cjs
@@ -5,8 +5,21 @@ const path = require('node:path');
 function readDaemonPort() {
   const configDir = path.join(os.homedir(), '.opencli');
   try {
-    const raw = fs.readFileSync(path.join(configDir, 'config.json'), 'utf8');
-    const port = Number(JSON.parse(raw)?.daemon?.port);
+    const raw = fs.readFileSync(path.join(configDir, 'config.toml'), 'utf8');
+    let inDaemon = false;
+    let port = NaN;
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const section = trimmed.match(/^\[([A-Za-z0-9_.-]+)\]$/);
+      if (section) {
+        inDaemon = section[1] === 'daemon';
+        continue;
+      }
+      if (!inDaemon) continue;
+      const value = trimmed.match(/^port\s*=\s*(\d+)\s*(?:#.*)?$/)?.[1];
+      if (value) port = Number(value);
+    }
     return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : 19825;
   } catch {
     return 19825;

--- a/scripts/preuninstall.cjs
+++ b/scripts/preuninstall.cjs
@@ -1,0 +1,20 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function readDaemonPort() {
+  const configDir = path.join(os.homedir(), '.opencli');
+  try {
+    const raw = fs.readFileSync(path.join(configDir, 'config.json'), 'utf8');
+    const port = Number(JSON.parse(raw)?.daemon?.port);
+    return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : 19825;
+  } catch {
+    return 19825;
+  }
+}
+
+fetch(`http://127.0.0.1:${readDaemonPort()}/shutdown`, {
+  method: 'POST',
+  headers: { 'X-OpenCLI': '1' },
+  signal: AbortSignal.timeout(3000),
+}).catch(() => {});

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -27,7 +27,7 @@ Until `doctor` is green, nothing else will work. Typical failures: Chrome not ru
 - `opencli browser *` commands keep an owned tab lease alive between calls. Owned leases share a dedicated automation container and are released with `opencli browser close` or when the idle timeout expires.
 - `opencli browser bind` binds a `bound:*` workspace to the Chrome tab you already have open. Use this for logged-in pages, SSO flows, or pages you manually positioned before handing control to the agent.
 - `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation container in the foreground. Use it when you want to watch the page live.
-- `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation lease open after the command returns so you can inspect the final page state.
+- `--live` (or `OPENCLI_WINDOW_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation lease open after the command returns so you can inspect the final page state.
 
 ### Bind Tab
 

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -80,6 +80,7 @@ A few commands override the default via `cmd.defaultFormat` (e.g. chat commands 
 | `OPENCLI_BROWSER_EXPLORE_TIMEOUT` | `120` | For long-running recon (plugin/adapter scaffolding). |
 | `OPENCLI_CACHE_DIR` | `~/.opencli/cache` | Network capture + browser-state cache. |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | `1` → automation window opens in the foreground. |
+| `OPENCLI_WINDOW_LIVE` | `false` | `1` → keep the automation lease open after adapter commands. |
 | `OPENCLI_VERBOSE` | `false` | Verbose logging (also triggered by `-v`). |
 
 Persistent config lives in `~/.opencli/config.yaml`:

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -77,16 +77,21 @@ A few commands override the default via `cmd.defaultFormat` (e.g. chat commands 
 
 | variable | default | purpose |
 |----------|---------|---------|
-| `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for the browser bridge. |
-| `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Per-command timeout. |
 | `OPENCLI_BROWSER_EXPLORE_TIMEOUT` | `120` | For long-running recon (plugin/adapter scaffolding). |
-| `OPENCLI_CDP_ENDPOINT` | — | Manual CDP endpoint override (dev / remote Chrome / Electron). |
-
-Daemon port is persistent config, not an environment variable:
-`opencli config set daemon.port <port>`, then set the same port in the Browser Bridge extension popup.
 | `OPENCLI_CACHE_DIR` | `~/.opencli/cache` | Network capture + browser-state cache. |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | `1` → automation window opens in the foreground. |
 | `OPENCLI_VERBOSE` | `false` | Verbose logging (also triggered by `-v`). |
+
+Persistent config lives in `~/.opencli/config.yaml`:
+
+```bash
+opencli config set daemon.port <port>
+opencli config set browser.connect_timeout <seconds>
+opencli config set browser.command_timeout <seconds>
+opencli config set browser.cdp_endpoint <endpoint>
+```
+
+After changing `daemon.port`, restart the daemon and set the same port in the Browser Bridge extension popup.
 
 ## Self-repair
 

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -77,11 +77,13 @@ A few commands override the default via `cmd.defaultFormat` (e.g. chat commands 
 
 | variable | default | purpose |
 |----------|---------|---------|
-| `OPENCLI_DAEMON_PORT` | `19825` | Daemon ↔ extension bridge port. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for the browser bridge. |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Per-command timeout. |
 | `OPENCLI_BROWSER_EXPLORE_TIMEOUT` | `120` | For long-running recon (plugin/adapter scaffolding). |
 | `OPENCLI_CDP_ENDPOINT` | — | Manual CDP endpoint override (dev / remote Chrome / Electron). |
+
+Daemon port is persistent config, not an environment variable:
+`opencli config set daemon.port <port>`, then set the same port in the Browser Bridge extension popup.
 | `OPENCLI_CACHE_DIR` | `~/.opencli/cache` | Network capture + browser-state cache. |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | `1` → automation window opens in the foreground. |
 | `OPENCLI_VERBOSE` | `false` | Verbose logging (also triggered by `-v`). |

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -7,7 +7,7 @@ import type { IPage } from '../types.js';
 import type { IBrowserFactory } from '../runtime.js';
 import { Page } from './page.js';
 import { getDaemonHealth, requestDaemonShutdown } from './daemon-client.js';
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
+import { getConfiguredDaemonPort } from '../config.js';
 import { BrowserConnectError } from '../errors.js';
 import { PKG_VERSION } from '../version.js';
 import { resolveProfileContextId } from './profile.js';
@@ -189,7 +189,7 @@ export class BrowserBridge implements IBrowserFactory {
 
     throw new BrowserConnectError(
       'Failed to start opencli daemon',
-      `Try running manually:\n  node ${resolveDaemonLaunchSpec().scriptPath}\nMake sure port ${DEFAULT_DAEMON_PORT} is available.`,
+      `Try running manually:\n  node ${resolveDaemonLaunchSpec().scriptPath}\nMake sure port ${getConfiguredDaemonPort()} is available.`,
       'daemon-not-running',
     );
   }

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 const { MockWebSocket } = vi.hoisted(() => {
   class MockWebSocket {
@@ -39,13 +42,35 @@ vi.mock('ws', () => ({
 import { CDPBridge } from './cdp.js';
 
 describe('CDPBridge cookies', () => {
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
   beforeEach(() => {
     vi.unstubAllEnvs();
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-cdp-home-'));
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
   });
 
-  it('filters cookies by actual domain match instead of substring match', async () => {
-    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'ws://127.0.0.1:9222/devtools/page/1');
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
 
+  function writeCdpEndpointConfig(endpoint: string): void {
+    const configDir = path.join(homeDir, '.opencli');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'config.yaml'), `browser:\n  cdp_endpoint: ${JSON.stringify(endpoint)}\n`, 'utf-8');
+  }
+
+  it('filters cookies by actual domain match instead of substring match', async () => {
+    writeCdpEndpointConfig('ws://127.0.0.1:9222/devtools/page/1');
     const bridge = new CDPBridge();
     vi.spyOn(bridge, 'send').mockResolvedValue({
       cookies: [
@@ -65,7 +90,7 @@ describe('CDPBridge cookies', () => {
   });
 
   it('exposes native input helpers on direct CDP pages', async () => {
-    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'ws://127.0.0.1:9222/devtools/page/1');
+    writeCdpEndpointConfig('ws://127.0.0.1:9222/devtools/page/1');
 
     const bridge = new CDPBridge();
     const send = vi.spyOn(bridge, 'send').mockResolvedValue({});

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -19,6 +19,7 @@ import { waitForDomStableJs } from './dom-helpers.js';
 import { isRecord, saveBase64ToFile } from '../utils.js';
 import { getAllElectronApps } from '../electron-apps.js';
 import { BasePage } from './base-page.js';
+import { getConfiguredCdpEndpoint } from '../config.js';
 
 export interface CDPTarget {
   type?: string;
@@ -56,8 +57,8 @@ export class CDPBridge implements IBrowserFactory {
   async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
-    const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
-    if (!endpoint) throw new Error('CDP endpoint not provided (pass cdpEndpoint or set OPENCLI_CDP_ENDPOINT)');
+    const endpoint = opts?.cdpEndpoint ?? getConfiguredCdpEndpoint();
+    if (!endpoint) throw new Error('CDP endpoint not provided (pass cdpEndpoint or run `opencli config set browser.cdp_endpoint <endpoint>`)');
 
     let wsUrl = endpoint;
     if (endpoint.startsWith('http')) {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -169,8 +169,8 @@ describe('daemon-client', () => {
     const configDir = path.join(homeDir, '.opencli');
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(
-      path.join(configDir, 'config.toml'),
-      '[daemon]\nport = 23456\n',
+      path.join(configDir, 'config.yaml'),
+      'daemon:\n  port: 23456\n',
       'utf-8',
     );
     vi.mocked(fetch).mockResolvedValue({

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import {
   fetchDaemonStatus,
@@ -8,11 +11,25 @@ import {
 } from './daemon-client.js';
 
 describe('daemon-client', () => {
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
   beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-daemon-client-home-'));
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
     vi.stubGlobal('fetch', vi.fn());
   });
 
   afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(homeDir, { recursive: true, force: true });
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
@@ -146,6 +163,32 @@ describe('daemon-client', () => {
     await fetchDaemonStatus({ contextId: 'work' });
 
     expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?contextId=work$/);
+  });
+
+  it('fetchDaemonStatus uses daemon.port from opencli config', async () => {
+    const configDir = path.join(homeDir, '.opencli');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ version: 1, daemon: { port: 23456 } }),
+      'utf-8',
+    );
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        ok: true,
+        pid: 1,
+        uptime: 0,
+        extensionConnected: true,
+        pending: 0,
+        memoryMB: 1,
+        port: 23456,
+      }),
+    } as Response);
+
+    await fetchDaemonStatus();
+
+    expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/^http:\/\/127\.0\.0\.1:23456\/status$/);
   });
 
   it('sendCommand includes the current pid in generated command ids', async () => {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -169,8 +169,8 @@ describe('daemon-client', () => {
     const configDir = path.join(homeDir, '.opencli');
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(
-      path.join(configDir, 'config.json'),
-      JSON.stringify({ version: 1, daemon: { port: 23456 } }),
+      path.join(configDir, 'config.toml'),
+      '[daemon]\nport = 23456\n',
       'utf-8',
     );
     vi.mocked(fetch).mockResolvedValue({

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -4,14 +4,12 @@
  * Provides a typed send() function that posts a Command and returns a Result.
  */
 
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
+import { getConfiguredDaemonPort } from '../config.js';
 import type { BrowserSessionInfo } from '../types.js';
 import { sleep } from '../utils.js';
 import { classifyBrowserError } from './errors.js';
 import { resolveProfileContextId } from './profile.js';
 
-const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
-const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
 const OPENCLI_HEADERS = { 'X-OpenCLI': '1' };
 
 let _idCounter = 0;
@@ -108,7 +106,7 @@ async function requestDaemon(pathname: string, init?: RequestInit & { timeout?: 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
   try {
-    return await fetch(`${DAEMON_URL}${pathname}`, {
+    return await fetch(`http://127.0.0.1:${getConfiguredDaemonPort()}${pathname}`, {
       ...rest,
       headers: { ...OPENCLI_HEADERS, ...headers },
       signal: controller.signal,

--- a/src/browser/errors.ts
+++ b/src/browser/errors.ts
@@ -6,7 +6,7 @@
  */
 
 import { BrowserConnectError, type BrowserConnectKind } from '../errors.js';
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
+import { getConfiguredDaemonPort } from '../config.js';
 
 /**
  * Unified browser error classification.
@@ -105,7 +105,7 @@ export function formatBrowserConnectError(kind: ConnectFailureKind, detail?: str
     case 'daemon-not-running':
       return new BrowserConnectError(
         'Cannot connect to opencli daemon.' + (detail ? `\n\n${detail}` : ''),
-        `The daemon should auto-start. If it keeps failing, make sure port ${DEFAULT_DAEMON_PORT} is available.`,
+        `The daemon should auto-start. If it keeps failing, make sure port ${getConfiguredDaemonPort()} is available.`,
         kind,
       );
     case 'extension-not-connected':

--- a/src/browser/profile.ts
+++ b/src/browser/profile.ts
@@ -11,8 +11,7 @@ export type ProfileConfig = {
 };
 
 function profileConfigPath(): string {
-  const baseDir = process.env.OPENCLI_CONFIG_DIR || path.join(os.homedir(), '.opencli');
-  return path.join(baseDir, 'browser-profiles.json');
+  return path.join(os.homedir(), '.opencli', 'browser-profiles.json');
 }
 
 export function normalizeContextId(value: string | undefined | null): string | undefined {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -604,7 +604,7 @@ describe('config command', () => {
 
     stdoutSpy.mockClear();
     await program.parseAsync(['node', 'opencli', 'config', 'unset', 'browser.cdp_endpoint']);
-    expect(stdoutSpy).toHaveBeenLastCalledWith('browser.cdp_endpoint =  (default)');
+    expect(stdoutSpy).toHaveBeenLastCalledWith('browser.cdp_endpoint = (unset)');
   });
 
   it('rejects unsupported config keys', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -541,6 +541,63 @@ describe('profile list', () => {
     const output = stdoutSpy.mock.calls.flat().join('\n');
     expect(output).toContain('No Browser Bridge profiles connected');
     expect(output).not.toContain('opencli daemon restart');
+  });
+});
+
+describe('config command', () => {
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-cli-config-home-'));
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    stdoutSpy.mockClear();
+    stderrSpy.mockClear();
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('offline');
+    }));
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+    process.exitCode = undefined;
+  });
+
+  it('sets, gets, unsets daemon.port through persistent config', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'config', 'set', 'daemon.port', '23456']);
+    expect(stdoutSpy.mock.calls.flat().join('\n')).toContain('daemon.port = 23456');
+    expect(fs.readFileSync(path.join(homeDir, '.opencli', 'config.json'), 'utf-8')).toContain('"port": 23456');
+
+    stdoutSpy.mockClear();
+    await program.parseAsync(['node', 'opencli', 'config', 'get', 'daemon.port']);
+    expect(stdoutSpy).toHaveBeenLastCalledWith('23456');
+
+    stdoutSpy.mockClear();
+    await program.parseAsync(['node', 'opencli', 'config', 'unset', 'daemon.port']);
+    expect(stdoutSpy.mock.calls.flat().join('\n')).toContain('daemon.port = 19825 (default)');
+  });
+
+  it('rejects unsupported config keys', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'config', 'get', 'unknown.key']);
+
+    expect(process.exitCode).toBe(2);
+    expect(stderrSpy.mock.calls.flat().join('\n')).toContain('unsupported config key');
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -580,7 +580,7 @@ describe('config command', () => {
 
     await program.parseAsync(['node', 'opencli', 'config', 'set', 'daemon.port', '23456']);
     expect(stdoutSpy.mock.calls.flat().join('\n')).toContain('daemon.port = 23456');
-    expect(fs.readFileSync(path.join(homeDir, '.opencli', 'config.toml'), 'utf-8')).toContain('port = 23456');
+    expect(fs.readFileSync(path.join(homeDir, '.opencli', 'config.yaml'), 'utf-8')).toContain('port: 23456');
 
     stdoutSpy.mockClear();
     await program.parseAsync(['node', 'opencli', 'config', 'get', 'daemon.port']);
@@ -589,6 +589,22 @@ describe('config command', () => {
     stdoutSpy.mockClear();
     await program.parseAsync(['node', 'opencli', 'config', 'unset', 'daemon.port']);
     expect(stdoutSpy.mock.calls.flat().join('\n')).toContain('daemon.port = 19825 (default)');
+  });
+
+  it('sets, gets, and unsets browser config values', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'config', 'set', 'browser.connect_timeout', '45']);
+    await program.parseAsync(['node', 'opencli', 'config', 'set', 'browser.command_timeout', '90']);
+    await program.parseAsync(['node', 'opencli', 'config', 'set', 'browser.cdp_endpoint', 'http://127.0.0.1:9222']);
+
+    stdoutSpy.mockClear();
+    await program.parseAsync(['node', 'opencli', 'config', 'get', 'browser.cdp_endpoint']);
+    expect(stdoutSpy).toHaveBeenLastCalledWith('http://127.0.0.1:9222');
+
+    stdoutSpy.mockClear();
+    await program.parseAsync(['node', 'opencli', 'config', 'unset', 'browser.cdp_endpoint']);
+    expect(stdoutSpy).toHaveBeenLastCalledWith('browser.cdp_endpoint =  (default)');
   });
 
   it('rejects unsupported config keys', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -580,7 +580,7 @@ describe('config command', () => {
 
     await program.parseAsync(['node', 'opencli', 'config', 'set', 'daemon.port', '23456']);
     expect(stdoutSpy.mock.calls.flat().join('\n')).toContain('daemon.port = 23456');
-    expect(fs.readFileSync(path.join(homeDir, '.opencli', 'config.json'), 'utf-8')).toContain('"port": 23456');
+    expect(fs.readFileSync(path.join(homeDir, '.opencli', 'config.toml'), 'utf-8')).toContain('port = 23456');
 
     stdoutSpy.mockClear();
     await program.parseAsync(['node', 'opencli', 'config', 'get', 'daemon.port']);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2603,7 +2603,7 @@ cli({
   function requireConfigKey(raw: string): SupportedConfigKey | null {
     if (isSupportedConfigKey(raw)) return raw;
     console.error(styleText('red', `Error: unsupported config key "${raw}".`));
-    console.error(styleText('dim', 'Supported keys: daemon.port'));
+    console.error(styleText('dim', 'Supported keys: daemon.port, browser.connect_timeout, browser.command_timeout, browser.cdp_endpoint'));
     process.exitCode = EXIT_CODES.USAGE_ERROR;
     return null;
   }
@@ -2621,28 +2621,28 @@ cli({
   configCmd
     .command('get')
     .description('Print one effective config value')
-    .argument('<key>', 'Config key, currently only daemon.port')
+    .argument('<key>', 'Config key')
     .action((rawKey: string) => {
       const key = requireConfigKey(rawKey);
       if (!key) return;
-      console.log(String(getConfigValue(key)));
+      console.log(String(getConfigValue(key) ?? ''));
     });
 
   configCmd
     .command('set')
     .description('Set a config value')
-    .argument('<key>', 'Config key, currently only daemon.port')
+    .argument('<key>', 'Config key')
     .argument('<value>', 'Config value')
     .action(async (rawKey: string, value: string) => {
       const key = requireConfigKey(rawKey);
       if (!key) return;
-      const previousPort = getConfigValue('daemon.port');
-      const status = await fetchDaemonStatus({ timeout: 500 });
+      const previousPort = key === 'daemon.port' ? getConfigValue('daemon.port') : undefined;
+      const status = key === 'daemon.port' ? await fetchDaemonStatus({ timeout: 500 }) : null;
       try {
         setConfigValue(key, value);
-        const nextPort = getConfigValue('daemon.port');
-        console.log(`${key} = ${nextPort}`);
-        if (key === 'daemon.port') printDaemonPortApplyHint(previousPort, nextPort, status);
+        const nextValue = getConfigValue(key);
+        console.log(`${key} = ${nextValue ?? ''}`);
+        if (key === 'daemon.port') printDaemonPortApplyHint(Number(previousPort), Number(nextValue), status);
       } catch (err) {
         console.error(styleText('red', `Error: ${getErrorMessage(err)}`));
         process.exitCode = EXIT_CODES.USAGE_ERROR;
@@ -2652,16 +2652,16 @@ cli({
   configCmd
     .command('unset')
     .description('Unset a config value and return to its default')
-    .argument('<key>', 'Config key, currently only daemon.port')
+    .argument('<key>', 'Config key')
     .action(async (rawKey: string) => {
       const key = requireConfigKey(rawKey);
       if (!key) return;
-      const previousPort = getConfigValue('daemon.port');
-      const status = await fetchDaemonStatus({ timeout: 500 });
+      const previousPort = key === 'daemon.port' ? getConfigValue('daemon.port') : undefined;
+      const status = key === 'daemon.port' ? await fetchDaemonStatus({ timeout: 500 }) : null;
       unsetConfigValue(key);
-      const nextPort = getConfigValue('daemon.port');
-      console.log(`${key} = ${nextPort} (default)`);
-      if (key === 'daemon.port') printDaemonPortApplyHint(previousPort, nextPort, status);
+      const nextValue = getConfigValue(key);
+      console.log(`${key} = ${nextValue ?? ''} (default)`);
+      if (key === 'daemon.port') printDaemonPortApplyHint(Number(previousPort), Number(nextValue), status);
     });
 
   // ── Built-in: daemon ──────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
-import { getConfigPath, getConfigValue, isSupportedConfigKey, loadConfig, setConfigValue, unsetConfigValue, type SupportedConfigKey } from './config.js';
+import { getConfigValue, isSupportedConfigKey, setConfigValue, unsetConfigValue, type SupportedConfigKey } from './config.js';
 import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
@@ -2619,21 +2619,10 @@ cli({
   }
 
   configCmd
-    .command('path')
-    .description('Print the OpenCLI config file path')
-    .action(() => {
-      console.log(getConfigPath());
-    });
-
-  configCmd
     .command('get')
-    .description('Get config as JSON, or print one effective config value')
-    .argument('[key]', 'Config key, currently only daemon.port')
-    .action((rawKey?: string) => {
-      if (!rawKey) {
-        console.log(JSON.stringify(loadConfig(), null, 2));
-        return;
-      }
+    .description('Print one effective config value')
+    .argument('<key>', 'Config key, currently only daemon.port')
+    .action((rawKey: string) => {
       const key = requireConfigKey(rawKey);
       if (!key) return;
       console.log(String(getConfigValue(key)));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
+import { getConfigPath, getConfigValue, isSupportedConfigKey, loadConfig, setConfigValue, unsetConfigValue, type SupportedConfigKey } from './config.js';
 import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
@@ -2594,6 +2595,84 @@ cli({
         console.error(styleText('red', `Error: ${getErrorMessage(err)}`));
         process.exitCode = EXIT_CODES.USAGE_ERROR;
       }
+    });
+
+  // ── Built-in: persistent config ───────────────────────────────────────────
+  const configCmd = program.command('config').description('Manage persistent OpenCLI config');
+
+  function requireConfigKey(raw: string): SupportedConfigKey | null {
+    if (isSupportedConfigKey(raw)) return raw;
+    console.error(styleText('red', `Error: unsupported config key "${raw}".`));
+    console.error(styleText('dim', 'Supported keys: daemon.port'));
+    process.exitCode = EXIT_CODES.USAGE_ERROR;
+    return null;
+  }
+
+  function printDaemonPortApplyHint(previousPort: number, nextPort: number, status: Awaited<ReturnType<typeof fetchDaemonStatus>>): void {
+    if (previousPort === nextPort) return;
+    if (status) {
+      console.log(styleText('yellow', `Daemon currently running on port ${status.port}. Run \`opencli daemon restart\` to apply.`));
+    } else {
+      console.log(styleText('dim', 'Run `opencli daemon restart` to apply if the daemon is already running.'));
+    }
+    console.log(styleText('dim', `Set the Browser Bridge extension popup Port to ${nextPort}.`));
+  }
+
+  configCmd
+    .command('path')
+    .description('Print the OpenCLI config file path')
+    .action(() => {
+      console.log(getConfigPath());
+    });
+
+  configCmd
+    .command('get')
+    .description('Get config as JSON, or print one effective config value')
+    .argument('[key]', 'Config key, currently only daemon.port')
+    .action((rawKey?: string) => {
+      if (!rawKey) {
+        console.log(JSON.stringify(loadConfig(), null, 2));
+        return;
+      }
+      const key = requireConfigKey(rawKey);
+      if (!key) return;
+      console.log(String(getConfigValue(key)));
+    });
+
+  configCmd
+    .command('set')
+    .description('Set a config value')
+    .argument('<key>', 'Config key, currently only daemon.port')
+    .argument('<value>', 'Config value')
+    .action(async (rawKey: string, value: string) => {
+      const key = requireConfigKey(rawKey);
+      if (!key) return;
+      const previousPort = getConfigValue('daemon.port');
+      const status = await fetchDaemonStatus({ timeout: 500 });
+      try {
+        setConfigValue(key, value);
+        const nextPort = getConfigValue('daemon.port');
+        console.log(`${key} = ${nextPort}`);
+        if (key === 'daemon.port') printDaemonPortApplyHint(previousPort, nextPort, status);
+      } catch (err) {
+        console.error(styleText('red', `Error: ${getErrorMessage(err)}`));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+      }
+    });
+
+  configCmd
+    .command('unset')
+    .description('Unset a config value and return to its default')
+    .argument('<key>', 'Config key, currently only daemon.port')
+    .action(async (rawKey: string) => {
+      const key = requireConfigKey(rawKey);
+      if (!key) return;
+      const previousPort = getConfigValue('daemon.port');
+      const status = await fetchDaemonStatus({ timeout: 500 });
+      unsetConfigValue(key);
+      const nextPort = getConfigValue('daemon.port');
+      console.log(`${key} = ${nextPort} (default)`);
+      if (key === 'daemon.port') printDaemonPortApplyHint(previousPort, nextPort, status);
     });
 
   // ── Built-in: daemon ──────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
 import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
-import { getConfigValue, isSupportedConfigKey, setConfigValue, unsetConfigValue, type SupportedConfigKey } from './config.js';
+import { getConfigValue, getConfiguredDaemonPort, isSupportedConfigKey, setConfigValue, unsetConfigValue, type SupportedConfigKey } from './config.js';
 import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
@@ -2618,6 +2618,11 @@ cli({
     console.log(styleText('dim', `Set the Browser Bridge extension popup Port to ${nextPort}.`));
   }
 
+  function formatUnsetConfigValue(key: SupportedConfigKey, value: number | string | undefined): string {
+    if (value === undefined) return `${key} = (unset)`;
+    return `${key} = ${value} (default)`;
+  }
+
   configCmd
     .command('get')
     .description('Print one effective config value')
@@ -2636,13 +2641,15 @@ cli({
     .action(async (rawKey: string, value: string) => {
       const key = requireConfigKey(rawKey);
       if (!key) return;
-      const previousPort = key === 'daemon.port' ? getConfigValue('daemon.port') : undefined;
+      const previousPort = key === 'daemon.port' ? getConfiguredDaemonPort() : undefined;
       const status = key === 'daemon.port' ? await fetchDaemonStatus({ timeout: 500 }) : null;
       try {
         setConfigValue(key, value);
         const nextValue = getConfigValue(key);
         console.log(`${key} = ${nextValue ?? ''}`);
-        if (key === 'daemon.port') printDaemonPortApplyHint(Number(previousPort), Number(nextValue), status);
+        if (key === 'daemon.port' && previousPort !== undefined) {
+          printDaemonPortApplyHint(previousPort, getConfiguredDaemonPort(), status);
+        }
       } catch (err) {
         console.error(styleText('red', `Error: ${getErrorMessage(err)}`));
         process.exitCode = EXIT_CODES.USAGE_ERROR;
@@ -2656,12 +2663,14 @@ cli({
     .action(async (rawKey: string) => {
       const key = requireConfigKey(rawKey);
       if (!key) return;
-      const previousPort = key === 'daemon.port' ? getConfigValue('daemon.port') : undefined;
+      const previousPort = key === 'daemon.port' ? getConfiguredDaemonPort() : undefined;
       const status = key === 'daemon.port' ? await fetchDaemonStatus({ timeout: 500 }) : null;
       unsetConfigValue(key);
       const nextValue = getConfigValue(key);
-      console.log(`${key} = ${nextValue ?? ''} (default)`);
-      if (key === 'daemon.port') printDaemonPortApplyHint(Number(previousPort), Number(nextValue), status);
+      console.log(formatUnsetConfigValue(key, nextValue));
+      if (key === 'daemon.port' && previousPort !== undefined) {
+        printDaemonPortApplyHint(previousPort, getConfiguredDaemonPort(), status);
+      }
     });
 
   // ── Built-in: daemon ──────────────────────────────────────────────────────

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,6 +6,9 @@ import { DEFAULT_DAEMON_PORT } from './constants.js';
 import {
   getConfigPath,
   getConfigValue,
+  getConfiguredBrowserCommandTimeout,
+  getConfiguredBrowserConnectTimeout,
+  getConfiguredCdpEndpoint,
   getConfiguredDaemonPort,
   loadConfig,
   setConfigValue,
@@ -33,31 +36,76 @@ describe('opencli config', () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
-  it('uses ~/.opencli/config.toml', () => {
-    expect(getConfigPath()).toBe(path.join(homeDir, '.opencli', 'config.toml'));
+  it('uses ~/.opencli/config.yaml', () => {
+    expect(getConfigPath()).toBe(path.join(homeDir, '.opencli', 'config.yaml'));
   });
 
   it('returns the default daemon port when config is missing or malformed', () => {
-    expect(loadConfig()).toEqual({ version: 1 });
+    expect(loadConfig()).toEqual({});
     expect(getConfiguredDaemonPort()).toBe(DEFAULT_DAEMON_PORT);
 
     fs.mkdirSync(path.dirname(getConfigPath()), { recursive: true });
     fs.writeFileSync(getConfigPath(), '{ nope', 'utf-8');
 
-    expect(loadConfig()).toEqual({ version: 1 });
+    expect(loadConfig()).toEqual({});
     expect(getConfigValue('daemon.port')).toBe(DEFAULT_DAEMON_PORT);
   });
 
   it('sets and unsets daemon.port atomically', () => {
     setConfigValue('daemon.port', '23456');
 
-    expect(loadConfig()).toEqual({ version: 1, daemon: { port: 23456 } });
+    expect(loadConfig()).toEqual({ daemon: { port: 23456 } });
     expect(getConfiguredDaemonPort()).toBe(23456);
 
     unsetConfigValue('daemon.port');
 
-    expect(loadConfig()).toEqual({ version: 1 });
+    expect(loadConfig()).toEqual({});
     expect(getConfiguredDaemonPort()).toBe(DEFAULT_DAEMON_PORT);
+  });
+
+  it('sets and unsets browser config values', () => {
+    setConfigValue('browser.connect_timeout', '45');
+    setConfigValue('browser.command_timeout', '90');
+    setConfigValue('browser.cdp_endpoint', '  http://127.0.0.1:9222  ');
+
+    expect(loadConfig()).toEqual({
+      browser: {
+        connect_timeout: 45,
+        command_timeout: 90,
+        cdp_endpoint: 'http://127.0.0.1:9222',
+      },
+    });
+    expect(getConfiguredBrowserConnectTimeout()).toBe(45);
+    expect(getConfiguredBrowserCommandTimeout()).toBe(90);
+    expect(getConfiguredCdpEndpoint()).toBe('http://127.0.0.1:9222');
+
+    unsetConfigValue('browser.connect_timeout');
+    unsetConfigValue('browser.command_timeout');
+    unsetConfigValue('browser.cdp_endpoint');
+
+    expect(loadConfig()).toEqual({});
+    expect(getConfiguredBrowserConnectTimeout()).toBe(30);
+    expect(getConfiguredBrowserCommandTimeout()).toBe(60);
+    expect(getConfiguredCdpEndpoint()).toBeUndefined();
+  });
+
+  it('parses quoted YAML strings without treating URL fragments as comments', () => {
+    fs.mkdirSync(path.dirname(getConfigPath()), { recursive: true });
+    fs.writeFileSync(getConfigPath(), [
+      'browser:',
+      '  connect_timeout: 31',
+      '  command_timeout: 62',
+      '  cdp_endpoint: "http://x.example/path?q=1#frag"',
+      '',
+    ].join('\n'), 'utf-8');
+
+    expect(loadConfig()).toEqual({
+      browser: {
+        connect_timeout: 31,
+        command_timeout: 62,
+        cdp_endpoint: 'http://x.example/path?q=1#frag',
+      },
+    });
   });
 
   it('rejects invalid daemon ports', () => {
@@ -65,5 +113,8 @@ describe('opencli config', () => {
     expect(() => setConfigValue('daemon.port', '65536')).toThrow(/between 1 and 65535/);
     expect(() => setConfigValue('daemon.port', '123.5')).toThrow(/between 1 and 65535/);
     expect(() => setConfigValue('daemon.port', 'abc')).toThrow(/between 1 and 65535/);
+    expect(() => setConfigValue('browser.connect_timeout', '0')).toThrow(/positive integer/);
+    expect(() => setConfigValue('browser.command_timeout', '1.5')).toThrow(/positive integer/);
+    expect(() => setConfigValue('browser.cdp_endpoint', '')).toThrow(/non-empty string/);
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -33,8 +33,8 @@ describe('opencli config', () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
-  it('uses ~/.opencli/config.json', () => {
-    expect(getConfigPath()).toBe(path.join(homeDir, '.opencli', 'config.json'));
+  it('uses ~/.opencli/config.toml', () => {
+    expect(getConfigPath()).toBe(path.join(homeDir, '.opencli', 'config.toml'));
   });
 
   it('returns the default daemon port when config is missing or malformed', () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DEFAULT_DAEMON_PORT } from './constants.js';
+import {
+  getConfigPath,
+  getConfigValue,
+  getConfiguredDaemonPort,
+  loadConfig,
+  setConfigValue,
+  unsetConfigValue,
+} from './config.js';
+
+describe('opencli config', () => {
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-config-home-'));
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it('uses ~/.opencli/config.json', () => {
+    expect(getConfigPath()).toBe(path.join(homeDir, '.opencli', 'config.json'));
+  });
+
+  it('returns the default daemon port when config is missing or malformed', () => {
+    expect(loadConfig()).toEqual({ version: 1 });
+    expect(getConfiguredDaemonPort()).toBe(DEFAULT_DAEMON_PORT);
+
+    fs.mkdirSync(path.dirname(getConfigPath()), { recursive: true });
+    fs.writeFileSync(getConfigPath(), '{ nope', 'utf-8');
+
+    expect(loadConfig()).toEqual({ version: 1 });
+    expect(getConfigValue('daemon.port')).toBe(DEFAULT_DAEMON_PORT);
+  });
+
+  it('sets and unsets daemon.port atomically', () => {
+    setConfigValue('daemon.port', '23456');
+
+    expect(loadConfig()).toEqual({ version: 1, daemon: { port: 23456 } });
+    expect(getConfiguredDaemonPort()).toBe(23456);
+
+    unsetConfigValue('daemon.port');
+
+    expect(loadConfig()).toEqual({ version: 1 });
+    expect(getConfiguredDaemonPort()).toBe(DEFAULT_DAEMON_PORT);
+  });
+
+  it('rejects invalid daemon ports', () => {
+    expect(() => setConfigValue('daemon.port', '0')).toThrow(/between 1 and 65535/);
+    expect(() => setConfigValue('daemon.port', '65536')).toThrow(/between 1 and 65535/);
+    expect(() => setConfigValue('daemon.port', '123.5')).toThrow(/between 1 and 65535/);
+    expect(() => setConfigValue('daemon.port', 'abc')).toThrow(/between 1 and 65535/);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 
+// Hand-rolled TOML is intentionally limited to [daemon].port. Switch to a TOML
+// library before adding more sections or string/path values.
 export type OpenCliConfig = {
   version: 1;
   daemon?: {
@@ -18,7 +20,7 @@ export function getConfigDir(): string {
 }
 
 export function getConfigPath(): string {
-  return path.join(getConfigDir(), 'config.json');
+  return path.join(getConfigDir(), 'config.toml');
 }
 
 export function emptyConfig(): OpenCliConfig {
@@ -36,15 +38,45 @@ export function parseDaemonPort(value: unknown): number | null {
   return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
 }
 
+function stripTomlComment(value: string): string {
+  const hash = value.indexOf('#');
+  return (hash === -1 ? value : value.slice(0, hash)).trim();
+}
+
+export function parseConfigToml(raw: string): OpenCliConfig {
+  let section = '';
+  let daemonPort: number | null = null;
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const sectionMatch = /^\[([A-Za-z0-9_.-]+)\]$/.exec(trimmed);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      continue;
+    }
+    if (section !== 'daemon') continue;
+    const assignment = /^([A-Za-z0-9_.-]+)\s*=\s*(.+)$/.exec(trimmed);
+    if (!assignment) continue;
+    if (assignment[1] === 'port') daemonPort = parseDaemonPort(stripTomlComment(assignment[2]));
+  }
+  return {
+    version: 1,
+    ...(daemonPort == null ? {} : { daemon: { port: daemonPort } }),
+  };
+}
+
+export function serializeConfigToml(config: OpenCliConfig): string {
+  const lines: string[] = [];
+  if (config.daemon?.port != null) {
+    lines.push('[daemon]', `port = ${config.daemon.port}`);
+  }
+  return lines.length === 0 ? '' : `${lines.join('\n')}\n`;
+}
+
 export function loadConfig(): OpenCliConfig {
   try {
     const raw = fs.readFileSync(getConfigPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<OpenCliConfig>;
-    const daemonPort = parseDaemonPort(parsed.daemon?.port);
-    return {
-      version: 1,
-      ...(daemonPort == null ? {} : { daemon: { port: daemonPort } }),
-    };
+    return parseConfigToml(raw);
   } catch {
     return emptyConfig();
   }
@@ -55,7 +87,7 @@ export function saveConfig(config: OpenCliConfig): void {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
   try {
-    fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    fs.writeFileSync(tmp, serializeConfigToml(config), 'utf-8');
     fs.renameSync(tmp, target);
   } finally {
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,30 +1,41 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import yaml from 'js-yaml';
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 
-// Hand-rolled TOML is intentionally limited to [daemon].port. Switch to a TOML
-// library before adding more sections or string/path values.
 export type OpenCliConfig = {
-  version: 1;
   daemon?: {
     port?: number;
   };
+  browser?: {
+    connect_timeout?: number;
+    command_timeout?: number;
+    cdp_endpoint?: string;
+  };
 };
 
-export const SUPPORTED_CONFIG_KEYS = ['daemon.port'] as const;
+export const SUPPORTED_CONFIG_KEYS = [
+  'daemon.port',
+  'browser.connect_timeout',
+  'browser.command_timeout',
+  'browser.cdp_endpoint',
+] as const;
 export type SupportedConfigKey = typeof SUPPORTED_CONFIG_KEYS[number];
+
+export const DEFAULT_BROWSER_CONNECT_TIMEOUT_SECONDS = 30;
+export const DEFAULT_BROWSER_COMMAND_TIMEOUT_SECONDS = 60;
 
 export function getConfigDir(): string {
   return path.join(os.homedir(), '.opencli');
 }
 
 export function getConfigPath(): string {
-  return path.join(getConfigDir(), 'config.toml');
+  return path.join(getConfigDir(), 'config.yaml');
 }
 
 export function emptyConfig(): OpenCliConfig {
-  return { version: 1 };
+  return {};
 }
 
 export function isSupportedConfigKey(key: string): key is SupportedConfigKey {
@@ -38,45 +49,56 @@ export function parseDaemonPort(value: unknown): number | null {
   return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
 }
 
-function stripTomlComment(value: string): string {
-  const hash = value.indexOf('#');
-  return (hash === -1 ? value : value.slice(0, hash)).trim();
+export function parsePositiveInt(value: unknown): number | null {
+  const raw = typeof value === 'string' ? value.trim() : value;
+  if (raw === '') return null;
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
-export function parseConfigToml(raw: string): OpenCliConfig {
-  let section = '';
-  let daemonPort: number | null = null;
-  for (const line of raw.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const sectionMatch = /^\[([A-Za-z0-9_.-]+)\]$/.exec(trimmed);
-    if (sectionMatch) {
-      section = sectionMatch[1];
-      continue;
-    }
-    if (section !== 'daemon') continue;
-    const assignment = /^([A-Za-z0-9_.-]+)\s*=\s*(.+)$/.exec(trimmed);
-    if (!assignment) continue;
-    if (assignment[1] === 'port') daemonPort = parseDaemonPort(stripTomlComment(assignment[2]));
-  }
+export function parseConfigString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function parseConfigYaml(raw: string): OpenCliConfig {
+  const parsed = objectRecord(yaml.load(raw));
+  const daemon = objectRecord(parsed.daemon);
+  const browser = objectRecord(parsed.browser);
+  const daemonPort = parseDaemonPort(daemon.port);
+  const connectTimeout = parsePositiveInt(browser.connect_timeout);
+  const commandTimeout = parsePositiveInt(browser.command_timeout);
+  const cdpEndpoint = parseConfigString(browser.cdp_endpoint);
   return {
-    version: 1,
     ...(daemonPort == null ? {} : { daemon: { port: daemonPort } }),
+    ...(connectTimeout == null && commandTimeout == null && cdpEndpoint == null
+      ? {}
+      : {
+          browser: {
+            ...(connectTimeout == null ? {} : { connect_timeout: connectTimeout }),
+            ...(commandTimeout == null ? {} : { command_timeout: commandTimeout }),
+            ...(cdpEndpoint == null ? {} : { cdp_endpoint: cdpEndpoint }),
+          },
+        }),
   };
 }
 
-export function serializeConfigToml(config: OpenCliConfig): string {
-  const lines: string[] = [];
-  if (config.daemon?.port != null) {
-    lines.push('[daemon]', `port = ${config.daemon.port}`);
-  }
-  return lines.length === 0 ? '' : `${lines.join('\n')}\n`;
+export function serializeConfigYaml(config: OpenCliConfig): string {
+  if (!config.daemon && !config.browser) return '';
+  return yaml.dump(config, { lineWidth: 120, noRefs: true, sortKeys: false });
 }
 
 export function loadConfig(): OpenCliConfig {
   try {
     const raw = fs.readFileSync(getConfigPath(), 'utf-8');
-    return parseConfigToml(raw);
+    return parseConfigYaml(raw);
   } catch {
     return emptyConfig();
   }
@@ -87,7 +109,7 @@ export function saveConfig(config: OpenCliConfig): void {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
   try {
-    fs.writeFileSync(tmp, serializeConfigToml(config), 'utf-8');
+    fs.writeFileSync(tmp, serializeConfigYaml(config), 'utf-8');
     fs.renameSync(tmp, target);
   } finally {
     try {
@@ -102,10 +124,25 @@ export function getConfiguredDaemonPort(): number {
   return loadConfig().daemon?.port ?? DEFAULT_DAEMON_PORT;
 }
 
-export function getConfigValue(key: SupportedConfigKey): number {
+export function getConfiguredBrowserConnectTimeout(): number {
+  return loadConfig().browser?.connect_timeout ?? DEFAULT_BROWSER_CONNECT_TIMEOUT_SECONDS;
+}
+
+export function getConfiguredBrowserCommandTimeout(): number {
+  return loadConfig().browser?.command_timeout ?? DEFAULT_BROWSER_COMMAND_TIMEOUT_SECONDS;
+}
+
+export function getConfiguredCdpEndpoint(): string | undefined {
+  return loadConfig().browser?.cdp_endpoint;
+}
+
+export function getConfigValue(key: SupportedConfigKey): number | string | undefined {
   if (key === 'daemon.port') return getConfiguredDaemonPort();
+  if (key === 'browser.connect_timeout') return getConfiguredBrowserConnectTimeout();
+  if (key === 'browser.command_timeout') return getConfiguredBrowserCommandTimeout();
+  if (key === 'browser.cdp_endpoint') return getConfiguredCdpEndpoint();
   key satisfies never;
-  return DEFAULT_DAEMON_PORT;
+  return undefined;
 }
 
 export function setConfigValue(key: SupportedConfigKey, value: unknown): OpenCliConfig {
@@ -117,16 +154,50 @@ export function setConfigValue(key: SupportedConfigKey, value: unknown): OpenCli
     saveConfig(config);
     return config;
   }
+  if (key === 'browser.connect_timeout' || key === 'browser.command_timeout') {
+    const timeout = parsePositiveInt(value);
+    if (timeout == null) throw new Error(`${key} must be a positive integer`);
+    const browserKey = key === 'browser.connect_timeout' ? 'connect_timeout' : 'command_timeout';
+    const config = loadConfig();
+    config.browser = { ...(config.browser ?? {}), [browserKey]: timeout };
+    saveConfig(config);
+    return config;
+  }
+  if (key === 'browser.cdp_endpoint') {
+    const endpoint = parseConfigString(value);
+    if (endpoint == null) throw new Error('browser.cdp_endpoint must be a non-empty string');
+    const config = loadConfig();
+    config.browser = { ...(config.browser ?? {}), cdp_endpoint: endpoint };
+    saveConfig(config);
+    return config;
+  }
   key satisfies never;
   return loadConfig();
 }
 
 export function unsetConfigValue(key: SupportedConfigKey): OpenCliConfig {
+  const config = loadConfig();
   if (key === 'daemon.port') {
-    const config = loadConfig();
     if (config.daemon) {
       delete config.daemon.port;
       if (Object.keys(config.daemon).length === 0) delete config.daemon;
+    }
+    saveConfig(config);
+    return config;
+  }
+  if (key === 'browser.connect_timeout' || key === 'browser.command_timeout') {
+    if (config.browser) {
+      const browserKey = key === 'browser.connect_timeout' ? 'connect_timeout' : 'command_timeout';
+      delete config.browser[browserKey];
+      if (Object.keys(config.browser).length === 0) delete config.browser;
+    }
+    saveConfig(config);
+    return config;
+  }
+  if (key === 'browser.cdp_endpoint') {
+    if (config.browser) {
+      delete config.browser.cdp_endpoint;
+      if (Object.keys(config.browser).length === 0) delete config.browser;
     }
     saveConfig(config);
     return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,104 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DEFAULT_DAEMON_PORT } from './constants.js';
+
+export type OpenCliConfig = {
+  version: 1;
+  daemon?: {
+    port?: number;
+  };
+};
+
+export const SUPPORTED_CONFIG_KEYS = ['daemon.port'] as const;
+export type SupportedConfigKey = typeof SUPPORTED_CONFIG_KEYS[number];
+
+export function getConfigDir(): string {
+  return path.join(os.homedir(), '.opencli');
+}
+
+export function getConfigPath(): string {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+export function emptyConfig(): OpenCliConfig {
+  return { version: 1 };
+}
+
+export function isSupportedConfigKey(key: string): key is SupportedConfigKey {
+  return (SUPPORTED_CONFIG_KEYS as readonly string[]).includes(key);
+}
+
+export function parseDaemonPort(value: unknown): number | null {
+  const raw = typeof value === 'string' ? value.trim() : value;
+  if (raw === '') return null;
+  const port = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+}
+
+export function loadConfig(): OpenCliConfig {
+  try {
+    const raw = fs.readFileSync(getConfigPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<OpenCliConfig>;
+    const daemonPort = parseDaemonPort(parsed.daemon?.port);
+    return {
+      version: 1,
+      ...(daemonPort == null ? {} : { daemon: { port: daemonPort } }),
+    };
+  } catch {
+    return emptyConfig();
+  }
+}
+
+export function saveConfig(config: OpenCliConfig): void {
+  const target = getConfigPath();
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, target);
+  } finally {
+    try {
+      if (fs.existsSync(tmp)) fs.rmSync(tmp, { force: true });
+    } catch {
+      // Best-effort cleanup only; the config target is already atomic.
+    }
+  }
+}
+
+export function getConfiguredDaemonPort(): number {
+  return loadConfig().daemon?.port ?? DEFAULT_DAEMON_PORT;
+}
+
+export function getConfigValue(key: SupportedConfigKey): number {
+  if (key === 'daemon.port') return getConfiguredDaemonPort();
+  key satisfies never;
+  return DEFAULT_DAEMON_PORT;
+}
+
+export function setConfigValue(key: SupportedConfigKey, value: unknown): OpenCliConfig {
+  if (key === 'daemon.port') {
+    const port = parseDaemonPort(value);
+    if (port == null) throw new Error('daemon.port must be an integer between 1 and 65535');
+    const config = loadConfig();
+    config.daemon = { ...(config.daemon ?? {}), port };
+    saveConfig(config);
+    return config;
+  }
+  key satisfies never;
+  return loadConfig();
+}
+
+export function unsetConfigValue(key: SupportedConfigKey): OpenCliConfig {
+  if (key === 'daemon.port') {
+    const config = loadConfig();
+    if (config.daemon) {
+      delete config.daemon.port;
+      if (Object.keys(config.daemon).length === 0) delete config.daemon;
+    }
+    saveConfig(config);
+    return config;
+  }
+  key satisfies never;
+  return loadConfig();
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -17,19 +17,19 @@
  * Lifecycle:
  *   - Auto-spawned by opencli on first browser command
  *   - Persistent — stays alive until explicit shutdown, SIGTERM, or uninstall
- *   - Listens on localhost:19825
+ *   - Listens on the configured localhost port (default 19825)
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { WebSocketServer, WebSocket, type RawData } from 'ws';
-import { DEFAULT_DAEMON_PORT } from './constants.js';
+import { getConfiguredDaemonPort } from './config.js';
 import { EXIT_CODES } from './errors.js';
 import { log } from './logger.js';
 import { PKG_VERSION } from './version.js';
 import { DEFAULT_CONTEXT_ID } from './browser/profile.js';
 import { recordExtensionVersion } from './update-check.js';
 
-const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
+const PORT = getConfiguredDaemonPort();
 
 // ─── State ───────────────────────────────────────────────────────────
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,9 +5,9 @@
  */
 
 import { styleText } from 'node:util';
-import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
 import { getDaemonHealth, listSessions } from './browser/daemon-client.js';
+import { getConfiguredDaemonPort } from './config.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
@@ -66,6 +66,7 @@ export type DoctorReport = {
   daemonRunning: boolean;
   daemonFlaky?: boolean;
   daemonStale?: boolean;
+  daemonPort?: number;
   daemonVersion?: string;
   extensionConnected: boolean;
   extensionFlaky?: boolean;
@@ -229,6 +230,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     daemonRunning,
     daemonFlaky,
     daemonStale,
+    daemonPort: health.status?.port ?? getConfiguredDaemonPort(),
     daemonVersion: health.status?.daemonVersion,
     extensionConnected,
     extensionFlaky,
@@ -254,7 +256,7 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
   const daemonLabel = report.daemonFlaky
     ? 'unstable (running during live check, then stopped)'
     : report.daemonRunning
-      ? `running on port ${DEFAULT_DAEMON_PORT} (${report.daemonStale
+      ? `running on port ${report.daemonPort ?? getConfiguredDaemonPort()} (${report.daemonStale
         ? `${formatDaemonVersion(report)}, stale; CLI v${report.cliVersion ?? 'unknown'}`
         : formatDaemonVersion(report)})`
       : 'not running';

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -119,7 +119,7 @@ export class TimeoutError extends CliError {
     super(
       'TIMEOUT',
       `${label} timed out after ${seconds}s`,
-      hint ?? 'Try again, or increase timeout with OPENCLI_BROWSER_COMMAND_TIMEOUT env var',
+      hint ?? 'Try again, or increase timeout with `opencli config set browser.command_timeout <seconds>`',
       EXIT_CODES.TEMPFAIL,
     );
   }

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -154,9 +154,11 @@ describe('executeCommand — non-browser timeout', () => {
   });
 
   it('exports a profile-scoped trace artifact on browser command failure when requested', async () => {
-    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-'));
-    const prevConfigDir = process.env.OPENCLI_CONFIG_DIR;
-    process.env.OPENCLI_CONFIG_DIR = baseDir;
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-home-'));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = {
@@ -197,7 +199,7 @@ describe('executeCommand — non-browser timeout', () => {
       expect(thrown).toBeInstanceOf(Error);
       expect((thrown as Error).message).toContain('adapter failure');
 
-      const tracesRoot = path.join(baseDir, 'profiles', 'default', 'traces');
+      const tracesRoot = path.join(homeDir, '.opencli', 'profiles', 'default', 'traces');
       const traceId = fs.readdirSync(tracesRoot)[0];
       const traceDir = path.join(tracesRoot, traceId);
       expect(fs.existsSync(path.join(traceDir, 'trace.jsonl'))).toBe(true);
@@ -217,18 +219,22 @@ describe('executeCommand — non-browser timeout', () => {
       });
       expect(closeWindow).toHaveBeenCalledTimes(1);
     } finally {
-      if (prevConfigDir === undefined) delete process.env.OPENCLI_CONFIG_DIR;
-      else process.env.OPENCLI_CONFIG_DIR = prevConfigDir;
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
       stderrSpy.mockRestore();
-      fs.rmSync(baseDir, { recursive: true, force: true });
+      fs.rmSync(homeDir, { recursive: true, force: true });
       vi.restoreAllMocks();
     }
   });
 
   it('exports a trace receipt on browser command success when trace is on', async () => {
-    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-success-'));
-    const prevConfigDir = process.env.OPENCLI_CONFIG_DIR;
-    process.env.OPENCLI_CONFIG_DIR = baseDir;
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-success-home-'));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const onTraceExport = vi.fn();
     const closeWindow = vi.fn().mockResolvedValue(undefined);
@@ -260,11 +266,11 @@ describe('executeCommand — non-browser timeout', () => {
 
       const stderr = stderrSpy.mock.calls.flat().join('\n');
       expect(stderr).toContain('OpenCLI trace artifact:');
-      const tracesRoot = path.join(baseDir, 'profiles', 'default', 'traces');
+      const tracesRoot = path.join(homeDir, '.opencli', 'profiles', 'default', 'traces');
       const traceId = fs.readdirSync(tracesRoot)[0];
       const receipt = JSON.parse(fs.readFileSync(path.join(tracesRoot, traceId, 'receipt.json'), 'utf-8'));
       expect(receipt.status).toBe('success');
-      expect(receipt.traceDir).toContain(path.join(baseDir, 'profiles', 'default', 'traces'));
+      expect(receipt.traceDir).toContain(path.join(homeDir, '.opencli', 'profiles', 'default', 'traces'));
       expect(receipt.scope).toMatchObject({
         site: 'test-execution',
         command: 'test-execution/browser-trace-success',
@@ -276,20 +282,24 @@ describe('executeCommand — non-browser timeout', () => {
       }));
       expect(closeWindow).toHaveBeenCalledTimes(1);
     } finally {
-      if (prevConfigDir === undefined) delete process.env.OPENCLI_CONFIG_DIR;
-      else process.env.OPENCLI_CONFIG_DIR = prevConfigDir;
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
       stderrSpy.mockRestore();
-      fs.rmSync(baseDir, { recursive: true, force: true });
+      fs.rmSync(homeDir, { recursive: true, force: true });
       vi.restoreAllMocks();
     }
   });
 
   it('keeps the original adapter error when trace export fails', async () => {
-    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-fail-'));
-    const blockedPath = path.join(baseDir, 'not-a-dir');
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-exec-trace-fail-home-'));
+    const blockedPath = path.join(homeDir, '.opencli');
     fs.writeFileSync(blockedPath, 'file');
-    const prevConfigDir = process.env.OPENCLI_CONFIG_DIR;
-    process.env.OPENCLI_CONFIG_DIR = blockedPath;
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const mockPage = {
       closeWindow: vi.fn().mockResolvedValue(undefined),
@@ -318,10 +328,12 @@ describe('executeCommand — non-browser timeout', () => {
       await expect(executeCommand(cmd, {}, false, { trace: 'retain-on-failure' })).rejects.toThrow('adapter failure');
       expect(stderrSpy.mock.calls.flat().join('\n')).toContain('[trace] Failed to export trace artifact');
     } finally {
-      if (prevConfigDir === undefined) delete process.env.OPENCLI_CONFIG_DIR;
-      else process.env.OPENCLI_CONFIG_DIR = prevConfigDir;
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
       stderrSpy.mockRestore();
-      fs.rmSync(baseDir, { recursive: true, force: true });
+      fs.rmSync(homeDir, { recursive: true, force: true });
       vi.restoreAllMocks();
     }
   });

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -78,15 +78,15 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
-  it('skips closeWindow when OPENCLI_LIVE=1 (success path)', async () => {
+  it('skips closeWindow when OPENCLI_WINDOW_LIVE=1 (success path)', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
 
-    const prev = process.env.OPENCLI_LIVE;
-    process.env.OPENCLI_LIVE = '1';
+    const prev = process.env.OPENCLI_WINDOW_LIVE;
+    process.env.OPENCLI_WINDOW_LIVE = '1';
     try {
       const cmd = cli({
         site: 'test-execution',
@@ -100,21 +100,21 @@ describe('executeCommand — non-browser timeout', () => {
       await executeCommand(cmd, {});
       expect(closeWindow).not.toHaveBeenCalled();
     } finally {
-      if (prev === undefined) delete process.env.OPENCLI_LIVE;
-      else process.env.OPENCLI_LIVE = prev;
+      if (prev === undefined) delete process.env.OPENCLI_WINDOW_LIVE;
+      else process.env.OPENCLI_WINDOW_LIVE = prev;
       vi.restoreAllMocks();
     }
   });
 
-  it('skips closeWindow when OPENCLI_LIVE=1 (failure path)', async () => {
+  it('skips closeWindow when OPENCLI_WINDOW_LIVE=1 (failure path)', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
 
-    const prev = process.env.OPENCLI_LIVE;
-    process.env.OPENCLI_LIVE = '1';
+    const prev = process.env.OPENCLI_WINDOW_LIVE;
+    process.env.OPENCLI_WINDOW_LIVE = '1';
     try {
       const cmd = cli({
         site: 'test-execution',
@@ -128,8 +128,8 @@ describe('executeCommand — non-browser timeout', () => {
       await expect(executeCommand(cmd, {})).rejects.toThrow('adapter failure');
       expect(closeWindow).not.toHaveBeenCalled();
     } finally {
-      if (prev === undefined) delete process.env.OPENCLI_LIVE;
-      else process.env.OPENCLI_LIVE = prev;
+      if (prev === undefined) delete process.env.OPENCLI_WINDOW_LIVE;
+      else process.env.OPENCLI_WINDOW_LIVE = prev;
       vi.restoreAllMocks();
     }
   });

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -26,7 +26,8 @@ import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
 import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceReceipt, getErrorMessage } from './errors.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
-import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT } from './runtime.js';
+import { getBrowserFactory, browserSession, runWithTimeout } from './runtime.js';
+import { getConfiguredBrowserCommandTimeout, getConfiguredCdpEndpoint } from './config.js';
 import { resolveProfileContextId } from './browser/profile.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
@@ -211,7 +212,7 @@ export async function executeCommand(
 
       if (electron) {
         // Electron apps: respect manual endpoint override, then try auto-detect
-        const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
+        const manualEndpoint = getConfiguredCdpEndpoint();
         if (manualEndpoint) {
           const port = Number(new URL(manualEndpoint).port);
           if (!await probeCDP(port)) {
@@ -303,7 +304,7 @@ export async function executeCommand(
         const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
           const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
-            timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT,
+            timeout: cmd.timeoutSeconds ?? getConfiguredBrowserCommandTimeout(),
             label: fullName(cmd),
           });
           observation?.record({

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -299,9 +299,9 @@ export async function executeCommand(
             throw wrapped;
           }
         }
-        // --live / OPENCLI_LIVE=1 keeps the automation window open after the
+        // --live / OPENCLI_WINDOW_LIVE=1 keeps the automation window open after the
         // command finishes, so agents (or humans) can inspect the page state.
-        const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
+        const keepOpen = process.env.OPENCLI_WINDOW_LIVE === '1' || process.env.OPENCLI_WINDOW_LIVE === 'true';
         try {
           const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
             timeout: cmd.timeoutSeconds ?? getConfiguredBrowserCommandTimeout(),

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -219,7 +219,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
       `${label} is not reachable on CDP port ${port}.`,
       `Auto-launch is not yet supported on ${process.platform}.\n` +
       `Start ${label} manually with --remote-debugging-port=${port}, then either:\n` +
-      `  • Set OPENCLI_CDP_ENDPOINT=http://127.0.0.1:${port}\n` +
+      `  • Run: opencli config set browser.cdp_endpoint http://127.0.0.1:${port}\n` +
       `  • Or just re-run the command once ${label} is listening on port ${port}.`,
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 {
   const liveIdx = process.argv.indexOf('--live');
   if (liveIdx !== -1) {
-    process.env.OPENCLI_LIVE = '1';
+    process.env.OPENCLI_WINDOW_LIVE = '1';
     process.argv.splice(liveIdx, 1);
   }
   const focusIdx = process.argv.indexOf('--focus');

--- a/src/observation/artifact.ts
+++ b/src/observation/artifact.ts
@@ -17,7 +17,7 @@ export interface ExportObservationOptions {
 }
 
 function baseOpenCliDir(): string {
-  return process.env.OPENCLI_CONFIG_DIR || path.join(os.homedir(), '.opencli');
+  return path.join(os.homedir(), '.opencli');
 }
 
 function safeSegment(value: string | undefined): string {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3,6 +3,7 @@ import type { IPage } from './types.js';
 import { TimeoutError } from './errors.js';
 import { isElectronApp } from './electron-apps.js';
 import { log } from './logger.js';
+import { getConfiguredBrowserConnectTimeout } from './config.js';
 
 /**
  * Returns the appropriate browser factory based on site type.
@@ -24,8 +25,6 @@ function parseEnvTimeout(envVar: string, fallback: number): number {
   return parsed;
 }
 
-export const DEFAULT_BROWSER_CONNECT_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_CONNECT_TIMEOUT', 30);
-export const DEFAULT_BROWSER_COMMAND_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_COMMAND_TIMEOUT', 60);
 export const DEFAULT_BROWSER_EXPLORE_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_EXPLORE_TIMEOUT', 120);
 
 /**
@@ -76,7 +75,7 @@ export async function browserSession<T>(
   const browser = new BrowserFactory();
   try {
     const page = await browser.connect({
-      timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
+      timeout: getConfiguredBrowserConnectTimeout(),
       workspace: opts.workspace,
       cdpEndpoint: opts.cdpEndpoint,
       contextId: opts.contextId,

--- a/tests/e2e/browser-tabs.test.ts
+++ b/tests/e2e/browser-tabs.test.ts
@@ -199,8 +199,8 @@ describe('browser tab CLI e2e', () => {
     const configDir = path.join(homeDir, '.opencli');
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(
-      path.join(configDir, 'config.json'),
-      JSON.stringify({ version: 1, daemon: { port: daemon.port } }, null, 2) + '\n',
+      path.join(configDir, 'config.toml'),
+      `[daemon]\nport = ${daemon.port}\n`,
       'utf-8',
     );
     return { HOME: homeDir, USERPROFILE: homeDir, ...extra };

--- a/tests/e2e/browser-tabs.test.ts
+++ b/tests/e2e/browser-tabs.test.ts
@@ -191,10 +191,27 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
 describe('browser tab CLI e2e', () => {
   const daemons: FakeDaemon[] = [];
   const cacheDirs: string[] = [];
+  const homeDirs: string[] = [];
+
+  function envForDaemon(daemon: FakeDaemon, extra: Record<string, string> = {}): Record<string, string> {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-tabs-home-'));
+    homeDirs.push(homeDir);
+    const configDir = path.join(homeDir, '.opencli');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ version: 1, daemon: { port: daemon.port } }, null, 2) + '\n',
+      'utf-8',
+    );
+    return { HOME: homeDir, USERPROFILE: homeDir, ...extra };
+  }
 
   afterEach(async () => {
     while (daemons.length > 0) {
       await daemons.pop()!.close();
+    }
+    while (homeDirs.length > 0) {
+      fs.rmSync(homeDirs.pop()!, { recursive: true, force: true });
     }
     while (cacheDirs.length > 0) {
       fs.rmSync(cacheDirs.pop()!, { recursive: true, force: true });
@@ -204,7 +221,7 @@ describe('browser tab CLI e2e', () => {
   it('lists, creates, and closes tabs through the built CLI', async () => {
     const daemon = await startFakeDaemon();
     daemons.push(daemon);
-    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+    const env = envForDaemon(daemon);
 
     const listed = await runCli(['browser', 'tab', 'list'], { env });
     expect(listed.code).toBe(0);
@@ -237,7 +254,7 @@ describe('browser tab CLI e2e', () => {
   it('routes concurrent browser commands to their requested tabs', async () => {
     const daemon = await startFakeDaemon();
     daemons.push(daemon);
-    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+    const env = envForDaemon(daemon);
 
     const [left, right] = await Promise.all([
       runCli(['browser', 'eval', '--tab', 'tab-1', 'window.__delay = "left"'], { env, timeout: 30_000 }),
@@ -260,10 +277,7 @@ describe('browser tab CLI e2e', () => {
     daemons.push(daemon);
     const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-tabs-'));
     cacheDirs.push(cacheDir);
-    const env = {
-      OPENCLI_DAEMON_PORT: String(daemon.port),
-      OPENCLI_CACHE_DIR: cacheDir,
-    };
+    const env = envForDaemon(daemon, { OPENCLI_CACHE_DIR: cacheDir });
 
     const created = await runCli(['browser', 'tab', 'new', 'https://three.example/'], { env });
     expect(created.code).toBe(0);
@@ -279,10 +293,7 @@ describe('browser tab CLI e2e', () => {
     daemons.push(daemon);
     const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-tabs-'));
     cacheDirs.push(cacheDir);
-    const env = {
-      OPENCLI_DAEMON_PORT: String(daemon.port),
-      OPENCLI_CACHE_DIR: cacheDir,
-    };
+    const env = envForDaemon(daemon, { OPENCLI_CACHE_DIR: cacheDir });
 
     const selected = await runCli(['browser', 'tab', 'select', 'tab-2'], { env });
     expect(selected.code).toBe(0);

--- a/tests/e2e/browser-tabs.test.ts
+++ b/tests/e2e/browser-tabs.test.ts
@@ -199,8 +199,8 @@ describe('browser tab CLI e2e', () => {
     const configDir = path.join(homeDir, '.opencli');
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(
-      path.join(configDir, 'config.toml'),
-      `[daemon]\nport = ${daemon.port}\n`,
+      path.join(configDir, 'config.yaml'),
+      `daemon:\n  port: ${daemon.port}\n`,
       'utf-8',
     );
     return { HOME: homeDir, USERPROFILE: homeDir, ...extra };


### PR DESCRIPTION
## Summary

Adds daemon port configuration support to the Browser Bridge extension so it can match `OPENCLI_DAEMON_PORT` in multi-profile or managed-browser environments.

Priority order:

1. Saved extension setting from `chrome.storage.local` (`opencli_daemon_port_v1`), editable from the extension popup.
2. Build-time `OPENCLI_DAEMON_PORT` injected by the extension Vite build.
3. Default fallback port `19825`.

## Why

The CLI and daemon already support `OPENCLI_DAEMON_PORT`, but the extension previously used a build-time constant. That made it difficult for managed environments to run multiple isolated Browser Bridge daemon ports without rewriting the built extension output.

## Changes

- Replaces fixed extension daemon URLs with runtime URL builders.
- Adds port parsing and fallback helpers.
- Adds popup UI for manually saving/resetting the daemon port.
- Injects `OPENCLI_DAEMON_PORT` during extension builds via Vite.
- Documents custom daemon port usage.
- Adds extension tests for port resolution priority and validation.

## Verification

- `npm run typecheck --prefix extension`
- `npx vitest run --project extension extension/src/background.test.ts`
- `npx vitest run --project extension`
- `OPENCLI_DAEMON_PORT=23456 npm run build --prefix extension` verified build-time injection
- `npm run build --prefix extension` rebuilt committed dist with default fallback
