### PR TITLE
feat: round 3 — 13 read adapters across 5 new sites + 4 extensions

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5081,6 +5081,46 @@
   },
   {
     "site": "coingecko",
+    "name": "derivatives",
+    "description": "Top crypto derivative (perpetual / futures) markets by 24h volume",
+    "access": "read",
+    "domain": "api.coingecko.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (1-500; CoinGecko returns one large page)."
+      },
+      {
+        "name": "symbol",
+        "type": "string",
+        "required": false,
+        "help": "Optional symbol substring filter (e.g. \"BTC\", \"ETHUSDT\")."
+      }
+    ],
+    "columns": [
+      "rank",
+      "market",
+      "symbol",
+      "indexId",
+      "contractType",
+      "price",
+      "change24hPct",
+      "fundingRate",
+      "openInterestUsd",
+      "volume24hUsd",
+      "expired"
+    ],
+    "type": "js",
+    "modulePath": "coingecko/derivatives.js",
+    "sourceFile": "coingecko/derivatives.js"
+  },
+  {
+    "site": "coingecko",
     "name": "exchanges",
     "description": "Top crypto exchanges by 24h BTC trading volume",
     "access": "read",
@@ -5298,6 +5338,83 @@
     "modulePath": "coupang/search.js",
     "sourceFile": "coupang/search.js",
     "navigateBefore": "https://www.coupang.com"
+  },
+  {
+    "site": "crates",
+    "name": "crate",
+    "description": "Single crates.io crate metadata (latest version, downloads, license, repo)",
+    "access": "read",
+    "domain": "crates.io",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "crates.io crate name (e.g. \"serde\", \"tokio\")"
+      }
+    ],
+    "columns": [
+      "name",
+      "latestVersion",
+      "description",
+      "downloads",
+      "recentDownloads",
+      "versions",
+      "license",
+      "homepage",
+      "documentation",
+      "repository",
+      "keywords",
+      "categories",
+      "created",
+      "updated",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "crates/crate.js",
+    "sourceFile": "crates/crate.js"
+  },
+  {
+    "site": "crates",
+    "name": "search",
+    "description": "Search the public crates.io registry by keyword",
+    "access": "read",
+    "domain": "crates.io",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (e.g. \"serde\", \"async runtime\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "latestVersion",
+      "description",
+      "downloads",
+      "recentDownloads",
+      "repository",
+      "updated",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "crates/search.js",
+    "sourceFile": "crates/search.js"
   },
   {
     "site": "ctrip",
@@ -5645,6 +5762,41 @@
     "type": "js",
     "modulePath": "dblp/search.js",
     "sourceFile": "dblp/search.js"
+  },
+  {
+    "site": "dblp",
+    "name": "venue",
+    "description": "Search dblp venue registry (conferences / journals) by name or acronym",
+    "access": "read",
+    "domain": "dblp.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Venue name or acronym (e.g. \"ICLR\", \"neural networks\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max venues (1-100, single dblp page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "acronym",
+      "venue",
+      "type",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dblp/venue.js",
+    "sourceFile": "dblp/venue.js"
   },
   {
     "site": "deepseek",
@@ -9746,6 +9898,56 @@
   },
   {
     "site": "hf",
+    "name": "spaces",
+    "description": "Top Hugging Face Spaces (likes / created_at / last_modified).",
+    "access": "read",
+    "domain": "huggingface.co",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "sort",
+        "type": "string",
+        "default": "likes",
+        "required": false,
+        "help": "Sort key: likes, created_at, last_modified"
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "required": false,
+        "help": "Optional name/owner substring filter (e.g. \"stability\", \"openai/\")"
+      },
+      {
+        "name": "sdk",
+        "type": "string",
+        "required": false,
+        "help": "Filter by Space SDK: gradio / streamlit / docker / static"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max spaces (max 100; one API page)."
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "author",
+      "sdk",
+      "likes",
+      "tags",
+      "lastModified",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "hf/spaces.js",
+    "sourceFile": "hf/spaces.js"
+  },
+  {
+    "site": "hf",
     "name": "top",
     "description": "Top upvoted Hugging Face papers",
     "access": "read",
@@ -13352,6 +13554,49 @@
     "navigateBefore": "https://maimai.cn"
   },
   {
+    "site": "mdn",
+    "name": "search",
+    "description": "Search MDN Web Docs by keyword",
+    "access": "read",
+    "domain": "developer.mozilla.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (e.g. \"fetch\", \"flexbox\", \"Array.prototype.map\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max results (1-50)"
+      },
+      {
+        "name": "locale",
+        "type": "str",
+        "default": "en-US",
+        "required": false,
+        "help": "Doc locale (en-US default; de / es / fr / ja / ko / pt-BR / ru / zh-CN / zh-TW)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "title",
+      "slug",
+      "locale",
+      "summary",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "mdn/search.js",
+    "sourceFile": "mdn/search.js"
+  },
+  {
     "site": "medium",
     "name": "feed",
     "description": "Medium 热门文章 Feed",
@@ -14718,6 +14963,149 @@
     "sourceFile": "nowcoder/trending.js"
   },
   {
+    "site": "npm",
+    "name": "downloads",
+    "description": "Daily download counts for an npm package over a window",
+    "access": "read",
+    "domain": "api.npmjs.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "npm package name (e.g. \"react\", \"@vercel/og\")"
+      },
+      {
+        "name": "period",
+        "type": "str",
+        "default": "last-week",
+        "required": false,
+        "help": "last-day / last-week / last-month / last-year, or YYYY-MM-DD:YYYY-MM-DD"
+      }
+    ],
+    "columns": [
+      "rank",
+      "package",
+      "day",
+      "downloads"
+    ],
+    "type": "js",
+    "modulePath": "npm/downloads.js",
+    "sourceFile": "npm/downloads.js"
+  },
+  {
+    "site": "npm",
+    "name": "package",
+    "description": "Single npm package metadata (latest version, license, homepage, repository). Use `npm downloads` for stats.",
+    "access": "read",
+    "domain": "registry.npmjs.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "npm package name (e.g. \"react\", \"@vercel/og\")"
+      }
+    ],
+    "columns": [
+      "name",
+      "latestVersion",
+      "description",
+      "license",
+      "homepage",
+      "repository",
+      "bugs",
+      "maintainers",
+      "keywords",
+      "created",
+      "modified",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "npm/package.js",
+    "sourceFile": "npm/package.js"
+  },
+  {
+    "site": "npm",
+    "name": "search",
+    "description": "Search the public npm registry by keyword",
+    "access": "read",
+    "domain": "registry.npmjs.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (e.g. \"react\", \"graphql client\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-250)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "version",
+      "description",
+      "weeklyDownloads",
+      "dependents",
+      "license",
+      "publisher",
+      "updated",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "npm/search.js",
+    "sourceFile": "npm/search.js"
+  },
+  {
+    "site": "nvd",
+    "name": "cve",
+    "description": "NIST NVD CVE detail (description, CVSS, CWE, KEV flag)",
+    "access": "read",
+    "domain": "services.nvd.nist.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "CVE identifier (e.g. \"CVE-2021-44228\")"
+      }
+    ],
+    "columns": [
+      "id",
+      "published",
+      "lastModified",
+      "vulnStatus",
+      "baseScore",
+      "severity",
+      "attackVector",
+      "cwe",
+      "kevAdded",
+      "description",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "nvd/cve.js",
+    "sourceFile": "nvd/cve.js"
+  },
+  {
     "site": "ones",
     "name": "login",
     "description": "ONES Project API — login via Chrome Bridge (POST auth/login); stderr prints export hints for ONES_USER_ID / TOKEN",
@@ -16074,6 +16462,77 @@
     "type": "js",
     "modulePath": "pubmed/search.js",
     "sourceFile": "pubmed/search.js"
+  },
+  {
+    "site": "pypi",
+    "name": "downloads",
+    "description": "PyPI download stats for a package (recent totals or full daily history)",
+    "access": "read",
+    "domain": "pypistats.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "PyPI package name (e.g. \"requests\", \"pandas\")"
+      },
+      {
+        "name": "period",
+        "type": "str",
+        "default": "recent",
+        "required": false,
+        "help": "recent (default — 1 row, last day/week/month) or overall (1 row per day)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "package",
+      "period",
+      "date",
+      "downloads"
+    ],
+    "type": "js",
+    "modulePath": "pypi/downloads.js",
+    "sourceFile": "pypi/downloads.js"
+  },
+  {
+    "site": "pypi",
+    "name": "package",
+    "description": "Single PyPI package metadata (latest version, license, homepage, classifiers)",
+    "access": "read",
+    "domain": "pypi.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "PyPI package name (e.g. \"requests\", \"pandas\")"
+      }
+    ],
+    "columns": [
+      "name",
+      "latestVersion",
+      "summary",
+      "author",
+      "license",
+      "homepage",
+      "repository",
+      "requiresPython",
+      "keywords",
+      "releases",
+      "firstReleased",
+      "lastReleased",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "pypi/package.js",
+    "sourceFile": "pypi/package.js"
   },
   {
     "site": "quark",
@@ -17847,6 +18306,55 @@
     "type": "js",
     "modulePath": "stackoverflow/read.js",
     "sourceFile": "stackoverflow/read.js"
+  },
+  {
+    "site": "stackoverflow",
+    "name": "related",
+    "description": "List Stack Overflow questions related to a given question id.",
+    "access": "read",
+    "domain": "stackoverflow.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Stack Overflow question id (numeric, e.g. 79935770)."
+      },
+      {
+        "name": "sort",
+        "type": "string",
+        "default": "rank",
+        "required": false,
+        "help": "Sort key: rank, activity, votes, creation (rank = SO relevance default)."
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max related questions (1-100)."
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "score",
+      "answers",
+      "views",
+      "isAnswered",
+      "tags",
+      "author",
+      "createdAt",
+      "lastActivityAt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "stackoverflow/related.js",
+    "sourceFile": "stackoverflow/related.js"
   },
   {
     "site": "stackoverflow",

--- a/clis/coingecko/derivatives.js
+++ b/clis/coingecko/derivatives.js
@@ -1,0 +1,84 @@
+// coingecko derivatives — perpetual / futures tickers across crypto exchanges.
+//
+// Hits the public `/api/v3/derivatives` endpoint (no auth, free tier). Each
+// row is one exchange-symbol combo: market, contract type, mark price, 24h
+// %, basis vs index, funding rate, open interest (USD), 24h volume.
+//
+// CoinGecko sorts the response by 24h volume desc, so `rank` mirrors the
+// listing order with no client-side reshuffling.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const ENDPOINT = 'https://api.coingecko.com/api/v3/derivatives';
+
+cli({
+    site: 'coingecko',
+    name: 'derivatives',
+    access: 'read',
+    description: 'Top crypto derivative (perpetual / futures) markets by 24h volume',
+    domain: 'api.coingecko.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (1-500; CoinGecko returns one large page).' },
+        { name: 'symbol', type: 'string', required: false, help: 'Optional symbol substring filter (e.g. "BTC", "ETHUSDT").' },
+    ],
+    columns: ['rank', 'market', 'symbol', 'indexId', 'contractType', 'price', 'change24hPct', 'fundingRate', 'openInterestUsd', 'volume24hUsd', 'expired'],
+    func: async (args) => {
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('coingecko derivatives limit must be a positive integer');
+        }
+        if (limit > 500) {
+            throw new ArgumentError('coingecko derivatives limit must be <= 500');
+        }
+        const filter = args.symbol == null ? '' : String(args.symbol).trim().toUpperCase();
+        let resp;
+        try {
+            resp = await fetch(ENDPOINT, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko derivatives request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'coingecko derivatives returned HTTP 429 (rate limited)',
+                'Free tier allows ~30 calls/min. Wait and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`coingecko derivatives returned HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`coingecko derivatives returned malformed JSON: ${err?.message ?? err}`);
+        }
+        if (!Array.isArray(data) || !data.length) {
+            throw new EmptyResultError('coingecko derivatives', 'CoinGecko returned no derivative tickers.');
+        }
+        let rows = data;
+        if (filter) {
+            rows = data.filter((d) => String(d.symbol ?? '').toUpperCase().includes(filter)
+                || String(d.index_id ?? '').toUpperCase().includes(filter));
+            if (!rows.length) {
+                throw new EmptyResultError('coingecko derivatives', `No derivative tickers matched symbol="${filter}".`);
+            }
+        }
+        return rows.slice(0, limit).map((d, i) => ({
+            rank: i + 1,
+            market: String(d.market ?? ''),
+            symbol: String(d.symbol ?? ''),
+            indexId: String(d.index_id ?? ''),
+            contractType: String(d.contract_type ?? ''),
+            price: d.price != null ? Number(d.price) : null,
+            change24hPct: d.price_percentage_change_24h != null ? Number(d.price_percentage_change_24h) : null,
+            fundingRate: d.funding_rate != null ? Number(d.funding_rate) : null,
+            openInterestUsd: d.open_interest != null ? Number(d.open_interest) : null,
+            volume24hUsd: d.volume_24h != null ? Number(d.volume_24h) : null,
+            expired: d.expired_at ? String(d.expired_at) : '',
+        }));
+    },
+});

