### PR TITLE
fix(douyin): handle empty response body in browserFetch

### DIFF
--- a/clis/douyin/_shared/browser-fetch.js
+++ b/clis/douyin/_shared/browser-fetch.js
@@ -15,10 +15,15 @@ export async function browserFetch(page, method, url, options = {}) {
         },
         ${options.body ? `body: JSON.stringify(${JSON.stringify(options.body)}),` : ''}
       });
-      return res.json();
+      const text = await res.text();
+      if (!text) return null;
+      return JSON.parse(text);
     })()
   `;
     const result = await page.evaluate(js);
+    if (result === null || result === undefined) {
+        throw new CommandExecutionError('Empty response from Douyin API');
+    }
     if (result && typeof result === 'object' && 'status_code' in result) {
         const code = result.status_code;
         if (code !== 0) {

--- a/clis/douyin/_shared/browser-fetch.js
+++ b/clis/douyin/_shared/browser-fetch.js
@@ -20,7 +20,14 @@ export async function browserFetch(page, method, url, options = {}) {
       return JSON.parse(text);
     })()
   `;
-    const result = await page.evaluate(js);
+    let result;
+    try {
+        result = await page.evaluate(js);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(`Douyin API request failed: ${message}`);
+    }
     if (result === null || result === undefined) {
         throw new CommandExecutionError('Empty response from Douyin API');
     }

--- a/clis/douyin/_shared/browser-fetch.test.js
+++ b/clis/douyin/_shared/browser-fetch.test.js
@@ -35,4 +35,9 @@ describe('browserFetch', () => {
         const page = makePage(undefined);
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Empty response from Douyin API');
     });
+    it('wraps browser-side fetch or JSON parse failures', async () => {
+        const page = makePage(null);
+        page.evaluate.mockRejectedValueOnce(new SyntaxError('Unexpected token < in JSON'));
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Douyin API request failed: Unexpected token < in JSON');
+    });
 });

--- a/clis/douyin/_shared/browser-fetch.test.js
+++ b/clis/douyin/_shared/browser-fetch.test.js
@@ -27,4 +27,12 @@ describe('browserFetch', () => {
         const result = await browserFetch(page, 'GET', 'https://creator.douyin.com/api/test');
         expect(result).toEqual({ some_field: 'value' });
     });
+    it('throws on empty response body (null from evaluate)', async () => {
+        const page = makePage(null);
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Empty response from Douyin API');
+    });
+    it('throws on undefined response body', async () => {
+        const page = makePage(undefined);
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Empty response from Douyin API');
+    });
 });


### PR DESCRIPTION
## Problem

`opencli douyin hashtag search --keyword King` crashes with `SyntaxError: Unexpected end of JSON input` when the Douyin API returns HTTP 200 with an empty body (content-length: 0).

The root cause is that `browserFetch` calls `res.json()` directly without checking if the response body is empty.

## Fix

- Read response as text first (`res.text()`), return `null` for empty bodies
- At the caller level, throw a descriptive `CommandExecutionError('Empty response from Douyin API')` instead of an opaque JSON parse error

This benefits all 20 douyin commands that use `browserFetch`.

## Testing

- Added 2 test cases for null/undefined responses
- All 100 existing douyin tests pass
- `npx vitest run clis/douyin/` ✅

Closes #1405