### PR TITLE
feat: 11 read adapters across 8 sites (round 2)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1958,6 +1958,41 @@
     "sourceFile": "bbc/news.js"
   },
   {
+    "site": "bbc",
+    "name": "topic",
+    "description": "BBC News headlines for a specific section (RSS feed)",
+    "access": "read",
+    "domain": "www.bbc.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "topic",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Section name (world / business / politics / health / education / science_and_environment / technology / entertainment_and_arts)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max headlines (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "title",
+      "description",
+      "pubDate",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bbc/topic.js",
+    "sourceFile": "bbc/topic.js"
+  },
+  {
     "site": "bilibili",
     "name": "comments",
     "description": "获取 B站视频评论（使用官方 API + WBI 签名）",
@@ -4960,6 +4995,43 @@
   },
   {
     "site": "coingecko",
+    "name": "categories",
+    "description": "Crypto categories ranked by aggregated market cap",
+    "access": "read",
+    "domain": "api.coingecko.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "market_cap_desc",
+        "required": false,
+        "help": "Sort order (market_cap_desc / market_cap_asc / name_desc / name_asc / market_cap_change_24h_desc / market_cap_change_24h_asc)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of categories (1-100; CoinGecko returns ~120 max)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "marketCap",
+      "volume24h",
+      "marketCapChange24hPct",
+      "top3Coins"
+    ],
+    "type": "js",
+    "modulePath": "coingecko/categories.js",
+    "sourceFile": "coingecko/categories.js"
+  },
+  {
+    "site": "coingecko",
     "name": "coin",
     "description": "Fetch a single cryptocurrency's market data by CoinGecko id (e.g. bitcoin, ethereum).",
     "access": "read",
@@ -5006,6 +5078,77 @@
     "type": "js",
     "modulePath": "coingecko/coin.js",
     "sourceFile": "coingecko/coin.js"
+  },
+  {
+    "site": "coingecko",
+    "name": "exchanges",
+    "description": "Top crypto exchanges by 24h BTC trading volume",
+    "access": "read",
+    "domain": "api.coingecko.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of exchanges (1-250, CoinGecko per_page upper bound)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Page number (1-based)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "trustScore",
+      "volume24hBtc",
+      "country",
+      "yearEstablished",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "coingecko/exchanges.js",
+    "sourceFile": "coingecko/exchanges.js"
+  },
+  {
+    "site": "coingecko",
+    "name": "global",
+    "description": "Aggregate crypto market stats: total market cap, volume, dominance",
+    "access": "read",
+    "domain": "api.coingecko.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "currency",
+        "type": "string",
+        "default": "usd",
+        "required": false,
+        "help": "Quote currency for total market cap / volume (usd, cny, eur, jpy, ...)"
+      }
+    ],
+    "columns": [
+      "currency",
+      "totalMarketCap",
+      "totalVolume24h",
+      "marketCapChange24hPct",
+      "btcDominancePct",
+      "ethDominancePct",
+      "activeCryptocurrencies",
+      "markets",
+      "ongoingIcos",
+      "updatedAt"
+    ],
+    "type": "js",
+    "modulePath": "coingecko/global.js",
+    "sourceFile": "coingecko/global.js"
   },
   {
     "site": "coingecko",
@@ -5383,6 +5526,52 @@
   },
   {
     "site": "dblp",
+    "name": "author",
+    "description": "List dblp publications by a given author (newest first; resolves to top PID match)",
+    "access": "read",
+    "domain": "dblp.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "author",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Author name (e.g. \"Yoshua Bengio\"). Optional when --pid is given."
+      },
+      {
+        "name": "pid",
+        "type": "str",
+        "required": false,
+        "help": "Canonical dblp PID (e.g. \"56/953\"). Bypasses author search."
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max publications (1-200)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "key",
+      "title",
+      "authors",
+      "venue",
+      "year",
+      "type",
+      "doi",
+      "pid",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dblp/author.js",
+    "sourceFile": "dblp/author.js"
+  },
+  {
+    "site": "dblp",
     "name": "paper",
     "aliases": [
       "detail",
@@ -5606,6 +5795,45 @@
     "modulePath": "deepseek/status.js",
     "sourceFile": "deepseek/status.js",
     "navigateBefore": false
+  },
+  {
+    "site": "devto",
+    "name": "latest",
+    "description": "Newest dev.to articles (firehose, all tags)",
+    "access": "read",
+    "domain": "dev.to",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Articles per page (1-100)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Page number (1-based)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "author",
+      "tags",
+      "reactions",
+      "comments",
+      "published",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "devto/latest.js",
+    "sourceFile": "devto/latest.js"
   },
   {
     "site": "devto",
@@ -9486,6 +9714,38 @@
   },
   {
     "site": "hf",
+    "name": "paper",
+    "description": "Hugging Face paper detail by arXiv id (full title / summary / authors / AI keywords)",
+    "access": "read",
+    "domain": "huggingface.co",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "arXiv id (e.g. \"1706.03762\") — same value HF uses to mirror the paper"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "authors",
+      "publishedAt",
+      "upvotes",
+      "aiKeywords",
+      "summary",
+      "aiSummary",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "hf/paper.js",
+    "sourceFile": "hf/paper.js"
+  },
+  {
+    "site": "hf",
     "name": "top",
     "description": "Top upvoted Hugging Face papers",
     "access": "read",
@@ -12764,6 +13024,46 @@
   },
   {
     "site": "lobsters",
+    "name": "domain",
+    "description": "Lobste.rs stories submitted from a specific domain",
+    "access": "read",
+    "domain": "lobste.rs",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "domain",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Source domain (e.g. github.com, arxiv.org, blog.cloudflare.com)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of stories (1-25 — single page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "score",
+      "author",
+      "comments",
+      "created_at",
+      "tags",
+      "submission_url",
+      "comments_url"
+    ],
+    "type": "js",
+    "modulePath": "lobsters/domain.js",
+    "sourceFile": "lobsters/domain.js"
+  },
+  {
+    "site": "lobsters",
     "name": "hot",
     "description": "Lobste.rs hottest stories",
     "access": "read",
@@ -13118,6 +13418,43 @@
     "modulePath": "medium/search.js",
     "sourceFile": "medium/search.js",
     "navigateBefore": "https://medium.com"
+  },
+  {
+    "site": "medium",
+    "name": "tag",
+    "description": "Latest Medium articles tagged with a given keyword (RSS feed)",
+    "access": "read",
+    "domain": "medium.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "tag",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Lowercase tag slug (e.g. \"programming\", \"machine-learning\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max articles (1-25 — single RSS page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "title",
+      "author",
+      "description",
+      "categories",
+      "published",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "medium/tag.js",
+    "sourceFile": "medium/tag.js"
   },
   {
     "site": "medium",
@@ -17666,6 +18003,97 @@
     "type": "js",
     "modulePath": "stackoverflow/user.js",
     "sourceFile": "stackoverflow/user.js"
+  },
+  {
+    "site": "steam",
+    "name": "app",
+    "description": "Steam storefront detail for a single app id",
+    "access": "read",
+    "domain": "store.steampowered.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Numeric Steam app id (e.g. \"620\" for Portal 2)"
+      },
+      {
+        "name": "currency",
+        "type": "str",
+        "default": "us",
+        "required": false,
+        "help": "Storefront country code (e.g. us / cn / jp / de)"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "type",
+      "isFree",
+      "releaseDate",
+      "developers",
+      "publishers",
+      "price",
+      "currency",
+      "metacritic",
+      "recommendations",
+      "genres",
+      "categories",
+      "shortDescription",
+      "website",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "steam/app.js",
+    "sourceFile": "steam/app.js"
+  },
+  {
+    "site": "steam",
+    "name": "search",
+    "description": "Search the Steam storefront by name keyword",
+    "access": "read",
+    "domain": "store.steampowered.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (e.g. \"portal\", \"stardew\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-50)"
+      },
+      {
+        "name": "currency",
+        "type": "str",
+        "default": "us",
+        "required": false,
+        "help": "Storefront country code (e.g. us / cn / jp / de)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "price",
+      "currency",
+      "metascore",
+      "platforms",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "steam/search.js",
+    "sourceFile": "steam/search.js"
   },
   {
     "site": "steam",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9786,6 +9786,13 @@
         ]
       }
     ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "upvotes",
+      "authors"
+    ],
     "type": "js",
     "modulePath": "hf/top.js",
     "sourceFile": "hf/top.js"

