### PR TITLE
docs(browser): document AX validation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **help / browser** — `opencli browser --help -f yaml|json` now emits a structured, agent-ready index of all browser leaf commands (including nested `tab`, `get`, and `dialog` commands), their positionals, command options, namespace options, and root global options. Individual browser commands also support structured help, backed by a shared Commander option/argument spec extractor.
 * **browser state** — add opt-in AX snapshot refs via `browser state --source ax`, including backend-node click resolution and role/name stale-ref recovery for the Phase 0 browser-agent runtime prototype.
+* **browser state** — AX snapshots now include same-origin iframe refs, and `browser state --compare-sources` prints DOM-vs-AX observation metrics for the Phase 1 default-source decision without dumping page contents.
 
 ### Bug Fixes
 

--- a/docs/design/browser-agent-runtime.md
+++ b/docs/design/browser-agent-runtime.md
@@ -421,6 +421,9 @@ Execution process:
 
 - Phase 0 completion: @opencli-质量官 runs Mercury, Brex, and Linear when access
   is available.
+- On each form page, collect `opencli browser state --compare-sources` so the AX
+  default decision has DOM-vs-AX metrics: refs, frame sections, approximate
+  tokens, elapsed time, and per-source errors.
 - Pass means the relevant category/field can be selected and the form state can
   be saved or committed.
 - Failures do not block the already-shipped MVP unless they expose a regression,

--- a/docs/design/mercury-fix-mvp.md
+++ b/docs/design/mercury-fix-mvp.md
@@ -183,6 +183,16 @@ Keep this additive. Do not replace `browser state` default in the same PR.
 Frame-aware routing is not part of the MVP. It moves to Phase 1 because the
 Mercury exit criteria do not require iframe support.
 
+Status after implementation:
+
+- PR 1 shipped CDP-primary click and component fixtures.
+- PR 2 shipped opt-in `browser state --source ax`, backend-node ref clicks, and
+  stale role/name/nth recovery.
+- Phase 1 same-origin iframe refs shipped for AX snapshots; cross-origin
+  session routing remains deferred.
+- Phase 1 metrics shipped as `browser state --compare-sources` so AX default
+  promotion can be decided from measured DOM-vs-AX data.
+
 ## Phase 1 Follow-Up
 
 - carry same-origin `frameId` and cross-origin session id when available,
@@ -230,6 +240,9 @@ Manual SaaS check:
   credentials/access are available.
 - Pass means the workflow can select the relevant category/field and save or
   commit the form state.
+- For each site, also run `opencli browser state --compare-sources` on the form
+  page and record `sources.dom.refs`, `sources.ax.refs`, `frame_sections`,
+  `approx_tokens`, `elapsed_ms`, and any per-source `error`.
 - Failure does not block MVP retroactively, but each failure must be recorded as
   a Phase 1 backlog item with observed command sequence and failure reason.
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -130,6 +130,8 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 | command | purpose |
 |---------|---------|
 | `browser state` | Snapshot: text tree with `[N]` refs, scroll hints, hidden-interactive hints, `compounds (N):` sidecar for date/select/file refs. |
+| `browser state --source ax` | Opt-in accessibility-tree snapshot. Use when custom controls, portals, or same-origin iframes are hard to identify in normal `state`. AX refs can recover stale React re-renders by role/name/nth. |
+| `browser state --compare-sources` | Metrics-only DOM vs AX comparison for deciding whether AX should become default. It prints counts and sizes, not page text, so it is safer to share for validation. |
 | `browser find --css <sel> [--limit N] [--text-max N]` | Run a CSS query and return one entry per match with `{nth, ref, tag, role, text, attrs, visible, compound?}`. Allocates refs for matches the prior snapshot didn't tag. Cheap alternative to `state` when you already know the selector. |
 | `browser frames` | List cross-origin iframe targets. Pass the index to `--frame` on `eval`. |
 | `browser screenshot [path]` | Viewport PNG. No path → base64 to stdout. Prefer `state` when you just need structure. |
@@ -321,6 +323,38 @@ opencli browser find --css "select[name=country]"
 opencli browser select 12 "Uruguay"
 opencli browser get value 12                   # { value: "uy", match_level: "exact" }
 ```
+
+### Pick from a custom React dropdown
+
+Use this for Radix, shadcn, Material UI, Mercury-style category fields, and
+other controls that are not native `<select>`.
+
+```bash
+opencli browser state                          # find category trigger ref
+# If the trigger/option is not clear, use AX:
+opencli browser state --source ax              # look for combobox/button/listbox/option names
+opencli browser click 7                        # click category trigger
+opencli browser state --source ax              # fresh refs after the portal/listbox opens
+opencli browser click 12                       # click option
+opencli browser get text 7                     # verify visible selected label
+```
+
+Do not use `browser select` on these widgets. `browser select` is only for
+native `<select>` elements. Custom dropdowns should be driven with
+`state -> click trigger -> state -> click option -> verify`.
+
+### Compare DOM vs AX observation
+
+When deciding whether AX refs are better for a page, collect metrics without
+sharing page contents:
+
+```bash
+opencli browser state --compare-sources
+```
+
+Report `sources.dom.refs`, `sources.ax.refs`, `frame_sections`,
+`approx_tokens`, `elapsed_ms`, and any per-source `error`. Use this before
+arguing that AX should become the default on a site.
 
 ### Scrape a list via network instead of DOM
 


### PR DESCRIPTION
## Summary
- document when agents should use `browser state --source ax` for custom React dropdowns, portals, and same-origin iframe refs
- document `browser state --compare-sources` as the metrics-only collection path for AX default decisions
- update browser-agent-runtime / Mercury MVP docs with implemented status and manual SaaS metric collection requirements
- add the same Phase 1 AX/metrics work to CHANGELOG

## Verification
- `npm run docs:build`
- `npm test -- --run src/cli.test.ts` (130/130)
- `git diff --check`