### PR TITLE
feat: 2 read adapters (nominatim, mempool) + contract tests

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14343,6 +14343,80 @@
     "navigateBefore": "https://medium.com"
   },
   {
+    "site": "mempool",
+    "name": "block",
+    "description": "Fetch a Bitcoin block by hash or height (one row)",
+    "access": "read",
+    "domain": "mempool.space",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "ref",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Block hash (64-hex) or height (integer)"
+      }
+    ],
+    "columns": [
+      "id",
+      "height",
+      "version",
+      "timestamp",
+      "txCount",
+      "size",
+      "weight",
+      "merkleRoot",
+      "previousBlockHash",
+      "mediantime",
+      "nonce",
+      "bits",
+      "difficulty",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "mempool/block.js",
+    "sourceFile": "mempool/block.js"
+  },
+  {
+    "site": "mempool",
+    "name": "tx",
+    "description": "Fetch a Bitcoin transaction by txid (one row)",
+    "access": "read",
+    "domain": "mempool.space",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "txid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Bitcoin transaction id (64-char hex)"
+      }
+    ],
+    "columns": [
+      "txid",
+      "version",
+      "locktime",
+      "size",
+      "weight",
+      "fee",
+      "vinCount",
+      "voutCount",
+      "totalOutputSats",
+      "confirmed",
+      "blockHeight",
+      "blockHash",
+      "blockTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "mempool/tx.js",
+    "sourceFile": "mempool/tx.js"
+  },
+  {
     "site": "mubu",
     "name": "doc",
     "description": "读取幕布文档内容（默认输出 Markdown，可用 --output text 输出纯文本）",
@@ -14543,6 +14617,105 @@
     "modulePath": "mubu/search.js",
     "sourceFile": "mubu/search.js",
     "navigateBefore": "https://mubu.com"
+  },
+  {
+    "site": "nominatim",
+    "name": "geocode",
+    "description": "Forward-geocode an address into lat/lon + structured address rows",
+    "access": "read",
+    "domain": "nominatim.openstreetmap.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Free-text address or place name"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max rows (1-50)"
+      },
+      {
+        "name": "countrycodes",
+        "type": "str",
+        "required": false,
+        "help": "Comma-separated ISO-3166-1 alpha-2 country filter (e.g. \"fr,de\")"
+      }
+    ],
+    "columns": [
+      "rank",
+      "displayName",
+      "lat",
+      "lon",
+      "type",
+      "class",
+      "importance",
+      "country",
+      "countryCode",
+      "city",
+      "state",
+      "postcode",
+      "osmType",
+      "osmId",
+      "placeId",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "nominatim/geocode.js",
+    "sourceFile": "nominatim/geocode.js"
+  },
+  {
+    "site": "nominatim",
+    "name": "reverse",
+    "description": "Reverse-geocode a lat/lon pair into a structured address",
+    "access": "read",
+    "domain": "nominatim.openstreetmap.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "lat",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Latitude in decimal degrees"
+      },
+      {
+        "name": "lon",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Longitude in decimal degrees"
+      }
+    ],
+    "columns": [
+      "displayName",
+      "lat",
+      "lon",
+      "type",
+      "class",
+      "country",
+      "countryCode",
+      "city",
+      "state",
+      "suburb",
+      "road",
+      "houseNumber",
+      "postcode",
+      "osmType",
+      "osmId",
+      "placeId",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "nominatim/reverse.js",
+    "sourceFile": "nominatim/reverse.js"
   },
   {
     "site": "notebooklm",

--- a/clis/mempool/block.js
+++ b/clis/mempool/block.js
@@ -1,0 +1,57 @@
+// mempool block — fetch a Bitcoin block by hash or height.
+//
+// Wraps `/api/block/<hash>`. If the user passes a numeric height we first hit
+// `/api/block-height/<n>` to resolve the hash, then the block endpoint.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    MEMPOOL_BASE, isoFromUnix, mempoolFetch, requireBlockRef,
+} from './utils.js';
+
+cli({
+    site: 'mempool',
+    name: 'block',
+    access: 'read',
+    description: 'Fetch a Bitcoin block by hash or height (one row)',
+    domain: 'mempool.space',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'ref', positional: true, required: true, help: 'Block hash (64-hex) or height (integer)' },
+    ],
+    columns: [
+        'id', 'height', 'version', 'timestamp', 'txCount', 'size', 'weight',
+        'merkleRoot', 'previousBlockHash', 'mediantime', 'nonce', 'bits', 'difficulty', 'url',
+    ],
+    func: async (args) => {
+        const ref = requireBlockRef(args.ref);
+        let hash = ref.value;
+        if (ref.kind === 'height') {
+            // Returns plain text body — the canonical hash for that height.
+            hash = await mempoolFetch(`${MEMPOOL_BASE}/api/block-height/${ref.value}`, 'mempool block-height', { expect: 'text' });
+            if (!hash || !/^[0-9a-fA-F]{64}$/.test(hash)) {
+                throw new EmptyResultError('mempool block', `No block at height ${ref.value}.`);
+            }
+        }
+        const body = await mempoolFetch(`${MEMPOOL_BASE}/api/block/${hash}`, 'mempool block');
+        if (!body || typeof body !== 'object' || typeof body.id !== 'string') {
+            throw new EmptyResultError('mempool block', `Block "${hash}" not found.`);
+        }
+        return [{
+            id: body.id,
+            height: typeof body.height === 'number' ? body.height : null,
+            version: typeof body.version === 'number' ? body.version : null,
+            timestamp: isoFromUnix(body.timestamp),
+            txCount: typeof body.tx_count === 'number' ? body.tx_count : null,
+            size: typeof body.size === 'number' ? body.size : null,
+            weight: typeof body.weight === 'number' ? body.weight : null,
+            merkleRoot: typeof body.merkle_root === 'string' ? body.merkle_root : null,
+            previousBlockHash: typeof body.previousblockhash === 'string' ? body.previousblockhash : null,
+            mediantime: isoFromUnix(body.mediantime),
+            nonce: typeof body.nonce === 'number' ? body.nonce : null,
+            bits: typeof body.bits === 'number' ? body.bits : null,
+            difficulty: typeof body.difficulty === 'number' ? body.difficulty : null,
+            url: `${MEMPOOL_BASE}/block/${body.id}`,
+        }];
+    },
+});

