### PR TITLE
refactor(tiktok): 6 read commands → page-context API (Phase 3 P0)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -21083,7 +21083,7 @@
   {
     "site": "tiktok",
     "name": "user",
-    "description": "Get recent videos from a TikTok user",
+    "description": "Get recent videos from a TikTok user via page-context APIs",
     "access": "read",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -21099,15 +21099,25 @@
       {
         "name": "limit",
         "type": "int",
-        "default": 10,
+        "default": 20,
         "required": false,
-        "help": "Number of videos"
+        "help": "Number of videos to return (max 120)"
       }
     ],
     "columns": [
       "index",
-      "views",
-      "url"
+      "id",
+      "source",
+      "author",
+      "url",
+      "cover",
+      "title",
+      "desc",
+      "plays",
+      "likes",
+      "comments",
+      "shares",
+      "createTime"
     ],
     "type": "js",
     "modulePath": "tiktok/user.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20679,7 +20679,7 @@
   {
     "site": "tiktok",
     "name": "explore",
-    "description": "Get trending TikTok videos from explore page",
+    "description": "Get trending TikTok videos from the recommend feed via page-context APIs",
     "access": "read",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20690,14 +20690,22 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of videos"
+        "help": "Number of videos to return (max 120)"
       }
     ],
     "columns": [
-      "rank",
+      "index",
+      "id",
       "author",
-      "views",
-      "url"
+      "url",
+      "cover",
+      "title",
+      "desc",
+      "plays",
+      "likes",
+      "comments",
+      "shares",
+      "createTime"
     ],
     "type": "js",
     "modulePath": "tiktok/explore.js",
@@ -20733,7 +20741,7 @@
   {
     "site": "tiktok",
     "name": "following",
-    "description": "List accounts you follow on TikTok",
+    "description": "List accounts the logged-in user follows on TikTok via page-context APIs",
     "access": "read",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20744,13 +20752,18 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of accounts"
+        "help": "Number of accounts (max 200)"
       }
     ],
     "columns": [
       "index",
       "username",
-      "name"
+      "name",
+      "secUid",
+      "verified",
+      "followers",
+      "following",
+      "url"
     ],
     "type": "js",
     "modulePath": "tiktok/following.js",
@@ -20760,7 +20773,7 @@
   {
     "site": "tiktok",
     "name": "friends",
-    "description": "Get TikTok friend suggestions",
+    "description": "Get TikTok friend / who-to-follow suggestions via page-context APIs",
     "access": "read",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20771,13 +20784,18 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of suggestions"
+        "help": "Number of suggestions (max 100)"
       }
     ],
     "columns": [
       "index",
       "username",
-      "name"
+      "name",
+      "secUid",
+      "verified",
+      "followers",
+      "following",
+      "url"
     ],
     "type": "js",
     "modulePath": "tiktok/friends.js",
@@ -20814,7 +20832,7 @@
   {
     "site": "tiktok",
     "name": "live",
-    "description": "Browse live streams on TikTok",
+    "description": "Browse TikTok live streams via page-context APIs",
     "access": "read",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20825,13 +20843,17 @@
         "type": "int",
         "default": 10,
         "required": false,
-        "help": "Number of streams"
+        "help": "Number of streams (max 60)"
       }
     ],
     "columns": [
       "index",
       "streamer",
+      "name",
+      "title",
       "viewers",
+      "likes",
+      "secUid",
       "url"
     ],
     "type": "js",
@@ -20842,7 +20864,7 @@
   {
     "site": "tiktok",
     "name": "notifications",
-    "description": "Get TikTok notifications (likes, comments, mentions, followers)",
+    "description": "Read TikTok inbox notifications (likes, comments, mentions, followers) via page-context APIs",
     "access": "read",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20853,7 +20875,7 @@
         "type": "int",
         "default": 15,
         "required": false,
-        "help": "Number of notifications"
+        "help": "Number of notifications (max 100)"
       },
       {
         "name": "type",
@@ -20872,7 +20894,10 @@
     ],
     "columns": [
       "index",
-      "text"
+      "id",
+      "from",
+      "text",
+      "createTime"
     ],
     "type": "js",
     "modulePath": "tiktok/notifications.js",

--- a/clis/tiktok/explore.js
+++ b/clis/tiktok/explore.js
@@ -8,10 +8,7 @@
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import {
-    ArgumentError,
-    CommandExecutionError,
     EmptyResultError,
-    getErrorMessage,
 } from '@jackwener/opencli/errors';
 import {
     BROWSER_HELPERS,
@@ -19,6 +16,7 @@ import {
     SERVER_PAGE_MAX,
     TIKTOK_AID,
     requireLimit,
+    throwTikTokPageContextError,
     VIDEO_ITEM_NORMALIZER,
 } from './utils.js';
 
@@ -110,11 +108,12 @@ async function listExploreVideos(page, args) {
     try {
         rows = await page.evaluate(buildExploreScript(limit));
     } catch (error) {
-        const message = getErrorMessage(error);
-        if (/No videos found/.test(message)) {
-            throw new EmptyResultError('tiktok explore', message);
-        }
-        throw new CommandExecutionError(`Failed to load TikTok explore feed: ${message}`);
+        throwTikTokPageContextError(error, {
+            authMessage: 'TikTok requires browser access to load the explore feed',
+            emptyPattern: /No videos found/,
+            emptyTarget: 'tiktok explore',
+            failureMessage: 'Failed to load TikTok explore feed',
+        });
     }
     if (!Array.isArray(rows) || rows.length === 0) {
         throw new EmptyResultError('tiktok explore', 'TikTok returned an empty recommend feed');

--- a/clis/tiktok/explore.js
+++ b/clis/tiktok/explore.js
@@ -1,36 +1,144 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Browse TikTok "For You" / explore feed via page-context API.
+//
+// Replaces legacy DOM-link scraping (`querySelectorAll('a[href*="/video/"]')`).
+// We borrow the live page session: read `__UNIVERSAL_DATA_FOR_REHYDRATION__` for
+// the warm `webapp.recommend-feed` snapshot, then extend with `/api/recommend/item_list/`
+// when a larger `--limit` is requested. Stays inside the browser, so the session
+// cookies + msToken go along automatically.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+    getErrorMessage,
+} from '@jackwener/opencli/errors';
+import {
+    BROWSER_HELPERS,
+    MAX_PAGES,
+    SERVER_PAGE_MAX,
+    TIKTOK_AID,
+    requireLimit,
+    VIDEO_ITEM_NORMALIZER,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 120;
+
+function buildExploreScript(limit) {
+    return `
+(async () => {
+  const limit = ${Number(limit)};
+  const maxPages = ${MAX_PAGES};
+  const SERVER_PAGE_MAX = ${SERVER_PAGE_MAX};
+  // limit was validated upfront (requireLimit). pageSize is the per-request
+  // cap TikTok accepts; we still loop until \`dedup.size < limit\` is satisfied.
+  const pageSize = limit < SERVER_PAGE_MAX ? limit : SERVER_PAGE_MAX;
+  const aid = ${JSON.stringify(TIKTOK_AID)};
+
+  ${BROWSER_HELPERS}
+  ${VIDEO_ITEM_NORMALIZER}
+
+  function collectFromState(root) {
+    if (!root) return [];
+    const out = [];
+    walkObjects(root, (node) => {
+      if (Array.isArray(node)) return false;
+      if (Array.isArray(node.itemList)) {
+        for (const item of node.itemList) out.push(item);
+      }
+      if (Array.isArray(node.items)) {
+        for (const item of node.items) out.push(item);
+      }
+      return false;
+    });
+    return out;
+  }
+
+  const dedup = new Map();
+  const universal = findUniversalData();
+  for (const item of collectFromState(universal)) {
+    const row = normalizeVideoItem(item, dedup.size + 1);
+    if (row && !dedup.has(row.id)) dedup.set(row.id, row);
+  }
+
+  const msToken = getCookie('msToken');
+  let apiFailure = null;
+  if (dedup.size < limit) {
+    let cursor = 0;
+    for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
+      const params = new URLSearchParams({
+        aid,
+        count: String(pageSize),
+        from_page: 'fyp',
+        cursor: String(cursor),
+      });
+      if (msToken) params.set('msToken', msToken);
+      try {
+        const data = await fetchJson('/api/recommend/item_list/?' + params.toString());
+        const items = Array.isArray(data.itemList) ? data.itemList : [];
+        for (const item of items) {
+          const row = normalizeVideoItem(item, dedup.size + 1);
+          if (row && !dedup.has(row.id)) dedup.set(row.id, row);
+        }
+        if (data.hasMore !== true && items.length === 0) break;
+        cursor = asNumber(data.cursor) ?? cursor + items.length;
+      } catch (error) {
+        apiFailure = error instanceof Error ? error.message : String(error);
+        break;
+      }
+    }
+  }
+
+  const rows = Array.from(dedup.values())
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, index: index + 1 }));
+
+  if (rows.length === 0) {
+    const suffix = apiFailure ? ' (recommend API failed: ' + apiFailure + ')' : '';
+    throw new Error('No videos found on /explore' + suffix);
+  }
+  return rows;
+})()
+`;
+}
+
+async function listExploreVideos(page, args) {
+    const limit = requireLimit(args.limit, { fallback: DEFAULT_LIMIT, max: MAX_LIMIT });
+    await page.goto('https://www.tiktok.com/explore', { waitUntil: 'load', settleMs: 5000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildExploreScript(limit));
+    } catch (error) {
+        const message = getErrorMessage(error);
+        if (/No videos found/.test(message)) {
+            throw new EmptyResultError('tiktok explore', message);
+        }
+        throw new CommandExecutionError(`Failed to load TikTok explore feed: ${message}`);
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError('tiktok explore', 'TikTok returned an empty recommend feed');
+    }
+    return rows;
+}
+
+export const exploreCommand = cli({
     site: 'tiktok',
     name: 'explore',
     access: 'read',
-    description: 'Get trending TikTok videos from explore page',
+    description: 'Get trending TikTok videos from the recommend feed via page-context APIs',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: 'Number of videos' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of videos to return (max ${MAX_LIMIT})` },
     ],
-    columns: ['rank', 'author', 'views', 'url'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/explore', settleMs: 5000 } },
-        { evaluate: `(() => {
-  const limit = \${{ args.limit }};
-  const links = Array.from(document.querySelectorAll('a[href*="/video/"]'));
-  const seen = new Set();
-  const results = [];
-  for (const a of links) {
-    const href = a.href;
-    if (seen.has(href)) continue;
-    seen.add(href);
-    const match = href.match(/@([^/]+)\\/video\\/(\\d+)/);
-    results.push({
-      rank: results.length + 1,
-      author: match ? match[1] : '',
-      views: a.textContent.trim() || '-',
-      url: href,
-    });
-    if (results.length >= limit) break;
-  }
-  return results;
-})()
-` },
-    ],
+    columns: ['index', 'id', 'author', 'url', 'cover', 'title', 'desc', 'plays', 'likes', 'comments', 'shares', 'createTime'],
+    func: listExploreVideos,
 });
+
+export const __test__ = {
+    buildExploreScript,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+};

--- a/clis/tiktok/explore.js
+++ b/clis/tiktok/explore.js
@@ -74,6 +74,7 @@ function buildExploreScript(limit) {
       if (msToken) params.set('msToken', msToken);
       try {
         const data = await fetchJson('/api/recommend/item_list/?' + params.toString());
+        assertTikTokApiSuccess(data, 'recommend');
         const items = Array.isArray(data.itemList) ? data.itemList : [];
         for (const item of items) {
           const row = normalizeVideoItem(item, dedup.size + 1);

--- a/clis/tiktok/following.js
+++ b/clis/tiktok/following.js
@@ -92,6 +92,7 @@ function buildFollowingScript(limit) {
     if (msToken) params.set('msToken', msToken);
     try {
       const data = await fetchJson('/api/user/list/?' + params.toString());
+      assertTikTokApiSuccess(data, 'user-list');
       const list = Array.isArray(data.userList)
         ? data.userList
         : (Array.isArray(data.user_list) ? data.user_list : []);

--- a/clis/tiktok/following.js
+++ b/clis/tiktok/following.js
@@ -1,43 +1,167 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// List the accounts the logged-in user follows via page-context API.
+//
+// Replaces legacy DOM-link scraping which mistakenly hoovered up navigation
+// links and "Profile" / "Upload" labels. We resolve the viewer's `secUid` from
+// the warm `__UNIVERSAL_DATA_FOR_REHYDRATION__` snapshot, then page through
+// `/api/user/list/?scene=21` (TikTok's own following endpoint).
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    getErrorMessage,
+} from '@jackwener/opencli/errors';
+import {
+    BROWSER_HELPERS,
+    MAX_PAGES,
+    SERVER_PAGE_MAX,
+    TIKTOK_AID,
+    USER_ITEM_NORMALIZER,
+    requireLimit,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 200;
+
+function buildFollowingScript(limit) {
+    return `
+(async () => {
+  const limit = ${Number(limit)};
+  const maxPages = ${MAX_PAGES * 2};
+  const SERVER_PAGE_MAX = ${SERVER_PAGE_MAX};
+  const pageSize = limit < SERVER_PAGE_MAX ? limit : SERVER_PAGE_MAX;
+  const aid = ${JSON.stringify(TIKTOK_AID)};
+
+  ${BROWSER_HELPERS}
+  ${USER_ITEM_NORMALIZER}
+
+  function findViewerSecUid(root) {
+    if (!root) return '';
+    let found = '';
+    walkObjects(root, (node) => {
+      if (Array.isArray(node)) return false;
+      const candidate = node?.user;
+      if (candidate && typeof candidate === 'object') {
+        const secUid = String(candidate.secUid || candidate.sec_uid || '').trim();
+        const isMe = Boolean(candidate.isOwner || candidate.is_owner || candidate.isCurrentUser);
+        if (secUid && isMe) {
+          found = secUid;
+          return true;
+        }
+      }
+      const direct = node?.userInfo?.user;
+      if (direct && (direct.isOwner || direct.is_owner)) {
+        const secUid = String(direct.secUid || direct.sec_uid || '').trim();
+        if (secUid) {
+          found = secUid;
+          return true;
+        }
+      }
+      return false;
+    });
+    return found;
+  }
+
+  const universal = findUniversalData();
+  let viewerSecUid = findViewerSecUid(universal);
+  const msToken = getCookie('msToken');
+
+  if (!viewerSecUid) {
+    try {
+      const me = await fetchJson('/api/user/info/?aid=' + aid + (msToken ? '&msToken=' + encodeURIComponent(msToken) : ''));
+      viewerSecUid = String(me?.userInfo?.user?.secUid || me?.user?.secUid || me?.userInfo?.secUid || '').trim();
+    } catch {
+      // Fall through to typed AUTH_REQUIRED below.
+    }
+  }
+  if (!viewerSecUid) {
+    throw new Error('AUTH_REQUIRED: cannot resolve viewer secUid (login required)');
+  }
+
+  const dedup = new Map();
+  let apiFailure = null;
+  let cursor = 0;
+  for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
+    const params = new URLSearchParams({
+      aid,
+      scene: '21',
+      secUid: viewerSecUid,
+      count: String(pageSize),
+      minCursor: String(cursor),
+      maxCursor: '0',
+    });
+    if (msToken) params.set('msToken', msToken);
+    try {
+      const data = await fetchJson('/api/user/list/?' + params.toString());
+      const list = Array.isArray(data.userList)
+        ? data.userList
+        : (Array.isArray(data.user_list) ? data.user_list : []);
+      if (list.length === 0) break;
+      for (const entry of list) {
+        const row = normalizeUserRow(entry?.user || entry, dedup.size + 1);
+        if (row && !dedup.has(row.username)) dedup.set(row.username, row);
+      }
+      if (data.hasMore !== true) break;
+      cursor = asNumber(data.minCursor) ?? asNumber(data.cursor) ?? cursor + list.length;
+    } catch (error) {
+      apiFailure = error instanceof Error ? error.message : String(error);
+      break;
+    }
+  }
+
+  const rows = Array.from(dedup.values())
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, index: index + 1 }));
+
+  if (rows.length === 0) {
+    const suffix = apiFailure ? ' (user-list API failed: ' + apiFailure + ')' : '';
+    throw new Error('No following entries returned' + suffix);
+  }
+  return rows;
+})()
+`;
+}
+
+async function listFollowing(page, args) {
+    const limit = requireLimit(args.limit, { fallback: DEFAULT_LIMIT, max: MAX_LIMIT });
+    await page.goto('https://www.tiktok.com/following', { waitUntil: 'load', settleMs: 5000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildFollowingScript(limit));
+    } catch (error) {
+        const message = getErrorMessage(error);
+        if (/AUTH_REQUIRED/.test(message)) {
+            throw new AuthRequiredError('tiktok.com', 'TikTok requires login to read your following list');
+        }
+        if (/No following entries/.test(message)) {
+            throw new EmptyResultError('tiktok following', message);
+        }
+        throw new CommandExecutionError(`Failed to load TikTok following list: ${message}`);
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError('tiktok following', 'TikTok returned no following entries');
+    }
+    return rows;
+}
+
+export const followingCommand = cli({
     site: 'tiktok',
     name: 'following',
     access: 'read',
-    description: 'List accounts you follow on TikTok',
+    description: 'List accounts the logged-in user follows on TikTok via page-context APIs',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: 'Number of accounts' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of accounts (max ${MAX_LIMIT})` },
     ],
