### PR TITLE
docs(adapter-author): typed-errors reference + 6 conventions from #1329

### DIFF
--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -188,6 +188,7 @@ DONE
 | `references/site-memory/<site>.md` | Step 2 读站点公共知识（eastmoney / xueqiu / bilibili / tonghuashun 已铺） |
 | `references/success-rate-pitfalls.md` | Step 7 / 11 踩坑前翻：10 种"verify 能过但数据是错的"静默失败 |
 | `references/jsdom-fixture-pattern.md` | 当 adapter 走 `page.evaluate` 内 DOM 抽取、且 mocked-evaluate 单测漏 silent bug 时——把 HTML 冻进 `clis/<site>/__fixtures__/` 用 JSDOM 跑（含 fixture 创建 mandatory `awk 'NF>0'` 收紧 + reverse-validate 纪律） |
+| `references/typed-errors.md` | 写 `func` 主体之前必读：5 类 typed error 落点表（ArgumentError / EmptyResultError / CommandExecutionError / AuthRequiredError / TimeoutError）+ 三大 silent anti-pattern（silent-clamp / sentinel-row / generic CliError）的反例修法 |
 
 ---
 
@@ -195,7 +196,9 @@ DONE
 
 - adapter 只引 `@jackwener/opencli/registry` + `@jackwener/opencli/errors`，不用第三方
 - `columns` 数组和 `func` 返回对象 keys 完全对齐（含顺序）