--- a/clis/crates/crate.js
+++ b/clis/crates/crate.js
@@ -1,0 +1,62 @@
+// crates crate — fetch a single crate's metadata.
+//
+// Hits `https://crates.io/api/v1/crates/<name>`. Returns the agent-useful
+// projection: name, latest version, description, total + recent downloads,
+// homepage / docs / repo, license (from latest version row), version count,
+// created / updated timestamps.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CRATES_BASE, cratesFetch, requireCrateName } from './utils.js';
+
+cli({
+    site: 'crates',
+    name: 'crate',
+    access: 'read',
+    description: 'Single crates.io crate metadata (latest version, downloads, license, repo)',
+    domain: 'crates.io',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'crates.io crate name (e.g. "serde", "tokio")' },
+    ],
+    columns: [
+        'name', 'latestVersion', 'description', 'downloads', 'recentDownloads', 'versions',
+        'license', 'homepage', 'documentation', 'repository', 'keywords', 'categories', 'created', 'updated', 'url',
+    ],
+    func: async (args) => {
+        const name = requireCrateName(args.name);
+        const body = await cratesFetch(`${CRATES_BASE}/api/v1/crates/${encodeURIComponent(name)}`, `crates crate ${name}`);
+        const c = body?.crate;
+        if (!c || !c.id) {
+            throw new EmptyResultError('crates crate', `crates.io returned no metadata for "${name}".`);
+        }
+        const versions = Array.isArray(body.versions) ? body.versions : [];
+        const latestRow = versions.find((v) => v.num === c.newest_version)
+            || versions.find((v) => v.num === c.max_stable_version)
+            || versions[0]
+            || {};
+        const keywords = Array.isArray(body.keywords)
+            ? body.keywords.map((k) => k?.keyword || k?.id || '').filter(Boolean).join(', ')
+            : '';
+        const categories = Array.isArray(body.categories)
+            ? body.categories.map((cat) => cat?.category || cat?.slug || '').filter(Boolean).join(', ')
+            : '';
+        return [{
+            name: String(c.name ?? c.id),
+            latestVersion: String(c.newest_version ?? c.max_stable_version ?? c.max_version ?? ''),
+            description: String(c.description ?? '').trim(),
+            downloads: c.downloads != null ? Number(c.downloads) : null,
+            recentDownloads: c.recent_downloads != null ? Number(c.recent_downloads) : null,
+            versions: c.num_versions != null ? Number(c.num_versions) : versions.length,
+            license: String(latestRow.license ?? ''),
+            homepage: String(c.homepage ?? ''),
+            documentation: String(c.documentation ?? ''),
+            repository: String(c.repository ?? ''),
+            keywords,
+            categories,
+            created: String(c.created_at ?? '').slice(0, 10),
+            updated: String(c.updated_at ?? '').slice(0, 10),
+            url: `https://crates.io/crates/${c.name ?? c.id}`,
+        }];
+    },
+});

--- a/clis/crates/search.js
+++ b/clis/crates/search.js
@@ -1,0 +1,44 @@
+// crates search — search the crates.io registry by free-text query.
+//
+// Hits `https://crates.io/api/v1/crates?q=…&per_page=…`. Returns name (round-
+// trips into `crates crate`), latest version, description, downloads, recent
+// downloads, repository, last-update.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CRATES_BASE, cratesFetch, requireBoundedInt, requireString } from './utils.js';
+
+cli({
+    site: 'crates',
+    name: 'search',
+    access: 'read',
+    description: 'Search the public crates.io registry by keyword',
+    domain: 'crates.io',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "serde", "async runtime")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-100)' },
+    ],
+    columns: ['rank', 'name', 'latestVersion', 'description', 'downloads', 'recentDownloads', 'repository', 'updated', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const url = `${CRATES_BASE}/api/v1/crates?q=${encodeURIComponent(query)}&per_page=${limit}`;
+        const body = await cratesFetch(url, 'crates search');
+        const list = Array.isArray(body?.crates) ? body.crates : [];
+        if (!list.length) {
+            throw new EmptyResultError('crates search', `No crates.io results matched "${query}".`);
+        }
+        return list.slice(0, limit).map((c, i) => ({
+            rank: i + 1,
+            name: String(c.name ?? c.id ?? ''),
+            latestVersion: String(c.newest_version ?? c.max_stable_version ?? c.max_version ?? ''),
+            description: String(c.description ?? '').trim(),
+            downloads: c.downloads != null ? Number(c.downloads) : null,
+            recentDownloads: c.recent_downloads != null ? Number(c.recent_downloads) : null,
+            repository: String(c.repository ?? c.homepage ?? ''),
+            updated: String(c.updated_at ?? '').slice(0, 10),
+            url: c.name ? `https://crates.io/crates/${c.name}` : '',
+        }));
+    },
+});

--- a/clis/crates/utils.js
+++ b/clis/crates/utils.js
@@ -1,0 +1,72 @@
+// Shared helpers for the crates.io adapters.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const CRATES_BASE = 'https://crates.io';
+const UA = 'opencli-crates-adapter (+https://github.com/jackwener/opencli)';
+
+// crates.io crate names: 1-64 chars, ascii letters/digits/-_, must start with a letter.
+const CRATE_NAME = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`crates ${label} cannot be empty`);
+    return s;
+}
+
+export function requireCrateName(value) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError('crates crate name is required (e.g. "serde", "tokio")');
+    if (!CRATE_NAME.test(s)) {
+        throw new ArgumentError(
+            `crates crate name "${value}" is not a valid crates.io name`,
+            'Names start with an ASCII letter, then 0-63 chars of letters / digits / "_-".',
+        );
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`crates ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`crates ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function cratesFetch(url, label) {
+    let resp;
+    try {
+        // crates.io requires a descriptive User-Agent per https://crates.io/data-access
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that crates.io is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `crates.io returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'crates.io rate-limits unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/dblp/venue.js
+++ b/clis/dblp/venue.js
@@ -1,0 +1,64 @@
+// dblp venue — search dblp's venue (conference / journal) registry.
+//
+// Hits `https://dblp.org/search/venue/api?q=…&format=json&h=…`. Returns a
+// row per matched venue. Useful for resolving an acronym (e.g. "ICLR" →
+// dblp's canonical venue page) and for browsing venues that match a topic.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    DBLP_ORIGIN,
+    decodeXmlEntities,
+    dblpFetchJson,
+    requireBoundedInt,
+    requireQuery,
+} from './utils.js';
+
+function simplifyVenueType(type) {
+    const t = String(type ?? '').trim();
+    if (!t) return '';
+    if (/Conference or Workshop/i.test(t)) return 'conf';
+    if (/Journal/i.test(t)) return 'journal';
+    if (/Series/i.test(t)) return 'series';
+    if (/Book/i.test(t)) return 'book';
+    if (/Reference/i.test(t)) return 'reference';
+    return t.toLowerCase().split(/\s+/)[0];
+}
+
+function venueHitToRow(hit, rank) {
+    const info = hit?.info ?? {};
+    const url = String(info.url ?? '').trim();
+    return {
+        rank,
+        acronym: String(info.acronym ?? '').trim(),
+        venue: decodeXmlEntities(info.venue ?? ''),
+        type: simplifyVenueType(info.type),
+        url: url.startsWith('http') ? url : url ? `${DBLP_ORIGIN}${url.startsWith('/') ? '' : '/'}${url}` : '',
+    };
+}
+
+cli({
+    site: 'dblp',
+    name: 'venue',
+    access: 'read',
+    description: 'Search dblp venue registry (conferences / journals) by name or acronym',
+    domain: 'dblp.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Venue name or acronym (e.g. "ICLR", "neural networks")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max venues (1-100, single dblp page)' },
+    ],
+    columns: ['rank', 'acronym', 'venue', 'type', 'url'],
+    func: async (args) => {
+        const query = requireQuery(args.query);
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const path = `/search/venue/api?q=${encodeURIComponent(query)}&format=json&h=${limit}`;
+        const json = await dblpFetchJson(path, 'dblp venue');
+        const hits = json?.result?.hits?.hit;
+        const list = Array.isArray(hits) ? hits : [];
+        if (list.length === 0) {
+            throw new EmptyResultError('dblp venue', `No dblp venues matched "${query}".`);
+        }
+        return list.slice(0, limit).map((hit, i) => venueHitToRow(hit, i + 1));
+    },
+});

