### PR TITLE
feat: 5 read adapters (crossref, openlibrary, pub-dev, hex-pm, open-meteo) + contract tests

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5417,6 +5417,88 @@
     "sourceFile": "crates/search.js"
   },
   {
+    "site": "crossref",
+    "name": "work",
+    "description": "Fetch full Crossref metadata for a DOI",
+    "access": "read",
+    "domain": "api.crossref.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "doi",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "DOI (e.g. \"10.1038/nature12373\"; \"doi:\" / \"https://doi.org/\" prefixes accepted)"
+      }
+    ],
+    "columns": [
+      "doi",
+      "title",
+      "authors",
+      "container",
+      "publisher",
+      "type",
+      "published",
+      "pages",
+      "volume",
+      "issue",
+      "issn",
+      "isbn",
+      "language",
+      "citations",
+      "referenceCount",
+      "license",
+      "subject",
+      "abstract",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "crossref/work.js",
+    "sourceFile": "crossref/work.js"
+  },
+  {
+    "site": "crossref",
+    "name": "works",
+    "description": "Search Crossref scholarly works (DOIs) by keyword",
+    "access": "read",
+    "domain": "api.crossref.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (title / author / abstract terms)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max works (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "doi",
+      "title",
+      "authors",
+      "container",
+      "publisher",
+      "type",
+      "published",
+      "citations",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "crossref/works.js",
+    "sourceFile": "crossref/works.js"
+  },
+  {
     "site": "ctrip",
     "name": "search",
     "description": "搜索携程目的地、景区和酒店联想结果",
@@ -10099,6 +10181,81 @@
     "sourceFile": "hackernews/user.js"
   },
   {
+    "site": "hex-pm",
+    "name": "package",
+    "description": "Fetch full Hex.pm package metadata (Erlang / Elixir)",
+    "access": "read",
+    "domain": "hex.pm",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "package",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Hex package name (e.g. \"phoenix\", \"ecto\", \"plug\")"
+      }
+    ],
+    "columns": [
+      "package",
+      "latestVersion",
+      "latestStableVersion",
+      "description",
+      "licenses",
+      "github",
+      "docsUrl",
+      "downloadsAll",
+      "downloadsRecent",
+      "downloadsWeek",
+      "downloadsDay",
+      "owners",
+      "releaseCount",
+      "insertedAt",
+      "updatedAt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "hex-pm/package.js",
+    "sourceFile": "hex-pm/package.js"
+  },
+  {
+    "site": "hex-pm",
+    "name": "versions",
+    "description": "List every published Hex.pm package version (newest first)",
+    "access": "read",
+    "domain": "hex.pm",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "package",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Hex package name"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max rows to return (1-500)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "package",
+      "version",
+      "insertedAt",
+      "hasDocs",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "hex-pm/versions.js",
+    "sourceFile": "hex-pm/versions.js"
+  },
+  {
     "site": "hf",
     "name": "datasets",
     "description": "Top Hugging Face datasets (downloads / likes / trending / freshness).",
@@ -14545,6 +14702,86 @@
     "navigateBefore": "https://mubu.com"
   },
   {
+    "site": "musicbrainz",
+    "name": "artist",
+    "description": "Search MusicBrainz artists by name",
+    "access": "read",
+    "domain": "musicbrainz.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Artist name (e.g. \"Radiohead\", \"Aretha Franklin\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max artists (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "mbid",
+      "name",
+      "sortName",
+      "type",
+      "country",
+      "begin",
+      "ended",
+      "disambiguation",
+      "score",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "musicbrainz/artist.js",
+    "sourceFile": "musicbrainz/artist.js"
+  },
+  {
+    "site": "musicbrainz",
+    "name": "release",
+    "description": "Fetch full MusicBrainz release detail by MBID",
+    "access": "read",
+    "domain": "musicbrainz.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "mbid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Release MBID (e.g. \"76df3287-6cda-33eb-8e9a-044b5e15ffdd\")"
+      }
+    ],
+    "columns": [
+      "mbid",
+      "title",
+      "artistCredit",
+      "status",
+      "releaseGroup",
+      "primaryType",
+      "firstReleaseDate",
+      "releaseCountry",
+      "releaseDate",
+      "label",
+      "catalogNumber",
+      "barcode",
+      "packaging",
+      "language",
+      "script",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "musicbrainz/release.js",
+    "sourceFile": "musicbrainz/release.js"
+  },
+  {
     "site": "notebooklm",
     "name": "current",
     "description": "Show metadata for the currently opened NotebookLM notebook tab",
@@ -16158,6 +16395,103 @@
     "navigateBefore": false
   },
   {
+    "site": "open-meteo",
+    "name": "forecast",
+    "description": "Daily weather forecast for a lat/lon pair (no API key required)",
+    "access": "read",
+    "domain": "api.open-meteo.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "latitude",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Latitude in decimal degrees (-90 to 90)"
+      },
+      {
+        "name": "longitude",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Longitude in decimal degrees (-180 to 180)"
+      },
+      {
+        "name": "days",
+        "type": "int",
+        "default": 7,
+        "required": false,
+        "help": "Forecast days (1-16)"
+      }
+    ],
+    "columns": [
+      "date",
+      "weatherCode",
+      "weather",
+      "tempMax",
+      "tempMin",
+      "apparentMax",
+      "apparentMin",
+      "sunrise",
+      "sunset",
+      "precipSum",
+      "precipHours",
+      "precipProbabilityMax",
+      "windMax",
+      "windGustMax",
+      "uvIndexMax",
+      "tempUnit",
+      "precipUnit",
+      "windUnit"
+    ],
+    "type": "js",
+    "modulePath": "open-meteo/forecast.js",
+    "sourceFile": "open-meteo/forecast.js"
+  },
+  {
+    "site": "open-meteo",
+    "name": "geocode",
+    "description": "Resolve a city / place name to lat/lon via Open-Meteo geocoding",
+    "access": "read",
+    "domain": "geocoding-api.open-meteo.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Place name (e.g. \"Tokyo\", \"San Francisco\", \"Munich\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max results (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "country",
+      "admin1",
+      "latitude",
+      "longitude",
+      "elevation",
+      "population",
+      "timezone",
+      "featureCode",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "open-meteo/geocode.js",
+    "sourceFile": "open-meteo/geocode.js"
+  },
+  {
     "site": "openalex",
     "name": "search",
     "description": "Search OpenAlex Works (papers, books, preprints) by keyword",
@@ -16235,6 +16569,86 @@
     "type": "js",
     "modulePath": "openalex/work.js",
     "sourceFile": "openalex/work.js"
+  },
+  {
+    "site": "openlibrary",
+    "name": "search",
+    "description": "Search Open Library books by keyword",
+    "access": "read",
+    "domain": "openlibrary.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (title / author / subject)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max books (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "workKey",
+      "title",
+      "author",
+      "firstPublished",
+      "editions",
+      "ebook",
+      "language",
+      "isbn",
+      "subjects",
+      "coverId",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openlibrary/search.js",
+    "sourceFile": "openlibrary/search.js"
+  },
+  {
+    "site": "openlibrary",
+    "name": "work",
+    "description": "Fetch Open Library metadata for a work id (OL...W)",
+    "access": "read",
+    "domain": "openlibrary.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "workKey",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Open Library work key (e.g. \"OL45804W\"; \"/works/OL45804W\" or full URL accepted)"
+      }
+    ],
+    "columns": [
+      "workKey",
+      "title",
+      "subtitle",
+      "authors",
+      "description",
+      "subjects",
+      "subjectPlaces",
+      "subjectPeople",
+      "subjectTimes",
+      "firstPublished",
+      "coverIds",
+      "rating",
+      "ratingsCount",
+      "editionsUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openlibrary/work.js",
+    "sourceFile": "openlibrary/work.js"
   },
   {
     "site": "openreview",
@@ -17130,6 +17544,78 @@
     "type": "js",
     "modulePath": "producthunt/today.js",
     "sourceFile": "producthunt/today.js"
+  },
+  {
+    "site": "pub-dev",
+    "name": "package",
+    "description": "Fetch latest pub.dev package metadata (Dart / Flutter)",
+    "access": "read",
+    "domain": "pub.dev",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "package",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "pub.dev package name (e.g. \"http\", \"provider\", \"riverpod\")"
+      }
+    ],
+    "columns": [
+      "package",
+      "version",
+      "publishedAt",
+      "description",
+      "repository",
+      "homepage",
+      "sdk",
+      "flutter",
+      "dependencies",
+      "devDependencies",
+      "topics",
+      "archive",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "pub-dev/package.js",
+    "sourceFile": "pub-dev/package.js"
+  },
+  {
+    "site": "pub-dev",
+    "name": "versions",
+    "description": "List every published pub.dev package version (newest first)",
+    "access": "read",
+    "domain": "pub.dev",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "package",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "pub.dev package name"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max rows to return (1-500)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "package",
+      "version",
+      "publishedAt",
+      "archive",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "pub-dev/versions.js",
+    "sourceFile": "pub-dev/versions.js"
   },
   {
     "site": "pubmed",

--- a/clis/crossref/crossref.test.js
+++ b/clis/crossref/crossref.test.js
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './works.js';
+import './work.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('crossref works adapter', () => {
+    const cmd = getRegistry().get('crossref/works');
+
+    it('rejects empty / oversized queries before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ query: 'whatever', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty items list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            status: 'ok', message: { items: [] },
+        }), { status: 200 })));
+        await expect(cmd.func({ query: 'no-matches', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips DOI shape into doi.org URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            status: 'ok',
+            message: {
+                items: [{
+                    DOI: '10.1038/nature12373',
+                    title: ['Nanometre-scale thermometry in a living cell'],
+                    author: [{ given: 'G.', family: 'Kucsko' }],
+                    publisher: 'Nature',
+                    type: 'journal-article',
+                    'is-referenced-by-count': 1763,
+                    issued: { 'date-parts': [[2013, 8]] },
+                }],
+            },
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'thermometry', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            doi: '10.1038/nature12373',
+            title: 'Nanometre-scale thermometry in a living cell',
+            authors: 'G. Kucsko',
+            published: '2013-08',
+            citations: 1763,
+            url: 'https://doi.org/10.1038/nature12373',
+        });
+    });
+});
+
+describe('crossref work adapter', () => {
+    const cmd = getRegistry().get('crossref/work');
+
+    it('rejects malformed DOI before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ doi: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ doi: 'not-a-doi' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ doi: 'doi:malformed/' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ doi: '10.0000/missing' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('strips DOI URL prefixes from input', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            status: 'ok',
+            message: {
+                DOI: '10.1038/nature12373',
+                title: ['T'],
+                author: [],
+                publisher: 'Nature',
+                type: 'journal-article',
+                issued: { 'date-parts': [[2013, 8, 1]] },
+            },
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ doi: 'https://doi.org/10.1038/nature12373' });
+        expect(rows[0]).toMatchObject({
+            doi: '10.1038/nature12373',
+            published: '2013-08-01',
+            url: 'https://doi.org/10.1038/nature12373',
+        });
+    });
+});

