### PR TITLE
feat: 10 read adapters across 6 new sites + contract tests (round 5)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5949,6 +5949,78 @@
     "navigateBefore": false
   },
   {
+    "site": "defillama",
+    "name": "protocol",
+    "description": "Single DefiLlama protocol details (current TVL, mcap, chains, twitter, github, description)",
+    "access": "read",
+    "domain": "defillama.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "slug",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "DefiLlama protocol slug (e.g. \"aave\", \"lido\")"
+      }
+    ],
+    "columns": [
+      "slug",
+      "name",
+      "category",
+      "isParent",
+      "tvl",
+      "tvlAt",
+      "mcap",
+      "chains",
+      "twitter",
+      "github",
+      "audits",
+      "listedAt",
+      "description",
+      "website",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "defillama/protocol.js",
+    "sourceFile": "defillama/protocol.js"
+  },
+  {
+    "site": "defillama",
+    "name": "protocols",
+    "description": "Top DeFi protocols on DefiLlama by current TVL (slug, name, category, TVL, mcap, change_1d/7d, chains)",
+    "access": "read",
+    "domain": "defillama.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Number of rows to return (1-500)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "slug",
+      "name",
+      "category",
+      "tvl",
+      "mcap",
+      "change_1d",
+      "change_7d",
+      "chains",
+      "listedAt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "defillama/protocols.js",
+    "sourceFile": "defillama/protocols.js"
+  },
+  {
     "site": "devto",
     "name": "latest",
     "description": "Newest dev.to articles (firehose, all tags)",
@@ -8450,6 +8522,40 @@
     "sourceFile": "eastmoney/sectors.js"
   },
   {
+    "site": "endoflife",
+    "name": "product",
+    "description": "Release cycles + EOL / LTS / support dates for one product on endoflife.date",
+    "access": "read",
+    "domain": "endoflife.date",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "product",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "endoflife.date product slug (e.g. \"nodejs\", \"python\", \"ubuntu\")"
+      }
+    ],
+    "columns": [
+      "product",
+      "cycle",
+      "releaseDate",
+      "latest",
+      "latestReleaseDate",
+      "lts",
+      "support",
+      "eol",
+      "extendedSupport",
+      "eolStatus",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "endoflife/product.js",
+    "sourceFile": "endoflife/product.js"
+  },
+  {
     "site": "facebook",
     "name": "add-friend",
     "description": "Send a friend request on Facebook",
@@ -9352,6 +9458,80 @@
     "modulePath": "google-scholar/search.js",
     "sourceFile": "google-scholar/search.js",
     "navigateBefore": false
+  },
+  {
+    "site": "goproxy",
+    "name": "module",
+    "description": "Latest version + VCS origin metadata for a Go module on proxy.golang.org",
+    "access": "read",
+    "domain": "proxy.golang.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "module",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Go module path (e.g. \"github.com/gin-gonic/gin\", \"golang.org/x/net\")"
+      }
+    ],
+    "columns": [
+      "module",
+      "version",
+      "publishedAt",
+      "vcs",
+      "repository",
+      "commit",
+      "ref",
+      "pkgGoDevUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "goproxy/module.js",
+    "sourceFile": "goproxy/module.js"
+  },
+  {
+    "site": "goproxy",
+    "name": "versions",
+    "description": "Published version tags for a Go module (newest first), optionally with publish times",
+    "access": "read",
+    "domain": "proxy.golang.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "module",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Go module path (e.g. \"github.com/gin-gonic/gin\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max rows to return (1-200)"
+      },
+      {
+        "name": "with-time",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Fetch each version's publish time (one extra request per row)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "module",
+      "version",
+      "publishedAt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "goproxy/versions.js",
+    "sourceFile": "goproxy/versions.js"
   },
   {
     "site": "gov-law",
@@ -15891,6 +16071,90 @@
     "sourceFile": "openreview/venue.js"
   },
   {
+    "site": "osv",
+    "name": "query",
+    "description": "OSV.dev vulnerabilities affecting a package (optionally pinned to a version)",
+    "access": "read",
+    "domain": "osv.dev",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "package",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Package name (e.g. \"lodash\", \"django\")"
+      },
+      {
+        "name": "ecosystem",
+        "type": "string",
+        "required": true,
+        "help": "OSV ecosystem (npm / PyPI / Go / Maven / NuGet / RubyGems / crates.io / Packagist / ...)"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "required": false,
+        "help": "Pin to a specific version (e.g. \"4.17.20\"); omit for all known vulns"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max rows to return (1-200)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "summary",
+      "severity",
+      "aliases",
+      "published",
+      "modified",
+      "affectedPackages",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "osv/query.js",
+    "sourceFile": "osv/query.js"
+  },
+  {
+    "site": "osv",
+    "name": "vulnerability",
+    "description": "Single OSV.dev vulnerability detail (severity, affected packages, CVE/GHSA aliases)",
+    "access": "read",
+    "domain": "osv.dev",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "OSV vulnerability id (e.g. \"GHSA-29mw-wpgm-hmr9\", \"CVE-2020-28500\")"
+      }
+    ],
+    "columns": [
+      "id",
+      "summary",
+      "severity",
+      "aliases",
+      "published",
+      "modified",
+      "affectedPackages",
+      "cwes",
+      "referenceCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "osv/vulnerability.js",
+    "sourceFile": "osv/vulnerability.js"
+  },
+  {
     "site": "packagist",
     "name": "package",
     "description": "Fetch a Packagist package's metadata (version, downloads, license, repo, GitHub stars)",
@@ -18053,6 +18317,41 @@
     "navigateBefore": "https://www.reuters.com"
   },
   {
+    "site": "rfc",
+    "name": "rfc",
+    "description": "Single IETF RFC metadata (title, abstract, working group, authors, std level)",
+    "access": "read",
+    "domain": "datatracker.ietf.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "number",
+        "type": "int",
+        "required": true,
+        "positional": true,
+        "help": "RFC number (e.g. 9000, 791, 2616)"
+      }
+    ],
+    "columns": [
+      "rfc",
+      "title",
+      "state",
+      "stdLevel",
+      "group",
+      "groupType",
+      "pages",
+      "published",
+      "authors",
+      "abstract",
+      "rfcEditorUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "rfc/rfc.js",
+    "sourceFile": "rfc/rfc.js"
+  },
+  {
     "site": "rubygems",
     "name": "gem",
     "description": "Fetch a RubyGems.org gem's metadata (version, downloads, license, links)",
@@ -20161,6 +20460,92 @@
     "modulePath": "toutiao/articles.js",
     "sourceFile": "toutiao/articles.js",
     "navigateBefore": "https://mp.toutiao.com"
+  },
+  {
+    "site": "tvmaze",
+    "name": "search",
+    "description": "TVmaze TV show search by title (returns id, name, network, premiered/ended, rating)",
+    "access": "read",
+    "domain": "tvmaze.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "TV show title or fragment to search for"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "type",
+      "language",
+      "genres",
+      "status",
+      "premiered",
+      "ended",
+      "network",
+      "rating",
+      "matchScore",
+      "summary",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "tvmaze/search.js",
+    "sourceFile": "tvmaze/search.js"
+  },
+  {
+    "site": "tvmaze",
+    "name": "show",
+    "description": "Single TVmaze TV show detail by id (network, schedule, rating, IMDB/TheTVDB cross-refs)",
+    "access": "read",
+    "domain": "tvmaze.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "int",
+        "required": true,
+        "positional": true,
+        "help": "TVmaze show id (positive integer)"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "type",
+      "language",
+      "genres",
+      "status",
+      "premiered",
+      "ended",
+      "runtime",
+      "averageRuntime",
+      "network",
+      "country",
+      "schedule",
+      "rating",
+      "imdb",
+      "thetvdb",
+      "officialSite",
+      "summary",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "tvmaze/show.js",
+    "sourceFile": "tvmaze/show.js"
   },
   {
     "site": "twitter",

--- a/clis/defillama/defillama.test.js
+++ b/clis/defillama/defillama.test.js
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './protocols.js';
+import './protocol.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('defillama protocols adapter', () => {
+    const cmd = getRegistry().get('defillama/protocols');
+
+    it('rejects bad limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ limit: 1000 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when API returns no protocols', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })));
+        await expect(cmd.func({ limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('returns rows whose slug round-trips into defillama protocol <slug>', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([
+            { name: 'Aave V3', slug: 'aave-v3', tvl: 1000, mcap: 500, category: 'Lending', chains: ['Ethereum', 'Polygon'], change_1d: 1, change_7d: 2, listedAt: 1668170565 },
+            { name: 'Lido', slug: 'lido', tvl: 800, mcap: 200, category: 'Liquid Staking', chains: ['Ethereum'], change_1d: 0.5, change_7d: 1, listedAt: 1640000000 },
+        ]), { status: 200 })));
+
+        const rows = await cmd.func({ limit: 10 });
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            rank: 1, slug: 'aave-v3', name: 'Aave V3', category: 'Lending', tvl: 1000,
+            chains: 'Ethereum, Polygon', url: 'https://defillama.com/protocol/aave-v3',
+        });
+        // slug is the round-trip key into defillama protocol
+        expect(rows[0].slug).toMatch(/^[a-z0-9][a-z0-9._-]*$/);
+    });
+});
+
+describe('defillama protocol adapter', () => {
+    const cmd = getRegistry().get('defillama/protocol');
+
+    it('rejects empty / malformed slug before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ slug: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ slug: 'BAD SLUG' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 400 "Protocol not found" to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Protocol not found', { status: 400 })));
+        await expect(cmd.func({ slug: 'no-such-thing' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('parent protocols aggregate chains from children in /protocols', async () => {
+        const detail = {
+            id: 'parent#aave',
+            name: 'Aave',
+            isParentProtocol: true,
+            chains: [],
+            tvl: [{ date: 1700000000, totalLiquidityUSD: 12345 }],
+            mcap: 1e9,
+            twitter: 'aave',
+            github: ['aave'],
+            description: 'lending',
+            url: 'https://aave.com',
+        };
+        const list = [
+            { name: 'Aave V3', slug: 'aave-v3', parentProtocol: 'parent#aave', chains: ['Ethereum', 'Polygon'], category: 'Lending' },
+            { name: 'Aave V2', slug: 'aave-v2', parentProtocol: 'parent#aave', chains: ['Ethereum'], category: 'Lending' },
+            { name: 'Other', slug: 'other', chains: ['Solana'] },
+        ];
+        const fetchMock = vi.fn()
+            .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify(detail), { status: 200 })))
+            .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify(list), { status: 200 })));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const rows = await cmd.func({ slug: 'aave' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            slug: 'aave', name: 'Aave', isParent: true, tvl: 12345, tvlAt: '2023-11-14',
+        });
+        // chains should include Ethereum + Polygon (children) but not Solana (unrelated)
+        expect(rows[0].chains.split(', ').sort()).toEqual(['Ethereum', 'Polygon']);
+    });
+});

