### PR TITLE
feat: 12 read adapters across 6 new sites + contract tests (round 12)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5252,6 +5252,82 @@
     "sourceFile": "coingecko/trending.js"
   },
   {
+    "site": "coinpaprika",
+    "name": "coins",
+    "description": "List Coinpaprika coins (ranked, with id for ticker round-trip)",
+    "access": "read",
+    "domain": "coinpaprika.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max rows (1-1000, default 50)"
+      },
+      {
+        "name": "active",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Only include active (non-delisted) coins"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "symbol",
+      "type",
+      "isNew",
+      "isActive",
+      "coinRank"
+    ],
+    "type": "js",
+    "modulePath": "coinpaprika/coins.js",
+    "sourceFile": "coinpaprika/coins.js"
+  },
+  {
+    "site": "coinpaprika",
+    "name": "ticker",
+    "description": "Live price + market cap + supply for a single coin",
+    "access": "read",
+    "domain": "coinpaprika.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "coin",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Coinpaprika coin id (e.g. btc-bitcoin, eth-ethereum)"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "symbol",
+      "rank",
+      "priceUsd",
+      "volume24hUsd",
+      "marketCapUsd",
+      "percentChange1h",
+      "percentChange24h",
+      "percentChange7d",
+      "totalSupply",
+      "maxSupply",
+      "circulatingSupply",
+      "firstDataAt",
+      "lastUpdated"
+    ],
+    "type": "js",
+    "modulePath": "coinpaprika/ticker.js",
+    "sourceFile": "coinpaprika/ticker.js"
+  },
+  {
     "site": "coupang",
     "name": "add-to-cart",
     "description": "Add a Coupang product to cart using logged-in browser session",
@@ -8556,6 +8632,80 @@
     "sourceFile": "endoflife/product.js"
   },
   {
+    "site": "eonet",
+    "name": "categories",
+    "description": "List EONET event categories (ids round-trip to events --category)",
+    "access": "read",
+    "domain": "gsfc.nasa.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "description",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "eonet/categories.js",
+    "sourceFile": "eonet/categories.js"
+  },
+  {
+    "site": "eonet",
+    "name": "events",
+    "description": "Natural events from NASA EONET (wildfires / storms / volcanoes / icebergs)",
+    "access": "read",
+    "domain": "gsfc.nasa.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows (1-200, default 20)"
+      },
+      {
+        "name": "days",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Days back to search (1-365, default 30)"
+      },
+      {
+        "name": "status",
+        "type": "str",
+        "required": false,
+        "help": "Event status: open (active) | closed (resolved). Default: open"
+      },
+      {
+        "name": "category",
+        "type": "str",
+        "required": false,
+        "help": "Category id (e.g. wildfires, volcanoes, severeStorms)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "description",
+      "closed",
+      "categories",
+      "sources",
+      "geometryType",
+      "lastDate",
+      "magnitudeValue",
+      "magnitudeUnit",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "eonet/events.js",
+    "sourceFile": "eonet/events.js"
+  },
+  {
     "site": "facebook",
     "name": "add-friend",
     "description": "Send a friend request on Facebook",
@@ -9179,6 +9329,76 @@
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
     "navigateBefore": false
+  },
+  {
+    "site": "ghibli",
+    "name": "films",
+    "description": "Studio Ghibli films (title, director, release year, RT score)",
+    "access": "read",
+    "domain": "ghibliapi.vercel.app",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max rows (1-50, default 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "originalTitle",
+      "originalTitleRomanised",
+      "description",
+      "director",
+      "producer",
+      "releaseDate",
+      "runningTime",
+      "rtScore",
+      "image",
+      "movieBanner",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "ghibli/films.js",
+    "sourceFile": "ghibli/films.js"
+  },
+  {
+    "site": "ghibli",
+    "name": "people",
+    "description": "Studio Ghibli characters (across all films)",
+    "access": "read",
+    "domain": "ghibliapi.vercel.app",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max rows (1-100, default 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "gender",
+      "age",
+      "eyeColor",
+      "hairColor",
+      "speciesId",
+      "filmsCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "ghibli/people.js",
+    "sourceFile": "ghibli/people.js"
   },
   {
     "site": "gitee",
@@ -10734,6 +10954,114 @@
     "modulePath": "hupu/unlike.js",
     "sourceFile": "hupu/unlike.js",
     "navigateBefore": false
+  },
+  {
+    "site": "iceandfire",
+    "name": "books",
+    "description": "Game of Thrones / ASOIAF books (filter by name + release date)",
+    "access": "read",
+    "domain": "anapioficeandfire.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows (1-200, default 20)"
+      },
+      {
+        "name": "name",
+        "type": "str",
+        "required": false,
+        "help": "Filter by book name substring"
+      },
+      {
+        "name": "from-release-date",
+        "type": "str",
+        "required": false,
+        "help": "ISO 8601 lower bound (e.g. 1996-01-01)"
+      },
+      {
+        "name": "to-release-date",
+        "type": "str",
+        "required": false,
+        "help": "ISO 8601 upper bound (e.g. 2025-12-31)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "isbn",
+      "authors",
+      "numberOfPages",
+      "publisher",
+      "country",
+      "mediaType",
+      "released",
+      "charactersCount",
+      "povCharactersCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "iceandfire/books.js",
+    "sourceFile": "iceandfire/books.js"
+  },
+  {
+    "site": "iceandfire",
+    "name": "characters",
+    "description": "ASOIAF character listing (filter by name / culture / gender)",
+    "access": "read",
+    "domain": "anapioficeandfire.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows (1-500, default 20)"
+      },
+      {
+        "name": "name",
+        "type": "str",
+        "required": false,
+        "help": "Filter by name substring"
+      },
+      {
+        "name": "culture",
+        "type": "str",
+        "required": false,
+        "help": "Filter by culture (e.g. Northmen, Dornish)"
+      },
+      {
+        "name": "gender",
+        "type": "str",
+        "required": false,
+        "help": "Filter by gender (Male | Female)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "gender",
+      "culture",
+      "born",
+      "died",
+      "aliases",
+      "titles",
+      "allegiances",
+      "books",
+      "tvSeries",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "iceandfire/characters.js",
+    "sourceFile": "iceandfire/characters.js"
   },
   {
     "site": "imdb",
@@ -16237,6 +16565,103 @@
     "sourceFile": "openalex/work.js"
   },
   {
+    "site": "openf1",
+    "name": "drivers",
+    "description": "F1 drivers entered for a session (use sessions to find session_key)",
+    "access": "read",
+    "domain": "openf1.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "session-key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "session_key from `openf1 sessions` (e.g. 9472)"
+      },
+      {
+        "name": "driver-number",
+        "type": "str",
+        "required": false,
+        "help": "Filter to a specific driver number (e.g. 1, 44)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "driverNumber",
+      "broadcastName",
+      "fullName",
+      "nameAcronym",
+      "firstName",
+      "lastName",
+      "teamName",
+      "teamColour",
+      "countryCode",
+      "sessionKey",
+      "meetingKey",
+      "headshotUrl"
+    ],
+    "type": "js",
+    "modulePath": "openf1/drivers.js",
+    "sourceFile": "openf1/drivers.js"
+  },
+  {
+    "site": "openf1",
+    "name": "sessions",
+    "description": "F1 sessions (Race / Qualifying / Practice / Sprint) with session_key for drilldown",
+    "access": "read",
+    "domain": "openf1.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max rows (1-200, default 30)"
+      },
+      {
+        "name": "year",
+        "type": "str",
+        "required": false,
+        "help": "Filter by season year (e.g. 2024)"
+      },
+      {
+        "name": "session-type",
+        "type": "str",
+        "required": false,
+        "help": "Race | Qualifying | Practice | Sprint | Sprint Shootout"
+      },
+      {
+        "name": "country-code",
+        "type": "str",
+        "required": false,
+        "help": "3-letter country code (e.g. BRN, MON, GBR)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "sessionKey",
+      "meetingKey",
+      "sessionType",
+      "sessionName",
+      "circuit",
+      "countryCode",
+      "countryName",
+      "location",
+      "dateStart",
+      "dateEnd",
+      "gmtOffset",
+      "year",
+      "isCancelled"
+    ],
+    "type": "js",
+    "modulePath": "openf1/sessions.js",
+    "sourceFile": "openf1/sessions.js"
+  },
+  {
     "site": "openreview",
     "name": "paper",
     "description": "Show full metadata for a single OpenReview paper",
@@ -18770,6 +19195,103 @@
     "type": "js",
     "modulePath": "rfc/rfc.js",
     "sourceFile": "rfc/rfc.js"
+  },
+  {
+    "site": "rickandmorty",
+    "name": "character",
+    "description": "Search Rick and Morty characters by name / status / species",
+    "access": "read",
+    "domain": "rickandmortyapi.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows (1-100, default 20)"
+      },
+      {
+        "name": "name",
+        "type": "str",
+        "required": false,
+        "help": "Filter by name substring (case-insensitive)"
+      },
+      {
+        "name": "status",
+        "type": "str",
+        "required": false,
+        "help": "alive | dead | unknown"
+      },
+      {
+        "name": "species",
+        "type": "str",
+        "required": false,
+        "help": "Species filter (e.g. Human, Alien, Robot)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "status",
+      "species",
+      "type",
+      "gender",
+      "origin",
+      "location",
+      "episodes",
+      "image",
+      "created",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "rickandmorty/character.js",
+    "sourceFile": "rickandmorty/character.js"
+  },
+  {
+    "site": "rickandmorty",
+    "name": "episode",
+    "description": "List Rick and Morty episodes (filter by name or season/episode code)",
+    "access": "read",
+    "domain": "rickandmortyapi.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows (1-100, default 20)"
+      },
+      {
+        "name": "name",
+        "type": "str",
+        "required": false,
+        "help": "Filter by episode title substring"
+      },
+      {
+        "name": "episode",
+        "type": "str",
+        "required": false,
+        "help": "Filter by production code (e.g. S01, S01E01)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "airDate",
+      "episodeCode",
+      "characters",
+      "created",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "rickandmorty/episode.js",
+    "sourceFile": "rickandmorty/episode.js"
   },
   {
     "site": "rubygems",

--- a/clis/coinpaprika/coinpaprika.test.js
+++ b/clis/coinpaprika/coinpaprika.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './coins.js';
+import './ticker.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleCoins = [
+    { id: 'btc-bitcoin', name: 'Bitcoin', symbol: 'BTC', rank: 1, is_new: false, is_active: true, type: 'coin' },
+    { id: 'eth-ethereum', name: 'Ethereum', symbol: 'ETH', rank: 2, is_new: false, is_active: true, type: 'coin' },
+    { id: 'unranked-x', name: 'Unranked X', symbol: 'UNX', rank: 0, is_new: true, is_active: false, type: 'token' },
+];
+
+const sampleTicker = {
+    id: 'btc-bitcoin',
+    name: 'Bitcoin',
+    symbol: 'BTC',
+    rank: 1,
+    total_supply: 20025434,
+    max_supply: 21000000,
+    circulating_supply: 19800000,
+    first_data_at: '2010-07-17T00:00:00Z',
+    last_updated: '2026-05-06T08:37:17Z',
+    quotes: {
+        USD: {
+            price: 81781.7,
+            volume_24h: 32144670153,
+            market_cap: 1637713866824,
+            percent_change_1h: 0.5,
+            percent_change_24h: 1.4,
+            percent_change_7d: -2.1,
+        },
+    },
+};
+
+describe('coinpaprika coins', () => {
+    const cmd = getRegistry().get('coinpaprika/coins');
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ limit: 99999 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('promotes empty array to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('[]', { status: 200 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('sorts unranked coins last (rank=0 → infinity)', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sampleCoins), { status: 200 })));
+        const rows = await cmd.func({ limit: 5 });
+        expect(rows[0].id).toBe('btc-bitcoin');
+        expect(rows[1].id).toBe('eth-ethereum');
+        expect(rows[2].id).toBe('unranked-x');
+        expect(rows[2].coinRank).toBeNull(); // null preserved (not 0)
+    });
+
+    it('--active filters out delisted coins', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sampleCoins), { status: 200 })));
+        const rows = await cmd.func({ active: true });
+        expect(rows.map((r) => r.id)).toEqual(['btc-bitcoin', 'eth-ethereum']);
+    });
+});
+
+describe('coinpaprika ticker', () => {
+    const cmd = getRegistry().get('coinpaprika/ticker');
+
+    it('rejects empty coin id', async () => {
+        await expect(cmd.func({ coin: '' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 404 (unknown coin) to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ coin: 'nonsense-xyz' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes ticker row + flattens USD quote', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sampleTicker), { status: 200 })));
+        const rows = await cmd.func({ coin: 'btc-bitcoin' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            id: 'btc-bitcoin',
+            symbol: 'BTC',
+            priceUsd: 81781.7,
+            marketCapUsd: 1637713866824,
+            percentChange24h: 1.4,
+        });
+    });
+
+    it('lowercases coin id before URL building', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(JSON.stringify(sampleTicker), { status: 200 }));
+        });
+        await cmd.func({ coin: 'BTC-BITCOIN' });
+        expect(calls[0]).toContain('btc-bitcoin');
+    });
+});

