### PR TITLE
fix(doubao): refresh history and detail extraction

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11874,6 +11874,62 @@
   },
   {
     "site": "doubao",
+    "name": "download",
+    "description": "Download images and media from a Doubao conversation",
+    "access": "read",
+    "domain": "www.doubao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Conversation ID (numeric or full URL)"
+      },
+      {
+        "name": "output",
+        "type": "str",
+        "default": "./doubao-downloads",
+        "required": false,
+        "help": "Output directory"
+      },
+      {
+        "name": "variant",
+        "type": "str",
+        "default": "original",
+        "required": false,
+        "help": "Image variant: original, raw, preview, or thumb"
+      },
+      {
+        "name": "limit",
+        "type": "str",
+        "default": "0",
+        "required": false,
+        "help": "Max media files to download; 0 means all"
+      },
+      {
+        "name": "timeout",
+        "type": "str",
+        "default": "15000",
+        "required": false,
+        "help": "Per-file download timeout in milliseconds"
+      }
+    ],
+    "columns": [
+      "index",
+      "type",
+      "status",
+      "size"
+    ],
+    "type": "js",
+    "modulePath": "doubao/download.js",
+    "sourceFile": "doubao/download.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "doubao",
     "name": "history",
     "description": "List conversation history from Doubao sidebar",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11921,7 +11921,9 @@
       "index",
       "type",
       "status",
-      "size"
+      "size",
+      "filename",
+      "url"
     ],
     "type": "js",
     "modulePath": "doubao/download.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11860,11 +11860,24 @@
         "required": true,
         "positional": true,
         "help": "Conversation ID (numeric or full URL)"
+      },
+      {
+        "name": "max-pages",
+        "type": "number",
+        "default": 500,
+        "required": false,
+        "help": "Maximum /im/chain/single pages to fetch (1-1000)"
       }
     ],
     "columns": [
+      "Index",
+      "MessageId",
       "Role",
-      "Text"
+      "Type",
+      "Mode",
+      "CreatedAt",
+      "Text",
+      "Metadata"
     ],
     "type": "js",
     "modulePath": "doubao/detail.js",

