### PR TITLE
feat(deepseek): add detail and send commands for explicit conversation control

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5869,6 +5869,32 @@
   },
   {
     "site": "deepseek",
+    "name": "detail",
+    "description": "Read a specific DeepSeek conversation by ID",
+    "access": "read",
+    "domain": "chat.deepseek.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Conversation ID (UUID) or full /a/chat/s/<id> URL"
+      }
+    ],
+    "columns": [
+      "Role",
+      "Text"
+    ],
+    "type": "js",
+    "modulePath": "deepseek/detail.js",
+    "sourceFile": "deepseek/detail.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "deepseek",
     "name": "history",
     "description": "List conversation history from DeepSeek sidebar",
     "access": "read",
@@ -5927,6 +5953,40 @@
     "type": "js",
     "modulePath": "deepseek/read.js",
     "sourceFile": "deepseek/read.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "deepseek",
+    "name": "send",
+    "description": "Send a prompt to a specific DeepSeek conversation by ID, without waiting for a response",
+    "access": "write",
+    "domain": "chat.deepseek.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Conversation ID (UUID) or full /a/chat/s/<id> URL"
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Prompt to send"
+      }
+    ],
+    "columns": [
+      "Status",
+      "InjectedText"
+    ],
+    "timeout": 60,
+    "type": "js",
+    "modulePath": "deepseek/send.js",
+    "sourceFile": "deepseek/send.js",
     "navigateBefore": false
   },
   {

--- a/clis/deepseek/detail.js
+++ b/clis/deepseek/detail.js
@@ -1,0 +1,37 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    DEEPSEEK_DOMAIN,
+    ensureOnDeepSeek,
+    getVisibleMessages,
+    parseDeepSeekConversationId,
+} from './utils.js';
+
+export const detailCommand = cli({
+    site: 'deepseek',
+    name: 'detail',
+    access: 'read',
+    description: 'Read a specific DeepSeek conversation by ID',
+    domain: DEEPSEEK_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },
+    ],
+    columns: ['Role', 'Text'],
+    func: async (page, kwargs) => {
+        const id = parseDeepSeekConversationId(kwargs.id);
+        await ensureOnDeepSeek(page);
+        await page.goto(`https://chat.deepseek.com/a/chat/s/${id}`);
+        await page.wait(5);
+        const messages = await getVisibleMessages(page);
+        if (messages.length === 0) {
+            throw new EmptyResultError(
+                'deepseek detail',
+                `No visible messages found for conversation ${id}. Verify the ID is correct and that you are logged in.`,
+            );
+        }
+        return messages;
+    },
+});

--- a/clis/deepseek/detail.test.js
+++ b/clis/deepseek/detail.test.js
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+const {
+  mockEnsureOnDeepSeek,
+  mockGetVisibleMessages,
+} = vi.hoisted(() => ({
+  mockEnsureOnDeepSeek: vi.fn(),
+  mockGetVisibleMessages: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+  const actual = await vi.importActual('./utils.js');
+  return {
+    ...actual,
+    ensureOnDeepSeek: mockEnsureOnDeepSeek,
+    getVisibleMessages: mockGetVisibleMessages,
+  };
+});
+
+import './detail.js';
+
+describe('deepseek detail', () => {
+  const command = getRegistry().get('deepseek/detail');
+  const id = '749e6bbd-6a45-4440-beaa-ae5238bf06d8';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
+  });
+
+  it('registers as a cookie-browser read command', () => {
+    expect(command).toBeDefined();
+    expect(command.browser).toBe(true);
+    expect(command.strategy).toBe('cookie');
+    expect(command.access).toBe('read');
+    expect(command.columns).toEqual(['Role', 'Text']);
+  });
+
+  it('navigates to the conversation URL and returns visible messages', async () => {
+    mockGetVisibleMessages.mockResolvedValue([
+      { Role: 'user', Text: 'hello' },
+      { Role: 'assistant', Text: 'hi' },
+    ]);
+    const page = { wait: vi.fn().mockResolvedValue(undefined), goto: vi.fn().mockResolvedValue(undefined) };
+
+    const rows = await command.func(page, { id });
+
+    expect(rows).toEqual([
+      { Role: 'user', Text: 'hello' },
+      { Role: 'assistant', Text: 'hi' },
+    ]);
+    expect(page.goto).toHaveBeenCalledWith(`https://chat.deepseek.com/a/chat/s/${id}`);
+    expect(mockGetVisibleMessages).toHaveBeenCalledWith(page);
+  });
+
+  it('accepts a full chat URL and normalises it before navigation', async () => {
+    mockGetVisibleMessages.mockResolvedValue([{ Role: 'user', Text: 'hi' }]);
+    const page = { wait: vi.fn().mockResolvedValue(undefined), goto: vi.fn().mockResolvedValue(undefined) };
+
+    await command.func(page, { id: `https://chat.deepseek.com/a/chat/s/${id.toUpperCase()}?ref=foo` });
+
+    expect(page.goto).toHaveBeenCalledWith(`https://chat.deepseek.com/a/chat/s/${id}`);
+  });
+
+  it('rejects malformed IDs before browser navigation', async () => {
+    const page = { wait: vi.fn(), goto: vi.fn() };
+
+    await expect(command.func(page, { id: 'not-a-uuid' })).rejects.toThrow(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockEnsureOnDeepSeek).not.toHaveBeenCalled();
+  });
+
+  it('throws EmptyResultError when the conversation has no visible messages', async () => {
+    mockGetVisibleMessages.mockResolvedValue([]);
+    const page = { wait: vi.fn().mockResolvedValue(undefined), goto: vi.fn().mockResolvedValue(undefined) };
+
+    await expect(command.func(page, { id })).rejects.toThrow(EmptyResultError);
+  });
+});