--- a/clis/bbc/topic.js
+++ b/clis/bbc/topic.js
@@ -1,0 +1,57 @@
+// bbc topic — BBC News headlines for a specific category, via public RSS.
+//
+// BBC publishes per-section RSS feeds at
+// `https://feeds.bbci.co.uk/news/<topic>/rss.xml`. We expose the eight
+// canonical sections and reject anything else with a typed argument error
+// so the user knows the supported set.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { bbcFetchRss, parseRssItems, pubDateToIso, requireBoundedInt } from './utils.js';
+
+const TOPICS = [
+    'world',
+    'business',
+    'politics',
+    'health',
+    'education',
+    'science_and_environment',
+    'technology',
+    'entertainment_and_arts',
+];
+
+cli({
+    site: 'bbc',
+    name: 'topic',
+    access: 'read',
+    description: 'BBC News headlines for a specific section (RSS feed)',
+    domain: 'www.bbc.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'topic', positional: true, required: true, help: `Section name (${TOPICS.join(' / ')})` },
+        { name: 'limit', type: 'int', default: 20, help: 'Max headlines (1-50)' },
+    ],
+    columns: ['rank', 'title', 'description', 'pubDate', 'url'],
+    func: async (args) => {
+        const raw = String(args.topic ?? '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+        if (!TOPICS.includes(raw)) {
+            throw new ArgumentError(
+                `bbc topic "${args.topic}" is not supported`,
+                `Supported topics: ${TOPICS.join(', ')}`,
+            );
+        }
+        const limit = requireBoundedInt(args.limit, 20, 50);
+        const xml = await bbcFetchRss(`${raw}/rss.xml`, `bbc topic ${raw}`);
+        const items = parseRssItems(xml);
+        if (!items.length) {
+            throw new EmptyResultError('bbc topic', `BBC ${raw} feed returned no items.`);
+        }
+        return items.slice(0, limit).map((it, i) => ({
+            rank: i + 1,
+            title: it.title,
+            description: it.description,
+            pubDate: pubDateToIso(it.pubDate),
+            url: it.link,
+        }));
+    },
+});

--- a/clis/bbc/utils.js
+++ b/clis/bbc/utils.js
@@ -1,0 +1,79 @@
+// Shared helpers for the bbc adapters that hit BBC's public RSS feeds.
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const BBC_FEED_BASE = 'https://feeds.bbci.co.uk/news';
+const UA = 'opencli-bbc-adapter (+https://github.com/jackwener/opencli)';
+
+const HTML_ENTITIES = {
+    '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&apos;': "'", '&#39;': "'", '&nbsp;': ' ',
+};
+
+export function decodeHtmlEntities(value) {
+    return String(value ?? '')
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+        .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(parseInt(d, 10)))
+        .replace(/&(amp|lt|gt|quot|apos|#39|nbsp);/g, (m) => HTML_ENTITIES[m] || m);
+}
+
+/** Extract `<tag>…</tag>` (CDATA-aware) from a block. */
+export function extractRssTag(block, tag) {
+    const cdata = block.match(new RegExp(`<${tag}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*<\\/${tag}>`));
+    if (cdata) return cdata[1];
+    const plain = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+    return plain ? plain[1] : '';
+}
+
+export function parseRssItems(xml) {
+    const out = [];
+    const re = /<item[^>]*>([\s\S]*?)<\/item>/g;
+    let m;
+    while ((m = re.exec(String(xml || ''))) !== null) {
+        const block = m[1];
+        out.push({
+            title: decodeHtmlEntities(extractRssTag(block, 'title')).trim(),
+            description: decodeHtmlEntities(extractRssTag(block, 'description')).trim(),
+            link: decodeHtmlEntities(extractRssTag(block, 'link')).trim(),
+            pubDate: decodeHtmlEntities(extractRssTag(block, 'pubDate')).trim(),
+            guid: decodeHtmlEntities(extractRssTag(block, 'guid')).trim(),
+        });
+    }
+    return out;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`bbc ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`bbc ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function bbcFetchRss(path, label) {
+    const url = `${BBC_FEED_BASE}/${path}`;
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/rss+xml, application/xml' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that feeds.bbci.co.uk is reachable from this network.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status} (${url})`);
+    }
+    return resp.text();
+}
+
+/** Convert RFC-822 pubDate to ISO `YYYY-MM-DD`; empty string on parse failure. */
+export function pubDateToIso(value) {
+    if (!value) return '';
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toISOString().slice(0, 10);
+}

--- a/clis/coingecko/categories.js
+++ b/clis/coingecko/categories.js
@@ -1,0 +1,75 @@
+// coingecko categories — top crypto categories by aggregated market cap.
+//
+// Hits the public `/api/v3/coins/categories` endpoint. Useful for spotting
+// which sectors (DeFi, L1, gaming, RWAs, …) are leading the market.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const ORDER_OPTIONS = ['market_cap_desc', 'market_cap_asc', 'name_desc', 'name_asc', 'market_cap_change_24h_desc', 'market_cap_change_24h_asc'];
+
+cli({
+    site: 'coingecko',
+    name: 'categories',
+    access: 'read',
+    description: 'Crypto categories ranked by aggregated market cap',
+    domain: 'api.coingecko.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'sort', default: 'market_cap_desc', help: `Sort order (${ORDER_OPTIONS.join(' / ')})` },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of categories (1-100; CoinGecko returns ~120 max)' },
+    ],
+    columns: ['rank', 'id', 'name', 'marketCap', 'volume24h', 'marketCapChange24hPct', 'top3Coins'],
+    func: async (args) => {
+        const sort = String(args.sort ?? 'market_cap_desc').trim().toLowerCase();
+        if (!ORDER_OPTIONS.includes(sort)) {
+            throw new ArgumentError(
+                `coingecko sort "${args.sort}" is not supported`,
+                `Supported sorts: ${ORDER_OPTIONS.join(', ')}`,
+            );
+        }
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('coingecko limit must be a positive integer');
+        }
+        if (limit > 100) {
+            throw new ArgumentError('coingecko limit must be <= 100');
+        }
+        const url = `https://api.coingecko.com/api/v3/coins/categories?order=${encodeURIComponent(sort)}`;
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko categories request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'coingecko returned HTTP 429 (rate limited)',
+                'Free tier allows ~30 calls/min. Wait and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`coingecko categories returned HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko categories returned malformed JSON: ${err?.message ?? err}`);
+        }
+        if (!Array.isArray(data) || !data.length) {
+            throw new EmptyResultError('coingecko categories', 'CoinGecko returned no category data.');
+        }
+        return data.slice(0, limit).map((cat, i) => ({
+            rank: i + 1,
+            id: String(cat.id ?? ''),
+            name: String(cat.name ?? ''),
+            marketCap: cat.market_cap != null ? Number(cat.market_cap) : null,
+            volume24h: cat.volume_24h != null ? Number(cat.volume_24h) : null,
+            marketCapChange24hPct: cat.market_cap_change_24h != null ? Number(cat.market_cap_change_24h) : null,
+            top3Coins: Array.isArray(cat.top_3_coins_id) ? cat.top_3_coins_id.join(', ') : '',
+        }));
+    },
+});

--- a/clis/coingecko/exchanges.js
+++ b/clis/coingecko/exchanges.js
@@ -1,0 +1,74 @@
+// coingecko exchanges — top crypto exchanges by 24h BTC trading volume.
+//
+// Hits the public `/api/v3/exchanges` endpoint. Returns the columns most
+// useful for an agent: trust score, 24h BTC volume, country, year founded,
+// canonical URL.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+cli({
+    site: 'coingecko',
+    name: 'exchanges',
+    access: 'read',
+    description: 'Top crypto exchanges by 24h BTC trading volume',
+    domain: 'api.coingecko.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Number of exchanges (1-250, CoinGecko per_page upper bound)' },
+        { name: 'page', type: 'int', default: 1, help: 'Page number (1-based)' },
+    ],
+    columns: ['rank', 'id', 'name', 'trustScore', 'volume24hBtc', 'country', 'yearEstablished', 'url'],
+    func: async (args) => {
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('coingecko limit must be a positive integer');
+        }
+        if (limit > 250) {
+            throw new ArgumentError('coingecko limit must be <= 250 (per_page upper bound)');
+        }
+        const page = Number(args.page ?? 1);
+        if (!Number.isInteger(page) || page <= 0) {
+            throw new ArgumentError('coingecko page must be a positive integer');
+        }
+        const url = new URL('https://api.coingecko.com/api/v3/exchanges');
+        url.searchParams.set('per_page', String(limit));
+        url.searchParams.set('page', String(page));
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko exchanges request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'coingecko returned HTTP 429 (rate limited)',
+                'Free tier allows ~30 calls/min. Wait and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`coingecko exchanges returned HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko exchanges returned malformed JSON: ${err?.message ?? err}`);
+        }
+        if (!Array.isArray(data) || !data.length) {
+            throw new EmptyResultError('coingecko exchanges', 'CoinGecko returned no exchange data.');
+        }
+        return data.map((ex, i) => ({
+            rank: (page - 1) * limit + i + 1,
+            id: String(ex.id ?? ''),
+            name: String(ex.name ?? ''),
+            trustScore: ex.trust_score != null ? Number(ex.trust_score) : null,
+            volume24hBtc: ex.trade_volume_24h_btc != null ? Number(ex.trade_volume_24h_btc) : null,
+            country: String(ex.country ?? ''),
+            yearEstablished: ex.year_established != null ? Number(ex.year_established) : null,
+            url: String(ex.url ?? ''),
+        }));
+    },
+});

