### PR TITLE
refactor(tiktok): write commands → button-walker Route 1 with typed errors

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20716,7 +20716,7 @@
   {
     "site": "tiktok",
     "name": "comment",
-    "description": "Comment on a TikTok video",
+    "description": "Post a comment on a TikTok video",
     "access": "write",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20727,20 +20727,20 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "TikTok video URL"
+        "help": "TikTok video URL (https://www.tiktok.com/@user/video/<id>)"
       },
       {
         "name": "text",
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "Comment text"
+        "help": "Comment text (≤150 chars)"
       }
     ],
     "columns": [
-      "status",
       "url",
-      "text"
+      "text",
+      "result"
     ],
     "type": "js",
     "modulePath": "tiktok/comment.js",
@@ -20826,7 +20826,7 @@
   {
     "site": "tiktok",
     "name": "follow",
-    "description": "Follow a TikTok user",
+    "description": "Follow a TikTok user by username",
     "access": "write",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -20841,8 +20841,9 @@
       }
     ],
     "columns": [
-      "status",
-      "username"
+      "username",
+      "url",
+      "result"
     ],
     "type": "js",
     "modulePath": "tiktok/follow.js",
@@ -21115,7 +21116,7 @@
   {
     "site": "tiktok",
     "name": "unfollow",
-    "description": "Unfollow a TikTok user",
+    "description": "Unfollow a TikTok user by username",
     "access": "write",
     "domain": "www.tiktok.com",
     "strategy": "cookie",
@@ -21130,8 +21131,9 @@
       }
     ],
     "columns": [
-      "status",
-      "username"
+      "username",
+      "url",
+      "result"
     ],
     "type": "js",
     "modulePath": "tiktok/unfollow.js",

--- a/clis/tiktok/comment.js
+++ b/clis/tiktok/comment.js
@@ -106,19 +106,20 @@ function buildCommentScript(commentText) {
 async function postComment(page, args) {
     const { url } = parseTikTokVideoUrl(args.url);
     const text = requireCommentText(args.text);
-    await page.goto(url, { waitUntil: 'load', settleMs: 6000 });
+    const throwFailure = (error) => throwButtonWalkerError(error, {
+        authMessage: 'TikTok requires login to post comments',
+        failureMessage: `Failed to post comment on ${url}`,
+        retryableHint: RETRYABLE_HINTS.commentFailure,
+    });
     let rows;
     try {
+        await page.goto(url, { waitUntil: 'load', settleMs: 6000 });
         rows = await page.evaluate(buildCommentScript(text));
     } catch (error) {
-        throwButtonWalkerError(error, {
-            authMessage: 'TikTok requires login to post comments',
-            failureMessage: `Failed to post comment on ${url}`,
-            retryableHint: RETRYABLE_HINTS.commentFailure,
-        });
+        throwFailure(error);
     }
     if (!Array.isArray(rows) || rows.length === 0) {
-        throw new Error(`Comment returned no row for ${url}`);
+        throwFailure(new Error(`STATE_VERIFY_FAIL: comment returned no row for ${url}`));
     }
     return rows;
 }

--- a/clis/tiktok/comment.js
+++ b/clis/tiktok/comment.js
@@ -1,58 +1,144 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
-    site: 'tiktok',
-    name: 'comment',
-    access: 'write',
-    description: 'Comment on a TikTok video',
-    domain: 'www.tiktok.com',
-    args: [
-        { name: 'url', required: true, positional: true, help: 'TikTok video URL' },
-        { name: 'text', required: true, positional: true, help: 'Comment text' },
-    ],
-    columns: ['status', 'url', 'text'],
-    pipeline: [
-        { navigate: { url: '${{ args.url }}', settleMs: 6000 } },
-        { evaluate: `(async () => {
-  const url = \${{ args.url | json }};
-  const commentText = \${{ args.text | json }};
-  const wait = (ms) => new Promise(r => setTimeout(r, ms));
+// Post a comment on a TikTok video via in-page button click + state
+// verification.
+//
+// Replaces the legacy pipeline-based adapter that returned a silent
+// failure row `{ status: posted ? 'Commented' : 'Comment may have failed' }`.
+// Route 1 keeps the live UI button + contenteditable input as the
+// trigger (TikTok's `/api/comment/publish/` write endpoint requires
+// X-Bogus signing — out of scope), and every transition raises a typed
+// error:
+//
+//   ArgumentError         — empty / overlong text, malformed video URL
+//   AuthRequiredError     — not logged in
+//   CommandExecutionError — comment input / post button missing /
+//                           state verification fails / rate limit
+//                           detected (retryable=false: TikTok may have
+//                           accepted the comment server-side even when
+//                           our state-verify timed out)
+//
+// `result` row enum: `posted`. There is no idempotent fast path: TikTok
+// allows multiple identical comments, so we cannot safely "detect"
+// already-posted by scanning the existing list. Failures throw — never
+// returned as a success row.
 
-  // Click comment icon to expand comment section
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    BROWSER_HELPERS,
+    BUTTON_WALKER_HELPERS,
+    RETRYABLE_HINTS,
+    parseTikTokVideoUrl,
+    requireCommentText,
+    throwButtonWalkerError,
+} from './utils.js';
+
+function buildCommentScript(commentText) {
+    return `
+(async () => {
+  const commentText = ${JSON.stringify(commentText)};
+
+  ${BROWSER_HELPERS}
+  ${BUTTON_WALKER_HELPERS}
+
+  ensureLoggedInOrThrow();
+  ensureNoRateLimitOrThrow();
+
+  // Expand the comment panel if it is collapsed (vertical feed pages).
   const commentIcon = document.querySelector('[data-e2e="comment-icon"]');
   if (commentIcon) {
     const cBtn = commentIcon.closest('button') || commentIcon.closest('[role="button"]') || commentIcon;
     cBtn.click();
-    await wait(3000);
+    await waitFor(() => Boolean(
+      document.querySelector('[data-e2e="comment-input"] [contenteditable="true"]')
+    ), { timeoutMs: 4000 });
   }
 
-  // Count existing comments for verification
   const beforeCount = document.querySelectorAll('[data-e2e="comment-level-1"]').length;
 
-  // Find comment input
-  const input = document.querySelector('[data-e2e="comment-input"] [contenteditable="true"]') ||
-                document.querySelector('[contenteditable="true"]');
-  if (!input) throw new Error('Comment input not found - make sure you are logged in');
+  const input = document.querySelector('[data-e2e="comment-input"] [contenteditable="true"]')
+    || document.querySelector('[contenteditable="true"]');
+  if (!input) {
+    throw new Error('BUTTON_NOT_FOUND: comment input not found (page not rendered, comments disabled, or selectors changed)');
+  }
 
   input.focus();
+  // execCommand is deprecated but still the only reliable way to inject
+  // text into TikTok's contenteditable so its React tree picks up the
+  // value; replicating with InputEvent fires but TikTok ignores it.
   document.execCommand('insertText', false, commentText);
-  await wait(1000);
 
-  // Click post button
-  const btns = Array.from(document.querySelectorAll('[data-e2e="comment-post"], button'));
-  const postBtn = btns.find(function(b) {
-    var t = b.textContent.trim();
-    return t === 'Post' || t === '发布' || t === '发送';
-  });
-  if (!postBtn) throw new Error('Post button not found');
+  // Wait for the post button to become enabled — TikTok disables it
+  // until non-empty text is detected by their input handler.
+  const postReady = await waitFor(() => {
+    const candidate = findButtonByText(['Post', '发布', '发送']);
+    if (!candidate) return false;
+    const ariaDisabled = candidate.getAttribute && candidate.getAttribute('aria-disabled');
+    return !candidate.disabled && ariaDisabled !== 'true';
+  }, { timeoutMs: 4000 });
+  if (!postReady) {
+    ensureNoRateLimitOrThrow();
+    throw new Error('BUTTON_NOT_FOUND: Post button never became enabled (text not registered or selectors changed)');
+  }
+
+  const postBtn = findButtonByText(['Post', '发布', '发送']);
   postBtn.click();
-  await wait(3000);
 
-  // Verify comment was posted by checking if comment count increased
-  const afterCount = document.querySelectorAll('[data-e2e="comment-level-1"]').length;
-  const posted = afterCount > beforeCount;
+  // State verification: a new comment-level-1 element should appear.
+  const flipped = await waitFor(
+    () => document.querySelectorAll('[data-e2e="comment-level-1"]').length > beforeCount,
+    { timeoutMs: 8000 },
+  );
+  if (!flipped) {
+    ensureNoRateLimitOrThrow();
+    throw new Error('STATE_VERIFY_FAIL: comment count did not increase within 8s; comment may or may not have been recorded server-side');
+  }
 
-  return [{ status: posted ? 'Commented' : 'Comment may have failed', url: url, text: commentText }];
+  ensureNoRateLimitOrThrow();
+
+  return [{
+    url: location.href,
+    text: commentText,
+    result: 'posted',
+  }];
 })()
-` },
+`;
+}
+
+async function postComment(page, args) {
+    const { url } = parseTikTokVideoUrl(args.url);
+    const text = requireCommentText(args.text);
+    await page.goto(url, { waitUntil: 'load', settleMs: 6000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildCommentScript(text));
+    } catch (error) {
+        throwButtonWalkerError(error, {
+            authMessage: 'TikTok requires login to post comments',
+            failureMessage: `Failed to post comment on ${url}`,
+            retryableHint: RETRYABLE_HINTS.commentFailure,
+        });
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new Error(`Comment returned no row for ${url}`);
+    }
+    return rows;
+}
+
+export const commentCommand = cli({
+    site: 'tiktok',
+    name: 'comment',
+    access: 'write',
+    description: 'Post a comment on a TikTok video',
+    domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'url', required: true, positional: true, help: 'TikTok video URL (https://www.tiktok.com/@user/video/<id>)' },
+        { name: 'text', required: true, positional: true, help: 'Comment text (≤150 chars)' },
     ],
+    columns: ['url', 'text', 'result'],
+    func: postComment,
 });