--- a/clis/defillama/protocol.js
+++ b/clis/defillama/protocol.js
@@ -1,0 +1,84 @@
+// defillama protocol — single DeFi protocol details by slug.
+//
+// Hits `https://api.llama.fi/protocol/<slug>`. The endpoint returns a rich
+// object that includes a `tvl` time-series array; we project the latest entry
+// as the current TVL plus identifying metadata (category from /protocols since
+// the per-protocol endpoint omits it).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { LLAMA_BASE, llamaFetch, requireSlug, unixToDate } from './utils.js';
+
+cli({
+    site: 'defillama',
+    name: 'protocol',
+    access: 'read',
+    description: 'Single DefiLlama protocol details (current TVL, mcap, chains, twitter, github, description)',
+    domain: 'defillama.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'slug', positional: true, type: 'string', required: true, help: 'DefiLlama protocol slug (e.g. "aave", "lido")' },
+    ],
+    columns: [
+        'slug', 'name', 'category', 'isParent', 'tvl', 'tvlAt', 'mcap',
+        'chains', 'twitter', 'github', 'audits', 'listedAt',
+        'description', 'website', 'url',
+    ],
+    func: async (args) => {
+        const slug = requireSlug(args.slug, 'slug');
+        // Per-protocol detail endpoint
+        const detail = await llamaFetch(`${LLAMA_BASE}/protocol/${encodeURIComponent(slug)}`, `defillama protocol ${slug}`);
+        if (!detail || !detail.name) {
+            throw new EmptyResultError('defillama protocol', `DefiLlama returned no metadata for "${slug}".`);
+        }
+        // Latest TVL from the time-series array (per-protocol endpoint omits a scalar tvl).
+        const tvlSeries = Array.isArray(detail.tvl) ? detail.tvl : [];
+        const lastPoint = tvlSeries.length ? tvlSeries[tvlSeries.length - 1] : null;
+        const tvl = lastPoint && Number.isFinite(Number(lastPoint.totalLiquidityUSD))
+            ? Number(lastPoint.totalLiquidityUSD)
+            : null;
+        const tvlAt = lastPoint ? unixToDate(lastPoint.date) : null;
+        // /protocols carries category + chains. Parent protocols (isParentProtocol=true)
+        // do NOT appear in /protocols themselves — only their children do — so we union
+        // child chains and leave category empty for parents.
+        const isParent = detail.isParentProtocol === true;
+        let category = '';
+        const chainsSet = new Set(Array.isArray(detail.chains) ? detail.chains : []);
+        const list = await llamaFetch(`${LLAMA_BASE}/protocols`, `defillama protocol ${slug} list lookup`);
+        if (Array.isArray(list)) {
+            if (!isParent) {
+                const match = list.find((p) => p && p.slug === slug);
+                if (match && typeof match.category === 'string') category = match.category;
+                if (match && Array.isArray(match.chains)) {
+                    for (const c of match.chains) chainsSet.add(c);
+                }
+            }
+            else {
+                // Aggregate chains across child protocols of this parent.
+                for (const p of list) {
+                    if (p && p.parentProtocol === detail.id && Array.isArray(p.chains)) {
+                        for (const c of p.chains) chainsSet.add(c);
+                    }
+                }
+            }
+        }
+        const githubArr = Array.isArray(detail.github) ? detail.github : [];
+        return [{
+            slug,
+            name: String(detail.name).trim(),
+            category,
+            isParent,
+            tvl,
+            tvlAt,
+            mcap: detail.mcap == null ? null : Number(detail.mcap),
+            chains: [...chainsSet].join(', '),
+            twitter: String(detail.twitter ?? '').trim(),
+            github: githubArr.join(', '),
+            audits: String(detail.audits ?? '').trim(),
+            listedAt: unixToDate(detail.listedAt),
+            description: String(detail.description ?? '').trim(),
+            website: String(detail.url ?? '').trim(),
+            url: `https://defillama.com/protocol/${slug}`,
+        }];
+    },
+});

--- a/clis/defillama/protocols.js
+++ b/clis/defillama/protocols.js
@@ -1,0 +1,55 @@
+// defillama protocols — top DeFi protocols by current TVL.
+//
+// Hits `https://api.llama.fi/protocols`, sorts by TVL (desc), and returns the
+// requested top-N. The API ships ~7400 entries today; we cap output at 500
+// rows so agents do not paginate their entire DeFi universe by accident.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { LLAMA_BASE, llamaFetch, requireBoundedInt, unixToDate } from './utils.js';
+
+cli({
+    site: 'defillama',
+    name: 'protocols',
+    access: 'read',
+    description: 'Top DeFi protocols on DefiLlama by current TVL (slug, name, category, TVL, mcap, change_1d/7d, chains)',
+    domain: 'defillama.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 30, help: 'Number of rows to return (1-500)' },
+    ],
+    columns: [
+        'rank', 'slug', 'name', 'category', 'tvl', 'mcap',
+        'change_1d', 'change_7d', 'chains', 'listedAt', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 30, 500, 'limit');
+        const list = await llamaFetch(`${LLAMA_BASE}/protocols`, 'defillama protocols');
+        if (!Array.isArray(list) || list.length === 0) {
+            throw new EmptyResultError('defillama protocols', 'DefiLlama returned no protocol entries.');
+        }
+        const ranked = list
+            .filter((p) => p && (p.slug || p.name) && Number.isFinite(Number(p.tvl)))
+            .sort((a, b) => Number(b.tvl) - Number(a.tvl))
+            .slice(0, limit);
+        if (ranked.length === 0) {
+            throw new EmptyResultError('defillama protocols', 'DefiLlama returned no protocols with numeric TVL.');
+        }
+        return ranked.map((p, i) => {
+            const slug = String(p.slug ?? '').trim();
+            return {
+                rank: i + 1,
+                slug,
+                name: String(p.name ?? '').trim(),
+                category: String(p.category ?? '').trim(),
+                tvl: Number(p.tvl),
+                mcap: p.mcap == null ? null : Number(p.mcap),
+                change_1d: p.change_1d == null ? null : Number(p.change_1d),
+                change_7d: p.change_7d == null ? null : Number(p.change_7d),
+                chains: Array.isArray(p.chains) ? p.chains.join(', ') : '',
+                listedAt: unixToDate(p.listedAt),
+                url: slug ? `https://defillama.com/protocol/${slug}` : '',
+            };
+        });
+    },
+});

--- a/clis/defillama/utils.js
+++ b/clis/defillama/utils.js
@@ -1,0 +1,99 @@
+// Shared helpers for the DefiLlama adapters.
+//
+// DefiLlama serves a public REST API (no auth) over https://api.llama.fi.
+// Docs: https://defillama.com/docs/api
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const LLAMA_BASE = 'https://api.llama.fi';
+const UA = 'opencli-defillama-adapter (+https://github.com/jackwener/opencli)';
+
+// DefiLlama slugs are lowercase with hyphens / digits / dots; allow up to 100 chars.
+const SLUG = /^[a-z0-9][a-z0-9._-]{0,99}$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`defillama ${label} cannot be empty`);
+    return s;
+}
+
+export function requireSlug(value, label = 'slug') {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError(
+            `defillama ${label} is required (e.g. "aave", "lido")`,
+            'Use the protocol slug as it appears on https://defillama.com/protocol/<slug>.',
+        );
+    }
+    if (!SLUG.test(s)) {
+        throw new ArgumentError(
+            `defillama ${label} "${value}" is not a valid DefiLlama slug`,
+            'Slugs are lowercase ASCII (letters / digits / "._-"), e.g. "aave", "lido", "pancakeswap-amm".',
+        );
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`defillama ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`defillama ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function llamaFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that api.llama.fi is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `DefiLlama returned 404 for ${url}.`);
+    }
+    if (resp.status === 400) {
+        // DefiLlama returns 400 + plain-text "Protocol not found" for unknown slugs.
+        const body = await resp.text().catch(() => '');
+        if (/not\s*found/i.test(body)) {
+            throw new EmptyResultError(label, `DefiLlama: ${body.trim() || 'not found'}.`);
+        }
+        throw new CommandExecutionError(`${label} returned HTTP 400: ${body.slice(0, 200)}`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'DefiLlama throttles unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+// Convert a unix-seconds timestamp (DefiLlama's listedAt convention) to YYYY-MM-DD,
+// or null when the value is missing / not a finite number.
+export function unixToDate(value) {
+    if (value == null) return null;
+    const n = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    const ms = n > 1e12 ? n : n * 1000;
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toISOString().slice(0, 10);
+}

--- a/clis/endoflife/endoflife.test.js
+++ b/clis/endoflife/endoflife.test.js
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './product.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('endoflife product adapter', () => {
+    const cmd = getRegistry().get('endoflife/product');
+
+    it('rejects empty / malformed product before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ product: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ product: 'BAD/PRODUCT' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ product: 'nodejs' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ product: 'no-such-product' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('normalises lts/support/eol booleans + dates and projects eolStatus', async () => {
+        const cycles = [
+            { cycle: '24', releaseDate: '2025-05-06', latest: '24.15.0', latestReleaseDate: '2026-04-15', lts: '2025-10-28', support: '2026-10-20', eol: '2028-04-30', extendedSupport: false },
+            { cycle: '20', releaseDate: '2023-04-18', latest: '20.20.2', latestReleaseDate: '2026-03-24', lts: '2023-10-24', support: '2024-10-22', eol: '2026-04-30', extendedSupport: true },
+            { cycle: 'rolling', releaseDate: '2020-01-01', latest: 'next', latestReleaseDate: '2026-01-01', lts: false, support: true, eol: false, extendedSupport: false },
+        ];
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(cycles), { status: 200 })));
+
+        const rows = await cmd.func({ product: 'nodejs' });
+        expect(rows).toHaveLength(3);
+        // Future eol -> active
+        expect(rows[0]).toMatchObject({ product: 'nodejs', cycle: '24', eol: '2028-04-30', eolStatus: 'active' });
+        expect(rows[1]).toMatchObject({ cycle: '20', eol: '2026-04-30', eolStatus: 'eol' });
+        // Boolean true -> "ongoing"; boolean false -> null
+        expect(rows[2]).toMatchObject({ cycle: 'rolling', lts: null, support: 'ongoing', eol: null, eolStatus: null });
+        // Round-trip: product is the slug into endoflife.date URLs
+        expect(rows[0].url).toBe('https://endoflife.date/nodejs');
+    });
+});

