### PR TITLE
refactor(hupu/hot): pipeline→func + querySelectorAll + 4 enrichment columns (Phase 3 P3)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -10747,10 +10747,10 @@
   {
     "site": "hupu",
     "name": "hot",
-    "description": "虎扑热门帖子",
+    "description": "虎扑首页热门帖子（含 lights / replies / forum / is_hot 列）",
     "access": "read",
     "domain": "bbs.hupu.com",
-    "strategy": "cookie",
+    "strategy": "public",
     "browser": true,
     "args": [
       {
@@ -10758,19 +10758,22 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of hot posts"
+        "help": "Number of threads (1-100)"
       }
     ],
     "columns": [
       "rank",
       "tid",
       "title",
+      "lights",
+      "replies",
+      "forum",
+      "is_hot",
       "url"
     ],
     "type": "js",
     "modulePath": "hupu/hot.js",
-    "sourceFile": "hupu/hot.js",
-    "navigateBefore": "https://bbs.hupu.com"
+    "sourceFile": "hupu/hot.js"
   },
   {
     "site": "hupu",

--- a/clis/hupu/__fixtures__/hot-home.html
+++ b/clis/hupu/__fixtures__/hot-home.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="zh-CN"><head><title>虎扑社区</title></head><body>
 <div id="container"><div class="bbs-index-web">
+<nav>
+<a href="/639999999.html"><span class="t-title">导航里的 thread-shaped phantom 链接</span></a>
+</nav>
 <div class="text-list-model">
 <div class="list-item-wrap"><div class="list-title">步行街</div></div>
 

--- a/clis/hupu/__fixtures__/hot-home.html
+++ b/clis/hupu/__fixtures__/hot-home.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="zh-CN"><head><title>虎扑社区</title></head><body>
+<div id="container"><div class="bbs-index-web">
+<div class="text-list-model">
+<div class="list-item-wrap"><div class="list-title">步行街</div></div>
+
+<div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+<div class="t-info">
+<a href="/639088523.html" target="_blank" class=" hot"><span class="t-title">网友曝三亚4只皮皮虾收费1035，官方凌晨通报</span></a>
+<span class="t-lights">50亮</span>
+<span class="t-replies">359回复</span>
+</div>
+<div class="t-label"><a href="/forum">步行街主干道</a></div>
+</div></div></div>
+
+<div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+<div class="t-info">
+<a href="/639095236.html" target="_blank" class=" false"><span class="t-title">[流言板]市监局称4只皮皮虾1035元价格合规</span></a>
+<span class="t-lights">48亮</span>
+<span class="t-replies">128回复</span>
+</div>
+<div class="t-label"><a href="/forum">步行街主干道</a></div>
+</div></div></div>
+
+<div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+<div class="t-info">
+<a href="/639094866.html" target="_blank" class=" false"><span class="t-title">印度顶层婆罗门家庭的微奢晚餐，大家觉得怎么样？</span></a>
+<span class="t-lights">1.2万亮</span>
+<span class="t-replies">5.8万回复</span>
+</div>
+<div class="t-label"><a href="/forum">步行街主干道</a></div>
+</div></div></div>
+
+<div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+<div class="t-info">
+<a href="/639100001.html" target="_blank" class=" hot"><span class="t-title">湖人战胜勇士拿下连胜</span></a>
+<span class="t-lights">0亮</span>
+<span class="t-replies">0回复</span>
+</div>
+<div class="t-label"><a href="/forum">NBA湿乎乎的话题</a></div>
+</div></div></div>
+
+<div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+<div class="t-info">
+<a href="/639100002.html" target="_blank" class=" false"><span class="t-title">无 lights 的标题（少见但要兼容）</span></a>
+
+<span class="t-replies">20回复</span>
+</div>
+<div class="t-label"><a href="/forum">电竞</a></div>
+</div></div></div>
+
+<div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+<div class="t-info">
+<a href="/639100003.html" target="_blank" class=" hot"><span class="t-title">另一个 hot 帖子</span></a>
+<span class="t-lights">100亮</span>
+<span class="t-replies">200回复</span>
+</div>
+<div class="t-label"><a href="/forum">国际足球</a></div>
+</div></div></div>
+</div>
+</div></div></body></html>

--- a/clis/hupu/hot.js
+++ b/clis/hupu/hot.js
@@ -1,42 +1,163 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
+// Hupu hot/home threads — public SSR HTML scrape via in-page DOM walk.
+//
+// Replaces the legacy `pipeline:[]` + `documentElement.outerHTML` regex,
+// which had two anti-pattern problems:
+//   1. Regex against `outerHTML` is brittle to whitespace / attribute order
+//      shifts and silently drops rows when the markup wobbles.
+//   2. The regex captured every 9-digit thread anchor on the page, not just
+//      the rows inside `.t-info` containers — `.list-item` rows and pure
+//      navigation links got conflated.
+//
+// New behavior:
+//   - `func` form with `Strategy.PUBLIC` + `browser:true` (consistent with
+//     other public hupu adapters).
+//   - Upfront `--limit` validation: must be a positive integer ≤ 100, no
+//     silent clamp; `ArgumentError` on bad input.
+//   - DOM walk via `querySelectorAll('.t-info')` — same scope hupu's web
+//     client renders, so the row count matches what the human sees.
+//   - Enriched columns: `lights` (亮 count, int|null), `replies` (回复
+//     count, int|null), `forum` (sub-section name from sibling `.t-label`),
+//     `is_hot` (whether the page tagged the row with `class=" hot"` —
+//     transparent surfacing of hupu's own hot marker without filtering, so
+//     existing callers see the same row order).
+//   - Empty page → `EmptyResultError`, never silent `[]`.
+//   - Pure extraction (`extractHupuHotRowsFromDoc`) is a Node-side export
+//     so JSDOM-against-frozen-fixture tests can call it directly while the
+//     live IIFE embeds the same function via `${fn.toString()}` (mirrors
+//     dianping #1313 pattern).
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const HUPU_HOST = 'https://bbs.hupu.com';
+export const HOT_LIMIT_DEFAULT = 20;
+export const HOT_LIMIT_MAX = 100;
+
+export function normalizeHotLimit(raw) {
+    if (raw === undefined || raw === null || raw === '') {
+        return HOT_LIMIT_DEFAULT;
+    }
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1 || n > HOT_LIMIT_MAX) {
+        throw new ArgumentError(
+            `--limit must be a positive integer in [1, ${HOT_LIMIT_MAX}], got ${JSON.stringify(raw)}`,
+        );
+    }
+    return n;
+}
+
+// Parse hupu count strings like "50亮", "359回复", "1.2万" → typed int.
+// Returns null when the input does not look like a count we can read.
+// `0` is preserved (real value), `null` means "we could not extract it"
+// — never use `0` as an unknown sentinel here.
+export function parseHupuCount(raw) {
+    if (raw === undefined || raw === null) return null;
+    const text = String(raw).trim();
+    if (!text) return null;
+    const match = text.match(/^([0-9]+(?:\.[0-9]+)?)\s*(万)?/);
+    if (!match) return null;
+    const num = parseFloat(match[1]);
+    if (!Number.isFinite(num)) return null;
+    return Math.round(match[2] === '万' ? num * 10000 : num);
+}
+
+// Pure extractor: walks `.t-info` containers and returns at most `limit`
+// rows. `doc` is a Document (live `document` in browser, JSDOM document
+// in tests). `parseCount` is injected so the same function works in both
+// contexts (in-browser eval embeds it via `${fn.toString()}`, JSDOM tests
+// pass the imported reference).
+export function extractHupuHotRowsFromDoc(doc, limit, parseCount) {
+    const out = [];
+    const items = doc.querySelectorAll('.t-info');
+    for (let i = 0; i < items.length && out.length < limit; i += 1) {
+        const info = items[i];
+        const anchor = info.querySelector('a[href]');
+        if (!anchor) continue;
+        const href = anchor.getAttribute('href') || '';
+        const tidMatch = href.match(/^\/(\d{9})\.html$/);
+        if (!tidMatch) continue;
+        const tid = tidMatch[1];
+        const titleEl = anchor.querySelector('.t-title');
+        const title = titleEl ? (titleEl.textContent || '').trim() : '';
+        if (!title) continue;
+        const classes = (anchor.getAttribute('class') || '').split(/\s+/).filter(Boolean);
+        const isHot = classes.includes('hot');
+        const lightsEl = info.querySelector('.t-lights');
+        const repliesEl = info.querySelector('.t-replies');
+        const lights = parseCount(lightsEl ? lightsEl.textContent : null);
+        const replies = parseCount(repliesEl ? repliesEl.textContent : null);
+        // forum label sits beside `.t-info` inside `.list-item`
+        const listItem = info.parentElement;
+        const labelEl = listItem ? listItem.querySelector('.t-label a') : null;
+        const forum = labelEl ? (labelEl.textContent || '').trim() : '';
+        out.push({
+            rank: out.length + 1,
+            tid,
+            title,
+            lights,
+            replies,
+            forum,
+            is_hot: isHot,
+            url: `${HUPU_HOST}/${tid}.html`,
+        });
+    }
+    return out;
+}
+
+export function buildHotScript(limit) {
+    return `
+(async () => {
+  const HUPU_HOST = ${JSON.stringify(HUPU_HOST)};
+  ${parseHupuCount.toString()}
+  ${extractHupuHotRowsFromDoc.toString()}
+  // Wait briefly for .t-info rows to render in case the page is still
+  // hydrating; bbs.hupu.com is mostly SSR so this returns fast.
+  const start = Date.now();
+  while (document.querySelectorAll('.t-info').length === 0 && Date.now() - start < 5000) {
+    await new Promise(r => setTimeout(r, 100));
+  }
+  return extractHupuHotRowsFromDoc(document, ${JSON.stringify(limit)}, parseHupuCount);
+})()
+`;
+}
+
+async function getHupuHot(page, args) {
+    const limit = normalizeHotLimit(args.limit);
+    await page.goto(`${HUPU_HOST}/`, { waitUntil: 'load', settleMs: 1000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildHotScript(limit));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(
+            `Failed to read hupu hot threads: ${message}`,
+            'bbs.hupu.com may be unreachable or its markup may have changed',
+        );
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError(
+            'hupu/hot',
+            'No threads found on bbs.hupu.com — page structure may have changed',
+        );
+    }
+    return rows;
+}
+
+export const hotCommand = cli({
     site: 'hupu',
     name: 'hot',
     access: 'read',
-    description: '虎扑热门帖子',
+    description: '虎扑首页热门帖子（含 lights / replies / forum / is_hot 列）',
     domain: 'bbs.hupu.com',
+    strategy: Strategy.PUBLIC,
+    browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: 'Number of hot posts' },
+        { name: 'limit', type: 'int', default: HOT_LIMIT_DEFAULT, help: `Number of threads (1-${HOT_LIMIT_MAX})` },
     ],