+
+export const __test__ = {
+    buildCommentScript,
+};

--- a/clis/tiktok/follow.js
+++ b/clis/tiktok/follow.js
@@ -1,40 +1,122 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Follow a TikTok user via in-page button click + state verification.
+//
+// Replaces the legacy pipeline-based adapter that returned silent failure
+// rows like `{ status: 'Follow button not found', username }`. Route 1
+// here is conservative: keep the live UI button as the trigger (TikTok's
+// `/api/commit/follow/user/` requires X-Bogus signing — out of scope for
+// this PR), but harden every transition with typed errors:
+//
+//   ArgumentError         — empty or malformed username
+//   AuthRequiredError     — not logged in (no sessionid + no viewer secUid)
+//   CommandExecutionError — button missing / state verification fails /
+//                           rate limit detected (retryable=true since
+//                           TikTok dedupes follow on retry)
+//
+// `result` row enum: `followed` / `already-following` / `already-friends`
+// (mutual). Failures throw — never returned as a success row.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    BROWSER_HELPERS,
+    BUTTON_WALKER_HELPERS,
+    RETRYABLE_HINTS,
+    TIKTOK_HOST,
+    normalizeUsername,
+    throwButtonWalkerError,
+} from './utils.js';
+
+function buildFollowScript(username) {
+    return `
+(async () => {
+  const username = ${JSON.stringify(username)};
+
+  ${BROWSER_HELPERS}
+  ${BUTTON_WALKER_HELPERS}
+
+  ensureLoggedInOrThrow();
+  ensureNoRateLimitOrThrow();
+
+  const FOLLOW_LABELS = ['Follow', '关注', 'フォロー'];
+  const FOLLOWING_LABELS = ['Following', '已关注', 'フォロー中'];
+  const FRIENDS_LABELS = ['Friends', '互关', 'フレンド'];
+  const ALREADY_LABELS = FOLLOWING_LABELS.concat(FRIENDS_LABELS);
+
+  // Idempotent fast path: already in target state.
+  if (buttonExists(FRIENDS_LABELS)) {
+    return [{ username, url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username), result: 'already-friends' }];
+  }
+  if (buttonExists(FOLLOWING_LABELS)) {
+    return [{ username, url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username), result: 'already-following' }];
+  }
+
+  const followBtn = findButtonByText(FOLLOW_LABELS);
+  if (!followBtn) {
+    throw new Error('BUTTON_NOT_FOUND: Follow button not on profile page (logged out, private account, or selectors changed)');
+  }
+
+  const target = followBtn.closest('button') || followBtn.closest('[role="button"]') || followBtn;
+  target.click();
+
+  // State verification: button text should flip to Following / 已关注 etc.
+  const flipped = await waitFor(() => buttonExists(ALREADY_LABELS), { timeoutMs: 5000 });
+  if (!flipped) {
+    ensureNoRateLimitOrThrow();
+    throw new Error('STATE_VERIFY_FAIL: follow button did not flip to Following within 5s; relation may not have been recorded');
+  }
+
+  // Re-check rate limit AFTER click — TikTok sometimes flashes captcha
+  // mid-flight even when the button text appears to flip.
+  ensureNoRateLimitOrThrow();
+
+  const becameFriends = buttonExists(FRIENDS_LABELS);
+  return [{
+    username,
+    url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username),
+    result: becameFriends ? 'already-friends' : 'followed',
+  }];
+})()
+`;
+}
+
+async function followUser(page, args) {
+    const username = normalizeUsername(args.username);
+    await page.goto(`${TIKTOK_HOST}/@${encodeURIComponent(username)}`, {
+        waitUntil: 'load',
+        settleMs: 5000,
+    });
+    let rows;
+    try {
+        rows = await page.evaluate(buildFollowScript(username));
+    } catch (error) {
+        throwButtonWalkerError(error, {
+            authMessage: 'TikTok requires login to follow users',
+            failureMessage: `Failed to follow @${username}`,
+            retryableHint: RETRYABLE_HINTS.relationFailure,
+        });
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        // Defensive: build script always returns a row on success path.
+        // If we land here, treat as state-verify failure.
+        throw new Error(`Follow returned no row for @${username}`);
+    }
+    return rows;
+}
+
+export const followCommand = cli({
     site: 'tiktok',
     name: 'follow',
     access: 'write',
-    description: 'Follow a TikTok user',
+    description: 'Follow a TikTok user by username',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        {
-            name: 'username',
-            required: true,
-            positional: true,
-            help: 'TikTok username (without @)',
-        },
+        { name: 'username', required: true, positional: true, help: 'TikTok username (without @)' },
     ],
-    columns: ['status', 'username'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/@${{ args.username }}', settleMs: 6000 } },
-        { evaluate: `(async () => {
-  const username = \${{ args.username | json }};
-  const buttons = Array.from(document.querySelectorAll('button, [role="button"]'));
-  const followBtn = buttons.find(function(b) {
-    var text = b.textContent.trim();
-    return text === 'Follow' || text === '关注';
-  });
-  if (!followBtn) {
-    var isFollowing = buttons.some(function(b) {
-      var t = b.textContent.trim();
-      return t === 'Following' || t === '已关注' || t === 'Friends' || t === '互关';
-    });
-    if (isFollowing) return [{ status: 'Already following', username: username }];
-    return [{ status: 'Follow button not found', username: username }];
-  }
-  followBtn.click();
-  await new Promise(r => setTimeout(r, 2000));
-  return [{ status: 'Followed', username: username }];
-})()
-` },
-    ],
+    columns: ['username', 'url', 'result'],
+    func: followUser,
 });
+
+export const __test__ = {
+    buildFollowScript,
+};

