### PR TITLE
feat(browser): add opt-in AX refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **help / browser** — `opencli browser --help -f yaml|json` now emits a structured, agent-ready index of all browser leaf commands (including nested `tab`, `get`, and `dialog` commands), their positionals, command options, namespace options, and root global options. Individual browser commands also support structured help, backed by a shared Commander option/argument spec extractor.
+* **browser state** — add opt-in AX snapshot refs via `browser state --source ax`, including backend-node click resolution and role/name stale-ref recovery for the Phase 0 browser-agent runtime prototype.
 
 ### Bug Fixes
 

--- a/src/browser/ax-snapshot.test.ts
+++ b/src/browser/ax-snapshot.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { buildAxSnapshot, findAxRefReplacement } from './ax-snapshot.js';
+
+describe('AX snapshot prototype', () => {
+  it('builds compact refs from Accessibility.getFullAXTree output', () => {
+    const result = buildAxSnapshot({
+      nodes: [
+        { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Example' }, childIds: ['2', '3'] },
+        { nodeId: '2', role: { value: 'heading' }, name: { value: 'Expenses' }, backendDOMNodeId: 20 },
+        {
+          nodeId: '3',
+          role: { value: 'combobox' },
+          name: { value: 'Category' },
+          backendDOMNodeId: 30,
+          properties: [{ name: 'expanded', value: { value: false } }],
+        },
+      ],
+    });
+
+    expect(result.text).toContain('source: ax');
+    expect(result.text).toContain('[1]heading "Expenses"');
+    expect(result.text).toContain('[2]combobox "Category" expanded=false');
+    expect(result.refs.get('2')).toEqual({
+      ref: '2',
+      backendNodeId: 30,
+      role: 'combobox',
+      name: 'Category',
+    });
+  });
+
+  it('tracks nth only for duplicate role/name pairs', () => {
+    const result = buildAxSnapshot({
+      nodes: [
+        { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2', '3'] },
+        { nodeId: '2', role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 10 },
+        { nodeId: '3', role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 11 },
+      ],
+    });
+
+    expect(result.refs.get('1')).toMatchObject({ role: 'button', name: 'Save', nth: 0 });
+    expect(result.refs.get('2')).toMatchObject({ role: 'button', name: 'Save', nth: 1 });
+  });
+
+  it('finds stale ref replacements by role/name/nth', () => {
+    const replacement = findAxRefReplacement({
+      nodes: [
+        { nodeId: '1', role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 10 },
+        { nodeId: '2', role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 42 },
+      ],
+    }, {
+      ref: '2',
+      role: 'button',
+      name: 'Save',
+      backendNodeId: 11,
+      nth: 1,
+    });
+
+    expect(replacement).toMatchObject({ ref: '2', backendNodeId: 42, role: 'button', name: 'Save', nth: 1 });
+  });
+});

--- a/src/browser/ax-snapshot.ts
+++ b/src/browser/ax-snapshot.ts
@@ -1,0 +1,235 @@
+/**
+ * AX-backed browser snapshot prototype.
+ *
+ * This is intentionally additive to the current DOM snapshot. It learns from
+ * agent-browser's accessibility-tree refs without changing default `state`
+ * output until the AX path proves itself on fixtures and real SaaS workflows.
+ */
+
+export interface BrowserRef {
+  ref: string;
+  backendNodeId?: number;
+  role: string;
+  name: string;
+  nth?: number;
+  frame?: { frameId?: string; sessionId?: string; url?: string };
+}
+
+export interface AxSnapshotBuildResult {
+  text: string;
+  refs: Map<string, BrowserRef>;
+}
+
+interface AxValue {
+  value?: unknown;
+}
+
+interface AxProperty {
+  name?: string;
+  value?: AxValue;
+}
+
+interface AxNode {
+  nodeId?: string;
+  ignored?: boolean;
+  role?: AxValue;
+  name?: AxValue;
+  value?: AxValue;
+  properties?: AxProperty[];
+  childIds?: string[];
+  backendDOMNodeId?: number;
+}
+
+const INTERACTIVE_ROLES = new Set([
+  'button',
+  'link',
+  'textbox',
+  'searchbox',
+  'checkbox',
+  'radio',
+  'combobox',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'treeitem',
+]);
+
+const CONTENT_ROLES = new Set([
+  'article',
+  'cell',
+  'columnheader',
+  'gridcell',
+  'heading',
+  'listitem',
+  'main',
+  'navigation',
+  'region',
+  'rowheader',
+]);
+
+const STRUCTURAL_ROLES = new Set([
+  'generic',
+  'group',
+  'list',
+  'none',
+  'presentation',
+  'RootWebArea',
+  'WebArea',
+]);
+
+export function buildAxSnapshot(
+  axTree: unknown,
+  opts: { maxDepth?: number; interactiveOnly?: boolean } = {},
+): AxSnapshotBuildResult {
+  const rawNodes = Array.isArray((axTree as { nodes?: unknown[] } | null)?.nodes)
+    ? ((axTree as { nodes: unknown[] }).nodes as AxNode[])
+    : [];
+  const nodes = rawNodes.filter((node) => node && !node.ignored);
+  const byId = new Map<string, AxNode>();
+  const parentIds = new Set<string>();
+  for (const node of nodes) {
+    if (typeof node.nodeId === 'string') byId.set(node.nodeId, node);
+    for (const childId of node.childIds ?? []) parentIds.add(childId);
+  }
+
+  const roots = nodes.filter((node) => {
+    if (!node.nodeId) return false;
+    const role = axString(node.role);
+    return !parentIds.has(node.nodeId) || role === 'RootWebArea' || role === 'WebArea';
+  });
+  const root = roots[0] ?? nodes[0];
+  const maxDepth = Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200));
+  const lines: string[] = ['source: ax', '---'];
+  const refs = new Map<string, BrowserRef>();
+  const roleNameCounts = countRoleNames(nodes);
+  const roleNameSeen = new Map<string, number>();
+  let nextRef = 1;
+
+  function render(node: AxNode | undefined, depth: number): boolean {
+    if (!node || depth > maxDepth) return false;
+    const role = axString(node.role) || 'generic';
+    const name = cleanText(axString(node.name));
+    const value = cleanText(axString(node.value) || propertyValue(node, 'value'));
+    const disabled = propertyValue(node, 'disabled');
+    const checked = propertyValue(node, 'checked');
+    const expanded = propertyValue(node, 'expanded');
+    const selected = propertyValue(node, 'selected');
+
+    const refEligible = shouldRef(role, name, node.backendDOMNodeId);
+    const shouldShowSelf = refEligible
+      || !!name
+      || !!value
+      || CONTENT_ROLES.has(role)
+      || (!opts.interactiveOnly && !STRUCTURAL_ROLES.has(role));
+
+    const childStart = lines.length;
+    let hasVisibleChild = false;
+    for (const childId of node.childIds ?? []) {
+      if (render(byId.get(childId), depth + 1)) hasVisibleChild = true;
+    }
+
+    if (!shouldShowSelf && !hasVisibleChild) {
+      lines.length = childStart;
+      return false;
+    }
+
+    if (shouldShowSelf) {
+      const indent = '  '.repeat(depth);
+      const parts: string[] = [];
+      let prefix = '';
+      if (refEligible) {
+        const ref = String(nextRef++);
+        prefix = `[${ref}]`;
+        const key = roleNameKey(role, name);
+        const seen = roleNameSeen.get(key) ?? 0;
+        roleNameSeen.set(key, seen + 1);
+        refs.set(ref, {
+          ref,
+          backendNodeId: node.backendDOMNodeId,
+          role,
+          name,
+          ...(roleNameCounts.get(key)! > 1 ? { nth: seen } : {}),
+        });
+      }
+      if (name) parts.push(JSON.stringify(name));
+      if (value && value !== name) parts.push(`value=${JSON.stringify(value)}`);
+      if (checked) parts.push(`checked=${checked}`);
+      if (expanded) parts.push(`expanded=${expanded}`);
+      if (selected) parts.push(`selected=${selected}`);
+      if (disabled === 'true') parts.push('disabled');
+      lines.splice(childStart, 0, `${indent}${prefix}${role}${parts.length ? ` ${parts.join(' ')}` : ''}`);
+    }
+
+    return true;
+  }
+
+  render(root, 0);
+  lines.push('---');
+  lines.push(`interactive: ${refs.size}`);
+  return { text: lines.join('\n'), refs };
+}
+
+export function findAxRefReplacement(axTree: unknown, ref: BrowserRef): BrowserRef | null {
+  const nodes = Array.isArray((axTree as { nodes?: unknown[] } | null)?.nodes)
+    ? ((axTree as { nodes: unknown[] }).nodes as AxNode[])
+    : [];
+  const targetNth = ref.nth ?? 0;
+  let seen = 0;
+  for (const node of nodes) {
+    if (!node || node.ignored) continue;
+    const role = axString(node.role);
+    const name = cleanText(axString(node.name));
+    if (role !== ref.role || name !== ref.name) continue;
+    if (seen === targetNth) {
+      if (typeof node.backendDOMNodeId !== 'number') return null;
+      return { ...ref, backendNodeId: node.backendDOMNodeId };
+    }
+    seen++;
+  }
+  return null;
+}
+
+function shouldRef(role: string, name: string, backendNodeId: unknown): backendNodeId is number {
+  if (typeof backendNodeId !== 'number') return false;
+  if (INTERACTIVE_ROLES.has(role)) return true;
+  return CONTENT_ROLES.has(role) && !!name;
+}
+
+function countRoleNames(nodes: AxNode[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const node of nodes) {
+    if (!node || node.ignored) continue;
+    const role = axString(node.role);
+    const name = cleanText(axString(node.name));
+    if (!shouldRef(role, name, node.backendDOMNodeId)) continue;
+    const key = roleNameKey(role, name);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function roleNameKey(role: string, name: string): string {
+  return `${role}\u0000${name}`;
+}
+
+function axString(value: AxValue | undefined): string {
+  const raw = value?.value;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'number' || typeof raw === 'boolean') return String(raw);
+  return '';
+}
+
+function propertyValue(node: AxNode, name: string): string {
+  const prop = node.properties?.find((candidate) => candidate.name === name);
+  return axString(prop?.value);
+}
+
+function cleanText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().slice(0, 160);
+}

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -282,6 +282,90 @@ describe('BasePage native input routing', () => {
     expect(page.scripts.join('\n')).not.toContain('el.click()');
   });
 