--- a/clis/endoflife/product.js
+++ b/clis/endoflife/product.js
@@ -1,0 +1,55 @@
+// endoflife product — release cycles + EOL / support dates for one product.
+//
+// Hits `https://endoflife.date/api/<product>.json`. Returns one row per cycle
+// (newest first), with the latest version, release / EOL / LTS / support dates,
+// and an `eolStatus` projection (`active` / `eol` / `ongoing`) so agents can
+// answer "is this version still supported" without parsing dates themselves.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { EOL_BASE, eolFetch, normaliseDateOrFlag, requireProduct } from './utils.js';
+
+cli({
+    site: 'endoflife',
+    name: 'product',
+    access: 'read',
+    description: 'Release cycles + EOL / LTS / support dates for one product on endoflife.date',
+    domain: 'endoflife.date',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'product', positional: true, type: 'string', required: true, help: 'endoflife.date product slug (e.g. "nodejs", "python", "ubuntu")' },
+    ],
+    columns: [
+        'product', 'cycle', 'releaseDate', 'latest', 'latestReleaseDate',
+        'lts', 'support', 'eol', 'extendedSupport', 'eolStatus', 'url',
+    ],
+    func: async (args) => {
+        const product = requireProduct(args.product);
+        const cycles = await eolFetch(`${EOL_BASE}/${encodeURIComponent(product)}.json`, `endoflife product ${product}`);
+        if (!Array.isArray(cycles) || cycles.length === 0) {
+            throw new EmptyResultError('endoflife product', `endoflife.date returned no cycles for "${product}".`);
+        }
+        const today = new Date().toISOString().slice(0, 10);
+        return cycles.map((c) => {
+            const eol = normaliseDateOrFlag(c?.eol);
+            // eolStatus projection — best-effort, derived from eol vs today (not from a remote field).
+            let eolStatus = null;
+            if (eol === 'ongoing') eolStatus = 'ongoing';
+            else if (typeof eol === 'string' && eol >= today) eolStatus = 'active';
+            else if (typeof eol === 'string') eolStatus = 'eol';
+            return {
+                product,
+                cycle: String(c?.cycle ?? '').trim(),
+                releaseDate: typeof c?.releaseDate === 'string' ? c.releaseDate : null,
+                latest: String(c?.latest ?? '').trim(),
+                latestReleaseDate: typeof c?.latestReleaseDate === 'string' ? c.latestReleaseDate : null,
+                lts: normaliseDateOrFlag(c?.lts),
+                support: normaliseDateOrFlag(c?.support),
+                eol,
+                extendedSupport: normaliseDateOrFlag(c?.extendedSupport),
+                eolStatus,
+                url: `https://endoflife.date/${product}`,
+            };
+        });
+    },
+});

--- a/clis/endoflife/utils.js
+++ b/clis/endoflife/utils.js
@@ -1,0 +1,89 @@
+// Shared helpers for the endoflife.date adapters.
+//
+// endoflife.date publishes a free, unauthenticated REST API with cycle / EOL /
+// LTS data for hundreds of products. Docs: https://endoflife.date/docs/api/
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const EOL_BASE = 'https://endoflife.date/api';
+const UA = 'opencli-endoflife-adapter (+https://github.com/jackwener/opencli)';
+
+// endoflife.date product slugs are lowercase ascii + digits + dashes / dots, up to 80 chars.
+const PRODUCT = /^[a-z0-9][a-z0-9._-]{0,79}$/;
+
+export function requireProduct(value) {
+    const s = String(value ?? '').trim().toLowerCase();
+    if (!s) {
+        throw new ArgumentError(
+            'endoflife product is required (e.g. "nodejs", "python", "ubuntu")',
+            'Use the slug visible at https://endoflife.date/<product>.',
+        );
+    }
+    if (!PRODUCT.test(s)) {
+        throw new ArgumentError(
+            `endoflife product "${value}" is not a valid endoflife.date slug`,
+            'Slugs are lowercase ASCII letters/digits/"._-", e.g. "nodejs", "python", "ubuntu".',
+        );
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`endoflife ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`endoflife ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function eolFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that endoflife.date is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `endoflife.date returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'endoflife.date throttles unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+// endoflife.date returns scalar fields that are either an ISO date "YYYY-MM-DD",
+// a boolean (true = supported / ongoing, false = not LTS), or null. Normalise:
+// - boolean true -> the literal string "ongoing"
+// - boolean false -> null (matches "no LTS phase" / "not in extended support")
+// - date string -> as-is
+// - anything else -> null
+export function normaliseDateOrFlag(value) {
+    if (value === true) return 'ongoing';
+    if (value === false || value == null) return null;
+    if (typeof value === 'string') {
+        const s = value.trim();
+        return s || null;
+    }
+    return null;
+}

--- a/clis/goproxy/goproxy.test.js
+++ b/clis/goproxy/goproxy.test.js
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './module.js';
+import './versions.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('goproxy module adapter', () => {
+    const cmd = getRegistry().get('goproxy/module');
+
+    it('rejects malformed module path before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ module: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ module: 'noslash' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ module: 'has spaces/foo' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 410 (gone, e.g. retracted) to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('gone', { status: 410 })));
+        await expect(cmd.func({ module: 'github.com/foo/bar' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ module: 'github.com/foo/bar' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('returns latest version with origin metadata', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            Version: 'v1.12.0',
+            Time: '2026-02-28T10:10:09Z',
+            Origin: { VCS: 'git', URL: 'https://github.com/gin-gonic/gin', Hash: 'abc123', Ref: 'refs/tags/v1.12.0' },
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ module: 'github.com/gin-gonic/gin' });
+        expect(rows).toEqual([expect.objectContaining({
+            module: 'github.com/gin-gonic/gin',
+            version: 'v1.12.0',
+            publishedAt: '2026-02-28T10:10:09Z',
+            vcs: 'git',
+            commit: 'abc123',
+        })]);
+    });
+});
+
+describe('goproxy versions adapter', () => {
+    const cmd = getRegistry().get('goproxy/versions');
+
+    it('rejects bad limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ module: 'github.com/foo/bar', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ module: 'github.com/foo/bar', limit: 500 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError when @v/list is empty', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 200 })));
+        await expect(cmd.func({ module: 'github.com/foo/bar', limit: 5 }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('sorts version tags semver-descending and round-trips module path', async () => {
+        // Note: this list is intentionally unsorted in calendar order.
+        const list = [
+            'v1.9.0', 'v1.10.0', 'v1.2.0', 'v1.10.1', 'v0.0.1', 'v2.0.0',
+            'v2.0.0-rc.2', 'v2.0.0-rc.10',
+        ].join('\n');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(list, { status: 200 })));
+
+        const rows = await cmd.func({ module: 'github.com/foo/bar', limit: 10 });
+        expect(rows.map((r) => r.version)).toEqual([
+            'v2.0.0', 'v2.0.0-rc.10', 'v2.0.0-rc.2',
+            'v1.10.1', 'v1.10.0', 'v1.9.0', 'v1.2.0', 'v0.0.1',
+        ]);
+        // module column round-trips to goproxy module <module>
+        expect(rows[0]).toMatchObject({ rank: 1, module: 'github.com/foo/bar', publishedAt: null });
+    });
+
+    it('fetches publish times only when --with-time is set', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response('v1.0.0\nv0.9.0', { status: 200 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify({ Time: '2024-01-02T03:04:05Z' }), { status: 200 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify({ Time: '2023-12-31T01:02:03Z' }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const rows = await cmd.func({ module: 'github.com/foo/bar', limit: 2, 'with-time': true });
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(rows.map((r) => [r.version, r.publishedAt])).toEqual([
+            ['v1.0.0', '2024-01-02T03:04:05Z'],
+            ['v0.9.0', '2023-12-31T01:02:03Z'],
+        ]);
+    });
+});

--- a/clis/goproxy/module.js
+++ b/clis/goproxy/module.js
@@ -1,0 +1,47 @@
+// goproxy module — latest version + origin metadata for one Go module.
+//
+// Hits `https://proxy.golang.org/<module>/@latest`, returning the canonical
+// version, publish time, and the upstream VCS / commit / tag the proxy resolved.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { GOPROXY_BASE, goproxyJson, requireModulePath, trimDate } from './utils.js';
+
+cli({
+    site: 'goproxy',
+    name: 'module',
+    access: 'read',
+    description: 'Latest version + VCS origin metadata for a Go module on proxy.golang.org',
+    domain: 'proxy.golang.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'module', positional: true, type: 'string', required: true, help: 'Go module path (e.g. "github.com/gin-gonic/gin", "golang.org/x/net")' },
+    ],
+    columns: [
+        'module', 'version', 'publishedAt', 'vcs', 'repository',
+        'commit', 'ref', 'pkgGoDevUrl', 'url',
+    ],
+    func: async (args) => {
+        const modulePath = requireModulePath(args.module);
+        // GOPROXY spec requires lowercase percent-encoding for capital letters in the
+        // module path (e.g. github.com/Foo/Bar -> github.com/!foo/!bar). Module paths
+        // we accept here are lowercase-only by convention; we still encode each segment.
+        const encoded = modulePath.split('/').map(encodeURIComponent).join('/');
+        const detail = await goproxyJson(`${GOPROXY_BASE}/${encoded}/@latest`, `goproxy module ${modulePath}`);
+        if (!detail || !detail.Version) {
+            throw new EmptyResultError('goproxy module', `proxy.golang.org returned no @latest entry for "${modulePath}".`);
+        }
+        const origin = detail.Origin && typeof detail.Origin === 'object' ? detail.Origin : {};
+        return [{
+            module: modulePath,
+            version: String(detail.Version),
+            publishedAt: trimDate(detail.Time),
+            vcs: String(origin.VCS ?? '').trim(),
+            repository: String(origin.URL ?? '').trim(),
+            commit: String(origin.Hash ?? '').trim(),
+            ref: String(origin.Ref ?? '').trim(),
+            pkgGoDevUrl: `https://pkg.go.dev/${modulePath}`,
+            url: `${GOPROXY_BASE}/${encoded}/@latest`,
+        }];
+    },
+});

--- a/clis/goproxy/utils.js
+++ b/clis/goproxy/utils.js
@@ -1,0 +1,165 @@
+// Shared helpers for the Go module proxy adapters.
+//
+// proxy.golang.org is the canonical Go module proxy. It is unauthenticated
+// and serves the GOPROXY protocol (`@latest`, `@v/list`, `@v/<ver>.info|mod|zip`).
+// Spec: https://go.dev/ref/mod#goproxy-protocol
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const GOPROXY_BASE = 'https://proxy.golang.org';
+const UA = 'opencli-goproxy-adapter (+https://github.com/jackwener/opencli)';
+
+// Module paths look like host/path/...; conservative shape: at least one slash,
+// host segment is alnum + dots, path segments are alnum + dashes/dots/underscores/slashes.
+// We enforce at most 200 chars and reject characters that would need URL-escaping.
+const MODULE_PATH = /^[A-Za-z0-9][A-Za-z0-9._\/-]{0,199}$/;
+
+// Go semver tags include "v" prefix; we accept the GOPROXY canonical form.
+const VERSION_TAG = /^v[0-9]+(\.[0-9]+)*([-+][A-Za-z0-9._-]+)?$/;
+
+export function requireModulePath(value) {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError(
+            'goproxy module path is required (e.g. "github.com/gin-gonic/gin", "golang.org/x/net")',
+            'Use the canonical module path that appears in `go.mod`.',
+        );
+    }
+    if (!MODULE_PATH.test(s) || !s.includes('/')) {
+        throw new ArgumentError(
+            `goproxy module path "${value}" is not a recognised Go module path`,
+            'Module paths look like "github.com/<org>/<repo>" or "golang.org/x/<name>".',
+        );
+    }
+    return s;
+}
+
+export function requireVersionTag(value) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError('goproxy --version cannot be empty');
+    if (!VERSION_TAG.test(s)) {
+        throw new ArgumentError(
+            `goproxy --version "${value}" is not a valid Go semver tag`,
+            'Use the GOPROXY canonical form like "v1.2.3" or "v0.0.0-20240101010101-abcdef012345".',
+        );
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`goproxy ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`goproxy ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+async function rawFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that proxy.golang.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404 || resp.status === 410) {
+        throw new EmptyResultError(label, `proxy.golang.org returned ${resp.status} for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    return resp;
+}
+
+export async function goproxyJson(url, label) {
+    const resp = await rawFetch(url, label);
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+export async function goproxyText(url, label) {
+    const resp = await rawFetch(url, label);
+    return resp.text();
+}
+
+// Sort version tags by their numeric components, newest first. Pre-release tags
+// (anything after "-" that isn't a pure number) sort lower than the matching
+// release. Returns a new sorted array; non-tag inputs are dropped.
+export function sortVersionsDescending(versions) {
+    return versions
+        .filter((v) => typeof v === 'string' && VERSION_TAG.test(v))
+        .map((v) => ({ v, parts: parseSemver(v) }))
+        .sort((a, b) => compareParts(b.parts, a.parts))
+        .map((entry) => entry.v);
+}
+
+function parseSemver(tag) {
+    // Strip leading "v"; split into <numbers>(-<pre>)?(+<build>)?
+    const stripped = tag.replace(/^v/, '');
+    const plusIdx = stripped.indexOf('+');
+    const noBuild = plusIdx >= 0 ? stripped.slice(0, plusIdx) : stripped;
+    const dashIdx = noBuild.indexOf('-');
+    const head = dashIdx >= 0 ? noBuild.slice(0, dashIdx) : noBuild;
+    const pre = dashIdx >= 0 ? noBuild.slice(dashIdx + 1) : '';
+    const numbers = head.split('.').map((s) => Number.parseInt(s, 10)).map((n) => Number.isFinite(n) ? n : 0);
+    return { numbers, pre };
+}
+
+function compareParts(a, b) {
+    const len = Math.max(a.numbers.length, b.numbers.length);
+    for (let i = 0; i < len; i += 1) {
+        const ai = a.numbers[i] ?? 0;
+        const bi = b.numbers[i] ?? 0;
+        if (ai !== bi) return ai - bi;
+    }
+    // No pre-release sorts higher than has pre-release.
+    if (a.pre === '' && b.pre !== '') return 1;
+    if (a.pre !== '' && b.pre === '') return -1;
+    if (a.pre === b.pre) return 0;
+    return comparePrerelease(a.pre, b.pre);
+}
+
+function comparePrerelease(a, b) {
+    const aParts = a.split('.');
+    const bParts = b.split('.');
+    const len = Math.max(aParts.length, bParts.length);
+    for (let i = 0; i < len; i += 1) {
+        const ai = aParts[i];
+        const bi = bParts[i];
+        if (ai == null) return -1;
+        if (bi == null) return 1;
+        const aNum = /^\d+$/.test(ai);
+        const bNum = /^\d+$/.test(bi);
+        if (aNum && bNum) {
+            const diff = Number(ai) - Number(bi);
+            if (diff !== 0) return diff;
+            continue;
+        }
+        if (aNum !== bNum) return aNum ? -1 : 1;
+        if (ai !== bi) return ai < bi ? -1 : 1;
+    }
+    return 0;
+}
+
+// Normalise GOPROXY ISO-Z timestamps to second precision (no fractional ms).
+export function trimDate(value) {
+    const s = String(value ?? '').trim();
+    if (!s) return null;
+    const noFrac = s.replace(/\.\d+/, '');
+    return noFrac.endsWith('Z') ? noFrac : (s.length >= 10 ? s.slice(0, 10) : null);
+}

--- a/clis/goproxy/versions.js
+++ b/clis/goproxy/versions.js
@@ -1,0 +1,59 @@
+// goproxy versions — published version tags for one Go module, newest first.
+//
+// Hits `https://proxy.golang.org/<module>/@v/list` (plain text, one tag per line).
+// Sort by semver (descending) and return up to `--limit` rows; per-tag publish
+// time comes from `@v/<ver>.info` and is fetched only when `--with-time` is set,
+// since it costs one HTTP request per row.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    GOPROXY_BASE, goproxyJson, goproxyText, requireBoundedInt, requireModulePath, sortVersionsDescending, trimDate,
+} from './utils.js';
+
+cli({
+    site: 'goproxy',
+    name: 'versions',
+    access: 'read',
+    description: 'Published version tags for a Go module (newest first), optionally with publish times',
+    domain: 'proxy.golang.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'module', positional: true, type: 'string', required: true, help: 'Go module path (e.g. "github.com/gin-gonic/gin")' },
+        { name: 'limit', type: 'int', default: 30, help: 'Max rows to return (1-200)' },
+        { name: 'with-time', type: 'boolean', default: false, help: 'Fetch each version\'s publish time (one extra request per row)' },
+    ],
+    columns: [
+        'rank', 'module', 'version', 'publishedAt', 'url',
+    ],
+    func: async (args) => {
+        const modulePath = requireModulePath(args.module);
+        const limit = requireBoundedInt(args.limit, 30, 200, 'limit');
+        const withTime = args['with-time'] === true;
+        const encoded = modulePath.split('/').map(encodeURIComponent).join('/');
+        const text = await goproxyText(`${GOPROXY_BASE}/${encoded}/@v/list`, `goproxy versions ${modulePath}`);
+        const raw = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+        if (raw.length === 0) {
+            throw new EmptyResultError('goproxy versions', `proxy.golang.org returned no published versions for "${modulePath}".`);
+        }
+        const sorted = sortVersionsDescending(raw).slice(0, limit);
+        if (sorted.length === 0) {
+            throw new EmptyResultError('goproxy versions', `"${modulePath}" has no semver-shaped tags on proxy.golang.org.`);
+        }
+        const rows = sorted.map((v, i) => ({
+            rank: i + 1,
+            module: modulePath,
+            version: v,
+            publishedAt: null,
+            url: `${GOPROXY_BASE}/${encoded}/@v/${encodeURIComponent(v)}.info`,
+        }));
+        if (withTime) {
+            // Sequential to keep the proxy happy; cap at limit which is already <=200.
+            for (const row of rows) {
+                const info = await goproxyJson(`${GOPROXY_BASE}/${encoded}/@v/${encodeURIComponent(row.version)}.info`, `goproxy versions ${modulePath} ${row.version}`);
+                row.publishedAt = trimDate(info?.Time);
+            }
+        }
+        return rows;
+    },
+});

