### PR TITLE
feat: 12 read adapters across 6 new sites + contract tests (round 7)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8899,6 +8899,85 @@
     "navigateBefore": "https://www.facebook.com"
   },
   {
+    "site": "flathub",
+    "name": "app",
+    "description": "Full Flathub appstream metadata for an app id (license, categories, latest release)",
+    "access": "read",
+    "domain": "flathub.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "AppStream id (e.g. \"org.mozilla.firefox\", \"org.gnome.Calculator\")"
+      }
+    ],
+    "columns": [
+      "appId",
+      "name",
+      "summary",
+      "developer",
+      "license",
+      "isFreeLicense",
+      "isEol",
+      "categories",
+      "keywords",
+      "latestVersion",
+      "latestReleaseDate",
+      "homepage",
+      "bugtracker",
+      "donation",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "flathub/app.js",
+    "sourceFile": "flathub/app.js"
+  },
+  {
+    "site": "flathub",
+    "name": "search",
+    "description": "Search Flathub apps by keyword",
+    "access": "read",
+    "domain": "flathub.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Max apps (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "appId",
+      "name",
+      "summary",
+      "developer",
+      "license",
+      "isFreeLicense",
+      "mainCategories",
+      "installsLastMonth",
+      "updatedAt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "flathub/search.js",
+    "sourceFile": "flathub/search.js"
+  },
+  {
     "site": "gemini",
     "name": "ask",
     "description": "Send a prompt to Gemini and return only the assistant response",
@@ -12985,6 +13064,86 @@
     "sourceFile": "lesswrong/user-posts.js"
   },
   {
+    "site": "lichess",
+    "name": "top",
+    "description": "Top-N Lichess leaderboard for a perf type (bullet/blitz/rapid/classical/...)",
+    "access": "read",
+    "domain": "lichess.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "perf",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Perf type (bullet, blitz, rapid, classical, ultraBullet, chess960, ...)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Top-N rows (1-200)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "username",
+      "id",
+      "title",
+      "rating",
+      "progress",
+      "patron",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "lichess/top.js",
+    "sourceFile": "lichess/top.js"
+  },
+  {
+    "site": "lichess",
+    "name": "user",
+    "description": "Fetch a Lichess player profile by username (rating, perfs, counts)",
+    "access": "read",
+    "domain": "lichess.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "username",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Lichess username (case-insensitive)"
+      }
+    ],
+    "columns": [
+      "username",
+      "id",
+      "title",
+      "patron",
+      "online",
+      "tosViolation",
+      "createdAt",
+      "seenAt",
+      "gamesAll",
+      "gamesWin",
+      "gamesLoss",
+      "gamesDraw",
+      "topPerfName",
+      "topPerfRating",
+      "topPerfGames",
+      "fideRating",
+      "country",
+      "bio",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "lichess/user.js",
+    "sourceFile": "lichess/user.js"
+  },
+  {
     "site": "linkedin",
     "name": "search",
     "description": "Search LinkedIn jobs",
@@ -15510,6 +15669,89 @@
     "sourceFile": "npm/search.js"
   },
   {
+    "site": "nuget",
+    "name": "package",
+    "description": "Full NuGet package version history (catalogEntry per release)",
+    "access": "read",
+    "domain": "api.nuget.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "NuGet package id (e.g. \"Newtonsoft.Json\", case-insensitive)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "version",
+      "title",
+      "authors",
+      "tags",
+      "language",
+      "licenseExpression",
+      "projectUrl",
+      "published",
+      "listed",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "nuget/package.js",
+    "sourceFile": "nuget/package.js"
+  },
+  {
+    "site": "nuget",
+    "name": "search",
+    "description": "Search NuGet packages by keyword",
+    "access": "read",
+    "domain": "api.nuget.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max packages (1-1000)"
+      },
+      {
+        "name": "prerelease",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Include prerelease versions"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "version",
+      "title",
+      "description",
+      "authors",
+      "tags",
+      "totalDownloads",
+      "verified",
+      "projectUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "nuget/search.js",
+    "sourceFile": "nuget/search.js"
+  },
+  {
     "site": "nvd",
     "name": "cve",
     "description": "NIST NVD CVE detail (description, CVSS, CWE, KEV flag)",
@@ -15542,6 +15784,82 @@
     "type": "js",
     "modulePath": "nvd/cve.js",
     "sourceFile": "nvd/cve.js"
+  },
+  {
+    "site": "oeis",
+    "name": "search",
+    "description": "Search OEIS sequences by keyword or numeric pattern",
+    "access": "read",
+    "domain": "oeis.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword or comma-separated terms (e.g. \"fibonacci\", \"1,1,2,3,5,8\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max sequences (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "keywords",
+      "preview",
+      "author",
+      "created",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "oeis/search.js",
+    "sourceFile": "oeis/search.js"
+  },
+  {
+    "site": "oeis",
+    "name": "sequence",
+    "description": "Full OEIS sequence detail by A-number (terms, name, keywords, formula counts)",
+    "access": "read",
+    "domain": "oeis.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "OEIS sequence id (e.g. \"A000045\" for Fibonacci)"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "keywords",
+      "preview",
+      "termCount",
+      "offset",
+      "author",
+      "created",
+      "revision",
+      "commentCount",
+      "formulaCount",
+      "referenceCount",
+      "xrefCount",
+      "linkCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "oeis/sequence.js",
+    "sourceFile": "oeis/sequence.js"
   },
   {
     "site": "ones",
@@ -18279,6 +18597,108 @@
     "modulePath": "reddit/user-posts.js",
     "sourceFile": "reddit/user-posts.js",
     "navigateBefore": "https://reddit.com"
+  },
+  {
+    "site": "rest-countries",
+    "name": "country",
+    "description": "Look up countries by name (common / official, substring match)",
+    "access": "read",
+    "domain": "restcountries.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Country name (e.g. \"japan\", \"united kingdom\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Max rows (1-250)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "commonName",
+      "officialName",
+      "cca2",
+      "cca3",
+      "ccn3",
+      "capital",
+      "region",
+      "subregion",
+      "population",
+      "area",
+      "languages",
+      "currencies",
+      "latitude",
+      "longitude",
+      "timezones",
+      "independent",
+      "unMember",
+      "landlocked",
+      "flag",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "rest-countries/country.js",
+    "sourceFile": "rest-countries/country.js"
+  },
+  {
+    "site": "rest-countries",
+    "name": "region",
+    "description": "List countries in a region (africa / americas / asia / europe / oceania / antarctic)",
+    "access": "read",
+    "domain": "restcountries.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "region",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Region name (case-insensitive)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 250,
+        "required": false,
+        "help": "Max rows (1-250)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "commonName",
+      "officialName",
+      "cca2",
+      "cca3",
+      "ccn3",
+      "capital",
+      "region",
+      "subregion",
+      "population",
+      "area",
+      "languages",
+      "currencies",
+      "latitude",
+      "longitude",
+      "timezones",
+      "independent",
+      "unMember",
+      "landlocked",
+      "flag",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "rest-countries/region.js",
+    "sourceFile": "rest-countries/region.js"
   },
   {
     "site": "reuters",
@@ -22842,6 +23262,90 @@
     "modulePath": "weread/shelf.js",
     "sourceFile": "weread/shelf.js",
     "navigateBefore": "https://weread.qq.com"
+  },
+  {
+    "site": "wikidata",
+    "name": "entity",
+    "description": "Fetch a Wikidata entity by Q/P/L id (label, description, aliases, claim summary)",
+    "access": "read",
+    "domain": "www.wikidata.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Entity id (e.g. Q937 = Albert Einstein, P31 = instance of)"
+      },
+      {
+        "name": "language",
+        "type": "str",
+        "default": "en",
+        "required": false,
+        "help": "Display language (ISO 639, falls back to English when missing)"
+      }
+    ],
+    "columns": [
+      "qid",
+      "type",
+      "label",
+      "description",
+      "aliases",
+      "claimPropertyCount",
+      "sitelinkCount",
+      "enwikiTitle",
+      "modified",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "wikidata/entity.js",
+    "sourceFile": "wikidata/entity.js"
+  },
+  {
+    "site": "wikidata",
+    "name": "search",
+    "description": "Search Wikidata items by keyword (returns Q-IDs)",
+    "access": "read",
+    "domain": "www.wikidata.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (label / alias)"
+      },
+      {
+        "name": "language",
+        "type": "str",
+        "default": "en",
+        "required": false,
+        "help": "Search & display language (ISO 639, e.g. en, fr, zh)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max items (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "qid",
+      "label",
+      "description",
+      "matchType",
+      "matchText",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "wikidata/search.js",
+    "sourceFile": "wikidata/search.js"
   },
   {
     "site": "wikipedia",

--- a/clis/flathub/app.js
+++ b/clis/flathub/app.js
@@ -1,0 +1,71 @@
+// flathub app — full appstream metadata for a Flathub app id.
+//
+// Hits `/api/v2/appstream/<appId>`. AppStream IDs are reverse-DNS (e.g.
+// "org.mozilla.firefox", "org.gnome.Calculator").
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    FLATHUB_API_BASE,
+    FLATHUB_APP_BASE,
+    flathubFetch,
+    joinList,
+    pickLatestRelease,
+    requireAppId,
+} from './utils.js';
+
+cli({
+    site: 'flathub',
+    name: 'app',
+    access: 'read',
+    description: 'Full Flathub appstream metadata for an app id (license, categories, latest release)',
+    domain: 'flathub.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'appId', positional: true, required: true, help: 'AppStream id (e.g. "org.mozilla.firefox", "org.gnome.Calculator")' },
+    ],
+    columns: [
+        'appId',
+        'name',
+        'summary',
+        'developer',
+        'license',
+        'isFreeLicense',
+        'isEol',
+        'categories',
+        'keywords',
+        'latestVersion',
+        'latestReleaseDate',
+        'homepage',
+        'bugtracker',
+        'donation',
+        'url',
+    ],
+    func: async (args) => {
+        const appId = requireAppId(args.appId);
+        const url = `${FLATHUB_API_BASE}/appstream/${encodeURIComponent(appId)}`;
+        const body = await flathubFetch(url, 'flathub app');
+        if (!body || typeof body !== 'object' || !body.id) {
+            throw new EmptyResultError('flathub app', `Flathub app "${appId}" returned empty payload.`);
+        }
+        const urls = body.urls && typeof body.urls === 'object' ? body.urls : {};
+        const release = pickLatestRelease(body.releases);
+        return [{
+            appId: typeof body.id === 'string' ? body.id : appId,
+            name: typeof body.name === 'string' ? body.name : null,
+            summary: typeof body.summary === 'string' ? body.summary : null,
+            developer: typeof body.developer_name === 'string' ? body.developer_name : null,
+            license: typeof body.project_license === 'string' ? body.project_license : null,
+            isFreeLicense: body.is_free_license === true,
+            isEol: body.is_eol === true,
+            categories: joinList(body.categories),
+            keywords: joinList(body.keywords, 8),
+            latestVersion: release.version,
+            latestReleaseDate: release.date,
+            homepage: typeof urls.homepage === 'string' ? urls.homepage : null,
+            bugtracker: typeof urls.bugtracker === 'string' ? urls.bugtracker : null,
+            donation: typeof urls.donation === 'string' ? urls.donation : null,
+            url: `${FLATHUB_APP_BASE}/${appId}`,
+        }];
+    },
+});