--- a/clis/mempool/mempool.test.js
+++ b/clis/mempool/mempool.test.js
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './tx.js';
+import './block.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('mempool tx adapter', () => {
+    const cmd = getRegistry().get('mempool/tx');
+
+    it('rejects malformed txids before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ txid: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ txid: 'beef' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ txid: 'g'.repeat(64) })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ txid: '0'.repeat(64) })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('sums vout values and exposes confirmed status as ISO timestamp', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            txid: 'a'.repeat(64), version: 2, locktime: 0, size: 250, weight: 1000, fee: 5000,
+            vin: [{}, {}], vout: [{ value: 1234 }, { value: 5678 }],
+            status: { confirmed: true, block_height: 800000, block_hash: 'b'.repeat(64), block_time: 1700000000 },
+        }), { status: 200 })));
+        const rows = await cmd.func({ txid: 'a'.repeat(64) });
+        expect(rows[0]).toMatchObject({
+            txid: 'a'.repeat(64), version: 2, vinCount: 2, voutCount: 2, totalOutputSats: 6912,
+            confirmed: true, blockHeight: 800000, url: `https://mempool.space/tx/${'a'.repeat(64)}`,
+        });
+        expect(rows[0].blockTime).toBe('2023-11-14T22:13:20.000Z');
+    });
+});
+
+describe('mempool block adapter', () => {
+    const cmd = getRegistry().get('mempool/block');
+
+    it('rejects refs that are neither 64-hex nor integer', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ ref: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ ref: 'not-a-block' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ ref: '-1' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 404 (block-height resolver) to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ ref: '99999999' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('resolves height → hash → block in two fetches', async () => {
+        // First fetch returns plain hash text (block-height endpoint), second
+        // returns the block JSON. We use mockImplementation so each call gets a
+        // fresh Response (mockResolvedValue would re-use one body and the second
+        // .text()/.json() would throw "Body has already been read").
+        const calls = [];
+        vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
+            calls.push(url);
+            if (url.includes('/api/block-height/')) {
+                return Promise.resolve(new Response('c'.repeat(64), { status: 200 }));
+            }
+            return Promise.resolve(new Response(JSON.stringify({
+                id: 'c'.repeat(64), height: 800000, version: 1, tx_count: 1234, size: 1024, weight: 4096,
+                merkle_root: 'd'.repeat(64), previousblockhash: 'e'.repeat(64),
+                timestamp: 1700000000, mediantime: 1699999000, nonce: 42, bits: 386015216, difficulty: 12345,
+            }), { status: 200 }));
+        }));
+        const rows = await cmd.func({ ref: '800000' });
+        expect(rows[0]).toMatchObject({
+            id: 'c'.repeat(64), height: 800000, txCount: 1234, nonce: 42,
+            url: `https://mempool.space/block/${'c'.repeat(64)}`,
+        });
+        expect(calls.length).toBe(2);
+        expect(calls[0]).toContain('/api/block-height/800000');
+    });
+});