--- a/clis/deepseek/send.js
+++ b/clis/deepseek/send.js
@@ -1,0 +1,139 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DEEPSEEK_DOMAIN,
+    MESSAGE_SELECTOR,
+    TEXTAREA_SELECTOR,
+    parseDeepSeekConversationId,
+} from './utils.js';
+
+export const sendCommand = cli({
+    site: 'deepseek',
+    name: 'send',
+    access: 'write',
+    description: 'Send a prompt to a specific DeepSeek conversation by ID, without waiting for a response',
+    domain: DEEPSEEK_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    timeoutSeconds: 60,
+    args: [
+        { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },
+        { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
+    ],
+    columns: ['Status', 'InjectedText'],
+    func: async (page, kwargs) => {
+        const id = parseDeepSeekConversationId(kwargs.id);
+        const prompt = kwargs.prompt;
+
+        // Navigate directly to the target conversation. The framework runs
+        // each browser command in an ephemeral per-command workspace (tab),
+        // so there is no shared "current conversation" between commands; the
+        // ID must be explicit. Skipping this navigation lands on the deepseek
+        // root, where the click silently no-ops because React has not bound
+        // the textarea on a freshly-opened tab.
+        await page.goto(`https://chat.deepseek.com/a/chat/s/${id}`);
+        await waitForTextareaReady(page);
+
+        // Focus the textarea via DOM, then drive input through CDP
+        // `Input.insertText`. This mirrors the doubao adapter (#1278) and is
+        // the only reliable path for the React-controlled DeepSeek composer
+        // on a freshly-opened tab: `execCommand('insertText')` plus a
+        // synthesised input event leaves the controlled state desynced and
+        // the resulting send click silently no-ops on the server side.
+        const focusOk = await page.evaluate(`(() => {
+            const box = document.querySelector('${TEXTAREA_SELECTOR}');
+            if (!box) return false;
+            box.focus();
+            return document.activeElement === box;
+        })()`);
+        if (!focusOk) {
+            throw new CommandExecutionError('Could not focus DeepSeek textarea before native input');
+        }
+        if (typeof page.nativeType !== 'function') {
+            throw new CommandExecutionError(
+                'Native CDP input is not available on this page object',
+                'deepseek send relies on Input.insertText; ensure the daemon and extension are up to date.',
+            );
+        }
+        await page.nativeType(prompt);
+        await page.wait(0.6);
+
+        // Submit + wait inside the same eval until the user bubble has
+        // rendered AND remains stable past a 3s settle window. Returning
+        // earlier lets the framework close the per-command workspace
+        // mid-flight, aborting the in-flight chat-completion request before
+        // the server has acknowledged it; the optimistic bubble then never
+        // persists.
+        const promptJson = JSON.stringify(prompt);
+        const result = await page.evaluate(`(async () => {
+            const TEXTAREA = '${TEXTAREA_SELECTOR}';
+            const MESSAGE = '${MESSAGE_SELECTOR}';
+            const expected = ${promptJson};
+            const isUser = (m) => m.className.split(/\\s+/).length > 2;
+            const box = document.querySelector(TEXTAREA);
+            if (!box) return { ok: false, reason: 'textarea not found' };
+            if ((box.value || '').trim() !== expected.trim()) {
+                return { ok: false, reason: 'native input did not populate textarea (got ' + JSON.stringify(box.value) + ')' };
+            }
+            let container = box.parentElement;
+            while (container && !container.querySelector('div[role="button"]')) {
+                container = container.parentElement;
+            }
+            const btns = container ? container.querySelectorAll('div[role="button"]:not(.ds-toggle-button)') : [];
+            const sendBtn = btns[btns.length - 1];
+            if (!sendBtn || sendBtn.querySelectorAll('svg').length === 0) {
+                return { ok: false, reason: 'send button not found' };
+            }
+            if (sendBtn.getAttribute('aria-disabled') !== 'false') {
+                return { ok: false, reason: 'send button stayed disabled after native input' };
+            }
+            sendBtn.click();
+            // Verify the prompt rendered as a user-class bubble that includes
+            // the expected text. Counting bubbles is unreliable under DeepSeek
+            // virtualization (the visible message list is windowed); a text
+            // match on any user bubble is the authoritative signal.
+            const matchesPrompt = (m) => isUser(m) && (m.innerText || '').trim().includes(expected);
+            const findUserBubble = () => Array.from(document.querySelectorAll(MESSAGE)).reverse().find(matchesPrompt);
+            let appeared = false;
+            for (let i = 0; i < 20 && !appeared; i++) {
+                await new Promise(r => setTimeout(r, 500));
+                if (findUserBubble()) appeared = true;
+            }
+            if (!appeared) return { ok: false, reason: 'prompt never rendered as a user bubble within 10s' };
+            // Settle: must still be present after 3s; an optimistic render
+            // that gets rolled back fails this check.
+            for (let i = 0; i < 3; i++) {
+                await new Promise(r => setTimeout(r, 1000));
+                if (!findUserBubble()) {
+                    return { ok: false, reason: 'prompt rendered then disappeared during the 3s settle window' };
+                }
+            }
+            return { ok: true };
+        })()`).catch((err) => {
+            const msg = String(err?.message || err);
+            // SPA navigation after click can collapse the eval context; the
+            // resulting "Promise was collected" only fires after the bubble
+            // settle has already passed, so treat it as a successful submit.
+            if (msg.includes('Promise was collected')) return { ok: true };
+            throw err;
+        });
+
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.reason || 'Failed to send message');
+        }
+        return [{ Status: 'Success', InjectedText: prompt }];
+    },
+});
+
+/** Poll for the deepseek textarea to mount before driving any input. */
+async function waitForTextareaReady(page) {
+    const probe = `(() => !!document.querySelector('${TEXTAREA_SELECTOR}'))()`;
+    for (let attempt = 0; attempt < 10; attempt++) {
+        if (await page.evaluate(probe)) return;
+        await page.wait(1);
+    }
+    throw new CommandExecutionError(
+        'DeepSeek textarea did not mount within 10s; the conversation page may not have loaded',
+    );
+}