--- a/clis/hf/spaces.js
+++ b/clis/hf/spaces.js
@@ -1,0 +1,101 @@
+// hf spaces — list top Hugging Face Spaces (gradio / streamlit / static demos).
+//
+// Hits `https://huggingface.co/api/spaces?sort=…&full=true`. Mirrors the shape
+// of `hf models` / `hf datasets`. The Spaces API does not expose `trending` as
+// a sort key (verified live: returns "Invalid sort parameter"), so the allowed
+// sort set is narrower.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const SORT_OPTIONS = ['likes', 'created_at', 'last_modified'];
+const SORT_ALIAS = { lastmodified: 'last_modified', createdat: 'created_at' };
+
+cli({
+    site: 'hf',
+    name: 'spaces',
+    access: 'read',
+    description: 'Top Hugging Face Spaces (likes / created_at / last_modified).',
+    domain: 'huggingface.co',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'sort', type: 'string', default: 'likes', help: `Sort key: ${SORT_OPTIONS.join(', ')}` },
+        { name: 'search', type: 'string', required: false, help: 'Optional name/owner substring filter (e.g. "stability", "openai/")' },
+        { name: 'sdk', type: 'string', required: false, help: 'Filter by Space SDK: gradio / streamlit / docker / static' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max spaces (max 100; one API page).' },
+    ],
+    columns: ['rank', 'id', 'author', 'sdk', 'likes', 'tags', 'lastModified', 'url'],
+    func: async (args) => {
+        const sortRaw = String(args.sort ?? 'likes').toLowerCase();
+        const sort = SORT_ALIAS[sortRaw] ?? sortRaw;
+        if (!SORT_OPTIONS.includes(sort)) {
+            throw new ArgumentError(`hf spaces sort must be one of ${SORT_OPTIONS.join(', ')}`);
+        }
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('hf spaces limit must be a positive integer');
+        }
+        if (limit > 100) {
+            throw new ArgumentError('hf spaces limit must be <= 100');
+        }
+        const sdk = args.sdk == null ? '' : String(args.sdk).trim().toLowerCase();
+        const allowedSdks = new Set(['', 'gradio', 'streamlit', 'docker', 'static']);
+        if (!allowedSdks.has(sdk)) {
+            throw new ArgumentError(`hf spaces sdk must be one of gradio / streamlit / docker / static`);
+        }
+
+        const url = new URL('https://huggingface.co/api/spaces');
+        url.searchParams.set('sort', sort);
+        url.searchParams.set('direction', '-1');
+        url.searchParams.set('limit', String(limit));
+        url.searchParams.set('full', 'true');
+        if (args.search) url.searchParams.set('search', String(args.search));
+        if (sdk) url.searchParams.set('sdk', sdk);
+
+        let resp;
+        try {
+            resp = await fetch(url, {
+                headers: { Accept: 'application/json', 'User-Agent': 'opencli/1.0 (+https://github.com/jackwener/opencli)' },
+            });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`hf spaces request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'hf spaces returned HTTP 429 (rate limited)',
+                'Hugging Face throttles unauthenticated traffic; wait a few seconds and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`hf spaces failed: HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`hf spaces returned malformed JSON: ${err?.message ?? err}`);
+        }
+        const list = Array.isArray(data) ? data : [];
+        if (!list.length) {
+            throw new EmptyResultError('hf spaces', 'No matching spaces on huggingface.co.');
+        }
+        return list.slice(0, limit).map((s, i) => {
+            const id = String(s.id ?? s._id ?? '');
+            const slash = id.indexOf('/');
+            const author = String(s.author ?? (slash > 0 ? id.slice(0, slash) : ''));
+            const tags = Array.isArray(s.tags) ? s.tags.filter((t) => !String(t).startsWith('license:')).slice(0, 10).join(', ') : '';
+            return {
+                rank: i + 1,
+                id,
+                author,
+                sdk: String(s.sdk ?? ''),
+                likes: s.likes != null ? Number(s.likes) : null,
+                tags,
+                lastModified: String(s.lastModified ?? '').slice(0, 10),
+                url: id ? `https://huggingface.co/spaces/${id}` : '',
+            };
+        });
+    },
+});

--- a/clis/mdn/search.js
+++ b/clis/mdn/search.js
@@ -1,0 +1,97 @@
+// mdn search — search MDN Web Docs.
+//
+// Hits `https://developer.mozilla.org/api/v1/search?q=…&locale=…`. Returns a
+// row per matched doc with title, slug-derived id, summary preview, and the
+// canonical MDN URL.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const MDN_BASE = 'https://developer.mozilla.org';
+const UA = 'opencli-mdn-adapter (+https://github.com/jackwener/opencli)';
+const ALLOWED_LOCALES = new Set(['en-US', 'de', 'es', 'fr', 'ja', 'ko', 'pt-BR', 'ru', 'zh-CN', 'zh-TW']);
+
+function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`mdn ${label} cannot be empty`);
+    return s;
+}
+
+function requireBoundedInt(value, defaultValue, maxValue) {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError('mdn limit must be a positive integer');
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`mdn limit must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+function requireLocale(value) {
+    const s = String(value ?? 'en-US').trim();
+    if (!ALLOWED_LOCALES.has(s)) {
+        throw new ArgumentError(
+            `mdn locale "${value}" is not supported`,
+            `Allowed locales: ${[...ALLOWED_LOCALES].join(' / ')}`,
+        );
+    }
+    return s;
+}
+
+cli({
+    site: 'mdn',
+    name: 'search',
+    access: 'read',
+    description: 'Search MDN Web Docs by keyword',
+    domain: 'developer.mozilla.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "fetch", "flexbox", "Array.prototype.map")' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max results (1-50)' },
+        { name: 'locale', default: 'en-US', help: 'Doc locale (en-US default; de / es / fr / ja / ko / pt-BR / ru / zh-CN / zh-TW)' },
+    ],
+    columns: ['rank', 'title', 'slug', 'locale', 'summary', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 10, 50);
+        const locale = requireLocale(args.locale);
+        const url = `${MDN_BASE}/api/v1/search?q=${encodeURIComponent(query)}&locale=${encodeURIComponent(locale)}&size=${limit}`;
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`mdn search request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'mdn search returned HTTP 429 (rate limited)',
+                'MDN throttles bursty traffic; wait a few seconds and retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`mdn search returned HTTP ${resp.status}`);
+        }
+        let body;
+        try {
+            body = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`mdn search returned malformed JSON: ${err?.message ?? err}`);
+        }
+        const docs = Array.isArray(body?.documents) ? body.documents : [];
+        if (!docs.length) {
+            throw new EmptyResultError('mdn search', `No MDN results matched "${query}" (locale ${locale}).`);
+        }
+        return docs.slice(0, limit).map((doc, i) => ({
+            rank: i + 1,
+            title: String(doc.title ?? ''),
+            slug: String(doc.slug ?? ''),
+            locale: String(doc.locale ?? locale),
+            summary: String(doc.summary ?? '').replace(/\s+/g, ' ').trim(),
+            url: doc.mdn_url ? `${MDN_BASE}${doc.mdn_url}` : '',
+        }));
+    },
+});

--- a/clis/npm/downloads.js
+++ b/clis/npm/downloads.js
@@ -1,0 +1,59 @@
+// npm downloads — fetch download counts for a single npm package over a window.
+//
+// Hits `api.npmjs.org/downloads/range/<period>/<pkg>`. Default window is the
+// last 7 days (one row per day). Use `--period last-month` for 30 days, or
+// pass a custom `YYYY-MM-DD:YYYY-MM-DD` range.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { NPM_API, npmFetch, requirePackageName } from './utils.js';
+
+const FIXED_PERIODS = new Set(['last-day', 'last-week', 'last-month', 'last-year']);
+const RANGE_PATTERN = /^(\d{4}-\d{2}-\d{2}):(\d{4}-\d{2}-\d{2})$/;
+
+function requirePeriod(value) {
+    const s = String(value ?? 'last-week').trim();
+    if (FIXED_PERIODS.has(s)) return s;
+    const m = RANGE_PATTERN.exec(s);
+    if (m) {
+        const [, start, end] = m;
+        if (new Date(start) > new Date(end)) {
+            throw new ArgumentError(`npm downloads period start ${start} is after end ${end}`);
+        }
+        return `${start}:${end}`;
+    }
+    throw new ArgumentError(
+        `npm downloads period "${value}" is invalid`,
+        'Use last-day / last-week (default) / last-month / last-year, or YYYY-MM-DD:YYYY-MM-DD.',
+    );
+}
+
+cli({
+    site: 'npm',
+    name: 'downloads',
+    access: 'read',
+    description: 'Daily download counts for an npm package over a window',
+    domain: 'api.npmjs.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'npm package name (e.g. "react", "@vercel/og")' },
+        { name: 'period', default: 'last-week', help: 'last-day / last-week / last-month / last-year, or YYYY-MM-DD:YYYY-MM-DD' },
+    ],
+    columns: ['rank', 'package', 'day', 'downloads'],
+    func: async (args) => {
+        const name = requirePackageName(args.name);
+        const period = requirePeriod(args.period);
+        const url = `${NPM_API}/downloads/range/${period}/${name}`;
+        const body = await npmFetch(url, `npm downloads ${name}`);
+        const days = Array.isArray(body?.downloads) ? body.downloads : [];
+        if (!days.length) {
+            throw new EmptyResultError('npm downloads', `npm has no download stats for "${name}" in window ${period}.`);
+        }
+        return days.map((row, i) => ({
+            rank: i + 1,
+            package: String(body.package ?? name),
+            day: String(row.day ?? ''),
+            downloads: row.downloads != null ? Number(row.downloads) : null,
+        }));
+    },
+});