--- a/clis/coinpaprika/coins.js
+++ b/clis/coinpaprika/coins.js
@@ -1,0 +1,55 @@
+// coinpaprika coins — listing of all coins (id, name, symbol, rank, type).
+//
+// Endpoint: GET /coins (returns ~3k+ coins, ranked).
+// No server-side limit param — client-side slice. The id column round-trips
+// to `coinpaprika ticker <coin-id>`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { cpFetch, requireBoundedInt, CP_BASE } from './utils.js';
+
+cli({
+    site: 'coinpaprika',
+    name: 'coins',
+    access: 'read',
+    description: 'List Coinpaprika coins (ranked, with id for ticker round-trip)',
+    domain: 'coinpaprika.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 50, help: 'Max rows (1-1000, default 50)' },
+        { name: 'active', type: 'bool', default: false, help: 'Only include active (non-delisted) coins' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'symbol', 'type', 'isNew', 'isActive', 'coinRank',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 50, 1000);
+        const url = `${CP_BASE}/coins`;
+        const body = await cpFetch(url, 'coinpaprika coins');
+        if (!Array.isArray(body) || body.length === 0) {
+            throw new EmptyResultError('coinpaprika coins', 'coinpaprika.com returned no coins.');
+        }
+        // Coinpaprika's rank=0 means "not ranked" — sort those to the end.
+        const sorted = body.slice().sort((a, b) => {
+            const ar = a?.rank > 0 ? a.rank : Number.POSITIVE_INFINITY;
+            const br = b?.rank > 0 ? b.rank : Number.POSITIVE_INFINITY;
+            return ar - br;
+        });
+        const filtered = args.active
+            ? sorted.filter((c) => c?.is_active === true)
+            : sorted;
+        if (!filtered.length) {
+            throw new EmptyResultError('coinpaprika coins', 'No coins matched --active filter.');
+        }
+        return filtered.slice(0, limit).map((c, i) => ({
+            rank: i + 1,
+            id: c?.id ?? null,
+            name: c?.name ?? null,
+            symbol: c?.symbol ?? null,
+            type: c?.type ?? null,
+            isNew: c?.is_new ?? null,
+            isActive: c?.is_active ?? null,
+            coinRank: c?.rank > 0 ? c.rank : null, // null preserves "unranked" semantics vs 0
+        }));
+    },
+});

--- a/clis/coinpaprika/ticker.js
+++ b/clis/coinpaprika/ticker.js
@@ -1,0 +1,52 @@
+// coinpaprika ticker — price + market cap + volume + supply for a single coin.
+//
+// Endpoint: GET /tickers/<coin-id> (e.g. btc-bitcoin, eth-ethereum).
+// USD quotes only via this endpoint — for other quotes use ?quotes=BTC,EUR.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { cpFetch, requireNonEmpty, CP_BASE } from './utils.js';
+
+cli({
+    site: 'coinpaprika',
+    name: 'ticker',
+    access: 'read',
+    description: 'Live price + market cap + supply for a single coin',
+    domain: 'coinpaprika.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'coin', positional: true, required: true, help: 'Coinpaprika coin id (e.g. btc-bitcoin, eth-ethereum)' },
+    ],
+    columns: [
+        'id', 'name', 'symbol', 'rank', 'priceUsd', 'volume24hUsd', 'marketCapUsd',
+        'percentChange1h', 'percentChange24h', 'percentChange7d',
+        'totalSupply', 'maxSupply', 'circulatingSupply',
+        'firstDataAt', 'lastUpdated',
+    ],
+    func: async (args) => {
+        const coin = requireNonEmpty(args.coin, 'coin').toLowerCase();
+        const url = `${CP_BASE}/tickers/${encodeURIComponent(coin)}`;
+        const body = await cpFetch(url, 'coinpaprika ticker');
+        if (!body || typeof body !== 'object') {
+            throw new EmptyResultError('coinpaprika ticker', `coinpaprika.com returned no ticker data for ${coin}.`);
+        }
+        const usd = body?.quotes?.USD ?? {};
+        return [{
+            id: body?.id ?? null,
+            name: body?.name ?? null,
+            symbol: body?.symbol ?? null,
+            rank: body?.rank ?? null,
+            priceUsd: usd?.price ?? null,
+            volume24hUsd: usd?.volume_24h ?? null,
+            marketCapUsd: usd?.market_cap ?? null,
+            percentChange1h: usd?.percent_change_1h ?? null,
+            percentChange24h: usd?.percent_change_24h ?? null,
+            percentChange7d: usd?.percent_change_7d ?? null,
+            totalSupply: body?.total_supply ?? null,
+            maxSupply: body?.max_supply ?? null,
+            circulatingSupply: body?.circulating_supply ?? null,
+            firstDataAt: body?.first_data_at ?? null,
+            lastUpdated: body?.last_updated ?? null,
+        }];
+    },
+});

--- a/clis/coinpaprika/utils.js
+++ b/clis/coinpaprika/utils.js
@@ -1,0 +1,48 @@
+// Coinpaprika public API — coin listing + ticker (price/market cap).
+//
+// Free tier at https://api.coinpaprika.com/v1. No API key required for read
+// traffic; ~25k req/month per IP soft cap. Stable schema.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const CP_BASE = 'https://api.coinpaprika.com/v1';
+const UA = 'opencli-coinpaprika/1.0';
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export function requireNonEmpty(value, name) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new ArgumentError(`<${name}> is required and must be a non-empty string.`);
+    }
+    return value.trim();
+}
+
+export async function cpFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, 'coinpaprika.com returned no matches.');
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}

--- a/clis/eonet/categories.js
+++ b/clis/eonet/categories.js
@@ -1,0 +1,35 @@
+// eonet categories — list of all event categories with id and description.
+//
+// Endpoint: GET /categories
+// Categories are stable over time — useful as a discovery command before
+// filtering `events --category <id>`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { eonetFetch, EONET_BASE } from './utils.js';
+
+cli({
+    site: 'eonet',
+    name: 'categories',
+    access: 'read',
+    description: 'List EONET event categories (ids round-trip to events --category)',
+    domain: 'gsfc.nasa.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [],
+    columns: ['rank', 'id', 'title', 'description', 'link'],
+    func: async () => {
+        const url = `${EONET_BASE}/categories`;
+        const body = await eonetFetch(url, 'eonet categories');
+        const list = Array.isArray(body?.categories) ? body.categories : [];
+        if (!list.length) {
+            throw new EmptyResultError('eonet categories', 'eonet.gsfc.nasa.gov returned no categories.');
+        }
+        return list.map((c, i) => ({
+            rank: i + 1,
+            id: c?.id ?? null,
+            title: c?.title ?? null,
+            description: c?.description ?? null,
+            link: c?.link ?? null,
+        }));
+    },
+});