--- a/clis/crossref/utils.js
+++ b/clis/crossref/utils.js
@@ -1,0 +1,147 @@
+// Shared helpers for the Crossref adapters.
+//
+// Hits the public, unauthenticated `api.crossref.org` REST endpoints — the
+// canonical DOI / scholarly metadata registry. Crossref encourages a polite
+// User-Agent + contact email so they can route abusers; we set one without
+// requiring users to register.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const CROSSREF_BASE = 'https://api.crossref.org';
+const UA = 'opencli-crossref-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// DOI registrant + suffix is intentionally permissive (RFC 3986 unreserved + `/`).
+// Crossref handles its own normalisation; we just guard against obvious junk.
+const DOI_PATTERN = /^10\.\d{4,9}\/[^\s]+$/;
+// ISSN is 7 digits + check char (digit or `X`), typically rendered as `NNNN-NNNN`.
+const ISSN_PATTERN = /^\d{4}-\d{3}[\dXx]$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`crossref ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`crossref ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`crossref ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireDoi(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('crossref doi is required (e.g. "10.1038/nature12373")');
+    // Trim courtesy prefixes users often paste from URLs.
+    const stripped = raw
+        .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+        .replace(/^doi:/i, '');
+    if (!DOI_PATTERN.test(stripped)) {
+        throw new ArgumentError(
+            `crossref doi "${value}" is not a valid DOI`,
+            'Expected format: "10.<registrant>/<suffix>" (e.g. "10.1038/nature12373").',
+        );
+    }
+    return stripped;
+}
+
+export function requireIssn(value) {
+    const raw = String(value ?? '').trim().toUpperCase();
+    if (!raw) throw new ArgumentError('crossref issn is required (e.g. "2167-8359")');
+    if (!ISSN_PATTERN.test(raw)) {
+        throw new ArgumentError(
+            `crossref issn "${value}" is not a valid ISSN`,
+            'Expected format: "NNNN-NNNN" with 7 digits + checksum (digit or X).',
+        );
+    }
+    return raw;
+}
+
+/** Flatten a Crossref date-parts array `[[YYYY, M, D]]` → `YYYY-MM-DD`. */
+export function joinDateParts(dateField) {
+    const parts = Array.isArray(dateField?.['date-parts']) ? dateField['date-parts'][0] : null;
+    if (!Array.isArray(parts) || parts.length === 0) return null;
+    const [y, m, d] = parts;
+    if (typeof y !== 'number') return null;
+    const pad = (n) => String(n).padStart(2, '0');
+    if (typeof m !== 'number') return String(y);
+    if (typeof d !== 'number') return `${y}-${pad(m)}`;
+    return `${y}-${pad(m)}-${pad(d)}`;
+}
+
+/**
+ * Extract first non-empty published date across `published-print`, `published-online`,
+ * `issued`, `created`. Crossref records may have any subset; pick what's available.
+ */
+export function extractPublished(item) {
+    const candidates = [item?.['published-print'], item?.['published-online'], item?.issued, item?.created];
+    for (const c of candidates) {
+        const d = joinDateParts(c);
+        if (d) return d;
+    }
+    return null;
+}
+
+export function formatAuthors(authors, maxNames = 6) {
+    if (!Array.isArray(authors)) return '';
+    const names = authors
+        .filter((a) => a && (a.family || a.given || a.name))
+        .map((a) => {
+            if (a.name) return String(a.name).trim();
+            const parts = [a.given, a.family].filter((p) => p != null && String(p).trim());
+            return parts.join(' ').trim();
+        })
+        .filter(Boolean);
+    if (names.length === 0) return '';
+    if (names.length > maxNames) {
+        return [...names.slice(0, maxNames), `et al. (+${names.length - maxNames})`].join(', ');
+    }
+    return names.join(', ');
+}
+
+export function pickTitle(item) {
+    const t = Array.isArray(item?.title) ? item.title[0] : item?.title;
+    return typeof t === 'string' ? t.trim() : '';
+}
+
+export function pickContainer(item) {
+    const c = Array.isArray(item?.['container-title']) ? item['container-title'][0] : item?.['container-title'];
+    return typeof c === 'string' ? c.trim() : '';
+}
+
+export async function crossrefFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that api.crossref.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Crossref returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Crossref throttles unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/crossref/work.js
+++ b/clis/crossref/work.js
@@ -1,0 +1,85 @@
+// crossref work — fetch full Crossref metadata for a single DOI.
+//
+// Hits `https://api.crossref.org/works/<doi>`. Returns the agent-useful
+// projection: title, authors (full list), container, publisher, type,
+// published date, abstract (when registered), citation count, references count,
+// license info, and links back to doi.org / crossref.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    CROSSREF_BASE,
+    crossrefFetch,
+    extractPublished,
+    formatAuthors,
+    pickContainer,
+    pickTitle,
+    requireDoi,
+} from './utils.js';
+
+function stripHtml(value) {
+    if (typeof value !== 'string') return '';
+    return value
+        .replace(/<[^>]+>/g, '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&nbsp;/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+cli({
+    site: 'crossref',
+    name: 'work',
+    access: 'read',
+    description: 'Fetch full Crossref metadata for a DOI',
+    domain: 'api.crossref.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'doi', positional: true, required: true, help: 'DOI (e.g. "10.1038/nature12373"; "doi:" / "https://doi.org/" prefixes accepted)' },
+    ],
+    columns: [
+        'doi', 'title', 'authors', 'container', 'publisher', 'type', 'published',
+        'pages', 'volume', 'issue', 'issn', 'isbn', 'language', 'citations',
+        'referenceCount', 'license', 'subject', 'abstract', 'url',
+    ],
+    func: async (args) => {
+        const doi = requireDoi(args.doi);
+        const url = `${CROSSREF_BASE}/works/${encodeURIComponent(doi)}`;
+        const body = await crossrefFetch(url, 'crossref work');
+        const item = body?.message;
+        if (!item) {
+            // Crossref answers 404 → EmptyResultError already in crossrefFetch;
+            // anything else with a missing message is structural breakage.
+            throw new CommandExecutionError('crossref work returned no message body');
+        }
+        const issns = Array.isArray(item.ISSN) ? item.ISSN : [];
+        const isbns = Array.isArray(item.ISBN) ? item.ISBN : [];
+        const subjects = Array.isArray(item.subject) ? item.subject : [];
+        const licenseEntry = Array.isArray(item.license) && item.license.length ? item.license[0] : null;
+        return [{
+            doi: String(item.DOI ?? doi),
+            title: pickTitle(item),
+            authors: formatAuthors(item.author, 50),
+            container: pickContainer(item),
+            publisher: String(item.publisher ?? '').trim(),
+            type: String(item.type ?? '').trim(),
+            published: extractPublished(item),
+            pages: String(item.page ?? '').trim() || null,
+            volume: String(item.volume ?? '').trim() || null,
+            issue: String(item.issue ?? '').trim() || null,
+            issn: issns.length ? issns.join(', ') : null,
+            isbn: isbns.length ? isbns.join(', ') : null,
+            language: String(item.language ?? '').trim() || null,
+            citations: typeof item['is-referenced-by-count'] === 'number' ? item['is-referenced-by-count'] : null,
+            referenceCount: typeof item['reference-count'] === 'number' ? item['reference-count'] : null,
+            license: licenseEntry?.URL ? String(licenseEntry.URL) : null,
+            subject: subjects.length ? subjects.join(', ') : null,
+            abstract: stripHtml(item.abstract) || null,
+            url: `https://doi.org/${item.DOI ?? doi}`,
+        }];
+    },
+});

--- a/clis/crossref/works.js
+++ b/clis/crossref/works.js
@@ -1,0 +1,57 @@
+// crossref works — search the Crossref scholarly metadata index.
+//
+// Hits `https://api.crossref.org/works?query=…&rows=…`. Returns the agent-useful
+// projection: DOI (round-trips into `crossref work`), title, authors, container,
+// publisher, type, published date, citation count.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    CROSSREF_BASE,
+    crossrefFetch,
+    extractPublished,
+    formatAuthors,
+    pickContainer,
+    pickTitle,
+    requireBoundedInt,
+    requireString,
+} from './utils.js';
+
+cli({
+    site: 'crossref',
+    name: 'works',
+    access: 'read',
+    description: 'Search Crossref scholarly works (DOIs) by keyword',
+    domain: 'api.crossref.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (title / author / abstract terms)' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max works (1-100)' },
+    ],
+    columns: ['rank', 'doi', 'title', 'authors', 'container', 'publisher', 'type', 'published', 'citations', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const url = `${CROSSREF_BASE}/works?query=${encodeURIComponent(query)}&rows=${limit}`;
+        const body = await crossrefFetch(url, 'crossref works');
+        const list = Array.isArray(body?.message?.items) ? body.message.items : [];
+        if (!list.length) {
+            throw new EmptyResultError('crossref works', `No Crossref works matched "${query}".`);
+        }
+        return list.slice(0, limit).map((item, i) => {
+            const doi = String(item.DOI ?? '').trim();
+            return {
+                rank: i + 1,
+                doi,
+                title: pickTitle(item),
+                authors: formatAuthors(item.author),
+                container: pickContainer(item),
+                publisher: String(item.publisher ?? '').trim(),
+                type: String(item.type ?? '').trim(),
+                published: extractPublished(item),
+                citations: typeof item['is-referenced-by-count'] === 'number' ? item['is-referenced-by-count'] : null,
+                url: doi ? `https://doi.org/${doi}` : '',
+            };
+        });
+    },
+});

--- a/clis/hex-pm/hex-pm.test.js
+++ b/clis/hex-pm/hex-pm.test.js
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './package.js';
+import './versions.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('hex-pm package adapter', () => {
+    const cmd = getRegistry().get('hex-pm/package');
+
+    it('rejects malformed package names before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ package: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'CamelCase' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'has spaces' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ package: 'unknown_pkg' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ package: 'phoenix' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('flattens metadata + downloads + ownership into a single row', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            name: 'phoenix',
+            html_url: 'https://hex.pm/packages/phoenix',
+            latest_version: '1.8.6',
+            latest_stable_version: '1.8.6',
+            inserted_at: '2014-04-21T22:38:32.000000Z',
+            updated_at: '2026-05-05T15:07:33.496465Z',
+            meta: {
+                description: 'Peace of mind from prototype to production',
+                licenses: ['MIT'],
+                links: { GitHub: 'https://github.com/phoenixframework/phoenix' },
+            },
+            owners: [{ username: 'chrismccord' }, { username: 'josevalim' }],
+            downloads: { all: 149099814, recent: 2836250, week: 238581, day: 50838 },
+            releases: [{ version: '1.8.6' }, { version: '1.8.5' }],
+            docs_html_url: 'https://hexdocs.pm/phoenix/',
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ package: 'phoenix' });
+        expect(rows[0]).toMatchObject({
+            package: 'phoenix',
+            latestVersion: '1.8.6',
+            licenses: 'MIT',
+            github: 'https://github.com/phoenixframework/phoenix',
+            owners: 'chrismccord, josevalim',
+            releaseCount: 2,
+            url: 'https://hex.pm/packages/phoenix',
+        });
+    });
+});
+
+describe('hex-pm versions adapter', () => {
+    const cmd = getRegistry().get('hex-pm/versions');
+
+    it('rejects bad limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ package: 'phoenix', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'phoenix', limit: 9999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('preserves hex.pm newest-first ordering and round-trips package name', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            releases: [
+                { version: '1.8.6', has_docs: true, inserted_at: '2026-05-05T14:57:20Z' },
+                { version: '1.8.5', has_docs: true, inserted_at: '2026-03-05T15:22:23Z' },
+                { version: '1.8.4', has_docs: false, inserted_at: '2026-02-23T17:02:40Z' },
+            ],
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ package: 'phoenix', limit: 10 });
+        expect(rows.map((r) => r.version)).toEqual(['1.8.6', '1.8.5', '1.8.4']);
+        expect(rows[0]).toMatchObject({ rank: 1, package: 'phoenix', hasDocs: true });
+        expect(rows[2]).toMatchObject({ hasDocs: false });
+    });
+
+    it('throws EmptyResultError on empty releases list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ releases: [] }), { status: 200 })));
+        await expect(cmd.func({ package: 'phoenix', limit: 10 })).rejects.toThrow(EmptyResultError);
+    });
+});

