### PR TITLE
fix(chatgpt): add Chinese locale selectors for image command

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -12,15 +12,23 @@ export const CHATGPT_URL = 'https://chatgpt.com';
 // Selectors
 const COMPOSER_SELECTORS = [
     '[aria-label="Chat with ChatGPT"]',
+    '[aria-label="与 ChatGPT 聊天"]',
     '[placeholder="Ask anything"]',
+    '[placeholder="有问题，尽管问"]',
     '#prompt-textarea',
     '[data-testid="prompt-textarea"]',
     '[contenteditable="true"][role="textbox"]',
 ];
+const SEND_BUTTON_SELECTOR = 'button[data-testid="send-button"]:not([disabled])';
 const SEND_BUTTON_LABELS = [
     'Send prompt',
     'Send message',
     'Send',
+    '发送提示',
+];
+const CLOSE_SIDEBAR_LABELS = [
+    'Close sidebar',
+    '关闭边栏',
 ];
 
 function isSameChatGPTConversation(currentUrl, expectedUrl) {
@@ -185,7 +193,8 @@ export async function sendChatGPTMessage(page, text) {
     // Close sidebar if open (it can cover the chat composer)
     await page.evaluate(`
         (() => {
-            const closeBtn = Array.from(document.querySelectorAll('button')).find(b => b.getAttribute('aria-label') === 'Close sidebar');
+            const labels = ${JSON.stringify(CLOSE_SIDEBAR_LABELS)};
+            const closeBtn = Array.from(document.querySelectorAll('button')).find(b => labels.includes(b.getAttribute('aria-label') || ''));
             if (closeBtn) closeBtn.click();
         })()
     `);
@@ -234,9 +243,10 @@ export async function sendChatGPTMessage(page, text) {
     // Click send button
     const sent = await page.evaluate(`
         (() => {
+            const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)});
             const btns = Array.from(document.querySelectorAll('button'));
             const labels = ${JSON.stringify(SEND_BUTTON_LABELS)};
-            const sendBtn = btns.find(b => labels.includes(b.getAttribute('aria-label') || '') && !b.disabled);
+            const sendBtn = primary || btns.find(b => labels.includes(b.getAttribute('aria-label') || '') && !b.disabled);
             return { sendBtnFound: !!sendBtn };
         })()
     `);
@@ -247,8 +257,9 @@ export async function sendChatGPTMessage(page, text) {
     
     await page.evaluate(`
         (() => {
+            const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)});
             const labels = ${JSON.stringify(SEND_BUTTON_LABELS)};
-            const sendBtn = Array.from(document.querySelectorAll('button')).find(b => labels.includes(b.getAttribute('aria-label') || '') && !b.disabled);
+            const sendBtn = primary || Array.from(document.querySelectorAll('button')).find(b => labels.includes(b.getAttribute('aria-label') || '') && !b.disabled);
             if (sendBtn) sendBtn.click();
         })()
     `);
@@ -532,7 +543,9 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
 
 export const __test__ = {
     COMPOSER_SELECTORS,
+    SEND_BUTTON_SELECTOR,
     SEND_BUTTON_LABELS,
+    CLOSE_SIDEBAR_LABELS,
     isSameChatGPTConversation,
     parseChatGPTConversationId,
 };

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { __test__, waitForChatGPTImages } from './utils.js';
+import { __test__, sendChatGPTMessage, waitForChatGPTImages } from './utils.js';
 
 function createPageMock({ location = '', generating = [], imageUrls = [] } = {}) {
     let generatingIndex = 0;
@@ -72,5 +72,40 @@ describe('chatgpt conversation id parsing', () => {
     it('rejects invalid detail ids', () => {
         expect(() => __test__.parseChatGPTConversationId('')).toThrow(/conversation id/);
         expect(() => __test__.parseChatGPTConversationId('https://chatgpt.com/')).toThrow(/conversation id/);
+    });
+});
+
+describe('chatgpt send selectors', () => {
+    it('keeps locale-independent send-button selector before aria-label fallbacks', async () => {
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            nativeType: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                if (script.includes('findComposer')) return Promise.resolve(true);
+                if (script.includes('sendBtnFound')) {
+                    expect(script).toContain('data-testid=\\\"send-button\\\"');
+                    return Promise.resolve({ sendBtnFound: true });
+                }
+                if (script.includes('if (sendBtn) sendBtn.click')) {
+                    expect(script).toContain('data-testid=\\\"send-button\\\"');
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        await expect(sendChatGPTMessage(page, 'hello')).resolves.toBe(true);
+    });
+
+    it('keeps zh-CN aria and placeholder fallbacks without replacing English selectors', () => {
+        expect(__test__.COMPOSER_SELECTORS).toEqual(expect.arrayContaining([
+            '[aria-label="Chat with ChatGPT"]',
+            '[aria-label="与 ChatGPT 聊天"]',
+            '[placeholder="Ask anything"]',
+            '[placeholder="有问题，尽管问"]',
+            '[data-testid="prompt-textarea"]',
+        ]));
+        expect(__test__.SEND_BUTTON_SELECTOR).toBe('button[data-testid="send-button"]:not([disabled])');
+        expect(__test__.SEND_BUTTON_LABELS).toEqual(expect.arrayContaining(['Send prompt', 'Send message', 'Send', '发送提示']));
+        expect(__test__.CLOSE_SIDEBAR_LABELS).toEqual(expect.arrayContaining(['Close sidebar', '关闭边栏']));
     });
 });


### PR DESCRIPTION
## 概述

ChatGPT 中文界面使用了本地化的 aria-label，导致 `sendChatGPTMessage()` 无法找到输入框和发送按钮，`opencli chatgpt image` 始终返回 `send-failed`。

## 变更内容

在 `clis/chatgpt/utils.js` 中为 5 处选择器添加了中文 locale 变体：

| 原始选择器 | 新增中文变体 |
|---|---|
| `aria-label="Chat with ChatGPT"` | `aria-label="与 ChatGPT 聊天"` |
| `placeholder="Ask anything"` | `placeholder="有问题，尽管问"` |
| `aria-label="Send prompt"` | `aria-label="发送提示"` |
| `aria-label="Close sidebar"` | `aria-label="关闭边栏"` |

## 测试

在 ChatGPT zh-CN 环境下验证 `opencli chatgpt image` 命令成功发送并生成图片。