-    columns: ['index', 'username', 'name'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/following', settleMs: 5000 } },
-        { evaluate: `(() => {
-  const limit = \${{ args.limit }};
-  const links = Array.from(document.querySelectorAll('a[href*="/@"]'))
-    .filter(function(a) {
-      const text = a.textContent.trim();
-      return text.length > 1 && text.length < 80 &&
-        !text.includes('Profile') && !text.includes('More') && !text.includes('Upload');
-    });
-
-  const seen = {};
-  const results = [];
-  for (const a of links) {
-    const match = a.href.match(/@([^/]+)/);
-    const username = match ? match[1] : '';
-    if (!username || seen[username]) continue;
-    seen[username] = true;
-    const raw = a.textContent.trim();
-    const name = raw.replace(username, '').replace('@', '').trim();
-    results.push({
-      index: results.length + 1,
-      username: username,
-      name: name || username,
-    });
-    if (results.length >= limit) break;
-  }
-  return results;
-})()
-` },
-    ],
+    columns: ['index', 'username', 'name', 'secUid', 'verified', 'followers', 'following', 'url'],
+    func: listFollowing,
 });
+
+export const __test__ = {
+    buildFollowingScript,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+};

--- a/clis/tiktok/following.js
+++ b/clis/tiktok/following.js
@@ -7,10 +7,7 @@
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import {
-    AuthRequiredError,
-    CommandExecutionError,
     EmptyResultError,
-    getErrorMessage,
 } from '@jackwener/opencli/errors';
 import {
     BROWSER_HELPERS,
@@ -19,6 +16,7 @@ import {
     TIKTOK_AID,
     USER_ITEM_NORMALIZER,
     requireLimit,
+    throwTikTokPageContextError,
 } from './utils.js';
 
 const DEFAULT_LIMIT = 20;
@@ -130,14 +128,12 @@ async function listFollowing(page, args) {
     try {
         rows = await page.evaluate(buildFollowingScript(limit));
     } catch (error) {
-        const message = getErrorMessage(error);
-        if (/AUTH_REQUIRED/.test(message)) {
-            throw new AuthRequiredError('tiktok.com', 'TikTok requires login to read your following list');
-        }
-        if (/No following entries/.test(message)) {
-            throw new EmptyResultError('tiktok following', message);
-        }
-        throw new CommandExecutionError(`Failed to load TikTok following list: ${message}`);
+        throwTikTokPageContextError(error, {
+            authMessage: 'TikTok requires login to read your following list',
+            emptyPattern: /No following entries/,
+            emptyTarget: 'tiktok following',
+            failureMessage: 'Failed to load TikTok following list',
+        });
     }
     if (!Array.isArray(rows) || rows.length === 0) {
         throw new EmptyResultError('tiktok following', 'TikTok returned no following entries');

--- a/clis/tiktok/friends.js
+++ b/clis/tiktok/friends.js
@@ -1,44 +1,145 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// TikTok friend / who-to-follow suggestions via page-context API.
+//
+// Replaces legacy DOM-link scraping (`querySelectorAll('a[href*="/@"]')` plus
+// fragile text filters that mistook UI labels for handles). We pull the
+// suggestion list from `__UNIVERSAL_DATA_FOR_REHYDRATION__` first, then
+// top up via `/api/recommend/user/` if the warm snapshot is short.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    CommandExecutionError,
+    EmptyResultError,
+    getErrorMessage,
+} from '@jackwener/opencli/errors';
+import {
+    BROWSER_HELPERS,
+    MAX_PAGES,
+    SERVER_PAGE_MAX,
+    TIKTOK_AID,
+    USER_ITEM_NORMALIZER,
+    requireLimit,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function buildFriendsScript(limit) {
+    return `
+(async () => {
+  const limit = ${Number(limit)};
+  const maxPages = ${MAX_PAGES};
+  const SERVER_PAGE_MAX = ${SERVER_PAGE_MAX};
+  const pageSize = limit < SERVER_PAGE_MAX ? limit : SERVER_PAGE_MAX;
+  const aid = ${JSON.stringify(TIKTOK_AID)};
+
+  ${BROWSER_HELPERS}
+  ${USER_ITEM_NORMALIZER}
+
+  function collectUsersFromState(root) {
+    if (!root) return [];
+    const out = [];
+    walkObjects(root, (node) => {
+      if (Array.isArray(node)) return false;
+      if (Array.isArray(node.userList)) {
+        for (const entry of node.userList) {
+          out.push(entry?.user || entry);
+        }
+      }
+      if (Array.isArray(node.suggestList)) {
+        for (const entry of node.suggestList) out.push(entry?.user || entry);
+      }
+      return false;
+    });
+    return out;
+  }
+
+  const dedup = new Map();
+  const universal = findUniversalData();
+  for (const user of collectUsersFromState(universal)) {
+    const row = normalizeUserRow(user, dedup.size + 1);
+    if (row && !dedup.has(row.username)) dedup.set(row.username, row);
+  }
+
+  let apiFailure = null;
+  const msToken = getCookie('msToken');
+  if (dedup.size < limit) {
+    let cursor = 0;
+    for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
+      const params = new URLSearchParams({
+        aid,
+        count: String(pageSize),
+        cursor: String(cursor),
+        scene: '15',
+      });
+      if (msToken) params.set('msToken', msToken);
+      try {
+        const data = await fetchJson('/api/recommend/user/?' + params.toString());
+        const list = Array.isArray(data.userList)
+          ? data.userList
+          : (Array.isArray(data.user_list) ? data.user_list : []);
+        if (list.length === 0) break;
+        for (const entry of list) {
+          const row = normalizeUserRow(entry?.user || entry, dedup.size + 1);
+          if (row && !dedup.has(row.username)) dedup.set(row.username, row);
+        }
+        if (data.hasMore !== true) break;
+        cursor = asNumber(data.cursor) ?? cursor + list.length;
+      } catch (error) {
+        apiFailure = error instanceof Error ? error.message : String(error);
+        break;
+      }
+    }
+  }
+
+  const rows = Array.from(dedup.values())
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, index: index + 1 }));
+
+  if (rows.length === 0) {
+    const suffix = apiFailure ? ' (recommend-user API failed: ' + apiFailure + ')' : '';
+    throw new Error('No friend suggestions returned by TikTok' + suffix);
+  }
+  return rows;
+})()
+`;
+}
+
+async function listFriends(page, args) {
+    const limit = requireLimit(args.limit, { fallback: DEFAULT_LIMIT, max: MAX_LIMIT });
+    await page.goto('https://www.tiktok.com/friends', { waitUntil: 'load', settleMs: 5000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildFriendsScript(limit));
+    } catch (error) {
+        const message = getErrorMessage(error);
+        if (/No friend suggestions/.test(message)) {
+            throw new EmptyResultError('tiktok friends', message);
+        }
+        throw new CommandExecutionError(`Failed to load TikTok friend suggestions: ${message}`);
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError('tiktok friends', 'TikTok returned no friend suggestions');
+    }
+    return rows;
+}
+
+export const friendsCommand = cli({
     site: 'tiktok',
     name: 'friends',
     access: 'read',
-    description: 'Get TikTok friend suggestions',
+    description: 'Get TikTok friend / who-to-follow suggestions via page-context APIs',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: 'Number of suggestions' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of suggestions (max ${MAX_LIMIT})` },
     ],
-    columns: ['index', 'username', 'name'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/friends', settleMs: 5000 } },
-        { evaluate: `(() => {
-  const limit = \${{ args.limit }};
-  const links = Array.from(document.querySelectorAll('a[href*="/@"]'))
-    .filter(function(a) {
-      const text = a.textContent.trim();
-      return text.length > 1 && text.length < 80 &&
-        !text.includes('Profile') && !text.includes('More') && !text.includes('Upload');
-    });
-
-  const seen = {};
-  const results = [];
-  for (const a of links) {
-    const match = a.href.match(/@([^/]+)/);
-    const username = match ? match[1] : '';
-    if (!username || seen[username]) continue;
-    seen[username] = true;
-    const raw = a.textContent.trim();
-    const hasFollow = raw.includes('Follow');
-    const name = raw.replace('Follow', '').replace(username, '').replace('@', '').trim();
-    results.push({
-      index: results.length + 1,
-      username: username,
-      name: name || username,
-    });
-    if (results.length >= limit) break;
-  }
-  return results;
-})()
-` },
-    ],
+    columns: ['index', 'username', 'name', 'secUid', 'verified', 'followers', 'following', 'url'],
+    func: listFriends,
 });
+
+export const __test__ = {
+    buildFriendsScript,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+};

--- a/clis/tiktok/friends.js
+++ b/clis/tiktok/friends.js
@@ -7,9 +7,7 @@
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import {
-    CommandExecutionError,
     EmptyResultError,
-    getErrorMessage,
 } from '@jackwener/opencli/errors';
 import {
     BROWSER_HELPERS,
@@ -18,6 +16,7 @@ import {
     TIKTOK_AID,
     USER_ITEM_NORMALIZER,
     requireLimit,
+    throwTikTokPageContextError,
 } from './utils.js';
 
 const DEFAULT_LIMIT = 20;
@@ -111,11 +110,12 @@ async function listFriends(page, args) {
     try {
         rows = await page.evaluate(buildFriendsScript(limit));
     } catch (error) {
-        const message = getErrorMessage(error);
-        if (/No friend suggestions/.test(message)) {
-            throw new EmptyResultError('tiktok friends', message);
-        }
-        throw new CommandExecutionError(`Failed to load TikTok friend suggestions: ${message}`);
+        throwTikTokPageContextError(error, {
+            authMessage: 'TikTok requires browser access to load friend suggestions',
+            emptyPattern: /No friend suggestions/,
+            emptyTarget: 'tiktok friends',
+            failureMessage: 'Failed to load TikTok friend suggestions',
+        });
     }
     if (!Array.isArray(rows) || rows.length === 0) {
         throw new EmptyResultError('tiktok friends', 'TikTok returned no friend suggestions');

--- a/clis/tiktok/friends.js
+++ b/clis/tiktok/friends.js
@@ -73,6 +73,7 @@ function buildFriendsScript(limit) {
       if (msToken) params.set('msToken', msToken);
       try {
         const data = await fetchJson('/api/recommend/user/?' + params.toString());
+        assertTikTokApiSuccess(data, 'recommend-user');
         const list = Array.isArray(data.userList)
           ? data.userList
           : (Array.isArray(data.user_list) ? data.user_list : []);

--- a/clis/tiktok/live.js
+++ b/clis/tiktok/live.js
@@ -1,48 +1,143 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Browse TikTok live streams via page-context API.
+//
+// Replaces legacy DOM card scraping (`[data-e2e="live-side-nav-item"]` plus a
+// regex pulling viewer counts from card text). We extract from the live-discover
+// state injected on `/live`, then top up via `/api/live/discover/get/`.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    CommandExecutionError,
+    EmptyResultError,
+    getErrorMessage,
+} from '@jackwener/opencli/errors';
+import {
+    BROWSER_HELPERS,
+    LIVE_ITEM_NORMALIZER,
+    SERVER_PAGE_MAX,
+    TIKTOK_AID,
+    requireLimit,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 60;
+
+function buildLiveScript(limit) {
+    return `
+(async () => {
+  const limit = ${Number(limit)};
+  const SERVER_PAGE_MAX = ${SERVER_PAGE_MAX};
+  const pageSize = limit < SERVER_PAGE_MAX ? limit : SERVER_PAGE_MAX;
+  const aid = ${JSON.stringify(TIKTOK_AID)};
+
+  ${BROWSER_HELPERS}
+  ${LIVE_ITEM_NORMALIZER}
+
+  function collectFromState(root) {
+    if (!root) return [];
+    const out = [];
+    walkObjects(root, (node) => {
+      if (Array.isArray(node)) return false;
+      if (Array.isArray(node.liveList)) {
+        for (const entry of node.liveList) out.push(entry);
+      }
+      if (Array.isArray(node.live_list)) {
+        for (const entry of node.live_list) out.push(entry);
+      }
+      if (Array.isArray(node.discoverList)) {
+        for (const entry of node.discoverList) out.push(entry);
+      }
+      return false;
+    });
+    return out;
+  }
+
+  const dedup = new Map();
+  const universal = findUniversalData();
+  for (const item of collectFromState(universal)) {
+    const row = normalizeLiveItem(item, dedup.size + 1);
+    if (row) {
+      const key = row.streamer || row.url;
+      if (key && !dedup.has(key)) dedup.set(key, row);
+    }
+  }
+
+  let apiFailure = null;
+  const msToken = getCookie('msToken');
+  if (dedup.size < limit) {
+    const params = new URLSearchParams({
+      aid,
+      count: String(pageSize),
+      from_page: 'live_discover',
+    });
+    if (msToken) params.set('msToken', msToken);
+    try {
+      const data = await fetchJson('/api/live/discover/get/?' + params.toString());
+      const list = Array.isArray(data.data?.list)
+        ? data.data.list
+        : (Array.isArray(data.list)
+          ? data.list
+          : (Array.isArray(data.live_list) ? data.live_list : []));
+      for (const entry of list) {
+        const row = normalizeLiveItem(entry, dedup.size + 1);
+        if (row) {
+          const key = row.streamer || row.url;
+          if (key && !dedup.has(key)) dedup.set(key, row);
+        }
+      }
+    } catch (error) {
+      apiFailure = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const rows = Array.from(dedup.values())
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, index: index + 1 }));
+
+  if (rows.length === 0) {
+    const suffix = apiFailure ? ' (live-discover API failed: ' + apiFailure + ')' : '';
+    throw new Error('No live streams returned' + suffix);
+  }
+  return rows;
+})()
+`;
+}
+
+async function listLive(page, args) {
+    const limit = requireLimit(args.limit, { fallback: DEFAULT_LIMIT, max: MAX_LIMIT });
+    await page.goto('https://www.tiktok.com/live', { waitUntil: 'load', settleMs: 5000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildLiveScript(limit));
+    } catch (error) {
+        const message = getErrorMessage(error);
+        if (/No live streams returned/.test(message)) {
+            throw new EmptyResultError('tiktok live', message);
+        }
+        throw new CommandExecutionError(`Failed to load TikTok live streams: ${message}`);
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError('tiktok live', 'TikTok returned no live streams');
+    }
+    return rows;
+}
+
+export const liveCommand = cli({
     site: 'tiktok',
     name: 'live',
     access: 'read',
-    description: 'Browse live streams on TikTok',
+    description: 'Browse TikTok live streams via page-context APIs',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 10, help: 'Number of streams' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of streams (max ${MAX_LIMIT})` },
     ],
-    columns: ['index', 'streamer', 'viewers', 'url'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/live', settleMs: 5000 } },
-        { evaluate: `(() => {
-  const limit = \${{ args.limit }};
-  // Sidebar live list has structured data
-  const items = document.querySelectorAll('[data-e2e="live-side-nav-item"]');
-  const sidebar = Array.from(items).slice(0, limit).map(function(el, i) {
-    const nameEl = el.querySelector('[data-e2e="live-side-nav-name"]');
-    const countEl = el.querySelector('[data-e2e="person-count"]');
-    const link = el.querySelector('a');
-    return {
-      index: i + 1,
-      streamer: nameEl ? nameEl.textContent.trim() : '',
-      viewers: countEl ? countEl.textContent.trim() : '-',
-      url: link ? link.href : '',
-    };
-  });
-
-  if (sidebar.length > 0) return sidebar;
-
-  // Fallback: main content cards
-  const cards = document.querySelectorAll('[data-e2e="discover-list-live-card"]');
-  return Array.from(cards).slice(0, limit).map(function(card, i) {
-    const text = card.textContent.trim().replace(/\\s+/g, ' ');
-    const link = card.querySelector('a[href*="/live"]');
-    const viewerMatch = text.match(/(\\d[\\d,.]*)\\s*watching/);
-    return {
-      index: i + 1,
-      streamer: text.replace(/LIVE.*$/, '').trim().substring(0, 40),
-      viewers: viewerMatch ? viewerMatch[1] : '-',
-      url: link ? link.href : '',
-    };
-  });
-})()
-` },
-    ],
+    columns: ['index', 'streamer', 'name', 'title', 'viewers', 'likes', 'secUid', 'url'],
+    func: listLive,
 });