--- a/clis/flathub/flathub.test.js
+++ b/clis/flathub/flathub.test.js
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './app.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('flathub search adapter', () => {
+    const cmd = getRegistry().get('flathub/search');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('throttled', { status: 429 })));
+        await expect(cmd.func({ query: 'firefox' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty hits', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ hits: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'no-such-app' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips appId into flathub.org URL and normalises updated_at unix-seconds to ISO', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            hits: [{
+                app_id: 'org.mozilla.firefox', name: 'Firefox', summary: 'Web browser',
+                developer_name: 'Mozilla', project_license: 'MPL-2.0', is_free_license: true,
+                main_categories: 'network', installs_last_month: 100000,
+                updated_at: 1730000000,
+            }],
+        }), { status: 200 })));
+        const rows = await cmd.func({ query: 'firefox', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, appId: 'org.mozilla.firefox', name: 'Firefox',
+            license: 'MPL-2.0', isFreeLicense: true, mainCategories: 'network',
+            installsLastMonth: 100000, updatedAt: '2024-10-27',
+            url: 'https://flathub.org/apps/org.mozilla.firefox',
+        });
+    });
+});
+
+describe('flathub app adapter', () => {
+    const cmd = getRegistry().get('flathub/app');
+
+    it('rejects malformed appId before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ appId: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ appId: 'no-dot' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ appId: '.starts.with.dot' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('missing', { status: 404 })));
+        await expect(cmd.func({ appId: 'org.example.does-not-exist' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('handles releases with string-typed timestamps (flathub appstream quirk)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            id: 'org.mozilla.firefox', name: 'Firefox', summary: 'Web browser',
+            developer_name: 'Mozilla', project_license: 'MPL-2.0', is_free_license: true,
+            categories: ['Network', 'WebBrowser'], keywords: ['Browser'],
+            urls: { homepage: 'https://www.mozilla.org/firefox/' },
+            releases: [
+                // upstream emits these as numeric strings, not numbers
+                { version: '150.0.1', timestamp: '1777248000', type: 'stable' },
+                { version: '149.0.0', timestamp: '1770000000', type: 'stable' },
+            ],
+        }), { status: 200 })));
+        const rows = await cmd.func({ appId: 'org.mozilla.firefox' });
+        expect(rows[0]).toMatchObject({
+            appId: 'org.mozilla.firefox', name: 'Firefox',
+            categories: 'Network, WebBrowser',
+            latestVersion: '150.0.1', latestReleaseDate: '2026-04-27',
+            homepage: 'https://www.mozilla.org/firefox/',
+            url: 'https://flathub.org/apps/org.mozilla.firefox',
+        });
+    });
+});

--- a/clis/flathub/search.js
+++ b/clis/flathub/search.js
@@ -1,0 +1,80 @@
+// flathub search — keyword search the Flathub app registry.
+//
+// POSTs to `/api/v2/search` with `{query}`. The `appId` column round-trips into
+// `flathub app` for full appstream detail. Note: the search hit's `id` is
+// underscored (e.g. `org_mozilla_firefox`); the actual reverse-DNS appId lives
+// at `app_id`. We surface the dotted form so it round-trips without translation.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    FLATHUB_API_BASE,
+    FLATHUB_APP_BASE,
+    flathubFetch,
+    joinList,
+    requireBoundedInt,
+    requireString,
+} from './utils.js';
+
+cli({
+    site: 'flathub',
+    name: 'search',
+    access: 'read',
+    description: 'Search Flathub apps by keyword',
+    domain: 'flathub.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword' },
+        { name: 'limit', type: 'int', default: 25, help: 'Max apps (1-100)' },
+    ],
+    columns: [
+        'rank',
+        'appId',
+        'name',
+        'summary',
+        'developer',
+        'license',
+        'isFreeLicense',
+        'mainCategories',
+        'installsLastMonth',
+        'updatedAt',
+        'url',
+    ],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 25, 100);
+        const url = `${FLATHUB_API_BASE}/search`;
+        const body = await flathubFetch(url, 'flathub search', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ query, hitsPerPage: limit, page: 1 }),
+        });
+        const list = Array.isArray(body?.hits) ? body.hits : [];
+        if (!list.length) {
+            throw new EmptyResultError('flathub search', `No Flathub apps matched "${query}".`);
+        }
+        return list.slice(0, limit).map((hit, i) => {
+            const appId = typeof hit?.app_id === 'string' ? hit.app_id : null;
+            return {
+                rank: i + 1,
+                appId,
+                name: typeof hit?.name === 'string' ? hit.name : null,
+                summary: typeof hit?.summary === 'string' ? hit.summary : null,
+                developer: typeof hit?.developer_name === 'string' ? hit.developer_name : null,
+                license: typeof hit?.project_license === 'string' ? hit.project_license : null,
+                isFreeLicense: hit?.is_free_license === true,
+                // `main_categories` comes back as a string (single value) on /search, not an array.
+                mainCategories: typeof hit?.main_categories === 'string'
+                    ? hit.main_categories
+                    : joinList(hit?.main_categories),
+                installsLastMonth: typeof hit?.installs_last_month === 'number' ? hit.installs_last_month : null,
+                // /search emits `updated_at` as unix-seconds int; /appstream emits ISO strings.
+                // Normalise to ISO date here so both surfaces look consistent.
+                updatedAt: typeof hit?.updated_at === 'number' && hit.updated_at > 0
+                    ? new Date(hit.updated_at * 1000).toISOString().slice(0, 10)
+                    : (typeof hit?.updated_at === 'string' ? hit.updated_at : null),
+                url: appId ? `${FLATHUB_APP_BASE}/${appId}` : '',
+            };
+        });
+    },
+});