--- a/clis/mempool/tx.js
+++ b/clis/mempool/tx.js
@@ -1,0 +1,54 @@
+// mempool tx — fetch a Bitcoin transaction by txid.
+//
+// Wraps `/api/tx/<txid>`. We surface counts + total output value rather than
+// dumping vin/vout arrays so rows stay scannable.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    MEMPOOL_BASE, isoFromUnix, mempoolFetch, requireTxid, sumVoutValues,
+} from './utils.js';
+
+cli({
+    site: 'mempool',
+    name: 'tx',
+    access: 'read',
+    description: 'Fetch a Bitcoin transaction by txid (one row)',
+    domain: 'mempool.space',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'txid', positional: true, required: true, help: 'Bitcoin transaction id (64-char hex)' },
+    ],
+    columns: [
+        'txid', 'version', 'locktime', 'size', 'weight', 'fee',
+        'vinCount', 'voutCount', 'totalOutputSats',
+        'confirmed', 'blockHeight', 'blockHash', 'blockTime', 'url',
+    ],
+    func: async (args) => {
+        const txid = requireTxid(args.txid);
+        const url = `${MEMPOOL_BASE}/api/tx/${txid}`;
+        const body = await mempoolFetch(url, 'mempool tx');
+        if (!body || typeof body !== 'object' || typeof body.txid !== 'string') {
+            // mempool.space returns 200 + text "Transaction not found" on some
+            // edge cases; mempoolFetch already errors on bad JSON, but if the
+            // shape is wrong (e.g. an empty `{}`) we treat it as Empty.
+            throw new (await import('@jackwener/opencli/errors')).EmptyResultError('mempool tx', `Transaction "${txid}" not found.`);
+        }
+        const status = body.status && typeof body.status === 'object' ? body.status : {};
+        return [{
+            txid: body.txid,
+            version: typeof body.version === 'number' ? body.version : null,
+            locktime: typeof body.locktime === 'number' ? body.locktime : null,
+            size: typeof body.size === 'number' ? body.size : null,
+            weight: typeof body.weight === 'number' ? body.weight : null,
+            fee: typeof body.fee === 'number' ? body.fee : null,
+            vinCount: Array.isArray(body.vin) ? body.vin.length : null,
+            voutCount: Array.isArray(body.vout) ? body.vout.length : null,
+            totalOutputSats: sumVoutValues(body.vout),
+            confirmed: typeof status.confirmed === 'boolean' ? status.confirmed : null,
+            blockHeight: typeof status.block_height === 'number' ? status.block_height : null,
+            blockHash: typeof status.block_hash === 'string' ? status.block_hash : null,
+            blockTime: isoFromUnix(status.block_time),
+            url: `${MEMPOOL_BASE}/tx/${body.txid}`,
+        }];
+    },
+});