+
+export const __test__ = {
+    buildLiveScript,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+};

--- a/clis/tiktok/live.js
+++ b/clis/tiktok/live.js
@@ -6,9 +6,7 @@
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import {
-    CommandExecutionError,
     EmptyResultError,
-    getErrorMessage,
 } from '@jackwener/opencli/errors';
 import {
     BROWSER_HELPERS,
@@ -16,6 +14,7 @@ import {
     SERVER_PAGE_MAX,
     TIKTOK_AID,
     requireLimit,
+    throwTikTokPageContextError,
 } from './utils.js';
 
 const DEFAULT_LIMIT = 10;
@@ -109,11 +108,12 @@ async function listLive(page, args) {
     try {
         rows = await page.evaluate(buildLiveScript(limit));
     } catch (error) {
-        const message = getErrorMessage(error);
-        if (/No live streams returned/.test(message)) {
-            throw new EmptyResultError('tiktok live', message);
-        }
-        throw new CommandExecutionError(`Failed to load TikTok live streams: ${message}`);
+        throwTikTokPageContextError(error, {
+            authMessage: 'TikTok requires browser access to load live streams',
+            emptyPattern: /No live streams returned/,
+            emptyTarget: 'tiktok live',
+            failureMessage: 'Failed to load TikTok live streams',
+        });
     }
     if (!Array.isArray(rows) || rows.length === 0) {
         throw new EmptyResultError('tiktok live', 'TikTok returned no live streams');

--- a/clis/tiktok/live.js
+++ b/clis/tiktok/live.js
@@ -71,6 +71,7 @@ function buildLiveScript(limit) {
     if (msToken) params.set('msToken', msToken);
     try {
       const data = await fetchJson('/api/live/discover/get/?' + params.toString());
+      assertTikTokApiSuccess(data, 'live-discover');
       const list = Array.isArray(data.data?.list)
         ? data.data.list
         : (Array.isArray(data.list)

--- a/clis/tiktok/notifications.js
+++ b/clis/tiktok/notifications.js
@@ -64,7 +64,6 @@ function buildNotificationsScript(limit, typeKey) {
   let apiFailure = null;
   const msToken = getCookie('msToken');
   let maxTime = 0;
-  let authRequired = false;
   for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
     const params = new URLSearchParams({
       aid,
@@ -75,10 +74,7 @@ function buildNotificationsScript(limit, typeKey) {
     if (msToken) params.set('msToken', msToken);
     try {
       const data = await fetchJson('/api/notice/multi/?' + params.toString());
-      if (data?.status_code === 8 || data?.statusCode === 8) {
-        authRequired = true;
-        break;
-      }
+      assertTikTokApiSuccess(data, 'notice');
       const list = Array.isArray(data.notice_list_v1)
         ? data.notice_list_v1
         : (Array.isArray(data.noticeList) ? data.noticeList : (Array.isArray(data.notice_list) ? data.notice_list : []));
@@ -93,10 +89,6 @@ function buildNotificationsScript(limit, typeKey) {
       apiFailure = error instanceof Error ? error.message : String(error);
       break;
     }
-  }
-
-  if (authRequired) {
-    throw new Error('AUTH_REQUIRED: TikTok inbox requires login (' + noticeLabel + ')');
   }
 
   const rows = Array.from(dedup.values())

--- a/clis/tiktok/notifications.js
+++ b/clis/tiktok/notifications.js
@@ -6,10 +6,7 @@
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import {
-    AuthRequiredError,
-    CommandExecutionError,
     EmptyResultError,
-    getErrorMessage,
 } from '@jackwener/opencli/errors';
 import {
     BROWSER_HELPERS,
@@ -20,6 +17,7 @@ import {
     TIKTOK_AID,
     requireLimit,
     requireNotificationType,
+    throwTikTokPageContextError,
 } from './utils.js';
 
 const DEFAULT_LIMIT = 15;
@@ -122,14 +120,12 @@ async function listNotifications(page, args) {
     try {
         rows = await page.evaluate(buildNotificationsScript(limit, typeKey));
     } catch (error) {
-        const message = getErrorMessage(error);
-        if (/AUTH_REQUIRED/.test(message)) {
-            throw new AuthRequiredError('tiktok.com', 'TikTok requires login to read notifications');
-        }
-        if (/No notifications returned/.test(message)) {
-            throw new EmptyResultError('tiktok notifications', message);
-        }
-        throw new CommandExecutionError(`Failed to load TikTok notifications: ${message}`);
+        throwTikTokPageContextError(error, {
+            authMessage: 'TikTok requires login to read notifications',
+            emptyPattern: /No notifications returned/,
+            emptyTarget: 'tiktok notifications',
+            failureMessage: 'Failed to load TikTok notifications',
+        });
     }
     if (!Array.isArray(rows) || rows.length === 0) {
         throw new EmptyResultError('tiktok notifications', 'TikTok returned no notifications');

--- a/clis/tiktok/notifications.js
+++ b/clis/tiktok/notifications.js
@@ -1,50 +1,165 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Read TikTok inbox notifications via page-context API.
+//
+// Replaces the legacy "click the bell icon then scrape `[data-e2e="inbox-list"]`
+// text content" pipeline. Calls `/api/notice/multi/?notice_type=N` directly
+// from inside the live page so cookies + msToken get forwarded by the browser.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    getErrorMessage,
+} from '@jackwener/opencli/errors';
+import {
+    BROWSER_HELPERS,
+    MAX_PAGES,
+    NOTIFICATION_NORMALIZER,
+    NOTIFICATION_TYPES,
+    SERVER_PAGE_MAX,
+    TIKTOK_AID,
+    requireLimit,
+    requireNotificationType,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 15;
+const MAX_LIMIT = 100;
+
+function buildNotificationsScript(limit, typeKey) {
+    const typeMeta = NOTIFICATION_TYPES[typeKey];
+    return `
+(async () => {
+  const limit = ${Number(limit)};
+  const maxPages = ${MAX_PAGES};
+  const SERVER_PAGE_MAX = ${SERVER_PAGE_MAX};
+  const pageSize = limit < SERVER_PAGE_MAX ? limit : SERVER_PAGE_MAX;
+  const noticeType = ${Number(typeMeta.code)};
+  const noticeLabel = ${JSON.stringify(typeMeta.label)};
+  const aid = ${JSON.stringify(TIKTOK_AID)};
+
+  ${BROWSER_HELPERS}
+  ${NOTIFICATION_NORMALIZER}
+
+  function collectFromState(root) {
+    if (!root) return [];
+    const out = [];
+    walkObjects(root, (node) => {
+      if (Array.isArray(node)) return false;
+      if (Array.isArray(node.noticeList)) {
+        for (const entry of node.noticeList) out.push(entry);
+      }
+      if (Array.isArray(node.notice_list)) {
+        for (const entry of node.notice_list) out.push(entry);
+      }
+      return false;
+    });
+    return out;
+  }
+
+  const dedup = new Map();
+  const universal = findUniversalData();
+  for (const item of collectFromState(universal)) {
+    const row = normalizeNotification(item, dedup.size + 1);
+    if (row && !dedup.has(row.id)) dedup.set(row.id, row);
+  }
+
+  let apiFailure = null;
+  const msToken = getCookie('msToken');
+  let maxTime = 0;
+  let authRequired = false;
+  for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
+    const params = new URLSearchParams({
+      aid,
+      notice_type: String(noticeType),
+      count: String(pageSize),
+      max_time: String(maxTime),
+    });
+    if (msToken) params.set('msToken', msToken);
+    try {
+      const data = await fetchJson('/api/notice/multi/?' + params.toString());
+      if (data?.status_code === 8 || data?.statusCode === 8) {
+        authRequired = true;
+        break;
+      }
+      const list = Array.isArray(data.notice_list_v1)
+        ? data.notice_list_v1
+        : (Array.isArray(data.noticeList) ? data.noticeList : (Array.isArray(data.notice_list) ? data.notice_list : []));
+      if (list.length === 0) break;
+      for (const entry of list) {
+        const row = normalizeNotification(entry, dedup.size + 1);
+        if (row && !dedup.has(row.id)) dedup.set(row.id, row);
+      }
+      if (data.has_more !== true && data.hasMore !== true) break;
+      maxTime = asNumber(data.min_time) ?? asNumber(data.maxTime) ?? maxTime + list.length;
+    } catch (error) {
+      apiFailure = error instanceof Error ? error.message : String(error);
+      break;
+    }
+  }
+
+  if (authRequired) {
+    throw new Error('AUTH_REQUIRED: TikTok inbox requires login (' + noticeLabel + ')');
+  }
+
+  const rows = Array.from(dedup.values())
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, index: index + 1 }));
+
+  if (rows.length === 0) {
+    const suffix = apiFailure ? ' (notice API failed: ' + apiFailure + ')' : '';
+    throw new Error('No notifications returned for ' + noticeLabel + suffix);
+  }
+  return rows;
+})()
+`;
+}
+
+async function listNotifications(page, args) {
+    const limit = requireLimit(args.limit, { fallback: DEFAULT_LIMIT, max: MAX_LIMIT });
+    const typeKey = requireNotificationType(args.type);
+    await page.goto('https://www.tiktok.com/foryou', { waitUntil: 'load', settleMs: 5000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildNotificationsScript(limit, typeKey));
+    } catch (error) {
+        const message = getErrorMessage(error);
+        if (/AUTH_REQUIRED/.test(message)) {
+            throw new AuthRequiredError('tiktok.com', 'TikTok requires login to read notifications');
+        }
+        if (/No notifications returned/.test(message)) {
+            throw new EmptyResultError('tiktok notifications', message);
+        }
+        throw new CommandExecutionError(`Failed to load TikTok notifications: ${message}`);
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError('tiktok notifications', 'TikTok returned no notifications');
+    }
+    return rows;
+}
+
+export const notificationsCommand = cli({
     site: 'tiktok',
     name: 'notifications',
     access: 'read',
-    description: 'Get TikTok notifications (likes, comments, mentions, followers)',
+    description: 'Read TikTok inbox notifications (likes, comments, mentions, followers) via page-context APIs',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 15, help: 'Number of notifications' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of notifications (max ${MAX_LIMIT})` },
         {
             name: 'type',
             default: 'all',
             help: 'Notification type',
-            choices: ['all', 'likes', 'comments', 'mentions', 'followers'],
+            choices: Object.keys(NOTIFICATION_TYPES),
         },
     ],
-    columns: ['index', 'text'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/following', settleMs: 5000 } },
-        { evaluate: `(async () => {
-  const limit = \${{ args.limit }};
-  const type = \${{ args.type | json }};
-  const wait = (ms) => new Promise(r => setTimeout(r, ms));
-
-  // Click inbox icon to open notifications panel
-  const inboxIcon = document.querySelector('[data-e2e="inbox-icon"]');
-  if (inboxIcon) inboxIcon.click();
-  await wait(1500);
-
-  // Click specific tab if needed
-  if (type !== 'all') {
-    const tab = document.querySelector('[data-e2e="' + type + '"]');
-    if (tab) {
-      tab.click();
-      await wait(1500);
-    }
-  }
-
-  const items = document.querySelectorAll('[data-e2e="inbox-list"] > div, [data-e2e="inbox-list"] [role="button"]');
-  return Array.from(items)
-    .filter(el => el.textContent.trim().length > 5)
-    .slice(0, limit)
-    .map((el, i) => ({
-      index: i + 1,
-      text: el.textContent.trim().replace(/\\s+/g, ' ').substring(0, 150),
-    }));
-})()
-` },
-    ],
+    columns: ['index', 'id', 'from', 'text', 'createTime'],
+    func: listNotifications,
 });
+
+export const __test__ = {
+    buildNotificationsScript,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+};

--- a/clis/tiktok/refactor.test.js
+++ b/clis/tiktok/refactor.test.js
@@ -147,16 +147,19 @@ describe('tiktok/explore (page-context refactor)', () => {
         expect(page.goto).not.toHaveBeenCalled();
     });
 
-    it('navigates to /explore and returns rows from evaluate, re-indexed', async () => {
+    it('navigates to /explore and returns the full video row shape from evaluate', async () => {
         const page = makePage([sampleVideoRow, { ...sampleVideoRow, id: '7350000000000000001', index: 99 }]);
         const rows = await exploreCommand.func(page, { limit: 5 });
         expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/explore', { waitUntil: 'load', settleMs: 5000 });
-        expect(rows).toHaveLength(2);
+        expect(rows).toEqual([sampleVideoRow, { ...sampleVideoRow, id: '7350000000000000001', index: 99 }]);
     });
 
     it('maps empty / unrecognised evaluate failures to typed errors', async () => {
         await expect(exploreCommand.func(makePage([]), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
         await expect(exploreCommand.func(makeFailingPage(new Error('No videos found on /explore')), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(exploreCommand.func(makeFailingPage(new Error('No videos found on /explore (recommend API failed: HTTP 500)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(exploreCommand.func(makeFailingPage(new Error('No videos found on /explore (recommend API failed: HTTP 403)')), { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(exploreCommand.func(makeFailingPage(new Error('No videos found on /explore (recommend API failed: invalid JSON)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
         await expect(exploreCommand.func(makeFailingPage(new Error('boom')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
@@ -186,9 +189,12 @@ describe('tiktok/friends (page-context refactor)', () => {
 
     it('navigates to /friends and surfaces empty as EmptyResultError', async () => {
         const page = makePage([sampleUserRow]);
-        await friendsCommand.func(page, { limit: 5 });
+        await expect(friendsCommand.func(page, { limit: 5 })).resolves.toEqual([sampleUserRow]);
         expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/friends', { waitUntil: 'load', settleMs: 5000 });
         await expect(friendsCommand.func(makePage([]), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(friendsCommand.func(makeFailingPage(new Error('No friend suggestions returned by TikTok (recommend-user API failed: HTTP 500)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(friendsCommand.func(makeFailingPage(new Error('No friend suggestions returned by TikTok (recommend-user API failed: HTTP 401)')), { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(friendsCommand.func(makeFailingPage(new Error('No friend suggestions returned by TikTok (recommend-user API failed: invalid JSON)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('build script targets recommend-user endpoint via state-then-API', () => {
@@ -218,6 +224,15 @@ describe('tiktok/following (page-context refactor)', () => {
     it('maps AUTH_REQUIRED sentinel to AuthRequiredError', async () => {
         const page = makeFailingPage(new Error('AUTH_REQUIRED: cannot resolve viewer secUid (login required)'));
         await expect(followingCommand.func(page, { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(followingCommand.func(makeFailingPage(new Error('No following entries returned (user-list API failed: HTTP 500)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(followingCommand.func(makeFailingPage(new Error('No following entries returned (user-list API failed: HTTP 403)')), { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(followingCommand.func(makeFailingPage(new Error('No following entries returned (user-list API failed: invalid JSON)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('navigates to /following and returns the full user row shape', async () => {
+        const page = makePage([sampleUserRow]);
+        await expect(followingCommand.func(page, { limit: 5 })).resolves.toEqual([sampleUserRow]);
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/following', { waitUntil: 'load', settleMs: 5000 });
     });
 
     it('build script resolves viewer secUid then pages user-list scene=21', () => {
@@ -252,8 +267,11 @@ describe('tiktok/notifications (page-context refactor)', () => {
             { limit: 5, type: 'likes' },
         )).rejects.toBeInstanceOf(AuthRequiredError);
         await expect(notificationsCommand.func(makePage([]), { limit: 5, type: 'all' })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(notificationsCommand.func(makeFailingPage(new Error('No notifications returned for all (notice API failed: HTTP 500)')), { limit: 5, type: 'all' })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(notificationsCommand.func(makeFailingPage(new Error('No notifications returned for all (notice API failed: HTTP 401)')), { limit: 5, type: 'all' })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(notificationsCommand.func(makeFailingPage(new Error('No notifications returned for all (notice API failed: invalid JSON)')), { limit: 5, type: 'all' })).rejects.toBeInstanceOf(CommandExecutionError);
         const page = makePage([sampleNotificationRow]);
-        await notificationsCommand.func(page, { limit: 5, type: 'comments' });
+        await expect(notificationsCommand.func(page, { limit: 5, type: 'comments' })).resolves.toEqual([sampleNotificationRow]);
     });
 
     it('embeds the requested notice_type code from NOTIFICATION_TYPES into the script', () => {
@@ -283,9 +301,12 @@ describe('tiktok/live (page-context refactor)', () => {
 
     it('navigates to /live and surfaces empty as EmptyResultError', async () => {
         const page = makePage([sampleLiveRow]);
-        await liveCommand.func(page, { limit: 5 });
+        await expect(liveCommand.func(page, { limit: 5 })).resolves.toEqual([sampleLiveRow]);
         expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/live', { waitUntil: 'load', settleMs: 5000 });
         await expect(liveCommand.func(makePage([]), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(liveCommand.func(makeFailingPage(new Error('No live streams returned (live-discover API failed: HTTP 500)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(liveCommand.func(makeFailingPage(new Error('No live streams returned (live-discover API failed: HTTP 403)')), { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(liveCommand.func(makeFailingPage(new Error('No live streams returned (live-discover API failed: invalid JSON)')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('build script targets live-discover endpoint via state-then-API', () => {

--- a/clis/tiktok/refactor.test.js
+++ b/clis/tiktok/refactor.test.js
@@ -1,5 +1,5 @@
 // Contract tests for the Phase-3 refactor that retired the legacy DOM-link
-// scraping pattern across explore / friends / following / notifications / live.
+// scraping pattern across explore / user / friends / following / notifications / live.
 // Each adapter is now func + Strategy.COOKIE + browser:true with shared helpers
 // from utils.js — these tests pin down (a) registration metadata, (b) typed-
 // error boundary, (c) build-script invariants (no raw user-input concatenation,
@@ -17,6 +17,7 @@ import { friendsCommand, __test__ as friendsTest } from './friends.js';
 import { followingCommand, __test__ as followingTest } from './following.js';
 import { notificationsCommand, __test__ as notificationsTest } from './notifications.js';
 import { liveCommand, __test__ as liveTest } from './live.js';
+import { userCommand, __test__ as userTest } from './user.js';
 import {
     BROWSER_HELPERS,
     NOTIFICATION_TYPES,
@@ -58,6 +59,11 @@ const sampleVideoRow = {
     comments: 9,
     shares: 1,
     createTime: 1710000000,
+};
+
+const sampleUserVideoRow = {
+    ...sampleVideoRow,
+    source: 'profile-api',
 };
 
 const sampleUserRow = {
@@ -179,6 +185,55 @@ describe('tiktok/explore (page-context refactor)', () => {
         expect(script).toContain("assertTikTokApiSuccess(data, 'recommend')");
         expect(script).toContain('findUniversalData');
         expect(script).toContain('normalizeVideoItem');
+    });
+});
+
+describe('tiktok/user (page-context refactor)', () => {
+    it('registers as read-only browser COOKIE adapter with sourced video columns', () => {
+        expect(userCommand.access).toBe('read');
+        expect(userCommand.browser).toBe(true);
+        expect(userCommand.strategy).toBe('cookie');
+        expect(userCommand.columns).toEqual([
+            'index', 'id', 'source', 'author', 'url', 'cover', 'title', 'desc',
+            'plays', 'likes', 'comments', 'shares', 'createTime',
+        ]);
+    });
+
+    it('validates username and --limit upfront before navigating', async () => {
+        const page = makePage([]);
+        await expect(userCommand.func(page, { username: '', limit: 5 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(userCommand.func(page, { username: '@bad/name', limit: 5 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(userCommand.func(page, { username: 'dictogo', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(userCommand.func(page, { username: 'dictogo', limit: userTest.MAX_LIMIT + 1 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to the profile and returns full sourced video rows', async () => {
+        const page = makePage([sampleUserVideoRow]);
+        await expect(userCommand.func(page, { username: '@dictogo', limit: 5 })).resolves.toEqual([sampleUserVideoRow]);
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/@dictogo', { waitUntil: 'load', settleMs: 6000 });
+    });
+
+    it('maps empty, auth, upstream, and invalid JSON failures to typed errors', async () => {
+        await expect(userCommand.func(makePage([]), { username: 'dictogo', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(userCommand.func(makeFailingPage(new Error('No videos found for @dictogo')), { username: 'dictogo', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(userCommand.func(makeFailingPage(new Error('No videos found for @dictogo (profile/search API failed: HTTP 500)')), { username: 'dictogo', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(userCommand.func(makeFailingPage(new Error('No videos found for @dictogo (profile/search API failed: HTTP 403)')), { username: 'dictogo', limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(userCommand.func(makeFailingPage(new Error('No videos found for @dictogo (profile/search API failed: invalid JSON)')), { username: 'dictogo', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('build script resolves secUid, pages post-list, and exact-author search fallback', () => {
+        const script = userTest.buildUserScript('dictogo', 20);
+        expect(script).toContain('/api/user/detail/');
+        expect(script).toContain("assertTikTokApiSuccess(detail, 'user-detail')");
+        expect(script).toContain('/api/post/item_list/');
+        expect(script).toContain("assertTikTokApiSuccess(data, 'post-list')");
+        expect(script).toContain('/api/search/general/full/');
+        expect(script).toContain("assertTikTokApiSuccess(data, 'search')");
+        expect(script).toContain("'profile-api'");
+        expect(script).toContain("'bootstrap'");
+        expect(script).toContain("'search-fallback'");
+        expect(script).toContain(JSON.stringify('dictogo'));
     });
 });
 

--- a/clis/tiktok/refactor.test.js
+++ b/clis/tiktok/refactor.test.js
@@ -1,0 +1,297 @@
+// Contract tests for the Phase-3 refactor that retired the legacy DOM-link
+// scraping pattern across explore / friends / following / notifications / live.
+// Each adapter is now func + Strategy.COOKIE + browser:true with shared helpers
+// from utils.js — these tests pin down (a) registration metadata, (b) typed-
+// error boundary, (c) build-script invariants (no raw user-input concatenation,
+// expected endpoint markers, JSON.stringify-embedded inputs).
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { exploreCommand, __test__ as exploreTest } from './explore.js';
+import { friendsCommand, __test__ as friendsTest } from './friends.js';
+import { followingCommand, __test__ as followingTest } from './following.js';
+import { notificationsCommand, __test__ as notificationsTest } from './notifications.js';
+import { liveCommand, __test__ as liveTest } from './live.js';
+import {
+    BROWSER_HELPERS,
+    NOTIFICATION_TYPES,
+    VIDEO_ITEM_NORMALIZER,
+    USER_ITEM_NORMALIZER,
+    LIVE_ITEM_NORMALIZER,
+    NOTIFICATION_NORMALIZER,
+    normalizeUsername,
+    requireLimit,
+    requireNotificationType,
+} from './utils.js';
+
+function makePage(rows) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(rows),
+    };
+}
+
+function makeFailingPage(error) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockRejectedValue(error),
+    };
+}
+
+const sampleVideoRow = {
+    index: 1,
+    id: '7350000000000000000',
+    author: 'creator',
+    url: 'https://www.tiktok.com/@creator/video/7350000000000000000',
+    cover: 'https://example.com/cover.jpg',
+    title: 'a fun clip',
+    desc: 'a fun clip',
+    plays: 12345,
+    likes: 678,
+    comments: 9,
+    shares: 1,
+    createTime: 1710000000,
+};
+
+const sampleUserRow = {
+    index: 1,
+    username: 'creator',
+    name: 'Creator',
+    secUid: 'MS4wLjA',
+    verified: false,
+    followers: 1000,
+    following: 50,
+    url: 'https://www.tiktok.com/@creator',
+};
+
+const sampleNotificationRow = {
+    index: 1,
+    id: 'notice-1',
+    from: 'someone',
+    text: 'liked your video',
+    createTime: 1710000000,
+};
+
+const sampleLiveRow = {
+    index: 1,
+    streamer: 'host1',
+    name: 'Host One',
+    title: 'cooking show',
+    viewers: 500,
+    likes: 0,
+    secUid: 'MS4wLjA',
+    url: 'https://www.tiktok.com/@host1/live',
+};
+
+describe('tiktok/utils', () => {
+    it('requireLimit rejects 0 / negative / non-integer / over-max with ArgumentError', () => {
+        expect(() => requireLimit(0, { fallback: 10, max: 50 })).toThrow(ArgumentError);
+        expect(() => requireLimit(-1, { fallback: 10, max: 50 })).toThrow(ArgumentError);
+        expect(() => requireLimit(1.5, { fallback: 10, max: 50 })).toThrow(ArgumentError);
+        expect(() => requireLimit(51, { fallback: 10, max: 50 })).toThrow(ArgumentError);
+        expect(requireLimit(undefined, { fallback: 10, max: 50 })).toBe(10);
+        expect(requireLimit(20, { fallback: 10, max: 50 })).toBe(20);
+    });
+
+    it('normalizeUsername strips @ and validates allowed charset', () => {
+        expect(normalizeUsername('@dictogo')).toBe('dictogo');
+        expect(normalizeUsername(' creator.name ')).toBe('creator.name');
+        expect(() => normalizeUsername('')).toThrow(ArgumentError);
+        expect(() => normalizeUsername('bad name')).toThrow(ArgumentError);
+        expect(() => normalizeUsername('bad/name')).toThrow(ArgumentError);
+    });
+
+    it('requireNotificationType maps known keys and rejects unknown via ArgumentError', () => {
+        expect(requireNotificationType('all')).toBe('all');
+        expect(requireNotificationType('LIKES')).toBe('likes');
+        expect(() => requireNotificationType('bogus')).toThrow(ArgumentError);
+    });
+
+    it('BROWSER_HELPERS is a string template that exposes the expected helper names', () => {
+        expect(typeof BROWSER_HELPERS).toBe('string');
+        for (const name of ['asNumber', 'cleanText', 'getCookie', 'fetchJson', 'findUniversalData', 'walkObjects']) {
+            expect(BROWSER_HELPERS).toContain('function ' + name + '(');
+        }
+    });
+
+    it('Item normalizers produce well-formed JS function declarations', () => {
+        expect(VIDEO_ITEM_NORMALIZER).toContain('function normalizeVideoItem(');
+        expect(USER_ITEM_NORMALIZER).toContain('function normalizeUserRow(');
+        expect(LIVE_ITEM_NORMALIZER).toContain('function normalizeLiveItem(');
+        expect(NOTIFICATION_NORMALIZER).toContain('function normalizeNotification(');
+    });
+});
+
+describe('tiktok/explore (page-context refactor)', () => {
+    it('registers as read-only browser COOKIE adapter with full video columns', () => {
+        expect(exploreCommand.access).toBe('read');
+        expect(exploreCommand.browser).toBe(true);
+        expect(exploreCommand.strategy).toBe('cookie');
+        expect(exploreCommand.columns).toEqual([
+            'index', 'id', 'author', 'url', 'cover', 'title', 'desc',
+            'plays', 'likes', 'comments', 'shares', 'createTime',
+        ]);
+    });
+
+    it('validates --limit upfront before navigating (no silent clamp)', async () => {
+        const page = makePage([]);
+        await expect(exploreCommand.func(page, { limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(exploreCommand.func(page, { limit: exploreTest.MAX_LIMIT + 1 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to /explore and returns rows from evaluate, re-indexed', async () => {
+        const page = makePage([sampleVideoRow, { ...sampleVideoRow, id: '7350000000000000001', index: 99 }]);
+        const rows = await exploreCommand.func(page, { limit: 5 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/explore', { waitUntil: 'load', settleMs: 5000 });
+        expect(rows).toHaveLength(2);
+    });
+
+    it('maps empty / unrecognised evaluate failures to typed errors', async () => {
+        await expect(exploreCommand.func(makePage([]), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(exploreCommand.func(makeFailingPage(new Error('No videos found on /explore')), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(exploreCommand.func(makeFailingPage(new Error('boom')), { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('build script targets recommend-feed state + recommend item_list endpoint', () => {
+        const script = exploreTest.buildExploreScript(15);
+        expect(script).toContain('/api/recommend/item_list/');
+        expect(script).toContain('findUniversalData');
+        expect(script).toContain('normalizeVideoItem');
+    });
+});
+
+describe('tiktok/friends (page-context refactor)', () => {
+    it('registers as read-only COOKIE adapter with user columns', () => {
+        expect(friendsCommand.access).toBe('read');
+        expect(friendsCommand.browser).toBe(true);
+        expect(friendsCommand.strategy).toBe('cookie');
+        expect(friendsCommand.columns).toEqual([
+            'index', 'username', 'name', 'secUid', 'verified', 'followers', 'following', 'url',
+        ]);
+    });
+
+    it('validates --limit upfront and never navigates on bad input', async () => {
+        const page = makePage([]);
+        await expect(friendsCommand.func(page, { limit: -2 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to /friends and surfaces empty as EmptyResultError', async () => {
+        const page = makePage([sampleUserRow]);
+        await friendsCommand.func(page, { limit: 5 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/friends', { waitUntil: 'load', settleMs: 5000 });
+        await expect(friendsCommand.func(makePage([]), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('build script targets recommend-user endpoint via state-then-API', () => {
+        const script = friendsTest.buildFriendsScript(20);
+        expect(script).toContain('/api/recommend/user/');
+        expect(script).toContain('findUniversalData');
+        expect(script).toContain('normalizeUserRow');
+    });
+});
+
+describe('tiktok/following (page-context refactor)', () => {
+    it('registers as read-only COOKIE adapter with user columns', () => {
+        expect(followingCommand.access).toBe('read');
+        expect(followingCommand.browser).toBe(true);
+        expect(followingCommand.strategy).toBe('cookie');
+        expect(followingCommand.columns).toEqual([
+            'index', 'username', 'name', 'secUid', 'verified', 'followers', 'following', 'url',
+        ]);
+    });
+
+    it('validates --limit upfront', async () => {
+        const page = makePage([]);
+        await expect(followingCommand.func(page, { limit: 999 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('maps AUTH_REQUIRED sentinel to AuthRequiredError', async () => {
+        const page = makeFailingPage(new Error('AUTH_REQUIRED: cannot resolve viewer secUid (login required)'));
+        await expect(followingCommand.func(page, { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('build script resolves viewer secUid then pages user-list scene=21', () => {
+        const script = followingTest.buildFollowingScript(20);
+        expect(script).toContain('/api/user/list/');
+        expect(script).toContain("scene: '21'");
+        expect(script).toContain('findViewerSecUid');
+        expect(script).toContain('normalizeUserRow');
+    });
+});
+
+describe('tiktok/notifications (page-context refactor)', () => {
+    it('registers as read-only COOKIE adapter with notification columns', () => {
+        expect(notificationsCommand.access).toBe('read');
+        expect(notificationsCommand.browser).toBe(true);
+        expect(notificationsCommand.strategy).toBe('cookie');
+        expect(notificationsCommand.columns).toEqual([
+            'index', 'id', 'from', 'text', 'createTime',
+        ]);
+    });
+
+    it('validates --limit and --type upfront before navigating', async () => {
+        const page = makePage([]);
+        await expect(notificationsCommand.func(page, { limit: 0, type: 'all' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(notificationsCommand.func(page, { limit: 5, type: 'bogus' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('maps AUTH_REQUIRED sentinel to AuthRequiredError, empty to EmptyResultError', async () => {
+        await expect(notificationsCommand.func(
+            makeFailingPage(new Error('AUTH_REQUIRED: TikTok inbox requires login (likes)')),
+            { limit: 5, type: 'likes' },
+        )).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(notificationsCommand.func(makePage([]), { limit: 5, type: 'all' })).rejects.toBeInstanceOf(EmptyResultError);
+        const page = makePage([sampleNotificationRow]);
+        await notificationsCommand.func(page, { limit: 5, type: 'comments' });
+    });
+
+    it('embeds the requested notice_type code from NOTIFICATION_TYPES into the script', () => {
+        for (const [key, meta] of Object.entries(NOTIFICATION_TYPES)) {
+            const script = notificationsTest.buildNotificationsScript(15, key);
+            expect(script).toContain('const noticeType = ' + meta.code);
+            expect(script).toContain('/api/notice/multi/');
+        }
+    });
+});
+
+describe('tiktok/live (page-context refactor)', () => {
+    it('registers as read-only COOKIE adapter with live columns', () => {
+        expect(liveCommand.access).toBe('read');
+        expect(liveCommand.browser).toBe(true);
+        expect(liveCommand.strategy).toBe('cookie');
+        expect(liveCommand.columns).toEqual([
+            'index', 'streamer', 'name', 'title', 'viewers', 'likes', 'secUid', 'url',
+        ]);
+    });
+
+    it('validates --limit upfront', async () => {
+        const page = makePage([]);
+        await expect(liveCommand.func(page, { limit: -1 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to /live and surfaces empty as EmptyResultError', async () => {
+        const page = makePage([sampleLiveRow]);
+        await liveCommand.func(page, { limit: 5 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/live', { waitUntil: 'load', settleMs: 5000 });
+        await expect(liveCommand.func(makePage([]), { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('build script targets live-discover endpoint via state-then-API', () => {
+        const script = liveTest.buildLiveScript(15);
+        expect(script).toContain('/api/live/discover/get/');
+        expect(script).toContain('findUniversalData');
+        expect(script).toContain('normalizeLiveItem');
+    });
+});

--- a/clis/tiktok/refactor.test.js
+++ b/clis/tiktok/refactor.test.js
@@ -116,13 +116,17 @@ describe('tiktok/utils', () => {
 
     it('BROWSER_HELPERS is a string template that exposes the expected helper names', () => {
         expect(typeof BROWSER_HELPERS).toBe('string');
-        for (const name of ['asNumber', 'cleanText', 'getCookie', 'fetchJson', 'findUniversalData', 'walkObjects']) {
+        for (const name of ['asNumber', 'cleanText', 'getCookie', 'fetchJson', 'assertTikTokApiSuccess', 'findUniversalData', 'walkObjects']) {
             expect(BROWSER_HELPERS).toContain('function ' + name + '(');
         }
         const asNumber = new Function(`${BROWSER_HELPERS}; return asNumber;`)();
         expect(asNumber(null)).toBeNull();
         expect(asNumber('')).toBeNull();
         expect(asNumber(0)).toBe(0);
+        const assertTikTokApiSuccess = new Function(`${BROWSER_HELPERS}; return assertTikTokApiSuccess;`)();
+        expect(() => assertTikTokApiSuccess({ status_code: 0 }, 'test')).not.toThrow();
+        expect(() => assertTikTokApiSuccess({ status_code: 8, status_msg: 'login required' }, 'test')).toThrow(/AUTH_REQUIRED/);
+        expect(() => assertTikTokApiSuccess({ status_code: 1001, status_msg: 'rate limited' }, 'test')).toThrow(/test API failed: rate limited/);
     });
 
     it('Item normalizers produce well-formed JS function declarations', () => {
@@ -172,6 +176,7 @@ describe('tiktok/explore (page-context refactor)', () => {
     it('build script targets recommend-feed state + recommend item_list endpoint', () => {
         const script = exploreTest.buildExploreScript(15);
         expect(script).toContain('/api/recommend/item_list/');
+        expect(script).toContain("assertTikTokApiSuccess(data, 'recommend')");
         expect(script).toContain('findUniversalData');
         expect(script).toContain('normalizeVideoItem');
     });
@@ -206,6 +211,7 @@ describe('tiktok/friends (page-context refactor)', () => {
     it('build script targets recommend-user endpoint via state-then-API', () => {
         const script = friendsTest.buildFriendsScript(20);
         expect(script).toContain('/api/recommend/user/');
+        expect(script).toContain("assertTikTokApiSuccess(data, 'recommend-user')");
         expect(script).toContain('findUniversalData');
         expect(script).toContain('normalizeUserRow');
     });
@@ -244,6 +250,7 @@ describe('tiktok/following (page-context refactor)', () => {
     it('build script resolves viewer secUid then pages user-list scene=21', () => {
         const script = followingTest.buildFollowingScript(20);
         expect(script).toContain('/api/user/list/');
+        expect(script).toContain("assertTikTokApiSuccess(data, 'user-list')");
         expect(script).toContain("scene: '21'");
         expect(script).toContain('findViewerSecUid');
         expect(script).toContain('normalizeUserRow');
@@ -285,6 +292,7 @@ describe('tiktok/notifications (page-context refactor)', () => {
             const script = notificationsTest.buildNotificationsScript(15, key);
             expect(script).toContain('const noticeType = ' + meta.code);
             expect(script).toContain('/api/notice/multi/');
+            expect(script).toContain("assertTikTokApiSuccess(data, 'notice')");
         }
     });
 });
@@ -318,6 +326,7 @@ describe('tiktok/live (page-context refactor)', () => {
     it('build script targets live-discover endpoint via state-then-API', () => {
         const script = liveTest.buildLiveScript(15);
         expect(script).toContain('/api/live/discover/get/');
+        expect(script).toContain("assertTikTokApiSuccess(data, 'live-discover')");
         expect(script).toContain('findUniversalData');
         expect(script).toContain('normalizeLiveItem');
     });

--- a/clis/tiktok/refactor.test.js
+++ b/clis/tiktok/refactor.test.js
@@ -119,12 +119,18 @@ describe('tiktok/utils', () => {
         for (const name of ['asNumber', 'cleanText', 'getCookie', 'fetchJson', 'findUniversalData', 'walkObjects']) {
             expect(BROWSER_HELPERS).toContain('function ' + name + '(');
         }
+        const asNumber = new Function(`${BROWSER_HELPERS}; return asNumber;`)();
+        expect(asNumber(null)).toBeNull();
+        expect(asNumber('')).toBeNull();
+        expect(asNumber(0)).toBe(0);
     });
 
     it('Item normalizers produce well-formed JS function declarations', () => {
         expect(VIDEO_ITEM_NORMALIZER).toContain('function normalizeVideoItem(');
         expect(USER_ITEM_NORMALIZER).toContain('function normalizeUserRow(');
         expect(LIVE_ITEM_NORMALIZER).toContain('function normalizeLiveItem(');
+        expect(LIVE_ITEM_NORMALIZER).toContain('room.user_count ?? room.viewerCount');
+        expect(LIVE_ITEM_NORMALIZER).toContain('room.like_count ?? room.likeCount');
         expect(NOTIFICATION_NORMALIZER).toContain('function normalizeNotification(');
     });
 });

--- a/clis/tiktok/refactor.test.js
+++ b/clis/tiktok/refactor.test.js
@@ -234,6 +234,7 @@ describe('tiktok/user (page-context refactor)', () => {
         expect(script).toContain("'bootstrap'");
         expect(script).toContain("'search-fallback'");
         expect(script).toContain(JSON.stringify('dictogo'));
+        expect(script).not.toContain('AUTH_REQUIRED: cannot resolve secUid');
     });
 });
 

--- a/clis/tiktok/user.js
+++ b/clis/tiktok/user.js
@@ -1,10 +1,201 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Get recent videos from a TikTok user's public profile via page-context APIs.
+//
+// This is the `tiktok user` counterpart to the Phase-3 read refactor: resolve
+// the profile `secUid`, page `/api/post/item_list/`, and use exact-author search
+// only as a lower-authority fallback. All requests run inside the live page so
+// cookies + msToken are forwarded by the browser.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    BROWSER_HELPERS,
+    MAX_PAGES,
+    SERVER_PAGE_MAX,
+    TIKTOK_AID,
+    VIDEO_ITEM_NORMALIZER,
+    normalizeUsername,
+    requireLimit,
+    throwTikTokPageContextError,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 120;
+
+function buildUserScript(username, limit) {
+    return `
+(async () => {
+  const username = ${JSON.stringify(username)};
+  const usernameLower = username.toLowerCase();
+  const limit = ${Number(limit)};
+  const maxPages = ${MAX_PAGES};
+  const SERVER_PAGE_MAX = ${SERVER_PAGE_MAX};
+  const pageSize = limit < SERVER_PAGE_MAX ? limit : SERVER_PAGE_MAX;
+  const aid = ${JSON.stringify(TIKTOK_AID)};
+
+  ${BROWSER_HELPERS}
+  ${VIDEO_ITEM_NORMALIZER}
+
+  function findProfileUser(root) {
+    if (!root) return null;
+    let found = null;
+    walkObjects(root, (node) => {
+      if (Array.isArray(node)) return false;
+      const user = node?.userInfo?.user || node?.user;
+      if (!user || typeof user !== 'object') return false;
+      const uniqueId = String(user.uniqueId || user.unique_id || '').toLowerCase();
+      if (uniqueId === usernameLower && (user.secUid || user.sec_uid)) {
+        found = user;
+        return true;
+      }
+      return false;
+    });
+    return found;
+  }
+
+  function collectProfileItems(root, secUid) {
+    if (!root) return [];
+    const out = [];
+    walkObjects(root, (node) => {
+      if (!node || typeof node !== 'object' || Array.isArray(node)) return false;
+      const item = node.itemStruct || node.item || node;
+      const id = item?.id || item?.item_id || item?.video_id;
+      const author = item?.author || item?.authorInfo || {};
+      const authorName = String(author.uniqueId || author.unique_id || item?.author_unique_id || '').toLowerCase();
+      const authorSecUid = String(author.secUid || author.sec_uid || '').trim();
+      if (id && (authorName === usernameLower || (secUid && authorSecUid === secUid))) {
+        out.push(item);
+      }
+      return false;
+    });
+    return out;
+  }
+
+  function addVideo(dedup, item, source) {
+    const row = normalizeVideoItem(item, dedup.size + 1);
+    if (!row || dedup.has(row.id)) return;
+    dedup.set(row.id, { ...row, source });
+  }
+
+  const universal = findUniversalData();
+  let secUid = '';
+  const profileUser = findProfileUser(universal);
+  if (profileUser) {
+    secUid = String(profileUser.secUid || profileUser.sec_uid || '').trim();
+  }
+
+  const msToken = getCookie('msToken');
+  if (!secUid) {
+    const params = new URLSearchParams({ uniqueId: username, aid });
+    if (msToken) params.set('msToken', msToken);
+    const detail = await fetchJson('/api/user/detail/?' + params.toString());
+    assertTikTokApiSuccess(detail, 'user-detail');
+    secUid = String(detail?.userInfo?.user?.secUid || detail?.user?.secUid || '').trim();
+  }
+  if (!secUid) {
+    throw new Error('AUTH_REQUIRED: cannot resolve secUid for @' + username);
+  }
+
+  const dedup = new Map();
+  for (const item of collectProfileItems(universal, secUid)) {
+    addVideo(dedup, item, 'bootstrap');
+  }
+
+  let cursor = 0;
+  let primaryFailure = null;
+  for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
+    const params = new URLSearchParams({
+      secUid,
+      count: String(pageSize),
+      cursor: String(cursor),
+      aid,
+    });
+    if (msToken) params.set('msToken', msToken);
+    try {
+      const data = await fetchJson('/api/post/item_list/?' + params.toString());
+      assertTikTokApiSuccess(data, 'post-list');
+      const items = Array.isArray(data.itemList) ? data.itemList : [];
+      for (const item of items) addVideo(dedup, item, 'profile-api');
+      if (data.hasMore !== true || items.length === 0) break;
+      cursor = asNumber(data.cursor) ?? cursor + items.length;
+    } catch (error) {
+      primaryFailure = error instanceof Error ? error.message : String(error);
+      break;
+    }
+  }
+
+  let searchFailure = null;
+  for (let offset = 0; offset < limit * 4 && dedup.size < limit; offset += pageSize) {
+    const params = new URLSearchParams({
+      keyword: username,
+      offset: String(offset),
+      count: String(pageSize),
+      aid,
+    });
+    if (msToken) params.set('msToken', msToken);
+    try {
+      const data = await fetchJson('/api/search/general/full/?' + params.toString());
+      assertTikTokApiSuccess(data, 'search');
+      const entries = Array.isArray(data.data) ? data.data : [];
+      if (entries.length === 0) break;
+      for (const entry of entries) {
+        if (entry?.type !== undefined && entry.type !== 1) continue;
+        const item = entry?.item || entry?.itemStruct || entry;
+        const author = item?.author || item?.authorInfo || {};
+        const authorName = String(author.uniqueId || author.unique_id || '').toLowerCase();
+        if (authorName !== usernameLower) continue;
+        addVideo(dedup, item, 'search-fallback');
+      }
+    } catch (error) {
+      searchFailure = error instanceof Error ? error.message : String(error);
+      break;
+    }
+  }
+
+  const rows = Array.from(dedup.values())
+    .sort((a, b) => (Number(b.createTime) || 0) - (Number(a.createTime) || 0))
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, index: index + 1 }));
+
+  if (rows.length === 0) {
+    const suffix = primaryFailure || searchFailure
+      ? ' (profile/search API failed: ' + (primaryFailure || searchFailure) + ')'
+      : '';
+    throw new Error('No videos found for @' + username + suffix);
+  }
+  return rows;
+})()
+`;
+}
+
+async function listUserVideos(page, args) {
+    const username = normalizeUsername(args.username);
+    const limit = requireLimit(args.limit, { fallback: DEFAULT_LIMIT, max: MAX_LIMIT });
+    await page.goto(`https://www.tiktok.com/@${encodeURIComponent(username)}`, { waitUntil: 'load', settleMs: 6000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildUserScript(username, limit));
+    } catch (error) {
+        throwTikTokPageContextError(error, {
+            authMessage: 'TikTok requires browser access to load user videos',
+            emptyPattern: /No videos found/,
+            emptyTarget: 'tiktok user',
+            failureMessage: 'Failed to fetch TikTok user videos',
+        });
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError('tiktok user', `No videos found for @${username}`);
+    }
+    return rows;
+}
+
+export const userCommand = cli({
     site: 'tiktok',
     name: 'user',
     access: 'read',
-    description: 'Get recent videos from a TikTok user',
+    description: 'Get recent videos from a TikTok user via page-context APIs',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
         {
             name: 'username',
@@ -12,31 +203,14 @@ cli({
             positional: true,
             help: 'TikTok username (without @)',
         },
-        { name: 'limit', type: 'int', default: 10, help: 'Number of videos' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of videos to return (max ${MAX_LIMIT})` },
     ],
-    columns: ['index', 'views', 'url'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/@${{ args.username }}', settleMs: 6000 } },
-        { evaluate: `(() => {
-  const limit = \${{ args.limit }};
-  const username = \${{ args.username | json }};
-  const links = Array.from(document.querySelectorAll('a[href*="/video/"]'));
-  const seen = {};
-  const results = [];
-  for (const a of links) {
-    const href = a.href;
-    if (seen[href]) continue;
-    seen[href] = true;
-    results.push({
-      index: results.length + 1,
-      views: a.textContent.trim() || '-',
-      url: href,
-    });
-    if (results.length >= limit) break;
-  }
-  if (results.length === 0) throw new Error('No videos found for @' + username);
-  return results;
-})()
-` },
-    ],
+    columns: ['index', 'id', 'source', 'author', 'url', 'cover', 'title', 'desc', 'plays', 'likes', 'comments', 'shares', 'createTime'],
+    func: listUserVideos,
 });
+
+export const __test__ = {
+    buildUserScript,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+};

--- a/clis/tiktok/user.js
+++ b/clis/tiktok/user.js
@@ -92,7 +92,7 @@ function buildUserScript(username, limit) {
     secUid = String(detail?.userInfo?.user?.secUid || detail?.user?.secUid || '').trim();
   }
   if (!secUid) {
-    throw new Error('AUTH_REQUIRED: cannot resolve secUid for @' + username);
+    throw new Error('No videos found for @' + username);
   }
 
   const dedup = new Map();

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -101,6 +101,7 @@ export function throwTikTokPageContextError(error, { authMessage, emptyPattern, 
 // `page.evaluate` script and call any helper inside.
 export const BROWSER_HELPERS = `
 function asNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
@@ -219,7 +220,7 @@ function normalizeVideoItem(item, indexHint) {
   const video = item.video || item.videoInfo || {};
   const cover = video.cover || video.originCover || video.dynamicCover || video.coverUrl || item.cover || item.cover_url || '';
   const desc = cleanText(item.desc || item.title || item.description, 500);
-  const createTime = asNumber(item.createTime || item.create_time || item.create_time_sec || item.post_time);
+  const createTime = asNumber(item.createTime ?? item.create_time ?? item.create_time_sec ?? item.post_time);
   const username = author.uniqueId;
   return {
     index: indexHint,
@@ -271,8 +272,8 @@ function normalizeLiveItem(item, indexHint) {
     streamer: username,
     name: cleanText(owner.nickname || owner.nickName || owner.name, 80) || username,
     title: cleanText(room.title || room.subtitle || item.title, 200),
-    viewers: asNumber(room.user_count || room.viewerCount || room.viewer_count || item.viewer_count),
-    likes: asNumber(room.like_count || room.likeCount || item.like_count),
+    viewers: asNumber(room.user_count ?? room.viewerCount ?? room.viewer_count ?? item.viewer_count),
+    likes: asNumber(room.like_count ?? room.likeCount ?? item.like_count),
     secUid: String(owner.secUid || owner.sec_uid || ''),
     url: username
       ? ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username) + '/live'

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -136,6 +136,17 @@ async function fetchJson(url) {
   }
 }
 
+function assertTikTokApiSuccess(data, label) {
+  if (!data || typeof data !== 'object') return;
+  const code = data.status_code ?? data.statusCode;
+  if (code === undefined || code === null || Number(code) === 0) return;
+  const message = cleanText(data.status_msg ?? data.statusMsg ?? data.message ?? data.msg ?? code, 240);
+  if (Number(code) === 8 || /auth|captcha|login|permission|unauthori[sz]ed|forbidden/i.test(message)) {
+    throw new Error('AUTH_REQUIRED: ' + label + ' API failed: ' + message);
+  }
+  throw new Error(label + ' API failed: ' + message);
+}
+
 function findUniversalData() {
   const scripts = Array.from(document.querySelectorAll('script'));
   for (const script of scripts) {

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -7,7 +7,13 @@
 //   identical across adapters without depending on a shared script being injected
 //   beforehand.
 
-import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    getErrorMessage,
+} from '@jackwener/opencli/errors';
 
 export const TIKTOK_AID = '1988';
 export const TIKTOK_HOST = 'https://www.tiktok.com';
@@ -66,6 +72,28 @@ export function requireNotificationType(value) {
         );
     }
     return key;
+}
+
+export function looksTikTokAuthFailure(message) {
+    return /\bAUTH_REQUIRED\b|\b(auth|captcha|login|log in|permission|unauthori[sz]ed|forbidden)\b|HTTP\s+(401|403)\b/i.test(String(message || ''));
+}
+
+export function looksTikTokUpstreamFailure(message) {
+    return /\b(API failed|HTTP\s+\d+|invalid JSON|Failed to fetch|network|fetch)\b/i.test(String(message || ''));
+}
+
+export function throwTikTokPageContextError(error, { authMessage, emptyPattern, emptyTarget, failureMessage }) {
+    const message = getErrorMessage(error);
+    if (looksTikTokAuthFailure(message)) {
+        throw new AuthRequiredError('tiktok.com', authMessage);
+    }
+    if (looksTikTokUpstreamFailure(message)) {
+        throw new CommandExecutionError(`${failureMessage}: ${message}`);
+    }
+    if (emptyPattern.test(message)) {
+        throw new EmptyResultError(emptyTarget, message);
+    }
+    throw new CommandExecutionError(`${failureMessage}: ${message}`);
 }
 
 // Browser-side helper bundle. Embedded into IIFEs as a string template.

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -1,0 +1,277 @@
+// Shared TikTok adapter helpers.
+//
+// - Node-side: input validation (typed errors per OpenCLI rules).
+// - Browser-side: a string template embedded into each `page.evaluate(...)` IIFE so
+//   the helpers run alongside the adapter-specific logic in the live page context.
+//   This keeps `findUniversalData / fetchJson / cleanText / asNumber / getCookie`
+//   identical across adapters without depending on a shared script being injected
+//   beforehand.
+
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+export const TIKTOK_AID = '1988';
+export const TIKTOK_HOST = 'https://www.tiktok.com';
+export const SERVER_PAGE_MAX = 30;
+export const MAX_PAGES = 4;
+
+export function requireLimit(value, { fallback, max, name = 'limit' }) {
+    const raw = value ?? fallback;
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new ArgumentError(
+            `${name} must be a positive integer`,
+            `Example: --${name} ${fallback}`,
+        );
+    }
+    if (parsed > max) {
+        throw new ArgumentError(
+            `${name} must be <= ${max}`,
+            `Example: --${name} ${max}`,
+        );
+    }
+    return parsed;
+}
+
+export function normalizeUsername(value) {
+    const username = String(value ?? '').trim().replace(/^@+/, '');
+    if (!username) {
+        throw new ArgumentError(
+            'username is required',
+            'Example: opencli tiktok following <username>',
+        );
+    }
+    if (!/^[A-Za-z0-9._-]+$/.test(username)) {
+        throw new ArgumentError(
+            'username contains unsupported characters',
+            'Pass the TikTok handle without @, for example: dictogo',
+        );
+    }
+    return username;
+}
+
+export const NOTIFICATION_TYPES = {
+    all: { code: 0, label: 'all' },
+    likes: { code: 3, label: 'likes' },
+    comments: { code: 7, label: 'comments' },
+    mentions: { code: 6, label: 'mentions' },
+    followers: { code: 4, label: 'followers' },
+};
+
+export function requireNotificationType(value) {
+    const key = String(value ?? 'all').trim().toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(NOTIFICATION_TYPES, key)) {
+        throw new ArgumentError(
+            `unsupported notification type: ${value}`,
+            `Allowed: ${Object.keys(NOTIFICATION_TYPES).join(', ')}`,
+        );
+    }
+    return key;
+}
+
+// Browser-side helper bundle. Embedded into IIFEs as a string template.
+// Stays self-contained so an adapter can paste `${BROWSER_HELPERS}` into its
+// `page.evaluate` script and call any helper inside.
+export const BROWSER_HELPERS = `
+function asNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function cleanText(value, maxLength) {
+  return String(value ?? '').replace(/\\s+/g, ' ').trim().slice(0, maxLength ?? 500);
+}
+
+function getCookie(name) {
+  const prefix = name + '=';
+  for (const part of (document.cookie || '').split('; ')) {
+    if (part.startsWith(prefix)) return decodeURIComponent(part.slice(prefix.length));
+  }
+  return '';
+}
+
+async function fetchJson(url) {
+  const requestUrl = new URL(url, ${JSON.stringify(TIKTOK_HOST)}).toString();
+  const res = await fetch(requestUrl, {
+    credentials: 'include',
+    headers: { accept: 'application/json,text/plain,*/*' },
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error('HTTP ' + res.status + ' from ' + requestUrl + ': ' + text.slice(0, 160));
+  }
+  if (!text.trim()) return {};
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error('invalid JSON from ' + requestUrl + ': ' + (error instanceof Error ? error.message : String(error)));
+  }
+}
+
+function findUniversalData() {
+  const scripts = Array.from(document.querySelectorAll('script'));
+  for (const script of scripts) {
+    const text = script.textContent || '';
+    if (!text || text.length < 32) continue;
+    const trimmed = text.trim();
+    if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) continue;
+    if (
+      !text.includes('webapp.user-detail') &&
+      !text.includes('webapp.recommend-feed') &&
+      !text.includes('webapp.live-discover') &&
+      !text.includes('ItemModule') &&
+      !text.includes('itemList') &&
+      !text.includes('userInfo') &&
+      !text.includes('userList') &&
+      !text.includes('noticeList')
+    ) {
+      continue;
+    }
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // Continue scanning; TikTok keeps multiple JSON-like script tags.
+    }
+  }
+  return null;
+}
+
+function walkObjects(root, visit) {
+  const stack = [root];
+  const seen = new Set();
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    if (visit(current) === true) return true;
+    if (Array.isArray(current)) {
+      for (const value of current) stack.push(value);
+      continue;
+    }
+    for (const value of Object.values(current)) {
+      if (value && typeof value === 'object') stack.push(value);
+    }
+  }
+  return false;
+}
+
+function findValueByKey(root, key) {
+  let found = null;
+  walkObjects(root, (node) => {
+    if (Array.isArray(node)) return false;
+    if (node && Object.prototype.hasOwnProperty.call(node, key) && node[key] != null) {
+      found = node[key];
+      return true;
+    }
+    return false;
+  });
+  return found;
+}
+
+function pickAuthor(author) {
+  if (!author || typeof author !== 'object') return {};
+  return {
+    uniqueId: String(author.uniqueId || author.unique_id || author.user_id || '').replace(/^@+/, ''),
+    nickname: cleanText(author.nickname || author.nickName || author.name, 80),
+    secUid: String(author.secUid || author.sec_uid || ''),
+    verified: Boolean(author.verified || author.is_verified || author.custom_verify),
+  };
+}
+`;
+
+// Sanitises a raw TikTok video item into the shape used across adapters.
+// Stays in browser context — the IIFE pastes this builder into its body via
+// the BROWSER_HELPERS bundle plus the adapter-specific normalisation.
+export const VIDEO_ITEM_NORMALIZER = `
+function normalizeVideoItem(item, indexHint) {
+  if (!item || typeof item !== 'object') return null;
+  const id = String(item.id || item.item_id || item.video_id || '').trim();
+  if (!id) return null;
+  const author = pickAuthor(item.author || item.authorInfo);
+  const stats = item.stats || item.statistics || item.statsV2 || {};
+  const video = item.video || item.videoInfo || {};
+  const cover = video.cover || video.originCover || video.dynamicCover || video.coverUrl || item.cover || item.cover_url || '';
+  const desc = cleanText(item.desc || item.title || item.description, 500);
+  const createTime = asNumber(item.createTime || item.create_time || item.create_time_sec || item.post_time);
+  const username = author.uniqueId;
+  return {
+    index: indexHint,
+    id,
+    author: username,
+    url: username ? ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username) + '/video/' + encodeURIComponent(id) : '',
+    cover: String(cover || ''),
+    title: desc,
+    desc,
+    plays: asNumber(stats.playCount ?? stats.play_count ?? stats.viewCount ?? stats.view_count),
+    likes: asNumber(stats.diggCount ?? stats.digg_count ?? stats.likeCount ?? stats.like_count),
+    comments: asNumber(stats.commentCount ?? stats.comment_count),
+    shares: asNumber(stats.shareCount ?? stats.share_count),
+    createTime,
+  };
+}
+`;
+
+export const USER_ITEM_NORMALIZER = `
+function normalizeUserRow(user, indexHint) {
+  if (!user || typeof user !== 'object') return null;
+  const username = String(user.uniqueId || user.unique_id || user.user_id || '').replace(/^@+/, '');
+  if (!username) return null;
+  const stats = user.stats || user.statistics || {};
+  return {
+    index: indexHint,
+    username,
+    name: cleanText(user.nickname || user.nickName || user.name, 80) || username,
+    secUid: String(user.secUid || user.sec_uid || ''),
+    verified: Boolean(user.verified || user.is_verified || user.custom_verify),
+    followers: asNumber(stats.followerCount ?? stats.follower_count),
+    following: asNumber(stats.followingCount ?? stats.following_count),
+    url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username),
+  };
+}
+`;
+
+// Live-stream items differ from videos: they expose roomId / hosts / viewer counts.
+export const LIVE_ITEM_NORMALIZER = `
+function normalizeLiveItem(item, indexHint) {
+  if (!item || typeof item !== 'object') return null;
+  const room = item.room || item.liveRoom || item;
+  const owner = room.owner || item.owner || room.user || {};
+  const roomId = String(room.id || room.room_id || item.id || '').trim();
+  const username = String(owner.uniqueId || owner.unique_id || owner.user_id || '').replace(/^@+/, '');
+  if (!roomId && !username) return null;
+  return {
+    index: indexHint,
+    streamer: username,
+    name: cleanText(owner.nickname || owner.nickName || owner.name, 80) || username,
+    title: cleanText(room.title || room.subtitle || item.title, 200),
+    viewers: asNumber(room.user_count || room.viewerCount || room.viewer_count || item.viewer_count),
+    likes: asNumber(room.like_count || room.likeCount || item.like_count),
+    secUid: String(owner.secUid || owner.sec_uid || ''),
+    url: username
+      ? ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username) + '/live'
+      : (roomId ? ${JSON.stringify(TIKTOK_HOST)} + '/live/' + encodeURIComponent(roomId) : ''),
+  };
+}
+`;
+
+export const NOTIFICATION_NORMALIZER = `
+function normalizeNotification(item, indexHint) {
+  if (!item || typeof item !== 'object') return null;
+  const id = String(item.notice_id || item.id || item.notification_id || '').trim() || ('idx-' + indexHint);
+  const fromUser = item.from_user || item.fromUser || item.user || {};
+  const fromName = String(fromUser.uniqueId || fromUser.unique_id || fromUser.nickname || fromUser.nickName || '').replace(/^@+/, '');
+  const text = cleanText(item.content || item.notice_content || item.text || item.body, 220);
+  const createTime = asNumber(
+    item.create_time
+      ?? item.createTime
+      ?? item.timestamp
+      ?? (typeof item.time === 'number' ? item.time : null),
+  );
+  return {
+    index: indexHint,
+    id,
+    from: fromName,
+    text,
+    createTime,
+  };
+}
+`;

--- a/docs/adapters/browser/tiktok.md
+++ b/docs/adapters/browser/tiktok.md
@@ -9,7 +9,7 @@
 | `opencli tiktok profile` | Get user profile info |
 | `opencli tiktok search` | Search videos |
 | `opencli tiktok explore` | Trending videos from explore page |
-| `opencli tiktok user` | Get recent videos from a user |
+| `opencli tiktok user` | Get recent videos from a user via page-context APIs |
 | `opencli tiktok following` | List accounts you follow |
 | `opencli tiktok friends` | Friend suggestions |
 | `opencli tiktok live` | Browse live streams |
@@ -34,6 +34,9 @@ opencli tiktok search "cooking" --limit 10
 
 # Trending explore videos
 opencli tiktok explore --limit 20
+
+# Recent videos from a user
+opencli tiktok user dictogo --limit 20
 
 # Browse live streams
 opencli tiktok live --limit 10
@@ -84,6 +87,19 @@ opencli tiktok profile --username tiktok -f json
 | `comments` | int \| null | Comment count |
 | `shares` | int \| null | Share count |
 | `createTime` | int \| null | Unix seconds when the video was posted |
+
+### `user`
+
+Same video columns as `explore`, plus:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `source` | string | `profile-api`, `bootstrap`, or lower-authority `search-fallback` |
+
+`user` resolves the profile `secUid`, pages `/api/post/item_list/`, and uses
+exact-author `/api/search/general/full/` only as a fallback when profile data is
+short. `source` lets callers distinguish first-party profile rows from fallback
+search rows.
 
 ### `friends`
 
@@ -139,6 +155,7 @@ caps:
 | Command | Default | Max |
 |---------|--------:|----:|
 | `explore` | 20 | 120 |
+| `user` | 20 | 120 |
 | `friends` | 20 | 100 |
 | `following` | 20 | 200 |
 | `notifications` | 15 | 100 |
@@ -152,19 +169,19 @@ empty rows — callers can treat any returned row as real data.
 
 ## Implementation Notes
 
-`explore` / `friends` / `following` / `notifications` / `live` all run inside
+`explore` / `user` / `friends` / `following` / `notifications` / `live` all run inside
 the live page (`Strategy.COOKIE` + `browser: true`) and call TikTok's own
 internal JSON endpoints with `fetch(..., { credentials: 'include' })`. The
 session cookie + `msToken` come from the logged-in browser, the same way
 TikTok's web client requests them. Each command first reads the warm
 `__UNIVERSAL_DATA_FOR_REHYDRATION__` snapshot for fast first-page results, then
 falls back to the corresponding API endpoint when more rows are requested
-(`/api/recommend/item_list/`, `/api/recommend/user/`, `/api/user/list/`,
+(`/api/recommend/item_list/`, `/api/user/detail/`, `/api/post/item_list/`,
+`/api/search/general/full/`, `/api/recommend/user/`, `/api/user/list/`,
 `/api/notice/multi/`, `/api/live/discover/get/`).
 
-This refactor follows the same baseline as `tiktok user` (PR #1382): page-
-context API call, typed errors, full numeric stats columns, no DOM-link
-scraping.
+This refactor applies the page-context API baseline across TikTok read commands:
+typed errors, full numeric stats columns, and no DOM-link scraping.
 
 ## Prerequisites
 

--- a/docs/adapters/browser/tiktok.md
+++ b/docs/adapters/browser/tiktok.md
@@ -66,6 +66,106 @@ opencli tiktok comment --url "https://www.tiktok.com/@user/video/123" --text "Gr
 opencli tiktok profile --username tiktok -f json
 ```
 
+## Output
+
+### `explore`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `index` | int | 1-based position in the recommend feed |
+| `id` | string | TikTok video id; round-trips into video URL |
+| `author` | string | `uniqueId` of the video author (without `@`) |
+| `url` | string | Canonical `https://www.tiktok.com/@author/video/id` |
+| `cover` | string | Cover image URL (may be empty) |
+| `title` | string | Cleaned description (synonym of `desc`) |
+| `desc` | string | Cleaned description (whitespace collapsed, ≤500 chars) |
+| `plays` | int \| null | Play count (`null` if upstream did not expose) |
+| `likes` | int \| null | Digg count |
+| `comments` | int \| null | Comment count |
+| `shares` | int \| null | Share count |
+| `createTime` | int \| null | Unix seconds when the video was posted |
+
+### `friends`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `index` | int | 1-based position in the suggestion list |
+| `username` | string | `uniqueId` of the suggested account (no `@`) |
+| `name` | string | Display nickname (falls back to `username`) |
+| `secUid` | string | TikTok internal stable id (round-trips into other endpoints) |
+| `verified` | bool | `true` when the account carries a verified badge |
+| `followers` | int \| null | Follower count if exposed by the suggestion payload |
+| `following` | int \| null | Following count if exposed |
+| `url` | string | Canonical profile URL |
+
+### `following`
+
+Same column shape as `friends`. `secUid` and follower / following counts come
+from `/api/user/list/?scene=21` (TikTok's own following endpoint), which is the
+same data their web client renders on the page.
+
+### `notifications`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `index` | int | 1-based position |
+| `id` | string | Notice id (or `idx-<n>` fallback when upstream omits) |
+| `from` | string | `uniqueId` of the actor (without `@`); empty for system notices |
+| `text` | string | Cleaned notice text (≤220 chars) |
+| `createTime` | int \| null | Unix seconds when the notice fired |
+
+`--type` accepts `all` / `likes` / `comments` / `mentions` / `followers`
+(any other value raises `ArgumentError`, no silent default).
+
+### `live`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `index` | int | 1-based position |
+| `streamer` | string | Host's `uniqueId` (without `@`) |
+| `name` | string | Host's display nickname |
+| `title` | string | Stream title (≤200 chars, whitespace collapsed) |
+| `viewers` | int \| null | Current viewer count |
+| `likes` | int \| null | Cumulative like count for the room |
+| `secUid` | string | Host's TikTok internal stable id |
+| `url` | string | Canonical `/@streamer/live` URL |
+
+## Validation (no silent clamp)
+
+`--limit` is validated upfront and `ArgumentError` is thrown for `0`, negative,
+non-integer or out-of-range values — no silent clamp to the cap. Per-command
+caps:
+
+| Command | Default | Max |
+|---------|--------:|----:|
+| `explore` | 20 | 120 |
+| `friends` | 20 | 100 |
+| `following` | 20 | 200 |
+| `notifications` | 15 | 100 |
+| `live` | 10 | 60 |
+
+`null` semantics: a numeric column returning `null` means upstream did not
+expose that field on this row (e.g. some live cards omit `like_count`). A
+column never returns `0` as an unknown sentinel. Authentication / empty result
+states raise `AuthRequiredError` / `EmptyResultError` instead of returning
+empty rows — callers can treat any returned row as real data.
+
+## Implementation Notes
+
+`explore` / `friends` / `following` / `notifications` / `live` all run inside
+the live page (`Strategy.COOKIE` + `browser: true`) and call TikTok's own
+internal JSON endpoints with `fetch(..., { credentials: 'include' })`. The
+session cookie + `msToken` come from the logged-in browser, the same way
+TikTok's web client requests them. Each command first reads the warm
+`__UNIVERSAL_DATA_FOR_REHYDRATION__` snapshot for fast first-page results, then
+falls back to the corresponding API endpoint when more rows are requested
+(`/api/recommend/item_list/`, `/api/recommend/user/`, `/api/user/list/`,
+`/api/notice/multi/`, `/api/live/discover/get/`).
+
+This refactor follows the same baseline as `tiktok user` (PR #1382): page-
+context API call, typed errors, full numeric stats columns, no DOM-link
+scraping.
+
 ## Prerequisites
 
 - Chrome running and **logged into** tiktok.com

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -1193,14 +1193,6 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "tiktok/user",
-    "file": "clis/tiktok/user.js",
-    "line": 32,
-    "text": "views: a.textContent.trim() || '-',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "twitter/accept",
     "file": "clis/twitter/accept.js",
     "line": 75,

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -1193,14 +1193,6 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "tiktok/explore",
-    "file": "clis/tiktok/explore.js",
-    "line": 27,
-    "text": "views: a.textContent.trim() || '-',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "tiktok/user",
     "file": "clis/tiktok/user.js",
     "line": 32,
@@ -1363,7 +1355,7 @@
     "rule": "silent-sentinel",
     "command": "web/read",
     "file": "clis/web/read.js",
-    "line": 348,
+    "line": 378,
     "text": "lines.push(`  [frame ${frame.index}] ${frame.sameOrigin ? 'same-origin' : 'cross-origin'} ${frame.accessible ? 'accessible' : 'blocked'} text=${frame.textLength || 0} ${frame.src || '-'}`);",
     "occurrence": 0
   },
@@ -1371,7 +1363,7 @@
     "rule": "silent-sentinel",
     "command": "web/read",
     "file": "clis/web/read.js",
-    "line": 360,
+    "line": 390,
     "text": "lines.push(`  ${entry.method} ${entry.status || '-'} ${entry.contentType || '-'} ${entry.url}`);",
     "occurrence": 0
   },
@@ -1379,7 +1371,7 @@
     "rule": "silent-sentinel",
     "command": "web/read",
     "file": "clis/web/read.js",
-    "line": 354,
+    "line": 384,
     "text": "lines.push(`  ${item.scope}: ${selector} (${item.url || '-'})`);",
     "occurrence": 0
   },
@@ -1387,7 +1379,7 @@
     "rule": "silent-sentinel",
     "command": "web/read",
     "file": "clis/web/read.js",
-    "line": 345,
+    "line": 375,
     "text": "lines.push(`url: ${diag.url || '-'}`);",
     "occurrence": 0
   },


### PR DESCRIPTION
## Context (rewrite — proactive refactor following #1382 findings)

PR #1382 introduced the page-context API call pattern for `tiktok user`
(no longer scraping `<a>` tags from rendered DOM; instead `fetch('/api/...',
{credentials:'include'})` from inside the live page so cookies + msToken go
along automatically). The old DOM-link-scraping shape was widespread in the
TikTok cluster — this PR ports the **TikTok read commands** to the same
baseline so `explore` / `user` / `friends` / `following` / `notifications` / `live`
return rich typed columns with proper pagination instead of shallow text
strings + brittle `[data-e2e="..."]` walks.

This is a **proactive refactor**, not a confirmed user-reported bug fix.
The legacy adapters had typed-error gaps (silent clamp, sentinel `'-'` for
unknown numbers) and shallow text-typed columns; this PR closes those
alongside the DOM → API switch.

## What changes

For each refactored command:

| Command | Endpoint chain | Old columns | New columns |
|---------|---------------|-------------|-------------|
| `explore` | state + `/api/recommend/item_list/` | 4 (rank, author, views-text, url) | 12 (index, id, author, url, cover, title, desc, plays, likes, comments, shares, createTime) |
| `user` | state + `/api/user/detail/` + `/api/post/item_list/` + exact-author search fallback | 3 (index, views-text, url) | 13 (index, id, source, author, url, cover, title, desc, plays, likes, comments, shares, createTime) |
| `friends` | state + `/api/recommend/user/` | 3 (index, username, name) | 8 (+ secUid, verified, followers, following, url) |
| `following` | self secUid + `/api/user/list/?scene=21` | 3 (index, username, name) | 8 (same as `friends`) |
| `notifications` | state + `/api/notice/multi/` | 2 (index, text) | 5 (index, id, from, text, createTime) |
| `live` | state + `/api/live/discover/get/` | 4 (index, streamer, viewers-text, url) | 8 (+ name, title, likes, secUid) |

Numeric stats columns are now typed `int \| null` instead of raw text like
`"1.2M"`. Authentication and empty states raise `AuthRequiredError` /
`EmptyResultError` (no more empty arrays papering over login walls).

## Implementation

- **New `clis/tiktok/utils.js`** collects:
  - Node-side validation: `requireLimit({fallback, max, name})`,
    `normalizeUsername`, `requireNotificationType` — all throw `ArgumentError`
    on bad input (no silent clamp).
  - Browser-side string templates: `BROWSER_HELPERS`,
    `VIDEO_ITEM_NORMALIZER`, `USER_ITEM_NORMALIZER`, `LIVE_ITEM_NORMALIZER`,
    `NOTIFICATION_NORMALIZER`. Each adapter pastes these into its own
    `page.evaluate(...)` IIFE so the helpers run alongside adapter-specific
    main flow without depending on shared script injection.
- **All user input enters the IIFE through `${JSON.stringify(value)}` /
  `${Number(value)}`** — never raw concatenation. e.g. `--type comments`
  flows to a numeric `noticeType` constant via `Number(typeMeta.code)`.
- **Field-alias fallback chains** (`stats.playCount ?? stats.play_count ?? ...`)
  cover the camelCase + snake_case API drift in TikTok's own JSON.
- **Each adapter starts with state extraction** (warm
  `__UNIVERSAL_DATA_FOR_REHYDRATION__` snapshot) and then tops up via the
  internal API endpoint when more rows are requested.

## Endpoints (probe-before-scope)

These are TikTok's own internal endpoints, the same ones their web client
calls. Endpoints are best-effort fallback chains following the same baseline
as #1382: state extraction is the verified primary path; API endpoints are
called inside the page session so cookies + msToken get forwarded by the
browser the same way they do on TikTok's own pages.

| Endpoint | Used by |
|----------|---------|
| `/api/recommend/item_list/` | explore |
| `/api/user/detail/` | user (resolve profile secUid) |
| `/api/post/item_list/` | user |
| `/api/search/general/full/` | user exact-author fallback |
| `/api/recommend/user/` | friends |
| `/api/user/list/?scene=21` | following |
| `/api/user/info/` | following (resolve viewer secUid) |
| `/api/notice/multi/` | notifications |
| `/api/live/discover/get/` | live |

## Tests

`clis/tiktok/refactor.test.js` adds contract assertions across the refactored read commands (38 total in
clis/tiktok). Each adapter is pinned on:

1. Registration metadata: `access:'read'`, `browser:true`,
   `strategy:'cookie'`, exact `columns:[...]`.
2. Input validation: `--limit` rejects 0 / negative / non-integer / above
   max with `ArgumentError`; `goto` is **not** called when validation fails
   upfront. `--type` (notifications) only accepts known keys.
3. Typed-error boundary: `evaluate` rejecting with `'AUTH_REQUIRED: ...'`
   maps to `AuthRequiredError`; empty result → `EmptyResultError`; other
   errors → `CommandExecutionError`.
4. Build-script invariants: each script contains its endpoint marker
   (`/api/...`), the correct normalizer name, and no raw user-input
   concatenation outside `JSON.stringify` boundaries.

## Lint gates

| Gate | Before | After | Delta |
|------|-------:|------:|------:|
| typed-error-lint | 192 | 190 | **−2 resolved** (silent-sentinel `views` fallbacks in old explore.js and user.js) |
| silent-column-drop | 103 | 103 | unchanged |
| listing-id-pairing | advisory only | advisory only | TikTok cluster has `id` / `username` / `secUid` round-trip fields |

No new violations introduced.

## What this PR does NOT address

- **JSDOM-against-frozen-fixture pattern (#1340) intentionally deferred.**
  These commands are API-call dominated; the in-browser DOM extraction
  surface is small. The frozen-fixture pattern will land alongside the next
  Phase 3 batch (Xiaoe catalog / courses / content) where DOM extraction is
  the heavier path and the ROI of fixture-driven regression tests is higher.
- **TikTok write commands (`comment`, `follow`, `unfollow`)** — these still
  walk button selectors and will be a separate Phase 3 P0.5 PR.
- **Other anti-pattern clusters** (Facebook 10×, Xiaoe 3×, toutiao /
  articles, hupu / hot, jimeng / generate) — each will be a separate PR per
  WAWQAQ's "都单独力量" directive.

## Test plan

- [x] `npx vitest run clis/tiktok/` (38 passed)
- [x] `npx tsx src/build-manifest.ts` (764 entries, +0 net)
- [x] `node scripts/check-typed-error-lint.mjs` (190, no new)
- [x] `node scripts/check-silent-column-drop.mjs` (103, no new)
- [x] `npm run build`
- [ ] Live verify by reviewer with logged-in TikTok session (cookie +
      msToken). Recommended: `opencli tiktok explore --limit 10 -f json`
      → confirm 12 columns including `plays/likes/comments/shares` are
      typed `int|null` not raw text; then `opencli tiktok following
      --limit 5 -f json` → confirm `secUid` populated.
