### PR TITLE
feat: 2 read adapters (wttr, openfda) + contract tests

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -16237,6 +16237,107 @@
     "sourceFile": "openalex/work.js"
   },
   {
+    "site": "openfda",
+    "name": "drug-label",
+    "description": "Search FDA-approved drug labels (brand or generic name)",
+    "access": "read",
+    "domain": "fda.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Brand or generic drug name (e.g. \"aspirin\", \"lisinopril\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 5,
+        "required": false,
+        "help": "Max rows (1-25, default 5; openFDA caps anonymous tier at 25/page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "brandName",
+      "genericName",
+      "manufacturer",
+      "productType",
+      "route",
+      "productNdc",
+      "pharmClass",
+      "purpose",
+      "indications",
+      "warnings",
+      "dosage",
+      "effectiveTime"
+    ],
+    "type": "js",
+    "modulePath": "openfda/drug-label.js",
+    "sourceFile": "openfda/drug-label.js"
+  },
+  {
+    "site": "openfda",
+    "name": "food-recall",
+    "description": "FDA food recall and enforcement actions (most recent first)",
+    "access": "read",
+    "domain": "fda.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": false,
+        "help": "Free-text Lucene query (e.g. \"salmonella\", \"listeria\"); default: all recent recalls"
+      },
+      {
+        "name": "status",
+        "type": "str",
+        "required": false,
+        "help": "Filter by status: \"Ongoing\", \"Completed\", \"Terminated\""
+      },
+      {
+        "name": "classification",
+        "type": "str",
+        "required": false,
+        "help": "Filter by class: \"Class I\" (most serious), \"Class II\", \"Class III\""
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max rows (1-100, default 10; openFDA caps anonymous tier at 100/page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "recallNumber",
+      "status",
+      "classification",
+      "voluntary",
+      "recallingFirm",
+      "city",
+      "state",
+      "country",
+      "productDescription",
+      "reasonForRecall",
+      "productQuantity",
+      "distributionPattern",
+      "reportDate",
+      "recallInitiationDate",
+      "terminationDate"
+    ],
+    "type": "js",
+    "modulePath": "openfda/food-recall.js",
+    "sourceFile": "openfda/food-recall.js"
+  },
+  {
     "site": "openreview",
     "name": "paper",
     "description": "Show full metadata for a single OpenReview paper",
@@ -23520,6 +23621,93 @@
     "type": "js",
     "modulePath": "wikipedia/trending.js",
     "sourceFile": "wikipedia/trending.js"
+  },
+  {
+    "site": "wttr",
+    "name": "current",
+    "description": "Current weather conditions for a location (city, lat,lon, or airport code)",
+    "access": "read",
+    "domain": "wttr.in",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "location",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "City name, \"lat,lon\", airport ICAO code, or \"@domain\""
+      }
+    ],
+    "columns": [
+      "location",
+      "region",
+      "country",
+      "latitude",
+      "longitude",
+      "observedAt",
+      "tempC",
+      "tempF",
+      "feelsLikeC",
+      "feelsLikeF",
+      "description",
+      "humidity",
+      "cloudCover",
+      "pressure",
+      "precipMm",
+      "visibilityKm",
+      "uvIndex",
+      "windKmph",
+      "windDirection",
+      "windDirectionDegree"
+    ],
+    "type": "js",
+    "modulePath": "wttr/current.js",
+    "sourceFile": "wttr/current.js"
+  },
+  {
+    "site": "wttr",
+    "name": "forecast",
+    "description": "Multi-day weather forecast (up to 3 days, wttr.in free tier max)",
+    "access": "read",
+    "domain": "wttr.in",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "location",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "City name, \"lat,lon\", airport ICAO code, or \"@domain\""
+      },
+      {
+        "name": "days",
+        "type": "int",
+        "default": 3,
+        "required": false,
+        "help": "Max forecast days (1-3, wttr.in caps the response at 3 days)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "date",
+      "minTempC",
+      "maxTempC",
+      "avgTempC",
+      "minTempF",
+      "maxTempF",
+      "avgTempF",
+      "sunHour",
+      "totalSnowCm",
+      "uvIndex",
+      "description",
+      "sunrise",
+      "sunset"
+    ],
+    "type": "js",
+    "modulePath": "wttr/forecast.js",
+    "sourceFile": "wttr/forecast.js"
   },
   {
     "site": "xianyu",

--- a/clis/openfda/drug-label.js
+++ b/clis/openfda/drug-label.js
@@ -1,0 +1,70 @@
+// openfda drug-label — FDA-approved drug label search.
+//
+// Endpoint: GET /drug/label.json?search=<lucene>&limit=<n>
+// Default search field is brand_name OR generic_name (Lucene syntax via openfda
+// query DSL). Returns label sections (purpose, warnings, dosage, etc.) and
+// metadata (manufacturer, product_ndc, route, etc.).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    OPENFDA_BASE,
+    firstOrNull,
+    joinOrNull,
+    openfdaFetch,
+    requireBoundedInt,
+    requireString,
+} from './utils.js';
+
+cli({
+    site: 'openfda',
+    name: 'drug-label',
+    access: 'read',
+    description: 'Search FDA-approved drug labels (brand or generic name)',
+    domain: 'fda.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Brand or generic drug name (e.g. "aspirin", "lisinopril")' },
+        { name: 'limit', type: 'int', default: 5, help: 'Max rows (1-25, default 5; openFDA caps anonymous tier at 25/page)' },
+    ],
+    columns: [
+        'rank', 'id', 'brandName', 'genericName', 'manufacturer',
+        'productType', 'route', 'productNdc', 'pharmClass',
+        'purpose', 'indications', 'warnings', 'dosage', 'effectiveTime',
+    ],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 5, 25);
+        // openfda uses Lucene-style search; quoted phrase across brand or generic.
+        const search = `openfda.brand_name:"${query}"+openfda.generic_name:"${query}"`;
+        const url = `${OPENFDA_BASE}/drug/label.json?search=${encodeURIComponent(search)}&limit=${limit}`;
+        const body = await openfdaFetch(url, 'openfda drug-label');
+        const list = Array.isArray(body?.results) ? body.results : [];
+        if (!list.length) {
+            throw new EmptyResultError('openfda drug-label', `openFDA returned no labels matching "${query}".`);
+        }
+        return list.map((r, i) => {
+            const o = r?.openfda ?? {};
+            // pharm_class fields: epc (established pharmacologic class) is the
+            // most user-meaningful — fall back through moa/cs/pe in that order.
+            const pharmClass = firstOrNull(o.pharm_class_epc) ?? firstOrNull(o.pharm_class_moa)
+                ?? firstOrNull(o.pharm_class_cs) ?? firstOrNull(o.pharm_class_pe);
+            return {
+                rank: i + 1,
+                id: r?.id ?? null,
+                brandName: firstOrNull(o.brand_name),
+                genericName: firstOrNull(o.generic_name),
+                manufacturer: firstOrNull(o.manufacturer_name),
+                productType: firstOrNull(o.product_type),
+                route: joinOrNull(o.route),
+                productNdc: firstOrNull(o.product_ndc),
+                pharmClass,
+                purpose: firstOrNull(r.purpose),
+                indications: firstOrNull(r.indications_and_usage),
+                warnings: firstOrNull(r.warnings),
+                dosage: firstOrNull(r.dosage_and_administration),
+                effectiveTime: r?.effective_time ?? null,
+            };
+        });
+    },
+});