--- a/clis/npm/package.js
+++ b/clis/npm/package.js
@@ -1,0 +1,70 @@
+// npm package — fetch a single package's registry metadata.
+//
+// Hits `https://registry.npmjs.org/<pkg>` and projects the fields most useful
+// for an agent: name, latest version, description, license, homepage,
+// repository, bug tracker, maintainers, last-modified time. Download stats
+// are intentionally separate (see `npm downloads`) so failure modes don't get
+// silently folded into a registry-metadata response.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { NPM_REGISTRY, npmFetch, requirePackageName } from './utils.js';
+
+function repoUrl(repo) {
+    if (!repo) return '';
+    if (typeof repo === 'string') return repo;
+    if (typeof repo === 'object' && typeof repo.url === 'string') {
+        return repo.url.replace(/^git\+/, '').replace(/\.git$/, '');
+    }
+    return '';
+}
+
+function bugUrl(bugs) {
+    if (!bugs) return '';
+    if (typeof bugs === 'string') return bugs;
+    if (typeof bugs === 'object' && typeof bugs.url === 'string') return bugs.url;
+    return '';
+}
+
+cli({
+    site: 'npm',
+    name: 'package',
+    access: 'read',
+    description: 'Single npm package metadata (latest version, license, homepage, repository). Use `npm downloads` for stats.',
+    domain: 'registry.npmjs.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'npm package name (e.g. "react", "@vercel/og")' },
+    ],
+    columns: [
+        'name', 'latestVersion', 'description', 'license', 'homepage', 'repository',
+        'bugs', 'maintainers', 'keywords', 'created', 'modified', 'url',
+    ],
+    func: async (args) => {
+        const name = requirePackageName(args.name);
+        const body = await npmFetch(`${NPM_REGISTRY}/${name.split('/').map(encodeURIComponent).join('/')}`, `npm package ${name}`);
+        const latest = body?.['dist-tags']?.latest;
+        if (!latest) {
+            throw new EmptyResultError('npm package', `npm registry has no latest version for "${name}".`);
+        }
+        const v = body?.versions?.[latest] ?? {};
+        const maintainers = Array.isArray(body.maintainers)
+            ? body.maintainers.map((m) => (typeof m === 'object' && m ? m.name || m.email || '' : String(m))).filter(Boolean).join(', ')
+            : '';
+        const keywords = Array.isArray(v.keywords) ? v.keywords.join(', ') : '';
+        return [{
+            name: String(body.name ?? name),
+            latestVersion: String(latest),
+            description: String(v.description ?? body.description ?? ''),
+            license: typeof v.license === 'string' ? v.license : (v.license?.type ?? ''),
+            homepage: String(v.homepage ?? ''),
+            repository: repoUrl(v.repository),
+            bugs: bugUrl(v.bugs),
+            maintainers,
+            keywords,
+            created: String(body.time?.created ?? '').slice(0, 10),
+            modified: String(body.time?.modified ?? '').slice(0, 10),
+            url: `https://www.npmjs.com/package/${name}`,
+        }];
+    },
+});

--- a/clis/npm/search.js
+++ b/clis/npm/search.js
@@ -1,0 +1,49 @@
+// npm search — search the public npm registry by free-text query.
+//
+// Hits `https://registry.npmjs.org/-/v1/search?text=…`. Returns enough per-row
+// to feed back into `npm package` / `npm downloads`: name (round-trips as id),
+// description, version, weekly downloads, dependents count, license, links.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { NPM_REGISTRY, npmFetch, requireBoundedInt, requireString } from './utils.js';
+
+cli({
+    site: 'npm',
+    name: 'search',
+    access: 'read',
+    description: 'Search the public npm registry by keyword',
+    domain: 'registry.npmjs.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (e.g. "react", "graphql client")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-250)' },
+    ],
+    columns: ['rank', 'name', 'version', 'description', 'weeklyDownloads', 'dependents', 'license', 'publisher', 'updated', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 250);
+        const url = `${NPM_REGISTRY}/-/v1/search?text=${encodeURIComponent(query)}&size=${limit}`;
+        const body = await npmFetch(url, 'npm search');
+        const objects = Array.isArray(body?.objects) ? body.objects : [];
+        if (!objects.length) {
+            throw new EmptyResultError('npm search', `No npm packages matched "${query}".`);
+        }
+        return objects.slice(0, limit).map((obj, i) => {
+            const pkg = obj?.package ?? {};
+            const dl = obj?.downloads ?? {};
+            return {
+                rank: i + 1,
+                name: String(pkg.name ?? ''),
+                version: String(pkg.version ?? ''),
+                description: String(pkg.description ?? ''),
+                weeklyDownloads: dl.weekly != null ? Number(dl.weekly) : null,
+                dependents: obj.dependents != null ? Number(obj.dependents) : null,
+                license: String(pkg.license ?? ''),
+                publisher: String(pkg.publisher?.username ?? ''),
+                updated: String(obj.updated ?? '').slice(0, 10),
+                url: pkg.links?.npm ? String(pkg.links.npm) : (pkg.name ? `https://www.npmjs.com/package/${pkg.name}` : ''),
+            };
+        });
+    },
+});

--- a/clis/npm/utils.js
+++ b/clis/npm/utils.js
@@ -1,0 +1,76 @@
+// Shared helpers for the npm adapters that hit the public npm registry
+// (registry.npmjs.org) and download stats API (api.npmjs.org).
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const NPM_REGISTRY = 'https://registry.npmjs.org';
+export const NPM_API = 'https://api.npmjs.org';
+const UA = 'opencli-npm-adapter (+https://github.com/jackwener/opencli)';
+
+// npm package names: 1-214 chars, lowercase letters/numbers/-._ , scoped form `@scope/name`.
+const PKG_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/i;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`npm ${label} cannot be empty`);
+    return s;
+}
+
+export function requirePackageName(value) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError('npm package name is required (e.g. "react", "@vercel/og")');
+    if (s.length > 214) {
+        throw new ArgumentError(`npm package name "${value}" is too long (max 214 chars)`);
+    }
+    if (!PKG_NAME.test(s)) {
+        throw new ArgumentError(
+            `npm package name "${value}" is not a valid registry name`,
+            'Names are 1–214 chars of lowercase a-z / 0-9 / "-._" (scoped form: "@scope/name").',
+        );
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`npm ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`npm ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function npmFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that registry.npmjs.org / api.npmjs.org are reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `npm registry returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'npm throttles unauthenticated bursts; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/nvd/cve.js
+++ b/clis/nvd/cve.js
@@ -1,0 +1,121 @@
+// nvd cve — fetch a single CVE from the NIST National Vulnerability Database.
+//
+// Hits the CVE API 2.0 (`services.nvd.nist.gov/rest/json/cves/2.0?cveId=…`).
+// Returns the agent-useful projection: id, published / last-modified dates,
+// vuln status, English description, CVSS v3.1 base score / severity / vector,
+// CWE id(s), CISA KEV flag.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const NVD_BASE = 'https://services.nvd.nist.gov/rest/json/cves/2.0';
+const UA = 'opencli-nvd-adapter (+https://github.com/jackwener/opencli)';
+const CVE_ID = /^CVE-\d{4}-\d{4,}$/i;
+
+function requireCveId(value) {
+    const s = String(value ?? '').trim().toUpperCase();
+    if (!s) throw new ArgumentError('nvd CVE id is required (e.g. "CVE-2021-44228")');
+    if (!CVE_ID.test(s)) {
+        throw new ArgumentError(
+            `nvd CVE id "${value}" is not a valid CVE identifier`,
+            'Expected the form "CVE-YYYY-N..." with at least 4 sequence digits.',
+        );
+    }
+    return s;
+}
+
+function pickEnglishDescription(descriptions) {
+    if (!Array.isArray(descriptions)) return '';
+    const en = descriptions.find((d) => d?.lang === 'en');
+    return String(en?.value ?? descriptions[0]?.value ?? '').trim();
+}
+
+function pickPrimaryCvss(metrics) {
+    if (!metrics || typeof metrics !== 'object') return null;
+    const candidates = [
+        ...(Array.isArray(metrics.cvssMetricV31) ? metrics.cvssMetricV31 : []),
+        ...(Array.isArray(metrics.cvssMetricV30) ? metrics.cvssMetricV30 : []),
+        ...(Array.isArray(metrics.cvssMetricV2) ? metrics.cvssMetricV2 : []),
+    ];
+    return candidates.find((m) => m?.type === 'Primary') || candidates[0] || null;
+}
+
+function joinCwes(weaknesses) {
+    if (!Array.isArray(weaknesses)) return '';
+    const ids = new Set();
+    for (const w of weaknesses) {
+        for (const desc of w?.description ?? []) {
+            if (desc?.value) ids.add(String(desc.value));
+        }
+    }
+    return [...ids].join(', ');
+}
+
+cli({
+    site: 'nvd',
+    name: 'cve',
+    access: 'read',
+    description: 'NIST NVD CVE detail (description, CVSS, CWE, KEV flag)',
+    domain: 'services.nvd.nist.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'CVE identifier (e.g. "CVE-2021-44228")' },
+    ],
+    columns: [
+        'id', 'published', 'lastModified', 'vulnStatus', 'baseScore', 'severity',
+        'attackVector', 'cwe', 'kevAdded', 'description', 'url',
+    ],
+    func: async (args) => {
+        const id = requireCveId(args.id);
+        const url = `${NVD_BASE}?cveId=${encodeURIComponent(id)}`;
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`nvd cve request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 403) {
+            throw new CommandExecutionError(
+                'nvd cve returned HTTP 403',
+                'NVD enforces aggressive rate limits without an API key. Wait, then retry or set NVD_API_KEY (not yet wired).',
+            );
+        }
+        if (resp.status === 429) {
+            throw new CommandExecutionError(
+                'nvd cve returned HTTP 429 (rate limited)',
+                'NVD throttles unauthenticated traffic; wait several seconds before retry.',
+            );
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`nvd cve returned HTTP ${resp.status}`);
+        }
+        let body;
+        try {
+            body = await resp.json();
+        }
+        catch (err) {
+            throw new CommandExecutionError(`nvd cve returned malformed JSON: ${err?.message ?? err}`);
+        }
+        const list = Array.isArray(body?.vulnerabilities) ? body.vulnerabilities : [];
+        const cve = list[0]?.cve;
+        if (!cve || !cve.id) {
+            throw new EmptyResultError('nvd cve', `NVD has no record for "${id}".`);
+        }
+        const cvss = pickPrimaryCvss(cve.metrics);
+        const cvssData = cvss?.cvssData ?? {};
+        return [{
+            id: String(cve.id),
+            published: String(cve.published ?? '').slice(0, 10),
+            lastModified: String(cve.lastModified ?? '').slice(0, 10),
+            vulnStatus: String(cve.vulnStatus ?? ''),
+            baseScore: cvssData.baseScore != null ? Number(cvssData.baseScore) : null,
+            severity: String(cvssData.baseSeverity ?? cvss?.baseSeverity ?? ''),
+            attackVector: String(cvssData.attackVector ?? ''),
+            cwe: joinCwes(cve.weaknesses),
+            kevAdded: cve.cisaExploitAdd ? String(cve.cisaExploitAdd).slice(0, 10) : '',
+            description: pickEnglishDescription(cve.descriptions),
+            url: `https://nvd.nist.gov/vuln/detail/${cve.id}`,
+        }];
+    },
+});