--- a/clis/hex-pm/package.js
+++ b/clis/hex-pm/package.js
@@ -1,0 +1,56 @@
+// hex-pm package — fetch full Hex.pm package metadata.
+//
+// Hits `https://hex.pm/api/packages/<name>`. Returns the agent-useful
+// projection: latest version + latest stable, total / recent downloads,
+// description, license list, repository / GitHub link, owner count, doc URL.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { HEX_BASE, hexFetch, requirePackageName } from './utils.js';
+
+cli({
+    site: 'hex-pm',
+    name: 'package',
+    access: 'read',
+    description: 'Fetch full Hex.pm package metadata (Erlang / Elixir)',
+    domain: 'hex.pm',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'package', positional: true, required: true, help: 'Hex package name (e.g. "phoenix", "ecto", "plug")' },
+    ],
+    columns: [
+        'package', 'latestVersion', 'latestStableVersion', 'description', 'licenses',
+        'github', 'docsUrl', 'downloadsAll', 'downloadsRecent', 'downloadsWeek', 'downloadsDay',
+        'owners', 'releaseCount', 'insertedAt', 'updatedAt', 'url',
+    ],
+    func: async (args) => {
+        const pkg = requirePackageName(args.package);
+        const url = `${HEX_BASE}/packages/${encodeURIComponent(pkg)}`;
+        const body = await hexFetch(url, 'hex-pm package');
+        const meta = body?.meta || {};
+        const links = meta.links || {};
+        const downloads = body?.downloads || {};
+        const owners = Array.isArray(body?.owners)
+            ? body.owners.map((o) => String(o.username ?? '').trim()).filter(Boolean)
+            : [];
+        const licenses = Array.isArray(meta.licenses) ? meta.licenses : [];
+        const github = String(links.GitHub ?? links.github ?? '').trim() || null;
+        return [{
+            package: pkg,
+            latestVersion: String(body?.latest_version ?? '').trim() || null,
+            latestStableVersion: String(body?.latest_stable_version ?? '').trim() || null,
+            description: String(meta.description ?? '').trim() || null,
+            licenses: licenses.length ? licenses.join(', ') : null,
+            github,
+            docsUrl: String(body?.docs_html_url ?? '').trim() || null,
+            downloadsAll: typeof downloads.all === 'number' ? downloads.all : null,
+            downloadsRecent: typeof downloads.recent === 'number' ? downloads.recent : null,
+            downloadsWeek: typeof downloads.week === 'number' ? downloads.week : null,
+            downloadsDay: typeof downloads.day === 'number' ? downloads.day : null,
+            owners: owners.length ? owners.join(', ') : null,
+            releaseCount: Array.isArray(body?.releases) ? body.releases.length : null,
+            insertedAt: String(body?.inserted_at ?? '').trim() || null,
+            updatedAt: String(body?.updated_at ?? '').trim() || null,
+            url: String(body?.html_url ?? `https://hex.pm/packages/${pkg}`).trim(),
+        }];
+    },
+});

--- a/clis/hex-pm/utils.js
+++ b/clis/hex-pm/utils.js
@@ -1,0 +1,75 @@
+// Shared helpers for the Hex.pm adapters.
+//
+// Hits the public, unauthenticated `hex.pm/api` REST endpoints — the canonical
+// Erlang / Elixir package registry. No API key required.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const HEX_BASE = 'https://hex.pm/api';
+const UA = 'opencli-hex-pm-adapter/1.0 (+https://github.com/jackwener/opencli)';
+
+// Hex package names: lowercase letters, digits, underscores. Same general shape
+// as Erlang module names.
+const PACKAGE_NAME = /^[a-z][a-z0-9_]{0,63}$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`hex-pm ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`hex-pm ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`hex-pm ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requirePackageName(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('hex-pm package name is required (e.g. "phoenix", "ecto")');
+    if (!PACKAGE_NAME.test(raw)) {
+        throw new ArgumentError(
+            `hex-pm package "${value}" is not a valid Hex package name`,
+            'Use lowercase letters / digits / underscores; must start with a letter.',
+        );
+    }
+    return raw;
+}
+
+export async function hexFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that hex.pm is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `hex.pm returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'hex.pm throttles unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/hex-pm/versions.js
+++ b/clis/hex-pm/versions.js
@@ -1,0 +1,40 @@
+// hex-pm versions — list every published version of a Hex.pm package.
+//
+// Reuses the `https://hex.pm/api/packages/<name>` endpoint (releases[] is
+// embedded; newest-first by `inserted_at` already). No extra requests needed.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { HEX_BASE, hexFetch, requireBoundedInt, requirePackageName } from './utils.js';
+
+cli({
+    site: 'hex-pm',
+    name: 'versions',
+    access: 'read',
+    description: 'List every published Hex.pm package version (newest first)',
+    domain: 'hex.pm',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'package', positional: true, required: true, help: 'Hex package name' },
+        { name: 'limit', type: 'int', default: 30, help: 'Max rows to return (1-500)' },
+    ],
+    columns: ['rank', 'package', 'version', 'insertedAt', 'hasDocs', 'url'],
+    func: async (args) => {
+        const pkg = requirePackageName(args.package);
+        const limit = requireBoundedInt(args.limit, 30, 500);
+        const url = `${HEX_BASE}/packages/${encodeURIComponent(pkg)}`;
+        const body = await hexFetch(url, 'hex-pm versions');
+        const releases = Array.isArray(body?.releases) ? body.releases : [];
+        if (!releases.length) {
+            throw new EmptyResultError('hex-pm versions', `hex.pm returned no releases for "${pkg}".`);
+        }
+        return releases.slice(0, limit).map((r, i) => ({
+            rank: i + 1,
+            package: pkg,
+            version: String(r.version ?? '').trim(),
+            insertedAt: String(r.inserted_at ?? '').trim() || null,
+            hasDocs: r.has_docs === true ? true : (r.has_docs === false ? false : null),
+            url: `https://hex.pm/packages/${pkg}/${encodeURIComponent(r.version ?? '')}`,
+        }));
+    },
+});

--- a/clis/musicbrainz/artist.js
+++ b/clis/musicbrainz/artist.js
@@ -1,0 +1,51 @@
+// musicbrainz artist — search the MusicBrainz artist index.
+//
+// Hits `https://musicbrainz.org/ws/2/artist?query=<query>&fmt=json`. Returns
+// the agent-useful projection: MBID (round-trips into `musicbrainz release`
+// queries), name, sort name, type (Group / Person / etc.), country, begin/end,
+// disambiguation, score.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { MB_BASE, mbFetch, requireBoundedInt, requireString } from './utils.js';
+
+cli({
+    site: 'musicbrainz',
+    name: 'artist',
+    access: 'read',
+    description: 'Search MusicBrainz artists by name',
+    domain: 'musicbrainz.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Artist name (e.g. "Radiohead", "Aretha Franklin")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max artists (1-100)' },
+    ],
+    columns: ['rank', 'mbid', 'name', 'sortName', 'type', 'country', 'begin', 'ended', 'disambiguation', 'score', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const url = `${MB_BASE}/artist?query=${encodeURIComponent(query)}&limit=${limit}&fmt=json`;
+        const body = await mbFetch(url, 'musicbrainz artist');
+        const list = Array.isArray(body?.artists) ? body.artists : [];
+        if (!list.length) {
+            throw new EmptyResultError('musicbrainz artist', `No MusicBrainz artists matched "${query}".`);
+        }
+        return list.slice(0, limit).map((a, i) => {
+            const lifeSpan = a['life-span'] || {};
+            const ended = lifeSpan.ended === true ? (lifeSpan.end || 'true') : (lifeSpan.ended === false ? null : (lifeSpan.end || null));
+            return {
+                rank: i + 1,
+                mbid: String(a.id ?? '').trim(),
+                name: String(a.name ?? '').trim(),
+                sortName: String(a['sort-name'] ?? '').trim(),
+                type: String(a.type ?? '').trim() || null,
+                country: String(a.country ?? '').trim() || null,
+                begin: String(lifeSpan.begin ?? '').trim() || null,
+                ended,
+                disambiguation: String(a.disambiguation ?? '').trim() || null,
+                score: typeof a.score === 'number' ? a.score : null,
+                url: a.id ? `https://musicbrainz.org/artist/${a.id}` : '',
+            };
+        });
+    },
+});

--- a/clis/musicbrainz/musicbrainz.test.js
+++ b/clis/musicbrainz/musicbrainz.test.js
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './artist.js';
+import './release.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('musicbrainz artist adapter', () => {
+    const cmd = getRegistry().get('musicbrainz/artist');
+
+    it('rejects empty / oversized queries before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 503 (typical anonymous throttle) to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('throttled', { status: 503 })));
+        await expect(cmd.func({ query: 'whatever', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty artist list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ artists: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'no-matches', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips MBID into /artist/<mbid> URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            artists: [{
+                id: 'a74b1b7f-71a5-4011-9441-d0b5e4122711',
+                name: 'Radiohead',
+                'sort-name': 'Radiohead',
+                type: 'Group',
+                country: 'GB',
+                'life-span': { begin: '1991', ended: false },
+                score: 100,
+            }],
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'radiohead', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            mbid: 'a74b1b7f-71a5-4011-9441-d0b5e4122711',
+            name: 'Radiohead',
+            ended: null,
+            url: 'https://musicbrainz.org/artist/a74b1b7f-71a5-4011-9441-d0b5e4122711',
+        });
+    });
+});
+
+describe('musicbrainz release adapter', () => {
+    const cmd = getRegistry().get('musicbrainz/release');
+
+    it('rejects malformed MBID before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ mbid: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ mbid: 'not-a-uuid' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ mbid: '76df3287-6cda-33eb-8e9a-044b5e15ffd' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ mbid: '00000000-0000-0000-0000-000000000000' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('joins artist credits with joinphrase and surfaces release-event country code', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            id: '76df3287-6cda-33eb-8e9a-044b5e15ffdd',
+            title: 'Dummy',
+            status: 'Official',
+            'artist-credit': [
+                { name: 'Portishead', joinphrase: ' & ', artist: { name: 'Portishead' } },
+                { name: 'Beth Gibbons', joinphrase: '', artist: { name: 'Beth Gibbons' } },
+            ],
+            'release-events': [{ date: '1994-08-22', area: { 'iso-3166-1-codes': ['GB'] } }],
+            'release-group': { title: 'Dummy', 'primary-type': 'Album', 'first-release-date': '1994-08-22' },
+            'label-info': [{ label: { name: 'Go! Beat' }, 'catalog-number': '828 553-2' }],
+            'text-representation': { language: 'eng', script: 'Latn' },
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ mbid: '76df3287-6cda-33eb-8e9a-044b5e15ffdd' });
+        expect(rows[0]).toMatchObject({
+            mbid: '76df3287-6cda-33eb-8e9a-044b5e15ffdd',
+            title: 'Dummy',
+            artistCredit: 'Portishead & Beth Gibbons',
+            releaseCountry: 'GB',
+            label: 'Go! Beat',
+            url: 'https://musicbrainz.org/release/76df3287-6cda-33eb-8e9a-044b5e15ffdd',
+        });
+    });
+});

--- a/clis/musicbrainz/release.js
+++ b/clis/musicbrainz/release.js
@@ -1,0 +1,73 @@
+// musicbrainz release — fetch full MusicBrainz release detail by MBID.
+//
+// Hits `https://musicbrainz.org/ws/2/release/<mbid>?inc=artist-credits+labels+release-groups&fmt=json`.
+// Returns the agent-useful projection: title, artist credit (joined), release
+// group, primary type, status, packaging, release country/date, label /
+// catalog number, language / script, barcode.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { MB_BASE, formatArtistCredit, mbFetch, requireMbid } from './utils.js';
+
+function pickFirstReleaseEvent(events) {
+    if (!Array.isArray(events) || events.length === 0) return { date: null, country: null };
+    const first = events[0] || {};
+    const area = first.area || {};
+    const codes = Array.isArray(area['iso-3166-1-codes']) ? area['iso-3166-1-codes'] : [];
+    return {
+        date: String(first.date ?? '').trim() || null,
+        country: codes[0] || String(area.name ?? '').trim() || null,
+    };
+}
+
+function formatLabelInfo(labelInfo) {
+    if (!Array.isArray(labelInfo) || labelInfo.length === 0) return { label: null, catalogNumber: null };
+    const first = labelInfo[0] || {};
+    return {
+        label: String(first.label?.name ?? '').trim() || null,
+        catalogNumber: String(first['catalog-number'] ?? '').trim() || null,
+    };
+}
+
+cli({
+    site: 'musicbrainz',
+    name: 'release',
+    access: 'read',
+    description: 'Fetch full MusicBrainz release detail by MBID',
+    domain: 'musicbrainz.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'mbid', positional: true, required: true, help: 'Release MBID (e.g. "76df3287-6cda-33eb-8e9a-044b5e15ffdd")' },
+    ],
+    columns: [
+        'mbid', 'title', 'artistCredit', 'status', 'releaseGroup', 'primaryType',
+        'firstReleaseDate', 'releaseCountry', 'releaseDate', 'label', 'catalogNumber',
+        'barcode', 'packaging', 'language', 'script', 'url',
+    ],
+    func: async (args) => {
+        const mbid = requireMbid(args.mbid, 'release');
+        const url = `${MB_BASE}/release/${mbid}?inc=artist-credits+labels+release-groups&fmt=json`;
+        const release = await mbFetch(url, 'musicbrainz release');
+        const event = pickFirstReleaseEvent(release['release-events']);
+        const labelInfo = formatLabelInfo(release['label-info']);
+        const textRep = release['text-representation'] || {};
+        const releaseGroup = release['release-group'] || {};
+        return [{
+            mbid,
+            title: String(release.title ?? '').trim(),
+            artistCredit: formatArtistCredit(release['artist-credit']),
+            status: String(release.status ?? '').trim() || null,
+            releaseGroup: String(releaseGroup.title ?? '').trim() || null,
+            primaryType: String(releaseGroup['primary-type'] ?? '').trim() || null,
+            firstReleaseDate: String(releaseGroup['first-release-date'] ?? '').trim() || null,
+            releaseCountry: event.country,
+            releaseDate: event.date,
+            label: labelInfo.label,
+            catalogNumber: labelInfo.catalogNumber,
+            barcode: String(release.barcode ?? '').trim() || null,
+            packaging: String(release.packaging ?? '').trim() || null,
+            language: String(textRep.language ?? '').trim() || null,
+            script: String(textRep.script ?? '').trim() || null,
+            url: `https://musicbrainz.org/release/${mbid}`,
+        }];
+    },
+});