--- a/clis/osv/osv.test.js
+++ b/clis/osv/osv.test.js
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './vulnerability.js';
+import './query.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('osv vulnerability adapter', () => {
+    const cmd = getRegistry().get('osv/vulnerability');
+
+    it('rejects empty / malformed id before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ id: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'has spaces' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ id: 'GHSA-aaaa-bbbb-cccc' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('returns flattened affected packages with severity from database_specific', async () => {
+        const vuln = {
+            id: 'GHSA-29mw-wpgm-hmr9',
+            summary: 'ReDoS in lodash',
+            aliases: ['CVE-2020-28500'],
+            published: '2022-01-06T20:30:46Z',
+            modified: '2025-09-29T21:12:31.102523Z',
+            database_specific: { severity: 'MODERATE', cwe_ids: ['CWE-1333', 'CWE-400'] },
+            severity: [{ type: 'CVSS_V3', score: 'CVSS:3.1/...' }],
+            affected: [
+                { package: { name: 'lodash', ecosystem: 'npm' } },
+                { package: { name: 'lodash-rails', ecosystem: 'RubyGems' } },
+            ],
+            references: [{ url: 'https://example' }],
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(vuln), { status: 200 })));
+
+        const rows = await cmd.func({ id: 'GHSA-29mw-wpgm-hmr9' });
+        expect(rows).toEqual([expect.objectContaining({
+            id: 'GHSA-29mw-wpgm-hmr9',
+            severity: 'MODERATE',
+            aliases: 'CVE-2020-28500',
+            affectedPackages: 'npm:lodash, RubyGems:lodash-rails',
+            cwes: 'CWE-1333, CWE-400',
+            referenceCount: 1,
+            modified: '2025-09-29T21:12:31Z',
+        })]);
+    });
+});
+
+describe('osv query adapter', () => {
+    const cmd = getRegistry().get('osv/query');
+
+    it('rejects bad ecosystem and bad limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ package: 'lodash', ecosystem: 'foo', limit: 5 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'django', ecosystem: 'pypi', limit: 5 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'lodash', ecosystem: 'npm', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: '', ecosystem: 'npm', limit: 5 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ package: 'lodash', ecosystem: 'npm', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when no vulns reported', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })));
+        await expect(cmd.func({ package: 'lodash', ecosystem: 'npm', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('sorts by published date descending and rows have id round-tripable into osv vulnerability', async () => {
+        const body = {
+            vulns: [
+                { id: 'GHSA-old', summary: 'old', published: '2020-01-01T00:00:00Z', affected: [{ package: { name: 'django', ecosystem: 'PyPI' } }] },
+                { id: 'GHSA-new', summary: 'new', published: '2026-01-01T00:00:00Z', affected: [{ package: { name: 'django', ecosystem: 'PyPI' } }] },
+            ],
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status: 200 })));
+
+        const rows = await cmd.func({ package: 'django', ecosystem: 'PyPI', limit: 5 });
+        expect(rows[0]).toMatchObject({ rank: 1, id: 'GHSA-new', published: '2026-01-01T00:00:00Z' });
+        expect(rows[1]).toMatchObject({ rank: 2, id: 'GHSA-old' });
+        expect(rows[0].url).toBe('https://osv.dev/vulnerability/GHSA-new');
+    });
+});

