### PR TITLE
fix(web): include relevant iframes outside main content

### DIFF
--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -202,6 +202,26 @@ function buildRenderAwareExtractorJs(options) {
             });
           });
         };
+        const hasDataContainerSignal = (root) => {
+          const likely = 'table, tbody, ul[id], ol[id], [id*="grid"], [id*="data"], [id*="list"], [id*="content"], [id*="result"], [class*="grid"], [class*="data"], [class*="list"], [class*="content"], [class*="result"]';
+          return !!root.querySelector?.(likely);
+        };
+        const shouldIncludeExternalFrame = (frameBody) => {
+          if (textLen(frameBody) >= 50) return true;
+          if (frameBody.querySelector?.('article, main, [role="main"], table, tbody, ul li, ol li')) return true;
+          return hasDataContainerSignal(frameBody);
+        };
+        const buildFrameSection = (frameBody, desc, fallbackLabel) => {
+          absolutizeTree(frameBody, desc.src || window.location.href);
+          collectEmptyContainers(frameBody, 'iframe', desc.src);
+          const section = document.createElement('section');
+          section.setAttribute('data-opencli-iframe-source', desc.src);
+          const heading = document.createElement('h2');
+          heading.textContent = '来自 iframe: ' + (desc.src || fallbackLabel);
+          section.appendChild(heading);
+          Array.from(frameBody.childNodes).forEach(node => section.appendChild(node));
+          return section;
+        };
 
         const ogTitle = document.querySelector('meta[property="og:title"]');
         if (ogTitle) result.title = ogTitle.getAttribute('content')?.trim() || '';
