### PR TITLE
fix(browser): drive click through CDP mouse events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* **browser click** — `browser click` now prefers CDP `Input.dispatchMouseEvent` over DOM `el.click()`, so custom dropdowns that depend on pointer/mouse events (Radix, shadcn, Material UI, Mercury-style category pickers) open and select reliably while retaining JS click as a fallback for older backends or zero-rect targets.
 * **help / build** — every positional arg must now declare a non-empty `help` string. The build-manifest step fails closed when a positional has empty / whitespace-only / missing `help`, so `opencli <site> <cmd> --help` always shows callers what each parameter is for. Pre-existing offenders (`twitter followers/following/list-add/list-remove/list-tweets/search/thread`, `reddit search/subreddit/user/user-comments/user-posts`, `douyin stats/update`, `bilibili subtitle`, `jike search`) now have explicit help text — most notably `twitter followers [user]` and `following [user]` now document that omitting the user fetches the currently logged-in account.
 
 ## [1.7.14](https://github.com/jackwener/opencli/compare/v1.7.13...v1.7.14) (2026-05-08)

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -27,6 +27,7 @@ class ActionPage extends BasePage {
   nativeType?: (text: string) => Promise<void>;
   insertText?: (text: string) => Promise<void>;
   nativeKeyPress?: (key: string, modifiers?: string[]) => Promise<void>;
+  nativeClick?: (x: number, y: number) => Promise<void>;
   cdp?: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
 
   async goto(): Promise<void> {}
@@ -249,20 +250,86 @@ describe('BasePage native input routing', () => {
     expect((err as TargetError).code).toBe('not_editable');
   });
 
-  it('uses CDP DOM scrollIntoViewIfNeeded before JS click when available', async () => {
+  it('uses CDP DOM scrollIntoViewIfNeeded before measuring rect for click', async () => {
     const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
     page.cdp = vi.fn()
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ root: { nodeId: 1 } })
       .mockResolvedValueOnce({ nodeId: 9 })
       .mockResolvedValueOnce({});
-    page.results = [resolveOk, { status: 'clicked', x: 1, y: 2 }];
+    page.results = [resolveOk, { x: 50, y: 100, w: 200, h: 32, visible: true }];
     page.withArgsResults = [{ ok: true }, undefined];
 
     await page.click('#save');
 
     expect(page.cdp).toHaveBeenCalledWith('DOM.scrollIntoViewIfNeeded', { nodeId: 9 });
+    // After CDP scroll, boundingRectResolvedJs runs with skipScroll=true.
     expect(page.scripts.at(-1)).toContain('if (false) el.scrollIntoView');
+  });
+
+  it('clicks via CDP Input.dispatchMouseEvent when rect is visible', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    page.results = [resolveOk, { x: 50, y: 100, w: 200, h: 32, visible: true }];
+
+    await page.click('#category');
+
+    expect(page.nativeClick).toHaveBeenCalledWith(50, 100);
+    expect(page.nativeClick).toHaveBeenCalledTimes(1);
+    expect(page.scripts).toHaveLength(2);
+    expect(page.scripts[1]).toContain('getBoundingClientRect');
+    expect(page.scripts.join('\n')).not.toContain('el.click()');
+  });
+
+  it('falls back to JS el.click() when nativeClick is unavailable', async () => {
+    const page = new ActionPage();
+    page.results = [
+      resolveOk,
+      { x: 50, y: 100, w: 200, h: 32, visible: true },
+      { status: 'clicked', x: 50, y: 100 },
+    ];
+
+    await page.click('#save');
+
+    expect(page.scripts).toHaveLength(3);
+    expect(page.scripts[1]).toContain('getBoundingClientRect');
+    expect(page.scripts[2]).toContain('el.click()');
+  });
+
+  it('falls back to JS el.click() when rect is zero-area', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    page.results = [
+      resolveOk,
+      { x: 0, y: 0, w: 0, h: 0, visible: false },
+      { status: 'clicked', x: 0, y: 0 },
+    ];
+
+    await page.click('#hidden');
+
+    expect(page.nativeClick).not.toHaveBeenCalled();
+    expect(page.scripts).toHaveLength(3);
+    expect(page.scripts[2]).toContain('el.click()');
+  });
+
+  it('retries CDP click when JS path throws but yields coordinates', async () => {
+    const page = new ActionPage();
+    const nativeClick = vi.fn()
+      .mockRejectedValueOnce(new Error('cdp transient'))
+      .mockResolvedValueOnce(undefined);
+    page.nativeClick = nativeClick;
+    page.results = [
+      resolveOk,
+      { x: 10, y: 20, w: 100, h: 30, visible: true },
+      { status: 'js_failed', x: 10, y: 20, error: 'click intercepted' },
+    ];
+
+    await page.click('#flaky');
+
+    expect(nativeClick).toHaveBeenCalledTimes(2);
+    expect(nativeClick).toHaveBeenNthCalledWith(1, 10, 20);
+    expect(nativeClick).toHaveBeenNthCalledWith(2, 10, 20);
   });
 
   it('presses key chords through native CDP key events when available', async () => {

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -23,6 +23,7 @@ import {
 } from './dom-helpers.js';
 import {
   resolveTargetJs,
+  boundingRectResolvedJs,
   clickResolvedJs,
   typeResolvedJs,
   prepareNativeTypeResolvedJs,
@@ -238,7 +239,19 @@ export abstract class BasePage implements IPage {
     const resolved = await runResolve(this, ref, opts);
     const nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
 
-    // Phase 2: Execute click on resolved element
+    // Phase 2: measure first so native click can run before DOM el.click().
+    // Custom dropdowns often listen to pointer/mouse down/up; DOM el.click()
+    // only fires click and can silently report success without opening/selecting.
+    const rect = await this.evaluate(boundingRectResolvedJs({ skipScroll: nativeScrolled })) as
+      | { x: number; y: number; w: number; h: number; visible: boolean }
+      | null;
+
+    if (rect?.visible === true) {
+      const success = await this.tryNativeClick(rect.x, rect.y);
+      if (success) return resolved;
+    }
+
+    // JS fallback for older backends or zero-rect targets.
     const result = await this.evaluate(clickResolvedJs({ skipScroll: nativeScrolled })) as
       | string
       | { status: string; x?: number; y?: number; w?: number; h?: number; error?: string }

--- a/src/browser/cdp-click-fixture.test.ts
+++ b/src/browser/cdp-click-fixture.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+function installDom(html: string): Document {
+  const dom = new JSDOM(html, { pretendToBeVisual: true });
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.Event = dom.window.Event;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  return dom.window.document;
+}
+
+function dispatchNativeMouseSequence(target: Element): void {
+  for (const type of ['mousemove', 'pointerdown', 'mousedown', 'mouseup', 'pointerup', 'click']) {
+    target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+  }
+}
+
+describe('CDP-primary click dropdown fixtures', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window');
+    Reflect.deleteProperty(globalThis, 'document');
+  });
+
+  it('captures the Radix/shadcn class of dropdowns that open on pointerdown and select on pointerup', () => {
+    const document = installDom(`
+      <button id="trigger" role="combobox" aria-expanded="false">Category</button>
+      <div id="portal-root"></div>
+      <output id="value"></output>
+    `);
+    const trigger = document.querySelector('#trigger') as HTMLButtonElement;
+    const portal = document.querySelector('#portal-root')!;
+    const value = document.querySelector('#value')!;
+
+    trigger.addEventListener('pointerdown', () => {
+      trigger.setAttribute('aria-expanded', 'true');
+      portal.innerHTML = `
+        <div role="listbox">
+          <div id="meals" role="option">Meals</div>
+        </div>
+      `;
+      portal.querySelector('#meals')!.addEventListener('pointerup', () => {
+        value.textContent = 'Meals';
+        trigger.textContent = 'Meals';
+        trigger.setAttribute('aria-expanded', 'false');
+      });
+    });
+
+    // Baseline: DOM el.click() dispatches click only. This is the old OpenCLI
+    // failure mode: the command reports success but the dropdown never opens.
+    trigger.click();
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(portal.querySelector('[role="option"]')).toBeNull();
+    expect(value.textContent).toBe('');
+
+    // CDP-style mouse input opens the portal and can commit the option.
+    dispatchNativeMouseSequence(trigger);
+    const option = portal.querySelector('#meals')!;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    dispatchNativeMouseSequence(option);
+    expect(value.textContent).toBe('Meals');
+    expect(trigger.textContent).toBe('Meals');
+  });
+
+  it('captures the MUI autocomplete class that opens on mousedown and commits on mousedown in a popper', () => {
+    const document = installDom(`
+      <label for="category">Category</label>
+      <input id="category" role="combobox" value="" />
+      <div id="mui-popper"></div>
+      <output id="value"></output>
+    `);
+    const input = document.querySelector('#category') as HTMLInputElement;
+    const popper = document.querySelector('#mui-popper')!;
+    const value = document.querySelector('#value')!;
+
+    input.addEventListener('mousedown', () => {
+      popper.innerHTML = `
+        <ul role="listbox">
+          <li id="travel" role="option">Travel</li>
+        </ul>
+      `;
+      popper.querySelector('#travel')!.addEventListener('mousedown', () => {
+        input.value = 'Travel';
+        value.textContent = 'Travel';
+      });
+    });
+
+    input.click();
+    expect(popper.querySelector('[role="option"]')).toBeNull();
+    expect(input.value).toBe('');
+
+    dispatchNativeMouseSequence(input);
+    const option = popper.querySelector('#travel')!;
+    dispatchNativeMouseSequence(option);
+
+    expect(input.value).toBe('Travel');
+    expect(value.textContent).toBe('Travel');
+  });
+});

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -89,6 +89,7 @@ describe('CDPBridge cookies', () => {
       ['Input.insertText', { text: 'hello' }],
       ['Input.dispatchKeyEvent', { type: 'keyDown', key: 'a', modifiers: 2 }],
       ['Input.dispatchKeyEvent', { type: 'keyUp', key: 'a', modifiers: 2 }],
+      ['Input.dispatchMouseEvent', { type: 'mouseMoved', x: 10, y: 20 }],
       ['Input.dispatchMouseEvent', { type: 'mousePressed', x: 10, y: 20, button: 'left', clickCount: 1 }],
       ['Input.dispatchMouseEvent', { type: 'mouseReleased', x: 10, y: 20, button: 'left', clickCount: 1 }],
       ['Page.handleJavaScriptDialog', { accept: true, promptText: 'ok' }],

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -421,6 +421,11 @@ class CDPPage extends BasePage {
 
   async nativeClick(x: number, y: number): Promise<void> {
     await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x,
+      y,
+    });
+    await this.cdp('Input.dispatchMouseEvent', {
       type: 'mousePressed',
       x,
       y,

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -377,6 +377,11 @@ export class Page extends BasePage {
 
   async nativeClick(x: number, y: number): Promise<void> {
     await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x,
+      y,
+    });
+    await this.cdp('Input.dispatchMouseEvent', {
       type: 'mousePressed',
       x, y,
       button: 'left',

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -295,8 +295,37 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
 }
 
 /**
+ * Generate JS that scrolls + measures `__resolved` without clicking.
+ *
+ * Generic click prefers CDP `Input.dispatchMouseEvent`, which fires the full
+ * pointer/mouse chain that Radix/MUI/shadcn dropdowns rely on. Keep measurement
+ * separate so the CDP-primary path does not call DOM `el.click()` first.
+ */
+export function boundingRectResolvedJs(opts: { skipScroll?: boolean } = {}): string {
+  const shouldScroll = opts.skipScroll ? 'false' : 'true';
+  return `
+    (() => {
+      const el = window.__resolved;
+      if (!el) throw new Error('No resolved element');
+      if (${shouldScroll}) el.scrollIntoView({ behavior: 'instant', block: 'center' });
+      const rect = el.getBoundingClientRect();
+      const w = Math.round(rect.width);
+      const h = Math.round(rect.height);
+      const x = Math.round(rect.left + rect.width / 2);
+      const y = Math.round(rect.top + rect.height / 2);
+      const visible = w > 0 && h > 0;
+      return { x, y, w, h, visible };
+    })()
+  `;
+}
+
+/**
  * Generate JS for click that uses the unified resolver.
  * Assumes resolveTargetJs has been called and __resolved is set.
+ *
+ * This is the JS fallback path. BasePage.click uses boundingRectResolvedJs for
+ * the CDP-primary path and only reaches this when native click is unavailable
+ * or the target has no usable rect.
  */
 export function clickResolvedJs(opts: { skipScroll?: boolean } = {}): string {
   const shouldScroll = opts.skipScroll ? 'false' : 'true';


### PR DESCRIPTION
## Summary

- Makes generic `browser click` CDP-primary: measure resolved target, send native mouse events through `nativeClick`, then fall back to DOM `el.click()` only for older backends / unusable rects.
- Adds Radix/shadcn-like and MUI-like dropdown fixtures proving DOM `el.click()` baseline does not open/select, while a native mouse sequence does.
- Preserves `browser select` behavior: native `<select>` still uses the JS option setter/change-event path.
- Adds CHANGELOG entry for the Mercury/custom dropdown reliability fix.

## Validation

- `npm test -- --run src/browser/base-page.test.ts src/browser/cdp-click-fixture.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `npm run test:adapter` (264 files / 2121 tests)
- `TMP_HOME=$(mktemp -d /tmp/opencli-test-home-XXXXXX); OPENCLI_DAEMON_PORT=19829 HOME="$TMP_HOME" npm test -- --run` (337 files / 3173 tests / 1 skipped)
- `npm run docs:build`
- `git diff --check`

Note: a first plain `npm test -- --run` failed due local state, not this PR: stale `~/.opencli/plugins/.plugin-a.bak-*` and port `19825` already in use. Re-run with temp HOME and alternate daemon port passed fully.
