### PR TITLE
fix(registry): pass example field through cli() registration

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -127,6 +127,7 @@ export function cli(opts: CliOptions): CliCommand {
     aliases: opts.aliases,
     description: opts.description ?? '',
     access: opts.access,
+    example: opts.example,
     domain: opts.domain,
     strategy: opts.strategy,
     browser: opts.browser,


### PR DESCRIPTION
## Description
The example optional field is defined on BaseCliCommand (registry.ts:38) and accepted by the CliOptions type through Partial<Omit<...>> , but the cli() function never assigned opts.example to the constructed RawCliCommand object. This meant any custom example set by adapter authors was silently discarded during registration, and downstream consumers ( formatCommandExample , build-manifest , discovery ) would always fall through to the auto-generated default.

This PR adds the missing example: opts.example assignment in cli() .

Related issue: N/A

## Type of Change
- 🐛 Bug fix


## Checklist
- I ran the checks relevant to this PR