--- a/clis/eonet/eonet.test.js
+++ b/clis/eonet/eonet.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './events.js';
+import './categories.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleEvent = {
+    id: 'EONET_19972',
+    title: 'Black Rush Lake RX Prescribed Fire, Swift, Minnesota',
+    description: null,
+    closed: null,
+    categories: [{ id: 'wildfires', title: 'Wildfires' }],
+    sources: [{ id: 'InciWeb' }, { id: 'IRWIN' }],
+    geometry: [{ magnitudeValue: 100, magnitudeUnit: 'acres', date: '2026-04-15T12:00:00Z', type: 'Point', coordinates: [-95.7, 45.7] }],
+    link: 'https://eonet.gsfc.nasa.gov/api/v3/events/EONET_19972',
+};
+
+const sampleCategory = {
+    id: 'wildfires',
+    title: 'Wildfires',
+    description: 'Wildfires include all wildland fires.',
+    link: 'https://eonet.gsfc.nasa.gov/api/v3/categories/wildfires',
+};
+
+describe('eonet events', () => {
+    const cmd = getRegistry().get('eonet/events');
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ limit: 99999 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects invalid --status', async () => {
+        await expect(cmd.func({ status: 'pending' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('promotes empty events array to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ events: [] }), { status: 200 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('preserves description=null and closed=null (not coerced to empty string)', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify({ events: [sampleEvent] }),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({});
+        expect(rows[0].description).toBeNull();
+        expect(rows[0].closed).toBeNull();
+    });
+
+    it('joins category titles + source ids with comma', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify({ events: [sampleEvent] }),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({});
+        expect(rows[0].categories).toBe('Wildfires');
+        expect(rows[0].sources).toBe('InciWeb, IRWIN');
+        expect(rows[0].magnitudeValue).toBe(100);
+        expect(rows[0].magnitudeUnit).toBe('acres');
+    });
+});
+
+describe('eonet categories', () => {
+    const cmd = getRegistry().get('eonet/categories');
+
+    it('shapes category rows', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify({ categories: [sampleCategory] }),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({});
+        expect(rows[0]).toMatchObject({
+            id: 'wildfires',
+            title: 'Wildfires',
+            link: 'https://eonet.gsfc.nasa.gov/api/v3/categories/wildfires',
+        });
+    });
+
+    it('promotes empty categories to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ categories: [] }), { status: 200 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});

--- a/clis/eonet/events.js
+++ b/clis/eonet/events.js
@@ -1,0 +1,66 @@
+// eonet events — natural events (wildfires, storms, volcanoes, icebergs).
+//
+// Endpoint: GET /events?limit=&days=&status=&category=
+// `status` is `open` (active) or `closed` (resolved); default = `open`.
+// `category` accepts a category id (drought, dustHaze, earthquakes, floods,
+//   landslides, manmade, seaLakeIce, severeStorms, snow, tempExtremes,
+//   volcanoes, waterColor, wildfires).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { eonetFetch, requireBoundedInt, EONET_BASE } from './utils.js';
+
+cli({
+    site: 'eonet',
+    name: 'events',
+    access: 'read',
+    description: 'Natural events from NASA EONET (wildfires / storms / volcanoes / icebergs)',
+    domain: 'gsfc.nasa.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows (1-200, default 20)' },
+        { name: 'days', type: 'int', default: 30, help: 'Days back to search (1-365, default 30)' },
+        { name: 'status', help: 'Event status: open (active) | closed (resolved). Default: open' },
+        { name: 'category', help: 'Category id (e.g. wildfires, volcanoes, severeStorms)' },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'description', 'closed', 'categories', 'sources',
+        'geometryType', 'lastDate', 'magnitudeValue', 'magnitudeUnit', 'link',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 200);
+        const days = requireBoundedInt(args.days, 30, 365, 'days');
+        const status = args.status == null || args.status === '' ? 'open' : String(args.status);
+        if (!['open', 'closed', 'all'].includes(status)) {
+            throw new ArgumentError(`--status must be one of: open, closed, all`);
+        }
+        const params = new URLSearchParams({ limit: String(limit), days: String(days), status });
+        if (args.category) params.set('category', String(args.category));
+        const url = `${EONET_BASE}/events?${params.toString()}`;
+        const body = await eonetFetch(url, 'eonet events');
+        const list = Array.isArray(body?.events) ? body.events : [];
+        if (!list.length) {
+            throw new EmptyResultError('eonet events', 'eonet.gsfc.nasa.gov returned no events for these filters.');
+        }
+        return list.map((e, i) => {
+            const cats = Array.isArray(e?.categories) ? e.categories.map((c) => c?.title).filter(Boolean) : [];
+            const sources = Array.isArray(e?.sources) ? e.sources.map((s) => s?.id).filter(Boolean) : [];
+            const geoms = Array.isArray(e?.geometry) ? e.geometry : [];
+            const lastGeom = geoms[geoms.length - 1] ?? null;
+            return {
+                rank: i + 1,
+                id: e?.id ?? null,
+                title: e?.title ?? null,
+                description: e?.description ?? null, // can be null per spec — preserve
+                closed: e?.closed ?? null,            // null when still open
+                categories: cats.length ? cats.join(', ') : null,
+                sources: sources.length ? sources.join(', ') : null,
+                geometryType: lastGeom?.type ?? null,  // Point or Polygon
+                lastDate: lastGeom?.date ?? null,
+                magnitudeValue: lastGeom?.magnitudeValue ?? null,
+                magnitudeUnit: lastGeom?.magnitudeUnit ?? null,
+                link: e?.link ?? null,
+            };
+        });
+    },
+});

--- a/clis/eonet/utils.js
+++ b/clis/eonet/utils.js
@@ -1,0 +1,42 @@
+// NASA EONET (Earth Observatory Natural Event Tracker).
+//
+// Public API at https://eonet.gsfc.nasa.gov/api/v3. No auth, generous rate limits.
+// Returns natural events (wildfires, volcanoes, storms, ice/icebergs) with
+// geometries (point or polygon) and category tags.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const EONET_BASE = 'https://eonet.gsfc.nasa.gov/api/v3';
+const UA = 'opencli-eonet/1.0';
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export async function eonetFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, 'eonet.gsfc.nasa.gov returned no matches.');
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}

--- a/clis/ghibli/films.js
+++ b/clis/ghibli/films.js
@@ -1,0 +1,57 @@
+// ghibli films — Studio Ghibli films catalog.
+//
+// Endpoint: GET /films
+// Server returns the full catalog (~22 films) as one array; client-side slice.
+// `rt_score` is Rotten Tomatoes %, `release_date` is YYYY (year only as string).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { ghibliFetch, requireBoundedInt, GHIBLI_BASE } from './utils.js';
+
+cli({
+    site: 'ghibli',
+    name: 'films',
+    access: 'read',
+    description: 'Studio Ghibli films (title, director, release year, RT score)',
+    domain: 'ghibliapi.vercel.app',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 50, help: 'Max rows (1-50, default 50)' },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'originalTitle', 'originalTitleRomanised',
+        'description', 'director', 'producer', 'releaseDate', 'runningTime',
+        'rtScore', 'image', 'movieBanner', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 50, 50);
+        const url = `${GHIBLI_BASE}/films`;
+        const body = await ghibliFetch(url, 'ghibli films');
+        if (!Array.isArray(body) || body.length === 0) {
+            throw new EmptyResultError('ghibli films', 'ghibliapi.vercel.app returned no films.');
+        }
+        // Server order is roughly chronological — sort by release_date ascending
+        // for stable presentation regardless of upstream churn.
+        const sorted = body.slice().sort((a, b) => {
+            const ay = Number(a?.release_date) || 0;
+            const by = Number(b?.release_date) || 0;
+            return ay - by;
+        });
+        return sorted.slice(0, limit).map((f, i) => ({
+            rank: i + 1,
+            id: f?.id ?? null,
+            title: f?.title ?? null,
+            originalTitle: f?.original_title ?? null,
+            originalTitleRomanised: f?.original_title_romanised ?? null,
+            description: f?.description ?? null,
+            director: f?.director ?? null,
+            producer: f?.producer ?? null,
+            releaseDate: f?.release_date ?? null,
+            runningTime: f?.running_time ?? null,
+            rtScore: f?.rt_score ?? null,
+            image: f?.image ?? null,
+            movieBanner: f?.movie_banner ?? null,
+            url: f?.url ?? null,
+        }));
+    },
+});

--- a/clis/ghibli/ghibli.test.js
+++ b/clis/ghibli/ghibli.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './films.js';
+import './people.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleFilm = {
+    id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
+    title: 'Castle in the Sky',
+    original_title: '天空の城ラピュタ',
+    original_title_romanised: 'Tenkū no shiro Rapyuta',
+    description: 'The orphan Sheeta inherited a mysterious crystal...',
+    director: 'Hayao Miyazaki',
+    producer: 'Isao Takahata',
+    release_date: '1986',
+    running_time: '124',
+    rt_score: '95',
+    image: 'https://image.tmdb.org/t/p/w600/...',
+    movie_banner: 'https://image.tmdb.org/t/p/w1280/...',
+    url: 'https://ghibliapi.vercel.app/films/2baf70d1-42bb-4437-b551-e5fed5a87abe',
+};
+
+const samplePerson = {
+    id: '267649ac-fb1b-11eb-9a03-0242ac130003',
+    name: 'Haku',
+    gender: 'Male',
+    age: '12',
+    eye_color: 'Green',
+    hair_color: 'Green',
+    films: ['https://ghibliapi.vercel.app/films/dc2e6bd1-8156-4886-adff-b39e6043af0c'],
+    species: 'https://ghibliapi.vercel.app/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2',
+    url: 'https://ghibliapi.vercel.app/people/267649ac-fb1b-11eb-9a03-0242ac130003',
+};
+
+describe('ghibli films', () => {
+    const cmd = getRegistry().get('ghibli/films');
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ limit: 99999 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('promotes empty array to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('[]', { status: 200 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes film rows + sorts ascending by release date', async () => {
+        const newer = { ...sampleFilm, id: 'newer', release_date: '2001', title: 'Spirited Away' };
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify([newer, sampleFilm]),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({});
+        expect(rows[0].id).toBe('2baf70d1-42bb-4437-b551-e5fed5a87abe'); // 1986
+        expect(rows[1].id).toBe('newer');                                 // 2001
+        expect(rows[0].rtScore).toBe('95');
+    });
+});
+
+describe('ghibli people', () => {
+    const cmd = getRegistry().get('ghibli/people');
+
+    it('extracts speciesId from URL + counts films', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([samplePerson]), { status: 200 })));
+        const rows = await cmd.func({});
+        expect(rows[0]).toMatchObject({
+            id: '267649ac-fb1b-11eb-9a03-0242ac130003',
+            name: 'Haku',
+            speciesId: 'af3910a6-429f-4c74-9ad5-dfe1c4aa04f2',
+            filmsCount: 1,
+        });
+    });
+
+    it('preserves null for empty string gender / age', async () => {
+        const partial = { ...samplePerson, gender: '', age: '' };
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([partial]), { status: 200 })));
+        const rows = await cmd.func({});
+        expect(rows[0].gender).toBeNull();
+        expect(rows[0].age).toBeNull();
+    });
+});

