### PR TITLE
feat(llm): reuse browser sessions by site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * **autofix** — retire `OPENCLI_DIAGNOSTIC`; adapter repair now uses `--trace retain-on-failure`, trace `summary.md`, and error-envelope trace metadata.
 * **browser** — `bind` attaches `bound:*` workspaces to user-owned Chrome tabs without taking over window lifecycle; `sessions` reports `idleMsRemaining: null` for bound workspaces because they do not schedule idle close timers. ([#1169](https://github.com/jackwener/opencli/issues/1169), [#929](https://github.com/jackwener/opencli/issues/929))
 * **browser lifecycle** — owned browser workspaces now lease tabs inside a shared dedicated automation container instead of owning one Chrome window per workspace; lease state is persisted for MV3 service-worker reconciliation and idle cleanup is backed by alarms.
-* **browser session** — adapter commands can opt into site-level tab reuse with `browserSession.reuse = 'site'`; users can override with `--reuse <none|site>`.
+* **browser session** — adapter commands can opt into site-level tab reuse with `browserSession.reuse = 'site'`; Grok and other browser-backed LLM adapters now keep a shared site tab by default, and users can override with `--reuse <none|site>`.
 * **web read** — make page extraction render-aware: same-origin iframe content is merged into the Markdown source, `--wait-for` can wait inside main/iframe documents, `--wait-until networkidle` waits for captured requests to settle, and `--diagnose` reports frames, empty containers, and API-like XHRs for shell/AJAX pages.
 
 ### Breaking Changes

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4167,7 +4167,10 @@
     "type": "js",
     "modulePath": "chatgpt/image.js",
     "sourceFile": "chatgpt/image.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "chatgpt-app",
@@ -4540,7 +4543,10 @@
     "type": "js",
     "modulePath": "claude/ask.js",
     "sourceFile": "claude/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "claude",
@@ -4567,7 +4573,10 @@
     "type": "js",
     "modulePath": "claude/detail.js",
     "sourceFile": "claude/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "claude",
@@ -4595,7 +4604,10 @@
     "type": "js",
     "modulePath": "claude/history.js",
     "sourceFile": "claude/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "claude",
@@ -4612,7 +4624,10 @@
     "type": "js",
     "modulePath": "claude/new.js",
     "sourceFile": "claude/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "claude",
@@ -4631,7 +4646,10 @@
     "type": "js",
     "modulePath": "claude/read.js",
     "sourceFile": "claude/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "claude",
@@ -4665,7 +4683,10 @@
     "type": "js",
     "modulePath": "claude/send.js",
     "sourceFile": "claude/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "claude",
@@ -4684,7 +4705,10 @@
     "type": "js",
     "modulePath": "claude/status.js",
     "sourceFile": "claude/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "cnki",
@@ -5982,7 +6006,10 @@
     "type": "js",
     "modulePath": "deepseek/ask.js",
     "sourceFile": "deepseek/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "deepseek",
@@ -6008,7 +6035,10 @@
     "type": "js",
     "modulePath": "deepseek/detail.js",
     "sourceFile": "deepseek/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "deepseek",
@@ -6035,7 +6065,10 @@
     "type": "js",
     "modulePath": "deepseek/history.js",
     "sourceFile": "deepseek/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "deepseek",
@@ -6052,7 +6085,10 @@
     "type": "js",
     "modulePath": "deepseek/new.js",
     "sourceFile": "deepseek/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "deepseek",
@@ -6070,7 +6106,10 @@
     "type": "js",
     "modulePath": "deepseek/read.js",
     "sourceFile": "deepseek/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "deepseek",
@@ -6110,7 +6149,10 @@
     "type": "js",
     "modulePath": "deepseek/send.js",
     "sourceFile": "deepseek/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "deepseek",
@@ -6129,7 +6171,10 @@
     "type": "js",
     "modulePath": "deepseek/status.js",
     "sourceFile": "deepseek/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "defillama",
@@ -7219,7 +7264,10 @@
     "type": "js",
     "modulePath": "doubao/ask.js",
     "sourceFile": "doubao/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7245,7 +7293,10 @@
     "type": "js",
     "modulePath": "doubao/detail.js",
     "sourceFile": "doubao/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7273,7 +7324,10 @@
     "type": "js",
     "modulePath": "doubao/history.js",
     "sourceFile": "doubao/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7306,7 +7360,10 @@
     "type": "js",
     "modulePath": "doubao/meeting-summary.js",
     "sourceFile": "doubao/meeting-summary.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7339,7 +7396,10 @@
     "type": "js",
     "modulePath": "doubao/meeting-transcript.js",
     "sourceFile": "doubao/meeting-transcript.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7357,7 +7417,10 @@
     "type": "js",
     "modulePath": "doubao/new.js",
     "sourceFile": "doubao/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7375,7 +7438,10 @@
     "type": "js",
     "modulePath": "doubao/read.js",
     "sourceFile": "doubao/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7402,7 +7468,10 @@
     "type": "js",
     "modulePath": "doubao/send.js",
     "sourceFile": "doubao/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao",
@@ -7422,7 +7491,10 @@
     "type": "js",
     "modulePath": "doubao/status.js",
     "sourceFile": "doubao/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "doubao-app",
@@ -9196,7 +9268,10 @@
     "type": "js",
     "modulePath": "gemini/ask.js",
     "sourceFile": "gemini/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "gemini",
@@ -9241,7 +9316,10 @@
     "type": "js",
     "modulePath": "gemini/deep-research.js",
     "sourceFile": "gemini/deep-research.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "gemini",
@@ -9284,7 +9362,10 @@
     "type": "js",
     "modulePath": "gemini/deep-research-result.js",
     "sourceFile": "gemini/deep-research-result.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "gemini",
@@ -9346,7 +9427,10 @@
     "type": "js",
     "modulePath": "gemini/image.js",
     "sourceFile": "gemini/image.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "gemini",
@@ -9364,7 +9448,10 @@
     "type": "js",
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "gitee",
@@ -18053,7 +18140,10 @@
     "type": "js",
     "modulePath": "qwen/ask.js",
     "sourceFile": "qwen/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "qwen",
@@ -18081,7 +18171,10 @@
     "type": "js",
     "modulePath": "qwen/history.js",
     "sourceFile": "qwen/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "qwen",
@@ -18136,7 +18229,10 @@
     "type": "js",
     "modulePath": "qwen/image.js",
     "sourceFile": "qwen/image.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "qwen",
@@ -18153,7 +18249,10 @@
     "type": "js",
     "modulePath": "qwen/new.js",
     "sourceFile": "qwen/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "qwen",
@@ -18179,7 +18278,10 @@
     "type": "js",
     "modulePath": "qwen/read.js",
     "sourceFile": "qwen/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "qwen",
@@ -18226,7 +18328,10 @@
     "type": "js",
     "modulePath": "qwen/send.js",
     "sourceFile": "qwen/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "qwen",
@@ -18247,7 +18352,10 @@
     "type": "js",
     "modulePath": "qwen/status.js",
     "sourceFile": "qwen/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "reddit",
@@ -26391,7 +26499,10 @@
     "type": "js",
     "modulePath": "yuanbao/ask.js",
     "sourceFile": "yuanbao/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "yuanbao",
@@ -26409,7 +26520,10 @@
     "type": "js",
     "modulePath": "yuanbao/new.js",
     "sourceFile": "yuanbao/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "zhihu",

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -55,6 +55,7 @@ export const imageCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/claude/ask.js
+++ b/clis/claude/ask.js
@@ -14,6 +14,7 @@ export const askCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/claude/detail.js
+++ b/clis/claude/detail.js
@@ -10,6 +10,7 @@ export const detailCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'id', positional: true, required: true, help: 'Conversation ID (UUID from /chat/<id>)' },

--- a/clis/claude/history.js
+++ b/clis/claude/history.js
@@ -10,6 +10,7 @@ export const historyCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },

--- a/clis/claude/new.js
+++ b/clis/claude/new.js
@@ -9,6 +9,7 @@ export const newCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/claude/read.js
+++ b/clis/claude/read.js
@@ -10,6 +10,7 @@ export const readCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Index', 'Role', 'Text'],

--- a/clis/claude/send.js
+++ b/clis/claude/send.js
@@ -10,6 +10,7 @@ export const sendCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/claude/status.js
+++ b/clis/claude/status.js
@@ -9,6 +9,7 @@ export const statusCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url'],

--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -14,6 +14,7 @@ export const askCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/deepseek/detail.js
+++ b/clis/deepseek/detail.js
@@ -15,6 +15,7 @@ export const detailCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },

--- a/clis/deepseek/history.js
+++ b/clis/deepseek/history.js
@@ -9,6 +9,7 @@ export const historyCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },

--- a/clis/deepseek/new.js
+++ b/clis/deepseek/new.js
@@ -9,6 +9,7 @@ export const newCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/deepseek/read.js
+++ b/clis/deepseek/read.js
@@ -9,6 +9,7 @@ export const readCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Role', 'Text'],

--- a/clis/deepseek/send.js
+++ b/clis/deepseek/send.js
@@ -15,6 +15,7 @@ export const sendCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },

--- a/clis/deepseek/status.js
+++ b/clis/deepseek/status.js
@@ -9,6 +9,7 @@ export const statusCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url'],