--- a/clis/flathub/utils.js
+++ b/clis/flathub/utils.js
@@ -1,0 +1,114 @@
+// Shared helpers for the Flathub adapters (https://flathub.org).
+//
+// Flathub is the canonical Linux flatpak app registry. Public REST API at
+// `flathub.org/api/v2`, no auth, no key. Two endpoints we surface:
+//   • POST /search      → keyword search, returns app metadata
+//   • GET  /appstream/<appId> → full appstream metadata for one app
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const FLATHUB_API_BASE = 'https://flathub.org/api/v2';
+export const FLATHUB_APP_BASE = 'https://flathub.org/apps';
+const UA = 'opencli-flathub-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// AppStream IDs are reverse-DNS (e.g. "org.gnome.Calculator"); the spec allows
+// letters, digits, `.`, `_`, `-`. Min two segments separated by `.`.
+const APP_ID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*(?:\.[A-Za-z0-9_][A-Za-z0-9_-]*){1,}$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`flathub ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`flathub ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`flathub ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireAppId(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('flathub appId is required (e.g. "org.mozilla.firefox")');
+    if (!APP_ID_PATTERN.test(raw)) {
+        throw new ArgumentError(
+            `flathub appId "${value}" is not a valid AppStream identifier`,
+            'AppStream IDs use reverse-DNS like "org.mozilla.firefox" — letters/digits/`._-` with at least one dot.',
+        );
+    }
+    return raw;
+}
+
+export async function flathubFetch(url, label, init) {
+    let resp;
+    try {
+        resp = await fetch(url, {
+            method: init?.method ?? 'GET',
+            headers: { 'user-agent': UA, accept: 'application/json', ...(init?.headers ?? {}) },
+            body: init?.body,
+        });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that flathub.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Flathub returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+export function joinList(value, max = 10) {
+    if (!Array.isArray(value)) return '';
+    const items = value.filter((v) => typeof v === 'string' && v.trim());
+    if (items.length === 0) return '';
+    if (items.length > max) return [...items.slice(0, max), `(+${items.length - max})`].join(', ');
+    return items.join(', ');
+}
+
+// Coerce flathub's `timestamp` field (sometimes int, sometimes numeric string).
+function timestampNumber(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && /^\d+$/.test(value.trim())) return Number(value.trim());
+    return 0;
+}
+
+/** Pick the most recent appstream `releases[].version` if present. */
+export function pickLatestRelease(releases) {
+    if (!Array.isArray(releases) || releases.length === 0) return { version: null, date: null };
+    // releases[].timestamp is unix-seconds; flathub returns either int or numeric string.
+    const sorted = [...releases].filter((r) => r && typeof r === 'object').sort((a, b) => {
+        return timestampNumber(b?.timestamp) - timestampNumber(a?.timestamp);
+    });
+    const top = sorted[0];
+    if (!top) return { version: null, date: null };
+    let date = null;
+    const ts = timestampNumber(top.timestamp);
+    if (ts > 0) {
+        const d = new Date(ts * 1000);
+        if (!Number.isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+    }
+    // Fallback: appstream emits `date` as ISO string ("2024-12-09") for some apps.
+    if (!date && typeof top.date === 'string' && top.date.trim()) date = top.date.trim();
+    return { version: typeof top.version === 'string' ? top.version : null, date };
+}

--- a/clis/lichess/lichess.test.js
+++ b/clis/lichess/lichess.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './user.js';
+import './top.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('lichess user adapter', () => {
+    const cmd = getRegistry().get('lichess/user');
+
+    it('rejects bad usernames before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ username: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ username: 'a' })).rejects.toThrow(ArgumentError); // too short
+        await expect(cmd.func({ username: 'has space' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ username: 'somebody' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('treats disabled accounts as EmptyResultError (not row of nulls)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            id: 'closed-user', username: 'ClosedUser', disabled: true,
+        }), { status: 200 })));
+        await expect(cmd.func({ username: 'ClosedUser' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('picks the most-played perf as topPerf', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            id: 'someplayer',
+            username: 'SomePlayer',
+            createdAt: 1543000000000,
+            seenAt: 1700000000000,
+            count: { all: 100, win: 50, loss: 30, draw: 20 },
+            perfs: {
+                bullet: { games: 9000, rating: 2700 },
+                blitz: { games: 100, rating: 2200 },
+                puzzle: { games: 99999, rating: 2900 }, // ignored — not playable
+            },
+        }), { status: 200 })));
+        const rows = await cmd.func({ username: 'SomePlayer' });
+        expect(rows[0]).toMatchObject({
+            username: 'SomePlayer', id: 'someplayer',
+            gamesAll: 100, topPerfName: 'bullet', topPerfRating: 2700, topPerfGames: 9000,
+            url: 'https://lichess.org/@/SomePlayer',
+        });
+    });
+});
+
+describe('lichess top adapter', () => {
+    const cmd = getRegistry().get('lichess/top');
+
+    it('rejects unknown perf types before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ perf: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ perf: 'turbo' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ perf: 'blitz', limit: 9999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError on empty leaderboard', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ users: [] }), { status: 200 })));
+        await expect(cmd.func({ perf: 'blitz', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips username from leaderboard into perf-specific URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            users: [{ id: 'magnus', username: 'Magnus', title: 'GM', perfs: { blitz: { rating: 3001, progress: 7 } } }],
+        }), { status: 200 })));
+        const rows = await cmd.func({ perf: 'blitz', limit: 3 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, username: 'Magnus', title: 'GM', rating: 3001, progress: 7,
+            url: 'https://lichess.org/@/Magnus/perf/blitz',
+        });
+    });
+});

--- a/clis/lichess/top.js
+++ b/clis/lichess/top.js
@@ -1,0 +1,46 @@
+// lichess top — top-N leaderboard for a given perf type.
+//
+// Hits `/api/player/top/<n>/<perf>`. Returns the leaderboard rows; usernames
+// round-trip into `lichess user` for full profile detail.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { LICHESS_BASE, lichessFetch, requireBoundedInt, requirePerf } from './utils.js';
+
+cli({
+    site: 'lichess',
+    name: 'top',
+    access: 'read',
+    description: 'Top-N Lichess leaderboard for a perf type (bullet/blitz/rapid/classical/...)',
+    domain: 'lichess.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'perf', positional: true, required: true, help: 'Perf type (bullet, blitz, rapid, classical, ultraBullet, chess960, ...)' },
+        { name: 'limit', type: 'int', default: 10, help: 'Top-N rows (1-200)' },
+    ],
+    columns: ['rank', 'username', 'id', 'title', 'rating', 'progress', 'patron', 'url'],
+    func: async (args) => {
+        const perf = requirePerf(args.perf);
+        const limit = requireBoundedInt(args.limit, 10, 200);
+        const url = `${LICHESS_BASE}/api/player/top/${limit}/${encodeURIComponent(perf)}`;
+        const body = await lichessFetch(url, 'lichess top');
+        const list = Array.isArray(body?.users) ? body.users : [];
+        if (!list.length) {
+            throw new EmptyResultError('lichess top', `Lichess returned no leaderboard rows for perf "${perf}".`);
+        }
+        return list.slice(0, limit).map((u, i) => {
+            const username = typeof u?.username === 'string' ? u.username : '';
+            const perfBlock = u?.perfs && typeof u.perfs === 'object' ? u.perfs[perf] ?? {} : {};
+            return {
+                rank: i + 1,
+                username,
+                id: typeof u?.id === 'string' ? u.id : null,
+                title: typeof u?.title === 'string' ? u.title : null,
+                rating: typeof perfBlock.rating === 'number' ? perfBlock.rating : null,
+                progress: typeof perfBlock.progress === 'number' ? perfBlock.progress : null,
+                patron: u?.patron === true,
+                url: username ? `${LICHESS_BASE}/@/${encodeURIComponent(username)}/perf/${encodeURIComponent(perf)}` : '',
+            };
+        });
+    },
+});

--- a/clis/lichess/user.js
+++ b/clis/lichess/user.js
@@ -1,0 +1,91 @@
+// lichess user — fetch a public Lichess player profile.
+//
+// Hits `/api/user/<username>`. Returns the agent-useful slice: handle, title,
+// flags (online / patron), counts, top-rated perf, profile bio.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { LICHESS_BASE, formatTimestamp, lichessFetch, requireUsername } from './utils.js';
+
+cli({
+    site: 'lichess',
+    name: 'user',
+    access: 'read',
+    description: 'Fetch a Lichess player profile by username (rating, perfs, counts)',
+    domain: 'lichess.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'username', positional: true, required: true, help: 'Lichess username (case-insensitive)' },
+    ],
+    columns: [
+        'username',
+        'id',
+        'title',
+        'patron',
+        'online',
+        'tosViolation',
+        'createdAt',
+        'seenAt',
+        'gamesAll',
+        'gamesWin',
+        'gamesLoss',
+        'gamesDraw',
+        'topPerfName',
+        'topPerfRating',
+        'topPerfGames',
+        'fideRating',
+        'country',
+        'bio',
+        'url',
+    ],
+    func: async (args) => {
+        const username = requireUsername(args.username);
+        const url = `${LICHESS_BASE}/api/user/${encodeURIComponent(username)}`;
+        const body = await lichessFetch(url, 'lichess user');
+        if (!body || typeof body !== 'object') {
+            throw new EmptyResultError('lichess user', `Lichess user "${username}" returned empty payload.`);
+        }
+        // Lichess marks closed accounts with `disabled: true` and strips data.
+        // Surface as EmptyResultError instead of a row of nulls (silent-fallback).
+        if (body.disabled === true) {
+            throw new EmptyResultError('lichess user', `Lichess user "${username}" is closed/disabled.`);
+        }
+        const perfs = body.perfs && typeof body.perfs === 'object' ? body.perfs : {};
+        // Pick the perf with the most games (excluding puzzle/storm/racer ephemera).
+        const playablePerfs = Object.entries(perfs).filter(([k, v]) => v && typeof v === 'object' && !['puzzle', 'storm', 'racer', 'streak'].includes(k));
+        let topPerfName = null;
+        let topPerfRating = null;
+        let topPerfGames = null;
+        for (const [name, p] of playablePerfs) {
+            const games = typeof p.games === 'number' ? p.games : 0;
+            if (topPerfGames == null || games > topPerfGames) {
+                topPerfName = name;
+                topPerfGames = games;
+                topPerfRating = typeof p.rating === 'number' ? p.rating : null;
+            }
+        }
+        const counts = body.count && typeof body.count === 'object' ? body.count : {};
+        const profile = body.profile && typeof body.profile === 'object' ? body.profile : {};
+        return [{
+            username: typeof body.username === 'string' ? body.username : username,
+            id: typeof body.id === 'string' ? body.id : null,
+            title: typeof body.title === 'string' ? body.title : null,
+            patron: body.patron === true,
+            online: body.online === true,
+            tosViolation: body.tosViolation === true,
+            createdAt: formatTimestamp(body.createdAt),
+            seenAt: formatTimestamp(body.seenAt),
+            gamesAll: typeof counts.all === 'number' ? counts.all : null,
+            gamesWin: typeof counts.win === 'number' ? counts.win : null,
+            gamesLoss: typeof counts.loss === 'number' ? counts.loss : null,
+            gamesDraw: typeof counts.draw === 'number' ? counts.draw : null,
+            topPerfName,
+            topPerfRating,
+            topPerfGames,
+            fideRating: typeof profile.fideRating === 'number' ? profile.fideRating : null,
+            country: typeof profile.country === 'string' ? profile.country : null,
+            bio: typeof profile.bio === 'string' ? profile.bio.trim() : null,
+            url: `${LICHESS_BASE}/@/${encodeURIComponent(typeof body.username === 'string' ? body.username : username)}`,
+        }];
+    },
+});

--- a/clis/lichess/utils.js
+++ b/clis/lichess/utils.js
@@ -1,0 +1,97 @@
+// Shared helpers for the lichess.org public REST adapters.
+//
+// Lichess exposes a generous unauthenticated API at `lichess.org/api`. We keep
+// the surface narrow: `user` (profile) + `top` (per-perf top-N leaderboard).
+// No API key required; rate limit is 60 req/min per IP.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const LICHESS_BASE = 'https://lichess.org';
+const UA = 'opencli-lichess-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// Lichess usernames are 2-30 chars: letters, digits, underscore, dash. Case-insensitive.
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]{2,30}$/;
+
+// `perfType` values lichess accepts for the `/api/player/top/<n>/<perf>` endpoint.
+// Source: lichess-org/api docs.
+export const LICHESS_PERFS = new Set([
+    'ultraBullet', 'bullet', 'blitz', 'rapid', 'classical',
+    'chess960', 'crazyhouse', 'antichess', 'atomic', 'horde',
+    'kingOfTheHill', 'racingKings', 'threeCheck',
+]);
+
+export function requireUsername(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('lichess username is required');
+    if (!USERNAME_PATTERN.test(raw)) {
+        throw new ArgumentError(
+            `lichess username "${value}" is not a valid handle`,
+            'Allowed: letters, digits, underscore, dash; length 2-30.',
+        );
+    }
+    return raw;
+}
+
+export function requirePerf(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('lichess perf is required (e.g. "blitz", "bullet", "rapid")');
+    if (!LICHESS_PERFS.has(raw)) {
+        throw new ArgumentError(
+            `lichess perf "${value}" is not recognised`,
+            `Allowed values: ${[...LICHESS_PERFS].join(', ')}.`,
+        );
+    }
+    return raw;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`lichess ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`lichess ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function lichessFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that lichess.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Lichess returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Lichess throttles anonymous traffic at ~60 req/min; back off and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+/** Format a lichess unix-ms timestamp as ISO date (YYYY-MM-DD). `null` when missing. */
+export function formatTimestamp(ms) {
+    if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) return null;
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toISOString();
+}

--- a/clis/nuget/nuget.test.js
+++ b/clis/nuget/nuget.test.js
@@ -84,4 +84,28 @@ describe('nuget package adapter', () => {
             url: 'https://www.nuget.org/packages/Newtonsoft.Json/13.0.3',
         });
     });
+
+    it('follows registration stub pages instead of silently dropping old versions', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response(JSON.stringify({
+                items: [{ '@id': 'https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/page/1.json' }],
+            }), { status: 200 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify({
+                items: [
+                    { catalogEntry: { id: 'Newtonsoft.Json', version: '1.0.0', published: '2010-01-01T00:00:00Z' } },
+                    { catalogEntry: { id: 'Newtonsoft.Json', version: '2.0.0', published: '2011-01-01T00:00:00Z' } },
+                ],
+            }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+        const rows = await cmd.func({ id: 'Newtonsoft.Json' });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(rows.map((r) => r.version)).toEqual(['2.0.0', '1.0.0']);
+    });
+
+    it('fails fast on malformed stub pages to avoid partial version history', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            items: [{ lower: '1.0.0', upper: '2.0.0' }],
+        }), { status: 200 })));
+        await expect(cmd.func({ id: 'Newtonsoft.Json' })).rejects.toThrow(CommandExecutionError);
+    });
 });

--- a/clis/nuget/nuget.test.js
+++ b/clis/nuget/nuget.test.js
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './package.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('nuget search adapter', () => {
+    const cmd = getRegistry().get('nuget/search');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 99999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('throttled', { status: 429 })));
+        await expect(cmd.func({ query: 'newtonsoft' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty data list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'no-such-package' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips package id into nuget.org URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            data: [{
+                id: 'Newtonsoft.Json', version: '13.0.3',
+                title: 'Json.NET', description: 'Json.NET is a popular high-performance JSON framework for .NET',
+                authors: ['James Newton-King'], tags: ['json'], totalDownloads: 1000000, verified: true,
+                projectUrl: 'https://www.newtonsoft.com/json',
+            }],
+        }), { status: 200 })));
+        const rows = await cmd.func({ query: 'json', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, id: 'Newtonsoft.Json', version: '13.0.3', verified: true,
+            authors: 'James Newton-King', tags: 'json',
+            url: 'https://www.nuget.org/packages/Newtonsoft.Json',
+        });
+    });
+});
+
+describe('nuget package adapter', () => {
+    const cmd = getRegistry().get('nuget/package');
+
+    it('rejects malformed package ids before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ id: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'has space' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: '.starts-with-dot' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('missing', { status: 404 })));
+        await expect(cmd.func({ id: 'No.Such.Package.1234' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('flattens inline registration pages and sorts versions newest-first', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            items: [
+                {
+                    items: [
+                        { catalogEntry: { id: 'Newtonsoft.Json', version: '13.0.3', authors: ['JNK'], tags: ['json'], licenseExpression: 'MIT', published: '2023-03-08T20:00:00Z', listed: true } },
+                        { catalogEntry: { id: 'Newtonsoft.Json', version: '12.0.0', authors: ['JNK'], tags: ['json'], licenseExpression: 'MIT', published: '2018-01-17T20:00:00Z', listed: true } },
+                    ],
+                },
+            ],
+        }), { status: 200 })));
+        const rows = await cmd.func({ id: 'Newtonsoft.Json' });
+        expect(rows.map((r) => r.version)).toEqual(['13.0.3', '12.0.0']);
+        expect(rows[0]).toMatchObject({
+            rank: 1, id: 'Newtonsoft.Json', version: '13.0.3', authors: 'JNK', tags: 'json',
+            licenseExpression: 'MIT', listed: true,
+            url: 'https://www.nuget.org/packages/Newtonsoft.Json/13.0.3',
+        });
+    });
+});

--- a/clis/nuget/package.js
+++ b/clis/nuget/package.js
@@ -3,7 +3,7 @@
 // Hits the registration index `api.nuget.org/v3/registration5-semver1/<id>/index.json`.
 // The id path segment must be lowercase per NuGet's CDN routing.
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { NUGET_REGISTRATION_BASE, joinAuthors, joinTags, nugetFetch, requirePackageId } from './utils.js';
 
 cli({
@@ -40,17 +40,31 @@ cli({
         // for older packages. Inline is the common case for everything published in
         // the last few years. We follow stub pages once each — at most ~5 round-trips.
         const allEntries = [];
-        for (const page of pages) {
+        for (const [pageIndex, page] of pages.entries()) {
             let pageItems = Array.isArray(page?.items) ? page.items : null;
             if (!pageItems) {
                 // Stub page → fetch the leaf.
                 const pageUrl = typeof page?.['@id'] === 'string' ? page['@id'] : null;
-                if (!pageUrl) continue;
+                if (!pageUrl) {
+                    throw new CommandExecutionError(
+                        `nuget package registration page ${pageIndex + 1} is missing @id for package "${id}"`,
+                    );
+                }
                 const leaf = await nugetFetch(pageUrl, 'nuget package page');
-                pageItems = Array.isArray(leaf?.items) ? leaf.items : [];
+                if (!Array.isArray(leaf?.items)) {
+                    throw new CommandExecutionError(
+                        `nuget package registration leaf ${pageUrl} did not include an items array`,
+                    );
+                }
+                pageItems = leaf.items;
             }
             for (const it of pageItems) {
-                if (it && typeof it === 'object') allEntries.push(it);
+                if (!it || typeof it !== 'object' || !it.catalogEntry || typeof it.catalogEntry !== 'object') {
+                    throw new CommandExecutionError(
+                        `nuget package registration page ${pageIndex + 1} contains a malformed version entry`,
+                    );
+                }
+                allEntries.push(it);
             }
         }
         if (!allEntries.length) {

--- a/clis/nuget/package.js
+++ b/clis/nuget/package.js
@@ -1,0 +1,87 @@
+// nuget package — full version history for a NuGet package id.
+//
+// Hits the registration index `api.nuget.org/v3/registration5-semver1/<id>/index.json`.
+// The id path segment must be lowercase per NuGet's CDN routing.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { NUGET_REGISTRATION_BASE, joinAuthors, joinTags, nugetFetch, requirePackageId } from './utils.js';
+
+cli({
+    site: 'nuget',
+    name: 'package',
+    access: 'read',
+    description: 'Full NuGet package version history (catalogEntry per release)',
+    domain: 'api.nuget.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'NuGet package id (e.g. "Newtonsoft.Json", case-insensitive)' },
+    ],
+    columns: [
+        'rank',
+        'id',
+        'version',
+        'title',
+        'authors',
+        'tags',
+        'language',
+        'licenseExpression',
+        'projectUrl',
+        'published',
+        'listed',
+        'url',
+    ],
+    func: async (args) => {
+        const id = requirePackageId(args.id);
+        const url = `${NUGET_REGISTRATION_BASE}/${encodeURIComponent(id.toLowerCase())}/index.json`;
+        const body = await nugetFetch(url, 'nuget package');
+        const pages = Array.isArray(body?.items) ? body.items : [];
+        // Each page can be inline (with `items`) or a stub that needs another fetch
+        // for older packages. Inline is the common case for everything published in
+        // the last few years. We follow stub pages once each — at most ~5 round-trips.
+        const allEntries = [];
+        for (const page of pages) {
+            let pageItems = Array.isArray(page?.items) ? page.items : null;
+            if (!pageItems) {
+                // Stub page → fetch the leaf.
+                const pageUrl = typeof page?.['@id'] === 'string' ? page['@id'] : null;
+                if (!pageUrl) continue;
+                const leaf = await nugetFetch(pageUrl, 'nuget package page');
+                pageItems = Array.isArray(leaf?.items) ? leaf.items : [];
+            }
+            for (const it of pageItems) {
+                if (it && typeof it === 'object') allEntries.push(it);
+            }
+        }
+        if (!allEntries.length) {
+            throw new EmptyResultError('nuget package', `No published versions found for NuGet package "${id}".`);
+        }
+        // Sort by published desc; ties broken by version string descending.
+        const sorted = [...allEntries].sort((a, b) => {
+            const ap = a?.catalogEntry?.published ?? '';
+            const bp = b?.catalogEntry?.published ?? '';
+            if (ap !== bp) return bp.localeCompare(ap);
+            const av = a?.catalogEntry?.version ?? '';
+            const bv = b?.catalogEntry?.version ?? '';
+            return bv.localeCompare(av);
+        });
+        return sorted.map((entry, i) => {
+            const cat = entry?.catalogEntry ?? {};
+            return {
+                rank: i + 1,
+                id: typeof cat?.id === 'string' ? cat.id : id,
+                version: typeof cat?.version === 'string' ? cat.version : null,
+                title: typeof cat?.title === 'string' ? cat.title : null,
+                authors: joinAuthors(cat?.authors),
+                tags: joinTags(cat?.tags),
+                language: typeof cat?.language === 'string' ? cat.language : null,
+                licenseExpression: typeof cat?.licenseExpression === 'string' ? cat.licenseExpression : null,
+                projectUrl: typeof cat?.projectUrl === 'string' ? cat.projectUrl : null,
+                published: typeof cat?.published === 'string' ? cat.published : null,
+                listed: typeof cat?.listed === 'boolean' ? cat.listed : null,
+                url: typeof cat?.id === 'string' && typeof cat?.version === 'string'
+                    ? `https://www.nuget.org/packages/${cat.id}/${cat.version}` : '',
+            };
+        });
+    },
+});

