### PR TITLE
fix(xiaohongshu): fallback to base64 upload when CDP setFileInput returns 'Not allowed'

### DIFF
--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -95,7 +95,7 @@ async function uploadImages(page, absPaths) {
         catch (err) {
             // If set-file-input action is not supported by extension, fall through to legacy
             const msg = err instanceof Error ? err.message : String(err);
-            if (msg.includes('Unknown action') || msg.includes('not supported')) {
+            if (msg.includes('Unknown action') || msg.includes('not supported') || msg.includes('Not allowed')) {
                 // Extension too old — fall through to legacy base64 method
             }
             else {


### PR DESCRIPTION
## Problem

`opencli xiaohongshu publish` fails with image upload when CDP `DOM.setFileInputFiles` returns `{"code":-32000,"message":"Not allowed"}`.

The `uploadImages` function catches this error but only checks for `Unknown action` and `not supported` to trigger the fallback to the legacy base64 DataTransfer method. The `Not allowed` error from Chrome's security policy is not matched, so the command fails instead of falling back.

## Fix

Added `'Not allowed'` to the fallback condition in `uploadImages`:

```diff
- if (msg.includes('Unknown action') || msg.includes('not supported')) {
+ if (msg.includes('Unknown action') || msg.includes('not supported') || msg.includes('Not allowed')) {
```

## Reproduction

```bash
opencli xiaohongshu publish "test" --title "test" --images /tmp/test.png
# Before fix: Image injection failed: {"code":-32000,"message":"Not allowed"}
# After fix: ✅ 发布成功
```