### PR TITLE
feat(browser): route AX refs through same-origin frames

### DIFF
--- a/src/browser/ax-snapshot.test.ts
+++ b/src/browser/ax-snapshot.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAxSnapshot, findAxRefReplacement } from './ax-snapshot.js';
+import { buildAxSnapshot, buildAxSnapshotFromTrees, findAxRefReplacement } from './ax-snapshot.js';
 
 describe('AX snapshot prototype', () => {
   it('builds compact refs from Accessibility.getFullAXTree output', () => {
@@ -56,5 +56,44 @@ describe('AX snapshot prototype', () => {
     });
 
     expect(replacement).toMatchObject({ ref: '2', backendNodeId: 42, role: 'button', name: 'Save', nth: 1 });
+  });
+
+  it('combines frame AX trees while keeping ref metadata frame-scoped', () => {
+    const result = buildAxSnapshotFromTrees([
+      {
+        tree: {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 10 },
+          ],
+        },
+      },
+      {
+        frame: { frameId: 'frame-1', url: 'https://app.example/embed' },
+        tree: {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 20 },
+          ],
+        },
+      },
+    ]);
+
+    expect(result.text).toContain('[1]button "Save"');
+    expect(result.text).toContain('frame "https://app.example/embed":');
+    expect(result.text).toContain('  [2]button "Save"');
+    expect(result.refs.get('1')).toEqual({
+      ref: '1',
+      backendNodeId: 10,
+      role: 'button',
+      name: 'Save',
+    });
+    expect(result.refs.get('2')).toEqual({
+      ref: '2',
+      backendNodeId: 20,
+      role: 'button',
+      name: 'Save',
+      frame: { frameId: 'frame-1', url: 'https://app.example/embed' },
+    });
   });
 });

--- a/src/browser/ax-snapshot.ts
+++ b/src/browser/ax-snapshot.ts
@@ -15,6 +15,11 @@ export interface BrowserRef {
   frame?: { frameId?: string; sessionId?: string; url?: string };
 }
 
+export interface AxSnapshotTree {
+  tree: unknown;
+  frame?: BrowserRef['frame'];
+}
+
 export interface AxSnapshotBuildResult {
   text: string;
   refs: Map<string, BrowserRef>;
@@ -87,6 +92,41 @@ export function buildAxSnapshot(
   axTree: unknown,
   opts: { maxDepth?: number; interactiveOnly?: boolean } = {},
 ): AxSnapshotBuildResult {
+  return buildAxSnapshotFromTrees([{ tree: axTree }], opts);
+}
+
+export function buildAxSnapshotFromTrees(
+  trees: AxSnapshotTree[],
+  opts: { maxDepth?: number; interactiveOnly?: boolean } = {},
+): AxSnapshotBuildResult {
+  const lines: string[] = ['source: ax', '---'];
+  const refs = new Map<string, BrowserRef>();
+  let nextRef = 1;
+
+  for (const [index, entry] of trees.entries()) {
+    if (index > 0) {
+      const label = entry.frame?.url ? JSON.stringify(entry.frame.url) : JSON.stringify(entry.frame?.frameId ?? `frame:${index}`);
+      lines.push(`frame ${label}:`);
+    }
+    nextRef = renderAxTree(entry.tree, lines, refs, nextRef, {
+      ...opts,
+      frame: entry.frame,
+      baseDepth: index > 0 ? 1 : 0,
+    });
+  }
+
+  lines.push('---');
+  lines.push(`interactive: ${refs.size}`);
+  return { text: lines.join('\n'), refs };
+}
+
+function renderAxTree(
+  axTree: unknown,
+  lines: string[],
+  refs: Map<string, BrowserRef>,
+  nextRef: number,
+  opts: { maxDepth?: number; interactiveOnly?: boolean; frame?: BrowserRef['frame']; baseDepth: number },
+): number {
   const rawNodes = Array.isArray((axTree as { nodes?: unknown[] } | null)?.nodes)
     ? ((axTree as { nodes: unknown[] }).nodes as AxNode[])
     : [];
@@ -105,11 +145,8 @@ export function buildAxSnapshot(
   });
   const root = roots[0] ?? nodes[0];
   const maxDepth = Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200));
-  const lines: string[] = ['source: ax', '---'];
-  const refs = new Map<string, BrowserRef>();
   const roleNameCounts = countRoleNames(nodes);
   const roleNameSeen = new Map<string, number>();
-  let nextRef = 1;
 
   function render(node: AxNode | undefined, depth: number): boolean {
     if (!node || depth > maxDepth) return false;
@@ -155,6 +192,7 @@ export function buildAxSnapshot(
           role,
           name,
           ...(roleNameCounts.get(key)! > 1 ? { nth: seen } : {}),
+          ...(opts.frame ? { frame: opts.frame } : {}),
         });
       }
       if (name) parts.push(JSON.stringify(name));