--- a/clis/ghibli/people.js
+++ b/clis/ghibli/people.js
@@ -1,0 +1,52 @@
+// ghibli people — Studio Ghibli film characters.
+//
+// Endpoint: GET /people
+// `films` field comes back as an array of film URLs — surface as count for
+// stable column shape (raw URL list would explode wide tables).
+// `species` is a single URL — surface as id from trailing path segment.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { ghibliFetch, requireBoundedInt, GHIBLI_BASE } from './utils.js';
+
+function urlToId(url) {
+    if (typeof url !== 'string' || !url) return null;
+    const m = url.match(/\/([^/]+)\/?$/);
+    return m ? m[1] : null;
+}
+
+cli({
+    site: 'ghibli',
+    name: 'people',
+    access: 'read',
+    description: 'Studio Ghibli characters (across all films)',
+    domain: 'ghibliapi.vercel.app',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 50, help: 'Max rows (1-100, default 50)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'gender', 'age', 'eyeColor', 'hairColor',
+        'speciesId', 'filmsCount', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 50, 100);
+        const url = `${GHIBLI_BASE}/people`;
+        const body = await ghibliFetch(url, 'ghibli people');
+        if (!Array.isArray(body) || body.length === 0) {
+            throw new EmptyResultError('ghibli people', 'ghibliapi.vercel.app returned no characters.');
+        }
+        return body.slice(0, limit).map((p, i) => ({
+            rank: i + 1,
+            id: p?.id ?? null,
+            name: p?.name ?? null,
+            gender: p?.gender ? p.gender : null, // explicit null for empty string
+            age: p?.age ? p.age : null,           // age can be 'NA' or '' — preserve null
+            eyeColor: p?.eye_color ?? null,
+            hairColor: p?.hair_color ?? null,
+            speciesId: urlToId(p?.species),
+            filmsCount: Array.isArray(p?.films) ? p.films.length : null,
+            url: p?.url ?? null,
+        }));
+    },
+});

--- a/clis/ghibli/utils.js
+++ b/clis/ghibli/utils.js
@@ -1,0 +1,42 @@
+// Studio Ghibli API — films + characters (people).
+//
+// Public REST API at https://ghibliapi.vercel.app. No auth, no rate limit
+// documented. Endpoints return JSON arrays directly. The dataset is
+// finite/curated (~22 films, ~50 characters).
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const GHIBLI_BASE = 'https://ghibliapi.vercel.app';
+const UA = 'opencli-ghibli/1.0';
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export async function ghibliFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, 'ghibliapi.vercel.app returned no matches.');
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}

--- a/clis/iceandfire/books.js
+++ b/clis/iceandfire/books.js
@@ -1,0 +1,55 @@
+// iceandfire books — ASOIAF books listing.
+//
+// Endpoint: GET /books?page=N&pageSize=M&name=&fromReleaseDate=&toReleaseDate=
+// API returns rich book metadata + URL-only references to characters / POVs.
+// We expose `charactersCount` / `povCharactersCount` derived from array length
+// (counts are useful, raw URL arrays would explode column shape).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { paginate, requireBoundedInt, urlToId, IAF_BASE } from './utils.js';
+
+cli({
+    site: 'iceandfire',
+    name: 'books',
+    access: 'read',
+    description: 'Game of Thrones / ASOIAF books (filter by name + release date)',
+    domain: 'anapioficeandfire.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows (1-200, default 20)' },
+        { name: 'name', help: 'Filter by book name substring' },
+        { name: 'from-release-date', help: 'ISO 8601 lower bound (e.g. 1996-01-01)' },
+        { name: 'to-release-date', help: 'ISO 8601 upper bound (e.g. 2025-12-31)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'isbn', 'authors', 'numberOfPages', 'publisher',
+        'country', 'mediaType', 'released', 'charactersCount', 'povCharactersCount', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 200);
+        const list = await paginate(`${IAF_BASE}/books`, limit, {
+            name: args.name,
+            fromReleaseDate: args['from-release-date'],
+            toReleaseDate: args['to-release-date'],
+        }, 'iceandfire books');
+        if (!list.length) {
+            throw new EmptyResultError('iceandfire books', 'anapioficeandfire.com returned no books for these filters.');
+        }
+        return list.map((b, i) => ({
+            rank: i + 1,
+            id: urlToId(b?.url),
+            name: b?.name ?? null,
+            isbn: b?.isbn ?? null,
+            authors: Array.isArray(b?.authors) ? b.authors.join(', ') : null,
+            numberOfPages: b?.numberOfPages ?? null,
+            publisher: b?.publisher ?? null,
+            country: b?.country ?? null,
+            mediaType: b?.mediaType ?? null,
+            released: b?.released ?? null,
+            charactersCount: Array.isArray(b?.characters) ? b.characters.length : null,
+            povCharactersCount: Array.isArray(b?.povCharacters) ? b.povCharacters.length : null,
+            url: b?.url ?? null,
+        }));
+    },
+});

--- a/clis/iceandfire/characters.js
+++ b/clis/iceandfire/characters.js
@@ -1,0 +1,59 @@
+// iceandfire characters — ASOIAF character listing with name / culture / gender filters.
+//
+// Endpoint: GET /characters?page=N&pageSize=M&name=&culture=&gender=&born=&died=
+// `aliases` and `titles` come back as arrays — we join with comma for stable
+// column shape; empty arrays normalize to null (not '').
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { paginate, requireBoundedInt, urlToId, IAF_BASE } from './utils.js';
+
+cli({
+    site: 'iceandfire',
+    name: 'characters',
+    access: 'read',
+    description: 'ASOIAF character listing (filter by name / culture / gender)',
+    domain: 'anapioficeandfire.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows (1-500, default 20)' },
+        { name: 'name', help: 'Filter by name substring' },
+        { name: 'culture', help: 'Filter by culture (e.g. Northmen, Dornish)' },
+        { name: 'gender', help: 'Filter by gender (Male | Female)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'gender', 'culture', 'born', 'died',
+        'aliases', 'titles', 'allegiances', 'books', 'tvSeries', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 500);
+        const list = await paginate(`${IAF_BASE}/characters`, limit, {
+            name: args.name,
+            culture: args.culture,
+            gender: args.gender,
+        }, 'iceandfire characters');
+        if (!list.length) {
+            throw new EmptyResultError('iceandfire characters', 'anapioficeandfire.com returned no characters for these filters.');
+        }
+        return list.map((c, i) => {
+            const aliases = Array.isArray(c?.aliases) ? c.aliases.filter(Boolean) : [];
+            const titles = Array.isArray(c?.titles) ? c.titles.filter(Boolean) : [];
+            const tvSeries = Array.isArray(c?.tvSeries) ? c.tvSeries.filter(Boolean) : [];
+            return {
+                rank: i + 1,
+                id: urlToId(c?.url),
+                name: c?.name ? c.name : null,                  // null preserves missing-name (some chars use only aliases)
+                gender: c?.gender ? c.gender : null,
+                culture: c?.culture ? c.culture : null,
+                born: c?.born ? c.born : null,
+                died: c?.died ? c.died : null,
+                aliases: aliases.length ? aliases.join(', ') : null,
+                titles: titles.length ? titles.join(', ') : null,
+                allegiances: Array.isArray(c?.allegiances) ? c.allegiances.length : null,
+                books: Array.isArray(c?.books) ? c.books.length : null,
+                tvSeries: tvSeries.length ? tvSeries.join(', ') : null,
+                url: c?.url ?? null,
+            };
+        });
+    },
+});

--- a/clis/iceandfire/iceandfire.test.js
+++ b/clis/iceandfire/iceandfire.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './books.js';
+import './characters.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleBook = {
+    url: 'https://anapioficeandfire.com/api/books/1',
+    name: 'A Game of Thrones',
+    isbn: '978-0553103540',
+    authors: ['George R. R. Martin'],
+    numberOfPages: 694,
+    publisher: 'Bantam Books',
+    country: 'United States',
+    mediaType: 'Hardcover',
+    released: '1996-08-01T00:00:00',
+    characters: ['https://anapioficeandfire.com/api/characters/2', 'https://anapioficeandfire.com/api/characters/12'],
+    povCharacters: ['https://anapioficeandfire.com/api/characters/148'],
+};
+
+const sampleCharacter = {
+    url: 'https://anapioficeandfire.com/api/characters/96',
+    name: 'Alys Karstark',
+    gender: 'Female',
+    culture: 'Northmen',
+    born: 'In 284 AC or 285 AC',
+    died: '',
+    titles: [''],
+    aliases: [],
+    allegiances: ['https://anapioficeandfire.com/api/houses/215'],
+    books: ['https://anapioficeandfire.com/api/books/8'],
+    tvSeries: ['Season 6'],
+};
+
+describe('iceandfire books', () => {
+    const cmd = getRegistry().get('iceandfire/books');
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ limit: 99999 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('promotes empty array to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('[]', { status: 200 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('extracts id from url + joins authors + counts characters', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([sampleBook]), { status: 200 })));
+        const rows = await cmd.func({ limit: 1 });
+        expect(rows[0]).toMatchObject({
+            id: '1',
+            name: 'A Game of Thrones',
+            authors: 'George R. R. Martin',
+            charactersCount: 2,
+            povCharactersCount: 1,
+        });
+    });
+});
+
+describe('iceandfire characters', () => {
+    const cmd = getRegistry().get('iceandfire/characters');
+
+    it('preserves null (not empty string) for empty died/aliases', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([sampleCharacter]), { status: 200 })));
+        const rows = await cmd.func({ limit: 1 });
+        expect(rows[0].died).toBeNull();    // sample.died is '' — must NOT round-trip as ''
+        expect(rows[0].aliases).toBeNull(); // sample.aliases is [] — must NOT round-trip as ''
+        expect(rows[0].titles).toBeNull();  // sample.titles is [''] — filter(Boolean) drops empty → []
+    });
+
+    it('threads --culture filter to query string', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(JSON.stringify([sampleCharacter]), { status: 200 }));
+        });
+        await cmd.func({ limit: 1, culture: 'Northmen' });
+        expect(calls[0]).toContain('culture=Northmen');
+    });
+
+    it('extracts id from url', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([sampleCharacter]), { status: 200 })));
+        const rows = await cmd.func({ limit: 1 });
+        expect(rows[0].id).toBe('96');
+    });
+});