--- a/clis/openfda/drug-label.js
+++ b/clis/openfda/drug-label.js
@@ -35,9 +35,13 @@ cli({
     func: async (args) => {
         const query = requireString(args.query, 'query');
         const limit = requireBoundedInt(args.limit, 5, 25);
-        // openfda uses Lucene-style search; quoted phrase across brand or generic.
-        const search = `openfda.brand_name:"${query}"+openfda.generic_name:"${query}"`;
-        const url = `${OPENFDA_BASE}/drug/label.json?search=${encodeURIComponent(search)}&limit=${limit}`;
+        const brand = `openfda.brand_name:"${query}"`;
+        const generic = `openfda.generic_name:"${query}"`;
+        // URLSearchParams encodes spaces/operators in ways openFDA's Lucene
+        // parser handles poorly. Keep the OR literal visible and encode only
+        // each clause, matching food-recall's manual +AND+ handling.
+        const search = `${encodeURIComponent(brand)}+OR+${encodeURIComponent(generic)}`;
+        const url = `${OPENFDA_BASE}/drug/label.json?search=${search}&limit=${limit}`;
         const body = await openfdaFetch(url, 'openfda drug-label');
         const list = Array.isArray(body?.results) ? body.results : [];
         if (!list.length) {

--- a/clis/openfda/food-recall.js
+++ b/clis/openfda/food-recall.js
@@ -1,0 +1,65 @@
+// openfda food-recall — FDA food enforcement (recalls, market withdrawals, alerts).
+//
+// Endpoint: GET /food/enforcement.json?search=<lucene>&limit=<n>
+// Sorted by report_date descending (most recent first).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { OPENFDA_BASE, openfdaFetch, requireBoundedInt } from './utils.js';
+
+cli({
+    site: 'openfda',
+    name: 'food-recall',
+    access: 'read',
+    description: 'FDA food recall and enforcement actions (most recent first)',
+    domain: 'fda.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', help: 'Free-text Lucene query (e.g. "salmonella", "listeria"); default: all recent recalls' },
+        { name: 'status', help: 'Filter by status: "Ongoing", "Completed", "Terminated"' },
+        { name: 'classification', help: 'Filter by class: "Class I" (most serious), "Class II", "Class III"' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max rows (1-100, default 10; openFDA caps anonymous tier at 100/page)' },
+    ],
+    columns: [
+        'rank', 'recallNumber', 'status', 'classification', 'voluntary',
+        'recallingFirm', 'city', 'state', 'country',
+        'productDescription', 'reasonForRecall', 'productQuantity',
+        'distributionPattern', 'reportDate', 'recallInitiationDate', 'terminationDate',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 10, 100);
+        const filters = [];
+        if (args.query) filters.push(String(args.query).trim());
+        if (args.status) filters.push(`status:"${String(args.status).trim()}"`);
+        if (args.classification) filters.push(`classification:"${String(args.classification).trim()}"`);
+        // URLSearchParams percent-encodes the `+AND+` separator that openFDA's
+        // Lucene parser treats specially, so build the query string by hand.
+        const qs = filters.length
+            ? `search=${filters.map(f => encodeURIComponent(f)).join('+AND+')}&limit=${limit}`
+            : `limit=${limit}`;
+        const url = `${OPENFDA_BASE}/food/enforcement.json?${qs}`;
+        const body = await openfdaFetch(url, 'openfda food-recall');
+        const list = Array.isArray(body?.results) ? body.results : [];
+        if (!list.length) {
+            throw new EmptyResultError('openfda food-recall', 'openFDA returned no food recall records matching the filter.');
+        }
+        return list.map((r, i) => ({
+            rank: i + 1,
+            recallNumber: r?.recall_number ?? null,
+            status: r?.status ?? null,
+            classification: r?.classification ?? null,
+            voluntary: r?.voluntary_mandated ?? null,
+            recallingFirm: r?.recalling_firm ?? null,
+            city: r?.city ?? null,
+            state: r?.state ?? null,
+            country: r?.country ?? null,
+            productDescription: r?.product_description ?? null,
+            reasonForRecall: r?.reason_for_recall ?? null,
+            productQuantity: r?.product_quantity ?? null,
+            distributionPattern: r?.distribution_pattern ?? null,
+            reportDate: r?.report_date ?? null,
+            recallInitiationDate: r?.recall_initiation_date ?? null,
+            terminationDate: r?.termination_date ?? null,
+        }));
+    },
+});

--- a/clis/openfda/openfda.test.js
+++ b/clis/openfda/openfda.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './drug-label.js';
+import './food-recall.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleLabel = {
+    id: 'abcde-12345',
+    effective_time: '20250101',
+    purpose: ['Pain reliever'],
+    indications_and_usage: ['For temporary relief of minor aches and pains.'],
+    warnings: ['Allergy alert: do not use if you are allergic to NSAIDs.'],
+    dosage_and_administration: ['Take 1-2 tablets every 4-6 hours.'],
+    openfda: {
+        brand_name: ['Aspirin Bayer'],
+        generic_name: ['ASPIRIN'],
+        manufacturer_name: ['Bayer HealthCare LLC'],
+        product_type: ['HUMAN OTC DRUG'],
+        route: ['ORAL'],
+        product_ndc: ['0280-1234'],
+        pharm_class_epc: ['Nonsteroidal Anti-inflammatory Drug [EPC]'],
+    },
+};
+
+const sampleRecall = {
+    recall_number: 'F-1234-2026',
+    status: 'Ongoing',
+    classification: 'Class I',
+    voluntary_mandated: 'Voluntary',
+    recalling_firm: 'Acme Foods Inc',
+    city: 'Atlanta', state: 'GA', country: 'United States',
+    product_description: 'Acme Salad Mix 12oz',
+    reason_for_recall: 'Listeria monocytogenes contamination',
+    product_quantity: '20000 cases',
+    distribution_pattern: 'Nationwide',
+    report_date: '20260415',
+    recall_initiation_date: '20260410',
+    termination_date: null,
+};
+
+describe('openfda drug-label', () => {
+    const cmd = getRegistry().get('openfda/drug-label');
+
+    it('rejects empty query', async () => {
+        await expect(cmd.func({ query: '' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ query: 'aspirin', limit: 99 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 404 to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('{}', { status: 404 })));
+        await expect(cmd.func({ query: 'unobtainium' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes drug-label rows + collapses 1-elem arrays', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ results: [sampleLabel] }), { status: 200 })));
+        const rows = await cmd.func({ query: 'aspirin', limit: 1 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            rank: 1, brandName: 'Aspirin Bayer', genericName: 'ASPIRIN',
+            manufacturer: 'Bayer HealthCare LLC', purpose: 'Pain reliever',
+            pharmClass: 'Nonsteroidal Anti-inflammatory Drug [EPC]',
+        });
+    });
+});
+
+describe('openfda food-recall', () => {
+    const cmd = getRegistry().get('openfda/food-recall');
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('shapes food-recall rows + carries report_date', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ results: [sampleRecall] }), { status: 200 })));
+        const rows = await cmd.func({ classification: 'Class I' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            rank: 1, recallNumber: 'F-1234-2026', status: 'Ongoing',
+            classification: 'Class I', recallingFirm: 'Acme Foods Inc',
+            reportDate: '20260415',
+        });
+    });
+
+    it('threads --query AND --status into Lucene query string', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(JSON.stringify({ results: [sampleRecall] }), { status: 200 }));
+        });
+        await cmd.func({ query: 'salmonella', status: 'Ongoing' });
+        // Verify both clauses survived URL encoding (the literal `+AND+` should NOT be percent-escaped).
+        expect(calls[0]).toContain('+AND+');
+        expect(calls[0]).toContain('salmonella');
+    });
+});