--- a/clis/nuget/search.js
+++ b/clis/nuget/search.js
@@ -1,0 +1,69 @@
+// nuget search — full-text search the NuGet package index.
+//
+// Hits `azuresearch-usnc.nuget.org/query?q=…&take=…&prerelease=false`. The `id`
+// column round-trips into `nuget package` for full version history.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    NUGET_SEARCH_BASE,
+    joinAuthors,
+    joinTags,
+    nugetFetch,
+    requireBoundedInt,
+    requireString,
+} from './utils.js';
+
+cli({
+    site: 'nuget',
+    name: 'search',
+    access: 'read',
+    description: 'Search NuGet packages by keyword',
+    domain: 'api.nuget.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max packages (1-1000)' },
+        { name: 'prerelease', type: 'boolean', default: false, help: 'Include prerelease versions' },
+    ],
+    columns: [
+        'rank',
+        'id',
+        'version',
+        'title',
+        'description',
+        'authors',
+        'tags',
+        'totalDownloads',
+        'verified',
+        'projectUrl',
+        'url',
+    ],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 1000);
+        const prerelease = args.prerelease === true ? 'true' : 'false';
+        const url = `${NUGET_SEARCH_BASE}/query?q=${encodeURIComponent(query)}&take=${limit}&prerelease=${prerelease}`;
+        const body = await nugetFetch(url, 'nuget search');
+        const list = Array.isArray(body?.data) ? body.data : [];
+        if (!list.length) {
+            throw new EmptyResultError('nuget search', `No NuGet packages matched "${query}".`);
+        }
+        return list.slice(0, limit).map((pkg, i) => {
+            const id = typeof pkg?.id === 'string' ? pkg.id : '';
+            return {
+                rank: i + 1,
+                id,
+                version: typeof pkg?.version === 'string' ? pkg.version : null,
+                title: typeof pkg?.title === 'string' ? pkg.title : null,
+                description: typeof pkg?.description === 'string' ? pkg.description : null,
+                authors: joinAuthors(pkg?.authors),
+                tags: joinTags(pkg?.tags),
+                totalDownloads: typeof pkg?.totalDownloads === 'number' ? pkg.totalDownloads : null,
+                verified: pkg?.verified === true,
+                projectUrl: typeof pkg?.projectUrl === 'string' ? pkg.projectUrl : null,
+                url: id ? `https://www.nuget.org/packages/${id}` : '',
+            };
+        });
+    },
+});

--- a/clis/nuget/utils.js
+++ b/clis/nuget/utils.js
@@ -1,0 +1,87 @@
+// Shared helpers for the NuGet adapters.
+//
+// NuGet exposes two complementary endpoints:
+//   • `azuresearch-usnc.nuget.org/query` — full-text package search (V3)
+//   • `api.nuget.org/v3/registration5-semver1/<id>/index.json` — package detail
+// No API key required. Anonymous traffic is generous; we set a polite UA.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const NUGET_SEARCH_BASE = 'https://azuresearch-usnc.nuget.org';
+export const NUGET_REGISTRATION_BASE = 'https://api.nuget.org/v3/registration5-semver1';
+const UA = 'opencli-nuget-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// NuGet ID grammar (NuGet docs §package-id): up to 100 chars, alnum + `.` + `_` + `-`,
+// must start with letter/digit. Case-insensitive; we lowercase for the registration URL
+// because NuGet's CDN is case-sensitive on the path.
+const PACKAGE_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`nuget ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`nuget ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`nuget ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requirePackageId(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('nuget package id is required (e.g. "Newtonsoft.Json")');
+    if (!PACKAGE_ID_PATTERN.test(raw)) {
+        throw new ArgumentError(
+            `nuget package id "${value}" is not a valid NuGet identifier`,
+            'NuGet IDs are 1-100 chars: letters/digits/`.`/`_`/`-`, starting with letter or digit.',
+        );
+    }
+    return raw;
+}
+
+export async function nugetFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that api.nuget.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `NuGet returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+export function joinTags(tags) {
+    if (!Array.isArray(tags)) return '';
+    return tags.filter((t) => typeof t === 'string' && t.trim()).join(', ');
+}
+
+export function joinAuthors(authors) {
+    if (Array.isArray(authors)) return authors.filter((a) => typeof a === 'string' && a.trim()).join(', ');
+    if (typeof authors === 'string') return authors.trim();
+    return '';
+}

--- a/clis/oeis/oeis.test.js
+++ b/clis/oeis/oeis.test.js
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './sequence.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('oeis search adapter', () => {
+    const cmd = getRegistry().get('oeis/search');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        // Fresh Response per call so we don't tickle "Body has already been read" between pages.
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response('throttled', { status: 429 }))));
+        await expect(cmd.func({ query: 'fibonacci', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when first page is empty', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))));
+        await expect(cmd.func({ query: 'no-results', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips A-id from search row into oeis.org URL', async () => {
+        const result = [{
+            number: 45, name: 'Fibonacci numbers', keyword: 'core,nonn,nice',
+            data: '0,1,1,2,3,5,8,13,21,34,55,89',
+            author: 'Sloane', created: '1991-04-30T03:00:00-04:00',
+        }];
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify(result), { status: 200 }))));
+        const rows = await cmd.func({ query: 'fibonacci', limit: 1 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, id: 'A000045', name: 'Fibonacci numbers',
+            keywords: 'core,nonn,nice',
+            preview: '0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89',
+            url: 'https://oeis.org/A000045',
+        });
+    });
+});
+
+describe('oeis sequence adapter', () => {
+    const cmd = getRegistry().get('oeis/sequence');
+
+    it('rejects malformed sequence ids before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ id: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'B000045' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'A' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError when search returns null/empty list', async () => {
+        // OEIS returns empty list (or sometimes null body) for unknown id.
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })));
+        await expect(cmd.func({ id: 'A9999999' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('counts comments / formulas / xrefs without dumping the full graph', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([{
+            number: 40, name: 'The prime numbers.', keyword: 'core,nonn',
+            data: '2,3,5,7,11,13,17,19,23',
+            offset: '1,1', author: 'Sloane', created: '1991-04-30T03:00:00-04:00', revision: 100,
+            comment: ['c1', 'c2', 'c3'],
+            formula: ['f1', 'f2'],
+            reference: ['r1'],
+            xref: ['A000001', 'A000002'],
+            link: ['l1', 'l2', 'l3', 'l4'],
+        }]), { status: 200 })));
+        const rows = await cmd.func({ id: 'A000040' });
+        expect(rows[0]).toMatchObject({
+            id: 'A000040', name: 'The prime numbers.',
+            termCount: 9, offset: '1,1', revision: 100,
+            commentCount: 3, formulaCount: 2, referenceCount: 1, xrefCount: 2, linkCount: 4,
+            url: 'https://oeis.org/A000040',
+        });
+    });
+});

--- a/clis/oeis/search.js
+++ b/clis/oeis/search.js
@@ -1,0 +1,63 @@
+// oeis search — keyword / pattern search against the OEIS index.
+//
+// OEIS' search supports both natural-language queries ("fibonacci") and
+// numeric pattern queries ("1,1,2,3,5,8"). Returns up to 10 results per
+// page; we honor `--limit` by paginating via `&start=`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { OEIS_BASE, formatId, oeisFetch, previewTerms, requireBoundedInt, requireString } from './utils.js';
+
+cli({
+    site: 'oeis',
+    name: 'search',
+    access: 'read',
+    description: 'Search OEIS sequences by keyword or numeric pattern',
+    domain: 'oeis.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword or comma-separated terms (e.g. "fibonacci", "1,1,2,3,5,8")' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max sequences (1-100)' },
+    ],
+    columns: ['rank', 'id', 'name', 'keywords', 'preview', 'author', 'created', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 10, 100);
+        // OEIS returns 10 per page; paginate via `&start=` until we have `limit` rows
+        // or run out of pages. No silent clamp — if upstream has fewer results, surface
+        // every row that came back.
+        const collected = [];
+        let start = 0;
+        const pageSize = 10;
+        // Cap iterations defensively at limit/pageSize + 1 so we never spin forever.
+        const maxPages = Math.ceil(limit / pageSize) + 1;
+        for (let page = 0; page < maxPages && collected.length < limit; page++) {
+            const url = `${OEIS_BASE}/search?q=${encodeURIComponent(query)}&fmt=json&start=${start}`;
+            const body = await oeisFetch(url, 'oeis search');
+            const list = Array.isArray(body) ? body : [];
+            if (!list.length) break;
+            for (const r of list) {
+                if (collected.length >= limit) break;
+                collected.push(r);
+            }
+            if (list.length < pageSize) break;
+            start += pageSize;
+        }
+        if (!collected.length) {
+            throw new EmptyResultError('oeis search', `No OEIS sequences matched "${query}".`);
+        }
+        return collected.map((r, i) => {
+            const id = formatId(r?.number);
+            return {
+                rank: i + 1,
+                id,
+                name: typeof r?.name === 'string' ? r.name : null,
+                keywords: typeof r?.keyword === 'string' ? r.keyword : null,
+                preview: previewTerms(r?.data),
+                author: typeof r?.author === 'string' ? r.author : null,
+                created: typeof r?.created === 'string' ? r.created : null,
+                url: id ? `${OEIS_BASE}/${id}` : '',
+            };
+        });
+    },
+});

