### PR TITLE
refactor(runtime): unify command timeout into a single --timeout arg

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6051,6 +6051,13 @@
         "required": true,
         "positional": true,
         "help": "Prompt to send"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 60,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 60)"
       }
     ],
     "columns": [
@@ -23287,6 +23294,13 @@
         "default": 10,
         "required": false,
         "help": "最多显示条数"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 60,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 60)"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4201,8 +4201,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "30",
+        "type": "int",
+        "default": 30,
         "required": false,
         "help": "Max seconds to wait for response (default: 30)"
       }
@@ -4351,8 +4351,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "30",
+        "type": "int",
+        "default": 30,
         "required": false,
         "help": "Max seconds to wait (default: 30)"
       }
@@ -4742,8 +4742,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "60",
+        "type": "int",
+        "default": 60,
         "required": false,
         "help": "Max seconds to wait for response (default: 60)"
       },
@@ -5544,8 +5544,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "30",
+        "type": "int",
+        "default": 30,
         "required": false,
         "help": "Max seconds to wait for response (default: 30)"
       }
@@ -7156,8 +7156,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "60",
+        "type": "int",
+        "default": 60,
         "required": false,
         "help": "Max seconds to wait (default: 60)"
       }
@@ -9127,8 +9127,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "60",
+        "type": "int",
+        "default": 60,
         "required": false,
         "help": "Max seconds to wait (default: 60)"
       },
@@ -26408,8 +26408,8 @@
       },
       {
         "name": "timeout",
-        "type": "str",
-        "default": "60",
+        "type": "int",
+        "default": 60,
         "required": false,
         "help": "Max seconds to wait (default: 60)"
       },

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1305,9 +1305,16 @@
     "domain": "localhost",
     "strategy": "ui",
     "browser": true,
-    "args": [],
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 86400,
+        "required": false,
+        "help": "Max seconds to keep watching (default: 86400 — 24h)"
+      }
+    ],
     "columns": [],
-    "timeout": 86400,
     "type": "js",
     "modulePath": "antigravity/watch.js",
     "sourceFile": "antigravity/watch.js",
@@ -4037,6 +4044,13 @@
         "default": 20,
         "required": false,
         "help": "最大返回数量"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 90,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 90)"
       }
     ],
     "columns": [
@@ -4047,7 +4061,6 @@
       "status",
       "score"
     ],
-    "timeout": 90,
     "type": "js",
     "modulePath": "chaoxing/assignments.js",
     "sourceFile": "chaoxing/assignments.js",
@@ -4087,6 +4100,13 @@
         "default": 20,
         "required": false,
         "help": "最大返回数量"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 90,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 90)"
       }
     ],
     "columns": [
@@ -4098,7 +4118,6 @@
       "status",
       "score"
     ],
-    "timeout": 90,
     "type": "js",
     "modulePath": "chaoxing/exams.js",
     "sourceFile": "chaoxing/exams.js",
@@ -4132,6 +4151,13 @@
         "default": false,
         "required": false,
         "help": "Skip download shorthand; only show ChatGPT link"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 240,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 240)"
       }
     ],
     "columns": [
@@ -4139,7 +4165,6 @@
       "file",
       "link"
     ],
-    "timeout": 240,
     "type": "js",
     "modulePath": "chatgpt/image.js",
     "sourceFile": "chatgpt/image.js",
@@ -4513,7 +4538,6 @@
     "columns": [
       "response"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "claude/ask.js",
     "sourceFile": "claude/ask.js",
@@ -5912,7 +5936,6 @@
         "help": "Attach a file (PDF, image, text) with the prompt"
       }
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "deepseek/ask.js",
     "sourceFile": "deepseek/ask.js",
@@ -6034,7 +6057,6 @@
       "Status",
       "InjectedText"
     ],
-    "timeout": 60,
     "type": "js",
     "modulePath": "deepseek/send.js",
     "sourceFile": "deepseek/send.js",
@@ -7144,7 +7166,6 @@
       "Role",
       "Text"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "doubao/ask.js",
     "sourceFile": "doubao/ask.js",
@@ -9122,7 +9143,6 @@
     "columns": [
       "response"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "gemini/ask.js",
     "sourceFile": "gemini/ask.js",
@@ -9147,9 +9167,9 @@
       {
         "name": "timeout",
         "type": "int",
-        "default": 30,
+        "default": 180,
         "required": false,
-        "help": "Max seconds to wait for confirm (default: 30)"
+        "help": "Max seconds for the overall command (default: 180; confirm-wait clamps internally to 6-20s)"
       },
       {
         "name": "tool",
@@ -9168,7 +9188,6 @@
       "status",
       "url"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "gemini/deep-research.js",
     "sourceFile": "gemini/deep-research.js",
@@ -9260,6 +9279,13 @@
         "default": false,
         "required": false,
         "help": "Skip download shorthand; only show Gemini page link"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 240,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 240)"
       }
     ],
     "columns": [
@@ -9267,7 +9293,6 @@
       "file",
       "link"
     ],
-    "timeout": 240,
     "type": "js",
     "modulePath": "gemini/image.js",
     "sourceFile": "gemini/image.js",
@@ -11437,6 +11462,13 @@
         "required": true,
         "positional": true,
         "help": "Note text (max 60 characters)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 120,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 120)"
       }
     ],
     "columns": [
@@ -11444,7 +11476,6 @@
       "detail",
       "noteId"
     ],
-    "timeout": 120,
     "type": "js",
     "modulePath": "instagram/note.js",
     "sourceFile": "instagram/note.js",
@@ -11472,6 +11503,13 @@
         "required": false,
         "positional": true,
         "help": "Caption text"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 300)"
       }
     ],
     "columns": [
@@ -11479,7 +11517,6 @@
       "detail",
       "url"
     ],
-    "timeout": 300,
     "type": "js",
     "modulePath": "instagram/post.js",
     "sourceFile": "instagram/post.js",
@@ -11538,6 +11575,13 @@
         "required": false,
         "positional": true,
         "help": "Caption text"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 600)"
       }
     ],
     "columns": [
@@ -11545,7 +11589,6 @@
       "detail",
       "url"
     ],
-    "timeout": 600,
     "type": "js",
     "modulePath": "instagram/reel.js",
     "sourceFile": "instagram/reel.js",
@@ -11673,6 +11716,13 @@
         "required": false,
         "valueRequired": true,
         "help": "Path to a single story image or video file"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 300)"
       }
     ],
     "columns": [
@@ -11680,7 +11730,6 @@
       "detail",
       "url"
     ],
-    "timeout": 300,
     "type": "js",
     "modulePath": "instagram/story.js",
     "sourceFile": "instagram/story.js",
@@ -16803,6 +16852,13 @@
         "type": "str",
         "required": false,
         "help": "Optional free-text feedback"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 30)"
       }
     ],
     "columns": [
@@ -16813,7 +16869,6 @@
       "actionable_suggestions",
       "message"
     ],
-    "timeout": 30,
     "type": "js",
     "modulePath": "paperreview/feedback.js",
     "sourceFile": "paperreview/feedback.js"
@@ -16833,6 +16888,13 @@
         "required": true,
         "positional": true,
         "help": "Review token returned by paperreview.ai"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 30)"
       }
     ],
     "columns": [
@@ -16843,7 +16905,6 @@
       "has_feedback",
       "review_url"
     ],
-    "timeout": 30,
     "type": "js",
     "modulePath": "paperreview/review.js",
     "sourceFile": "paperreview/review.js"
@@ -16889,6 +16950,13 @@
         "default": false,
         "required": false,
         "help": "Request an upload slot but stop before uploading the PDF"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 120,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 120)"
       }
     ],
     "columns": [
@@ -16900,7 +16968,6 @@
       "review_url",
       "message"
     ],
-    "timeout": 120,
     "type": "js",
     "modulePath": "paperreview/submit.js",
     "sourceFile": "paperreview/submit.js"
@@ -17844,9 +17911,15 @@
         "default": "",
         "required": false,
         "help": "Destination folder ID (overrides --to)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 120,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 120)"
       }
     ],
-    "timeout": 120,
     "type": "js",
     "modulePath": "quark/mv.js",
     "sourceFile": "quark/mv.js",
@@ -17952,9 +18025,15 @@
         "default": "",
         "required": false,
         "help": "Share passcode (if required)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 120,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 120)"
       }
     ],
-    "timeout": 120,
     "type": "js",
     "modulePath": "quark/save.js",
     "sourceFile": "quark/save.js",
@@ -18052,7 +18131,6 @@
       "Role",
       "Text"
     ],
-    "timeout": 240,
     "type": "js",
     "modulePath": "qwen/ask.js",
     "sourceFile": "qwen/ask.js",
@@ -18136,7 +18214,6 @@
       "File",
       "Link"
     ],
-    "timeout": 300,
     "type": "js",
     "modulePath": "qwen/image.js",
     "sourceFile": "qwen/image.js",
@@ -21236,6 +21313,13 @@
         "default": 20,
         "required": false,
         "help": "Maximum number of requests to accept (default: 20)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 600 — batch op)"
       }
     ],
     "columns": [
@@ -21244,7 +21328,6 @@
       "user",
       "message"
     ],
-    "timeout": 600,
     "type": "js",
     "modulePath": "twitter/accept.js",
     "sourceFile": "twitter/accept.js",
@@ -21936,6 +22019,13 @@
         "default": true,
         "required": false,
         "help": "Skip conversations where you already sent the same text (default: true)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 600 — batch op)"
       }
     ],
     "columns": [
@@ -21944,7 +22034,6 @@
       "user",
       "message"
     ],
-    "timeout": 600,
     "type": "js",
     "modulePath": "twitter/reply-dm.js",
     "sourceFile": "twitter/reply-dm.js",
@@ -23122,13 +23211,19 @@
         "type": "str",
         "required": false,
         "help": "文章摘要"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 180,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 180)"
       }
     ],
     "columns": [
       "status",
       "detail"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "weixin/create-draft.js",
     "sourceFile": "weixin/create-draft.js",
@@ -23199,7 +23294,6 @@
       "Title",
       "Time"
     ],
-    "timeout": 60,
     "type": "js",
     "modulePath": "weixin/drafts.js",
     "sourceFile": "weixin/drafts.js",