--- a/clis/iceandfire/utils.js
+++ b/clis/iceandfire/utils.js
@@ -1,0 +1,70 @@
+// An API of Ice and Fire — Game of Thrones / ASOIAF books, characters, houses.
+//
+// Public API at https://anapioficeandfire.com/api. No auth, no API key.
+// Pagination via `?page=N&pageSize=M` (server caps pageSize at 50). Pagination
+// links surfaced via `Link` header (RFC 5988); we walk pages until limit hit.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const IAF_BASE = 'https://anapioficeandfire.com/api';
+const UA = 'opencli-iceandfire/1.0';
+const PAGE_SIZE = 50; // server cap
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export async function iafFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, 'anapioficeandfire.com returned no matches.');
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}
+
+// Walk pages of `?page=N&pageSize=PAGE_SIZE` until we have at least `limit`
+// rows or the server returns fewer than PAGE_SIZE (last page).
+export async function paginate(baseUrl, limit, extraParams, label) {
+    const out = [];
+    let page = 1;
+    while (out.length < limit) {
+        const params = new URLSearchParams({ page: String(page), pageSize: String(PAGE_SIZE) });
+        for (const [k, v] of Object.entries(extraParams || {})) {
+            if (v != null && v !== '') params.set(k, String(v));
+        }
+        const url = `${baseUrl}?${params.toString()}`;
+        const body = await iafFetch(url, label);
+        if (!Array.isArray(body) || body.length === 0) break;
+        out.push(...body);
+        if (body.length < PAGE_SIZE) break;
+        page += 1;
+    }
+    return out.slice(0, limit);
+}
+
+// Extract the trailing path segment as a stable id (e.g. /api/books/1 → "1").
+export function urlToId(url) {
+    if (typeof url !== 'string' || !url) return null;
+    const m = url.match(/\/(\d+)\/?$/);
+    return m ? m[1] : null;
+}

--- a/clis/openf1/drivers.js
+++ b/clis/openf1/drivers.js
@@ -1,0 +1,56 @@
+// openf1 drivers — F1 drivers entered for a specific session.
+//
+// Endpoint: GET /drivers?session_key=<key>
+// session_key comes from `openf1 sessions`. Returns one row per driver entry
+// (driver_number is per-session, not stable across seasons for some drivers).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { openf1Fetch, optionalInt, OPENF1_BASE } from './utils.js';
+
+cli({
+    site: 'openf1',
+    name: 'drivers',
+    access: 'read',
+    description: 'F1 drivers entered for a session (use sessions to find session_key)',
+    domain: 'openf1.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'session-key', positional: true, required: true, help: 'session_key from `openf1 sessions` (e.g. 9472)' },
+        { name: 'driver-number', help: 'Filter to a specific driver number (e.g. 1, 44)' },
+    ],
+    columns: [
+        'rank', 'driverNumber', 'broadcastName', 'fullName', 'nameAcronym',
+        'firstName', 'lastName', 'teamName', 'teamColour',
+        'countryCode', 'sessionKey', 'meetingKey', 'headshotUrl',
+    ],
+    func: async (args) => {
+        const sessionKey = optionalInt(args['session-key'], 'session-key');
+        if (sessionKey == null) {
+            throw new ArgumentError('<session-key> is required (use `openf1 sessions` to find one).');
+        }
+        const driverNumber = optionalInt(args['driver-number'], 'driver-number');
+        const params = new URLSearchParams({ session_key: String(sessionKey) });
+        if (driverNumber != null) params.set('driver_number', String(driverNumber));
+        const url = `${OPENF1_BASE}/drivers?${params.toString()}`;
+        const body = await openf1Fetch(url, 'openf1 drivers');
+        if (!Array.isArray(body) || body.length === 0) {
+            throw new EmptyResultError('openf1 drivers', `api.openf1.org returned no drivers for session_key=${sessionKey}.`);
+        }
+        return body.map((d, i) => ({
+            rank: i + 1,
+            driverNumber: d?.driver_number ?? null,
+            broadcastName: d?.broadcast_name ?? null,
+            fullName: d?.full_name ?? null,
+            nameAcronym: d?.name_acronym ?? null,
+            firstName: d?.first_name ?? null,
+            lastName: d?.last_name ?? null,
+            teamName: d?.team_name ?? null,
+            teamColour: d?.team_colour ?? null,
+            countryCode: d?.country_code ?? null,
+            sessionKey: d?.session_key ?? null,
+            meetingKey: d?.meeting_key ?? null,
+            headshotUrl: d?.headshot_url ?? null,
+        }));
+    },
+});

--- a/clis/openf1/openf1.test.js
+++ b/clis/openf1/openf1.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './sessions.js';
+import './drivers.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleSession = {
+    session_key: 9472,
+    session_type: 'Race',
+    session_name: 'Race',
+    date_start: '2024-03-02T15:00:00+00:00',
+    date_end: '2024-03-02T17:00:00+00:00',
+    meeting_key: 1229,
+    circuit_short_name: 'Sakhir',
+    country_code: 'BRN',
+    country_name: 'Bahrain',
+    location: 'Sakhir',
+    gmt_offset: '03:00:00',
+    year: 2024,
+    is_cancelled: false,
+};
+
+const sampleDriver = {
+    meeting_key: 1229,
+    session_key: 9472,
+    driver_number: 1,
+    broadcast_name: 'M VERSTAPPEN',
+    full_name: 'Max VERSTAPPEN',
+    name_acronym: 'VER',
+    team_name: 'Red Bull Racing',
+    team_colour: '3671c6',
+    first_name: 'Max',
+    last_name: 'Verstappen',
+    country_code: 'NED',
+    headshot_url: 'https://media.formula1.com/...',
+};
+
+describe('openf1 sessions', () => {
+    const cmd = getRegistry().get('openf1/sessions');
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ limit: 99999 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects non-positive year', async () => {
+        await expect(cmd.func({ year: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('promotes empty array to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('[]', { status: 200 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes session rows', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([sampleSession]), { status: 200 })));
+        const rows = await cmd.func({ year: 2024 });
+        expect(rows[0]).toMatchObject({
+            sessionKey: 9472,
+            sessionType: 'Race',
+            circuit: 'Sakhir',
+            countryCode: 'BRN',
+            year: 2024,
+        });
+    });
+
+    it('uppercases --country-code', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(JSON.stringify([sampleSession]), { status: 200 }));
+        });
+        await cmd.func({ 'country-code': 'brn' });
+        expect(calls[0]).toContain('country_code=BRN');
+    });
+});
+
+describe('openf1 drivers', () => {
+    const cmd = getRegistry().get('openf1/drivers');
+
+    it('rejects missing session-key', async () => {
+        await expect(cmd.func({})).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('shapes driver rows', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify([sampleDriver]), { status: 200 })));
+        const rows = await cmd.func({ 'session-key': 9472 });
+        expect(rows[0]).toMatchObject({
+            driverNumber: 1,
+            nameAcronym: 'VER',
+            teamName: 'Red Bull Racing',
+            countryCode: 'NED',
+        });
+    });
+
+    it('threads --driver-number to query string', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(JSON.stringify([sampleDriver]), { status: 200 }));
+        });
+        await cmd.func({ 'session-key': 9472, 'driver-number': 1 });
+        expect(calls[0]).toContain('driver_number=1');
+    });
+});

--- a/clis/openf1/sessions.js
+++ b/clis/openf1/sessions.js
@@ -1,0 +1,59 @@
+// openf1 sessions — F1 race / qualifying / practice sessions, filterable by year + type.
+//
+// Endpoint: GET /sessions?year=&session_type=&country_code=
+// Each session has a `session_key` that round-trips to drivers / car-data / laps.
+// Sorted by `date_start` ascending (server-side).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { openf1Fetch, requireBoundedInt, optionalInt, OPENF1_BASE } from './utils.js';
+
+cli({
+    site: 'openf1',
+    name: 'sessions',
+    access: 'read',
+    description: 'F1 sessions (Race / Qualifying / Practice / Sprint) with session_key for drilldown',
+    domain: 'openf1.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 30, help: 'Max rows (1-200, default 30)' },
+        { name: 'year', help: 'Filter by season year (e.g. 2024)' },
+        { name: 'session-type', help: 'Race | Qualifying | Practice | Sprint | Sprint Shootout' },
+        { name: 'country-code', help: '3-letter country code (e.g. BRN, MON, GBR)' },
+    ],
+    columns: [
+        'rank', 'sessionKey', 'meetingKey', 'sessionType', 'sessionName',
+        'circuit', 'countryCode', 'countryName', 'location',
+        'dateStart', 'dateEnd', 'gmtOffset', 'year', 'isCancelled',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 30, 200);
+        const year = optionalInt(args.year, 'year');
+        const params = new URLSearchParams();
+        if (year != null) params.set('year', String(year));
+        if (args['session-type']) params.set('session_type', String(args['session-type']));
+        if (args['country-code']) params.set('country_code', String(args['country-code']).toUpperCase());
+        const qs = params.toString();
+        const url = `${OPENF1_BASE}/sessions${qs ? `?${qs}` : ''}`;
+        const body = await openf1Fetch(url, 'openf1 sessions');
+        if (!Array.isArray(body) || body.length === 0) {
+            throw new EmptyResultError('openf1 sessions', 'api.openf1.org returned no sessions for these filters.');
+        }
+        return body.slice(0, limit).map((s, i) => ({
+            rank: i + 1,
+            sessionKey: s?.session_key ?? null,
+            meetingKey: s?.meeting_key ?? null,
+            sessionType: s?.session_type ?? null,
+            sessionName: s?.session_name ?? null,
+            circuit: s?.circuit_short_name ?? null,
+            countryCode: s?.country_code ?? null,
+            countryName: s?.country_name ?? null,
+            location: s?.location ?? null,
+            dateStart: s?.date_start ?? null,
+            dateEnd: s?.date_end ?? null,
+            gmtOffset: s?.gmt_offset ?? null,
+            year: s?.year ?? null,
+            isCancelled: s?.is_cancelled ?? null,
+        }));
+    },
+});

--- a/clis/openf1/utils.js
+++ b/clis/openf1/utils.js
@@ -1,0 +1,51 @@
+// OpenF1 — Formula 1 telemetry, sessions, drivers (real-time + archive).
+//
+// Public API at https://api.openf1.org/v1. No auth, no rate limit officially
+// documented (community-run; reasonable use expected). Filter via query
+// params; server returns JSON arrays directly (no envelope).
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const OPENF1_BASE = 'https://api.openf1.org/v1';
+const UA = 'opencli-openf1/1.0';
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export function optionalInt(value, name) {
+    if (value == null || value === '') return null;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new ArgumentError(`--${name} must be a positive integer (got ${value}).`);
+    }
+    return n;
+}
+
+export async function openf1Fetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, 'api.openf1.org returned no matches.');
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}