--- a/clis/musicbrainz/utils.js
+++ b/clis/musicbrainz/utils.js
@@ -1,0 +1,92 @@
+// Shared helpers for the MusicBrainz adapters.
+//
+// Hits the public, unauthenticated `musicbrainz.org/ws/2` REST endpoints — the
+// canonical open music metadata registry. MusicBrainz strictly enforces a
+// descriptive User-Agent and 1 req/s rate limit on anonymous traffic; we send
+// a polite UA and surface 503/429 explicitly.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const MB_BASE = 'https://musicbrainz.org/ws/2';
+const UA = 'opencli-musicbrainz-adapter/1.0 (+https://github.com/jackwener/opencli)';
+
+// MusicBrainz uses lowercase MBIDs (UUID v4 format). Validate strictly so a
+// typo doesn't waste a precious anonymous request slot.
+const MBID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`musicbrainz ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`musicbrainz ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`musicbrainz ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireMbid(value, label) {
+    const raw = String(value ?? '').trim().toLowerCase();
+    if (!raw) throw new ArgumentError(`musicbrainz ${label} mbid is required`);
+    if (!MBID.test(raw)) {
+        throw new ArgumentError(
+            `musicbrainz ${label} "${value}" is not a valid MBID`,
+            'Expected a UUID-v4-shaped MusicBrainz id (e.g. "a74b1b7f-71a5-4011-9441-d0b5e4122711").',
+        );
+    }
+    return raw;
+}
+
+export function formatArtistCredit(credits) {
+    if (!Array.isArray(credits)) return '';
+    // joinphrase is the connective glue (e.g. " & ", " feat. ") that MusicBrainz
+    // emits *with surrounding whitespace* — preserve it verbatim so multi-artist
+    // credits stay readable. Only trim the final result.
+    return credits
+        .map((c) => {
+            const name = String(c?.name ?? c?.artist?.name ?? '');
+            const join = String(c?.joinphrase ?? '');
+            return `${name}${join}`;
+        })
+        .join('')
+        .trim();
+}
+
+export async function mbFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that musicbrainz.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `MusicBrainz returned 404 for ${url}.`);
+    }
+    if (resp.status === 429 || resp.status === 503) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP ${resp.status} (rate limited)`,
+            'MusicBrainz throttles anonymous traffic to 1 req/s; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/open-meteo/forecast.js
+++ b/clis/open-meteo/forecast.js
@@ -1,0 +1,117 @@
+// open-meteo forecast — daily weather forecast for a lat/lon pair.
+//
+// Hits `https://api.open-meteo.com/v1/forecast?latitude=…&longitude=…&daily=…`.
+// Returns one row per forecast day with high/low temp, precipitation hours +
+// probability, weather code, sunrise / sunset, wind max. Lat/lon round-trips
+// from `open-meteo geocode`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { FORECAST_BASE, meteoFetch, requireBoundedInt, requireFloat } from './utils.js';
+
+const DAILY_FIELDS = [
+    'weather_code',
+    'temperature_2m_max',
+    'temperature_2m_min',
+    'apparent_temperature_max',
+    'apparent_temperature_min',
+    'sunrise',
+    'sunset',
+    'precipitation_sum',
+    'precipitation_hours',
+    'precipitation_probability_max',
+    'wind_speed_10m_max',
+    'wind_gusts_10m_max',
+    'uv_index_max',
+];
+
+// Open-Meteo's WMO weather code → human label. Source:
+// https://open-meteo.com/en/docs#weather_variable_documentation. Provided here
+// so agents can show a readable value next to the raw code.
+const WMO_CODES = new Map([
+    [0, 'Clear sky'], [1, 'Mainly clear'], [2, 'Partly cloudy'], [3, 'Overcast'],
+    [45, 'Fog'], [48, 'Depositing rime fog'],
+    [51, 'Drizzle: light'], [53, 'Drizzle: moderate'], [55, 'Drizzle: dense'],
+    [56, 'Freezing drizzle: light'], [57, 'Freezing drizzle: dense'],
+    [61, 'Rain: slight'], [63, 'Rain: moderate'], [65, 'Rain: heavy'],
+    [66, 'Freezing rain: light'], [67, 'Freezing rain: heavy'],
+    [71, 'Snow fall: slight'], [73, 'Snow fall: moderate'], [75, 'Snow fall: heavy'],
+    [77, 'Snow grains'],
+    [80, 'Rain showers: slight'], [81, 'Rain showers: moderate'], [82, 'Rain showers: violent'],
+    [85, 'Snow showers: slight'], [86, 'Snow showers: heavy'],
+    [95, 'Thunderstorm: slight or moderate'],
+    [96, 'Thunderstorm with slight hail'], [99, 'Thunderstorm with heavy hail'],
+]);
+
+function buildRow(daily, idx, units) {
+    function pick(key) {
+        const arr = daily?.[key];
+        return Array.isArray(arr) && idx < arr.length ? arr[idx] : null;
+    }
+    const code = pick('weather_code');
+    return {
+        date: typeof daily?.time?.[idx] === 'string' ? daily.time[idx] : null,
+        weatherCode: typeof code === 'number' ? code : null,
+        weather: typeof code === 'number' && WMO_CODES.has(code) ? WMO_CODES.get(code) : null,
+        tempMax: pick('temperature_2m_max'),
+        tempMin: pick('temperature_2m_min'),
+        apparentMax: pick('apparent_temperature_max'),
+        apparentMin: pick('apparent_temperature_min'),
+        sunrise: pick('sunrise'),
+        sunset: pick('sunset'),
+        precipSum: pick('precipitation_sum'),
+        precipHours: pick('precipitation_hours'),
+        precipProbabilityMax: pick('precipitation_probability_max'),
+        windMax: pick('wind_speed_10m_max'),
+        windGustMax: pick('wind_gusts_10m_max'),
+        uvIndexMax: pick('uv_index_max'),
+        tempUnit: units?.temperature_2m_max ?? null,
+        precipUnit: units?.precipitation_sum ?? null,
+        windUnit: units?.wind_speed_10m_max ?? null,
+    };
+}
+
+cli({
+    site: 'open-meteo',
+    name: 'forecast',
+    access: 'read',
+    description: 'Daily weather forecast for a lat/lon pair (no API key required)',
+    domain: 'api.open-meteo.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'latitude', positional: true, required: true, help: 'Latitude in decimal degrees (-90 to 90)' },
+        { name: 'longitude', positional: true, required: true, help: 'Longitude in decimal degrees (-180 to 180)' },
+        { name: 'days', type: 'int', default: 7, help: 'Forecast days (1-16)' },
+    ],
+    columns: [
+        'date', 'weatherCode', 'weather', 'tempMax', 'tempMin', 'apparentMax',
+        'apparentMin', 'sunrise', 'sunset', 'precipSum', 'precipHours',
+        'precipProbabilityMax', 'windMax', 'windGustMax', 'uvIndexMax',
+        'tempUnit', 'precipUnit', 'windUnit',
+    ],
+    func: async (args) => {
+        const lat = requireFloat(args.latitude, 'latitude', { min: -90, max: 90 });
+        const lon = requireFloat(args.longitude, 'longitude', { min: -180, max: 180 });
+        const days = requireBoundedInt(args.days, 7, 16, 'days');
+        const params = new URLSearchParams({
+            latitude: String(lat),
+            longitude: String(lon),
+            daily: DAILY_FIELDS.join(','),
+            forecast_days: String(days),
+            timezone: 'auto',
+        });
+        const url = `${FORECAST_BASE}/forecast?${params}`;
+        const body = await meteoFetch(url, 'open-meteo forecast');
+        const daily = body?.daily;
+        const dailyUnits = body?.daily_units || {};
+        const times = Array.isArray(daily?.time) ? daily.time : [];
+        if (!times.length) {
+            throw new EmptyResultError('open-meteo forecast', `Open-Meteo returned no daily data for (${lat}, ${lon}).`);
+        }
+        // Open-Meteo honors `forecast_days` server-side; if the response length
+        // differs from what we asked for, surface every row (no silent clamp).
+        const rows = [];
+        for (let i = 0; i < times.length; i++) rows.push(buildRow(daily, i, dailyUnits));
+        return rows;
+    },
+});

--- a/clis/open-meteo/geocode.js
+++ b/clis/open-meteo/geocode.js
@@ -1,0 +1,51 @@
+// open-meteo geocode — resolve a city / place name to lat/lon.
+//
+// Hits `https://geocoding-api.open-meteo.com/v1/search?name=…`. Returns the
+// agent-useful projection: name, country, admin1, latitude, longitude,
+// elevation, population, timezone, feature code. The (latitude, longitude)
+// pair round-trips into `open-meteo forecast`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { GEOCODE_BASE, meteoFetch, requireBoundedInt, requireString } from './utils.js';
+
+cli({
+    site: 'open-meteo',
+    name: 'geocode',
+    access: 'read',
+    description: 'Resolve a city / place name to lat/lon via Open-Meteo geocoding',
+    domain: 'geocoding-api.open-meteo.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'Place name (e.g. "Tokyo", "San Francisco", "Munich")' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max results (1-100)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'country', 'admin1', 'latitude', 'longitude',
+        'elevation', 'population', 'timezone', 'featureCode', 'url',
+    ],
+    func: async (args) => {
+        const name = requireString(args.name, 'name');
+        const limit = requireBoundedInt(args.limit, 10, 100);
+        const url = `${GEOCODE_BASE}/search?name=${encodeURIComponent(name)}&count=${limit}`;
+        const body = await meteoFetch(url, 'open-meteo geocode');
+        const list = Array.isArray(body?.results) ? body.results : [];
+        if (!list.length) {
+            throw new EmptyResultError('open-meteo geocode', `No Open-Meteo locations matched "${name}".`);
+        }
+        return list.slice(0, limit).map((r, i) => ({
+            rank: i + 1,
+            id: typeof r.id === 'number' ? r.id : null,
+            name: String(r.name ?? '').trim(),
+            country: String(r.country ?? '').trim() || null,
+            admin1: String(r.admin1 ?? '').trim() || null,
+            latitude: typeof r.latitude === 'number' ? r.latitude : null,
+            longitude: typeof r.longitude === 'number' ? r.longitude : null,
+            elevation: typeof r.elevation === 'number' ? r.elevation : null,
+            population: typeof r.population === 'number' ? r.population : null,
+            timezone: String(r.timezone ?? '').trim() || null,
+            featureCode: String(r.feature_code ?? '').trim() || null,
+            url: r.id ? `https://www.openstreetmap.org/?mlat=${r.latitude}&mlon=${r.longitude}#map=10/${r.latitude}/${r.longitude}` : '',
+        }));
+    },
+});