--- a/clis/oeis/sequence.js
+++ b/clis/oeis/sequence.js
@@ -1,0 +1,71 @@
+// oeis sequence — full detail for a single OEIS sequence (A-number).
+//
+// OEIS' search endpoint, when given `q=id:Annnnnn`, returns one full record
+// with all sub-fields populated. We surface formula / xref / reference counts
+// instead of dumping the full graph.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { OEIS_BASE, formatId, oeisFetch, previewTerms, requireSequenceId } from './utils.js';
+
+function asArray(value) {
+    return Array.isArray(value) ? value : [];
+}
+
+cli({
+    site: 'oeis',
+    name: 'sequence',
+    access: 'read',
+    description: 'Full OEIS sequence detail by A-number (terms, name, keywords, formula counts)',
+    domain: 'oeis.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'OEIS sequence id (e.g. "A000045" for Fibonacci)' },
+    ],
+    columns: [
+        'id',
+        'name',
+        'keywords',
+        'preview',
+        'termCount',
+        'offset',
+        'author',
+        'created',
+        'revision',
+        'commentCount',
+        'formulaCount',
+        'referenceCount',
+        'xrefCount',
+        'linkCount',
+        'url',
+    ],
+    func: async (args) => {
+        const id = requireSequenceId(args.id);
+        const url = `${OEIS_BASE}/search?q=id:${encodeURIComponent(id)}&fmt=json`;
+        const body = await oeisFetch(url, 'oeis sequence');
+        const list = Array.isArray(body) ? body : [];
+        if (!list.length) {
+            throw new EmptyResultError('oeis sequence', `OEIS sequence "${id}" not found.`);
+        }
+        const r = list[0];
+        const data = typeof r?.data === 'string' ? r.data : '';
+        const termCount = data ? data.split(',').filter(Boolean).length : 0;
+        return [{
+            id: formatId(r?.number) ?? id,
+            name: typeof r?.name === 'string' ? r.name : null,
+            keywords: typeof r?.keyword === 'string' ? r.keyword : null,
+            preview: previewTerms(data),
+            termCount,
+            offset: typeof r?.offset === 'string' ? r.offset : null,
+            author: typeof r?.author === 'string' ? r.author : null,
+            created: typeof r?.created === 'string' ? r.created : null,
+            revision: typeof r?.revision === 'number' ? r.revision : null,
+            commentCount: asArray(r?.comment).length,
+            formulaCount: asArray(r?.formula).length,
+            referenceCount: asArray(r?.reference).length,
+            xrefCount: asArray(r?.xref).length,
+            linkCount: asArray(r?.link).length,
+            url: `${OEIS_BASE}/${formatId(r?.number) ?? id}`,
+        }];
+    },
+});

--- a/clis/oeis/utils.js
+++ b/clis/oeis/utils.js
@@ -1,0 +1,88 @@
+// Shared helpers for the OEIS adapter (Online Encyclopedia of Integer Sequences).
+//
+// OEIS exposes a single search endpoint that handles both keyword search and
+// id lookup via `q=id:Annnnnn`. JSON output via `fmt=json`. No API key.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const OEIS_BASE = 'https://oeis.org';
+const UA = 'opencli-oeis-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// OEIS ids are A followed by 6 zero-padded digits (older entries use 6 by convention,
+// modern entries can be longer; OEIS itself accepts any digits after A).
+const SEQUENCE_ID_PATTERN = /^A\d{1,7}$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`oeis ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`oeis ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`oeis ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireSequenceId(value) {
+    const raw = String(value ?? '').trim().toUpperCase();
+    if (!raw) throw new ArgumentError('oeis sequence id is required (e.g. "A000045" for Fibonacci)');
+    // Tolerate common URL paste like `https://oeis.org/A000045`.
+    const stripped = raw.replace(/^HTTPS?:\/\/(?:WWW\.)?OEIS\.ORG\//, '').replace(/\/.*$/, '');
+    if (!SEQUENCE_ID_PATTERN.test(stripped)) {
+        throw new ArgumentError(
+            `oeis sequence id "${value}" is not a valid A-number`,
+            'Expected format: "A" + digits (e.g. "A000045").',
+        );
+    }
+    return stripped;
+}
+
+export async function oeisFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that oeis.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `OEIS returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+/** Format OEIS' `number: 40` into the canonical zero-padded id `A000040`. */
+export function formatId(number) {
+    if (typeof number !== 'number' || !Number.isInteger(number) || number < 0) return null;
+    return `A${String(number).padStart(6, '0')}`;
+}
+
+/** Take the first N comma-separated terms from OEIS' `data` string. */
+export function previewTerms(data, max = 12) {
+    if (typeof data !== 'string') return '';
+    const terms = data.split(',').map((t) => t.trim()).filter(Boolean);
+    if (terms.length <= max) return terms.join(', ');
+    return [...terms.slice(0, max), `(+${terms.length - max})`].join(', ');
+}

--- a/clis/rest-countries/country.js
+++ b/clis/rest-countries/country.js
@@ -1,0 +1,65 @@
+// rest-countries country — look up a country by common / official name.
+//
+// REST Countries' `name/<query>` endpoint matches as substring across both
+// common and official names; multiple matches are returned (e.g. "guinea"
+// matches Guinea, Guinea-Bissau, Equatorial Guinea, Papua New Guinea).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    COUNTRY_FIELDS,
+    REST_COUNTRIES_BASE,
+    projectCountry,
+    requireBoundedInt,
+    requireString,
+    restCountriesFetch,
+} from './utils.js';
+
+cli({
+    site: 'rest-countries',
+    name: 'country',
+    access: 'read',
+    description: 'Look up countries by name (common / official, substring match)',
+    domain: 'restcountries.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, help: 'Country name (e.g. "japan", "united kingdom")' },
+        { name: 'limit', type: 'int', default: 25, help: 'Max rows (1-250)' },
+    ],
+    columns: [
+        'rank',
+        'commonName',
+        'officialName',
+        'cca2',
+        'cca3',
+        'ccn3',
+        'capital',
+        'region',
+        'subregion',
+        'population',
+        'area',
+        'languages',
+        'currencies',
+        'latitude',
+        'longitude',
+        'timezones',
+        'independent',
+        'unMember',
+        'landlocked',
+        'flag',
+        'url',
+    ],
+    func: async (args) => {
+        const name = requireString(args.name, 'name');
+        const limit = requireBoundedInt(args.limit, 25, 250);
+        const url = `${REST_COUNTRIES_BASE}/name/${encodeURIComponent(name)}?fields=${COUNTRY_FIELDS}`;
+        const body = await restCountriesFetch(url, 'rest-countries country');
+        const list = Array.isArray(body) ? body : [];
+        if (!list.length) {
+            throw new EmptyResultError('rest-countries country', `No countries matched "${name}".`);
+        }
+        // Sort by population descending so the most "expected" hit is first.
+        const sorted = [...list].sort((a, b) => (b?.population ?? 0) - (a?.population ?? 0));
+        return sorted.slice(0, limit).map((c, i) => ({ rank: i + 1, ...projectCountry(c) }));
+    },
+});

--- a/clis/rest-countries/region.js
+++ b/clis/rest-countries/region.js
@@ -1,0 +1,64 @@
+// rest-countries region — list every country in a region.
+//
+// Region values: africa / americas / asia / europe / oceania / antarctic.
+// Subregions ("eastern asia") are not supported by this command — they go
+// through the v3.1 `subregion/` endpoint which behaves identically.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    COUNTRY_FIELDS,
+    REST_COUNTRIES_BASE,
+    projectCountry,
+    requireBoundedInt,
+    requireRegion,
+    restCountriesFetch,
+} from './utils.js';
+
+cli({
+    site: 'rest-countries',
+    name: 'region',
+    access: 'read',
+    description: 'List countries in a region (africa / americas / asia / europe / oceania / antarctic)',
+    domain: 'restcountries.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'region', positional: true, required: true, help: 'Region name (case-insensitive)' },
+        { name: 'limit', type: 'int', default: 250, help: 'Max rows (1-250)' },
+    ],
+    columns: [
+        'rank',
+        'commonName',
+        'officialName',
+        'cca2',
+        'cca3',
+        'ccn3',
+        'capital',
+        'region',
+        'subregion',
+        'population',
+        'area',
+        'languages',
+        'currencies',
+        'latitude',
+        'longitude',
+        'timezones',
+        'independent',
+        'unMember',
+        'landlocked',
+        'flag',
+        'url',
+    ],
+    func: async (args) => {
+        const region = requireRegion(args.region);
+        const limit = requireBoundedInt(args.limit, 250, 250);
+        const url = `${REST_COUNTRIES_BASE}/region/${encodeURIComponent(region)}?fields=${COUNTRY_FIELDS}`;
+        const body = await restCountriesFetch(url, 'rest-countries region');
+        const list = Array.isArray(body) ? body : [];
+        if (!list.length) {
+            throw new EmptyResultError('rest-countries region', `No countries returned for region "${region}".`);
+        }
+        const sorted = [...list].sort((a, b) => (b?.population ?? 0) - (a?.population ?? 0));
+        return sorted.slice(0, limit).map((c, i) => ({ rank: i + 1, ...projectCountry(c) }));
+    },
+});

--- a/clis/rest-countries/rest-countries.test.js
+++ b/clis/rest-countries/rest-countries.test.js
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './country.js';
+import './region.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('rest-countries country adapter', () => {
+    const cmd = getRegistry().get('rest-countries/country');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ name: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ name: 'japan', limit: 9999 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('throttled', { status: 429 })));
+        await expect(cmd.func({ name: 'japan' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ name: 'no-country-by-this-name' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips cca3 from row into restcountries.com alpha URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([
+            {
+                name: { common: 'Japan', official: 'Japan' },
+                cca2: 'JP', cca3: 'JPN', ccn3: '392',
+                capital: ['Tokyo'],
+                region: 'Asia', subregion: 'Eastern Asia',
+                population: 125000000, area: 377000,
+                languages: { jpn: 'Japanese' },
+                currencies: { JPY: { name: 'Japanese yen', symbol: '¥' } },
+                latlng: [36, 138], timezones: ['UTC+09:00'], independent: true, unMember: true, landlocked: false, flag: '🇯🇵',
+            },
+        ]), { status: 200 })));
+        const rows = await cmd.func({ name: 'japan', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, commonName: 'Japan', cca2: 'JP', cca3: 'JPN',
+            capital: 'Tokyo', region: 'Asia',
+            languages: 'Japanese', currencies: 'JPY (Japanese yen)',
+            latitude: 36, longitude: 138,
+            url: 'https://restcountries.com/v3.1/alpha/jpn',
+        });
+    });
+});
+
+describe('rest-countries region adapter', () => {
+    const cmd = getRegistry().get('rest-countries/region');
+
+    it('rejects unknown regions before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ region: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ region: 'middle-earth' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError on empty payload', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })));
+        await expect(cmd.func({ region: 'oceania' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('sorts by population descending so largest country is rank 1', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([
+            { name: { common: 'Tuvalu' }, cca3: 'TUV', population: 12000 },
+            { name: { common: 'Australia' }, cca3: 'AUS', population: 26000000 },
+            { name: { common: 'Fiji' }, cca3: 'FJI', population: 900000 },
+        ]), { status: 200 })));
+        const rows = await cmd.func({ region: 'oceania' });
+        expect(rows.map((r) => r.commonName)).toEqual(['Australia', 'Fiji', 'Tuvalu']);
+        expect(rows[0]).toMatchObject({ cca3: 'AUS', url: 'https://restcountries.com/v3.1/alpha/aus' });
+    });
+});

--- a/clis/rest-countries/utils.js
+++ b/clis/rest-countries/utils.js
@@ -1,0 +1,126 @@
+// Shared helpers for the REST Countries adapter (https://restcountries.com).
+//
+// REST Countries is a free public country-metadata API, no API key required.
+// We hit v3.1 only. The `fields=` query param is mandatory in v3.1 to keep
+// payloads small; we always specify the agent-useful projection.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const REST_COUNTRIES_BASE = 'https://restcountries.com/v3.1';
+const UA = 'opencli-rest-countries-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// REST Countries valid region values; subregions are validated server-side.
+export const REST_COUNTRIES_REGIONS = new Set(['africa', 'americas', 'asia', 'europe', 'oceania', 'antarctic']);
+
+// Fields the adapter always requests; keep this list aligned with `columns` so
+// rows never have null-where-absent silent drops.
+export const COUNTRY_FIELDS = [
+    'name', 'cca2', 'cca3', 'ccn3', 'capital', 'region', 'subregion',
+    'population', 'area', 'languages', 'currencies', 'flag', 'latlng', 'timezones',
+    'independent', 'unMember', 'landlocked',
+].join(',');
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`rest-countries ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`rest-countries ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`rest-countries ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireRegion(value) {
+    const raw = String(value ?? '').trim().toLowerCase();
+    if (!raw) throw new ArgumentError('rest-countries region is required (e.g. "europe", "asia")');
+    if (!REST_COUNTRIES_REGIONS.has(raw)) {
+        throw new ArgumentError(
+            `rest-countries region "${value}" is not recognised`,
+            `Allowed regions: ${[...REST_COUNTRIES_REGIONS].join(', ')}.`,
+        );
+    }
+    return raw;
+}
+
+export async function restCountriesFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that restcountries.com is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `REST Countries returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+/** Convert REST Countries' `{cur: {name, symbol}}` map to a comma-joined list. */
+export function joinCurrencies(currencies) {
+    if (!currencies || typeof currencies !== 'object') return '';
+    return Object.entries(currencies)
+        .map(([code, info]) => {
+            const name = info && typeof info.name === 'string' ? info.name : '';
+            return name ? `${code} (${name})` : code;
+        })
+        .join(', ');
+}
+
+/** Convert `{eng: 'English', fra: 'French'}` map to a comma-joined list of language names. */
+export function joinLanguages(languages) {
+    if (!languages || typeof languages !== 'object') return '';
+    return Object.values(languages).filter((v) => typeof v === 'string' && v.trim()).join(', ');
+}
+
+/** Project a REST Countries v3.1 country object into a row matching the adapter columns. */
+export function projectCountry(c) {
+    const common = c?.name?.common ?? null;
+    const official = c?.name?.official ?? null;
+    const cca3 = typeof c?.cca3 === 'string' ? c.cca3 : null;
+    return {
+        commonName: typeof common === 'string' ? common : null,
+        officialName: typeof official === 'string' ? official : null,
+        cca2: typeof c?.cca2 === 'string' ? c.cca2 : null,
+        cca3,
+        ccn3: typeof c?.ccn3 === 'string' ? c.ccn3 : null,
+        capital: Array.isArray(c?.capital) ? c.capital.join(', ') : null,
+        region: typeof c?.region === 'string' ? c.region : null,
+        subregion: typeof c?.subregion === 'string' ? c.subregion : null,
+        population: typeof c?.population === 'number' ? c.population : null,
+        area: typeof c?.area === 'number' ? c.area : null,
+        languages: joinLanguages(c?.languages),
+        currencies: joinCurrencies(c?.currencies),
+        latitude: Array.isArray(c?.latlng) && typeof c.latlng[0] === 'number' ? c.latlng[0] : null,
+        longitude: Array.isArray(c?.latlng) && typeof c.latlng[1] === 'number' ? c.latlng[1] : null,
+        timezones: Array.isArray(c?.timezones) ? c.timezones.join(', ') : null,
+        independent: typeof c?.independent === 'boolean' ? c.independent : null,
+        unMember: typeof c?.unMember === 'boolean' ? c.unMember : null,
+        landlocked: typeof c?.landlocked === 'boolean' ? c.landlocked : null,
+        flag: typeof c?.flag === 'string' ? c.flag : null,
+        url: cca3 ? `https://restcountries.com/v3.1/alpha/${cca3.toLowerCase()}` : '',
+    };
+}