--- a/clis/tiktok/follow.js
+++ b/clis/tiktok/follow.js
@@ -68,11 +68,10 @@ function buildFollowScript(username) {
   // mid-flight even when the button text appears to flip.
   ensureNoRateLimitOrThrow();
 
-  const becameFriends = buttonExists(FRIENDS_LABELS);
   return [{
     username,
     url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username),
-    result: becameFriends ? 'already-friends' : 'followed',
+    result: 'followed',
   }];
 })()
 `;
@@ -80,24 +79,25 @@ function buildFollowScript(username) {
 
 async function followUser(page, args) {
     const username = normalizeUsername(args.username);
-    await page.goto(`${TIKTOK_HOST}/@${encodeURIComponent(username)}`, {
-        waitUntil: 'load',
-        settleMs: 5000,
+    const throwFailure = (error) => throwButtonWalkerError(error, {
+        authMessage: 'TikTok requires login to follow users',
+        failureMessage: `Failed to follow @${username}`,
+        retryableHint: RETRYABLE_HINTS.relationFailure,
     });
     let rows;
     try {
+        await page.goto(`${TIKTOK_HOST}/@${encodeURIComponent(username)}`, {
+            waitUntil: 'load',
+            settleMs: 5000,
+        });
         rows = await page.evaluate(buildFollowScript(username));
     } catch (error) {
-        throwButtonWalkerError(error, {
-            authMessage: 'TikTok requires login to follow users',
-            failureMessage: `Failed to follow @${username}`,
-            retryableHint: RETRYABLE_HINTS.relationFailure,
-        });
+        throwFailure(error);
     }
     if (!Array.isArray(rows) || rows.length === 0) {
         // Defensive: build script always returns a row on success path.
         // If we land here, treat as state-verify failure.
-        throw new Error(`Follow returned no row for @${username}`);
+        throwFailure(new Error(`STATE_VERIFY_FAIL: follow returned no row for @${username}`));
     }
     return rows;
 }

--- a/clis/tiktok/unfollow.js
+++ b/clis/tiktok/unfollow.js
@@ -90,22 +90,23 @@ function buildUnfollowScript(username) {
 
 async function unfollowUser(page, args) {
     const username = normalizeUsername(args.username);
-    await page.goto(`${TIKTOK_HOST}/@${encodeURIComponent(username)}`, {
-        waitUntil: 'load',
-        settleMs: 5000,
+    const throwFailure = (error) => throwButtonWalkerError(error, {
+        authMessage: 'TikTok requires login to unfollow users',
+        failureMessage: `Failed to unfollow @${username}`,
+        retryableHint: RETRYABLE_HINTS.relationFailure,
     });
     let rows;
     try {
+        await page.goto(`${TIKTOK_HOST}/@${encodeURIComponent(username)}`, {
+            waitUntil: 'load',
+            settleMs: 5000,
+        });
         rows = await page.evaluate(buildUnfollowScript(username));
     } catch (error) {
-        throwButtonWalkerError(error, {
-            authMessage: 'TikTok requires login to unfollow users',
-            failureMessage: `Failed to unfollow @${username}`,
-            retryableHint: RETRYABLE_HINTS.relationFailure,
-        });
+        throwFailure(error);
     }
     if (!Array.isArray(rows) || rows.length === 0) {
-        throw new Error(`Unfollow returned no row for @${username}`);
+        throwFailure(new Error(`STATE_VERIFY_FAIL: unfollow returned no row for @${username}`));
     }
     return rows;
 }

--- a/clis/tiktok/unfollow.js
+++ b/clis/tiktok/unfollow.js
@@ -1,45 +1,130 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Unfollow a TikTok user via in-page button click + state verification.
+//
+// Replaces the legacy pipeline-based adapter that returned silent failure
+// rows like `{ status: 'Not following this user', username }`. Route 1
+// keeps the live UI button + confirm-dialog flow (the page-context
+// `/api/commit/follow/user/` write endpoint requires X-Bogus signing —
+// out of scope for this PR), but every transition raises a typed error:
+//
+//   ArgumentError         — empty or malformed username
+//   AuthRequiredError     — not logged in
+//   CommandExecutionError — Following button missing / confirm dialog
+//                           missing / state verification fails / rate
+//                           limit detected (retryable=true: server-side
+//                           dedupes unfollow on retry)
+//
+// `result` row enum: `unfollowed` / `already-not-following`. Failures
+// throw — never returned as a success row.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    BROWSER_HELPERS,
+    BUTTON_WALKER_HELPERS,
+    RETRYABLE_HINTS,
+    TIKTOK_HOST,
+    normalizeUsername,
+    throwButtonWalkerError,
+} from './utils.js';
+
+function buildUnfollowScript(username) {
+    return `
+(async () => {
+  const username = ${JSON.stringify(username)};
+
+  ${BROWSER_HELPERS}
+  ${BUTTON_WALKER_HELPERS}
+
+  ensureLoggedInOrThrow();
+  ensureNoRateLimitOrThrow();
+
+  const FOLLOW_LABELS = ['Follow', '关注', 'フォロー'];
+  const FOLLOWING_LABELS = ['Following', '已关注', 'フォロー中'];
+  const FRIENDS_LABELS = ['Friends', '互关', 'フレンド'];
+  const RELATION_LABELS = FOLLOWING_LABELS.concat(FRIENDS_LABELS);
+  const CONFIRM_LABELS = ['Unfollow', '取消关注'];
+
+  // Idempotent fast path: not currently following.
+  if (!buttonExists(RELATION_LABELS) && buttonExists(FOLLOW_LABELS)) {
+    return [{ username, url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username), result: 'already-not-following' }];
+  }
+
+  const relationBtn = findButtonByText(RELATION_LABELS);
+  if (!relationBtn) {
+    // Neither Follow nor Following — page may not have rendered, or
+    // private account / blocked: refuse to silently succeed.
+    throw new Error('BUTTON_NOT_FOUND: neither Follow nor Following button found (page not rendered, blocked, or selectors changed)');
+  }
+
+  const target = relationBtn.closest('button') || relationBtn.closest('[role="button"]') || relationBtn;
+  target.click();
+
+  // TikTok shows a confirm-unfollow dialog. Wait for it to render.
+  const dialogShown = await waitFor(() => buttonExists(CONFIRM_LABELS), { timeoutMs: 3000 });
+  if (dialogShown) {
+    const confirmBtn = findButtonByText(CONFIRM_LABELS);
+    if (!confirmBtn) {
+      throw new Error('BUTTON_NOT_FOUND: confirm-unfollow dialog detected but confirm button could not be located');
+    }
+    confirmBtn.click();
+  }
+
+  const flipped = await waitFor(
+    () => buttonExists(FOLLOW_LABELS) && !buttonExists(RELATION_LABELS),
+    { timeoutMs: 5000 },
+  );
+  if (!flipped) {
+    ensureNoRateLimitOrThrow();
+    throw new Error('STATE_VERIFY_FAIL: relation did not flip back to Follow within 5s; unfollow may not have been recorded');
+  }
+
+  ensureNoRateLimitOrThrow();
+
+  return [{
+    username,
+    url: ${JSON.stringify(TIKTOK_HOST)} + '/@' + encodeURIComponent(username),
+    result: 'unfollowed',
+  }];
+})()
+`;
+}
+
+async function unfollowUser(page, args) {
+    const username = normalizeUsername(args.username);
+    await page.goto(`${TIKTOK_HOST}/@${encodeURIComponent(username)}`, {
+        waitUntil: 'load',
+        settleMs: 5000,
+    });
+    let rows;
+    try {
+        rows = await page.evaluate(buildUnfollowScript(username));
+    } catch (error) {
+        throwButtonWalkerError(error, {
+            authMessage: 'TikTok requires login to unfollow users',
+            failureMessage: `Failed to unfollow @${username}`,
+            retryableHint: RETRYABLE_HINTS.relationFailure,
+        });
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new Error(`Unfollow returned no row for @${username}`);
+    }
+    return rows;
+}
+
+export const unfollowCommand = cli({
     site: 'tiktok',
     name: 'unfollow',
     access: 'write',
-    description: 'Unfollow a TikTok user',
+    description: 'Unfollow a TikTok user by username',
     domain: 'www.tiktok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
     args: [
-        {
-            name: 'username',
-            required: true,
-            positional: true,
-            help: 'TikTok username (without @)',
-        },
+        { name: 'username', required: true, positional: true, help: 'TikTok username (without @)' },
     ],
-    columns: ['status', 'username'],
-    pipeline: [
-        { navigate: { url: 'https://www.tiktok.com/@${{ args.username }}', settleMs: 6000 } },
-        { evaluate: `(async () => {
-  const username = \${{ args.username | json }};
-  const buttons = Array.from(document.querySelectorAll('button, [role="button"]'));
-  const followingBtn = buttons.find(function(b) {
-    var text = b.textContent.trim();
-    return text === 'Following' || text === '已关注' || text === 'Friends' || text === '互关';
-  });
-  if (!followingBtn) {
-    return [{ status: 'Not following this user', username: username }];
-  }
-  followingBtn.click();
-  await new Promise(r => setTimeout(r, 2000));
-  // Confirm unfollow if dialog appears
-  var allBtns = Array.from(document.querySelectorAll('button'));
-  var confirm = allBtns.find(function(b) {
-    var t = b.textContent.trim();
-    return t === 'Unfollow' || t === '取消关注';
-  });
-  if (confirm) {
-    confirm.click();
-    await new Promise(r => setTimeout(r, 1500));
-  }
-  return [{ status: 'Unfollowed', username: username }];
-})()
-` },
-    ],
+    columns: ['username', 'url', 'result'],
+    func: unfollowUser,
 });
+
+export const __test__ = {
+    buildUnfollowScript,
+};

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -190,6 +190,12 @@ export const RETRYABLE_HINTS = {
 // itself failed to render — they still surface as CommandExecutionError.
 export function throwButtonWalkerError(error, { authMessage, failureMessage, retryableHint }) {
     const message = getErrorMessage(error);
+    if (/\bRATE_LIMITED\b|\b(captcha|too many requests|rate limit|try again later|slow down)\b/i.test(message)) {
+        throw new CommandExecutionError(
+            `${failureMessage}: ${message}`,
+            retryableHint,
+        );
+    }
     if (looksTikTokAuthFailure(message)) {
         throw new AuthRequiredError('tiktok.com', authMessage);
     }

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -74,6 +74,70 @@ export function requireNotificationType(value) {
     return key;
 }
 
+// Comment text bound: TikTok rejects long comments at submit time.
+// We validate length + non-empty up-front so the adapter never tries to
+// paste an empty / overlong string into the contenteditable input.
+export const COMMENT_TEXT_MAX = 150;
+
+export function requireCommentText(value) {
+    const text = String(value ?? '').trim();
+    if (!text) {
+        throw new ArgumentError(
+            'comment text is required',
+            'Example: opencli tiktok comment <url> "great video"',
+        );
+    }
+    if (text.length > COMMENT_TEXT_MAX) {
+        throw new ArgumentError(
+            `comment text must be <= ${COMMENT_TEXT_MAX} characters (got ${text.length})`,
+            'TikTok rejects long comments at submit time; trim before retrying',
+        );
+    }
+    return text;
+}
+
+// Parses a TikTok video URL into {username, videoId, url}. Rejects bad
+// shapes up-front so we never `goto()` an arbitrary page and silently
+// pretend the click target was found. Both share-style links
+// (vm.tiktok.com/...) and bare video IDs are out of scope — callers must
+// pass the canonical /@user/video/id form.
+export function parseTikTokVideoUrl(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) {
+        throw new ArgumentError(
+            'video URL is required',
+            'Example: opencli tiktok comment https://www.tiktok.com/@user/video/1234567890 "..."',
+        );
+    }
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch {
+        throw new ArgumentError(
+            `invalid video URL: ${raw}`,
+            'Example: https://www.tiktok.com/@user/video/1234567890',
+        );
+    }
+    if (!/(^|\.)tiktok\.com$/i.test(parsed.hostname)) {
+        throw new ArgumentError(
+            `URL must be on tiktok.com (got ${parsed.hostname})`,
+            'Example: https://www.tiktok.com/@user/video/1234567890',
+        );
+    }
+    const match = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/video\/(\d+)/);
+    if (!match) {
+        throw new ArgumentError(
+            'URL must follow /@<username>/video/<id> format',
+            'Example: https://www.tiktok.com/@user/video/1234567890',
+        );
+    }
+    return {
+        url: parsed.toString(),
+        username: match[1],
+        videoId: match[2],
+    };
+}
+
 export function looksTikTokAuthFailure(message) {
     return /\bAUTH_REQUIRED\b|\b(auth|captcha|login|log in|permission|unauthori[sz]ed|forbidden)\b|HTTP\s+(401|403)\b/i.test(String(message || ''));
 }
@@ -94,6 +158,45 @@ export function throwTikTokPageContextError(error, { authMessage, emptyPattern, 
         throw new EmptyResultError(emptyTarget, message);
     }
     throw new CommandExecutionError(`${failureMessage}: ${message}`);
+}
+
+// Sentinels emitted by Route 1 (button-walker) IIFEs and mapped here to
+// typed errors. Keeping the strings constant in one place makes the IIFE
+// `throw new Error(...)` callsites greppable and the mapper exhaustive.
+export const BUTTON_WALKER_SENTINELS = {
+    AUTH_REQUIRED: 'AUTH_REQUIRED',
+    BUTTON_NOT_FOUND: 'BUTTON_NOT_FOUND',
+    STATE_VERIFY_FAIL: 'STATE_VERIFY_FAIL',
+    RATE_LIMITED: 'RATE_LIMITED',
+};
+
+// Retryability for write-class typed errors. Captured in the hint string
+// so the human-readable output makes the retry contract explicit and
+// downstream agents/scripts can grep for `retryable=true|false`.
+//
+// Comment is server-fan-out: a stale state-verify timeout does not prove
+// the server rejected the comment, so retry can double-post.
+// Follow / unfollow are client-safe: TikTok server-side dedupes the
+// relation flip, so retry after a transient blip is harmless.
+export const RETRYABLE_HINTS = {
+    commentFailure: 'retryable=false reason=server-fan-out — TikTok may have accepted the comment but state verification timed out; do NOT auto-retry',
+    relationFailure: 'retryable=true reason=idempotent — TikTok dedupes follow/unfollow on retry; safe to re-run',
+};
+
+// Maps a Route 1 (button-walker) IIFE error to a typed error. We do NOT
+// map to EmptyResultError for write commands: a missing button or failed
+// state verification is a contract violation, not an empty result set.
+// Network / page-load failures reach this path only when the live page
+// itself failed to render — they still surface as CommandExecutionError.
+export function throwButtonWalkerError(error, { authMessage, failureMessage, retryableHint }) {
+    const message = getErrorMessage(error);
+    if (looksTikTokAuthFailure(message)) {
+        throw new AuthRequiredError('tiktok.com', authMessage);
+    }
+    throw new CommandExecutionError(
+        `${failureMessage}: ${message}`,
+        retryableHint,
+    );
 }
 
 // Browser-side helper bundle. Embedded into IIFEs as a string template.
@@ -313,5 +416,84 @@ function normalizeNotification(item, indexHint) {
     text,
     createTime,
   };
+}
+`;
+
+// Browser-side helpers for Route 1 (button-walker) write commands.
+// Depends on `findUniversalData / walkObjects / getCookie` from
+// BROWSER_HELPERS — adapters must paste BROWSER_HELPERS first, then
+// BUTTON_WALKER_HELPERS, in the same `page.evaluate` script.
+//
+// Sentinels (AUTH_REQUIRED / BUTTON_NOT_FOUND / STATE_VERIFY_FAIL /
+// RATE_LIMITED) are mirrored from BUTTON_WALKER_SENTINELS — Node-side
+// `throwButtonWalkerError()` matches on these strings to map back to
+// typed errors. Keep both sides in sync.
+export const BUTTON_WALKER_HELPERS = `
+function checkLoggedIn() {
+  if (getCookie('sessionid') || getCookie('sid_tt') || getCookie('uid_tt')) return true;
+  const root = findUniversalData();
+  if (!root) return false;
+  let found = false;
+  walkObjects(root, (node) => {
+    if (Array.isArray(node)) return false;
+    const candidate = node && node.user;
+    if (candidate && typeof candidate === 'object') {
+      const secUid = String(candidate.secUid || candidate.sec_uid || '').trim();
+      const isMe = Boolean(candidate.isOwner || candidate.is_owner || candidate.isCurrentUser);
+      if (secUid && isMe) {
+        found = true;
+        return true;
+      }
+    }
+    return false;
+  });
+  return found;
+}
+
+function findButtonByText(texts) {
+  const targets = new Set(texts);
+  const buttons = Array.from(document.querySelectorAll('button, [role="button"]'));
+  for (const btn of buttons) {
+    const text = (btn.textContent || '').trim();
+    if (targets.has(text)) return btn;
+  }
+  return null;
+}
+
+function buttonExists(texts) {
+  return findButtonByText(texts) !== null;
+}
+
+function detectRateLimitPopup() {
+  const text = (document.body && document.body.textContent || '').toLowerCase();
+  if (/too many requests|rate limit|try again later|slow down/.test(text)) return true;
+  if (document.querySelector('[data-e2e="captcha"], .captcha-mask, .secsdk-captcha-wrapper')) {
+    return true;
+  }
+  return false;
+}
+
+async function waitFor(predicate, options) {
+  const opts = options || {};
+  const timeoutMs = typeof opts.timeoutMs === 'number' ? opts.timeoutMs : 5000;
+  const intervalMs = typeof opts.intervalMs === 'number' ? opts.intervalMs : 200;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try { if (predicate()) return true; } catch { /* swallow predicate errors */ }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
+function ensureLoggedInOrThrow() {
+  if (!checkLoggedIn()) {
+    throw new Error('AUTH_REQUIRED: TikTok login required');
+  }
+}
+
+function ensureNoRateLimitOrThrow() {
+  if (detectRateLimitPopup()) {
+    throw new Error('RATE_LIMITED: TikTok rate limit / captcha detected');
+  }
 }
 `;