--- a/clis/pypi/downloads.js
+++ b/clis/pypi/downloads.js
@@ -1,0 +1,66 @@
+// pypi downloads — fetch download counts for a single PyPI package via
+// pypistats.org's public JSON API.
+//
+// Default endpoint is `/api/packages/<pkg>/recent` which returns last-day /
+// last-week / last-month totals as a single row. Pass `--period overall` to
+// hit `/api/packages/<pkg>/overall` for the full daily history (one row per
+// day).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { PYPISTATS_BASE, pypiFetch, requirePackageName } from './utils.js';
+
+const PERIODS = new Set(['recent', 'overall']);
+
+function requirePeriod(value) {
+    const s = String(value ?? 'recent').trim().toLowerCase();
+    if (!PERIODS.has(s)) {
+        throw new ArgumentError(
+            `pypi downloads period "${value}" is invalid`,
+            'Allowed values: recent (default — last day/week/month totals) or overall (full daily history).',
+        );
+    }
+    return s;
+}
+
+cli({
+    site: 'pypi',
+    name: 'downloads',
+    access: 'read',
+    description: 'PyPI download stats for a package (recent totals or full daily history)',
+    domain: 'pypistats.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'PyPI package name (e.g. "requests", "pandas")' },
+        { name: 'period', default: 'recent', help: 'recent (default — 1 row, last day/week/month) or overall (1 row per day)' },
+    ],
+    columns: ['rank', 'package', 'period', 'date', 'downloads'],
+    func: async (args) => {
+        const name = requirePackageName(args.name);
+        const period = requirePeriod(args.period);
+        if (period === 'recent') {
+            const body = await pypiFetch(`${PYPISTATS_BASE}/api/packages/${encodeURIComponent(name)}/recent`, `pypi downloads ${name}`);
+            const data = body?.data;
+            if (!data || (data.last_day == null && data.last_week == null && data.last_month == null)) {
+                throw new EmptyResultError('pypi downloads', `pypistats has no recent download data for "${name}".`);
+            }
+            return [
+                { rank: 1, package: String(body.package ?? name), period: 'last_day', date: '', downloads: data.last_day != null ? Number(data.last_day) : null },
+                { rank: 2, package: String(body.package ?? name), period: 'last_week', date: '', downloads: data.last_week != null ? Number(data.last_week) : null },
+                { rank: 3, package: String(body.package ?? name), period: 'last_month', date: '', downloads: data.last_month != null ? Number(data.last_month) : null },
+            ];
+        }
+        const body = await pypiFetch(`${PYPISTATS_BASE}/api/packages/${encodeURIComponent(name)}/overall?mirrors=false`, `pypi downloads ${name}`);
+        const days = Array.isArray(body?.data) ? body.data : [];
+        if (!days.length) {
+            throw new EmptyResultError('pypi downloads', `pypistats has no overall download history for "${name}".`);
+        }
+        return days.map((row, i) => ({
+            rank: i + 1,
+            package: String(body.package ?? name),
+            period: 'daily',
+            date: String(row.date ?? ''),
+            downloads: row.downloads != null ? Number(row.downloads) : null,
+        }));
+    },
+});

--- a/clis/pypi/package.js
+++ b/clis/pypi/package.js
@@ -1,0 +1,79 @@
+// pypi package — fetch a single PyPI package's metadata.
+//
+// Hits `https://pypi.org/pypi/<pkg>/json`. Returns the most agent-useful
+// projection: name, latest version, summary, author, license, homepage,
+// project URLs, requires-python, last-modified time. Download stats are
+// intentionally separate (see `pypi downloads`).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { PYPI_BASE, pypiFetch, requirePackageName } from './utils.js';
+
+function pickHomepage(info) {
+    if (info.home_page) return String(info.home_page);
+    const proj = info.project_urls;
+    if (proj && typeof proj === 'object') {
+        return String(proj.Homepage || proj.homepage || proj.Documentation || proj.Source || proj['Source Code'] || '');
+    }
+    return '';
+}
+
+function pickRepository(info) {
+    const proj = info.project_urls;
+    if (proj && typeof proj === 'object') {
+        return String(proj.Source || proj['Source Code'] || proj.Repository || proj.repository || '');
+    }
+    return '';
+}
+
+cli({
+    site: 'pypi',
+    name: 'package',
+    access: 'read',
+    description: 'Single PyPI package metadata (latest version, license, homepage, classifiers)',
+    domain: 'pypi.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'PyPI package name (e.g. "requests", "pandas")' },
+    ],
+    columns: [
+        'name', 'latestVersion', 'summary', 'author', 'license', 'homepage', 'repository',
+        'requiresPython', 'keywords', 'releases', 'firstReleased', 'lastReleased', 'url',
+    ],
+    func: async (args) => {
+        const name = requirePackageName(args.name);
+        const body = await pypiFetch(`${PYPI_BASE}/pypi/${encodeURIComponent(name)}/json`, `pypi package ${name}`);
+        const info = body?.info;
+        if (!info || !info.name) {
+            throw new EmptyResultError('pypi package', `PyPI returned no metadata for "${name}".`);
+        }
+        const releases = body?.releases ?? {};
+        const releaseVersions = Object.keys(releases).filter((v) => Array.isArray(releases[v]) && releases[v].length > 0);
+        // earliest / latest release timestamps from the upload_time fields
+        let firstReleased = '';
+        let lastReleased = '';
+        for (const v of releaseVersions) {
+            for (const file of releases[v]) {
+                const t = String(file?.upload_time ?? '').slice(0, 10);
+                if (!t) continue;
+                if (!firstReleased || t < firstReleased) firstReleased = t;
+                if (!lastReleased || t > lastReleased) lastReleased = t;
+            }
+        }
+        return [{
+            name: String(info.name),
+            latestVersion: String(info.version ?? ''),
+            summary: String(info.summary ?? ''),
+            author: String(info.author ?? info.author_email ?? ''),
+            license: String(info.license_expression ?? info.license ?? ''),
+            homepage: pickHomepage(info),
+            repository: pickRepository(info),
+            requiresPython: String(info.requires_python ?? ''),
+            keywords: String(info.keywords ?? ''),
+            releases: releaseVersions.length,
+            firstReleased,
+            lastReleased,
+            url: String(info.package_url ?? `${PYPI_BASE}/project/${info.name}/`),
+        }];
+    },
+});