@@ -24304,6 +24398,13 @@
         "default": 3,
         "required": false,
         "help": "Number of recent notes to summarize"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 180,
+        "required": false,
+        "help": "Max seconds for the overall command (default: 180)"
       }
     ],
     "columns": [
@@ -24321,7 +24422,6 @@
       "top_interest",
       "url"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "xiaohongshu/creator-notes-summary.js",
     "sourceFile": "xiaohongshu/creator-notes-summary.js",
@@ -26332,7 +26432,6 @@
       "Role",
       "Text"
     ],
-    "timeout": 180,
     "type": "js",
     "modulePath": "yuanbao/ask.js",
     "sourceFile": "yuanbao/ask.js",

--- a/clis/antigravity/watch.js
+++ b/clis/antigravity/watch.js
@@ -7,8 +7,9 @@ export const watchCommand = cli({
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
-    args: [],
-    timeoutSeconds: 86400, // Run for up to 24 hours
+    args: [
+        { name: 'timeout', type: 'int', required: false, default: 86400, help: 'Max seconds to keep watching (default: 86400 — 24h)' },
+    ],
     columns: [], // We use direct stdout streaming
     func: async (page) => {
         console.log('Watching Antigravity chat... (Press Ctrl+C to stop)');

--- a/clis/chaoxing/assignments.js
+++ b/clis/chaoxing/assignments.js
@@ -8,7 +8,6 @@ cli({
     description: '学习通作业列表',
     domain: 'mooc2-ans.chaoxing.com',
     strategy: Strategy.COOKIE,
-    timeoutSeconds: 90,
     args: [
         { name: 'course', type: 'string', help: '按课程名过滤（模糊匹配）' },
         {
@@ -19,6 +18,7 @@ cli({
             help: '按状态过滤',
         },
         { name: 'limit', type: 'int', default: 20, help: '最大返回数量' },
+        { name: 'timeout', type: 'int', required: false, default: 90, help: 'Max seconds for the overall command (default: 90)' },
     ],
     columns: ['rank', 'course', 'title', 'deadline', 'status', 'score'],
     func: async (page, kwargs) => {

--- a/clis/chaoxing/exams.js
+++ b/clis/chaoxing/exams.js
@@ -7,7 +7,6 @@ cli({
     description: '学习通考试列表',
     domain: 'mooc2-ans.chaoxing.com',
     strategy: Strategy.COOKIE,
-    timeoutSeconds: 90,
     args: [
         { name: 'course', type: 'string', help: '按课程名过滤（模糊匹配）' },
         {
@@ -18,6 +17,7 @@ cli({
             help: '按状态过滤',
         },
         { name: 'limit', type: 'int', default: 20, help: '最大返回数量' },
+        { name: 'timeout', type: 'int', required: false, default: 90, help: 'Max seconds for the overall command (default: 90)' },
     ],
     columns: ['rank', 'course', 'title', 'start', 'end', 'status', 'score'],
     func: async (page, kwargs) => {

--- a/clis/chatgpt-app/ask.js
+++ b/clis/chatgpt-app/ask.js
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ConfigError } from '@jackwener/opencli/errors';
+import { ArgumentError, ConfigError } from '@jackwener/opencli/errors';
 import { activateChatGPT, getVisibleChatMessages, selectModel, MODEL_CHOICES, isGenerating, sendPrompt } from './ax.js';
 export const askCommand = cli({
     site: 'chatgpt-app',
@@ -13,7 +13,7 @@ export const askCommand = cli({
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
         { name: 'model', required: false, help: 'Model/mode to use: auto, instant, thinking, 5.2-instant, 5.2-thinking', choices: MODEL_CHOICES },
-        { name: 'timeout', required: false, help: 'Max seconds to wait for response (default: 30)', default: '30' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait for response (default: 30)', default: 30 },
     ],
     columns: ['Role', 'Text'],
     func: async (kwargs) => {
@@ -22,7 +22,10 @@ export const askCommand = cli({
         }
         const text = kwargs.text;
         const model = kwargs.model;
-        const timeout = parseInt(kwargs.timeout, 10) || 30;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         // Switch model before sending if requested
         if (model) {
             activateChatGPT();

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getChatGPTVisibleImageUrls, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
@@ -69,7 +69,10 @@ export const imageCommand = cli({
         const outputDir = resolveOutputDir(kwargs.op);
         const skipDownloadRaw = kwargs.sd;
         const skipDownload = skipDownloadRaw === '' || skipDownloadRaw === true || normalizeBooleanFlag(skipDownloadRaw);
-        const timeout = 120;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
 
         // Navigate to chatgpt.com/new with full reload to clear React sidebar state
         await page.goto(`https://${CHATGPT_DOMAIN}/new`, { settleMs: 2000 });

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -57,11 +57,11 @@ export const imageCommand = cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 240,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to ChatGPT' },
         { name: 'op', help: 'Output directory (default: ~/Pictures/chatgpt)' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show ChatGPT link' },
+        { name: 'timeout', type: 'int', required: false, default: 240, help: 'Max seconds for the overall command (default: 240)' },
     ],
     columns: ['status', 'file', 'link'],
     func: async (page, kwargs) => {

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -70,6 +70,7 @@ describe('chatgpt image failure contracts', () => {
             prompt: 'cat',
             op: '',
             sd: false,
+            timeout: 240,
         })).rejects.toMatchObject({
             code: 'EMPTY_RESULT',
             message: expect.stringContaining('chatgpt image returned no data'),
@@ -84,6 +85,7 @@ describe('chatgpt image failure contracts', () => {
             prompt: 'cat',
             op: '',
             sd: false,
+            timeout: 240,
         })).rejects.toMatchObject({
             code: 'COMMAND_EXEC',
             message: expect.stringContaining('Failed to export generated ChatGPT image assets'),

--- a/clis/chatwise/ask.js
+++ b/clis/chatwise/ask.js
@@ -4,7 +4,7 @@ import {
     buildChatwiseInjectTextJs,
     buildChatwiseMessageCountJs,
     buildChatwiseResponseAfterJs,
-    normalizeTimeout,
+    requirePositiveTimeout,
 } from './utils.js';
 export const askCommand = cli({
     site: 'chatwise',
@@ -16,12 +16,12 @@ export const askCommand = cli({
     browser: true,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
-        { name: 'timeout', required: false, help: 'Max seconds to wait (default: 30)', default: '30' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait (default: 30)', default: 30 },
     ],
     columns: ['Role', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const timeout = normalizeTimeout(kwargs.timeout);
+        const timeout = requirePositiveTimeout(kwargs.timeout);
         // Snapshot content length
         const beforeLen = await page.evaluate(buildChatwiseMessageCountJs());
         // Send message

--- a/clis/chatwise/composer.test.js
+++ b/clis/chatwise/composer.test.js
@@ -5,7 +5,7 @@ import {
     buildChatwiseInjectTextJs,
     buildChatwiseMessageCountJs,
     buildChatwiseResponseAfterJs,
-    normalizeTimeout,
+    requirePositiveTimeout,
     scoreChatwiseComposerCandidate,
     selectBestChatwiseComposer,
 } from './utils.js';
@@ -168,9 +168,9 @@ describe('chatwise composer selection', () => {
     });
 
     it('validates timeout explicitly', () => {
-        expect(normalizeTimeout(undefined)).toBe(30);
-        expect(() => normalizeTimeout('0')).toThrow(ArgumentError);
-        expect(() => normalizeTimeout('301')).toThrow(ArgumentError);
+        expect(requirePositiveTimeout(30)).toBe(30);
+        expect(() => requirePositiveTimeout('30')).toThrow(ArgumentError);
+        expect(() => requirePositiveTimeout(0)).toThrow(ArgumentError);
     });
 
     it('fails fast when ask times out instead of returning a System success row', async () => {

--- a/clis/chatwise/utils.js
+++ b/clis/chatwise/utils.js
@@ -3,14 +3,10 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 export const MESSAGE_WRAPPER_SELECTOR = '[class*="group/message"]';
 export const MIN_COMPOSER_SCORE = 120;
 
-export function normalizeTimeout(value, defaultSeconds = 30, maxSeconds = 300) {
-    const raw = value ?? defaultSeconds;
-    const timeout = Number(raw);
+export function requirePositiveTimeout(value) {
+    const timeout = value;
     if (!Number.isInteger(timeout) || timeout <= 0) {
-        throw new ArgumentError('timeout must be a positive integer', `Example: opencli chatwise ask "hello" --timeout ${defaultSeconds}`);
-    }
-    if (timeout > maxSeconds) {
-        throw new ArgumentError(`timeout must be <= ${maxSeconds}`, `Example: opencli chatwise ask "hello" --timeout ${maxSeconds}`);
+        throw new ArgumentError('--timeout must be a positive integer (seconds)');
     }
     return timeout;
 }

--- a/clis/claude/ask.js
+++ b/clis/claude/ask.js
@@ -15,7 +15,6 @@ export const askCommand = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    timeoutSeconds: 180,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response' },

--- a/clis/codex/ask.js
+++ b/clis/codex/ask.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { selectorError } from '@jackwener/opencli/errors';
-import { conversationSelectionArgs, openCodexConversation, parsePositiveIntegerOption } from './sidebar.js';
+import { ArgumentError, selectorError } from '@jackwener/opencli/errors';
+import { conversationSelectionArgs, openCodexConversation } from './sidebar.js';
 export const askCommand = cli({
     site: 'codex',
     name: 'ask',
@@ -11,13 +11,16 @@ export const askCommand = cli({
     browser: true,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
-        { name: 'timeout', required: false, help: 'Max seconds to wait for response (default: 60)', default: '60' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait for response (default: 60)', default: 60 },
         ...conversationSelectionArgs,
     ],
     columns: ['Role', 'Project', 'Conversation', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const timeout = parsePositiveIntegerOption(kwargs.timeout ?? '60', 'codex ask --timeout');
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         const selected = await openCodexConversation(page, kwargs);
         // Snapshot the current content length before sending
         const beforeLen = await page.evaluate(`

--- a/clis/cursor/ask.js
+++ b/clis/cursor/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { selectorError } from '@jackwener/opencli/errors';
+import { ArgumentError, selectorError } from '@jackwener/opencli/errors';
 export const askCommand = cli({
     site: 'cursor',
     name: 'ask',
@@ -10,12 +10,15 @@ export const askCommand = cli({
     browser: true,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
-        { name: 'timeout', required: false, help: 'Max seconds to wait for response (default: 30)', default: '30' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait for response (default: 30)', default: 30 },
     ],
     columns: ['Role', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const timeout = parseInt(kwargs.timeout, 10) || 30;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         // Count existing messages before sending
         const beforeCount = await page.evaluate(`
       document.querySelectorAll('[data-message-role]').length

--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -15,7 +15,6 @@ export const askCommand = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    timeoutSeconds: 180,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response' },

--- a/clis/deepseek/send.js
+++ b/clis/deepseek/send.js
@@ -19,6 +19,7 @@ export const sendCommand = cli({
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
+        { name: 'timeout', type: 'int', required: false, default: 60, help: 'Max seconds for the overall command (default: 60)' },
     ],
     columns: ['Status', 'InjectedText'],
     func: async (page, kwargs) => {

--- a/clis/deepseek/send.js
+++ b/clis/deepseek/send.js
@@ -16,7 +16,6 @@ export const sendCommand = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    timeoutSeconds: 60,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },

--- a/clis/deepseek/send.test.js
+++ b/clis/deepseek/send.test.js
@@ -29,7 +29,8 @@ describe('deepseek send', () => {
     expect(command.strategy).toBe('cookie');
     expect(command.access).toBe('write');
     expect(command.columns).toEqual(['Status', 'InjectedText']);
-    expect(command.args.map((a) => a.name)).toEqual(['id', 'prompt']);
+    expect(command.args.map((a) => a.name)).toEqual(['id', 'prompt', 'timeout']);
+    expect(command.args.find((a) => a.name === 'timeout')).toMatchObject({ type: 'int', default: 60 });
   });
 
   it('rejects malformed conversation IDs before any browser navigation', async () => {

--- a/clis/doubao/ask.js
+++ b/clis/doubao/ask.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { DOUBAO_DOMAIN, getDoubaoTranscriptLines, getDoubaoVisibleTurns, sendDoubaoMessage, waitForDoubaoResponse } from './utils.js';
 export const askCommand = cli({
     site: 'doubao',
@@ -11,12 +12,15 @@ export const askCommand = cli({
     navigateBefore: false,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
-        { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait (default: 60)', default: 60 },
     ],
     columns: ['Role', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const timeout = parseInt(kwargs.timeout, 10) || 60;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         const beforeTurns = await getDoubaoVisibleTurns(page);
         const beforeLines = await getDoubaoTranscriptLines(page);
         await sendDoubaoMessage(page, text);

--- a/clis/doubao/ask.js
+++ b/clis/doubao/ask.js
@@ -9,7 +9,6 @@ export const askCommand = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    timeoutSeconds: 180,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },
         { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { GEMINI_DOMAIN, readGeminiSnapshot, sendGeminiMessage, startNewGeminiChat, waitForGeminiResponse, waitForGeminiSubmission } from './utils.js';
 function normalizeBooleanFlag(value) {
     if (typeof value === 'boolean')
@@ -19,13 +20,16 @@ export const askCommand = cli({
     defaultFormat: 'plain',
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
-        { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait (default: 60)', default: 60 },
         { name: 'new', required: false, help: 'Start a new chat first (true/false, default: false)', default: 'false' },
     ],
     columns: ['response'],
     func: async (page, kwargs) => {
         const prompt = kwargs.prompt;
-        const timeout = parseInt(kwargs.timeout, 10) || 60;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         const startFresh = normalizeBooleanFlag(kwargs.new);
         if (startFresh)
             await startNewGeminiChat(page);

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -17,7 +17,6 @@ export const askCommand = cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 180,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
         { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },

--- a/clis/gemini/ask.test.js
+++ b/clis/gemini/ask.test.js
@@ -79,7 +79,7 @@ describe('gemini ask orchestration', () => {
         mocks.sendGeminiMessage.mockResolvedValueOnce('button');
         mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
         mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
-        const result = await askCommand.func(page, { prompt: '请只回复：OK', timeout: '20', new: 'false' });
+        const result = await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
         expect(mocks.readGeminiSnapshot).toHaveBeenCalledWith(page);
         expect(mocks.waitForGeminiSubmission).toHaveBeenCalledWith(page, baseline, 20);
         expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 18);
@@ -94,7 +94,7 @@ describe('gemini ask orchestration', () => {
         mocks.sendGeminiMessage.mockResolvedValueOnce('button');
         mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
         mocks.waitForGeminiResponse.mockResolvedValueOnce('');
-        await askCommand.func(page, { prompt: '请只回复：OK', timeout: '20', new: 'false' });
+        await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
         expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 0);
     });
 });

--- a/clis/gemini/deep-research-result.js
+++ b/clis/gemini/deep-research-result.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { GEMINI_DOMAIN, clickGeminiConversationByTitle, exportGeminiDeepResearchReport, getLatestGeminiAssistantResponse, getGeminiPageState, parseGeminiConversationUrl, parseGeminiTitleMatchMode, readGeminiSnapshot, resolveGeminiConversationForQuery, waitForGeminiTranscript, getGeminiConversationList, } from './utils.js';
 const DEEP_RESEARCH_WAITING_MESSAGE = 'Deep Research is still running. Please wait and retry later.';
 const DEEP_RESEARCH_NO_DOCS_MESSAGE = 'No Docs URL found. Please check Share & Export -> Export to Docs in Gemini UI.';
@@ -54,8 +55,10 @@ export const deepResearchResultCommand = cli({
     func: async (page, kwargs) => {
         const query = String(kwargs.query ?? '').trim();
         const matchMode = parseGeminiTitleMatchMode(kwargs.match);
-        const timeoutRaw = Number.parseInt(String(kwargs.timeout ?? ''), 10);
-        const timeoutSeconds = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : 120;
+        const timeoutSeconds = kwargs.timeout;
+        if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         if (!matchMode) {
             return [{ response: 'Invalid match mode. Use contains or exact.' }];
         }

--- a/clis/gemini/deep-research-result.test.js
+++ b/clis/gemini/deep-research-result.test.js
@@ -53,52 +53,53 @@ describe('gemini/deep-research-result', () => {
             structuredTurnsTrusted: true,
         });
     });
+    const runCommand = (kwargs) => deepResearchResultCommand.func(page, { timeout: 120, ...kwargs });
     it('uses latest conversation when query is empty', async () => {
-        const result = await deepResearchResultCommand.func(page, { query: '   ' });
+        const result = await runCommand({ query: '   ' });
         expect(page.goto).toHaveBeenCalledWith('https://gemini.google.com/app/abc', { waitUntil: 'load', settleMs: 2500 });
         expect(result).toEqual([{ response: 'https://files.example.com/report.md' }]);
     });
     it('falls back to current page response when query is empty and sidebar has no conversations', async () => {
         mockGetGeminiConversationList.mockResolvedValue([]);
         mockResolveGeminiConversationForQuery.mockReturnValue(null);
-        const result = await deepResearchResultCommand.func(page, { query: '' });
+        const result = await runCommand({ query: '' });
         expect(page.goto).not.toHaveBeenCalled();
         expect(result).toEqual([{ response: 'https://files.example.com/report.md' }]);
     });
     it('returns a validation message when match mode is invalid', async () => {
-        const result = await deepResearchResultCommand.func(page, { query: 'A', match: 'prefix' });
+        const result = await runCommand({ query: 'A', match: 'prefix' });
         expect(result).toEqual([{ response: 'Invalid match mode. Use contains or exact.' }]);
     });
     it('returns a signed-out message when Gemini page state indicates logged out', async () => {
         mockGetGeminiPageState.mockResolvedValue({ isSignedIn: false });
-        const result = await deepResearchResultCommand.func(page, { query: 'A' });
+        const result = await runCommand({ query: 'A' });
         expect(result).toEqual([{ response: 'Not signed in to Gemini.' }]);
     });
     it('opens matched conversation by URL and returns exported report url', async () => {
-        const result = await deepResearchResultCommand.func(page, { query: 'A title', match: 'exact' });
+        const result = await runCommand({ query: 'A title', match: 'exact' });
         expect(page.goto).toHaveBeenCalledWith('https://gemini.google.com/app/abc', { waitUntil: 'load', settleMs: 2500 });
         expect(result).toEqual([{ response: 'https://files.example.com/report.md' }]);
     });
     it('accepts a direct conversation URL and reads response from that page', async () => {
         const url = 'https://gemini.google.com/app/direct-id';
-        const result = await deepResearchResultCommand.func(page, { query: url, match: 'contains' });
+        const result = await runCommand({ query: url, match: 'contains' });
         expect(page.goto).toHaveBeenCalledWith(url, { waitUntil: 'load', settleMs: 2500 });
         expect(result).toEqual([{ response: 'https://files.example.com/report.md' }]);
     });
     it('passes query and mode into resolveGeminiConversationForQuery', async () => {
-        const result = await deepResearchResultCommand.func(page, { query: 'title', match: 'contains' });
+        const result = await runCommand({ query: 'title', match: 'contains' });
         expect(mockResolveGeminiConversationForQuery).toHaveBeenCalledWith([{ Title: 'A title', Url: 'https://gemini.google.com/app/abc' }], 'title', 'contains');
         expect(result).toEqual([{ response: 'https://files.example.com/report.md' }]);
     });
     it('falls back to click-by-title and returns not-found when click fails', async () => {
         mockResolveGeminiConversationForQuery.mockReturnValue(null);
         mockClickGeminiConversationByTitle.mockResolvedValue(false);
-        const result = await deepResearchResultCommand.func(page, { query: 'missing', match: 'contains' });
+        const result = await runCommand({ query: 'missing', match: 'contains' });
         expect(result).toEqual([{ response: 'No conversation matched: missing' }]);
     });
     it('returns pending message when export url is unavailable and completion is not confirmed', async () => {
         mockExportGeminiDeepResearchReport.mockResolvedValue({ url: '', source: 'none' });
-        const result = await deepResearchResultCommand.func(page, { query: 'A title' });
+        const result = await runCommand({ query: 'A title' });
         expect(result).toEqual([{ response: 'Deep Research may still be running or preparing export. Please wait and retry later.' }]);
     });
     it('returns waiting message when deep research is still generating', async () => {
@@ -110,13 +111,13 @@ describe('gemini/deep-research-result', () => {
             isGenerating: true,
             structuredTurnsTrusted: true,
         });
-        const result = await deepResearchResultCommand.func(page, { query: 'A title' });
+        const result = await runCommand({ query: 'A title' });
         expect(result).toEqual([{ response: 'Deep Research is still running. Please wait and retry later.' }]);
     });
     it('returns waiting message when assistant response indicates research in progress', async () => {
         mockExportGeminiDeepResearchReport.mockResolvedValue({ url: '', source: 'none' });
         mockGetLatestGeminiAssistantResponse.mockResolvedValue('正在研究中，请稍候。');
-        const result = await deepResearchResultCommand.func(page, { query: 'A title' });
+        const result = await runCommand({ query: 'A title' });
         expect(result).toEqual([{ response: 'Deep Research is still running. Please wait and retry later.' }]);
     });
     it('returns waiting message when transcript indicates in-progress status', async () => {
@@ -129,7 +130,7 @@ describe('gemini/deep-research-result', () => {
             isGenerating: false,
             structuredTurnsTrusted: true,
         });
-        const result = await deepResearchResultCommand.func(page, { query: 'A title' });
+        const result = await runCommand({ query: 'A title' });
         expect(result).toEqual([{ response: 'Deep Research is still running. Please wait and retry later.' }]);
     });
     it('returns no-docs message when text indicates completed state', async () => {
@@ -142,13 +143,13 @@ describe('gemini/deep-research-result', () => {
             isGenerating: false,
             structuredTurnsTrusted: true,
         });
-        const result = await deepResearchResultCommand.func(page, { query: 'A title' });
+        const result = await runCommand({ query: 'A title' });
         expect(result).toEqual([{ response: 'No Docs URL found. Please check Share & Export -> Export to Docs in Gemini UI.' }]);
     });
     it('returns pending message when assistant response is empty', async () => {
         mockExportGeminiDeepResearchReport.mockResolvedValue({ url: '', source: 'none' });
         mockGetLatestGeminiAssistantResponse.mockResolvedValue('');
-        const result = await deepResearchResultCommand.func(page, { query: 'A title' });
+        const result = await runCommand({ query: 'A title' });
         expect(result).toEqual([{ response: 'Deep Research may still be running or preparing export. Please wait and retry later.' }]);
     });
 });

--- a/clis/gemini/deep-research.js
+++ b/clis/gemini/deep-research.js
@@ -24,10 +24,9 @@ export const deepResearchCommand = cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 180,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },
-        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait for confirm (default: 30)', default: 30 },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds for the overall command (default: 180; confirm-wait clamps internally to 6-20s)', default: 180 },
         { name: 'tool', required: false, help: 'Override tool label (default: Deep Research)' },
         { name: 'confirm', required: false, help: 'Override confirm button label (default: Start research)' },
     ],

--- a/clis/gemini/deep-research.js
+++ b/clis/gemini/deep-research.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { GEMINI_DEEP_RESEARCH_DEFAULT_CONFIRM_LABELS, GEMINI_DEEP_RESEARCH_DEFAULT_TOOL_LABELS, GEMINI_APP_URL, GEMINI_DOMAIN, getCurrentGeminiUrl, getLatestGeminiAssistantResponse, parseGeminiPositiveInt, readGeminiSnapshot, resolveGeminiLabels, selectGeminiTool, sendGeminiMessage, startNewGeminiChat, waitForGeminiSubmission, waitForGeminiConfirmButton, } from './utils.js';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { GEMINI_DEEP_RESEARCH_DEFAULT_CONFIRM_LABELS, GEMINI_DEEP_RESEARCH_DEFAULT_TOOL_LABELS, GEMINI_APP_URL, GEMINI_DOMAIN, getCurrentGeminiUrl, getLatestGeminiAssistantResponse, readGeminiSnapshot, resolveGeminiLabels, selectGeminiTool, sendGeminiMessage, startNewGeminiChat, waitForGeminiSubmission, waitForGeminiConfirmButton, } from './utils.js';
 function isGeminiRootAppUrl(url) {
     try {
         const parsed = new URL(url);
@@ -33,7 +34,10 @@ export const deepResearchCommand = cli({
     columns: ['status', 'url'],
     func: async (page, kwargs) => {
         const prompt = kwargs.prompt;
-        const timeout = parseGeminiPositiveInt(kwargs.timeout, 30);
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         const submitTimeout = Math.min(Math.max(timeout, 6), 20);
         await startNewGeminiChat(page);
         const toolLabels = resolveGeminiLabels(kwargs.tool, GEMINI_DEEP_RESEARCH_DEFAULT_TOOL_LABELS);

--- a/clis/gemini/deep-research.test.js
+++ b/clis/gemini/deep-research.test.js
@@ -28,10 +28,6 @@ vi.mock('./utils.js', () => ({
         '\u751f\u6210\u7814\u7a76\u8ba1\u5212',
         '\u751f\u6210\u8c03\u7814\u8ba1\u5212',
     ],
-    parseGeminiPositiveInt: (value, fallback) => {
-        const parsed = Number.parseInt(String(value ?? ''), 10);
-        return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-    },
     resolveGeminiLabels: (value, fallback) => {
         const label = String(value ?? '').trim();
         return label ? [label] : fallback;
@@ -48,6 +44,7 @@ vi.mock('./utils.js', () => ({
 import { deepResearchCommand } from './deep-research.js';
 describe('gemini/deep-research', () => {
     const page = {};
+    const runCommand = (kwargs) => deepResearchCommand.func(page, { timeout: 180, ...kwargs });
     beforeEach(() => {
         vi.clearAllMocks();
         mockGetCurrentGeminiUrl.mockResolvedValue('https://gemini.google.com/app/chat');
@@ -71,17 +68,17 @@ describe('gemini/deep-research', () => {
         mockGetLatestGeminiAssistantResponse.mockResolvedValue('');
     });
     it('starts a new chat by default, then sends prompt and confirms deep research', async () => {
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(mockStartNewGeminiChat).toHaveBeenCalledTimes(1);
         expect(mockSelectGeminiTool).toHaveBeenCalledTimes(1);
         expect(mockSendGeminiMessage).toHaveBeenCalledWith(page, 'research this topic');
         expect(mockWaitForGeminiSubmission).toHaveBeenCalledTimes(1);
-        expect(mockWaitForGeminiConfirmButton).toHaveBeenCalledWith(page, expect.arrayContaining(['Start research', 'Start deep research', 'Generate research plan', '\u751f\u6210\u7814\u7a76\u8ba1\u5212']), 30);
+        expect(mockWaitForGeminiConfirmButton).toHaveBeenCalledWith(page, expect.arrayContaining(['Start research', 'Start deep research', 'Generate research plan', '\u751f\u6210\u7814\u7a76\u8ba1\u5212']), 180);
         expect(result).toEqual([{ status: 'started', url: 'https://gemini.google.com/app/chat' }]);
     });
     it('returns tool-not-found when the tool cannot be selected', async () => {
         mockSelectGeminiTool.mockResolvedValue('');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(result).toEqual([{ status: 'tool-not-found', url: 'https://gemini.google.com/app/chat' }]);
         expect(mockSendGeminiMessage).not.toHaveBeenCalled();
         expect(mockWaitForGeminiSubmission).not.toHaveBeenCalled();
@@ -94,7 +91,7 @@ describe('gemini/deep-research', () => {
             userAnchorTurn: null,
             reason: 'user_turn',
         });
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(mockSelectGeminiTool).toHaveBeenCalledTimes(2);
         expect(mockReadGeminiSnapshot).toHaveBeenCalledTimes(2);
         expect(mockSendGeminiMessage).toHaveBeenCalledTimes(2);
@@ -103,7 +100,7 @@ describe('gemini/deep-research', () => {
     });
     it('returns submit-not-found when submission cannot be confirmed after retry', async () => {
         mockWaitForGeminiSubmission.mockResolvedValue(null);
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(mockSelectGeminiTool).toHaveBeenCalledTimes(2);
         expect(mockSendGeminiMessage).toHaveBeenCalledTimes(2);
         expect(mockWaitForGeminiConfirmButton).not.toHaveBeenCalled();
@@ -111,27 +108,27 @@ describe('gemini/deep-research', () => {
     });
     it('returns confirm-not-found when no confirm button is found', async () => {
         mockWaitForGeminiConfirmButton.mockResolvedValue('');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(result).toEqual([{ status: 'confirm-not-found', url: 'https://gemini.google.com/app/chat' }]);
     });
     it('returns started when confirm is missing but research appears to be running', async () => {
         mockWaitForGeminiConfirmButton.mockResolvedValue('');
         mockGetCurrentGeminiUrl.mockResolvedValue('https://gemini.google.com/app/abc123');
         mockGetLatestGeminiAssistantResponse.mockResolvedValue('Researching websites now');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(result).toEqual([{ status: 'started', url: 'https://gemini.google.com/app/abc123' }]);
     });
     it('does not treat conversation url alone as started when confirm is missing', async () => {
         mockWaitForGeminiConfirmButton.mockResolvedValue('');
         mockGetCurrentGeminiUrl.mockResolvedValue('https://gemini.google.com/app/abc999');
         mockGetLatestGeminiAssistantResponse.mockResolvedValue('I drafted a plan. Start research');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic' });
+        const result = await runCommand({ prompt: 'research this topic' });
         expect(result).toEqual([{ status: 'confirm-not-found', url: 'https://gemini.google.com/app/abc999' }]);
     });
     it('retries once when stuck on root app URL and starts successfully on second confirm', async () => {
         mockWaitForGeminiConfirmButton.mockResolvedValueOnce('').mockResolvedValueOnce('Start research');
         mockGetCurrentGeminiUrl.mockResolvedValueOnce('https://gemini.google.com/app').mockResolvedValueOnce('https://gemini.google.com/app/retry123');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic', timeout: '20' });
+        const result = await runCommand({ prompt: 'research this topic', timeout: 20 });
         expect(mockSelectGeminiTool).toHaveBeenCalledTimes(2);
         expect(mockSendGeminiMessage).toHaveBeenCalledTimes(1);
         expect(mockWaitForGeminiConfirmButton).toHaveBeenCalledTimes(2);
@@ -140,7 +137,7 @@ describe('gemini/deep-research', () => {
     it('treats root-url confirm as false-positive and retries', async () => {
         mockWaitForGeminiConfirmButton.mockResolvedValueOnce('Start research').mockResolvedValueOnce('Start research');
         mockGetCurrentGeminiUrl.mockResolvedValueOnce('https://gemini.google.com/app').mockResolvedValueOnce('https://gemini.google.com/app/retry456');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic', timeout: '20' });
+        const result = await runCommand({ prompt: 'research this topic', timeout: 20 });
         expect(mockSelectGeminiTool).toHaveBeenCalledTimes(2);
         expect(mockSendGeminiMessage).toHaveBeenCalledTimes(1);
         expect(result).toEqual([{ status: 'started', url: 'https://gemini.google.com/app/retry456' }]);
@@ -149,7 +146,7 @@ describe('gemini/deep-research', () => {
         mockWaitForGeminiConfirmButton.mockResolvedValueOnce('Start research').mockResolvedValueOnce('');
         mockGetCurrentGeminiUrl.mockResolvedValueOnce('https://gemini.google.com/app').mockResolvedValueOnce('https://gemini.google.com/app');
         mockGetLatestGeminiAssistantResponse.mockResolvedValue('');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic', timeout: '20' });
+        const result = await runCommand({ prompt: 'research this topic', timeout: 20 });
         expect(mockSelectGeminiTool).toHaveBeenCalledTimes(2);
         expect(mockSendGeminiMessage).toHaveBeenCalledTimes(1);
         expect(mockWaitForGeminiConfirmButton).toHaveBeenCalledTimes(2);
@@ -165,18 +162,18 @@ describe('gemini/deep-research', () => {
         mockGetLatestGeminiAssistantResponse
             .mockResolvedValueOnce('I drafted a plan. Start research')
             .mockResolvedValueOnce('Researching websites now');
-        const result = await deepResearchCommand.func(page, { prompt: 'research this topic', timeout: '20' });
+        const result = await runCommand({ prompt: 'research this topic', timeout: 20 });
         expect(mockWaitForGeminiConfirmButton).toHaveBeenCalledTimes(2);
         expect(mockWaitForGeminiConfirmButton).toHaveBeenNthCalledWith(2, page, expect.arrayContaining(['Start research', 'Start deep research', '开始研究', '开始深度研究']), 8);
         expect(mockSendGeminiMessage).toHaveBeenCalledTimes(1);
         expect(result).toEqual([{ status: 'started', url: 'https://gemini.google.com/app/xyz123' }]);
     });
     it('uses custom tool/confirm labels when provided', async () => {
-        await deepResearchCommand.func(page, {
+        await runCommand({
             prompt: 'research this topic',
             tool: 'Custom Tool',
             confirm: 'Custom Confirm',
-            timeout: '42',
+            timeout: 42,
         });
         expect(mockSelectGeminiTool).toHaveBeenCalledWith(page, ['Custom Tool']);
         expect(mockWaitForGeminiConfirmButton).toHaveBeenCalledWith(page, ['Custom Confirm'], 42);

--- a/clis/gemini/image.js
+++ b/clis/gemini/image.js
@@ -2,6 +2,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { GEMINI_DOMAIN, exportGeminiImages, getGeminiVisibleImageUrls, sendGeminiMessage, startNewGeminiChat, waitForGeminiImages } from './utils.js';
 function extFromMime(mime) {
     if (mime.includes('png'))
@@ -67,7 +68,10 @@ export const imageCommand = cli({
         const ratio = normalizeRatio(String(kwargs.rt ?? '1:1'));
         const style = String(kwargs.st ?? '').trim();
         const outputDir = kwargs.op || path.join(os.homedir(), 'tmp', 'gemini-images');
-        const timeout = 120;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         const startFresh = true;
         const skipDownloadRaw = kwargs.sd;
         const skipDownload = skipDownloadRaw === '' || skipDownloadRaw === true || normalizeBooleanFlag(skipDownloadRaw);

--- a/clis/gemini/image.js
+++ b/clis/gemini/image.js
@@ -53,13 +53,13 @@ export const imageCommand = cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 240,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to Gemini' },
         { name: 'rt', default: '1:1', help: 'Ratio shorthand for aspect ratio (1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3)' },
         { name: 'st', default: '', help: 'Style shorthand, e.g. anime, icon, watercolor' },
         { name: 'op', default: '~/tmp/gemini-images', help: 'Output directory shorthand' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show Gemini page link' },
+        { name: 'timeout', type: 'int', required: false, default: 240, help: 'Max seconds for the overall command (default: 240)' },
     ],
     columns: ['status', 'file', 'link'],
     func: async (page, kwargs) => {

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -78,10 +78,6 @@ export function resolveGeminiLabels(value, fallback) {
     const label = String(value ?? '').trim();
     return label ? [label] : fallback;
 }
-export function parseGeminiPositiveInt(value, fallback) {
-    const parsed = Number.parseInt(String(value ?? ''), 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
 export function parseGeminiTitleMatchMode(value, fallback = 'contains') {
     const raw = String(value ?? fallback).trim().toLowerCase();
     if (raw === 'contains' || raw === 'exact')

--- a/clis/instagram/note.js
+++ b/clis/instagram/note.js
@@ -203,9 +203,9 @@ cli({
     domain: 'www.instagram.com',
     strategy: Strategy.UI,
     browser: true,
-    timeoutSeconds: 120,
     args: [
         { name: 'content', positional: true, required: true, help: 'Note text (max 60 characters)' },
+        { name: 'timeout', type: 'int', required: false, default: 120, help: 'Max seconds for the overall command (default: 120)' },
     ],
     columns: ['status', 'detail', 'noteId'],
     validateArgs: validateInstagramNoteArgs,

--- a/clis/instagram/post.js
+++ b/clis/instagram/post.js
@@ -1402,10 +1402,10 @@ cli({
     domain: 'www.instagram.com',
     strategy: Strategy.UI,
     browser: true,
-    timeoutSeconds: 300,
     args: [
         { name: 'media', required: false, valueRequired: true, help: `Comma-separated media paths (images/videos, up to ${MAX_MEDIA_ITEMS})` },
         { name: 'content', positional: true, required: false, help: 'Caption text' },
+        { name: 'timeout', type: 'int', required: false, default: 300, help: 'Max seconds for the overall command (default: 300)' },
     ],
     columns: ['status', 'detail', 'url'],
     validateArgs: validateInstagramPostArgs,

--- a/clis/instagram/post.test.js
+++ b/clis/instagram/post.test.js
@@ -370,7 +370,7 @@ describe('instagram post registration', () => {
         const cmd = getRegistry().get('instagram/post');
         expect(cmd).toBeDefined();
         expect(cmd?.browser).toBe(true);
-        expect(cmd?.timeoutSeconds).toBe(300);
+        expect(cmd?.args.some((arg) => arg.name === 'timeout' && arg.default === 300)).toBe(true);
         expect(cmd?.args.some((arg) => arg.name === 'media' && !arg.required && arg.valueRequired)).toBe(true);
         expect(cmd?.args.some((arg) => arg.name === 'content' && !arg.required && arg.positional)).toBe(true);
     });

--- a/clis/instagram/reel.js
+++ b/clis/instagram/reel.js
@@ -737,10 +737,10 @@ cli({
     domain: 'www.instagram.com',
     strategy: Strategy.UI,
     browser: true,
-    timeoutSeconds: INSTAGRAM_REEL_TIMEOUT_SECONDS,
     args: [
         { name: 'video', required: false, valueRequired: true, help: 'Path to a single .mp4 video file' },
         { name: 'content', positional: true, required: false, help: 'Caption text' },
+        { name: 'timeout', type: 'int', required: false, default: INSTAGRAM_REEL_TIMEOUT_SECONDS, help: `Max seconds for the overall command (default: ${INSTAGRAM_REEL_TIMEOUT_SECONDS})` },
     ],
     columns: ['status', 'detail', 'url'],
     validateArgs: validateInstagramReelArgs,

--- a/clis/instagram/story.js
+++ b/clis/instagram/story.js
@@ -87,9 +87,9 @@ cli({
     domain: 'www.instagram.com',
     strategy: Strategy.UI,
     browser: true,
-    timeoutSeconds: 300,
     args: [
         { name: 'media', required: false, valueRequired: true, help: 'Path to a single story image or video file' },
+        { name: 'timeout', type: 'int', required: false, default: 300, help: 'Max seconds for the overall command (default: 300)' },
     ],
     columns: ['status', 'detail', 'url'],
     validateArgs: validateInstagramStoryArgs,

--- a/clis/paperreview/feedback.js
+++ b/clis/paperreview/feedback.js
@@ -9,13 +9,13 @@ cli({
     domain: PAPERREVIEW_DOMAIN,
     strategy: Strategy.PUBLIC,
     browser: false,
-    timeoutSeconds: 30,
     args: [
         { name: 'token', positional: true, required: true, help: 'Review token returned by paperreview.ai' },
         { name: 'helpfulness', required: true, type: 'int', help: 'Helpfulness score from 1 to 5' },
         { name: 'critical-error', required: true, choices: ['yes', 'no'], help: 'Whether the review contains a critical error' },
         { name: 'actionable-suggestions', required: true, choices: ['yes', 'no'], help: 'Whether the review contains actionable suggestions' },
         { name: 'additional-comments', help: 'Optional free-text feedback' },
+        { name: 'timeout', type: 'int', required: false, default: 30, help: 'Max seconds for the overall command (default: 30)' },
     ],
     columns: ['status', 'token', 'helpfulness', 'critical_error', 'actionable_suggestions', 'message'],
     func: async (kwargs) => {

--- a/clis/paperreview/review.js
+++ b/clis/paperreview/review.js
@@ -9,9 +9,9 @@ cli({
     domain: PAPERREVIEW_DOMAIN,
     strategy: Strategy.PUBLIC,
     browser: false,
-    timeoutSeconds: 30,
     args: [
         { name: 'token', positional: true, required: true, help: 'Review token returned by paperreview.ai' },
+        { name: 'timeout', type: 'int', required: false, default: 30, help: 'Max seconds for the overall command (default: 30)' },
     ],
     columns: ['status', 'title', 'venue', 'numerical_score', 'has_feedback', 'review_url'],
     func: async (kwargs) => {

--- a/clis/paperreview/submit.js
+++ b/clis/paperreview/submit.js
@@ -9,13 +9,13 @@ cli({
     domain: PAPERREVIEW_DOMAIN,
     strategy: Strategy.PUBLIC,
     browser: false,
-    timeoutSeconds: 120,
     args: [
         { name: 'pdf', positional: true, required: true, help: 'Path to the paper PDF' },
         { name: 'email', required: true, help: 'Email address for the submission' },
         { name: 'venue', help: 'Optional target venue such as ICLR or NeurIPS' },
         { name: 'dry-run', type: 'bool', default: false, help: 'Validate the input and stop before remote submission' },
         { name: 'prepare-only', type: 'bool', default: false, help: 'Request an upload slot but stop before uploading the PDF' },
+        { name: 'timeout', type: 'int', required: false, default: 120, help: 'Max seconds for the overall command (default: 120)' },
     ],
     columns: ['status', 'file', 'email', 'venue', 'token', 'review_url', 'message'],
     footerExtra: (kwargs) => {

--- a/clis/quark/mv.js
+++ b/clis/quark/mv.js
@@ -9,11 +9,11 @@ cli({
     domain: 'pan.quark.cn',
     strategy: Strategy.COOKIE,
     defaultFormat: 'json',
-    timeoutSeconds: 120,
     args: [
         { name: 'fids', required: true, positional: true, help: 'File IDs to move (comma-separated)' },
         { name: 'to', default: '', help: 'Destination folder path (required unless --to-fid is set)' },
         { name: 'to-fid', default: '', help: 'Destination folder ID (overrides --to)' },
+        { name: 'timeout', type: 'int', required: false, default: 120, help: 'Max seconds for the overall command (default: 120)' },
     ],
     func: async (page, kwargs) => {
         const to = kwargs.to;

--- a/clis/quark/save.js
+++ b/clis/quark/save.js
@@ -21,7 +21,6 @@ cli({
     domain: 'pan.quark.cn',
     strategy: Strategy.COOKIE,
     defaultFormat: 'json',
-    timeoutSeconds: 120,
     args: [
         { name: 'url', required: true, positional: true, help: 'Quark share URL or pwd_id' },
         { name: 'to', default: '', help: 'Destination folder path' },
@@ -29,6 +28,7 @@ cli({
         { name: 'fids', default: '', help: 'File IDs to save (comma-separated, from share-tree). Omit to save all.' },
         { name: 'stoken', default: '', help: 'Share token (from share-tree output, required with --fids)' },
         { name: 'passcode', default: '', help: 'Share passcode (if required)' },
+        { name: 'timeout', type: 'int', required: false, default: 120, help: 'Max seconds for the overall command (default: 120)' },
     ],
     func: async (page, kwargs) => {
         const url = kwargs.url;

--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -26,7 +26,6 @@ cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 240,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send to Qianwen' },
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for the response' },

--- a/clis/qwen/image.js
+++ b/clis/qwen/image.js
@@ -101,7 +101,6 @@ cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 300,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Image prompt to send' },
         { name: 'op', default: '~/Pictures/qianwen', help: 'Output directory' },

--- a/clis/twitter/accept.js
+++ b/clis/twitter/accept.js
@@ -8,10 +8,10 @@ cli({
     domain: 'x.com',
     strategy: Strategy.UI,
     browser: true,
-    timeoutSeconds: 600, // 10 min — batch operation iterating many conversations
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: 'Keywords to match (comma-separated for OR, e.g. "群,微信")' },
         { name: 'max', type: 'int', required: false, default: 20, help: 'Maximum number of requests to accept (default: 20)' },
+        { name: 'timeout', type: 'int', required: false, default: 600, help: 'Max seconds for the overall command (default: 600 — batch op)' },
     ],
     columns: ['index', 'status', 'user', 'message'],
     func: async (page, kwargs) => {

--- a/clis/twitter/reply-dm.js
+++ b/clis/twitter/reply-dm.js
@@ -8,11 +8,11 @@ cli({
     domain: 'x.com',
     strategy: Strategy.UI,
     browser: true,
-    timeoutSeconds: 600, // 10 min — batch operation
     args: [
         { name: 'text', type: 'string', required: true, positional: true, help: 'Message text to send (e.g. "我的微信 wxkabi")' },
         { name: 'max', type: 'int', required: false, default: 20, help: 'Maximum number of conversations to reply to (default: 20)' },
         { name: 'skip-replied', type: 'boolean', required: false, default: true, help: 'Skip conversations where you already sent the same text (default: true)' },
+        { name: 'timeout', type: 'int', required: false, default: 600, help: 'Max seconds for the overall command (default: 600 — batch op)' },
     ],
     columns: ['index', 'status', 'user', 'message'],
     func: async (page, kwargs) => {

--- a/clis/weixin/create-draft.js
+++ b/clis/weixin/create-draft.js
@@ -179,13 +179,13 @@ export const createDraftCommand = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    timeoutSeconds: 180,
     args: [
         { name: 'title', required: true, help: '文章标题 (最长64字)' },
         { name: 'content', required: true, positional: true, help: '文章正文' },
         { name: 'author', help: '作者名 (最长8字)' },
         { name: 'cover-image', help: '封面图片路径 (会先上传到正文再设为封面)' },
         { name: 'summary', help: '文章摘要' },
+        { name: 'timeout', type: 'int', required: false, default: 180, help: 'Max seconds for the overall command (default: 180)' },
     ],
     columns: ['status', 'detail'],
 

--- a/clis/weixin/drafts.js
+++ b/clis/weixin/drafts.js
@@ -12,7 +12,6 @@ export const draftsCommand = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    timeoutSeconds: 60,
     args: [
         { name: 'limit', type: 'int', default: 10, help: '最多显示条数' },
     ],

--- a/clis/weixin/drafts.js
+++ b/clis/weixin/drafts.js
@@ -14,6 +14,7 @@ export const draftsCommand = cli({
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 10, help: '最多显示条数' },
+        { name: 'timeout', type: 'int', required: false, default: 60, help: 'Max seconds for the overall command (default: 60)' },
     ],
     columns: ['Index', 'Title', 'Time'],
 

--- a/clis/weixin/drafts.test.js
+++ b/clis/weixin/drafts.test.js
@@ -19,7 +19,9 @@ describe('weixin command registration', () => {
         const registry = getRegistry();
         const values = [...registry.values()];
         expect(values.find(c => c.site === 'weixin' && c.name === 'create-draft')).toBeDefined();
-        expect(values.find(c => c.site === 'weixin' && c.name === 'drafts')).toBeDefined();
+        const draftsCommand = values.find(c => c.site === 'weixin' && c.name === 'drafts');
+        expect(draftsCommand).toBeDefined();
+        expect(draftsCommand.args.find((arg) => arg.name === 'timeout')).toMatchObject({ type: 'int', default: 60 });
         expect(values.find(c => c.site === 'weixin' && c.name === 'search')).toBeDefined();
     });
 });

--- a/clis/xiaohongshu/creator-notes-summary.js
+++ b/clis/xiaohongshu/creator-notes-summary.js
@@ -54,9 +54,9 @@ cli({
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 3, help: 'Number of recent notes to summarize' },
+        { name: 'timeout', type: 'int', required: false, default: 180, help: 'Max seconds for the overall command (default: 180)' },
     ],
     columns: ['rank', 'id', 'title', 'views', 'likes', 'collects', 'comments', 'shares', 'avg_view_time', 'rise_fans', 'top_source', 'top_interest', 'url'],
-    timeoutSeconds: 180,
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 3;
         const notes = await fetchCreatorNotes(page, limit);

--- a/clis/yuanbao/ask.js
+++ b/clis/yuanbao/ask.js
@@ -359,7 +359,6 @@ export const askCommand = cli({
     browser: true,
     navigateBefore: false,
     defaultFormat: 'plain',
-    timeoutSeconds: 180,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
         { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },

--- a/clis/yuanbao/ask.js
+++ b/clis/yuanbao/ask.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { htmlToMarkdown } from '@jackwener/opencli/utils';
-import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { YUANBAO_DOMAIN, IS_VISIBLE_JS, authRequired, isOnYuanbao, ensureYuanbaoPage, hasLoginGate } from './shared.js';
 const YUANBAO_RESPONSE_POLL_INTERVAL_SECONDS = 2;
 const YUANBAO_MIN_WAIT_MS = 8_000;
@@ -361,14 +361,17 @@ export const askCommand = cli({
     defaultFormat: 'plain',
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
-        { name: 'timeout', required: false, help: 'Max seconds to wait (default: 60)', default: '60' },
+        { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait (default: 60)', default: 60 },
         { name: 'search', type: 'boolean', required: false, help: 'Enable Yuanbao internet search (default: true)', default: true },
         { name: 'think', type: 'boolean', required: false, help: 'Enable Yuanbao deep thinking (default: false)', default: false },
     ],
     columns: ['Role', 'Text'],
     func: async (page, kwargs) => {
         const prompt = kwargs.prompt;
-        const timeout = parseInt(kwargs.timeout, 10) || 60;
+        const timeout = kwargs.timeout;
+        if (!Number.isInteger(timeout) || timeout < 1) {
+            throw new ArgumentError('--timeout must be a positive integer (seconds)');
+        }
         const useSearch = normalizeBooleanFlag(kwargs.search, true);
         const useThink = normalizeBooleanFlag(kwargs.think, false);
         await ensureYuanbaoPage(page);

--- a/clis/yuanbao/ask.test.js
+++ b/clis/yuanbao/ask.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AuthRequiredError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { __test__ } from './ask.js';
 import { askCommand } from './ask.js';
 describe('yuanbao ask helpers', () => {
@@ -101,7 +101,7 @@ function createAskPageMock(overrides = {}) {
 describe('yuanbao ask command', () => {
     it('throws AuthRequiredError when Yuanbao shows a login gate before sending', async () => {
         const page = createAskPageMock({ hasLoginGate: true });
-        await expect(askCommand.func(page, { prompt: '你好', timeout: '60', search: true, think: false }))
+        await expect(askCommand.func(page, { prompt: '你好', timeout: 60, search: true, think: false }))
             .rejects.toBeInstanceOf(AuthRequiredError);
     });
     it('throws CommandExecutionError when the prompt cannot be sent', async () => {
@@ -111,14 +111,14 @@ describe('yuanbao ask command', () => {
                 reason: 'Yuanbao composer was not found.',
             },
         });
-        await expect(askCommand.func(page, { prompt: '你好', timeout: '60', search: true, think: false }))
+        await expect(askCommand.func(page, { prompt: '你好', timeout: 60, search: true, think: false }))
             .rejects.toBeInstanceOf(CommandExecutionError);
     });
     it('throws TimeoutError when no response arrives before timeout', async () => {
         const page = createAskPageMock({
             sendResult: { ok: true, action: 'click' },
         });
-        await expect(askCommand.func(page, { prompt: '你好', timeout: '-1', search: true, think: false }))
-            .rejects.toBeInstanceOf(TimeoutError);
+        await expect(askCommand.func(page, { prompt: '你好', timeout: -1, search: true, think: false }))
+            .rejects.toBeInstanceOf(ArgumentError);
     });
 });

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -115,7 +115,6 @@ function toManifestEntry(cmd: CliCommand, modulePath: string, sourceFile?: strin
     browser: cmd.browser ?? true,
     args: toManifestArgs(cmd.args),
     columns: cmd.columns,
-    timeout: cmd.timeoutSeconds,
     deprecated: cmd.deprecated,
     replacedBy: cmd.replacedBy,
     type: 'js',

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -131,7 +131,6 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
         args: entry.args ?? [],
         columns: entry.columns,
         pipeline: entry.pipeline,
-        timeoutSeconds: entry.timeout,
         source: entry.sourceFile ? path.resolve(clisDir, entry.sourceFile) : modulePath,
         deprecated: entry.deprecated,
         replacedBy: entry.replacedBy,

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -87,6 +87,63 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('applies the user --timeout arg as the ceiling for browser commands (with +30s padding)', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+    const runWithTimeoutSpy = vi.spyOn(runtime, 'runWithTimeout');
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-with-timeout', access: 'read',
+      description: 'test browser --timeout enforcement',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      args: [
+        { name: 'timeout', type: 'int', required: false, default: 5, help: 'Max seconds' },
+      ],
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+
+    expect(runWithTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(runWithTimeoutSpy.mock.calls[0]?.[1]).toMatchObject({
+      timeout: 35,
+      label: 'test-execution/browser-with-timeout',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to DEFAULT_BROWSER_COMMAND_TIMEOUT for browser commands without a --timeout arg', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+    const runWithTimeoutSpy = vi.spyOn(runtime, 'runWithTimeout');
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-no-timeout', access: 'read',
+      description: 'test browser fallback to global default',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+
+    expect(runWithTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(runWithTimeoutSpy.mock.calls[0]?.[1]).toMatchObject({
+      timeout: runtime.DEFAULT_BROWSER_COMMAND_TIMEOUT,
+      label: 'test-execution/browser-no-timeout',
+    });
+    vi.restoreAllMocks();
+  });
+
   it('calls closeWindow on browser command failure', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -11,44 +11,80 @@ import * as runtime from './runtime.js';
 import * as capRouting from './capabilityRouting.js';
 
 describe('executeCommand — non-browser timeout', () => {
-  it('applies timeoutSeconds to non-browser commands', async () => {
+  it('applies the user --timeout arg as the ceiling for non-browser commands', async () => {
+    const runWithTimeoutSpy = vi.spyOn(runtime, 'runWithTimeout');
     const cmd = cli({
       site: 'test-execution',
       name: 'non-browser-timeout', access: 'read',
-      description: 'test non-browser timeout',
+      description: 'test non-browser --timeout enforcement',
       browser: false,
       strategy: Strategy.PUBLIC,
-      timeoutSeconds: 0.01,
+      args: [
+        { name: 'timeout', type: 'int', required: false, default: 5, help: 'Max seconds' },
+      ],
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+
+    expect(runWithTimeoutSpy).toHaveBeenCalledTimes(1);
+    // Ceiling = user-supplied/default timeout + 30s padding (adapter return room).
+    expect(runWithTimeoutSpy.mock.calls[0]?.[1]).toMatchObject({
+      timeout: 35,
+      label: 'test-execution/non-browser-timeout',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('fires a TimeoutError when the inner adapter exceeds the --timeout ceiling', async () => {
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'non-browser-timeout-fires', access: 'read',
+      description: 'test that the ceiling actually cancels the adapter',
+      browser: false,
+      strategy: Strategy.PUBLIC,
+      args: [
+        { name: 'timeout', type: 'int', required: false, default: 1, help: 'Max seconds' },
+      ],
       func: () => new Promise(() => {}),
     });
 
-    // Sentinel timeout at 200ms — if the inner 10ms timeout fires first,
-    // the error will be a TimeoutError with the command label, not 'sentinel'.
-    const error = await withTimeoutMs(executeCommand(cmd, {}), 200, 'sentinel timeout')
-      .catch((err) => err);
+    // Spy on runWithTimeout to intercept and pass a tiny ceiling so the test
+    // doesn't have to wait the real (1+30)s. We still verify the TimeoutError
+    // surface — code, label, hint — that users see.
+    vi.spyOn(runtime, 'runWithTimeout').mockImplementation(async (promise, opts) => {
+      return runtime.withTimeoutMs(
+        promise as Promise<unknown>,
+        50,
+        () => new TimeoutError(opts.label ?? 'op', opts.timeout, opts.hint),
+      ) as never;
+    });
+
+    const error = await executeCommand(cmd, {}).catch((err) => err);
 
     expect(error).toBeInstanceOf(TimeoutError);
     expect(error).toMatchObject({
       code: 'TIMEOUT',
-      message: 'test-execution/non-browser-timeout timed out after 0.01s',
+      hint: 'Pass a higher --timeout value (currently 1s)',
     });
+    vi.restoreAllMocks();
   });
 
-  it('skips timeout when timeoutSeconds is 0', async () => {
+  it('runs non-browser commands without a ceiling when no --timeout arg is declared', async () => {
+    const runWithTimeoutSpy = vi.spyOn(runtime, 'runWithTimeout');
     const cmd = cli({
       site: 'test-execution',
-      name: 'non-browser-zero-timeout', access: 'read',
-      description: 'test zero timeout bypasses wrapping',
+      name: 'non-browser-no-timeout', access: 'read',
+      description: 'test that omitting --timeout means no ceiling',
       browser: false,
       strategy: Strategy.PUBLIC,
-      timeoutSeconds: 0,
-      func: () => new Promise(() => {}),
+      func: async () => [{ ok: true }],
     });
 
-    // With timeout guard skipped, the sentinel fires instead.
-    await expect(
-      withTimeoutMs(executeCommand(cmd, {}), 50, 'sentinel timeout'),
-    ).rejects.toThrow('sentinel timeout');
+    await executeCommand(cmd, {});
+
+    expect(runWithTimeoutSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 
   it('calls closeWindow on browser command failure', async () => {

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -192,6 +192,28 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('rejects invalid browser --timeout before opening a session or pre-navigating', async () => {
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    const browserSessionSpy = vi.spyOn(runtime, 'browserSession');
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-invalid-timeout-prenav', access: 'read',
+      description: 'test invalid browser --timeout fails before session setup',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      navigateBefore: 'https://example.com/',
+      args: [
+        { name: 'timeout', type: 'int', required: false, default: 5, help: 'Max seconds' },
+      ],
+      func: async () => [{ ok: true }],
+    });
+
+    await expect(executeCommand(cmd, { timeout: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    expect(browserSessionSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
   it('calls closeWindow on browser command failure', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { CliCommand } from './registry.js';
 import { executeCommand, prepareCommandArgs } from './execution.js';
-import { TimeoutError, toEnvelope } from './errors.js';
+import { ArgumentError, TimeoutError, toEnvelope } from './errors.js';
 import { cli, Strategy } from './registry.js';
 import { withTimeoutMs } from './runtime.js';
 import * as runtime from './runtime.js';
@@ -87,6 +87,27 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('rejects invalid --timeout values instead of silently disabling the non-browser ceiling', async () => {
+    const runWithTimeoutSpy = vi.spyOn(runtime, 'runWithTimeout');
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'non-browser-invalid-timeout', access: 'read',
+      description: 'test invalid --timeout fails upfront',
+      browser: false,
+      strategy: Strategy.PUBLIC,
+      args: [
+        { name: 'timeout', type: 'int', required: false, default: 5, help: 'Max seconds' },
+      ],
+      func: async () => [{ ok: true }],
+    });
+
+    await expect(executeCommand(cmd, { timeout: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(executeCommand(cmd, { timeout: -1 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(executeCommand(cmd, { timeout: 1.5 })).rejects.toBeInstanceOf(ArgumentError);
+    expect(runWithTimeoutSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
   it('applies the user --timeout arg as the ceiling for browser commands (with +30s padding)', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
@@ -141,6 +162,33 @@ describe('executeCommand — non-browser timeout', () => {
       timeout: runtime.DEFAULT_BROWSER_COMMAND_TIMEOUT,
       label: 'test-execution/browser-no-timeout',
     });
+    vi.restoreAllMocks();
+  });
+
+  it('rejects invalid --timeout values instead of falling back to the browser default', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+    const runWithTimeoutSpy = vi.spyOn(runtime, 'runWithTimeout');
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-invalid-timeout', access: 'read',
+      description: 'test invalid browser --timeout fails upfront',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      args: [
+        { name: 'timeout', type: 'int', required: false, default: 5, help: 'Max seconds' },
+      ],
+      func: async () => [{ ok: true }],
+    });
+
+    await expect(executeCommand(cmd, { timeout: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(executeCommand(cmd, { timeout: -1 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(executeCommand(cmd, { timeout: 1.5 })).rejects.toBeInstanceOf(ArgumentError);
+    expect(runWithTimeoutSpy).not.toHaveBeenCalled();
     vi.restoreAllMocks();
   });
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -302,8 +302,12 @@ export async function executeCommand(
         // the command finishes, so agents (or humans) can inspect the page state.
         const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
+          const userTimeoutSec = readUserTimeoutSeconds(cmd, kwargs);
+          const browserTimeout = userTimeoutSec !== null
+            ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
+            : DEFAULT_BROWSER_COMMAND_TIMEOUT;
           const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
-            timeout: cmd.timeoutSeconds ?? DEFAULT_BROWSER_COMMAND_TIMEOUT,
+            timeout: browserTimeout,
             label: fullName(cmd),
           });
           observation?.record({
@@ -346,13 +350,17 @@ export async function executeCommand(
         }
       }, { workspace: `site:${cmd.site}:${crypto.randomUUID()}`, cdpEndpoint, contextId });
     } else {
-      // Non-browser commands: apply timeout only when explicitly configured.
-      const timeout = cmd.timeoutSeconds;
-      if (timeout !== undefined && timeout > 0) {
+      // Non-browser commands: enforce a timeout only when the command exposes
+      // a `--timeout` arg (and the resolved value is positive). Without that
+      // arg there is no meaningful default — non-browser cmds are diverse
+      // enough that a hard cap would do more harm than good.
+      const userTimeoutSec = readUserTimeoutSeconds(cmd, kwargs);
+      if (userTimeoutSec !== null) {
+        const ceiling = userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS;
         result = await runWithTimeout(runCommand(cmd, null, kwargs, debug), {
-          timeout,
+          timeout: ceiling,
           label: fullName(cmd),
-          hint: `Increase the adapter's timeoutSeconds setting (currently ${timeout}s)`,
+          hint: `Pass a higher --timeout value (currently ${userTimeoutSec}s)`,
         });
       } else {
         result = await runCommand(cmd, null, kwargs, debug);
@@ -449,4 +457,31 @@ export function prepareCommandArgs(
   const kwargs = coerceAndValidateArgs(cmd.args, rawKwargs);
   cmd.validateArgs?.(kwargs);
   return kwargs;
+}
+
+/**
+ * Runtime ceiling padding (seconds) added on top of the user's `--timeout`.
+ * The adapter's polling loop typically uses the full user value; the padding
+ * gives us room for the adapter to return + closeWindow + trace export before
+ * the runtime kills the Promise.
+ */
+const RUNTIME_TIMEOUT_PADDING_SECONDS = 30;
+
+/**
+ * Resolve the user-controllable `--timeout` arg, in seconds.
+ *
+ * Convention: a command opts into runtime-enforced timeouts by declaring an
+ * arg named `timeout`. The arg's `default` flows through `prepareCommandArgs`
+ * into `kwargs.timeout`, so by the time runtime enforcement runs, the value
+ * is the merged user-supplied-or-default seconds.
+ *
+ * Returns the parsed positive integer (seconds) or null if the command does
+ * not expose a `timeout` arg or the value is unparseable.
+ */
+function readUserTimeoutSeconds(cmd: CliCommand, kwargs: CommandArgs): number | null {
+  if (!cmd.args.some(a => a.name === 'timeout')) return null;
+  const raw = kwargs.timeout;
+  if (raw === undefined || raw === null || raw === '') return null;
+  const parsed = parseInt(String(raw), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -194,6 +194,7 @@ export async function executeCommand(
     throw new ArgumentError(getErrorMessage(err));
   }
 
+  const userTimeoutSec = readUserTimeoutSeconds(cmd, kwargs);
   const traceMode = normalizeTraceMode(opts.trace);
 
   const hookCtx: HookContext = {
@@ -302,7 +303,6 @@ export async function executeCommand(
         // the command finishes, so agents (or humans) can inspect the page state.
         const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
-          const userTimeoutSec = readUserTimeoutSeconds(cmd, kwargs);
           const browserTimeout = userTimeoutSec !== null
             ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
             : DEFAULT_BROWSER_COMMAND_TIMEOUT;
@@ -354,7 +354,6 @@ export async function executeCommand(
       // a `--timeout` arg (and the resolved value is positive). Without that
       // arg there is no meaningful default — non-browser cmds are diverse
       // enough that a hard cap would do more harm than good.
-      const userTimeoutSec = readUserTimeoutSeconds(cmd, kwargs);
       if (userTimeoutSec !== null) {
         const ceiling = userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS;
         result = await runWithTimeout(runCommand(cmd, null, kwargs, debug), {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -475,13 +475,20 @@ const RUNTIME_TIMEOUT_PADDING_SECONDS = 30;
  * into `kwargs.timeout`, so by the time runtime enforcement runs, the value
  * is the merged user-supplied-or-default seconds.
  *
- * Returns the parsed positive integer (seconds) or null if the command does
- * not expose a `timeout` arg or the value is unparseable.
+ * Returns the parsed positive integer (seconds), or null if the command does
+ * not expose a `timeout` arg. Declaring `timeout` opts into runtime timeout
+ * enforcement, so invalid values must fail upfront instead of silently
+ * disabling the runtime ceiling.
  */
 function readUserTimeoutSeconds(cmd: CliCommand, kwargs: CommandArgs): number | null {
   if (!cmd.args.some(a => a.name === 'timeout')) return null;
   const raw = kwargs.timeout;
-  if (raw === undefined || raw === null || raw === '') return null;
-  const parsed = parseInt(String(raw), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  if (raw === undefined || raw === null || raw === '') {
+    throw new ArgumentError(`Argument "timeout" must be a positive integer. Received: "${String(raw)}"`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new ArgumentError(`Argument "timeout" must be a positive integer. Received: "${String(raw)}"`);
+  }
+  return parsed;
 }

--- a/src/manifest-types.ts
+++ b/src/manifest-types.ts
@@ -29,7 +29,6 @@ export interface ManifestEntry {
   }>;
   columns?: string[];
   pipeline?: Record<string, unknown>[];
-  timeout?: number;
   deprecated?: boolean | string;
   replacedBy?: string;
   type: 'js';

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -47,7 +47,6 @@ interface BaseCliCommand {
   args: Arg[];
   columns?: string[];
   pipeline?: Record<string, unknown>[];
-  timeoutSeconds?: number;
   /** Origin of this command: 'yaml', 'ts', or plugin name. */
   source?: string;
   footerExtra?: (kwargs: CommandArgs) => string | undefined;
@@ -142,7 +141,6 @@ export function cli(opts: CliOptions): CliCommand {
     columns: opts.columns,
     func: opts.func,
     pipeline: opts.pipeline,
-    timeoutSeconds: opts.timeoutSeconds,
     footerExtra: opts.footerExtra,
     requiredEnv: opts.requiredEnv,
     deprecated: opts.deprecated,


### PR DESCRIPTION
## Summary

Drops the cli-level `timeoutSeconds` build-time ceiling field. A command now opts into runtime-enforced timeouts purely by declaring an arg named `timeout`; the user-facing `--timeout` value (its default or override) is the single authoritative knob, used both by the adapter polling loop and by the runtime ceiling (with a +30s padding for return + closeWindow + trace export).

This addresses the underlying design issue that surfaced in PR #1227 (per-site `OPENCLI_GEMINI_ASK_TIMEOUT` env var). The chat thread starts at #OpenCLI:5779e1c6.

## Behavior

- **Browser commands** without a `--timeout` arg fall back to `OPENCLI_BROWSER_COMMAND_TIMEOUT` (default 60s, unchanged).
- **Non-browser commands** without a `--timeout` arg now run unbounded rather than against the previously implicit `timeoutSeconds` cap. Affected commands keep their old caps via newly added `--timeout` args (paperreview, quark, chaoxing, etc.).
- **LLM adapters** (gemini/claude/deepseek/doubao/qwen/yuanbao `ask`) keep their current `--timeout` defaults; the runtime ceiling is now strictly more generous (`userTimeout + 30s` vs. the previous 180s cap), so `--timeout 600` actually buys 600s of polling instead of dying at 180s — which was the original `gemini ask` long-prompt bug PR #1227 tried to patch over.

## Why a single knob

Before: `timeoutSeconds` was a build-time ceiling, `--timeout` was the user-visible knob the adapter respected. They were independent. Users passing `--timeout 600` to `gemini ask` still got killed at 180s because the runtime ceiling didn't read the user value.

After: one arg, one source of truth. If a command exposes `--timeout`, both the adapter and the runtime use it. If it doesn't, the command runs against the global browser default (or unbounded for non-browser).

## Test plan

- [x] `npm test -- --run src/execution.test.ts` (10 passed; old `timeoutSeconds`-based tests rewritten to assert the `--timeout`-arg-based ceiling behavior)
- [x] `npm test -- --run clis/instagram/post.test.js` (43 passed; assertion updated to `args.some(a => a.name === 'timeout' && a.default === 300)`)
- [x] `npm test -- --run clis/gemini/ask.test.js` (2 passed)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` regenerates `cli-manifest.json` cleanly (no top-level `timeout:` field, `--timeout` args preserved)
- [ ] CI green

## Files changed

- `src/registry.ts` — drop `timeoutSeconds?: number` from `BaseCliCommand`
- `src/execution.ts` — replace `timeoutSeconds` ceiling logic with `readUserTimeoutSeconds(cmd, kwargs)` helper that resolves `--timeout` arg
- `src/manifest-types.ts`, `src/build-manifest.ts`, `src/discovery.ts` — drop `timeout` field from manifest serialization round-trip
- `src/execution.test.ts` — rewrite two `timeoutSeconds`-based tests, add a new test covering the unbounded-non-browser case
- 27 cli files — delete `timeoutSeconds:` line; add `--timeout` arg where the command needed an explicit ceiling
- `cli-manifest.json` — regenerated