--- a/clis/osv/query.js
+++ b/clis/osv/query.js
@@ -1,0 +1,72 @@
+// osv query — find vulnerabilities affecting a given package (and optional version).
+//
+// Hits `POST https://api.osv.dev/v1/query` with `{package:{name,ecosystem}, version?}`.
+// Returns one row per vulnerability ranked by published date (newest first), so
+// agents can answer "is package X@Y vulnerable?" in one shot.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    OSV_BASE, osvPost, requireBoundedInt, requireEcosystem, requireString, severityLabel, trimDate,
+} from './utils.js';
+
+cli({
+    site: 'osv',
+    name: 'query',
+    access: 'read',
+    description: 'OSV.dev vulnerabilities affecting a package (optionally pinned to a version)',
+    domain: 'osv.dev',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'package', positional: true, type: 'string', required: true, help: 'Package name (e.g. "lodash", "django")' },
+        { name: 'ecosystem', type: 'string', required: true, help: 'OSV ecosystem (npm / PyPI / Go / Maven / NuGet / RubyGems / crates.io / Packagist / ...)' },
+        { name: 'version', type: 'string', required: false, help: 'Pin to a specific version (e.g. "4.17.20"); omit for all known vulns' },
+        { name: 'limit', type: 'int', default: 30, help: 'Max rows to return (1-200)' },
+    ],
+    columns: [
+        'rank', 'id', 'summary', 'severity', 'aliases',
+        'published', 'modified', 'affectedPackages', 'url',
+    ],
+    func: async (args) => {
+        const name = requireString(args.package, 'package');
+        const ecosystem = requireEcosystem(args.ecosystem);
+        const limit = requireBoundedInt(args.limit, 30, 200, 'limit');
+        const payload = { package: { name, ecosystem } };
+        if (args.version != null && String(args.version).trim() !== '') {
+            payload.version = String(args.version).trim();
+        }
+        const body = await osvPost(`${OSV_BASE}/v1/query`, payload, `osv query ${ecosystem}:${name}`);
+        const vulns = Array.isArray(body?.vulns) ? body.vulns : [];
+        if (vulns.length === 0) {
+            throw new EmptyResultError(
+                'osv query',
+                `OSV.dev returned no vulnerabilities for ${ecosystem}:${name}${payload.version ? `@${payload.version}` : ''}.`,
+            );
+        }
+        const sorted = vulns
+            .slice()
+            .sort((a, b) => String(b?.published ?? '').localeCompare(String(a?.published ?? '')))
+            .slice(0, limit);
+        return sorted.map((v, i) => {
+            const affected = Array.isArray(v.affected) ? v.affected : [];
+            const pkgPairs = [];
+            for (const a of affected) {
+                const eco = a?.package?.ecosystem;
+                const aname = a?.package?.name;
+                if (eco && aname) pkgPairs.push(`${eco}:${aname}`);
+            }
+            const aliases = Array.isArray(v.aliases) ? v.aliases.filter(Boolean) : [];
+            return {
+                rank: i + 1,
+                id: String(v.id ?? ''),
+                summary: String(v.summary ?? '').trim(),
+                severity: severityLabel(v),
+                aliases: aliases.join(', '),
+                published: trimDate(v.published),
+                modified: trimDate(v.modified),
+                affectedPackages: pkgPairs.join(', '),
+                url: v.id ? `https://osv.dev/vulnerability/${v.id}` : '',
+            };
+        });
+    },
+});

--- a/clis/osv/utils.js
+++ b/clis/osv/utils.js
@@ -1,0 +1,169 @@
+// Shared helpers for the OSV.dev (Open Source Vulnerabilities) adapters.
+//
+// OSV.dev publishes a free, unauthenticated REST API at https://api.osv.dev.
+// Docs: https://google.github.io/osv.dev/api/
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const OSV_BASE = 'https://api.osv.dev';
+const UA = 'opencli-osv-adapter (+https://github.com/jackwener/opencli)';
+
+// OSV vulnerability IDs are short tokens like "GHSA-29mw-wpgm-hmr9", "CVE-2020-28500", "PYSEC-2021-1".
+const VULN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
+
+// OSV ecosystems we accept on input. The full canonical list is at
+// https://ossf.github.io/osv-schema/#defined-ecosystems — we accept the public
+// ones that map cleanly to package registries opencli already supports.
+export const OSV_ECOSYSTEMS = new Set([
+    'npm',
+    'PyPI',
+    'Go',
+    'Maven',
+    'NuGet',
+    'RubyGems',
+    'crates.io',
+    'Packagist',
+    'Pub',
+    'Hex',
+    'Hackage',
+    'CRAN',
+    'Bitnami',
+    'GitHub Actions',
+    'SwiftURL',
+]);
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`osv ${label} cannot be empty`);
+    return s;
+}
+
+export function requireVulnId(value) {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError(
+            'osv vulnerability id is required (e.g. "GHSA-29mw-wpgm-hmr9", "CVE-2020-28500")',
+            'IDs are listed at https://osv.dev — paste the canonical id from the vulnerability page.',
+        );
+    }
+    if (!VULN_ID.test(s)) {
+        throw new ArgumentError(
+            `osv vulnerability id "${value}" is not a valid OSV id`,
+            'IDs are short ASCII tokens like "GHSA-...", "CVE-...", "PYSEC-...".',
+        );
+    }
+    return s;
+}
+
+export function requireEcosystem(value) {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError(
+            'osv --ecosystem is required when querying by package',
+            `Pick one of: ${[...OSV_ECOSYSTEMS].join(', ')}.`,
+        );
+    }
+    if (!OSV_ECOSYSTEMS.has(s)) {
+        throw new ArgumentError(
+            `osv --ecosystem "${value}" is not a recognised OSV ecosystem`,
+            `Pick one of: ${[...OSV_ECOSYSTEMS].join(', ')}.`,
+        );
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`osv ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`osv ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+async function readJson(resp, label) {
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+export async function osvGet(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that api.osv.dev is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `OSV.dev returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    return readJson(resp, label);
+}
+
+export async function osvPost(url, payload, label) {
+    let resp;
+    try {
+        resp = await fetch(url, {
+            method: 'POST',
+            headers: { 'user-agent': UA, accept: 'application/json', 'content-type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that api.osv.dev is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `OSV.dev returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        const text = await resp.text().catch(() => '');
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}${text ? `: ${text.slice(0, 200)}` : ''}`);
+    }
+    return readJson(resp, label);
+}
+
+// Reduce OSV's `severity` array to a single human-readable label.
+// Returns null when no severity is recorded; never invents a value.
+export function severityLabel(vuln) {
+    const dbSpecific = vuln?.database_specific;
+    if (dbSpecific && typeof dbSpecific.severity === 'string' && dbSpecific.severity.trim()) {
+        return dbSpecific.severity.trim();
+    }
+    const arr = Array.isArray(vuln?.severity) ? vuln.severity : [];
+    for (const entry of arr) {
+        if (entry && typeof entry.score === 'string' && entry.score.trim()) {
+            return entry.score.trim();
+        }
+    }
+    return null;
+}
+
+export function trimDate(value) {
+    const s = String(value ?? '').trim();
+    if (!s) return null;
+    const noFrac = s.replace(/\.\d+/, '');
+    return noFrac.endsWith('Z') ? noFrac : (s.length >= 10 ? s.slice(0, 10) : null);
+}

--- a/clis/osv/vulnerability.js
+++ b/clis/osv/vulnerability.js
@@ -1,0 +1,54 @@
+// osv vulnerability — fetch a single OSV vulnerability by id.
+//
+// Hits `https://api.osv.dev/v1/vulns/<id>`. Returns one row with the canonical
+// id, summary, severity, aliases (CVE / GHSA mappings), publish / modify dates,
+// and the affected packages (flattened to a comma-separated "ecosystem:name" list).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { OSV_BASE, osvGet, requireVulnId, severityLabel, trimDate } from './utils.js';
+
+cli({
+    site: 'osv',
+    name: 'vulnerability',
+    access: 'read',
+    description: 'Single OSV.dev vulnerability detail (severity, affected packages, CVE/GHSA aliases)',
+    domain: 'osv.dev',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, type: 'string', required: true, help: 'OSV vulnerability id (e.g. "GHSA-29mw-wpgm-hmr9", "CVE-2020-28500")' },
+    ],
+    columns: [
+        'id', 'summary', 'severity', 'aliases', 'published', 'modified',
+        'affectedPackages', 'cwes', 'referenceCount', 'url',
+    ],
+    func: async (args) => {
+        const id = requireVulnId(args.id);
+        const vuln = await osvGet(`${OSV_BASE}/v1/vulns/${encodeURIComponent(id)}`, `osv vulnerability ${id}`);
+        if (!vuln || !vuln.id) {
+            throw new EmptyResultError('osv vulnerability', `OSV.dev returned no record for "${id}".`);
+        }
+        const affected = Array.isArray(vuln.affected) ? vuln.affected : [];
+        const pkgPairs = [];
+        for (const a of affected) {
+            const eco = a?.package?.ecosystem;
+            const name = a?.package?.name;
+            if (eco && name) pkgPairs.push(`${eco}:${name}`);
+        }
+        const aliases = Array.isArray(vuln.aliases) ? vuln.aliases.filter(Boolean) : [];
+        const cwes = Array.isArray(vuln?.database_specific?.cwe_ids) ? vuln.database_specific.cwe_ids : [];
+        const refs = Array.isArray(vuln.references) ? vuln.references : [];
+        return [{
+            id: String(vuln.id),
+            summary: String(vuln.summary ?? '').trim(),
+            severity: severityLabel(vuln),
+            aliases: aliases.join(', '),
+            published: trimDate(vuln.published),
+            modified: trimDate(vuln.modified),
+            affectedPackages: pkgPairs.join(', '),
+            cwes: cwes.join(', '),
+            referenceCount: refs.length,
+            url: `https://osv.dev/vulnerability/${vuln.id}`,
+        }];
+    },
+});

--- a/clis/rfc/rfc.js
+++ b/clis/rfc/rfc.js
@@ -1,0 +1,52 @@
+// rfc rfc — fetch a single IETF RFC's metadata.
+//
+// Hits `https://datatracker.ietf.org/doc/rfc<N>/doc.json` and projects the
+// agent-useful fields: title, abstract (full text — RFCs don't truncate well),
+// page count, working group, authors, std level, publish date, plus rendered URLs.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { RFC_BASE, requireRfcNumber, rfcFetch, trimDate } from './utils.js';
+
+cli({
+    site: 'rfc',
+    name: 'rfc',
+    access: 'read',
+    description: 'Single IETF RFC metadata (title, abstract, working group, authors, std level)',
+    domain: 'datatracker.ietf.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'number', positional: true, type: 'int', required: true, help: 'RFC number (e.g. 9000, 791, 2616)' },
+    ],
+    columns: [
+        'rfc', 'title', 'state', 'stdLevel', 'group', 'groupType',
+        'pages', 'published', 'authors', 'abstract', 'rfcEditorUrl', 'url',
+    ],
+    func: async (args) => {
+        const number = requireRfcNumber(args.number);
+        const name = `rfc${number}`;
+        const doc = await rfcFetch(`${RFC_BASE}/doc/${name}/doc.json`, `rfc ${number}`);
+        if (!doc || !doc.name) {
+            throw new EmptyResultError('rfc rfc', `IETF datatracker returned no metadata for RFC ${number}.`);
+        }
+        const authors = Array.isArray(doc.authors)
+            ? doc.authors.map((a) => String(a?.name ?? '').trim()).filter(Boolean).join(', ')
+            : '';
+        const groupName = String(doc.group?.name ?? '').trim();
+        const groupType = String(doc.group?.type ?? '').trim();
+        return [{
+            rfc: number,
+            title: String(doc.title ?? '').trim(),
+            state: String(doc.state ?? '').trim(),
+            stdLevel: String(doc.std_level ?? '').trim(),
+            group: groupName,
+            groupType,
+            pages: doc.pages == null ? null : Number(doc.pages),
+            published: trimDate(doc.time),
+            authors,
+            abstract: String(doc.abstract ?? '').trim(),
+            rfcEditorUrl: `https://www.rfc-editor.org/rfc/rfc${number}`,
+            url: `${RFC_BASE}/doc/${name}/`,
+        }];
+    },
+});

