### PR TITLE
fix(youtube): request srv3 format for caption URLs (#1420)

### DIFF
--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -88,28 +88,33 @@ cli({
         // Step 2: Fetch caption XML and parse segments
         // Ensure caption URL requests srv3 XML format — YouTube may return empty
         // responses when no explicit format is specified.
-        let captionUrl = captionData.captionUrl;
-        if (!/[&?]fmt=/.test(captionUrl)) {
-            captionUrl += (captionUrl.includes('?') ? '&' : '?') + 'fmt=srv3';
+        const originalCaptionUrl = captionData.captionUrl;
+        let captionUrl = originalCaptionUrl;
+        if (!/[&?]fmt=/.test(originalCaptionUrl)) {
+            captionUrl = originalCaptionUrl + (originalCaptionUrl.includes('?') ? '&' : '?') + 'fmt=srv3';
         }
         const segments = await page.evaluate(`
       (async () => {
         async function fetchCaptionXml(url) {
           const resp = await fetch(url);
-          if (!resp.ok) return '';
-          return await resp.text() || '';
+          if (!resp.ok) return { error: 'Caption URL returned HTTP ' + resp.status };
+          return { xml: await resp.text() || '' };
         }
 
         const primaryUrl = ${JSON.stringify(captionUrl)};
-        let xml = await fetchCaptionXml(primaryUrl);
+        const originalUrl = ${JSON.stringify(originalCaptionUrl)};
+        let result = await fetchCaptionXml(primaryUrl);
+        if (result.error) return result;
 
-        // If srv3 format returned empty, retry with original URL (no fmt override)
-        if (!xml.length) {
-          const fallbackUrl = primaryUrl.replace(/[&?]fmt=srv3$/, '');
-          if (fallbackUrl !== primaryUrl) {
-            xml = await fetchCaptionXml(fallbackUrl);
+        // If srv3 format returned an empty successful body, retry with the
+        // original URL. Do not hide HTTP/non-OK failures behind fallback.
+        if (!result.xml.length && originalUrl !== primaryUrl) {
+          result = await fetchCaptionXml(originalUrl);
+          if (result.error) {
+            return result;
           }
         }
+        const xml = result.xml;
 
         if (!xml.length) {
           return { error: 'Caption URL returned empty response' };

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -86,12 +86,32 @@ cli({
             console.error(`Warning: --lang "${captionData.requestedLang}" not found. Using "${captionData.language}" instead. Available: ${captionData.available.join(', ')}`);
         }
         // Step 2: Fetch caption XML and parse segments
+        // Ensure caption URL requests srv3 XML format — YouTube may return empty
+        // responses when no explicit format is specified.
+        let captionUrl = captionData.captionUrl;
+        if (!/[&?]fmt=/.test(captionUrl)) {
+            captionUrl += (captionUrl.includes('?') ? '&' : '?') + 'fmt=srv3';
+        }
         const segments = await page.evaluate(`
       (async () => {
-        const resp = await fetch(${JSON.stringify(captionData.captionUrl)});
-        const xml = await resp.text();
+        async function fetchCaptionXml(url) {
+          const resp = await fetch(url);
+          if (!resp.ok) return '';
+          return await resp.text() || '';
+        }
 
-        if (!xml?.length) {
+        const primaryUrl = ${JSON.stringify(captionUrl)};
+        let xml = await fetchCaptionXml(primaryUrl);
+
+        // If srv3 format returned empty, retry with original URL (no fmt override)
+        if (!xml.length) {
+          const fallbackUrl = primaryUrl.replace(/[&?]fmt=srv3$/, '');
+          if (fallbackUrl !== primaryUrl) {
+            xml = await fetchCaptionXml(fallbackUrl);
+          }
+        }
+
+        if (!xml.length) {
           return { error: 'Caption URL returned empty response' };
         }
 

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -14,4 +14,12 @@ describe('youtube transcript source contract', () => {
         expect(transcriptSource).not.toContain('/youtubei/v1/player');
         expect(transcriptSource).not.toContain("clientName: 'ANDROID'");
     });
+
+    it('normalizes caption URL to request srv3 XML format', () => {
+        expect(transcriptSource).toContain('fmt=srv3');
+    });
+
+    it('checks HTTP status before reading caption response body', () => {
+        expect(transcriptSource).toContain('resp.ok');
+    });
 });

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -1,10 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './transcript.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const transcriptSource = readFileSync(resolve(__dirname, 'transcript.js'), 'utf8');
+
+function createPageMock(captionUrl) {
+    const page = {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(),
+    };
+    page.evaluate
+        .mockResolvedValueOnce({
+        captionUrl,
+        language: 'en',
+        kind: 'manual',
+        available: ['en'],
+        requestedLang: null,
+        langMatched: false,
+        langPrefixMatched: false,
+    })
+        .mockResolvedValue([{ start: 1, end: 3, text: 'hello & world' }]);
+    return page;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 describe('youtube transcript source contract', () => {
     it('gets caption tracks from watch page bootstrap data, not Android InnerTube', () => {
@@ -21,5 +47,60 @@ describe('youtube transcript source contract', () => {
 
     it('checks HTTP status before reading caption response body', () => {
         expect(transcriptSource).toContain('resp.ok');
+    });
+});
+
+describe('youtube transcript caption fetch', () => {
+    const command = getRegistry().get('youtube/transcript');
+
+    it('requests srv3 when the caption track URL has no explicit format', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+
+        const rows = await command.func(page, { url: 'abc', mode: 'raw' });
+
+        expect(page.evaluate.mock.calls[1][0]).toContain('const primaryUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=srv3"');
+        expect(page.evaluate.mock.calls[1][0]).toContain('const originalUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en"');
+        expect(rows).toEqual([{ index: 1, start: '1.00s', end: '3.00s', text: 'hello & world' }]);
+    });
+
+    it('does not override an existing caption format', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt');
+
+        await command.func(page, { url: 'abc', mode: 'raw' });
+
+        expect(page.evaluate.mock.calls[1][0]).toContain('const primaryUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt"');
+        expect(page.evaluate.mock.calls[1][0]).toContain('const originalUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt"');
+    });
+
+    it('falls back to the original URL only after an empty successful srv3 response', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+
+        await command.func(page, { url: 'abc', mode: 'raw' });
+
+        const script = page.evaluate.mock.calls[1][0];
+        expect(script).toContain('if (!result.xml.length && originalUrl !== primaryUrl)');
+        expect(script).toContain('result = await fetchCaptionXml(originalUrl)');
+        expect(script).toContain('if (result.error) {');
+    });
+
+    it('fails typed on caption HTTP errors instead of falling back silently', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+        page.evaluate.mockReset();
+        page.evaluate
+            .mockResolvedValueOnce({
+            captionUrl: 'https://www.youtube.com/api/timedtext?v=abc&lang=en',
+            language: 'en',
+            kind: 'manual',
+            available: ['en'],
+            requestedLang: null,
+            langMatched: false,
+            langPrefixMatched: false,
+        })
+            .mockResolvedValueOnce({ error: 'Caption URL returned HTTP 503' });
+
+        await expect(command.func(page, { url: 'abc', mode: 'raw' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('HTTP 503'),
+        });
     });
 });


### PR DESCRIPTION
## Problem

YouTube transcript command fails with `Caption URL returned empty response` for all videos (#1420). Step 1 (caption track discovery via watch page HTML) succeeds, but Step 2 (fetching caption content from `captionTracks[].baseUrl`) returns an empty response.

## Root cause

YouTube's `baseUrl` in `captionTracks` may not include an explicit format parameter. Without one, YouTube can return empty responses instead of the expected XML caption data.

## Fix

1. **Normalize caption URL with `fmt=srv3`** — append `&fmt=srv3` (standard YouTube XML caption format) when no `fmt` parameter is present
2. **Add HTTP status checking** — check `resp.ok` before reading the response body, preventing silent failures on non-200 responses
3. **Fallback to original URL** — if `srv3` still returns empty, retry with the original URL (in case the URL already had an implicit format that worked)

## Changes

- `clis/youtube/transcript.js` — format normalization + HTTP status check + fallback logic in Step 2
- `clis/youtube/transcript.test.js` — 2 new source-contract tests (srv3 format presence + resp.ok check)

## Verification

- `npm test -- --run clis/youtube/transcript.test.js` — 3/3 pass
- `npm test` — 2884 pass (32 failures are pre-existing `article-extract` missing `@mozilla/readability` module, unrelated)
- `git diff --stat` confirms 2 files changed

Fixes #1420