--- a/clis/open-meteo/open-meteo.test.js
+++ b/clis/open-meteo/open-meteo.test.js
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './geocode.js';
+import './forecast.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('open-meteo geocode adapter', () => {
+    const cmd = getRegistry().get('open-meteo/geocode');
+
+    it('rejects empty / oversized queries before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ name: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ name: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ name: 'tokyo' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when results array is missing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })));
+        await expect(cmd.func({ name: 'zzz-nowhere' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips lat/lon into forecast-ready row shape', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            results: [{
+                id: 1850147,
+                name: 'Tokyo',
+                country: 'Japan',
+                admin1: 'Tokyo',
+                latitude: 35.6895,
+                longitude: 139.69171,
+                elevation: 44,
+                population: 9733276,
+                timezone: 'Asia/Tokyo',
+                feature_code: 'PPLC',
+            }],
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ name: 'tokyo', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            id: 1850147,
+            name: 'Tokyo',
+            latitude: 35.6895,
+            longitude: 139.69171,
+            country: 'Japan',
+        });
+    });
+});
+
+describe('open-meteo forecast adapter', () => {
+    const cmd = getRegistry().get('open-meteo/forecast');
+
+    it('rejects out-of-range lat/lon and bad days before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ latitude: 999, longitude: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ latitude: 0, longitude: 999 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ latitude: 0, longitude: 0, days: 99 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ latitude: 'NaN', longitude: 0 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 400 (Open-Meteo bad params) to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ reason: 'No data is available' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } },
+        )));
+        await expect(cmd.func({ latitude: 0, longitude: 0, days: 3 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when daily.time is empty', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            daily: { time: [] }, daily_units: {},
+        }), { status: 200 })));
+        await expect(cmd.func({ latitude: 35.6895, longitude: 139.69171, days: 3 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('decodes WMO weather codes and projects daily fields without silent clamp', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            daily: {
+                time: ['2026-05-06', '2026-05-07'],
+                weather_code: [51, 95],
+                temperature_2m_max: [20.1, 24.8],
+                temperature_2m_min: [12.2, 14.2],
+                apparent_temperature_max: [20.3, 28.4],
+                apparent_temperature_min: [11.5, 15.0],
+                sunrise: ['2026-05-06T04:44', '2026-05-07T04:43'],
+                sunset: ['2026-05-06T18:31', '2026-05-07T18:32'],
+                precipitation_sum: [0.6, 0],
+                precipitation_hours: [2, 0],
+                precipitation_probability_max: [43, 41],
+                wind_speed_10m_max: [8.4, 9.8],
+                wind_gusts_10m_max: [37.1, 28.4],
+                uv_index_max: [5.95, 7.95],
+            },
+            daily_units: {
+                temperature_2m_max: '°C',
+                precipitation_sum: 'mm',
+                wind_speed_10m_max: 'km/h',
+            },
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ latitude: 35.6895, longitude: 139.69171, days: 2 });
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            date: '2026-05-06',
+            weatherCode: 51,
+            weather: 'Drizzle: light',
+            tempMax: 20.1,
+            tempUnit: '°C',
+        });
+        expect(rows[1]).toMatchObject({
+            weatherCode: 95,
+            weather: 'Thunderstorm: slight or moderate',
+        });
+    });
+});

--- a/clis/open-meteo/utils.js
+++ b/clis/open-meteo/utils.js
@@ -1,0 +1,85 @@
+// Shared helpers for the Open-Meteo adapters.
+//
+// Hits the public, unauthenticated `api.open-meteo.com` and
+// `geocoding-api.open-meteo.com` endpoints — Open-Meteo is a free weather +
+// geocoding service that does not require an API key. Two-host setup so we
+// keep the host wiring centralised.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const FORECAST_BASE = 'https://api.open-meteo.com/v1';
+export const GEOCODE_BASE = 'https://geocoding-api.open-meteo.com/v1';
+const UA = 'opencli-open-meteo-adapter/1.0 (+https://github.com/jackwener/opencli)';
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`open-meteo ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit', minValue = 1) {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n < minValue) {
+        throw new ArgumentError(`open-meteo ${label} must be an integer >= ${minValue}`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`open-meteo ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireFloat(value, label, { min, max } = {}) {
+    if (value === null || value === undefined || value === '') {
+        throw new ArgumentError(`open-meteo ${label} is required`);
+    }
+    const n = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(n)) {
+        throw new ArgumentError(`open-meteo ${label} must be a finite number (got "${value}")`);
+    }
+    if (typeof min === 'number' && n < min) {
+        throw new ArgumentError(`open-meteo ${label} must be >= ${min}`);
+    }
+    if (typeof max === 'number' && n > max) {
+        throw new ArgumentError(`open-meteo ${label} must be <= ${max}`);
+    }
+    return n;
+}
+
+export async function meteoFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that *.open-meteo.com is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Open-Meteo returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Open-Meteo throttles unauthenticated traffic at ~10k req/day; wait and retry.',
+        );
+    }
+    if (resp.status === 400) {
+        // Open-Meteo serves rich JSON 400s for bad params; surface the reason.
+        let detail = '';
+        try { const j = await resp.json(); detail = j?.reason ? ` (${j.reason})` : ''; } catch { /* noop */ }
+        throw new CommandExecutionError(`${label} returned HTTP 400${detail}`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/openlibrary/openlibrary.test.js
+++ b/clis/openlibrary/openlibrary.test.js
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './work.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('openlibrary search adapter', () => {
+    const cmd = getRegistry().get('openlibrary/search');
+
+    it('rejects empty / oversized queries before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ query: 'whatever', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty docs list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ docs: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'no-matches', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips work key into /works/<id> URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            docs: [{
+                key: '/works/OL45804W',
+                title: 'Fantastic Mr Fox',
+                author_name: ['Roald Dahl'],
+                first_publish_year: 1970,
+                edition_count: 139,
+                ebook_access: 'borrowable',
+                language: ['eng', 'sco'],
+                cover_i: 6498519,
+            }],
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'mr fox', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            workKey: 'OL45804W',
+            title: 'Fantastic Mr Fox',
+            language: 'eng, sco',
+            url: 'https://openlibrary.org/works/OL45804W',
+        });
+    });
+});
+
+describe('openlibrary work adapter', () => {
+    const cmd = getRegistry().get('openlibrary/work');
+
+    it('rejects malformed work keys before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ workKey: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ workKey: 'OL12M' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ workKey: 'not-a-key' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ workKey: 'OL999999999W' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('flattens description object form to plain string + tolerates missing ratings', async () => {
+        // Fetch is called twice: once for the work, once for ratings (404 here).
+        const callTargets = [];
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url) => {
+            callTargets.push(String(url));
+            if (url.endsWith('/ratings.json')) {
+                return new Response('{}', { status: 404 });
+            }
+            return new Response(JSON.stringify({
+                title: 'Fantastic Mr Fox',
+                description: { type: '/type/text', value: '  A fox steals food.  ' },
+                subjects: ['Animals'],
+                covers: [6498519],
+                authors: [{ author: { key: '/authors/OL34184A' } }],
+                first_publish_date: '1970',
+            }), { status: 200 });
+        }));
+
+        const rows = await cmd.func({ workKey: 'OL45804W' });
+        expect(rows[0]).toMatchObject({
+            workKey: 'OL45804W',
+            title: 'Fantastic Mr Fox',
+            description: 'A fox steals food.',
+            authors: 'OL34184A',
+            rating: null,
+            ratingsCount: null,
+        });
+        // Ratings 404 must not propagate; both URLs were attempted.
+        expect(callTargets.some((u) => u.endsWith('/ratings.json'))).toBe(true);
+    });
+});

--- a/clis/openlibrary/openlibrary.test.js
+++ b/clis/openlibrary/openlibrary.test.js
@@ -32,7 +32,7 @@ describe('openlibrary search adapter', () => {
     });
 
     it('round-trips work key into /works/<id> URL', async () => {
-        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
             docs: [{
                 key: '/works/OL45804W',
                 title: 'Fantastic Mr Fox',
@@ -41,16 +41,23 @@ describe('openlibrary search adapter', () => {
                 edition_count: 139,
                 ebook_access: 'borrowable',
                 language: ['eng', 'sco'],
+                isbn: ['9780140328721', '0140328726'],
+                subject: ['Foxes', 'Juvenile fiction'],
                 cover_i: 6498519,
             }],
-        }), { status: 200 })));
+        }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
 
         const rows = await cmd.func({ query: 'mr fox', limit: 5 });
+        const url = new URL(fetchMock.mock.calls[0][0]);
+        expect(url.searchParams.get('fields')).toBe('key,title,author_name,first_publish_year,edition_count,ebook_access,language,isbn,subject,cover_i');
         expect(rows[0]).toMatchObject({
             rank: 1,
             workKey: 'OL45804W',
             title: 'Fantastic Mr Fox',
             language: 'eng, sco',
+            isbn: '9780140328721, 0140328726',
+            subjects: 'Foxes, Juvenile fiction',
             url: 'https://openlibrary.org/works/OL45804W',
         });
     });

--- a/clis/openlibrary/search.js
+++ b/clis/openlibrary/search.js
@@ -1,0 +1,64 @@
+// openlibrary search — search the Open Library book index.
+//
+// Hits `https://openlibrary.org/search.json?q=…`. Returns the agent-useful
+// projection: work key (round-trips into `openlibrary work`), title, author,
+// first publish year, edition count, ebook access, ISBN list, language list,
+// cover id, subject highlights.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { OL_BASE, olFetch, requireBoundedInt, requireString } from './utils.js';
+
+function pickWorkKey(doc) {
+    const k = String(doc?.key ?? '').trim();
+    if (!k) return '';
+    const slash = k.lastIndexOf('/');
+    return slash >= 0 ? k.slice(slash + 1) : k;
+}
+
+function pickFirst(arr, max = 3) {
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    const filtered = arr.slice(0, max).filter((v) => typeof v === 'string' && v.trim());
+    return filtered.length ? filtered.join(', ') : null;
+}
+
+cli({
+    site: 'openlibrary',
+    name: 'search',
+    access: 'read',
+    description: 'Search Open Library books by keyword',
+    domain: 'openlibrary.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (title / author / subject)' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max books (1-100)' },
+    ],
+    columns: ['rank', 'workKey', 'title', 'author', 'firstPublished', 'editions', 'ebook', 'language', 'isbn', 'subjects', 'coverId', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const url = `${OL_BASE}/search.json?q=${encodeURIComponent(query)}&limit=${limit}`;
+        const body = await olFetch(url, 'openlibrary search');
+        const list = Array.isArray(body?.docs) ? body.docs : [];
+        if (!list.length) {
+            throw new EmptyResultError('openlibrary search', `No Open Library books matched "${query}".`);
+        }
+        return list.slice(0, limit).map((doc, i) => {
+            const workKey = pickWorkKey(doc);
+            return {
+                rank: i + 1,
+                workKey,
+                title: String(doc.title ?? '').trim(),
+                author: pickFirst(doc.author_name, 5),
+                firstPublished: typeof doc.first_publish_year === 'number' ? doc.first_publish_year : null,
+                editions: typeof doc.edition_count === 'number' ? doc.edition_count : null,
+                ebook: String(doc.ebook_access ?? '').trim() || null,
+                language: pickFirst(doc.language, 5),
+                isbn: pickFirst(doc.isbn, 3),
+                subjects: pickFirst(doc.subject, 3),
+                coverId: typeof doc.cover_i === 'number' ? doc.cover_i : null,
+                url: workKey ? `${OL_BASE}/works/${workKey}` : '',
+            };
+        });
+    },
+});

--- a/clis/openlibrary/search.js
+++ b/clis/openlibrary/search.js
@@ -8,6 +8,19 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
 import { OL_BASE, olFetch, requireBoundedInt, requireString } from './utils.js';
 