+  it('clicks AX snapshot refs through backend node coordinates without DOM resolver', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    page.cdp = vi.fn()
+      .mockResolvedValueOnce({
+        nodes: [
+          { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Demo' }, childIds: ['2'] },
+          { nodeId: '2', role: { value: 'button' }, name: { value: 'Submit' }, backendDOMNodeId: 10 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        model: { content: [10, 20, 50, 20, 50, 40, 10, 40] },
+      });
+
+    await expect(page.snapshot({ source: 'ax' })).resolves.toContain('[1]button "Submit"');
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenNthCalledWith(1, 'Accessibility.getFullAXTree', {});
+    expect(page.cdp).toHaveBeenNthCalledWith(2, 'DOM.getBoxModel', { backendNodeId: 10 });
+    expect(page.nativeClick).toHaveBeenCalledWith(30, 30);
+    expect(page.scripts).toHaveLength(0);
+  });
+
+  it('recovers stale AX refs by role/name/nth before clicking', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    let axCalls = 0;
+    page.cdp = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'Accessibility.getFullAXTree') {
+        axCalls++;
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Demo' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Submit' }, backendDOMNodeId: axCalls === 1 ? 10 : 42 },
+          ],
+        };
+      }
+      if (method === 'DOM.getBoxModel') {
+        if (params?.backendNodeId === 10) throw new Error('No node with given id found');
+        return { model: { content: [100, 200, 140, 200, 140, 220, 100, 220] } };
+      }
+      return {};
+    });
+
+    await page.snapshot({ source: 'ax' });
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 10 });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 42 });
+    expect(page.nativeClick).toHaveBeenCalledWith(120, 210);
+  });
+
+  it('recovers AX refs across 10 repeated React-style rerenders', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    let currentBackendId = 100;
+    const staleBackendIds = new Set<number>();
+    page.cdp = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'Accessibility.getFullAXTree') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Demo' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Submit' }, backendDOMNodeId: currentBackendId },
+          ],
+        };
+      }
+      if (method === 'DOM.getBoxModel') {
+        const id = params?.backendNodeId as number;
+        if (staleBackendIds.has(id)) throw new Error('No node with given id found');
+        return { model: { content: [id, id, id + 20, id, id + 20, id + 10, id, id + 10] } };
+      }
+      return {};
+    });
+
+    await page.snapshot({ source: 'ax' });
+    for (let i = 0; i < 10; i++) {
+      staleBackendIds.add(currentBackendId);
+      currentBackendId += 1;
+      await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+    }
+
+    expect(page.nativeClick).toHaveBeenCalledTimes(10);
+  });
+
   it('falls back to JS el.click() when nativeClick is unavailable', async () => {
     const page = new ActionPage();
     page.results = [

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -11,6 +11,7 @@
 
 import type { BrowserCookie, FetchJsonOptions, IPage, ScreenshotOptions, SnapshotOptions, WaitOptions } from '../types.js';
 import { generateSnapshotJs, getFormStateJs } from './dom-snapshot.js';
+import { buildAxSnapshot, findAxRefReplacement, type BrowserRef } from './ax-snapshot.js';
 import {
   pressKeyJs,
   waitForTextJs,
@@ -109,6 +110,7 @@ export abstract class BasePage implements IPage {
   /** Cached previous snapshot hashes for incremental diff marking */
   private _prevSnapshotHashes: string | null = null;
   private _cdpTargetMarkerSeq = 0;
+  private _axRefs = new Map<string, BrowserRef>();
 
   // ── Transport-specific methods (must be implemented by subclasses) ──
 
@@ -235,6 +237,9 @@ export abstract class BasePage implements IPage {
   // ── Shared DOM helper implementations ──
 
   async click(ref: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
+    const axClick = await this.tryClickAxRef(ref);
+    if (axClick) return axClick;
+
     // Phase 1: Resolve target with fingerprint verification
     const resolved = await runResolve(this, ref, opts);
     const nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
@@ -280,6 +285,60 @@ export abstract class BasePage implements IPage {
     } catch {
       return false;
     }
+  }
+
+  protected async tryClickAxRef(ref: string): Promise<ResolveSuccess | null> {
+    if (!/^\d+$/.test(ref)) return null;
+    const entry = this._axRefs.get(ref);
+    if (!entry) return null;
+    const nativeClick = (this as IPage).nativeClick;
+    if (typeof nativeClick !== 'function') return null;
+
+    const resolved = await this.resolveAxRefPoint(entry);
+    if (!resolved) return null;
+    try {
+      await nativeClick.call(this, resolved.x, resolved.y);
+      return { matches_n: 1, match_level: resolved.matchLevel };
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveAxRefPoint(entry: BrowserRef): Promise<{ x: number; y: number; matchLevel: TargetMatchLevel } | null> {
+    const cdp = (this as IPage).cdp;
+    if (typeof cdp !== 'function') return null;
+
+    if (entry.backendNodeId != null) {
+      const point = await this.axBoxCenter(entry.backendNodeId).catch(() => null);
+      if (point) return { ...point, matchLevel: 'exact' };
+    }
+
+    const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', {}).catch(() => null);
+    const recovered = findAxRefReplacement(axTree, entry);
+    if (!recovered?.backendNodeId) return null;
+    this._axRefs.set(entry.ref, recovered);
+    const point = await this.axBoxCenter(recovered.backendNodeId).catch(() => null);
+    return point ? { ...point, matchLevel: 'reidentified' } : null;
+  }
+
+  private async axBoxCenter(backendNodeId: number): Promise<{ x: number; y: number } | null> {
+    const cdp = (this as IPage).cdp;
+    if (typeof cdp !== 'function') return null;
+    const result = await cdp.call(this, 'DOM.getBoxModel', { backendNodeId }) as
+      | { model?: { content?: unknown[]; border?: unknown[] } }
+      | null;
+    const quad = Array.isArray(result?.model?.content) && result.model.content.length >= 8
+      ? result.model.content
+      : Array.isArray(result?.model?.border) && result.model.border.length >= 8
+        ? result.model.border
+        : null;
+    if (!quad) return null;
+    const nums = quad.slice(0, 8).map((value) => typeof value === 'number' ? value : Number(value));
+    if (nums.some((value) => !Number.isFinite(value))) return null;
+    return {
+      x: Math.round((nums[0] + nums[2] + nums[4] + nums[6]) / 4),
+      y: Math.round((nums[1] + nums[3] + nums[5] + nums[7]) / 4),
+    };
   }
 
   /** Uses native CDP text insertion when the concrete page exposes it. */
@@ -527,6 +586,25 @@ export abstract class BasePage implements IPage {
   }
 
   async snapshot(opts: SnapshotOptions = {}): Promise<unknown> {
+    if (opts.source === 'ax') {
+      const cdp = (this as IPage).cdp;
+      if (typeof cdp !== 'function') {
+        throw new CliError(
+          'BROWSER_AX_UNAVAILABLE',
+          'AX snapshot requires CDP support from the active browser backend.',
+          'Use the default DOM state, or update/reload the Browser Bridge extension.',
+        );
+      }
+      const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', {});
+      const built = buildAxSnapshot(axTree, {
+        maxDepth: opts.maxDepth,
+        interactiveOnly: opts.interactive,
+      });
+      this._axRefs = built.refs;
+      return built.text;
+    }
+
+    this._axRefs.clear();
     const snapshotJs = generateSnapshotJs({
       viewportExpand: opts.viewportExpand ?? 2000,
       maxDepth: Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200)),

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -858,6 +858,25 @@ describe('browser tab targeting commands', () => {
     expect(browserState.page?.snapshot).toHaveBeenCalled();
   });
 
+  it('passes the opt-in AX source to browser state', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'state', '--source', 'ax']);
+
+    expect(browserState.page?.snapshot).toHaveBeenCalledWith({ viewportExpand: 2000, source: 'ax' });
+  });
+
+  it('rejects unknown browser state sources before touching the page', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'state', '--source', 'magic']);
+
+    expect(browserState.page?.snapshot).not.toHaveBeenCalled();
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('invalid_source');
+    expect(process.exitCode).toBeDefined();
+  });
+
   it('blocks history navigation on bound workspaces unless explicitly allowed', async () => {
     browserState.page = {
       ...browserState.page,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -974,9 +974,21 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   // ── Inspect ──
 
-  addBrowserTabOption(browser.command('state').description('Page state: URL, title, interactive elements with [N] indices'))
-    .action(browserAction(async (page) => {
-      const snapshot = await page.snapshot({ viewportExpand: 2000 });
+  addBrowserTabOption(browser.command('state').description('Page state: URL, title, interactive elements with [N] indices')
+    .option('--source <source>', 'Snapshot backend: dom (default) or ax prototype', 'dom'))
+    .action(browserAction(async (page, opts) => {
+      const source = String(opts.source ?? 'dom').toLowerCase();
+      if (source !== 'dom' && source !== 'ax') {
+        console.log(JSON.stringify({
+          error: {
+            code: 'invalid_source',
+            message: `--source must be "dom" or "ax", got "${opts.source}"`,
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const snapshot = await page.snapshot({ viewportExpand: 2000, source: source as 'dom' | 'ax' });
       const url = await page.getCurrentUrl?.() ?? '';
       console.log(`URL: ${url}\n`);
       console.log(typeof snapshot === 'string' ? snapshot : JSON.stringify(snapshot, null, 2));

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface SnapshotOptions {
   raw?: boolean;
   viewportExpand?: number;
   maxTextLength?: number;
+  /** Observation backend. `dom` is the stable default; `ax` is an opt-in prototype. */
+  source?: 'dom' | 'ax';
 }
 
 export interface WaitOptions {


### PR DESCRIPTION
## Summary

Phase 0 PR 2 from `docs/design/mercury-fix-mvp.md`.

- adds opt-in `browser state --source ax` backed by `Accessibility.getFullAXTree`
- builds numeric AX refs with `role`, `name`, optional duplicate `nth`, and `backendDOMNodeId`
- lets `browser click <ref>` use cached AX backend-node coordinates through `DOM.getBoxModel` + native CDP click
- recovers stale AX refs by re-querying the AX tree with role/name/nth before clicking
- encodes the Phase 0 stale-ref metric with a 10-run React-style rerender recovery test
- keeps default `browser state` DOM output unchanged and clears AX refs on DOM snapshots
- avoids extension allowlist broadening: this slice only uses already-allowed `Accessibility.getFullAXTree` and `DOM.getBoxModel`

## Validation

- `npm test -- --run src/browser/ax-snapshot.test.ts src/browser/base-page.test.ts src/cli.test.ts`
- `npm test -- --run src/browser/base-page.test.ts src/browser/ax-snapshot.test.ts` after adding the 10-run recovery lock
- `npm run typecheck`
- `npm run build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `npm run test:adapter`
- `TMP_HOME=$(mktemp -d /tmp/opencli-test-home-XXXXXX); OPENCLI_DAEMON_PORT=19831 HOME="$TMP_HOME" npm test -- --run` → 338 files / 3180 passed / 1 skipped
- empty-HOME `node dist/src/main.js browser state --help` smoke shows `--source <source>`
