### PR TITLE
feat(extension): mark automation tabs with group

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -615,6 +615,7 @@ function emptyRegistry() {
     version: 1,
     contextId: currentContextId,
     ownedContainerWindowId,
+    ownedContainerGroupId,
     leases: {}
   };
 }
@@ -629,6 +630,7 @@ async function readRegistry() {
       version: 1,
       contextId: currentContextId,
       ownedContainerWindowId: typeof stored.ownedContainerWindowId === "number" ? stored.ownedContainerWindowId : null,
+      ownedContainerGroupId: typeof stored.ownedContainerGroupId === "number" ? stored.ownedContainerGroupId : null,
       leases: stored.leases
     };
   } catch {
@@ -660,6 +662,7 @@ async function persistRuntimeState() {
     version: 1,
     contextId: currentContextId,
     ownedContainerWindowId,
+    ownedContainerGroupId,
     leases
   });
 }
@@ -1632,6 +1635,7 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
 async function reconcileTargetLeaseRegistry() {
   const registry = await readRegistry();
   ownedContainerWindowId = registry.ownedContainerWindowId;
+  ownedContainerGroupId = registry.ownedContainerGroupId ?? null;
   if (ownedContainerWindowId !== null) {
     try {
       await chrome.windows.get(ownedContainerWindowId);

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -547,11 +547,14 @@ function scheduleReconnect() {
 }
 const automationSessions = /* @__PURE__ */ new Map();
 let ownedContainerWindowId = null;
+let ownedContainerGroupId = null;
 const IDLE_TIMEOUT_DEFAULT = 3e4;
 const IDLE_TIMEOUT_INTERACTIVE = 6e5;
 const IDLE_TIMEOUT_NONE = -1;
 const REGISTRY_KEY = "opencli_target_lease_registry_v1";
 const LEASE_IDLE_ALARM_PREFIX = "opencli:lease-idle:";
+const AUTOMATION_TAB_GROUP_TITLE = "OpenCLI";
+const AUTOMATION_TAB_GROUP_COLOR = "orange";
 let leaseMutationQueue = Promise.resolve();
 let ownedContainerWindowPromise = null;
 class CommandFailure extends Error {
@@ -704,6 +707,50 @@ function resetWindowIdleTimer(workspace) {
     await releaseWorkspaceLease(workspace, "idle timeout");
   }, timeout);
 }
+async function getOwnedContainerGroupId(windowId) {
+  if (ownedContainerGroupId !== null) {
+    try {
+      const group = await chrome.tabGroups.get(ownedContainerGroupId);
+      if (group.windowId === windowId) return ownedContainerGroupId;
+    } catch {
+    }
+    ownedContainerGroupId = null;
+  }
+  const groups = await chrome.tabGroups.query({ windowId, title: AUTOMATION_TAB_GROUP_TITLE });
+  const existing = groups.find((group) => group.title === AUTOMATION_TAB_GROUP_TITLE);
+  if (!existing) return null;
+  ownedContainerGroupId = existing.id;
+  return existing.id;
+}
+async function ensureOwnedContainerTabGroup(windowId, tabIds) {
+  const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
+  if (ids.length === 0) return;
+  try {
+    const existingGroupId = await getOwnedContainerGroupId(windowId);
+    if (existingGroupId !== null) {
+      const tabs = await chrome.tabs.query({ windowId });
+      const alreadyGrouped = new Set(
+        tabs.filter((tab) => tab.id !== void 0 && ids.includes(tab.id) && tab.groupId === existingGroupId).map((tab) => tab.id)
+      );
+      const missing = ids.filter((id) => !alreadyGrouped.has(id));
+      if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
+      await chrome.tabGroups.update(existingGroupId, {
+        color: AUTOMATION_TAB_GROUP_COLOR,
+        title: AUTOMATION_TAB_GROUP_TITLE,
+        collapsed: false
+      });
+      return;
+    }
+    ownedContainerGroupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
+    await chrome.tabGroups.update(ownedContainerGroupId, {
+      color: AUTOMATION_TAB_GROUP_COLOR,
+      title: AUTOMATION_TAB_GROUP_TITLE,
+      collapsed: false
+    });
+  } catch (err) {
+    console.warn(`[opencli] Failed to mark automation tab group: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
 async function ensureOwnedContainerWindow(initialUrl) {
   if (ownedContainerWindowPromise) return ownedContainerWindowPromise;
   ownedContainerWindowPromise = ensureOwnedContainerWindowUnlocked(initialUrl).finally(() => {
@@ -715,12 +762,15 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl) {
   if (ownedContainerWindowId !== null) {
     try {
       await chrome.windows.get(ownedContainerWindowId);
+      const initialTabId2 = await findReusableOwnedContainerTab(ownedContainerWindowId);
+      await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId2]);
       return {
         windowId: ownedContainerWindowId,
-        initialTabId: await findReusableOwnedContainerTab(ownedContainerWindowId)
+        initialTabId: initialTabId2
       };
     } catch {
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
   const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
@@ -753,6 +803,7 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl) {
       }
     });
   }
+  await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId]);
   await persistRuntimeState();
   return { windowId: ownedContainerWindowId, initialTabId };
 }
@@ -792,6 +843,7 @@ async function createOwnedTabLeaseUnlocked(workspace, initialUrl) {
     tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
   }
   if (!tab.id) throw new Error("Failed to create tab lease in automation container");
+  await ensureOwnedContainerTabGroup(windowId, [tab.id]);
   setWorkspaceSession(workspace, {
     windowId,
     owned: true,
@@ -834,6 +886,7 @@ async function getAutomationWindow(workspace, initialUrl) {
 chrome.windows.onRemoved.addListener(async (windowId) => {
   if (ownedContainerWindowId === windowId) {
     ownedContainerWindowId = null;
+    ownedContainerGroupId = null;
   }
   for (const [workspace, session] of automationSessions.entries()) {
     if (session.windowId === windowId) {
@@ -863,6 +916,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
       await chrome.windows.remove(ownedContainerWindowId).catch(() => {
       });
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
   await persistRuntimeState();
@@ -1345,6 +1399,7 @@ async function handleTabs(cmd, workspace) {
       const windowId = await getAutomationWindow(workspace);
       const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
       if (!tab.id) return { id: cmd.id, ok: false, error: "Failed to create tab" };
+      await ensureOwnedContainerTabGroup(windowId, [tab.id]);
       setWorkspaceSession(workspace, {
         windowId: tab.windowId,
         owned: true,
@@ -1559,6 +1614,7 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
       await chrome.windows.remove(session.windowId).catch(() => {
       });
       if (ownedContainerWindowId === session.windowId) ownedContainerWindowId = null;
+      if (ownedContainerWindowId === null) ownedContainerGroupId = null;
       console.log(`[opencli] Released legacy owned window lease ${session.windowId} (${workspace}, ${reason})`);
     }
   } else if (session.preferredTabId !== null) {
@@ -1573,6 +1629,7 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
       await chrome.windows.remove(ownedContainerWindowId).catch(() => {
       });
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
   await persistRuntimeState();
@@ -1585,6 +1642,7 @@ async function reconcileTargetLeaseRegistry() {
       await chrome.windows.get(ownedContainerWindowId);
     } catch {
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
   automationSessions.clear();
@@ -1606,6 +1664,7 @@ async function reconcileTargetLeaseRegistry() {
         idleDeadlineAt: stored.idleDeadlineAt
       });
       if (session.owned && ownedContainerWindowId === null) ownedContainerWindowId = tab.windowId;
+      if (session.owned) await ensureOwnedContainerTabGroup(tab.windowId, [tabId]);
       const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
       if (timeout > 0) {
         if (remaining <= 0) {
@@ -1623,6 +1682,7 @@ async function reconcileTargetLeaseRegistry() {
       await chrome.windows.remove(ownedContainerWindowId).catch(() => {
       });
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
   await persistRuntimeState();

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -717,7 +717,7 @@ async function getOwnedContainerGroupId(windowId) {
     ownedContainerGroupId = null;
   }
   const groups = await chrome.tabGroups.query({ windowId, title: AUTOMATION_TAB_GROUP_TITLE });
-  const existing = groups.find((group) => group.title === AUTOMATION_TAB_GROUP_TITLE);
+  const existing = groups[0];
   if (!existing) return null;
   ownedContainerGroupId = existing.id;
   return existing.id;
@@ -734,11 +734,6 @@ async function ensureOwnedContainerTabGroup(windowId, tabIds) {
       );
       const missing = ids.filter((id) => !alreadyGrouped.has(id));
       if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
-      await chrome.tabGroups.update(existingGroupId, {
-        color: AUTOMATION_TAB_GROUP_COLOR,
-        title: AUTOMATION_TAB_GROUP_TITLE,
-        collapsed: false
-      });
       return;
     }
     ownedContainerGroupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,8 @@
     "cookies",
     "activeTab",
     "alarms",
-    "storage"
+    "storage",
+    "tabGroups"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -12,6 +12,15 @@ type MockTab = {
   title?: string;
   active?: boolean;
   status?: string;
+  groupId?: number;
+};
+
+type MockTabGroup = {
+  id: number;
+  windowId: number;
+  title?: string;
+  color?: chrome.tabGroups.ColorEnum;
+  collapsed?: boolean;
 };
 
 class MockWebSocket {
@@ -32,12 +41,14 @@ class MockWebSocket {
 
 function createChromeMock() {
   let nextTabId = 10;
+  let nextGroupId = 100;
   const storageState: Record<string, unknown> = {};
   const tabs: MockTab[] = [
-    { id: 1, windowId: 1, url: 'https://automation.example', title: 'automation', active: true, status: 'complete' },
-    { id: 2, windowId: 2, url: 'https://user.example', title: 'user', active: true, status: 'complete' },
-    { id: 3, windowId: 1, url: 'chrome://extensions', title: 'chrome', active: false, status: 'complete' },
+    { id: 1, windowId: 1, url: 'https://automation.example', title: 'automation', active: true, status: 'complete', groupId: -1 },
+    { id: 2, windowId: 2, url: 'https://user.example', title: 'user', active: true, status: 'complete', groupId: -1 },
+    { id: 3, windowId: 1, url: 'chrome://extensions', title: 'chrome', active: false, status: 'complete', groupId: -1 },
   ];
+  const groups: MockTabGroup[] = [];
   let lastFocusedWindowId = 2;
 
   const query = vi.fn(async (queryInfo: { windowId?: number; active?: boolean; lastFocusedWindow?: boolean } = {}) => {
@@ -56,6 +67,7 @@ function createChromeMock() {
       title: url ?? 'blank',
       active: !!active,
       status: 'complete',
+      groupId: -1,
     };
     tabs.push(tab);
     return tab;
@@ -85,8 +97,45 @@ function createChromeMock() {
         tab.windowId = moveProps.windowId;
         return tab;
       }),
+      group: vi.fn(async (options: { tabIds?: number | number[]; groupId?: number; createProperties?: { windowId?: number } }) => {
+        const tabIds = Array.isArray(options.tabIds) ? options.tabIds : [options.tabIds].filter((id): id is number => typeof id === 'number');
+        let groupId = options.groupId;
+        if (groupId === undefined) {
+          groupId = nextGroupId++;
+          groups.push({
+            id: groupId,
+            windowId: options.createProperties?.windowId ?? tabs.find((tab) => tab.id === tabIds[0])?.windowId ?? 1,
+            collapsed: false,
+          });
+        }
+        for (const tabId of tabIds) {
+          const tab = tabs.find((entry) => entry.id === tabId);
+          if (!tab) throw new Error(`Unknown tab ${tabId}`);
+          tab.groupId = groupId;
+        }
+        return groupId;
+      }),
       onUpdated: { addListener: vi.fn(), removeListener: vi.fn() } as Listener<(id: number, info: chrome.tabs.TabChangeInfo) => void>,
       onRemoved: { addListener: vi.fn() } as Listener<(tabId: number) => void>,
+    },
+    tabGroups: {
+      TAB_GROUP_ID_NONE: -1,
+      get: vi.fn(async (groupId: number) => {
+        const group = groups.find((entry) => entry.id === groupId);
+        if (!group) throw new Error(`Unknown group ${groupId}`);
+        return group;
+      }),
+      query: vi.fn(async (queryInfo: { windowId?: number; title?: string } = {}) => groups.filter((group) => {
+        if (queryInfo.windowId !== undefined && group.windowId !== queryInfo.windowId) return false;
+        if (queryInfo.title !== undefined && group.title !== queryInfo.title) return false;
+        return true;
+      })),
+      update: vi.fn(async (groupId: number, updates: { title?: string; color?: chrome.tabGroups.ColorEnum; collapsed?: boolean }) => {
+        const group = groups.find((entry) => entry.id === groupId);
+        if (!group) throw new Error(`Unknown group ${groupId}`);
+        Object.assign(group, updates);
+        return group;
+      }),
     },
     debugger: {
       getTargets: vi.fn(async () => tabs.map(t => ({
@@ -133,7 +182,7 @@ function createChromeMock() {
     },
   };
 
-  return { chrome, tabs, query, create, update };
+  return { chrome, tabs, groups, query, create, update };
 }
 
 describe('background tab isolation', () => {
@@ -680,6 +729,56 @@ describe('background tab isolation', () => {
     expect(first).toEqual(expect.objectContaining({ ok: true }));
     expect(second).toEqual(expect.objectContaining({ ok: true }));
     expect(chrome.windows.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a newly created owned automation window with an OpenCLI tab group', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, 'site:new-group');
+
+    expect(tabId).toBe(1);
+    expect(tabs[0].groupId).toBe(100);
+    expect(groups).toEqual([
+      expect.objectContaining({
+        id: 100,
+        windowId: 1,
+        title: 'OpenCLI',
+        color: 'orange',
+        collapsed: false,
+      }),
+    ]);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ tabIds: [1], createProperties: { windowId: 1 } });
+  });
+
+  it('reuses the existing automation tab group when adding another owned lease tab', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await mod.__test__.resolveTabId(undefined, 'site:first');
+    const secondTabId = await mod.__test__.resolveTabId(undefined, 'site:second');
+
+    expect(secondTabId).toBe(10);
+    expect(groups).toHaveLength(1);
+    expect(tabs.find((tab) => tab.id === 10)?.groupId).toBe(100);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [10] });
+  });
+
+  it('does not group borrowed user tabs for bound workspaces', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const result = await mod.__test__.handleBind(
+      { id: 'bind', action: 'bind', workspace: 'bound:default' },
+      'bound:default',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(chrome.tabs.group).not.toHaveBeenCalled();
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
   });
 
   it('keeps site:notebooklm inside its owned automation lease instead of rebinding to a user tab', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -766,6 +766,27 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [10] });
   });
 
+  it('discovers and reuses an existing OpenCLI group after service worker restart', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    groups.push({
+      id: 99,
+      windowId: 1,
+      title: 'OpenCLI',
+      color: 'orange',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, 'site:restored-group');
+
+    expect(tabId).toBe(1);
+    expect(tabs[0].groupId).toBe(99);
+    expect(groups).toHaveLength(1);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [1] });
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+  });
+
   it('does not group borrowed user tabs for bound workspaces', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -787,6 +787,95 @@ describe('background tab isolation', () => {
     expect(chrome.tabGroups.update).not.toHaveBeenCalled();
   });
 
+  it('reuses a persisted automation group id after service worker restart even if the user renamed it', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    groups.push({
+      id: 99,
+      windowId: 1,
+      title: 'My Automation',
+      color: 'cyan',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v1: {
+        version: 1,
+        contextId: 'user-default',
+        ownedContainerWindowId: 1,
+        ownedContainerGroupId: 99,
+        leases: {
+          'site:restored-group': {
+            windowId: 1,
+            owned: true,
+            preferredTabId: 1,
+            contextId: 'user-default',
+            ownership: 'owned',
+            lifecycle: 'ephemeral',
+            surface: 'dedicated-container',
+            idleDeadlineAt: Date.now() + 30_000,
+            updatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(tabs[0].groupId).toBe(99);
+    expect(groups).toEqual([
+      expect.objectContaining({
+        id: 99,
+        title: 'My Automation',
+        color: 'cyan',
+        collapsed: true,
+      }),
+    ]);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [1] });
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+  });
+
+  it('falls back to title discovery when a persisted automation group id is stale', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    groups.push({
+      id: 99,
+      windowId: 1,
+      title: 'OpenCLI',
+      color: 'orange',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v1: {
+        version: 1,
+        contextId: 'user-default',
+        ownedContainerWindowId: 1,
+        ownedContainerGroupId: 404,
+        leases: {
+          'site:restored-group': {
+            windowId: 1,
+            owned: true,
+            preferredTabId: 1,
+            contextId: 'user-default',
+            ownership: 'owned',
+            lifecycle: 'ephemeral',
+            surface: 'dedicated-container',
+            idleDeadlineAt: Date.now() + 30_000,
+            updatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(tabs[0].groupId).toBe(99);
+    expect(groups).toHaveLength(1);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [1] });
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+  });
+
   it('does not group borrowed user tabs for bound workspaces', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -210,6 +210,7 @@ type StoredRegistry = {
   version: 1;
   contextId: BrowserContextId;
   ownedContainerWindowId: number | null;
+  ownedContainerGroupId?: number | null;
   leases: Record<string, StoredLease>;
 };
 
@@ -283,6 +284,7 @@ function emptyRegistry(): StoredRegistry {
     version: 1,
     contextId: currentContextId,
     ownedContainerWindowId,
+    ownedContainerGroupId,
     leases: {},
   };
 }
@@ -298,6 +300,7 @@ async function readRegistry(): Promise<StoredRegistry> {
       version: 1,
       contextId: currentContextId,
       ownedContainerWindowId: typeof stored.ownedContainerWindowId === 'number' ? stored.ownedContainerWindowId : null,
+      ownedContainerGroupId: typeof stored.ownedContainerGroupId === 'number' ? stored.ownedContainerGroupId : null,
       leases: stored.leases as Record<string, StoredLease>,
     };
   } catch {
@@ -332,6 +335,7 @@ async function persistRuntimeState(): Promise<void> {
     version: 1,
     contextId: currentContextId,
     ownedContainerWindowId,
+    ownedContainerGroupId,
     leases,
   });
 }
@@ -1485,6 +1489,7 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
 async function reconcileTargetLeaseRegistry(): Promise<void> {
   const registry = await readRegistry();
   ownedContainerWindowId = registry.ownedContainerWindowId;
+  ownedContainerGroupId = registry.ownedContainerGroupId ?? null;
 
   if (ownedContainerWindowId !== null) {
     try {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -190,11 +190,14 @@ type TargetLease = {
 
 const automationSessions = new Map<string, TargetLease>();
 let ownedContainerWindowId: number | null = null;
+let ownedContainerGroupId: number | null = null;
 const IDLE_TIMEOUT_DEFAULT = 30_000;      // 30s — adapter-driven automation
 const IDLE_TIMEOUT_INTERACTIVE = 600_000; // 10min — human-paced browser:* / operate:*
 const IDLE_TIMEOUT_NONE = -1;             // borrowed bound tabs stay bound until unbound/closed
 const REGISTRY_KEY = 'opencli_target_lease_registry_v1';
 const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
+const AUTOMATION_TAB_GROUP_TITLE = 'OpenCLI';
+const AUTOMATION_TAB_GROUP_COLOR: chrome.tabGroups.ColorEnum = 'orange';
 let leaseMutationQueue: Promise<void> = Promise.resolve();
 let ownedContainerWindowPromise: Promise<{ windowId: number; initialTabId?: number }> | null = null;
 
@@ -383,6 +386,58 @@ function resetWindowIdleTimer(workspace: string): void {
   }, timeout);
 }
 
+async function getOwnedContainerGroupId(windowId: number): Promise<number | null> {
+  if (ownedContainerGroupId !== null) {
+    try {
+      const group = await chrome.tabGroups.get(ownedContainerGroupId);
+      if (group.windowId === windowId) return ownedContainerGroupId;
+    } catch {
+      // Group IDs are browser-session state and can disappear when the last tab closes.
+    }
+    ownedContainerGroupId = null;
+  }
+
+  const groups = await chrome.tabGroups.query({ windowId, title: AUTOMATION_TAB_GROUP_TITLE });
+  const existing = groups.find((group) => group.title === AUTOMATION_TAB_GROUP_TITLE);
+  if (!existing) return null;
+  ownedContainerGroupId = existing.id;
+  return existing.id;
+}
+
+async function ensureOwnedContainerTabGroup(windowId: number, tabIds: Array<number | undefined>): Promise<void> {
+  const ids = [...new Set(tabIds.filter((id): id is number => id !== undefined))];
+  if (ids.length === 0) return;
+
+  try {
+    const existingGroupId = await getOwnedContainerGroupId(windowId);
+    if (existingGroupId !== null) {
+      const tabs = await chrome.tabs.query({ windowId });
+      const alreadyGrouped = new Set(
+        tabs
+          .filter((tab) => tab.id !== undefined && ids.includes(tab.id) && tab.groupId === existingGroupId)
+          .map((tab) => tab.id!),
+      );
+      const missing = ids.filter((id) => !alreadyGrouped.has(id));
+      if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
+      await chrome.tabGroups.update(existingGroupId, {
+        color: AUTOMATION_TAB_GROUP_COLOR,
+        title: AUTOMATION_TAB_GROUP_TITLE,
+        collapsed: false,
+      });
+      return;
+    }
+
+    ownedContainerGroupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
+    await chrome.tabGroups.update(ownedContainerGroupId, {
+      color: AUTOMATION_TAB_GROUP_COLOR,
+      title: AUTOMATION_TAB_GROUP_TITLE,
+      collapsed: false,
+    });
+  } catch (err) {
+    console.warn(`[opencli] Failed to mark automation tab group: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 /**
  * Ensure the shared owned automation surface exists.
  *
@@ -404,12 +459,15 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<
   if (ownedContainerWindowId !== null) {
     try {
       await chrome.windows.get(ownedContainerWindowId);
+      const initialTabId = await findReusableOwnedContainerTab(ownedContainerWindowId);
+      await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId]);
       return {
         windowId: ownedContainerWindowId,
-        initialTabId: await findReusableOwnedContainerTab(ownedContainerWindowId),
+        initialTabId,
       };
     } catch {
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
 
@@ -449,6 +507,7 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<
       }
     });
   }
+  await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId]);
   await persistRuntimeState();
   return { windowId: ownedContainerWindowId, initialTabId };
 }
@@ -495,6 +554,7 @@ async function createOwnedTabLeaseUnlocked(workspace: string, initialUrl?: strin
     tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
   }
   if (!tab.id) throw new Error('Failed to create tab lease in automation container');
+  await ensureOwnedContainerTabGroup(windowId, [tab.id]);
 
   setWorkspaceSession(workspace, {
     windowId,
@@ -548,6 +608,7 @@ async function getAutomationWindow(workspace: string, initialUrl?: string): Prom
 chrome.windows.onRemoved.addListener(async (windowId) => {
   if (ownedContainerWindowId === windowId) {
     ownedContainerWindowId = null;
+    ownedContainerGroupId = null;
   }
   for (const [workspace, session] of automationSessions.entries()) {
     if (session.windowId === windowId) {
@@ -578,6 +639,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
     if (!hasOwnedLease) {
       await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
   await persistRuntimeState();
@@ -1175,6 +1237,7 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
       const windowId = await getAutomationWindow(workspace);
       const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
       if (!tab.id) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
+      await ensureOwnedContainerTabGroup(windowId, [tab.id]);
       setWorkspaceSession(workspace, {
         windowId: tab.windowId,
         owned: true,
@@ -1401,6 +1464,7 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
       // Legacy fallback for sessions created before tab leases existed.
       await chrome.windows.remove(session.windowId).catch(() => {});
       if (ownedContainerWindowId === session.windowId) ownedContainerWindowId = null;
+      if (ownedContainerWindowId === null) ownedContainerGroupId = null;
       console.log(`[opencli] Released legacy owned window lease ${session.windowId} (${workspace}, ${reason})`);
     }
   } else if (session.preferredTabId !== null) {
@@ -1416,6 +1480,7 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
     if (!stillHasOwnedLeases) {
       await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
 
@@ -1431,6 +1496,7 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
       await chrome.windows.get(ownedContainerWindowId);
     } catch {
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
 
@@ -1453,6 +1519,7 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
         idleDeadlineAt: stored.idleDeadlineAt,
       });
       if (session.owned && ownedContainerWindowId === null) ownedContainerWindowId = tab.windowId;
+      if (session.owned) await ensureOwnedContainerTabGroup(tab.windowId, [tabId]);
       const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
       if (timeout > 0) {
         if (remaining <= 0) {
@@ -1472,6 +1539,7 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
     if (!hasOwnedLease) {
       await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
       ownedContainerWindowId = null;
+      ownedContainerGroupId = null;
     }
   }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -398,7 +398,7 @@ async function getOwnedContainerGroupId(windowId: number): Promise<number | null
   }
 
   const groups = await chrome.tabGroups.query({ windowId, title: AUTOMATION_TAB_GROUP_TITLE });
-  const existing = groups.find((group) => group.title === AUTOMATION_TAB_GROUP_TITLE);
+  const existing = groups[0];
   if (!existing) return null;
   ownedContainerGroupId = existing.id;
   return existing.id;
@@ -419,11 +419,6 @@ async function ensureOwnedContainerTabGroup(windowId: number, tabIds: Array<numb
       );
       const missing = ids.filter((id) => !alreadyGrouped.has(id));
       if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
-      await chrome.tabGroups.update(existingGroupId, {
-        color: AUTOMATION_TAB_GROUP_COLOR,
-        title: AUTOMATION_TAB_GROUP_TITLE,
-        collapsed: false,
-      });
       return;
     }
 


### PR DESCRIPTION
## Summary

Add a visible Chrome tab group marker for OpenCLI-owned automation tabs.

- Adds the `tabGroups` extension permission only.
- Groups owned automation container tabs under an orange `OpenCLI` tab group.
- Reuses an existing OpenCLI group when adding more owned lease tabs.
- Leaves `bound:*` user tabs untouched.
- Re-marks restored owned leases during service worker registry reconciliation.

## Verification

- `npx vitest run extension/src/background.test.ts --project extension`
- `npm run typecheck` from repo root
- `npm run typecheck` in `extension/`
- `npm run build` from repo root
- `npm run build` in `extension/`
