### PR TITLE
fix(web/read): extract same-origin iframes outside contentEl

### DIFF
--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -277,6 +277,31 @@ function buildRenderAwareExtractorJs(options) {
               result.diagnostics.includedFrameCount += 1;
             } catch {}
           });
+
+          // Also extract same-origin iframes that live outside contentEl.
+          // originalFrames only covers iframes inside the selected content element;
+          // meaningful iframes elsewhere in the document (e.g. above the fold) are
+          // never processed by the loop above, so their content is silently dropped.
+          allFrames.forEach((frame, index) => {
+            if (contentEl.contains(frame)) return; // already handled above
+            const desc = describeFrame(frame, index);
+            if (!desc.sameOrigin || !desc.accessible || (desc.textLength || 0) < 50) return;
+            try {
+              const doc = frame.contentDocument;
+              if (!doc?.body) return;
+              const frameBody = doc.body.cloneNode(true);
+              absolutizeTree(frameBody, desc.src || window.location.href);
+              collectEmptyContainers(frameBody, 'iframe', desc.src);
+              const section = document.createElement('section');
+              section.setAttribute('data-opencli-iframe-source', desc.src);
+              const heading = document.createElement('h2');
+              heading.textContent = '来自 iframe: ' + (desc.src || frame.getAttribute('src') || ('#' + index));
+              section.appendChild(heading);
+              Array.from(frameBody.childNodes).forEach(node => section.appendChild(node));
+              clone.appendChild(section);
+              result.diagnostics.includedFrameCount += 1;
+            } catch {}
+          });
         }
 
         collectEmptyContainers(clone, 'main', window.location.href);


### PR DESCRIPTION
## Problem

When `--frames same-origin` is enabled, `buildRenderAwareExtractorJs()` builds `originalFrames` by querying only within `contentEl` (the heuristically selected main content element):

```js
const originalFrames = Array.from(contentEl.querySelectorAll('iframe'));
```

Any same-origin iframe that exists **outside** `contentEl` — for example above the fold, in a header region, or in a sidebar — appears in `allFrames` and is reported in diagnostics (`frames: N, included_same_origin: 0`), but its content is never extracted or merged into the output. The result is silent content loss for pages where meaningful data lives in an iframe that the content-selection heuristic places outside the main element.

## Root cause

`allFrames` was only used to populate `result.diagnostics.frames`. It played no role in content extraction. The `originalFrames` loop, which does the actual extraction, only iterates over iframes inside `contentEl`.

## Fix

After the existing `originalFrames.forEach(...)` loop, add a second pass over `allFrames` that:

1. **Skips** any frame already contained within `contentEl` (to avoid duplication with the first loop).
2. **Filters** to accessible same-origin frames with at least 50 characters of text content — this threshold excludes navigation bars, ad slots, and other low-signal iframes without requiring any site-specific logic.
3. **Appends** the qualifying frame bodies as `<section data-opencli-iframe-source="...">` elements to `clone`, following the same pattern used by the first loop.

```js
// Also extract same-origin iframes that live outside contentEl.
allFrames.forEach((frame, index) => {
  if (contentEl.contains(frame)) return; // already handled above
  const desc = describeFrame(frame, index);
  if (!desc.sameOrigin || !desc.accessible || (desc.textLength || 0) < 50) return;
  try {
    const doc = frame.contentDocument;
    if (!doc?.body) return;
    const frameBody = doc.body.cloneNode(true);
    absolutizeTree(frameBody, desc.src || window.location.href);
    collectEmptyContainers(frameBody, 'iframe', desc.src);
    const section = document.createElement('section');
    section.setAttribute('data-opencli-iframe-source', desc.src);
    const heading = document.createElement('h2');
    heading.textContent = '来自 iframe: ' + (desc.src || frame.getAttribute('src') || ('#' + index));
    section.appendChild(heading);
    Array.from(frameBody.childNodes).forEach(node => section.appendChild(node));
    clone.appendChild(section);
    result.diagnostics.includedFrameCount += 1;
  } catch {}
});
```

## Verification

With this fix, `--diagnose` output changes from `included_same_origin: 0` to `included_same_origin: 1` (or more) for pages that have qualifying iframes outside `contentEl`, and the previously missing content appears in the Markdown output. Pages without such iframes are unaffected.

## Notes

- The 50-character `textLength` threshold is intentionally generic — it filters noise without encoding any site-specific knowledge.
- The fix follows the identical cloning/absolutizing/section-wrapping pattern already used in the `originalFrames` loop, so behavior is consistent.
- No changes to the diagnostics schema or CLI interface.