@@ -169,10 +207,8 @@ export function buildAxSnapshot(
     return true;
   }
 
-  render(root, 0);
-  lines.push('---');
-  lines.push(`interactive: ${refs.size}`);
-  return { text: lines.join('\n'), refs };
+  render(root, opts.baseDepth);
+  return nextRef;
 }
 
 export function findAxRefReplacement(axTree: unknown, ref: BrowserRef): BrowserRef | null {

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -285,24 +285,130 @@ describe('BasePage native input routing', () => {
   it('clicks AX snapshot refs through backend node coordinates without DOM resolver', async () => {
     const page = new ActionPage();
     page.nativeClick = vi.fn().mockResolvedValue(undefined);
-    page.cdp = vi.fn()
-      .mockResolvedValueOnce({
-        nodes: [
-          { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Demo' }, childIds: ['2'] },
-          { nodeId: '2', role: { value: 'button' }, name: { value: 'Submit' }, backendDOMNodeId: 10 },
-        ],
-      })
-      .mockResolvedValueOnce({
-        model: { content: [10, 20, 50, 20, 50, 40, 10, 40] },
-      });
+    page.cdp = vi.fn(async (method: string) => {
+      if (method === 'Accessibility.getFullAXTree') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Demo' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Submit' }, backendDOMNodeId: 10 },
+          ],
+        };
+      }
+      if (method === 'Page.getFrameTree') {
+        return {
+          frameTree: { frame: { id: 'root', url: 'https://app.example/' } },
+        };
+      }
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [10, 20, 50, 20, 50, 40, 10, 40] } };
+      }
+      return {};
+    });
 
     await expect(page.snapshot({ source: 'ax' })).resolves.toContain('[1]button "Submit"');
     await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
 
-    expect(page.cdp).toHaveBeenNthCalledWith(1, 'Accessibility.getFullAXTree', {});
-    expect(page.cdp).toHaveBeenNthCalledWith(2, 'DOM.getBoxModel', { backendNodeId: 10 });
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', {});
+    expect(page.cdp).toHaveBeenCalledWith('Page.getFrameTree', {});
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 10 });
     expect(page.nativeClick).toHaveBeenCalledWith(30, 30);
     expect(page.scripts).toHaveLength(0);
