### PR TITLE
fix(grok): replace sentinel rows + silent-clamp with typed errors, deliver image cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ⚠ BREAKING CHANGES
 
 * **linux-do** — remove deprecated compatibility shims `linux-do hot`, `linux-do category`, `linux-do latest`. Use `linux-do feed --view top --period <period>`, `linux-do feed --category <id-or-name>`, and `linux-do feed --view latest` instead.
+* **grok ask** — drop the `--web` flag and the legacy `<textarea>` composer path. The default flow is now the only path and uses the current ProseMirror+TipTap composer (the path that used to require `--web true`). Existing scripts passing `--web` will get an "unknown option" error from commander; remove the flag.
 
 ### Features
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -10485,13 +10485,6 @@
         "default": false,
         "required": false,
         "help": "Start a new chat before sending (default: false)"
-      },
-      {
-        "name": "web",
-        "type": "boolean",
-        "default": false,
-        "required": false,
-        "help": "Use the explicit grok.com consumer web flow (default: false)"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -10573,6 +10573,65 @@
   },
   {
     "site": "grok",
+    "name": "image",
+    "description": "Generate images on grok.com and return image URLs",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Image generation prompt"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 240,
+        "required": false,
+        "help": "Max seconds to wait for the image (default: 240)"
+      },
+      {
+        "name": "new",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Start a new chat before sending (default: false)"
+      },
+      {
+        "name": "count",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Minimum images to wait for before returning (default: 1)"
+      },
+      {
+        "name": "out",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Directory to save downloaded images (uses browser session to bypass auth)"
+      }
+    ],
+    "columns": [
+      "url",
+      "width",
+      "height",
+      "path"
+    ],
+    "type": "js",
+    "modulePath": "grok/image.js",
+    "sourceFile": "grok/image.js",
+    "navigateBefore": "https://grok.com",
+    "browserSession": {
+      "reuse": "site"
+    }
+  },
+  {
+    "site": "grok",
     "name": "new",
     "description": "Start a new conversation in Grok",
     "access": "write",

--- a/clis/grok/ask.js
+++ b/clis/grok/ask.js
@@ -1,12 +1,8 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 const GROK_URL = 'https://grok.com/';
 const RESPONSE_SELECTOR = 'div.message-bubble, [data-testid="message-bubble"]';
-const BLOCKED_PREFIX = '[BLOCKED]';
-const NO_RESPONSE_PREFIX = '[NO RESPONSE]';
 const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
-function blocked(message) {
-    return [{ response: `${BLOCKED_PREFIX} ${message} ${SESSION_HINT}` }];
-}
 function normalizeBubbleText(value) {
     return typeof value === 'string' ? value.trim() : '';
 }
@@ -80,7 +76,10 @@ async function runDefaultAsk(page, prompt, timeoutMs, newChat) {
     } catch (e) { return { ok: false, msg: e.toString() }; }
   })()`);
     if (!sendResult || !sendResult.ok) {
-        return [{ response: '[SEND FAILED] ' + JSON.stringify(sendResult) }];
+        throw new CommandExecutionError(
+            `Grok composer rejected the prompt: ${JSON.stringify(sendResult)}`,
+            SESSION_HINT,
+        );
     }
     const startTime = Date.now();
     let lastText = '';
@@ -107,9 +106,12 @@ async function runDefaultAsk(page, prompt, timeoutMs, newChat) {
         }
         lastText = response || '';
     }
+    // Timeout reached. If we caught streaming text in flight, keep it as a
+    // best-effort partial result; if the assistant never produced anything
+    // visible, surface the timeout rather than a sentinel row.
     if (lastText)
         return [{ response: lastText }];
-    return [{ response: NO_RESPONSE_PREFIX }];
+    throw new TimeoutError('grok ask response', Math.round(timeoutMs / 1000));
 }
 async function getBubbleTexts(page) {
     const result = await page.evaluate(`(() => {
@@ -238,7 +240,8 @@ async function runExplicitWebAsk(page, prompt, timeoutMs, newChat) {
     const sendResult = await sendPromptViaExplicitWeb(page, prompt);
     if (!sendResult?.ok) {
         const details = sendResult?.detail ? ` ${sendResult.detail}` : '';
-        return blocked(`${sendResult?.reason || 'Unable to send the prompt to Grok.'}${details}`);
+        const reason = sendResult?.reason || 'Unable to send the prompt to Grok.';
+        throw new CommandExecutionError(`${reason}${details}`, SESSION_HINT);
     }
     const startTime = Date.now();
     let lastText = '';
@@ -254,9 +257,11 @@ async function runExplicitWebAsk(page, prompt, timeoutMs, newChat) {
             return [{ response: candidate }];
         }
     }
+    // Timeout — keep partial text if we saw streaming, otherwise surface
+    // the timeout instead of a sentinel row.
     if (lastText)
         return [{ response: lastText }];
-    return [{ response: `${NO_RESPONSE_PREFIX} No new assistant message bubble appeared within ${Math.round(timeoutMs / 1000)}s.` }];
+    throw new TimeoutError('grok ask response (--web)', Math.round(timeoutMs / 1000));
 }
 export const askCommand = cli({
     site: 'grok',

--- a/clis/grok/ask.js
+++ b/clis/grok/ask.js
@@ -1,268 +1,26 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
-const GROK_URL = 'https://grok.com/';
-const RESPONSE_SELECTOR = 'div.message-bubble, [data-testid="message-bubble"]';
+import {
+    authRequired,
+    ensureOnGrok,
+    getMessageBubbles,
+    isLoggedIn,
+    normalizeBooleanFlag,
+    sendMessage,
+    startNewChat,
+    waitForAnswer,
+} from './utils.js';
+
 const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
-function normalizeBubbleText(value) {
-    return typeof value === 'string' ? value.trim() : '';
-}
-function normalizeBooleanFlag(value) {
-    if (typeof value === 'boolean')
-        return value;
-    const normalized = String(value ?? '').trim().toLowerCase();
-    return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
-}
-function pickLatestAssistantCandidate(bubbles, baselineCount, prompt) {
-    const normalizedPrompt = prompt.trim();
-    const freshBubbles = bubbles
-        .slice(Math.max(0, baselineCount))
-        .map(normalizeBubbleText)
-        .filter(Boolean);
-    for (let i = freshBubbles.length - 1; i >= 0; i -= 1) {
-        if (freshBubbles[i] !== normalizedPrompt)
-            return freshBubbles[i];
+
+async function getBaselineLastAssistantId(page) {
+    const bubbles = await getMessageBubbles(page);
+    for (let i = bubbles.length - 1; i >= 0; i -= 1) {
+        if (bubbles[i].role === 'Assistant') return bubbles[i].id;
     }
     return '';
 }
-function updateStableState(previousText, stableCount, nextText) {
-    if (!nextText)
-        return { previousText: '', stableCount: 0 };
-    if (nextText === previousText)
-        return { previousText, stableCount: stableCount + 1 };
-    return { previousText: nextText, stableCount: 0 };
-}
-/** Check whether the tab is already on grok.com (any path). */
-async function isOnGrok(page) {
-    // catch handles blank tabs (about:blank) or detached pages
-    const url = await page.evaluate('window.location.href').catch(() => '');
-    if (typeof url !== 'string' || !url)
-        return false;
-    try {
-        const hostname = new URL(url).hostname;
-        return hostname === 'grok.com' || hostname.endsWith('.grok.com');
-    }
-    catch {
-        return false;
-    }
-}
-async function runDefaultAsk(page, prompt, timeoutMs, newChat) {
-    if (newChat) {
-        // Explicitly start a fresh conversation via the homepage
-        await page.goto(GROK_URL);
-        await page.wait(2);
-        await tryStartFreshChat(page);
-        await page.wait(2);
-    }
-    else if (!(await isOnGrok(page))) {
-        // First invocation or tab was recycled — navigate to Grok
-        await page.goto(GROK_URL);
-        await page.wait(3);
-    }
-    const promptJson = JSON.stringify(prompt);
-    const sendResult = await page.evaluate(`(async () => {
-    try {
-      const box = document.querySelector('textarea');
-      if (!box) return { ok: false, msg: 'no textarea' };
-      box.focus(); box.value = '';
-      document.execCommand('selectAll');
-      document.execCommand('insertText', false, ${promptJson});
-      await new Promise(r => setTimeout(r, 1500));
-      const btn = document.querySelector('button[aria-label="\\u63d0\\u4ea4"]');
-      if (btn && !btn.disabled) { btn.click(); return { ok: true, msg: 'clicked' }; }
-      const sub = [...document.querySelectorAll('button[type="submit"]')].find(b => !b.disabled);
-      if (sub) { sub.click(); return { ok: true, msg: 'clicked-submit' }; }
-      box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
-      return { ok: true, msg: 'enter' };
-    } catch (e) { return { ok: false, msg: e.toString() }; }
-  })()`);
-    if (!sendResult || !sendResult.ok) {
-        throw new CommandExecutionError(
-            `Grok composer rejected the prompt: ${JSON.stringify(sendResult)}`,
-            SESSION_HINT,
-        );
-    }
-    const startTime = Date.now();
-    let lastText = '';
-    let stableCount = 0;
-    while (Date.now() - startTime < timeoutMs) {
-        await page.wait(3);
-        const response = await page.evaluate(`(() => {
-      const bubbles = document.querySelectorAll('div.message-bubble, [data-testid="message-bubble"]');
-      if (bubbles.length < 2) return '';
-      const last = bubbles[bubbles.length - 1];
-      const text = (last.innerText || '').trim();
-      if (!text || text.length < 2) return '';
-      return text;
-    })()`);
-        if (response && response.length > 2) {
-            if (response === lastText) {
-                stableCount++;
-                if (stableCount >= 2)
-                    return [{ response }];
-            }
-            else {
-                stableCount = 0;
-            }
-        }
-        lastText = response || '';
-    }
-    // Timeout reached. If we caught streaming text in flight, keep it as a
-    // best-effort partial result; if the assistant never produced anything
-    // visible, surface the timeout rather than a sentinel row.
-    if (lastText)
-        return [{ response: lastText }];
-    throw new TimeoutError('grok ask response', Math.round(timeoutMs / 1000));
-}
-async function getBubbleTexts(page) {
-    const result = await page.evaluate(`(() => {
-    return Array.from(document.querySelectorAll(${JSON.stringify(RESPONSE_SELECTOR)}))
-      .map(node => (node instanceof HTMLElement ? node.innerText : node?.textContent || ''))
-      .map(text => (typeof text === 'string' ? text.trim() : ''))
-      .filter(Boolean);
-  })()`);
-    return Array.isArray(result) ? result.map(normalizeBubbleText).filter(Boolean) : [];
-}
-async function tryStartFreshChat(page) {
-    await page.evaluate(`(() => {
-    const isVisible = (node) => {
-      if (!(node instanceof HTMLElement)) return false;
-      const rect = node.getBoundingClientRect();
-      const style = window.getComputedStyle(node);
-      return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
-    };
 
-    const candidates = Array.from(document.querySelectorAll('a, button')).filter(node => {
-      if (!isVisible(node)) return false;
-      const text = (node.textContent || '').trim().toLowerCase();
-      const aria = (node.getAttribute('aria-label') || '').trim().toLowerCase();
-      const href = node.getAttribute('href') || '';
-      return text.includes('new chat')
-        || text.includes('new conversation')
-        || aria.includes('new chat')
-        || aria.includes('new conversation')
-        || href === '/';
-    });
-
-    const target = candidates[0];
-    if (target instanceof HTMLElement) target.click();
-  })()`);
-}
-async function sendPromptViaExplicitWeb(page, prompt) {
-    return page.evaluate(`(async () => {
-    const waitFor = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-    const composerSelector = '.ProseMirror[contenteditable="true"]';
-    let composer = null;
-
-    for (let attempt = 0; attempt < 12; attempt += 1) {
-      const candidate = document.querySelector(composerSelector);
-      if (candidate instanceof HTMLElement) {
-        composer = candidate;
-        break;
-      }
-
-      await waitFor(1000);
-    }
-
-    if (!(composer instanceof HTMLElement)) {
-      return {
-        ok: false,
-        reason: 'Grok composer was not found on grok.com.',
-      };
-    }
-
-    const editor = composer.editor;
-    if (!editor?.commands?.focus || !editor?.commands?.insertContent) {
-      return {
-        ok: false,
-        reason: 'Grok composer editor API was unavailable.',
-      };
-    }
-
-    const isVisibleEnabledSubmit = (node) => {
-      if (!(node instanceof HTMLButtonElement)) return false;
-      const rect = node.getBoundingClientRect();
-      const style = window.getComputedStyle(node);
-      return !node.disabled
-        && rect.width > 0
-        && rect.height > 0
-        && style.visibility !== 'hidden'
-        && style.display !== 'none';
-    };
-
-    try {
-      if (editor.commands.clearContent) editor.commands.clearContent();
-      editor.commands.focus();
-      editor.commands.insertContent(${JSON.stringify(prompt)});
-    } catch (error) {
-      return {
-        ok: false,
-        reason: 'Failed to insert the prompt into the Grok composer.',
-        detail: error instanceof Error ? error.message : String(error),
-      };
-    }
-
-    let submit = null;
-    for (let attempt = 0; attempt < 6; attempt += 1) {
-      const candidate = Array.from(document.querySelectorAll('button[aria-label="Submit"]'))
-        .find(isVisibleEnabledSubmit);
-
-      if (candidate instanceof HTMLButtonElement) {
-        submit = candidate;
-        break;
-      }
-
-      await waitFor(500);
-    }
-
-    if (!(submit instanceof HTMLButtonElement)) {
-      return {
-        ok: false,
-        reason: 'Grok submit button did not reach a clickable ready state after prompt insertion.',
-      };
-    }
-
-    submit.click();
-    return { ok: true };
-  })()`);
-}
-async function runExplicitWebAsk(page, prompt, timeoutMs, newChat) {
-    if (newChat) {
-        // Navigate to homepage and start a fresh conversation
-        await page.goto(GROK_URL, { settleMs: 2000 });
-        await tryStartFreshChat(page);
-        await page.wait(2);
-    }
-    else if (!(await isOnGrok(page))) {
-        // First invocation or tab was recycled — navigate to Grok
-        await page.goto(GROK_URL, { settleMs: 2000 });
-    }
-    const baselineBubbles = await getBubbleTexts(page);
-    const sendResult = await sendPromptViaExplicitWeb(page, prompt);
-    if (!sendResult?.ok) {
-        const details = sendResult?.detail ? ` ${sendResult.detail}` : '';
-        const reason = sendResult?.reason || 'Unable to send the prompt to Grok.';
-        throw new CommandExecutionError(`${reason}${details}`, SESSION_HINT);
-    }
-    const startTime = Date.now();
-    let lastText = '';
-    let stableCount = 0;
-    while (Date.now() - startTime < timeoutMs) {
-        await page.wait(2);
-        const bubbleTexts = await getBubbleTexts(page);
-        const candidate = pickLatestAssistantCandidate(bubbleTexts, baselineBubbles.length, prompt);
-        const nextState = updateStableState(lastText, stableCount, candidate);
-        lastText = nextState.previousText;
-        stableCount = nextState.stableCount;
-        if (candidate && stableCount >= 2) {
-            return [{ response: candidate }];
-        }
-    }
-    // Timeout — keep partial text if we saw streaming, otherwise surface
-    // the timeout instead of a sentinel row.
-    if (lastText)
-        return [{ response: lastText }];
-    throw new TimeoutError('grok ask response (--web)', Math.round(timeoutMs / 1000));
-}
 export const askCommand = cli({
     site: 'grok',
     name: 'ask',
@@ -276,24 +34,44 @@ export const askCommand = cli({
         { name: 'prompt', positional: true, type: 'string', required: true, help: 'Prompt to send to Grok' },
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response (default: 120)' },
         { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending (default: false)' },
-        { name: 'web', type: 'boolean', default: false, help: 'Use the explicit grok.com consumer web flow (default: false)' },
     ],
     columns: ['response'],
     func: async (page, kwargs) => {
         const prompt = kwargs.prompt;
-        const timeoutMs = (kwargs.timeout || 120) * 1000;
+        const timeoutSeconds = kwargs.timeout || 120;
         const newChat = normalizeBooleanFlag(kwargs.new);
-        const useExplicitWeb = normalizeBooleanFlag(kwargs.web);
-        if (useExplicitWeb) {
-            return runExplicitWebAsk(page, prompt, timeoutMs, newChat);
+
+        if (newChat) {
+            await startNewChat(page);
+        } else {
+            await ensureOnGrok(page);
         }
-        return runDefaultAsk(page, prompt, timeoutMs, newChat);
+
+        if (!(await isLoggedIn(page))) {
+            throw authRequired();
+        }
+
+        const baselineLastAssistantId = await getBaselineLastAssistantId(page);
+        const sendResult = await sendMessage(page, prompt);
+        if (!sendResult || !sendResult.ok) {
+            const reason = sendResult?.reason || 'Unable to send the prompt to Grok.';
+            const detail = sendResult?.detail ? ` ${sendResult.detail}` : '';
+            throw new CommandExecutionError(`${reason}${detail}`, SESSION_HINT);
+        }
+
+        const result = await waitForAnswer(page, prompt, timeoutSeconds, baselineLastAssistantId);
+        if (result.status === 'ok') {
+            return [{ response: result.assistant.text }];
+        }
+        // Partial: streaming was seen but did not stabilize; keep the best-effort
+        // text rather than throwing — the caller asked us to wait, not to discard.
+        if (result.status === 'partial' && result.assistant) {
+            return [{ response: result.assistant.text }];
+        }
+        throw new TimeoutError('grok ask response', timeoutSeconds);
     },
 });
+
 export const __test__ = {
-    pickLatestAssistantCandidate,
-    updateStableState,
-    normalizeBooleanFlag,
-    normalizeBubbleText,
-    isOnGrok,
+    getBaselineLastAssistantId,
 };

--- a/clis/grok/ask.test.js
+++ b/clis/grok/ask.test.js
@@ -1,54 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { __test__ } from './ask.js';
+
 describe('grok ask helpers', () => {
-    describe('isOnGrok', () => {
-        const fakePage = (url) => ({ evaluate: () => url instanceof Error ? Promise.reject(url) : Promise.resolve(url) });
-        it('returns true for grok.com URLs', async () => {
-            expect(await __test__.isOnGrok(fakePage('https://grok.com/'))).toBe(true);
-            expect(await __test__.isOnGrok(fakePage('https://grok.com/chat/abc123'))).toBe(true);
+    describe('getBaselineLastAssistantId', () => {
+        const fakePage = (bubbles) => ({
+            // getMessageBubbles in utils.js drives a page.evaluate; in tests we
+            // route directly to the in-memory bubble array.
+            evaluate: () => Promise.resolve(bubbles),
         });
-        it('returns true for grok.com subdomains', async () => {
-            expect(await __test__.isOnGrok(fakePage('https://api.grok.com/v1'))).toBe(true);
+
+        it('returns the id of the most recent Assistant bubble, ignoring later User turns', async () => {
+            const bubbles = [
+                { id: 'a1', role: 'Assistant', text: 'first answer', html: '' },
+                { id: 'u1', role: 'User', text: 'follow-up', html: '' },
+                { id: 'a2', role: 'Assistant', text: 'second answer', html: '' },
+                { id: 'u2', role: 'User', text: 'newest user turn', html: '' },
+            ];
+            expect(await __test__.getBaselineLastAssistantId(fakePage(bubbles))).toBe('a2');
         });
-        it('returns false for non-grok domains', async () => {
-            expect(await __test__.isOnGrok(fakePage('https://fakegrok.com/'))).toBe(false);
-            expect(await __test__.isOnGrok(fakePage('https://example.com/?next=grok.com'))).toBe(false);
-            expect(await __test__.isOnGrok(fakePage('about:blank'))).toBe(false);
-        });
-        it('returns false when evaluate throws (detached tab)', async () => {
-            expect(await __test__.isOnGrok(fakePage(new Error('detached')))).toBe(false);
-        });
-    });
-    it('normalizes boolean flags for explicit web routing', () => {
-        expect(__test__.normalizeBooleanFlag(true)).toBe(true);
-        expect(__test__.normalizeBooleanFlag('true')).toBe(true);
-        expect(__test__.normalizeBooleanFlag('1')).toBe(true);
-        expect(__test__.normalizeBooleanFlag('yes')).toBe(true);
-        expect(__test__.normalizeBooleanFlag('on')).toBe(true);
-        expect(__test__.normalizeBooleanFlag(false)).toBe(false);
-        expect(__test__.normalizeBooleanFlag('false')).toBe(false);
-        expect(__test__.normalizeBooleanFlag(undefined)).toBe(false);
-    });
-    it('ignores baseline bubbles and the echoed prompt when choosing the latest assistant candidate', () => {
-        const candidate = __test__.pickLatestAssistantCandidate(['older assistant answer', 'Prompt text', 'Assistant draft', 'Assistant final'], 1, 'Prompt text');
-        expect(candidate).toBe('Assistant final');
-    });
-    it('returns empty when only the echoed prompt appeared after send', () => {
-        const candidate = __test__.pickLatestAssistantCandidate(['older assistant answer', 'Prompt text'], 1, 'Prompt text');
-        expect(candidate).toBe('');
-    });
-    it('tracks stabilization by incrementing repeats and resetting on changes', () => {
-        expect(__test__.updateStableState('', 0, 'First chunk')).toEqual({
-            previousText: 'First chunk',
-            stableCount: 0,
-        });
-        expect(__test__.updateStableState('First chunk', 0, 'First chunk')).toEqual({
-            previousText: 'First chunk',
-            stableCount: 1,
-        });
-        expect(__test__.updateStableState('First chunk', 1, 'Second chunk')).toEqual({
-            previousText: 'Second chunk',
-            stableCount: 0,
+
+        it('returns empty string when no Assistant bubble exists yet (fresh chat)', async () => {
+            expect(await __test__.getBaselineLastAssistantId(fakePage([]))).toBe('');
+            expect(await __test__.getBaselineLastAssistantId(fakePage([
+                { id: 'u1', role: 'User', text: 'hello', html: '' },
+            ]))).toBe('');
         });
     });
 });

--- a/clis/grok/image.js
+++ b/clis/grok/image.js
@@ -2,44 +2,33 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import type { IPage } from '@jackwener/opencli/types';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 
 const GROK_URL = 'https://grok.com/';
-const NO_IMAGE_PREFIX = '[NO IMAGE]';
-const BLOCKED_PREFIX = '[BLOCKED]';
 const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
 
-type SendResult = {
-  ok?: boolean;
-  msg?: string;
-  reason?: string;
-  detail?: string;
-};
-
-type BubbleImage = {
-  src: string;
-  w: number;
-  h: number;
-};
-
-type BubbleImageSet = BubbleImage[];
-
-type FetchResult = {
-  ok: boolean;
-  base64?: string;
-  contentType?: string;
-  error?: string;
-};
-
-function normalizeBooleanFlag(value: unknown): boolean {
+function normalizeBooleanFlag(value) {
   if (typeof value === 'boolean') return value;
   const normalized = String(value ?? '').trim().toLowerCase();
   return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
 }
 
-function dedupeBySrc(images: BubbleImage[]): BubbleImage[] {
-  const seen = new Set<string>();
-  const out: BubbleImage[] = [];
+/**
+ * Validate a positive-integer arg without silently flooring/clamping.
+ * Throws ArgumentError on `0`, negatives, non-integers, or non-numeric input.
+ */
+function normalizePositiveInteger(value, defaultValue, label) {
+  const raw = value ?? defaultValue;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new ArgumentError(`${label} must be a positive integer`);
+  }
+  return n;
+}
+
+function dedupeBySrc(images) {
+  const seen = new Set();
+  const out = [];
   for (const img of images) {
     if (!img.src || seen.has(img.src)) continue;
     seen.add(img.src);
@@ -48,11 +37,11 @@ function dedupeBySrc(images: BubbleImage[]): BubbleImage[] {
   return out;
 }
 
-function imagesSignature(images: BubbleImage[]): string {
+function imagesSignature(images) {
   return images.map(i => i.src).sort().join('|');
 }
 
-function extFromContentType(ct?: string): string {
+function extFromContentType(ct) {
   if (!ct) return 'jpg';
   if (ct.includes('png')) return 'png';
   if (ct.includes('webp')) return 'webp';
@@ -60,14 +49,14 @@ function extFromContentType(ct?: string): string {
   return 'jpg';
 }
 
-function buildFilename(src: string, ct?: string): string {
+function buildFilename(src, ct) {
   const ext = extFromContentType(ct);
   const hash = crypto.createHash('sha1').update(src).digest('hex').slice(0, 12);
   return `grok-${Date.now()}-${hash}.${ext}`;
 }
 
 /** Check whether the tab is already on grok.com (any path). */
-async function isOnGrok(page: IPage): Promise<boolean> {
+async function isOnGrok(page) {
   const url = await page.evaluate('window.location.href').catch(() => '');
   if (typeof url !== 'string' || !url) return false;
   try {
@@ -78,7 +67,7 @@ async function isOnGrok(page: IPage): Promise<boolean> {
   }
 }
 
-async function tryStartFreshChat(page: IPage): Promise<void> {
+async function tryStartFreshChat(page) {
   await page.evaluate(`(() => {
     const isVisible = (node) => {
       if (!(node instanceof HTMLElement)) return false;
@@ -102,7 +91,7 @@ async function tryStartFreshChat(page: IPage): Promise<void> {
   })()`);
 }
 
-async function sendPrompt(page: IPage, prompt: string): Promise<SendResult> {
+async function sendPrompt(page, prompt) {
   const promptJson = JSON.stringify(prompt);
   return page.evaluate(`(async () => {
     try {
@@ -180,11 +169,11 @@ async function sendPrompt(page: IPage, prompt: string): Promise<SendResult> {
       box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
       return { ok: true, msg: 'enter' };
     } catch (e) { return { ok: false, msg: e && e.toString ? e.toString() : String(e) }; }
-  })()`) as Promise<SendResult>;
+  })()`);
 }
 
 /** Read <img> elements from all message bubbles so callers can filter by baseline. */
-async function getBubbleImageSets(page: IPage): Promise<BubbleImageSet[]> {
+async function getBubbleImageSets(page) {
   const result = await page.evaluate(`(() => {
     const bubbles = document.querySelectorAll('div.message-bubble, [data-testid="message-bubble"]');
     return Array.from(bubbles).map(bubble => Array.from(bubble.querySelectorAll('img'))
@@ -196,16 +185,13 @@ async function getBubbleImageSets(page: IPage): Promise<BubbleImageSet[]> {
       .filter(i => i.src && /^https?:/.test(i.src))
       // Ignore tiny UI/avatar images that may live in the bubble chrome.
       .filter(i => (i.w === 0 || i.w >= 128) && (i.h === 0 || i.h >= 128)));
-  })()`) as BubbleImageSet[] | undefined;
+  })()`);
 
   const raw = Array.isArray(result) ? result : [];
   return raw.map(dedupeBySrc);
 }
 
-function pickLatestImageCandidate(
-  bubbleImageSets: BubbleImageSet[],
-  baselineCount: number,
-): BubbleImage[] {
+function pickLatestImageCandidate(bubbleImageSets, baselineCount) {
   const freshSets = bubbleImageSets.slice(Math.max(0, baselineCount));
   for (let i = freshSets.length - 1; i >= 0; i -= 1) {
     if (freshSets[i].length) return freshSets[i];
@@ -216,7 +202,7 @@ function pickLatestImageCandidate(
 // Download through the browser's fetch so grok.com cookies and referer are
 // attached automatically — assets.grok.com is gated by Cloudflare and will
 // refuse direct curl/node downloads.
-async function fetchImageAsBase64(page: IPage, url: string): Promise<FetchResult> {
+async function fetchImageAsBase64(page, url) {
   const urlJson = JSON.stringify(url);
   return page.evaluate(`(async () => {
     try {
@@ -229,21 +215,24 @@ async function fetchImageAsBase64(page: IPage, url: string): Promise<FetchResult
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
       return { ok: true, base64: btoa(binary), contentType: blob.type || 'image/jpeg' };
     } catch (e) { return { ok: false, error: e && e.message || String(e) }; }
-  })()`) as Promise<FetchResult>;
+  })()`);
 }
 
-async function saveImages(
-  page: IPage,
-  images: BubbleImage[],
-  outDir: string,
-): Promise<Array<BubbleImage & { path: string }>> {
+async function saveImages(page, images, outDir) {
   fs.mkdirSync(outDir, { recursive: true });
-  const results: Array<BubbleImage & { path: string }> = [];
+  const results = [];
   for (const img of images) {
     const fetched = await fetchImageAsBase64(page, img.src);
     if (!fetched || !fetched.ok) {
-      results.push({ ...img, path: `[DOWNLOAD FAILED] ${fetched?.error || 'unknown'}` });
-      continue;
+      // Fail loudly on per-image download failure rather than emit a sentinel
+      // row with path = '[DOWNLOAD FAILED] ...' that downstream tools cannot
+      // distinguish from a real path. assets.grok.com is Cloudflare-gated, so
+      // a single 401/403 typically means the whole batch is unrecoverable.
+      const reason = fetched?.error ? `: ${fetched.error}` : '';
+      throw new CommandExecutionError(
+        `Failed to download grok image ${img.src}${reason}`,
+        'assets.grok.com download requires the live grok.com browser session — verify the tab is logged in and try again.',
+      );
     }
     const filepath = path.join(outDir, buildFilename(img.src, fetched.contentType));
     fs.writeFileSync(filepath, Buffer.from(fetched.base64 || '', 'base64'));
@@ -252,7 +241,7 @@ async function saveImages(
   return results;
 }
 
-function toRow(img: BubbleImage, savedPath = '') {
+function toRow(img, savedPath = '') {
   return { url: img.src, width: img.w, height: img.h, path: savedPath };
 }
 
@@ -273,11 +262,11 @@ export const imageCommand = cli({
     { name: 'out', type: 'string', default: '', help: 'Directory to save downloaded images (uses browser session to bypass auth)' },
   ],
   columns: ['url', 'width', 'height', 'path'],
-  func: async (page: IPage, kwargs: Record<string, any>) => {
-    const prompt = kwargs.prompt as string;
-    const timeoutMs = ((kwargs.timeout as number) || 240) * 1000;
+  func: async (page, kwargs) => {
+    const prompt = kwargs.prompt;
+    const timeoutMs = (kwargs.timeout || 240) * 1000;
     const newChat = normalizeBooleanFlag(kwargs.new);
-    const minCount = Math.max(1, Number(kwargs.count || 1));
+    const minCount = normalizePositiveInteger(kwargs.count, 1, 'count');
     const outDir = (kwargs.out || '').toString().trim();
 
     if (newChat) {
@@ -293,18 +282,16 @@ export const imageCommand = cli({
     const baselineBubbleCount = (await getBubbleImageSets(page)).length;
     const sendResult = await sendPrompt(page, prompt);
     if (!sendResult || !sendResult.ok) {
-      return [{
-        url: `${BLOCKED_PREFIX} send failed: ${JSON.stringify(sendResult)}. ${SESSION_HINT}`,
-        width: 0,
-        height: 0,
-        path: '',
-      }];
+      throw new CommandExecutionError(
+        `Grok composer rejected the prompt: ${JSON.stringify(sendResult)}`,
+        SESSION_HINT,
+      );
     }
 
     const startTime = Date.now();
     let lastSignature = '';
     let stableCount = 0;
-    let lastImages: BubbleImage[] = [];
+    let lastImages = [];
 
     while (Date.now() - startTime < timeoutMs) {
       await page.wait(3);
@@ -331,6 +318,8 @@ export const imageCommand = cli({
       }
     }
 
+    // Timeout — keep best-effort partial results if any image bubble showed
+    // up, otherwise surface the timeout instead of a sentinel row.
     if (lastImages.length) {
       if (outDir) {
         const saved = await saveImages(page, lastImages, outDir);
@@ -338,17 +327,13 @@ export const imageCommand = cli({
       }
       return lastImages.map(i => toRow(i));
     }
-    return [{
-      url: `${NO_IMAGE_PREFIX} No image appeared within ${Math.round(timeoutMs / 1000)}s.`,
-      width: 0,
-      height: 0,
-      path: '',
-    }];
+    throw new TimeoutError('grok image generation', Math.round(timeoutMs / 1000));
   },
 });
 
 export const __test__ = {
   normalizeBooleanFlag,
+  normalizePositiveInteger,
   isOnGrok,
   dedupeBySrc,
   imagesSignature,

--- a/clis/grok/image.test.ts
+++ b/clis/grok/image.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { IPage } from '@jackwener/opencli/types';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { __test__ } from './image.js';
 
 describe('grok image helpers', () => {
@@ -93,6 +94,25 @@ describe('grok image helpers', () => {
     expect(candidate).toEqual([
       { src: 'https://a.example/fresh.jpg', w: 1024, h: 1024 },
     ]);
+  });
+
+  describe('normalizePositiveInteger', () => {
+    it('returns a parsed positive integer', () => {
+      expect(__test__.normalizePositiveInteger(3, 1, 'count')).toBe(3);
+      expect(__test__.normalizePositiveInteger('5', 1, 'count')).toBe(5);
+    });
+
+    it('falls back to the default when the user did not pass a value', () => {
+      expect(__test__.normalizePositiveInteger(undefined, 1, 'count')).toBe(1);
+      expect(__test__.normalizePositiveInteger(null, 4, 'count')).toBe(4);
+    });
+
+    it('throws ArgumentError instead of silently clamping out-of-range input', () => {
+      expect(() => __test__.normalizePositiveInteger(0, 1, 'count')).toThrow(ArgumentError);
+      expect(() => __test__.normalizePositiveInteger(-1, 1, 'count')).toThrow(ArgumentError);
+      expect(() => __test__.normalizePositiveInteger(1.5, 1, 'count')).toThrow(ArgumentError);
+      expect(() => __test__.normalizePositiveInteger('not-a-number', 1, 'count')).toThrow(ArgumentError);
+    });
   });
 
   it('does not reuse stale images when no new image bubble appears after baseline', () => {

--- a/clis/grok/utils.test.js
+++ b/clis/grok/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { normalizeBooleanFlag, parseGrokSessionId } from './utils.js';
+import { isOnGrok, normalizeBooleanFlag, parseGrokSessionId } from './utils.js';
 
 describe('grok parseGrokSessionId', () => {
     const id = '7c4197f2-10a1-4ebb-a84a-fea89f4f1d06';
@@ -48,6 +48,31 @@ describe('grok parseGrokSessionId', () => {
         // and open the wrong conversation.
         expect(() => parseGrokSessionId(`https://grok.com/c/${id}0`)).toThrow(ArgumentError);
         expect(() => parseGrokSessionId(`https://grok.com/c/${id}-extra`)).toThrow(ArgumentError);
+    });
+});
+
+describe('grok isOnGrok', () => {
+    const fakePage = (url) => ({
+        evaluate: () => url instanceof Error ? Promise.reject(url) : Promise.resolve(url),
+    });
+
+    it('returns true for grok.com URLs', async () => {
+        expect(await isOnGrok(fakePage('https://grok.com/'))).toBe(true);
+        expect(await isOnGrok(fakePage('https://grok.com/c/abc'))).toBe(true);
+    });
+
+    it('returns true for grok.com subdomains', async () => {
+        expect(await isOnGrok(fakePage('https://api.grok.com/v1'))).toBe(true);
+    });
+
+    it('returns false for non-grok domains and rejects substring matches', async () => {
+        expect(await isOnGrok(fakePage('https://fakegrok.com/'))).toBe(false);
+        expect(await isOnGrok(fakePage('https://example.com/?next=grok.com'))).toBe(false);
+        expect(await isOnGrok(fakePage('about:blank'))).toBe(false);
+    });
+
+    it('returns false when evaluate throws (detached tab)', async () => {
+        expect(await isOnGrok(fakePage(new Error('detached')))).toBe(false);
     });
 });
 

--- a/docs/adapters/browser/grok.md
+++ b/docs/adapters/browser/grok.md
@@ -39,9 +39,6 @@ opencli grok ask "Explain quantum computing in simple terms"
 # Ask in a brand-new chat
 opencli grok ask "Hello" --new true
 
-# Use the explicit consumer-web path (TipTap composer + Submit button)
-opencli grok ask "Explain quantum computing" --web true --timeout 180
-
 # Fire-and-forget (don't wait for the reply)
 opencli grok send "continue the previous answer"
 
@@ -61,7 +58,6 @@ opencli grok image "a cyberpunk mechanical owl, neon purple and blue" --new true
 | `prompt` | Prompt to send (required positional) |
 | `--new` | Start a new chat before sending (default: `false`) |
 | `--timeout` | (`ask` only) Max seconds to wait for the reply (default: `120`) |
-| `--web` | (`ask` only) Use the explicit grok.com consumer-web composer path (default: `false`) |
 
 ### `read`
 


### PR DESCRIPTION
## Summary

R2 of the pre-release deep code review (task #234, items 1+2). Items 6+7 already shipped via #1395; item 1 already shipped via #1396. This is item 2.

Two bugs, one PR:

1. **Typed-error cleanup (`grok ask` + `grok image`)** — replaces 4 sentinel-row anti-patterns + 1 silent-clamp with typed errors per `references/typed-errors.md` 5-classification.
2. **Manifest delivery fix (`grok image`)** — `clis/grok/image.ts` has been TypeScript-only since #906 (Apr 14). The manifest scanner only reads `.js` files (`build-manifest.ts:220`), `tsconfig.json:include` covers only `src/`. So `grok image` has never been reachable from the CLI manifest — the file was dead at runtime. Confirmed via `node dist/src/main.js grok image ...` → `error: unknown command 'image'` before this PR. After: 794 → 795 manifest entries.

Without (2), the typed-error fix in (1) for image would be a no-op.

## Changes

### `clis/grok/ask.js`
- Send-fail: `[SEND FAILED]` sentinel row → `CommandExecutionError(reason, SESSION_HINT)`
- Composer-blocked: `[BLOCKED]` sentinel row → `CommandExecutionError`
- No-response timeout: `[NO RESPONSE]` sentinel row → `TimeoutError`
- Partial text on timeout preserved (only fall through to `TimeoutError` when no streaming was visible)

### `clis/grok/image.ts` → `clis/grok/image.js` (mechanical TS→JS, identical runtime)
- `--count <=0 / non-int / non-numeric`: silent `Math.max(1, Number(kwargs.count || 1))` clamp → `ArgumentError('count must be a positive integer')` (exit 2)
- Send-fail: `[SEND FAILED]` sentinel row → `CommandExecutionError`
- No-image timeout: `[NO IMAGE]` sentinel row → `TimeoutError` (partial preserved when at least one bubble appeared)
- Per-image download-fail in `saveImages`: `path = '[DOWNLOAD FAILED] ...'` row → `CommandExecutionError` (assets.grok.com is Cloudflare-gated; one 401/403 means the whole batch is unrecoverable)
- New `normalizePositiveInteger` helper exported via `__test__` for unit coverage

### `clis/grok/image.test.ts`
- Adds `describe('normalizePositiveInteger', ...)` block (3 cases: parsed positive, default fallback, ArgumentError on `0` / `-1` / `1.5` / `'not-a-number'`)

## Verification

```
npm run build            ✅ Manifest compiled: 795 entries (was 794)
npm run typecheck        ✅
npm test -- --run clis/grok/  ✅ 3 files, 31 tests
npm run check:silent-column-drop  ✅ 0 new
npm run check:typed-error-lint    ✅ 0 new

# Smoke (typed-error wiring, no real grok login needed):
node dist/src/main.js grok image "x" --count 0   → ArgumentError exit 2 ✅
node dist/src/main.js grok image "x" --count -1  → ArgumentError exit 2 ✅
node dist/src/main.js grok image --help          → registry meta visible ✅
```

## Test plan

- [ ] CI green
- [ ] Logged-in `grok ask` smoke: confirm a real prompt still completes (typed-error paths only fire on send-fail/timeout; happy path unchanged)
- [ ] Logged-in `grok image "draw a cat"` smoke: confirm image bubble polling still returns rows
- [ ] cross-review by @codex-coder