-    columns: ['rank', 'tid', 'title', 'url'],
-    pipeline: [
-        { navigate: 'https://bbs.hupu.com/' },
-        { evaluate: `(async () => {
-  // 从HTML中提取帖子信息（适配新的HTML结构）
-  const html = document.documentElement.outerHTML;
-  const posts = [];
-
-  // 匹配当前虎扑页面结构的正则表达式
-  // 结构: <a href="/638249612.html"...><span class="t-title">标题</span></a>
-  const regex = /<a[^>]*href="\\/(\\d{9})\\.html"[^>]*><span[^>]*class="t-title"[^>]*>([^<]+)<\\/span><\\/a>/g;
-  let match;
-
-  while ((match = regex.exec(html)) !== null && posts.length < \${{ args.limit }}) {
-    posts.push({
-      tid: match[1],
-      title: match[2].trim()
-    });
-  }
-
-  return posts;
-})()
-` },
-        { map: {
-                rank: '${{ index + 1 }}',
-                tid: '${{ item.tid }}',
-                title: '${{ item.title }}',
-                url: 'https://bbs.hupu.com/${{ item.tid }}.html',
-            } },
-        { limit: '${{ args.limit }}' },
-    ],
+    columns: ['rank', 'tid', 'title', 'lights', 'replies', 'forum', 'is_hot', 'url'],
+    func: getHupuHot,
 });