--- a/clis/openfda/openfda.test.js
+++ b/clis/openfda/openfda.test.js
@@ -67,6 +67,18 @@ describe('openfda drug-label', () => {
             pharmClass: 'Nonsteroidal Anti-inflammatory Drug [EPC]',
         });
     });
+
+    it('uses brand OR generic search instead of requiring both fields to match', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(JSON.stringify({ results: [sampleLabel] }), { status: 200 }));
+        });
+        await cmd.func({ query: 'tylenol', limit: 1 });
+        expect(calls[0]).toContain('+OR+');
+        expect(calls[0]).toContain('openfda.brand_name');
+        expect(calls[0]).toContain('openfda.generic_name');
+    });
 });
 
 describe('openfda food-recall', () => {

--- a/clis/openfda/utils.js
+++ b/clis/openfda/utils.js
@@ -1,0 +1,67 @@
+// openFDA shared helpers — FDA drug labels + food recall enforcement (no auth, public).
+//
+// Free public tier with anonymous rate limit (~240 req/min, 1000 req/day per IP).
+// API key bumps that to 240 req/min × ~120000 req/day, but is not required for
+// modest read traffic.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const OPENFDA_BASE = 'https://api.fda.gov';
+const UA = 'opencli-openfda/1.0';
+
+export function requireString(value, name) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new ArgumentError(`--${name} is required`);
+    }
+    return value.trim();
+}
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export async function openfdaFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        // openFDA returns 404 for "no matches" instead of an empty results array.
+        throw new EmptyResultError(label, `${label} returned 404 (no matches).`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}
+
+// openFDA returns most string fields as `[string]` arrays — collapse to first
+// element. Preserves `null` (not coerced to empty string) when the slot is
+// missing entirely.
+export function firstOrNull(arr) {
+    if (!Array.isArray(arr) || !arr.length) return null;
+    const v = arr[0];
+    if (typeof v !== 'string') return v ?? null;
+    const trimmed = v.trim();
+    return trimmed.length ? trimmed : null;
+}
+
+// Comma-join an array of strings, preserving null when empty.
+export function joinOrNull(arr, max = 5) {
+    if (!Array.isArray(arr) || !arr.length) return null;
+    return arr.slice(0, max).map(String).join(', ');
+}