--- a/clis/mempool/utils.js
+++ b/clis/mempool/utils.js
@@ -1,0 +1,97 @@
+// Shared helpers for the mempool.space adapters.
+//
+// mempool.space exposes a public Esplora-compatible REST API for Bitcoin
+// transactions and blocks. No API key.
+//   • /api/tx/<txid>          — tx detail (json object)
+//   • /api/block/<hash>       — block detail by hash
+//   • /api/block-height/<n>   — returns the block hash as a plain string
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const MEMPOOL_BASE = 'https://mempool.space';
+
+const TXID_PATTERN = /^[0-9a-fA-F]{64}$/;
+const BLOCK_HASH_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+export function requireTxid(value) {
+    const raw = String(value ?? '').trim().toLowerCase();
+    if (!raw) throw new ArgumentError('mempool txid is required');
+    if (!TXID_PATTERN.test(raw)) {
+        throw new ArgumentError(
+            `mempool txid "${value}" is not a valid 64-char hex string`,
+        );
+    }
+    return raw;
+}
+
+// Block reference: either a 64-char hex block hash, or a non-negative integer
+// height. Returns `{kind: 'hash'|'height', value: string}`.
+export function requireBlockRef(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('mempool block id (hash or height) is required');
+    if (BLOCK_HASH_PATTERN.test(raw)) {
+        return { kind: 'hash', value: raw.toLowerCase() };
+    }
+    if (/^\d+$/.test(raw)) {
+        const h = Number(raw);
+        if (!Number.isInteger(h) || h < 0) {
+            throw new ArgumentError(`mempool block height "${value}" must be a non-negative integer`);
+        }
+        return { kind: 'height', value: String(h) };
+    }
+    throw new ArgumentError(
+        `mempool block ref "${value}" is neither a 64-hex hash nor a non-negative integer height`,
+    );
+}
+
+export async function mempoolFetch(url, label, { expect = 'json' } = {}) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { accept: expect === 'json' ? 'application/json' : 'text/plain' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that mempool.space is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `mempool.space returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'mempool.space caps anonymous traffic; back off and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    if (expect === 'text') {
+        return (await resp.text()).trim();
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        // mempool.space returns plain "Transaction not found" text on the json
+        // endpoint when a tx is unknown — surface as EmptyResultError.
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+// `vin` / `vout` arrays can be huge; we only surface counts and aggregate values.
+export function sumVoutValues(vout) {
+    if (!Array.isArray(vout)) return null;
+    let total = 0;
+    for (const v of vout) {
+        if (typeof v?.value === 'number' && Number.isFinite(v.value)) total += v.value;
+    }
+    return total;
+}
+
+export function isoFromUnix(seconds) {
+    if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return null;
+    return new Date(seconds * 1000).toISOString();
+}

--- a/clis/nominatim/geocode.js
+++ b/clis/nominatim/geocode.js
@@ -1,0 +1,64 @@
+// nominatim geocode — forward-geocode an address string into lat/lon + structured address rows.
+//
+// Wraps `/search` on nominatim.openstreetmap.org. Returns one row per match
+// sorted by Nominatim's `importance` desc (their relevance ranking).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    NOMINATIM_BASE, normalizeCountryCodes, nominatimFetch, pickCity, placeUrl,
+    requireBoundedInt, requireString,
+} from './utils.js';
+
+cli({
+    site: 'nominatim',
+    name: 'geocode',
+    access: 'read',
+    description: 'Forward-geocode an address into lat/lon + structured address rows',
+    domain: 'nominatim.openstreetmap.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Free-text address or place name' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max rows (1-50)' },
+        { name: 'countrycodes', help: 'Comma-separated ISO-3166-1 alpha-2 country filter (e.g. "fr,de")' },
+    ],
+    columns: [
+        'rank', 'displayName', 'lat', 'lon', 'type', 'class', 'importance',
+        'country', 'countryCode', 'city', 'state', 'postcode',
+        'osmType', 'osmId', 'placeId', 'url',
+    ],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 10, 50);
+        const countrycodes = normalizeCountryCodes(args.countrycodes);
+        let url = `${NOMINATIM_BASE}/search?q=${encodeURIComponent(query)}`
+            + `&format=json&addressdetails=1&limit=${limit}`;
+        if (countrycodes) url += `&countrycodes=${encodeURIComponent(countrycodes)}`;
+        const body = await nominatimFetch(url, 'nominatim geocode');
+        const list = Array.isArray(body) ? body : [];
+        if (!list.length) {
+            throw new EmptyResultError('nominatim geocode', `No matches for "${query}".`);
+        }
+        return list.slice(0, limit).map((hit, i) => {
+            const addr = hit?.address && typeof hit.address === 'object' ? hit.address : {};
+            return {
+                rank: i + 1,
+                displayName: typeof hit?.display_name === 'string' ? hit.display_name : null,
+                lat: typeof hit?.lat === 'string' ? Number(hit.lat) : null,
+                lon: typeof hit?.lon === 'string' ? Number(hit.lon) : null,
+                type: typeof hit?.type === 'string' ? hit.type : null,
+                class: typeof hit?.class === 'string' ? hit.class : null,
+                importance: typeof hit?.importance === 'number' ? hit.importance : null,
+                country: typeof addr.country === 'string' ? addr.country : null,
+                countryCode: typeof addr.country_code === 'string' ? addr.country_code : null,
+                city: pickCity(addr),
+                state: typeof addr.state === 'string' ? addr.state : null,
+                postcode: typeof addr.postcode === 'string' ? addr.postcode : null,
+                osmType: typeof hit?.osm_type === 'string' ? hit.osm_type : null,
+                osmId: typeof hit?.osm_id === 'number' ? hit.osm_id : null,
+                placeId: typeof hit?.place_id === 'number' ? hit.place_id : null,
+                url: placeUrl(hit?.osm_type, hit?.osm_id),
+            };
+        });
+    },
+});

--- a/clis/nominatim/nominatim.test.js
+++ b/clis/nominatim/nominatim.test.js
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './geocode.js';
+import './reverse.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('nominatim geocode adapter', () => {
+    const cmd = getRegistry().get('nominatim/geocode');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'paris', limit: 999 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'paris', countrycodes: 'xx,!!' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('throttled', { status: 429 })));
+        await expect(cmd.func({ query: 'paris', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty array response', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })));
+        await expect(cmd.func({ query: 'no-such-place' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('coerces lat/lon strings to numbers and resolves OSM url', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([{
+            place_id: 12345, osm_type: 'way', osm_id: 5013364,
+            lat: '48.8582599', lon: '2.2945006', class: 'man_made', type: 'tower',
+            importance: 0.62, display_name: 'Tour Eiffel, Paris, France',
+            address: { country: 'France', country_code: 'fr', city: 'Paris', state: 'Île-de-France', postcode: '75007' },
+        }]), { status: 200 })));
+        const rows = await cmd.func({ query: 'eiffel tower', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1, lat: 48.8582599, lon: 2.2945006,
+            country: 'France', countryCode: 'fr', city: 'Paris', state: 'Île-de-France',
+            osmType: 'way', osmId: 5013364, placeId: 12345,
+            url: 'https://www.openstreetmap.org/way/5013364',
+        });
+    });
+});
+
+describe('nominatim reverse adapter', () => {
+    const cmd = getRegistry().get('nominatim/reverse');
+
+    it('rejects malformed coords before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ lat: 'NaN', lon: '0' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ lat: '91', lon: '0' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ lat: '0', lon: '181' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 403 to CommandExecutionError (UA-policy violation)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('blocked', { status: 403 })));
+        await expect(cmd.func({ lat: '0', lon: '0' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('treats {error: ...} body as EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'Unable to geocode' }), { status: 200 })));
+        await expect(cmd.func({ lat: '0', lon: '0' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('falls back through city precedence chain (town/village/hamlet)', async () => {
+        // Some rural reverse hits have no `city` but have `village`; the picker
+        // must surface it so the row's `city` column is not silently null.
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            place_id: 1, osm_type: 'node', osm_id: 999,
+            lat: '50.0', lon: '8.0', display_name: 'A village', type: 'house', class: 'place',
+            address: { country: 'Germany', country_code: 'de', village: 'Kleindorf', state: 'Hessen', postcode: '00000' },
+        }), { status: 200 })));
+        const rows = await cmd.func({ lat: '50.0', lon: '8.0' });
+        expect(rows[0]).toMatchObject({
+            country: 'Germany', countryCode: 'de', city: 'Kleindorf', state: 'Hessen',
+            url: 'https://www.openstreetmap.org/node/999',
+        });
+    });
+});

--- a/clis/nominatim/reverse.js
+++ b/clis/nominatim/reverse.js
@@ -1,0 +1,57 @@
+// nominatim reverse — reverse-geocode lat/lon into a structured address row.
+//
+// Wraps `/reverse` on nominatim.openstreetmap.org. Returns exactly one row.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    NOMINATIM_BASE, nominatimFetch, pickCity, placeUrl, requireCoord,
+} from './utils.js';
+
+cli({
+    site: 'nominatim',
+    name: 'reverse',
+    access: 'read',
+    description: 'Reverse-geocode a lat/lon pair into a structured address',
+    domain: 'nominatim.openstreetmap.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'lat', positional: true, required: true, help: 'Latitude in decimal degrees' },
+        { name: 'lon', positional: true, required: true, help: 'Longitude in decimal degrees' },
+    ],
+    columns: [
+        'displayName', 'lat', 'lon', 'type', 'class',
+        'country', 'countryCode', 'city', 'state', 'suburb', 'road', 'houseNumber', 'postcode',
+        'osmType', 'osmId', 'placeId', 'url',
+    ],
+    func: async (args) => {
+        const lat = requireCoord(args.lat, 'lat');
+        const lon = requireCoord(args.lon, 'lon');
+        const url = `${NOMINATIM_BASE}/reverse?lat=${lat}&lon=${lon}&format=json&addressdetails=1`;
+        const body = await nominatimFetch(url, 'nominatim reverse');
+        // Nominatim signals "no result" with `{error: 'Unable to geocode'}`.
+        if (body?.error) {
+            throw new EmptyResultError('nominatim reverse', `No address found for (${lat}, ${lon}).`);
+        }
+        const addr = body?.address && typeof body.address === 'object' ? body.address : {};
+        return [{
+            displayName: typeof body?.display_name === 'string' ? body.display_name : null,
+            lat: typeof body?.lat === 'string' ? Number(body.lat) : null,
+            lon: typeof body?.lon === 'string' ? Number(body.lon) : null,
+            type: typeof body?.type === 'string' ? body.type : null,
+            class: typeof body?.class === 'string' ? body.class : null,
+            country: typeof addr.country === 'string' ? addr.country : null,
+            countryCode: typeof addr.country_code === 'string' ? addr.country_code : null,
+            city: pickCity(addr),
+            state: typeof addr.state === 'string' ? addr.state : null,
+            suburb: typeof addr.suburb === 'string' ? addr.suburb : null,
+            road: typeof addr.road === 'string' ? addr.road : null,
+            houseNumber: typeof addr.house_number === 'string' ? addr.house_number : null,
+            postcode: typeof addr.postcode === 'string' ? addr.postcode : null,
+            osmType: typeof body?.osm_type === 'string' ? body.osm_type : null,
+            osmId: typeof body?.osm_id === 'number' ? body.osm_id : null,
+            placeId: typeof body?.place_id === 'number' ? body.place_id : null,
+            url: placeUrl(body?.osm_type, body?.osm_id),
+        }];
+    },
+});

--- a/clis/nominatim/utils.js
+++ b/clis/nominatim/utils.js
@@ -1,0 +1,114 @@
+// Shared helpers for the Nominatim (OpenStreetMap) adapters.
+//
+// Nominatim is OSM's public geocoder. Two endpoints we care about:
+//   • `/search?q=...` for forward geocode (text → coords)
+//   • `/reverse?lat=&lon=` for reverse geocode (coords → address)
+// No API key. Their usage policy *requires* a real User-Agent and recommends
+// <= 1 req/s for anonymous traffic; we set a polite UA and surface 429 verbatim.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
+const UA = 'opencli-nominatim-adapter/1.0 (+https://github.com/jackwener/opencli)';
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`nominatim ${label} cannot be empty`);
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`nominatim ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`nominatim ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+// Latitude in [-90, 90], longitude in [-180, 180]. Reject NaN explicitly so
+// callers see ArgumentError instead of a 400 from upstream.
+export function requireCoord(value, kind) {
+    const raw = value ?? '';
+    const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+    if (!Number.isFinite(n)) {
+        throw new ArgumentError(`nominatim ${kind} "${value}" is not a finite number`);
+    }
+    if (kind === 'lat' && (n < -90 || n > 90)) {
+        throw new ArgumentError(`nominatim lat ${n} is out of range [-90, 90]`);
+    }
+    if (kind === 'lon' && (n < -180 || n > 180)) {
+        throw new ArgumentError(`nominatim lon ${n} is out of range [-180, 180]`);
+    }
+    return n;
+}
+
+// Country-code filter: ISO 3166-1 alpha-2, comma-separated, lowercased.
+export function normalizeCountryCodes(value) {
+    if (value === undefined || value === null || value === '') return null;
+    const parts = String(value).split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+    if (!parts.length) return null;
+    for (const p of parts) {
+        if (!/^[a-z]{2}$/.test(p)) {
+            throw new ArgumentError(`nominatim countrycode "${p}" is not a 2-letter ISO 3166-1 alpha-2 code`);
+        }
+    }
+    return parts.join(',');
+}
+
+export async function nominatimFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that nominatim.openstreetmap.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Nominatim returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'OSM Nominatim caps anonymous traffic at ~1 req/s; back off and retry.',
+        );
+    }
+    if (resp.status === 403) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 403`,
+            'Nominatim usage policy blocks bare User-Agent traffic; ensure UA is set.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    return body;
+}
+
+// Project Nominatim's nested address blob into a flat row. Nominatim's address
+// keys are not stable per row (a `village` may be present where `city` is not),
+// so we fall through a precedence list rather than picking exactly one key.
+export function pickCity(address) {
+    if (!address || typeof address !== 'object') return null;
+    return address.city || address.town || address.village || address.hamlet
+        || address.municipality || address.county || null;
+}
+
+export function placeUrl(osmType, osmId) {
+    if (!osmType || !osmId) return null;
+    // OSM's URL prefix is the first letter of the osm_type (node/way/relation).
+    const prefix = osmType[0].toUpperCase();
+    return `https://www.openstreetmap.org/${osmType}/${osmId}`;
+}