--- a/clis/wikidata/entity.js
+++ b/clis/wikidata/entity.js
@@ -1,0 +1,60 @@
+// wikidata entity — fetch a single Wikidata entity by Q/P/L identifier.
+//
+// Hits `Special:EntityData/<id>.json`, the canonical public dump. Surfaces the
+// agent-useful projection: localised label/description/aliases plus high-level
+// counts (claim properties, sitelinks). The full claim graph is huge; we keep
+// the projection narrow by design.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { WIKIDATA_BASE, joinAliases, pickLocalised, requireEntityId, requireLanguage, wikidataFetch } from './utils.js';
+
+cli({
+    site: 'wikidata',
+    name: 'entity',
+    access: 'read',
+    description: 'Fetch a Wikidata entity by Q/P/L id (label, description, aliases, claim summary)',
+    domain: 'www.wikidata.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Entity id (e.g. Q937 = Albert Einstein, P31 = instance of)' },
+        { name: 'language', default: 'en', help: 'Display language (ISO 639, falls back to English when missing)' },
+    ],
+    columns: [
+        'qid',
+        'type',
+        'label',
+        'description',
+        'aliases',
+        'claimPropertyCount',
+        'sitelinkCount',
+        'enwikiTitle',
+        'modified',
+        'url',
+    ],
+    func: async (args) => {
+        const qid = requireEntityId(args.id);
+        const language = requireLanguage(args.language);
+        const url = `${WIKIDATA_BASE}/wiki/Special:EntityData/${encodeURIComponent(qid)}.json`;
+        const body = await wikidataFetch(url, 'wikidata entity');
+        const entity = body?.entities?.[qid];
+        if (!entity) {
+            throw new EmptyResultError('wikidata entity', `Wikidata entity ${qid} returned no payload.`);
+        }
+        const claims = entity.claims && typeof entity.claims === 'object' ? entity.claims : {};
+        const sitelinks = entity.sitelinks && typeof entity.sitelinks === 'object' ? entity.sitelinks : {};
+        const enwiki = sitelinks?.enwiki?.title;
+        return [{
+            qid,
+            type: typeof entity.type === 'string' ? entity.type : null,
+            label: pickLocalised(entity.labels, language),
+            description: pickLocalised(entity.descriptions, language),
+            aliases: joinAliases(entity.aliases, language),
+            claimPropertyCount: Object.keys(claims).length,
+            sitelinkCount: Object.keys(sitelinks).length,
+            enwikiTitle: typeof enwiki === 'string' && enwiki.trim() ? enwiki : null,
+            modified: typeof entity.modified === 'string' ? entity.modified : null,
+            url: `${WIKIDATA_BASE}/wiki/${qid}`,
+        }];
+    },
+});

--- a/clis/wikidata/search.js
+++ b/clis/wikidata/search.js
@@ -1,0 +1,50 @@
+// wikidata search — find Wikidata entities (items) by keyword.
+//
+// Hits `wbsearchentities` on the public MediaWiki API. Returns Q-IDs that
+// round-trip into `wikidata entity` for full detail.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { WIKIDATA_BASE, requireBoundedInt, requireLanguage, requireString, wikidataFetch } from './utils.js';
+
+cli({
+    site: 'wikidata',
+    name: 'search',
+    access: 'read',
+    description: 'Search Wikidata items by keyword (returns Q-IDs)',
+    domain: 'www.wikidata.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword (label / alias)' },
+        { name: 'language', default: 'en', help: 'Search & display language (ISO 639, e.g. en, fr, zh)' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max items (1-50)' },
+    ],
+    columns: ['rank', 'qid', 'label', 'description', 'matchType', 'matchText', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const language = requireLanguage(args.language);
+        const limit = requireBoundedInt(args.limit, 20, 50);
+        const url = `${WIKIDATA_BASE}/w/api.php?action=wbsearchentities`
+            + `&search=${encodeURIComponent(query)}`
+            + `&language=${encodeURIComponent(language)}`
+            + `&uselang=${encodeURIComponent(language)}`
+            + `&type=item&format=json&limit=${limit}&origin=*`;
+        const body = await wikidataFetch(url, 'wikidata search');
+        const list = Array.isArray(body?.search) ? body.search : [];
+        if (!list.length) {
+            throw new EmptyResultError('wikidata search', `No Wikidata items matched "${query}" in language "${language}".`);
+        }
+        return list.slice(0, limit).map((item, i) => {
+            const qid = String(item?.id ?? '').trim();
+            return {
+                rank: i + 1,
+                qid,
+                label: typeof item?.label === 'string' ? item.label : null,
+                description: typeof item?.description === 'string' ? item.description : null,
+                matchType: typeof item?.match?.type === 'string' ? item.match.type : null,
+                matchText: typeof item?.match?.text === 'string' ? item.match.text : null,
+                url: qid ? `${WIKIDATA_BASE}/wiki/${qid}` : '',
+            };
+        });
+    },
+});

--- a/clis/wikidata/utils.js
+++ b/clis/wikidata/utils.js
@@ -1,0 +1,117 @@
+// Shared helpers for the Wikidata adapters.
+//
+// Wikidata exposes two complementary public endpoints:
+//   • `wbsearchentities` on `www.wikidata.org/w/api.php` for keyword → Q-IDs
+//   • `Special:EntityData/<qid>.json` for the canonical entity dump
+// No API key. Anonymous traffic is rate-limited but generous; we set a polite UA.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const WIKIDATA_BASE = 'https://www.wikidata.org';
+const UA = 'opencli-wikidata-adapter/1.0 (+https://github.com/jackwener/opencli; mailto:opencli@example.com)';
+
+// Q-ID = an item; P-ID = a property; L-ID = a lexeme. We accept all three so the
+// adapter can be reused for properties / lexemes without a separate command, but
+// search only returns Q-IDs by default.
+const ENTITY_ID_PATTERN = /^[QPL]\d+$/;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`wikidata ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`wikidata ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`wikidata ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireEntityId(value) {
+    const raw = String(value ?? '').trim().toUpperCase();
+    if (!raw) throw new ArgumentError('wikidata entity id is required (e.g. "Q937")');
+    // Tolerate URL-paste like `https://www.wikidata.org/wiki/Q937`.
+    const stripped = raw.replace(/^HTTPS?:\/\/[^/]+\/WIKI\//i, '');
+    if (!ENTITY_ID_PATTERN.test(stripped)) {
+        throw new ArgumentError(
+            `wikidata entity id "${value}" is not a valid Q/P/L identifier`,
+            'Expected format: "Q<digits>" (item), "P<digits>" (property), or "L<digits>" (lexeme).',
+        );
+    }
+    return stripped;
+}
+
+export function requireLanguage(value, defaultValue = 'en') {
+    const raw = String(value ?? defaultValue).trim().toLowerCase();
+    // Wikidata language codes are 2-3 letter ISO 639 codes plus optional region (`zh-hans`).
+    if (!/^[a-z]{2,3}(-[a-z]{2,8})?$/.test(raw)) {
+        throw new ArgumentError(
+            `wikidata language "${value}" is not a valid language code`,
+            'Expected an ISO 639 language code such as "en", "fr", "zh", "zh-hans".',
+        );
+    }
+    return raw;
+}
+
+export async function wikidataFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that www.wikidata.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Wikidata returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Wikidata throttles anonymous traffic; back off and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+/**
+ * Pick a localised label / description from a `{<lang>: {value}}` map.
+ * Falls back to English if the requested language is missing.
+ */
+export function pickLocalised(map, language) {
+    if (!map || typeof map !== 'object') return null;
+    const direct = map[language];
+    if (direct && typeof direct.value === 'string' && direct.value.trim()) return direct.value;
+    if (language !== 'en' && map.en && typeof map.en.value === 'string' && map.en.value.trim()) {
+        return map.en.value;
+    }
+    return null;
+}
+
+export function joinAliases(aliases, language, max = 5) {
+    if (!aliases || typeof aliases !== 'object') return '';
+    // Mirror the label/description fallback: prefer requested language, then English.
+    let list = Array.isArray(aliases[language]) ? aliases[language] : [];
+    if (list.length === 0 && language !== 'en' && Array.isArray(aliases.en)) list = aliases.en;
+    const names = list.map((a) => (a && typeof a.value === 'string' ? a.value : '')).filter(Boolean);
+    if (names.length === 0) return '';
+    if (names.length > max) return [...names.slice(0, max), `(+${names.length - max})`].join(', ');
+    return names.join(', ');
+}