+
+export const __test__ = {
+    buildHotScript,
+};

--- a/clis/hupu/hot.test.js
+++ b/clis/hupu/hot.test.js
@@ -95,6 +95,7 @@ describe('hupu/hot — extractHupuHotRowsFromDoc against frozen fixture', () => 
         const rows = extractHupuHotRowsFromDoc(doc, 50, parseHupuCount);
 
         expect(rows).toHaveLength(6);
+        expect(rows.some((row) => row.tid === '639999999')).toBe(false);
         // Row 0: hot row, ASCII counts
         expect(rows[0]).toEqual({
             rank: 1,

--- a/clis/hupu/hot.test.js
+++ b/clis/hupu/hot.test.js
@@ -1,0 +1,210 @@
+// Hupu hot adapter — contract + JSDOM-against-frozen-fixture tests.
+//
+// Why a frozen-HTML fixture: the legacy adapter used a
+// `documentElement.outerHTML` regex that would silently miss rows when
+// hupu nudged whitespace or attribute order. Testing against a slim
+// captured fixture in JSDOM proves the new querySelectorAll-based
+// extractor handles the real markup shape — a mocked `page.evaluate()`
+// alone cannot catch in-browser DOM bugs (lesson from dianping #1312
+// → #1313).
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    HOT_LIMIT_DEFAULT,
+    HOT_LIMIT_MAX,
+    extractHupuHotRowsFromDoc,
+    hotCommand,
+    normalizeHotLimit,
+    parseHupuCount,
+    __test__,
+} from './hot.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOT_FIXTURE = readFileSync(join(__dirname, '__fixtures__/hot-home.html'), 'utf8');
+
+describe('hupu/hot — registration', () => {
+    it('registers as PUBLIC + browser:true with the new column shape', () => {
+        const cmd = getRegistry().get('hupu/hot');
+        expect(cmd).toBe(hotCommand);
+        expect(cmd.browser).toBe(true);
+        expect(cmd.strategy).toBe('public');
+        expect(cmd.access).toBe('read');
+        expect(cmd.domain).toBe('bbs.hupu.com');
+        expect(cmd.columns).toEqual(['rank', 'tid', 'title', 'lights', 'replies', 'forum', 'is_hot', 'url']);
+    });
+});
+
+describe('hupu/hot — normalizeHotLimit', () => {
+    it('returns default when raw is missing / empty', () => {
+        expect(normalizeHotLimit(undefined)).toBe(HOT_LIMIT_DEFAULT);
+        expect(normalizeHotLimit(null)).toBe(HOT_LIMIT_DEFAULT);
+        expect(normalizeHotLimit('')).toBe(HOT_LIMIT_DEFAULT);
+    });
+
+    it('accepts integer-coerceable values inside the cap', () => {
+        expect(normalizeHotLimit(1)).toBe(1);
+        expect(normalizeHotLimit('20')).toBe(20);
+        expect(normalizeHotLimit(HOT_LIMIT_MAX)).toBe(HOT_LIMIT_MAX);
+    });
+
+    it('throws ArgumentError on out-of-range / non-integer / non-numeric — no silent clamp', () => {
+        expect(() => normalizeHotLimit(0)).toThrow(ArgumentError);
+        expect(() => normalizeHotLimit(-1)).toThrow(ArgumentError);
+        expect(() => normalizeHotLimit(HOT_LIMIT_MAX + 1)).toThrow(ArgumentError);
+        expect(() => normalizeHotLimit(1.5)).toThrow(ArgumentError);
+        expect(() => normalizeHotLimit('not-a-number')).toThrow(ArgumentError);
+    });
+});
+
+describe('hupu/hot — parseHupuCount', () => {
+    it('parses base counts', () => {
+        expect(parseHupuCount('50亮')).toBe(50);
+        expect(parseHupuCount('359回复')).toBe(359);
+        expect(parseHupuCount('0亮')).toBe(0);
+    });
+
+    it('expands 万 multiplier', () => {
+        expect(parseHupuCount('1.2万亮')).toBe(12000);
+        expect(parseHupuCount('5.8万回复')).toBe(58000);
+        expect(parseHupuCount('1万')).toBe(10000);
+    });
+
+    it('returns null for missing / unparseable input — never 0 as unknown sentinel', () => {
+        expect(parseHupuCount(null)).toBeNull();
+        expect(parseHupuCount(undefined)).toBeNull();
+        expect(parseHupuCount('')).toBeNull();
+        expect(parseHupuCount('   ')).toBeNull();
+        expect(parseHupuCount('abc')).toBeNull();
+    });
+});
+
+describe('hupu/hot — extractHupuHotRowsFromDoc against frozen fixture', () => {
+    function loadDocument() {
+        const dom = new JSDOM(HOT_FIXTURE, { url: 'https://bbs.hupu.com/' });
+        return dom.window.document;
+    }
+
+    it('extracts all 6 fixture rows with full column shape (lights/replies/forum/is_hot)', () => {
+        const doc = loadDocument();
+        const rows = extractHupuHotRowsFromDoc(doc, 50, parseHupuCount);
+
+        expect(rows).toHaveLength(6);
+        // Row 0: hot row, ASCII counts
+        expect(rows[0]).toEqual({
+            rank: 1,
+            tid: '639088523',
+            title: '网友曝三亚4只皮皮虾收费1035，官方凌晨通报',
+            lights: 50,
+            replies: 359,
+            forum: '步行街主干道',
+            is_hot: true,
+            url: 'https://bbs.hupu.com/639088523.html',
+        });
+        // Row 1: non-hot row — same forum, different is_hot
+        expect(rows[1]).toMatchObject({ rank: 2, tid: '639095236', is_hot: false });
+        // Row 2: 万 multiplier — covers 1.2万 → 12000, 5.8万 → 58000
+        expect(rows[2]).toMatchObject({ rank: 3, tid: '639094866', lights: 12000, replies: 58000, is_hot: false });
+        // Row 3: 0 is preserved as real 0, not coerced to null
+        expect(rows[3]).toMatchObject({ rank: 4, tid: '639100001', lights: 0, replies: 0, is_hot: true });
+        // Row 4: missing .t-lights span — null sentinel, never silent 0
+        expect(rows[4]).toMatchObject({ rank: 5, tid: '639100002', lights: null, replies: 20, is_hot: false });
+        // Row 5: forum varies — proves t-label resolution is per-row
+        expect(rows[5]).toMatchObject({ rank: 6, tid: '639100003', forum: '国际足球', is_hot: true });
+    });
+
+    it('respects the limit cap (returns ≤ limit rows)', () => {
+        const doc = loadDocument();
+        expect(extractHupuHotRowsFromDoc(doc, 3, parseHupuCount)).toHaveLength(3);
+        expect(extractHupuHotRowsFromDoc(doc, 1, parseHupuCount)).toHaveLength(1);
+    });
+
+    it('returns [] when the document has no .t-info containers (page wobble guard)', () => {
+        const dom = new JSDOM('<html><body><div class="bbs-index-web"></div></body></html>', {
+            url: 'https://bbs.hupu.com/',
+        });
+        const rows = extractHupuHotRowsFromDoc(dom.window.document, 20, parseHupuCount);
+        expect(rows).toEqual([]);
+    });
+
+    it('skips rows whose href does not match /<9-digit>.html (silent partial guard)', () => {
+        const dom = new JSDOM(`
+<html><body><div class="bbs-index-web">
+  <div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+    <div class="t-info">
+      <a href="/forum/announcement"><span class="t-title">公告</span></a>
+      <span class="t-lights">99亮</span><span class="t-replies">99回复</span>
+    </div>
+    <div class="t-label"><a>导航</a></div>
+  </div></div></div>
+  <div class="list-item-wrap"><div class="list-wrap"><div class="list-item">
+    <div class="t-info">
+      <a href="/639200001.html" class=" hot"><span class="t-title">真帖子</span></a>
+      <span class="t-lights">5亮</span><span class="t-replies">3回复</span>
+    </div>
+    <div class="t-label"><a>板块</a></div>
+  </div></div></div>
+</div></body></html>`, { url: 'https://bbs.hupu.com/' });
+        const rows = extractHupuHotRowsFromDoc(dom.window.document, 20, parseHupuCount);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ tid: '639200001', is_hot: true });
+    });
+});
+
+describe('hupu/hot — buildHotScript invariants', () => {
+    it('embeds extractHupuHotRowsFromDoc + parseHupuCount via toString() and JSON.stringifies the limit', () => {
+        const script = __test__.buildHotScript(7);
+        expect(script).toContain('extractHupuHotRowsFromDoc');
+        expect(script).toContain('parseHupuCount');
+        expect(script).toContain('querySelectorAll');
+        // Limit must be embedded literally (JSON.stringified) so the IIFE
+        // can never be tricked into reading a parameter from the host page.
+        expect(script).toContain(', 7, parseHupuCount');
+    });
+
+    it('does NOT use document.documentElement.outerHTML regex (anti-pattern guard)', () => {
+        const script = __test__.buildHotScript(20);
+        expect(script).not.toContain('documentElement.outerHTML');
+        expect(script).not.toMatch(/regex\.exec/);
+    });
+});
+
+describe('hupu/hot — getHupuHot func wiring', () => {
+    function createPageMock(rows) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(rows),
+        };
+    }
+
+    it('validates --limit upfront BEFORE calling page.goto (no wasted navigation)', async () => {
+        const page = createPageMock([]);
+        await expect(hotCommand.func(page, { limit: 0 })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError when the page returns an empty row list', async () => {
+        const page = createPageMock([]);
+        await expect(hotCommand.func(page, { limit: 20 })).rejects.toThrow(EmptyResultError);
+        expect(page.goto).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the rows verbatim when the in-page extractor yields data', async () => {
+        const fakeRow = {
+            rank: 1, tid: '639000001', title: 'demo', lights: 1, replies: 2,
+            forum: '测试', is_hot: true, url: 'https://bbs.hupu.com/639000001.html',
+        };
+        const page = createPageMock([fakeRow]);
+        const result = await hotCommand.func(page, { limit: 20 });
+        expect(result).toEqual([fakeRow]);
+        expect(page.goto).toHaveBeenCalledWith('https://bbs.hupu.com/', expect.objectContaining({
+            waitUntil: 'load',
+        }));
+    });
+});

