### PR TITLE
chore(release): 1.7.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.7.14](https://github.com/jackwener/opencli/compare/v1.7.13...v1.7.14) (2026-05-08)
+
+### Features
+
+* **help** — adapter help is now agent-friendly: per-command listings drop the `[options]` noise from globally-shared options (`--format`, `--trace`, `-v`, `-h`, etc.) and only mention them at the site level, so `opencli twitter` etc. read like a flat command index. ([#1401](https://github.com/jackwener/opencli/issues/1401))
+* **twitter** — write-action symmetry P0: add `unlike`, `retweet`, `unretweet`, and `quote` to round out the read/write coverage. ([#1400](https://github.com/jackwener/opencli/issues/1400))
+
+### Bug Fixes
+
+* **browser daemon** — `npm install -g @jackwener/opencli@latest` now correctly auto-restarts a stale ready-state daemon so users pick up the new version without a manual `opencli daemon restart`. ([#1399](https://github.com/jackwener/opencli/issues/1399))
+
 ## [1.7.13](https://github.com/jackwener/opencli/compare/v1.7.12...v1.7.13) (2026-05-07)
 
 Extension bumped to 1.0.6 (screenshot `--width` / `--height` / `--full-page` flags, automation tab group color marker, automation container reuse fix).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- bump opencli to **1.7.14** (was 1.7.13)
- extension stays at **1.0.6** (no extension changes since v1.7.13)
- finalize CHANGELOG with the three landed PRs

## Highlights since 1.7.13

- **#1399** browser daemon — `npm install -g @jackwener/opencli@latest` correctly auto-restarts a stale ready-state daemon so users pick up the new version without a manual `opencli daemon restart`.
- **#1400** twitter — write-action symmetry P0: add `unlike`, `retweet`, `unretweet`, and `quote`.
- **#1401** help — adapter help is now agent-friendly: per-command listings drop the `[options]` noise from globally-shared options (`--format`, `--trace`, `-v`, `-h`) and only mention them at the site level.

No breaking changes.

## Verification

- [x] `npm run build` clean (manifest 799 entries)
- [ ] CI green (build / unit / adapter / audit / docs)

## Release flow

After merge: tag `v1.7.14` triggers Release CI — npm publish + GitHub Release.