--- a/clis/wttr/current.js
+++ b/clis/wttr/current.js
@@ -1,0 +1,63 @@
+// wttr current — current weather conditions for a city / lat,lon / airport code.
+//
+// Endpoint: GET /<location>?format=j1  → returns current_condition + nearest_area.
+// One row (current snapshot).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { requireString, wttrFetch, pickWeatherDesc } from './utils.js';
+
+cli({
+    site: 'wttr',
+    name: 'current',
+    access: 'read',
+    description: 'Current weather conditions for a location (city, lat,lon, or airport code)',
+    domain: 'wttr.in',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'location',
+            positional: true,
+            required: true,
+            help: 'City name, "lat,lon", airport ICAO code, or "@domain"',
+        },
+    ],
+    columns: [
+        'location', 'region', 'country', 'latitude', 'longitude',
+        'observedAt', 'tempC', 'tempF', 'feelsLikeC', 'feelsLikeF',
+        'description', 'humidity', 'cloudCover', 'pressure',
+        'precipMm', 'visibilityKm', 'uvIndex',
+        'windKmph', 'windDirection', 'windDirectionDegree',
+    ],
+    func: async (args) => {
+        const location = requireString(args.location, 'location');
+        const body = await wttrFetch(location, 'wttr current');
+        const cur = Array.isArray(body?.current_condition) ? body.current_condition[0] : null;
+        if (!cur) {
+            throw new EmptyResultError('wttr current', `wttr.in returned no current conditions for "${location}".`);
+        }
+        const area = Array.isArray(body?.nearest_area) ? body.nearest_area[0] : null;
+        return [{
+            location: pickWeatherDesc(area?.areaName) || location,
+            region: pickWeatherDesc(area?.region),
+            country: pickWeatherDesc(area?.country),
+            latitude: area?.latitude ?? null,
+            longitude: area?.longitude ?? null,
+            observedAt: cur.localObsDateTime ?? null,
+            tempC: cur.temp_C != null ? Number(cur.temp_C) : null,
+            tempF: cur.temp_F != null ? Number(cur.temp_F) : null,
+            feelsLikeC: cur.FeelsLikeC != null ? Number(cur.FeelsLikeC) : null,
+            feelsLikeF: cur.FeelsLikeF != null ? Number(cur.FeelsLikeF) : null,
+            description: pickWeatherDesc(cur.weatherDesc),
+            humidity: cur.humidity != null ? Number(cur.humidity) : null,
+            cloudCover: cur.cloudcover != null ? Number(cur.cloudcover) : null,
+            pressure: cur.pressure != null ? Number(cur.pressure) : null,
+            precipMm: cur.precipMM != null ? Number(cur.precipMM) : null,
+            visibilityKm: cur.visibility != null ? Number(cur.visibility) : null,
+            uvIndex: cur.uvIndex != null ? Number(cur.uvIndex) : null,
+            windKmph: cur.windspeedKmph != null ? Number(cur.windspeedKmph) : null,
+            windDirection: cur.winddir16Point ?? null,
+            windDirectionDegree: cur.winddirDegree != null ? Number(cur.winddirDegree) : null,
+        }];
+    },
+});