--- a/clis/doubao/ask.js
+++ b/clis/doubao/ask.js
@@ -9,6 +9,7 @@ export const askCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },

--- a/clis/doubao/detail.js
+++ b/clis/doubao/detail.js
@@ -8,6 +8,7 @@ export const detailCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },

--- a/clis/doubao/history.js
+++ b/clis/doubao/history.js
@@ -8,6 +8,7 @@ export const historyCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'limit', required: false, help: 'Max number of conversations to show', default: '50' },

--- a/clis/doubao/meeting-summary.js
+++ b/clis/doubao/meeting-summary.js
@@ -8,6 +8,7 @@ export const meetingSummaryCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },

--- a/clis/doubao/meeting-transcript.js
+++ b/clis/doubao/meeting-transcript.js
@@ -8,6 +8,7 @@ export const meetingTranscriptCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },

--- a/clis/doubao/new.js
+++ b/clis/doubao/new.js
@@ -8,6 +8,7 @@ export const newCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Action'],

--- a/clis/doubao/read.js
+++ b/clis/doubao/read.js
@@ -8,6 +8,7 @@ export const readCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Role', 'Text'],

--- a/clis/doubao/send.js
+++ b/clis/doubao/send.js
@@ -8,6 +8,7 @@ export const sendCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [{ name: 'text', required: true, positional: true, help: 'Message to send' }],
     columns: ['Status', 'SubmittedBy', 'InjectedText'],

--- a/clis/doubao/status.js
+++ b/clis/doubao/status.js
@@ -8,6 +8,7 @@ export const statusCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url', 'Title'],

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -16,6 +16,7 @@ export const askCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/deep-research-result.js
+++ b/clis/gemini/deep-research-result.js
@@ -44,6 +44,7 @@ export const deepResearchResultCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/deep-research.js
+++ b/clis/gemini/deep-research.js
@@ -23,6 +23,7 @@ export const deepResearchCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/image.js
+++ b/clis/gemini/image.js
@@ -52,6 +52,7 @@ export const imageCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/new.js
+++ b/clis/gemini/new.js
@@ -8,6 +8,7 @@ export const newCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Action'],

