### PR TITLE
fix(browser): enable Accessibility before AX snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * **browser click** — `browser click` now prefers CDP `Input.dispatchMouseEvent` over DOM `el.click()`, so custom dropdowns that depend on pointer/mouse events (Radix, shadcn, Material UI, Mercury-style category pickers) open and select reliably while retaining JS click as a fallback for older backends or zero-rect targets.
+* **browser state / extension 1.0.7** — `browser state --source ax` now enables the CDP Accessibility domain before reading the AX tree, fixing real-Chrome snapshots that previously returned only `RootWebArea` with zero refs.
 * **help / build** — every positional arg must now declare a non-empty `help` string. The build-manifest step fails closed when a positional has empty / whitespace-only / missing `help`, so `opencli <site> <cmd> --help` always shows callers what each parameter is for. Pre-existing offenders (`twitter followers/following/list-add/list-remove/list-tweets/search/thread`, `reddit search/subreddit/user/user-comments/user-posts`, `douyin stats/update`, `bilibili subtitle`, `jike search`) now have explicit help text — most notably `twitter followers [user]` and `following [user]` now document that omitting the user fetches the currently logged-in account.
 
 ## [1.7.14](https://github.com/jackwener/opencli/compare/v1.7.13...v1.7.14) (2026-05-08)

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.5.5",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.5.5",
+      "version": "1.0.7",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -264,6 +264,30 @@ describe('background tab isolation', () => {
     ]);
   });
 
+  it('allows Accessibility.enable through the guarded CDP passthrough', async () => {
+    const { chrome } = createChromeMock();
+    chrome.debugger.sendCommand = vi.fn(async () => ({}));
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId('site:twitter', 1);
+
+    const result = await mod.__test__.handleCommand({
+      id: 'ax-enable',
+      action: 'cdp',
+      workspace: 'site:twitter',
+      cdpMethod: 'Accessibility.enable',
+      cdpParams: {},
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true }));
+    expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+      { tabId: 1 },
+      'Accessibility.enable',
+      {},
+    );
+  });
+
   it('routes exec frameIndex through the same cross-origin frame ordering as handleFrames', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1333,6 +1333,7 @@ async function handleScreenshot(cmd: Command, workspace: string): Promise<Result
 /** CDP methods permitted via the 'cdp' passthrough action. */
 const CDP_ALLOWLIST = new Set([
   // Agent DOM context
+  'Accessibility.enable',
   'Accessibility.getFullAXTree',
   'DOM.enable',
   'DOM.getDocument',

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -308,6 +308,8 @@ describe('BasePage native input routing', () => {
     await expect(page.snapshot({ source: 'ax' })).resolves.toContain('[1]button "Submit"');
     await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
 
+    expect(page.cdp).toHaveBeenNthCalledWith(1, 'Accessibility.enable', {});
+    expect(page.cdp).toHaveBeenNthCalledWith(2, 'Accessibility.getFullAXTree', {});
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', {});
     expect(page.cdp).toHaveBeenCalledWith('Page.getFrameTree', {});
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 10 });
@@ -405,6 +407,7 @@ describe('BasePage native input routing', () => {
     await page.snapshot({ source: 'ax' });
     await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
 
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', {});
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 20 });
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 42 });

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -318,6 +318,7 @@ export abstract class BasePage implements IPage {
       if (point) return { ...point, matchLevel: 'exact' };
     }
 
+    await cdp.call(this, 'Accessibility.enable', {});
     const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', axTreeParams(entry.frame)).catch(() => null);
     const recovered = findAxRefReplacement(axTree, entry);
     if (!recovered?.backendNodeId) return null;
@@ -642,6 +643,7 @@ export abstract class BasePage implements IPage {
   private async collectAxSnapshotTrees(
     cdp: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
   ): Promise<AxSnapshotTree[]> {
+    await cdp.call(this, 'Accessibility.enable', {});
     const rootTree = await cdp.call(this, 'Accessibility.getFullAXTree', {});
     const trees: AxSnapshotTree[] = [{ tree: rootTree }];
 


### PR DESCRIPTION
## Summary
- call `Accessibility.enable` before every AX tree read, including stale-ref recovery re-query
- allow `Accessibility.enable` through the extension guarded CDP passthrough
- add regression coverage for call order and extension allowlist passthrough

## Why
Real Chrome returns only `RootWebArea` from `Accessibility.getFullAXTree` unless the Accessibility domain is enabled first. Our mocks hid this, so `browser state --source ax` could produce zero refs in live pages such as Hacker News.

## Verification
- `npm test -- --run src/browser/base-page.test.ts src/browser/ax-snapshot.test.ts extension/src/background.test.ts` (72/72)
- `npm run typecheck`
- `npm --prefix extension run typecheck`
- `npm run build`
- `npm --prefix extension run build`
- `npm run docs:build`
- `git diff --check`