@@ -253,27 +273,37 @@ function buildRenderAwareExtractorJs(options) {
         const originalFrames = Array.from(contentEl.querySelectorAll('iframe'));
         const clonedFrames = Array.from(clone.querySelectorAll('iframe'));
         const allFrames = Array.from(document.querySelectorAll('iframe'));
-        result.diagnostics.frames = allFrames.map(describeFrame);
+        const frameDescriptions = new Map();
+        allFrames.forEach((frame, index) => frameDescriptions.set(frame, describeFrame(frame, index)));
+        const getFrameDescription = (frame, fallbackIndex) => frameDescriptions.get(frame) || describeFrame(frame, fallbackIndex);
+        result.diagnostics.frames = allFrames.map(frame => frameDescriptions.get(frame));
 
         if (frameMode === 'same-origin') {
           originalFrames.forEach((frame, index) => {
             const cloned = clonedFrames[index];
             if (!cloned) return;
-            const desc = describeFrame(frame, index);
+            const desc = getFrameDescription(frame, index);
             if (!desc.sameOrigin || !desc.accessible) return;
             try {
               const doc = frame.contentDocument;
               if (!doc?.body) return;
               const frameBody = doc.body.cloneNode(true);
-              absolutizeTree(frameBody, desc.src || window.location.href);
-              collectEmptyContainers(frameBody, 'iframe', desc.src);
-              const section = document.createElement('section');
-              section.setAttribute('data-opencli-iframe-source', desc.src);
-              const heading = document.createElement('h2');
-              heading.textContent = '来自 iframe: ' + (desc.src || frame.getAttribute('src') || ('#' + index));
-              section.appendChild(heading);
-              Array.from(frameBody.childNodes).forEach(node => section.appendChild(node));
+              const section = buildFrameSection(frameBody, desc, frame.getAttribute('src') || ('#' + index));
               cloned.replaceWith(section);
+              result.diagnostics.includedFrameCount += 1;
+            } catch {}
+          });
+          allFrames.forEach((frame, index) => {
+            if (contentEl.contains(frame)) return;
+            const desc = getFrameDescription(frame, index);
+            if (!desc.sameOrigin || !desc.accessible) return;
+            try {
+              const doc = frame.contentDocument;
+              if (!doc?.body) return;
+              const frameBody = doc.body.cloneNode(true);
+              if (!shouldIncludeExternalFrame(frameBody)) return;
+              const section = buildFrameSection(frameBody, desc, frame.getAttribute('src') || ('#' + index));
+              clone.appendChild(section);
               result.diagnostics.includedFrameCount += 1;
             } catch {}
           });

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -228,6 +228,70 @@ describe('web/read render-aware helpers', () => {
         expect(result.contentHtml).toContain('Station A 42');
     });
 
+    it('merges readable same-origin iframes outside the selected content element', () => {
+        const dom = new JSDOM(`
+          <main>
+            <h1>Main Article</h1>
+            <p>${'Main content '.repeat(30)}</p>
+          </main>
+          <aside>
+            <iframe id="outside" src="/outside.html"></iframe>
+          </aside>
+        `, { url: 'https://example.com/main.html', runScripts: 'outside-only' });
+        const frame = dom.window.document.querySelector('iframe');
+        frame.contentDocument.open();
+        frame.contentDocument.write(`<body><h1>Outside Frame</h1><p>${'Frame data '.repeat(12)}</p></body>`);
+        frame.contentDocument.close();
+
+        const result = dom.window.eval(__test__.buildRenderAwareExtractorJs({ frames: 'same-origin' }));
+
+        expect(result.diagnostics.includedFrameCount).toBe(1);
+        expect(result.contentHtml).toContain('data-opencli-iframe-source="https://example.com/outside.html"');
+        expect(result.contentHtml).toContain('Outside Frame');
+        expect(result.contentHtml).toContain('Frame data');
+    });
+
+    it('keeps short data-like iframes outside the selected content element', () => {
+        const dom = new JSDOM(`
+          <main>
+            <h1>Main Article</h1>
+            <p>${'Main content '.repeat(30)}</p>
+          </main>
+          <iframe id="data-frame" src="/data.html"></iframe>
+        `, { url: 'https://example.com/main.html', runScripts: 'outside-only' });
+        const frame = dom.window.document.querySelector('iframe');
+        frame.contentDocument.open();
+        frame.contentDocument.write('<body><table id="gridHd"><tr><th>水位</th></tr><tr><td>42</td></tr></table><ul id="gridDatas"></ul></body>');
+        frame.contentDocument.close();
+
+        const result = dom.window.eval(__test__.buildRenderAwareExtractorJs({ frames: 'same-origin' }));
+
+        expect(result.diagnostics.includedFrameCount).toBe(1);
+        expect(result.contentHtml).toContain('42');
+        expect(result.diagnostics.emptyContainers).toEqual(expect.arrayContaining([
+            expect.objectContaining({ scope: 'iframe', id: 'gridDatas', url: 'https://example.com/data.html' }),
+        ]));
+    });
+
+    it('skips short non-structural iframes outside the selected content element', () => {
+        const dom = new JSDOM(`
+          <main>
+            <h1>Main Article</h1>
+            <p>${'Main content '.repeat(30)}</p>
+          </main>
+          <iframe id="tiny-frame" src="/tiny.html"></iframe>
+        `, { url: 'https://example.com/main.html', runScripts: 'outside-only' });
+        const frame = dom.window.document.querySelector('iframe');
+        frame.contentDocument.open();
+        frame.contentDocument.write('<body><p>tiny note</p></body>');
+        frame.contentDocument.close();
+
+        const result = dom.window.eval(__test__.buildRenderAwareExtractorJs({ frames: 'same-origin' }));
+
+        expect(result.diagnostics.includedFrameCount).toBe(0);
+        expect(result.contentHtml).not.toContain('tiny note');
+    });
+
     it('marks API-like network entries as interesting and ignores static assets', () => {
         expect(__test__.isInterestingNetworkEntry({
             method: 'POST',


### PR DESCRIPTION
## Summary
- fix `web read --frames same-origin` dropping same-origin iframes that sit outside the selected `contentEl`
- refactor iframe section construction so in-content replacement and outside-content append use the same wrapping/absolutizing/diagnostic path
- include outside iframes when they have readable text or structural data signals (`table`, list items, article/main, grid/data/list/content/result containers)
- keep short non-structural outside iframes out of the composed document to avoid sidebar/header iframe noise
- add regression coverage for readable outside iframe, short data-like outside iframe, and short non-structural outside iframe

## Design Notes
This is intended to supersede the narrow #1333 patch. The issue #1333 found is real, but a hard `textLength >= 50` gate would still silently drop short data/status tables and empty-but-important containers like `#gridDatas`. This PR treats same-origin iframes as page-owned sources, then uses content/structure signals only for iframes outside the selected main content element.

## Verification
- `npm test -- --run clis/web/read.test.js`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`