--- a/clis/coingecko/global.js
+++ b/clis/coingecko/global.js
@@ -1,0 +1,71 @@
+// coingecko global — total crypto market cap, volume, BTC/ETH dominance,
+// active currencies, ICO counts, in a single row.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+cli({
+    site: 'coingecko',
+    name: 'global',
+    access: 'read',
+    description: 'Aggregate crypto market stats: total market cap, volume, dominance',
+    domain: 'api.coingecko.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'currency', type: 'string', default: 'usd', help: 'Quote currency for total market cap / volume (usd, cny, eur, jpy, ...)' },
+    ],
+    columns: ['currency', 'totalMarketCap', 'totalVolume24h', 'marketCapChange24hPct', 'btcDominancePct', 'ethDominancePct', 'activeCryptocurrencies', 'markets', 'ongoingIcos', 'updatedAt'],
+    func: async (args) => {
+        const currency = String(args.currency ?? 'usd').trim().toLowerCase();
+        if (!/^[a-z0-9-]{2,20}$/.test(currency)) {
+            throw new ArgumentError(`coingecko currency must look like a currency slug (got "${args.currency}")`);
+        }
+        let resp;
+        try {
+            resp = await fetch('https://api.coingecko.com/api/v3/global', { headers: { 'User-Agent': 'Mozilla/5.0' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko global request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'coingecko returned HTTP 429 (rate limited)',
+                'Free tier allows ~30 calls/min. Wait and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`coingecko global returned HTTP ${resp.status}`);
+        }
+        let body;
+        try {
+            body = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko global returned malformed JSON: ${err?.message ?? err}`);
+        }
+        const data = body?.data;
+        if (!data) {
+            throw new CommandExecutionError('coingecko global returned no data envelope');
+        }
+        const totalMarketCap = data?.total_market_cap?.[currency];
+        const totalVolume = data?.total_volume?.[currency];
+        if (totalMarketCap == null && totalVolume == null) {
+            throw new ArgumentError(
+                `coingecko has no market totals for currency "${currency}"`,
+                'Use a CoinGecko-supported quote currency such as usd, cny, eur, or jpy.',
+            );
+        }
+        return [{
+            currency: currency.toUpperCase(),
+            totalMarketCap: totalMarketCap != null ? Number(totalMarketCap) : null,
+            totalVolume24h: totalVolume != null ? Number(totalVolume) : null,
+            marketCapChange24hPct: data.market_cap_change_percentage_24h_usd != null ? Number(data.market_cap_change_percentage_24h_usd) : null,
+            btcDominancePct: data?.market_cap_percentage?.btc != null ? Number(data.market_cap_percentage.btc) : null,
+            ethDominancePct: data?.market_cap_percentage?.eth != null ? Number(data.market_cap_percentage.eth) : null,
+            activeCryptocurrencies: data.active_cryptocurrencies != null ? Number(data.active_cryptocurrencies) : null,
+            markets: data.markets != null ? Number(data.markets) : null,
+            ongoingIcos: data.ongoing_icos != null ? Number(data.ongoing_icos) : null,
+            updatedAt: data.updated_at ? new Date(data.updated_at * 1000).toISOString() : '',
+        }];
+    },
+});

--- a/clis/dblp/author.js
+++ b/clis/dblp/author.js
@@ -1,0 +1,133 @@
+// dblp author — resolve an author name to a PID and list their publications
+// newest first.
+//
+// Two-step lookup against dblp's public API:
+//   1. `search/author/api?q=<name>` returns candidate authors (each with a
+//      stable PID URL like `https://dblp.org/pid/56/953`).
+//   2. `pid/<pid>.xml` returns every publication under that PID, ordered
+//      newest first.
+//
+// We auto-resolve to the top hit. dblp's author search returns a single
+// best-match for unique names; for ambiguous names (e.g. "Wei Wang") it
+// returns multiple PIDs — we pick the highest-scored one and surface the
+// resolved name + PID in the row metadata so the caller can refine.
+//
+// To bypass author search entirely, pass `--pid <prefix>/<id>` (e.g.
+// `--pid 56/953`). This is the canonical disambiguator.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    DBLP_ORIGIN,
+    decodeXmlEntities,
+    dblpFetchJson,
+    dblpFetchXml,
+    extractRecordKey,
+    recordXmlToRow,
+    requireBoundedInt,
+    requireQuery,
+} from './utils.js';
+
+const PID_PATTERN = /^[0-9a-z]+(?:\/[0-9a-z-]+)+$/i;
+
+function extractPidFromAuthorHit(hit) {
+    const url = String(hit?.info?.url ?? '').trim();
+    const m = url.match(/\/pid\/([^/]+(?:\/[^/]+)+)$/);
+    return m ? m[1] : '';
+}
+
+function pickTopAuthor(hits) {
+    // dblp returns hits sorted by score desc; we just take the head.
+    return hits[0];
+}
+
+function splitRecords(xml) {
+    // Each publication is wrapped in <r>…</r> directly under <dblpperson>.
+    const out = [];
+    const re = /<r>\s*([\s\S]*?)\s*<\/r>/g;
+    let m;
+    while ((m = re.exec(String(xml || ''))) !== null) {
+        const inner = m[1];
+        // Skip cross-references that have no concrete record (rare).
+        if (/^<crossref/.test(inner)) continue;
+        out.push(inner);
+    }
+    return out;
+}
+
+cli({
+    site: 'dblp',
+    name: 'author',
+    access: 'read',
+    description: 'List dblp publications by a given author (newest first; resolves to top PID match)',
+    domain: 'dblp.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'author', positional: true, required: false, help: 'Author name (e.g. "Yoshua Bengio"). Optional when --pid is given.' },
+        { name: 'pid', help: 'Canonical dblp PID (e.g. "56/953"). Bypasses author search.' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max publications (1-200)' },
+    ],
+    columns: ['rank', 'key', 'title', 'authors', 'venue', 'year', 'type', 'doi', 'pid', 'url'],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 200);
+        const pidArg = args.pid != null ? String(args.pid).trim() : '';
+        let pid = '';
+        let resolvedName = '';
+        if (pidArg) {
+            if (!PID_PATTERN.test(pidArg)) {
+                throw new ArgumentError(
+                    `dblp pid "${pidArg}" is not a valid PID`,
+                    'Expected something like "56/953" — visit the author page on dblp.org to find it.',
+                );
+            }
+            pid = pidArg;
+        }
+        else {
+            const name = requireQuery(args.author, 'author');
+            const json = await dblpFetchJson(
+                `/search/author/api?q=${encodeURIComponent(name)}&format=json&h=20`,
+                'dblp author search',
+            );
+            const raw = json?.result?.hits?.hit;
+            const hits = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+            if (!hits.length) {
+                throw new EmptyResultError(
+                    'dblp author',
+                    `No dblp author matched "${name}". Try a different spelling, or pass --pid to bypass author search.`,
+                );
+            }
+            const top = pickTopAuthor(hits);
+            pid = extractPidFromAuthorHit(top);
+            if (!pid) {
+                throw new CommandExecutionError(
+                    `dblp author search for "${name}" returned a hit without a PID URL`,
+                    'dblp may have changed its author-search response shape; retry or pass --pid manually.',
+                );
+            }
+            resolvedName = decodeXmlEntities(String(top?.info?.author ?? '')).trim();
+        }
+        const xml = await dblpFetchXml(`/pid/${pid}.xml`, `dblp pid ${pid}`);
+        const records = splitRecords(xml);
+        if (!records.length) {
+            throw new EmptyResultError(
+                'dblp author',
+                `dblp PID ${pid}${resolvedName ? ` (${resolvedName})` : ''} has no publications.`,
+            );
+        }
+        return records.slice(0, limit).map((recordXml, i) => {
+            const row = recordXmlToRow(`<root>${recordXml}</root>`);
+            return {
+                rank: i + 1,
+                key: row.key || extractRecordKey(recordXml),
+                title: row.title,
+                authors: row.authors,
+                venue: row.venue,
+                year: row.year,
+                type: row.type,
+                doi: row.doi,
+                pid,
+                url: row.open_access_url || row.dblp_url,
+            };
+        });
+    },
+});

--- a/clis/devto/latest.js
+++ b/clis/devto/latest.js
@@ -1,0 +1,74 @@
+// devto latest — newest dev.to articles, regardless of tag.
+//
+// Hits the public `/api/articles/latest` endpoint. Complements the existing
+// `devto top` (most-reactioned) and `devto tag` (filtered) commands by
+// surfacing the firehose of brand-new posts.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+function requireBoundedInt(value, defaultValue, maxValue) {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError('devto limit must be a positive integer');
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`devto limit must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+cli({
+    site: 'devto',
+    name: 'latest',
+    access: 'read',
+    description: 'Newest dev.to articles (firehose, all tags)',
+    domain: 'dev.to',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Articles per page (1-100)' },
+        { name: 'page', type: 'int', default: 1, help: 'Page number (1-based)' },
+    ],
+    columns: ['rank', 'id', 'title', 'author', 'tags', 'reactions', 'comments', 'published', 'url'],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const page = requireBoundedInt(args.page, 1, 1000);
+        const url = `https://dev.to/api/articles/latest?per_page=${limit}&page=${page}`;
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { accept: 'application/json' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(
+                `devto latest request failed: ${err?.message ?? err}`,
+                'Check that dev.to is reachable from this network.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`devto latest returned HTTP ${resp.status}`);
+        }
+        let body;
+        try {
+            body = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`devto latest returned malformed JSON: ${err?.message ?? err}`);
+        }
+        const list = Array.isArray(body) ? body : [];
+        if (!list.length) {
+            throw new EmptyResultError('devto latest', `dev.to /articles/latest returned no items at page ${page}.`);
+        }
+        return list.map((item, i) => ({
+            rank: (page - 1) * limit + i + 1,
+            id: item.id != null ? String(item.id) : '',
+            title: String(item.title ?? ''),
+            author: String(item?.user?.username ?? ''),
+            tags: String(item.tag_list ?? '').replace(/,\s*/g, ', '),
+            reactions: item.public_reactions_count != null ? Number(item.public_reactions_count) : null,
+            comments: item.comments_count != null ? Number(item.comments_count) : null,
+            published: String(item.published_at ?? '').slice(0, 10),
+            url: String(item.url ?? ''),
+        }));
+    },
+});