--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -24,6 +24,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/qwen/history.js
+++ b/clis/qwen/history.js
@@ -24,6 +24,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show (default 20, max 100)' },

--- a/clis/qwen/image.js
+++ b/clis/qwen/image.js
@@ -99,6 +99,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/qwen/new.js
+++ b/clis/qwen/new.js
@@ -9,6 +9,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/qwen/read.js
+++ b/clis/qwen/read.js
@@ -16,6 +16,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },

--- a/clis/qwen/send.js
+++ b/clis/qwen/send.js
@@ -20,6 +20,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send to Qianwen' },

--- a/clis/qwen/status.js
+++ b/clis/qwen/status.js
@@ -9,6 +9,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Model', 'SessionId', 'Url'],

--- a/clis/yuanbao/ask.js
+++ b/clis/yuanbao/ask.js
@@ -357,6 +357,7 @@ export const askCommand = cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/yuanbao/new.js
+++ b/clis/yuanbao/new.js
@@ -55,6 +55,7 @@ export const newCommand = cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Action'],

--- a/docs/adapters/browser/claude.md
+++ b/docs/adapters/browser/claude.md
@@ -61,7 +61,7 @@ opencli claude ask "hello" -f json
 ## Caveats
 
 - This adapter drives the Claude web UI in the browser, not an API
-- `claude read` queries the current automation tab; pair it with `--live` on the prior command (or chain after `claude detail <id>`) so the tab stays on the conversation between invocations
+- Claude commands default to site-level browser tab reuse, so consecutive `claude ask` / `claude read` / `claude detail` invocations continue in the same Claude page. Pass `--reuse none` for a one-shot tab.
 - `--model opus` requires a paid Claude plan; on a free-tier account the adapter surfaces a usage error rather than silently falling back
 - The default Sonnet 4.6 model uses Adaptive thinking by default; `--think` is the explicit switch but Claude may still invoke thinking for complex prompts even when not requested
 - Adaptive-thinking and file-thumbnail widgets render duplicated label paragraphs (`Thought process` / `View uploaded image`) at the top of the response; these are stripped automatically so the row value is the actual answer

--- a/docs/adapters/browser/deepseek.md
+++ b/docs/adapters/browser/deepseek.md
@@ -99,8 +99,9 @@ opencli deepseek send 749e6bbd-6a45-4440-beaa-ae5238bf06d8 "continue from the la
 ## Caveats
 
 - This adapter drives the DeepSeek web UI in the browser, not an API
+- DeepSeek commands default to site-level browser tab reuse, so consecutive `deepseek ask` / `deepseek read` / `deepseek detail` invocations continue in the same DeepSeek page. Pass `--reuse none` for a one-shot tab.
 - Default mode is Instant with DeepThink and Search disabled; each flag (`--model`, `--think`, `--search`) is synced on every invocation so omitting a flag resets it
 - Vision mode does not support `--search`; use `--model instant` or `--model expert` for web search
-- `send` requires an explicit conversation ID because each browser command runs in its own tab/workspace; use `history` to find a conversation URL or ID first
+- `send` requires an explicit conversation ID; use `history` to find a conversation URL or ID first
 - Long responses (code, essays) may need a higher `--timeout`
 - File upload prefers the browser file-input path, falls back to base64 injection when needed, and rejects files over 100 MB

--- a/docs/adapters/browser/doubao.md
+++ b/docs/adapters/browser/doubao.md
@@ -35,5 +35,6 @@ opencli doubao ask "请写一个 Python 快速排序示例" --timeout 90
 ## Notes
 
 - The adapter targets the web chat page at `https://www.doubao.com/chat`
+- Doubao commands default to site-level browser tab reuse, so consecutive `doubao ask` / `doubao read` / `doubao detail` invocations continue in the same Doubao page. Pass `--reuse none` for a one-shot tab.
 - `new` first tries the visible "New Chat / 新对话" button, then falls back to the new-thread route
 - `ask` uses DOM polling, so very long generations may need a larger `--timeout`