-- 已知失败抛 `CliError('CODE', 'msg')` 或 `AuthRequiredError(domain)`，不要 silent `return []`
+- **中间解析对象 key 不能跟 `columns` 任一项重叠**（否则 silent-column-drop audit 误判，PR #1329 R1 真踩过；改成专属命名 + push row 时 destructure aliasing）
+- **`browser:` field 决定 func 签名**：`browser:false → (args)`，`browser:true → (page, args)`。搞反时 `args` 实际是 debug flag，所有外部参数 silent fallback 到 default（PR #1329 upstream 之前 8 个 non-browser adapter 全踩过这个）
+- 已知失败按 [`references/typed-errors.md`](./references/typed-errors.md) 5-classification 抛对应 typed error；**不要** silent `return []`，**不要** silent `return [{sentinel}]`，**不要** `Math.max/min` silent clamp 外部参数
 - 写私人 adapter 用 `~/.opencli/clis/<site>/<name>.js`（免 build）；要提 PR 才 copy 到 `clis/<site>/<name>.js`
 - 站点记忆每轮回写：没记忆 → 用 skill → 产生记忆 → 下次变 5 分钟
 - **调试过程中的原始 dump / 抓包 / HTML 样本只能落在 `~/.opencli/sites/<site>/fixtures/` 或 `/tmp/`。严禁在 repo 根目录、`clis/<site>/` 或当前工作目录留 `.dbg-*.html / raw-*.json / sample.*` 这类临时文件**（PR diff 会带上去，别人 review 时很烦）。

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -258,7 +258,7 @@ cli({
 const data = await page.fetchJson(`${BASE}/api/list`, {
   method: 'POST',
   headers: { 'X-Requested-With': 'XMLHttpRequest' },
-  body: { page: 1, size: Number(args.limit) || 20 },
+  body: { page: 1, size: limit },
 });
 ```
 

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -118,7 +118,7 @@ columns: ['rank', 'bondCode', 'bondName', /* ... */ ],
 - `default` 必填（缺失的命令会拒绝启动）
 - `columns` 数组必须跟 `func` 返回的 object keys 完全对上，顺序也一致（决定表格列顺序）
 - 列名 camelCase，跟 `cli({...})` 其他 adapter 保持统一
-- **中间解析对象 key 不能跟 columns 任一项重叠** —— 否则 `silent-column-drop` audit 会把它当 row 候选误判。`{pid, html, start}` 这类中间结构改成 `{postId, body, offset}`，最后在 push row 时再 destructure aliasing 回 column 命名。背景：PR #1329 R1 codex-mini0 catch 的（[`clis/1point3acres/thread.js#L50-L65`](../../../clis/1point3acres/thread.js)）
+- **中间解析对象 key 不能跟 columns 任一项重叠** —— 否则 `silent-column-drop` audit 会把它当 row 候选误判。`{pid, html, start}` 这类中间结构改成 `{postId, body, offset}`，最后在 push row 时再 destructure aliasing 回 column 命名。背景：PR #1329 R1 codex-mini0 catch 的（[before](https://github.com/jackwener/OpenCLI/blob/384bcd6fdd93f3075bd2c835e82689c42bfe4b2f/clis/1point3acres/thread.js#L50-L63) → [after](../../../clis/1point3acres/thread.js#L50-L65)）
 
 ### 3. func — 主体
 
@@ -262,7 +262,7 @@ const data = await page.fetchJson(`${BASE}/api/list`, {
 });
 ```
 
-它固定 `credentials: 'include'`，带 timeout，HTTP 非 2xx / 非 JSON 会抛统一 `CliError`。
+它固定 `credentials: 'include'`，带 timeout，HTTP 非 2xx / 非 JSON 会抛统一 runtime error。adapter 里不用再手写 `page.evaluate(fetch(...))`；如果你需要额外包一层业务语义，按 [`typed-errors.md`](./typed-errors.md) 映射到 `CommandExecutionError` / `AuthRequiredError` / `EmptyResultError`。
 
 ### HTML 不走 browser fetch
 

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -8,6 +8,8 @@
 
 ## 活例子：convertible.js
 
+> **注意（2026-05 起）**：下面这份 `convertible.js` 的 limit clamp 和 `CliError('HTTP_ERROR' / 'NO_DATA')` 是 grandfathered 写法（在 [`scripts/typed-error-lint-baseline.json`](../../../scripts/typed-error-lint-baseline.json) 里）。结构布局（cli 声明 / args / columns / map）仍然是好范本，但 **error 处理 + limit 校验请按下文 §3 + [`typed-errors.md`](./typed-errors.md) 写**。新写 adapter 抄这个文件别连 `Math.max(1, Math.min(...))` 和 `CliError(...)` 一起抄过去。
+
 ```javascript
 // eastmoney convertible — on-market convertible bond listing.
 import { cli, Strategy } from '@jackwener/opencli/registry';
@@ -116,26 +118,37 @@ columns: ['rank', 'bondCode', 'bondName', /* ... */ ],
 - `default` 必填（缺失的命令会拒绝启动）
 - `columns` 数组必须跟 `func` 返回的 object keys 完全对上，顺序也一致（决定表格列顺序）
 - 列名 camelCase，跟 `cli({...})` 其他 adapter 保持统一
+- **中间解析对象 key 不能跟 columns 任一项重叠** —— 否则 `silent-column-drop` audit 会把它当 row 候选误判。`{pid, html, start}` 这类中间结构改成 `{postId, body, offset}`，最后在 push row 时再 destructure aliasing 回 column 命名。背景：PR #1329 R1 codex-mini0 catch 的（[`clis/1point3acres/thread.js#L50-L65`](../../../clis/1point3acres/thread.js)）
 
 ### 3. func — 主体
 
 ```javascript
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
 func: async (args) => {
-  // 1. 解析参数
-  const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+  // 1. 解析参数 — 越界一律抛，不要 silent clamp
+  const n = Number(args.limit ?? 20);
+  if (!Number.isInteger(n) || n <= 0) throw new ArgumentError('limit must be a positive integer');
+  if (n > 100) throw new ArgumentError('limit must be <= 100');
+  const limit = n;
 
   // 2. 构造 URL / 请求
   const url = new URL(...);
   url.searchParams.set(...);
 
-  // 3. 发请求
-  const resp = await fetch(url, { headers: {...} });
-  if (!resp.ok) throw new CliError('HTTP_ERROR', `... HTTP ${resp.status}`);
+  // 3. 发请求 — fetch 抛 / HTTP 非 2xx 都归 CommandExecutionError
+  let resp;
+  try {
+    resp = await fetch(url, { headers: { /* ... */ } });
+  } catch (error) {
+    throw new CommandExecutionError(`request failed: ${error?.message || error}`);
+  }
+  if (!resp.ok) throw new CommandExecutionError(`request failed: HTTP ${resp.status}`);
 
-  // 4. 解析 + 业务校验
+  // 4. 解析 + 业务校验 — 业务空 → EmptyResultError，不要 sentinel row 也不要 return []
   const data = await resp.json();
   const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
-  if (diff.length === 0) throw new CliError('NO_DATA', '...');
+  if (diff.length === 0) throw new EmptyResultError('site command', 'API returned no rows');
 
   // 5. map 到 columns 同名 keys
   return diff.slice(0, limit).map((it, i) => ({
@@ -146,23 +159,15 @@ func: async (args) => {
 },
 ```
 
-**参数形态**：
+**站点级 helper**：≥ 2 个同站 adapter 都做相同 limit / page 校验时，把校验抽成 `clis/<site>/utils.js` 的 `normalizeLimit(value, default, max, label)` / `normalizePositiveInteger(value, default, label, { min })`，避免每个 adapter 都 inline 一遍。模板见 [`typed-errors.md` §2](./typed-errors.md) 和 [`clis/1point3acres/utils.js`](../../../clis/1point3acres/utils.js)。1 个 adapter 用就直接 inline，不要为 1 处单点抽 helper。
 
-- `browser: false`：`func: async (args, debug?) => { ... }`，不会收到 `page`
-- `browser: true`：`func: async (page, args, debug?) => { ... }`，`page` 是浏览器上下文
+**参数形态**（**踩过最多次的坑**：搞反签名后 `args` 实际是 `debug` flag，所有 `args.foo` 静默 undefined → fallback 到 default。#1329 upstream 之前 8 个 non-browser adapter 写错过签名，全部 silently fallback 到默认参数）：
+
+- `browser: false`：`func: async (args, debug?) => { ... }` —— **单参 args**，不会收到 `page`
+- `browser: true`：`func: async (page, args, debug?) => { ... }` —— **双参 (page, args)**，第一参是浏览器上下文
 - `args`：所有 `args[]` 声明的参数解析后的 object
 
-**错误处理**：
-
-| 场景 | 写法 |
-|------|------|
-| 参数不合法 | `throw new CliError('INVALID_ARGUMENT', '...')` |
-| HTTP 非 2xx | `throw new CliError('HTTP_ERROR', 'HTTP <status>')` |
-| 业务返回空 | `throw new CliError('NO_DATA', '...')` 或 `'EMPTY_RESULT'` |
-| 需要登录 | `throw new AuthRequiredError(domain)`（从 `@jackwener/opencli/errors` 引） |
-| 接口约束失败 | `throw new CliError('API_ERROR', '...')` |
-
-不要 `return []` 了事。autofix skill 靠 CliError 的 code 决定要不要重试。
+**错误处理**：用 typed error 5-classification（参见 [`typed-errors.md`](./typed-errors.md)），**不要** `CliError('XXX', ...)` 直传，**不要** `return []` 了事，**不要** `return [{sentinel}]` 装一行业务数据冒充 empty。autofix skill 靠 typed error 的 exit code（66 = empty / 77 = auth / 75 = timeout / 2 = argument / 1 = exec）决定要不要重试。
 
 ---
 
@@ -176,7 +181,7 @@ PUBLIC 模式不够（接口 401 / 302 到 login / 响应是"请登录"页）就
 
 ```javascript
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 const BASE = 'https://www.example.com';
 const HOST = 'www.example.com';
@@ -196,17 +201,22 @@ async function readCookie(page) {
 }
 
 async function fetchHtml(url, { cookie, encoding = 'utf-8', headers = {} } = {}) {
-    const resp = await fetch(url, {
-        headers: {
-            'User-Agent': 'Mozilla/5.0',
-            'Accept-Language': 'zh-CN,zh;q=0.9',
-            Referer: `${BASE}/`,
-            ...(cookie ? { Cookie: cookie } : {}),
-            ...headers,
-        },
-        redirect: 'follow',
-    });
-    if (!resp.ok) throw new CliError('HTTP_ERROR', `HTTP ${resp.status}`);
+    let resp;
+    try {
+        resp = await fetch(url, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0',
+                'Accept-Language': 'zh-CN,zh;q=0.9',
+                Referer: `${BASE}/`,
+                ...(cookie ? { Cookie: cookie } : {}),
+                ...headers,
+            },
+            redirect: 'follow',
+        });
+    } catch (error) {
+        throw new CommandExecutionError(`example request failed: ${error?.message || error}`);
+    }
+    if (!resp.ok) throw new CommandExecutionError(`example request failed: HTTP ${resp.status}`);
     const buf = await resp.arrayBuffer();
     return new TextDecoder(encoding).decode(buf);
 }
@@ -214,6 +224,7 @@ async function fetchHtml(url, { cookie, encoding = 'utf-8', headers = {} } = {})
 cli({
     site: 'example',
     name: 'me',
+    access: 'read',
     description: '示例：需要登录的私有页面',
     domain: HOST,
     strategy: Strategy.COOKIE,
@@ -222,6 +233,9 @@ cli({
     args: [{ name: 'limit', type: 'int', default: 20, help: '返回条数' }],
     columns: ['index', 'title', 'time'],
     func: async (page, args) => {
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) throw new ArgumentError('limit must be a positive integer');
+
         const cookie = await readCookie(page);
         const html = await fetchHtml(`${BASE}/inbox`, { cookie, encoding: 'gbk' });
 
@@ -230,7 +244,8 @@ cli({
         }
 
         // parse html → rows
-        return rows.slice(0, Math.max(1, Number(args.limit) || 20));
+        if (!rows.length) throw new EmptyResultError('example me', 'inbox is empty');
+        return rows.slice(0, limit);
     },
 });
 ```
@@ -275,15 +290,25 @@ for (const opts of [{ domain: HOST }, { domain: ROOT }]) { ... }
 
 双查成本很低，不确定就两个都查，用 Map 去重第一次出现的 name。
 
-### 明确的空态要返回哨兵行，不要 `[]`
+### 空态抛 `EmptyResultError`，**不**塞 sentinel 行
 
-空态（"暂时没有提醒内容" / "暂无通知" / "No results"）返回 `[]`，下游 agent 会当成"接口挂了"而重试。正确做法是返回**一行明确写着当前状态的数据**：
+历史上这里写的是"返回一行说明 row 比 `return []` 安全"。**这条已经反过来了**——见 PR #1329 R3 的 four anti-pattern fixes。现在的契约：
 
 ```javascript
+import { EmptyResultError } from '@jackwener/opencli/errors';
+
+// ❌ 老写法：sentinel 行污染 row 合同，让 listing→detail round-trip 拿到 tid='' 白跑
 if (/暂时没有提醒内容/.test(html)) {
     return [{ index: 0, from: '', summary: '暂时没有提醒内容', time: '', threadUrl: '' }];
 }
+
+// ✅ 新写法：empty 是合法状态，但不是 row。exit code 66 让 agent 直接 branch
+if (/暂时没有提醒内容/.test(html)) {
+    throw new EmptyResultError('1point3acres notifications', '暂时没有提醒内容');
+}
 ```
+
+更多反例和详细 routing 见 [`typed-errors.md` §3](./typed-errors.md)。
 
 ---
 

--- a/skills/opencli-adapter-author/references/typed-errors.md
+++ b/skills/opencli-adapter-author/references/typed-errors.md
@@ -1,6 +1,6 @@
 # Typed Error Conventions
 
-OpenCLI 用 5 类 typed error 让 agent 能从 exit code 直接分辨"参数错 / 没数据 / 接口挂 / 要登录 / 超时"。silent `return []` / silent `return [{sentinel}]` / `Math.max/min` silent clamp / `CliError('HTTP_ERROR')` 这些"绿但错"的写法都被 audit gate 抓得越来越紧（[`scripts/check-typed-error-lint.mjs`](../../../scripts/check-typed-error-lint.mjs) 的 baseline JSON 只能减不能加，新违例必须立刻收掉）。
+OpenCLI 用 5 类 typed error 让 agent 能从 exit code 直接分辨"参数错 / 没数据 / 接口挂 / 要登录 / 超时"。silent `return []` / silent `return [{sentinel}]` / scalar sentinel (`'-'`) / `Math.max/min` silent clamp / `CliError('HTTP_ERROR')` 这些"绿但错"的写法都被 audit gate 抓得越来越紧（[`scripts/check-typed-error-lint.mjs`](../../../scripts/check-typed-error-lint.mjs) 的 baseline JSON 只能减不能加，新违例必须立刻收掉）。
 
 每条 rule 都挂了真实 anti-pattern 反例（PR #1329 三轮迭代是主要素材库）。
 
@@ -24,7 +24,7 @@ OpenCLI 用 5 类 typed error 让 agent 能从 exit code 直接分辨"参数错 
 
 ## 2. Anti-pattern A：silent-clamp 不止 limit
 
-**反例**（PR #1329 R3 codex-mini0 直接修，commit `c40daf7`）：
+**反例**（PR #1329 R3 codex-mini0 直接修，commit `c40daf7`；pre-fix lines: [`thread page/limit/contentLimit`](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/1point3acres/thread.js#L37-L39), [`notifications limit`](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/1point3acres/notifications.js#L41), [`qwen ask timeout`](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/qwen/ask.js#L42), [`qwen image timeout`](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/qwen/image.js#L119), [`qwen history API page_size`](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/qwen/utils.js#L311)）：
 
 ```js
 // ❌ silent clamp — 200 当 100，0/-1 当 1，timeout=5 当 15
@@ -72,9 +72,9 @@ const contentLimit = normalizePositiveInteger(args.contentLimit, 400, 'contentLi
 
 ---
 
-## 3. Anti-pattern B：success-row 当 sentinel 吞 empty / failure
+## 3. Anti-pattern B：sentinel row / scalar sentinel 吞 empty / unknown / failure
 
-**反例 1**（PR #1329 R3 修掉的，[`clis/1point3acres/notifications.js`](../../../clis/1point3acres/notifications.js) before）：
+**反例 1**（PR #1329 R3 修掉的，[`clis/1point3acres/notifications.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/1point3acres/notifications.js#L35-L37)）：
 
 ```js
 // ❌ "暂时没有提醒内容" 是 empty result，不是一行业务数据
@@ -83,7 +83,7 @@ if (/暂时没有提醒内容/.test(html)) {
 }
 ```
 
-**反例 2**（[`clis/1point3acres/search.js`](../../../clis/1point3acres/search.js) before）：
+**反例 2**（[`clis/1point3acres/search.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/1point3acres/search.js#L52-L60)）：
 
 ```js
 // ❌ "抱歉" hint 是搜索无结果，不是 rank=0 的伪结果行
@@ -96,7 +96,7 @@ if (items.length === 0) {
 }
 ```
 
-**反例 3**（[`clis/qwen/history.js`](../../../clis/qwen/history.js) before）：
+**反例 3**（[`clis/qwen/history.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/qwen/history.js#L44-L51)）：
 
 ```js
 // ❌ API failure 不是 conversation 的一行
@@ -105,7 +105,7 @@ if (!result.ok && !result.sessions.length) {
 }
 ```
 
-**反例 4**（[`clis/qwen/image.js`](../../../clis/qwen/image.js) before）：
+**反例 4**（[`clis/qwen/image.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/qwen/image.js#L160-L164)）：
 
 ```js
 // ❌ 单张图片 fetch 失败，伪装成 "⚠️ fetch-failed" 状态行继续
@@ -134,6 +134,26 @@ if (!asset?.ok) {
 }
 ```
 
+**反例 5：scalar sentinel**（PR #1329 R2 修掉的，[`clis/qwen/status.js` before](https://github.com/jackwener/OpenCLI/blob/42e5303c792d9f71d9a30dde2e391405e03661e7/clis/qwen/status.js#L24-L29)）：
+
+```js
+// ❌ '-' 会被下游当成真实 model/session id 字符串
+return [{
+    Status: 'Connected',
+    Login: loggedIn ? 'Yes' : 'No (guest mode)',
+    Model: model || '-',
+    SessionId: sessionId || '-',
+}];
+
+// ✅ unknown 用 null，agent 可以 if (row.Model === null) 干净分支
+return [{
+    Status: 'Connected',
+    Login: loggedIn ? 'Yes' : 'No (guest mode)',
+    Model: model ? model : null,
+    SessionId: sessionId ? sessionId : null,
+}];
+```
+
 **根因**：success row 是"业务数据"的合同。把 empty / failure 塞进 row 会破坏：
 
 1. **round-trip pipeline**：listing → detail 类下游 adapter 拿到 `tid: ''` 会去查 `thread `（""），白跑一轮
@@ -160,7 +180,34 @@ if (items.length === 0) throw new EmptyResultError('site command', `optional con
 
 ---
 
-## 5. Verify fixture 怎么挡这三类
+## 5. Anti-pattern D：generic `CliError('CODE')` 隐藏分类
+
+**反例**（PR #1329 R3 修掉的，[`clis/coingecko/top.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/coingecko/top.js#L36-L38), [`clis/1point3acres/thread.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/1point3acres/thread.js#L45-L46), [`clis/1point3acres/user.js` before](https://github.com/jackwener/OpenCLI/blob/2b8609b82fccaf98505c5b1b1859e3ffdaa1a55c/clis/1point3acres/user.js#L35-L36)）：
+
+```js
+// ❌ 都是 exit 1，agent 无法区分服务失败 vs 空结果 vs bad args
+if (!resp.ok) throw new CliError('HTTP_ERROR', `HTTP ${resp.status}`);
+if (!Array.isArray(data) || data.length === 0) throw new CliError('NO_DATA', 'no data');
+if (!/id="postlist"/.test(html)) throw new CliError('THREAD_NOT_FOUND', `帖子 ${tid} 不存在`);
+```
+
+**修法**：
+
+```js
+// HTTP / fetch / JSON / in-band API error → runtime failure
+if (!resp.ok) throw new CommandExecutionError(`request failed: HTTP ${resp.status}`);
+if (!Array.isArray(data)) throw new CommandExecutionError('unexpected response shape');
+
+// valid empty / resource missing → empty result
+if (data.length === 0) throw new EmptyResultError('coingecko top', 'no market data');
+if (!/id="postlist"/.test(html)) throw new EmptyResultError('1point3acres thread', `帖子 ${tid} 不存在`);
+```
+
+`CliError` is still the base class underneath every typed error, and core runtime primitives may throw it internally. Adapter code should not directly `new CliError(...)`; pick one of the five classes in §1 so scripts and agents can branch on stable exit codes.
+
+---
+
+## 6. Verify fixture 怎么挡这三类
 
 新写 fixture 时（`~/.opencli/sites/<site>/verify/<cmd>.json`）：
 
@@ -171,16 +218,17 @@ if (items.length === 0) throw new EmptyResultError('site command', `optional con
 
 ---
 
-## 6. 已经 grandfathered 的旧 adapter
+## 7. 已经 grandfathered 的旧 adapter
 
 repo 里仍有相当数量的 `CliError('HTTP_ERROR')` / `Math.max(1, Math.min(...))` 式的旧写法，被 [`scripts/typed-error-lint-baseline.json`](../../../scripts/typed-error-lint-baseline.json) 圈住（baseline 只允许减、不允许加）。**新写 adapter 必须按本文档**；旧 adapter 不强制立刻迁移，但碰到时顺手收一条是欢迎的——清掉一条 baseline 自然下降一条，gate 不会卡。
 
 ---
 
-## 7. 自查清单（PR push 前）
+## 8. 自查清单（PR push 前）
 
 - [ ] adapter 没有 `Math.max(1, Math.min(...))` / `Math.max(N, ...)` clamp 在外部参数上
 - [ ] adapter 没有 `return []` / `return [{...sentinel...}]` 当 empty / failure 兜底
+- [ ] adapter 没有 `'-'` / `'N/A'` 这类 scalar sentinel 冒充 real value；语义可空就返回 `null`
 - [ ] adapter 抛的不是 `CliError('XXX')`，而是 5 类 typed error 之一
 - [ ] verify fixture 的 `rowCount.min ≥ 1`，sentinel row 过不了
 - [ ] `npm run check:typed-error-lint` 跑过 → baseline 没增加

--- a/skills/opencli-adapter-author/references/typed-errors.md
+++ b/skills/opencli-adapter-author/references/typed-errors.md
@@ -1,0 +1,186 @@
+# Typed Error Conventions
+
+OpenCLI 用 5 类 typed error 让 agent 能从 exit code 直接分辨"参数错 / 没数据 / 接口挂 / 要登录 / 超时"。silent `return []` / silent `return [{sentinel}]` / `Math.max/min` silent clamp / `CliError('HTTP_ERROR')` 这些"绿但错"的写法都被 audit gate 抓得越来越紧（[`scripts/check-typed-error-lint.mjs`](../../../scripts/check-typed-error-lint.mjs) 的 baseline JSON 只能减不能加，新违例必须立刻收掉）。
+
+每条 rule 都挂了真实 anti-pattern 反例（PR #1329 三轮迭代是主要素材库）。
+
+---
+
+## 1. 5-classification 落点表
+
+| 场景 | 抛 | code | exit |
+|------|-----|------|------|
+| 参数不合法（包括越界、格式错、缺主语 positional） | `ArgumentError(message)` | `ARGUMENT` | 2 |
+| 业务无数据 / 资源不存在 | `EmptyResultError(command, hint?)` | `EMPTY_RESULT` | 66 |
+| HTTP 非 2xx / fetch throw / JSON parse 错 / 接口业务报错 | `CommandExecutionError(message)` | `COMMAND_EXEC` | 1 |
+| 需要登录（cookie 缺 / 401 / 302 → /login / "请登录" 页） | `AuthRequiredError(domain, message?)` | `AUTH_REQUIRED` | 77 |
+| 等响应超时（CDP / page.evaluate / 流式回复） | `TimeoutError(label, seconds)` | `TIMEOUT` | 75 |
+
+类签名定义见 [`src/errors.ts`](../../../src/errors.ts)。
+
+**禁止泛用 `CliError('HTTP_ERROR' / 'NO_DATA' / 'USER_NOT_FOUND' / 'FETCH_ERROR' / 'INVALID_ARGUMENT' / 'API_ERROR' / 'THREAD_NOT_FOUND')`** —— 这些都对应到 5 类里其中一个，没有不能映射的场景（PR #1329 R3 commit `c40daf7` 把 7 处 `CliError(...)` 全部替换成了上面 5 类）。`CliError` 基类只用作子类的实现细节，adapter 代码不应直接 new。
+
+---
+
+## 2. Anti-pattern A：silent-clamp 不止 limit
+
+**反例**（PR #1329 R3 codex-mini0 直接修，commit `c40daf7`）：
+
+```js
+// ❌ silent clamp — 200 当 100，0/-1 当 1，timeout=5 当 15
+const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+const timeout = Math.max(15, parseInt(kwargs.timeout, 10) || 120);
+const contentLimit = Math.max(50, Number(args.contentLimit) || 400);
+const page = Math.max(1, Number(args.page) || 1);
+```
+
+**修法**（[`clis/1point3acres/utils.js`](../../../clis/1point3acres/utils.js) 的 `normalizePositiveInteger` / `normalizeLimit`）：
+
+```js
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+/** Validate a positive integer arg without silently flooring/clamping. */
+export function normalizePositiveInteger(value, defaultValue, label = 'value', { min = 1 } = {}) {
+    const raw = value ?? defaultValue;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n <= 0) throw new ArgumentError(`${label} must be a positive integer`);
+    if (n < min) throw new ArgumentError(`${label} must be >= ${min}`);
+    return n;
+}
+
+/** With both lower bound and an explicit ceiling. */
+export function normalizeLimit(value, defaultValue, maxValue, label = 'limit') {
+    const n = normalizePositiveInteger(value, defaultValue, label);
+    if (n > maxValue) throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    return n;
+}
+```
+
+**用法**（[`clis/1point3acres/thread.js#L37-L39`](../../../clis/1point3acres/thread.js)）：
+
+```js
+const page = normalizePositiveInteger(args.page, 1, 'page');
+const limit = normalizePositiveInteger(args.limit, 10, 'limit');
+const contentLimit = normalizePositiveInteger(args.contentLimit, 400, 'contentLimit', { min: 50 });
+```
+
+**注意**：当前 silent-clamp 检测的 regex（在 [`src/convention-audit.ts`](../../../src/convention-audit.ts) 的 `auditTypedErrorPatterns` 节，由 [`scripts/check-typed-error-lint.mjs`](../../../scripts/check-typed-error-lint.mjs) 调）只抓 `Math.min(...limit...)`。`Math.max(1, ...)` 单边 floor 和非-`limit` 命名（`page` / `timeout` / `contentLimit`）都不在 regex 里，所以 #1329 R3 时被 F-P-0 review 而不是 gate 挡下来 → 必须靠**人审 checklist** 兜：**任何外部参数（args.\* / kwargs.\*）做 Math.max / Math.min / `|| N` 当兜底都是 silent-clamp**。
+
+### 何时抽 site-level helper
+
+≥ 2 个同站 adapter 都要做同样的 limit / page 校验时，把 `normalizeLimit` / `normalizePositiveInteger` 抽到 `clis/<site>/utils.js`。1 个 adapter 用就直接 inline，别为 1 处单点抽 helper。
+
+---
+
+## 3. Anti-pattern B：success-row 当 sentinel 吞 empty / failure
+
+**反例 1**（PR #1329 R3 修掉的，[`clis/1point3acres/notifications.js`](../../../clis/1point3acres/notifications.js) before）：
+
+```js
+// ❌ "暂时没有提醒内容" 是 empty result，不是一行业务数据
+if (/暂时没有提醒内容/.test(html)) {
+    return [{ index: 0, from: '', summary: '暂时没有提醒内容', time: '', threadUrl: '' }];
+}
+```
+
+**反例 2**（[`clis/1point3acres/search.js`](../../../clis/1point3acres/search.js) before）：
+
+```js
+// ❌ "抱歉" hint 是搜索无结果，不是 rank=0 的伪结果行
+if (items.length === 0) {
+    const hint = html.match(/<p>([^<]*?抱歉[^<]*?)<\/p>/);
+    if (hint) {
+        return [{ rank: 0, tid: '', title: hint[1].trim(), forum: '', author: '', replies: 0, views: 0, postTime: '', url: '' }];
+    }
+    return [];
+}
+```
+
+**反例 3**（[`clis/qwen/history.js`](../../../clis/qwen/history.js) before）：
+
+```js
+// ❌ API failure 不是 conversation 的一行
+if (!result.ok && !result.sessions.length) {
+    return [{ Index: 0, Title: `API failed (status=${result.status})`, Updated: '', Url: '' }];
+}
+```
+
+**反例 4**（[`clis/qwen/image.js`](../../../clis/qwen/image.js) before）：
+
+```js
+// ❌ 单张图片 fetch 失败，伪装成 "⚠️ fetch-failed" 状态行继续
+if (!asset?.ok) {
+    results.push({ Status: `⚠️ fetch-failed(${asset?.status || '?'})`, File: '-', Link: link });
+    continue;
+}
+```
+
+**修法**：
+
+```js
+import { EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+if (/暂时没有提醒内容/.test(html)) {
+    throw new EmptyResultError('1point3acres notifications', '暂时没有提醒内容');
+}
+if (items.length === 0) {
+    throw new EmptyResultError('1point3acres search', `No results for "${query}"`);
+}
+if (!result.ok && !result.sessions.length) {
+    throw new CommandExecutionError(`Qianwen history API failed (status=${result.status})`);
+}
+if (!asset?.ok) {
+    throw new CommandExecutionError(`Failed to fetch image: status=${asset?.status || '?'}`);
+}
+```
+
+**根因**：success row 是"业务数据"的合同。把 empty / failure 塞进 row 会破坏：
+
+1. **round-trip pipeline**：listing → detail 类下游 adapter 拿到 `tid: ''` 会去查 `thread `（""），白跑一轮
+2. **exit code semantics**：empty 应该 exit 66、API fail 应该 exit 1，混进 row 后两者都 exit 0，agent 没法 branch
+3. **fixture rowCount.min=1**：sentinel row 让 verify 永远过 → 真的接口挂了也看不见
+
+**对比 #1290 twitter trending**：当时也踩过 silent N/A row 的坑，drop 掉那行比留个 silent-wrong 字段诚实——这是 2026-05-04 的早期教训。typed-errors 把"drop"升级成"throw EmptyResultError"，下游 agent 能直接从 exit code 66 分辨 empty vs 真实数据错位。
+
+---
+
+## 4. Anti-pattern C：`return []` 当 silent fallback
+
+`adapter` 跑完什么都没拿到不能 `return []`：
+
+```js
+// ❌
+if (items.length === 0) return [];
+
+// ✅
+if (items.length === 0) throw new EmptyResultError('site command', `optional context`);
+```
+
+`EmptyResultError` 的 hint 默认是 `'The page structure may have changed, or you may need to log in'`（见 [`src/errors.ts#L134`](../../../src/errors.ts)），自己传 message 比默认更有用：写**为什么空了**（"No results for '<query>'" / "uid=<X> 在该论坛没有发过帖子"）。
+
+---
+
+## 5. Verify fixture 怎么挡这三类
+
+新写 fixture 时（`~/.opencli/sites/<site>/verify/<cmd>.json`）：
+
+- **rowCount.min ≥ 1**：保证 sentinel-row 不能伪装通过
+- **patterns**：核心 id 列加 `^\d+$` 类正则，挡 `tid: ''` / `pid: ''` 之类空字符串污染
+- **mustBeTruthy**：业务数值列（`replies` / `views` / `count`）必须 truthy，挡 `|| 0` silent fallback
+- **预期 EmptyResultError 是合法返回时**（例如某条 fixture 故意搜不出来）用 `expect.exitCode: 66` 让"空态合法"和"adapter 崩了"在 fixture 层就分开（参见 [`site-memory.md`](./site-memory.md) verify schema）
+
+---
+
+## 6. 已经 grandfathered 的旧 adapter
+
+repo 里仍有相当数量的 `CliError('HTTP_ERROR')` / `Math.max(1, Math.min(...))` 式的旧写法，被 [`scripts/typed-error-lint-baseline.json`](../../../scripts/typed-error-lint-baseline.json) 圈住（baseline 只允许减、不允许加）。**新写 adapter 必须按本文档**；旧 adapter 不强制立刻迁移，但碰到时顺手收一条是欢迎的——清掉一条 baseline 自然下降一条，gate 不会卡。
+
+---
+
+## 7. 自查清单（PR push 前）
+
+- [ ] adapter 没有 `Math.max(1, Math.min(...))` / `Math.max(N, ...)` clamp 在外部参数上
+- [ ] adapter 没有 `return []` / `return [{...sentinel...}]` 当 empty / failure 兜底
+- [ ] adapter 抛的不是 `CliError('XXX')`，而是 5 类 typed error 之一
+- [ ] verify fixture 的 `rowCount.min ≥ 1`，sentinel row 过不了
+- [ ] `npm run check:typed-error-lint` 跑过 → baseline 没增加


### PR DESCRIPTION
## Summary

Distills the 6 reusable conventions from PR #1329's three-round review into the `opencli-adapter-author` skill so the next agent writing an adapter for a new site doesn't re-litigate the same review-round trips.

This is the follow-up skill PR pr-monitor and I agreed on after #1329 merged ([msg=fca5a202](https://github.com/jackwener/OpenCLI/pull/1329) / msg=d20b5069). All 6 rules link concrete file/line references in real `c40daf7` (round 3) / `42e5303c` (round 1) / `2b8609b8` (round 2) commits as anti-pattern reversal examples.

### What's new

- **`skills/opencli-adapter-author/references/typed-errors.md`** (new, ~190 LOC)
  - §1 — 5-classification routing table: ArgumentError / EmptyResultError / CommandExecutionError / AuthRequiredError / TimeoutError, with codes + exit codes
  - §2 — Anti-pattern A: silent-clamp **not just `limit`** (covers `page` / `contentLimit` / `timeout`); `normalizeLimit` / `normalizePositiveInteger` site-helper template referencing `clis/1point3acres/utils.js`; honest disclaimer that current `silent-clamp` regex only catches `Math.min(...limit...)` so non-`limit` clamps need human-review checklist
  - §3 — Anti-pattern B: success-row carrying empty / failure semantics, with 4 concrete pre-`c40daf7` reversal examples (1point3acres `notifications` 暂时没有提醒 row / 1point3acres `search` 抱歉 row / qwen `history` 'API failed' row / qwen `image` ⚠️ fetch-failed row)
  - §4 — Anti-pattern C: `return []` silent fallback → `EmptyResultError(command, hint)`
  - §5 — Verify-fixture defenses (`rowCount.min ≥ 1`, `patterns` on id columns, `mustBeTruthy` on numeric columns)
  - §6 — Grandfathering policy: `scripts/typed-error-lint-baseline.json` is the legacy-violation snapshot, baseline-only-decreases gate
  - §7 — Pre-PR self-check (5 items)

- **`skills/opencli-adapter-author/references/adapter-template.md`** (modified)
  - Flipped the misleading "sentinel-row for empty" section — now shows before/after with `EmptyResultError`
  - Replaced legacy error-handling table with typed-errors.md pointer + the three concrete bans
  - Loud `browser:` field-vs-signature callout (8 adapters in pre-#1329 backlog hit this)
  - Intermediate-object naming rule (R1 lesson) — keys must not overlap with `columns`
  - Updated `func` body example + COOKIE skeleton to use typed errors instead of `CliError(...)`
  - Tagged `convertible.js` as grandfathered so agents don't blindly copy its legacy clamp + `CliError` style

- **`skills/opencli-adapter-author/SKILL.md`** (modified)
  - Reference-table row for typed-errors.md
  - 关键约定 updated with three new conventions; removed outdated "throw `CliError('CODE', 'msg')`" advice

### What's NOT in this PR

- No code changes (no `.ts` / `.js` edits, no adapter migrations)
- No new CI gates or scripts (the existing `scripts/check-typed-error-lint.mjs` baseline already enforces this)
- No new schema / config

Per the team's "no over-engineering" preference (cf. #1311 review feedback), this PR is precision-fix on existing skill docs, not new infrastructure. Just words explaining what the audit gates already enforce, anchored to real PR #1329 commits.

## Test plan

- [ ] Doc-only — sanity check: no `.ts` / `.js` / `clis/` / `scripts/` edits in diff
- [ ] All cross-file refs in typed-errors.md resolve to existing files (verified locally for `clis/1point3acres/utils.js`, `clis/1point3acres/thread.js`, `clis/1point3acres/notifications.js`, `clis/1point3acres/search.js`, `clis/qwen/history.js`, `clis/qwen/image.js`, `src/errors.ts`, `src/convention-audit.ts`, `scripts/check-typed-error-lint.mjs`, `scripts/typed-error-lint-baseline.json`, `clis/eastmoney/convertible.js`)
- [ ] CI green (typecheck + build + manifest + silent-column-drop + typed-error-lint + doc-coverage; this PR doesn't touch any of their inputs)