### PR TITLE
feat(browser): compare DOM and AX state metrics

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -866,6 +866,48 @@ describe('browser tab targeting commands', () => {
     expect(browserState.page?.snapshot).toHaveBeenCalledWith({ viewportExpand: 2000, source: 'ax' });
   });
 
+  it('prints DOM vs AX snapshot metrics without changing default state output', async () => {
+    browserState.page = {
+      ...browserState.page,
+      snapshot: vi.fn(async (opts?: { source?: string }) => {
+        if (opts?.source === 'ax') {
+          return 'source: ax\n---\n[1]button "Save"\nframe "https://app.example/embed":\n  [2]button "Frame Save"\n---\ninteractive: 2';
+        }
+        return 'URL: https://app.example\n[1] button "Save"';
+      }),
+    } as unknown as IPage;
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'state', '--compare-sources']);
+
+    expect(browserState.page?.snapshot).toHaveBeenCalledWith({ viewportExpand: 2000, source: 'dom' });
+    expect(browserState.page?.snapshot).toHaveBeenCalledWith({ viewportExpand: 2000, source: 'ax' });
+    const out = lastJsonLog();
+    expect(out.url).toBe('https://one.example');
+    expect(out.sources.dom).toMatchObject({ ok: true, refs: 1, frame_sections: 0 });
+    expect(out.sources.ax).toMatchObject({ ok: true, refs: 2, frame_sections: 1, interactive: 2 });
+  });
+
+  it('keeps compare-sources usable when one observation backend fails', async () => {
+    browserState.page = {
+      ...browserState.page,
+      snapshot: vi.fn(async (opts?: { source?: string }) => {
+        if (opts?.source === 'ax') throw new Error('AX unavailable');
+        return '[1] button "Save"';
+      }),
+    } as unknown as IPage;
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'state', '--compare-sources']);
+
+    const out = lastJsonLog();
+    expect(out.sources.dom).toMatchObject({ ok: true, refs: 1 });
+    expect(out.sources.ax).toMatchObject({
+      ok: false,
+      error: { message: 'AX unavailable' },
+    });
+  });
+
   it('rejects unknown browser state sources before touching the page', async () => {
     const program = createProgram('', '');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
-import type { ScreenshotOptions } from './types.js';
+import type { IPage, ScreenshotOptions } from './types.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -439,6 +439,45 @@ function getPageWorkspace(page: import('./types.js').IPage): string {
 function getPageScope(page: import('./types.js').IPage): string {
   const contextId = (page as unknown as { contextId?: unknown }).contextId;
   return getBrowserScope(getPageWorkspace(page), typeof contextId === 'string' && contextId.trim() ? contextId.trim() : undefined);
+}
+
+type SnapshotSource = 'dom' | 'ax';
+
+function snapshotMetricText(snapshot: unknown): string {
+  return typeof snapshot === 'string' ? snapshot : JSON.stringify(snapshot, null, 2);
+}
+
+function snapshotMetrics(snapshot: unknown, elapsedMs: number): Record<string, unknown> {
+  const text = snapshotMetricText(snapshot);
+  const interactiveMatch = text.match(/^interactive:\s*(\d+)\s*$/m);
+  return {
+    ok: true,
+    chars: text.length,
+    bytes: Buffer.byteLength(text, 'utf8'),
+    lines: text ? text.split(/\r?\n/).length : 0,
+    approx_tokens: Math.ceil(text.length / 4),
+    refs: (text.match(/(^|\n)\s*\[\d+\]/g) ?? []).length,
+    frame_sections: (text.match(/(^|\n)frame /g) ?? []).length,
+    ...(interactiveMatch ? { interactive: Number(interactiveMatch[1]) } : {}),
+    elapsed_ms: elapsedMs,
+  };
+}
+
+async function snapshotSourceMetrics(page: IPage, source: SnapshotSource): Promise<Record<string, unknown>> {
+  const started = Date.now();
+  try {
+    const snapshot = await page.snapshot({ viewportExpand: 2000, source });
+    return snapshotMetrics(snapshot, Date.now() - started);
+  } catch (err) {
+    return {
+      ok: false,
+      elapsed_ms: Date.now() - started,
+      error: {
+        ...(err instanceof Error && 'code' in err ? { code: String((err as { code?: unknown }).code) } : {}),
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
 }
 
 function resolveBrowserTabTarget(targetId?: string, opts?: { tab?: string } | Command): string | undefined {
@@ -975,8 +1014,20 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   // ── Inspect ──
 
   addBrowserTabOption(browser.command('state').description('Page state: URL, title, interactive elements with [N] indices')
-    .option('--source <source>', 'Snapshot backend: dom (default) or ax prototype', 'dom'))
+    .option('--source <source>', 'Snapshot backend: dom (default) or ax prototype', 'dom')
+    .option('--compare-sources', 'Print DOM vs AX snapshot metrics for observation promotion decisions', false))
     .action(browserAction(async (page, opts) => {
+      if (opts.compareSources === true) {
+        const [dom, ax] = await Promise.all([
+          snapshotSourceMetrics(page, 'dom'),
+          snapshotSourceMetrics(page, 'ax'),
+        ]);
+        console.log(JSON.stringify({
+          url: await page.getCurrentUrl?.() ?? '',
+          sources: { dom, ax },
+        }, null, 2));
+        return;
+      }
       const source = String(opts.source ?? 'dom').toLowerCase();
       if (source !== 'dom' && source !== 'ax') {
         console.log(JSON.stringify({


### PR DESCRIPTION
## Summary
- add `opencli browser state --compare-sources` to collect DOM vs AX observation metrics without dumping snapshots
- report per-source ok/error, chars/bytes/lines, approximate tokens, ref count, frame section count, AX interactive count, and elapsed ms
- keep default `browser state` output unchanged and keep `--source dom|ax` behavior intact

## Why
This is the Phase 1 promotion-decision slice after AX refs and same-origin iframe refs. It gives us real SaaS/fixture data for whether AX should become default instead of deciding by intuition.

## Verification
- `npm test -- --run src/cli.test.ts src/browser/ax-snapshot.test.ts src/browser/base-page.test.ts` (157/157)
- `npm run typecheck`
- `npm run build`
- `git diff --check`