### PR TITLE
fix(browser): keep automation container window reusable

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -908,15 +908,6 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
       console.log(`[opencli] Workspace ${workspace} lease detached from tab ${tabId} (tab closed)`);
     }
   }
-  if (ownedContainerWindowId !== null) {
-    const hasOwnedLease = [...automationSessions.values()].some((s) => s.owned && s.windowId === ownedContainerWindowId);
-    if (!hasOwnedLease) {
-      await chrome.windows.remove(ownedContainerWindowId).catch(() => {
-      });
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
-    }
-  }
   await persistRuntimeState();
 });
 let initialized = false;
@@ -1604,16 +1595,28 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
   if (session.owned) {
     const tabId = session.preferredTabId;
     if (tabId !== null) {
+      const hasOtherOwnedLease = [...automationSessions.entries()].some(
+        ([otherWorkspace, otherSession]) => otherWorkspace !== workspace && otherSession.owned && otherSession.windowId === session.windowId && otherSession.preferredTabId !== null
+      );
       await safeDetach(tabId);
-      await chrome.tabs.remove(tabId).catch(() => {
-      });
-      console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+      evictTab(tabId);
+      if (hasOtherOwnedLease) {
+        await chrome.tabs.remove(tabId).catch(() => {
+        });
+        console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+      } else {
+        try {
+          const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
+          await ensureOwnedContainerTabGroup(session.windowId, [tab.id ?? tabId]);
+          console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (${workspace}, ${reason})`);
+        } catch {
+          await chrome.tabs.remove(tabId).catch(() => {
+          });
+          console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+        }
+      }
     } else {
-      await chrome.windows.remove(session.windowId).catch(() => {
-      });
-      if (ownedContainerWindowId === session.windowId) ownedContainerWindowId = null;
-      if (ownedContainerWindowId === null) ownedContainerGroupId = null;
-      console.log(`[opencli] Released legacy owned window lease ${session.windowId} (${workspace}, ${reason})`);
+      console.log(`[opencli] Released legacy owned window lease ${session.windowId} without closing container (${workspace}, ${reason})`);
     }
   } else if (session.preferredTabId !== null) {
     await safeDetach(session.preferredTabId);
@@ -1621,15 +1624,6 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
   }
   automationSessions.delete(workspace);
   workspaceTimeoutOverrides.delete(workspace);
-  if (ownedContainerWindowId !== null) {
-    const stillHasOwnedLeases = [...automationSessions.values()].some((s) => s.owned && s.windowId === ownedContainerWindowId);
-    if (!stillHasOwnedLeases) {
-      await chrome.windows.remove(ownedContainerWindowId).catch(() => {
-      });
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
-    }
-  }
   await persistRuntimeState();
 }
 async function reconcileTargetLeaseRegistry() {
@@ -1673,15 +1667,6 @@ async function reconcileTargetLeaseRegistry() {
         }
       }
     } catch {
-    }
-  }
-  if (ownedContainerWindowId !== null) {
-    const hasOwnedLease = [...automationSessions.values()].some((s) => s.owned && s.windowId === ownedContainerWindowId);
-    if (!hasOwnedLease) {
-      await chrome.windows.remove(ownedContainerWindowId).catch(() => {
-      });
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
     }
   }
   await persistRuntimeState();

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -571,7 +571,7 @@ describe('background tab isolation', () => {
     expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'about:blank', active: true });
   });
 
-  it('releases owned workspaces as tab leases before closing the shared container', async () => {
+  it('releases owned workspaces without closing the shared container', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -583,13 +583,14 @@ describe('background tab isolation', () => {
     const closeSecond = await mod.__test__.handleCommand({ id: 'close-second', action: 'close-window', workspace: 'site:second' });
     expect(closeSecond).toEqual(expect.objectContaining({ ok: true }));
     expect(chrome.tabs.remove).toHaveBeenCalledWith(10);
+    expect(chrome.tabs.update).not.toHaveBeenCalledWith(10, { url: 'about:blank', active: true });
     expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession('site:first')).not.toBeNull();
     expect(mod.__test__.getSession('site:second')).toBeNull();
 
     await mod.__test__.handleCommand({ id: 'close-first', action: 'close-window', workspace: 'site:first' });
-    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
-    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
   });
 
   it('releases the current owned tab lease when tabs close targets it', async () => {
@@ -609,12 +610,12 @@ describe('background tab isolation', () => {
       ok: true,
       data: { closed: 'target-1' },
     }));
-    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
-    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession('site:closetab')).toBeNull();
   });
 
-  it('reconciles an owned container with no stored leases by closing it', async () => {
+  it('reconciles an owned container with no stored leases without closing it', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
@@ -629,7 +630,15 @@ describe('background tab isolation', () => {
     const mod = await import('./background');
     await mod.__test__.reconcileTargetLeaseRegistry();
 
-    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+    expect(mod.__test__.getAutomationWindowId()).toBeNull();
+    chrome.windows.create.mockClear();
+
+    const tabId = await mod.__test__.resolveTabId(undefined, 'site:after-restart', 'https://after.example');
+
+    expect(tabId).toBe(1);
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'https://after.example' });
   });
 
   it('restores owned and borrowed leases from the registry', async () => {
@@ -704,9 +713,30 @@ describe('background tab isolation', () => {
     const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
     await onAlarmListener({ name: 'opencli:lease-idle:site%3Aalarm' });
 
-    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
-    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession('site:alarm')).toBeNull();
+  });
+
+  it('reuses the placeholder tab left by an idle release', async () => {
+    const { chrome, tabs } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await mod.__test__.resolveTabId(undefined, 'site:first');
+
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    await onAlarmListener({ name: 'opencli:lease-idle:site%3Afirst' });
+
+    expect(tabs[0].url).toBe('about:blank');
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+    chrome.windows.create.mockClear();
+
+    const reused = await mod.__test__.resolveTabId(undefined, 'site:next', 'https://next.example');
+
+    expect(reused).toBe(1);
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'https://next.example' });
   });
 
   it('deduplicates concurrent automation container creation', async () => {
@@ -958,7 +988,7 @@ describe('background tab isolation', () => {
     mod.__test__.resetWindowIdleTimer('site:notebooklm');
     await vi.advanceTimersByTimeAsync(30001);
 
-    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession('site:notebooklm')).toBeNull();
   });
 
@@ -977,7 +1007,7 @@ describe('background tab isolation', () => {
 
     // After 10 min total, session should be cleaned up
     await vi.advanceTimersByTimeAsync(600000 - 30001);
-    expect(chrome.windows.remove).toHaveBeenCalledWith(1);
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession('browser:default')).toBeNull();
   });
 
@@ -1167,6 +1197,26 @@ describe('background tab isolation', () => {
 
     expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession('bound:default')).not.toBeNull();
+  });
+
+  it('explicit close on a borrowed bound session detaches without touching tabs or windows', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession('bound:default', { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const result = await mod.__test__.handleCommand({
+      id: 'bound-close',
+      action: 'close-window',
+      workspace: 'bound:default',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true }));
+    expect(chrome.tabs.remove).not.toHaveBeenCalled();
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+    expect(chrome.windows.remove).not.toHaveBeenCalled();
+    expect(mod.__test__.getSession('bound:default')).toBeNull();
   });
 
   it('cleans borrowed sessions when the bound tab is closed', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -633,14 +633,6 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
       console.log(`[opencli] Workspace ${workspace} lease detached from tab ${tabId} (tab closed)`);
     }
   }
-  if (ownedContainerWindowId !== null) {
-    const hasOwnedLease = [...automationSessions.values()].some(s => s.owned && s.windowId === ownedContainerWindowId);
-    if (!hasOwnedLease) {
-      await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
-    }
-  }
   await persistRuntimeState();
 });
 
@@ -1456,15 +1448,29 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
   if (session.owned) {
     const tabId = session.preferredTabId;
     if (tabId !== null) {
+      const hasOtherOwnedLease = [...automationSessions.entries()].some(([otherWorkspace, otherSession]) =>
+        otherWorkspace !== workspace &&
+        otherSession.owned &&
+        otherSession.windowId === session.windowId &&
+        otherSession.preferredTabId !== null,
+      );
       await safeDetach(tabId);
-      await chrome.tabs.remove(tabId).catch(() => {});
-      console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+      identity.evictTab(tabId);
+      if (hasOtherOwnedLease) {
+        await chrome.tabs.remove(tabId).catch(() => {});
+        console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+      } else {
+        try {
+          const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
+          await ensureOwnedContainerTabGroup(session.windowId, [tab.id ?? tabId]);
+          console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (${workspace}, ${reason})`);
+        } catch {
+          await chrome.tabs.remove(tabId).catch(() => {});
+          console.log(`[opencli] Released owned tab lease ${tabId} (${workspace}, ${reason})`);
+        }
+      }
     } else {
-      // Legacy fallback for sessions created before tab leases existed.
-      await chrome.windows.remove(session.windowId).catch(() => {});
-      if (ownedContainerWindowId === session.windowId) ownedContainerWindowId = null;
-      if (ownedContainerWindowId === null) ownedContainerGroupId = null;
-      console.log(`[opencli] Released legacy owned window lease ${session.windowId} (${workspace}, ${reason})`);
+      console.log(`[opencli] Released legacy owned window lease ${session.windowId} without closing container (${workspace}, ${reason})`);
     }
   } else if (session.preferredTabId !== null) {
     await safeDetach(session.preferredTabId);
@@ -1473,15 +1479,6 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
 
   automationSessions.delete(workspace);
   workspaceTimeoutOverrides.delete(workspace);
-
-  if (ownedContainerWindowId !== null) {
-    const stillHasOwnedLeases = [...automationSessions.values()].some(s => s.owned && s.windowId === ownedContainerWindowId);
-    if (!stillHasOwnedLeases) {
-      await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
-    }
-  }
 
   await persistRuntimeState();
 }