--- a/docs/adapters/browser/mempool.md
+++ b/docs/adapters/browser/mempool.md
@@ -1,0 +1,60 @@
+# mempool.space
+
+**Mode**: 🌐 Public · **Domain**: `mempool.space`
+
+Bitcoin transaction and block lookup against mempool.space's Esplora-compatible REST API. No API key.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli mempool tx <txid>` | Fetch a Bitcoin transaction by 64-hex txid |
+| `opencli mempool block <ref>` | Fetch a block by 64-hex hash or integer height |
+
+## Usage Examples
+
+```bash
+# Tx detail
+opencli mempool tx 4ae286f67e24e41bfa0d0ad491b2669dc0e166cb9d4f54bc1661f37c69b79735
+
+# Block by hash
+opencli mempool block 000000000000000000000978c2de1ec6d5fca5f23d25bb92c1d2ae6b24c88883
+
+# Block by height (resolved internally via /api/block-height)
+opencli mempool block 800000
+opencli mempool block 0          # genesis block
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `tx` | `txid, version, locktime, size, weight, fee, vinCount, voutCount, totalOutputSats, confirmed, blockHeight, blockHash, blockTime, url` |
+| `block` | `id, height, version, timestamp, txCount, size, weight, merkleRoot, previousBlockHash, mediantime, nonce, bits, difficulty, url` |
+
+The `blockHash` from a `tx` row round-trips into `mempool block <hash>`.
+
+## Options
+
+### `tx`
+
+| Option | Description |
+|--------|-------------|
+| `txid` (positional) | Bitcoin transaction id (64-char lowercase hex) |
+
+### `block`
+
+| Option | Description |
+|--------|-------------|
+| `ref` (positional) | Block hash (64-hex) **or** non-negative integer height |
+
+## Notes
+
+- **Two-fetch height resolution.** `block <height>` first hits `/api/block-height/<n>` (returns the canonical hash as plain text), then `/api/block/<hash>` for the JSON. Hash inputs skip the first hop. The contract test exercises both call sites with `mockImplementation` to avoid the "Body has already been read" trap of `mockResolvedValue`.
+- **`vin` / `vout` counts only**, not the full input/output arrays. `vout` arrays can be hundreds of entries long for high-fanout txs; we surface counts + `totalOutputSats` (sum of all output values) so a single row stays scannable.
+- **`fee` and `totalOutputSats` are in satoshis** (1 BTC = 100,000,000 sats). Convert at the call site if you need BTC.
+- **`confirmed: false`** indicates a tx still in the mempool; `blockHeight` / `blockHash` / `blockTime` are `null` until inclusion.
+- **`timestamp` and `mediantime` are normalised** from unix-seconds to ISO. Genesis (`height: 0`) has `timestamp: '2009-01-03T18:15:05.000Z'`.
+- **Difficulty.** `difficulty` is a float (Bitcoin Core's published difficulty number). For raw nBits, use the `bits` column.
+- **No API key required.** mempool.space's public REST is free for everyone; bursts → `CommandExecutionError`.
+- **Errors.** Bad txid (not 64-hex) / bad block ref / negative height → `ArgumentError`; HTTP 404 (unknown txid/hash/height) → `EmptyResultError`; transport / 429 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/nominatim.md
+++ b/docs/adapters/browser/nominatim.md
@@ -1,0 +1,60 @@
+# Nominatim (OpenStreetMap)
+
+**Mode**: 🌐 Public · **Domain**: `nominatim.openstreetmap.org`
+
+Forward- and reverse-geocode addresses against OpenStreetMap's official Nominatim service. No API key; usage policy requires a real `User-Agent` and recommends ~1 req/s for anonymous traffic — the adapter sets a polite UA and surfaces 429 verbatim.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli nominatim geocode <query>` | Forward-geocode an address into lat/lon + structured rows |
+| `opencli nominatim reverse <lat> <lon>` | Reverse-geocode a lat/lon pair into a structured address |
+
+## Usage Examples
+
+```bash
+# Forward geocode
+opencli nominatim geocode "eiffel tower" --limit 3
+opencli nominatim geocode "1600 Pennsylvania Ave"
+opencli nominatim geocode "tokyo" --countrycodes jp
+
+# Reverse geocode
+opencli nominatim reverse 48.8582 2.2945           # Eiffel Tower
+opencli nominatim reverse 40.7484 -73.9857         # Empire State Building
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `geocode` | `rank, displayName, lat, lon, type, class, importance, country, countryCode, city, state, postcode, osmType, osmId, placeId, url` |
+| `reverse` | `displayName, lat, lon, type, class, country, countryCode, city, state, suburb, road, houseNumber, postcode, osmType, osmId, placeId, url` |
+
+The `osmType` + `osmId` pair round-trips into an `openstreetmap.org/<type>/<id>` URL.
+
+## Options
+
+### `geocode`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Free-text address or place name |
+| `--limit` | Max rows (1–50, default: 10) |
+| `--countrycodes` | Comma-separated ISO-3166-1 alpha-2 codes (e.g. `fr,de`) |
+
+### `reverse`
+
+| Option | Description |
+|--------|-------------|
+| `lat` (positional) | Latitude in decimal degrees, range `[-90, 90]` |
+| `lon` (positional) | Longitude in decimal degrees, range `[-180, 180]` |
+
+## Notes
+
+- **`city` precedence chain.** Nominatim's address blob has stable schemas only for the largest cities. Rural reverse hits often have `village` / `town` / `hamlet` instead of `city`. The adapter falls through `city → town → village → hamlet → municipality → county` so the `city` column is never silently `null` when *some* settlement name is available.
+- **`lat` / `lon` are coerced to numbers**, not the raw `string` Nominatim returns. Easier to feed straight into geo math without re-parsing.
+- **`importance`** is Nominatim's relevance score in `[0, 1]`; useful for filtering noisy `geocode` queries.
+- **Country filter**. `--countrycodes` is a server-side filter — passing `fr,de` skips non-FR/DE results before they're ranked, so the most-important hit returned is the most-important hit *in the filtered set*.
+- **Usage policy.** Per [OSM Nominatim policy](https://operations.osmfoundation.org/policies/nominatim/): set a real `User-Agent`, ≤1 req/s, no bulk geocoding. The adapter sets `User-Agent: opencli-nominatim-adapter/1.0`; HTTP 403 from the policy enforcer surfaces as `CommandExecutionError`.
+- **Errors.** Empty query / bad limit / bad countrycode / out-of-range lat-lon → `ArgumentError`; empty result list (`[]`) or `{error: ...}` body → `EmptyResultError`; transport / 429 / 403 / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -134,6 +134,8 @@ Run `opencli list` for the live registry.
 | **[nuget](./browser/nuget.md)**                   | `search` `package`                                                                                                                             | 🌐 Public    |
 | **[flathub](./browser/flathub.md)**               | `search` `app`                                                                                                                                 | 🌐 Public    |
 | **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
+| **[nominatim](./browser/nominatim.md)**           | `geocode` `reverse`                                                                                                                            | 🌐 Public    |
+| **[mempool](./browser/mempool.md)**               | `tx` `block`                                                                                                                                   | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

Trimmed scope per WAWQAQ feedback (drop low-utility novelty sites, keep dev-relevant Public/no-auth APIs).

| Site          | Commands         | Highlights                                   |
|---------------|------------------|----------------------------------------------|
| nominatim     | geocode, reverse | OSM forward/reverse geocoding; UA per policy |
| mempool.space | tx, block        | Esplora REST; height→hash two-fetch          |

## Dropped from this PR

- codeforces (user, rating)
- datamuse (words, suggest)
- usgs-quakes (recent, event)
- open-food-facts (search, product)

Also reverted `^code$` listing-id pairing advisor patch (only served OFF, OFF dropped).

## Audits

- typed-error-lint: 196 = 196 (unchanged baseline)
- silent-column-drop: 103 = 103 (unchanged baseline)
- listing-id-pairing: advisory only, no new violations

## Manifest

757 → 761 entries (+4)

## Test plan

- [x] `npx vitest run clis/nominatim clis/mempool` — 14 tests passing
- [x] All 4 commands live-verified against real APIs