--- a/clis/hf/hf.test.js
+++ b/clis/hf/hf.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './top.js';
+import './paper.js';
+
+describe('hf adapter registry contracts', () => {
+    it('declares hf top columns so paper ids round-trip into hf paper', () => {
+        const top = getRegistry().get('hf/top');
+        const paper = getRegistry().get('hf/paper');
+
+        expect(top).toBeDefined();
+        expect(paper).toBeDefined();
+        expect(top.columns).toEqual(['rank', 'id', 'title', 'upvotes', 'authors']);
+        expect(paper.columns).toContain('id');
+    });
+});

--- a/clis/hf/paper.js
+++ b/clis/hf/paper.js
@@ -1,0 +1,79 @@
+// hf paper — fetch a single Hugging Face paper page (mirrors arXiv id),
+// returning the full title / summary / upvote count / authors and the
+// AI-generated keyword list HF curates.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const ARXIV_ID_PATTERN = /^\d{4}\.\d{4,5}(?:v\d+)?$/;
+
+cli({
+    site: 'hf',
+    name: 'paper',
+    access: 'read',
+    description: 'Hugging Face paper detail by arXiv id (full title / summary / authors / AI keywords)',
+    domain: 'huggingface.co',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'arXiv id (e.g. "1706.03762") — same value HF uses to mirror the paper' },
+    ],
+    columns: ['id', 'title', 'authors', 'publishedAt', 'upvotes', 'aiKeywords', 'summary', 'aiSummary', 'url'],
+    func: async (args) => {
+        const raw = String(args.id ?? '').trim();
+        if (!raw) {
+            throw new ArgumentError('hf paper id cannot be empty', 'Example: opencli hf paper 1706.03762');
+        }
+        if (!ARXIV_ID_PATTERN.test(raw)) {
+            throw new ArgumentError(
+                `hf paper id "${args.id}" is not a valid arXiv id`,
+                'Expected the modern arXiv form `YYMM.NNNNN` (optionally with a version suffix like `v3`).',
+            );
+        }
+        const endpoint = process.env.HF_ENDPOINT?.replace(/\/+$/, '') || 'https://huggingface.co';
+        const url = `${endpoint}/api/papers/${encodeURIComponent(raw)}`;
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { accept: 'application/json' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`hf paper request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 404) {
+            throw new EmptyResultError('hf paper', `Hugging Face has no paper page for "${raw}".`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'hf paper returned HTTP 429 (rate limited)',
+                'Hugging Face throttles unauthenticated traffic; wait a few seconds and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`hf paper returned HTTP ${resp.status}`);
+        }
+        let body;
+        try {
+            body = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`hf paper returned malformed JSON: ${err?.message ?? err}`);
+        }
+        if (!body || typeof body !== 'object' || !body.id) {
+            throw new EmptyResultError('hf paper', `Hugging Face returned no paper data for "${raw}".`);
+        }
+        const authors = Array.isArray(body.authors)
+            ? body.authors.map((a) => (typeof a === 'object' && a ? (a.name || a.fullname || '') : String(a))).filter(Boolean)
+            : [];
+        const aiKeywords = Array.isArray(body.ai_keywords) ? body.ai_keywords.join(', ') : '';
+        return [{
+            id: String(body.id),
+            title: String(body.title ?? ''),
+            authors: authors.join(', '),
+            publishedAt: String(body.publishedAt ?? '').slice(0, 10),
+            upvotes: body.upvotes != null ? Number(body.upvotes) : null,
+            aiKeywords,
+            summary: String(body.summary ?? ''),
+            aiSummary: String(body.ai_summary ?? ''),
+            url: `${endpoint}/papers/${body.id}`,
+        }];
+    },
+});

--- a/clis/hf/top.js
+++ b/clis/hf/top.js
@@ -42,6 +42,7 @@ cli({
         { name: 'date', type: 'str', required: false, help: 'Date (YYYY-MM-DD), defaults to most recent' },
         { name: 'period', type: 'str', default: 'daily', choices: ['daily', 'weekly', 'monthly'], help: 'Time period: daily, weekly, or monthly' },
     ],
+    columns: ['rank', 'id', 'title', 'upvotes', 'authors'],
     footerExtra: (kwargs) => {
         if (kwargs._footerDate)
             return kwargs._footerDate;

--- a/clis/lobsters/domain.js
+++ b/clis/lobsters/domain.js
@@ -1,0 +1,92 @@
+// lobsters domain — list Lobste.rs stories submitted from a specific domain.
+//
+// Hits the public `https://lobste.rs/domains/<domain>.json` endpoint
+// (returns the same per-story shape used by `lobsters tag` / `lobsters
+// hot`). Lets agents ask "what did Lobsters surface from github.com /
+// blog.cloudflare.com / arxiv.org lately?".
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const DOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/i;
+
+function requireDomain(value) {
+    const s = String(value ?? '').trim().toLowerCase();
+    if (!s) {
+        throw new ArgumentError('lobsters domain is required (e.g. "github.com" or "arxiv.org")');
+    }
+    if (!DOMAIN_PATTERN.test(s)) {
+        throw new ArgumentError(`lobsters domain "${value}" is not a valid hostname`);
+    }
+    return s;
+}
+
+function requireBoundedInt(value, defaultValue, maxValue) {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError('lobsters limit must be a positive integer');
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`lobsters limit must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+cli({
+    site: 'lobsters',
+    name: 'domain',
+    access: 'read',
+    description: 'Lobste.rs stories submitted from a specific domain',
+    domain: 'lobste.rs',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'domain', positional: true, required: true, help: 'Source domain (e.g. github.com, arxiv.org, blog.cloudflare.com)' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of stories (1-25 — single page)' },
+    ],
+    columns: ['rank', 'id', 'title', 'score', 'author', 'comments', 'created_at', 'tags', 'submission_url', 'comments_url'],
+    func: async (args) => {
+        const domain = requireDomain(args.domain);
+        const limit = requireBoundedInt(args.limit, 20, 25);
+        const url = `https://lobste.rs/domains/${encodeURIComponent(domain)}.json`;
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { 'user-agent': 'opencli-lobsters-adapter (+https://github.com/jackwener/opencli)' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(
+                `lobsters domain request failed: ${err?.message ?? err}`,
+                'Check that lobste.rs is reachable from this network.',
+            );
+        }
+        if (resp.status === 404) {
+            throw new EmptyResultError('lobsters domain', `No Lobste.rs stories found for domain "${domain}".`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`lobsters domain returned HTTP ${resp.status}`);
+        }
+        let body;
+        try {
+            body = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`lobsters domain returned malformed JSON: ${err?.message ?? err}`);
+        }
+        const list = Array.isArray(body) ? body : [];
+        if (!list.length) {
+            throw new EmptyResultError('lobsters domain', `No Lobste.rs stories found for domain "${domain}".`);
+        }
+        return list.slice(0, limit).map((item, i) => ({
+            rank: i + 1,
+            id: String(item.short_id ?? ''),
+            title: String(item.title ?? ''),
+            score: item.score != null ? Number(item.score) : null,
+            author: String(item.submitter_user ?? ''),
+            comments: item.comment_count != null ? Number(item.comment_count) : null,
+            created_at: String(item.created_at ?? '').slice(0, 10),
+            tags: Array.isArray(item.tags) ? item.tags.join(', ') : '',
+            submission_url: String(item.url ?? ''),
+            comments_url: String(item.comments_url ?? ''),
+        }));
+    },
+});