+const SEARCH_FIELDS = [
+    'key',
+    'title',
+    'author_name',
+    'first_publish_year',
+    'edition_count',
+    'ebook_access',
+    'language',
+    'isbn',
+    'subject',
+    'cover_i',
+];
+
 function pickWorkKey(doc) {
     const k = String(doc?.key ?? '').trim();
     if (!k) return '';
@@ -37,7 +50,12 @@ cli({
     func: async (args) => {
         const query = requireString(args.query, 'query');
         const limit = requireBoundedInt(args.limit, 20, 100);
-        const url = `${OL_BASE}/search.json?q=${encodeURIComponent(query)}&limit=${limit}`;
+        const params = new URLSearchParams({
+            q: query,
+            limit: String(limit),
+            fields: SEARCH_FIELDS.join(','),
+        });
+        const url = `${OL_BASE}/search.json?${params}`;
         const body = await olFetch(url, 'openlibrary search');
         const list = Array.isArray(body?.docs) ? body.docs : [];
         if (!list.length) {

--- a/clis/openlibrary/utils.js
+++ b/clis/openlibrary/utils.js
@@ -1,0 +1,99 @@
+// Shared helpers for the Open Library adapters.
+//
+// Hits the public, unauthenticated `openlibrary.org` REST endpoints. Open Library
+// is the Internet Archive's open book metadata service; everything is JSON, no
+// API key. Work / edition / author keys look like `OL45804W` (W=work, M=edition,
+// A=author). Search is `https://openlibrary.org/search.json`.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const OL_BASE = 'https://openlibrary.org';
+const UA = 'opencli-openlibrary-adapter/1.0 (+https://github.com/jackwener/opencli)';
+
+const WORK_KEY = /^OL\d+W$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`openlibrary ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`openlibrary ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`openlibrary ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+/**
+ * Normalise a work key to the canonical `OL<digits>W` form. Accepts a bare key
+ * (`OL45804W`), an `/works/OL45804W` path, or an `https://openlibrary.org/...`
+ * URL. Editions (`OL...M`) and authors (`OL...A`) are rejected — `work` only
+ * supports works.
+ */
+export function requireWorkKey(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) {
+        throw new ArgumentError('openlibrary work key is required (e.g. "OL45804W")');
+    }
+    const stripped = raw
+        .replace(/^https?:\/\/openlibrary\.org/i, '')
+        .replace(/^\/works\//i, '')
+        .replace(/\.json$/i, '');
+    if (!WORK_KEY.test(stripped)) {
+        throw new ArgumentError(
+            `openlibrary work key "${value}" is not a valid work id`,
+            'Expected format: "OL<digits>W" (e.g. "OL45804W"). Editions (OL...M) are not supported.',
+        );
+    }
+    return stripped;
+}
+
+/**
+ * Open Library descriptions can be either a plain string or an object
+ * `{type: '/type/text', value: '...'}`. Normalise to a plain trimmed string.
+ */
+export function flattenDescription(field) {
+    if (typeof field === 'string') return field.trim();
+    if (field && typeof field === 'object' && typeof field.value === 'string') {
+        return field.value.trim();
+    }
+    return '';
+}
+
+export async function olFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that openlibrary.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Open Library returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Open Library throttles unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/openlibrary/work.js
+++ b/clis/openlibrary/work.js
@@ -1,0 +1,80 @@
+// openlibrary work — fetch full Open Library metadata for a work.
+//
+// Hits `https://openlibrary.org/works/<id>.json`. Returns the agent-useful
+// projection: title, description, subject taxonomy, cover ids, first published
+// date, link to OL author page (round-trip not supported — author keys go to a
+// different endpoint), ratings via separate `/works/<id>/ratings.json` lookup.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { OL_BASE, flattenDescription, olFetch, requireWorkKey } from './utils.js';
+
+function pickAuthorKeys(work) {
+    if (!Array.isArray(work?.authors)) return [];
+    return work.authors
+        .map((entry) => {
+            const k = entry?.author?.key;
+            if (typeof k !== 'string') return null;
+            const slash = k.lastIndexOf('/');
+            return slash >= 0 ? k.slice(slash + 1) : k;
+        })
+        .filter(Boolean);
+}
+
+cli({
+    site: 'openlibrary',
+    name: 'work',
+    access: 'read',
+    description: 'Fetch Open Library metadata for a work id (OL...W)',
+    domain: 'openlibrary.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'workKey', positional: true, required: true, help: 'Open Library work key (e.g. "OL45804W"; "/works/OL45804W" or full URL accepted)' },
+    ],
+    columns: [
+        'workKey', 'title', 'subtitle', 'authors', 'description', 'subjects',
+        'subjectPlaces', 'subjectPeople', 'subjectTimes', 'firstPublished',
+        'coverIds', 'rating', 'ratingsCount', 'editionsUrl', 'url',
+    ],
+    func: async (args) => {
+        const workKey = requireWorkKey(args.workKey);
+        const url = `${OL_BASE}/works/${workKey}.json`;
+        const work = await olFetch(url, 'openlibrary work');
+        // Ratings live on a sibling endpoint; tolerate missing ratings without
+        // failing the whole detail call.
+        let ratingSummary = null;
+        let ratingsCount = null;
+        try {
+            const r = await olFetch(`${OL_BASE}/works/${workKey}/ratings.json`, 'openlibrary work ratings');
+            const avg = r?.summary?.average;
+            if (typeof avg === 'number') ratingSummary = Number(avg.toFixed(2));
+            if (typeof r?.summary?.count === 'number') ratingsCount = r.summary.count;
+        } catch (err) {
+            // Empty / 404 ratings are normal for niche works; non-network errors
+            // still bubble out so we don't silently mask broader regressions.
+            if (!(err instanceof EmptyResultError)) throw err;
+        }
+        const subjects = Array.isArray(work?.subjects) ? work.subjects : [];
+        const subjectPlaces = Array.isArray(work?.subject_places) ? work.subject_places : [];
+        const subjectPeople = Array.isArray(work?.subject_people) ? work.subject_people : [];
+        const subjectTimes = Array.isArray(work?.subject_times) ? work.subject_times : [];
+        const covers = Array.isArray(work?.covers) ? work.covers.filter((c) => typeof c === 'number' && c > 0) : [];
+        return [{
+            workKey,
+            title: String(work?.title ?? '').trim(),
+            subtitle: String(work?.subtitle ?? '').trim() || null,
+            authors: pickAuthorKeys(work).join(', ') || null,
+            description: flattenDescription(work?.description) || null,
+            subjects: subjects.slice(0, 20).join(', ') || null,
+            subjectPlaces: subjectPlaces.slice(0, 10).join(', ') || null,
+            subjectPeople: subjectPeople.slice(0, 10).join(', ') || null,
+            subjectTimes: subjectTimes.slice(0, 10).join(', ') || null,
+            firstPublished: String(work?.first_publish_date ?? '').trim() || null,
+            coverIds: covers.length ? covers.slice(0, 5).join(', ') : null,
+            rating: ratingSummary,
+            ratingsCount,
+            editionsUrl: `${OL_BASE}/works/${workKey}/editions.json`,
+            url: `${OL_BASE}/works/${workKey}`,
+        }];
+    },
+});

--- a/clis/pub-dev/package.js
+++ b/clis/pub-dev/package.js
@@ -1,0 +1,55 @@
+// pub-dev package — fetch latest pub.dev package metadata.
+//
+// Hits `https://pub.dev/api/packages/<name>`. Returns the agent-useful
+// projection: latest version + published timestamp, description, repository /
+// homepage, SDK constraint, dependency count, license info (best-effort from
+// pubspec).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { PUB_BASE, pubFetch, requirePackageName } from './utils.js';
+
+cli({
+    site: 'pub-dev',
+    name: 'package',
+    access: 'read',
+    description: 'Fetch latest pub.dev package metadata (Dart / Flutter)',
+    domain: 'pub.dev',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'package', positional: true, required: true, help: 'pub.dev package name (e.g. "http", "provider", "riverpod")' },
+    ],
+    columns: [
+        'package', 'version', 'publishedAt', 'description', 'repository', 'homepage',
+        'sdk', 'flutter', 'dependencies', 'devDependencies', 'topics', 'archive', 'url',
+    ],
+    func: async (args) => {
+        const pkg = requirePackageName(args.package);
+        const url = `${PUB_BASE}/packages/${encodeURIComponent(pkg)}`;
+        const body = await pubFetch(url, 'pub-dev package');
+        const latest = body?.latest || {};
+        const pubspec = latest.pubspec || {};
+        const env = pubspec.environment || {};
+        const deps = pubspec.dependencies && typeof pubspec.dependencies === 'object'
+            ? Object.keys(pubspec.dependencies)
+            : [];
+        const devDeps = pubspec.dev_dependencies && typeof pubspec.dev_dependencies === 'object'
+            ? Object.keys(pubspec.dev_dependencies)
+            : [];
+        const topics = Array.isArray(pubspec.topics) ? pubspec.topics : [];
+        return [{
+            package: pkg,
+            version: String(latest.version ?? '').trim() || null,
+            publishedAt: String(latest.published ?? '').trim() || null,
+            description: String(pubspec.description ?? '').trim() || null,
+            repository: String(pubspec.repository ?? '').trim() || null,
+            homepage: String(pubspec.homepage ?? '').trim() || null,
+            sdk: String(env.sdk ?? '').trim() || null,
+            flutter: String(env.flutter ?? '').trim() || null,
+            dependencies: deps.length ? deps.join(', ') : null,
+            devDependencies: devDeps.length ? devDeps.join(', ') : null,
+            topics: topics.length ? topics.join(', ') : null,
+            archive: String(latest.archive_url ?? '').trim() || null,
+            url: `https://pub.dev/packages/${pkg}`,
+        }];
+    },
+});

--- a/clis/pub-dev/pub-dev.test.js
+++ b/clis/pub-dev/pub-dev.test.js
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './package.js';
+import './versions.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('pub-dev package adapter', () => {
+    const cmd = getRegistry().get('pub-dev/package');
+
+    it('rejects malformed package names before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ package: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'Invalid-Name' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: '0starts_digit' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 (unknown package) to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ package: 'no_such_package' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ package: 'http' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('flattens latest pubspec into a single row', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            name: 'http',
+            latest: {
+                version: '1.6.0',
+                published: '2025-11-10T18:27:56.434747Z',
+                archive_url: 'https://pub.dev/api/archives/http-1.6.0.tar.gz',
+                pubspec: {
+                    description: 'A composable HTTP client.',
+                    repository: 'https://github.com/dart-lang/http',
+                    topics: ['http', 'network'],
+                    environment: { sdk: '^3.4.0' },
+                    dependencies: { async: '^2.5.0', meta: '^1.3.0' },
+                    dev_dependencies: { test: '^1.21.2' },
+                },
+            },
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ package: 'http' });
+        expect(rows[0]).toMatchObject({
+            package: 'http',
+            version: '1.6.0',
+            description: 'A composable HTTP client.',
+            sdk: '^3.4.0',
+            dependencies: 'async, meta',
+            devDependencies: 'test',
+            topics: 'http, network',
+            url: 'https://pub.dev/packages/http',
+        });
+    });
+});
+
+describe('pub-dev versions adapter', () => {
+    const cmd = getRegistry().get('pub-dev/versions');
+
+    it('rejects bad limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ package: 'http', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ package: 'http', limit: 9999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('reverses pub.dev oldest-first list to newest-first and round-trips package name', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            versions: [
+                { version: '0.1.0', published: '2020-01-01T00:00:00Z', archive_url: 'a' },
+                { version: '0.2.0', published: '2021-01-01T00:00:00Z', archive_url: 'b' },
+                { version: '1.0.0', published: '2024-01-01T00:00:00Z', archive_url: 'c' },
+            ],
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ package: 'http', limit: 10 });
+        expect(rows.map((r) => r.version)).toEqual(['1.0.0', '0.2.0', '0.1.0']);
+        expect(rows[0]).toMatchObject({ rank: 1, package: 'http', publishedAt: '2024-01-01T00:00:00Z' });
+    });
+
+    it('throws EmptyResultError on empty versions list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ versions: [] }), { status: 200 })));
+        await expect(cmd.func({ package: 'http', limit: 10 })).rejects.toThrow(EmptyResultError);
+    });
+});

