### PR TITLE
feat: 3 read adapters (frankfurter, nws, worldbank) + contract tests

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8978,6 +8978,87 @@
     "sourceFile": "flathub/search.js"
   },
   {
+    "site": "frankfurter",
+    "name": "historical",
+    "description": "Historical ECB FX rates for a single date or date range",
+    "access": "read",
+    "domain": "api.frankfurter.dev",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Start date YYYY-MM-DD (or single day if --to omitted)"
+      },
+      {
+        "name": "to",
+        "type": "str",
+        "required": false,
+        "help": "End date YYYY-MM-DD; if set, returns daily rates from <date> to <to>"
+      },
+      {
+        "name": "base",
+        "type": "str",
+        "default": "EUR",
+        "required": false,
+        "help": "Base currency (ISO 4217, default EUR)"
+      },
+      {
+        "name": "symbols",
+        "type": "str",
+        "required": false,
+        "help": "Comma-separated target currencies (e.g. USD,JPY)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "date",
+      "base",
+      "target",
+      "rate"
+    ],
+    "type": "js",
+    "modulePath": "frankfurter/historical.js",
+    "sourceFile": "frankfurter/historical.js"
+  },
+  {
+    "site": "frankfurter",
+    "name": "latest",
+    "description": "Latest ECB-published FX rates against a base currency",
+    "access": "read",
+    "domain": "api.frankfurter.dev",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "base",
+        "type": "str",
+        "default": "EUR",
+        "required": false,
+        "help": "Base currency (ISO 4217, default EUR)"
+      },
+      {
+        "name": "symbols",
+        "type": "str",
+        "required": false,
+        "help": "Comma-separated target currencies (e.g. USD,JPY,GBP); default: all"
+      }
+    ],
+    "columns": [
+      "rank",
+      "base",
+      "target",
+      "rate",
+      "date"
+    ],
+    "type": "js",
+    "modulePath": "frankfurter/latest.js",
+    "sourceFile": "frankfurter/latest.js"
+  },
+  {
     "site": "gemini",
     "name": "ask",
     "description": "Send a prompt to Gemini and return only the assistant response",
@@ -15784,6 +15865,84 @@
     "type": "js",
     "modulePath": "nvd/cve.js",
     "sourceFile": "nvd/cve.js"
+  },
+  {
+    "site": "nws",
+    "name": "alerts",
+    "description": "Active US weather alerts (optionally filtered by state)",
+    "access": "read",
+    "domain": "api.weather.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "state",
+        "type": "str",
+        "required": false,
+        "help": "2-letter US state code (e.g. CA, TX); default: all states"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max rows (1-500, default 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "event",
+      "severity",
+      "urgency",
+      "certainty",
+      "headline",
+      "areaDesc",
+      "sent",
+      "effective",
+      "expires",
+      "senderName",
+      "description",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "nws/alerts.js",
+    "sourceFile": "nws/alerts.js"
+  },
+  {
+    "site": "nws",
+    "name": "forecast",
+    "description": "US weather forecast for a lat/lon point (National Weather Service)",
+    "access": "read",
+    "domain": "api.weather.gov",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "point",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Latitude,longitude (e.g. \"37.7749,-122.4194\")"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "startTime",
+      "endTime",
+      "isDaytime",
+      "temperature",
+      "temperatureUnit",
+      "windSpeed",
+      "windDirection",
+      "shortForecast",
+      "detailedForecast",
+      "precipitationProbability"
+    ],
+    "type": "js",
+    "modulePath": "nws/forecast.js",
+    "sourceFile": "nws/forecast.js"
   },
   {
     "site": "oeis",
@@ -23520,6 +23679,87 @@
     "type": "js",
     "modulePath": "wikipedia/trending.js",
     "sourceFile": "wikipedia/trending.js"
+  },
+  {
+    "site": "worldbank",
+    "name": "country",
+    "description": "World Bank country profile (region, income group, capital, lat/lon)",
+    "access": "read",
+    "domain": "api.worldbank.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "country",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "ISO country code (alpha-2 or alpha-3)"
+      }
+    ],
+    "columns": [
+      "iso2",
+      "iso3",
+      "name",
+      "region",
+      "incomeLevel",
+      "lendingType",
+      "capital",
+      "longitude",
+      "latitude"
+    ],
+    "type": "js",
+    "modulePath": "worldbank/country.js",
+    "sourceFile": "worldbank/country.js"
+  },
+  {
+    "site": "worldbank",
+    "name": "indicator",
+    "description": "World Bank indicator time series for a country",
+    "access": "read",
+    "domain": "api.worldbank.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "country",
+        "type": "str",
+        "required": true,
+        "help": "ISO country code (alpha-2 or alpha-3)"
+      },
+      {
+        "name": "indicator",
+        "type": "str",
+        "required": true,
+        "help": "World Bank indicator code (e.g. NY.GDP.MKTP.CD)"
+      },
+      {
+        "name": "years",
+        "type": "str",
+        "required": false,
+        "help": "Year range YYYY:YYYY (e.g. 2000:2024)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max data points (1-500, default 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "country",
+      "iso3",
+      "indicator",
+      "indicatorCode",
+      "date",
+      "value",
+      "unit"
+    ],
+    "type": "js",
+    "modulePath": "worldbank/indicator.js",
+    "sourceFile": "worldbank/indicator.js"
   },
   {
     "site": "xianyu",

--- a/clis/frankfurter/frankfurter.test.js
+++ b/clis/frankfurter/frankfurter.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './latest.js';
+import './historical.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+describe('frankfurter latest', () => {
+    const cmd = getRegistry().get('frankfurter/latest');
+
+    it('rejects bad base', async () => {
+        await expect(cmd.func({ base: 'us' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes 422 to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response('{}', { status: 422 })));
+        await expect(cmd.func({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes rate rows + carries date', async () => {
+        const sample = { amount: 1, base: 'EUR', date: '2026-05-05', rates: { USD: 1.08, JPY: 165.5, GBP: 0.86 } };
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        const rows = await cmd.func({ base: 'EUR', symbols: 'USD,JPY,GBP' });
+        expect(rows).toHaveLength(3);
+        expect(rows[0]).toEqual({ rank: 1, base: 'EUR', target: 'USD', rate: 1.08, date: '2026-05-05' });
+        expect(rows[2].target).toBe('GBP');
+    });
+});
+
+describe('frankfurter historical', () => {
+    const cmd = getRegistry().get('frankfurter/historical');
+
+    it('rejects bad date format', async () => {
+        await expect(cmd.func({ date: '2026/05/05' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects --to before <date>', async () => {
+        await expect(cmd.func({ date: '2026-05-05', to: '2026-05-01' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('shapes a single-day historical row', async () => {
+        const sample = { amount: 1, base: 'EUR', date: '2026-05-01', rates: { USD: 1.07 } };
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        const rows = await cmd.func({ date: '2026-05-01', base: 'EUR' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toEqual({ rank: 1, date: '2026-05-01', base: 'EUR', target: 'USD', rate: 1.07 });
+    });
+
+    it('flattens range response newest-first', async () => {
+        const sample = {
+            amount: 1, base: 'EUR', start_date: '2026-05-01', end_date: '2026-05-03',
+            rates: {
+                '2026-05-01': { USD: 1.07 },
+                '2026-05-02': { USD: 1.075 },
+                '2026-05-03': { USD: 1.08 },
+            },
+        };
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        const rows = await cmd.func({ date: '2026-05-01', to: '2026-05-03', base: 'EUR' });
+        expect(rows).toHaveLength(3);
+        expect(rows[0].date).toBe('2026-05-03');
+        expect(rows[2].date).toBe('2026-05-01');
+    });
+});

--- a/clis/frankfurter/historical.js
+++ b/clis/frankfurter/historical.js
@@ -1,0 +1,81 @@
+// frankfurter historical — historical ECB FX rates for a single date or range.
+//
+// Endpoint: GET /v1/<date>?base=<base>&symbols=<csv>          (single day)
+//           GET /v1/<from>..<to>?base=<base>&symbols=<csv>    (range)
+//
+// Single day: one row per target currency.
+// Range: one row per (date, target) pair, newest-first.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    FRANKFURTER_BASE,
+    frankfurterFetch,
+    requireCurrency,
+    requireDate,
+    requireOptionalCurrency,
+    requireOptionalDate,
+} from './utils.js';
+
+cli({
+    site: 'frankfurter',
+    name: 'historical',
+    access: 'read',
+    description: 'Historical ECB FX rates for a single date or date range',
+    domain: 'api.frankfurter.dev',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'date', positional: true, required: true, help: 'Start date YYYY-MM-DD (or single day if --to omitted)' },
+        { name: 'to', help: 'End date YYYY-MM-DD; if set, returns daily rates from <date> to <to>' },
+        { name: 'base', default: 'EUR', help: 'Base currency (ISO 4217, default EUR)' },
+        { name: 'symbols', help: 'Comma-separated target currencies (e.g. USD,JPY)' },
+    ],
+    columns: ['rank', 'date', 'base', 'target', 'rate'],
+    func: async (args) => {
+        const fromDate = requireDate(args.date, 'date');
+        const toDate = requireOptionalDate(args.to, 'to');
+        if (toDate && toDate < fromDate) {
+            throw new ArgumentError('--to must be ≥ <date>');
+        }
+        const base = requireCurrency(args.base ?? 'EUR', 'base');
+        let symbols = null;
+        if (args.symbols != null && String(args.symbols).trim()) {
+            symbols = String(args.symbols).split(',').map((s) => requireOptionalCurrency(s, 'symbols')).filter(Boolean);
+        }
+        const path = toDate ? `${fromDate}..${toDate}` : fromDate;
+        const params = [`base=${base}`];
+        if (symbols && symbols.length) params.push(`symbols=${symbols.join(',')}`);
+        const url = `${FRANKFURTER_BASE}/${path}?${params.join('&')}`;
+        const body = await frankfurterFetch(url, 'frankfurter historical');
+
+        const out = [];
+        if (toDate) {
+            const ratesByDate = body && typeof body.rates === 'object' ? body.rates : null;
+            if (!ratesByDate) {
+                throw new EmptyResultError('frankfurter historical', 'frankfurter returned no rates.');
+            }
+            const dates = Object.keys(ratesByDate).sort().reverse();
+            for (const d of dates) {
+                const rates = ratesByDate[d];
+                if (!rates || typeof rates !== 'object') continue;
+                for (const [target, rate] of Object.entries(rates)) {
+                    out.push({ rank: out.length + 1, date: d, base, target, rate: Number(rate) });
+                }
+            }
+        } else {
+            const rates = body && typeof body.rates === 'object' ? body.rates : null;
+            if (!rates) {
+                throw new EmptyResultError('frankfurter historical', 'frankfurter returned no rates.');
+            }
+            const date = String(body.date ?? fromDate);
+            for (const [target, rate] of Object.entries(rates)) {
+                out.push({ rank: out.length + 1, date, base, target, rate: Number(rate) });
+            }
+        }
+
+        if (!out.length) {
+            throw new EmptyResultError('frankfurter historical', 'frankfurter returned an empty rates map.');
+        }
+        return out;
+    },
+});

--- a/clis/frankfurter/latest.js
+++ b/clis/frankfurter/latest.js
@@ -1,0 +1,58 @@
+// frankfurter latest — latest exchange rates from ECB (frankfurter.app).
+//
+// Endpoint: GET /v1/latest?base=<base>&symbols=<csv>
+//
+// Returns one row per target currency with the rate against `--base`.
+// Default base is EUR (ECB convention). Optional `--symbols` narrows to
+// a comma-separated list of target codes; otherwise every supported
+// currency is returned.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    FRANKFURTER_BASE,
+    frankfurterFetch,
+    requireCurrency,
+    requireOptionalCurrency,
+} from './utils.js';
+
+cli({
+    site: 'frankfurter',
+    name: 'latest',
+    access: 'read',
+    description: 'Latest ECB-published FX rates against a base currency',
+    domain: 'api.frankfurter.dev',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'base', default: 'EUR', help: 'Base currency (ISO 4217, default EUR)' },
+        { name: 'symbols', help: 'Comma-separated target currencies (e.g. USD,JPY,GBP); default: all' },
+    ],
+    columns: ['rank', 'base', 'target', 'rate', 'date'],
+    func: async (args) => {
+        const base = requireCurrency(args.base ?? 'EUR', 'base');
+        let symbols = null;
+        if (args.symbols != null && String(args.symbols).trim()) {
+            symbols = String(args.symbols).split(',').map((s) => requireOptionalCurrency(s, 'symbols')).filter(Boolean);
+        }
+        const params = [`base=${base}`];
+        if (symbols && symbols.length) params.push(`symbols=${symbols.join(',')}`);
+        const url = `${FRANKFURTER_BASE}/latest?${params.join('&')}`;
+        const body = await frankfurterFetch(url, 'frankfurter latest');
+        const rates = body && typeof body.rates === 'object' ? body.rates : null;
+        if (!rates) {
+            throw new EmptyResultError('frankfurter latest', 'frankfurter returned no rates.');
+        }
+        const date = String(body.date ?? '').trim();
+        const entries = Object.entries(rates);
+        if (!entries.length) {
+            throw new EmptyResultError('frankfurter latest', 'frankfurter returned an empty rates map.');
+        }
+        return entries.map(([target, rate], i) => ({
+            rank: i + 1,
+            base,
+            target,
+            rate: Number(rate),
+            date,
+        }));
+    },
+});

--- a/clis/frankfurter/utils.js
+++ b/clis/frankfurter/utils.js
@@ -1,0 +1,61 @@
+// frankfurter shared helpers — currency rates from frankfurter.app (ECB data, free, no auth).
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const FRANKFURTER_BASE = 'https://api.frankfurter.dev/v1';
+const UA = 'opencli-frankfurter/1.0';
+
+const CURRENCY_PATTERN = /^[A-Z]{3}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function requireString(value, name) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new ArgumentError(`--${name} is required`);
+    }
+    return value.trim();
+}
+
+export function requireCurrency(value, name) {
+    const v = requireString(value, name).toUpperCase();
+    if (!CURRENCY_PATTERN.test(v)) {
+        throw new ArgumentError(`--${name} must be an ISO 4217 currency code (3 letters, e.g. USD)`);
+    }
+    return v;
+}
+
+export function requireOptionalCurrency(value, name) {
+    if (value == null || value === '') return null;
+    return requireCurrency(value, name);
+}
+
+export function requireDate(value, name) {
+    const v = requireString(value, name);
+    if (!DATE_PATTERN.test(v)) {
+        throw new ArgumentError(`--${name} must be YYYY-MM-DD`);
+    }
+    return v;
+}
+
+export function requireOptionalDate(value, name) {
+    if (value == null || value === '') return null;
+    return requireDate(value, name);
+}
+
+export async function frankfurterFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404 || resp.status === 422) {
+        throw new EmptyResultError(label, `${label} returned ${resp.status}.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    try {
+        return await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+}

--- a/clis/nws/alerts.js
+++ b/clis/nws/alerts.js
@@ -1,0 +1,64 @@
+// nws alerts — active US weather alerts (filterable by state).
+//
+// Endpoint: GET /alerts/active                         (national)
+//           GET /alerts/active?area=<state>            (per-state)
+//
+// Returns one row per active alert with severity, urgency, and headline.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { NWS_BASE, nwsFetch, requireOptionalState } from './utils.js';
+
+cli({
+    site: 'nws',
+    name: 'alerts',
+    access: 'read',
+    description: 'Active US weather alerts (optionally filtered by state)',
+    domain: 'api.weather.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'state', help: '2-letter US state code (e.g. CA, TX); default: all states' },
+        { name: 'limit', type: 'int', default: 50, help: 'Max rows (1-500, default 50)' },
+    ],
+    columns: [
+        'rank', 'id', 'event', 'severity', 'urgency', 'certainty',
+        'headline', 'areaDesc', 'sent', 'effective', 'expires',
+        'senderName', 'description', 'url',
+    ],
+    func: async (args) => {
+        const state = requireOptionalState(args.state, 'state');
+        const limit = Number(args.limit ?? 50);
+        if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+            throw new ArgumentError('--limit must be an integer between 1 and 500');
+        }
+        // NWS rejects `limit=` on /alerts/active (HTTP 400 "Query parameter not recognized").
+        // We pass it as a soft client-side cap below.
+        const params = ['status=actual'];
+        if (state) params.push(`area=${state}`);
+        const url = `${NWS_BASE}/alerts/active?${params.join('&')}`;
+        const body = await nwsFetch(url, 'nws alerts');
+        const features = Array.isArray(body?.features) ? body.features : [];
+        if (!features.length) {
+            throw new EmptyResultError('nws alerts', state ? `No active NWS alerts for ${state}.` : 'No active NWS alerts.');
+        }
+        return features.slice(0, limit).map((f, i) => {
+            const p = f?.properties ?? {};
+            return {
+                rank: i + 1,
+                id: String(f.id ?? p.id ?? '').trim(),
+                event: String(p.event ?? '').trim(),
+                severity: String(p.severity ?? '').trim(),
+                urgency: String(p.urgency ?? '').trim(),
+                certainty: String(p.certainty ?? '').trim(),
+                headline: String(p.headline ?? '').trim(),
+                areaDesc: String(p.areaDesc ?? '').trim(),
+                sent: String(p.sent ?? '').trim(),
+                effective: String(p.effective ?? '').trim(),
+                expires: String(p.expires ?? '').trim(),
+                senderName: String(p.senderName ?? '').trim(),
+                description: String(p.description ?? '').trim(),
+                url: String(p['@id'] ?? f.id ?? '').trim(),
+            };
+        });
+    },
+});

--- a/clis/nws/forecast.js
+++ b/clis/nws/forecast.js
@@ -1,0 +1,58 @@
+// nws forecast — US weather forecast for a lat/lon point.
+//
+// Endpoint chain:
+//   1. GET /points/<lat>,<lon>            → {properties.forecast: <url>, gridId, ...}
+//   2. GET <forecast url>                 → {properties.periods: [{name, temperature, ...}]}
+//
+// Returns one row per forecast period (NWS exposes ~14 periods, day + night).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { NWS_BASE, nwsFetch, requireCoord } from './utils.js';
+
+cli({
+    site: 'nws',
+    name: 'forecast',
+    access: 'read',
+    description: 'US weather forecast for a lat/lon point (National Weather Service)',
+    domain: 'api.weather.gov',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'point', positional: true, required: true, help: 'Latitude,longitude (e.g. "37.7749,-122.4194")' },
+    ],
+    columns: [
+        'rank', 'name', 'startTime', 'endTime', 'isDaytime',
+        'temperature', 'temperatureUnit', 'windSpeed', 'windDirection',
+        'shortForecast', 'detailedForecast', 'precipitationProbability',
+    ],
+    func: async (args) => {
+        const point = requireCoord(args.point, 'point');
+        const pointUrl = `${NWS_BASE}/points/${point.str}`;
+        const pointBody = await nwsFetch(pointUrl, 'nws forecast (point lookup)');
+        const forecastUrl = pointBody?.properties?.forecast;
+        if (typeof forecastUrl !== 'string' || !forecastUrl) {
+            throw new EmptyResultError('nws forecast', `NWS does not have a forecast for ${point.str} (likely outside US coverage).`);
+        }
+        const forecastBody = await nwsFetch(forecastUrl, 'nws forecast');
+        const periods = Array.isArray(forecastBody?.properties?.periods) ? forecastBody.properties.periods : [];
+        if (!periods.length) {
+            throw new EmptyResultError('nws forecast', 'NWS returned an empty periods list.');
+        }
+        return periods.map((p, i) => ({
+            rank: i + 1,
+            name: String(p.name ?? '').trim(),
+            startTime: String(p.startTime ?? '').trim(),
+            endTime: String(p.endTime ?? '').trim(),
+            isDaytime: Boolean(p.isDaytime),
+            temperature: p.temperature != null ? Number(p.temperature) : null,
+            temperatureUnit: String(p.temperatureUnit ?? '').trim(),
+            windSpeed: String(p.windSpeed ?? '').trim(),
+            windDirection: String(p.windDirection ?? '').trim(),
+            shortForecast: String(p.shortForecast ?? '').trim(),
+            detailedForecast: String(p.detailedForecast ?? '').trim(),
+            precipitationProbability: p?.probabilityOfPrecipitation?.value != null
+                ? Number(p.probabilityOfPrecipitation.value)
+                : null,
+        }));
+    },
+});

--- a/clis/nws/nws.test.js
+++ b/clis/nws/nws.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './forecast.js';
+import './alerts.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+describe('nws forecast', () => {
+    const cmd = getRegistry().get('nws/forecast');
+
+    it('rejects bad coord format', async () => {
+        await expect(cmd.func({ point: '37.77, San Francisco' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects out-of-range latitude', async () => {
+        await expect(cmd.func({ point: '95.0,-122.4' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('chains points → forecast in two fetches', async () => {
+        const pointResp = { properties: { forecast: 'https://api.weather.gov/gridpoints/MTR/85,105/forecast' } };
+        const forecastResp = {
+            properties: {
+                periods: [
+                    {
+                        name: 'Tonight', startTime: '2026-05-06T18:00:00-07:00', endTime: '2026-05-07T06:00:00-07:00',
+                        isDaytime: false, temperature: 52, temperatureUnit: 'F',
+                        windSpeed: '5 to 10 mph', windDirection: 'W',
+                        shortForecast: 'Mostly Clear', detailedForecast: 'Mostly clear, with a low around 52.',
+                        probabilityOfPrecipitation: { value: 10 },
+                    },
+                ],
+            },
+        };
+        let call = 0;
+        global.fetch = vi.fn(() => {
+            call += 1;
+            if (call === 1) return Promise.resolve(new Response(JSON.stringify(pointResp), { status: 200 }));
+            return Promise.resolve(new Response(JSON.stringify(forecastResp), { status: 200 }));
+        });
+        const rows = await cmd.func({ point: '37.7749,-122.4194' });
+        expect(call).toBe(2);
+        expect(rows[0].name).toBe('Tonight');
+        expect(rows[0].temperature).toBe(52);
+        expect(rows[0].precipitationProbability).toBe(10);
+    });
+
+    it('promotes missing forecast url to EmptyResultError', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ properties: {} }), { status: 200 })));
+        await expect(cmd.func({ point: '0.0,0.0' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('nws alerts', () => {
+    const cmd = getRegistry().get('nws/alerts');
+
+    it('rejects bad state', async () => {
+        await expect(cmd.func({ state: 'cal' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects --limit > 500', async () => {
+        await expect(cmd.func({ limit: 5000 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('shapes an alert row + handles areaDesc', async () => {
+        const sample = {
+            features: [{
+                id: 'urn:oid:2.49.0.1.840.0.123',
+                properties: {
+                    event: 'Heat Advisory', severity: 'Moderate', urgency: 'Expected', certainty: 'Likely',
+                    headline: 'Heat Advisory issued May 6 at 3:00 PM PDT',
+                    areaDesc: 'Central Sacramento Valley; San Joaquin Valley',
+                    sent: '2026-05-06T22:00:00Z', effective: '2026-05-06T22:00:00Z', expires: '2026-05-08T03:00:00Z',
+                    senderName: 'NWS Sacramento CA',
+                    description: 'Temperatures up to 105.',
+                    '@id': 'https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.123',
+                },
+            }],
+        };
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        const rows = await cmd.func({ state: 'CA' });
+        expect(rows[0].event).toBe('Heat Advisory');
+        expect(rows[0].severity).toBe('Moderate');
+        expect(rows[0].areaDesc).toContain('Sacramento');
+    });
+});

--- a/clis/nws/utils.js
+++ b/clis/nws/utils.js
@@ -1,0 +1,56 @@
+// nws shared helpers — National Weather Service public API (api.weather.gov, no auth).
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const NWS_BASE = 'https://api.weather.gov';
+// NWS strongly recommends an identifying User-Agent so support can contact you on issues.
+const UA = 'opencli-nws/1.0 (https://github.com/jackwener/opencli)';
+
+const COORD_PATTERN = /^-?\d{1,3}(?:\.\d+)?,-?\d{1,3}(?:\.\d+)?$/;
+const STATE_PATTERN = /^[A-Z]{2}$/;
+
+export function requireString(value, name) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new ArgumentError(`--${name} is required`);
+    }
+    return value.trim();
+}
+
+export function requireCoord(value, name) {
+    const v = requireString(value, name).replace(/\s+/g, '');
+    if (!COORD_PATTERN.test(v)) {
+        throw new ArgumentError(`--${name} must be "lat,lon" decimal degrees (e.g. "37.7749,-122.4194")`);
+    }
+    const [lat, lon] = v.split(',').map(Number);
+    if (lat < -90 || lat > 90) throw new ArgumentError(`--${name} latitude out of range`);
+    if (lon < -180 || lon > 180) throw new ArgumentError(`--${name} longitude out of range`);
+    return { lat, lon, str: `${lat},${lon}` };
+}
+
+export function requireOptionalState(value, name) {
+    if (value == null || value === '') return null;
+    const v = requireString(value, name).toUpperCase();
+    if (!STATE_PATTERN.test(v)) {
+        throw new ArgumentError(`--${name} must be a 2-letter US state code (e.g. CA)`);
+    }
+    return v;
+}
+
+export async function nwsFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/geo+json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `${label} returned 404.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    try {
+        return await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+}

--- a/clis/worldbank/country.js
+++ b/clis/worldbank/country.js
@@ -1,0 +1,45 @@
+// worldbank country — country profile (region, income group, capital, etc).
+//
+// Endpoint: GET /v2/country/<iso>?format=json
+//
+// Single-row response. Round-trips into `worldbank indicator --country <iso>`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { WB_BASE, wbFetch, requireCountry } from './utils.js';
+
+cli({
+    site: 'worldbank',
+    name: 'country',
+    access: 'read',
+    description: 'World Bank country profile (region, income group, capital, lat/lon)',
+    domain: 'api.worldbank.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'country', positional: true, required: true, help: 'ISO country code (alpha-2 or alpha-3)' },
+    ],
+    columns: [
+        'iso2', 'iso3', 'name', 'region', 'incomeLevel', 'lendingType',
+        'capital', 'longitude', 'latitude',
+    ],
+    func: async (args) => {
+        const country = requireCountry(args.country, 'country');
+        const url = `${WB_BASE}/country/${country}?format=json`;
+        const { results } = await wbFetch(url, 'worldbank country');
+        if (!results.length) {
+            throw new EmptyResultError('worldbank country', `World Bank has no record for "${country}".`);
+        }
+        const c = results[0];
+        return [{
+            iso2: String(c.iso2Code ?? '').trim(),
+            iso3: String(c.id ?? '').trim(),
+            name: String(c.name ?? '').trim(),
+            region: String(c.region?.value ?? '').trim(),
+            incomeLevel: String(c.incomeLevel?.value ?? '').trim(),
+            lendingType: String(c.lendingType?.value ?? '').trim(),
+            capital: String(c.capitalCity ?? '').trim(),
+            longitude: c.longitude !== '' && c.longitude != null ? Number(c.longitude) : null,
+            latitude: c.latitude !== '' && c.latitude != null ? Number(c.latitude) : null,
+        }];
+    },
+});

--- a/clis/worldbank/indicator.js
+++ b/clis/worldbank/indicator.js
@@ -1,0 +1,65 @@
+// worldbank indicator — time series for a country + indicator.
+//
+// Endpoint: GET /v2/country/<iso>/indicator/<indicator>?format=json&per_page=<N>&date=<YYYY:YYYY>
+//
+// Returns one row per (country, year) data point, newest year first. Pinned
+// `per_page` is enough to capture decades of annual data.
+//
+// Common indicators:
+//   NY.GDP.MKTP.CD          — GDP (current US$)
+//   SP.POP.TOTL              — Population, total
+//   FP.CPI.TOTL.ZG           — Inflation, consumer prices (annual %)
+//   SL.UEM.TOTL.ZS           — Unemployment, total (% of labor force)
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { WB_BASE, wbFetch, requireCountry, requireIndicator } from './utils.js';
+
+cli({
+    site: 'worldbank',
+    name: 'indicator',
+    access: 'read',
+    description: 'World Bank indicator time series for a country',
+    domain: 'api.worldbank.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'country', required: true, help: 'ISO country code (alpha-2 or alpha-3)' },
+        { name: 'indicator', required: true, help: 'World Bank indicator code (e.g. NY.GDP.MKTP.CD)' },
+        { name: 'years', help: 'Year range YYYY:YYYY (e.g. 2000:2024)' },
+        { name: 'limit', type: 'int', default: 50, help: 'Max data points (1-500, default 50)' },
+    ],
+    columns: ['rank', 'country', 'iso3', 'indicator', 'indicatorCode', 'date', 'value', 'unit'],
+    func: async (args) => {
+        const country = requireCountry(args.country, 'country');
+        const indicator = requireIndicator(args.indicator, 'indicator');
+        const limit = Number(args.limit ?? 50);
+        if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+            throw new ArgumentError('--limit must be an integer between 1 and 500');
+        }
+        let yearsParam = '';
+        if (args.years != null && String(args.years).trim()) {
+            const y = String(args.years).trim();
+            if (!/^\d{4}:\d{4}$/.test(y)) {
+                throw new ArgumentError('--years must be in YYYY:YYYY form (e.g. 2000:2024)');
+            }
+            const [from, to] = y.split(':').map(Number);
+            if (from > to) throw new ArgumentError('--years start must be ≤ end');
+            yearsParam = `&date=${from}:${to}`;
+        }
+        const url = `${WB_BASE}/country/${country}/indicator/${indicator}?format=json&per_page=${limit}${yearsParam}`;
+        const { results } = await wbFetch(url, 'worldbank indicator');
+        if (!results.length) {
+            throw new EmptyResultError('worldbank indicator', `No data points for ${country} / ${indicator}.`);
+        }
+        return results.slice(0, limit).map((d, i) => ({
+            rank: i + 1,
+            country: String(d.country?.value ?? '').trim(),
+            iso3: String(d.country?.id ?? d.countryiso3code ?? '').trim(),
+            indicator: String(d.indicator?.value ?? '').trim(),
+            indicatorCode: String(d.indicator?.id ?? indicator).trim(),
+            date: String(d.date ?? '').trim(),
+            value: d.value != null ? Number(d.value) : null,
+            unit: String(d.unit ?? '').trim(),
+        }));
+    },
+});

--- a/clis/worldbank/utils.js
+++ b/clis/worldbank/utils.js
@@ -1,0 +1,63 @@
+// worldbank shared helpers — World Bank Open Data API (api.worldbank.org/v2, no auth).
+//
+// Quirk: World Bank wraps every JSON response in a 2-element array
+// [meta, results]. Helpers below unwrap so callers can think in terms of
+// the result list directly.
+import { ArgumentError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const WB_BASE = 'https://api.worldbank.org/v2';
+const UA = 'opencli-worldbank/1.0';
+
+const ISO_PATTERN = /^[A-Z0-9]{2,3}$/;
+
+export function requireString(value, name) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new ArgumentError(`--${name} is required`);
+    }
+    return value.trim();
+}
+
+export function requireCountry(value, name) {
+    const v = requireString(value, name).toUpperCase();
+    if (!ISO_PATTERN.test(v)) {
+        throw new ArgumentError(`--${name} must be a 2- or 3-letter ISO country code (e.g. US, USA)`);
+    }
+    return v;
+}
+
+export function requireIndicator(value, name) {
+    const v = requireString(value, name).toUpperCase();
+    // World Bank indicator codes look like NY.GDP.MKTP.CD — letters / digits / dots
+    if (!/^[A-Z0-9.]{3,40}$/.test(v)) {
+        throw new ArgumentError(`--${name} must be a World Bank indicator code (e.g. NY.GDP.MKTP.CD)`);
+    }
+    return v;
+}
+
+export async function wbFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    } catch (err) {
+        throw new CommandExecutionError(`${label} request failed: ${err.message}`);
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `${label} returned 404.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}.`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned non-JSON body: ${err.message}`);
+    }
+    // World Bank shape: [meta, results]. If the wrapper is missing or empty,
+    // surface as EmptyResult — they often signal "country not found" with
+    // `[{ message: [{...}]}]` which has no second element.
+    if (!Array.isArray(body) || body.length < 2 || !Array.isArray(body[1])) {
+        throw new EmptyResultError(label, `${label} returned no results (likely unknown country/indicator).`);
+    }
+    return { meta: body[0] ?? {}, results: body[1] };
+}

--- a/clis/worldbank/worldbank.test.js
+++ b/clis/worldbank/worldbank.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './country.js';
+import './indicator.js';
+
+const origFetch = global.fetch;
+afterEach(() => { global.fetch = origFetch; });
+
+describe('worldbank country', () => {
+    const cmd = getRegistry().get('worldbank/country');
+
+    it('rejects bad country code', async () => {
+        await expect(cmd.func({ country: 'usaa' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes message-only response to EmptyResultError', async () => {
+        const sample = [{ message: [{ id: '120', value: 'Invalid value' }] }];
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        await expect(cmd.func({ country: 'XX' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('shapes a country profile row', async () => {
+        const sample = [{ page: 1, pages: 1, per_page: 50, total: 1 }, [{
+            id: 'JPN', iso2Code: 'JP', name: 'Japan',
+            region: { value: 'East Asia & Pacific' },
+            incomeLevel: { value: 'High income' },
+            lendingType: { value: 'Not classified' },
+            capitalCity: 'Tokyo', longitude: '139.7700', latitude: '35.6700',
+        }]];
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        const rows = await cmd.func({ country: 'JPN' });
+        expect(rows[0].iso3).toBe('JPN');
+        expect(rows[0].iso2).toBe('JP');
+        expect(rows[0].capital).toBe('Tokyo');
+        expect(rows[0].latitude).toBeCloseTo(35.67);
+    });
+});
+
+describe('worldbank indicator', () => {
+    const cmd = getRegistry().get('worldbank/indicator');
+
+    it('rejects bad indicator', async () => {
+        await expect(cmd.func({ country: 'JP', indicator: 'gdp!' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects malformed --years', async () => {
+        await expect(cmd.func({ country: 'JP', indicator: 'NY.GDP.MKTP.CD', years: '2000-2020' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('shapes a time-series row', async () => {
+        const sample = [{ page: 1, pages: 1, per_page: 50, total: 2 }, [
+            {
+                indicator: { id: 'NY.GDP.MKTP.CD', value: 'GDP (current US$)' },
+                country: { id: 'JP', value: 'Japan' },
+                countryiso3code: 'JPN', date: '2024', value: 4.21e12, unit: '',
+            },
+            {
+                indicator: { id: 'NY.GDP.MKTP.CD', value: 'GDP (current US$)' },
+                country: { id: 'JP', value: 'Japan' },
+                countryiso3code: 'JPN', date: '2023', value: 4.20e12, unit: '',
+            },
+        ]];
+        global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(sample), { status: 200 })));
+        const rows = await cmd.func({ country: 'JP', indicator: 'NY.GDP.MKTP.CD' });
+        expect(rows).toHaveLength(2);
+        expect(rows[0].date).toBe('2024');
+        expect(rows[0].value).toBe(4.21e12);
+        expect(rows[0].indicatorCode).toBe('NY.GDP.MKTP.CD');
+    });
+});

--- a/docs/adapters/browser/frankfurter.md
+++ b/docs/adapters/browser/frankfurter.md
@@ -1,0 +1,61 @@
+# Frankfurter
+
+**Mode**: 🌐 Public · **Domain**: `api.frankfurter.dev`
+
+ECB-published foreign-exchange rates from `frankfurter.dev`. No auth, no signup.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli frankfurter latest` | Latest FX rates against a base currency |
+| `opencli frankfurter historical <date>` | Historical rates for a single day or a date range |
+
+## Usage Examples
+
+```bash
+# Latest USD rates
+opencli frankfurter latest --base USD
+
+# Specific targets
+opencli frankfurter latest --base EUR --symbols USD,JPY,GBP
+
+# Single historical day
+opencli frankfurter historical 2024-01-02 --base USD
+
+# Range (newest-first)
+opencli frankfurter historical 2026-05-01 --to 2026-05-05 --base USD --symbols JPY
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `latest` | `rank, base, target, rate, date` |
+| `historical` | `rank, date, base, target, rate` |
+
+## Options
+
+### `latest`
+
+| Option | Description |
+|--------|-------------|
+| `--base` | Base currency (ISO 4217, default `EUR`) |
+| `--symbols` | Comma-separated target currencies (e.g. `USD,JPY`); default: all |
+
+### `historical`
+
+| Option | Description |
+|--------|-------------|
+| `date` (positional) | Start date `YYYY-MM-DD` (or single day if `--to` omitted) |
+| `--to` | End date; if set, returns daily rates from `date` to `to` |
+| `--base` | Base currency (default `EUR`) |
+| `--symbols` | Comma-separated target currencies |
+
+## Notes
+
+- **ECB midmarket rates.** Frankfurter republishes the European Central Bank's daily reference rates — published ~16:00 CET on TARGET2 trading days. Weekends/holidays return the most recent trading day.
+- **Newest-first range.** Frankfurter's range response is `{rates: {date: {...}}}` keyed by date; the adapter sorts dates desc so the first row is the latest.
+- **Currency validator** rejects anything that isn't 3 ASCII letters — `--base usa`, `--base us`, `--base US$` all `ArgumentError`.
+- **No API key.** Public ECB data; bursts may return HTTP 422 (parameter validation) which surfaces as `EmptyResultError`.
+- **Errors.** Bad currency / bad date / `--to < date` → `ArgumentError`; 404/422 → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/nws.md
+++ b/docs/adapters/browser/nws.md
@@ -1,0 +1,56 @@
+# NWS
+
+**Mode**: 🌐 Public · **Domain**: `api.weather.gov`
+
+US National Weather Service public API. Forecast lookup by lat/lon and active alerts (national or per-state).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli nws forecast <lat,lon>` | 7-day forecast for a US lat/lon point (~14 day+night periods) |
+| `opencli nws alerts` | Active US weather alerts (optionally filtered by state) |
+
+## Usage Examples
+
+```bash
+# Forecast for downtown San Francisco
+opencli nws forecast "37.7749,-122.4194"
+
+# All active alerts (national)
+opencli nws alerts
+
+# Per-state filter
+opencli nws alerts --state CA --limit 10
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `forecast` | `rank, name, startTime, endTime, isDaytime, temperature, temperatureUnit, windSpeed, windDirection, shortForecast, detailedForecast, precipitationProbability` |
+| `alerts` | `rank, id, event, severity, urgency, certainty, headline, areaDesc, sent, effective, expires, senderName, description, url` |
+
+## Options
+
+### `forecast`
+
+| Option | Description |
+|--------|-------------|
+| `point` (positional) | `lat,lon` decimal degrees (US only — Alaska/Hawaii/territories supported) |
+
+### `alerts`
+
+| Option | Description |
+|--------|-------------|
+| `--state` | 2-letter US state code (e.g. `CA`, `TX`); default: all |
+| `--limit` | Max rows (1–500, default 50) — applied client-side, NWS rejects `limit=` query param |
+
+## Notes
+
+- **Two-fetch forecast chain.** `forecast` first hits `/points/<lat>,<lon>` to discover the gridpoint forecast URL, then fetches the actual periods. NWS only covers US territory — points outside the US (or far at sea) return no `forecast` URL → `EmptyResultError`.
+- **`temperatureUnit`** is always `F` for the standard forecast endpoint; metric units would require a different endpoint not exposed here.
+- **`precipitationProbability`** comes from `properties.probabilityOfPrecipitation.value` and is `null` (not zero) when NWS doesn't supply a value — never silently coerced to 0.
+- **NWS `limit=` query.** The `/alerts/active` endpoint rejects a `limit` query param with HTTP 400 ("Query parameter not recognized"). The adapter omits it from the URL and slices client-side instead.
+- **User-Agent.** NWS terms ask for an identifying User-Agent so they can contact you on issues; the adapter sends `opencli-nws/1.0 (https://github.com/jackwener/opencli)`.
+- **Errors.** Bad coord / bad state / out-of-range limit → `ArgumentError`; no forecast (off-coverage) / no active alerts → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/browser/worldbank.md
+++ b/docs/adapters/browser/worldbank.md
@@ -1,0 +1,70 @@
+# World Bank
+
+**Mode**: 🌐 Public · **Domain**: `api.worldbank.org`
+
+World Bank Open Data API. Country profiles + indicator time series (GDP, population, inflation, etc).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli worldbank country <iso>` | Country profile (region, income group, capital, lat/lon) |
+| `opencli worldbank indicator --country <iso> --indicator <code>` | Indicator time series for a country |
+
+## Usage Examples
+
+```bash
+# Country profile
+opencli worldbank country JPN
+opencli worldbank country US
+
+# GDP time series for Japan, last 20 years
+opencli worldbank indicator --country JPN --indicator NY.GDP.MKTP.CD --years 2005:2024
+
+# Population, default range
+opencli worldbank indicator --country IND --indicator SP.POP.TOTL --limit 30
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `country` | `iso2, iso3, name, region, incomeLevel, lendingType, capital, longitude, latitude` |
+| `indicator` | `rank, country, iso3, indicator, indicatorCode, date, value, unit` |
+
+The `iso3` column from `country` round-trips into `indicator --country`.
+
+## Options
+
+### `country`
+
+| Option | Description |
+|--------|-------------|
+| `country` (positional) | ISO country code (alpha-2 like `US`, or alpha-3 like `USA`) |
+
+### `indicator`
+
+| Option | Description |
+|--------|-------------|
+| `--country` | ISO country code |
+| `--indicator` | World Bank indicator code (e.g. `NY.GDP.MKTP.CD`, `SP.POP.TOTL`) |
+| `--years` | Year range `YYYY:YYYY` (e.g. `2000:2024`); optional |
+| `--limit` | Max data points (1–500, default 50) |
+
+## Common Indicator Codes
+
+| Code | Meaning |
+|------|---------|
+| `NY.GDP.MKTP.CD` | GDP (current US$) |
+| `NY.GDP.PCAP.CD` | GDP per capita (current US$) |
+| `SP.POP.TOTL` | Population, total |
+| `FP.CPI.TOTL.ZG` | Inflation, consumer prices (annual %) |
+| `SL.UEM.TOTL.ZS` | Unemployment, total (% of labor force) |
+
+## Notes
+
+- **`[meta, results]` envelope.** Every World Bank response is a 2-element array — meta first, then results. The adapter unwraps so you get rows directly.
+- **Empty / unknown lookup.** When you pass an unknown ISO code, World Bank returns `[{message: [...]}]` (no second element) — the adapter promotes this to `EmptyResultError` instead of crashing on `body[1]`.
+- **`value: null`** is preserved (not silently coerced to 0) for missing data points, since 0 has real economic meaning.
+- **Newest year first.** World Bank's default ordering is descending by `date`; the adapter does not reorder.
+- **Errors.** Bad ISO code / bad indicator / malformed `--years` / out-of-range limit → `ArgumentError`; unknown country/indicator → `EmptyResultError`; transport / non-200 → `CommandExecutionError`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -134,6 +134,9 @@ Run `opencli list` for the live registry.
 | **[nuget](./browser/nuget.md)**                   | `search` `package`                                                                                                                             | 🌐 Public    |
 | **[flathub](./browser/flathub.md)**               | `search` `app`                                                                                                                                 | 🌐 Public    |
 | **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
+| **[frankfurter](./browser/frankfurter.md)**       | `latest` `historical`                                                                                                                          | 🌐 Public    |
+| **[nws](./browser/nws.md)**                       | `forecast` `alerts`                                                                                                                            | 🌐 Public    |
+| **[worldbank](./browser/worldbank.md)**           | `country` `indicator`                                                                                                                          | 🌐 Public    |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Summary

Trimmed scope per WAWQAQ feedback (drop low-utility novelty sites, keep dev-relevant Public/no-auth APIs).

> Replaces closed #1353 (force-push diverged the original PR head, GitHub refuses reopen).

| Site        | Commands         | Highlights                                                        |
|-------------|------------------|-------------------------------------------------------------------|
| frankfurter | latest, history  | ECB FX rates; no API key                                          |
| nws         | alerts, forecast | US NWS alerts/forecast; \`limit=\` rejected by /alerts/active → slice client-side |
| worldbank   | indicator, country | WB indicators; \`[meta, results]\` 2-element envelope unwrap; lone-element \`[{message}]\` → EmptyResultError |

## Dropped from this PR

- disease-sh, jikan, mealdb — novelty

## Audits

- typed-error-lint: 196 = 196 (unchanged baseline)
- silent-column-drop: 103 = 103 (unchanged baseline)
- listing-id-pairing: advisory only, no new violations

## Manifest

757 → 760 entries (+6 commands across 3 sites = 2 cmds/site)

## Test plan

- [x] \`npx vitest run clis/frankfurter clis/nws clis/worldbank\` — 20 tests passing
- [x] All 6 commands live-verified against real APIs