### PR TITLE
feat(youtube): support channel Shorts tab

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -27057,7 +27057,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "Channel ID (UCxxxx) or handle (@name)"
+        "help": "Channel ID (UCxxxx), handle (@name), or channel URL"
       },
       {
         "name": "limit",
@@ -27065,6 +27065,13 @@
         "default": 10,
         "required": false,
         "help": "Max recent videos (max 30)"
+      },
+      {
+        "name": "tab",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "Channel tab to list: videos or shorts"
       }
     ],
     "columns": [

--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -18,6 +18,112 @@ export function extractSelectedRichGridContents(browseData) {
     return Array.isArray(fallbackContents) ? fallbackContents : [];
 }
 
+export function isShortsInput(input) {
+    const raw = String(input || '').trim().replace(/[?#].*$/, '').replace(/\/+$/, '');
+    if (!raw)
+        return false;
+    try {
+        const url = new URL(raw);
+        return url.pathname.replace(/\/+$/, '').endsWith('/shorts');
+    }
+    catch { }
+    return raw.endsWith('/shorts');
+}
+
+export function getChannelResolveUrl(input) {
+    const raw = String(input || '').trim();
+    if (!raw)
+        return '';
+    try {
+        const url = new URL(raw);
+        if (/^(www\.)?youtube\.com$/i.test(url.hostname) || /(^|\.)youtube\.com$/i.test(url.hostname))
+            return url.origin + url.pathname.replace(/\/+$/, '');
+        return '';
+    }
+    catch { }
+    if (raw.startsWith('@'))
+        return 'https://www.youtube.com/' + raw.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (raw.startsWith('/@') || raw.startsWith('/channel/'))
+        return 'https://www.youtube.com' + raw.replace(/\/+$/, '');
+    return '';
+}
+
+export function isShortsTab(tabEntry) {
+    const tab = tabEntry?.tabRenderer;
+    const url = tab?.endpoint?.commandMetadata?.webCommandMetadata?.url || '';
+    return tab?.tabIdentifier === 'SHORTS'
+        || url.replace(/\/+$/, '').endsWith('/shorts')
+        || tab?.title === 'Shorts';
+}
+
+export function isVideosTab(tabEntry) {
+    const tab = tabEntry?.tabRenderer;
+    const url = tab?.endpoint?.commandMetadata?.webCommandMetadata?.url || '';
+    return tab?.tabIdentifier === 'VIDEOS'
+        || url.replace(/\/+$/, '').endsWith('/videos')
+        || tab?.title === 'Videos';
+}
+
+export function extractShortsLockupVideo(item) {
+    const lockup = item?.richItemRenderer?.content?.shortsLockupViewModel || item?.shortsLockupViewModel;
+    if (!lockup)
+        return null;
+    const readText = (value) => {
+        if (!value)
+            return '';
+        if (typeof value === 'string')
+            return value;
+        if (value.content)
+            return String(value.content);
+        if (value.simpleText)
+            return String(value.simpleText);
+        if (value.text)
+            return String(value.text);
+        if (Array.isArray(value.runs))
+            return value.runs.map(run => run.text || '').join('');
+        const label = value.accessibility?.accessibilityData?.label || value.accessibilityData?.label;
+        return label ? String(label) : '';
+    };
+    const videoId = lockup.onTap?.innertubeCommand?.reelWatchEndpoint?.videoId
+        || lockup.onTap?.innertubeCommand?.watchEndpoint?.videoId
+        || lockup.navigationEndpoint?.reelWatchEndpoint?.videoId
+        || lockup.navigationEndpoint?.watchEndpoint?.videoId
+        || lockup.inlinePlayerData?.onVisible?.innertubeCommand?.watchEndpoint?.videoId
+        || lockup.videoId
+        || lockup.contentId
+        || String(lockup.entityId || '').replace(/^shorts-shelf-item-/, '');
+    if (!videoId)
+        return null;
+    const accessibilityText = readText(lockup.accessibilityText);
+    const title = readText(lockup.overlayMetadata?.primaryText)
+        || readText(lockup.title)
+        || accessibilityText.split(',')[0]
+        || '';
+    const views = readText(lockup.overlayMetadata?.secondaryText)
+        || readText(lockup.viewCountText)
+        || (accessibilityText.match(/([^,]+views?)/i)?.[1] || '');
+    return {
+        videoId,
+        title,
+        duration: 'Shorts',
+        views,
+        url: 'https://www.youtube.com/shorts/' + videoId,
+    };
+}
+
+export function extractRichGridVideo(item) {
+    const v = item?.richItemRenderer?.content?.videoRenderer;
+    if (!v)
+        return null;
+    return {
+        videoId: v.videoId || '',
+        title: v.title?.runs?.[0]?.text || '',
+        duration: v.lengthText?.simpleText || '',
+        views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
+        url: 'https://www.youtube.com/watch?v=' + v.videoId,
+    };
+}
+
 cli({
     site: 'youtube',
     name: 'channel',
@@ -26,13 +132,15 @@ cli({
     domain: 'www.youtube.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'id', required: true, positional: true, help: 'Channel ID (UCxxxx) or handle (@name)' },
+        { name: 'id', required: true, positional: true, help: 'Channel ID (UCxxxx), handle (@name), or channel URL' },
         { name: 'limit', type: 'int', default: 10, help: 'Max recent videos (max 30)' },
+        { name: 'tab', default: '', help: 'Channel tab to list: videos or shorts' },
     ],
     columns: ['field', 'value'],
     func: async (page, kwargs) => {
         const channelId = String(kwargs.id);
         const limit = Math.min(kwargs.limit || 10, 30);
+        const tab = String(kwargs.tab || '').toLowerCase();
         await page.goto('https://www.youtube.com');
         await page.wait(2);
         const data = await page.evaluate(`
@@ -43,19 +151,30 @@ cli({
         const apiKey = cfg.INNERTUBE_API_KEY;
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return {error: 'YouTube config not found'};
+        const requestedTab = ${JSON.stringify(tab)};
         const extractSelectedRichGridContents = ${extractSelectedRichGridContents.toString()};
+        const isShortsInput = ${isShortsInput.toString()};
+        const getChannelResolveUrl = ${getChannelResolveUrl.toString()};
+        const isShortsTab = ${isShortsTab.toString()};
+        const isVideosTab = ${isVideosTab.toString()};
+        const extractShortsLockupVideo = ${extractShortsLockupVideo.toString()};
+        const extractRichGridVideo = ${extractRichGridVideo.toString()};
 
-        // Resolve handle to browseId if needed
+        // Resolve handles and channel URLs to the browseId used by InnerTube.
         let browseId = channelId;
-        if (channelId.startsWith('@')) {
+        let resolvedTabParams = '';
+        const resolveUrl = getChannelResolveUrl(channelId);
+        if (resolveUrl) {
           const resolveResp = await fetch('/youtubei/v1/navigation/resolve_url?key=' + apiKey + '&prettyPrint=false', {
             method: 'POST', credentials: 'include',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({context, url: 'https://www.youtube.com/' + channelId})
+            body: JSON.stringify({context, url: resolveUrl})
           });
           if (resolveResp.ok) {
             const resolveData = await resolveResp.json();
-            browseId = resolveData.endpoint?.browseEndpoint?.browseId || channelId;
+            const browseEndpoint = resolveData.endpoint?.browseEndpoint;
+            browseId = browseEndpoint?.browseId || channelId;
+            resolvedTabParams = browseEndpoint?.params || '';
           }
         }
 
@@ -92,8 +211,10 @@ cli({
         const tabs = data.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
         const homeTab = tabs.find(t => t.tabRenderer?.selected);
         const recentVideos = [];
+        const wantsShorts = requestedTab === 'shorts' || isShortsInput(channelId);
+        const wantsVideos = requestedTab === 'videos';
 
-        if (homeTab) {
+        if (!wantsShorts && !wantsVideos && homeTab) {
           const sections = homeTab.tabRenderer?.content?.sectionListRenderer?.contents || [];
           for (const section of sections) {
             for (const shelf of (section.itemSectionRenderer?.contents || [])) {
@@ -132,15 +253,9 @@ cli({
           }
         }
 
-        // If Home tab has no videos, try Videos tab
-        if (recentVideos.length === 0) {
-          const videosTab = tabs.find(t => {
-            const tab = t.tabRenderer;
-            const url = tab?.endpoint?.commandMetadata?.webCommandMetadata?.url || '';
-            return tab?.tabIdentifier === 'VIDEOS'
-              || url.endsWith('/videos')
-              || tab?.title === 'Videos';
-          });
+        // If Home tab has no videos, or --tab videos was requested, try Videos tab.
+        if (!wantsShorts && (wantsVideos || recentVideos.length === 0)) {
+          const videosTab = tabs.find(isVideosTab);
           const videosTabParams = videosTab?.tabRenderer?.endpoint?.browseEndpoint?.params;
           if (videosTabParams) {
             const videosResp = await fetch('/youtubei/v1/browse?key=' + apiKey + '&prettyPrint=false', {
@@ -156,17 +271,36 @@ cli({
               const richGrid = extractSelectedRichGridContents(videosData);
               for (const item of richGrid) {
                 if (recentVideos.length >= limit) break;
-                const v = item.richItemRenderer?.content?.videoRenderer;
-                if (v) {
-                  recentVideos.push({
-                    title: v.title?.runs?.[0]?.text || '',
-                    duration: v.lengthText?.simpleText || '',
-                    views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
-                    url: 'https://www.youtube.com/watch?v=' + v.videoId,
-                  });
-                }
+                const video = extractRichGridVideo(item);
+                if (video) recentVideos.push(video);
               }
             }
+          }
+        }
+
+        if (wantsShorts) {
+          const shortsTab = tabs.find(isShortsTab);
+          const shortsTabParams = shortsTab?.tabRenderer?.endpoint?.browseEndpoint?.params || resolvedTabParams;
+          const collectShorts = (richGrid) => {
+            for (const item of (richGrid || [])) {
+              if (recentVideos.length >= limit) break;
+              const video = extractShortsLockupVideo(item);
+              if (video) recentVideos.push(video);
+            }
+          };
+          if (shortsTabParams) {
+            const shortsResp = await fetch('/youtubei/v1/browse?key=' + apiKey + '&prettyPrint=false', {
+              method: 'POST', credentials: 'include',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({context, browseId, params: shortsTabParams})
+            });
+            if (shortsResp.ok) {
+              const shortsData = await shortsResp.json();
+              collectShorts(extractSelectedRichGridContents(shortsData));
+            }
+          }
+          if (recentVideos.length === 0) {
+            collectShorts(extractSelectedRichGridContents(data));
           }
         }
 
@@ -195,9 +329,11 @@ cli({
             value: String(value),
         }));
         if (videos && videos.length > 0) {
-            rows.push({ field: '---', value: '--- Recent Videos ---' });
+            const sectionLabel = videos.some(v => v.url?.includes('/shorts/')) ? '--- Shorts ---' : '--- Recent Videos ---';
+            rows.push({ field: '---', value: sectionLabel });
             for (const v of videos) {
-                rows.push({ field: v.title, value: `${v.duration} | ${v.views} | ${v.url}` });
+                const videoId = v.videoId && v.url?.includes('/shorts/') ? `${v.videoId} | ` : '';
+                rows.push({ field: v.title, value: `${v.duration} | ${v.views} | ${videoId}${v.url}` });
             }
         }
         return rows;
@@ -206,4 +342,10 @@ cli({
 
 export const __test__ = {
     extractSelectedRichGridContents,
+    extractRichGridVideo,
+    extractShortsLockupVideo,
+    getChannelResolveUrl,
+    isShortsInput,
+    isShortsTab,
+    isVideosTab,
 };

--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -124,6 +124,33 @@ export function extractRichGridVideo(item) {
     };
 }
 
+export function formatChannelRows(result) {
+    const videos = Array.isArray(result?.recentVideos) ? result.recentVideos : [];
+    const info = { ...(result || {}) };
+    delete info.recentVideos;
+    // Keep the legacy field/value rows while preserving structured Shorts data for JSON consumers.
+    const rows = Object.entries(info).map(([field, value]) => ({
+        field,
+        value: String(value),
+    }));
+    if (videos.length > 0) {
+        const sectionLabel = videos.some(v => v.url?.includes('/shorts/')) ? '--- Shorts ---' : '--- Recent Videos ---';
+        rows.push({ field: '---', value: sectionLabel });
+        for (const v of videos) {
+            const row = { field: v.title, value: `${v.duration} | ${v.views} | ${v.url}` };
+            if (v.url?.includes('/shorts/')) {
+                row.type = 'shorts';
+                row.videoId = v.videoId || '';
+                row.title = v.title || '';
+                row.viewCount = v.views || '';
+                row.url = v.url || '';
+            }
+            rows.push(row);
+        }
+    }
+    return rows;
+}
+
 cli({
     site: 'youtube',
     name: 'channel',
@@ -320,23 +347,7 @@ cli({
             throw new CommandExecutionError('Failed to fetch channel data');
         if (data.error)
             throw new CommandExecutionError(String(data.error));
-        const result = data;
-        const videos = result.recentVideos;
-        delete result.recentVideos;
-        // Channel info as field/value pairs + recent videos as table
-        const rows = Object.entries(result).map(([field, value]) => ({
-            field,
-            value: String(value),
-        }));
-        if (videos && videos.length > 0) {
-            const sectionLabel = videos.some(v => v.url?.includes('/shorts/')) ? '--- Shorts ---' : '--- Recent Videos ---';
-            rows.push({ field: '---', value: sectionLabel });
-            for (const v of videos) {
-                const videoId = v.videoId && v.url?.includes('/shorts/') ? `${v.videoId} | ` : '';
-                rows.push({ field: v.title, value: `${v.duration} | ${v.views} | ${videoId}${v.url}` });
-            }
-        }
-        return rows;
+        return formatChannelRows(data);
     },
 });
 
@@ -344,6 +355,7 @@ export const __test__ = {
     extractSelectedRichGridContents,
     extractRichGridVideo,
     extractShortsLockupVideo,
+    formatChannelRows,
     getChannelResolveUrl,
     isShortsInput,
     isShortsTab,

--- a/clis/youtube/channel.test.js
+++ b/clis/youtube/channel.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { __test__ } from './channel.js';
 
-function tab(title, contents, selected = false) {
+function tab(title, contents, selected = false, overrides = {}) {
     return {
         tabRenderer: {
             title,
@@ -11,6 +11,7 @@ function tab(title, contents, selected = false) {
                     contents,
                 },
             },
+            ...overrides,
         },
     };
 }
@@ -55,5 +56,47 @@ describe('youtube channel helpers', () => {
             tab('Home', []),
             tab('Videos', videos, true),
         ]))).toEqual(videos);
+    });
+
+    it('detects shorts channel URLs and tab renderers', () => {
+        expect(__test__.isShortsInput('https://www.youtube.com/@openai/shorts')).toBe(true);
+        expect(__test__.isShortsInput('@openai/shorts')).toBe(true);
+        expect(__test__.isShortsInput('@openai/videos')).toBe(false);
+        expect(__test__.getChannelResolveUrl('https://www.youtube.com/@openai/shorts?view=0')).toBe('https://www.youtube.com/@openai/shorts');
+        expect(__test__.getChannelResolveUrl('@openai/shorts')).toBe('https://www.youtube.com/@openai/shorts');
+        expect(__test__.isShortsTab(tab('Shorts', [], false, {
+            tabIdentifier: 'SHORTS',
+            endpoint: { commandMetadata: { webCommandMetadata: { url: '/@openai/shorts' } } },
+        }))).toBe(true);
+    });
+
+    it('extracts shortsLockupViewModel items separately from videoRenderer items', () => {
+        const short = __test__.extractShortsLockupVideo({
+            richItemRenderer: {
+                content: {
+                    shortsLockupViewModel: {
+                        entityId: 'shorts-shelf-item-fallback-id',
+                        overlayMetadata: {
+                            primaryText: { content: 'A short title' },
+                            secondaryText: { content: '42K views' },
+                        },
+                        onTap: {
+                            innertubeCommand: {
+                                reelWatchEndpoint: { videoId: 'short-video-id' },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(short).toEqual({
+            videoId: 'short-video-id',
+            title: 'A short title',
+            duration: 'Shorts',
+            views: '42K views',
+            url: 'https://www.youtube.com/shorts/short-video-id',
+        });
+        expect(__test__.extractRichGridVideo({ richItemRenderer: { content: { shortsLockupViewModel: {} } } })).toBeNull();
     });
 });

--- a/clis/youtube/channel.test.js
+++ b/clis/youtube/channel.test.js
@@ -99,4 +99,52 @@ describe('youtube channel helpers', () => {
         });
         expect(__test__.extractRichGridVideo({ richItemRenderer: { content: { shortsLockupViewModel: {} } } })).toBeNull();
     });
+
+    it('keeps field/value compatibility while exposing stable shorts JSON fields', () => {
+        const rows = __test__.formatChannelRows({
+            name: 'OpenAI',
+            recentVideos: [
+                {
+                    videoId: 'short-video-id',
+                    title: 'A short title',
+                    duration: 'Shorts',
+                    views: '42K views',
+                    url: 'https://www.youtube.com/shorts/short-video-id',
+                },
+            ],
+        });
+
+        const shortRow = rows.find(row => row.type === 'shorts');
+        expect(shortRow).toMatchObject({
+            field: 'A short title',
+            value: 'Shorts | 42K views | https://www.youtube.com/shorts/short-video-id',
+            type: 'shorts',
+            videoId: 'short-video-id',
+            title: 'A short title',
+            viewCount: '42K views',
+            url: 'https://www.youtube.com/shorts/short-video-id',
+        });
+        expect(shortRow.value).not.toContain(' | short-video-id | ');
+    });
+
+    it('does not add shorts-only JSON fields to normal channel video rows', () => {
+        const rows = __test__.formatChannelRows({
+            name: 'OpenAI',
+            recentVideos: [
+                {
+                    videoId: 'normal-video-id',
+                    title: 'A normal video',
+                    duration: '10:00',
+                    views: '1K views',
+                    url: 'https://www.youtube.com/watch?v=normal-video-id',
+                },
+            ],
+        });
+
+        const videoRow = rows.find(row => row.field === 'A normal video');
+        expect(videoRow).toEqual({
+            field: 'A normal video',
+            value: '10:00 | 1K views | https://www.youtube.com/watch?v=normal-video-id',
+        });
+    });
 });

--- a/docs/adapters/browser/youtube.md
+++ b/docs/adapters/browser/youtube.md
@@ -34,6 +34,8 @@ opencli youtube subscriptions --limit 30
 opencli youtube search "rust programming" --limit 5
 opencli youtube video "https://www.youtube.com/watch?v=xxx"
 opencli youtube transcript "https://www.youtube.com/watch?v=xxx"
+opencli youtube channel @ChannelHandle --tab shorts --limit 10
+opencli youtube channel "https://www.youtube.com/@ChannelHandle/shorts" --limit 10
 
 # Write commands (requires login)
 opencli youtube like "https://www.youtube.com/watch?v=xxx"


### PR DESCRIPTION
## What changed

- Add `--tab` support to `youtube channel`, including `shorts` tab routing.
- Detect Shorts channel URLs such as `https://www.youtube.com/@handle/shorts` and `@handle/shorts`.
- Parse YouTube `shortsLockupViewModel` entries separately from regular `videoRenderer` rows.
- Expose stable JSON fields for Shorts rows: `type`, `videoId`, `title`, `viewCount`, and `url`, while keeping the existing `field` / `value` table-compatible output.
- Update YouTube channel adapter tests, docs, and manifest.

Upstreamed from EasyMetaAu/opencli#15.

## Acceptance Criteria

- [x] `opencli youtube channel --tab shorts @handle` requests the channel Shorts tab.
- [x] `opencli youtube channel "https://www.youtube.com/@handle/shorts"` is detected as a Shorts-tab request.
- [x] Shorts rows expose `type/videoId/title/viewCount/url` in JSON output without requiring consumers to parse a pipe-delimited string.
- [x] Existing default channel output and `--tab videos` behavior stay compatible.

## Tests

- `npx vitest run --project adapter clis/youtube/channel.test.js` — passed, 7 tests.
- `npm run build` — passed.
- `git diff --check` — passed.