--- a/clis/medium/tag.js
+++ b/clis/medium/tag.js
@@ -1,0 +1,135 @@
+// medium tag — Medium articles for a tag, newest first, via the public
+// RSS feed at `https://medium.com/feed/tag/<tag>`.
+//
+// Complements existing `medium feed` (per-publication / per-user) and
+// `medium search` by surfacing topical streams.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/i;
+
+const HTML_ENTITIES = {
+    '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&apos;': "'", '&#39;': "'", '&nbsp;': ' ',
+};
+
+function decodeHtml(value) {
+    return String(value ?? '')
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+        .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(parseInt(d, 10)))
+        .replace(/&(amp|lt|gt|quot|apos|#39|nbsp);/g, (m) => HTML_ENTITIES[m] || m);
+}
+
+function extractTag(block, tag) {
+    const cdata = block.match(new RegExp(`<${tag}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*<\\/${tag}>`));
+    if (cdata) return cdata[1];
+    const plain = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+    return plain ? plain[1] : '';
+}
+
+function extractCategories(block) {
+    const out = [];
+    const re = /<category(?:[^>]*)>(?:<!\[CDATA\[([\s\S]*?)\]\]>|([\s\S]*?))<\/category>/g;
+    let m;
+    while ((m = re.exec(block)) !== null) {
+        const v = decodeHtml((m[1] ?? m[2] ?? '').trim());
+        if (v) out.push(v);
+    }
+    return out;
+}
+
+function isoDateFromRfc822(value) {
+    if (!value) return '';
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toISOString().slice(0, 10);
+}
+
+function stripHtml(value) {
+    return decodeHtml(String(value ?? '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+}
+
+function requireTag(value) {
+    const s = String(value ?? '').trim().toLowerCase();
+    if (!s) {
+        throw new ArgumentError('medium tag is required (e.g. "programming", "javascript")');
+    }
+    if (!TAG_PATTERN.test(s)) {
+        throw new ArgumentError(
+            `medium tag "${value}" is not valid`,
+            'Tags are lowercase alphanumeric, optionally hyphenated (e.g. "machine-learning").',
+        );
+    }
+    return s;
+}
+
+function requireBoundedInt(value, defaultValue, maxValue) {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError('medium limit must be a positive integer');
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`medium limit must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+cli({
+    site: 'medium',
+    name: 'tag',
+    access: 'read',
+    description: 'Latest Medium articles tagged with a given keyword (RSS feed)',
+    domain: 'medium.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'tag', positional: true, required: true, help: 'Lowercase tag slug (e.g. "programming", "machine-learning")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max articles (1-25 — single RSS page)' },
+    ],
+    columns: ['rank', 'title', 'author', 'description', 'categories', 'published', 'url'],
+    func: async (args) => {
+        const tag = requireTag(args.tag);
+        const limit = requireBoundedInt(args.limit, 20, 25);
+        const url = `https://medium.com/feed/tag/${tag}`;
+        let resp;
+        try {
+            resp = await fetch(url, {
+                headers: {
+                    'user-agent': 'opencli-medium-adapter (+https://github.com/jackwener/opencli)',
+                    accept: 'application/rss+xml, application/xml',
+                },
+            });
+        }
+        catch (err) {
+            throw new CommandExecutionError(
+                `medium tag request failed: ${err?.message ?? err}`,
+                'Check that medium.com is reachable from this network.',
+            );
+        }
+        if (resp.status === 404) {
+            throw new EmptyResultError('medium tag', `Medium tag "${tag}" does not exist.`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`medium tag returned HTTP ${resp.status}`);
+        }
+        const xml = await resp.text();
+        const items = [];
+        const re = /<item[^>]*>([\s\S]*?)<\/item>/g;
+        let m;
+        while ((m = re.exec(xml)) !== null) {
+            items.push(m[1]);
+        }
+        if (!items.length) {
+            throw new EmptyResultError('medium tag', `Medium tag "${tag}" RSS feed has no items.`);
+        }
+        return items.slice(0, limit).map((block, i) => ({
+            rank: i + 1,
+            title: decodeHtml(extractTag(block, 'title')).trim(),
+            author: decodeHtml(extractTag(block, 'dc:creator')).trim(),
+            description: stripHtml(extractTag(block, 'description')),
+            categories: extractCategories(block).join(', '),
+            published: isoDateFromRfc822(decodeHtml(extractTag(block, 'pubDate')).trim()),
+            url: decodeHtml(extractTag(block, 'link')).trim(),
+        }));
+    },
+});

--- a/clis/steam/app.js
+++ b/clis/steam/app.js
@@ -1,0 +1,67 @@
+// steam app — fetch a single Steam game / DLC / app's storefront detail.
+//
+// Hits the public appdetails API (`/api/appdetails?appids=<id>`). Surfaces
+// the columns most useful for an agent: name, type, free flag, release
+// date, developers / publishers, price, metacritic, recommendations,
+// genres / categories joined.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { STEAM_STORE, decodeHtmlEntities, priceCents, requireAppId, steamFetch } from './utils.js';
+
+function joinNames(list) {
+    if (!Array.isArray(list)) return '';
+    return list
+        .map((entry) => (entry && typeof entry === 'object' ? entry.description ?? entry.name ?? '' : String(entry)))
+        .filter(Boolean)
+        .join(', ');
+}
+
+cli({
+    site: 'steam',
+    name: 'app',
+    access: 'read',
+    description: 'Steam storefront detail for a single app id',
+    domain: 'store.steampowered.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Numeric Steam app id (e.g. "620" for Portal 2)' },
+        { name: 'currency', default: 'us', help: 'Storefront country code (e.g. us / cn / jp / de)' },
+    ],
+    columns: [
+        'id', 'name', 'type', 'isFree', 'releaseDate', 'developers', 'publishers',
+        'price', 'currency', 'metacritic', 'recommendations', 'genres', 'categories',
+        'shortDescription', 'website', 'url',
+    ],
+    func: async (args) => {
+        const appId = requireAppId(args.id);
+        const cc = String(args.currency ?? 'us').trim().toLowerCase() || 'us';
+        const url = `${STEAM_STORE}/api/appdetails?appids=${appId}&l=en&cc=${encodeURIComponent(cc)}`;
+        const body = await steamFetch(url, `steam app ${appId}`);
+        const wrapper = body?.[appId];
+        if (!wrapper || wrapper.success !== true || !wrapper.data) {
+            throw new EmptyResultError('steam app', `Steam app id ${appId} returned no data (may be region-locked or removed).`);
+        }
+        const data = wrapper.data;
+        const isFree = data.is_free === true;
+        const priceFinal = priceCents(data?.price_overview?.final ?? null);
+        return [{
+            id: String(data.steam_appid ?? appId),
+            name: decodeHtmlEntities(data.name ?? ''),
+            type: String(data.type ?? ''),
+            isFree,
+            releaseDate: String(data?.release_date?.date ?? ''),
+            developers: Array.isArray(data.developers) ? data.developers.join(', ') : '',
+            publishers: Array.isArray(data.publishers) ? data.publishers.join(', ') : '',
+            price: isFree ? 0 : priceFinal,
+            currency: String(data?.price_overview?.currency ?? '').toUpperCase(),
+            metacritic: data?.metacritic?.score != null ? Number(data.metacritic.score) : null,
+            recommendations: data?.recommendations?.total != null ? Number(data.recommendations.total) : null,
+            genres: joinNames(data.genres),
+            categories: joinNames(data.categories),
+            shortDescription: decodeHtmlEntities(data.short_description ?? ''),
+            website: String(data.website ?? ''),
+            url: `${STEAM_STORE}/app/${data.steam_appid ?? appId}/`,
+        }];
+    },
+});