--- a/clis/pypi/utils.js
+++ b/clis/pypi/utils.js
@@ -1,0 +1,55 @@
+// Shared helpers for the pypi adapters that hit the PyPI public JSON API
+// (pypi.org/pypi/<pkg>/json) and pypistats.org for download stats.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const PYPI_BASE = 'https://pypi.org';
+export const PYPISTATS_BASE = 'https://pypistats.org';
+const UA = 'opencli-pypi-adapter (+https://github.com/jackwener/opencli)';
+
+// PEP 508 / PEP 426 normalized name: letters, digits, "._-", with leading-letter rule relaxed by PyPI.
+const PKG_NAME = /^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+export function requirePackageName(value) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError('pypi package name is required (e.g. "requests", "pandas")');
+    if (!PKG_NAME.test(s)) {
+        throw new ArgumentError(
+            `pypi package name "${value}" is not a valid distribution name`,
+            'PyPI accepts ASCII letters / digits / "._-" with no leading or trailing separator.',
+        );
+    }
+    return s;
+}
+
+export async function pypiFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that pypi.org / pypistats.org are reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `PyPI returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'PyPI throttles unauthenticated bursts; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/stackoverflow/related.js
+++ b/clis/stackoverflow/related.js
@@ -1,0 +1,66 @@
+// stackoverflow related — find Stack Overflow questions related to a given question id.
+//
+// Hits the public `/questions/{id}/related` endpoint. Useful for follow-up
+// research from a single SO question — agents can read one question with
+// `stackoverflow read`, then expand the search to related/duplicate threads
+// without rerunning a free-text search.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    seFetch,
+    normalizeLimit,
+    epochToDate,
+    ensureItems,
+    decodeHtmlEntities,
+} from './utils.js';
+
+const SORT_OPTIONS = ['rank', 'activity', 'votes', 'creation'];
+
+cli({
+    site: 'stackoverflow',
+    name: 'related',
+    access: 'read',
+    description: 'List Stack Overflow questions related to a given question id.',
+    domain: 'stackoverflow.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, type: 'string', help: 'Stack Overflow question id (numeric, e.g. 79935770).' },
+        { name: 'sort', type: 'string', default: 'rank', help: `Sort key: ${SORT_OPTIONS.join(', ')} (rank = SO relevance default).` },
+        { name: 'limit', type: 'int', default: 20, help: 'Max related questions (1-100).' },
+    ],
+    columns: ['rank', 'id', 'title', 'score', 'answers', 'views', 'isAnswered', 'tags', 'author', 'createdAt', 'lastActivityAt', 'url'],
+    func: async (args) => {
+        const id = String(args.id ?? '').trim();
+        if (!/^\d+$/.test(id)) {
+            throw new ArgumentError(`stackoverflow related id must be a numeric question id, got ${JSON.stringify(args.id)}`);
+        }
+        const sort = String(args.sort ?? 'rank').toLowerCase();
+        if (!SORT_OPTIONS.includes(sort)) {
+            throw new ArgumentError(`stackoverflow related sort must be one of ${SORT_OPTIONS.join(', ')}`);
+        }
+        const limit = normalizeLimit(args.limit, 20, 100, 'limit');
+        const data = await seFetch(`/questions/${encodeURIComponent(id)}/related`, {
+            searchParams: {
+                order: 'desc',
+                sort,
+                pagesize: limit,
+            },
+        });
+        const items = ensureItems(data, `stackoverflow related ${id}`);
+        return items.slice(0, limit).map((q, i) => ({
+            rank: i + 1,
+            id: q.question_id,
+            title: decodeHtmlEntities(q.title || ''),
+            score: q.score ?? 0,
+            answers: q.answer_count ?? 0,
+            views: q.view_count ?? 0,
+            isAnswered: Boolean(q.is_answered),
+            tags: Array.isArray(q.tags) ? q.tags.join(', ') : '',
+            author: decodeHtmlEntities(q.owner?.display_name || ''),
+            createdAt: epochToDate(q.creation_date),
+            lastActivityAt: epochToDate(q.last_activity_date),
+            url: q.link || (q.question_id ? `https://stackoverflow.com/questions/${q.question_id}` : ''),
+        }));
+    },
+});