@@ -1531,15 +1528,6 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
     } catch {
       // Registry is semantic state, not truth. If Chrome no longer has the tab,
       // drop the lease record and never close unrelated user resources.
-    }
-  }
-
-  if (ownedContainerWindowId !== null) {
-    const hasOwnedLease = [...automationSessions.values()].some(s => s.owned && s.windowId === ownedContainerWindowId);
-    if (!hasOwnedLease) {
-      await chrome.windows.remove(ownedContainerWindowId).catch(() => {});
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
     }
   }
 

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -150,7 +150,7 @@ export class Page extends BasePage {
     return Array.isArray(result) ? result : [];
   }
 
-  /** Close the automation window in the extension */
+  /** Release the current automation tab lease in the extension */
   async closeWindow(): Promise<void> {
     try {
       await sendCommand('close-window', { ...this._wsOpt() });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2205,10 +2205,10 @@ cli({
 
   // ── Session ──
 
-  browser.command('close').description('Close the automation window')
+  browser.command('close').description('Release the current automation tab lease')
     .action(browserAction(async (page) => {
       await page.closeWindow?.();
-      console.log('Automation window closed');
+      console.log('Automation tab lease released');
     }));
 
   // ── Built-in: doctor / completion ──────────────────────────────────────────

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -298,8 +298,8 @@ export async function executeCommand(
             throw wrapped;
           }
         }
-        // --live / OPENCLI_LIVE=1 keeps the automation window open after the
-        // command finishes, so agents (or humans) can inspect the page state.
+        // --live / OPENCLI_LIVE=1 keeps the current automation tab lease after
+        // the command finishes, so agents (or humans) can inspect the page state.
         const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
           const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
@@ -315,8 +315,9 @@ export async function executeCommand(
             await collectObservationEvidence(observation, page).catch(() => {});
             exportTraceArtifact(observation, 'success', undefined, opts.onTraceExport);
           }
-          // Adapter commands are one-shot — close the automation window immediately
-          // instead of waiting for the 30s idle timeout.
+          // Adapter commands are one-shot — release the current tab lease immediately
+          // instead of waiting for the 30s idle timeout. The automation container
+          // window stays open for reuse.
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
@@ -337,9 +338,9 @@ export async function executeCommand(
               exportTraceArtifact(observation, 'failure', err, opts.onTraceExport);
             }
           }
-          // Close the automation window on failure too — without this, the window
-          // lingers until the extension's idle timer fires (unreliable on Windows
-          // where MV3 service workers may be suspended before setTimeout triggers).
+          // Release the tab lease on failure too — without this, the lease lingers
+          // until the extension's idle timer fires (unreliable on Windows where
+          // MV3 service workers may be suspended before setTimeout triggers).
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           throw err;
         }

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -48,7 +48,7 @@ export async function executePipeline(
       }
     }
   } catch (err) {
-    // Attempt cleanup: close automation window on pipeline failure
+    // Attempt cleanup: release automation tab lease on pipeline failure.
     if (page?.closeWindow) {
       try { await page.closeWindow(); } catch { /* ignore */ }
     }


### PR DESCRIPTION
## Summary
- stop proactively closing the owned automation container window when a lease is released, idle-expired, or reconciled with no active leases
- release non-last owned tab leases by closing the tab, but keep the last owned tab as an `about:blank` reusable placeholder in the OpenCLI tab group
- update `browser close` wording and cleanup comments from "close window" to "release tab lease"

## Tests
- `npx vitest run extension/src/background.test.ts --project extension`
- `npx vitest run src/execution.test.ts src/cli.test.ts --project unit`
- `npm run typecheck`
- `(cd extension && npm run typecheck)`
- `npm run build`
- `(cd extension && npm run build)`
- `git diff --check`