--- a/clis/rickandmorty/character.js
+++ b/clis/rickandmorty/character.js
@@ -1,0 +1,55 @@
+// rickandmorty character — character listing with optional --name / --status / --species filters.
+//
+// Endpoint: GET /character/?page=N&name=&status=&species=
+// Pagination: server-fixed 20/page; we walk pages until we hit --limit.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { paginate, requireBoundedInt, RM_BASE } from './utils.js';
+
+cli({
+    site: 'rickandmorty',
+    name: 'character',
+    access: 'read',
+    description: 'Search Rick and Morty characters by name / status / species',
+    domain: 'rickandmortyapi.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows (1-100, default 20)' },
+        { name: 'name', help: 'Filter by name substring (case-insensitive)' },
+        { name: 'status', help: 'alive | dead | unknown' },
+        { name: 'species', help: 'Species filter (e.g. Human, Alien, Robot)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'status', 'species', 'type', 'gender',
+        'origin', 'location', 'episodes', 'image', 'created', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const params = new URLSearchParams();
+        if (args.name) params.set('name', String(args.name));
+        if (args.status) params.set('status', String(args.status));
+        if (args.species) params.set('species', String(args.species));
+        const qs = params.toString();
+        const url = `${RM_BASE}/character/${qs ? `?${qs}` : ''}`;
+        const list = await paginate(url, limit, 'rickandmorty character');
+        if (!list.length) {
+            throw new EmptyResultError('rickandmorty character', 'rickandmortyapi.com returned no characters.');
+        }
+        return list.map((c, i) => ({
+            rank: i + 1,
+            id: c?.id ?? null,
+            name: c?.name ?? null,
+            status: c?.status ?? null,
+            species: c?.species ?? null,
+            type: c?.type ? c.type : null, // explicit `null` not `''` for missing
+            gender: c?.gender ?? null,
+            origin: c?.origin?.name ?? null,
+            location: c?.location?.name ?? null,
+            episodes: Array.isArray(c?.episode) ? c.episode.length : null,
+            image: c?.image ?? null,
+            created: c?.created ?? null,
+            url: c?.url ?? null,
+        }));
+    },
+});

--- a/clis/rickandmorty/episode.js
+++ b/clis/rickandmorty/episode.js
@@ -1,0 +1,47 @@
+// rickandmorty episode — episode listing with optional --name / --episode (S01E01 code).
+//
+// Endpoint: GET /episode/?page=N&name=&episode=
+// `episode` field on each row is the production code (S01E01); `name` is the title.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { paginate, requireBoundedInt, RM_BASE } from './utils.js';
+
+cli({
+    site: 'rickandmorty',
+    name: 'episode',
+    access: 'read',
+    description: 'List Rick and Morty episodes (filter by name or season/episode code)',
+    domain: 'rickandmortyapi.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows (1-100, default 20)' },
+        { name: 'name', help: 'Filter by episode title substring' },
+        { name: 'episode', help: 'Filter by production code (e.g. S01, S01E01)' },
+    ],
+    columns: [
+        'rank', 'id', 'name', 'airDate', 'episodeCode', 'characters', 'created', 'url',
+    ],
+    func: async (args) => {
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const params = new URLSearchParams();
+        if (args.name) params.set('name', String(args.name));
+        if (args.episode) params.set('episode', String(args.episode));
+        const qs = params.toString();
+        const url = `${RM_BASE}/episode/${qs ? `?${qs}` : ''}`;
+        const list = await paginate(url, limit, 'rickandmorty episode');
+        if (!list.length) {
+            throw new EmptyResultError('rickandmorty episode', 'rickandmortyapi.com returned no episodes.');
+        }
+        return list.map((e, i) => ({
+            rank: i + 1,
+            id: e?.id ?? null,
+            name: e?.name ?? null,
+            airDate: e?.air_date ?? null,
+            episodeCode: e?.episode ?? null,
+            characters: Array.isArray(e?.characters) ? e.characters.length : null,
+            created: e?.created ?? null,
+            url: e?.url ?? null,
+        }));
+    },
+});

--- a/clis/rickandmorty/rickandmorty.test.js
+++ b/clis/rickandmorty/rickandmorty.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './character.js';
+import './episode.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+const sampleCharacter = {
+    id: 1,
+    name: 'Rick Sanchez',
+    status: 'Alive',
+    species: 'Human',
+    type: '',
+    gender: 'Male',
+    origin: { name: 'Earth (C-137)', url: 'https://rickandmortyapi.com/api/location/1' },
+    location: { name: 'Citadel of Ricks', url: 'https://rickandmortyapi.com/api/location/3' },
+    image: 'https://rickandmortyapi.com/api/character/avatar/1.jpeg',
+    episode: ['https://rickandmortyapi.com/api/episode/1', 'https://rickandmortyapi.com/api/episode/2'],
+    url: 'https://rickandmortyapi.com/api/character/1',
+    created: '2017-11-04T18:48:46.250Z',
+};
+
+const sampleEpisode = {
+    id: 1,
+    name: 'Pilot',
+    air_date: 'December 2, 2013',
+    episode: 'S01E01',
+    characters: ['https://rickandmortyapi.com/api/character/1', 'https://rickandmortyapi.com/api/character/2'],
+    url: 'https://rickandmortyapi.com/api/episode/1',
+    created: '2017-11-10T12:56:33.798Z',
+};
+
+describe('rickandmorty character', () => {
+    const cmd = getRegistry().get('rickandmorty/character');
+
+    it('rejects --limit out of range', async () => {
+        await expect(cmd.func({ limit: 500 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 404 (no-match) to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('not found', { status: 404 })));
+        await expect(cmd.func({ name: 'nonsense-xyz' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('promotes 429 to CommandExecutionError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('preserves null (not empty string) for missing type', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify({ info: { next: null }, results: [sampleCharacter] }),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({ limit: 1 });
+        expect(rows[0].type).toBeNull(); // sampleCharacter.type is '' — must NOT be coerced to ''
+    });
+
+    it('shapes rows with origin/location flattened to name', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify({ info: { next: null }, results: [sampleCharacter] }),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({ limit: 1 });
+        expect(rows[0]).toMatchObject({
+            id: 1,
+            name: 'Rick Sanchez',
+            origin: 'Earth (C-137)',
+            location: 'Citadel of Ricks',
+            episodes: 2,
+        });
+    });
+
+    it('threads --name filter to query string', async () => {
+        const calls = [];
+        global.fetch = vi.fn((url) => {
+            calls.push(url);
+            return Promise.resolve(new Response(
+                JSON.stringify({ info: { next: null }, results: [sampleCharacter] }),
+                { status: 200 },
+            ));
+        });
+        await cmd.func({ limit: 1, name: 'Rick' });
+        expect(calls[0]).toContain('name=Rick');
+    });
+});
+
+describe('rickandmorty episode', () => {
+    const cmd = getRegistry().get('rickandmorty/episode');
+
+    it('shapes episode rows with episodeCode + characters count', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(
+            JSON.stringify({ info: { next: null }, results: [sampleEpisode] }),
+            { status: 200 },
+        )));
+        const rows = await cmd.func({ limit: 1 });
+        expect(rows[0]).toMatchObject({
+            id: 1,
+            name: 'Pilot',
+            episodeCode: 'S01E01',
+            airDate: 'December 2, 2013',
+            characters: 2,
+        });
+    });
+
+    it('walks pagination via info.next', async () => {
+        let call = 0;
+        global.fetch = vi.fn(() => {
+            call += 1;
+            const next = call === 1 ? 'https://rickandmortyapi.com/api/episode/?page=2' : null;
+            return Promise.resolve(new Response(
+                JSON.stringify({ info: { next }, results: [{ ...sampleEpisode, id: call }] }),
+                { status: 200 },
+            ));
+        });
+        const rows = await cmd.func({ limit: 2 });
+        expect(rows).toHaveLength(2);
+        expect(rows.map((r) => r.id)).toEqual([1, 2]);
+    });
+});

--- a/clis/rickandmorty/utils.js
+++ b/clis/rickandmorty/utils.js
@@ -1,0 +1,60 @@
+// Rick and Morty API — character / episode listing.
+//
+// Public REST API at https://rickandmortyapi.com/api/. No auth, generous rate
+// limits (~10000/day per IP, no per-second cap documented). Schema is stable
+// — pagination is `?page=N` returning {info: {count, pages, next, prev}, results: [...]}.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const RM_BASE = 'https://rickandmortyapi.com/api';
+const UA = 'opencli-rickandmorty/1.0';
+const PAGE_SIZE = 20; // server-fixed, can't override
+
+export function requireBoundedInt(value, def, max, name = 'limit') {
+    const n = value == null || value === '' ? def : Number(value);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError(`--${name} must be an integer between 1 and ${max}`);
+    }
+    return n;
+}
+
+export async function rmFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        // RM API returns 404 with `{error: "There is nothing here"}` for no-match filters.
+        throw new EmptyResultError(label, 'rickandmortyapi.com returned no matches.');
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} rate-limited (HTTP 429); back off and retry.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    return body;
+}
+
+// Walk pages until we've collected at least `limit` rows or run out.
+// Each page is server-fixed at 20. Caller slices to `limit`.
+export async function paginate(firstUrl, limit, label) {
+    const out = [];
+    let url = firstUrl;
+    while (url && out.length < limit) {
+        const body = await rmFetch(url, label);
+        const list = Array.isArray(body?.results) ? body.results : [];
+        out.push(...list);
+        url = body?.info?.next ?? null;
+    }
+    return out.slice(0, limit);
+}
+
+export { PAGE_SIZE };