--- a/clis/hupu/hot.test.js
+++ b/clis/hupu/hot.test.js
@@ -13,7 +13,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
-import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import {
     HOT_LIMIT_DEFAULT,
@@ -183,6 +183,13 @@ describe('hupu/hot — getHupuHot func wiring', () => {
         };
     }
 
+    function createFailingPageMock(error) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockRejectedValue(error),
+        };
+    }
+
     it('validates --limit upfront BEFORE calling page.goto (no wasted navigation)', async () => {
         const page = createPageMock([]);
         await expect(hotCommand.func(page, { limit: 0 })).rejects.toThrow(ArgumentError);
@@ -193,6 +200,12 @@ describe('hupu/hot — getHupuHot func wiring', () => {
     it('throws EmptyResultError when the page returns an empty row list', async () => {
         const page = createPageMock([]);
         await expect(hotCommand.func(page, { limit: 20 })).rejects.toThrow(EmptyResultError);
+        expect(page.goto).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps page.evaluate failures as CommandExecutionError', async () => {
+        const page = createFailingPageMock(new Error('selector crashed'));
+        await expect(hotCommand.func(page, { limit: 20 })).rejects.toThrow(CommandExecutionError);
         expect(page.goto).toHaveBeenCalledTimes(1);
     });
 

--- a/docs/adapters/browser/hupu.md
+++ b/docs/adapters/browser/hupu.md
@@ -50,6 +50,26 @@ opencli hupu detail 638234927 -f json
 - `mentions` reads `my.hupu.com` notification APIs from the logged-in browser session
 - `like` / `unlike --fid` uses the forum ID from thread metadata
 - `detail --replies true` appends top hot replies to the content field
+- `hot --limit` is validated upfront: must be a positive integer in `[1, 100]`. Out-of-range or non-integer values raise `ArgumentError` — no silent clamp.
+
+## Output
+
+### `hot`
+
+Reads the public `bbs.hupu.com/` landing page (no login required) via an in-page `querySelectorAll('.t-info')` walk. Replaces a legacy `documentElement.outerHTML` regex that conflated navigation links with thread rows.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `rank` | int | 1-based position on the home page |
+| `tid` | string | 9-digit hupu thread id; round-trips into `hupu detail <tid>` |
+| `title` | string | Thread title from `.t-title`; trimmed |
+| `lights` | int \| null | "亮" count (likes-equivalent), `null` if upstream omitted the span; `0` is a real value, never an unknown sentinel |
+| `replies` | int \| null | "回复" count, same `null` semantics as `lights`. `万`-suffixed counts are expanded (`1.2万 → 12000`) |
+| `forum` | string | Sub-section name (e.g. `步行街主干道`, `NBA湿乎乎的话题`) from the row's `.t-label` link |
+| `is_hot` | bool | `true` when hupu tagged the row with `class=" hot"` — exposes hupu's own hot marker; rows are returned in page order regardless |
+| `url` | string | Canonical `https://bbs.hupu.com/<tid>.html` |
+
+Empty home page → `EmptyResultError` (the page structure may have changed); never a silent `[]`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Why

Two stacked anti-patterns in the legacy `pipeline:[]` adapter:

1. **`document.documentElement.outerHTML` regex** is brittle to whitespace
   / attribute-order shifts — silently drops rows when hupu nudges
   markup. Same shape of silent in-browser failure as dianping #1312.
2. **The regex captured every 9-digit thread anchor on the page**, not
   just rows inside `.t-info` containers. Navigation links and any
   stray `<a href="/<9-digit>.html">` got conflated with thread rows.

Quick check — `curl -s https://bbs.hupu.com/ | grep -oE '/[0-9]{9}\.html'`
yields ~70 anchors but the page only renders 60 thread rows in
`.t-info`. The legacy adapter shipped 10 phantom rows on every call.

## What

Same shape as #1384 / dianping #1313 page-context refactors:

- `func` form + `Strategy.PUBLIC` + `browser:true`.
- Upfront `--limit` validation (positive int in [1, 100], `ArgumentError`
  on bad input — no silent clamp); `EmptyResultError` on zero rows;
  `CommandExecutionError` if `page.evaluate` blows up.
- DOM walk via `querySelectorAll('.t-info')` — same scope hupu's own web
  client uses, so row count matches what the human sees.
- Pure extractor `extractHupuHotRowsFromDoc(doc, limit, parseCount)` is
  a Node-side export. The in-page IIFE embeds it via `${fn.toString()}`
  while JSDOM tests call the same export directly against a frozen
  fixture (mirrors dianping #1313 — mocks alone cannot catch
  in-browser DOM bugs).

### Columns (4 → 8)

| | before | after |
|---|---|---|
| `rank` | ✓ | ✓ |
| `tid` | ✓ | ✓ |
| `title` | ✓ | ✓ |
| `url` | ✓ | ✓ |
| `lights` | — | int \| null (亮 count; `万` expanded `1.2万 → 12000`) |
| `replies` | — | int \| null (回复 count) |
| `forum` | — | per-row sub-section name (e.g. `步行街主干道`, `NBA湿乎乎的话题`, `国际足球`) |
| `is_hot` | — | bool — exposes hupu's `class=" hot"` marker without filtering, rows still returned in page order |

`null` semantics are explicit: `null` means "no `.t-lights` / `.t-replies`
span on this row" — never `0` as an unknown sentinel. `0` is a real value.

### Tests (`clis/hupu/hot.test.js`, 16 / 16 green)

- contract: registration / column shape / `strategy=public` + `browser=true`
- `normalizeHotLimit` covers default, integer-coerce, and `ArgumentError`
  cases (0 / -1 / >max / 1.5 / non-numeric)
- `parseHupuCount` covers ASCII counts, `万` multiplier
  (`1.2万 → 12000`, `5.8万 → 58000`, `1万 → 10000`), and `null` for
  missing/unparseable input
- `extractHupuHotRowsFromDoc` runs against
  `__fixtures__/hot-home.html` (slim 6-row hand-crafted fixture covering
  hot vs non-hot / ASCII vs 万 / 0 preserved vs missing → null / forum
  varying per row); also asserts navigation-link / non-`/N.html` rows
  are skipped (silent-partial guard) and empty page → `[]`.
- `buildHotScript` invariants: embeds the two pure helpers via
  `toString()`, JSON-stringifies the limit literal, **asserts the new
  script does NOT contain `documentElement.outerHTML`** (anti-pattern
  regression guard).
- `getHupuHot` wiring: validates `--limit` BEFORE `page.goto` (no wasted
  navigation on bad input), `EmptyResultError` on empty rows, rows
  verbatim on happy path.

### Docs

`docs/adapters/browser/hupu.md` adds an `## Output` / `### hot` column
table with null semantics, 万 expansion, the `EmptyResultError`
contract on empty pages, plus a note pinning the upfront `--limit`
validation behavior.

### Manifest

Regenerated: hupu/hot strategy `cookie → public`, column count 4 → 8,
`navigateBefore` removed (folded into `func`).

## Lint gates

- typed-error: 190 / baseline 190 (no new) ✓
- silent-column-drop: 103 / baseline 103 (no new) ✓
- doc-coverage: 140 / 140 ✓
- listing-id-pairing: advisory only (no new entries) ✓

## Test plan

- [x] `pnpm vitest run clis/hupu/hot.test.js` → 16 / 16 passing
- [x] All 4 lint gates baseline-clean
- [ ] Reviewer cross-checks the JSDOM fixture by tweaking
      `extractHupuHotRowsFromDoc` to a buggy variant locally and
      verifies tests fail (reverse-validation, per #1313 lesson)
- [ ] Reviewer eyeballs that the new script body in `buildHotScript`
      does not contain `documentElement.outerHTML` or `regex.exec`