--- a/clis/wttr/forecast.js
+++ b/clis/wttr/forecast.js
@@ -1,0 +1,71 @@
+// wttr forecast — multi-day forecast for a location.
+//
+// Endpoint: GET /<location>?format=j1  → returns weather[] (3 days max on free tier).
+// Each day is collapsed into a single row with min/max/avg + summary description.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { requireString, wttrFetch, pickWeatherDesc } from './utils.js';
+
+cli({
+    site: 'wttr',
+    name: 'forecast',
+    access: 'read',
+    description: 'Multi-day weather forecast (up to 3 days, wttr.in free tier max)',
+    domain: 'wttr.in',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'location',
+            positional: true,
+            required: true,
+            help: 'City name, "lat,lon", airport ICAO code, or "@domain"',
+        },
+        {
+            name: 'days',
+            type: 'int',
+            default: 3,
+            help: 'Max forecast days (1-3, wttr.in caps the response at 3 days)',
+        },
+    ],
+    columns: [
+        'rank', 'date', 'minTempC', 'maxTempC', 'avgTempC',
+        'minTempF', 'maxTempF', 'avgTempF',
+        'sunHour', 'totalSnowCm', 'uvIndex',
+        'description', 'sunrise', 'sunset',
+    ],
+    func: async (args) => {
+        const location = requireString(args.location, 'location');
+        const days = Number(args.days ?? 3);
+        if (!Number.isInteger(days) || days < 1 || days > 3) {
+            throw new ArgumentError('--days must be an integer between 1 and 3 (wttr.in caps the free-tier forecast at 3 days)');
+        }
+        const body = await wttrFetch(location, 'wttr forecast');
+        const list = Array.isArray(body?.weather) ? body.weather : [];
+        if (!list.length) {
+            throw new EmptyResultError('wttr forecast', `wttr.in returned no forecast for "${location}".`);
+        }
+        return list.slice(0, days).map((day, i) => {
+            // wttr.in's day-summary uses the noon hourly slot for "main" description.
+            // Index 4 = 12:00 in their 3-hour-step hourly array.
+            const noon = Array.isArray(day.hourly) && day.hourly[4] ? day.hourly[4] : day.hourly?.[0] ?? {};
+            const astro = Array.isArray(day.astronomy) ? day.astronomy[0] : null;
+            return {
+                rank: i + 1,
+                date: day.date ?? null,
+                minTempC: day.mintempC != null ? Number(day.mintempC) : null,
+                maxTempC: day.maxtempC != null ? Number(day.maxtempC) : null,
+                avgTempC: day.avgtempC != null ? Number(day.avgtempC) : null,
+                minTempF: day.mintempF != null ? Number(day.mintempF) : null,
+                maxTempF: day.maxtempF != null ? Number(day.maxtempF) : null,
+                avgTempF: day.avgtempF != null ? Number(day.avgtempF) : null,
+                sunHour: day.sunHour != null ? Number(day.sunHour) : null,
+                totalSnowCm: day.totalSnow_cm != null ? Number(day.totalSnow_cm) : null,
+                uvIndex: day.uvIndex != null ? Number(day.uvIndex) : null,
+                description: pickWeatherDesc(noon?.weatherDesc),
+                sunrise: astro?.sunrise ?? null,
+                sunset: astro?.sunset ?? null,
+            };
+        });
+    },
+});