--- a/clis/rfc/rfc.test.js
+++ b/clis/rfc/rfc.test.js
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './rfc.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('rfc rfc adapter', () => {
+    const cmd = getRegistry().get('rfc/rfc');
+
+    it('rejects malformed RFC numbers before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ number: 'abc' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ number: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ number: -5 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ number: 1000000 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ number: 999998 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ number: 9000 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('flattens authors + group, normalises space-separated date, and emits rfcEditorUrl', async () => {
+        const doc = {
+            name: 'rfc9000',
+            title: 'QUIC: A UDP-Based Multiplexed and Secure Transport',
+            state: 'Published',
+            std_level: 'Proposed Standard',
+            group: { name: 'QUIC', type: 'WG' },
+            pages: 151,
+            time: '2022-02-19 08:46:51',
+            authors: [
+                { name: 'Jana Iyengar', email: 'jri@example' },
+                { name: 'Martin Thomson', email: 'mt@example' },
+            ],
+            abstract: 'This document defines QUIC.',
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(doc), { status: 200 })));
+
+        const rows = await cmd.func({ number: 9000 });
+        expect(rows[0]).toMatchObject({
+            rfc: 9000,
+            title: 'QUIC: A UDP-Based Multiplexed and Secure Transport',
+            stdLevel: 'Proposed Standard',
+            group: 'QUIC',
+            groupType: 'WG',
+            pages: 151,
+            published: '2022-02-19',
+            authors: 'Jana Iyengar, Martin Thomson',
+            rfcEditorUrl: 'https://www.rfc-editor.org/rfc/rfc9000',
+            url: 'https://datatracker.ietf.org/doc/rfc9000/',
+        });
+    });
+
+    it('accepts "rfc<N>" prefix as a courtesy', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            name: 'rfc791', title: 'Internet Protocol', authors: [], group: {},
+        }), { status: 200 })));
+        const rows = await cmd.func({ number: 'rfc791' });
+        expect(rows[0].rfc).toBe(791);
+    });
+});

--- a/clis/rfc/utils.js
+++ b/clis/rfc/utils.js
@@ -1,0 +1,72 @@
+// Shared helpers for the IETF RFC adapter.
+//
+// datatracker.ietf.org publishes a free, unauthenticated REST API. The
+// `/doc/<name>/doc.json` endpoint returns rich metadata for any IETF document
+// (RFCs, internet drafts, etc.). Docs: https://datatracker.ietf.org/api/
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const RFC_BASE = 'https://datatracker.ietf.org';
+const UA = 'opencli-rfc-adapter (+https://github.com/jackwener/opencli)';
+
+export function requireRfcNumber(value) {
+    const raw = value;
+    if (raw == null || String(raw).trim() === '') {
+        throw new ArgumentError(
+            'rfc number is required (e.g. 9000, 791, 2616)',
+            'Pass the integer RFC number; do not include the "rfc" prefix.',
+        );
+    }
+    // Accept "9000" or 9000 or "rfc9000" as a courtesy.
+    const s = String(raw).trim().toLowerCase().replace(/^rfc/, '');
+    const n = Number.parseInt(s, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== s) {
+        throw new ArgumentError(
+            `rfc number "${value}" is not a valid RFC number`,
+            'Pass a positive integer (e.g. 9000, 791, 2616).',
+        );
+    }
+    if (n > 999999) {
+        throw new ArgumentError('rfc number must be <= 999999');
+    }
+    return n;
+}
+
+export async function rfcFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that datatracker.ietf.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `IETF datatracker returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+// IETF datatracker timestamps are like "2022-02-19 08:46:51" (no T, no Z)
+// or ISO with offset like "2016-07-08T21:03:52+00:00". Normalise to YYYY-MM-DD.
+export function trimDate(value) {
+    const s = String(value ?? '').trim();
+    if (!s) return null;
+    // Take the first 10 chars only if they form a YYYY-MM-DD prefix.
+    if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0, 10);
+    return null;
+}

--- a/clis/tvmaze/search.js
+++ b/clis/tvmaze/search.js
@@ -1,0 +1,61 @@
+// tvmaze search — TV show search by title.
+//
+// Hits `https://api.tvmaze.com/search/shows?q=<query>` and returns one row per
+// match. Includes the show id (round-tripable into `tvmaze show <id>`),
+// premiered/ended dates, network, and TVmaze rating so agents can rank.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    TVMAZE_BASE, joinList, requireBoundedInt, requireString, stripHtml, tvmazeFetch,
+} from './utils.js';
+
+cli({
+    site: 'tvmaze',
+    name: 'search',
+    access: 'read',
+    description: 'TVmaze TV show search by title (returns id, name, network, premiered/ended, rating)',
+    domain: 'tvmaze.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, type: 'string', required: true, help: 'TV show title or fragment to search for' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (1-50)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'type', 'language', 'genres',
+        'status', 'premiered', 'ended', 'network', 'rating',
+        'matchScore', 'summary', 'url',
+    ],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 50, 'limit');
+        const list = await tvmazeFetch(
+            `${TVMAZE_BASE}/search/shows?q=${encodeURIComponent(query)}`,
+            `tvmaze search ${query}`,
+        );
+        if (!Array.isArray(list) || list.length === 0) {
+            throw new EmptyResultError('tvmaze search', `TVmaze returned no shows matching "${query}".`);
+        }
+        const rows = list.slice(0, limit).map((entry, i) => {
+            const show = entry?.show ?? {};
+            const network = show.network?.name ?? show.webChannel?.name ?? '';
+            return {
+                rank: i + 1,
+                id: typeof show.id === 'number' ? show.id : null,
+                name: String(show.name ?? '').trim(),
+                type: String(show.type ?? '').trim(),
+                language: String(show.language ?? '').trim(),
+                genres: joinList(show.genres),
+                status: String(show.status ?? '').trim(),
+                premiered: typeof show.premiered === 'string' ? show.premiered : null,
+                ended: typeof show.ended === 'string' ? show.ended : null,
+                network: String(network).trim(),
+                rating: show.rating?.average == null ? null : Number(show.rating.average),
+                matchScore: typeof entry?.score === 'number' ? entry.score : null,
+                summary: stripHtml(show.summary),
+                url: String(show.url ?? '').trim(),
+            };
+        });
+        return rows;
+    },
+});

--- a/clis/tvmaze/show.js
+++ b/clis/tvmaze/show.js
@@ -1,0 +1,60 @@
+// tvmaze show — full TV show details by TVmaze id.
+//
+// Hits `https://api.tvmaze.com/shows/<id>`. Returns one row with name, status,
+// premiered/ended dates, network, runtime, rating, official site, IMDB / TheTVDB
+// cross-refs (so agents can hop into other adapters), and a plain-text summary.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { TVMAZE_BASE, joinList, requireShowId, stripHtml, tvmazeFetch } from './utils.js';
+
+cli({
+    site: 'tvmaze',
+    name: 'show',
+    access: 'read',
+    description: 'Single TVmaze TV show detail by id (network, schedule, rating, IMDB/TheTVDB cross-refs)',
+    domain: 'tvmaze.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, type: 'int', required: true, help: 'TVmaze show id (positive integer)' },
+    ],
+    columns: [
+        'id', 'name', 'type', 'language', 'genres', 'status',
+        'premiered', 'ended', 'runtime', 'averageRuntime', 'network',
+        'country', 'schedule', 'rating', 'imdb', 'thetvdb',
+        'officialSite', 'summary', 'url',
+    ],
+    func: async (args) => {
+        const id = requireShowId(args.id);
+        const show = await tvmazeFetch(`${TVMAZE_BASE}/shows/${id}`, `tvmaze show ${id}`);
+        if (!show || show.id == null) {
+            throw new EmptyResultError('tvmaze show', `TVmaze returned no show for id ${id}.`);
+        }
+        const network = show.network?.name ?? show.webChannel?.name ?? '';
+        const country = show.network?.country?.name ?? show.webChannel?.country?.name ?? '';
+        const days = Array.isArray(show.schedule?.days) ? show.schedule.days.join(', ') : '';
+        const time = String(show.schedule?.time ?? '').trim();
+        const schedule = days || time ? `${days}${days && time ? ' ' : ''}${time}`.trim() : '';
+        return [{
+            id: Number(show.id),
+            name: String(show.name ?? '').trim(),
+            type: String(show.type ?? '').trim(),
+            language: String(show.language ?? '').trim(),
+            genres: joinList(show.genres),
+            status: String(show.status ?? '').trim(),
+            premiered: typeof show.premiered === 'string' ? show.premiered : null,
+            ended: typeof show.ended === 'string' ? show.ended : null,
+            runtime: show.runtime == null ? null : Number(show.runtime),
+            averageRuntime: show.averageRuntime == null ? null : Number(show.averageRuntime),
+            network: String(network).trim(),
+            country: String(country).trim(),
+            schedule,
+            rating: show.rating?.average == null ? null : Number(show.rating.average),
+            imdb: String(show.externals?.imdb ?? '').trim(),
+            thetvdb: show.externals?.thetvdb == null ? null : Number(show.externals.thetvdb),
+            officialSite: String(show.officialSite ?? '').trim(),
+            summary: stripHtml(show.summary),
+            url: String(show.url ?? '').trim(),
+        }];
+    },
+});

--- a/clis/tvmaze/tvmaze.test.js
+++ b/clis/tvmaze/tvmaze.test.js
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './show.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('tvmaze search adapter', () => {
+    const cmd = getRegistry().get('tvmaze/search');
+
+    it('rejects empty query and bad limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '', limit: 5 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 100 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ query: 'foo', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when no shows match', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('[]', { status: 200 })));
+        await expect(cmd.func({ query: 'asdfghjkl', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('strips HTML from summary and ids round-trip into tvmaze show <id>', async () => {
+        const list = [{
+            score: 1.2,
+            show: {
+                id: 169, name: 'Breaking Bad', type: 'Scripted', language: 'English',
+                genres: ['Drama'], status: 'Ended', premiered: '2008-01-20', ended: '2019-10-11',
+                network: { name: 'AMC' }, rating: { average: 9.2 },
+                summary: '<p><b>Breaking Bad</b> is a show with &amp; entities &#39;here&#39;, &#x27;hex&#x27;, and &hellip;.</p>',
+                url: 'https://www.tvmaze.com/shows/169/breaking-bad',
+            },
+        }];
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(list), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'breaking bad', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, id: 169, name: 'Breaking Bad', network: 'AMC', rating: 9.2, matchScore: 1.2,
+        });
+        expect(rows[0].summary).toBe("Breaking Bad is a show with & entities 'here', 'hex', and ….");
+        // id round-trip
+        expect(typeof rows[0].id).toBe('number');
+    });
+});
+
+describe('tvmaze show adapter', () => {
+    const cmd = getRegistry().get('tvmaze/show');
+
+    it('rejects non-positive id before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ id: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: -5 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'abc' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ id: 99999999 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('returns full show detail with externals + schedule', async () => {
+        const show = {
+            id: 169, name: 'Breaking Bad', type: 'Scripted', language: 'English', genres: ['Drama'],
+            status: 'Ended', premiered: '2008-01-20', ended: '2019-10-11', runtime: 60, averageRuntime: 60,
+            network: { name: 'AMC', country: { name: 'United States' } }, schedule: { time: '22:00', days: ['Sunday'] },
+            rating: { average: 9.2 }, externals: { imdb: 'tt0903747', thetvdb: 81189 },
+            officialSite: 'http://www.amc.com/shows/breaking-bad',
+            summary: '<p>Plain.</p>', url: 'https://www.tvmaze.com/shows/169/breaking-bad',
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(show), { status: 200 })));
+
+        const rows = await cmd.func({ id: 169 });
+        expect(rows[0]).toMatchObject({
+            id: 169, name: 'Breaking Bad', country: 'United States', schedule: 'Sunday 22:00',
+            imdb: 'tt0903747', thetvdb: 81189, rating: 9.2, summary: 'Plain.',
+        });
+    });
+});