--- a/clis/pub-dev/utils.js
+++ b/clis/pub-dev/utils.js
@@ -1,0 +1,75 @@
+// Shared helpers for the pub.dev adapters.
+//
+// Hits the public, unauthenticated `pub.dev/api` REST endpoints — the canonical
+// Dart / Flutter package registry. No API key required; standard HTTP.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const PUB_BASE = 'https://pub.dev/api';
+const UA = 'opencli-pub-dev-adapter/1.0 (+https://github.com/jackwener/opencli)';
+
+// pub.dev package names: lowercase letters, digits, underscores. 1-64 chars per
+// the Dart package layout spec; we mirror that conservatively.
+const PACKAGE_NAME = /^[a-z][a-z0-9_]{0,63}$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`pub-dev ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`pub-dev ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`pub-dev ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requirePackageName(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('pub-dev package name is required (e.g. "http", "provider")');
+    if (!PACKAGE_NAME.test(raw)) {
+        throw new ArgumentError(
+            `pub-dev package "${value}" is not a valid pub.dev package name`,
+            'Use lowercase letters / digits / underscores; must start with a letter (Dart package layout).',
+        );
+    }
+    return raw;
+}
+
+export async function pubFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that pub.dev is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `pub.dev returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'pub.dev throttles unauthenticated traffic; wait a few seconds and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}

--- a/clis/pub-dev/versions.js
+++ b/clis/pub-dev/versions.js
@@ -1,0 +1,44 @@
+// pub-dev versions — list every published version of a pub.dev package.
+//
+// Uses the same `https://pub.dev/api/packages/<name>` endpoint as `pub-dev
+// package` and walks the `versions[]` list (newest-first; pub.dev returns
+// versions oldest-first, we reverse). Each entry carries `published` and the
+// archive URL — no extra requests needed.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { PUB_BASE, pubFetch, requireBoundedInt, requirePackageName } from './utils.js';
+
+cli({
+    site: 'pub-dev',
+    name: 'versions',
+    access: 'read',
+    description: 'List every published pub.dev package version (newest first)',
+    domain: 'pub.dev',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'package', positional: true, required: true, help: 'pub.dev package name' },
+        { name: 'limit', type: 'int', default: 30, help: 'Max rows to return (1-500)' },
+    ],
+    columns: ['rank', 'package', 'version', 'publishedAt', 'archive', 'url'],
+    func: async (args) => {
+        const pkg = requirePackageName(args.package);
+        const limit = requireBoundedInt(args.limit, 30, 500);
+        const url = `${PUB_BASE}/packages/${encodeURIComponent(pkg)}`;
+        const body = await pubFetch(url, 'pub-dev versions');
+        const versions = Array.isArray(body?.versions) ? body.versions : [];
+        if (!versions.length) {
+            throw new EmptyResultError('pub-dev versions', `pub.dev returned no versions for "${pkg}".`);
+        }
+        // pub.dev API returns versions oldest-first. Reverse so newest sits at rank 1.
+        const newestFirst = [...versions].reverse();
+        return newestFirst.slice(0, limit).map((entry, i) => ({
+            rank: i + 1,
+            package: pkg,
+            version: String(entry.version ?? '').trim(),
+            publishedAt: String(entry.published ?? '').trim() || null,
+            archive: String(entry.archive_url ?? '').trim() || null,
+            url: `https://pub.dev/packages/${pkg}/versions/${encodeURIComponent(entry.version ?? '')}`,
+        }));
+    },
+});

--- a/docs/adapters/browser/crossref.md
+++ b/docs/adapters/browser/crossref.md
@@ -1,0 +1,59 @@
+# Crossref
+
+**Mode**: 🌐 Public · **Domain**: `api.crossref.org`
+
+Search the Crossref scholarly metadata index by keyword and fetch full metadata for any DOI. Crossref is the canonical DOI registry behind ~140M scholarly works (papers, chapters, datasets, preprints). No API key required.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli crossref works <query>` | Crossref scholarly works by keyword (DOI, title, authors, container, citations) |
+| `opencli crossref work <doi>` | Full metadata for a DOI (authors, abstract, license, references, ISSN/ISBN) |
+
+## Usage Examples
+
+```bash
+# Title / author search
+opencli crossref works "quantum computing"
+opencli crossref works "Hopfield networks" --limit 10
+
+# DOI detail (round-trips from `works`)
+opencli crossref work 10.1038/nature12373
+opencli crossref work "https://doi.org/10.1038/nature12373"   # courtesy: full URL accepted
+opencli crossref work "doi:10.1038/nature12373"               # courtesy: doi: prefix accepted
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `works` | `rank, doi, title, authors, container, publisher, type, published, citations, url` |
+| `work` | `doi, title, authors, container, publisher, type, published, pages, volume, issue, issn, isbn, language, citations, referenceCount, license, subject, abstract, url` |
+
+The `doi` column from `works` round-trips into `work`.
+
+## Options
+
+### `works`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Search keyword (title / author / abstract) |
+| `--limit` | Max rows (1–100, default: 20) |
+
+### `work`
+
+| Option | Description |
+|--------|-------------|
+| `doi` (positional) | DOI (e.g. `10.1038/nature12373`); `doi:` and `https://doi.org/` prefixes are stripped automatically |
+
+## Notes
+
+- **`abstract` is the full Crossref abstract** with HTML stripped (`<jats:p>...</jats:p>` becomes plain text). `null` when no abstract is registered with Crossref — many papers don't deposit one even if the published version has one.
+- **`authors` in `works`** is capped at the first 6 names + `et al. (+N)` suffix to keep rows scannable. The `work` detail returns up to 50 names so you can dump full author lists.
+- **`published`** prefers `published-print` → `published-online` → `issued` → `created`, returning the first non-empty date as `YYYY[-MM[-DD]]`.
+- **`type`** distinguishes work kinds (`journal-article`, `book-chapter`, `posted-content` for preprints, `dataset`, etc.). Useful for filtering.
+- **`citations`** is `is-referenced-by-count` — how many other Crossref-indexed works cite this DOI. `referenceCount` (only on `work`) is the inverse: how many works *this* one cites.
+- **No API key required.** Crossref asks for a polite User-Agent + contact email; the adapter sets one. Anonymous traffic is rate-limited but generous.
+- **Errors.** Bad DOI shape / bad limit → `ArgumentError`; unknown DOI → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/hex-pm.md
+++ b/docs/adapters/browser/hex-pm.md
@@ -1,0 +1,59 @@
+# Hex.pm
+
+**Mode**: 🌐 Public · **Domain**: `hex.pm`
+
+Fetch full Hex.pm package metadata or list every published version for an Erlang / Elixir package. Hits the unauthenticated `hex.pm/api` JSON endpoints.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli hex-pm package <name>` | Hex.pm package metadata (latest version, downloads, owners, license) |
+| `opencli hex-pm versions <name>` | Published Hex.pm package versions (newest first) |
+
+## Usage Examples
+
+```bash
+# Latest version + downloads + owners
+opencli hex-pm package phoenix
+opencli hex-pm package ecto
+opencli hex-pm package plug
+
+# Every released version, newest first
+opencli hex-pm versions phoenix
+opencli hex-pm versions ecto --limit 50
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `package` | `package, latestVersion, latestStableVersion, description, licenses, github, docsUrl, downloadsAll, downloadsRecent, downloadsWeek, downloadsDay, owners, releaseCount, insertedAt, updatedAt, url` |
+| `versions` | `rank, package, version, insertedAt, hasDocs, url` |
+
+The `package` column round-trips between commands.
+
+## Options
+
+### `package`
+
+| Option | Description |
+|--------|-------------|
+| `package` (positional) | Hex package name (e.g. `phoenix`, `ecto`, `plug`) |
+
+### `versions`
+
+| Option | Description |
+|--------|-------------|
+| `package` (positional) | Hex package name |
+| `--limit` | Max rows (1–500, default: 30) |
+
+## Notes
+
+- **`latestVersion` vs `latestStableVersion`** — Hex distinguishes pre-release tags (`1.8.0-rc.0`) from stable (`1.8.0`). Both fields are surfaced; for production lookups use `latestStableVersion`.
+- **`downloads*` covers four windows**: `all` (lifetime), `recent` (last ~90 days), `week`, `day`. All are integers; `null` when the registry hasn't computed a value yet (rare, only for brand-new packages).
+- **`owners` is comma-joined Hex usernames** — the people who can publish new versions. Useful for ecosystem mapping.
+- **`hasDocs` (versions only)** indicates whether HexDocs has built API docs for that release. `true` / `false` / `null` (not yet known).
+- **Versions are returned newest-first** as Hex.pm API stores them. No client-side semver sort needed.
+- **No API key required.** Hex.pm throttles unauthenticated traffic; bursts → `CommandExecutionError`.
+- **Errors.** Bad package name / bad limit → `ArgumentError`; unknown package → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/musicbrainz.md
+++ b/docs/adapters/browser/musicbrainz.md
@@ -1,0 +1,56 @@
+# MusicBrainz
+
+**Mode**: 🌐 Public · **Domain**: `musicbrainz.org`
+
+Search MusicBrainz artists by name and fetch full release detail by MBID. MusicBrainz is the canonical open music metadata registry; every entity has a UUID-shaped MBID. No API key required.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli musicbrainz artist <query>` | Search MusicBrainz artists by name (MBID, type, country, lifespan) |
+| `opencli musicbrainz release <mbid>` | Full release detail (artist credit, label, catalog number, packaging) |
+
+## Usage Examples
+
+```bash
+# Artist search
+opencli musicbrainz artist "radiohead"
+opencli musicbrainz artist "aretha franklin" --limit 5
+
+# Release detail (MBID from MusicBrainz; not yet round-trip from search — search
+# returns artist MBIDs, releases need a separate browse pass)
+opencli musicbrainz release 76df3287-6cda-33eb-8e9a-044b5e15ffdd
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `artist` | `rank, mbid, name, sortName, type, country, begin, ended, disambiguation, score, url` |
+| `release` | `mbid, title, artistCredit, status, releaseGroup, primaryType, firstReleaseDate, releaseCountry, releaseDate, label, catalogNumber, barcode, packaging, language, script, url` |
+
+## Options
+
+### `artist`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Artist name (e.g. `Radiohead`, `Aretha Franklin`) |
+| `--limit` | Max rows (1–100, default: 20) |
+
+### `release`
+
+| Option | Description |
+|--------|-------------|
+| `mbid` (positional) | Release MBID (UUID v4 form, e.g. `76df3287-6cda-33eb-8e9a-044b5e15ffdd`) |
+
+## Notes
+
+- **`artistCredit` preserves MusicBrainz `joinphrase` whitespace verbatim** — for collaborations, MB emits join glue like `' & '`, `' feat. '` between credits. Trimming would corrupt formatting; the adapter keeps the spaces inside the join and only trims the final string.
+- **`ended`**: MusicBrainz uses three states. `null` when the artist is still active, an ISO date when there's a known end date, or `'true'` when the artist explicitly ended without a date on file.
+- **`releaseCountry` prefers ISO-3166-1 codes** (`'GB'`, `'US'`) when available; falls back to area name for super-national releases (`'XE'` for Europe, etc.).
+- **`type`** classifies artists as `Group`, `Person`, `Orchestra`, `Choir`, `Character`, or `Other`.
+- **`score`** (artist search only) is MusicBrainz's relevance score (0–100). Higher = stronger title match.
+- **No API key required**, but **MusicBrainz strictly rate-limits anonymous traffic to ~1 req/s.** Bursts → `CommandExecutionError`. The adapter sets a polite User-Agent so MB can route abusers if necessary.
+- **Errors.** Bad MBID shape / bad limit → `ArgumentError`; unknown MBID → `EmptyResultError`; transport / 503 / 429 → `CommandExecutionError`.

