### PR TITLE
feat(qwen): add detail command + fix stale message bubble selector

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18150,6 +18150,42 @@
   },
   {
     "site": "qwen",
+    "name": "detail",
+    "description": "Open a Qianwen conversation by ID and read its messages",
+    "access": "read",
+    "domain": "www.qianwen.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Session ID (32-char hex) or full https://www.qianwen.com/chat/<id> URL"
+      },
+      {
+        "name": "markdown",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Emit assistant replies as markdown"
+      }
+    ],
+    "columns": [
+      "Role",
+      "Text"
+    ],
+    "type": "js",
+    "modulePath": "qwen/detail.js",
+    "sourceFile": "qwen/detail.js",
+    "navigateBefore": false,
+    "browserSession": {
+      "reuse": "site"
+    }
+  },
+  {
+    "site": "qwen",
     "name": "history",
     "description": "List recent Qianwen conversations (requires login)",
     "access": "read",

--- a/clis/qwen/detail.js
+++ b/clis/qwen/detail.js
@@ -1,0 +1,62 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    QIANWEN_DOMAIN,
+    bubbleHtmlToMarkdown,
+    dismissLoginModal,
+    getMessageBubbles,
+    normalizeBooleanFlag,
+    parseQianwenSessionId,
+} from './utils.js';
+
+cli({
+    site: 'qwen',
+    name: 'detail',
+    access: 'read',
+    description: 'Open a Qianwen conversation by ID and read its messages',
+    domain: QIANWEN_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    browserSession: { reuse: 'site' },
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Session ID (32-char hex) or full https://www.qianwen.com/chat/<id> URL' },
+        { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },
+    ],
+    columns: ['Role', 'Text'],
+    func: async (page, kwargs) => {
+        const sessionId = parseQianwenSessionId(kwargs.id);
+        const wantMarkdown = normalizeBooleanFlag(kwargs.markdown, false);
+
+        await page.goto(`https://www.qianwen.com/chat/${sessionId}`);
+        await page.wait(2);
+        await dismissLoginModal(page);
+
+        // Poll for the conversation transcript to load. Qianwen renders the chat
+        // page shell before fetching message history, so a fixed wait can race the
+        // initial empty render. Cap at ~20s to surface real "no data" cases without
+        // hanging on broken IDs.
+        let bubbles = [];
+        const POLL_DEADLINE_MS = 20_000;
+        const POLL_INTERVAL_S = 1;
+        const startedAt = Date.now();
+        while (Date.now() - startedAt < POLL_DEADLINE_MS) {
+            bubbles = await getMessageBubbles(page);
+            if (bubbles.length > 0) break;
+            await page.wait(POLL_INTERVAL_S);
+        }
+
+        if (!bubbles.length) {
+            throw new EmptyResultError(
+                'qwen detail',
+                `No visible messages found for conversation ${sessionId}. Verify the ID is correct and that the session belongs to the current device's b-user-id (or that you are logged in for cross-device sync).`,
+            );
+        }
+        return bubbles.map((b) => ({
+            Role: b.role,
+            Text: wantMarkdown && b.role === 'Assistant' && b.html
+                ? (bubbleHtmlToMarkdown(b.html) || b.text)
+                : b.text,
+        }));
+    },
+});

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -1,5 +1,5 @@
 import { htmlToMarkdown } from '@jackwener/opencli/utils';