--- a/docs/adapters/browser/coinpaprika.md
+++ b/docs/adapters/browser/coinpaprika.md
@@ -1,0 +1,58 @@
+# Coinpaprika
+
+**Mode**: 🌐 Public · **Domain**: `coinpaprika.com`
+
+Cryptocurrency listing + per-coin live ticker from the public REST API at `api.coinpaprika.com/v1`. No auth, no API key, generous rate limits on the free tier. Stable schema, ranks ~3000 coins.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli coinpaprika coins` | Listing of all coins (id, name, symbol, rank, type) |
+| `opencli coinpaprika ticker <coin-id>` | Live price + market cap + supply for a single coin |
+
+## Usage Examples
+
+```bash
+# Coin listing
+opencli coinpaprika coins --limit 20
+opencli coinpaprika coins --active --limit 50
+opencli coinpaprika coins --limit 1000
+
+# Live ticker (use coins to find an id)
+opencli coinpaprika ticker btc-bitcoin
+opencli coinpaprika ticker eth-ethereum
+opencli coinpaprika ticker sol-solana
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `coins` | `rank, id, name, symbol, type, isNew, isActive, coinRank` |
+| `ticker` | `id, name, symbol, rank, priceUsd, volume24hUsd, marketCapUsd, percentChange1h, percentChange24h, percentChange7d, totalSupply, maxSupply, circulatingSupply, firstDataAt, lastUpdated` |
+
+`coinRank` is the upstream Coinpaprika rank (1-based). The `rank` column on `coins` is the row index after sorting/filtering and is what the table view displays.
+
+## Options
+
+### `coins`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–1000, default 50). Server returns the full list; client-side slice. |
+| `--active` | Only include coins where `is_active === true` (filters out delisted). |
+
+### `ticker`
+
+| Option | Description |
+|--------|-------------|
+| `<coin-id>` | Required positional. Coinpaprika coin id (lowercased automatically; e.g. `btc-bitcoin`). |
+
+## Notes
+
+- **`rank: 0` means "not ranked".** Upstream uses `0` as a sentinel for unranked coins. Adapter sorts those to the end with `Number.POSITIVE_INFINITY` and surfaces them as `coinRank: null` so the column doesn't lie.
+- **`coins → ticker` round-trip.** The `id` column on `coins` is exactly what `ticker <coin-id>` expects. No transformation needed.
+- **USD quotes only.** `ticker` flattens `quotes.USD.*` to top-level `priceUsd / volume24hUsd / marketCapUsd / percentChange*`. For other quote currencies the upstream supports `?quotes=BTC,EUR` but this adapter doesn't expose it.
+- **Coin id is lowercased.** `ticker BTC-Bitcoin` and `ticker btc-bitcoin` both work — the positional is normalised to lowercase before the URL is built.
+- **Errors.** `--limit` out of range → `ArgumentError`; missing `<coin-id>` → `ArgumentError`; coin not found / empty result → `EmptyResultError`; 429 → `CommandExecutionError` with rate-limit hint; other non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/eonet.md
+++ b/docs/adapters/browser/eonet.md
@@ -1,0 +1,56 @@
+# EONET (NASA Earth Observatory Natural Event Tracker)
+
+**Mode**: 🌐 Public · **Domain**: `gsfc.nasa.gov`
+
+Natural event tracking (wildfires, storms, volcanoes, icebergs, floods) from NASA's public REST API at `eonet.gsfc.nasa.gov/api/v3`. No auth, no API key. Use `categories` to discover event types, then filter `events --category <id>`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli eonet events` | Natural events with status / category / lookback filters |
+| `opencli eonet categories` | List all event categories (ids round-trip into `events --category`) |
+
+## Usage Examples
+
+```bash
+# Recent open events
+opencli eonet events --limit 20
+opencli eonet events --category wildfires --days 90 --limit 50
+opencli eonet events --status closed --days 30
+
+# Category discovery
+opencli eonet categories
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `events` | `rank, id, title, description, closed, categories, sources, geometryType, lastDate, magnitudeValue, magnitudeUnit, link` |
+| `categories` | `rank, id, title, description, link` |
+
+## Options
+
+### `events`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–200, default 20) |
+| `--days` | Days back to search (1–365, default 30) |
+| `--status` | `open` (active, default) \| `closed` (resolved) \| `all` |
+| `--category` | Category id (e.g. `wildfires`, `volcanoes`, `severeStorms`). Use `categories` for the canonical list. |
+
+### `categories`
+
+No options — the category list is small and stable.
+
+## Notes
+
+- **Most-recent geometry is surfaced.** Events have an array of `geometry` entries (one per observation). Adapter takes the last entry for `geometryType / lastDate / magnitudeValue / magnitudeUnit` since that's the freshest snapshot.
+- **`closed: null` means still open.** Upstream omits the `closed` timestamp on active events; preserved as `null` rather than coerced to a fake date or empty string.
+- **`description: null` is normal.** Many events have no human-readable summary; preserved as `null`.
+- **`magnitudeValue` / `magnitudeUnit` are sparse.** Most categories don't carry magnitudes (wildfires usually do via acres burned; storms via wind speed). Both are `null` when not provided — don't assume non-null on filtered queries.
+- **`categories` / `sources` joined with comma.** Each event has a small array of category titles and source ids — joined for stable column shape.
+- **`categories.id → events --category id`.** The id column round-trips. `categories` returns `wildfires`, `volcanoes`, `severeStorms`, etc. — those are exactly the values `events --category` accepts.
+- **Errors.** `--limit` / `--days` out of range → `ArgumentError`; bad `--status` value → `ArgumentError`; empty result for filters → `EmptyResultError`; 429 → `CommandExecutionError`; other non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/ghibli.md
+++ b/docs/adapters/browser/ghibli.md
@@ -1,0 +1,57 @@
+# Studio Ghibli
+
+**Mode**: 🌐 Public · **Domain**: `ghibliapi.vercel.app`
+
+Studio Ghibli films + character data from the public REST API at `ghibliapi.vercel.app`. No auth, no API key. Curated dataset (~22 films, ~50 characters) — server returns full collections in one request.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli ghibli films` | Studio Ghibli films catalog (title, director, release year, RT score) |
+| `opencli ghibli people` | Studio Ghibli characters across all films |
+
+## Usage Examples
+
+```bash
+# Films
+opencli ghibli films --limit 50
+opencli ghibli films --limit 5
+
+# Characters
+opencli ghibli people --limit 50
+opencli ghibli people --limit 100
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `films` | `rank, id, title, originalTitle, originalTitleRomanised, description, director, producer, releaseDate, runningTime, rtScore, image, movieBanner, url` |
+| `people` | `rank, id, name, gender, age, eyeColor, hairColor, speciesId, filmsCount, url` |
+
+## Options
+
+### `films`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–50, default 50). The full catalog has ~22 films — the cap is loose. |
+
+### `people`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–100, default 50). |
+
+## Notes
+
+- **Films sorted ascending by release date.** Server order is roughly chronological but unstable across deploys; adapter sorts by `release_date` (year-only string, parsed as `Number`) for stable presentation.
+- **`originalTitle` is Japanese.** `originalTitle: 天空の城ラピュタ`, `originalTitleRomanised: Tenkū no shiro Rapyuta` — both surfaced separately for searchability and display.
+- **`rtScore` is Rotten Tomatoes percentage.** Upstream returns it as a string (`"95"`); preserved as-is for column-shape stability rather than coerced to int.
+- **`releaseDate` is year-only.** Upstream returns `"1986"`, not a full date — preserved as string.
+- **`speciesId` extracted from species URL.** Upstream returns `species: "https://ghibliapi.vercel.app/species/<uuid>"`; adapter pulls the trailing UUID via regex for a stable id column. Empty / null URL → `speciesId: null`.
+- **`filmsCount` is array length.** `films` field comes back as URL array — counted for stable column shape.
+- **`gender: ''` / `age: ''` preserved as `null`.** Many characters have empty `gender` or `age` fields — coerced to `null` rather than rendered as `''`.
+- **No filter params.** Upstream supports neither `?title=` nor `?name=`; full catalog is returned and sliced client-side. For filtered work, slice the rows after the call.
+- **Errors.** `--limit` out of range → `ArgumentError`; empty response → `EmptyResultError`; 429 → `CommandExecutionError`; other non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/iceandfire.md
+++ b/docs/adapters/browser/iceandfire.md
@@ -1,0 +1,66 @@
+# An API of Ice and Fire
+
+**Mode**: 🌐 Public · **Domain**: `anapioficeandfire.com`
+
+A Song of Ice and Fire (Game of Thrones) book + character data from the public REST API at `anapioficeandfire.com/api`. No auth, no API key. Server pages at 50/req max — adapter walks pages until `--limit` is hit.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli iceandfire books` | ASOIAF books (filter by name + release date) |
+| `opencli iceandfire characters` | ASOIAF character listing (filter by name / culture / gender) |
+
+## Usage Examples
+
+```bash
+# Books
+opencli iceandfire books --limit 20
+opencli iceandfire books --name "Game of Thrones"
+opencli iceandfire books --from-release-date 1996-01-01 --to-release-date 2000-12-31
+
+# Characters
+opencli iceandfire characters --limit 50
+opencli iceandfire characters --culture Northmen --limit 100
+opencli iceandfire characters --gender Female --culture Dornish
+opencli iceandfire characters --name Stark
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `books` | `rank, id, name, isbn, authors, numberOfPages, publisher, country, mediaType, released, charactersCount, povCharactersCount, url` |
+| `characters` | `rank, id, name, gender, culture, born, died, aliases, titles, allegiances, books, tvSeries, url` |
+
+`charactersCount` / `povCharactersCount` (on `books`) and `allegiances` / `books` (on `characters`) are array lengths — raw URL arrays would explode column shape. Use the canonical book / character URL fields to drill down.
+
+## Options
+
+### `books`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–200, default 20). Pages walked at 50/page until limit hit. |
+| `--name` | Filter by book name substring |
+| `--from-release-date` | ISO 8601 lower bound (e.g. `1996-01-01`) |
+| `--to-release-date` | ISO 8601 upper bound (e.g. `2025-12-31`) |
+
+### `characters`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–500, default 20). Pages walked at 50/page until limit hit. |
+| `--name` | Filter by name substring |
+| `--culture` | Filter by culture (e.g. `Northmen`, `Dornish`, `Ironborn`) |
+| `--gender` | Filter by gender (`Male` \| `Female`) |
+
+## Notes
+
+- **Server-fixed page size of 50.** Upstream uses `?page=N&pageSize=50`; adapter walks pages until `--limit` is reached or the last page returns < 50 rows.
+- **`id` extracted from `url`.** Upstream returns no integer id field — only URLs like `https://anapioficeandfire.com/api/characters/823`. Adapter pulls the trailing digits via regex for a stable round-trip key.
+- **Empty strings preserved as `null`.** `gender: ''` / `born: ''` / `died: ''` / `culture: ''` are common (especially for minor characters) — coerced to `null` so the column doesn't silently render as `''`.
+- **`aliases` / `titles` joined with comma; empty → `null`.** Upstream returns `[]` or `['']` for missing fields; adapter filters falsy entries before joining and surfaces `null` when nothing is left.
+- **`allegiances` / `books` are counts.** Raw URL arrays would explode wide tables — counts let you see at a glance which characters have rich relationships.
+- **`tvSeries` joined as comma list.** Small array (~8 entries max for season names) — surfaced as a string for readability.
+- **Errors.** `--limit` out of range → `ArgumentError`; empty result for filters → `EmptyResultError`; 429 → `CommandExecutionError`; other non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/openf1.md
+++ b/docs/adapters/browser/openf1.md
@@ -1,0 +1,62 @@
+# OpenF1
+
+**Mode**: 🌐 Public · **Domain**: `openf1.org`
+
+Formula 1 telemetry + session metadata from the public REST API at `api.openf1.org/v1`. No auth, no API key. Covers seasons from 2023 onward (older seasons have partial coverage). Use `sessions` to find a `session_key`, then drill down with `drivers`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli openf1 sessions` | F1 sessions (Race / Qualifying / Practice / Sprint) with session_key for drilldown |
+| `opencli openf1 drivers <session-key>` | Drivers entered for a specific session |
+
+## Usage Examples
+
+```bash
+# Session listing
+opencli openf1 sessions --year 2024 --limit 30
+opencli openf1 sessions --year 2024 --session-type Race
+opencli openf1 sessions --year 2024 --country-code MON
+opencli openf1 sessions --session-type Qualifying --limit 10
+
+# Drivers for a session (use sessions to find session_key first)
+opencli openf1 drivers 9472
+opencli openf1 drivers 9472 --driver-number 1
+opencli openf1 drivers 9472 --driver-number 44
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `sessions` | `rank, sessionKey, meetingKey, sessionType, sessionName, circuit, countryCode, countryName, location, dateStart, dateEnd, gmtOffset, year, isCancelled` |
+| `drivers` | `rank, driverNumber, broadcastName, fullName, nameAcronym, firstName, lastName, teamName, teamColour, countryCode, sessionKey, meetingKey, headshotUrl` |
+
+## Options
+
+### `sessions`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–200, default 30). Sliced client-side; upstream has no `limit=` param. |
+| `--year` | Filter by season year (e.g. `2024`) |
+| `--session-type` | `Race` \| `Qualifying` \| `Practice` \| `Sprint` \| `Sprint Shootout` |
+| `--country-code` | 3-letter country code (e.g. `BRN`, `MON`, `GBR`). Auto-uppercased. |
+
+### `drivers`
+
+| Option | Description |
+|--------|-------------|
+| `<session-key>` | Required positional. session_key from `openf1 sessions` (e.g. `9472`). |
+| `--driver-number` | Filter to a specific driver number (e.g. `1`, `44`). |
+
+## Notes
+
+- **No server-side `limit=` param.** OpenF1 doesn't accept `?limit=N`; the adapter slices the full filtered response client-side. For `sessions` that's small (<100 even for a full season). `drivers` is always ~20 rows so no slice needed.
+- **`sessions → drivers` round-trip.** `sessionKey` from `sessions` is exactly what `drivers <session-key>` expects.
+- **`country-code` is auto-uppercased.** `--country-code mon` and `--country-code MON` both work.
+- **`driver_number` is per-session, not stable.** Some drivers change numbers across seasons. Always filter with the session you care about.
+- **`<session-key>` is required.** `drivers` without it raises `ArgumentError` with a hint to run `sessions` first — no silent "all drivers ever" fallback.
+- **Server sorts `sessions` by `date_start` ascending.** Most-recent year-end shows last; combine with `--year` and slicing for filtered tables.
+- **Errors.** Missing `<session-key>` / out-of-range `--limit` → `ArgumentError`; empty result → `EmptyResultError`; 429 → `CommandExecutionError`; other non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/rickandmorty.md
+++ b/docs/adapters/browser/rickandmorty.md
@@ -1,0 +1,63 @@
+# Rick and Morty
+
+**Mode**: 🌐 Public · **Domain**: `rickandmortyapi.com`
+
+Rick and Morty character / episode / location data from the public REST API at `rickandmortyapi.com/api`. No auth, no API key. Stable schema with documented filter params.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli rickandmorty character` | Search characters by name / status / species |
+| `opencli rickandmorty episode` | List episodes (filter by name or production code) |
+
+## Usage Examples
+
+```bash
+# Search characters
+opencli rickandmorty character --name Rick --limit 5
+opencli rickandmorty character --status alive --species Human --limit 10
+opencli rickandmorty character --limit 50
+
+# Episode listing
+opencli rickandmorty episode --limit 5
+opencli rickandmorty episode --episode S01
+opencli rickandmorty episode --name Pilot
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `character` | `rank, id, name, status, species, type, gender, origin, location, episodes, image, created, url` |
+| `episode` | `rank, id, name, airDate, episodeCode, characters, created, url` |
+
+`episodes` (count) and `characters` (count) summarize array lengths — raw URL arrays would explode column shape.
+
+## Options
+
+### `character`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–100, default 20). Pages walked client-side at 20/page. |
+| `--name` | Substring filter on character name (case-insensitive on the server) |
+| `--status` | `alive` \| `dead` \| `unknown` |
+| `--species` | Species filter (e.g. `Human`, `Alien`, `Robot`) |
+
+### `episode`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max rows (1–100, default 20) |
+| `--name` | Substring filter on episode title |
+| `--episode` | Production code filter (e.g. `S01` to match all of season 1, `S01E01` for a specific episode) |
+
+## Notes
+
+- **Server-fixed page size of 20.** No `?limit=N` param exists; the adapter walks pages until `--limit` is hit or `info.next` is null. Pages are 50 ms apart on average so `--limit 100` is ~5 round-trips.
+- **`type: ''` preserved as `null`.** Most characters have an empty `type` field on the upstream — adapter coerces empty string → `null` so the column doesn't silently fall back to `''`.
+- **404 = no matches, not error.** When a filter combination matches zero characters/episodes, the API returns HTTP 404 with `{error: "There is nothing here"}`. Adapter promotes this to `EmptyResultError`.
+- **`origin` / `location` flattened to `name`.** Upstream returns `{name, url}` objects — adapter surfaces just `name` since the URL adds no value over the `id` column.
+- **`episodes` / `characters` as counts, not URL arrays.** Stable column shape for tabular display. Use detail commands or follow the upstream URL for individual episode/character lookups.
+- **Errors.** `--limit` out of range → `ArgumentError`; 404 / empty results → `EmptyResultError`; 429 → `CommandExecutionError` with rate-limit hint; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -134,6 +134,12 @@ Run `opencli list` for the live registry.
 | **[nuget](./browser/nuget.md)**                   | `search` `package`                                                                                                                             | 🌐 Public    |
 | **[flathub](./browser/flathub.md)**               | `search` `app`                                                                                                                                 | 🌐 Public    |
 | **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