--- a/clis/wikidata/wikidata.test.js
+++ b/clis/wikidata/wikidata.test.js
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './entity.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('wikidata search adapter', () => {
+    const cmd = getRegistry().get('wikidata/search');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', limit: 999 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'foo', language: '!!' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('throttled', { status: 429 })));
+        await expect(cmd.func({ query: 'einstein', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty search list', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ search: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'no-such-thing', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('round-trips Q-id from search row into wikidata.org URL', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            search: [{ id: 'Q937', label: 'Albert Einstein', description: 'physicist', match: { type: 'alias', text: 'Einstein' } }],
+        }), { status: 200 })));
+        const rows = await cmd.func({ query: 'einstein', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, qid: 'Q937', label: 'Albert Einstein', matchType: 'alias',
+            url: 'https://www.wikidata.org/wiki/Q937',
+        });
+    });
+});
+
+describe('wikidata entity adapter', () => {
+    const cmd = getRegistry().get('wikidata/entity');
+
+    it('rejects malformed entity ids before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ id: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'not-a-qid' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: 'Q' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('missing', { status: 404 })));
+        await expect(cmd.func({ id: 'Q9999999999' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('falls back to English label when requested language is missing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            entities: {
+                Q937: {
+                    id: 'Q937', type: 'item', modified: '2026-01-01T00:00:00Z',
+                    labels: { en: { value: 'Albert Einstein', language: 'en' } },
+                    descriptions: { en: { value: 'physicist', language: 'en' } },
+                    aliases: { en: [{ value: 'A. Einstein', language: 'en' }] },
+                    claims: { P31: [], P21: [] },
+                    sitelinks: { enwiki: { title: 'Albert Einstein', site: 'enwiki' } },
+                },
+            },
+        }), { status: 200 })));
+        const rows = await cmd.func({ id: 'Q937', language: 'qq' });
+        expect(rows[0]).toMatchObject({
+            qid: 'Q937', label: 'Albert Einstein', description: 'physicist',
+            aliases: 'A. Einstein', claimPropertyCount: 2, sitelinkCount: 1,
+            enwikiTitle: 'Albert Einstein', url: 'https://www.wikidata.org/wiki/Q937',
+        });
+    });
+});

--- a/docs/adapters/browser/flathub.md
+++ b/docs/adapters/browser/flathub.md
@@ -1,0 +1,62 @@
+# Flathub
+
+**Mode**: 🌐 Public · **Domain**: `flathub.org`
+
+Search the Flathub Linux flatpak app registry and fetch full appstream metadata for any app. Flathub is the canonical flatpak distribution channel for Linux desktop applications.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli flathub search <query>` | Search Flathub apps by keyword |
+| `opencli flathub app <appId>` | Full Flathub appstream metadata for an app id |
+
+## Usage Examples
+
+```bash
+# Keyword search
+opencli flathub search firefox
+opencli flathub search "image editor" --limit 10
+opencli flathub search blender
+
+# App detail (appId round-trips from search)
+opencli flathub app org.mozilla.firefox
+opencli flathub app org.gnome.Calculator
+opencli flathub app org.blender.Blender
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, appId, name, summary, developer, license, isFreeLicense, mainCategories, installsLastMonth, updatedAt, url` |
+| `app` | `appId, name, summary, developer, license, isFreeLicense, isEol, categories, keywords, latestVersion, latestReleaseDate, homepage, bugtracker, donation, url` |
+
+The `appId` column round-trips between commands.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Search keyword |
+| `--limit` | Max apps (1–100, default: 25) |
+
+### `app`
+
+| Option | Description |
+|--------|-------------|
+| `appId` (positional) | AppStream id, reverse-DNS form (e.g. `org.mozilla.firefox`, `org.gnome.Calculator`) |
+
+## Notes
+
+- **`appId` is the reverse-DNS AppStream id** (`org.mozilla.firefox`), not the underscored cache id (`org_mozilla_firefox`) Flathub returns alongside it. We always emit the dotted form so the `search → app` round-trip works without translation.
+- **`updatedAt` normalisation**: Flathub's `/search` endpoint emits `updated_at` as unix-seconds (integer); `/appstream/<id>` emits it as ISO date strings. The adapter normalises `/search` to ISO date (`YYYY-MM-DD`) so both surfaces look consistent.
+- **`releases[].timestamp` is a numeric string**, not an int — quirk of the appstream layer. The adapter coerces both shapes when picking the latest release.
+- **`isEol`** is `true` for end-of-life apps (no longer maintained).
+- **`isFreeLicense`** uses Flathub's classification of `project_license` (e.g. `MPL-2.0`, `GPL-3.0-or-later`). Don't use this in lieu of reading the actual license; useful as a quick filter.
+- **`installsLastMonth` (search only)** is Flathub's 30-day install count per app. Useful for popularity ranking; `null` when not yet aggregated.
+- **`mainCategories`** is a single string in `/search` (e.g. `'network'`); on `/appstream/<id>` the broader `categories` list is used (`'Network, WebBrowser'`).
+- **No API key required.** Flathub's API is public and unauthenticated; bursts → `CommandExecutionError`.
+- **Errors.** Empty query / bad appId / bad limit → `ArgumentError`; unknown appId (HTTP 404) → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/lichess.md
+++ b/docs/adapters/browser/lichess.md
@@ -1,0 +1,60 @@
+# Lichess
+
+**Mode**: 🌐 Public · **Domain**: `lichess.org`
+
+Look up public Lichess player profiles and per-perf top-N leaderboards. Lichess is a free open-source chess platform; its REST API is fully public and unauthenticated for these read-only endpoints.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli lichess user <username>` | Lichess player profile (rating, perfs, win/loss counts) |
+| `opencli lichess top <perf>` | Top-N leaderboard for a perf type (bullet/blitz/rapid/classical/...) |
+
+## Usage Examples
+
+```bash
+# Player profile
+opencli lichess user DrNykterstein
+opencli lichess user penguingm1
+
+# Top-N leaderboards (username round-trips into `lichess user`)
+opencli lichess top blitz
+opencli lichess top bullet --limit 50
+opencli lichess top rapid --limit 25
+opencli lichess top chess960
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `user` | `username, id, title, patron, online, tosViolation, createdAt, seenAt, gamesAll, gamesWin, gamesLoss, gamesDraw, topPerfName, topPerfRating, topPerfGames, fideRating, country, bio, url` |
+| `top` | `rank, username, id, title, rating, progress, patron, url` |
+
+The `username` column round-trips from `top` into `user`.
+
+## Options
+
+### `user`
+
+| Option | Description |
+|--------|-------------|
+| `username` (positional) | Lichess username (case-insensitive, 2–30 chars, letters/digits/underscore/dash) |
+
+### `top`
+
+| Option | Description |
+|--------|-------------|
+| `perf` (positional) | Perf type: `ultraBullet`, `bullet`, `blitz`, `rapid`, `classical`, `chess960`, `crazyhouse`, `antichess`, `atomic`, `horde`, `kingOfTheHill`, `racingKings`, `threeCheck` |
+| `--limit` | Top-N rows (1–200, default: 10) |
+
+## Notes
+
+- **`topPerfName`/`topPerfRating`/`topPerfGames`** picks the perf with the most games played, excluding non-game perfs (`puzzle`, `storm`, `racer`, `streak`). For most active accounts this is `bullet` or `blitz`. For inactive accounts the field surfaces whatever the account played most before going quiet.
+- **Closed accounts → `EmptyResultError`.** Lichess marks deleted/closed accounts with `disabled: true` and strips most fields; surfacing a row of nulls would be silent-fallback. We surface as `EmptyResultError` instead so the agent knows the account is gone.
+- **`tosViolation`** is `true` when the account has been flagged for cheating / TOS abuse — important when interpreting their rating progression.
+- **`progress`** (top only) is the perf's recent rating delta (last 12 games). `null` when not enough recent games to compute.
+- **`fideRating` / `country` / `bio`** are user-supplied profile fields; commonly `null` for accounts that haven't filled them in.
+- **No API key required.** Lichess throttles anonymous traffic at ~60 req/min per IP; bursts → `CommandExecutionError`.
+- **Errors.** Bad username / unknown perf / bad limit → `ArgumentError`; unknown / disabled user → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/nuget.md
+++ b/docs/adapters/browser/nuget.md
@@ -1,0 +1,61 @@
+# NuGet
+
+**Mode**: 🌐 Public · **Domain**: `api.nuget.org`
+
+Search the NuGet package index by keyword and fetch full version history for a package id. NuGet is the canonical .NET package registry; both endpoints are public V3 JSON.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli nuget search <query>` | Search NuGet packages by keyword |
+| `opencli nuget package <id>` | Full NuGet package version history (catalog entries) |
+
+## Usage Examples
+
+```bash
+# Keyword search
+opencli nuget search newtonsoft
+opencli nuget search "asp.net core" --limit 10
+opencli nuget search serilog --prerelease=true
+
+# Full version history (id round-trips from search)
+opencli nuget package Newtonsoft.Json
+opencli nuget package Serilog
+opencli nuget package Microsoft.Extensions.Logging
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, id, version, title, description, authors, tags, totalDownloads, verified, projectUrl, url` |
+| `package` | `rank, id, version, title, authors, tags, language, licenseExpression, projectUrl, published, listed, url` |
+
+The `id` column round-trips between commands.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Search keyword |
+| `--limit` | Max packages (1–1000, default: 20) — NuGet's max page size is 1000 |
+| `--prerelease` | Include prerelease versions (default: `false`) |
+
+### `package`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | NuGet package id (case-insensitive). Allowed: 1–100 chars of letters/digits/`.`/`_`/`-`, must start with letter or digit. |
+
+## Notes
+
+- **`package` returns the full version history**, newest-first (sorted by `published` desc, ties broken by version string desc). Each row is one published release. NuGet's CDN paginates internally; the adapter walks pages so even 100+ version histories come back in one call.
+- **`listed` flag**: when `false`, the version was unlisted by the publisher (still installable by exact pin, but hidden from search). `null` when NuGet didn't include the field (rare, very old packages).
+- **`verified` (search only)**: NuGet's "verified publisher" badge — packages signed by a verified org. Useful for filtering hostile typo-squats.
+- **`totalDownloads`** is a single global counter; it does NOT split per-version. For per-version downloads NuGet exposes a different endpoint we don't surface here.
+- **`tags` / `authors`** are comma-joined; raw shape is space-separated tags + JSON author array, normalised to consistent comma joins.
+- **No API key required.** NuGet's V3 service index is public; no rate limit doc but bursts → `CommandExecutionError`.
+- **Errors.** Bad id / bad limit / empty query → `ArgumentError`; unknown package (HTTP 404) → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/oeis.md
+++ b/docs/adapters/browser/oeis.md
@@ -1,0 +1,69 @@
+# OEIS
+
+**Mode**: 🌐 Public · **Domain**: `oeis.org`
+
+Search the Online Encyclopedia of Integer Sequences by keyword or pattern, and fetch full sequence detail by A-number. OEIS is the canonical reference for integer sequences in mathematics — every sequence has a unique `Annnnnn` id.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli oeis search <query>` | Search OEIS sequences by keyword or numeric pattern |
+| `opencli oeis sequence <id>` | Full OEIS sequence detail by A-number |
+
+## Usage Examples
+
+```bash
+# Keyword search
+opencli oeis search fibonacci
+opencli oeis search "prime gaps" --limit 5
+
+# Numeric pattern search (find sequences matching a prefix)
+opencli oeis search "1,1,2,3,5,8"            # Fibonacci
+opencli oeis search "2,3,5,7,11,13,17"       # primes
+
+# Sequence detail (A-number round-trips from search)
+opencli oeis sequence A000045                  # Fibonacci
+opencli oeis sequence A000040                  # Primes
+opencli oeis sequence A000041                  # Partitions
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, id, name, keywords, preview, author, created, url` |
+| `sequence` | `id, name, keywords, preview, termCount, offset, author, created, revision, commentCount, formulaCount, referenceCount, xrefCount, linkCount, url` |
+
+The `id` column round-trips between commands.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Keyword or comma-separated terms |
+| `--limit` | Max sequences (1–100, default: 10). OEIS' wire format returns 10 per page; the adapter paginates server-side until `limit` is satisfied or upstream runs out. |
+
+### `sequence`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | OEIS A-number (e.g. `A000045`). Full URLs (`https://oeis.org/A000045`) and lowercase (`a000045`) are accepted. |
+
+## Notes
+
+- **`id` is always zero-padded to 6 digits** (`A000045`, `A000040`) — OEIS' canonical form. Search responses have raw integers (`number: 45`); the adapter formats them into the canonical id.
+- **`preview` is the first 12 terms**, comma-joined. The full term sequence can be hundreds of integers; we cap with `(+N)` suffix so rows stay scannable. Use `sequence` + the `data` API tier (not exposed here) for the full term stream.
+- **`keywords` is a comma-joined string**, OEIS' raw format. Common keywords:
+  - `core` — universally referenced
+  - `nice` — pleasing / well-known
+  - `easy` — easy to compute
+  - `nonn` — non-negative
+  - `mult` — multiplicative
+  - `cofr` — continued-fraction ish
+- **`offset`** is OEIS' notation for where the sequence begins (`'0,4'` means first term is at index 0, first term ≥ 2 is at index 4). Useful for sequences that start with `1, 1` and you need to know where the "interesting" terms are.
+- **`commentCount` / `formulaCount` / `referenceCount` / `xrefCount` / `linkCount`** are integer counts of how rich the OEIS page is. The full graphs are not surfaced — they can be enormous (Fibonacci has 250 links).
+- **No API key required.** OEIS' free service is generous; bursts → `CommandExecutionError`.
+- **Errors.** Empty query / bad A-number / bad limit → `ArgumentError`; unknown id / no matches → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/rest-countries.md
+++ b/docs/adapters/browser/rest-countries.md
@@ -1,0 +1,71 @@
+# REST Countries
+
+**Mode**: 🌐 Public · **Domain**: `restcountries.com`
+
+Look up countries by name (substring match) and list every country in a region. REST Countries is a free public country-metadata registry covering ISO codes, capitals, languages, currencies, lat/lon, timezones, UN membership, and more.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli rest-countries country <name>` | Look up countries by common / official name |
+| `opencli rest-countries region <region>` | List every country in a region |
+
+## Usage Examples
+
+```bash
+# Name search (substring, returns 1 or many)
+opencli rest-countries country japan
+opencli rest-countries country "united kingdom"
+opencli rest-countries country guinea          # matches Guinea, Guinea-Bissau, etc.
+
+# Region listing (sorted by population desc)
+opencli rest-countries region europe
+opencli rest-countries region asia --limit 20
+opencli rest-countries region oceania
+```
+
+## Output Columns
+
+Both commands share the same column set:
+
+| Column | Description |
+|--------|-------------|
+| `rank` | Population rank within the response |
+| `commonName` / `officialName` | Common and official country names |
+| `cca2` / `cca3` / `ccn3` | ISO 3166-1 alpha-2 / alpha-3 / numeric codes |
+| `capital` | Comma-joined capitals (most countries have 1, but South Africa has 3) |
+| `region` / `subregion` | Geographic region & subregion |
+| `population` / `area` | Population (people), area (km²) |
+| `languages` | Comma-joined official language names |
+| `currencies` | Comma-joined `CODE (Name)` pairs |
+| `latitude` / `longitude` | Country centroid in decimal degrees |
+| `timezones` | Comma-joined UTC offsets |
+| `independent` / `unMember` / `landlocked` | Boolean flags |
+| `flag` | Unicode flag emoji |
+| `url` | REST Countries `alpha/<cca3>` lookup URL |
+
+## Options
+
+### `country`
+
+| Option | Description |
+|--------|-------------|
+| `name` (positional) | Country name (substring match across common & official names) |
+| `--limit` | Max rows (1–250, default: 25) |
+
+### `region`
+
+| Option | Description |
+|--------|-------------|
+| `region` (positional) | One of: `africa`, `americas`, `asia`, `europe`, `oceania`, `antarctic` (case-insensitive) |
+| `--limit` | Max rows (1–250, default: 250) |
+
+## Notes
+
+- **Population-sorted by default.** Both `country` and `region` sort responses by `population` descending so the most-populous match appears at rank 1. This makes `rest-countries country guinea --limit 1` reliably surface Guinea (the country) rather than Guinea-Bissau or Papua New Guinea.
+- **`languages` / `currencies` are comma-joined**, not nested objects. REST Countries' raw shape is `{eng: 'English'}` / `{USD: {name, symbol}}`; we flatten to `'English'` / `'USD (United States dollar)'` for agent-readable rows.
+- **`capital` is comma-joined**, since some countries have multiple capitals (e.g. South Africa: `Pretoria, Cape Town, Bloemfontein`).
+- **`independent` / `unMember` / `landlocked`** are tri-state (boolean or `null`) — REST Countries doesn't fill them for every entity (rare territories may omit).
+- **No API key required.** REST Countries' free tier is very generous; bursts → `CommandExecutionError`.
+- **Errors.** Empty name / unknown region / bad limit → `ArgumentError`; unknown name (HTTP 404) → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/wikidata.md
+++ b/docs/adapters/browser/wikidata.md
@@ -1,0 +1,62 @@
+# Wikidata
+
+**Mode**: 🌐 Public · **Domain**: `www.wikidata.org`
+
+Search Wikidata items by keyword and fetch full entity detail by Q/P/L identifier. Wikidata is the canonical structured-data registry behind Wikipedia, with ~110M entities and a global property graph.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli wikidata search <query>` | Search Wikidata items by label / alias (returns Q-IDs) |
+| `opencli wikidata entity <id>` | Full entity detail: label, description, aliases, claim & sitelink counts |
+
+## Usage Examples
+
+```bash
+# Find Q-IDs by keyword
+opencli wikidata search einstein
+opencli wikidata search "san francisco" --limit 10
+opencli wikidata search 哈尔滨 --language zh
+
+# Entity detail (Q-IDs round-trip from search)
+opencli wikidata entity Q937           # Albert Einstein
+opencli wikidata entity Q90            # Paris
+opencli wikidata entity Q937 --language zh
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, qid, label, description, matchType, matchText, url` |
+| `entity` | `qid, type, label, description, aliases, claimPropertyCount, sitelinkCount, enwikiTitle, modified, url` |
+
+The `qid` column round-trips between commands.
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Search keyword (matches labels and aliases) |
+| `--language` | Search & display language (ISO 639, default: `en`). Examples: `en`, `fr`, `zh`, `zh-hans`. |
+| `--limit` | Max items (1–50, default: 20) |
+
+### `entity`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Entity id: `Q<digits>` (item), `P<digits>` (property), `L<digits>` (lexeme). Full URLs (`https://www.wikidata.org/wiki/Q937`) are stripped. |
+| `--language` | Display language (ISO 639, default: `en`). Falls back to English when missing. |
+
+## Notes
+
+- **Label / description / aliases fall back to English** when the requested language is missing — Wikidata stores localisations independently per field, so a Chinese-only article may have an English label but no Chinese description, and we surface what's available rather than emitting `null` row-by-row.
+- **`claimPropertyCount` ≠ claim count.** It counts the number of distinct properties (P-IDs) on the entity. Some properties have many statements (e.g. `P31` may have multiple "instance of" claims); we don't sum them. Useful as a rough indicator of how rich the entity is.
+- **`sitelinkCount`** is the number of language Wikipedias linking to this entity. High values (300+) indicate broadly-known concepts.
+- **`enwikiTitle`** is the corresponding English Wikipedia article title, if any. `null` for entities not linked to enwiki (Q-IDs that exist only as Wikidata structured data).
+- **`matchType` (search only)** is one of `label`, `alias`, `description`, indicating how the keyword matched. `alias` matches are common for famous entities (e.g. searching "Einstein" matches Q937 via alias, not label).
+- **No API key required.** Wikidata throttles anonymous traffic at ~5000 req/hour; bursts → `CommandExecutionError`.
+- **Errors.** Bad Q-ID shape / bad language code / bad limit → `ArgumentError`; unknown id → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -128,6 +128,12 @@ Run `opencli list` for the live registry.
 | **[goproxy](./browser/goproxy.md)**               | `module` `versions`                                                                                                                            | 🌐 Public    |
 | **[tvmaze](./browser/tvmaze.md)**                 | `search` `show`                                                                                                                                | 🌐 Public    |
 | **[rfc](./browser/rfc.md)**                       | `rfc`                                                                                                                                          | 🌐 Public    |