-import { AuthRequiredError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 
 export const QIANWEN_DOMAIN = 'www.qianwen.com';
 export const QIANWEN_URL = 'https://www.qianwen.com/';
@@ -101,6 +101,24 @@ export async function getCurrentSessionId(page) {
     return match ? match[1] : '';
 }
 
+const QIANWEN_SESSION_ID_RE = /^[a-f0-9]{32}$/i;
+
+export function parseQianwenSessionId(input) {
+    const raw = String(input ?? '').trim();
+    if (!raw) {
+        throw new ArgumentError('id', 'must be a non-empty session ID or qianwen.com chat URL');
+    }
+    const urlMatch = raw.match(/qianwen\.com\/chat\/([a-f0-9]{32})/i);
+    const candidate = urlMatch ? urlMatch[1] : raw;
+    if (!QIANWEN_SESSION_ID_RE.test(candidate)) {
+        throw new ArgumentError(
+            'id',
+            `not a valid Qianwen session ID (got "${input}"); expected a 32-char hex ID like "abcd1234ef567890abcd1234ef567890" or a full https://www.qianwen.com/chat/<id> URL`,
+        );
+    }
+    return candidate.toLowerCase();
+}
+
 export async function getModelLabel(page) {
     const result = await page.evaluate(`(() => {
     ${IS_VISIBLE_JS}
@@ -186,24 +204,49 @@ export async function sendMessage(page, prompt) {
 }
 
 export async function getMessageBubbles(page) {
+    // Qianwen's chat DOM marks each turn with two siblings:
+    //   [data-chat-question-wrap]  - user message
+    //   [data-chat-answers-wrap]   - assistant message
+    // The earlier `[data-msgid]` selector matched citation cards inside
+    // assistant responses (which use `data-message-id`), so it would silently
+    // miss the actual chat turns after Qianwen reshipped its frontend.
+    //
+    // We walk both wrap selectors in DOM order to interleave Q/A correctly,
+    // and use the nearest sibling `data-req-id` (anchored on
+    // `.chat-msg-bottom-anchor`) as the stable per-turn identifier so polling
+    // dedupe + waitForAnswer's seenAssistantId tracking still work.
     const result = await page.evaluate(`(() => {
     ${IS_VISIBLE_JS}
-    const bubbles = Array.from(document.querySelectorAll('[data-msgid]'))
-      .filter((node) => node instanceof HTMLElement);
+    const wraps = Array.from(document.querySelectorAll('[data-chat-question-wrap], [data-chat-answers-wrap]'))
+      .filter((node) => node instanceof HTMLElement && isVisible(node));
 
-    const seen = new Set();
+    const findTurnReqId = (node) => {
+      let parent = node.parentElement;
+      while (parent && parent !== document.body) {
+        const reqEl = parent.querySelector('[data-req-id]');
+        if (reqEl && reqEl.getAttribute('data-req-id')) {
+          return reqEl.getAttribute('data-req-id');
+        }
+        parent = parent.parentElement;
+      }
+      return '';
+    };
+
     const out = [];
-    for (const node of bubbles) {
-      const id = node.getAttribute('data-msgid') || '';
-      if (!id || seen.has(id)) continue;
-      seen.add(id);
-      const isAnswer = id.endsWith('-answer');
-      const role = isAnswer ? 'Assistant' : 'User';
+    let positional = 0;
+    for (const node of wraps) {
+      const isAnswer = node.hasAttribute('data-chat-answers-wrap');
+      const reqId = findTurnReqId(node);
+      const baseId = reqId || ('pos-' + positional);
+      const id = baseId + (isAnswer ? '-answer' : '-question');
+      positional += 1;
+
       const contentNode = isAnswer
-        ? (node.querySelector('[class*="markdown"]') || node.querySelector('[class*="content"]') || node)
-        : (node.querySelector('[class*="bubble"]') || node);
+        ? (node.querySelector('#qk-markdown-react') || node.querySelector('[class*="markdown"]') || node)
+        : node;
       const html = (contentNode instanceof HTMLElement) ? (contentNode.innerHTML || '') : '';
       const text = (contentNode instanceof HTMLElement) ? (contentNode.innerText || contentNode.textContent || '') : '';
+      const role = isAnswer ? 'Assistant' : 'User';
       out.push({ id, role, text: (text || '').replace(/\\s+/g, ' ').trim(), html });
     }
     return out;

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -108,7 +108,13 @@ export function parseQianwenSessionId(input) {
     if (!raw) {
         throw new ArgumentError('id', 'must be a non-empty session ID or qianwen.com chat URL');
     }
-    const urlMatch = raw.match(/qianwen\.com\/chat\/([a-f0-9]{32})/i);
+    // Anchor the right-hand side so a 33+ hex URL does not silently truncate
+    // to its first 32 chars. Acceptable terminators: end-of-string, path slash,
+    // query string, or fragment. Without the boundary,
+    // `https://www.qianwen.com/chat/<33 hex>` would parse as a valid 32-char
+    // ID instead of being rejected — opening the wrong conversation is a
+    // worse failure mode than throwing.
+    const urlMatch = raw.match(/qianwen\.com\/chat\/([a-f0-9]{32})(?:[/?#]|$)/i);
     const candidate = urlMatch ? urlMatch[1] : raw;
     if (!QIANWEN_SESSION_ID_RE.test(candidate)) {
         throw new ArgumentError(

--- a/clis/qwen/utils.test.js
+++ b/clis/qwen/utils.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { parseQianwenSessionId } from './utils.js';
+
+describe('qwen parseQianwenSessionId', () => {
+    const id = 'abcd1234ef567890abcd1234ef567890';
+
+    it('returns a bare 32-char hex ID unchanged', () => {
+        expect(parseQianwenSessionId(id)).toBe(id);
+    });
+
+    it('lowercases an upper-case ID', () => {
+        expect(parseQianwenSessionId(id.toUpperCase())).toBe(id);
+    });
+
+    it('extracts the session ID from a full qianwen.com chat URL', () => {
+        expect(parseQianwenSessionId(`https://www.qianwen.com/chat/${id}`)).toBe(id);
+        expect(parseQianwenSessionId(`https://www.qianwen.com/chat/${id}?from=share`)).toBe(id);
+        expect(parseQianwenSessionId(`http://qianwen.com/chat/${id}`)).toBe(id);
+    });
+
+    it('throws ArgumentError on empty input', () => {
+        expect(() => parseQianwenSessionId('')).toThrow(ArgumentError);
+        expect(() => parseQianwenSessionId(null)).toThrow(ArgumentError);
+        expect(() => parseQianwenSessionId(undefined)).toThrow(ArgumentError);
+        expect(() => parseQianwenSessionId('   ')).toThrow(ArgumentError);
+    });
+
+    it('throws ArgumentError on non-hex input', () => {
+        expect(() => parseQianwenSessionId('not-an-id')).toThrow(ArgumentError);
+        expect(() => parseQianwenSessionId('123')).toThrow(ArgumentError);
+        // 32 chars but not all hex
+        expect(() => parseQianwenSessionId('zbcd1234ef567890abcd1234ef567890')).toThrow(ArgumentError);
+        // 31 hex chars — too short
+        expect(() => parseQianwenSessionId('abcd1234ef567890abcd1234ef56789')).toThrow(ArgumentError);
+        // 33 hex chars — too long
+        expect(() => parseQianwenSessionId('abcd1234ef567890abcd1234ef5678900')).toThrow(ArgumentError);
+        // URL with the wrong path shape must not silently fall through.
+        expect(() => parseQianwenSessionId('https://www.qianwen.com/somewhere/else')).toThrow(ArgumentError);
+    });
+});

--- a/clis/qwen/utils.test.js
+++ b/clis/qwen/utils.test.js
@@ -37,5 +37,9 @@ describe('qwen parseQianwenSessionId', () => {
         expect(() => parseQianwenSessionId('abcd1234ef567890abcd1234ef5678900')).toThrow(ArgumentError);
         // URL with the wrong path shape must not silently fall through.
         expect(() => parseQianwenSessionId('https://www.qianwen.com/somewhere/else')).toThrow(ArgumentError);
+        // URL embedding a 33+ hex tail must not silently truncate to 32 chars
+        // and open the wrong conversation.
+        expect(() => parseQianwenSessionId(`https://www.qianwen.com/chat/${id}0`)).toThrow(ArgumentError);
+        expect(() => parseQianwenSessionId(`https://www.qianwen.com/chat/${id}abc`)).toThrow(ArgumentError);
     });
 });

--- a/docs/adapters/browser/qwen.md
+++ b/docs/adapters/browser/qwen.md
@@ -11,6 +11,7 @@ Drive **Qianwen / Qwen** chat from the terminal. All commands run through your e
 | `opencli qwen status` | Page availability, login state, current model and session | read |
 | `opencli qwen history` | List recent conversations (requires login) | read |
 | `opencli qwen read` | Read messages in the current conversation | read |
+| `opencli qwen detail <id>` | Open a conversation by ID and read its messages | read |
 | `opencli qwen ask <prompt>` | Send a prompt and wait for the assistant reply | write |
 | `opencli qwen send <prompt>` | Fire-and-forget: send a prompt without waiting | write |
 | `opencli qwen new` | Start a fresh conversation | write |
@@ -27,6 +28,10 @@ opencli qwen history --limit 10
 
 # Read the active conversation as markdown
 opencli qwen read --markdown true
+
+# Read a specific historical conversation by ID (or full URL)
+opencli qwen detail abcd1234ef567890abcd1234ef567890
+opencli qwen detail https://www.qianwen.com/chat/abcd1234ef567890abcd1234ef567890 --markdown true
 
 # Ask a question and wait for the reply
 opencli qwen ask "用一段话解释 transformer attention"
@@ -79,6 +84,13 @@ opencli qwen image "a tiny robot" --sd true
 |--------|-------------|
 | `--markdown` | Emit assistant replies as markdown (default: `false`) |
 
+### `detail`
+
+| Option | Description |
+|--------|-------------|
+| `id` | Session ID (32-char hex) or full `https://www.qianwen.com/chat/<id>` URL (required positional) |
+| `--markdown` | Emit assistant replies as markdown (default: `false`) |
+
 ### `history`
 
 | Option | Description |
@@ -92,6 +104,7 @@ opencli qwen image "a tiny robot" --sd true
 | `status` | `Status, Login, Model, SessionId, Url` |
 | `history` | `Index, Title, Updated, Url` |
 | `read` | `Role, Text` |
+| `detail` | `Role, Text` |
 | `ask` | `Role, Text` |
 | `send` | `Status, Prompt` |
 | `new` | `Status` |


### PR DESCRIPTION
## Summary

- New `opencli qwen detail <id|url>` command — open a specific Qianwen conversation by 32-char hex session ID or full `https://www.qianwen.com/chat/<id>` URL and read its transcript. Polls up to 20s for messages to render to surface real "no data" cases without hanging on broken IDs.
- Fix silently-broken `getMessageBubbles`: Qianwen reshipped the chat frontend; the old `[data-msgid="<id>-question|answer"]` selector is dead. `[data-message-id]` now marks citation cards inside assistant responses, not chat turns themselves — `qwen read` has been silently returning empty (`"No visible messages..."`) for an unknown duration.
- Rewire to walk `[data-chat-question-wrap]` / `[data-chat-answers-wrap]` in DOM order (correct Q/A interleaving) and synthesize stable IDs from the nearest sibling `data-req-id` so `waitForAnswer.seenAssistantId` plus all dedupe/poll paths keep working. This fixes `read` + `ask` + the new `detail` simultaneously.
- Add `parseQianwenSessionId` helper with 5 unit tests covering bare ID, URL extraction, case normalization, and `ArgumentError` on empty/non-hex/wrong-path input.
- Adapter follows post-#1385 convention: `Strategy.COOKIE` + `browserSession: { reuse: 'site' }` + `navigateBefore: false`. Consecutive `qwen ask` / `qwen read` / `qwen detail` continue in the same Qwen tab.

Verified live on `https://www.qianwen.com/chat/<real session>`: old selector returned 0 nodes, new selector returns 3 user + 3 assistant turns interleaved correctly. Markdown mode (`--markdown true`) round-trips through `bubbleHtmlToMarkdown` against `#qk-markdown-react`.

## Test plan

- [x] `npm test -- clis/qwen` — 5/5 unit tests pass (`parseQianwenSessionId`)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (manifest 765 entries; `qwen/detail` registered with `browserSession.reuse: site` + `navigateBefore: false`)
- [x] CLI smoke: `qwen detail --help`, invalid ID rejection, empty ID rejection, full URL accepted
- [x] End-to-end: `qwen detail <real session id>` returns full Q/A transcript (default + `--markdown true`)
- [x] End-to-end: `qwen detail <full chat URL>` accepts URL form
- [x] Sanity: `getMessageBubbles` change verified against live page via `opencli browser eval` — new selector finds 6 wraps, old selector finds 0