### PR TITLE
fix(deepseek): skip pinned conversations and fail fast when resume target unavailable

### DIFF
--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -3,6 +3,7 @@ import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/
 import {
     DEEPSEEK_DOMAIN, DEEPSEEK_URL, ensureOnDeepSeek, selectModel, setFeature,
     sendMessage, sendWithFile, getBubbleCount, waitForResponse, parseBoolFlag, withRetry,
+    pickResumeUrl,
 } from './utils.js';
 
 export const askCommand = cli({
@@ -38,12 +39,16 @@ export const askCommand = cli({
         } else {
             const navigated = await ensureOnDeepSeek(page);
             if (navigated) {
-                // Workspace was recycled; try to resume the most recent
-                // conversation instead of starting a new one.
-                await page.evaluate(`(() => {
-                    var link = document.querySelector('a[href*="/a/chat/s/"]');
-                    if (link) link.click();
-                })()`);
+                // Pinned conversations sit in their own DOM section and are
+                // skipped so the resume never lands on a topped chat.
+                const resumeUrl = await pickResumeUrl(page);
+                if (!resumeUrl) {
+                    throw new CommandExecutionError(
+                        'Workspace was recycled but no prior conversation could be loaded',
+                        'Pass --new to start a fresh chat, or wait for the sidebar to populate before retrying.',
+                    );
+                }
+                await page.goto(resumeUrl);
                 await page.wait(2);
             }
         }

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -11,6 +11,7 @@ const {
   mockWaitForResponse,
   mockParseBoolFlag,
   mockWithRetry,
+  mockPickResumeUrl,
 } = vi.hoisted(() => ({
   mockEnsureOnDeepSeek: vi.fn(),
   mockSelectModel: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockWaitForResponse: vi.fn(),
   mockParseBoolFlag: vi.fn((v) => v === true || v === 'true'),
   mockWithRetry: vi.fn(async (fn) => fn()),
+  mockPickResumeUrl: vi.fn(),
 }));
 
 vi.mock('./utils.js', () => ({
@@ -35,6 +37,7 @@ vi.mock('./utils.js', () => ({
   waitForResponse: mockWaitForResponse,
   parseBoolFlag: mockParseBoolFlag,
   withRetry: mockWithRetry,
+  pickResumeUrl: mockPickResumeUrl,
 }));
 
 import { askCommand } from './ask.js';
@@ -185,9 +188,8 @@ describe('deepseek ask conversation resume', () => {
 
   it('resumes the most recent conversation and skips model selection', async () => {
     mockEnsureOnDeepSeek.mockResolvedValue(true);
-    // first evaluate: sidebar resume click (returns undefined)
-    page.evaluate.mockResolvedValueOnce(undefined);
-    // second evaluate: URL check (now inside a conversation)
+    mockPickResumeUrl.mockResolvedValue('https://chat.deepseek.com/a/chat/s/abc-123');
+    // URL check after resume navigation: now inside a conversation.
     page.evaluate.mockResolvedValueOnce('https://chat.deepseek.com/a/chat/s/abc-123');
 
     const rows = await askCommand.func(page, {
@@ -200,6 +202,7 @@ describe('deepseek ask conversation resume', () => {
     });
 
     expect(rows).toEqual([{ response: 'follow-up reply' }]);
+    expect(page.goto).toHaveBeenCalledWith('https://chat.deepseek.com/a/chat/s/abc-123');
     expect(mockSelectModel).not.toHaveBeenCalled();
     expect(mockSendMessage).toHaveBeenCalled();
   });
@@ -243,25 +246,22 @@ describe('deepseek ask conversation resume', () => {
     expect(mockSelectModel).not.toHaveBeenCalled();
   });
 
-  it('still selects model when no conversation to resume', async () => {
+  it('fails fast when the workspace was recycled but no conversation surfaces in time', async () => {
     mockEnsureOnDeepSeek.mockResolvedValue(true);
-    mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
-    // first evaluate: sidebar resume click (no link found)
-    page.evaluate.mockResolvedValueOnce(undefined);
-    // second evaluate: URL check (still on root page)
-    page.evaluate.mockResolvedValueOnce('https://chat.deepseek.com/');
+    mockPickResumeUrl.mockResolvedValue(null);
 
-    const rows = await askCommand.func(page, {
+    await expect(askCommand.func(page, {
       prompt: 'hello',
       timeout: 120,
       new: false,
       model: 'instant',
       think: false,
       search: false,
-    });
+    })).rejects.toBeInstanceOf(CommandExecutionError);
 
-    expect(rows).toEqual([{ response: 'follow-up reply' }]);
-    expect(mockSelectModel).toHaveBeenCalled();
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockSelectModel).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   it('skips search toggle in vision mode when search is not requested', async () => {

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -274,6 +274,46 @@ export async function getConversationList(page) {
     return [];
 }
 
+/**
+ * Pick the URL of the most recent non-pinned conversation, or the first overall
+ * if every visible conversation is pinned.
+ *
+ * Used by `ask` when the workspace was recycled and we need to resume an
+ * existing thread instead of opening a new chat. Polls the sidebar for up to
+ * 10s and returns null if no conversation links surface in time, so callers
+ * can fail fast instead of silently navigating to a fresh page.
+ *
+ * Pinned detection is text-based on the section header ("置顶" / "Pinned"),
+ * because DeepSeek's CSS-module class names are randomized per build.
+ */
+export async function pickResumeUrl(page) {
+    await page.evaluate(`(() => {
+        if (document.querySelectorAll('a[href*="/a/chat/s/"]').length === 0) {
+            const btn = document.querySelector('div[tabindex="0"][role="button"]');
+            if (btn) btn.click();
+        }
+    })()`);
+    for (let attempt = 0; attempt < 5; attempt++) {
+        await page.wait(2);
+        const url = await page.evaluate(`(() => {
+            const links = document.querySelectorAll('a[href*="/a/chat/s/"]');
+            if (links.length === 0) return null;
+            const PINNED_HEADER = /^\\s*(置\\s*顶|Pinned)\\s*$/i;
+            const isPinned = (link) => {
+                const section = link.parentElement;
+                const header = section && section.firstElementChild;
+                if (!header || header === link) return false;
+                return PINNED_HEADER.test((header.innerText || header.textContent || '').trim());
+            };
+            const target = Array.from(links).find((l) => !isPinned(l)) || links[0];
+            const href = target.getAttribute('href') || '';
+            return href ? 'https://chat.deepseek.com' + href : null;
+        })()`);
+        if (url) return url;
+    }
+    return null;
+}
+
 async function waitForFilePreview(page, fileName) {
     for (let attempt = 0; attempt < 8; attempt++) {
         await page.wait(2);

--- a/clis/deepseek/utils.test.js
+++ b/clis/deepseek/utils.test.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { selectModel, sendWithFile, parseThinkingResponse } from './utils.js';
+import { selectModel, sendWithFile, parseThinkingResponse, pickResumeUrl } from './utils.js';
 
 describe('deepseek parseThinkingResponse', () => {
   it('returns plain response when no thinking header is present', () => {
@@ -260,5 +260,72 @@ describe('deepseek sendWithFile Not allowed fallback', () => {
     expect(result).toEqual({ ok: false, reason: 'file preview did not appear' });
     expect(page.evaluate.mock.calls[1][0]).toContain('img[src], canvas, video');
     expect(page.evaluate.mock.calls[1][0]).not.toContain("aria-disabled') === 'false'");
+  });
+});
+
+describe('deepseek pickResumeUrl', () => {
+  function createPage() {
+    return {
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn(),
+    };
+  }
+
+  it('returns the URL on the first attempt when the sidebar is already populated', async () => {
+    const page = createPage();
+    // First evaluate is the sidebar-expand no-op; subsequent ones look up the resume URL.
+    page.evaluate
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce('https://chat.deepseek.com/a/chat/s/recent-id');
+
+    const url = await pickResumeUrl(page);
+
+    expect(url).toBe('https://chat.deepseek.com/a/chat/s/recent-id');
+    // Sidebar expand + one resume lookup. No retry needed.
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(page.wait).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls until the sidebar finishes loading and returns the late URL', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(undefined)               // sidebar-expand
+      .mockResolvedValueOnce(null)                    // attempt 1: nothing
+      .mockResolvedValueOnce(null)                    // attempt 2: nothing
+      .mockResolvedValueOnce('https://chat.deepseek.com/a/chat/s/late-id'); // attempt 3: ready
+
+    const url = await pickResumeUrl(page);
+
+    expect(url).toBe('https://chat.deepseek.com/a/chat/s/late-id');
+    expect(page.evaluate).toHaveBeenCalledTimes(4);
+    expect(page.wait).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns null after exhausting all retries instead of falling through silently', async () => {
+    const page = createPage();
+    // Sidebar expand + 5 polling attempts, each returning null.
+    page.evaluate.mockResolvedValue(null);
+
+    const url = await pickResumeUrl(page);
+
+    expect(url).toBeNull();
+    expect(page.evaluate).toHaveBeenCalledTimes(6);
+    expect(page.wait).toHaveBeenCalledTimes(5);
+  });
+
+  it('embeds the pinned-section text matcher inside the resume lookup', async () => {
+    const page = createPage();
+    page.evaluate.mockResolvedValue(null);
+
+    await pickResumeUrl(page);
+
+    const lookupSrc = page.evaluate.mock.calls
+      .map(([js]) => js)
+      .find((js) => js.includes('firstElementChild'));
+    expect(lookupSrc, 'expected a resume-lookup evaluate call').toBeDefined();
+    // Pinned detection must be text-based on the section header (CSS-module class names are randomized per build).
+    expect(lookupSrc).toContain('置');
+    expect(lookupSrc).toContain('Pinned');
+    expect(lookupSrc).toContain('firstElementChild');
   });
 });


### PR DESCRIPTION
## Description

Fixes two bugs in `opencli deepseek ask` (without `--new`) reported in #1342.

The previous logic resumed the most recent conversation by clicking the first `a[href*="/a/chat/s/"]` in DOM order after a fixed 2-second wait:

```js
await page.evaluate(`(() => {
    var link = document.querySelector('a[href*="/a/chat/s/"]');
    if (link) link.click();
})()`);
await page.wait(2);
```

**Bug 1 (pinned).** DeepSeek renders pinned conversations in their own sidebar section labeled `置顶`, sitting above the normal `30 天内` / `今天` sections. Click-first-anchor lands on the pinned thread, not the user's most recent. I reproduced this live by pinning a conversation through the right-click context menu in my own DeepSeek session and observing the existing logic targets the pinned anchor.

**Bug 2 (timing).** The fixed 2-second wait is fragile. On a slow network the sidebar has not populated yet, the click is a no-op, and `ask` silently falls through to the new-chat path. The user types "follow up" and a brand-new conversation gets created.

**Fix.** New helper `pickResumeUrl(page)` in `utils.js`:

- polls the sidebar for up to 10s (5 attempts x 2s),
- identifies pinned anchors by a text-based check on the section header (`/^\s*(置\s*顶|Pinned)\s*$/i`); DeepSeek's CSS-module class names are randomized per build so text is the only stable signal,
- returns the URL of the first non-pinned anchor (falls back to the first overall if every visible anchor is pinned),
- returns null if no anchor surfaces in time.

`ask.js` calls the helper, `page.goto`s the returned URL, and throws a `CommandExecutionError` when null. The user gets a clear "pass `--new`" hint and the prompt is never sent to a wrong conversation.

Related issue: closes #1342.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

**Live verification of pinned-section detection** (against my own DeepSeek session):

```
{
  "totalLinks": 100,
  "debug": [
    { "i": 0, "title": "Secret number is 42",            "sectionHeader": "置顶",   "pinned": true  },
    { "i": 1, "title": "Today date April 29 2026",       "sectionHeader": "30 天内", "pinned": false },
    { "i": 2, "title": "2+2 equals 4",                   "sectionHeader": "30 天内", "pinned": false }
  ],
  "target": "Today date April 29 2026",
  "targetUrl": "https://chat.deepseek.com/a/chat/s/37947a72-..."
}
```

The picked target is the first non-pinned anchor, exactly the contract described in the fix.

**Tests** (4 new in `utils.test.js`, 2 updated in `ask.test.js`):

`utils.test.js`:

- `pickResumeUrl` returns the URL on the first attempt when the sidebar is already populated
- `pickResumeUrl` polls until the sidebar finishes loading and returns the late URL (covers Bug 2)
- `pickResumeUrl` returns null after exhausting all retries instead of falling through silently (covers Bug 2 fail-fast contract)
- `pickResumeUrl` embeds the pinned-section text matcher in the resume lookup (locks `置` / `Pinned` / `firstElementChild` into the embedded DOM walker, so a future refactor that tries to switch to fragile CSS-module classes fails the assertion)

`ask.test.js`:

- updated `resumes the most recent conversation and skips model selection` to use the new helper mock + asserts `page.goto` is called with the resume URL
- replaced the prior `still selects model when no conversation to resume` test (which exercised the silent fall-through) with `fails fast when the workspace was recycled but no conversation surfaces in time`, asserting `CommandExecutionError` is thrown and neither `page.goto`, `selectModel`, nor `sendMessage` is called

```
Test Files  293 passed (293)
     Tests  2532 passed | 1 skipped (2533)
```

**Manual reproduction** (the bug itself, before the fix):

1. Pin any conversation in DeepSeek (right-click sidebar entry → 置顶).
2. Wait for the workspace to be recycled (or run `opencli daemon restart`).
3. Run `opencli deepseek ask "follow up"` (no `--new`).
4. Observe `ask` resumes the pinned conversation rather than the most recent thread.

After this PR step 4 picks the most recent non-pinned conversation. If the sidebar fails to populate within 10s, `ask` raises `CommandExecutionError` with a hint to pass `--new`, instead of quietly creating a new chat.