--- a/docs/adapters/browser/gemini.md
+++ b/docs/adapters/browser/gemini.md
@@ -70,5 +70,6 @@ opencli gemini image "A flat illustration of a robot" --op ~/tmp/gemini-images
 ## Caveats
 
 - This adapter drives the Gemini consumer web UI, not a public API.
+- Gemini commands default to site-level browser tab reuse, so consecutive `gemini ask` / `gemini image` / `gemini deep-research-result` invocations continue in the same Gemini page. Pass `--reuse none` for a one-shot tab.
 - It depends on the current browser session and may fail if Gemini shows login, consent, challenge, quota, or other gating UI.
 - DOM or product changes on Gemini can break composer detection, new-chat handling, or image export behavior.

--- a/docs/adapters/browser/qwen.md
+++ b/docs/adapters/browser/qwen.md
@@ -106,6 +106,7 @@ opencli qwen image "a tiny robot" --sd true
 ## Notes
 
 - `read` works without login (guest mode), but `history` and most `write` flows require an authenticated session
+- Qwen commands default to site-level browser tab reuse, so consecutive `qwen ask` / `qwen read` / `qwen image` invocations continue in the same Qwen page. Pass `--reuse none` for a one-shot tab.
 - `ask` waits for the streaming reply to finish; `send` returns immediately after submission
 - DeepThink (`--think`) and DeepResearch (`--research`) toggle the corresponding composer chips before submitting
 - Generated image files are timestamped to avoid overwriting prior runs

--- a/docs/adapters/browser/yuanbao.md
+++ b/docs/adapters/browser/yuanbao.md
@@ -60,5 +60,6 @@ opencli yuanbao ask "你好" --think true
 ## Caveats
 
 - This adapter drives the Yuanbao web UI, not a public API.
+- Yuanbao commands default to site-level browser tab reuse, so consecutive `yuanbao ask` / `yuanbao new` invocations continue in the same Yuanbao page. Pass `--reuse none` for a one-shot tab.
 - It depends on the current browser session and may fail if Yuanbao shows login, consent, challenge, or other gating UI.
 - DOM or product changes on Yuanbao can break composer detection, submit behavior, or transcript extraction.


### PR DESCRIPTION
## Summary
- opt browser-backed LLM adapters into `browserSession: { reuse: 'site' }`
- covers ChatGPT, Claude, Gemini, DeepSeek, Doubao, Qwen, Yuanbao, and keeps Grok from #1383
- update manifest and changelog

## Scope notes
- Desktop adapters (`chatgpt-app`, `doubao-app`, `chatwise`, `codex`, `cursor`, `antigravity`) are intentionally out of scope.
- `notebooklm` is intentionally out of scope; it is stateful but not part of this browser-backed chat LLM adapter set.

## Verification
- `npm run build`
- `npm test -- --run clis/chatgpt/image.test.js clis/claude/ask.test.js clis/claude/commands.test.js clis/claude/utils.test.js clis/gemini/ask.test.js clis/gemini/deep-research.test.js clis/gemini/deep-research-result.test.js clis/gemini/reply-state.test.js clis/gemini/utils.test.js clis/deepseek/ask.test.js clis/deepseek/detail.test.js clis/deepseek/send.test.js clis/deepseek/utils.test.js clis/doubao/detail.test.js clis/doubao/history.test.js clis/doubao/utils.test.js clis/yuanbao/ask.test.js clis/yuanbao/new.test.js clis/grok/ask.test.js clis/grok/image.test.ts src/registry.test.ts` (232/232)
- `npx tsc --noEmit`
- `npm run docs:build`
- source audit: no browser-backed command in the 8 LLM sites is missing `browserSession: { reuse: 'site' }`
- manifest audit: no browser-backed command in the 8 LLM sites is missing `browserSession.reuse = 'site'`
- `git diff --check`