--- a/clis/steam/app.js
+++ b/clis/steam/app.js
@@ -6,7 +6,7 @@
 // genres / categories joined.
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { STEAM_STORE, decodeHtmlEntities, priceCents, requireAppId, steamFetch } from './utils.js';
+import { STEAM_STORE, decodeHtmlEntities, priceCents, requireAppId, requireCountryCode, steamFetch } from './utils.js';
 
 function joinNames(list) {
     if (!Array.isArray(list)) return '';
@@ -35,7 +35,7 @@ cli({
     ],
     func: async (args) => {
         const appId = requireAppId(args.id);
-        const cc = String(args.currency ?? 'us').trim().toLowerCase() || 'us';
+        const cc = requireCountryCode(args.currency);
         const url = `${STEAM_STORE}/api/appdetails?appids=${appId}&l=en&cc=${encodeURIComponent(cc)}`;
         const body = await steamFetch(url, `steam app ${appId}`);
         const wrapper = body?.[appId];

--- a/clis/steam/search.js
+++ b/clis/steam/search.js
@@ -1,0 +1,57 @@
+// steam search — search the Steam storefront catalog.
+//
+// Hits the public storesearch API (`/api/storesearch/?term=…`). Returns
+// matched apps with id / name / price / metascore / platform support so
+// the row's `id` round-trips into `steam app`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    STEAM_STORE,
+    decodeHtmlEntities,
+    priceCents,
+    requireBoundedInt,
+    requireString,
+    steamFetch,
+} from './utils.js';
+
+function platformList(platforms) {
+    if (!platforms || typeof platforms !== 'object') return '';
+    return ['windows', 'mac', 'linux'].filter((p) => platforms[p]).join(',');
+}
+
+cli({
+    site: 'steam',
+    name: 'search',
+    access: 'read',
+    description: 'Search the Steam storefront by name keyword',
+    domain: 'store.steampowered.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "portal", "stardew")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-50)' },
+        { name: 'currency', default: 'us', help: 'Storefront country code (e.g. us / cn / jp / de)' },
+    ],
+    columns: ['rank', 'id', 'name', 'price', 'currency', 'metascore', 'platforms', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 50);
+        const cc = String(args.currency ?? 'us').trim().toLowerCase() || 'us';
+        const url = `${STEAM_STORE}/api/storesearch/?term=${encodeURIComponent(query)}&l=en&cc=${encodeURIComponent(cc)}`;
+        const body = await steamFetch(url, 'steam search');
+        const items = Array.isArray(body?.items) ? body.items : [];
+        if (!items.length) {
+            throw new EmptyResultError('steam search', `No Steam results matched "${query}".`);
+        }
+        return items.slice(0, limit).map((item, i) => ({
+            rank: i + 1,
+            id: String(item.id ?? ''),
+            name: decodeHtmlEntities(item.name ?? ''),
+            price: priceCents(item?.price?.final ?? null),
+            currency: String(item?.price?.currency ?? '').toUpperCase(),
+            metascore: item.metascore != null && item.metascore !== '' ? Number(item.metascore) : null,
+            platforms: platformList(item.platforms),
+            url: item.id ? `${STEAM_STORE}/app/${item.id}/` : '',
+        }));
+    },
+});

--- a/clis/steam/search.js
+++ b/clis/steam/search.js
@@ -10,6 +10,7 @@ import {
     decodeHtmlEntities,
     priceCents,
     requireBoundedInt,
+    requireCountryCode,
     requireString,
     steamFetch,
 } from './utils.js';