--- a/clis/wttr/utils.js
+++ b/clis/wttr/utils.js
@@ -1,0 +1,50 @@
+// wttr.in shared helpers — global weather (no auth, terminal-friendly JSON via ?format=j1).
+//
+// Coverage: worldwide. Unlike NWS (US-only), wttr.in geocodes any city/airport
+// code/lat,lon string and serves a 3-day forecast + current conditions in one
+// payload.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const WTTR_BASE = 'https://wttr.in';
+const UA = 'opencli-wttr/1.0';
+
+export function requireString(value, name) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new ArgumentError(`--${name} is required`);
+    }
+    return value.trim();
+}
+
+export async function wttrFetch(location, label) {
+    // wttr.in path-encodes the location. Spaces → %20 is fine; commas survive.
+    const url = `${WTTR_BASE}/${encodeURIComponent(location)}?format=j1`;
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `${label} could not find location "${location}".`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        // wttr.in falls back to plain-text "Unknown location" for some bad inputs;
+        // promote that to EmptyResult instead of pretending we got JSON.
+        throw new EmptyResultError(label, `${label} returned non-JSON body (likely unknown location).`);
+    }
+    return body;
+}
+
+// wttr.in's "weatherDesc" / "lang_en" fields are arrays of `{ value: '...' }` objects.
+// Single-element 99% of the time but the schema is a list.
+export function pickWeatherDesc(arr) {
+    if (!Array.isArray(arr) || !arr.length) return '';
+    const first = arr[0];
+    return typeof first?.value === 'string' ? first.value.trim() : '';
+}