--- a/clis/deepseek/send.test.js
+++ b/clis/deepseek/send.test.js
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+import './send.js';
+
+describe('deepseek send', () => {
+  const command = getRegistry().get('deepseek/send');
+  const id = '749e6bbd-6a45-4440-beaa-ae5238bf06d8';
+
+  function createPage(overrides = {}) {
+    return {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn(),
+      nativeType: vi.fn().mockResolvedValue(undefined),
+      screenshot: vi.fn().mockResolvedValue(''),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers as a cookie-browser write command with id + prompt positional args', () => {
+    expect(command).toBeDefined();
+    expect(command.browser).toBe(true);
+    expect(command.strategy).toBe('cookie');
+    expect(command.access).toBe('write');
+    expect(command.columns).toEqual(['Status', 'InjectedText']);
+    expect(command.args.map((a) => a.name)).toEqual(['id', 'prompt']);
+  });
+
+  it('rejects malformed conversation IDs before any browser navigation', async () => {
+    const page = createPage();
+    await expect(command.func(page, { id: 'not-a-uuid', prompt: 'hi' })).rejects.toThrow(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(page.nativeType).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the conversation, drives input through nativeType, and verifies the bubble', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(true)             // waitForTextareaReady probe
+      .mockResolvedValueOnce(true)             // focus check
+      .mockResolvedValueOnce({ ok: true });    // submit + verify IIFE
+
+    const rows = await command.func(page, { id, prompt: 'hello' });
+
+    expect(rows).toEqual([{ Status: 'Success', InjectedText: 'hello' }]);
+    expect(page.goto).toHaveBeenCalledWith(`https://chat.deepseek.com/a/chat/s/${id}`);
+    expect(page.nativeType).toHaveBeenCalledWith('hello');
+  });
+
+  it('throws when the textarea never mounts within the readiness timeout', async () => {
+    const page = createPage();
+    page.evaluate.mockResolvedValue(false);    // probe always fails
+
+    await expect(command.func(page, { id, prompt: 'hi' })).rejects.toThrow(CommandExecutionError);
+    expect(page.nativeType).not.toHaveBeenCalled();
+  });
+
+  it('throws when nativeType is not exposed on the page object', async () => {
+    const page = createPage({ nativeType: undefined });
+    page.evaluate
+      .mockResolvedValueOnce(true)             // waitForTextareaReady
+      .mockResolvedValueOnce(true);            // focus
+
+    await expect(command.func(page, { id, prompt: 'hi' })).rejects.toThrow(CommandExecutionError);
+  });
+
+  it('throws when the focus probe reports the textarea did not take focus', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(true)             // waitForTextareaReady
+      .mockResolvedValueOnce(false);           // focus failed
+
+    await expect(command.func(page, { id, prompt: 'hi' })).rejects.toThrow(CommandExecutionError);
+    expect(page.nativeType).not.toHaveBeenCalled();
+  });
+
+  it('translates the IIFE failure reason into a CommandExecutionError', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce({ ok: false, reason: 'send button stayed disabled after native input' });
+
+    await expect(command.func(page, { id, prompt: 'hi' })).rejects.toThrow(
+      new CommandExecutionError('send button stayed disabled after native input'),
+    );
+  });
+
+  it('treats "Promise was collected" from the IIFE as a successful submit', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error('{"code":-32000,"message":"Promise was collected"}'));
+
+    const rows = await command.func(page, { id, prompt: 'hi' });
+
+    expect(rows).toEqual([{ Status: 'Success', InjectedText: 'hi' }]);
+  });
+});

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -1,7 +1,33 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+
 export const DEEPSEEK_DOMAIN = 'chat.deepseek.com';
 export const DEEPSEEK_URL = 'https://chat.deepseek.com/';
 export const TEXTAREA_SELECTOR = 'textarea[placeholder*="DeepSeek"]';
 export const MESSAGE_SELECTOR = '.ds-message';