--- a/clis/tvmaze/utils.js
+++ b/clis/tvmaze/utils.js
@@ -1,0 +1,110 @@
+// Shared helpers for the TVmaze adapters.
+//
+// TVmaze publishes a free, unauthenticated REST API at https://api.tvmaze.com.
+// Docs: https://www.tvmaze.com/api
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const TVMAZE_BASE = 'https://api.tvmaze.com';
+const UA = 'opencli-tvmaze-adapter (+https://github.com/jackwener/opencli)';
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`tvmaze ${label} cannot be empty`);
+    return s;
+}
+
+export function requireShowId(value) {
+    const raw = value;
+    const n = typeof raw === 'number' ? raw : Number(String(raw ?? '').trim());
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(
+            'tvmaze show id is required and must be a positive integer',
+            'TVmaze show ids appear in the URL: https://www.tvmaze.com/shows/<id>/<slug>.',
+        );
+    }
+    return n;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`tvmaze ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`tvmaze ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function tvmazeFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that api.tvmaze.com is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `TVmaze returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'TVmaze caps unauthenticated traffic at ~20 req/10s; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+const HTML_ENTITY_MAP = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    rsquo: '’',
+    lsquo: '‘',
+    rdquo: '”',
+    ldquo: '“',
+    hellip: '…',
+    ndash: '–',
+    mdash: '—',
+};
+
+// TVmaze ships HTML in `summary` ("<p><b>...</b> ...</p>"). Strip tags + decode
+// named and numeric entities so output is plain text.
+export function stripHtml(html) {
+    if (html == null) return '';
+    let s = String(html);
+    s = s.replace(/<[^>]+>/g, '');
+    s = s
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+            const code = parseInt(hex, 16);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+        })
+        .replace(/&#(\d+);/g, (_, dec) => {
+            const code = parseInt(dec, 10);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+        })
+        .replace(/&([a-zA-Z]+);/g, (match, name) => HTML_ENTITY_MAP[name] ?? match);
+    return s.replace(/\s+/g, ' ').trim();
+}
+
+export function joinList(value) {
+    return Array.isArray(value) ? value.filter(Boolean).join(', ') : '';
+}

--- a/docs/adapters/browser/defillama.md
+++ b/docs/adapters/browser/defillama.md
@@ -1,0 +1,60 @@
+# DefiLlama
+
+**Mode**: 🌐 Public · **Domain**: `defillama.com`
+
+Browse top DeFi protocols by TVL and fetch detailed protocol metadata. Both commands hit the unauthenticated `api.llama.fi` directly.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli defillama protocols` | Top DeFi protocols by current TVL (slug, name, category, TVL, mcap, change, chains) |
+| `opencli defillama protocol <slug>` | Single protocol details (current TVL, mcap, chains, twitter, github, description) |
+
+## Usage Examples
+
+```bash
+# Top 30 protocols by TVL (default)
+opencli defillama protocols
+
+# Top 100, JSON output
+opencli defillama protocols --limit 100 -f json
+
+# Single protocol details (slug from protocols rows)
+opencli defillama protocol aave-v3
+opencli defillama protocol lido
+
+# Parent protocols (e.g. "aave") aggregate their children's chains
+opencli defillama protocol aave
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `protocols` | `rank, slug, name, category, tvl, mcap, change_1d, change_7d, chains, listedAt, url` |
+| `protocol` | `slug, name, category, isParent, tvl, tvlAt, mcap, chains, twitter, github, audits, listedAt, description, website, url` |
+
+The `slug` column from `protocols` round-trips into `protocol`.
+
+## Options
+
+### `protocols`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Number of rows to return (1–500, default: 30). DefiLlama lists ~7400 protocols total. |
+
+### `protocol`
+
+| Option | Description |
+|--------|-------------|
+| `slug` (positional) | DefiLlama protocol slug (e.g. `aave-v3`, `lido`, `pancakeswap-amm`) |
+
+## Notes
+
+- **TVL is in USD.** `tvl` and `mcap` are scalar floats; consumers should format as money.
+- **Parent vs child protocols.** "Parent" entries (`isParent=true`, e.g. `aave` covers `aave-v3`, `aave-v2`, etc.) are present on `protocol` but not on `protocols`. The adapter aggregates child chains so parents still surface a useful `chains` value.
+- **`change_1d` / `change_7d` are percentages** (already as percent, e.g. `0.84` = +0.84%).
+- **No API key required.** DefiLlama throttles unauthenticated traffic; an `HTTP 429` surfaces as `CommandExecutionError`.
+- **Errors.** Bad slug → `ArgumentError`; unknown slug → `EmptyResultError` (DefiLlama returns `HTTP 400 "Protocol not found"` which is normalised); other 4xx/5xx → `CommandExecutionError`.

--- a/docs/adapters/browser/endoflife.md
+++ b/docs/adapters/browser/endoflife.md
@@ -1,0 +1,48 @@
+# endoflife.date
+
+**Mode**: 🌐 Public · **Domain**: `endoflife.date`
+
+Look up release cycles and end-of-life / LTS / support dates for hundreds of products (Node.js, Python, Ubuntu, Java, Postgres, Kubernetes, etc.). Hits the unauthenticated `endoflife.date/api` directly.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli endoflife product <name>` | Release cycles + EOL / LTS / support dates for one product |
+
+## Usage Examples
+
+```bash
+# Node.js cycles (newest first)
+opencli endoflife product nodejs
+
+# Python, JSON output for scripts
+opencli endoflife product python -f json
+
+# Ubuntu LTS schedule
+opencli endoflife product ubuntu
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `product` | `product, cycle, releaseDate, latest, latestReleaseDate, lts, support, eol, extendedSupport, eolStatus, url` |
+
+## Options
+
+### `product`
+
+| Option | Description |
+|--------|-------------|
+| `product` (positional) | endoflife.date product slug (e.g. `nodejs`, `python`, `ubuntu`, `kubernetes`) |
+
+## Notes
+
+- **`eolStatus`** is a derived projection (`active` / `eol` / `ongoing` / `null`) computed against today's UTC date — agents can answer "is this version still supported?" without parsing dates.
+- **Boolean dates → strings.** endoflife.date sometimes ships `true` for "ongoing support" / `false` for "no LTS". The adapter normalises:
+  - `true` → `"ongoing"`
+  - `false` / `null` → `null`
+  - ISO date string → returned as-is
+- **No API key required.** Slugs are exactly what appears at `https://endoflife.date/<product>`.
+- **Errors.** Bad slug shape → `ArgumentError`; unknown product → `EmptyResultError` (HTTP 404); rate-limited → `CommandExecutionError`.