--- a/clis/tiktok/utils.js
+++ b/clis/tiktok/utils.js
@@ -124,7 +124,7 @@ export function parseTikTokVideoUrl(value) {
             'Example: https://www.tiktok.com/@user/video/1234567890',
         );
     }
-    const match = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/video\/(\d+)/);
+    const match = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/video\/(\d+)\/?$/);
     if (!match) {
         throw new ArgumentError(
             'URL must follow /@<username>/video/<id> format',

--- a/clis/tiktok/write-refactor.test.js
+++ b/clis/tiktok/write-refactor.test.js
@@ -1,0 +1,310 @@
+// Contract tests for the Phase-3 P0.5 refactor that retired the legacy
+// pipeline-based silent-failure pattern across comment / follow / unfollow.
+//
+// Each adapter is now `func + Strategy.COOKIE + browser:true` with a
+// shared button-walker helper bundle from utils.js. These tests pin
+// down (a) registration metadata, (b) typed-error boundary, including
+// the retryable-hint contract that distinguishes server-fan-out
+// (comment) from idempotent client-safe (follow / unfollow) failures,
+// (c) build-script invariants — sentinels, login + rate-limit guards,
+// expected button labels and selectors.
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+} from '@jackwener/opencli/errors';
+import { commentCommand, __test__ as commentTest } from './comment.js';
+import { followCommand, __test__ as followTest } from './follow.js';
+import { unfollowCommand, __test__ as unfollowTest } from './unfollow.js';
+import {
+    BUTTON_WALKER_HELPERS,
+    BUTTON_WALKER_SENTINELS,
+    COMMENT_TEXT_MAX,
+    RETRYABLE_HINTS,
+    parseTikTokVideoUrl,
+    requireCommentText,
+    throwButtonWalkerError,
+} from './utils.js';
+
+function makePage(rows) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(rows),
+    };
+}
+
+function makeFailingPage(error) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockRejectedValue(error),
+    };
+}
+
+const VIDEO_URL = 'https://www.tiktok.com/@creator/video/7350000000000000000';
+
+const sampleCommentRow = { url: VIDEO_URL, text: 'great clip', result: 'posted' };
+const sampleFollowRow = { username: 'creator', url: 'https://www.tiktok.com/@creator', result: 'followed' };
+const sampleUnfollowRow = { username: 'creator', url: 'https://www.tiktok.com/@creator', result: 'unfollowed' };
+
+describe('tiktok/utils (P0.5 button-walker additions)', () => {
+    it('requireCommentText rejects empty / whitespace / overlong with ArgumentError', () => {
+        expect(() => requireCommentText('')).toThrow(ArgumentError);
+        expect(() => requireCommentText('   ')).toThrow(ArgumentError);
+        expect(() => requireCommentText(undefined)).toThrow(ArgumentError);
+        expect(() => requireCommentText('x'.repeat(COMMENT_TEXT_MAX + 1))).toThrow(ArgumentError);
+        expect(requireCommentText('  hello  ')).toBe('hello');
+        expect(requireCommentText('x'.repeat(COMMENT_TEXT_MAX))).toHaveLength(COMMENT_TEXT_MAX);
+    });
+
+    it('parseTikTokVideoUrl rejects non-tiktok / bad shape and accepts canonical URL', () => {
+        expect(() => parseTikTokVideoUrl('')).toThrow(ArgumentError);
+        expect(() => parseTikTokVideoUrl('not a url')).toThrow(ArgumentError);
+        expect(() => parseTikTokVideoUrl('https://example.com/@u/video/123')).toThrow(ArgumentError);
+        expect(() => parseTikTokVideoUrl('https://www.tiktok.com/@user/photo/123')).toThrow(ArgumentError);
+        expect(() => parseTikTokVideoUrl('https://vm.tiktok.com/abc')).toThrow(ArgumentError);
+        const parsed = parseTikTokVideoUrl(VIDEO_URL);
+        expect(parsed.username).toBe('creator');
+        expect(parsed.videoId).toBe('7350000000000000000');
+        expect(parsed.url).toBe(VIDEO_URL);
+        // accepts trailing slash + extra path segments
+        expect(parseTikTokVideoUrl(`${VIDEO_URL}/?lang=en`).videoId).toBe('7350000000000000000');
+    });
+
+    it('BUTTON_WALKER_SENTINELS exposes the 4 sentinel strings used by IIFEs', () => {
+        expect(BUTTON_WALKER_SENTINELS.AUTH_REQUIRED).toBe('AUTH_REQUIRED');
+        expect(BUTTON_WALKER_SENTINELS.BUTTON_NOT_FOUND).toBe('BUTTON_NOT_FOUND');
+        expect(BUTTON_WALKER_SENTINELS.STATE_VERIFY_FAIL).toBe('STATE_VERIFY_FAIL');
+        expect(BUTTON_WALKER_SENTINELS.RATE_LIMITED).toBe('RATE_LIMITED');
+    });
+
+    it('RETRYABLE_HINTS encodes retryable=true|false plus reason in human-readable form', () => {
+        expect(RETRYABLE_HINTS.commentFailure).toMatch(/retryable=false/);
+        expect(RETRYABLE_HINTS.commentFailure).toMatch(/server-fan-out/);
+        expect(RETRYABLE_HINTS.relationFailure).toMatch(/retryable=true/);
+        expect(RETRYABLE_HINTS.relationFailure).toMatch(/idempotent/);
+    });
+
+    it('BUTTON_WALKER_HELPERS string template exposes the expected helper names', () => {
+        expect(typeof BUTTON_WALKER_HELPERS).toBe('string');
+        for (const name of [
+            'checkLoggedIn',
+            'findButtonByText',
+            'buttonExists',
+            'detectRateLimitPopup',
+            'waitFor',
+            'ensureLoggedInOrThrow',
+            'ensureNoRateLimitOrThrow',
+        ]) {
+            expect(BUTTON_WALKER_HELPERS).toContain('function ' + name + '(');
+        }
+    });
+
+    it('throwButtonWalkerError maps AUTH_REQUIRED-shaped messages to AuthRequiredError', () => {
+        expect(() => throwButtonWalkerError(new Error('AUTH_REQUIRED: login required'), {
+            authMessage: 'login pls',
+            failureMessage: 'op failed',
+            retryableHint: RETRYABLE_HINTS.relationFailure,
+        })).toThrow(AuthRequiredError);
+        expect(() => throwButtonWalkerError(new Error('captcha verification needed'), {
+            authMessage: 'login pls',
+            failureMessage: 'op failed',
+            retryableHint: RETRYABLE_HINTS.relationFailure,
+        })).toThrow(AuthRequiredError);
+    });
+
+    it('throwButtonWalkerError maps everything else to CommandExecutionError with retryable hint', () => {
+        try {
+            throwButtonWalkerError(new Error('BUTTON_NOT_FOUND: missing'), {
+                authMessage: 'a',
+                failureMessage: 'op failed',
+                retryableHint: RETRYABLE_HINTS.commentFailure,
+            });
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(CommandExecutionError);
+            expect(err.message).toMatch(/op failed: BUTTON_NOT_FOUND/);
+            expect(err.hint).toMatch(/retryable=false/);
+        }
+        try {
+            throwButtonWalkerError(new Error('STATE_VERIFY_FAIL: did not flip'), {
+                authMessage: 'a',
+                failureMessage: 'op failed',
+                retryableHint: RETRYABLE_HINTS.relationFailure,
+            });
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(CommandExecutionError);
+            expect(err.hint).toMatch(/retryable=true/);
+        }
+    });
+});
+
+describe('tiktok/comment (Route 1 button-walker refactor)', () => {
+    it('registers as write-access COOKIE browser adapter with url/text/result columns', () => {
+        expect(commentCommand.access).toBe('write');
+        expect(commentCommand.browser).toBe(true);
+        expect(commentCommand.strategy).toBe('cookie');
+        expect(commentCommand.columns).toEqual(['url', 'text', 'result']);
+    });
+
+    it('validates --url and --text upfront before navigating', async () => {
+        const page = makePage([sampleCommentRow]);
+        await expect(commentCommand.func(page, { url: '', text: 'hi' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(commentCommand.func(page, { url: VIDEO_URL, text: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(commentCommand.func(page, { url: 'https://example.com/x', text: 'hi' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(commentCommand.func(page, { url: VIDEO_URL, text: 'x'.repeat(COMMENT_TEXT_MAX + 1) })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to the canonical video URL and returns the row from evaluate', async () => {
+        const page = makePage([sampleCommentRow]);
+        const rows = await commentCommand.func(page, { url: VIDEO_URL, text: 'great clip' });
+        expect(page.goto).toHaveBeenCalledWith(VIDEO_URL, { waitUntil: 'load', settleMs: 6000 });
+        expect(rows).toEqual([sampleCommentRow]);
+    });
+
+    it('maps page-evaluate errors to typed errors with comment retryable=false hint', async () => {
+        await expect(commentCommand.func(
+            makeFailingPage(new Error('AUTH_REQUIRED: TikTok login required')),
+            { url: VIDEO_URL, text: 'hi' },
+        )).rejects.toBeInstanceOf(AuthRequiredError);
+        try {
+            await commentCommand.func(
+                makeFailingPage(new Error('STATE_VERIFY_FAIL: comment count did not increase')),
+                { url: VIDEO_URL, text: 'hi' },
+            );
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(CommandExecutionError);
+            expect(err.message).toMatch(/Failed to post comment/);
+            expect(err.hint).toMatch(/retryable=false/);
+            expect(err.hint).toMatch(/server-fan-out/);
+        }
+    });
+
+    it('build script embeds text via JSON.stringify and calls login + rate-limit guards', () => {
+        const script = commentTest.buildCommentScript('he said "hi"\nbye');
+        expect(script).toContain('const commentText = "he said \\"hi\\"\\nbye";');
+        expect(script).toContain('ensureLoggedInOrThrow()');
+        expect(script).toContain('ensureNoRateLimitOrThrow()');
+        expect(script).toContain('STATE_VERIFY_FAIL');
+        expect(script).toContain('BUTTON_NOT_FOUND');
+        expect(script).toContain('[data-e2e="comment-input"]');
+        expect(script).toContain('[data-e2e="comment-level-1"]');
+        expect(script).toContain("['Post', '发布', '发送']");
+    });
+});
+
+describe('tiktok/follow (Route 1 button-walker refactor)', () => {
+    it('registers as write-access COOKIE browser adapter with username/url/result columns', () => {
+        expect(followCommand.access).toBe('write');
+        expect(followCommand.browser).toBe(true);
+        expect(followCommand.strategy).toBe('cookie');
+        expect(followCommand.columns).toEqual(['username', 'url', 'result']);
+    });
+
+    it('validates username upfront before navigating', async () => {
+        const page = makePage([sampleFollowRow]);
+        await expect(followCommand.func(page, { username: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(followCommand.func(page, { username: 'bad name' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to /@username (with @ stripped) and returns the row from evaluate', async () => {
+        const page = makePage([sampleFollowRow]);
+        const rows = await followCommand.func(page, { username: '@creator' });
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/@creator', { waitUntil: 'load', settleMs: 5000 });
+        expect(rows).toEqual([sampleFollowRow]);
+    });
+
+    it('maps AUTH_REQUIRED to AuthRequiredError; other failures get retryable=true hint', async () => {
+        await expect(followCommand.func(
+            makeFailingPage(new Error('AUTH_REQUIRED: TikTok login required')),
+            { username: 'creator' },
+        )).rejects.toBeInstanceOf(AuthRequiredError);
+        try {
+            await followCommand.func(
+                makeFailingPage(new Error('STATE_VERIFY_FAIL: follow button did not flip')),
+                { username: 'creator' },
+            );
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(CommandExecutionError);
+            expect(err.message).toMatch(/Failed to follow @creator/);
+            expect(err.hint).toMatch(/retryable=true/);
+            expect(err.hint).toMatch(/idempotent/);
+        }
+    });
+
+    it('build script embeds username via JSON.stringify and pins all relation labels', () => {
+        const script = followTest.buildFollowScript('creator');
+        expect(script).toContain('const username = "creator";');
+        expect(script).toContain('ensureLoggedInOrThrow()');
+        expect(script).toContain('ensureNoRateLimitOrThrow()');
+        expect(script).toContain("'Follow', '关注'");
+        expect(script).toContain("'Following', '已关注'");
+        expect(script).toContain("'Friends', '互关'");
+        expect(script).toContain("'already-following'");
+        expect(script).toContain("'already-friends'");
+        expect(script).toContain('STATE_VERIFY_FAIL');
+        expect(script).toContain('BUTTON_NOT_FOUND');
+    });
+});
+
+describe('tiktok/unfollow (Route 1 button-walker refactor)', () => {
+    it('registers as write-access COOKIE browser adapter with username/url/result columns', () => {
+        expect(unfollowCommand.access).toBe('write');
+        expect(unfollowCommand.browser).toBe(true);
+        expect(unfollowCommand.strategy).toBe('cookie');
+        expect(unfollowCommand.columns).toEqual(['username', 'url', 'result']);
+    });
+
+    it('validates username upfront before navigating', async () => {
+        const page = makePage([sampleUnfollowRow]);
+        await expect(unfollowCommand.func(page, { username: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(unfollowCommand.func(page, { username: 'bad/name' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('navigates to /@username and returns the row from evaluate', async () => {
+        const page = makePage([sampleUnfollowRow]);
+        const rows = await unfollowCommand.func(page, { username: 'creator' });
+        expect(page.goto).toHaveBeenCalledWith('https://www.tiktok.com/@creator', { waitUntil: 'load', settleMs: 5000 });
+        expect(rows).toEqual([sampleUnfollowRow]);
+    });
+
+    it('maps AUTH_REQUIRED to AuthRequiredError; other failures get retryable=true hint', async () => {
+        await expect(unfollowCommand.func(
+            makeFailingPage(new Error('AUTH_REQUIRED: login required')),
+            { username: 'creator' },
+        )).rejects.toBeInstanceOf(AuthRequiredError);
+        try {
+            await unfollowCommand.func(
+                makeFailingPage(new Error('STATE_VERIFY_FAIL: relation did not flip back')),
+                { username: 'creator' },
+            );
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(CommandExecutionError);
+            expect(err.message).toMatch(/Failed to unfollow @creator/);
+            expect(err.hint).toMatch(/retryable=true/);
+            expect(err.hint).toMatch(/idempotent/);
+        }
+    });
+
+    it('build script handles confirm-dialog flow + flips back to Follow', () => {
+        const script = unfollowTest.buildUnfollowScript('creator');
+        expect(script).toContain('const username = "creator";');
+        expect(script).toContain('ensureLoggedInOrThrow()');
+        expect(script).toContain('ensureNoRateLimitOrThrow()');
+        expect(script).toContain("'Unfollow', '取消关注'");
+        expect(script).toContain("'already-not-following'");
+        expect(script).toContain("'unfollowed'");
+        expect(script).toContain('STATE_VERIFY_FAIL');
+        expect(script).toContain('BUTTON_NOT_FOUND');
+    });
+});

--- a/clis/tiktok/write-refactor.test.js
+++ b/clis/tiktok/write-refactor.test.js
@@ -73,12 +73,14 @@ describe('tiktok/utils (P0.5 button-walker additions)', () => {
         expect(() => parseTikTokVideoUrl('not a url')).toThrow(ArgumentError);
         expect(() => parseTikTokVideoUrl('https://example.com/@u/video/123')).toThrow(ArgumentError);
         expect(() => parseTikTokVideoUrl('https://www.tiktok.com/@user/photo/123')).toThrow(ArgumentError);
+        expect(() => parseTikTokVideoUrl('https://www.tiktok.com/@user/video/123abc')).toThrow(ArgumentError);
+        expect(() => parseTikTokVideoUrl('https://www.tiktok.com/@user/video/123/extra')).toThrow(ArgumentError);
         expect(() => parseTikTokVideoUrl('https://vm.tiktok.com/abc')).toThrow(ArgumentError);
         const parsed = parseTikTokVideoUrl(VIDEO_URL);
         expect(parsed.username).toBe('creator');
         expect(parsed.videoId).toBe('7350000000000000000');
         expect(parsed.url).toBe(VIDEO_URL);
-        // accepts trailing slash + extra path segments
+        // accepts a trailing slash plus query string, but not extra path segments
         expect(parseTikTokVideoUrl(`${VIDEO_URL}/?lang=en`).videoId).toBe('7350000000000000000');
     });
 

--- a/clis/tiktok/write-refactor.test.js
+++ b/clis/tiktok/write-refactor.test.js
@@ -44,6 +44,14 @@ function makeFailingPage(error) {
     };
 }
 
+function makeGotoFailingPage(error) {
+    return {
+        goto: vi.fn().mockRejectedValue(error),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(),
+    };
+}
+
 const VIDEO_URL = 'https://www.tiktok.com/@creator/video/7350000000000000000';
 
 const sampleCommentRow = { url: VIDEO_URL, text: 'great clip', result: 'posted' };
@@ -109,11 +117,26 @@ describe('tiktok/utils (P0.5 button-walker additions)', () => {
             failureMessage: 'op failed',
             retryableHint: RETRYABLE_HINTS.relationFailure,
         })).toThrow(AuthRequiredError);
-        expect(() => throwButtonWalkerError(new Error('captcha verification needed'), {
-            authMessage: 'login pls',
-            failureMessage: 'op failed',
-            retryableHint: RETRYABLE_HINTS.relationFailure,
-        })).toThrow(AuthRequiredError);
+    });
+
+    it('throwButtonWalkerError keeps captcha / rate-limit as retryable CommandExecutionError, not AuthRequiredError', () => {
+        for (const message of [
+            'RATE_LIMITED: TikTok rate limit / captcha detected',
+            'captcha verification needed',
+            'Too many requests, try again later',
+        ]) {
+            try {
+                throwButtonWalkerError(new Error(message), {
+                    authMessage: 'login pls',
+                    failureMessage: 'op failed',
+                    retryableHint: RETRYABLE_HINTS.relationFailure,
+                });
+                throw new Error('should have thrown');
+            } catch (err) {
+                expect(err).toBeInstanceOf(CommandExecutionError);
+                expect(err.hint).toMatch(/retryable=true/);
+            }
+        }
     });
 
     it('throwButtonWalkerError maps everything else to CommandExecutionError with retryable hint', () => {
@@ -131,7 +154,7 @@ describe('tiktok/utils (P0.5 button-walker additions)', () => {
         }
         try {
             throwButtonWalkerError(new Error('STATE_VERIFY_FAIL: did not flip'), {
-                authMessage: 'a',
+                authMessage: 'login pls',
                 failureMessage: 'op failed',
                 retryableHint: RETRYABLE_HINTS.relationFailure,
             });
@@ -184,6 +207,17 @@ describe('tiktok/comment (Route 1 button-walker refactor)', () => {
             expect(err.hint).toMatch(/retryable=false/);
             expect(err.hint).toMatch(/server-fan-out/);
         }
+    });
+
+    it('maps navigation failures and empty evaluate rows to CommandExecutionError', async () => {
+        await expect(commentCommand.func(
+            makeGotoFailingPage(new Error('net::ERR_ABORTED')),
+            { url: VIDEO_URL, text: 'hi' },
+        )).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(commentCommand.func(
+            makePage([]),
+            { url: VIDEO_URL, text: 'hi' },
+        )).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('build script embeds text via JSON.stringify and calls login + rate-limit guards', () => {
@@ -240,6 +274,17 @@ describe('tiktok/follow (Route 1 button-walker refactor)', () => {
         }
     });
 
+    it('maps navigation failures and empty evaluate rows to retryable CommandExecutionError', async () => {
+        await expect(followCommand.func(
+            makeGotoFailingPage(new Error('Execution context was destroyed')),
+            { username: 'creator' },
+        )).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(followCommand.func(
+            makePage([]),
+            { username: 'creator' },
+        )).rejects.toMatchObject({ hint: expect.stringMatching(/retryable=true/) });
+    });
+
     it('build script embeds username via JSON.stringify and pins all relation labels', () => {
         const script = followTest.buildFollowScript('creator');
         expect(script).toContain('const username = "creator";');
@@ -250,6 +295,8 @@ describe('tiktok/follow (Route 1 button-walker refactor)', () => {
         expect(script).toContain("'Friends', '互关'");
         expect(script).toContain("'already-following'");
         expect(script).toContain("'already-friends'");
+        expect(script).toContain("result: 'followed'");
+        expect(script).not.toContain('becameFriends ?');
         expect(script).toContain('STATE_VERIFY_FAIL');
         expect(script).toContain('BUTTON_NOT_FOUND');
     });
@@ -294,6 +341,17 @@ describe('tiktok/unfollow (Route 1 button-walker refactor)', () => {
             expect(err.hint).toMatch(/retryable=true/);
             expect(err.hint).toMatch(/idempotent/);
         }
+    });
+
+    it('maps navigation failures and empty evaluate rows to retryable CommandExecutionError', async () => {
+        await expect(unfollowCommand.func(
+            makeGotoFailingPage(new Error('Execution context was destroyed')),
+            { username: 'creator' },
+        )).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(unfollowCommand.func(
+            makePage([]),
+            { username: 'creator' },
+        )).rejects.toMatchObject({ hint: expect.stringMatching(/retryable=true/) });
     });
 
     it('build script handles confirm-dialog flow + flips back to Follow', () => {

--- a/docs/adapters/browser/tiktok.md
+++ b/docs/adapters/browser/tiktok.md
@@ -146,6 +146,38 @@ same data their web client renders on the page.
 | `secUid` | string | Host's TikTok internal stable id |
 | `url` | string | Canonical `/@streamer/live` URL |
 
+### `comment` / `follow` / `unfollow` (write commands)
+
+These three commands click the live UI button + verify the post-click state
+before returning. They never return a silent failure row — every failure
+path raises a typed error. The `result` enum makes idempotent fast paths
+(already-following / already-not-following / already-friends) explicit, so
+callers can distinguish "we just did it" from "it was already done".
+
+#### `comment`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `url` | string | Canonical video URL the comment was posted on |
+| `text` | string | Comment text actually submitted (trimmed, ≤150 chars) |
+| `result` | enum | `posted` (only — TikTok permits duplicate comments, no idempotent fast path) |
+
+#### `follow`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `username` | string | Target user's `uniqueId` (without `@`) |
+| `url` | string | Canonical profile URL |
+| `result` | enum | `followed` / `already-following` / `already-friends` (mutual) |
+
+#### `unfollow`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `username` | string | Target user's `uniqueId` (without `@`) |
+| `url` | string | Canonical profile URL |
+| `result` | enum | `unfollowed` / `already-not-following` |
+
 ## Validation (no silent clamp)
 
 `--limit` is validated upfront and `ArgumentError` is thrown for `0`, negative,
@@ -167,6 +199,30 @@ column never returns `0` as an unknown sentinel. Authentication / empty result
 states raise `AuthRequiredError` / `EmptyResultError` instead of returning
 empty rows — callers can treat any returned row as real data.
 
+### Write commands — typed errors and retryability
+
+`comment` / `follow` / `unfollow` validate input upfront and verify post-click
+state. Failure modes:
+
+| Failure | Typed error | `retryable` (in `hint`) |
+|---------|-------------|-------------------------|
+| Empty / overlong / malformed input | `ArgumentError` | n/a |
+| Not logged in (no session cookie + no viewer secUid) | `AuthRequiredError` | n/a |
+| Required button missing (UI changed, blocked, private account) | `CommandExecutionError` | follow / unfollow: `true` (idempotent); comment: `false` |
+| State did not flip within timeout (likes/follows count unchanged) | `CommandExecutionError` | follow / unfollow: `true`; comment: `false` |
+| Captcha / rate-limit popup detected | `CommandExecutionError` | same as above |
+
+The `retryable=` flag is encoded in the error `hint` string in the form
+`retryable=<true\|false> reason=<...>` so downstream agents and scripts can
+grep it without parsing structured metadata. **Comment is `retryable=false`**
+because the server may still have accepted the comment when our state-verify
+times out (server-fan-out semantics) — auto-retrying would double-post.
+**Follow / unfollow are `retryable=true`** because TikTok dedupes the relation
+flip server-side, so a transient blip can be safely retried.
+
+> Importing `retryable` as a first-class metadata layer in OpenCLI core is a
+> candidate for follow-up — for now we keep the contract human-readable.
+
 ## Implementation Notes
 
 `explore` / `user` / `friends` / `following` / `notifications` / `live` all run inside
@@ -182,6 +238,18 @@ falls back to the corresponding API endpoint when more rows are requested
 
 This refactor applies the page-context API baseline across TikTok read commands:
 typed errors, full numeric stats columns, and no DOM-link scraping.
+
+`comment` / `follow` / `unfollow` (Route 1) keep the UI button as the
+trigger and harden every transition with state verification + typed errors.
+We **do not** call `/api/commit/follow/user/` or `/api/comment/publish/`
+directly: those endpoints require X-Bogus signing engineering, which is a
+separate scope. The IIFE checks `sessionid`/`sid_tt` cookies and the
+`__UNIVERSAL_DATA_FOR_REHYDRATION__` viewer snapshot for logged-in state,
+then asserts a button-text flip (Follow → Following etc.) or comment-list
+delta within 5–8 seconds. Captcha / rate-limit popups
+(`.secsdk-captcha-wrapper`, "Too many requests" body text) are detected
+both before and after the click so a flash captcha cannot masquerade as a
+successful state transition.
 
 ## Prerequisites
 

--- a/docs/adapters/browser/tiktok.md
+++ b/docs/adapters/browser/tiktok.md
@@ -51,19 +51,19 @@ opencli tiktok creator-videos --limit 20
 opencli tiktok friends --limit 10
 
 # Like/unlike a video
-opencli tiktok like --url "https://www.tiktok.com/@user/video/123"
-opencli tiktok unlike --url "https://www.tiktok.com/@user/video/123"
+opencli tiktok like "https://www.tiktok.com/@user/video/123"
+opencli tiktok unlike "https://www.tiktok.com/@user/video/123"
 
 # Save/unsave (Favorites)
-opencli tiktok save --url "https://www.tiktok.com/@user/video/123"
-opencli tiktok unsave --url "https://www.tiktok.com/@user/video/123"
+opencli tiktok save "https://www.tiktok.com/@user/video/123"
+opencli tiktok unsave "https://www.tiktok.com/@user/video/123"
 
 # Follow/unfollow
-opencli tiktok follow --username nasa
-opencli tiktok unfollow --username nasa
+opencli tiktok follow nasa
+opencli tiktok unfollow nasa
 
 # Comment on a video
-opencli tiktok comment --url "https://www.tiktok.com/@user/video/123" --text "Great!"
+opencli tiktok comment "https://www.tiktok.com/@user/video/123" "Great!"
 
 # JSON output
 opencli tiktok profile --username tiktok -f json


### PR DESCRIPTION
## Summary

Phase 3 P0.5 — refactor TikTok `comment` / `follow` / `unfollow` from legacy `pipeline:[]` button-walker (silent failure rows like `{status: 'Comment may have failed'}` / `{status: 'Already following'}` / `{status: 'Not following this user'}`) to `func + Strategy.COOKIE + browser:true` with typed errors and explicit state verification.

Companion to #1384 (read commands: `explore` / `friends` / `following` / `live` / `notifications` / `user` — all 6 already on main as `9a7dd44b`). Where #1384 unified read commands behind `BROWSER_HELPERS` + `assertTikTokApiSuccess` + `throwTikTokPageContextError`, this PR unifies the 3 write commands behind a parallel `BUTTON_WALKER_HELPERS` (browser-side) + `throwButtonWalkerError` (Node-side) two-layer boundary.

## What changes

**3 adapter rewrites** (`comment.js` / `follow.js` / `unfollow.js`):
- Validate input upfront → `ArgumentError` on empty/malformed username, comment text > 150 chars, or malformed video URL. **No `page.goto` is called on bad input.**
- Pre-click guards: `ensureLoggedInOrThrow` (sessionid/sid_tt cookie + `__UNIVERSAL_DATA_FOR_REHYDRATION__` viewer secUid) + `ensureNoRateLimitOrThrow` (`.secsdk-captcha-wrapper`, `'Too many requests'` body text).
- **Idempotent fast paths**: short-circuit before click — `follow` → `already-following` / `already-friends`; `unfollow` → `already-not-following`. Distinguishes "we just did it" from "it was already done".
- **State verification** replaces wait-and-assume — button-text flip (Follow ↔ Following ↔ Friends, with zh / ja labels) within 5s, or comment-list count delta within 8s. Captcha re-checked post-click to catch mid-flight flash.
- **`result` enum column**: `posted` / `followed` / `already-following` / `already-friends` / `unfollowed` / `already-not-following`.

**Shared helpers** in `clis/tiktok/utils.js`:
- Node-side: `parseTikTokVideoUrl`, `requireCommentText` (≤150 chars), `BUTTON_WALKER_SENTINELS`, `RETRYABLE_HINTS`, `throwButtonWalkerError`.
- Browser-side string template: `BUTTON_WALKER_HELPERS` (`checkLoggedIn` / `findButtonByText` / `buttonExists` / `detectRateLimitPopup` / `waitFor` / `ensureLoggedInOrThrow` / `ensureNoRateLimitOrThrow`).

**`retryable=` contract** encoded in `CommandExecutionError` hint string (`retryable=<true\|false> reason=<...>` — grep-friendly, no new core API):

| Command | retryable | Reason |
|---------|-----------|--------|
| `comment` | `false` | server-fan-out — server may have accepted the comment when state-verify times out, auto-retry would double-post |
| `follow` / `unfollow` | `true`  | TikTok dedupes the relation flip server-side, transient blip is safe to retry |

## Why button-walker, not /api/commit/*

**Intentionally NOT switching to `/api/commit/follow/user/` or `/api/comment/publish/`.** Those endpoints require X-Bogus signing — separate scope. Route 1 (button-walker + typed errors + state verification) is the conservative win: removes silent failure rows now, reuses the live UI button as trigger, and leaves the page-context API call path open for a future PR once X-Bogus signing is reverse-engineered.

## What this PR does NOT address

- X-Bogus signing for direct API calls (deferred to follow-up).
- Importing `retryable` as first-class metadata in OpenCLI core (`hint=` string is the human-readable contract for now — promotion candidate post-merge).
- TikTok Studio creator commands (`creator-videos` etc.) — out of scope.

## Typed errors emitted

| Failure | Error type | Notes |
|---------|------------|-------|
| Empty / overlong / malformed input | `ArgumentError` | upfront, before navigation |
| Not logged in (no session cookie + no viewer secUid) | `AuthRequiredError` | for `tiktok.com` |
| Required button missing (UI changed, blocked, private account) | `CommandExecutionError` | follow / unfollow: `retryable=true`; comment: `retryable=false` |
| State did not flip within timeout | `CommandExecutionError` | same as above |
| Captcha / rate-limit popup detected | `CommandExecutionError` | same as above |

Note that button-walker mapper does **not** raise `EmptyResultError` — button-not-found is a contract violation, not an empty result. (Same boundary discipline that resolved the `!secUid` blocker in #1384.)

## Test plan
- [x] Local: `npm run build` clean, manifest 764 entries (3 entries updated with new column shapes)
- [x] Local: `clis/tiktok/` 60/60 tests pass (38 read from #1384 + 22 new write contract assertions)
- [x] `node scripts/check-typed-error-lint.mjs` — 190/190, no new violations
- [x] `node scripts/check-silent-column-drop.mjs` — 103/103, no new violations
- [x] `bash scripts/check-doc-coverage.sh` — 140/140 adapters documented
- [x] `node scripts/check-listing-id-pairing.mjs` — clean (write commands aren't listings)
- [ ] CI green (build × 3 / unit × 2 / bun / adapter-test / docs-build / audit)

## Files
- `clis/tiktok/comment.js` (rewrite) — columns `[url, text, result]`
- `clis/tiktok/follow.js` (rewrite) — columns `[username, url, result]`
- `clis/tiktok/unfollow.js` (rewrite) — columns `[username, url, result]`
- `clis/tiktok/utils.js` (extend) — Node validators + browser helper template + Node mapper
- `clis/tiktok/write-refactor.test.js` (new) — 22 contract assertions
- `cli-manifest.json` (regen) — 764 entries; comment/follow/unfollow column shapes updated
- `docs/adapters/browser/tiktok.md` (extend) — column tables for write commands + retryable failure mode table