### PR TITLE
feat(help): hard-gate empty positional help text + fix 18 offenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **help / build** — every positional arg must now declare a non-empty `help` string. The build-manifest step fails closed when a positional has empty / whitespace-only / missing `help`, so `opencli <site> <cmd> --help` always shows callers what each parameter is for. Pre-existing offenders (`twitter followers/following/list-add/list-remove/list-tweets/search/thread`, `reddit search/subreddit/user/user-comments/user-posts`, `douyin stats/update`, `bilibili subtitle`, `jike search`) now have explicit help text — most notably `twitter followers [user]` and `following [user]` now document that omitting the user fetches the currently logged-in account.
+
 ## [1.7.14](https://github.com/jackwener/opencli/compare/v1.7.13...v1.7.14) (2026-05-08)
 
 ### Features

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2443,7 +2443,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Bilibili 视频 BV ID（如 BV1xx411c7mD），或视频 URL / b23.tv 短链"
       },
       {
         "name": "lang",
@@ -8491,7 +8491,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "抖音作品 ID（aweme_id，可从作品 URL 末尾获取）"
       }
     ],
     "columns": [
@@ -8517,7 +8517,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "抖音作品 ID（aweme_id，可从作品 URL 末尾获取）"
       },
       {
         "name": "reschedule",
@@ -13173,7 +13173,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "即刻搜索关键词"
       },
       {
         "name": "limit",
@@ -19350,7 +19350,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Reddit search query"
       },
       {
         "name": "subreddit",
@@ -19408,7 +19408,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Subreddit name (no `r/` prefix; e.g. `python`)"
       },
       {
         "name": "sort",
@@ -19553,7 +19553,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Reddit username (no `u/` prefix needed)"
       }
     ],
     "columns": [
@@ -19579,7 +19579,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Reddit username (no `u/` prefix needed)"
       },
       {
         "name": "limit",
@@ -19614,7 +19614,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Reddit username (no `u/` prefix needed)"
       },
       {
         "name": "limit",
@@ -22375,7 +22375,7 @@
         "type": "string",
         "required": false,
         "positional": true,
-        "help": ""
+        "help": "Twitter/X handle (with or without @). Omit to fetch followers of the currently logged-in account."
       },
       {
         "name": "limit",
@@ -22409,7 +22409,7 @@
         "type": "string",
         "required": false,
         "positional": true,
-        "help": ""
+        "help": "Twitter/X handle (with or without @). Omit to fetch the accounts the currently logged-in user follows."
       },
       {
         "name": "limit",
@@ -22537,14 +22537,14 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Numeric ID of the list you own (e.g. from `opencli twitter lists`)"
       },
       {
         "name": "username",
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Twitter/X handle to add (with or without @)"
       }
     ],
     "columns": [
@@ -22573,14 +22573,14 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Numeric ID of the list you own (e.g. from `opencli twitter lists`)"
       },
       {
         "name": "username",
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Twitter/X handle to remove (with or without @)"
       }
     ],
     "columns": [
@@ -22609,7 +22609,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Numeric ID of a Twitter/X list (e.g. from `opencli twitter lists`)"
       },
       {
         "name": "limit",
@@ -22929,7 +22929,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Twitter/X search query (operators like `from:` and `since:` are supported)"
       },
       {
         "name": "filter",
@@ -22980,7 +22980,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": ""
+        "help": "Tweet numeric ID (e.g. 1234567890) or full status URL"
       },
       {
         "name": "limit",

--- a/clis/bilibili/subtitle.js
+++ b/clis/bilibili/subtitle.js
@@ -8,7 +8,7 @@ cli({
     description: '获取 Bilibili 视频的字幕',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'bvid', required: true, positional: true },
+        { name: 'bvid', required: true, positional: true, help: 'Bilibili 视频 BV ID（如 BV1xx411c7mD），或视频 URL / b23.tv 短链' },
         { name: 'lang', required: false, help: '字幕语言代码 (如 zh-CN, en-US, ai-zh)，默认取第一个' },
     ],
     columns: ['index', 'from', 'to', 'content'],

--- a/clis/douyin/stats.js
+++ b/clis/douyin/stats.js
@@ -8,7 +8,7 @@ cli({
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'aweme_id', required: true, positional: true },
+        { name: 'aweme_id', required: true, positional: true, help: '抖音作品 ID（aweme_id，可从作品 URL 末尾获取）' },
     ],
     columns: ['metric', 'value'],
     func: async (page, kwargs) => {

--- a/clis/douyin/update.js
+++ b/clis/douyin/update.js
@@ -10,7 +10,7 @@ cli({
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'aweme_id', required: true, positional: true },
+        { name: 'aweme_id', required: true, positional: true, help: '抖音作品 ID（aweme_id，可从作品 URL 末尾获取）' },
         { name: 'reschedule', default: '', help: '新的发布时间（ISO8601 或 Unix 秒）' },
         { name: 'caption', default: '', help: '新的正文内容' },
     ],

--- a/clis/jike/search.js
+++ b/clis/jike/search.js
@@ -15,7 +15,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'query', type: 'string', required: true, positional: true },
+        { name: 'query', type: 'string', required: true, positional: true, help: '即刻搜索关键词' },
         { name: 'limit', type: 'int', default: 20 },
     ],
     columns: ['id', 'author', 'content', 'likes', 'comments', 'time', 'url'],

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -8,7 +8,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'query', type: 'string', required: true, positional: true },
+        { name: 'query', type: 'string', required: true, positional: true, help: 'Reddit search query' },
         {
             name: 'subreddit',
             type: 'string',

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -8,7 +8,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'name', type: 'string', required: true, positional: true },
+        { name: 'name', type: 'string', required: true, positional: true, help: 'Subreddit name (no `r/` prefix; e.g. `python`)' },
         {
             name: 'sort',
             type: 'string',

--- a/clis/reddit/user-comments.js
+++ b/clis/reddit/user-comments.js
@@ -8,7 +8,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'username', type: 'string', required: true, positional: true },
+        { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
         { name: 'limit', type: 'int', default: 15 },
     ],
     columns: ['subreddit', 'score', 'body', 'url'],