+const CONVERSATION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+/**
+ * Normalize a DeepSeek conversation ID. Accepts a bare UUID or any URL that
+ * embeds one (`/a/chat/s/<id>` or full chat URL).
+ *
+ * Throws ArgumentError when the input does not contain a UUID-shaped id, so
+ * `detail` fails before any browser navigation happens.
+ */
+export function parseDeepSeekConversationId(input) {
+    const raw = String(input ?? '').trim();
+    if (!raw) {
+        throw new ArgumentError('id', 'must be a non-empty conversation ID or URL');
+    }
+    const urlMatch = raw.match(/\/a\/chat\/s\/([a-f0-9-]+)/i);
+    const candidate = urlMatch ? urlMatch[1] : raw;
+    if (!CONVERSATION_ID_RE.test(candidate)) {
+        throw new ArgumentError(
+            'id',
+            `not a valid DeepSeek conversation ID (got "${input}"); expected a UUID like "749e6bbd-6a45-4440-beaa-ae5238bf06d8" or a full /a/chat/s/<id> URL`,
+        );
+    }
+    return candidate.toLowerCase();
+}
 
 export async function isOnDeepSeek(page) {
     const url = await page.evaluate('window.location.href').catch(() => '');

--- a/clis/deepseek/utils.test.js
+++ b/clis/deepseek/utils.test.js
@@ -2,7 +2,46 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { selectModel, sendWithFile, parseThinkingResponse, pickResumeUrl } from './utils.js';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+  selectModel,
+  sendWithFile,
+  parseThinkingResponse,
+  parseDeepSeekConversationId,
+  pickResumeUrl,
+} from './utils.js';
+
+describe('deepseek parseDeepSeekConversationId', () => {
+  const id = '749e6bbd-6a45-4440-beaa-ae5238bf06d8';
+
+  it('returns a bare UUID unchanged', () => {
+    expect(parseDeepSeekConversationId(id)).toBe(id);
+  });
+
+  it('lowercases an upper-case UUID', () => {
+    expect(parseDeepSeekConversationId(id.toUpperCase())).toBe(id);
+  });
+
+  it('extracts the UUID from a full /a/chat/s/<id> URL', () => {
+    expect(parseDeepSeekConversationId(`https://chat.deepseek.com/a/chat/s/${id}`)).toBe(id);
+    expect(parseDeepSeekConversationId(`https://chat.deepseek.com/a/chat/s/${id}?from=share`)).toBe(id);
+    expect(parseDeepSeekConversationId(`/a/chat/s/${id}`)).toBe(id);
+  });
+
+  it('throws ArgumentError on empty input', () => {
+    expect(() => parseDeepSeekConversationId('')).toThrow(ArgumentError);
+    expect(() => parseDeepSeekConversationId(null)).toThrow(ArgumentError);
+    expect(() => parseDeepSeekConversationId(undefined)).toThrow(ArgumentError);
+    expect(() => parseDeepSeekConversationId('   ')).toThrow(ArgumentError);
+  });
+
+  it('throws ArgumentError on non-UUID input', () => {
+    expect(() => parseDeepSeekConversationId('not-an-id')).toThrow(ArgumentError);
+    expect(() => parseDeepSeekConversationId('123')).toThrow(ArgumentError);
+    // URL with the wrong path shape must not silently fall through to "use raw input".
+    expect(() => parseDeepSeekConversationId('https://chat.deepseek.com/somewhere/else')).toThrow(ArgumentError);
+  });
+});
 
 describe('deepseek parseThinkingResponse', () => {
   it('returns plain response when no thinking header is present', () => {

--- a/docs/adapters/browser/deepseek.md
+++ b/docs/adapters/browser/deepseek.md
@@ -11,6 +11,8 @@
 | `opencli deepseek status` | Check login state and page availability |
 | `opencli deepseek read` | Read the current conversation |
 | `opencli deepseek history` | List conversation history from sidebar |
+| `opencli deepseek detail <id>` | Read a specific conversation by ID or URL |
+| `opencli deepseek send <id> <prompt>` | Send a prompt to a specific conversation without waiting for a response |
 
 ## Usage Examples
 
@@ -56,6 +58,12 @@ opencli deepseek read
 
 # List recent conversations
 opencli deepseek history --limit 10
+
+# Read a specific conversation by UUID or /a/chat/s/<id> URL
+opencli deepseek detail 749e6bbd-6a45-4440-beaa-ae5238bf06d8
+
+# Send to a specific existing conversation
+opencli deepseek send 749e6bbd-6a45-4440-beaa-ae5238bf06d8 "continue from the last answer"
 ```
 
 ### Options (ask)
@@ -70,6 +78,19 @@ opencli deepseek history --limit 10
 | `--search` | Enable web search (default: false) |
 | `--file` | Attach a file (PDF, image, text) with the prompt (max 100 MB) |
 
+### Options (detail)
+
+| Option | Description |
+|--------|-------------|
+| `<id>` | DeepSeek conversation UUID or full `/a/chat/s/<id>` URL |
+
+### Options (send)
+
+| Option | Description |
+|--------|-------------|
+| `<id>` | DeepSeek conversation UUID or full `/a/chat/s/<id>` URL |
+| `<prompt>` | The message to send (required, positional) |
+
 ## Prerequisites
 
 - Chrome running with [Browser Bridge extension](/guide/browser-bridge) installed
@@ -80,5 +101,6 @@ opencli deepseek history --limit 10
 - This adapter drives the DeepSeek web UI in the browser, not an API
 - Default mode is Instant with DeepThink and Search disabled; each flag (`--model`, `--think`, `--search`) is synced on every invocation so omitting a flag resets it
 - Vision mode does not support `--search`; use `--model instant` or `--model expert` for web search
+- `send` requires an explicit conversation ID because each browser command runs in its own tab/workspace; use `history` to find a conversation URL or ID first
 - Long responses (code, essays) may need a higher `--timeout`
 - File upload prefers the browser file-input path, falls back to base64 injection when needed, and rejects files over 100 MB


### PR DESCRIPTION
## Description

doubao already ships `detail <id>` and `send` for ID-explicit conversation read/write; deepseek had only `read` (current page only) plus the implicit-resume `ask`. Adding both gives users a stable handle when they know the conversation ID, without going through `ask`'s resume detection or its full prompt-then-wait pipeline. Especially relevant alongside #1342 / #1343, where the implicit-resume heuristic in `ask` was landing on pinned conversations.

`deepseek detail <id>`:

- parses a bare UUID or any URL containing `/a/chat/s/<id>`,
- rejects malformed input via `ArgumentError` before any browser navigation,
- navigates to `https://chat.deepseek.com/a/chat/s/<id>` and returns the visible message list,
- throws `EmptyResultError` when the conversation has no rendered messages.

`deepseek send <id> <prompt>`:

- takes the conversation id as a required positional, because the framework runs each browser command in an ephemeral per-command workspace (a fresh tab) and there is no shared "current conversation" across commands; the navigation must be explicit,
- drives input through CDP `Input.insertText` via `page.nativeType`, mirroring the doubao adapter. `execCommand('insertText')` plus a synthesised input event leaves the React-controlled state desynced on a freshly-opened tab, and the resulting click silently no-ops,
- keeps the verification loop inside the same `page.evaluate` so the framework cannot close the tab mid-flight; identifies the new bubble by text match (DeepSeek virtualises the message list, so a numeric bubble-count check is unreliable),
- throws `CommandExecutionError` with a specific reason when the textarea did not populate, the send button stayed disabled, the bubble never settled, or the optimistic render rolled back during a 3s settle window,
- treats "Promise was collected" from the post-click eval as success, matching the pattern in `ask --file`.

Helper `parseDeepSeekConversationId` is exported from `utils.js` so the same parser feeds both commands and the round-trip lower-cases the canonical ID.

Related issue: none. Closes a structural gap rather than a bug report.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

**Live verification** against my own DeepSeek session:

```
$ opencli deepseek detail 749e6bbd-6a45-4440-beaa-ae5238bf06d8
- Role: user
  Text: |-
    test_vision_txt.txt
    TXT 18B
    what is the secret number
- Role: assistant
  Text: Based on the file you provided, the secret number is 42.

$ opencli deepseek detail 'https://chat.deepseek.com/a/chat/s/96e8ca3e-b5be-4345-841f-1b0ff21752b9'
- Role: user
  Text: what is 2+2
- Role: assistant
  Text: |-
    已思考（用时 1 秒）
    ...
    2+2 equals 4.

$ opencli deepseek detail not-an-id
ok: false
error:
  code: ARGUMENT
  help: not a valid DeepSeek conversation ID (got "not-an-id"); expected a UUID...

$ opencli deepseek send 37947a72-e238-4377-a16f-b9eede9b533b "url-form send 9245"
- Status: Success
  InjectedText: url-form send 9245

$ opencli deepseek send 'https://chat.deepseek.com/a/chat/s/37947a72-...' "test"
- Status: Success
  InjectedText: test

$ opencli deepseek send not-a-uuid "test"
ok: false
error:
  code: ARGUMENT
  help: not a valid DeepSeek conversation ID (got "not-a-uuid"); ...
```

After each successful `send`, reloading the conversation page in a separate tab shows the prompt as the latest user message and DeepSeek's reply, confirming the message persisted server-side.

**Tests** (5 in `utils.test.js`, 5 in `detail.test.js`, 7 in `send.test.js`):

- `parseDeepSeekConversationId`: bare UUID unchanged, upper-case normalisation, URL extraction with and without query string, empty / null / whitespace rejection, non-UUID rejection
- `detail`: registration, navigation + message return, URL normalisation, ArgumentError before browser navigation, EmptyResultError on no-messages
- `send`: registration with `id` + `prompt` positional contract, ArgumentError on bad id before navigation, happy-path through `nativeType` + IIFE verification, textarea-mount timeout, missing `nativeType` helper, focus probe failure, IIFE-reason to CommandExecutionError translation, "Promise was collected" success path

```
Test Files  293 passed (293)
     Tests  2542 passed | 1 skipped (2543)
```

**Why `send` requires an explicit `id`** (different from doubao's no-id `send`):

The framework runs each browser command in an ephemeral per-command workspace (`src/execution.ts` opens a fresh tab keyed by `site:<adapter>:<uuid>` per invocation). There is no shared "current conversation" across commands, so a no-id `send` has no deterministic target; an early prototype landed on the deepseek root and silently no-op'd because React had not yet bound the textarea on a freshly-opened tab. Requiring `id` makes the navigation explicit, lets `nativeType` drive React-friendly input events on a known-mounted page, and gives the verification loop a target it can text-match against.

The same workflow naturally pairs with `deepseek history` (list) → `deepseek detail <id>` (read) → `deepseek send <id> <prompt>` (write).