+| **[rickandmorty](./browser/rickandmorty.md)**     | `character` `episode`                                                                                                                          | 🌐 Public    |
+| **[coinpaprika](./browser/coinpaprika.md)**       | `coins` `ticker`                                                                                                                               | 🌐 Public    |
+| **[eonet](./browser/eonet.md)**                   | `events` `categories`                                                                                                                          | 🌐 Public    |
+| **[openf1](./browser/openf1.md)**                 | `sessions` `drivers`                                                                                                                           | 🌐 Public    |
+| **[iceandfire](./browser/iceandfire.md)**         | `books` `characters`                                                                                                                           | 🌐 Public    |
+| **[ghibli](./browser/ghibli.md)**                 | `films` `people`                                                                                                                               | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary
Round 12 of the read-adapter expansion. 6 new public-API sites × 2 commands each = 12 new adapters. All zero-auth.

- **rickandmorty** (`character`, `episode`) — rickandmortyapi.com. Server-fixed 20/page; adapter walks `info.next` until `--limit`. Filters: `--name / --status / --species` for characters; `--name / --episode` (production code like S01E01) for episodes.
- **coinpaprika** (`coins`, `ticker`) — `coins` lists ~3k ranked coins with `rank=0`-unranked-last sort (POSITIVE_INFINITY) and `--active` filter; `ticker <coin-id>` flattens `quotes.USD.*` to top-level. Id round-trips between the two.
- **eonet** (`events`, `categories`) — NASA Earth Observatory natural events. `events` filters on `--status open/closed/all`, `--days`, `--category`; surfaces last-element of geometry array for freshest snapshot. `categories` discovers id values that round-trip into `events --category`.
- **openf1** (`sessions`, `drivers`) — F1 telemetry from 2023+. `sessions` filters by year/session-type/country-code (auto-uppercased); `drivers <session-key>` requires the positional and raises `ArgumentError` if missing. No silent fallback to "all drivers ever".
- **iceandfire** (`books`, `characters`) — ASOIAF. Server pages at 50/req — adapter walks `?page=N&pageSize=50` until limit hit. `urlToId()` extracts trailing digits since upstream has no integer id field.
- **ghibli** (`films`, `people`) — Studio Ghibli. `films` sorted ascending by release_date; `people` extracts `speciesId` from species URL via UUID regex. `gender: ''` / `age: ''` / `died: ''` → `null`.

47 contract tests across 6 sites covering: paginate `info.next` walking; type=''→null preservation; urlToId extraction (digits + UUIDs); filter threading; ArgumentError on missing positionals; 404→EmptyResultError, 429→CommandExecutionError, generic non-200 → CommandExecutionError.

## Self-check
- ✅ All 12 commands declare `access: 'read'`
- ✅ All limit args validated via `requireBoundedInt` (no silent clamp)
- ✅ Typed errors only: `ArgumentError / EmptyResultError / CommandExecutionError`
- ✅ No silent-fallback / silent-sentinel / silent-column-drop — empty arrays, empty strings, missing data all preserved as `null`
- ✅ Listing↔detail id pairing: rickandmorty character/episode have `id` columns; coinpaprika `coins.id → ticker <coin-id>`; eonet `categories.id → events --category`; openf1 `sessions.sessionKey → drivers <session-key>`; iceandfire books/characters have `id` from urlToId; ghibli films/people have `id`.
- ✅ Audits clean: `typed-error-lint=196, silent-column-drop=103, listing-id-pairing exit 0`. No new violations.
- ✅ All 47 contract tests pass: `npx vitest run clis/{rickandmorty,coinpaprika,eonet,openf1,iceandfire,ghibli}/`
- ✅ Live-verified all 12 commands against real APIs

## Quirks documented in NOTES (per-site)
- rickandmorty: type:''→null; 404 on no-match → EmptyResultError; origin/location flattened to name; episodes/characters as counts
- coinpaprika: rank=0 sentinel → POSITIVE_INFINITY sort + coinRank=null; auto-lowercase coin id positional; USD-only quotes
- eonet: last-element geometry for freshest snapshot; description/closed nullable per spec; magnitudeValue/Unit sparse
- openf1: no server limit= param; auto-uppercase country-code; missing session-key → ArgumentError (no fallback)
- iceandfire: server-fixed 50/page; urlToId trailing digits; empty arrays + empty strings → null
- ghibli: ascending release_date sort; UUID regex for speciesId; no server filter params (full catalog returned)

## Test plan
- [x] `npx vitest run clis/{rickandmorty,coinpaprika,eonet,openf1,iceandfire,ghibli}/` — 47/47 passing
- [x] `node scripts/check-typed-error-lint.mjs` — 196 baseline preserved
- [x] `node scripts/check-silent-column-drop.mjs` — 103 baseline preserved
- [x] `node scripts/check-listing-id-pairing.mjs` — exit 0
- [x] `npx tsx src/build-manifest.ts` — 769 entries
- [x] Live-verified all 12 commands against real APIs

Manifest 757→769 (+12). Pure-additive: no new gates / schemas / scripts / shared deps.