--- a/clis/reddit/user-posts.js
+++ b/clis/reddit/user-posts.js
@@ -8,7 +8,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'username', type: 'string', required: true, positional: true },
+        { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
         { name: 'limit', type: 'int', default: 15 },
     ],
     columns: ['title', 'subreddit', 'score', 'comments', 'url'],

--- a/clis/reddit/user.js
+++ b/clis/reddit/user.js
@@ -8,7 +8,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'username', type: 'string', required: true, positional: true },
+        { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
     ],
     columns: ['field', 'value'],
     pipeline: [

--- a/clis/twitter/followers.js
+++ b/clis/twitter/followers.js
@@ -84,7 +84,13 @@ cli({
     strategy: Strategy.UI,
     browser: true,
     args: [
-        { name: 'user', positional: true, type: 'string', required: false },
+        {
+            name: 'user',
+            positional: true,
+            type: 'string',
+            required: false,
+            help: 'Twitter/X handle (with or without @). Omit to fetch followers of the currently logged-in account.',
+        },
         { name: 'limit', type: 'int', default: 50 },
     ],
     // `followers` (count) is NOT exposed: the SPA followers-list view does not

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -140,7 +140,13 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'user', positional: true, type: 'string', required: false },
+        {
+            name: 'user',
+            positional: true,
+            type: 'string',
+            required: false,
+            help: 'Twitter/X handle (with or without @). Omit to fetch the accounts the currently logged-in user follows.',
+        },
         { name: 'limit', type: 'int', default: 50 },
     ],
     columns: ['screen_name', 'name', 'bio', 'followers'],

--- a/clis/twitter/list-add.js
+++ b/clis/twitter/list-add.js
@@ -71,8 +71,8 @@ cli({
     strategy: Strategy.UI,
     browser: true,
     args: [
-        { name: 'listId', positional: true, type: 'string', required: true },
-        { name: 'username', positional: true, type: 'string', required: true },
+        { name: 'listId', positional: true, type: 'string', required: true, help: 'Numeric ID of the list you own (e.g. from `opencli twitter lists`)' },
+        { name: 'username', positional: true, type: 'string', required: true, help: 'Twitter/X handle to add (with or without @)' },
     ],
     columns: ['listId', 'username', 'userId', 'status', 'message'],
     func: async (page, kwargs) => {

--- a/clis/twitter/list-remove.js
+++ b/clis/twitter/list-remove.js
@@ -80,8 +80,8 @@ cli({
     strategy: Strategy.UI,
     browser: true,
     args: [
-        { name: 'listId', positional: true, type: 'string', required: true },
-        { name: 'username', positional: true, type: 'string', required: true },
+        { name: 'listId', positional: true, type: 'string', required: true, help: 'Numeric ID of the list you own (e.g. from `opencli twitter lists`)' },
+        { name: 'username', positional: true, type: 'string', required: true, help: 'Twitter/X handle to remove (with or without @)' },
     ],
     columns: ['listId', 'username', 'userId', 'status', 'message'],
     func: async (page, kwargs) => {

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -113,7 +113,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'listId', positional: true, type: 'string', required: true },
+        { name: 'listId', positional: true, type: 'string', required: true, help: 'Numeric ID of a Twitter/X list (e.g. from `opencli twitter lists`)' },
         { name: 'limit', type: 'int', default: 50 },
     ],
     columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -100,7 +100,7 @@ cli({
     strategy: Strategy.INTERCEPT, // Use intercept strategy
     browser: true,
     args: [
-        { name: 'query', type: 'string', required: true, positional: true },
+        { name: 'query', type: 'string', required: true, positional: true, help: 'Twitter/X search query (operators like `from:` and `since:` are supported)' },
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'] },
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -101,7 +101,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'tweet-id', positional: true, type: 'string', required: true },
+        { name: 'tweet-id', positional: true, type: 'string', required: true, help: 'Tweet numeric ID (e.g. 1234567890) or full status URL' },
         { name: 'limit', type: 'int', default: 50 },
     ],
     columns: ['id', 'author', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls'],

--- a/src/build-manifest.test.ts
+++ b/src/build-manifest.test.ts
@@ -6,6 +6,7 @@ import { cli, getRegistry, Strategy } from './registry.js';
 import {
   ManifestImportError,
   diffRemovedEntries,
+  findManifestMetadataIssues,
   loadManifestEntries,
   normalizeManifestPath,
   parseBuildManifestArgs,
@@ -260,6 +261,116 @@ describe('manifest helper rules', () => {
     expect(diffRemovedEntries(prev, next)).toEqual(['a/2', 'b/3']);
     expect(diffRemovedEntries(prev, prev)).toEqual([]);
     expect(diffRemovedEntries([], next)).toEqual([]);
+  });
+
+  it('findManifestMetadataIssues flags positionals with empty/missing help', () => {
+    // The build-time hard gate. A positional with `help: ''` or no `help` at
+    // all renders `Arguments:\n  <name>` with a blank trailing column —
+    // unrecoverable for both humans and agents reading help. Failing closed
+    // here is the only way to keep help text trustworthy as adapters land.
+    //
+    // Semantic quality (e.g. what does an *optional* positional mean when
+    // omitted?) is intentionally NOT enforced — that belongs to the planned
+    // Arg metadata v2 advisory pass.
+    const entries: ManifestEntry[] = [
+      // Positional with usable help — clean.
+      {
+        site: 'demo',
+        name: 'ok',
+        access: 'read',
+        description: '',
+        strategy: 'public',
+        browser: false,
+        args: [
+          { name: 'q', positional: true, required: true, help: 'Search query' },
+        ],
+        type: 'js',
+        sourceFile: 'demo/ok.js',
+      },
+      // Positional with empty help string — must flag.
+      {
+        site: 'demo',
+        name: 'empty-help',
+        access: 'read',
+        description: '',
+        strategy: 'public',
+        browser: false,
+        args: [
+          { name: 'user', positional: true, required: false, help: '' },
+        ],
+        type: 'js',
+        sourceFile: 'demo/empty.js',
+      },
+      // Positional with whitespace-only help — must flag.
+      {
+        site: 'demo',
+        name: 'whitespace-help',
+        access: 'read',
+        description: '',
+        strategy: 'public',
+        browser: false,
+        args: [
+          { name: 'id', positional: true, required: true, help: '   ' },
+        ],
+        type: 'js',
+      },
+      // Positional with no help field at all — must flag.
+      {
+        site: 'demo',
+        name: 'missing-help',
+        access: 'read',
+        description: '',
+        strategy: 'public',
+        browser: false,
+        args: [
+          { name: 'name', positional: true, required: true },
+        ],
+        type: 'js',
+      },
+      // NON-positional flag with empty help — must NOT flag (gate is
+      // intentionally scoped to positionals; named flags carry the flag
+      // name itself in the help line).
+      {
+        site: 'demo',
+        name: 'flag-only',
+        access: 'read',
+        description: '',
+        strategy: 'public',
+        browser: false,
+        args: [
+          { name: 'limit', required: false, help: '' },
+        ],
+        type: 'js',
+      },
+    ];
+
+    const issues = findManifestMetadataIssues(entries);
+    expect(issues).toHaveLength(3);
+    expect(issues.map(i => `${i.site}/${i.command}/${i.arg}`).sort()).toEqual([
+      'demo/empty-help/user',
+      'demo/missing-help/name',
+      'demo/whitespace-help/id',
+    ]);
+    // sourceFile flows through when present so the build error points at the
+    // exact file to fix.
+    const emptyHelp = issues.find(i => i.command === 'empty-help');
+    expect(emptyHelp?.sourceFile).toBe('demo/empty.js');
+  });
+
+  it('findManifestMetadataIssues returns [] for fully-documented entries', () => {
+    expect(findManifestMetadataIssues([])).toEqual([]);
+    expect(findManifestMetadataIssues([
+      {
+        site: 'demo',
+        name: 'no-args',
+        access: 'read',
+        description: '',
+        strategy: 'public',
+        browser: false,
+        args: [],
+        type: 'js',
+      },
+    ])).toEqual([]);
   });
 
   it('parseBuildManifestArgs reads --allow-removals[=N]', () => {

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -251,6 +251,52 @@ export function serializeManifest(manifest: ManifestEntry[]): string {
 }
 
 /**
+ * Metadata audit: every positional arg must carry a non-empty `help` string.
+ *
+ * Why this is a hard gate (not advisory):
+ *   - `opencli twitter followers --help` rendered `Arguments:\n  user  ` with
+ *     an empty trailing column. Agents and humans both saw a blank field —
+ *     impossible to recover the parameter's purpose without reading source.
+ *   - This is metadata completeness, not stylistic taste; failing closed is
+ *     the only way to keep the help surface trustworthy as adapters land.
+ *
+ * Note: semantic quality (e.g. "what does the optional positional mean when
+ * omitted?") is intentionally NOT enforced here. That belongs to a follow-up
+ * advisory audit — see PR plan `Arg metadata v2` for the structured
+ * `when_omitted / when_present / value_format` schema.
+ */
+export interface ManifestMetadataIssue {
+  site: string;
+  command: string;
+  arg: string;
+  sourceFile?: string;
+  reason: string;
+}
+
+export function findManifestMetadataIssues(
+  entries: readonly ManifestEntry[],
+): ManifestMetadataIssue[] {
+  const issues: ManifestMetadataIssue[] = [];
+  for (const entry of entries) {
+    if (!Array.isArray(entry.args)) continue;
+    for (const arg of entry.args) {
+      if (!arg.positional) continue;
+      const help = typeof arg.help === 'string' ? arg.help.trim() : '';
+      if (help === '') {
+        issues.push({
+          site: entry.site,
+          command: entry.name,
+          arg: arg.name,
+          sourceFile: entry.sourceFile,
+          reason: 'positional arg missing non-empty `help` text',
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+/**
  * Diff helper: returns site/name keys that exist in `prev` but not in
  * `next`. Used as a safety net to detect accidental mass-deletions caused
  * by silently failing adapter imports.
@@ -326,6 +372,25 @@ async function main(): Promise<void> {
     process.stderr.write(
       `\nManifest NOT written. Likely cause: stale dist/ or a broken adapter import.\n`
       + `Always run via tsx (\`npm run build-manifest\`), not against compiled dist/.\n`,
+    );
+    process.exit(1);
+  }
+
+  const metadataIssues = findManifestMetadataIssues(entries);
+  if (metadataIssues.length > 0) {
+    process.stderr.write(
+      `❌ ${metadataIssues.length} positional arg(s) missing \`help\` text:\n`,
+    );
+    for (const issue of metadataIssues) {
+      const where = issue.sourceFile ? ` (${issue.sourceFile})` : '';
+      process.stderr.write(
+        `  - ${issue.site}/${issue.command} positional "${issue.arg}"${where}\n`,
+      );
+    }
+    process.stderr.write(
+      `\nEvery positional arg must declare a non-empty \`help\` string so\n`
+      + `\`opencli <site> <cmd> --help\` shows callers what the parameter is for.\n`
+      + `Add \`help: '...'\` to each arg above and re-run the build.\n`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

- Build-manifest fails closed when any positional arg has empty/whitespace/missing `help`. `opencli twitter followers --help` used to render `Arguments:\n  user  ` with a blank column — unrecoverable for both humans and agents.
- Fix the 18 offenders surfaced by the new gate (16 required + 2 optional). Most notably, the optional `[user]` positional on `twitter followers` and `following` now documents that omitting it fetches the **currently logged-in account** — exactly the gap WAWQAQ flagged in #OpenCLI:8bc52e11.
- Adds 2 tests covering the gate (positive + negative cases).

This is **PR α** in the help-system overhaul plan agreed in #OpenCLI:8bc52e11. It is intentionally narrow: metadata completeness only, no semantic-quality enforcement, no named-flag scope. Follow-up PRs (A0 OptionSpec registry + browser dogfood, β Arg metadata v2 with `when_omitted/when_present/value_format`, C list schema unify) will land separately.

## Why this is a hard gate, not advisory

`opencli twitter followers --help` rendered an empty trailing column for the `user` arg. There is no way to recover the parameter's purpose without reading source. This is metadata completeness, not stylistic taste — failing closed is the only way to keep the help surface trustworthy as adapters land. Semantic quality (e.g. "what does the optional positional mean when omitted?") is intentionally NOT enforced here; that belongs to the planned Arg metadata v2 advisory pass.

## Affected adapters

| Site | Commands |
|------|---------|
| twitter | `followers` (optional), `following` (optional), `list-add`, `list-remove`, `list-tweets`, `search`, `thread` |
| reddit | `search`, `subreddit`, `user`, `user-comments`, `user-posts` |
| douyin | `stats`, `update` |
| bilibili | `subtitle` |
| jike | `search` |

The two optional positionals get omit-semantics text:

> `user` — Twitter/X handle (with or without @). Omit to fetch followers of the currently logged-in account.

## Test plan

- [x] `npm run build` → 799 entries, clean
- [x] `npm run typecheck` → clean
- [x] `npx vitest run src/build-manifest.test.ts src/cli.test.ts src/help.test.ts src/commanderAdapter.test.ts` → 161 tests passed
- [x] `npx vitest run --project adapter` → 2007 tests passed (no regression)
- [x] `npm run check:silent-column-drop` baseline unchanged (103/103)
- [x] `npm run check:typed-error-lint` baseline unchanged (189/189)
- [x] Smoke: temporarily revert `followers.js` help to empty → build aborts with `twitter/followers positional "user" (twitter/followers.js)`; restored, build is clean
- [x] Smoke: `node dist/src/main.js twitter followers --help` shows the new help line

cc @codex-coder for review per the plan in #OpenCLI:8bc52e11.