### PR TITLE
feat(browser): add adapter session reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * **autofix** — retire `OPENCLI_DIAGNOSTIC`; adapter repair now uses `--trace retain-on-failure`, trace `summary.md`, and error-envelope trace metadata.
 * **browser** — `bind` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
 * **browser lifecycle** — owned browser workspaces now lease tabs inside a shared dedicated automation container instead of owning one Chrome window per workspace; lease state is persisted for MV3 service-worker reconciliation and idle cleanup is backed by alarms.
+* **browser session** — adapter commands can opt into site-level tab reuse with `browserSession.reuse = 'site'`; users can override with `--reuse <none|site>`.
 * **web read** — make page extraction render-aware: same-origin iframe content is merged into the Markdown source, `--wait-for` can wait inside main/iframe documents, `--wait-until networkidle` waits for captured requests to settle, and `--diagnose` reports frames, empty containers, and API-like XHRs for shell/AJAX pages.
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
 | `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
+| `OPENCLI_BROWSER_REUSE` | adapter default | Set to `none` or `site` to override adapter browser tab reuse. The `--reuse <none\|site>` flag sets this. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |
@@ -207,7 +208,7 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
-`--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation lease open until you run `opencli browser close` or the idle timeout expires.
+`--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation lease open until you run `opencli browser close` or the idle timeout expires. Some interactive adapters default to `--reuse site` so repeated commands continue in the same site tab; pass `--reuse none` for a one-shot tab.
 
 ## Update
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9967,7 +9967,10 @@
     "type": "js",
     "modulePath": "grok/ask.js",
     "sourceFile": "grok/ask.js",
-    "navigateBefore": "https://grok.com"
+    "navigateBefore": "https://grok.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "hackernews",

--- a/clis/grok/ask.js
+++ b/clis/grok/ask.js
@@ -266,6 +266,7 @@ export const askCommand = cli({
     domain: 'grok.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'prompt', positional: true, type: 'string', required: true, help: 'Prompt to send to Grok' },
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response (default: 120)' },

--- a/clis/grok/image.ts
+++ b/clis/grok/image.ts
@@ -264,6 +264,7 @@ export const imageCommand = cli({
   domain: 'grok.com',
   strategy: Strategy.COOKIE,
   browser: true,
+  browserSession: { reuse: 'site' },
   args: [
     { name: 'prompt', positional: true, type: 'string', required: true, help: 'Image generation prompt' },
     { name: 'timeout', type: 'int', default: 240, help: 'Max seconds to wait for the image (default: 240)' },

--- a/docs/adapters/browser/grok.md
+++ b/docs/adapters/browser/grok.md
@@ -48,7 +48,8 @@ opencli grok image "a watercolor lighthouse on a cliff" --out /tmp/grok-img --ti
 - `opencli grok ask` keeps the upstream/default behavior intact.
 - `opencli grok ask --web` switches to the newer hardened consumer-web implementation.
 - The `--web` path adds stricter composer detection, clearer blocked/session-gated hints, and waits for a stabilized assistant bubble before returning.
-- `opencli grok image` reuses the existing browser-backed Grok session, waits for the latest assistant image bubble to stabilize, and can optionally download the resulting images through the authenticated page context.
+- `opencli grok ask` and `opencli grok image` default to site-level browser tab reuse, so repeated Grok commands continue in the same Grok page. Pass `--reuse none` for a one-shot tab.
+- `opencli grok image` waits for the latest assistant image bubble to stabilize and can optionally download the resulting images through the authenticated page context.
 
 ## Prerequisites
 

--- a/docs/developer/ts-adapter.md
+++ b/docs/developer/ts-adapter.md
@@ -85,6 +85,26 @@ for context, the full pattern table, and how to add an id to a listing.
 | Intercept | `Strategy.INTERCEPT` | Capture browser requests/responses |
 | UI | `Strategy.UI` | Drive authenticated browser UI |
 
+## Browser Session Reuse
+
+Browser-backed commands are one-shot by default: each execution gets a fresh
+tab lease and releases it when the command returns. For interactive sites where
+successive commands should continue in the same page, opt into site-level reuse:
+
+```typescript
+cli({
+  site: 'mysite',
+  name: 'ask',
+  strategy: Strategy.COOKIE,
+  browserSession: { reuse: 'site' },
+  // ...
+});
+```
+
+`reuse: 'site'` makes commands for the same site share `site:<site>` and use the
+interactive idle timeout. Users can override the adapter default with
+`--reuse none` or force reuse with `--reuse site`.
+
 ## The `page` Object
 
 The `page` parameter provides browser interaction methods:

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -53,7 +53,7 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -121,6 +121,7 @@ function toManifestEntry(cmd: CliCommand, modulePath: string, sourceFile?: strin
     modulePath,
     sourceFile,
     navigateBefore: cmd.navigateBefore,
+    browserSession: cmd.browserSession,
   };
 }
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -135,6 +135,7 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
         deprecated: entry.deprecated,
         replacedBy: entry.replacedBy,
         navigateBefore: entry.navigateBefore,
+        browserSession: entry.browserSession,
         _lazy: true,
         _modulePath: modulePath,
       };

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -165,6 +165,168 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('reuses a site-scoped browser workspace and keeps the tab lease open', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number }> = [];
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
+      sessionOpts.push(opts ?? {});
+      return fn(mockPage);
+    });
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-reuse-site', access: 'read',
+      description: 'test site-scoped browser reuse',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      browserSession: { reuse: 'site' },
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+    await executeCommand(cmd, {});
+
+    expect(sessionOpts).toHaveLength(2);
+    expect(sessionOpts[0]).toMatchObject({ workspace: 'site:test-execution', idleTimeout: 600 });
+    expect(sessionOpts[1]).toMatchObject({ workspace: 'site:test-execution', idleTimeout: 600 });
+    expect(closeWindow).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps default browser commands on one-shot workspaces', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number }> = [];
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
+      sessionOpts.push(opts ?? {});
+      return fn(mockPage);
+    });
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-reuse-default', access: 'read',
+      description: 'test default one-shot browser workspace',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+    await executeCommand(cmd, {});
+
+    expect(sessionOpts).toHaveLength(2);
+    expect(sessionOpts[0]?.workspace).toMatch(/^site:test-execution:/);
+    expect(sessionOpts[1]?.workspace).toMatch(/^site:test-execution:/);
+    expect(sessionOpts[0]?.workspace).not.toBe(sessionOpts[1]?.workspace);
+    expect(sessionOpts[0]?.idleTimeout).toBeUndefined();
+    expect(sessionOpts[1]?.idleTimeout).toBeUndefined();
+    expect(closeWindow).toHaveBeenCalledTimes(2);
+    vi.restoreAllMocks();
+  });
+
+  it('lets user --reuse none override adapter reuse metadata', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number }> = [];
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
+      sessionOpts.push(opts ?? {});
+      return fn(mockPage);
+    });
+
+    const prev = process.env.OPENCLI_BROWSER_REUSE;
+    process.env.OPENCLI_BROWSER_REUSE = 'none';
+    try {
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'browser-reuse-override-none', access: 'read',
+        description: 'test user reuse override',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        browserSession: { reuse: 'site' },
+        func: async () => [{ ok: true }],
+      });
+
+      await executeCommand(cmd, {});
+
+      expect(sessionOpts).toHaveLength(1);
+      expect(sessionOpts[0]?.workspace).toMatch(/^site:test-execution:/);
+      expect(sessionOpts[0]?.idleTimeout).toBeUndefined();
+      expect(closeWindow).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prev === undefined) delete process.env.OPENCLI_BROWSER_REUSE;
+      else process.env.OPENCLI_BROWSER_REUSE = prev;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('skips repeated domain pre-navigation for site-reused browser sessions', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const goto = vi.fn().mockResolvedValue(undefined);
+    const mockPage = {
+      closeWindow,
+      goto,
+      getCurrentUrl: vi.fn().mockResolvedValue('https://grok.com/chat/abc'),
+    } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-reuse-skip-prenav', access: 'read',
+      description: 'test reused same-domain tabs do not reset conversation state',
+      browser: true,
+      strategy: Strategy.COOKIE,
+      domain: 'grok.com',
+      browserSession: { reuse: 'site' },
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+
+    expect(goto).not.toHaveBeenCalled();
+    expect(closeWindow).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps explicit path pre-navigation for site-reused browser sessions', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const goto = vi.fn().mockResolvedValue(undefined);
+    const mockPage = {
+      closeWindow,
+      goto,
+      getCurrentUrl: vi.fn().mockResolvedValue('https://example.com/other'),
+    } as any;
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-reuse-path-prenav', access: 'read',
+      description: 'test explicit path pre-navigation still runs',
+      browser: true,
+      strategy: Strategy.COOKIE,
+      domain: 'example.com',
+      navigateBefore: 'https://example.com/dashboard',
+      browserSession: { reuse: 'site' },
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+
+    expect(goto).toHaveBeenCalledWith('https://example.com/dashboard');
+    expect(closeWindow).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
   it('rejects invalid --timeout values instead of falling back to the browser default', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -14,6 +14,7 @@ import {
   type BrowserCliCommand,
   type CliCommand,
   type InternalCliCommand,
+  type BrowserSessionReuse,
   type Arg,
   type CommandArgs,
   getRegistry,
@@ -21,6 +22,7 @@ import {
 } from './registry.js';
 import type { IPage } from './types.js';
 import { pathToFileURL } from 'node:url';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
@@ -39,6 +41,7 @@ const _loadedModules = new Map<string, Promise<void>>();
 /** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
 const _moduleMtimes = new Map<string, number>();
 const _userClisDir = `${os.homedir()}/.opencli/clis/`;
+const INTERACTIVE_BROWSER_IDLE_TIMEOUT_SECONDS = 600;
 
 type TraceMode = 'off' | 'on' | 'retain-on-failure';
 
@@ -162,6 +165,35 @@ function resolvePreNav(cmd: CliCommand): string | null {
   return null;
 }
 
+function urlMatchesDomain(url: string | null | undefined, domain: string | undefined): boolean {
+  if (!url || !domain) return false;
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname === domain || hostname.endsWith(`.${domain}`);
+  } catch {
+    return false;
+  }
+}
+
+function isDomainRootPreNav(preNavUrl: string, domain: string | undefined): boolean {
+  if (!domain) return false;
+  try {
+    const parsed = new URL(preNavUrl);
+    const hostnameMatches = parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`);
+    const rootPath = parsed.pathname === '' || parsed.pathname === '/';
+    return hostnameMatches && rootPath && parsed.search === '' && parsed.hash === '';
+  } catch {
+    return false;
+  }
+}
+
+async function shouldRunPreNav(cmd: CliCommand, page: IPage, reuse: BrowserSessionReuse, preNavUrl: string): Promise<boolean> {
+  if (reuse !== 'site' || !cmd.domain) return true;
+  if (!isDomainRootPreNav(preNavUrl, cmd.domain)) return true;
+  const currentUrl = await page.getCurrentUrl?.().catch(() => null);
+  return !urlMatchesDomain(currentUrl, cmd.domain);
+}
+
 export async function executeCommand(
   cmd: CliCommand,
   rawKwargs: CommandArgs,
@@ -217,13 +249,16 @@ export async function executeCommand(
       const BrowserFactory = getBrowserFactory(cmd.site);
       const contextId = resolveProfileContextId(opts.profile);
       const internal = cmd as InternalCliCommand;
+      const browserReuse = resolveBrowserSessionReuse(cmd);
+      const workspace = resolveBrowserWorkspace(cmd, browserReuse);
+      const idleTimeout = browserReuse === 'site' ? INTERACTIVE_BROWSER_IDLE_TIMEOUT_SECONDS : undefined;
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
           ? null
           : new ObservationSession({
             scope: {
               contextId,
-              workspace: `site:${cmd.site}`,
+              workspace,
               target: page.getActivePage?.(),
               site: cmd.site,
               command: fullName(cmd),
@@ -240,7 +275,7 @@ export async function executeCommand(
           await page.startNetworkCapture?.().catch(() => false);
         }
         const preNavUrl = resolvePreNav(cmd);
-        if (preNavUrl) {
+        if (preNavUrl && await shouldRunPreNav(cmd, page, browserReuse, preNavUrl)) {
           observation?.record({
             stream: 'action',
             name: 'pre_navigate',
@@ -287,7 +322,7 @@ export async function executeCommand(
         }
         // --live / OPENCLI_LIVE=1 keeps the current automation tab lease after
         // the command finishes, so agents (or humans) can inspect the page state.
-        const keepOpen = process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
+        const keepOpen = browserReuse !== 'none' || process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
           const browserTimeout = userTimeoutSec !== null
             ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
@@ -334,7 +369,7 @@ export async function executeCommand(
           if (!keepOpen) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { workspace: `site:${cmd.site}:${crypto.randomUUID()}`, cdpEndpoint, contextId });
+      }, { workspace, cdpEndpoint, contextId, idleTimeout });
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that
@@ -451,6 +486,22 @@ export function prepareCommandArgs(
  * the runtime kills the Promise.
  */
 const RUNTIME_TIMEOUT_PADDING_SECONDS = 30;
+
+function readEnvBrowserSessionReuse(): BrowserSessionReuse | null {
+  const raw = process.env.OPENCLI_BROWSER_REUSE;
+  if (raw === undefined || raw === '') return null;
+  if (raw === 'none' || raw === 'site') return raw;
+  throw new ArgumentError(`--reuse must be one of: none, site. Received: "${raw}"`);
+}
+
+function resolveBrowserSessionReuse(cmd: CliCommand): BrowserSessionReuse {
+  return readEnvBrowserSessionReuse() ?? cmd.browserSession?.reuse ?? 'none';
+}
+
+function resolveBrowserWorkspace(cmd: CliCommand, reuse: BrowserSessionReuse): string {
+  if (reuse === 'site') return `site:${cmd.site}`;
+  return `site:${cmd.site}:${crypto.randomUUID()}`;
+}
 
 /**
  * Resolve the user-controllable `--timeout` arg, in seconds.

--- a/src/help.ts
+++ b/src/help.ts
@@ -129,6 +129,7 @@ function compactCommand(cmd: CliCommand, opts: { includeColumns?: boolean } = {}
     ...(cmd.aliases?.length ? { aliases: cmd.aliases } : {}),
     args: cmd.args.map(compactArg),
     example: formatCommandExample(cmd),
+    ...(cmd.browserSession ? { browserSession: cmd.browserSession } : {}),
     ...(opts.includeColumns && cmd.columns?.length ? { columns: cmd.columns } : {}),
     ...(cmd.deprecated ? { deprecated: cmd.deprecated } : {}),
     ...(cmd.replacedBy ? { replacedBy: cmd.replacedBy } : {}),

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 
 // ── Session lifecycle flags ──────────────────────────────────────────────
-// `--live` / `--focus` are top-level-ish toggles that tweak the automation
+// `--live` / `--focus` / `--reuse` are top-level-ish toggles that tweak the automation
 // window's lifecycle. We strip them from argv before Commander runs so they
 // can be placed anywhere and work on any subcommand (adapter or browser).
 {
@@ -44,6 +44,19 @@ const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
   if (focusIdx !== -1) {
     process.env.OPENCLI_WINDOW_FOCUSED = '1';
     process.argv.splice(focusIdx, 1);
+  }
+  const reuseIdx = process.argv.findIndex(arg => arg === '--reuse' || arg.startsWith('--reuse='));
+  if (reuseIdx !== -1) {
+    const arg = process.argv[reuseIdx];
+    const value = arg.startsWith('--reuse=')
+      ? arg.slice('--reuse='.length)
+      : process.argv[reuseIdx + 1];
+    if (value !== 'none' && value !== 'site') {
+      process.stderr.write(`--reuse must be one of: none, site. Received: "${value ?? ''}"\n`);
+      process.exit(EXIT_CODES.USAGE_ERROR);
+    }
+    process.env.OPENCLI_BROWSER_REUSE = value;
+    process.argv.splice(reuseIdx, arg.startsWith('--reuse=') ? 1 : 2);
   }
 }
 

--- a/src/manifest-types.ts
+++ b/src/manifest-types.ts
@@ -38,4 +38,8 @@ export interface ManifestEntry {
   sourceFile?: string;
   /** Pre-navigation control — see CliCommand.navigateBefore */
   navigateBefore?: boolean | string;
+  /** Browser session lifecycle defaults — see CliCommand.browserSession */
+  browserSession?: {
+    reuse?: 'none' | 'site';
+  };
 }

--- a/src/registry-api.ts
+++ b/src/registry-api.ts
@@ -8,7 +8,7 @@
  */
 
 export { cli, Strategy, getRegistry, fullName, registerCommand } from './registry.js';
-export type { CliCommand, Arg, CliOptions, CommandArgs } from './registry.js';
+export type { CliCommand, Arg, CliOptions, CommandArgs, BrowserSessionOptions, BrowserSessionReuse } from './registry.js';
 export type { IPage } from './types.js';
 export { onStartup, onBeforeExecute, onAfterExecute } from './hooks.js';
 export type { HookFn, HookContext, HookName } from './hooks.js';

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -27,6 +27,17 @@ export type CommandArgs = Record<string, any>;
 export type BrowserCommandFunc = (page: IPage, kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
 export type NonBrowserCommandFunc = (kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
 export type CommandAccess = 'read' | 'write';
+export type BrowserSessionReuse = 'none' | 'site';
+
+export interface BrowserSessionOptions {
+  /**
+   * Control whether browser-backed adapter commands reuse a stable tab lease.
+   *
+   * - `none`: one-shot workspace per command execution (default)
+   * - `site`: all commands for this site share `site:<site>` until idle expiry
+   */
+  reuse?: BrowserSessionReuse;
+}
 
 interface BaseCliCommand {
   site: string;
@@ -65,6 +76,8 @@ interface BaseCliCommand {
    * Adapter authors can set this explicitly to override the strategy-based default.
    */
   navigateBefore?: boolean | string;
+  /** Browser session lifecycle defaults for adapter commands. */
+  browserSession?: BrowserSessionOptions;
   /** Override the default CLI output format when the user does not pass -f/--format. */
   defaultFormat?: 'table' | 'plain' | 'json' | 'yaml' | 'yml' | 'md' | 'markdown' | 'csv';
 }
@@ -138,6 +151,7 @@ export function cli(opts: CliOptions): CliCommand {
     deprecated: opts.deprecated,
     replacedBy: opts.replacedBy,
     navigateBefore: opts.navigateBefore,
+    browserSession: opts.browserSession,
     defaultFormat: opts.defaultFormat,
   };
 
@@ -172,6 +186,7 @@ export function strategyLabel(cmd: CliCommand): string {
  */
 function normalizeCommand(cmd: RawCliCommand): CliCommand {
   assertCommandAccess(cmd);
+  assertBrowserSessionOptions(cmd);
 
   const strategy = cmd.strategy ?? (cmd.browser === false ? Strategy.PUBLIC : Strategy.COOKIE);
   const browser = cmd.browser ?? (strategy !== Strategy.PUBLIC && strategy !== Strategy.LOCAL);
@@ -197,6 +212,18 @@ function assertCommandAccess(cmd: Pick<RawCliCommand, 'site' | 'name'> & { acces
   if (cmd.access === 'read' || cmd.access === 'write') return;
   const key = `${cmd.site}/${cmd.name}`;
   throw new Error(`Command ${key} must declare access: 'read' | 'write'`);
+}
+
+function assertBrowserSessionOptions(cmd: Pick<RawCliCommand, 'site' | 'name'> & { browserSession?: unknown }): void {
+  if (cmd.browserSession === undefined) return;
+  const key = `${cmd.site}/${cmd.name}`;
+  if (cmd.browserSession === null || typeof cmd.browserSession !== 'object' || Array.isArray(cmd.browserSession)) {
+    throw new Error(`Command ${key} browserSession must be an object`);
+  }
+  const reuse = (cmd.browserSession as BrowserSessionOptions).reuse;
+  if (reuse !== undefined && reuse !== 'none' && reuse !== 'site') {
+    throw new Error(`Command ${key} browserSession.reuse must be one of: none, site`);
+  }
 }
 
 export function registerCommand(cmd: RawCliCommand): void {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -64,14 +64,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string }): Promise<IPage>;
+  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { workspace?: string; cdpEndpoint?: string; contextId?: string } = {},
+  opts: { workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -80,6 +80,7 @@ export async function browserSession<T>(
       workspace: opts.workspace,
       cdpEndpoint: opts.cdpEndpoint,
       contextId: opts.contextId,
+      idleTimeout: opts.idleTimeout,
     });
     return await fn(page);
   } finally {

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -52,6 +52,7 @@ export function serializeCommand(cmd: CliCommand) {
     example: formatCommandExample(cmd),
     deprecated: cmd.deprecated ?? null,
     replacedBy: cmd.replacedBy ?? null,
+    browserSession: cmd.browserSession ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `browserSession.reuse?: 'none' | 'site'` command metadata and serialize it through the manifest/lazy discovery path
- add global `--reuse <none|site>` / `OPENCLI_BROWSER_REUSE` override with precedence over adapter metadata
- make `reuse: 'site'` use stable `site:<site>` workspace, keep the tab lease open, and send a 10min interactive idle timeout
- skip repeated root-domain pre-navigation for site-reused sessions so conversation URLs like `grok.com/chat/...` are not reset; explicit path pre-navigation still runs
- enable site reuse for `grok ask` (and the existing Grok image TS command), with docs/changelog updates

## Verification
- `npm test -- --run src/execution.test.ts src/registry.test.ts src/serialization.test.ts src/commanderAdapter.test.ts clis/grok/ask.test.js clis/grok/image.test.ts` (79/79)
- `npx tsc --noEmit`
- `npm run build`
- `npm run docs:build`
- `node dist/src/main.js --reuse site --version`
- `node dist/src/main.js --reuse=none --version`
- invalid `--reuse bad` exits 2 with validation error
- manifest audit: grok/ask has `browserSession: { reuse: 'site' }`; `bad_browserSession=0`
- `git diff --check`
