### PR TITLE
feat(browser): add --width / --height / --full-page flags to screenshot

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -119,17 +119,35 @@ const evaluateAsync = evaluate;
 async function screenshot(tabId, options = {}) {
   await ensureAttached(tabId);
   const format = options.format ?? "png";
-  if (options.fullPage) {
-    const metrics = await chrome.debugger.sendCommand({ tabId }, "Page.getLayoutMetrics");
-    const size = metrics.cssContentSize || metrics.contentSize;
-    if (size) {
+  const fullPage = options.fullPage === true;
+  const overrideWidth = options.width && options.width > 0 ? Math.ceil(options.width) : void 0;
+  const overrideHeight = !fullPage && options.height && options.height > 0 ? Math.ceil(options.height) : void 0;
+  const needsOverride = fullPage || overrideWidth !== void 0 || overrideHeight !== void 0;
+  if (needsOverride) {
+    if (overrideWidth !== void 0 && fullPage) {
       await chrome.debugger.sendCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
         mobile: false,
-        width: Math.ceil(size.width),
-        height: Math.ceil(size.height),
+        width: overrideWidth,
+        height: 0,
         deviceScaleFactor: 1
       });
     }
+    let finalWidth = overrideWidth ?? 0;
+    let finalHeight = overrideHeight ?? 0;
+    if (fullPage) {
+      const metrics = await chrome.debugger.sendCommand({ tabId }, "Page.getLayoutMetrics");
+      const size = metrics.cssContentSize || metrics.contentSize;
+      if (size) {
+        if (finalWidth === 0) finalWidth = Math.ceil(size.width);
+        finalHeight = Math.ceil(size.height);
+      }
+    }
+    await chrome.debugger.sendCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
+      mobile: false,
+      width: finalWidth,
+      height: finalHeight,
+      deviceScaleFactor: 1
+    });
   }
   try {
     const params = { format };
@@ -139,7 +157,7 @@ async function screenshot(tabId, options = {}) {
     const result = await chrome.debugger.sendCommand({ tabId }, "Page.captureScreenshot", params);
     return result.data;
   } finally {
-    if (options.fullPage) {
+    if (needsOverride) {
       await chrome.debugger.sendCommand({ tabId }, "Emulation.clearDeviceMetricsOverride").catch(() => {
       });
     }
@@ -1434,7 +1452,9 @@ async function handleScreenshot(cmd, workspace) {
     const data = await screenshot(tabId, {
       format: cmd.format,
       quality: cmd.quality,
-      fullPage: cmd.fullPage
+      fullPage: cmd.fullPage,
+      width: cmd.width,
+      height: cmd.height
     });
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1267,6 +1267,8 @@ async function handleScreenshot(cmd: Command, workspace: string): Promise<Result
       format: cmd.format,
       quality: cmd.quality,
       fullPage: cmd.fullPage,
+      width: cmd.width,
+      height: cmd.height,
     });
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -92,3 +92,158 @@ describe('cdp attach recovery', () => {
   });
 
 });