@@ -36,7 +37,7 @@ cli({
     func: async (args) => {
         const query = requireString(args.query, 'query');
         const limit = requireBoundedInt(args.limit, 20, 50);
-        const cc = String(args.currency ?? 'us').trim().toLowerCase() || 'us';
+        const cc = requireCountryCode(args.currency);
         const url = `${STEAM_STORE}/api/storesearch/?term=${encodeURIComponent(query)}&l=en&cc=${encodeURIComponent(cc)}`;
         const body = await steamFetch(url, 'steam search');
         const items = Array.isArray(body?.items) ? body.items : [];

--- a/clis/steam/steam.test.js
+++ b/clis/steam/steam.test.js
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { decodeHtmlEntities, requireCountryCode } from './utils.js';
+import './search.js';
+import './app.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('steam adapter helpers', () => {
+    it('decodes Steam HTML entities from API strings', () => {
+        expect(decodeHtmlEntities('&quot;Perpetual Testing Initiative&quot; &amp; Co-op')).toBe('"Perpetual Testing Initiative" & Co-op');
+        expect(decodeHtmlEntities('Portal &#x32;')).toBe('Portal 2');
+    });
+
+    it('validates storefront country code without silent fallback', () => {
+        expect(requireCountryCode(undefined)).toBe('us');
+        expect(requireCountryCode(' CN ')).toBe('cn');
+        expect(() => requireCountryCode('')).toThrow(ArgumentError);
+        expect(() => requireCountryCode('usd')).toThrow(ArgumentError);
+        expect(() => requireCountryCode('$$')).toThrow(ArgumentError);
+    });
+});
+
+describe('steam command argument contracts', () => {
+    it('rejects invalid search currency before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = getRegistry().get('steam/search');
+        await expect(search.func({ query: 'portal', limit: 5, currency: '$$$' })).rejects.toThrow(ArgumentError);
+        await expect(search.func({ query: 'portal', limit: 5, currency: '' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid app currency before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const app = getRegistry().get('steam/app');
+        await expect(app.func({ id: '620', currency: 'usd' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/clis/steam/utils.js
+++ b/clis/steam/utils.js
@@ -1,0 +1,95 @@
+// Shared helpers for the steam adapters that hit Steam's storefront JSON
+// endpoints (no browser).
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const STEAM_STORE = 'https://store.steampowered.com';
+const UA = 'opencli-steam-adapter (+https://github.com/jackwener/opencli)';
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError(`steam ${label} cannot be empty`);
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`steam ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`steam ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireAppId(value) {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError('steam app id is required (e.g. "620" for Portal 2)');
+    }
+    if (!/^\d+$/.test(s)) {
+        throw new ArgumentError(
+            `steam app id "${value}" must be a positive integer`,
+            'Copy the numeric id from `steam search` or the URL `store.steampowered.com/app/<id>/`.',
+        );
+    }
+    return s;
+}
+
+export async function steamFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that store.steampowered.com is reachable from this network.',
+        );
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Steam throttles bursty traffic; wait a few seconds and retry.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, 'Steam returned 404 — the resource does not exist.');
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+export function asString(value) {
+    return value == null ? '' : String(value);
+}
+
+const HTML_ENTITIES = {
+    '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&apos;': "'", '&#39;': "'", '&nbsp;': ' ',
+};
+
+export function decodeHtmlEntities(value) {
+    return String(value ?? '')
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+        .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(parseInt(d, 10)))
+        .replace(/&(amp|lt|gt|quot|apos|#39|nbsp);/g, (m) => HTML_ENTITIES[m] || m);
+}
+
+export function priceCents(cents) {
+    if (cents == null || cents === '') return null;
+    const n = Number(cents);
+    if (!Number.isFinite(n)) return null;
+    return Number((n / 100).toFixed(2));
+}

--- a/clis/steam/utils.js
+++ b/clis/steam/utils.js
@@ -13,6 +13,18 @@ export function requireString(value, label) {
     return s;
 }
 
+export function requireCountryCode(value, defaultValue = 'us') {
+    const raw = value === undefined || value === null ? defaultValue : value;
+    const code = String(raw).trim().toLowerCase();
+    if (!/^[a-z]{2}$/.test(code)) {
+        throw new ArgumentError(
+            `steam currency must be a two-letter storefront country code (got "${value}")`,
+            'Examples: us, cn, jp, de. This controls Steam regional pricing and availability.',
+        );
+    }
+    return code;
+}
+
 export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
     const raw = value ?? defaultValue;
     const n = typeof raw === 'number' ? raw : Number(raw);

--- a/docs/adapters/browser/bbc.md
+++ b/docs/adapters/browser/bbc.md
@@ -6,21 +6,49 @@
 
 | Command | Description |
 |---------|-------------|
-| `opencli bbc news` | |
+| `opencli bbc news` | Latest BBC News headlines (top stories) |
+| `opencli bbc topic <topic>` | Latest headlines for a single BBC topic feed |
 
 ## Usage Examples
 
 ```bash
-# Quick start
+# Top stories
 opencli bbc news --limit 5
 
-# JSON output
-opencli bbc news -f json
+# Topic-scoped feeds (RSS at feeds.bbci.co.uk/news/<topic>/rss.xml)
+opencli bbc topic technology --limit 10
+opencli bbc topic world --limit 20
+opencli bbc topic business
+opencli bbc topic science_and_environment
 
-# Verbose mode
-opencli bbc news -v
+# JSON output
+opencli bbc topic technology -f json
 ```
+
+## Topics
+
+Valid `<topic>` values:
+
+| Topic slug | Feed |
+|------------|------|
+| `world` | World news |
+| `business` | Business |
+| `politics` | UK politics |
+| `health` | Health |
+| `education` | Education & family |
+| `science_and_environment` | Science & environment |
+| `technology` | Technology |
+| `entertainment_and_arts` | Entertainment & arts |
+
+Pass any other value and the adapter raises `ArgumentError` with the full list.
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `news` | (see existing news row schema) |
+| `topic` | `rank, title, description, pubDate, url` |
 
 ## Prerequisites
 
-- No browser required — uses public API
+- No browser required — uses the public BBC RSS feeds at `feeds.bbci.co.uk`.

--- a/docs/adapters/browser/coingecko.md
+++ b/docs/adapters/browser/coingecko.md
@@ -11,6 +11,9 @@ Access **CoinGecko** crypto market data from the terminal via the public API (no
 | `opencli coingecko top` | Top coins by market cap |
 | `opencli coingecko coin <id>` | Single coin's market detail (price / supply / ATH / homepage) |
 | `opencli coingecko trending` | Top trending coins on CoinGecko in the last 24h |
+| `opencli coingecko exchanges` | Top exchanges ranked by trust score / 24h BTC volume |
+| `opencli coingecko categories` | Crypto sector categories (DeFi / Layer1 / Memes / …) with market cap |
+| `opencli coingecko global` | Aggregate market totals: total cap, volume, BTC/ETH dominance |
 
 ## Usage Examples
 
@@ -30,6 +33,17 @@ opencli coingecko coin ethereum --currency cny
 
 # Trending in the last 24h (search-volume based)
 opencli coingecko trending
+
+# Top exchanges (trust score, 24h BTC volume)
+opencli coingecko exchanges --limit 20
+
+# Crypto sector categories (default sort: market_cap_desc)
+opencli coingecko categories --limit 10
+opencli coingecko categories --sort market_cap_change_24h_desc --limit 10
+
+# Aggregate market totals (BTC dominance, total cap, etc.)
+opencli coingecko global
+opencli coingecko global --currency cny
 
 # JSON output
 opencli coingecko top -f json
@@ -55,6 +69,25 @@ opencli coingecko top -f json
 
 No arguments — returns the current top-7 trending list.
 
+### `exchanges`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Number of exchanges to return (1–250, default: 20) |
+
+### `categories`
+
+| Option | Description |
+|--------|-------------|
+| `--sort` | One of `market_cap_desc` (default), `market_cap_asc`, `name_desc`, `name_asc`, `market_cap_change_24h_desc`, `market_cap_change_24h_asc` |
+| `--limit` | Number of categories to return (1–250, default: 20) |
+
+### `global`
+
+| Option | Description |
+|--------|-------------|
+| `--currency` | Quote currency for total market cap / volume (default: `usd`) |
+
 ## Output Columns
 
 | Command | Columns |
@@ -62,6 +95,9 @@ No arguments — returns the current top-7 trending list.
 | `top` | `rank, symbol, name, price, change24hPct, marketCap, volume24h, high24h, low24h` |
 | `coin` | `id, symbol, name, rank, price, marketCap, volume24h, change24hPct, change7dPct, change30dPct, ath, athDate, atl, atlDate, circulatingSupply, totalSupply, maxSupply, genesisDate, homepage` |
 | `trending` | `rank, id, symbol, name, marketCapRank, priceBtc, thumb` |
+| `exchanges` | `rank, id, name, trustScore, volume24hBtc, country, yearEstablished, url` |
+| `categories` | `rank, id, name, marketCap, volume24h, marketCapChange24hPct, top3Coins` |
+| `global` | `currency, totalMarketCap, totalVolume24h, marketCapChange24hPct, btcDominancePct, ethDominancePct, activeCryptocurrencies, markets, ongoingIcos, updatedAt` |
 
 ## Prerequisites
 

--- a/docs/adapters/browser/coingecko.md
+++ b/docs/adapters/browser/coingecko.md
@@ -80,7 +80,7 @@ No arguments — returns the current top-7 trending list.
 | Option | Description |
 |--------|-------------|
 | `--sort` | One of `market_cap_desc` (default), `market_cap_asc`, `name_desc`, `name_asc`, `market_cap_change_24h_desc`, `market_cap_change_24h_asc` |
-| `--limit` | Number of categories to return (1–250, default: 20) |
+| `--limit` | Number of categories to return (1–100, default: 20) |
 
 ### `global`
 

--- a/docs/adapters/browser/dblp.md
+++ b/docs/adapters/browser/dblp.md
@@ -9,6 +9,7 @@
 | Command | Description |
 |---------|-------------|
 | `opencli dblp search <query>` | Free-text search across titles, authors, and venues |
+| `opencli dblp author <name>` | List one author's recent publications (newest first) by name or `--pid` |
 | `opencli dblp paper <key>` | Fetch a single record's full metadata by canonical dblp key |
 
 ## Usage Examples
@@ -19,6 +20,12 @@ opencli dblp search "attention is all you need" --limit 5
 
 # Author search
 opencli dblp search "Yoshua Bengio" --limit 20
+
+# Newest publications by a specific author (resolves the dblp PID for you)
+opencli dblp author "Yoshua Bengio" --limit 20
+
+# Same call, but skip name resolution by supplying the PID directly
+opencli dblp author --pid 56/953 --limit 20
 
 # Venue search
 opencli dblp search "ICLR 2024" --limit 30
@@ -38,9 +45,12 @@ opencli dblp search "graph neural network" -f json
 | Command | Columns |
 |---------|---------|
 | `search` | `rank, key, title, authors, venue, year, type, doi, url` |
+| `author` | `rank, key, title, authors, venue, year, type, doi, pid, url` |
 | `paper` | `key, type, title, authors, venue, year, pages, doi, open_access_url, dblp_url` |
 
-The `key` column from `search` round-trips into `paper` — it is dblp's canonical record identifier (e.g. `conf/nips/VaswaniSPUJGKP17`, `journals/corr/abs-2509-05821`, `phd/Smith20`).
+The `key` column from `search` and `author` round-trips into `paper` — it is dblp's canonical record identifier (e.g. `conf/nips/VaswaniSPUJGKP17`, `journals/corr/abs-2509-05821`, `phd/Smith20`).
+
+The `pid` column on `author` is dblp's stable per-author identifier (e.g. `56/953` for Yoshua Bengio). Pass it back with `--pid` to skip name resolution on subsequent calls.
 
 ## Type Tag
 

--- a/docs/adapters/browser/devto.md
+++ b/docs/adapters/browser/devto.md
@@ -9,13 +9,14 @@ Fetch the latest and greatest developer articles from the DEV community without 
 | Command | Description |
 |---------|-------------|
 | `opencli devto top` | Top DEV.to articles of the day |
+| `opencli devto latest` | Latest published articles across all tags (paginated) |
 | `opencli devto tag <tag>` | Latest articles for a specific tag |
 | `opencli devto user <username>` | Recent articles from a specific user |
 | `opencli devto read <id>` | Read the body of a single article |
 
 ## Listing columns
 
-`top`, `tag`, and `user` all surface the same agent-native columns so the
+`top`, `latest`, `tag`, and `user` all surface the same agent-native columns so the
 article id is round-trippable into `devto read`:
 
 | Column | Source | Notes |
@@ -53,6 +54,10 @@ does not expose article comments, so this reader does not emit a comment tree.
 ```bash
 # Top articles today
 opencli devto top --limit 5
+
+# Latest published articles (newest first; supports --page for pagination)
+opencli devto latest --limit 20
+opencli devto latest --limit 20 --page 2
 
 # Articles by tag (positional argument)
 opencli devto tag javascript

--- a/docs/adapters/browser/hf.md
+++ b/docs/adapters/browser/hf.md
@@ -7,6 +7,7 @@
 | Command | Description |
 |---------|-------------|
 | `opencli hf top` | Top upvoted Hugging Face papers |
+| `opencli hf paper <arxivId>` | Single paper detail (title / authors / summary / AI keywords / upvotes) |
 | `opencli hf models` | Top Hugging Face models (downloads / likes / trending / freshness) |
 | `opencli hf datasets` | Top Hugging Face datasets |
 
@@ -15,6 +16,10 @@
 ```bash
 # Today's top papers
 opencli hf top --limit 10
+
+# Single paper detail by arXiv id (mirrors HF's paper page)
+opencli hf paper 1706.03762         # Attention Is All You Need
+opencli hf paper 2005.14165         # GPT-3 paper
 
 # All papers (no limit)
 opencli hf top --all
@@ -47,6 +52,14 @@ opencli hf top -f json
 | `--all` | Return all papers, ignoring limit |
 | `--date` | Date in `YYYY-MM-DD` format (defaults to most recent) |
 | `--period` | Time period: `daily`, `weekly`, or `monthly` (default: daily) |
+
+### `paper` Options
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | arXiv id (e.g. `1706.03762`, optionally with version suffix `v3`) |
+
+Returns one row with `id, title, authors, publishedAt, upvotes, aiKeywords, summary, aiSummary, url`. The `summary` is the original arXiv abstract; `aiSummary` and `aiKeywords` are HF's AI-generated metadata (may be empty for older or non-curated papers). Returns `EmptyResultError` if HF has no paper page for that id.
 
 ### `models` Options
 

--- a/docs/adapters/browser/hf.md
+++ b/docs/adapters/browser/hf.md
@@ -53,6 +53,8 @@ opencli hf top -f json
 | `--date` | Date in `YYYY-MM-DD` format (defaults to most recent) |
 | `--period` | Time period: `daily`, `weekly`, or `monthly` (default: daily) |
 
+Returns paper listing rows with `rank, id, title, upvotes, authors`. The `id` value round-trips into `opencli hf paper <id>`.
+
 ### `paper` Options
 
 | Option | Description |

--- a/docs/adapters/browser/lobsters.md
+++ b/docs/adapters/browser/lobsters.md
@@ -10,6 +10,7 @@
 | `opencli lobsters newest` | Latest stories |
 | `opencli lobsters active` | Most active discussions |
 | `opencli lobsters tag <tag>` | Stories by tag |
+| `opencli lobsters domain <domain>` | Stories submitted from a specific source domain |
 | `opencli lobsters read <short_id>` | Read a story and its comment tree |
 
 ## Usage Examples
@@ -20,6 +21,10 @@ opencli lobsters hot --limit 10
 
 # Filter by tag
 opencli lobsters tag rust --limit 5
+
+# Stories from a specific source domain
+opencli lobsters domain github.com --limit 10
+opencli lobsters domain arxiv.org --limit 5
 
 # Read a specific story (use the short_id surfaced as `id` in any listing)
 opencli lobsters read 6cmh6h --limit 25 --depth 2
@@ -33,9 +38,12 @@ opencli lobsters hot -f json
 | Command | Columns |
 |---------|---------|
 | `hot` / `newest` / `active` / `tag` | `rank, id, title, score, author, comments, created_at, tags, url` |
+| `domain` | `rank, id, title, score, author, comments, created_at, tags, submission_url, comments_url` |
 | `read` | `type, author, score, text` (POST + L0/L1/… comments, with `[+N more replies]` stubs) |
 
 `id` is the lobste.rs `short_id` — pipe it into `read` to drill into the discussion.
+
+`domain` returns both `submission_url` (the underlying article URL on the source site) and `comments_url` (the lobste.rs discussion page). The legacy listing commands collapse these into a single `url` (= `comments_url`).
 
 ## Prerequisites
 

--- a/docs/adapters/browser/medium.md
+++ b/docs/adapters/browser/medium.md
@@ -9,6 +9,7 @@
 | `opencli medium feed` | Get hot Medium posts, optionally scoped to a topic |
 | `opencli medium search` | Search Medium posts by keyword |
 | `opencli medium user` | Get recent articles by a user |
+| `opencli medium tag <tag>` | Latest articles for a Medium tag (public RSS, no browser) |
 
 ## Usage Examples
 
@@ -24,9 +25,21 @@ opencli medium user @username
 
 # Topic feed as JSON
 opencli medium feed --topic programming -f json
+
+# Latest articles for a tag (public RSS — fastest, no browser)
+opencli medium tag programming --limit 10
+opencli medium tag artificial-intelligence --limit 20
 ```
+
+## `tag` columns
+
+`rank, title, author, description, categories, published, url`
+
+- `description` is the full RSS `<description>` (no silent truncation; pipe through `head` if you want a preview).
+- `categories` is comma-joined Medium tags from each item's `<category>` blocks.
+- `published` is the original `pubDate` ISO string when available.
 
 ## Prerequisites
 
-- `opencli medium search` can run without a browser
+- `opencli medium search` and `opencli medium tag` can run without a browser (the latter parses `medium.com/feed/tag/<tag>` RSS)
 - `opencli medium feed` and `opencli medium user` require Browser Bridge access to `medium.com`

--- a/docs/adapters/browser/steam.md
+++ b/docs/adapters/browser/steam.md
@@ -7,20 +7,48 @@
 | Command | Description |
 |---------|-------------|
 | `opencli steam top-sellers` | Top selling games on Steam |
+| `opencli steam search <query>` | Search the Steam storefront by name keyword |
+| `opencli steam app <id>` | Storefront detail for a single app id (game / DLC / package) |
 
 ## Usage Examples
 
 ```bash
-# Quick start
-opencli steam top-sellers
+# Top sellers
+opencli steam top-sellers --limit 10
 
-# Limit results
-opencli steam top-sellers --limit 5
+# Free-text search
+opencli steam search "portal" --limit 5
+opencli steam search "stardew" --limit 5
+
+# App detail (round-trip from search.id)
+opencli steam app 620      # Portal 2
+opencli steam app 413150   # Stardew Valley
+
+# Different storefront / currency
+opencli steam search "portal" --currency cn
+opencli steam app 620 --currency jp
 
 # JSON output
-opencli steam top-sellers -f json
+opencli steam app 620 -f json
 ```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `top-sellers` | (see existing top-sellers row schema) |
+| `search` | `rank, id, name, price, currency, metascore, platforms, url` |
+| `app` | `id, name, type, isFree, releaseDate, developers, publishers, price, currency, metacritic, recommendations, genres, categories, shortDescription, website, url` |
+
+The `id` column on `search` round-trips into `app` — it's Steam's numeric app id (also visible in the storefront URL `store.steampowered.com/app/<id>/`).
+
+## Notes
+
+- `price` is the storefront's localized final price expressed as a decimal (e.g. `9.99`), not cents. The accompanying `currency` column gives the ISO code.
+- `--currency` is a Steam country code (`us`, `cn`, `jp`, `de`, ...). It controls both pricing and regional availability — some apps return `success: false` outside their licensed regions; the adapter raises `EmptyResultError` with a hint when that happens.
+- `metascore` / `metacritic` are returned only when Steam has a Metacritic mapping; otherwise they are `null`.
+- HTML entities in `name` and `shortDescription` are decoded (e.g. `&quot;` → `"`).
 
 ## Prerequisites
 
-- No login required (public API)
+- No login required (public APIs `/api/storesearch/` and `/api/appdetails`).


### PR DESCRIPTION
## Summary

Round 2 of the adapter expansion sweep — 11 new read commands across 8 existing sites. All hit public APIs, no browser, no auth, no login. Live-verified against real endpoints; all three audit gates green.

| Site | New command | What it does |
|------|-------------|--------------|
| dblp | `author <name>` | Recent publications for one author (resolves PID by name, or `--pid` direct) |
| steam | `search <query>` | Storefront name search via `/api/storesearch/` |
| steam | `app <id>` | Single app detail via `/api/appdetails`; HTML entities decoded |
| bbc | `topic <topic>` | Per-topic RSS (8 canonical BBC News feeds) |
| devto | `latest` | `/api/articles/latest` with `--page` pagination |
| lobsters | `domain <domain>` | Stories from a specific source domain (`/domains/<d>.json`) |
| medium | `tag <tag>` | Tag RSS at `medium.com/feed/tag/<tag>`; full description, no truncation |
| coingecko | `exchanges` | Trust score + 24h BTC volume leaderboard |
| coingecko | `categories` | Sector buckets with 6 sort options |
| coingecko | `global` | Aggregate market totals + BTC/ETH dominance |
| hf | `paper <arxivId>` | Single paper detail (summary, ai_summary, ai_keywords, upvotes) |

Also adds `clis/steam/utils.js` + `clis/bbc/utils.js` as shared helpers (HTML entity decode, RSS parsing).

## Discipline

- All 11 commands declare `access: 'read'`, no silent clamps, no sentinel rows, no scalar `'-'` / `'N/A'`, no generic `CliError`. Failures route through the 5 typed errors per the post-#1332 convention.
- `medium tag` started with a `.slice(0, 240)` snippet truncation in the first draft — caught and removed before commit; column renamed `description` to match the RSS schema and returns full content (caller pipes through `head` if they want a preview).
- `steam app` initial live test surfaced `&quot;Perpetual Testing Initiative&quot;` HTML entities — fixed by adding `decodeHtmlEntities` to `clis/steam/utils.js` and wiring it through `app.js` (name + shortDescription) and `search.js` (name).
- All listings carry a round-trippable id where a detail sibling exists. `advise:listing-id-pairing` reports zero new violations; `lobsters domain` returns both `submission_url` and `comments_url` (legacy lobsters listings collapse these into one `url`).
- `typed-error-lint` and `silent-column-drop` baselines unchanged.

## Manifest

698 → 709 (+11 entries).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run check:typed-error-lint` (baseline 196, no new violations)
- [x] `npm run check:silent-column-drop` (baseline 103, no new violations)
- [x] `npm run advise:listing-id-pairing` (no new advisories from this PR)
- [x] Live verify each new command against its real endpoint
- [ ] Reviewer spot-check: `opencli dblp author "Yoshua Bengio" --limit 5`, `opencli steam app 620`, `opencli bbc topic technology`, `opencli coingecko global`, `opencli hf paper 1706.03762`