--- a/docs/adapters/browser/goproxy.md
+++ b/docs/adapters/browser/goproxy.md
@@ -1,0 +1,63 @@
+# Go Module Proxy
+
+**Mode**: 🌐 Public · **Domain**: `proxy.golang.org`
+
+Fetch latest version + VCS origin metadata or list every published version tag for a Go module. Hits the unauthenticated Go module proxy (the canonical mirror used by `GOPROXY`).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli goproxy module <path>` | Latest version + VCS origin metadata for a Go module |
+| `opencli goproxy versions <path>` | Published version tags for a Go module (newest first) |
+
+## Usage Examples
+
+```bash
+# Latest released version of a module
+opencli goproxy module github.com/gin-gonic/gin
+opencli goproxy module golang.org/x/net
+
+# Every published tag, semver-sorted (descending)
+opencli goproxy versions github.com/gin-gonic/gin
+
+# Larger window
+opencli goproxy versions github.com/spf13/cobra --limit 100
+
+# Include publish times (one extra request per row)
+opencli goproxy versions golang.org/x/net --limit 10 --with-time
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `module` | `module, version, publishedAt, vcs, repository, commit, ref, pkgGoDevUrl, url` |
+| `versions` | `rank, module, version, publishedAt, url` |
+
+The `module` column round-trips between commands; the `version` column from `versions` round-trips into `goproxy module`'s `version` field.
+
+## Options
+
+### `module`
+
+| Option | Description |
+|--------|-------------|
+| `module` (positional) | Go module path (e.g. `github.com/gin-gonic/gin`, `golang.org/x/net`) |
+
+### `versions`
+
+| Option | Description |
+|--------|-------------|
+| `module` (positional) | Go module path |
+| `--limit` | Max rows to return (1–200, default: 30) |
+| `--with-time` | Fetch each version's publish time (one extra request per row, slower but adds the `publishedAt` column) |
+
+## Notes
+
+- **Module paths must be canonical.** Use what appears in your `go.mod` (host/path/...). The adapter rejects bare names without a host segment.
+- **Pre-release tags sort lower than releases.** The default sort is descending semver; `v2.0.0` > `v1.10.1` > `v1.10.0` > `v1.9.0` (NOT alphabetic).
+- **`publishedAt` is `null` by default** for `versions` to keep the request count at 1. Use `--with-time` only when you actually need the dates.
+- **`module` returns the proxy's resolved upstream** — `vcs` (e.g. `git`), the actual repo URL, the resolved commit hash, and the tag/ref. Useful when a module path doesn't obviously map to a GitHub repo (`golang.org/x/net` → `go.googlesource.com/net`).
+- **No API key required.** HTTP 404 / 410 (gone, e.g. retracted modules) → `EmptyResultError`; 429 → `CommandExecutionError`.
+- **Errors.** Malformed module path or bad limit → `ArgumentError`; unknown module → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/osv.md
+++ b/docs/adapters/browser/osv.md
@@ -1,0 +1,67 @@
+# OSV.dev
+
+**Mode**: 🌐 Public · **Domain**: `osv.dev`
+
+Look up open-source vulnerabilities by id (GHSA / CVE / PYSEC / etc.), or query by package + ecosystem (+ optional version) to find every vuln affecting it. Hits the unauthenticated `api.osv.dev` directly.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli osv vulnerability <id>` | Single OSV.dev vulnerability detail (severity, affected packages, CVE/GHSA aliases) |
+| `opencli osv query <package> --ecosystem <eco>` | Vulnerabilities affecting a package (optionally pinned to a version) |
+
+## Usage Examples
+
+```bash
+# Specific advisory by GHSA id
+opencli osv vulnerability GHSA-29mw-wpgm-hmr9
+
+# Same advisory by CVE alias
+opencli osv vulnerability CVE-2020-28500
+
+# All known npm-lodash vulns (newest first)
+opencli osv query lodash --ecosystem npm
+
+# Vulns affecting a pinned version
+opencli osv query lodash --ecosystem npm --version 4.17.20
+
+# Cross-ecosystem queries
+opencli osv query django --ecosystem PyPI --limit 10
+opencli osv query log4j-core --ecosystem Maven
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `vulnerability` | `id, summary, severity, aliases, published, modified, affectedPackages, cwes, referenceCount, url` |
+| `query` | `rank, id, summary, severity, aliases, published, modified, affectedPackages, url` |
+
+The `id` column from `query` round-trips into `vulnerability`.
+
+## Options
+
+### `vulnerability`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | OSV vulnerability id (e.g. `GHSA-29mw-wpgm-hmr9`, `CVE-2020-28500`, `PYSEC-2021-1`) |
+
+### `query`
+
+| Option | Description |
+|--------|-------------|
+| `package` (positional) | Package name (e.g. `lodash`, `django`, `log4j-core`) |
+| `--ecosystem` | OSV ecosystem (`npm`, `PyPI`, `Go`, `Maven`, `NuGet`, `RubyGems`, `crates.io`, `Packagist`, `Pub`, `Hex`, `Hackage`, `CRAN`, `Bitnami`, `GitHub Actions`, `SwiftURL`) |
+| `--version` | Optional version pin (e.g. `4.17.20`); omit to get all known vulns |
+| `--limit` | Max rows to return (1–200, default: 30) |
+
+## Notes
+
+- **Ecosystem strings are case-sensitive** — they match the [OSV defined ecosystem list](https://ossf.github.io/osv-schema/#defined-ecosystems) verbatim. `npm` is lowercase, `PyPI` capitalised, etc. Bad values → `ArgumentError`.
+- **`severity`** prefers `database_specific.severity` (`LOW`/`MODERATE`/`HIGH`/`CRITICAL`); falls back to the first `severity[].score` (CVSS string) when the registry didn't compute a label. `null` when both are missing.
+- **`affectedPackages`** is a flat `ecosystem:name` list across all entries in `affected[]` — useful for a quick "what packages does this advisory touch" view.
+- **`query` results are sorted newest-first** by `published`; pre-sort makes "what's the latest issue for X?" a single read.
+- **No API key required.** Rate-limit hits → `CommandExecutionError`.
+- **Errors.** Bad id / ecosystem / limit → `ArgumentError` (before fetch); unknown id or no vulns matched → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/rfc.md
+++ b/docs/adapters/browser/rfc.md
@@ -1,0 +1,49 @@
+# IETF RFC
+
+**Mode**: 🌐 Public · **Domain**: `datatracker.ietf.org`
+
+Fetch metadata for any IETF RFC by number — title, abstract, publishing working group, authors, std level, page count, publish date, plus links into the RFC Editor and datatracker. Hits the unauthenticated IETF datatracker directly.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli rfc rfc <number>` | Single IETF RFC metadata (title, abstract, working group, authors, std level) |
+
+## Usage Examples
+
+```bash
+# Modern RFCs
+opencli rfc rfc 9000     # QUIC
+opencli rfc rfc 9110     # HTTP semantics
+
+# Classic RFCs
+opencli rfc rfc 791      # IP
+opencli rfc rfc 2616     # HTTP/1.1 (now obsoleted by 9110)
+
+# Courtesy: "rfcN" prefix accepted
+opencli rfc rfc rfc9000
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `rfc` | `rfc, title, state, stdLevel, group, groupType, pages, published, authors, abstract, rfcEditorUrl, url` |
+
+## Options
+
+### `rfc`
+
+| Option | Description |
+|--------|-------------|
+| `number` (positional) | RFC number (positive integer ≤ 999999). The `rfc` prefix is accepted as a courtesy. |
+
+## Notes
+
+- **`abstract` is the full IETF abstract** — RFCs don't truncate well, so the adapter never drops content.
+- **`stdLevel`** classifies the document (e.g. `Proposed Standard`, `Internet Standard`, `Best Current Practice`, `Informational`, `Experimental`, `Historic`).
+- **`group`** is the working group / area / IRTF research group that published the RFC; `groupType` distinguishes (e.g. `WG`, `IETF`).
+- **`rfcEditorUrl`** points at the canonical RFC Editor copy (text/HTML); `url` points at the IETF datatracker page (with rev history, related drafts, and stats).
+- **No API key required.** Datatracker is fast but bursts can return `HTTP 429` → `CommandExecutionError`.
+- **Errors.** Non-numeric input or out-of-range RFC number → `ArgumentError`; unknown RFC → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/tvmaze.md
+++ b/docs/adapters/browser/tvmaze.md
@@ -1,0 +1,57 @@
+# TVmaze
+
+**Mode**: 🌐 Public · **Domain**: `tvmaze.com`
+
+Search TVmaze for TV shows by title, or fetch full show details by id. Hits the unauthenticated `api.tvmaze.com` directly.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli tvmaze search <query>` | TVmaze TV show search by title (returns id, name, network, premiered/ended, rating) |
+| `opencli tvmaze show <id>` | Single TV show detail (network, schedule, rating, IMDB/TheTVDB cross-refs) |
+
+## Usage Examples
+
+```bash
+# Title search
+opencli tvmaze search "breaking bad"
+opencli tvmaze search succession --limit 5
+
+# Show detail (id from search)
+opencli tvmaze show 169
+opencli tvmaze show 169 -f json
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, id, name, type, language, genres, status, premiered, ended, network, rating, matchScore, summary, url` |
+| `show` | `id, name, type, language, genres, status, premiered, ended, runtime, averageRuntime, network, country, schedule, rating, imdb, thetvdb, officialSite, summary, url` |
+
+The `id` column from `search` round-trips into `show`.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Title or fragment to search for |
+| `--limit` | Max rows (1–50, default: 20) |
+
+### `show`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | TVmaze show id (positive integer; visible in `https://www.tvmaze.com/shows/<id>/<slug>`) |
+
+## Notes
+
+- **`summary` is plain text** — TVmaze ships HTML (`<p><b>...</b></p>`); the adapter strips tags and decodes named / decimal / hex HTML entities.
+- **`rating` is the TVmaze average** (0–10 scale) or `null` when no rating is recorded.
+- **`imdb` / `thetvdb`** are cross-references to other registries — useful for joining with other adapters.
+- **`schedule`** combines days + airtime (e.g. `"Sunday 22:00"`); empty string when the show has no fixed schedule.
+- **No API key required.** TVmaze caps unauthenticated traffic at ~20 req / 10s — bursts surface as `CommandExecutionError`.
+- **Errors.** Bad id / empty query / out-of-range limit → `ArgumentError`; unknown id or no matches → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -122,6 +122,12 @@ Run `opencli list` for the live registry.
 | **[packagist](./browser/packagist.md)**           | `search` `package`                                                                                                                             | 🌐 Public    |
 | **[maven](./browser/maven.md)**                   | `search` `artifact`                                                                                                                            | 🌐 Public    |
 | **[openalex](./browser/openalex.md)**             | `search` `work`                                                                                                                                | 🌐 Public    |
+| **[defillama](./browser/defillama.md)**           | `protocols` `protocol`                                                                                                                         | 🌐 Public    |
+| **[endoflife](./browser/endoflife.md)**           | `product`                                                                                                                                      | 🌐 Public    |
+| **[osv](./browser/osv.md)**                       | `vulnerability` `query`                                                                                                                        | 🌐 Public    |
+| **[goproxy](./browser/goproxy.md)**               | `module` `versions`                                                                                                                            | 🌐 Public    |
+| **[tvmaze](./browser/tvmaze.md)**                 | `search` `show`                                                                                                                                | 🌐 Public    |
+| **[rfc](./browser/rfc.md)**                       | `rfc`                                                                                                                                          | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

Round 5 expands OpenCLI to 6 new public registries (10 commands), all read-only, no auth, no browser. First round to ship contract tests per pr-monitor msg=3152d6dd follow-up.

| Site | Commands | What it covers |
|------|----------|----------------|
| **defillama** | `protocols`, `protocol` | TVL leaderboard + per-protocol detail (with parent-protocol chain aggregation) |
| **endoflife** | `product` | Product release lifecycle (EOL / support / LTS) for 350+ products |
| **osv** | `vulnerability`, `query` | OSV.dev vuln by id + package/ecosystem/version queries |
| **goproxy** | `module`, `versions` | Go module proxy: latest version + VCS origin / semver-sorted version list |
| **tvmaze** | `search`, `show` | TV show search + detail (with IMDB/TheTVDB cross-refs) |
| **rfc** | `rfc` | IETF RFC metadata (title, abstract, std level, working group) |

All 10 commands live-verified.

## Contract tests (new)

Per pr-monitor msg=3152d6dd follow-up — 4-contract suite per site, 6 files / 37 assertions, all green:

1. Bad args → upfront `ArgumentError` (no API tail validation)
2. HTTP 429 → `CommandExecutionError`
3. Empty result (404 / no matches) → `EmptyResultError`
4. Round-trip row shape (listing → detail handoff column)

## Field semantics highlights

- **defillama parent-protocol fix**: parent (`isParentProtocol=true`) doesn't appear in `/protocols` listing — only children with `parentProtocol: 'parent#aave'`. Detect parent + union child chains so \`aave\` shows full chain set instead of empty.
- **endoflife boolean dates**: `eol: true` → \`'ongoing'\`, `false`/null → null, ISO date string as-is. Derived `eolStatus` = ongoing | active | eol vs today.
- **osv ecosystem strings case-sensitive** per OSV schema (\`npm\` lowercase, \`PyPI\` capitalized) — bad value → ArgumentError pre-fetch.
- **goproxy semver-aware sort**: pre-release tags lower than releases; v2.0.0 > v1.10.1 > v1.9.0 (NOT alphabetic).
- **tvmaze HTML decode**: strips \`<p><b>...</b></p>\` and decodes \`&amp;\` / \`&#39;\` / \`&nbsp;\` etc. emitted by the API.
- **rfc datatracker timestamps**: \`'2022-02-19 08:46:51'\` (space-separated, no Z) — trim to \`YYYY-MM-DD\`.

## Convention audits

- typed-error-lint: 196 = baseline, 0 new
- silent-column-drop: 103 = baseline, 0 new
- listing-id-pairing: no Round 5 violations (defillama/protocols→protocol via slug; osv/query→vulnerability via id; goproxy/versions→module via version; tvmaze/search→show via id all wired)
- doc-coverage: 745/745 ✓

## Test plan
- [x] All 10 commands live-verified against real API
- [x] 37 contract assertions across 6 sites — all green
- [x] Convention audits clean (typed-error-lint, silent-column-drop, listing-id-pairing)
- [x] Manifest rebuilt
- [x] Doc pages added for all 6 sites + index updated