+  });
+
+  it('adds same-origin iframe AX refs and clicks them by frame-scoped backend node', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    page.cdp = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'Accessibility.getFullAXTree' && params?.frameId === 'same-frame') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Embedded' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Frame Save' }, backendDOMNodeId: 20 },
+          ],
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Demo' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Main Save' }, backendDOMNodeId: 10 },
+          ],
+        };
+      }
+      if (method === 'Page.getFrameTree') {
+        return {
+          frameTree: {
+            frame: { id: 'root', url: 'https://app.example/' },
+            childFrames: [
+              { frame: { id: 'same-frame', url: 'https://app.example/embed' } },
+              { frame: { id: 'cross-frame', url: 'https://other.example/embed' } },
+            ],
+          },
+        };
+      }
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [100, 200, 140, 200, 140, 220, 100, 220] } };
+      }
+      return {};
+    });
+
+    const snapshot = await page.snapshot({ source: 'ax' }) as string;
+    expect(snapshot).toContain('[1]button "Main Save"');
+    expect(snapshot).toContain('frame "https://app.example/embed":');
+    expect(snapshot).toContain('[2]button "Frame Save"');
+
+    await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
+    expect(page.cdp).not.toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame' });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 20 });
+    expect(page.nativeClick).toHaveBeenCalledWith(120, 210);
+  });
+
+  it('recovers stale iframe AX refs inside the original frame', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    let iframeAxCalls = 0;
+    page.cdp = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'Page.getFrameTree') {
+        return {
+          frameTree: {
+            frame: { id: 'root', url: 'https://app.example/' },
+            childFrames: [{ frame: { id: 'same-frame', url: 'https://app.example/embed' } }],
+          },
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree' && params?.frameId === 'same-frame') {
+        iframeAxCalls++;
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Frame Save' }, backendDOMNodeId: iframeAxCalls === 1 ? 20 : 42 },
+          ],
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Main Save' }, backendDOMNodeId: 10 },
+          ],
+        };
+      }
+      if (method === 'DOM.getBoxModel') {
+        if (params?.backendNodeId === 20) throw new Error('No node with given id found');
+        return { model: { content: [200, 300, 240, 300, 240, 320, 200, 320] } };
+      }
+      return {};
+    });
+
+    await page.snapshot({ source: 'ax' });
+    await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 20 });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 42 });
+    expect(page.nativeClick).toHaveBeenCalledWith(220, 310);
   });
 
   it('recovers stale AX refs by role/name/nth before clicking', async () => {

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -11,7 +11,7 @@
 
 import type { BrowserCookie, FetchJsonOptions, IPage, ScreenshotOptions, SnapshotOptions, WaitOptions } from '../types.js';
 import { generateSnapshotJs, getFormStateJs } from './dom-snapshot.js';
-import { buildAxSnapshot, findAxRefReplacement, type BrowserRef } from './ax-snapshot.js';
+import { buildAxSnapshotFromTrees, findAxRefReplacement, type AxSnapshotTree, type BrowserRef } from './ax-snapshot.js';
 import {
   pressKeyJs,
   waitForTextJs,
@@ -55,6 +55,11 @@ export interface FillTextResult extends ResolveSuccess {
   actual: string;
   length: number;
   mode?: 'input' | 'textarea' | 'contenteditable';
+}
+
+interface CdpFrameTreeNode {
+  frame?: { id?: string; url?: string; unreachableUrl?: string; name?: string };
+  childFrames?: CdpFrameTreeNode[];
 }
 
 /**
@@ -313,7 +318,7 @@ export abstract class BasePage implements IPage {
       if (point) return { ...point, matchLevel: 'exact' };
     }
 
-    const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', {}).catch(() => null);
+    const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', axTreeParams(entry.frame)).catch(() => null);
     const recovered = findAxRefReplacement(axTree, entry);
     if (!recovered?.backendNodeId) return null;
     this._axRefs.set(entry.ref, recovered);
@@ -595,8 +600,8 @@ export abstract class BasePage implements IPage {
           'Use the default DOM state, or update/reload the Browser Bridge extension.',
         );
       }
-      const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', {});
-      const built = buildAxSnapshot(axTree, {
+      const axTrees = await this.collectAxSnapshotTrees(cdp);
+      const built = buildAxSnapshotFromTrees(axTrees, {
         maxDepth: opts.maxDepth,
         interactiveOnly: opts.interactive,
       });
@@ -632,6 +637,22 @@ export abstract class BasePage implements IPage {
       }
       return this._basicSnapshot(opts);
     }
+  }
+
+  private async collectAxSnapshotTrees(
+    cdp: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
+  ): Promise<AxSnapshotTree[]> {
+    const rootTree = await cdp.call(this, 'Accessibility.getFullAXTree', {});
+    const trees: AxSnapshotTree[] = [{ tree: rootTree }];
+
+    const frameTreeResult = await cdp.call(this, 'Page.getFrameTree', {}).catch(() => null);
+    const frames = collectSameOriginFrameRefs(frameTreeResult);
+    for (const frame of frames) {
+      const tree = await cdp.call(this, 'Accessibility.getFullAXTree', { frameId: frame.frameId }).catch(() => null);
+      if (tree) trees.push({ tree, frame });
+    }
+
+    return trees;
   }
 
   async getCurrentUrl(): Promise<string | null> {
@@ -701,5 +722,40 @@ export abstract class BasePage implements IPage {
     if (opts.raw) return raw;
     if (typeof raw === 'string') return formatSnapshot(raw, opts);
     return raw;
+  }
+}
+
+function axTreeParams(frame: BrowserRef['frame'] | undefined): Record<string, unknown> {
+  return frame?.frameId ? { frameId: frame.frameId } : {};
+}
+
+function collectSameOriginFrameRefs(frameTreeResult: unknown): Array<NonNullable<BrowserRef['frame']>> {
+  const root = (frameTreeResult as { frameTree?: CdpFrameTreeNode } | null)?.frameTree;
+  const rootUrl = root?.frame?.url || root?.frame?.unreachableUrl || '';
+  const rootOrigin = urlOrigin(rootUrl);
+  if (!root || !rootOrigin) return [];
+
+  const frames: Array<NonNullable<BrowserRef['frame']>> = [];
+  function collect(node: CdpFrameTreeNode | undefined): void {
+    for (const child of node?.childFrames ?? []) {
+      const frame = child.frame;
+      const frameId = frame?.id;
+      const frameUrl = frame?.url || frame?.unreachableUrl || '';
+      const origin = urlOrigin(frameUrl);
+      if (frameId && origin === rootOrigin) {
+        frames.push({ frameId, url: frameUrl });
+        collect(child);
+      }
+    }
+  }
+  collect(root);
+  return frames;
+}
+
+function urlOrigin(url: string): string | null {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- extend opt-in AX snapshots to collect same-origin iframe AX trees via `Page.getFrameTree` + `Accessibility.getFullAXTree({ frameId })`
- annotate AX refs with `frame.frameId/url`, while keeping cross-origin iframe routing out of scope
- recover stale iframe refs by re-querying the original frame before clicking

## Scope
- Only affects `browser state --source ax` and AX numeric refs produced by that snapshot.
- Default DOM `browser state` remains unchanged.
- Cross-origin frame session routing remains a later Phase 1 slice because extension `cdp` passthrough still has no sessionId routing.

## Verification
- `npm test -- --run src/browser/ax-snapshot.test.ts src/browser/base-page.test.ts` (27/27)
- `npm run typecheck`
- `npm run build`
- `git diff --check`