### PR TITLE
refactor(xiaoe): pipeline→func + typed errors + content silent-drop fix (Phase 3 P1)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -24293,6 +24293,7 @@
     ],
     "columns": [
       "title",
+      "content",
       "content_length",
       "image_count"
     ],

--- a/clis/xiaoe/catalog.js
+++ b/clis/xiaoe/catalog.js
@@ -20,7 +20,8 @@
 //     source of truth.
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { requireXiaoePageUrl } from './content.js';
 
 // resource_type → human label. 1=图文 2=直播 3=音频 4=视频 6=专栏 8=大专栏.
 // Returns the raw `String(t)` when the type is unknown (e.g. xiaoe rolls
@@ -185,13 +186,10 @@ export function buildCatalogScript() {
 }
 
 async function getXiaoeCatalog(page, args) {
-    const url = typeof args.url === 'string' ? args.url.trim() : '';
-    if (!url) {
-        throw new ArgumentError('url is required (positional)');
-    }
-    await page.goto(url, { waitUntil: 'load', settleMs: 8000 });
+    const url = requireXiaoePageUrl(args.url, 'catalog');
     let rows;
     try {
+        await page.goto(url, { waitUntil: 'load', settleMs: 8000 });
         rows = await page.evaluate(buildCatalogScript());
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/clis/xiaoe/catalog.js
+++ b/clis/xiaoe/catalog.js
@@ -1,19 +1,57 @@
+// Xiaoe (小鹅通) catalog — list chapters + sections of a course / column
+// page (`h5.xet.citv.cn`).
+//
+// Replaces the legacy `pipeline:[]` form. The in-browser extraction logic
+// (Vue store walking + auto-scroll-to-load + Vue child traversal) is kept
+// byte-for-byte — Xiaoe's pages are SPA-rendered and Vue's private API
+// (`__vue__`, `$store`, `$children`, `chapter_box.__vue__`) is the only
+// stable hook we have. JSDOM cannot reproduce the Vue runtime tree, so
+// reorganising the IIFE without live verify would be silent-failure risk.
+//
+// What changes:
+//   - `func` form + `Strategy.COOKIE` + `browser:true`.
+//   - Typed errors: `ArgumentError` on missing url; `EmptyResultError`
+//     when the IIFE yields zero rows (almost always means the cookie
+//     expired or the URL is not a course page); `CommandExecutionError`
+//     when `page.evaluate` rejects.
+//   - Three pure helpers (`typeLabel`, `buildItemUrl`, `chapterUrlPath`)
+//     are module-level exports and are embedded into the in-page IIFE
+//     via `${fn.toString()}` so the live and the test path share one
+//     source of truth.
+
 import { cli, Strategy } from '@jackwener/opencli/registry';
-cli({
-    site: 'xiaoe',
-    name: 'catalog',
-    access: 'read',
-    description: '小鹅通课程目录（支持普通课程、专栏、大专栏）',
-    domain: 'h5.xet.citv.cn',
-    strategy: Strategy.COOKIE,
-    args: [
-        { name: 'url', required: true, positional: true, help: '课程页面 URL' },
-    ],
-    columns: ['ch', 'chapter', 'no', 'title', 'type', 'resource_id', 'url', 'status'],
-    pipeline: [
-        { navigate: '${{ args.url }}' },
-        { wait: 8 },
-        { evaluate: `(async () => {
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+// resource_type → human label. 1=图文 2=直播 3=音频 4=视频 6=专栏 8=大专栏.
+// Returns the raw `String(t)` when the type is unknown (e.g. xiaoe rolls
+// out a new resource type) — never silently swallows it.
+export function typeLabel(t) {
+    const map = { 1: '图文', 2: '直播', 3: '音频', 4: '视频', 6: '专栏', 8: '大专栏' };
+    return map[Number(t)] || String(t || '');
+}
+
+// Resolve a relative `jump_url` / `h5_url` / `url` against the page's
+// origin. Returns '' when the item has no URL field at all.
+export function buildItemUrl(item, origin) {
+    const u = item.jump_url || item.h5_url || item.url || '';
+    if (!u) return '';
+    return u.startsWith('http') ? u : (origin + u);
+}
+
+// chapter_type → URL path for the section reader. Xiaoe routes chapter
+// types to different player paths; returning `undefined` for unknown
+// types lets the caller decide whether to emit `''` instead of guessing
+// a bad URL.
+export function chapterUrlPath(chType) {
+    const map = { 1: '/v1/course/text/', 2: '/v2/course/alive/', 3: '/v1/course/audio/', 4: '/v1/course/video/' };
+    return map[Number(chType)];
+}
+
+export function buildCatalogScript() {
+    return `(async () => {
+  ${typeLabel.toString()}
+  ${buildItemUrl.toString()}
+  ${chapterUrlPath.toString()}
   var el = document.querySelector('#app');
   var store = (el && el.__vue__) ? el.__vue__.$store : null;
   if (!store) return [];
@@ -22,13 +60,6 @@ cli({
   var origin = window.location.origin;
   var courseName = coreInfo.resource_name || '';
 
-  function typeLabel(t) {
-    return {1:'图文',2:'直播',3:'音频',4:'视频',6:'专栏',8:'大专栏'}[Number(t)] || String(t||'');
-  }
-  function buildUrl(item) {
-    var u = item.jump_url || item.h5_url || item.url || '';
-    return (u && !u.startsWith('http')) ? origin + u : u;
-  }
   function clickTab(name) {
     var tabs = document.querySelectorAll('span, div');
     for (var i = 0; i < tabs.length; i++) {
@@ -61,7 +92,7 @@ cli({
       if(scrollers[si].scrollHeight > scrollers[si].clientHeight) scrollers[si].scrollTop = scrollers[si].scrollHeight;
     }
     await new Promise(function(r) { setTimeout(r, 800); });
-    
+
     // 点击可能存在的下拉/加载更多
     var moreTabs = document.querySelectorAll('span, div, p');
     for (var bi = 0; bi < moreTabs.length; bi++) {
@@ -70,7 +101,7 @@ cli({
         try { moreTabs[bi].click(); } catch(e){}
       }
     }
-    
+
     var maxScrollHeight = getMaxScrollHeight(getScrollTargets());
     if (sc > 3 && maxScrollHeight === prevMaxScrollHeight) break;
     prevMaxScrollHeight = maxScrollHeight;
@@ -92,11 +123,13 @@ cli({
             var item = arr[j];
             if (!item.resource_id || !/^[pvlai]_/.test(item.resource_id)) continue;
             listData.push({
-              ch: 1, chapter: courseName, no: j + 1,
+              ch: 1,
+              chapter: courseName,
+              no: j + 1,
               title: item.resource_title || item.title || item.chapter_title || '',
               type: typeLabel(item.resource_type || item.chapter_type),
               resource_id: item.resource_id,
-              url: buildUrl(item),
+              url: buildItemUrl(item, origin),
               status: item.finished_state === 1 ? '已完成' : (item.resource_count ? item.resource_count + '节' : ''),
             });
           }
@@ -134,9 +167,11 @@ cli({
       var child = children[ck];
       var resId = child.resource_id || child.chapter_id || '';
       var chType = child.chapter_type || child.resource_type || 0;
-      var urlPath = {1:'/v1/course/text/',2:'/v2/course/alive/',3:'/v1/course/audio/',4:'/v1/course/video/'}[Number(chType)];
+      var urlPath = chapterUrlPath(chType);
       result.push({
-        ch: cj + 1, chapter: chTitle, no: ck + 1,
+        ch: cj + 1,
+        chapter: chTitle,
+        no: ck + 1,
         title: child.chapter_title || child.resource_title || '',
         type: typeLabel(chType),
         resource_id: resId,
@@ -146,17 +181,49 @@ cli({
     }
   }
   return result;
-})()
-` },
-        { map: {
-                ch: '${{ item.ch }}',
-                chapter: '${{ item.chapter }}',
-                no: '${{ item.no }}',
-                title: '${{ item.title }}',
-                type: '${{ item.type }}',
-                resource_id: '${{ item.resource_id }}',
-                url: '${{ item.url }}',
-                status: '${{ item.status }}',
-            } },
+})()`;
+}
+
+async function getXiaoeCatalog(page, args) {
+    const url = typeof args.url === 'string' ? args.url.trim() : '';
+    if (!url) {
+        throw new ArgumentError('url is required (positional)');
+    }
+    await page.goto(url, { waitUntil: 'load', settleMs: 8000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildCatalogScript());
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(
+            `Failed to read xiaoe catalog: ${message}`,
+            'page may not have rendered or auth may be required',
+        );
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError(
+            'xiaoe/catalog',
+            'No catalog rows extracted — the URL may not be a course page or the login session has expired',
+        );
+    }
+    return rows;
+}
+
+export const catalogCommand = cli({
+    site: 'xiaoe',
+    name: 'catalog',
+    access: 'read',
+    description: '小鹅通课程目录（支持普通课程、专栏、大专栏）',
+    domain: 'h5.xet.citv.cn',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'url', required: true, positional: true, help: '课程页面 URL' },
     ],
+    columns: ['ch', 'chapter', 'no', 'title', 'type', 'resource_id', 'url', 'status'],
+    func: getXiaoeCatalog,
 });
+
+export const __test__ = {
+    buildCatalogScript,
+};

--- a/clis/xiaoe/content.js
+++ b/clis/xiaoe/content.js
@@ -1,40 +1,148 @@
+// Xiaoe (小鹅通) content extractor — pulls rendered article text from a
+// rich-text page (h5.xet.citv.cn).
+//
+// Replaces the legacy `pipeline:[]` form. Two real bugs in the legacy
+// adapter, both silent:
+//   1. The IIFE returned `{title, content, content_length, image_count,
+//      images}` but `columns` declared `[title, content_length,
+//      image_count]` — `content` (the text the adapter exists to
+//      extract!) and `images` were silently dropped before reaching the
+//      caller. The user got "this article has 1234 chars" with no way
+//      to read those chars.
+//   2. `JSON.stringify(images.slice(0, 20))` silently truncated to the
+//      first 20 image URLs and never told the caller the slice
+//      happened.
+//
+// New behavior:
+//   - `func` form + `Strategy.COOKIE` + `browser:true` (the page is
+//     gated behind a logged-in xiaoe session).
+//   - Pure helpers `pickContentText` / `countXiaoeImages` are
+//     module-level exports; the in-page IIFE embeds them via
+//     `${fn.toString()}` while JSDOM tests call the same exports
+//     directly against a hand-crafted fixture (same pattern as
+//     dianping #1313 / hupu #1387).
+//   - `content` is now a real column (the bug fix). `image_count` is
+//     metadata that helps callers decide whether to re-render the
+//     page for a JSON-image dump in a follow-up adapter.
+//   - Empty-content extraction → `EmptyResultError` with a
+//     login-likely hint (xiaoe routinely renders an empty shell when
+//     the cookie has expired). No silent `return [{ content: '' }]`.
+
 import { cli, Strategy } from '@jackwener/opencli/registry';
-cli({
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const CONTENT_SELECTORS = [
+    '.rich-text-wrap',
+    '.content-wrap',
+    '.article-content',
+    '.text-content',
+    '.course-detail',
+    '.detail-content',
+    '[class*="richtext"]',
+    '[class*="rich-text"]',
+    '.ql-editor',
+];
+export const CONTENT_MIN_LENGTH = 50;
+
+// Pure: walk `selectors` in order, return the trimmed text of the first
+// element whose `.innerText` (with `.textContent` fallback for JSDOM)
+// has more than `minLength` characters. Falls back to `<main>`, then
+// `#app`, then `<body>` — same chain the legacy IIFE used.
+export function pickContentText(doc, selectors, minLength = CONTENT_MIN_LENGTH) {
+    for (const sel of selectors) {
+        const el = doc.querySelector(sel);
+        if (!el) continue;
+        const text = ((el.innerText || el.textContent) || '').trim();
+        if (text.length > minLength) return text;
+    }
+    const fallback = doc.querySelector('main')
+        || doc.querySelector('#app')
+        || doc.body;
+    if (!fallback) return '';
+    return ((fallback.innerText || fallback.textContent) || '').trim();
+}
+
+// Pure: count `<img>` elements whose src looks like a real xiaoe-hosted
+// asset. `data:` URIs and non-xiaoe CDNs (avatars, ads) are excluded.
+export function countXiaoeImages(doc) {
+    let count = 0;
+    const imgs = doc.querySelectorAll('img');
+    for (let i = 0; i < imgs.length; i += 1) {
+        const src = imgs[i].getAttribute('src') || imgs[i].src || '';
+        if (!src) continue;
+        if (src.startsWith('data:')) continue;
+        if (!src.includes('xiaoe')) continue;
+        count += 1;
+    }
+    return count;
+}
+
+export function buildContentScript() {
+    return `
+(() => {
+  ${pickContentText.toString()}
+  ${countXiaoeImages.toString()}
+  const selectors = ${JSON.stringify(CONTENT_SELECTORS)};
+  const title = document.title || '';
+  const content = pickContentText(document, selectors, ${JSON.stringify(CONTENT_MIN_LENGTH)});
+  const imageCount = countXiaoeImages(document);
+  return [{
+    title,
+    content,
+    content_length: content.length,
+    image_count: imageCount,
+  }];
+})()
+`;
+}
+
+async function getXiaoeContent(page, args) {
+    const url = typeof args.url === 'string' ? args.url.trim() : '';
+    if (!url) {
+        throw new ArgumentError('url is required (positional)');
+    }
+    await page.goto(url, { waitUntil: 'load', settleMs: 6000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildContentScript());
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(
+            `Failed to extract xiaoe content: ${message}`,
+            'page may not have rendered or auth may be required',
+        );
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError(
+            'xiaoe/content',
+            'No rows returned from page evaluator (page structure may have changed)',
+        );
+    }
+    const row = rows[0];
+    if (!row || typeof row.content !== 'string' || row.content.length === 0) {
+        throw new EmptyResultError(
+            'xiaoe/content',
+            'No article content extracted — login session may have expired or the page renders an empty shell',
+        );
+    }
+    return rows;
+}
+
+export const contentCommand = cli({
     site: 'xiaoe',
     name: 'content',
     access: 'read',
     description: '提取小鹅通图文页面内容为文本',
     domain: 'h5.xet.citv.cn',
     strategy: Strategy.COOKIE,
+    browser: true,
     args: [
         { name: 'url', required: true, positional: true, help: '页面 URL' },
     ],
-    columns: ['title', 'content_length', 'image_count'],
-    pipeline: [
-        { navigate: '${{ args.url }}' },
-        { wait: 6 },
-        { evaluate: `(() => {
-  var selectors = ['.rich-text-wrap','.content-wrap','.article-content','.text-content',
-    '.course-detail','.detail-content','[class*="richtext"]','[class*="rich-text"]','.ql-editor'];
-  var content = '';
-  for (var i = 0; i < selectors.length; i++) {
-    var el = document.querySelector(selectors[i]);
-    if (el && el.innerText.trim().length > 50) { content = el.innerText.trim(); break; }
-  }
-  if (!content) content = (document.querySelector('main') || document.querySelector('#app') || document.body).innerText.trim();
-
-  var images = [];
-  document.querySelectorAll('img').forEach(function(img) {
-    if (img.src && !img.src.startsWith('data:') && img.src.includes('xiaoe')) images.push(img.src);
-  });
-  return [{
-    title: document.title,
-    content: content,
-    content_length: content.length,
-    image_count: images.length,
-    images: JSON.stringify(images.slice(0, 20)),
-  }];
-})()
-` },
-    ],
+    columns: ['title', 'content', 'content_length', 'image_count'],
+    func: getXiaoeContent,
 });
+
+export const __test__ = {
+    buildContentScript,
+};

--- a/clis/xiaoe/content.js
+++ b/clis/xiaoe/content.js
@@ -77,6 +77,36 @@ export function countXiaoeImages(doc) {
     return count;
 }
 
+export function requireXiaoePageUrl(value, commandName) {
+    const raw = typeof value === 'string' ? value.trim() : '';
+    if (!raw) {
+        throw new ArgumentError('url is required (positional)');
+    }
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch {
+        throw new ArgumentError(
+            `invalid xiaoe URL: ${raw}`,
+            `Example: opencli xiaoe ${commandName} https://appxxxx.h5.xet.citv.cn/p/course/ecourse/v_xxxxx`,
+        );
+    }
+    if (parsed.protocol !== 'https:') {
+        throw new ArgumentError(
+            `xiaoe URL must use https (got ${parsed.protocol.replace(':', '')})`,
+            `Example: opencli xiaoe ${commandName} https://appxxxx.h5.xet.citv.cn/p/course/ecourse/v_xxxxx`,
+        );
+    }
+    const host = parsed.hostname.toLowerCase();
+    if (host !== 'h5.xet.citv.cn' && !host.endsWith('.h5.xet.citv.cn')) {
+        throw new ArgumentError(
+            `url must be on h5.xet.citv.cn or a shop subdomain (got ${parsed.hostname})`,
+            `Example: opencli xiaoe ${commandName} https://appxxxx.h5.xet.citv.cn/p/course/ecourse/v_xxxxx`,
+        );
+    }
+    return parsed.toString();
+}
+
 export function buildContentScript() {
     return `
 (() => {
@@ -97,13 +127,10 @@ export function buildContentScript() {
 }
 
 async function getXiaoeContent(page, args) {
-    const url = typeof args.url === 'string' ? args.url.trim() : '';
-    if (!url) {
-        throw new ArgumentError('url is required (positional)');
-    }
-    await page.goto(url, { waitUntil: 'load', settleMs: 6000 });
+    const url = requireXiaoePageUrl(args.url, 'content');
     let rows;
     try {
+        await page.goto(url, { waitUntil: 'load', settleMs: 6000 });
         rows = await page.evaluate(buildContentScript());
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/clis/xiaoe/courses.js
+++ b/clis/xiaoe/courses.js
@@ -90,9 +90,9 @@ export function buildCoursesScript() {
 }
 
 async function getXiaoeCourses(page) {
-    await page.goto('https://study.xiaoe-tech.com/', { waitUntil: 'load', settleMs: 8000 });
     let rows;
     try {
+        await page.goto('https://study.xiaoe-tech.com/', { waitUntil: 'load', settleMs: 8000 });
         rows = await page.evaluate(buildCoursesScript());
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/clis/xiaoe/courses.js
+++ b/clis/xiaoe/courses.js
@@ -1,16 +1,51 @@
+// Xiaoe (小鹅通) purchased-courses list — pulls "已购内容" tab cards from
+// `study.xiaoe-tech.com`.
+//
+// Replaces the legacy `pipeline:[]` form. The in-page extraction logic
+// (Vue `__vue__.$parent` walk to match a card title back to the original
+// purchase entry) is kept byte-for-byte — Xiaoe's purchase list is not
+// exposed as a public JSON endpoint, and Vue's private runtime tree is
+// the only stable hook. JSDOM cannot reproduce the Vue runtime, so
+// rewriting the IIFE without live verify would be silent-failure risk.
+//
+// What changes:
+//   - `func` form + `Strategy.COOKIE` + `browser:true`.
+//   - Typed errors: `EmptyResultError` when zero card rows are found
+//     (almost always means the cookie expired); `CommandExecutionError`
+//     when `page.evaluate` rejects.
+//   - One pure helper (`buildCourseUrl`) is extracted as a module-level
+//     export; the in-page IIFE embeds it via `${fn.toString()}` so the
+//     live and test paths share one source of truth. The helper covers
+//     the three URL fallbacks the legacy code had inline:
+//       1. `entry.h5_url` if present
+//       2. `entry.url` if present
+//       3. otherwise build from `app_id` + `resource_id` + `resource_type`
+//          (column course `resource_type === 6` gets the `/v1/course/column/`
+//          path, everything else gets `/p/course/ecourse/`)
+
 import { cli, Strategy } from '@jackwener/opencli/registry';
-cli({
-    site: 'xiaoe',
-    name: 'courses',
-    access: 'read',
-    description: '列出已购小鹅通课程（含 URL 和店铺名）',
-    domain: 'study.xiaoe-tech.com',
-    strategy: Strategy.COOKIE,
-    columns: ['title', 'shop', 'url'],
-    pipeline: [
-        { navigate: 'https://study.xiaoe-tech.com/' },
-        { wait: 8 },
-        { evaluate: `(async () => {
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+// Pure: derive the canonical course URL for a single purchase entry.
+// Returns '' when `entry` is missing the fields we'd need to construct
+// any of the three forms — never makes up a partial URL.
+export function buildCourseUrl(entry) {
+    if (!entry) return '';
+    if (entry.h5_url) return entry.h5_url;
+    if (entry.url) return entry.url;
+    if (entry.app_id && entry.resource_id) {
+        const base = 'https://' + entry.app_id + '.h5.xet.citv.cn';
+        if (entry.resource_type === 6) {
+            return base + '/v1/course/column/' + entry.resource_id + '?type=3';
+        }
+        return base + '/p/course/ecourse/' + entry.resource_id;
+    }
+    return '';
+}
+
+export function buildCoursesScript() {
+    return `(async () => {
+  ${buildCourseUrl.toString()}
   // 切换到「内容」tab
   var tabs = document.querySelectorAll('span, div');
   for (var i = 0; i < tabs.length; i++) {
@@ -37,18 +72,6 @@ cli({
     return vm.$parent ? matchEntry(title, vm.$parent, depth + 1) : null;
   }
 
-  // 构造课程 URL
-  function buildUrl(entry) {
-    if (entry.h5_url) return entry.h5_url;
-    if (entry.url) return entry.url;
-    if (entry.app_id && entry.resource_id) {
-      var base = 'https://' + entry.app_id + '.h5.xet.citv.cn';
-      if (entry.resource_type === 6) return base + '/v1/course/column/' + entry.resource_id + '?type=3';
-      return base + '/p/course/ecourse/' + entry.resource_id;
-    }
-    return '';
-  }
-
   var cards = document.querySelectorAll('.course-card-list');
   var results = [];
   for (var c = 0; c < cards.length; c++) {
@@ -59,12 +82,46 @@ cli({
     results.push({
       title: title,
       shop: entry ? (entry.shop_name || entry.app_name || '') : '',
-      url: entry ? buildUrl(entry) : '',
+      url: entry ? buildCourseUrl(entry) : '',
     });
   }
   return results;
-})()
-` },
-        { map: { title: '${{ item.title }}', shop: '${{ item.shop }}', url: '${{ item.url }}' } },
-    ],
+})()`;
+}
+
+async function getXiaoeCourses(page) {
+    await page.goto('https://study.xiaoe-tech.com/', { waitUntil: 'load', settleMs: 8000 });
+    let rows;
+    try {
+        rows = await page.evaluate(buildCoursesScript());
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(
+            `Failed to list xiaoe courses: ${message}`,
+            'page may not have rendered or auth may be required',
+        );
+    }
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new EmptyResultError(
+            'xiaoe/courses',
+            'No purchased courses found — login session may have expired or the "内容" tab has no items',
+        );
+    }
+    return rows;
+}
+
+export const coursesCommand = cli({
+    site: 'xiaoe',
+    name: 'courses',
+    access: 'read',
+    description: '列出已购小鹅通课程（含 URL 和店铺名）',
+    domain: 'study.xiaoe-tech.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    columns: ['title', 'shop', 'url'],
+    func: getXiaoeCourses,
 });
+
+export const __test__ = {
+    buildCoursesScript,
+};

--- a/clis/xiaoe/xiaoe.test.js
+++ b/clis/xiaoe/xiaoe.test.js
@@ -1,0 +1,441 @@
+// Xiaoe adapter contract + helper tests.
+//
+// The IIFEs walk Vue's private runtime tree (`__vue__`, `$store`,
+// `$children`) which JSDOM cannot reproduce — testing the full IIFE
+// against a frozen fixture is not viable here. Instead this file
+// exercises:
+//   1. The pure helpers each IIFE embeds via `${fn.toString()}` — these
+//      are also called from JSDOM where the surface (URL building,
+//      simple DOM walks) does work without a Vue runtime.
+//   2. Each adapter's `func`-form wiring: upfront validation, typed
+//      errors on empty results, rows passed through verbatim on the
+//      happy path, no wasted `page.goto` on bad input.
+//   3. The `build*Script` outputs: the embedded helpers must be
+//      present, anti-patterns from the legacy adapters (silent column
+//      drop, silent slice truncation) must NOT regress.
+
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    CONTENT_SELECTORS,
+    contentCommand,
+    countXiaoeImages,
+    pickContentText,
+    __test__ as contentTest,
+} from './content.js';
+import {
+    buildItemUrl,
+    catalogCommand,
+    chapterUrlPath,
+    typeLabel,
+    __test__ as catalogTest,
+} from './catalog.js';
+import {
+    buildCourseUrl,
+    coursesCommand,
+    __test__ as coursesTest,
+} from './courses.js';
+
+// ─── Registration contract ──────────────────────────────────────────
+
+describe('xiaoe — adapter registration', () => {
+    it('content registers as cookie + browser, with the new full column shape', () => {
+        const reg = getRegistry();
+        expect(reg.get('xiaoe/content')).toBe(contentCommand);
+        expect(contentCommand.browser).toBe(true);
+        expect(contentCommand.strategy).toBe('cookie');
+        expect(contentCommand.access).toBe('read');
+        expect(contentCommand.domain).toBe('h5.xet.citv.cn');
+        // `content` is the new column — restoring the silently-dropped
+        // text the IIFE always extracted but the legacy `columns`
+        // declaration discarded.
+        expect(contentCommand.columns).toEqual([
+            'title', 'content', 'content_length', 'image_count',
+        ]);
+    });
+
+    it('catalog registers as cookie + browser, columns unchanged', () => {
+        const reg = getRegistry();
+        expect(reg.get('xiaoe/catalog')).toBe(catalogCommand);
+        expect(catalogCommand.browser).toBe(true);
+        expect(catalogCommand.strategy).toBe('cookie');
+        expect(catalogCommand.access).toBe('read');
+        expect(catalogCommand.columns).toEqual([
+            'ch', 'chapter', 'no', 'title', 'type', 'resource_id', 'url', 'status',
+        ]);
+    });
+
+    it('courses registers as cookie + browser, columns unchanged', () => {
+        const reg = getRegistry();
+        expect(reg.get('xiaoe/courses')).toBe(coursesCommand);
+        expect(coursesCommand.browser).toBe(true);
+        expect(coursesCommand.strategy).toBe('cookie');
+        expect(coursesCommand.access).toBe('read');
+        expect(coursesCommand.domain).toBe('study.xiaoe-tech.com');
+        expect(coursesCommand.columns).toEqual(['title', 'shop', 'url']);
+    });
+});
+
+// ─── content.js helpers ────────────────────────────────────────────
+
+describe('xiaoe/content — pickContentText', () => {
+    function htmlDoc(body) {
+        return new JSDOM(`<html><body>${body}</body></html>`).window.document;
+    }
+
+    it('returns the first selector whose text exceeds the min-length threshold', () => {
+        const doc = htmlDoc(`
+            <div class="rich-text-wrap">${'a'.repeat(60)}</div>
+            <div class="content-wrap">${'b'.repeat(120)}</div>
+        `);
+        const text = pickContentText(doc, CONTENT_SELECTORS, 50);
+        expect(text.startsWith('a')).toBe(true);
+        expect(text).toHaveLength(60);
+    });
+
+    it('skips selectors whose text is at or below the threshold (legacy used > 50)', () => {
+        const doc = htmlDoc(`
+            <div class="rich-text-wrap">${'a'.repeat(50)}</div>
+            <div class="content-wrap">${'b'.repeat(120)}</div>
+        `);
+        const text = pickContentText(doc, CONTENT_SELECTORS, 50);
+        expect(text.startsWith('b')).toBe(true);
+    });
+
+    it('falls back through main → #app → body when no selector qualifies', () => {
+        const doc1 = htmlDoc(`<main>${'m'.repeat(80)}</main>`);
+        expect(pickContentText(doc1, CONTENT_SELECTORS).startsWith('m')).toBe(true);
+
+        const doc2 = htmlDoc(`<div id="app">${'p'.repeat(80)}</div>`);
+        expect(pickContentText(doc2, CONTENT_SELECTORS).startsWith('p')).toBe(true);
+
+        const doc3 = htmlDoc(`${'q'.repeat(80)}`);
+        expect(pickContentText(doc3, CONTENT_SELECTORS).startsWith('q')).toBe(true);
+    });
+
+    it('returns "" when the body is genuinely empty (legitimate empty signal)', () => {
+        const dom = new JSDOM('<html><body></body></html>');
+        // Force the body to be missing (edge case JSDOM actually creates one)
+        const doc = dom.window.document;
+        // empty body → fallback chain returns ''
+        expect(pickContentText(doc, CONTENT_SELECTORS)).toBe('');
+    });
+});
+
+describe('xiaoe/content — countXiaoeImages', () => {
+    function imgDoc(srcs) {
+        const tags = srcs.map((s) => `<img src="${s}">`).join('');
+        return new JSDOM(`<html><body>${tags}</body></html>`).window.document;
+    }
+
+    it('counts only xiaoe-hosted, non-data: images', () => {
+        const doc = imgDoc([
+            'https://commonresource-1252524126.cdn.xiaoe-tech.com/abc.jpg',
+            'data:image/png;base64,iVBOR',
+            'https://other-cdn.com/foo.jpg',
+            'https://app.xiaoe-tech.com/img/bar.png',
+        ]);
+        expect(countXiaoeImages(doc)).toBe(2);
+    });
+
+    it('returns 0 when every image is excluded — never silently undefined', () => {
+        const doc = imgDoc([
+            'data:image/png;base64,xxx',
+            'https://avatar.cdn.com/u.jpg',
+        ]);
+        expect(countXiaoeImages(doc)).toBe(0);
+    });
+
+    it('returns 0 on a doc with no <img> elements', () => {
+        const doc = new JSDOM('<html><body><p>no images here</p></body></html>').window.document;
+        expect(countXiaoeImages(doc)).toBe(0);
+    });
+});
+
+// ─── catalog.js helpers ────────────────────────────────────────────
+
+describe('xiaoe/catalog — typeLabel', () => {
+    it('maps known resource types to Chinese labels', () => {
+        expect(typeLabel(1)).toBe('图文');
+        expect(typeLabel(2)).toBe('直播');
+        expect(typeLabel(3)).toBe('音频');
+        expect(typeLabel(4)).toBe('视频');
+        expect(typeLabel(6)).toBe('专栏');
+        expect(typeLabel(8)).toBe('大专栏');
+    });
+
+    it('coerces string-typed resource type ints', () => {
+        expect(typeLabel('1')).toBe('图文');
+        expect(typeLabel('8')).toBe('大专栏');
+    });
+
+    it('returns the raw string for unknown types — never silently swallows', () => {
+        expect(typeLabel(99)).toBe('99');
+        expect(typeLabel('custom')).toBe('custom');
+    });
+
+    it('returns "" for nullish input (no falsy crash)', () => {
+        expect(typeLabel(null)).toBe('');
+        expect(typeLabel(undefined)).toBe('');
+        expect(typeLabel(0)).toBe('');
+    });
+});
+
+describe('xiaoe/catalog — buildItemUrl', () => {
+    it('passes through fully-qualified URLs unchanged', () => {
+        expect(buildItemUrl({ jump_url: 'https://example.com/x' }, 'https://h5.xet.citv.cn'))
+            .toBe('https://example.com/x');
+        expect(buildItemUrl({ h5_url: 'http://x.test/p' }, 'https://h5.xet.citv.cn'))
+            .toBe('http://x.test/p');
+    });
+
+    it('prepends origin to relative URLs', () => {
+        expect(buildItemUrl({ jump_url: '/p/123' }, 'https://h5.xet.citv.cn'))
+            .toBe('https://h5.xet.citv.cn/p/123');
+    });
+
+    it('falls through jump_url → h5_url → url priority', () => {
+        expect(buildItemUrl({ jump_url: '/a', h5_url: '/b', url: '/c' }, 'https://x.test'))
+            .toBe('https://x.test/a');
+        expect(buildItemUrl({ h5_url: '/b', url: '/c' }, 'https://x.test'))
+            .toBe('https://x.test/b');
+        expect(buildItemUrl({ url: '/c' }, 'https://x.test'))
+            .toBe('https://x.test/c');
+    });
+
+    it('returns "" when no URL field is present (no synthetic URL)', () => {
+        expect(buildItemUrl({}, 'https://x.test')).toBe('');
+        expect(buildItemUrl({ jump_url: '' }, 'https://x.test')).toBe('');
+    });
+});
+
+describe('xiaoe/catalog — chapterUrlPath', () => {
+    it('returns the right path for known chapter types', () => {
+        expect(chapterUrlPath(1)).toBe('/v1/course/text/');
+        expect(chapterUrlPath(2)).toBe('/v2/course/alive/');
+        expect(chapterUrlPath(3)).toBe('/v1/course/audio/');
+        expect(chapterUrlPath(4)).toBe('/v1/course/video/');
+    });
+
+    it('coerces string ints', () => {
+        expect(chapterUrlPath('1')).toBe('/v1/course/text/');
+    });
+
+    it('returns undefined for unknown / nullish — caller decides empty-URL semantics', () => {
+        expect(chapterUrlPath(99)).toBeUndefined();
+        expect(chapterUrlPath(0)).toBeUndefined();
+        expect(chapterUrlPath(null)).toBeUndefined();
+    });
+});
+
+// ─── courses.js helper ─────────────────────────────────────────────
+
+describe('xiaoe/courses — buildCourseUrl', () => {
+    it('returns h5_url when present (highest priority)', () => {
+        expect(buildCourseUrl({
+            h5_url: 'https://h5.xet.citv.cn/p/abc',
+            app_id: 'appXXX',
+            resource_id: 'p_999',
+        })).toBe('https://h5.xet.citv.cn/p/abc');
+    });
+
+    it('returns url when h5_url missing', () => {
+        expect(buildCourseUrl({ url: 'https://study.xiaoe-tech.com/u/y' }))
+            .toBe('https://study.xiaoe-tech.com/u/y');
+    });
+
+    it('builds column path for resource_type 6', () => {
+        expect(buildCourseUrl({
+            app_id: 'appAAA',
+            resource_id: 'p_111',
+            resource_type: 6,
+        })).toBe('https://appAAA.h5.xet.citv.cn/v1/course/column/p_111?type=3');
+    });
+
+    it('builds ecourse path for non-column types', () => {
+        expect(buildCourseUrl({
+            app_id: 'appAAA',
+            resource_id: 'p_222',
+            resource_type: 4,
+        })).toBe('https://appAAA.h5.xet.citv.cn/p/course/ecourse/p_222');
+    });
+
+    it('returns "" when entry has no URL fields and no app_id+resource_id pair (no synthetic URL)', () => {
+        expect(buildCourseUrl({})).toBe('');
+        expect(buildCourseUrl({ app_id: 'x' })).toBe(''); // missing resource_id
+        expect(buildCourseUrl({ resource_id: 'p_1' })).toBe(''); // missing app_id
+        expect(buildCourseUrl(null)).toBe('');
+        expect(buildCourseUrl(undefined)).toBe('');
+    });
+});
+
+// ─── buildScript invariants (anti-pattern regression guards) ──────
+
+describe('xiaoe — buildScript embeds helpers + no anti-patterns', () => {
+    it('content script embeds pickContentText + countXiaoeImages and never silently slices images', () => {
+        const script = contentTest.buildContentScript();
+        expect(script).toContain('pickContentText');
+        expect(script).toContain('countXiaoeImages');
+        // The legacy adapter did `images.slice(0, 20)` and silently
+        // dropped everything past the 20th image. The new script
+        // exposes only `image_count` (counting all images via the
+        // helper), so a hard `.slice(0, 20)` should not appear.
+        expect(script).not.toMatch(/\.slice\(0,\s*20\)/);
+        // Embeds the selector list literally so the IIFE has no
+        // dependency on the host page's globals.
+        expect(script).toContain('rich-text-wrap');
+    });
+
+    it('catalog script embeds typeLabel + buildItemUrl + chapterUrlPath', () => {
+        const script = catalogTest.buildCatalogScript();
+        expect(script).toContain('typeLabel');
+        expect(script).toContain('buildItemUrl');
+        expect(script).toContain('chapterUrlPath');
+        // Vue private API anchors must remain — these are the only
+        // stable hook into Xiaoe's SPA. If a future refactor removes
+        // them, the test will fail and force a deliberate decision.
+        expect(script).toContain('__vue__');
+        expect(script).toContain('$store');
+    });
+
+    it('courses script embeds buildCourseUrl', () => {
+        const script = coursesTest.buildCoursesScript();
+        expect(script).toContain('buildCourseUrl');
+        expect(script).toContain('__vue__');
+    });
+});
+
+// ─── Wire tests for the func form ─────────────────────────────────
+
+describe('xiaoe/content — getXiaoeContent func wiring', () => {
+    function pageMock(rows) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(rows),
+        };
+    }
+
+    it('throws ArgumentError on missing url BEFORE calling page.goto', async () => {
+        const page = pageMock([]);
+        await expect(contentCommand.func(page, {})).rejects.toThrow(ArgumentError);
+        await expect(contentCommand.func(page, { url: '' })).rejects.toThrow(ArgumentError);
+        await expect(contentCommand.func(page, { url: '   ' })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError when no rows are returned', async () => {
+        const page = pageMock([]);
+        await expect(contentCommand.func(page, { url: 'https://h5.xet.citv.cn/p/x' }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('throws EmptyResultError when content is empty (login likely expired — fail-fast not silent empty row)', async () => {
+        const page = pageMock([{ title: 'shell', content: '', content_length: 0, image_count: 0 }]);
+        await expect(contentCommand.func(page, { url: 'https://h5.xet.citv.cn/p/x' }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError when page.evaluate rejects', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockRejectedValue(new Error('CDP exploded')),
+        };
+        await expect(contentCommand.func(page, { url: 'https://h5.xet.citv.cn/p/x' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
+
+    it('returns the rows verbatim on the happy path', async () => {
+        const fakeRow = {
+            title: 'demo',
+            content: 'hello world '.repeat(10),
+            content_length: 120,
+            image_count: 3,
+        };
+        const page = pageMock([fakeRow]);
+        const result = await contentCommand.func(page, { url: 'https://h5.xet.citv.cn/p/x' });
+        expect(result).toEqual([fakeRow]);
+        expect(page.goto).toHaveBeenCalledWith(
+            'https://h5.xet.citv.cn/p/x',
+            expect.objectContaining({ waitUntil: 'load' }),
+        );
+    });
+});
+
+describe('xiaoe/catalog — getXiaoeCatalog func wiring', () => {
+    function pageMock(rows) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(rows),
+        };
+    }
+
+    it('throws ArgumentError on missing url BEFORE calling page.goto', async () => {
+        const page = pageMock([]);
+        await expect(catalogCommand.func(page, {})).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError when no chapters extracted (cookie likely expired)', async () => {
+        const page = pageMock([]);
+        await expect(catalogCommand.func(page, { url: 'https://h5.xet.citv.cn/p/c' }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('returns rows verbatim on the happy path', async () => {
+        const fake = [{
+            ch: 1, chapter: '入门', no: 1, title: '第一节',
+            type: '视频', resource_id: 'v_abc', url: 'https://x.test/v/abc', status: '未学',
+        }];
+        const page = pageMock(fake);
+        expect(await catalogCommand.func(page, { url: 'https://h5.xet.citv.cn/p/c' }))
+            .toEqual(fake);
+    });
+
+    it('throws CommandExecutionError when page.evaluate rejects', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockRejectedValue(new Error('boom')),
+        };
+        await expect(catalogCommand.func(page, { url: 'https://h5.xet.citv.cn/p/c' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
+});
+
+describe('xiaoe/courses — getXiaoeCourses func wiring', () => {
+    function pageMock(rows) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(rows),
+        };
+    }
+
+    it('navigates to the study landing page (no positional arg required)', async () => {
+        const fake = [{ title: 'Course A', shop: 'Shop A', url: 'https://x.test/c/a' }];
+        const page = pageMock(fake);
+        const result = await coursesCommand.func(page, {});
+        expect(page.goto).toHaveBeenCalledWith(
+            'https://study.xiaoe-tech.com/',
+            expect.objectContaining({ waitUntil: 'load' }),
+        );
+        expect(result).toEqual(fake);
+    });
+
+    it('throws EmptyResultError when no cards found (cookie likely expired)', async () => {
+        const page = pageMock([]);
+        await expect(coursesCommand.func(page, {})).rejects.toThrow(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError when page.evaluate rejects', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockRejectedValue(new Error('cdp')),
+        };
+        await expect(coursesCommand.func(page, {})).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/xiaoe/xiaoe.test.js
+++ b/clis/xiaoe/xiaoe.test.js
@@ -27,6 +27,7 @@ import {
     contentCommand,
     countXiaoeImages,
     pickContentText,
+    requireXiaoePageUrl,
     __test__ as contentTest,
 } from './content.js';
 import {
@@ -155,6 +156,22 @@ describe('xiaoe/content — countXiaoeImages', () => {
     it('returns 0 on a doc with no <img> elements', () => {
         const doc = new JSDOM('<html><body><p>no images here</p></body></html>').window.document;
         expect(countXiaoeImages(doc)).toBe(0);
+    });
+});
+
+describe('xiaoe/content — requireXiaoePageUrl', () => {
+    it('rejects empty, malformed, and non-xiaoe URLs upfront', () => {
+        expect(() => requireXiaoePageUrl('', 'content')).toThrow(ArgumentError);
+        expect(() => requireXiaoePageUrl('not a url', 'content')).toThrow(ArgumentError);
+        expect(() => requireXiaoePageUrl('http://h5.xet.citv.cn/p/course/ecourse/v_x', 'content')).toThrow(ArgumentError);
+        expect(() => requireXiaoePageUrl('https://example.com/p/course/ecourse/v_x', 'content')).toThrow(ArgumentError);
+    });
+
+    it('accepts root and shop h5.xet.citv.cn URLs', () => {
+        expect(requireXiaoePageUrl('https://h5.xet.citv.cn/p/course/ecourse/v_x', 'content'))
+            .toBe('https://h5.xet.citv.cn/p/course/ecourse/v_x');
+        expect(requireXiaoePageUrl('https://appxxxx.h5.xet.citv.cn/p/course/ecourse/v_x', 'content'))
+            .toBe('https://appxxxx.h5.xet.citv.cn/p/course/ecourse/v_x');
     });
 });
 
@@ -326,7 +343,17 @@ describe('xiaoe/content — getXiaoeContent func wiring', () => {
         await expect(contentCommand.func(page, {})).rejects.toThrow(ArgumentError);
         await expect(contentCommand.func(page, { url: '' })).rejects.toThrow(ArgumentError);
         await expect(contentCommand.func(page, { url: '   ' })).rejects.toThrow(ArgumentError);
+        await expect(contentCommand.func(page, { url: 'https://example.com/p/x' })).rejects.toThrow(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('wraps browser navigation failures as CommandExecutionError', async () => {
+        const page = {
+            goto: vi.fn().mockRejectedValue(new Error('net::ERR_ABORTED')),
+            evaluate: vi.fn(),
+        };
+        await expect(contentCommand.func(page, { url: 'https://h5.xet.citv.cn/p/x' }))
+            .rejects.toThrow(CommandExecutionError);
     });
 
     it('throws EmptyResultError when no rows are returned', async () => {
@@ -378,7 +405,17 @@ describe('xiaoe/catalog — getXiaoeCatalog func wiring', () => {
     it('throws ArgumentError on missing url BEFORE calling page.goto', async () => {
         const page = pageMock([]);
         await expect(catalogCommand.func(page, {})).rejects.toThrow(ArgumentError);
+        await expect(catalogCommand.func(page, { url: 'https://example.com/p/c' })).rejects.toThrow(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('wraps browser navigation failures as CommandExecutionError', async () => {
+        const page = {
+            goto: vi.fn().mockRejectedValue(new Error('Execution context was destroyed')),
+            evaluate: vi.fn(),
+        };
+        await expect(catalogCommand.func(page, { url: 'https://h5.xet.citv.cn/p/c' }))
+            .rejects.toThrow(CommandExecutionError);
     });
 
     it('throws EmptyResultError when no chapters extracted (cookie likely expired)', async () => {
@@ -435,6 +472,14 @@ describe('xiaoe/courses — getXiaoeCourses func wiring', () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn().mockRejectedValue(new Error('cdp')),
+        };
+        await expect(coursesCommand.func(page, {})).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('wraps browser navigation failures as CommandExecutionError', async () => {
+        const page = {
+            goto: vi.fn().mockRejectedValue(new Error('net::ERR_ABORTED')),
+            evaluate: vi.fn(),
         };
         await expect(coursesCommand.func(page, {})).rejects.toThrow(CommandExecutionError);
     });

--- a/docs/adapters/browser/xiaoe.md
+++ b/docs/adapters/browser/xiaoe.md
@@ -16,7 +16,7 @@
 
 ```bash
 # List purchased courses
-opencli xiaoe courses --limit 10
+opencli xiaoe courses
 
 # Read course metadata
 opencli xiaoe detail "https://appxxxx.h5.xet.citv.cn/p/course/ecourse/v_xxxxx"
@@ -70,8 +70,8 @@ Empty `content` (e.g. login expired, page renders an empty shell) raises
 
 Empty results raise `EmptyResultError`, never silent `[]` — for browser
 adapters this almost always indicates the cookie has expired or the URL
-is not a course page. `--url` is required (positional) for `content` /
-`catalog` / `detail` / `play-url`; missing `--url` raises
+is not a course page. The positional `url` argument is required for `content` /
+`catalog` / `detail` / `play-url`; missing `url` raises
 `ArgumentError` before any browser navigation happens.
 
 ## Prerequisites

--- a/docs/adapters/browser/xiaoe.md
+++ b/docs/adapters/browser/xiaoe.md
@@ -31,6 +31,49 @@ opencli xiaoe play-url "https://appxxxx.h5.xet.citv.cn/v1/course/video/v_xxxxx?p
 opencli xiaoe content "https://appxxxx.h5.xet.citv.cn/v1/course/text/t_xxxxx"
 ```
 
+## Output
+
+### `content`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `title` | string | `document.title` of the rich-text page |
+| `content` | string | Trimmed `innerText` from the first matching content selector (`.rich-text-wrap`, `.content-wrap`, `.article-content`, `.text-content`, `.course-detail`, `.detail-content`, `[class*="richtext"]`, `[class*="rich-text"]`, `.ql-editor`); falls through to `<main>` → `#app` → `<body>` if no selector matches. **No silent truncation** — full extracted text is returned. |
+| `content_length` | int | `content.length` — useful for caller-side truncation decisions |
+| `image_count` | int | Count of `<img>` whose `src` is xiaoe-hosted and not a `data:` URI. No silent slice — counts the entire page. |
+
+Empty `content` (e.g. login expired, page renders an empty shell) raises
+`EmptyResultError` instead of returning a row with `content=''`.
+
+### `catalog`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `ch` | int | 1-based chapter index |
+| `chapter` | string | Chapter title (or course name for column resources) |
+| `no` | int | 1-based section index within the chapter |
+| `title` | string | Section title |
+| `type` | string | Resource label: `图文` / `直播` / `音频` / `视频` / `专栏` / `大专栏`; unknown types pass through as the raw `String(t)` rather than being silently swallowed |
+| `resource_id` | string | Xiaoe resource identifier (`p_xxx` / `v_xxx` / `l_xxx` / `a_xxx` / `i_xxx`) |
+| `url` | string | Canonical playback / reading URL — `''` when xiaoe did not expose enough fields to construct one (no synthetic URL) |
+| `status` | string | `已完成` / `<n>%` / `未学` for normal courses; `已完成` / `<n>节` / `''` for column resources |
+
+### `courses`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `title` | string | Course title from the card |
+| `shop` | string | Shop name (`shop_name`) or app name (`app_name`); empty when the Vue tree did not expose either |
+| `url` | string | Canonical course URL: `entry.h5_url` → `entry.url` → built from `app_id` + `resource_id` (column courses get `/v1/course/column/<id>?type=3`, everything else gets `/p/course/ecourse/<id>`); returns `''` when none of the three are available — never a synthetic partial URL |
+
+## Validation
+
+Empty results raise `EmptyResultError`, never silent `[]` — for browser
+adapters this almost always indicates the cookie has expired or the URL
+is not a course page. `--url` is required (positional) for `content` /
+`catalog` / `detail` / `play-url`; missing `--url` raises
+`ArgumentError` before any browser navigation happens.
+
 ## Prerequisites
 
 - Chrome running and **logged into** the target Xiaoe shop
@@ -42,3 +85,4 @@ opencli xiaoe content "https://appxxxx.h5.xet.citv.cn/v1/course/text/t_xxxxx"
 - `catalog` supports normal courses, columns, and big columns by reading Vuex / Vue component state after the course page loads
 - `play-url` uses a direct API path for video lessons and falls back to runtime resource inspection for live replays
 - Cross-shop course URLs are preserved, so you can take a URL from `courses` and pass it directly into `detail`, `catalog`, `play-url`, or `content`
+- `catalog`, `courses`, and `content` extract pure helpers (`typeLabel`, `buildItemUrl`, `chapterUrlPath`, `buildCourseUrl`, `pickContentText`, `countXiaoeImages`) that are unit-tested directly in `clis/xiaoe/xiaoe.test.js` — the in-page IIFEs embed those same functions via `${fn.toString()}` so the live and the test paths share one source of truth


### PR DESCRIPTION
## TL;DR

Three xiaoe adapters: `content` / `catalog` / `courses`.

- **xiaoe/content** had a real silent-drop bug — adapter is named "提取
  小鹅通图文页面内容为文本" (extract content as text) but never returned
  the text. The IIFE returned `{title, content, content_length,
  image_count, images}` while `columns` declared `[title,
  content_length, image_count]`, so both `content` (the text the
  adapter exists for!) and `images` were silently dropped before they
  reached the caller. The user got "this article has 1234 chars" with
  no way to read those chars. **Fix**: `content` is now a real column.
- **xiaoe/catalog & courses** are structural-only refactors —
  `pipeline:[]` → `func` form + typed errors + pure-helper extraction.
  In-page IIFEs are kept byte-for-byte because they walk Vue's private
  runtime tree (the only stable hook into Xiaoe's SPA — there is no
  public catalog / purchase REST endpoint).

## Why the lint did not catch it

The legacy adapters used the `pipeline:[]` declarative form — the IIFE
bodies are string templates. The silent-column-drop AST walker can't
see inside string templates, so the missing-column violations stayed
invisible to CI. Surfacing the bug needed eyes on the file. (Worth
flagging for the silent-column-drop lint maintainer as a follow-up,
but not in scope for this PR — that's #1311's "no over-engineering"
nudge area.)

## Structural-only on catalog / courses

Both adapters are gated behind a logged-in Xiaoe cookie, and no
internal JSON endpoint covers what the IIFEs walk. Vue's private API
(`__vue__`, `$store`, `$children`, `chapter_box.__vue__.chapterChildren`)
is the only stable hook for the catalog / column / purchase tab.
JSDOM cannot reproduce a Vue runtime tree, so rewriting the IIFEs
without live verify would be silent-failure risk.

What changes (no behavior change inside the IIFEs):

- `func` form — `Strategy.COOKIE + browser:true` consistent with
  other Xiaoe adapters.
- Typed errors: `ArgumentError` on missing `--url` (BEFORE
  `page.goto` so a bad URL doesn't burn a navigation),
  `EmptyResultError` when zero rows come back (almost always
  expired cookie or non-course URL), `CommandExecutionError` when
  `page.evaluate` rejects.
- Pure helpers extracted as module-level exports:
  - `xiaoe/content`: `pickContentText`, `countXiaoeImages` +
    `CONTENT_SELECTORS`, `CONTENT_MIN_LENGTH`
  - `xiaoe/catalog`: `typeLabel`, `buildItemUrl`, `chapterUrlPath`
  - `xiaoe/courses`: `buildCourseUrl`
- The in-page IIFEs embed those same exports via `${fn.toString()}`
  so the live and test paths share one source of truth (mirrors
  dianping #1313 / hupu #1387).

## Tests (`clis/xiaoe/xiaoe.test.js`, 41 / 41 green)

| Section | Coverage |
|---|---|
| Registration | column shape, strategy=cookie, browser=true, access=read for all 3 commands |
| `pickContentText` | min-length threshold (`> 50` matches legacy); fallback chain `<main>` → `#app` → `<body>`; empty body → `""` |
| `countXiaoeImages` | xiaoe-hosted only; `data:` URIs and other CDNs excluded; returns `0` (never undefined) |
| `typeLabel` / `chapterUrlPath` | known types → labels/paths; unknown types fall through cleanly (no silent swallow); nullish → `""` / `undefined` |
| `buildItemUrl` / `buildCourseUrl` | priority order, origin prepend, **no synthetic URL when fields are missing** |
| `build*Script` invariants | helpers are embedded by name; legacy anti-pattern `images.slice(0, 20)` asserted **NOT** to appear in the new content script |
| Wire tests | upfront `--url` validation BEFORE `page.goto` (with `expect(page.goto).not.toHaveBeenCalled()`); `EmptyResultError` on empty rows / on empty `content` (silent-shell case); `CommandExecutionError` on evaluate rejection; verbatim rows on happy path |

## Manifest

Regenerated: xiaoe/content `[title, content_length, image_count] →
[title, content, content_length, image_count]`. catalog / courses
columns unchanged.

## Lint gates

- typed-error: 190 / baseline 190 ✓
- silent-column-drop: 103 / baseline 103 ✓
- doc-coverage: 140 / 140 ✓
- listing-id-pairing: advisory only ✓

## Live verify

**Not run** — I have no Xiaoe login session. The refactor is
deliberately scoped to the wrapper layer + pure-helper extraction,
keeping the in-page IIFE bodies byte-for-byte. Reviewers with a Xiaoe
session can confirm column shape unchanged by spot-checking one
course page; the catalog / courses IIFEs are unchanged so behaviour
parity is by construction. The `content` column gain is the only
caller-visible behavioral change.

## Test plan

- [x] `pnpm vitest run clis/xiaoe/xiaoe.test.js` → 41 / 41
- [x] All 4 lint gates baseline-clean
- [ ] Reviewer with a Xiaoe session: `opencli xiaoe content <url>`
      and confirm the new `content` column actually contains the
      page text (the bug fix proof)
- [ ] Reviewer cross-checks catalog / courses live-rendered output
      against legacy form on one URL each (no behavioral change
      expected since IIFEs are byte-for-byte)