+| **[wikidata](./browser/wikidata.md)**             | `search` `entity`                                                                                                                              | 🌐 Public    |
+| **[lichess](./browser/lichess.md)**               | `user` `top`                                                                                                                                   | 🌐 Public    |
+| **[rest-countries](./browser/rest-countries.md)** | `country` `region`                                                                                                                             | 🌐 Public    |
+| **[nuget](./browser/nuget.md)**                   | `search` `package`                                                                                                                             | 🌐 Public    |
+| **[flathub](./browser/flathub.md)**               | `search` `app`                                                                                                                                 | 🌐 Public    |
+| **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

Round 7 of the adapter-expansion sweep — 12 read commands across **6 new public no-auth sites**, each backed by a 7-assertion contract test file (42 total).

| Site | Commands | Highlights |
|------|----------|-----------|
| **wikidata** | `search`, `entity` | wbsearchentities + Special:EntityData; Q/P/L ids; localised label/description with English fallback |
| **lichess** | `user`, `top` | 13 perf types validated; closed accounts → `EmptyResultError` (no silent disabled-row of nulls) |
| **rest-countries** | `country`, `region` | Population-sorted by default; flattened languages/currencies/capitals so rows stay scannable |
| **nuget** | `search`, `package` | Registration page-walking handles 100+ version histories in one call; case-insensitive id with strict shape gate |
| **flathub** | `search`, `app` | appId reverse-DNS canonicalised; dual-shape timestamp coercion (search = unix-seconds int, /appstream = ISO string) |
| **oeis** | `search`, `sequence` | A-id zero-padded to 6 digits; 12-term preview with `(+N)` suffix; pagination via `&start=` (10 per page) |

## Design highlights (caught during live verify)

- **Wikidata `joinAliases` English fallback** — first iteration only consulted `aliases[language]`, parity with `pickLocalised` required adding the same `en` fallback when the requested language has no aliases.
- **Lichess disabled accounts** — `body.disabled === true` raises `EmptyResultError('lichess user', '… is closed/disabled.')` instead of returning a row of nulls (silent-sentinel anti-pattern).
- **Flathub `mainCategories` / `updatedAt`** — `/search` ships `main_categories` as a single string and `updated_at` as unix-seconds int; `/appstream/<id>` uses an array + ISO string. Adapter normalises so both surfaces look consistent. Contract test asserts unix-seconds → `'2024-10-27'`.
- **Flathub `releases[].timestamp`** — appstream layer returns numeric STRING (`'1777248000'`), not int. `pickLatestRelease` coerces both shapes plus falls back to `date` field.
- **NuGet registration page-walking** — V3 may inline page items or stub them with a follow-up `@id`. Adapter detects stubs and walks them (`nugetFetch(pageUrl, …)`) so 100+ version histories come back in one call.
- **OEIS pagination** — `&start=N` (10 per page, OEIS' wire format); test uses `mockImplementation(() => Promise.resolve(new Response(...)))` to avoid the "Body has already been read" trap from `mockResolvedValue` on multi-fetch paths.

## Audit deltas

- typed-error-lint: `196=baseline` (no new violations)
- silent-column-drop: `103=baseline` (no new violations)
- listing-id-pairing: 0 Round-7 violations — all 6 listing commands carry round-trip ids: `qid` / `username` / `cca3` / `id` / `appId` / `id`

## Live verify

All 12 commands run successfully against real APIs:
- `wikidata search einstein --limit 5`, `wikidata entity Q937`
- `lichess user DrNykterstein`, `lichess top 10 blitz`
- `rest-countries country japan`, `rest-countries region oceania --limit 10`
- `nuget search newtonsoft --limit 5`, `nuget package Newtonsoft.Json`
- `flathub search firefox --limit 5`, `flathub app org.mozilla.firefox`
- `oeis search fibonacci --limit 5`, `oeis sequence A000045`

## Test plan

- [x] `npx vitest run clis/{wikidata,lichess,rest-countries,nuget,flathub,oeis}/*.test.js` → 6 files / 42 tests passed
- [x] All 12 commands live-verified against real APIs (no mocks)
- [x] `node scripts/check-typed-error-lint.mjs` → no new violations
- [x] `node scripts/check-silent-column-drop.mjs` → no new violations
- [x] `node scripts/check-listing-id-pairing.mjs` → 0 Round-7 violations
- [x] `npx tsx src/build-manifest.ts` → 757 entries (12 new)
