### PR TITLE
fix(linkedin): surface detail_error on --details (no silent catch / no silent empty)

### DIFF
--- a/clis/linkedin/search.js
+++ b/clis/linkedin/search.js
@@ -1,5 +1,9 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+const LINKEDIN_DOMAIN = 'linkedin.com';
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+const MIN_START = 0;
 // ── Filter value mappings ──────────────────────────────────────────────
 const EXPERIENCE_LEVELS = {
     internship: '1',
@@ -66,6 +70,19 @@ function mapFilterValues(input, mapping, label) {
 function normalizeWhitespace(value) {
     return String(value ?? '').replace(/\s+/g, ' ').trim();
 }
+function parseIntegerArg(value, label, fallback, min, max = Infinity) {
+    if (value === undefined || value === null || value === '')
+        return fallback;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+        throw new ArgumentError(`${label} must be an integer, got ${JSON.stringify(value)}`);
+    }
+    if (parsed < min || parsed > max) {
+        const range = Number.isFinite(max) ? `between ${min} and ${max}` : `at least ${min}`;
+        throw new ArgumentError(`${label} must be ${range}, got ${parsed}`);
+    }
+    return parsed;
+}
 function decodeLinkedinRedirect(url) {
     if (!url)
         return '';
@@ -119,6 +136,31 @@ function buildVoyagerUrl(input, offset, count) {
         .replace(/%28/gi, '(')
         .replace(/%29/gi, ')');
     return '/voyager/api/voyagerJobsDashJobCards?' + params.toString() + '&query=' + query + '&start=' + offset;
+}
+function looksLinkedInAuthWallText(value) {
+    const text = String(value ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
+    if (!text)
+        return false;
+    return /\b(sign in|log in|join linkedin)\b/.test(text) ||
+        /linkedin\.com\/(login|checkpoint|authwall)/i.test(text) ||
+        /\b(captcha|verification required)\b/.test(text) ||
+        /(请登录|登录领英|安全验证)/.test(text);
+}
+function buildLinkedInAuthProbeScript() {
+    return `(() => {
+      const text = [
+        window.location.href || '',
+        document.title || '',
+        document.body ? (document.body.innerText || '').slice(0, 4000) : '',
+      ].join('\\n');
+      return ${looksLinkedInAuthWallText.toString()}(text);
+    })()`;
+}
+async function assertLinkedInAuthenticated(page, context) {
+    const authRequired = await page.evaluate(buildLinkedInAuthProbeScript());
+    if (authRequired) {
+        throw new AuthRequiredError(LINKEDIN_DOMAIN, `${context} requires an active signed-in LinkedIn browser session`);
+    }
 }
 // ── Company ID resolution (requires DOM interaction) ──────────────────
 async function resolveCompanyIds(page, input) {
@@ -209,13 +251,25 @@ async function fetchJobCards(page, input) {
         const batch = await page.evaluate(`(async () => {
       const jsession = document.cookie.split(';').map(p => p.trim())
         .find(p => p.startsWith('JSESSIONID='))?.slice('JSESSIONID='.length);
-      if (!jsession) return { error: 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.' };
+      if (!jsession) {
+        return {
+          authRequired: true,
+          error: 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.'
+        };
+      }
 
       const csrf = jsession.replace(/^"|"$/g, '');
       const res = await fetch(${JSON.stringify(apiPath)}, {
         credentials: 'include',
         headers: { 'csrf-token': csrf, 'x-restli-protocol-version': '2.0.0' },
       });
+      if (res.status === 401 || res.status === 403) {
+        const text = await res.text();
+        return {
+          authRequired: true,
+          error: 'LinkedIn API authentication failed: HTTP ' + res.status + ' ' + text.slice(0, 200)
+        };
+      }
       if (!res.ok) {
         const text = await res.text();
         return { error: 'LinkedIn API error: HTTP ' + res.status + ' ' + text.slice(0, 200) };
@@ -223,6 +277,9 @@ async function fetchJobCards(page, input) {
       return res.json();
     })()`);
         if (!batch || batch.error) {
+            if (batch?.authRequired) {
+                throw new AuthRequiredError(LINKEDIN_DOMAIN, batch.error);
+            }
             throw new CommandExecutionError(batch?.error || 'LinkedIn search returned an unexpected response');
         }
         const elements = Array.isArray(batch?.elements) ? batch.elements : [];
@@ -283,6 +340,7 @@ async function enrichJobDetails(page, jobs) {
         }
         try {
             await page.goto(job.url);
+            await assertLinkedInAuthenticated(page, 'LinkedIn job detail');
             await page.wait({ text: 'About the job', timeout: 8 });
             // Expand "Show more" button if present
             await page.evaluate(`(() => {
@@ -328,6 +386,8 @@ async function enrichJobDetails(page, jobs) {
             });
         }
         catch (err) {
+            if (err instanceof AuthRequiredError)
+                throw err;
             const reason = `fetch failed: ${err?.message || err}`;
             console.error(`[opencli:linkedin] Detail fetch failed for ${job.url}: ${reason}`);
             enriched.push({ ...job, description: null, apply_url: null, detail_error: reason });
@@ -358,8 +418,8 @@ cli({
     ],
     columns: ['rank', 'title', 'company', 'location', 'listed', 'salary', 'url'],
     func: async (page, kwargs) => {
-        const limit = Math.max(1, Math.min(kwargs.limit ?? 10, 100));
-        const start = Math.max(0, kwargs.start ?? 0);
+        const limit = parseIntegerArg(kwargs.limit, '--limit', 10, MIN_LIMIT, MAX_LIMIT);
+        const start = parseIntegerArg(kwargs.start, '--start', 0, MIN_START);
         const includeDetails = Boolean(kwargs.details);
         const location = (kwargs.location ?? '').trim();
         const keywords = String(kwargs.query ?? '').trim();
@@ -369,6 +429,7 @@ cli({
         if (location)
             searchParams.set('location', location);
         await page.goto(`https://www.linkedin.com/jobs/search/?${searchParams.toString()}`);
+        await assertLinkedInAuthenticated(page, 'LinkedIn search');
         await page.wait({ text: 'Jobs', timeout: 10 });
         const companyIds = await resolveCompanyIds(page, kwargs.company);
         const input = {
@@ -391,12 +452,14 @@ cli({
 
 export const __test__ = {
     parseCsvArg,
+    parseIntegerArg,
     mapFilterValues,
     decodeLinkedinRedirect,
+    looksLinkedInAuthWallText,
+    assertLinkedInAuthenticated,
     enrichJobDetails,
     EXPERIENCE_LEVELS,
     JOB_TYPES,
     DATE_POSTED,
     REMOTE_TYPES,
 };
-

--- a/clis/linkedin/search.js
+++ b/clis/linkedin/search.js
@@ -259,13 +259,26 @@ async function fetchJobCards(page, input) {
     }));
 }
 // ── Job detail enrichment (--details flag) ────────────────────────────
+//
+// Per-row failures should NOT abort the whole list (--details enriches N rows;
+// partial failure is expected). But silent empty-string fields hide the failure
+// from callers — previously `catch {}` and the `if (!job.url)` early-return
+// both produced indistinguishable `description: '', apply_url: ''` payloads,
+// so users could not tell "fetch failed" from "upstream had no description".
+//
+// The fix: surface `null` instead of `''` for missing/failed rows, set
+// `detail_error` to a short reason ("no url" / "fetch failed: <message>" /
+// "missing description"), and log every failure to stderr with the offending
+// URL so debugging is possible. Successful rows have `detail_error: null`.
 async function enrichJobDetails(page, jobs) {
     const enriched = [];
     for (let i = 0; i < jobs.length; i++) {
         const job = jobs[i];
         console.error(`[opencli:linkedin] Fetching details ${i + 1}/${jobs.length}: ${job.title}`);
         if (!job.url) {
-            enriched.push({ ...job, description: '', apply_url: '' });
+            const reason = 'no url';
+            console.error(`[opencli:linkedin] Skipping detail for "${job.title}": ${reason}`);
+            enriched.push({ ...job, description: null, apply_url: null, detail_error: reason });
             continue;
         }
         try {
@@ -301,14 +314,23 @@ async function enrichJobDetails(page, jobs) {
 
         return { description, applyUrl: applyLink?.href || '' };
       })()`);
+            const description = normalizeWhitespace(detail?.description);
+            const apply_url = decodeLinkedinRedirect(String(detail?.applyUrl ?? ''));
+            // Empty description after a successful fetch is itself a
+            // recognizable signal — surface it via detail_error instead of
+            // silently emitting an empty string.
+            const detail_error = description ? null : 'missing description';
             enriched.push({
                 ...job,
-                description: normalizeWhitespace(detail?.description),
-                apply_url: decodeLinkedinRedirect(String(detail?.applyUrl ?? '')),
+                description: description || null,
+                apply_url: apply_url || null,
+                detail_error,
             });
         }
-        catch {
-            enriched.push({ ...job, description: '', apply_url: '' });
+        catch (err) {
+            const reason = `fetch failed: ${err?.message || err}`;
+            console.error(`[opencli:linkedin] Detail fetch failed for ${job.url}: ${reason}`);
+            enriched.push({ ...job, description: null, apply_url: null, detail_error: reason });
         }
     }
     return enriched;
@@ -366,3 +388,15 @@ cli({
         return enrichJobDetails(page, data);
     },
 });
+
+export const __test__ = {
+    parseCsvArg,
+    mapFilterValues,
+    decodeLinkedinRedirect,
+    enrichJobDetails,
+    EXPERIENCE_LEVELS,
+    JOB_TYPES,
+    DATE_POSTED,
+    REMOTE_TYPES,
+};
+

--- a/clis/linkedin/search.test.js
+++ b/clis/linkedin/search.test.js
@@ -1,17 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
 import { __test__ } from './search.js';
 
 const {
     parseCsvArg,
+    parseIntegerArg,
     mapFilterValues,
     decodeLinkedinRedirect,
+    looksLinkedInAuthWallText,
     enrichJobDetails,
     EXPERIENCE_LEVELS,
     JOB_TYPES,
     DATE_POSTED,
     REMOTE_TYPES,
 } = __test__;
+
+const getSearchCommand = () => getRegistry().get('linkedin/search');
 
 describe('linkedin parseCsvArg', () => {
     it('returns empty array for empty / null / undefined', () => {
@@ -40,6 +45,48 @@ describe('linkedin mapFilterValues', () => {
     it('returns empty array for empty input', () => {
         expect(mapFilterValues('', EXPERIENCE_LEVELS, 'experience_level')).toEqual([]);
         expect(mapFilterValues(undefined, DATE_POSTED, 'date_posted')).toEqual([]);
+    });
+});
+
+describe('linkedin argument validation', () => {
+    it('rejects --limit outside 1..100 instead of silently clamping', () => {
+        expect(() => parseIntegerArg(0, '--limit', 10, 1, 100)).toThrow(ArgumentError);
+        expect(() => parseIntegerArg(101, '--limit', 10, 1, 100)).toThrow(ArgumentError);
+        expect(() => parseIntegerArg('10.5', '--limit', 10, 1, 100)).toThrow(ArgumentError);
+    });
+
+    it('rejects negative --start instead of silently clamping to zero', () => {
+        expect(() => parseIntegerArg(-1, '--start', 0, 0)).toThrow(ArgumentError);
+        expect(parseIntegerArg(undefined, '--start', 0, 0)).toBe(0);
+        expect(parseIntegerArg('25', '--start', 0, 0)).toBe(25);
+    });
+
+    it('validates command args before browser navigation', async () => {
+        const command = getSearchCommand();
+        const page = { goto: vi.fn(), wait: vi.fn(), evaluate: vi.fn() };
+
+        await expect(command.func(page, { query: 'engineer', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func(page, { query: 'engineer', start: -1 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});
+
+describe('linkedin auth wall detection', () => {
+    it('recognizes login/authwall signals', () => {
+        expect(looksLinkedInAuthWallText('https://www.linkedin.com/authwall?trk=guest Sign in to continue')).toBe(true);
+        expect(looksLinkedInAuthWallText('LinkedIn Login, Sign in')).toBe(true);
+        expect(looksLinkedInAuthWallText('About the job Senior infrastructure engineer')).toBe(false);
+    });
+
+    it('throws AuthRequiredError when search lands on a login wall', async () => {
+        const command = getSearchCommand();
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(true),
+        };
+
+        await expect(command.func(page, { query: 'engineer', limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
     });
 });
 
@@ -108,6 +155,7 @@ describe('linkedin enrichJobDetails (silent failure fix)', () => {
     it('surfaces detail_error="missing description" on empty description (signals upstream gap, not crash)', async () => {
         const page = makeFakePage({
             evaluateResults: [
+                false, // auth wall probe
                 undefined, // expand-show-more click result (ignored)
                 { description: '', applyUrl: '' },
             ],
@@ -123,6 +171,7 @@ describe('linkedin enrichJobDetails (silent failure fix)', () => {
     it('surfaces detail_error=null on a fully successful enrichment', async () => {
         const page = makeFakePage({
             evaluateResults: [
+                false, // auth wall probe
                 undefined,
                 { description: '  An interesting role  ', applyUrl: 'https://example.com/apply' },
             ],
@@ -141,9 +190,11 @@ describe('linkedin enrichJobDetails (silent failure fix)', () => {
         const page = makeFakePage({
             evaluateResults: [
                 // Row 1 (success)
+                false,
                 undefined,
                 { description: 'Good', applyUrl: 'https://a.example/' },
                 // Row 3 (success — row 2 had no URL so didn't navigate)
+                false,
                 undefined,
                 { description: 'Also good', applyUrl: 'https://b.example/' },
             ],
@@ -159,5 +210,13 @@ describe('linkedin enrichJobDetails (silent failure fix)', () => {
         expect(out[2].detail_error).toBeNull();
         // Goto was only called for rows with URL (1 and 3)
         expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws AuthRequiredError on detail auth wall instead of burying it in detail_error', async () => {
+        const page = makeFakePage({ evaluateResults: [true] });
+
+        await expect(enrichJobDetails(page, [
+            { rank: 1, title: 'Needs Auth', company: 'X', url: 'https://www.linkedin.com/jobs/view/4' },
+        ])).rejects.toBeInstanceOf(AuthRequiredError);
     });
 });

--- a/clis/linkedin/search.test.js
+++ b/clis/linkedin/search.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './search.js';
+
+const {
+    parseCsvArg,
+    mapFilterValues,
+    decodeLinkedinRedirect,
+    enrichJobDetails,
+    EXPERIENCE_LEVELS,
+    JOB_TYPES,
+    DATE_POSTED,
+    REMOTE_TYPES,
+} = __test__;
+
+describe('linkedin parseCsvArg', () => {
+    it('returns empty array for empty / null / undefined', () => {
+        expect(parseCsvArg(undefined)).toEqual([]);
+        expect(parseCsvArg(null)).toEqual([]);
+        expect(parseCsvArg('')).toEqual([]);
+    });
+
+    it('splits and trims comma-separated values', () => {
+        expect(parseCsvArg('full-time, contract')).toEqual(['full-time', 'contract']);
+        expect(parseCsvArg(' a , b , , c ')).toEqual(['a', 'b', 'c']);
+    });
+});
+
+describe('linkedin mapFilterValues', () => {
+    it('maps known values to upstream codes and dedupes', () => {
+        expect(mapFilterValues('full-time, contract, full', JOB_TYPES, 'job_type')).toEqual(['F', 'C']);
+        expect(mapFilterValues('remote, hybrid', REMOTE_TYPES, 'remote')).toEqual(['2', '3']);
+    });
+
+    it('throws ArgumentError on unknown filter values (no silent drop)', () => {
+        expect(() => mapFilterValues('martian', JOB_TYPES, 'job_type')).toThrow(ArgumentError);
+        expect(() => mapFilterValues('full-time, ufo', JOB_TYPES, 'job_type')).toThrow(ArgumentError);
+    });
+
+    it('returns empty array for empty input', () => {
+        expect(mapFilterValues('', EXPERIENCE_LEVELS, 'experience_level')).toEqual([]);
+        expect(mapFilterValues(undefined, DATE_POSTED, 'date_posted')).toEqual([]);
+    });
+});
+
+describe('linkedin decodeLinkedinRedirect', () => {
+    it('extracts the underlying url from a /redir/redirect/ wrapper', () => {
+        const target = 'https://example.com/jobs/apply?id=42';
+        const wrapped = `https://www.linkedin.com/redir/redirect/?url=${encodeURIComponent(target)}&source=jobs`;
+        expect(decodeLinkedinRedirect(wrapped)).toBe(target);
+    });
+
+    it('returns the input unchanged for non-redirect urls', () => {
+        const direct = 'https://example.com/jobs/42/';
+        expect(decodeLinkedinRedirect(direct)).toBe(direct);
+    });
+
+    it('returns empty string for falsy input', () => {
+        expect(decodeLinkedinRedirect('')).toBe('');
+        expect(decodeLinkedinRedirect(null)).toBe('');
+    });
+});
+
+describe('linkedin enrichJobDetails (silent failure fix)', () => {
+    function makeFakePage({ evaluateResults = [], gotoFails = [], evaluateFails = [] } = {}) {
+        let evalCall = 0;
+        let gotoCall = 0;
+        return {
+            goto: vi.fn(async () => {
+                if (gotoFails[gotoCall++]) {
+                    throw new Error(gotoFails[gotoCall - 1]);
+                }
+            }),
+            wait: vi.fn(async () => undefined),
+            evaluate: vi.fn(async () => {
+                const idx = evalCall++;
+                if (evaluateFails[idx]) throw new Error(evaluateFails[idx]);
+                return evaluateResults[idx];
+            }),
+        };
+    }
+
+    it('surfaces detail_error="no url" when row has no URL (instead of silent empty string)', async () => {
+        const page = makeFakePage();
+        const out = await enrichJobDetails(page, [
+            { rank: 1, title: 'No URL Job', company: 'X', url: '' },
+        ]);
+        expect(out).toHaveLength(1);
+        expect(out[0]).toMatchObject({
+            description: null,
+            apply_url: null,
+            detail_error: 'no url',
+        });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('surfaces detail_error="fetch failed: ..." when goto throws (no silent swallow)', async () => {
+        const page = makeFakePage({ gotoFails: ['network down'] });
+        const out = await enrichJobDetails(page, [
+            { rank: 1, title: 'Fetch Fail', company: 'X', url: 'https://www.linkedin.com/jobs/view/1' },
+        ]);
+        expect(out).toHaveLength(1);
+        expect(out[0].description).toBeNull();
+        expect(out[0].apply_url).toBeNull();
+        expect(out[0].detail_error).toMatch(/^fetch failed: .*network down/);
+    });
+
+    it('surfaces detail_error="missing description" on empty description (signals upstream gap, not crash)', async () => {
+        const page = makeFakePage({
+            evaluateResults: [
+                undefined, // expand-show-more click result (ignored)
+                { description: '', applyUrl: '' },
+            ],
+        });
+        const out = await enrichJobDetails(page, [
+            { rank: 1, title: 'Empty Desc', company: 'X', url: 'https://www.linkedin.com/jobs/view/2' },
+        ]);
+        expect(out[0].description).toBeNull();
+        expect(out[0].apply_url).toBeNull();
+        expect(out[0].detail_error).toBe('missing description');
+    });
+
+    it('surfaces detail_error=null on a fully successful enrichment', async () => {
+        const page = makeFakePage({
+            evaluateResults: [
+                undefined,
+                { description: '  An interesting role  ', applyUrl: 'https://example.com/apply' },
+            ],
+        });
+        const out = await enrichJobDetails(page, [
+            { rank: 1, title: 'OK', company: 'X', url: 'https://www.linkedin.com/jobs/view/3' },
+        ]);
+        expect(out[0]).toMatchObject({
+            description: 'An interesting role',
+            apply_url: 'https://example.com/apply',
+            detail_error: null,
+        });
+    });
+
+    it('processes multiple rows with mixed outcomes without aborting the batch', async () => {
+        const page = makeFakePage({
+            evaluateResults: [
+                // Row 1 (success)
+                undefined,
+                { description: 'Good', applyUrl: 'https://a.example/' },
+                // Row 3 (success — row 2 had no URL so didn't navigate)
+                undefined,
+                { description: 'Also good', applyUrl: 'https://b.example/' },
+            ],
+        });
+        const out = await enrichJobDetails(page, [
+            { rank: 1, title: 'A', company: 'X', url: 'https://www.linkedin.com/jobs/view/10' },
+            { rank: 2, title: 'B', company: 'X', url: '' },
+            { rank: 3, title: 'C', company: 'X', url: 'https://www.linkedin.com/jobs/view/30' },
+        ]);
+        expect(out).toHaveLength(3);
+        expect(out[0].detail_error).toBeNull();
+        expect(out[1].detail_error).toBe('no url');
+        expect(out[2].detail_error).toBeNull();
+        // Goto was only called for rows with URL (1 and 3)
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+});

--- a/docs/adapters/browser/linkedin.md
+++ b/docs/adapters/browser/linkedin.md
@@ -45,6 +45,8 @@ When `--details` is set, each row additionally has:
 
 Previously the adapter returned `description: '', apply_url: ''` for both the missing-url path and the silent-catch path — callers couldn't tell upstream gaps apart from fetch failures. The current shape preserves backward compatibility on success and surfaces failures with `null` + a typed reason on `detail_error`. Per-row failures still don't abort the batch.
 
+`--limit` must be between 1 and 100, and `--start` must be a non-negative integer. LinkedIn login/auth walls abort with `AuthRequiredError` instead of being folded into `detail_error`.
+
 ## Prerequisites
 
 - Chrome running and **logged into** linkedin.com

--- a/docs/adapters/browser/linkedin.md
+++ b/docs/adapters/browser/linkedin.md
@@ -6,7 +6,7 @@
 
 | Command | Description |
 |---------|-------------|
-| `opencli linkedin search` | |
+| `opencli linkedin search` | Search LinkedIn jobs (Voyager API), with optional `--details` enrichment |
 | `opencli linkedin timeline` | Read posts from your LinkedIn home feed |
 
 ## Usage Examples
@@ -15,17 +15,35 @@
 # Quick start
 opencli linkedin search --limit 5
 
+# Search with filters
+opencli linkedin search "site reliability engineer" --location "San Francisco Bay Area" --remote remote
+
+# Enrich with full description and apply URL (slower; 1 page navigation per row)
+opencli linkedin search "data scientist" --limit 3 --details
+
 # Read your home timeline
 opencli linkedin timeline --limit 5
 
 # JSON output
 opencli linkedin search -f json
-
 opencli linkedin timeline -f json
-
-# Verbose mode
-opencli linkedin search -v
 ```
+
+## Output
+
+### `search`
+
+Always returns: `rank` · `title` · `company` · `location` · `listed` · `salary` · `url`
+
+When `--details` is set, each row additionally has:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `description` | string \| null | Full "About the job" body. `null` if upstream had nothing or fetch failed (see `detail_error`). |
+| `apply_url` | string \| null | First `apply`-labelled link on the page. `null` if upstream had nothing or fetch failed. |
+| `detail_error` | string \| null | `null` on success. Otherwise short reason: `'no url'` (row had no jobId), `'fetch failed: <message>'` (navigation/parse threw), or `'missing description'` (page loaded but body was empty). |
+
+Previously the adapter returned `description: '', apply_url: ''` for both the missing-url path and the silent-catch path — callers couldn't tell upstream gaps apart from fetch failures. The current shape preserves backward compatibility on success and surfaces failures with `null` + a typed reason on `detail_error`. Per-row failures still don't abort the batch.
 
 ## Prerequisites
 

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -419,16 +419,8 @@
     "rule": "silent-clamp",
     "command": "linkedin/search",
     "file": "clis/linkedin/search.js",
-    "line": 207,
+    "line": 249,
     "text": "const count = Math.min(MAX_BATCH, input.limit - allJobs.length);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
-    "command": "linkedin/search",
-    "file": "clis/linkedin/search.js",
-    "line": 339,
-    "text": "const limit = Math.max(1, Math.min(kwargs.limit ?? 10, 100));",
     "occurrence": 0
   },
   {


### PR DESCRIPTION
## Context (rewrite — original framing was misleading)

The original framing of this PR claimed users were observing two indistinguishable silent failure modes (`description: ''` / `apply_url: ''`) on `linkedin search --details`. In practice the failures we saw came from a **local proxy that redirected `linkedin.com` → `linkedin.cn`** during testing — so the page DOM that `page.evaluate(...)` parsed wasn't actually LinkedIn's job page at all, and the `} catch {}` swallowed the redirect-induced parse errors into silent empty cells.

That is to say: **the bug we "fixed" may not be observable in a clean linkedin.com session**. We're not solving a confirmed-in-production silent failure — we're hardening a code path that *would* silently fail under any number of real conditions (network / redirect / DOM change / auth wall) but might not fail in a healthy environment today.

The fix is still correct as defensive hardening for an agent-native CLI: silent catch + empty-string-as-sentinel violates OpenCLI's typed-error / no-silent-fallback rules regardless of whether the trigger was a real bug or an env artifact. The reworded framing below reflects that.

## What this PR does

`linkedin search --details` previously had two enrichment failure paths that both produced `description: '', apply_url: ''`:

1. `if (!job.url)` early return — row had no jobId, so we couldn't navigate.
2. `} catch {}` — `page.goto` / `page.evaluate` threw (network / redirect / timeout / parse error / auth wall).

Callers couldn't distinguish "upstream had no description" from "we failed to fetch", and the catch logged nothing.

## Fix

Replace empty strings with `null` for missing/failed rows; add `detail_error` column (string|null) carrying a short typed reason:

| `detail_error` value | Meaning |
|---|---|
| `null` | Success — `description` and `apply_url` are real values |
| `'no url'` | Row had no jobId (the `--details` step couldn't navigate) |
| `'fetch failed: <message>'` | `page.goto` / `page.evaluate` threw |
| `'missing description'` | Page loaded but body was empty |

Every failure also logs to stderr with the offending URL. Per-row failures still don't abort the batch (the original intent), but they're now visible. Reviewer's `14fc906` patch added `AuthRequiredError` for the LinkedIn auth wall and `ArgumentError` upfront for `--limit` / `--start`.

Backward compatibility on success: rows without `--details` are unchanged. Rows with `--details` keep `description` / `apply_url` columns; `detail_error` is purely additive.

## Coverage

- 13 new contract assertions in `clis/linkedin/search.test.js` covering `parseCsvArg`, `mapFilterValues` (ArgumentError on unknown values), `decodeLinkedinRedirect`, and 5 `enrichJobDetails` paths (no-url / goto-throw / empty-description / success / multi-row-mixed).
- 23/23 passing including existing `timeline.test.js` (10).
- Audits clean: typed-error-lint 194/194, silent-column-drop 103/103.

## What this PR does NOT address

- The actual `linkedin.com` ↔ `linkedin.cn` redirect handling. If a user's network/proxy still redirects, the adapter will surface `detail_error: 'fetch failed: ...'` rows but won't recover. A follow-up could detect the redirect and fail fast with a typed error pointing at the network config, instead of letting `page.goto` succeed on the wrong host.

## Test plan

- [x] `npx vitest run clis/linkedin/` — 23/23 passing
- [x] Audits at baseline
- [ ] Live verify on a clean linkedin.com session (deferred — local env had redirect artifact at time of authoring)