### PR TITLE
fix(web): avoid duplicate iframe diagnostics

### DIFF
--- a/clis/web/read.js
+++ b/clis/web/read.js
@@ -18,6 +18,7 @@ import { downloadArticle } from '@jackwener/opencli/download/article-download';
 
 const NETWORK_IDLE_QUIET_MS = 1000;
 const NETWORK_IDLE_POLL_MS = 500;
+const MIN_NON_STRUCTURAL_IFRAME_TEXT_CHARS = 50;
 
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -144,6 +145,7 @@ function buildRenderAwareExtractorJs(options) {
     return `
       (() => {
         const frameMode = ${JSON.stringify(options.frames)};
+        const minNonStructuralIframeTextChars = ${MIN_NON_STRUCTURAL_IFRAME_TEXT_CHARS};
         const result = {
           title: '',
           author: '',
@@ -188,6 +190,7 @@ function buildRenderAwareExtractorJs(options) {
         const collectEmptyContainers = (root, scope, baseUrl) => {
           const likely = 'table, tbody, ul[id], ol[id], div[id], section[id], [class*="grid"], [class*="data"], [class*="list"], [id*="grid"], [id*="data"], [id*="list"]';
           root.querySelectorAll?.(likely).forEach((el) => {
+            if (scope === 'main' && el.closest?.('[data-opencli-iframe-source]')) return;
             const id = el.getAttribute('id') || '';
             const cls = el.getAttribute('class') || '';
             const name = [id, cls].join(' ').toLowerCase();
@@ -207,7 +210,10 @@ function buildRenderAwareExtractorJs(options) {
           return !!root.querySelector?.(likely);
         };
         const shouldIncludeExternalFrame = (frameBody) => {
-          if (textLen(frameBody) >= 50) return true;
+          // Outside-content iframes are less trusted than placeholders inside
+          // contentEl. Long plain text is the fallback for simple same-origin
+          // frames that lack article/table/list structure.
+          if (textLen(frameBody) >= minNonStructuralIframeTextChars) return true;
           if (frameBody.querySelector?.('article, main, [role="main"], table, tbody, ul li, ol li')) return true;
           return hasDataContainerSignal(frameBody);
         };
@@ -272,6 +278,11 @@ function buildRenderAwareExtractorJs(options) {
 
         const originalFrames = Array.from(contentEl.querySelectorAll('iframe'));
         const clonedFrames = Array.from(clone.querySelectorAll('iframe'));
+        const clonedFrameByOriginal = new Map();
+        originalFrames.forEach((frame, index) => {
+          const cloned = clonedFrames[index];
+          if (cloned) clonedFrameByOriginal.set(frame, cloned);
+        });
         const allFrames = Array.from(document.querySelectorAll('iframe'));
         const frameDescriptions = new Map();
         allFrames.forEach((frame, index) => frameDescriptions.set(frame, describeFrame(frame, index)));
@@ -279,31 +290,20 @@ function buildRenderAwareExtractorJs(options) {
         result.diagnostics.frames = allFrames.map(frame => frameDescriptions.get(frame));
 
         if (frameMode === 'same-origin') {
-          originalFrames.forEach((frame, index) => {
-            const cloned = clonedFrames[index];
-            if (!cloned) return;
-            const desc = getFrameDescription(frame, index);
-            if (!desc.sameOrigin || !desc.accessible) return;
-            try {
-              const doc = frame.contentDocument;
-              if (!doc?.body) return;
-              const frameBody = doc.body.cloneNode(true);
-              const section = buildFrameSection(frameBody, desc, frame.getAttribute('src') || ('#' + index));
-              cloned.replaceWith(section);
-              result.diagnostics.includedFrameCount += 1;
-            } catch {}
-          });
           allFrames.forEach((frame, index) => {
-            if (contentEl.contains(frame)) return;
+            const insideContent = contentEl.contains(frame);
+            const cloned = insideContent ? clonedFrameByOriginal.get(frame) : null;
+            if (insideContent && !cloned) return;
             const desc = getFrameDescription(frame, index);
             if (!desc.sameOrigin || !desc.accessible) return;
             try {
               const doc = frame.contentDocument;
               if (!doc?.body) return;
               const frameBody = doc.body.cloneNode(true);
-              if (!shouldIncludeExternalFrame(frameBody)) return;
+              if (!insideContent && !shouldIncludeExternalFrame(frameBody)) return;
               const section = buildFrameSection(frameBody, desc, frame.getAttribute('src') || ('#' + index));
-              clone.appendChild(section);
+              if (insideContent) cloned.replaceWith(section);
+              else clone.appendChild(section);
               result.diagnostics.includedFrameCount += 1;
             } catch {}
           });

--- a/clis/web/read.test.js
+++ b/clis/web/read.test.js
@@ -217,7 +217,7 @@ describe('web/read render-aware helpers', () => {
         `, { url: 'https://example.com/main.html', runScripts: 'outside-only' });
         const frame = dom.window.document.querySelector('iframe');
         frame.contentDocument.open();
-        frame.contentDocument.write('<body><table id="gridHd"><tr><th>Name</th></tr></table><ul id="gridDatas"><li>Station A 42</li></ul></body>');
+        frame.contentDocument.write('<body><table id="gridHd"><tr><th>Name</th></tr></table><ul id="gridDatas"></ul><p>Station A 42</p></body>');
         frame.contentDocument.close();
 
         const result = dom.window.eval(__test__.buildRenderAwareExtractorJs({ frames: 'same-origin' }));
@@ -226,6 +226,10 @@ describe('web/read render-aware helpers', () => {
         expect(result.contentHtml).toContain('data-opencli-iframe-source="https://example.com/frame.html"');
         expect(result.contentHtml).toContain('来自 iframe: https://example.com/frame.html');
         expect(result.contentHtml).toContain('Station A 42');
+        expect(result.diagnostics.emptyContainers).toEqual(expect.arrayContaining([
+            expect.objectContaining({ scope: 'iframe', id: 'gridDatas', url: 'https://example.com/frame.html' }),
+        ]));
+        expect(result.diagnostics.emptyContainers.every(item => item.scope === 'iframe')).toBe(true);
     });
 
     it('merges readable same-origin iframes outside the selected content element', () => {
@@ -271,6 +275,7 @@ describe('web/read render-aware helpers', () => {
         expect(result.diagnostics.emptyContainers).toEqual(expect.arrayContaining([
             expect.objectContaining({ scope: 'iframe', id: 'gridDatas', url: 'https://example.com/data.html' }),
         ]));
+        expect(result.diagnostics.emptyContainers.every(item => item.scope === 'iframe')).toBe(true);
     });
 
     it('skips short non-structural iframes outside the selected content element', () => {


### PR DESCRIPTION
## Summary
- prevent iframe-derived empty containers from being reported again as `scope: main`
- name and document the non-structural outside-iframe text fallback as `MIN_NON_STRUCTURAL_IFRAME_TEXT_CHARS`
- collapse inside/outside iframe processing into one `allFrames` pass with an explicit `Map<originalFrame, clonedFrame>` for replace-vs-append decisions
- tighten regression assertions so iframe empty-container diagnostics cannot silently duplicate as main diagnostics

## Design Notes
This follows up #1371. `--frames=all` is intentionally not added here: the short pure-text iframe case is currently theoretical and diagnose already exposes frame existence. Keeping that as a future real-case-driven escape hatch avoids adding CLI surface prematurely.

## Verification
- `npm test -- --run clis/web/read.test.js`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`