--- a/docs/adapters/browser/coingecko.md
+++ b/docs/adapters/browser/coingecko.md
@@ -13,6 +13,7 @@ Access **CoinGecko** crypto market data from the terminal via the public API (no
 | `opencli coingecko trending` | Top trending coins on CoinGecko in the last 24h |
 | `opencli coingecko exchanges` | Top exchanges ranked by trust score / 24h BTC volume |
 | `opencli coingecko categories` | Crypto sector categories (DeFi / Layer1 / Memes / …) with market cap |
+| `opencli coingecko derivatives` | Top crypto derivative (perpetual / futures) markets by 24h volume |
 | `opencli coingecko global` | Aggregate market totals: total cap, volume, BTC/ETH dominance |
 
 ## Usage Examples
@@ -40,6 +41,12 @@ opencli coingecko exchanges --limit 20
 # Crypto sector categories (default sort: market_cap_desc)
 opencli coingecko categories --limit 10
 opencli coingecko categories --sort market_cap_change_24h_desc --limit 10
+
+# Top derivative tickers (perpetuals + futures, sorted by 24h USD volume)
+opencli coingecko derivatives --limit 20
+
+# Filter derivatives by symbol substring (BTC pairs only)
+opencli coingecko derivatives --symbol BTC --limit 10
 
 # Aggregate market totals (BTC dominance, total cap, etc.)
 opencli coingecko global
@@ -82,6 +89,13 @@ No arguments — returns the current top-7 trending list.
 | `--sort` | One of `market_cap_desc` (default), `market_cap_asc`, `name_desc`, `name_asc`, `market_cap_change_24h_desc`, `market_cap_change_24h_asc` |
 | `--limit` | Number of categories to return (1–100, default: 20) |
 
+### `derivatives`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows to return (1–500, default: 20) |
+| `--symbol` | Optional symbol substring filter (e.g. `BTC`, `ETHUSDT`) — also matches the `index_id` field |
+
 ### `global`
 
 | Option | Description |
@@ -97,6 +111,7 @@ No arguments — returns the current top-7 trending list.
 | `trending` | `rank, id, symbol, name, marketCapRank, priceBtc, thumb` |
 | `exchanges` | `rank, id, name, trustScore, volume24hBtc, country, yearEstablished, url` |
 | `categories` | `rank, id, name, marketCap, volume24h, marketCapChange24hPct, top3Coins` |
+| `derivatives` | `rank, market, symbol, indexId, contractType, price, change24hPct, fundingRate, openInterestUsd, volume24hUsd, expired` |
 | `global` | `currency, totalMarketCap, totalVolume24h, marketCapChange24hPct, btcDominancePct, ethDominancePct, activeCryptocurrencies, markets, ongoingIcos, updatedAt` |
 
 ## Prerequisites

--- a/docs/adapters/browser/crates.md
+++ b/docs/adapters/browser/crates.md
@@ -1,0 +1,62 @@
+# crates.io
+
+**Mode**: 🌐 Public · **Domain**: `crates.io`
+
+Search and inspect crates on the public Rust crate registry. Both commands hit the unauthenticated `crates.io/api/v1` directly.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli crates search <query>` | Search the public crates.io registry by keyword |
+| `opencli crates crate <name>` | Single crate metadata (latest version, downloads, license, repo) |
+
+## Usage Examples
+
+```bash
+# Free-text search (name / keywords / description)
+opencli crates search tokio --limit 10
+opencli crates search "async runtime" --limit 20
+
+# Single-crate detail (name from search rows)
+opencli crates crate serde
+opencli crates crate tokio
+
+# JSON output
+opencli crates search tokio -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, name, latestVersion, description, downloads, recentDownloads, repository, updated, url` |
+| `crate` | `name, latestVersion, description, downloads, recentDownloads, versions, license, homepage, documentation, repository, keywords, categories, created, updated, url` |
+
+The `name` column from `search` round-trips into `crate`.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Free-text search query |
+| `--limit` | Max results (1–100, default: 20). 100 is crates.io's per-page upper bound. |
+
+### `crate`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | crates.io crate name (e.g. `serde`, `tokio`). Must match Rust's identifier rule. |
+
+## Caveats
+
+- crates.io requires a descriptive `User-Agent` per [the data-access policy](https://crates.io/data-access). The adapter sets one automatically.
+- `license` is sourced from the **latest version row** in the package's version index — crate-level metadata does not carry a license field.
+- `recentDownloads` is the rolling 90-day count exposed by the API; `downloads` is the lifetime total.
+- `keywords` and `categories` are joined with `, ` for display.
+
+## Prerequisites
+
+- No browser required — uses `crates.io/api/v1`.

--- a/docs/adapters/browser/dblp.md
+++ b/docs/adapters/browser/dblp.md
@@ -11,6 +11,7 @@
 | `opencli dblp search <query>` | Free-text search across titles, authors, and venues |
 | `opencli dblp author <name>` | List one author's recent publications (newest first) by name or `--pid` |
 | `opencli dblp paper <key>` | Fetch a single record's full metadata by canonical dblp key |
+| `opencli dblp venue <query>` | Search dblp's venue (conference / journal) registry |
 
 ## Usage Examples
 
@@ -36,6 +37,12 @@ opencli dblp paper conf/nips/VaswaniSPUJGKP17
 # arXiv mirror records use the journals/corr/abs-* form
 opencli dblp paper journals/corr/abs-2509-05821
 
+# Resolve a venue acronym to dblp's canonical venue page
+opencli dblp venue ICLR --limit 5
+
+# Browse venues that match a topic keyword
+opencli dblp venue "neural networks" --limit 10
+
 # JSON output
 opencli dblp search "graph neural network" -f json
 ```
@@ -47,6 +54,7 @@ opencli dblp search "graph neural network" -f json
 | `search` | `rank, key, title, authors, venue, year, type, doi, url` |
 | `author` | `rank, key, title, authors, venue, year, type, doi, pid, url` |
 | `paper` | `key, type, title, authors, venue, year, pages, doi, open_access_url, dblp_url` |
+| `venue` | `rank, acronym, venue, type, url` |
 
 The `key` column from `search` and `author` round-trips into `paper` — it is dblp's canonical record identifier (e.g. `conf/nips/VaswaniSPUJGKP17`, `journals/corr/abs-2509-05821`, `phd/Smith20`).
 

--- a/docs/adapters/browser/hf.md
+++ b/docs/adapters/browser/hf.md
@@ -10,6 +10,7 @@
 | `opencli hf paper <arxivId>` | Single paper detail (title / authors / summary / AI keywords / upvotes) |
 | `opencli hf models` | Top Hugging Face models (downloads / likes / trending / freshness) |
 | `opencli hf datasets` | Top Hugging Face datasets |
+| `opencli hf spaces` | Top Hugging Face Spaces (gradio / streamlit / docker / static demos) |
 
 ## Usage Examples
 
@@ -39,6 +40,12 @@ opencli hf models --pipeline text-generation --search llama --sort likes --limit
 
 # Top datasets by likes
 opencli hf datasets --sort likes --limit 10
+
+# Top Spaces by likes
+opencli hf spaces --limit 20
+
+# Filter Spaces by SDK
+opencli hf spaces --sdk gradio --search llm --limit 10
 
 # JSON output
 opencli hf top -f json
@@ -79,6 +86,17 @@ Returns one row with `id, title, authors, publishedAt, upvotes, aiKeywords, summ
 | `--sort` | Same set as `models` (default: `downloads`) |
 | `--search` | Optional name/owner substring filter |
 | `--limit` | Max datasets (1–100, default: 20) |
+
+### `spaces` Options
+
+| Option | Description |
+|--------|-------------|
+| `--sort` | `likes` / `created_at` / `last_modified` (default: `likes`; HF doesn't accept `trending` for spaces) |
+| `--search` | Optional name/owner substring filter (e.g. `stability`, `openai/`) |
+| `--sdk` | SDK filter: `gradio` / `streamlit` / `docker` / `static` |
+| `--limit` | Max spaces (1–100, default: 20) |
+
+Returns rows with `rank, id, author, sdk, likes, tags, lastModified, url`.
 
 ## Prerequisites
 

--- a/docs/adapters/browser/mdn.md
+++ b/docs/adapters/browser/mdn.md
@@ -1,0 +1,55 @@
+# MDN Web Docs
+
+**Mode**: 🌐 Public · **Domain**: `developer.mozilla.org`
+
+Search the official Mozilla Developer Network web docs without auth or browser. One command.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli mdn search <query>` | Search MDN Web Docs by keyword |
+
+## Usage Examples
+
+```bash
+# Web platform feature search
+opencli mdn search fetch --limit 10
+opencli mdn search flexbox --limit 5
+
+# JS reference lookups
+opencli mdn search "Array.prototype.map"
+
+# Localized search (default: en-US)
+opencli mdn search fetch --locale ja --limit 5
+opencli mdn search fetch --locale zh-CN --limit 5
+
+# JSON output
+opencli mdn search fetch -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, title, slug, locale, summary, url` |
+
+The `slug` column round-trips into MDN's URL space (`https://developer.mozilla.org/<locale>/docs/<slug>`).
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Free-text query |
+| `--limit` | Max results (1–50, default: 10) |
+| `--locale` | Doc locale (default: `en-US`). Allowed: `en-US`, `de`, `es`, `fr`, `ja`, `ko`, `pt-BR`, `ru`, `zh-CN`, `zh-TW`. |
+
+## Caveats
+
+- Only the locales MDN actually publishes are accepted; passing anything else raises `ArgumentError`.
+- The `summary` field is MDN's pre-computed search excerpt with whitespace collapsed; it is **not** the full document body.
+- MDN throttles aggressive bursts; `HTTP 429` surfaces as a typed `CommandExecutionError` with a retry hint.
+
+## Prerequisites
+
+- No browser required — uses `developer.mozilla.org/api/v1/search`.

--- a/docs/adapters/browser/npm.md
+++ b/docs/adapters/browser/npm.md
@@ -1,0 +1,79 @@
+# npm
+
+**Mode**: 🌐 Public · **Domain**: `registry.npmjs.org` (+ `api.npmjs.org` for download stats)
+
+Search and inspect packages on the public npm registry without auth or browser. Three commands cover discovery, single-package metadata, and download stats.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli npm search <query>` | Search the public npm registry by keyword |
+| `opencli npm package <name>` | Single-package registry metadata (latest version, license, repo, maintainers) |
+| `opencli npm downloads <name>` | Download stats for one package over a fixed period or `YYYY-MM-DD:YYYY-MM-DD` range |
+
+## Usage Examples
+
+```bash
+# Search the registry
+opencli npm search react --limit 10
+opencli npm search "graphql client" --limit 20
+
+# Inspect a single package (use `name` from search rows)
+opencli npm package react
+opencli npm package @vercel/og
+
+# Download stats for a fixed period
+opencli npm downloads react --period last-week
+opencli npm downloads react --period last-month
+opencli npm downloads react --period last-year
+
+# Custom date range (max 365 days, npm API limit)
+opencli npm downloads react --period 2025-01-01:2025-01-31
+
+# JSON output
+opencli npm package react -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, name, version, description, weeklyDownloads, dependents, license, publisher, updated, url` |
+| `package` | `name, latestVersion, description, license, homepage, repository, bugs, maintainers, keywords, created, modified, url` |
+| `downloads` | `rank, package, day, downloads` (range) or `rank, package, day, downloads` for fixed periods (single row, `day` = `last-week:start..end`) |
+
+The `name` column from `search` round-trips into `package` and `downloads`.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Free-text query (matches name / description / keywords / readme) |
+| `--limit` | Max results (1–250, default: 20) |
+
+### `package`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | npm package name (e.g. `react`, `@vercel/og`). Validates 1–214 chars and the npm naming rule. |
+
+### `downloads`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | npm package name |
+| `--period` | One of `last-day`, `last-week`, `last-month`, `last-year`, **or** a `YYYY-MM-DD:YYYY-MM-DD` range (default: `last-week`) |
+
+## Caveats
+
+- The `--period` argument is validated upfront — anything that's neither one of the four named periods nor a valid `YYYY-MM-DD:YYYY-MM-DD` range raises `ArgumentError` (no silent fallback).
+- npm rate-limits the search and download APIs; `HTTP 429` surfaces as a typed `CommandExecutionError` with a retry hint.
+- Download stats are intentionally a separate command from `package`. If the stats endpoint fails, the registry-metadata response from `package` is unaffected.
+- The package-name regex matches `^(?:@scope\/)?name$` (lowercase letters / digits / `._-`), capped at 214 chars per npm's spec.
+
+## Prerequisites
+
+- No browser required — uses public registry endpoints.

--- a/docs/adapters/browser/nvd.md
+++ b/docs/adapters/browser/nvd.md
@@ -1,0 +1,57 @@
+# NVD (NIST National Vulnerability Database)
+
+**Mode**: 🌐 Public · **Domain**: `services.nvd.nist.gov`
+
+Fetch a single CVE record from the NIST National Vulnerability Database via the public CVE 2.0 API.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli nvd cve <id>` | Fetch a CVE detail (description, CVSS, CWE, KEV flag) |
+
+## Usage Examples
+
+```bash
+# Log4Shell
+opencli nvd cve CVE-2021-44228
+
+# Heartbleed
+opencli nvd cve CVE-2014-0160
+
+# JSON output for downstream tooling
+opencli nvd cve CVE-2021-44228 -f json
+```
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `id` | Canonical CVE id |
+| `published` | First published date (`YYYY-MM-DD`) |
+| `lastModified` | Last modified date (`YYYY-MM-DD`) |
+| `vulnStatus` | NVD analysis status (e.g. `Analyzed`, `Awaiting Analysis`) |
+| `baseScore` | CVSS base score (numeric, 0–10) |
+| `severity` | CVSS severity (`CRITICAL` / `HIGH` / `MEDIUM` / `LOW` / `NONE`) |
+| `attackVector` | CVSS attack vector (`NETWORK` / `LOCAL` / `PHYSICAL` / `ADJACENT`) |
+| `cwe` | Comma-separated CWE id(s) |
+| `kevAdded` | CISA KEV (Known Exploited Vulnerabilities) date if present |
+| `description` | English description |
+| `url` | Canonical NVD detail URL |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | CVE identifier (`CVE-YYYY-N…`, case-insensitive). Validated upfront. |
+
+## Caveats
+
+- The CVE id is validated against `^CVE-\d{4}-\d{4,}$`; bad input raises `ArgumentError`.
+- CVSS columns prefer v3.1, fall back to v3.0, then v2 if neither v3 record is present.
+- NVD enforces aggressive rate limits without an API key. `HTTP 403` and `HTTP 429` both surface as typed `CommandExecutionError` with a retry hint.
+- Empty / unanalyzed records (no CVSS payload) leave `baseScore` / `severity` / `attackVector` as `null` / empty rather than fabricating defaults.
+
+## Prerequisites
+
+- No browser required — uses `services.nvd.nist.gov/rest/json/cves/2.0`.

--- a/docs/adapters/browser/pypi.md
+++ b/docs/adapters/browser/pypi.md
@@ -1,0 +1,62 @@
+# PyPI
+
+**Mode**: 🌐 Public · **Domain**: `pypi.org` (+ `pypistats.org` for download stats)
+
+Inspect Python packages on the Python Package Index. Two commands: registry metadata for one package and download stats over a recent or historical window.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli pypi package <name>` | Single PyPI package metadata (latest version, summary, repo, license, release timeline) |
+| `opencli pypi downloads <name>` | Download stats from pypistats.org (recent totals or daily history) |
+
+## Usage Examples
+
+```bash
+# Single-package metadata
+opencli pypi package requests
+opencli pypi package fastapi
+
+# Download stats — three rows (last-day / last-week / last-month) totals
+opencli pypi downloads requests --period recent
+
+# Daily history for ~180 days (pypistats default window)
+opencli pypi downloads requests --period overall
+
+# JSON output
+opencli pypi package requests -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `package` | `name, latestVersion, summary, author, license, homepage, repository, requiresPython, keywords, releases, firstReleased, lastReleased, url` |
+| `downloads` | `rank, package, period, date, downloads` |
+
+## Options
+
+### `package`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | PyPI package name (e.g. `requests`, `numpy`). Validates 1–64 chars and PyPI's naming rule. |
+
+### `downloads`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | PyPI package name |
+| `--period` | `recent` (3-row totals: last_day / last_week / last_month) or `overall` (daily history). Default: `recent`. |
+
+## Caveats
+
+- pypistats only goes back ~180 days for `overall`; older history is not exposed.
+- `requires_python` reflects the latest release's metadata; older releases may declare different ranges.
+- `firstReleased` / `lastReleased` are computed from the full release index, so they reflect the upload time of the earliest / latest **uploaded file**, not necessarily the version listed under `latestVersion`.
+- `--period` is validated upfront — `recent` or `overall` only; anything else raises `ArgumentError`.
+
+## Prerequisites
+
+- No browser required — uses `pypi.org/pypi/<pkg>/json` and `pypistats.org/api/packages/<pkg>/...`.

--- a/docs/adapters/browser/stackoverflow.md
+++ b/docs/adapters/browser/stackoverflow.md
@@ -13,6 +13,7 @@
 | `opencli stackoverflow read <id>` | Read a question with answers and comments |
 | `opencli stackoverflow user <name>` | Find users by display name (highest reputation first) |
 | `opencli stackoverflow tag <tag>` | List questions tagged with a given tag (most active first) |
+| `opencli stackoverflow related <id>` | List questions related to a given question id |
 
 ## Listing columns
 
@@ -72,6 +73,10 @@ opencli stackoverflow unanswered --limit 10
 
 # Tagged questions (id feeds stackoverflow read)
 opencli stackoverflow tag rust --limit 10
+
+# Related questions for a given question id (rows feed stackoverflow read)
+opencli stackoverflow related 11227809 --limit 10
+opencli stackoverflow related 11227809 --sort votes --limit 5
 
 # User profile search (returns userId/profile URL rows)
 opencli stackoverflow user "Jon Skeet" --limit 5

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -96,20 +96,26 @@ Run `opencli list` for the live registry.
 | **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download` `transcript` (local credentials required)                                                   | 🔑 Local API |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
-| **[dblp](./browser/dblp.md)**                     | `search` `paper`                                                                                                                               | 🌐 Public    |
+| **[dblp](./browser/dblp.md)**                     | `search` `author` `paper` `venue`                                                                                                              | 🌐 Public    |
 | **[pubmed](./browser/pubmed.md)**                 | `search` `article` `author` `citations` `related`                                                                                              | 🌐 Public    |
 | **[openreview](./browser/openreview.md)**         | `search` `venue` `paper` `reviews`                                                                                                             | 🌐 Public    |
 | **[paperreview](./browser/paperreview.md)**       | `submit` `review` `feedback`                                                                                                                   | 🌐 Public    |
 | **[barchart](./browser/barchart.md)**             | `quote` `options` `greeks` `flow`                                                                                                              | 🌐 Public    |
 | **[binance](./browser/binance.md)**               | `price` `prices` `ticker` `pairs` `trades` `depth` `asks` `klines` `top` `gainers` `losers`                                                 | 🌐 Public    |
-| **[hf](./browser/hf.md)**                         | `top`                                                                                                                                          | 🌐 Public    |
+| **[hf](./browser/hf.md)**                         | `top` `paper` `models` `datasets` `spaces`                                                                                                     | 🌐 Public    |
 | **[sinafinance](./browser/sinafinance.md)**       | `news` `rolling-news` `stock` `stock-rank`                                                                                                     | 🌐 / 🔐      |
 | **[spotify](./browser/spotify.md)**               | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat`                                                      | 🔑 OAuth API |
-| **[stackoverflow](./browser/stackoverflow.md)**   | `hot` `search` `bounties` `unanswered`                                                                                                         | 🌐 Public    |
+| **[stackoverflow](./browser/stackoverflow.md)**   | `hot` `search` `bounties` `unanswered` `tag` `user` `read` `related`                                                                           | 🌐 Public    |
 | **[wikipedia](./browser/wikipedia.md)**           | `search` `summary` `random` `trending`                                                                                                         | 🌐 Public    |
 | **[lesswrong](./browser/lesswrong.md)**           | `curated` `frontpage` `new` `top` `top-week` `top-month` `top-year` `read` `comments` `user` `user-posts` `tag` `tags` `sequences` `shortform` | 🌐 Public    |
 | **[lobsters](./browser/lobsters.md)**             | `hot` `newest` `active` `tag` `read`                                                                                                           | 🌐 Public    |
 | **[steam](./browser/steam.md)**                   | `top-sellers`                                                                                                                                  | 🌐 Public    |
+| **[coingecko](./browser/coingecko.md)**           | `top` `coin` `trending` `exchanges` `categories` `derivatives` `global`                                                                        | 🌐 Public    |
+| **[npm](./browser/npm.md)**                       | `search` `package` `downloads`                                                                                                                 | 🌐 Public    |
+| **[pypi](./browser/pypi.md)**                     | `package` `downloads`                                                                                                                          | 🌐 Public    |
+| **[crates](./browser/crates.md)**                 | `search` `crate`                                                                                                                               | 🌐 Public    |
+| **[mdn](./browser/mdn.md)**                       | `search`                                                                                                                                       | 🌐 Public    |
+| **[nvd](./browser/nvd.md)**                       | `cve`                                                                                                                                          | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

Round 3 of the adapter expansion. Adds **13 read commands** across **5 new sites** and **4 existing-site extensions**. Every command hits a public unauthenticated endpoint (`Strategy.PUBLIC`, `browser:false`) and uses the typed-fail-fast convention (no silent clamp, no silent fallback, no sentinel rows).

### New sites (8 commands)

| Site | Commands | Endpoint |
|------|----------|---------|
| **npm** | `search` / `package` / `downloads` | `registry.npmjs.org` + `api.npmjs.org` |
| **pypi** | `package` / `downloads` | `pypi.org` + `pypistats.org` |
| **crates** | `search` / `crate` | `crates.io/api/v1` |
| **mdn** | `search` | `developer.mozilla.org/api/v1/search` |
| **nvd** | `cve` | `services.nvd.nist.gov/rest/json/cves/2.0` |

### Extensions (5 commands)

- `hf spaces` — Top Hugging Face Spaces (likes / created_at / last_modified; sdk filter: gradio/streamlit/docker/static).
- `dblp venue` — Search dblp's venue registry by acronym or topic. Index row also picks up the long-existing `dblp author` command (was missing from the table).
- `coingecko derivatives` — Top crypto derivative tickers (perpetuals / futures) by 24h USD volume, with optional `--symbol` substring filter.
- `stackoverflow related` — Related questions for a given question id; rows feed `stackoverflow read`.

### Audit gates (all green vs baseline)

| Gate | Before | After | Δ |
|------|--------|-------|---|
| `check:typed-error-lint` | 196 | 196 | 0 |
| `check:silent-column-drop` | 103 | 103 | 0 |
| `advise:listing-id-pairing` | 12 | 13 | +1 (dblp/venue — venue listing has no corresponding venue-detail command; advisory only, non-blocking) |
| `bash scripts/check-doc-coverage.sh --strict` | 115/115 | 120/120 | +5 docs |
| Manifest | 709 | 722 | +13 |

### Self-audit (anti-patterns explicitly avoided)

- ✅ No `Math.min(args.limit, MAX)` silent clamps — every limit is `requireBoundedInt(... maxValue, 'limit')` that throws `ArgumentError` above the bound.
- ✅ No `String(args.x ?? 'default') || 'default'` silent fallback — defaults live in one place (the `??`), validation rejects bad non-empty input (e.g. `nvd CVE id`, `npm --period`, `mdn --locale`, `hf --sort`).
- ✅ No sentinel rows — empty results raise `EmptyResultError`.
- ✅ No scalar `'-' / 'N/A' / 'unknown'` placeholders — typed-unknown = `null` or empty string.
- ✅ Generic `CliError('HTTP_ERROR'/'NOT_FOUND')` not introduced — everything goes through one of the five typed errors.
- ✅ `npm package` deliberately does NOT include `weeklyDownloads` — download stats are a separate `npm downloads` command so a stats-endpoint failure cannot silently zero a registry-metadata field.

### Live-verified

```bash
opencli npm search react --limit 3            # ✓
opencli npm package react                       # ✓
opencli npm downloads react --period last-week # ✓
opencli npm downloads react --period 2025-01-01:2025-01-05 # ✓
opencli pypi package requests                   # ✓
opencli pypi downloads requests --period recent # ✓
opencli pypi downloads requests --period overall # ✓
opencli crates search tokio --limit 3           # ✓
opencli crates crate serde                       # ✓
opencli mdn search fetch --limit 3              # ✓
opencli nvd cve CVE-2021-44228                  # ✓
opencli hf spaces --limit 3                     # ✓
opencli dblp venue ICLR                         # ✓
opencli coingecko derivatives --limit 3         # ✓
opencli stackoverflow related 79935770 --limit 3 # ✓
# typed-error sanity (all raise ArgumentError):
opencli npm package "Foo Bar"                   # ✓ npm package name not valid
opencli nvd cve "not-a-cve"                     # ✓ nvd CVE id not valid
opencli npm downloads react --period bogus      # ✓ npm downloads period invalid
```

### Files

```
clis/
  npm/             utils.js  search.js  package.js  downloads.js
  pypi/            utils.js  package.js downloads.js
  crates/          utils.js  search.js  crate.js
  mdn/             search.js
  nvd/             cve.js
  hf/              spaces.js
  dblp/            venue.js
  coingecko/       derivatives.js
  stackoverflow/   related.js

docs/adapters/browser/
  npm.md  pypi.md  crates.md  mdn.md  nvd.md   (new)
  hf.md   dblp.md  coingecko.md  stackoverflow.md  (extended)

docs/adapters/index.md  (5 new rows + 3 extended rows)
cli-manifest.json       (rebuilt: 722 entries)
```

## Test plan

- [x] All 13 commands live-verified against the real public endpoints.
- [x] `npm run check:typed-error-lint` clean (196 = 196).
- [x] `npm run check:silent-column-drop` clean (103 = 103).
- [x] `npm run advise:listing-id-pairing` — only +1 advisory (dblp/venue, by design — no venue-detail command exists; the advisory is non-blocking and the rule is case-by-case per #1311).
- [x] `bash scripts/check-doc-coverage.sh --strict` — 120/120 documented.
- [x] Sanity-checked typed `ArgumentError` paths for invalid inputs across npm / pypi / nvd / mdn / hf.
- [x] No `clis/<site>/_dump.*` or other transient artifacts left in the tree.