--- a/docs/adapters/browser/open-meteo.md
+++ b/docs/adapters/browser/open-meteo.md
@@ -1,0 +1,61 @@
+# Open-Meteo
+
+**Mode**: 🌐 Public · **Domain**: `api.open-meteo.com`, `geocoding-api.open-meteo.com`
+
+Resolve a city / place name to lat/lon coordinates and fetch a daily weather forecast. Open-Meteo is a free no-API-key weather service backed by ECMWF / DWD / GFS forecast models.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli open-meteo geocode <name>` | Resolve a city / place name to lat/lon (no API key) |
+| `opencli open-meteo forecast <latitude> <longitude>` | Daily weather forecast for a lat/lon pair (1–16 days) |
+
+## Usage Examples
+
+```bash
+# Resolve a city name (returns multiple candidates ranked by population)
+opencli open-meteo geocode tokyo
+opencli open-meteo geocode "san francisco" --limit 5
+
+# Forecast (lat/lon round-trips from geocode)
+opencli open-meteo forecast 35.6895 139.69171              # default 7 days
+opencli open-meteo forecast 37.7749 -122.4194 --days 10    # SF, 10 days
+opencli open-meteo forecast 51.5074 -0.1278 --days 16      # London, full 16-day window
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `geocode` | `rank, id, name, country, admin1, latitude, longitude, elevation, population, timezone, featureCode, url` |
+| `forecast` | `date, weatherCode, weather, tempMax, tempMin, apparentMax, apparentMin, sunrise, sunset, precipSum, precipHours, precipProbabilityMax, windMax, windGustMax, uvIndexMax, tempUnit, precipUnit, windUnit` |
+
+The `latitude` / `longitude` columns from `geocode` round-trip into `forecast`.
+
+## Options
+
+### `geocode`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | Place name (e.g. `Tokyo`, `San Francisco`) |
+| `--limit` | Max results (1–100, default: 10) |
+
+### `forecast`
+
+| Option | Description |
+|--------|-------------|
+| `latitude` (positional) | Latitude in decimal degrees (-90 to 90) |
+| `longitude` (positional) | Longitude in decimal degrees (-180 to 180) |
+| `--days` | Forecast days (1–16, default: 7) |
+
+## Notes
+
+- **`weather` decodes WMO weather codes** to human labels (`'Clear sky'`, `'Drizzle: light'`, `'Thunderstorm with heavy hail'`). The raw `weatherCode` is also surfaced for programmatic use.
+- **Units travel with the row.** `tempUnit` is `'°C'` (Open-Meteo default), `precipUnit` is `'mm'`, `windUnit` is `'km/h'`. They are returned per-row so agents can show units alongside values without a separate lookup.
+- **Timezone is auto-detected from the lat/lon pair** (`timezone=auto`). Sunrise / sunset / time-of-day fields come back in the location's local timezone.
+- **No silent clamping on `--days`.** The adapter requests exactly `forecast_days=N` from Open-Meteo and emits one row per returned day. If Open-Meteo returns fewer rows (e.g. because the model horizon is exceeded), every row that came back is surfaced — no padding, no truncation.
+- **`featureCode`** is the GeoNames feature class (`PPLC` = capital city, `PPL` = populated place, `PPLA` = first-order admin division). Useful for filtering geocode hits.
+- **No API key required.** Open-Meteo's free tier allows ~10k requests/day from a single IP; bursts → `CommandExecutionError`.
+- **Errors.** Out-of-range lat/lon, bad days, empty geocode query → `ArgumentError`; unknown place → `EmptyResultError`; HTTP 400 (Open-Meteo bad-params) / 429 / transport → `CommandExecutionError`.

--- a/docs/adapters/browser/openlibrary.md
+++ b/docs/adapters/browser/openlibrary.md
@@ -1,0 +1,59 @@
+# Open Library
+
+**Mode**: 🌐 Public · **Domain**: `openlibrary.org`
+
+Search Open Library by keyword and fetch full work metadata by Open Library work id. Open Library is the Internet Archive's open book registry — every public work has a stable `OL<digits>W` key. No API key required.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli openlibrary search <query>` | Open Library books by keyword (title, author, first publish year, ebook access) |
+| `opencli openlibrary work <workKey>` | Full Open Library work metadata (description, subjects, ratings, cover ids) |
+
+## Usage Examples
+
+```bash
+# Title / author / subject search
+opencli openlibrary search "fantastic mr fox"
+opencli openlibrary search "ursula le guin" --limit 30
+
+# Work detail (key round-trips from search)
+opencli openlibrary work OL45804W
+opencli openlibrary work /works/OL45804W                          # courtesy: path form accepted
+opencli openlibrary work https://openlibrary.org/works/OL45804W   # courtesy: full URL accepted
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, workKey, title, author, firstPublished, editions, ebook, language, isbn, subjects, coverId, url` |
+| `work` | `workKey, title, subtitle, authors, description, subjects, subjectPlaces, subjectPeople, subjectTimes, firstPublished, coverIds, rating, ratingsCount, editionsUrl, url` |
+
+The `workKey` column from `search` round-trips into `work`.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Search keyword (title / author / subject) |
+| `--limit` | Max rows (1–100, default: 20) |
+
+### `work`
+
+| Option | Description |
+|--------|-------------|
+| `workKey` (positional) | Open Library work key (e.g. `OL45804W`); `/works/<id>` paths and full URLs are stripped automatically. Editions (`OL...M`) and authors (`OL...A`) are rejected. |
+
+## Notes
+
+- **`description` flattens both Open Library description shapes** — sometimes a plain string, sometimes `{type: '/type/text', value: '...'}`. The adapter normalises to a trimmed string and returns `null` when empty.
+- **`rating` / `ratingsCount`** come from a sibling endpoint (`/works/<id>/ratings.json`). When ratings 404 (common for niche works), both fields fall back to `null` instead of failing the whole detail request.
+- **`subjects`, `subjectPlaces`, `subjectPeople`, `subjectTimes`** are Open Library's three-axis taxonomy. Each column is comma-joined; the column itself is `null` when the work has no entries on that axis.
+- **`authors` returns Open Library author keys** (`OL34184A`-style), comma-joined. Open Library doesn't ship author display names on the work payload — agents that need names should call `https://openlibrary.org/authors/<id>.json` directly.
+- **`coverIds` is at most 5 ids.** Construct a cover URL with `https://covers.openlibrary.org/b/id/<id>-L.jpg` (`-S`/`-M`/`-L` for size).
+- **No API key required.** Open Library throttles unauthenticated traffic; bursts → `CommandExecutionError`.
+- **Errors.** Bad work key shape / bad limit → `ArgumentError`; unknown work → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/pub-dev.md
+++ b/docs/adapters/browser/pub-dev.md
@@ -1,0 +1,59 @@
+# pub.dev
+
+**Mode**: 🌐 Public · **Domain**: `pub.dev`
+
+Fetch latest pub.dev package metadata or list every published version for a Dart / Flutter package. Hits the unauthenticated `pub.dev/api` JSON endpoints.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli pub-dev package <name>` | Latest pub.dev package metadata (version, dependencies, SDK constraint) |
+| `opencli pub-dev versions <name>` | Published versions of a pub.dev package (newest first) |
+
+## Usage Examples
+
+```bash
+# Latest version + pubspec
+opencli pub-dev package http
+opencli pub-dev package provider
+opencli pub-dev package riverpod
+
+# Every published version, newest first
+opencli pub-dev versions http
+opencli pub-dev versions provider --limit 50
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `package` | `package, version, publishedAt, description, repository, homepage, sdk, flutter, dependencies, devDependencies, topics, archive, url` |
+| `versions` | `rank, package, version, publishedAt, archive, url` |
+
+The `package` column round-trips between commands; the `version` column from `versions` becomes the `version` field on `package` (latest only — pub.dev's archive URL also shows historical versions).
+
+## Options
+
+### `package`
+
+| Option | Description |
+|--------|-------------|
+| `package` (positional) | pub.dev package name (e.g. `http`, `provider`, `riverpod`) |
+
+### `versions`
+
+| Option | Description |
+|--------|-------------|
+| `package` (positional) | pub.dev package name |
+| `--limit` | Max rows (1–500, default: 30) |
+
+## Notes
+
+- **Package names are validated as `^[a-z][a-z0-9_]*$`** — Dart's package layout spec, lowercase letters / digits / underscores, leading letter. Bad shapes → `ArgumentError` (no wasted request).
+- **`versions` are reversed to newest-first.** pub.dev's API returns `versions[]` oldest-first; the adapter reverses so rank 1 = latest. The latest version also surfaces directly on `package` (`version` + `publishedAt`).
+- **`dependencies` / `devDependencies`** are flat name lists (comma-joined). Versions / constraints are not included — fetch the archive (`archive` column) for full pubspec.yaml.
+- **`topics`** is the pub.dev tags list (`http`, `network`, `flutter`, etc.) — useful for filtering / discovery.
+- **`flutter`** is null for pure-Dart packages; populated when the pubspec sets a Flutter SDK constraint.
+- **No API key required.** pub.dev throttles unauthenticated traffic; bursts → `CommandExecutionError`.
+- **Errors.** Bad package name / bad limit → `ArgumentError`; unknown package → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -134,6 +134,12 @@ Run `opencli list` for the live registry.
 | **[nuget](./browser/nuget.md)**                   | `search` `package`                                                                                                                             | 🌐 Public    |
 | **[flathub](./browser/flathub.md)**               | `search` `app`                                                                                                                                 | 🌐 Public    |
 | **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
+| **[crossref](./browser/crossref.md)**             | `works` `work`                                                                                                                                 | 🌐 Public    |
+| **[openlibrary](./browser/openlibrary.md)**       | `search` `work`                                                                                                                                | 🌐 Public    |
+| **[musicbrainz](./browser/musicbrainz.md)**       | `artist` `release`                                                                                                                             | 🌐 Public    |
+| **[pub-dev](./browser/pub-dev.md)**               | `package` `versions`                                                                                                                           | 🌐 Public    |
+| **[hex-pm](./browser/hex-pm.md)**                 | `package` `versions`                                                                                                                           | 🌐 Public    |
+| **[open-meteo](./browser/open-meteo.md)**         | `geocode` `forecast`                                                                                                                           | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

**Scope-reduced per WAWQAQ feedback (msg=3899a382)**: original Round 6 added 6 sites; musicbrainz (niche music metadata DB) has been dropped. Kept only sites with clear real-world utility:

- **crossref** (`works`, `work`) — academic DOI lookup, no auth.
- **openlibrary** (`search`, `work`) — book/work metadata + ISBN round-trip via `id` from work key.
- **pub-dev** (`package`, `versions`) — Dart/Flutter packages.
- **hex-pm** (`package`, `versions`) — Elixir/Erlang packages.
- **open-meteo** (`geocode`, `forecast`) — weather + geocoding, no API key.

Includes the openlibrary `/search.json?fields=` projection fix (squashed): default response silently drops isbn / subject — explicit projection added so columns aren't silently empty.

40 contract tests covering MusicBrainz removal, paginated ratings 404 tolerance, pub-dev versions reversed oldest→newest, hex-pm surfaces both latestVersion + latestStableVersion (no silent fallback), crossref Lucene operator handling, openlibrary fields projection.

Manifest 757→762 (+5). Audits clean: `typed-error-lint=196` baseline preserved.

## Self-check
- ✅ All 10 commands declare `access: 'read'`
- ✅ Typed errors only: `ArgumentError / EmptyResultError / CommandExecutionError`
- ✅ No silent-fallback / silent-sentinel / silent-column-drop
- ✅ Live-verified all 5 sites
- ✅ Audits clean, 36/36 tests pass
- ✅ Listing↔detail id pairing: openlibrary `search.id → work <work-id>`, crossref `works.doi → work <doi>`, pub-dev/hex-pm `package.name → versions <name>`

## Test plan
- [x] `npx vitest run clis/{crossref,openlibrary,pub-dev,hex-pm,open-meteo}/` — 36/36 passing
- [x] `node scripts/check-typed-error-lint.mjs` — 196 baseline preserved
- [x] `npx tsx src/build-manifest.ts` — 762 entries
- [x] Live-verified all 5 sites