--- a/clis/doubao/detail.js
+++ b/clis/doubao/detail.js
@@ -1,6 +1,13 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { DOUBAO_DOMAIN, getConversationDetail, parseDoubaoConversationId } from './utils.js';
+function parseMaxPages(value) {
+    const pages = Number(value ?? 500);
+    if (!Number.isInteger(pages) || pages < 1 || pages > 1000) {
+        throw new ArgumentError('max-pages must be an integer between 1 and 1000');
+    }
+    return pages;
+}
 export const detailCommand = cli({
     site: 'doubao',
     name: 'detail',
@@ -13,23 +20,31 @@ export const detailCommand = cli({
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },
+        { name: 'max-pages', type: 'number', default: 500, help: 'Maximum /im/chain/single pages to fetch (1-1000)' },
     ],
-    columns: ['Role', 'Text'],
+    columns: ['Index', 'MessageId', 'Role', 'Type', 'Mode', 'CreatedAt', 'Text', 'Metadata'],
     func: async (page, kwargs) => {
         const conversationId = parseDoubaoConversationId(kwargs.id);
-        const { messages, meeting } = await getConversationDetail(page, conversationId);
+        const maxPages = parseMaxPages(kwargs['max-pages']);
+        const { messages, meeting } = await getConversationDetail(page, conversationId, { maxPages });
         if (messages.length === 0 && !meeting) {
             throw new EmptyResultError('doubao detail', `No messages were extracted for conversation ${conversationId}. Verify the conversation ID and login state.`);
         }
         const result = [];
         if (meeting) {
             result.push({
+                Index: 0,
+                MessageId: '',
                 Role: 'Meeting',
+                Type: 'meeting',
+                Mode: '',
+                CreatedAt: null,
                 Text: `${meeting.title}${meeting.time ? ` (${meeting.time})` : ''}`,
+                Metadata: '{}',
             });
         }
         for (const m of messages) {
-            result.push({ Role: m.Role, Text: m.Text });
+            result.push(m);
         }
         return result;
     },

--- a/clis/doubao/detail.js
+++ b/clis/doubao/detail.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { DOUBAO_DOMAIN, getConversationDetail, parseDoubaoConversationId } from './utils.js';
 export const detailCommand = cli({
     site: 'doubao',
@@ -18,7 +19,7 @@ export const detailCommand = cli({
         const conversationId = parseDoubaoConversationId(kwargs.id);
         const { messages, meeting } = await getConversationDetail(page, conversationId);
         if (messages.length === 0 && !meeting) {
-            return [{ Role: 'System', Text: 'No messages found. Verify the conversation ID.' }];
+            throw new EmptyResultError('doubao detail', `No messages were extracted for conversation ${conversationId}. Verify the conversation ID and login state.`);
         }
         const result = [];
         if (meeting) {

--- a/clis/doubao/detail.js
+++ b/clis/doubao/detail.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { DOUBAO_DOMAIN, getConversationDetail, parseDoubaoConversationId } from './utils.js';
 function parseMaxPages(value) {
     const pages = Number(value ?? 500);
@@ -27,9 +27,6 @@ export const detailCommand = cli({
         const conversationId = parseDoubaoConversationId(kwargs.id);
         const maxPages = parseMaxPages(kwargs['max-pages']);
         const { messages, meeting } = await getConversationDetail(page, conversationId, { maxPages });
-        if (messages.length === 0 && !meeting) {
-            throw new EmptyResultError('doubao detail', `No messages were extracted for conversation ${conversationId}. Verify the conversation ID and login state.`);
-        }
         const result = [];
         if (meeting) {
             result.push({

--- a/clis/doubao/detail.test.js
+++ b/clis/doubao/detail.test.js
@@ -29,14 +29,13 @@ describe('doubao detail', () => {
             { Role: 'Meeting', Text: 'Weekly Sync (2026-03-28 10:00)' },
         ]);
     });
-    it('still returns an error row for a truly empty conversation', async () => {
+    it('throws a typed empty-result error for a truly empty conversation', async () => {
         mockGetConversationDetail.mockResolvedValue({
             messages: [],
             meeting: null,
         });
-        const result = await detail.func({}, { id: '1234567890' });
-        expect(result).toEqual([
-            { Role: 'System', Text: 'No messages found. Verify the conversation ID.' },
-        ]);
+        await expect(detail.func({}, { id: '1234567890' })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+        });
     });
 });

--- a/clis/doubao/detail.test.js
+++ b/clis/doubao/detail.test.js
@@ -24,9 +24,19 @@ describe('doubao detail', () => {
                 time: '2026-03-28 10:00',
             },
         });
-        const result = await detail.func({}, { id: '1234567890' });
+        const result = await detail.func({}, { id: '1234567890', 'max-pages': 500 });
+        expect(mockGetConversationDetail).toHaveBeenCalledWith({}, '1234567890', { maxPages: 500 });
         expect(result).toEqual([
-            { Role: 'Meeting', Text: 'Weekly Sync (2026-03-28 10:00)' },
+            {
+                Index: 0,
+                MessageId: '',
+                Role: 'Meeting',
+                Type: 'meeting',
+                Mode: '',
+                CreatedAt: null,
+                Text: 'Weekly Sync (2026-03-28 10:00)',
+                Metadata: '{}',
+            },
         ]);
     });
     it('throws a typed empty-result error for a truly empty conversation', async () => {
@@ -34,8 +44,13 @@ describe('doubao detail', () => {
             messages: [],
             meeting: null,
         });
-        await expect(detail.func({}, { id: '1234567890' })).rejects.toMatchObject({
+        await expect(detail.func({}, { id: '1234567890', 'max-pages': 500 })).rejects.toMatchObject({
             code: 'EMPTY_RESULT',
+        });
+    });
+    it('rejects invalid max-pages without silently clamping it', async () => {
+        await expect(detail.func({}, { id: '1234567890', 'max-pages': 0 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
         });
     });
 });

--- a/clis/doubao/detail.test.js
+++ b/clis/doubao/detail.test.js
@@ -39,14 +39,14 @@ describe('doubao detail', () => {
             },
         ]);
     });
-    it('throws a typed empty-result error for a truly empty conversation', async () => {
+    it('returns an empty result when the API proves a conversation is complete but has no messages', async () => {
         mockGetConversationDetail.mockResolvedValue({
             messages: [],
             meeting: null,
+            captureComplete: true,
+            hasMore: false,
         });
-        await expect(detail.func({}, { id: '1234567890', 'max-pages': 500 })).rejects.toMatchObject({
-            code: 'EMPTY_RESULT',
-        });
+        await expect(detail.func({}, { id: '1234567890', 'max-pages': 500 })).resolves.toEqual([]);
     });
     it('rejects invalid max-pages without silently clamping it', async () => {
         await expect(detail.func({}, { id: '1234567890', 'max-pages': 0 })).rejects.toMatchObject({

--- a/clis/doubao/download.js
+++ b/clis/doubao/download.js
@@ -1,0 +1,95 @@
+import * as path from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { formatCookieHeader } from '@jackwener/opencli/download';
+import { downloadMedia } from '@jackwener/opencli/download/media-download';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { DOUBAO_DOMAIN, getConversationAssets, parseDoubaoConversationId } from './utils.js';
+
+const SUPPORTED_VARIANTS = new Set(['original', 'raw', 'preview', 'thumb']);
+
+function sanitizeFilenamePart(value) {
+    return String(value || '')
+        .replace(/[\\/:*?"<>|]+/g, '_')
+        .replace(/\s+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .slice(0, 120);
+}
+
+function extensionFromAsset(asset) {
+    const format = String(asset.format || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (format) {
+        if (format === 'jpeg')
+            return '.jpg';
+        if (format === 'heic')
+            return '.heic';
+        return `.${format}`;
+    }
+    try {
+        const ext = path.extname(new URL(asset.url).pathname).toLowerCase();
+        if (ext)
+            return ext;
+    }
+    catch { }
+    return asset.type === 'video' ? '.mp4' : '.jpg';
+}
+
+function filenameForAsset(conversationId, asset, index) {
+    const rawStem = String(asset.resourceId || asset.identifier || asset.key || `${conversationId}_${index}`);
+    const basename = rawStem.split('/').filter(Boolean).pop() || rawStem;
+    const stem = sanitizeFilenamePart(basename.replace(/\.[a-z0-9]{2,5}$/i, ''));
+    const ext = extensionFromAsset(asset);
+    return `${String(index).padStart(3, '0')}_${stem || conversationId}${ext}`;
+}
+
+export const downloadCommand = cli({
+    site: 'doubao',
+    name: 'download',
+    access: 'read',
+    description: 'Download images and media from a Doubao conversation',
+    domain: DOUBAO_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },
+        { name: 'output', required: false, default: './doubao-downloads', help: 'Output directory' },
+        { name: 'variant', required: false, default: 'original', help: 'Image variant: original, raw, preview, or thumb' },
+        { name: 'limit', required: false, default: '0', help: 'Max media files to download; 0 means all' },
+        { name: 'timeout', required: false, default: '15000', help: 'Per-file download timeout in milliseconds' },
+    ],
+    columns: ['index', 'type', 'status', 'size'],
+    func: async (page, kwargs) => {
+        const conversationId = parseDoubaoConversationId(String(kwargs.id || ''));
+        const output = String(kwargs.output || './doubao-downloads');
+        const variant = String(kwargs.variant || 'original');
+        if (!SUPPORTED_VARIANTS.has(variant)) {
+            throw new ArgumentError(`Invalid Doubao image variant: ${variant}`, 'Use original, raw, preview, or thumb.');
+        }
+        const limit = parseInt(String(kwargs.limit || '0'), 10) || 0;
+        if (limit < 0) {
+            throw new ArgumentError(`Invalid Doubao media limit: ${kwargs.limit}`, 'Use 0 for all media, or a positive integer.');
+        }
+        const timeout = parseInt(String(kwargs.timeout || '15000'), 10) || 15000;
+        if (timeout <= 0) {
+            throw new ArgumentError(`Invalid Doubao download timeout: ${kwargs.timeout}`, 'Use a positive timeout in milliseconds.');
+        }
+        const assets = await getConversationAssets(page, conversationId, { variant });
+        const selectedAssets = limit > 0 ? assets.slice(0, limit) : assets;
+        if (selectedAssets.length === 0) {
+            return [{ index: 0, type: '-', status: 'failed', size: 'No media found' }];
+        }
+        const cookies = formatCookieHeader(await page.getCookies({ domain: 'doubao.com' }));
+        const mediaItems = selectedAssets.map((asset, index) => ({
+            type: asset.type === 'video' ? 'video' : 'image',
+            url: asset.url,
+            filename: filenameForAsset(conversationId, asset, index + 1),
+        }));
+        return downloadMedia(mediaItems, {
+            output,
+            subdir: conversationId,
+            cookies,
+            filenamePrefix: conversationId,
+            timeout,
+        });
+    },
+});

--- a/clis/doubao/download.js
+++ b/clis/doubao/download.js
@@ -2,10 +2,22 @@ import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { formatCookieHeader } from '@jackwener/opencli/download';
 import { downloadMedia } from '@jackwener/opencli/download/media-download';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { DOUBAO_DOMAIN, getConversationAssets, parseDoubaoConversationId } from './utils.js';
 
 const SUPPORTED_VARIANTS = new Set(['original', 'raw', 'preview', 'thumb']);
+
+function parseIntegerOption(rawValue, fallback, label, allowZero = false) {
+    const value = rawValue ?? String(fallback);
+    const parsed = Number(value);
+    const minimum = allowZero ? 0 : 1;
+    if (!Number.isInteger(parsed) || parsed < minimum) {
+        throw new ArgumentError(`Invalid Doubao ${label}: ${value}`, allowZero
+            ? 'Use 0 or a positive integer.'
+            : 'Use a positive integer.');
+    }
+    return parsed;
+}
 
 function sanitizeFilenamePart(value) {
     return String(value || '')
@@ -65,18 +77,12 @@ export const downloadCommand = cli({
         if (!SUPPORTED_VARIANTS.has(variant)) {
             throw new ArgumentError(`Invalid Doubao image variant: ${variant}`, 'Use original, raw, preview, or thumb.');
         }
-        const limit = parseInt(String(kwargs.limit || '0'), 10) || 0;
-        if (limit < 0) {
-            throw new ArgumentError(`Invalid Doubao media limit: ${kwargs.limit}`, 'Use 0 for all media, or a positive integer.');
-        }
-        const timeout = parseInt(String(kwargs.timeout || '15000'), 10) || 15000;
-        if (timeout <= 0) {
-            throw new ArgumentError(`Invalid Doubao download timeout: ${kwargs.timeout}`, 'Use a positive timeout in milliseconds.');
-        }
+        const limit = parseIntegerOption(kwargs.limit, 0, 'media limit', true);
+        const timeout = parseIntegerOption(kwargs.timeout, 15000, 'download timeout');
         const assets = await getConversationAssets(page, conversationId, { variant });
         const selectedAssets = limit > 0 ? assets.slice(0, limit) : assets;
         if (selectedAssets.length === 0) {
-            return [{ index: 0, type: '-', status: 'failed', size: 'No media found' }];
+            throw new EmptyResultError('doubao download', `No media was extracted for conversation ${conversationId}.`);
         }
         const cookies = formatCookieHeader(await page.getCookies({ domain: 'doubao.com' }));
         const mediaItems = selectedAssets.map((asset, index) => ({

--- a/clis/doubao/download.js
+++ b/clis/doubao/download.js
@@ -69,7 +69,7 @@ export const downloadCommand = cli({
         { name: 'limit', required: false, default: '0', help: 'Max media files to download; 0 means all' },
         { name: 'timeout', required: false, default: '15000', help: 'Per-file download timeout in milliseconds' },
     ],
-    columns: ['index', 'type', 'status', 'size'],
+    columns: ['index', 'type', 'status', 'size', 'filename', 'url'],
     func: async (page, kwargs) => {
         const conversationId = parseDoubaoConversationId(String(kwargs.id || ''));
         const output = String(kwargs.output || './doubao-downloads');

--- a/clis/doubao/download.test.js
+++ b/clis/doubao/download.test.js
@@ -86,12 +86,12 @@ describe('doubao download', () => {
         }));
     });
 
-    it('returns an explicit failed row when no media is present', async () => {
+    it('throws a typed empty-result error when no media is present', async () => {
         const page = createPageMock();
         mockGetConversationAssets.mockResolvedValue([]);
-        await expect(download.func(page, { id: '1234567890123' })).resolves.toEqual([
-            { index: 0, type: '-', status: 'failed', size: 'No media found' },
-        ]);
+        await expect(download.func(page, { id: '1234567890123' })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+        });
         expect(mockDownloadMedia).not.toHaveBeenCalled();
     });
 
@@ -109,7 +109,13 @@ describe('doubao download', () => {
         await expect(download.func(page, { id: '1234567890123', limit: '-1' })).rejects.toMatchObject({
             code: 'ARGUMENT',
         });
+        await expect(download.func(page, { id: '1234567890123', limit: '2.5' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
         await expect(download.func(page, { id: '1234567890123', timeout: '-1' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        await expect(download.func(page, { id: '1234567890123', timeout: 'ten' })).rejects.toMatchObject({
             code: 'ARGUMENT',
         });
         expect(mockGetConversationAssets).not.toHaveBeenCalled();

--- a/clis/doubao/download.test.js
+++ b/clis/doubao/download.test.js
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDownloadMedia, mockFormatCookieHeader, mockGetConversationAssets } = vi.hoisted(() => ({
+    mockDownloadMedia: vi.fn(),
+    mockFormatCookieHeader: vi.fn(() => 'sid=secret'),
+    mockGetConversationAssets: vi.fn(),
+}));
+
+vi.mock('@jackwener/opencli/download/media-download', () => ({
+    downloadMedia: mockDownloadMedia,
+}));
+
+vi.mock('@jackwener/opencli/download', () => ({
+    formatCookieHeader: mockFormatCookieHeader,
+}));
+
+vi.mock('./utils.js', async () => {
+    const actual = await vi.importActual('./utils.js');
+    return {
+        ...actual,
+        getConversationAssets: mockGetConversationAssets,
+    };
+});
+
+import { getRegistry } from '@jackwener/opencli/registry';
+import './download.js';
+
+function createPageMock() {
+    return {
+        getCookies: vi.fn().mockResolvedValue([{ name: 'sid', value: 'secret', domain: '.doubao.com' }]),
+    };
+}
+
+describe('doubao download', () => {
+    const download = getRegistry().get('doubao/download');
+
+    beforeEach(() => {
+        mockDownloadMedia.mockReset();
+        mockFormatCookieHeader.mockClear();
+        mockGetConversationAssets.mockReset();
+        mockDownloadMedia.mockResolvedValue([{ index: 1, type: 'image', status: 'success', size: '2 MB' }]);
+    });
+
+    it('extracts media for a conversation URL and downloads into a conversation subdirectory', async () => {
+        const page = createPageMock();
+        mockGetConversationAssets.mockResolvedValue([
+            {
+                type: 'image',
+                url: 'https://p3-flow-imagex-sign.byteimg.com/tos-cn/example.jpeg?x-signature=abc',
+                key: 'tos-cn/example.jpeg',
+                format: 'jpeg',
+            },
+        ]);
+        await download.func(page, {
+            id: 'https://www.doubao.com/chat/1234567890123',
+            output: './out',
+        });
+        expect(mockGetConversationAssets).toHaveBeenCalledWith(page, '1234567890123', { variant: 'original' });
+        expect(page.getCookies).toHaveBeenCalledWith({ domain: 'doubao.com' });
+        expect(mockDownloadMedia).toHaveBeenCalledWith([
+            {
+                type: 'image',
+                url: 'https://p3-flow-imagex-sign.byteimg.com/tos-cn/example.jpeg?x-signature=abc',
+                filename: '001_example.jpg',
+            },
+        ], expect.objectContaining({
+            output: './out',
+            subdir: '1234567890123',
+            cookies: 'sid=secret',
+            filenamePrefix: '1234567890123',
+            timeout: 15000,
+        }));
+    });
+
+    it('supports limiting the number of downloaded media items', async () => {
+        const page = createPageMock();
+        mockGetConversationAssets.mockResolvedValue([
+            { type: 'image', url: 'https://example.com/1.png', key: 'one.png' },
+            { type: 'image', url: 'https://example.com/2.png', key: 'two.png' },
+        ]);
+        await download.func(page, { id: '1234567890123', output: './out', limit: '1', timeout: '5000' });
+        expect(mockDownloadMedia).toHaveBeenCalledWith([
+            expect.objectContaining({ url: 'https://example.com/1.png' }),
+        ], expect.objectContaining({
+            timeout: 5000,
+        }));
+    });
+
+    it('returns an explicit failed row when no media is present', async () => {
+        const page = createPageMock();
+        mockGetConversationAssets.mockResolvedValue([]);
+        await expect(download.func(page, { id: '1234567890123' })).resolves.toEqual([
+            { index: 0, type: '-', status: 'failed', size: 'No media found' },
+        ]);
+        expect(mockDownloadMedia).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsupported image variants before browser work', async () => {
+        const page = createPageMock();
+        await expect(download.func(page, { id: '1234567890123', variant: 'large' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('Invalid Doubao image variant'),
+        });
+        expect(mockGetConversationAssets).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid limit and timeout values before browser work', async () => {
+        const page = createPageMock();
+        await expect(download.func(page, { id: '1234567890123', limit: '-1' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        await expect(download.func(page, { id: '1234567890123', timeout: '-1' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        expect(mockGetConversationAssets).not.toHaveBeenCalled();
+    });
+});

--- a/clis/doubao/history.js
+++ b/clis/doubao/history.js
@@ -1,5 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { DOUBAO_DOMAIN, getDoubaoConversationList } from './utils.js';
+const MAX_HISTORY_LIMIT = 5000;
 export const historyCommand = cli({
     site: 'doubao',
     name: 'history',
@@ -15,10 +17,14 @@ export const historyCommand = cli({
     ],
     columns: ['Index', 'Id', 'Title', 'Url'],
     func: async (page, kwargs) => {
-        const limit = parseInt(kwargs.limit, 10) || 50;
+        const rawLimit = kwargs.limit ?? '50';
+        const limit = Number(rawLimit);
+        if (!Number.isInteger(limit) || limit < 1 || limit > MAX_HISTORY_LIMIT) {
+            throw new ArgumentError(`Doubao history limit must be an integer between 1 and ${MAX_HISTORY_LIMIT}: ${rawLimit}`);
+        }
         const conversations = await getDoubaoConversationList(page, { limit });
         if (conversations.length === 0) {
-            return [{ Index: 0, Id: '', Title: 'No conversation history found. Make sure you are logged in.', Url: '' }];
+            throw new EmptyResultError('doubao history', 'No conversations were extracted. Verify the Doubao login state and retry.');
         }
         return conversations.slice(0, limit).map((conv, i) => ({
             Index: i + 1,

--- a/clis/doubao/history.js
+++ b/clis/doubao/history.js
@@ -16,7 +16,7 @@ export const historyCommand = cli({
     columns: ['Index', 'Id', 'Title', 'Url'],
     func: async (page, kwargs) => {
         const limit = parseInt(kwargs.limit, 10) || 50;
-        const conversations = await getDoubaoConversationList(page);
+        const conversations = await getDoubaoConversationList(page, { limit });
         if (conversations.length === 0) {
             return [{ Index: 0, Id: '', Title: 'No conversation history found. Make sure you are logged in.', Url: '' }];
         }

--- a/clis/doubao/history.test.js
+++ b/clis/doubao/history.test.js
@@ -33,5 +33,32 @@ describe('doubao history', () => {
                 Url: 'https://www.doubao.com/chat/1234567890123',
             },
         ]);
+        expect(mockGetDoubaoConversationList).toHaveBeenCalledWith({}, { limit: 50 });
+    });
+    it('accepts a full-history limit larger than the old 1000-row cap', async () => {
+        mockGetDoubaoConversationList.mockResolvedValue([
+            {
+                Id: '1234567890123',
+                Title: 'Weekly Sync',
+                Url: 'https://www.doubao.com/chat/1234567890123',
+            },
+        ]);
+        await history.func({}, { limit: '5000' });
+        expect(mockGetDoubaoConversationList).toHaveBeenCalledWith({}, { limit: 5000 });
+    });
+    it('rejects invalid limits before browser work', async () => {
+        await expect(history.func({}, { limit: '3.5' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        await expect(history.func({}, { limit: '5001' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        expect(mockGetDoubaoConversationList).not.toHaveBeenCalled();
+    });
+    it('throws a typed empty-result error when no conversations are extracted', async () => {
+        mockGetDoubaoConversationList.mockResolvedValue([]);
+        await expect(history.func({}, {})).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+        });
     });
 });

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -834,6 +834,7 @@ function getRecentConversationsScript(limit) {
       const seen = new Set();
       let convVersion = 0;
       let hasMore = true;
+      let pcPinQueryType = 0;
 
       for (let pageIndex = 0; pageIndex < 60 && hasMore && conversations.length < requestedLimit; pageIndex += 1) {
         const batchLimit = Math.max(1, Math.min(50, requestedLimit - conversations.length));
@@ -855,7 +856,7 @@ function getRecentConversationsScript(limit) {
                 need_coco_conversation: Number(convVersion) === 0,
                 need_coco_bot: Number(convVersion) === 0,
                 need_pc_pin_chain: true,
-                pc_pin_query_type: 0,
+                pc_pin_query_type: pcPinQueryType,
               },
             },
           },
@@ -894,6 +895,7 @@ function getRecentConversationsScript(limit) {
 
         hasMore = Boolean(downlink.has_more);
         convVersion = downlink.next_conv_version || 0;
+        pcPinQueryType = downlink.extra?.pc_pin_query_type ?? pcPinQueryType;
         if (!convVersion || !(downlink.cells || []).length) break;
       }
 
@@ -1355,6 +1357,7 @@ export const __test__ = {
     clickSendButtonScript,
     composerStateScript,
     detectDoubaoVerificationScript,
+    getRecentConversationsScript,
     getTurnsScript,
     getTranscriptLinesScript,
 };

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -1272,19 +1272,41 @@ function getConversationAssetsScript(conversationId, variant) {
       };
 
       const loaderData = window._ROUTER_DATA?.loaderData || {};
-      const scoped = Object.entries(loaderData)
-        .filter(([key, value]) => key.includes(conversationId) || key.includes('chat_') || value?.messageList || value?.messages)
-        .map(([, value]) => value);
-      const roots = scoped.length > 0 ? scoped : [loaderData];
+      const scoped = [];
+      const collectScoped = (value, key = '', depth = 0) => {
+        if (!value || typeof value !== 'object' || depth > 6) return;
+        if (
+          key.includes(conversationId)
+          || value.conversationId === conversationId
+          || value.conversation_id === conversationId
+          || value.conversationInfo?.conversation_id === conversationId
+        ) {
+          scoped.push(value);
+          return;
+        }
+        for (const [childKey, childValue] of Object.entries(value)) {
+          collectScoped(childValue, childKey, depth + 1);
+        }
+      };
+      collectScoped(loaderData);
+
+      const roots = scoped.flatMap((root) => {
+        if (root?.messageList) return [root.messageList];
+        if (root?.messages) return [root.messages];
+        return [root];
+      });
       for (const root of roots) visit(root);
 
       const domSeen = new Set(assets.map((item) => item.url));
-      document.querySelectorAll('img').forEach((img) => {
+      const messageList = document.querySelector('[data-testid="message-list"], .conversation-page-message-host, [class*="message-list-"]');
+      const isIgnoredDomImage = (url) => !/^https?:\\/\\//i.test(url)
+        || /doubao_avatar|user-avatar|passport|FileBizType\\.BIZ_BOT_ICON|\\/chat\\/static\\/image\\/intro/i.test(url);
+      (messageList || document).querySelectorAll('img').forEach((img) => {
         const url = img.currentSrc || img.src || '';
         const width = img.naturalWidth || img.width || 0;
         const height = img.naturalHeight || img.height || 0;
-        if (!isHttpUrl(url) || domSeen.has(url)) return;
-        if (width > 0 && height > 0 && width <= 64 && height <= 64) return;
+        if (isIgnoredDomImage(url) || domSeen.has(url)) return;
+        if (width > 0 && height > 0 && (width <= 256 || height <= 256)) return;
         push({ type: 'image', url, label: 'dom', width, height });
       });
 

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -1133,6 +1133,173 @@ export async function getConversationDetail(page, conversationId) {
     }));
     return { messages, meeting: raw.meeting };
 }
+function getConversationAssetsScript(conversationId, variant) {
+    return `
+    (() => {
+      const conversationId = ${JSON.stringify(conversationId)};
+      const variant = ${JSON.stringify(variant)};
+      const assets = [];
+      const seen = new Set();
+
+      const clean = (value) => String(value || '').trim();
+      const isHttpUrl = (value) => /^https?:\\/\\//i.test(clean(value));
+      const push = (item) => {
+        const url = clean(item.url);
+        if (!isHttpUrl(url)) return;
+        const key = item.type + ':' + url;
+        if (seen.has(key)) return;
+        seen.add(key);
+        assets.push({
+          type: item.type,
+          url,
+          key: clean(item.key),
+          label: clean(item.label),
+          width: Number(item.width) || 0,
+          height: Number(item.height) || 0,
+          resourceId: clean(item.resourceId),
+          identifier: clean(item.identifier),
+          format: clean(item.format),
+        });
+      };
+
+      const pickUrlObject = (image) => {
+        const candidates = [
+          ['raw', image.image_raw || image.raw_image],
+          ['original', image.image_ori || image.image_original],
+          ['preview', image.preview_img || image.image_preview],
+          ['thumb', image.image_thumb],
+          ['url', image],
+        ];
+        const preferred = candidates.find(([name, value]) => name === variant && isHttpUrl(value?.url));
+        if (preferred) return { label: preferred[0], value: preferred[1] };
+        return candidates
+          .map(([name, value]) => ({ label: name, value }))
+          .find((item) => isHttpUrl(item.value?.url));
+      };
+
+      const pushImage = (image, owner = {}) => {
+        if (!image || typeof image !== 'object') return;
+        const picked = pickUrlObject(image);
+        if (!picked) return;
+        push({
+          type: 'image',
+          url: picked.value.url,
+          key: image.key || owner.key,
+          label: picked.label,
+          width: picked.value.width || image.width,
+          height: picked.value.height || image.height,
+          resourceId: image.resource_id || owner.resource_id,
+          identifier: image.identifier || owner.identifier,
+          format: picked.value.format || image.format,
+        });
+      };
+
+      const looksLikeVideoUrl = (value) => /\\.(?:mp4|m3u8|webm)(?:[?#]|$)|\\/video\\//i.test(value);
+      const visit = (value, owner = {}) => {
+        if (!value) return;
+
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+            try {
+              visit(JSON.parse(trimmed), owner);
+            } catch {}
+          }
+          return;
+        }
+
+        if (Array.isArray(value)) {
+          for (const item of value) visit(item, owner);
+          return;
+        }
+
+        if (typeof value !== 'object') return;
+        const record = value;
+        const nextOwner = {
+          key: record.key || owner.key,
+          resource_id: record.resource_id || owner.resource_id,
+          identifier: record.identifier || owner.identifier,
+        };
+
+        if (record.entity_content?.image) pushImage(record.entity_content.image, nextOwner);
+        if (record.image) pushImage(record.image, nextOwner);
+        if (record.cover) pushImage(record.cover, nextOwner);
+        if (
+          (record.image_ori || record.image_raw || record.raw_image || record.preview_img || record.image_thumb)
+          && (record.key || record.url || record.image_ori?.url || record.image_raw?.url || record.raw_image?.url)
+        ) {
+          pushImage(record, nextOwner);
+        }
+
+        for (const [key, child] of Object.entries(record)) {
+          if (key === 'download_url' && isHttpUrl(child)) {
+            push({
+              type: looksLikeVideoUrl(child) ? 'video' : 'image',
+              url: child,
+              key: record.vid || record.key || nextOwner.key,
+              label: key,
+              width: record.width,
+              height: record.height,
+              resourceId: record.resource_id || nextOwner.resource_id,
+              identifier: record.identifier || nextOwner.identifier,
+              format: record.video_type || record.format,
+            });
+            continue;
+          }
+
+          if ((key === 'main_url' || key.startsWith('backup_url')) && typeof child === 'string') {
+            try {
+              const decoded = atob(child);
+              if (isHttpUrl(decoded)) {
+                push({
+                  type: looksLikeVideoUrl(decoded) ? 'video' : 'image',
+                  url: decoded,
+                  key: record.file_id || record.vid || nextOwner.key,
+                  label: key,
+                  width: record.vwidth || record.width,
+                  height: record.vheight || record.height,
+                  resourceId: record.resource_id || nextOwner.resource_id,
+                  identifier: record.identifier || nextOwner.identifier,
+                  format: record.vtype || record.video_type || record.format,
+                });
+                continue;
+              }
+            } catch {}
+          }
+
+          visit(child, nextOwner);
+        }
+      };
+
+      const loaderData = window._ROUTER_DATA?.loaderData || {};
+      const scoped = Object.entries(loaderData)
+        .filter(([key, value]) => key.includes(conversationId) || key.includes('chat_') || value?.messageList || value?.messages)
+        .map(([, value]) => value);
+      const roots = scoped.length > 0 ? scoped : [loaderData];
+      for (const root of roots) visit(root);
+
+      const domSeen = new Set(assets.map((item) => item.url));
+      document.querySelectorAll('img').forEach((img) => {
+        const url = img.currentSrc || img.src || '';
+        const width = img.naturalWidth || img.width || 0;
+        const height = img.naturalHeight || img.height || 0;
+        if (!isHttpUrl(url) || domSeen.has(url)) return;
+        if (width > 0 && height > 0 && width <= 64 && height <= 64) return;
+        push({ type: 'image', url, label: 'dom', width, height });
+      });
+
+      return assets;
+    })()
+  `;
+}
+export async function getConversationAssets(page, conversationId, options = {}) {
+    const variant = ['original', 'raw', 'preview', 'thumb'].includes(options.variant)
+        ? options.variant
+        : 'original';
+    await navigateToConversation(page, conversationId);
+    const assets = await page.evaluate(getConversationAssetsScript(conversationId, variant));
+    return Array.isArray(assets) ? assets : [];
+}
 // ---------------------------------------------------------------------------
 // Meeting minutes panel helpers
 // ---------------------------------------------------------------------------
@@ -1358,6 +1525,7 @@ export const __test__ = {
     composerStateScript,
     detectDoubaoVerificationScript,
     getRecentConversationsScript,
+    getConversationAssetsScript,
     getTurnsScript,
     getTranscriptLinesScript,
 };

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -823,7 +823,7 @@ function getRecentConversationsScript(limit) {
     return `
     (async () => {
       const clean = (value) => String(value || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
-      const requestedLimit = Math.max(1, Math.min(Number(${JSON.stringify(limit)}) || 50, 1000));
+      const requestedLimit = Number(${JSON.stringify(limit)});
       const resources = performance.getEntriesByType('resource')
         .map((entry) => entry.name)
         .filter((name) => typeof name === 'string');
@@ -836,7 +836,7 @@ function getRecentConversationsScript(limit) {
       let hasMore = true;
       let pcPinQueryType = 0;
 
-      for (let pageIndex = 0; pageIndex < 60 && hasMore && conversations.length < requestedLimit; pageIndex += 1) {
+      for (let pageIndex = 0; pageIndex < 100 && hasMore && conversations.length < requestedLimit; pageIndex += 1) {
         const batchLimit = Math.max(1, Math.min(50, requestedLimit - conversations.length));
         const body = {
           cmd: 3200,
@@ -932,7 +932,7 @@ function getConversationListScript() {
 }
 export async function getDoubaoConversationList(page, options = {}) {
     await ensureDoubaoChatPage(page);
-    const requestedLimit = Math.max(1, parseInt(String(options.limit || '50'), 10) || 50);
+    const requestedLimit = Number(options.limit ?? 50);
     const apiResult = await page.evaluate(getRecentConversationsScript(requestedLimit)).catch(() => null);
     if (apiResult?.ok && Array.isArray(apiResult.conversations) && apiResult.conversations.length > 0) {
         return apiResult.conversations.map((item) => ({

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -1076,6 +1076,7 @@ function cleanDoubaoText(value) {
     return String(value || '')
         .replace(/\u00a0/g, ' ')
         .replace(/\r\n?/g, '\n')
+        .replace(/[ \t]+$/gm, '')
         .replace(/\n{3,}/g, '\n\n')
         .trim();
 }

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -819,22 +819,105 @@ export function collectDoubaoTranscriptAdditions(beforeLines, currentLines, prom
         .map(({ sanitized }) => sanitized)
         .join('\n');
 }
+function getRecentConversationsScript(limit) {
+    return `
+    (async () => {
+      const clean = (value) => String(value || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
+      const requestedLimit = Math.max(1, Math.min(Number(${JSON.stringify(limit)}) || 50, 1000));
+      const resources = performance.getEntriesByType('resource')
+        .map((entry) => entry.name)
+        .filter((name) => typeof name === 'string');
+      const recentUrl = [...resources].reverse().find((name) => name.includes('/im/chain/recent_conv'));
+      if (!recentUrl) return { ok: false, reason: 'recent_conv resource not found', conversations: [] };
+
+      const conversations = [];
+      const seen = new Set();
+      let convVersion = 0;
+      let hasMore = true;
+
+      for (let pageIndex = 0; pageIndex < 60 && hasMore && conversations.length < requestedLimit; pageIndex += 1) {
+        const batchLimit = Math.max(1, Math.min(50, requestedLimit - conversations.length));
+        const body = {
+          cmd: 3200,
+          sequence_id: String(Date.now()) + '_' + pageIndex,
+          channel: 2,
+          version: '1',
+          uplink_body: {
+            pull_recent_conv_chain_uplink_body: {
+              api_version: 1,
+              conv_version: Number(convVersion) || 0,
+              direction: Number(convVersion) === 0 ? 3 : 1,
+              limit: batchLimit,
+              message_count_per_conv: 10,
+              option: {
+                not_need_message: true,
+                need_complete_conversation: true,
+                need_coco_conversation: Number(convVersion) === 0,
+                need_coco_bot: Number(convVersion) === 0,
+                need_pc_pin_chain: true,
+                pc_pin_query_type: 0,
+              },
+            },
+          },
+        };
+        const response = await fetch(recentUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json; encoding=utf-8' },
+          body: JSON.stringify(body),
+        });
+        const json = await response.json().catch(() => ({}));
+        if (json.status_code !== 0) {
+          return {
+            ok: false,
+            reason: json.status_desc || json.message || 'recent_conv request failed',
+            conversations,
+          };
+        }
+
+        const downlink = json.downlink_body?.pull_recent_conv_chain_downlink_body || {};
+        for (const cell of downlink.cells || []) {
+          const conversation = cell?.conversation || {};
+          const id = clean(conversation.conversation_id || cell?.id || '');
+          if (!id || seen.has(id)) continue;
+          seen.add(id);
+          conversations.push({
+            id,
+            title: clean(conversation.name || conversation.title || 'Untitled conversation').slice(0, 200),
+            href: '/chat/' + id,
+            updateTime: clean(conversation.update_time || ''),
+            latestIndex: clean(conversation.latest_index || ''),
+            botId: clean(conversation.bot_id || ''),
+            botType: conversation.bot_type ?? '',
+          });
+          if (conversations.length >= requestedLimit) break;
+        }
+
+        hasMore = Boolean(downlink.has_more);
+        convVersion = downlink.next_conv_version || 0;
+        if (!convVersion || !(downlink.cells || []).length) break;
+      }
+
+      return { ok: true, conversations };
+    })()
+  `;
+}
 function getConversationListScript() {
     return `
     (() => {
-      const sidebar = document.querySelector('[data-testid="flow_chat_sidebar"]');
+      const sidebar = document.querySelector('[data-testid="flow_chat_sidebar"], #flow_chat_sidebar');
       if (!sidebar) return [];
 
       const items = Array.from(
-        sidebar.querySelectorAll('a[data-testid="chat_list_thread_item"]')
+        sidebar.querySelectorAll('a[data-testid="chat_list_thread_item"], a[id^="conversation_"], a[href*="/chat/"]')
       );
 
       return items
         .map(a => {
           const href = a.getAttribute('href') || '';
-          const match = href.match(/\\/chat\\/(\\d{10,})/);
-          if (!match) return null;
-          const id = match[1];
+          const idFromAttr = (a.getAttribute('id') || '').match(/^conversation_(\\d{10,})$/)?.[1] || '';
+          const idFromHref = href.match(/\\/chat\\/(?:bot\\/chat\\/)?(\\d{10,})/)?.[1] || '';
+          const id = idFromAttr || idFromHref;
+          if (!id) return null;
           const textContent = (a.textContent || a.innerText || '').trim();
           const title = textContent
             .replace(/\\s+/g, ' ')
@@ -845,8 +928,21 @@ function getConversationListScript() {
     })()
   `;
 }
-export async function getDoubaoConversationList(page) {
+export async function getDoubaoConversationList(page, options = {}) {
     await ensureDoubaoChatPage(page);
+    const requestedLimit = Math.max(1, parseInt(String(options.limit || '50'), 10) || 50);
+    const apiResult = await page.evaluate(getRecentConversationsScript(requestedLimit)).catch(() => null);
+    if (apiResult?.ok && Array.isArray(apiResult.conversations) && apiResult.conversations.length > 0) {
+        return apiResult.conversations.map((item) => ({
+            Id: item.id,
+            Title: item.title || 'Untitled conversation',
+            Url: `${DOUBAO_CHAT_URL}/${item.id}`,
+            UpdateTime: item.updateTime,
+            LatestIndex: item.latestIndex,
+            BotId: item.botId,
+            BotType: item.botType,
+        }));
+    }
     const raw = await page.evaluate(getConversationListScript());
     if (!Array.isArray(raw))
         return [];
@@ -863,9 +959,22 @@ export function parseDoubaoConversationId(input) {
 function getConversationDetailScript() {
     return `
     (() => {
-      const clean = (v) => (v || '').replace(/\\u00a0/g, ' ').replace(/\\n{3,}/g, '\\n\\n').trim();
+      const clean = (v) => (v || '')
+        .replace(/\\u00a0/g, ' ')
+        .replace(/\\n{3,}/g, '\\n\\n')
+        .trim();
 
-      const messageList = document.querySelector('[data-testid="message-list"]');
+      const isVisible = (el) => {
+        if (!(el instanceof HTMLElement)) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const messageList = document.querySelector(
+        '[data-testid="message-list"], .conversation-page-message-host, [class*="message-list-"]'
+      );
       if (!messageList) return { messages: [], meeting: null };
 
       const meetingCard = messageList.querySelector('[data-testid="meeting-minutes-card"]');
@@ -879,8 +988,114 @@ function getConversationDetailScript() {
         };
       }
 
+      const roleFor = (root) => {
+        if (
+          root.matches('[data-testid="send_message"], [class*="send-message"], [class*="justify-end"]')
+          || root.querySelector('[data-testid="send_message"], [class*="send-message"], [class*="bg-g-send-msg-bubble"]')
+          || root.querySelector('[data-foundation-type="send-message-action-bar"]')
+        ) {
+          return 'User';
+        }
+        if (
+          root.matches('[data-testid="receive_message"], [data-testid*="receive_message"], [class*="receive-message"]')
+          || root.querySelector('[data-testid="receive_message"], [data-testid*="receive_message"], [class*="receive-message"]')
+          || root.querySelector('[data-foundation-type="receive-message-action-bar"]')
+          || root.querySelector('.md-box-root, [class*="md-box-root"], .flow-markdown-body, [class*="markdown"]')
+        ) {
+          return 'Assistant';
+        }
+        return '';
+      };
+
+      const textSelectors = [
+        '[data-testid="message_text_content"]',
+        '[data-testid="message_content"]',
+        '[data-testid*="message_text"]',
+        '[data-testid*="message_content"]',
+        '[class*="bg-g-send-msg-bubble"]',
+        '[class*="bg-g-receive-msg-bubble"]',
+        '.md-box-root',
+        '[class*="md-box-root"]',
+        '.flow-markdown-body',
+        '[class*="message-content"]',
+      ];
+
+      const extractImageLines = (root) => Array.from(root.querySelectorAll('img'))
+        .filter((img) => img instanceof HTMLImageElement && isVisible(img))
+        .map((img) => {
+          const width = img.naturalWidth || img.width || 0;
+          const height = img.naturalHeight || img.height || 0;
+          if (width > 0 && height > 0 && width <= 48 && height <= 48) return '';
+          const url = clean(img.currentSrc || img.src || '');
+          return /^https?:\\/\\//i.test(url) ? 'Image: ' + url : '';
+        })
+        .filter((line, index, lines) => line && lines.indexOf(line) === index);
+
+      const extractText = (root) => {
+        const chunks = [];
+        const seenText = new Set();
+        for (const selector of textSelectors) {
+          const nodes = Array.from(root.querySelectorAll(selector)).filter(isVisible);
+          for (const node of nodes) {
+            const text = clean(node.innerText || node.textContent || '');
+            if (!text || seenText.has(text)) continue;
+            seenText.add(text);
+            chunks.push(text);
+          }
+          if (chunks.length > 0) break;
+        }
+        const text = chunks.length > 0 ? clean(chunks.join('\\n')) : clean(root.innerText || root.textContent || '');
+        const imageLines = extractImageLines(root);
+        return clean([text, ...imageLines].filter(Boolean).join('\\n'));
+      };
+
+      const roots = [];
+      const seenNodes = new Set();
+      const selectors = [
+        '[data-testid="union_message"]',
+        '[data-testid="message-block-container"]',
+        '.v_list_row [data-message-id]',
+        '[data-message-id]',
+      ];
+      for (const selector of selectors) {
+        messageList.querySelectorAll(selector).forEach((node) => {
+          if (!(node instanceof HTMLElement) || seenNodes.has(node)) return;
+          seenNodes.add(node);
+          roots.push(node);
+        });
+      }
+
+      const filteredRoots = roots
+        .filter((node) => isVisible(node) && !node.closest('script, style, noscript'))
+        .filter((node, index, nodes) => !nodes.some((other, otherIndex) => otherIndex !== index && other.contains(node)));
+
+      filteredRoots.sort((a, b) => {
+        if (a === b) return 0;
+        const pos = a.compareDocumentPosition(b);
+        return pos & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+      });
+
+      const deduped = [];
+      const seenMessages = new Set();
+      for (const root of filteredRoots) {
+        const role = roleFor(root) || 'System';
+        const text = extractText(root);
+        if (!text) continue;
+        const key = role + '::' + text;
+        if (seenMessages.has(key)) continue;
+        seenMessages.add(key);
+        deduped.push({
+          role,
+          text,
+          hasMeetingCard: !!root.querySelector('[data-testid="meeting-minutes-card"]'),
+        });
+      }
+
+      const messages = deduped.filter((message) => message.text);
+      if (messages.length > 0) return { messages, meeting };
+
       const unions = Array.from(messageList.querySelectorAll('[data-testid="union_message"]'));
-      const messages = unions.map(u => {
+      const legacyMessages = unions.map(u => {
         const isSend = !!u.querySelector('[data-testid="send_message"]');
         const isReceive = !!u.querySelector('[data-testid="receive_message"]');
         const textEl = u.querySelector('[data-testid="message_text_content"]');
@@ -892,7 +1107,7 @@ function getConversationDetailScript() {
         };
       }).filter(m => m.text);
 
-      return { messages, meeting };
+      return { messages: legacyMessages, meeting };
     })()
   `;
 }

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -958,160 +958,257 @@ export function parseDoubaoConversationId(input) {
     const match = input.match(/(\d{10,})/);
     return match ? match[1] : input;
 }
-function getConversationDetailScript() {
+function getConversationDetailScript(conversationId, maxPages) {
     return `
-    (() => {
-      const clean = (v) => (v || '')
-        .replace(/\\u00a0/g, ' ')
-        .replace(/\\n{3,}/g, '\\n\\n')
-        .trim();
+    (async () => {
+      const conversationId = ${JSON.stringify(conversationId)};
+      const maxPages = ${JSON.stringify(maxPages)};
+      const resources = performance.getEntriesByType('resource')
+        .map((entry) => entry.name)
+        .filter((name) => typeof name === 'string');
+      const singleUrl = [...resources].reverse().find((name) => name.includes('/im/chain/single'));
+      if (!singleUrl) {
+        return { ok: false, reason: 'single-chain resource not found', messages: [], pages: 0, hasMore: true };
+      }
 
-      const isVisible = (el) => {
-        if (!(el instanceof HTMLElement)) return false;
-        const style = window.getComputedStyle(el);
-        if (style.display === 'none' || style.visibility === 'hidden') return false;
-        const rect = el.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      };
+      const messages = [];
+      const seenMessageIds = new Set();
+      const seenAnchors = new Set();
+      let anchorIndex = Number.MAX_SAFE_INTEGER;
+      let hasMore = true;
+      let pages = 0;
 
-      const messageList = document.querySelector(
-        '[data-testid="message-list"], .conversation-page-message-host, [class*="message-list-"]'
-      );
-      if (!messageList) return { messages: [], meeting: null };
-
-      const meetingCard = messageList.querySelector('[data-testid="meeting-minutes-card"]');
-      let meeting = null;
-      if (meetingCard) {
-        const raw = clean(meetingCard.textContent || '');
-        const match = raw.match(/^(.+?)(?:会议时间：|\\s*$)(.*)/);
-        meeting = {
-          title: match ? match[1].trim() : raw,
-          time: match && match[2] ? match[2].trim() : '',
+      while (hasMore && pages < maxPages) {
+        if (seenAnchors.has(anchorIndex)) {
+          return {
+            ok: false,
+            reason: 'single-chain cursor repeated',
+            messages,
+            pages,
+            hasMore,
+          };
+        }
+        seenAnchors.add(anchorIndex);
+        const body = {
+          cmd: 3100,
+          uplink_body: {
+            pull_singe_chain_uplink_body: {
+              conversation_id: conversationId,
+              anchor_index: anchorIndex,
+              conversation_type: 3,
+              direction: 1,
+              limit: 20,
+              ext: {},
+              filter: { index_list: [] },
+              evaluate_ab_params: '',
+              evaluate_common_params: '',
+            },
+          },
+          sequence_id: String(Date.now()) + '_' + pages,
+          channel: 2,
+          version: '1',
         };
-      }
-
-      const roleFor = (root) => {
-        if (
-          root.matches('[data-testid="send_message"], [class*="send-message"], [class*="justify-end"]')
-          || root.querySelector('[data-testid="send_message"], [class*="send-message"], [class*="bg-g-send-msg-bubble"]')
-          || root.querySelector('[data-foundation-type="send-message-action-bar"]')
-        ) {
-          return 'User';
-        }
-        if (
-          root.matches('[data-testid="receive_message"], [data-testid*="receive_message"], [class*="receive-message"]')
-          || root.querySelector('[data-testid="receive_message"], [data-testid*="receive_message"], [class*="receive-message"]')
-          || root.querySelector('[data-foundation-type="receive-message-action-bar"]')
-          || root.querySelector('.md-box-root, [class*="md-box-root"], .flow-markdown-body, [class*="markdown"]')
-        ) {
-          return 'Assistant';
-        }
-        return '';
-      };
-
-      const textSelectors = [
-        '[data-testid="message_text_content"]',
-        '[data-testid="message_content"]',
-        '[data-testid*="message_text"]',
-        '[data-testid*="message_content"]',
-        '[class*="bg-g-send-msg-bubble"]',
-        '[class*="bg-g-receive-msg-bubble"]',
-        '.md-box-root',
-        '[class*="md-box-root"]',
-        '.flow-markdown-body',
-        '[class*="message-content"]',
-      ];
-
-      const extractImageLines = (root) => Array.from(root.querySelectorAll('img'))
-        .filter((img) => img instanceof HTMLImageElement && isVisible(img))
-        .map((img) => {
-          const width = img.naturalWidth || img.width || 0;
-          const height = img.naturalHeight || img.height || 0;
-          if (width > 0 && height > 0 && width <= 48 && height <= 48) return '';
-          const url = clean(img.currentSrc || img.src || '');
-          return /^https?:\\/\\//i.test(url) ? 'Image: ' + url : '';
-        })
-        .filter((line, index, lines) => line && lines.indexOf(line) === index);
-
-      const extractText = (root) => {
-        const chunks = [];
-        const seenText = new Set();
-        for (const selector of textSelectors) {
-          const nodes = Array.from(root.querySelectorAll(selector)).filter(isVisible);
-          for (const node of nodes) {
-            const text = clean(node.innerText || node.textContent || '');
-            if (!text || seenText.has(text)) continue;
-            seenText.add(text);
-            chunks.push(text);
-          }
-          if (chunks.length > 0) break;
-        }
-        const text = chunks.length > 0 ? clean(chunks.join('\\n')) : clean(root.innerText || root.textContent || '');
-        const imageLines = extractImageLines(root);
-        return clean([text, ...imageLines].filter(Boolean).join('\\n'));
-      };
-
-      const roots = [];
-      const seenNodes = new Set();
-      const selectors = [
-        '[data-testid="union_message"]',
-        '[data-testid="message-block-container"]',
-        '.v_list_row [data-message-id]',
-        '[data-message-id]',
-      ];
-      for (const selector of selectors) {
-        messageList.querySelectorAll(selector).forEach((node) => {
-          if (!(node instanceof HTMLElement) || seenNodes.has(node)) return;
-          seenNodes.add(node);
-          roots.push(node);
+        const response = await fetch(singleUrl, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Accept: 'application/json, text/plain, */*',
+            'Agw-Js-Conv': 'str',
+            'Content-Type': 'application/json; encoding=utf-8',
+          },
+          body: JSON.stringify(body),
         });
+        if (!response.ok) {
+          return {
+            ok: false,
+            reason: 'single-chain HTTP ' + response.status,
+            messages,
+            pages,
+            hasMore,
+          };
+        }
+        const json = await response.json().catch(() => ({}));
+        if (json.status_code !== 0) {
+          return {
+            ok: false,
+            reason: json.status_desc || json.message || 'single-chain request failed',
+            statusCode: json.status_code,
+            messages,
+            pages,
+            hasMore,
+          };
+        }
+        const downlink = json.downlink_body?.pull_singe_chain_downlink_body || {};
+        const batch = Array.isArray(downlink.messages) ? downlink.messages : [];
+        for (const message of batch) {
+          const id = String(message?.message_id || '');
+          if (!id || seenMessageIds.has(id)) continue;
+          seenMessageIds.add(id);
+          messages.push(message);
+        }
+        pages += 1;
+        hasMore = Boolean(downlink.has_more);
+        if (!hasMore) break;
+        const nextIndex = Number(downlink.next_index);
+        if (!Number.isSafeInteger(nextIndex) || nextIndex < 0 || nextIndex >= anchorIndex || batch.length === 0) {
+          return {
+            ok: false,
+            reason: 'single-chain returned an invalid next_index',
+            messages,
+            pages,
+            hasMore,
+          };
+        }
+        anchorIndex = nextIndex;
       }
 
-      const filteredRoots = roots
-        .filter((node) => isVisible(node) && !node.closest('script, style, noscript'))
-        .filter((node, index, nodes) => !nodes.some((other, otherIndex) => otherIndex !== index && other.contains(node)));
-
-      filteredRoots.sort((a, b) => {
-        if (a === b) return 0;
-        const pos = a.compareDocumentPosition(b);
-        return pos & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
-      });
-
-      const deduped = [];
-      const seenMessages = new Set();
-      for (const root of filteredRoots) {
-        const role = roleFor(root) || 'System';
-        const text = extractText(root);
-        if (!text) continue;
-        const key = role + '::' + text;
-        if (seenMessages.has(key)) continue;
-        seenMessages.add(key);
-        deduped.push({
-          role,
-          text,
-          hasMeetingCard: !!root.querySelector('[data-testid="meeting-minutes-card"]'),
-        });
-      }
-
-      const messages = deduped.filter((message) => message.text);
-      if (messages.length > 0) return { messages, meeting };
-
-      const unions = Array.from(messageList.querySelectorAll('[data-testid="union_message"]'));
-      const legacyMessages = unions.map(u => {
-        const isSend = !!u.querySelector('[data-testid="send_message"]');
-        const isReceive = !!u.querySelector('[data-testid="receive_message"]');
-        const textEl = u.querySelector('[data-testid="message_text_content"]');
-        const text = textEl ? clean(textEl.innerText || textEl.textContent || '') : '';
-        return {
-          role: isSend ? 'User' : isReceive ? 'Assistant' : 'System',
-          text,
-          hasMeetingCard: !!u.querySelector('[data-testid="meeting-minutes-card"]'),
-        };
-      }).filter(m => m.text);
-
-      return { messages: legacyMessages, meeting };
+      return {
+        ok: !hasMore,
+        reason: hasMore ? 'single-chain max page limit reached' : '',
+        messages,
+        pages,
+        hasMore,
+      };
     })()
   `;
+}
+function cleanDoubaoText(value) {
+    return String(value || '')
+        .replace(/\u00a0/g, ' ')
+        .replace(/\r\n?/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+function parseGeneralTaskSkills(ext) {
+    try {
+        const parsed = JSON.parse(ext?.general_task_param || '{}');
+        return Array.isArray(parsed.selected_skills) ? parsed.selected_skills.map(String) : [];
+    }
+    catch {
+        return [];
+    }
+}
+function formatDoubaoMode(ext = {}) {
+    const parts = [];
+    const needDeepThink = cleanDoubaoText(ext.need_deep_think);
+    const cotSwitch = cleanDoubaoText(ext.cot_switch);
+    const modelId = cleanDoubaoText(ext.model_id || ext.model_type || ext.llm_model_type);
+    if (needDeepThink)
+        parts.push(`deep_think=${needDeepThink}`);
+    if (cotSwitch)
+        parts.push(`cot=${cotSwitch}`);
+    if (modelId)
+        parts.push(`model=${modelId}`);
+    if (cleanDoubaoText(ext.cot_ui_style))
+        parts.push(`ui=${cleanDoubaoText(ext.cot_ui_style)}`);
+    const skills = parseGeneralTaskSkills(ext);
+    if (skills.length > 0)
+        parts.push(`skills=${skills.join(',')}`);
+    return parts.join('; ');
+}
+function formatReferenceBlock(reference) {
+    const text = cleanDoubaoText(reference?.text?.text || reference?.text);
+    const messageId = cleanDoubaoText(reference?.text?.message_id);
+    return [
+        'Reference:',
+        text,
+        messageId ? `Referenced message: ${messageId}` : '',
+    ].filter(Boolean).join('\n');
+}
+function formatArtifactBlock(artifact) {
+    const lines = [
+        'AI document card:',
+        cleanDoubaoText(artifact?.title),
+        cleanDoubaoText(artifact?.brief),
+        artifact?.resource_id ? `Resource ID: ${artifact.resource_id}` : '',
+        artifact?.artifact_meta_id ? `Artifact meta ID: ${artifact.artifact_meta_id}` : '',
+        artifact?.artifact_version_id ? `Artifact version ID: ${artifact.artifact_version_id}` : '',
+        artifact?.resource_content_type ? `Content type: ${artifact.resource_content_type}` : '',
+    ];
+    return lines.filter(Boolean).join('\n');
+}
+function jsonForUnknownBlock(block) {
+    try {
+        return `Block ${block?.block_type ?? 'unknown'}:\n${JSON.stringify(block?.content || {}, null, 2)}`;
+    }
+    catch {
+        return `Block ${block?.block_type ?? 'unknown'}: [unserializable content]`;
+    }
+}
+export function normalizeDoubaoApiMessage(message) {
+    const blocks = Array.isArray(message?.content_block) ? message.content_block : [];
+    const thinkingIds = new Set(blocks
+        .filter((block) => block?.content?.thinking_block)
+        .map((block) => String(block.block_id || ''))
+        .filter(Boolean));
+    const parts = [];
+    const types = [];
+    for (const block of blocks) {
+        const content = block?.content || {};
+        if (content.thinking_block) {
+            const thinking = content.thinking_block;
+            const title = cleanDoubaoText(thinking.finish_title
+                || thinking.unfold_streaming_title
+                || thinking.streaming_title);
+            parts.push(`Thinking${title ? `: ${title}` : ''}`);
+            types.push('thinking');
+            continue;
+        }
+        if (content.text_block) {
+            const text = cleanDoubaoText(content.text_block.text);
+            if (text) {
+                const isThinking = thinkingIds.has(String(block.parent_id || ''));
+                parts.push(isThinking ? `Thinking detail:\n${text}` : text);
+                types.push(isThinking ? 'thinking' : 'text');
+            }
+            continue;
+        }
+        if (content.reference_block) {
+            parts.push(formatReferenceBlock(content.reference_block));
+            types.push('reference');
+            continue;
+        }
+        if (content.artifact_block) {
+            parts.push(formatArtifactBlock(content.artifact_block));
+            types.push('artifact');
+            continue;
+        }
+        parts.push(jsonForUnknownBlock(block));
+        types.push(`block-${block?.block_type ?? 'unknown'}`);
+    }
+    const ext = message?.ext || {};
+    const metadata = {
+        conversation_id: cleanDoubaoText(message?.conversation_id),
+        content_type: message?.content_type ?? null,
+        record_status: cleanDoubaoText(ext.record_status),
+        feishu_record_id: cleanDoubaoText(ext.feishu_record_id),
+        feishu_note_id: cleanDoubaoText(ext.feishu_note_id),
+        feishu_record_generated_type: cleanDoubaoText(ext.feishu_record_generated_type),
+        agent_name: cleanDoubaoText(ext.agent_name),
+        general_task_param: cleanDoubaoText(ext.general_task_param),
+    };
+    const compactMetadata = Object.fromEntries(Object.entries(metadata)
+        .filter(([, value]) => value !== '' && value != null));
+    if (parts.length === 0) {
+        const legacyText = cleanDoubaoText(message?.content || message?.thinking_content);
+        parts.push(legacyText || JSON.stringify(compactMetadata));
+        types.push(legacyText ? 'legacy-text' : 'metadata');
+    }
+    const seconds = Number(message?.create_time);
+    const createdAt = Number.isFinite(seconds) && seconds > 0
+        ? new Date(seconds * 1000).toISOString()
+        : null;
+    const numericIndex = Number(message?.index_in_conv);
+    return {
+        Index: Number.isSafeInteger(numericIndex) ? numericIndex : cleanDoubaoText(message?.index_in_conv),
+        MessageId: cleanDoubaoText(message?.message_id),
+        Role: Number(message?.user_type) === 1 ? 'User' : Number(message?.user_type) === 2 ? 'Assistant' : 'System',
+        Type: [...new Set(types)].join('+'),
+        Mode: formatDoubaoMode(ext),
+        CreatedAt: createdAt,
+        Text: parts.filter(Boolean).join('\n\n'),
+        Metadata: JSON.stringify(compactMetadata),
+    };
 }
 export async function navigateToConversation(page, conversationId) {
     const url = `${DOUBAO_CHAT_URL}/${conversationId}`;
@@ -1123,15 +1220,33 @@ export async function navigateToConversation(page, conversationId) {
     await page.goto(url, { waitUntil: 'load', settleMs: 3000 });
     await page.wait(2);
 }
-export async function getConversationDetail(page, conversationId) {
-    await navigateToConversation(page, conversationId);
-    const raw = await page.evaluate(getConversationDetailScript());
-    const messages = (raw.messages || []).map((m) => ({
-        Role: m.role,
-        Text: m.text,
-        HasMeetingCard: m.hasMeetingCard,
-    }));
-    return { messages, meeting: raw.meeting };
+function hasConversationDetailResourceScript() {
+    return `
+    performance.getEntriesByType('resource')
+      .some((entry) => typeof entry.name === 'string' && entry.name.includes('/im/chain/single'))
+  `;
+}
+export async function getConversationDetail(page, conversationId, options = {}) {
+    const hasSingleChainResource = await page.evaluate(hasConversationDetailResourceScript()).catch(() => false);
+    if (!hasSingleChainResource) {
+        await navigateToConversation(page, conversationId);
+    }
+    const maxPages = Number(options.maxPages ?? 500);
+    const raw = await page.evaluate(getConversationDetailScript(conversationId, maxPages));
+    if (!raw?.ok) {
+        throw new CommandExecutionError(`Doubao full detail capture failed: ${raw?.reason || 'unknown error'} (pages=${raw?.pages || 0}, captured=${raw?.messages?.length || 0})`);
+    }
+    const messages = (raw.messages || [])
+        .map(normalizeDoubaoApiMessage)
+        .sort((a, b) => Number(a.Index) - Number(b.Index));
+    return {
+        messages,
+        meeting: null,
+        captureComplete: true,
+        hasMore: false,
+        pages: raw.pages,
+        messagesTotal: messages.length,
+    };
 }
 function getConversationAssetsScript(conversationId, variant) {
     return `
@@ -1547,6 +1662,8 @@ export const __test__ = {
     composerStateScript,
     detectDoubaoVerificationScript,
     getRecentConversationsScript,
+    getConversationDetailScript,
+    hasConversationDetailResourceScript,
     getConversationAssetsScript,
     getTurnsScript,
     getTranscriptLinesScript,

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -5,6 +5,7 @@ import {
     __test__,
     collectDoubaoTranscriptAdditions,
     mergeTranscriptSnapshots,
+    normalizeDoubaoApiMessage,
     parseDoubaoConversationId,
     sendDoubaoMessage,
     waitForDoubaoResponse,
@@ -43,6 +44,106 @@ describe('parseDoubaoConversationId', () => {
     });
     it('keeps a raw id unchanged', () => {
         expect(parseDoubaoConversationId('1234567890123')).toBe('1234567890123');
+    });
+});
+describe('doubao full-detail API normalization', () => {
+    it('keeps mode metadata, thinking detail, references, and AI document cards', () => {
+        const row = normalizeDoubaoApiMessage({
+            conversation_id: '38435747148282626',
+            message_id: '50884875153104386',
+            index_in_conv: '26',
+            user_type: 2,
+            content_type: 9999,
+            create_time: '1784923464',
+            ext: {
+                need_deep_think: '4',
+                cot_switch: '4',
+                model_id: '38',
+                agent_name: 'Agent-GeneralTask',
+                feishu_record_id: '7666165203839044576',
+                feishu_note_id: '7666178835515591969',
+                feishu_record_generated_type: 'audio_subtitle',
+                general_task_param: JSON.stringify({ selected_skills: ['doubao-record'] }),
+            },
+            content_block: [
+                {
+                    block_type: 10040,
+                    block_id: 'thinking-1',
+                    parent_id: '',
+                    content: {
+                        thinking_block: {
+                            finish_title: '明确录音转写相关疑问',
+                        },
+                    },
+                },
+                {
+                    block_type: 10000,
+                    block_id: 'thinking-text',
+                    parent_id: 'thinking-1',
+                    content: {
+                        text_block: {
+                            text: '这是完整思考内容。',
+                        },
+                    },
+                },
+                {
+                    block_type: 10056,
+                    block_id: 'reference-1',
+                    parent_id: '',
+                    content: {
+                        reference_block: {
+                            text: {
+                                text: '你开始录音，帮我录一下。',
+                                message_id: '50890292596784898',
+                            },
+                        },
+                    },
+                },
+                {
+                    block_type: 10030,
+                    block_id: 'artifact-1',
+                    parent_id: '',
+                    content: {
+                        artifact_block: {
+                            title: '智能纪要：新录音 2026年7月25日',
+                            brief: '未能生成纪要，可查看原始记录',
+                            resource_id: 'BHpodrxcdoWz8XxPqwIcCumknMb',
+                            artifact_meta_id: '50854067750682626',
+                            artifact_version_id: '50854067750682882',
+                            resource_content_type: 'type/ddxml',
+                        },
+                    },
+                },
+            ],
+        });
+        expect(row).toMatchObject({
+            Index: 26,
+            MessageId: '50884875153104386',
+            Role: 'Assistant',
+            Type: 'thinking+reference+artifact',
+            Mode: 'deep_think=4; cot=4; model=38; skills=doubao-record',
+            CreatedAt: '2026-07-24T20:04:24.000Z',
+        });
+        expect(row.Text).toContain('Thinking: 明确录音转写相关疑问');
+        expect(row.Text).toContain('Thinking detail:\n这是完整思考内容。');
+        expect(row.Text).toContain('Referenced message: 50890292596784898');
+        expect(row.Text).toContain('AI document card:');
+        expect(row.Text).toContain('智能纪要：新录音 2026年7月25日');
+        expect(row.Text).toContain('Resource ID: BHpodrxcdoWz8XxPqwIcCumknMb');
+        expect(JSON.parse(row.Metadata)).toMatchObject({
+            feishu_record_id: '7666165203839044576',
+            feishu_note_id: '7666178835515591969',
+            feishu_record_generated_type: 'audio_subtitle',
+        });
+    });
+    it('builds a cursor loop with the required Doubao gateway headers', () => {
+        const script = __test__.getConversationDetailScript('38435747148282626', 500);
+        expect(script).toContain("'Agw-Js-Conv': 'str'");
+        expect(script).toContain("'Content-Type': 'application/json; encoding=utf-8'");
+        expect(script).toContain('anchor_index: anchorIndex');
+        expect(script).toContain('downlink.next_index');
+        expect(script).toContain('while (hasMore && pages < maxPages)');
+        expect(script).toContain("reason: hasMore ? 'single-chain max page limit reached' : ''");
     });
 });
 describe('doubao send strategy', () => {

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -275,6 +275,13 @@ describe('doubao receive strategy', () => {
         expect(transcriptScript).toContain('请仔细甄别');
         expect(transcriptScript).toContain('下载电脑版');
     });
+
+    it('carries the server pc_pin_query_type across recent-conversation pages', () => {
+        const recentScript = __test__.getRecentConversationsScript(100);
+        expect(recentScript).toContain('let pcPinQueryType = 0');
+        expect(recentScript).toContain('pc_pin_query_type: pcPinQueryType');
+        expect(recentScript).toContain('pcPinQueryType = downlink.extra?.pc_pin_query_type ?? pcPinQueryType');
+    });
 });
 describe('collectDoubaoTranscriptAdditions', () => {
     it('ignores landing-page capability chips that are not assistant content', () => {

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     __test__,
@@ -281,6 +282,74 @@ describe('doubao receive strategy', () => {
         expect(recentScript).toContain('let pcPinQueryType = 0');
         expect(recentScript).toContain('pc_pin_query_type: pcPinQueryType');
         expect(recentScript).toContain('pcPinQueryType = downlink.extra?.pc_pin_query_type ?? pcPinQueryType');
+    });
+
+    it('extracts image and video media from Doubao route data', () => {
+        const dom = new JSDOM('<img src="https://example.com/dom.png" width="800" height="600">', {
+            url: 'https://www.doubao.com/chat/1234567890123',
+            runScripts: 'outside-only',
+        });
+        dom.window._ROUTER_DATA = {
+            loaderData: {
+                'chat_1234567890123/page': {
+                    messageList: [
+                        {
+                            entities: [
+                                {
+                                    entity_content: {
+                                        image: {
+                                            key: 'tos-cn-i-a9rns2rl98/example.jpeg',
+                                            image_ori: {
+                                                url: 'https://p3-flow-imagex-sign.byteimg.com/tos-cn-i-a9rns2rl98/example.jpeg?x-signature=abc',
+                                                width: 1440,
+                                                height: 1080,
+                                                format: 'jpeg',
+                                            },
+                                            resource_id: 'resource-1',
+                                        },
+                                    },
+                                    identifier: 'identifier-1',
+                                },
+                            ],
+                        },
+                        {
+                            content: {
+                                creation_block: {
+                                    creations: [
+                                        {
+                                            video: {
+                                                vid: 'video-1',
+                                                download_url: 'https://v.example.com/video/example.mp4',
+                                                video_type: 'mp4',
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+        const assets = dom.window.eval(__test__.getConversationAssetsScript('1234567890123', 'original'));
+        expect(assets).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                type: 'image',
+                url: 'https://p3-flow-imagex-sign.byteimg.com/tos-cn-i-a9rns2rl98/example.jpeg?x-signature=abc',
+                key: 'tos-cn-i-a9rns2rl98/example.jpeg',
+                resourceId: 'resource-1',
+            }),
+            expect.objectContaining({
+                type: 'video',
+                url: 'https://v.example.com/video/example.mp4',
+                key: 'video-1',
+            }),
+            expect.objectContaining({
+                type: 'image',
+                url: 'https://example.com/dom.png',
+                label: 'dom',
+            }),
+        ]));
     });
 });
 describe('collectDoubaoTranscriptAdditions', () => {

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -1,6 +1,5 @@
 import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
-import { JSDOM } from 'jsdom';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     __test__,

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -82,7 +82,7 @@ describe('doubao full-detail API normalization', () => {
                     parent_id: 'thinking-1',
                     content: {
                         text_block: {
-                            text: '这是完整思考内容。',
+                            text: '这是完整思考内容。  \n第二行。 \t',
                         },
                     },
                 },
@@ -125,7 +125,7 @@ describe('doubao full-detail API normalization', () => {
             CreatedAt: '2026-07-24T20:04:24.000Z',
         });
         expect(row.Text).toContain('Thinking: 明确录音转写相关疑问');
-        expect(row.Text).toContain('Thinking detail:\n这是完整思考内容。');
+        expect(row.Text).toContain('Thinking detail:\n这是完整思考内容。\n第二行。');
         expect(row.Text).toContain('Referenced message: 50890292596784898');
         expect(row.Text).toContain('AI document card:');
         expect(row.Text).toContain('智能纪要：新录音 2026年7月25日');


### PR DESCRIPTION
## Summary
- update Doubao history extraction to support the current sidebar DOM (`#flow_chat_sidebar`, `conversation_*` anchors, and `/chat/<id>` links)
- update Doubao detail extraction to support current message list/item classes, user send bubbles, and assistant `.flow-markdown-body` content
- add regression coverage for the new sidebar and detail selectors

## Verification
- `PATH=/Users/lmm333/.nvm/versions/node/v24.13.0/bin:$PATH npm exec vitest run --project adapter clis/doubao/utils.test.js clis/doubao/history.test.js clis/doubao/detail.test.js`
- `PATH=/Users/lmm333/.nvm/versions/node/v24.13.0/bin:$PATH npm run typecheck`
- manually verified on logged-in Doubao browser session that `opencli doubao history --limit 5` returns real conversations and `opencli doubao detail <conversation_id>` returns user/assistant messages