+
+function chromeMockForScreenshot(content: { width: number; height: number } = { width: 1024, height: 2048 }) {
+  const calls: Array<{ method: string; params?: unknown }> = [];
+  const debuggerApi = {
+    attach: vi.fn(async () => {}),
+    detach: vi.fn(async () => {}),
+    sendCommand: vi.fn(async (_target: unknown, method: string, params?: unknown) => {
+      calls.push({ method, params });
+      if (method === 'Page.captureScreenshot') return { data: 'BASE64DATA' };
+      if (method === 'Page.getLayoutMetrics') return { cssContentSize: content };
+      return {};
+    }),
+    onDetach: { addListener: vi.fn() },
+    onEvent: { addListener: vi.fn() },
+  };
+  const tabs = {
+    get: vi.fn(async () => ({ id: 1, windowId: 1, url: 'https://example.com' })),
+    onRemoved: { addListener: vi.fn() },
+    onUpdated: { addListener: vi.fn() },
+  };
+  return {
+    chrome: { tabs, debugger: debuggerApi, scripting: {}, runtime: { id: 'opencli-test' } },
+    debuggerApi,
+    calls,
+  };
+}
+
+describe('cdp screenshot', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('takes a viewport screenshot without overriding device metrics by default', async () => {
+    const { chrome, calls } = chromeMockForScreenshot();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    const data = await mod.screenshot(1);
+
+    expect(data).toBe('BASE64DATA');
+    const methods = calls.map((c) => c.method);
+    expect(methods).not.toContain('Emulation.setDeviceMetricsOverride');
+    expect(methods).not.toContain('Emulation.clearDeviceMetricsOverride');
+    expect(methods).toContain('Page.captureScreenshot');
+  });
+
+  it('overrides only width when --width is given without --full-page', async () => {
+    const { chrome, calls } = chromeMockForScreenshot();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await mod.screenshot(1, { width: 1080 });
+
+    const overrides = calls.filter((c) => c.method === 'Emulation.setDeviceMetricsOverride');
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0].params).toEqual({ mobile: false, width: 1080, height: 0, deviceScaleFactor: 1 });
+    expect(calls.some((c) => c.method === 'Page.getLayoutMetrics')).toBe(false);
+    expect(calls.at(-1)?.method).toBe('Emulation.clearDeviceMetricsOverride');
+  });
+
+  it('overrides only height when --height is given without --full-page', async () => {
+    const { chrome, calls } = chromeMockForScreenshot();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await mod.screenshot(1, { height: 720 });
+
+    const overrides = calls.filter((c) => c.method === 'Emulation.setDeviceMetricsOverride');
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0].params).toEqual({ mobile: false, width: 0, height: 720, deviceScaleFactor: 1 });
+    expect(calls.at(-1)?.method).toBe('Emulation.clearDeviceMetricsOverride');
+  });
+
+  it('uses content size for fullPage screenshots without explicit dimensions', async () => {
+    const { chrome, calls } = chromeMockForScreenshot({ width: 1024, height: 2048 });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await mod.screenshot(1, { fullPage: true });
+
+    const overrides = calls.filter((c) => c.method === 'Emulation.setDeviceMetricsOverride');
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0].params).toEqual({ mobile: false, width: 1024, height: 2048, deviceScaleFactor: 1 });
+    expect(calls.at(-1)?.method).toBe('Emulation.clearDeviceMetricsOverride');
+  });
+
+  it('ignores --height under --full-page so the existing measure-from-content path is preserved', async () => {
+    const { chrome, calls } = chromeMockForScreenshot({ width: 1024, height: 2048 });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await mod.screenshot(1, { fullPage: true, height: 600 });
+
+    const overrides = calls.filter((c) => c.method === 'Emulation.setDeviceMetricsOverride');
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0].params).toEqual({ mobile: false, width: 1024, height: 2048, deviceScaleFactor: 1 });
+    expect(calls.at(-1)?.method).toBe('Emulation.clearDeviceMetricsOverride');
+  });
+
+  it('reflows at the requested width before measuring full-page height', async () => {
+    // Simulate that at width=1080 the page reflows to a different content height.
+    const { chrome, calls } = chromeMockForScreenshot({ width: 1080, height: 1500 });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await mod.screenshot(1, { fullPage: true, width: 1080 });
+
+    const overrides = calls.filter((c) => c.method === 'Emulation.setDeviceMetricsOverride');
+    expect(overrides).toHaveLength(2);
+    expect(overrides[0].params).toEqual({ mobile: false, width: 1080, height: 0, deviceScaleFactor: 1 });
+    expect(overrides[1].params).toEqual({ mobile: false, width: 1080, height: 1500, deviceScaleFactor: 1 });
+
+    const layoutBetween = calls.findIndex((c) => c.method === 'Page.getLayoutMetrics');
+    const firstOverride = calls.findIndex((c) => c.method === 'Emulation.setDeviceMetricsOverride');
+    expect(layoutBetween).toBeGreaterThan(firstOverride);
+    expect(calls.at(-1)?.method).toBe('Emulation.clearDeviceMetricsOverride');
+  });
+
+  it('clears the device metrics override even when capture throws', async () => {
+    const debuggerApi = {
+      attach: vi.fn(async () => {}),
+      detach: vi.fn(async () => {}),
+      sendCommand: vi.fn(async (_t: unknown, method: string) => {
+        if (method === 'Page.captureScreenshot') throw new Error('capture-failed');
+        if (method === 'Page.getLayoutMetrics') return { cssContentSize: { width: 800, height: 600 } };
+        return {};
+      }),
+      onDetach: { addListener: vi.fn() },
+      onEvent: { addListener: vi.fn() },
+    };
+    const chrome = {
+      tabs: {
+        get: vi.fn(async () => ({ id: 1, windowId: 1, url: 'https://example.com' })),
+        onRemoved: { addListener: vi.fn() },
+        onUpdated: { addListener: vi.fn() },
+      },
+      debugger: debuggerApi,
+      scripting: {},
+      runtime: { id: 'opencli-test' },
+    };
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await expect(mod.screenshot(1, { width: 800 })).rejects.toThrow('capture-failed');
+
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith(
+      { tabId: 1 },
+      'Emulation.clearDeviceMetricsOverride',
+    );
+  });
+});

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -190,29 +190,46 @@ export const evaluateAsync = evaluate;
  */
 export async function screenshot(
   tabId: number,
-  options: { format?: 'png' | 'jpeg'; quality?: number; fullPage?: boolean } = {},
+  options: { format?: 'png' | 'jpeg'; quality?: number; fullPage?: boolean; width?: number; height?: number } = {},
 ): Promise<string> {
   await ensureAttached(tabId);
 
   const format = options.format ?? 'png';
+  const fullPage = options.fullPage === true;
+  const overrideWidth = options.width && options.width > 0 ? Math.ceil(options.width) : undefined;
+  // height is ignored under fullPage so the existing measure-from-content path stays unchanged for users who pass --height alongside --full-page.
+  const overrideHeight = !fullPage && options.height && options.height > 0 ? Math.ceil(options.height) : undefined;
+  const needsOverride = fullPage || overrideWidth !== undefined || overrideHeight !== undefined;
 
-  // For full-page screenshots, get the full page dimensions first
-  if (options.fullPage) {
-    // Get full page metrics
-    const metrics = await chrome.debugger.sendCommand({ tabId }, 'Page.getLayoutMetrics') as {
-      contentSize?: { width: number; height: number };
-      cssContentSize?: { width: number; height: number };
-    };
-    const size = metrics.cssContentSize || metrics.contentSize;
-    if (size) {
-      // Set device metrics to full page size
+  if (needsOverride) {
+    // When width is set, apply it first so layout reflows before we read content size.
+    if (overrideWidth !== undefined && fullPage) {
       await chrome.debugger.sendCommand({ tabId }, 'Emulation.setDeviceMetricsOverride', {
         mobile: false,
-        width: Math.ceil(size.width),
-        height: Math.ceil(size.height),
+        width: overrideWidth,
+        height: 0,
         deviceScaleFactor: 1,
       });
     }
+    let finalWidth = overrideWidth ?? 0;
+    let finalHeight = overrideHeight ?? 0;
+    if (fullPage) {
+      const metrics = await chrome.debugger.sendCommand({ tabId }, 'Page.getLayoutMetrics') as {
+        contentSize?: { width: number; height: number };
+        cssContentSize?: { width: number; height: number };
+      };
+      const size = metrics.cssContentSize || metrics.contentSize;
+      if (size) {
+        if (finalWidth === 0) finalWidth = Math.ceil(size.width);
+        finalHeight = Math.ceil(size.height);
+      }
+    }
+    await chrome.debugger.sendCommand({ tabId }, 'Emulation.setDeviceMetricsOverride', {
+      mobile: false,
+      width: finalWidth,
+      height: finalHeight,
+      deviceScaleFactor: 1,
+    });
   }
 
   try {
@@ -227,8 +244,7 @@ export async function screenshot(
 
     return result.data;
   } finally {
-    // Reset device metrics if we changed them for full-page
-    if (options.fullPage) {
+    if (needsOverride) {
       await chrome.debugger.sendCommand({ tabId }, 'Emulation.clearDeviceMetricsOverride').catch(() => {});
     }
   }

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -50,6 +50,10 @@ export interface Command {
   quality?: number;
   /** Whether to capture full page (not just viewport) */
   fullPage?: boolean;
+  /** Override viewport width in CSS pixels for screenshot (0 / undefined = use current) */
+  width?: number;
+  /** Override viewport height in CSS pixels for screenshot (0 / undefined = use current; ignored when fullPage) */
+  height?: number;
   /** Local file paths for set-file-input action */
   files?: string[];
   /** CSS selector for file input element (set-file-input action) */

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -244,16 +244,58 @@ class CDPPage extends BasePage {
   }
 
   async screenshot(options: ScreenshotOptions = {}): Promise<string> {
-    const result = await this.bridge.send('Page.captureScreenshot', {
-      format: options.format ?? 'png',
-      quality: options.format === 'jpeg' ? (options.quality ?? 80) : undefined,
-      captureBeyondViewport: options.fullPage ?? false,
-    });
-    const base64 = isRecord(result) && typeof result.data === 'string' ? result.data : '';
-    if (options.path) {
-      await saveBase64ToFile(base64, options.path);
+    const fullPage = options.fullPage === true;
+    const overrideWidth = options.width && options.width > 0 ? Math.ceil(options.width) : undefined;
+    // height is ignored under fullPage so the captureBeyondViewport path stays unchanged for users who pass --height alongside --full-page.
+    const overrideHeight = !fullPage && options.height && options.height > 0 ? Math.ceil(options.height) : undefined;
+    const needsOverride = overrideWidth !== undefined || overrideHeight !== undefined;
+
+    if (needsOverride) {
+      if (overrideWidth !== undefined && fullPage) {
+        await this.bridge.send('Emulation.setDeviceMetricsOverride', {
+          mobile: false,
+          width: overrideWidth,
+          height: 0,
+          deviceScaleFactor: 1,
+        });
+      }
+      let finalWidth = overrideWidth ?? 0;
+      let finalHeight = overrideHeight ?? 0;
+      if (fullPage) {
+        const metrics = await this.bridge.send('Page.getLayoutMetrics');
+        const m = isRecord(metrics) ? metrics : {};
+        const css = isRecord(m.cssContentSize) ? m.cssContentSize : undefined;
+        const fb = isRecord(m.contentSize) ? m.contentSize : undefined;
+        const size = css ?? fb;
+        if (size && typeof size.width === 'number' && typeof size.height === 'number') {
+          if (finalWidth === 0) finalWidth = Math.ceil(size.width);
+          finalHeight = Math.ceil(size.height);
+        }
+      }
+      await this.bridge.send('Emulation.setDeviceMetricsOverride', {
+        mobile: false,
+        width: finalWidth,
+        height: finalHeight,
+        deviceScaleFactor: 1,
+      });
     }
-    return base64;
+
+    try {
+      const result = await this.bridge.send('Page.captureScreenshot', {
+        format: options.format ?? 'png',
+        quality: options.format === 'jpeg' ? (options.quality ?? 80) : undefined,
+        captureBeyondViewport: !needsOverride && fullPage,
+      });
+      const base64 = isRecord(result) && typeof result.data === 'string' ? result.data : '';
+      if (options.path) {
+        await saveBase64ToFile(base64, options.path);
+      }
+      return base64;
+    } finally {
+      if (needsOverride) {
+        await this.bridge.send('Emulation.clearDeviceMetricsOverride').catch(() => {});
+      }
+    }
   }
 
   async startNetworkCapture(pattern: string = ''): Promise<boolean> {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -36,6 +36,10 @@ export interface DaemonCommand {
   format?: 'png' | 'jpeg';
   quality?: number;
   fullPage?: boolean;
+  /** Override viewport width in CSS pixels for screenshot (0 / undefined = use current) */
+  width?: number;
+  /** Override viewport height in CSS pixels for screenshot (0 / undefined = use current; ignored when fullPage) */
+  height?: number;
 
   /** Local file paths for set-file-input action */
   files?: string[];

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -278,3 +278,39 @@ describe('Page active target tracking', () => {
     expect(evalCall?.[1]).not.toHaveProperty('page');
   });
 });
+
+describe('Page.screenshot', () => {
+  beforeEach(() => {
+    sendCommandMock.mockReset();
+    sendCommandFullMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it('forwards width / height / fullPage options to the bridge', async () => {
+    sendCommandMock.mockResolvedValueOnce('BASE64');
+
+    const page = new Page('browser:default');
+    const data = await page.screenshot({ fullPage: true, width: 1080 });
+
+    expect(data).toBe('BASE64');
+    expect(sendCommandMock).toHaveBeenCalledWith('screenshot', expect.objectContaining({
+      workspace: 'browser:default',
+      fullPage: true,
+      width: 1080,
+    }));
+  });
+
+  it('omits viewport overrides when none are set', async () => {
+    sendCommandMock.mockResolvedValueOnce('BASE64');
+
+    const page = new Page('browser:default');
+    await page.screenshot();
+
+    const call = sendCommandMock.mock.calls.at(-1);
+    expect(call?.[0]).toBe('screenshot');
+    const args = call?.[1] as Record<string, unknown>;
+    expect(args.width).toBeUndefined();
+    expect(args.height).toBeUndefined();
+    expect(args.fullPage).toBeUndefined();
+  });
+});

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -213,6 +213,8 @@ export class Page extends BasePage {
       format: options.format,
       quality: options.quality,
       fullPage: options.fullPage,
+      width: options.width,
+      height: options.height,
     }) as string;
 
     if (options.path) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { styleText } from 'node:util';
 import { findPackageRoot, getBuiltEntryCandidates } from './package-paths.js';
 import { type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
@@ -36,6 +36,7 @@ import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
+import type { ScreenshotOptions } from './types.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -451,6 +452,17 @@ function parsePositiveIntOption(val: string | undefined, label: string, fallback
   if (Number.isNaN(parsed) || parsed <= 0) {
     console.error(`[cli] Invalid ${label}="${val}", using default ${fallback}`);
     return fallback;
+  }
+  return parsed;
+}
+
+function parseScreenshotDim(val: string, label: string): number {
+  if (!/^\d+$/.test(val)) {
+    throw new InvalidArgumentError(`--${label} must be a positive integer (got "${val}")`);
+  }
+  const parsed = parseInt(val, 10);
+  if (parsed <= 0) {
+    throw new InvalidArgumentError(`--${label} must be a positive integer (got "${val}")`);
   }
   return parsed;
 }
@@ -974,13 +986,21 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     }));
 
   addBrowserTabOption(browser.command('screenshot').argument('[path]', 'Save to file (base64 if omitted)'))
+    .option('--full-page', 'Capture the full scrollable page, not just the viewport', false)
+    .option('--width <n>', 'Override viewport width in CSS pixels for this screenshot only', (v: string) => parseScreenshotDim(v, 'width'))
+    .option('--height <n>', 'Override viewport height in CSS pixels for this screenshot only (ignored with --full-page)', (v: string) => parseScreenshotDim(v, 'height'))
     .description('Take screenshot')
-    .action(browserAction(async (page, path) => {
+    .action(browserAction(async (page, path, opts) => {
+      const shotOpts: ScreenshotOptions = {
+        fullPage: opts.fullPage === true,
+        width: opts.width,
+        height: opts.height,
+      };
       if (path) {
-        await page.screenshot({ path });
+        await page.screenshot({ ...shotOpts, path });
         console.log(`Screenshot saved to: ${path}`);
       } else {
-        console.log(await page.screenshot({ format: 'png' }));
+        console.log(await page.screenshot({ ...shotOpts, format: 'png' }));
       }
     }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,10 @@ export interface ScreenshotOptions {
   format?: 'png' | 'jpeg';
   quality?: number;
   fullPage?: boolean;
+  /** Override viewport width in CSS pixels for the screenshot only (cleared after). */
+  width?: number;
+  /** Override viewport height in CSS pixels for the screenshot only (ignored when fullPage). */
+  height?: number;
   path?: string;
 }
 


### PR DESCRIPTION
## Description

The CDP layer already supports viewport overrides for screenshots; this exposes them at the CLI.

The ljg-card HTML to PNG use case (fixed 1080px width, full content height) becomes a one-liner:

```bash
opencli browser screenshot --full-page --width 1080 out.png
```

**Behavior:**
- `--width W` overrides device-metrics width; height is unchanged.
- `--height H` overrides height. Ignored under `--full-page`; the existing `captureBeyondViewport` path is preserved when only `--full-page` (with or without `--height`) is set.
- `--full-page` alone keeps the existing `captureBeyondViewport` path; no behavior change for the prior `page.screenshot({ fullPage: true })` API.
- `--full-page --width W` reflows at W first, then re-overrides to `(W, contentH)` from the post-reflow content size, then captures.
- Override is always cleared in `finally`, including when capture throws.
- `--width` / `--height` reject non-integer input (`1080px`, `1080.5`, `-1`, `0`, `abc`) via a strict `^\d+$` check.

**Compatibility:** new fields are optional, so old extension on a new CLI silently falls back to current behavior; new flags require the extension built from this PR. Manifest version bump left to a release PR (matches #1278 / #1259 / #1266 / #1320).

Related issue: closes #1334.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

**Validation UX:**

```
$ opencli browser screenshot --width abc out.png
error: option '--width <n>' argument 'abc' is invalid. --width must be a positive integer (got "abc")
$ opencli browser screenshot --width 1080.5 out.png
error: option '--width <n>' argument '1080.5' is invalid. --width must be a positive integer (got "1080.5")
$ opencli browser screenshot --width 1080px out.png
error: option '--width <n>' argument '1080px' is invalid. --width must be a positive integer (got "1080px")
```

**Tests** (`extension/src/cdp.test.ts` 7 cases, `src/browser/page.test.ts` 2 cases):

- default: no override
- `--width` only: single override `(width, 0)`, no `Page.getLayoutMetrics`
- `--height` only: single override `(0, height)`
- `--full-page` only: existing single override using `cssContentSize`
- `--full-page --height`: height ignored; existing measure-from-content path preserved
- `--full-page --width`: two overrides (reflow then measure) with `Page.getLayoutMetrics` between
- cleared in `finally` when `Page.captureScreenshot` throws
- `Page.screenshot({ fullPage, width })` forwards new fields; omitted when unset

```
Test Files  71 passed (71)
     Tests  1011 passed | 1 skipped (1012)
```

**End-to-end** via `CDPBridge` against headless Chrome at `--remote-debugging-port=9222`:

| Command | Result |
|---|---|
| baseline (no flags) | 1280x633 |
| `--width 1080` | 1080x633 |
| `--full-page` (example.com) | 1280x633 |
| `--full-page --width 1080` (example.com) | 1080x633 |
| `--full-page --width 1080` (news.ycombinator.com) | **1080x1246** |
| `--full-page --height 600` (news.ycombinator.com) | 1280x1246 (height ignored) |