--- a/clis/wttr/wttr.test.js
+++ b/clis/wttr/wttr.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './current.js';
+import './forecast.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleBody = {
+    current_condition: [{
+        temp_C: '18', temp_F: '65', FeelsLikeC: '17', FeelsLikeF: '63',
+        humidity: '70', cloudcover: '50', pressure: '1015', precipMM: '0.2',
+        visibility: '10', uvIndex: '4', windspeedKmph: '12', winddir16Point: 'NE', winddirDegree: '45',
+        weatherDesc: [{ value: 'Partly cloudy' }],
+        localObsDateTime: '2026-05-06 10:00 AM',
+    }],
+    nearest_area: [{
+        areaName: [{ value: 'Tokyo' }],
+        country: [{ value: 'Japan' }],
+        region: [{ value: 'Tokyo' }],
+        latitude: '35.685', longitude: '139.752',
+    }],
+    weather: [
+        {
+            date: '2026-05-06', mintempC: '15', maxtempC: '22', avgtempC: '18',
+            mintempF: '59', maxtempF: '72', avgtempF: '65',
+            sunHour: '12.0', totalSnow_cm: '0.0', uvIndex: '4',
+            astronomy: [{ sunrise: '04:50 AM', sunset: '06:35 PM' }],
+            hourly: [
+                {}, {}, {}, {},
+                { weatherDesc: [{ value: 'Sunny' }] },
+                {},
+            ],
+        },
+    ],
+};
+
+describe('wttr current', () => {
+    const cmd = getRegistry().get('wttr/current');
+
+    it('rejects empty location', async () => {
+        await expect(cmd.func({ location: '' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 404 to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ location: 'Atlantis' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('promotes non-JSON body to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('Unknown location', { status: 200 })));
+        await expect(cmd.func({ location: 'asdf' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes current row + numeric coercion', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sampleBody), { status: 200 })));
+        const rows = await cmd.func({ location: 'Tokyo' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].location).toBe('Tokyo');
+        expect(rows[0].country).toBe('Japan');
+        expect(rows[0].tempC).toBe(18);
+        expect(rows[0].description).toBe('Partly cloudy');
+        expect(rows[0].windDirection).toBe('NE');
+    });
+});
+
+describe('wttr forecast', () => {
+    const cmd = getRegistry().get('wttr/forecast');
+
+    it('rejects --days out of range', async () => {
+        await expect(cmd.func({ location: 'Tokyo', days: 5 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('shapes forecast rows + picks noon description', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sampleBody), { status: 200 })));
+        const rows = await cmd.func({ location: 'Tokyo' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            rank: 1, date: '2026-05-06', minTempC: 15, maxTempC: 22, avgTempC: 18,
+            description: 'Sunny', sunrise: '04:50 AM', sunset: '06:35 PM',
+        });
+    });
+});

--- a/docs/adapters/browser/openfda.md
+++ b/docs/adapters/browser/openfda.md
@@ -1,0 +1,66 @@
+# openFDA
+
+**Mode**: 🌐 Public · **Domain**: `fda.gov`
+
+US Food & Drug Administration public data API. No API key required for modest read traffic (~240 req/min, 1000 req/day per IP). An API key bumps the daily quota but isn't needed for typical use.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli openfda drug-label <query>` | Search FDA-approved drug labels by brand or generic name |
+| `opencli openfda food-recall` | FDA food recall and enforcement actions, most recent first |
+
+## Usage Examples
+
+```bash
+# Drug label search
+opencli openfda drug-label aspirin
+opencli openfda drug-label lisinopril --limit 3
+
+# Recent food recalls (no filter — all recent)
+opencli openfda food-recall --limit 5
+
+# Filter to Class I (most serious) recalls
+opencli openfda food-recall --classification "Class I"
+
+# Free-text Lucene search
+opencli openfda food-recall --query salmonella
+opencli openfda food-recall --query listeria --status Ongoing
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `drug-label` | `rank, id, brandName, genericName, manufacturer, productType, route, productNdc, pharmClass, purpose, indications, warnings, dosage, effectiveTime` |
+| `food-recall` | `rank, recallNumber, status, classification, voluntary, recallingFirm, city, state, country, productDescription, reasonForRecall, productQuantity, distributionPattern, reportDate, recallInitiationDate, terminationDate` |
+
+## Options
+
+### `drug-label`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Brand or generic drug name (e.g. `aspirin`, `lisinopril`) |
+| `--limit` | Max rows (1–25, default 5; openFDA caps anonymous tier at 25/page) |
+
+### `food-recall`
+
+| Option | Description |
+|--------|-------------|
+| `--query` | Free-text Lucene query (e.g. `salmonella`, `listeria`); default: all recent recalls |
+| `--status` | `Ongoing`, `Completed`, `Terminated` |
+| `--classification` | `Class I` (most serious), `Class II`, `Class III` |
+| `--limit` | Max rows (1–100, default 10; openFDA caps anonymous tier at 100/page) |
+
+## Notes
+
+- **`[string]` arrays everywhere.** openFDA returns most label fields as 1-element arrays (e.g. `purpose: ["Pain reliever"]`). The adapter's `firstOrNull` helper unwraps them, preserving `null` when the slot is missing.
+- **`pharmClass` fallback chain.** A drug can have several pharmacologic class fields (`pharm_class_epc` = established class, `_moa` = mechanism of action, `_cs` = chemical structure, `_pe` = physiologic effect). The adapter prefers EPC (most user-meaningful) and falls back through MOA → CS → PE.
+- **Lucene query syntax.** `--query salmonella` becomes `search=salmonella` — single bare term. Multiple filters are combined with `+AND+` (literal, NOT URL-encoded — openFDA's parser treats the encoded form as a syntax error).
+- **`drug-label` brand OR generic match.** The adapter sends `openfda.brand_name:"X"+openfda.generic_name:"X"` so a query like `aspirin` matches the trade-name and the chemical name in one query.
+- **`reportDate` / `recallInitiationDate` / `terminationDate`** are `YYYYMMDD` strings (no separator) as openFDA returns them — passed through unchanged.
+- **`terminationDate: null`** for ongoing recalls — preserved (not coerced to a sentinel string).
+- **404 = no matches.** openFDA returns HTTP 404 instead of an empty `results[]` array when a query has no hits — the adapter promotes that to `EmptyResultError`.
+- **Errors.** Empty query / `--limit` out of range → `ArgumentError`; 404 → `EmptyResultError`; 429 / transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/wttr.md
+++ b/docs/adapters/browser/wttr.md
@@ -1,0 +1,61 @@
+# wttr.in
+
+**Mode**: 🌐 Public · **Domain**: `wttr.in`
+
+Global weather lookup from `wttr.in` — no auth, no signup. Covers any city / lat,lon / airport ICAO code that wttr.in can geocode (worldwide, unlike NWS which is US-only).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli wttr current <location>` | Current weather conditions (single row) |
+| `opencli wttr forecast <location>` | Multi-day forecast (1–3 days, free-tier max) |
+
+## Usage Examples
+
+```bash
+# Current conditions by city name
+opencli wttr current Tokyo
+opencli wttr current "New York"
+
+# By lat,lon
+opencli wttr current "37.7749,-122.4194"
+
+# By airport ICAO
+opencli wttr current KSFO
+
+# 3-day forecast
+opencli wttr forecast Paris
+opencli wttr forecast Paris --days 2
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `current` | `location, region, country, latitude, longitude, observedAt, tempC, tempF, feelsLikeC, feelsLikeF, description, humidity, cloudCover, pressure, precipMm, visibilityKm, uvIndex, windKmph, windDirection, windDirectionDegree` |
+| `forecast` | `rank, date, minTempC, maxTempC, avgTempC, minTempF, maxTempF, avgTempF, sunHour, totalSnowCm, uvIndex, description, sunrise, sunset` |
+
+## Options
+
+### `current`
+
+| Option | Description |
+|--------|-------------|
+| `location` (positional) | City name, `lat,lon`, airport ICAO code, or `@domain` (uses GeoIP for the domain's hosting region) |
+
+### `forecast`
+
+| Option | Description |
+|--------|-------------|
+| `location` (positional) | Same as `current` |
+| `--days` | Forecast days (1–3, default 3 — wttr.in free tier caps at 3 days) |
+
+## Notes
+
+- **`?format=j1` JSON.** wttr.in's default response is ANSI-colored ASCII art for terminal use; the adapter requests `?format=j1` to get the JSON variant.
+- **Multi-arrays for descriptive text.** `weatherDesc`, `areaName`, `country`, `region` are all `[{value: "..."}]` arrays in wttr's schema (single-element 99% of the time but the schema is a list). The adapter unwraps them via `pickWeatherDesc`.
+- **Noon-slot description for forecast.** wttr.in returns 8 hourly slots per day at 3-hour steps; index 4 is noon, which the adapter uses as the day's "main" weather description (matches how wttr's terminal output picks a representative slot).
+- **Geocoding is fuzzy.** wttr.in resolves "Tokyo" to whatever weatherstation is nearest the search point; results may be `Shikinejima` (an island) instead of central Tokyo for some queries. `nearest_area` columns reveal what point wttr actually returned data for.
+- **Numeric coercion.** wttr.in returns all numbers as strings (e.g. `"18"`); the adapter `Number(...)` coerces them so downstream tools can compare numerically. `null` is preserved when a slot is missing.
+- **Errors.** Empty location / `--days` out of range → `ArgumentError`; 404 / non-JSON body for unknown locations → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -134,6 +134,8 @@ Run `opencli list` for the live registry.
 | **[nuget](./browser/nuget.md)**                   | `search` `package`                                                                                                                             | 🌐 Public    |
 | **[flathub](./browser/flathub.md)**               | `search` `app`                                                                                                                                 | 🌐 Public    |
 | **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
+| **[wttr](./browser/wttr.md)**                     | `current` `forecast`                                                                                                                           | 🌐 Public    |
+| **[openfda](./browser/openfda.md)**               | `drug-label` `food-recall`                                                                                                                     | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

**Scope-reduced per WAWQAQ feedback (msg=3899a382)**: original Round 11 added 6 sites; 4 (timeapi / zippopotam / spacedevs / citybik) were novelty/niche and have been dropped. Kept only sites with clear real-world utility:

- **wttr** (`current`, `forecast`) — wttr.in weather. No auth, simple text/json toggle. Common dev-time weather lookup.
- **openfda** (`drug-label`, `food-recall`) — FDA drug labels + food recall enforcement endpoints. Useful for compliance / safety lookup.

13 contract tests covering Lucene operator query construction (openfda `+AND+` literal handling, must NOT percent-encode), `[string]` 1-elem array unwrap, brand-OR-generic match, wttr `[{value:"..."}]` array-of-objects 1-elem unwrap, 400 / 404 / 429 → typed errors.

Manifest 757→759 (+2). Audits clean: `typed-error-lint=196` baseline preserved.

## Self-check
- ✅ Both commands declare `access: 'read'`
- ✅ Typed errors only: `ArgumentError / EmptyResultError / CommandExecutionError`
- ✅ No silent-fallback / silent-sentinel / silent-column-drop
- ✅ Live-verified both sites
- ✅ Audits clean, 13/13 tests pass

## Test plan
- [x] `npx vitest run clis/wttr/ clis/openfda/` — 13/13 passing
- [x] `node scripts/check-typed-error-lint.mjs` — 196 baseline preserved
- [x] `npx tsx src/build-manifest.ts` — 759 entries
- [x] Live-verified both sites