### PR TITLE
feat(qimao): add qimao site adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18489,6 +18489,371 @@
     "sourceFile": "pypi/package.js"
   },
   {
+    "site": "qimao",
+    "name": "book",
+    "description": "Read Qimao book details",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "book",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Qimao book id or book URL"
+      }
+    ],
+    "columns": [
+      "book_id",
+      "title",
+      "author",
+      "category",
+      "status",
+      "score",
+      "words",
+      "chapters",
+      "characters",
+      "latest_chapter",
+      "updated_at",
+      "url",
+      "cover",
+      "intro"
+    ],
+    "type": "js",
+    "modulePath": "qimao/book.js",
+    "sourceFile": "qimao/book.js"
+  },
+  {
+    "site": "qimao",
+    "name": "browse",
+    "description": "Browse Qimao category listings with filters and sorting",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "category",
+        "type": "str",
+        "required": false,
+        "help": "Category name/id, subcategory name/id, or a Qimao classify URL"
+      },
+      {
+        "name": "channel",
+        "type": "str",
+        "required": false,
+        "help": "all, female, male, publish"
+      },
+      {
+        "name": "words",
+        "type": "str",
+        "required": false,
+        "help": "all, lt30w, 30to50w, 50to100w, 100to200w, gt200w"
+      },
+      {
+        "name": "updated-within",
+        "type": "str",
+        "required": false,
+        "help": "all, 3d, 7d, 30d"
+      },
+      {
+        "name": "status",
+        "type": "str",
+        "required": false,
+        "help": "all, finished, serial"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "required": false,
+        "help": "click, words, update, favorite"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Starting page number (1-based)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 15,
+        "required": false,
+        "help": "Max rows to return across pages (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "book_id",
+      "title",
+      "author",
+      "category",
+      "status",
+      "words",
+      "latest_chapter",
+      "updated_at",
+      "url",
+      "intro"
+    ],
+    "type": "js",
+    "modulePath": "qimao/browse.js",
+    "sourceFile": "qimao/browse.js",
+    "navigateBefore": "https://www.qimao.com/shuku/a-a-a-a-a-a-a-click-1/"
+  },
+  {
+    "site": "qimao",
+    "name": "browse-options",
+    "description": "List Qimao browse filter options for programmatic use",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "group",
+        "type": "str",
+        "required": false,
+        "help": "Optional group: channel, words, updated-within, status, sort, category1, category2, category"
+      }
+    ],
+    "columns": [
+      "group",
+      "label",
+      "value",
+      "parent_label",
+      "parent_value"
+    ],
+    "type": "js",
+    "modulePath": "qimao/browse-options.js",
+    "sourceFile": "qimao/browse-options.js",
+    "navigateBefore": "https://www.qimao.com/shuku/a-a-a-a-a-a-a-click-1/"
+  },
+  {
+    "site": "qimao",
+    "name": "catalog",
+    "description": "List Qimao chapters for a book",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "book",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Qimao book id or book URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max chapters to return (1-500)"
+      },
+      {
+        "name": "offset",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Zero-based chapter offset"
+      }
+    ],
+    "columns": [
+      "index",
+      "chapter_id",
+      "title",
+      "words",
+      "is_vip",
+      "updated_at",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "qimao/catalog.js",
+    "sourceFile": "qimao/catalog.js",
+    "navigateBefore": "https://www.qimao.com"
+  },
+  {
+    "site": "qimao",
+    "name": "rank",
+    "description": "Read Qimao ranking lists",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "channel",
+        "type": "str",
+        "required": false,
+        "help": "boy/girl or 男生/女生"
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "required": false,
+        "help": "hot/new/over/collect/update or 大热榜/新书榜/完结榜/收藏榜/更新榜"
+      },
+      {
+        "name": "period",
+        "type": "str",
+        "required": false,
+        "help": "date/month or 日榜/月榜"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "book_id",
+      "title",
+      "author",
+      "category1",
+      "category",
+      "status",
+      "words",
+      "latest_chapter",
+      "updated_at",
+      "hot_value",
+      "hot_unit",
+      "url",
+      "intro"
+    ],
+    "type": "js",
+    "modulePath": "qimao/rank.js",
+    "sourceFile": "qimao/rank.js",
+    "navigateBefore": "https://www.qimao.com/paihang/boy/hot/date/"
+  },
+  {
+    "site": "qimao",
+    "name": "rank-options",
+    "description": "List Qimao ranking dimensions for programmatic use",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "group",
+        "type": "str",
+        "required": false,
+        "help": "Optional group: channel, type, period"
+      }
+    ],
+    "columns": [
+      "group",
+      "label",
+      "value"
+    ],
+    "type": "js",
+    "modulePath": "qimao/rank-options.js",
+    "sourceFile": "qimao/rank-options.js",
+    "navigateBefore": "https://www.qimao.com/paihang/boy/hot/date/"
+  },
+  {
+    "site": "qimao",
+    "name": "read",
+    "description": "Read a Qimao chapter by chapter id or chapter index",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "book",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Qimao book id or book URL"
+      },
+      {
+        "name": "chapter-id",
+        "type": "str",
+        "required": false,
+        "help": "Specific Qimao chapter id or chapter URL"
+      },
+      {
+        "name": "chapter-index",
+        "type": "int",
+        "required": false,
+        "help": "1-based chapter index from the catalog"
+      }
+    ],
+    "columns": [
+      "book_id",
+      "book_title",
+      "author",
+      "chapter_id",
+      "index",
+      "chapter_title",
+      "words",
+      "updated_at",
+      "url",
+      "content"
+    ],
+    "type": "js",
+    "modulePath": "qimao/read.js",
+    "sourceFile": "qimao/read.js"
+  },
+  {
+    "site": "qimao",
+    "name": "search",
+    "description": "Search Qimao books by title, author, or character",
+    "access": "read",
+    "domain": "www.qimao.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Book title, author, or character keyword"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max rows to return (1-50)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Result page number (1-based)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "book_id",
+      "title",
+      "author",
+      "category",
+      "status",
+      "words",
+      "characters",
+      "latest_chapter",
+      "updated_at",
+      "url",
+      "intro"
+    ],
+    "type": "js",
+    "modulePath": "qimao/search.js",
+    "sourceFile": "qimao/search.js",
+    "navigateBefore": "https://www.qimao.com"
+  },
+  {
     "site": "quark",
     "name": "ls",
     "description": "List files in your Quark Drive",

--- a/clis/qimao/book.js
+++ b/clis/qimao/book.js
@@ -1,0 +1,102 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    QIMAO_DOMAIN,
+    buildBookUrl,
+    cleanText,
+    normalizeStatus,
+    parseBookId,
+} from './utils.js';
+
+export function normalizeBookSnapshot(snapshot, bookId) {
+    const title = cleanText(snapshot?.title);
+    if (!title) {
+        throw new EmptyResultError('qimao book', `No book detail found for book ${bookId}.`);
+    }
+    return {
+        book_id: bookId,
+        title,
+        author: cleanText(snapshot?.author),
+        category: cleanText(snapshot?.category),
+        status: normalizeStatus(snapshot?.status),
+        score: cleanText(snapshot?.score),
+        words: cleanText(snapshot?.words),
+        chapters: Number.parseInt(String(snapshot?.chapters ?? ''), 10) || null,
+        characters: cleanText(snapshot?.characters),
+        latest_chapter: cleanText(snapshot?.latest_chapter),
+        updated_at: cleanText(snapshot?.updated_at),
+        intro: cleanText(snapshot?.intro),
+        cover: cleanText(snapshot?.cover),
+        url: cleanText(snapshot?.url) || buildBookUrl(bookId),
+    };
+}
+
+async function extractBookSnapshot(page) {
+    return page.evaluate(`
+      (() => {
+        const clean = (value) => String(value ?? '').replace(/\\s+/g, ' ').trim();
+        const nuxt = window.__NUXT__ || {};
+        const state = nuxt.state || {};
+        const common = state.common || {};
+        const related = common.bookRelatedInfo || {};
+        const detail = related.bookDetail || {};
+        const introData = related.bookIntroData || {};
+        const authorDetail = related.authorDetail || {};
+        return {
+          title: clean(detail.title || document.querySelector('h1')?.textContent || ''),
+          author: clean(detail.author || authorDetail.author_name || document.querySelector('a[href*="/zuozhe/"]')?.textContent || ''),
+          category: clean(detail.category_2_name || ''),
+          status: detail.is_over,
+          score: clean(detail.score || ''),
+          words: clean(detail.words_num || ''),
+          chapters: clean(detail.catalogue_num || ''),
+          characters: clean(detail.characters || ''),
+          latest_chapter: clean(detail.latest_chapter_title || ''),
+          updated_at: clean(detail.update_time || ''),
+          intro: clean(introData.intro || ''),
+          cover: clean(detail.image_link || document.querySelector('img')?.src || ''),
+          url: clean(window.location.href || ''),
+        };
+      })()
+    `);
+}
+
+cli({
+    site: 'qimao',
+    name: 'book',
+    access: 'read',
+    description: 'Read Qimao book details',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    args: [
+        { name: 'book', positional: true, required: true, help: 'Qimao book id or book URL' },
+    ],
+    columns: [
+        'book_id',
+        'title',
+        'author',
+        'category',
+        'status',
+        'score',
+        'words',
+        'chapters',
+        'characters',
+        'latest_chapter',
+        'updated_at',
+        'url',
+        'cover',
+        'intro',
+    ],
+    func: async (page, args) => {
+        const bookId = parseBookId(args.book);
+        await page.goto(buildBookUrl(bookId), { waitUntil: 'load', settleMs: 2000 });
+        await page.wait({ time: 1 });
+        const snapshot = await extractBookSnapshot(page);
+        return [normalizeBookSnapshot(snapshot, bookId)];
+    },
+});
+
+export const __test__ = {
+    normalizeBookSnapshot,
+};

--- a/clis/qimao/browse-options.js
+++ b/clis/qimao/browse-options.js
@@ -1,0 +1,57 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { QIMAO_DOMAIN, QIMAO_ORIGIN, cleanText } from './utils.js';
+import { fetchBrowseMetadata, normalizeBrowseOptionRows } from './browse.shared.js';
+
+const GROUP_ALIASES = {
+    channel: ['channel', '频道'],
+    words: ['words', '字数', '作品字数'],
+    'updated-within': ['updated-within', 'update-time', '更新时间'],
+    status: ['status', 'is-over', '完结', '是否完结'],
+    sort: ['sort', 'order', '排序'],
+    category1: ['category1', '一级分类', '大类'],
+    category2: ['category2', '二级分类', '子分类', '小类'],
+    category: ['category', '分类'],
+};
+
+function normalizeGroup(value) {
+    const text = cleanText(value).toLowerCase();
+    if (!text) {
+        return '';
+    }
+    for (const [group, aliases] of Object.entries(GROUP_ALIASES)) {
+        if (aliases.some((alias) => cleanText(alias).toLowerCase() === text)) {
+            return group;
+        }
+    }
+    throw new ArgumentError(`qimao group must be one of: ${Object.keys(GROUP_ALIASES).join(', ')}`);
+}
+
+cli({
+    site: 'qimao',
+    name: 'browse-options',
+    access: 'read',
+    description: 'List Qimao browse filter options for programmatic use',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    navigateBefore: `${QIMAO_ORIGIN}/shuku/a-a-a-a-a-a-a-click-1/`,
+    args: [
+        { name: 'group', help: 'Optional group: channel, words, updated-within, status, sort, category1, category2, category' },
+    ],
+    columns: ['group', 'label', 'value', 'parent_label', 'parent_value'],
+    func: async (page, args) => {
+        const rows = normalizeBrowseOptionRows(await fetchBrowseMetadata(page));
+        const group = normalizeGroup(args.group);
+        const filtered = group === ''
+            ? rows
+            : group === 'category'
+                ? rows.filter((row) => row.group === 'category1' || row.group === 'category2')
+                : rows.filter((row) => row.group === group);
+
+        if (filtered.length === 0) {
+            throw new EmptyResultError('qimao browse-options', 'No options found for the selected group.');
+        }
+        return filtered;
+    },
+});

--- a/clis/qimao/browse.js
+++ b/clis/qimao/browse.js
@@ -1,0 +1,176 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    QIMAO_ORIGIN,
+    QIMAO_DOMAIN,
+    buildClassifyBookListApiUrl,
+    cleanText,
+    qimaoFetchJson,
+    requireLimit,
+    requirePositiveInt,
+    stripHtml,
+} from './utils.js';
+import { fetchBrowseMetadata, normalizeBrowseOptionRows, resolveCategoryValue } from './browse.shared.js';
+
+const PAGE_SIZE = 15;
+
+const FILTER_OPTIONS = {
+    channel: [
+        { value: 'a', aliases: ['a', 'all', '全部'] },
+        { value: '1', aliases: ['1', 'female', 'women', 'girl', '女生', '女生原创'] },
+        { value: '0', aliases: ['0', 'male', 'men', 'boy', '男生', '男生原创'] },
+        { value: '2', aliases: ['2', 'publish', 'published', 'book', '出版', '出版图书'] },
+    ],
+    words: [
+        { value: 'a', aliases: ['a', 'all', '全部'] },
+        { value: '1', aliases: ['1', 'lt30w', 'under-300k', '30万以下'] },
+        { value: '2', aliases: ['2', '30to50w', '30万-50万'] },
+        { value: '3', aliases: ['3', '50to100w', '50万-100万'] },
+        { value: '4', aliases: ['4', '100to200w', '100万-200万'] },
+        { value: '5', aliases: ['5', 'gt200w', 'over-200w', '200万以上'] },
+    ],
+    update_time: [
+        { value: 'a', aliases: ['a', 'all', '全部'] },
+        { value: '1', aliases: ['1', '3d', '3days', '3天内'] },
+        { value: '2', aliases: ['2', '7d', '7days', '7天内'] },
+        { value: '3', aliases: ['3', '30d', '30days', '30天内'] },
+    ],
+    is_over: [
+        { value: 'a', aliases: ['a', 'all', '全部'] },
+        { value: '1', aliases: ['1', 'finished', 'completed', '已完结', '完结'] },
+        { value: '0', aliases: ['0', 'serial', 'ongoing', '连载中'] },
+    ],
+    order: [
+        { value: 'click', aliases: ['click', '按点击量'] },
+        { value: 'words_num', aliases: ['words_num', 'words', '按总字数'] },
+        { value: 'update_time', aliases: ['update_time', 'update', 'recent', '最近更新'] },
+        { value: 'favorite_uv', aliases: ['favorite_uv', 'favorite', 'favorites', '按收藏数'] },
+    ],
+};
+
+function normalizeAlias(value) {
+    return cleanText(value).toLowerCase();
+}
+
+function resolveFilterValue(rawValue, label, options, defaultValue) {
+    if (rawValue == null) {
+        return defaultValue;
+    }
+    const normalized = normalizeAlias(rawValue);
+    const matched = options.find((option) => option.aliases.some((alias) => normalizeAlias(alias) === normalized));
+    if (!matched) {
+        throw new ArgumentError(`qimao ${label} must be one of: ${options.map((item) => item.aliases[0]).join(', ')}`);
+    }
+    return matched.value;
+}
+
+export function normalizeBrowseRow(item, rank) {
+    return {
+        rank,
+        book_id: cleanText(item?.book_id),
+        title: cleanText(item?.title),
+        author: cleanText(item?.author),
+        category: cleanText(item?.category2_name),
+        status: cleanText(item?.is_over_txt),
+        words: cleanText(item?.words_num),
+        latest_chapter: cleanText(item?.latest_chapter_title),
+        updated_at: cleanText(item?.update_time_txt || item?.update_time),
+        url: cleanText(item?.read_url),
+        category_url: cleanText(item?.category_url),
+        intro: stripHtml(item?.intro),
+    };
+}
+
+cli({
+    site: 'qimao',
+    name: 'browse',
+    access: 'read',
+    description: 'Browse Qimao category listings with filters and sorting',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    navigateBefore: `${QIMAO_ORIGIN}/shuku/a-a-a-a-a-a-a-click-1/`,
+    args: [
+        { name: 'category', help: 'Category name/id, subcategory name/id, or a Qimao classify URL' },
+        { name: 'channel', help: 'all, female, male, publish' },
+        { name: 'words', help: 'all, lt30w, 30to50w, 50to100w, 100to200w, gt200w' },
+        { name: 'updated-within', help: 'all, 3d, 7d, 30d' },
+        { name: 'status', help: 'all, finished, serial' },
+        { name: 'sort', help: 'click, words, update, favorite' },
+        { name: 'page', type: 'int', default: 1, help: 'Starting page number (1-based)' },
+        { name: 'limit', type: 'int', default: 15, help: 'Max rows to return across pages (1-50)' },
+    ],
+    columns: [
+        'rank',
+        'book_id',
+        'title',
+        'author',
+        'category',
+        'status',
+        'words',
+        'latest_chapter',
+        'updated_at',
+        'url',
+        'intro',
+    ],
+    func: async (page, args) => {
+        const startPage = requirePositiveInt(args.page, 1, 'page');
+        const limit = requireLimit(args.limit, 15, 50);
+        const metadata = await fetchBrowseMetadata(page);
+        const categoryOptions = Array.isArray(metadata.category) ? metadata.category : [];
+        const category = resolveCategoryValue(args.category, categoryOptions);
+        const channel = resolveFilterValue(args.channel, 'channel', FILTER_OPTIONS.channel, 'a');
+        const words = resolveFilterValue(args.words, 'words', FILTER_OPTIONS.words, 'a');
+        const updateTime = resolveFilterValue(args['updated-within'], 'updated-within', FILTER_OPTIONS.update_time, 'a');
+        const isOver = resolveFilterValue(args.status, 'status', FILTER_OPTIONS.is_over, 'a');
+        const order = resolveFilterValue(args.sort, 'sort', FILTER_OPTIONS.order, 'click');
+
+        const rows = [];
+        const pagesToFetch = Math.ceil(limit / PAGE_SIZE);
+
+        for (let offset = 0; offset < pagesToFetch; offset += 1) {
+            const currentPage = startPage + offset;
+            const data = await qimaoFetchJson(
+                buildClassifyBookListApiUrl({
+                    channel,
+                    category1: category.category1,
+                    category2: category.category2,
+                    words,
+                    updateTime,
+                    isVip: 'a',
+                    isOver,
+                    order,
+                    page: currentPage,
+                }),
+                `qimao browse page ${currentPage}`,
+                `${QIMAO_ORIGIN}/shuku/a-a-a-a-a-a-a-click-1/`,
+                page,
+            );
+
+            const list = Array.isArray(data.book_list) ? data.book_list : [];
+            if (list.length === 0) {
+                break;
+            }
+            for (const item of list) {
+                rows.push(normalizeBrowseRow(item, rows.length + 1));
+                if (rows.length >= limit) {
+                    break;
+                }
+            }
+            if (rows.length >= limit || list.length < PAGE_SIZE) {
+                break;
+            }
+        }
+
+        if (rows.length === 0) {
+            throw new EmptyResultError('qimao browse', 'Qimao returned no books for the selected filters.');
+        }
+        return rows;
+    },
+});
+
+export const __test__ = {
+    normalizeBrowseRow,
+    normalizeBrowseOptionRows,
+    resolveCategoryValue,
+};

--- a/clis/qimao/browse.shared.js
+++ b/clis/qimao/browse.shared.js
@@ -1,0 +1,142 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { QIMAO_ORIGIN, buildClassifySelectOptionApiUrl, cleanText, qimaoFetchJson } from './utils.js';
+
+function normalizeAlias(value) {
+    return cleanText(value).toLowerCase();
+}
+
+function parseBrowseUrl(rawValue) {
+    if (!/^https?:\/\//i.test(rawValue)) {
+        return null;
+    }
+    let parsed;
+    try {
+        parsed = new URL(rawValue);
+    }
+    catch {
+        return null;
+    }
+    const matched = parsed.pathname.match(/^\/shuku\/([^/]+)\/?$/);
+    if (!matched?.[1]) {
+        return null;
+    }
+    const parts = matched[1].split('-');
+    if (parts.length < 9) {
+        return null;
+    }
+    return {
+        channel: parts[1] || 'a',
+        category1: parts[2] || 'a',
+        category2: parts[3] || 'a',
+        words: parts[4] || 'a',
+        updateTime: parts[5] || 'a',
+        isVip: parts[6] || 'a',
+        isOver: parts[7] || 'a',
+        order: parts[8] || 'click',
+    };
+}
+
+export function resolveCategoryValue(rawValue, categories) {
+    if (rawValue == null || normalizeAlias(rawValue) === '' || ['a', 'all', '全部'].includes(normalizeAlias(rawValue))) {
+        return { category1: 'a', category2: 'a', label: '全部' };
+    }
+
+    const fromUrl = parseBrowseUrl(String(rawValue));
+    if (fromUrl) {
+        return {
+            category1: fromUrl.category1,
+            category2: fromUrl.category2,
+            label: cleanText(rawValue),
+        };
+    }
+
+    const normalized = normalizeAlias(rawValue);
+    const parentMatches = [];
+    const childMatches = [];
+
+    for (const parent of categories) {
+        if (!parent || cleanText(parent.id) === 'a') {
+            continue;
+        }
+        if ([cleanText(parent.id), cleanText(parent.name)].some((item) => normalizeAlias(item) === normalized)) {
+            parentMatches.push(parent);
+        }
+        for (const child of Array.isArray(parent.children) ? parent.children : []) {
+            if ([cleanText(child.id), cleanText(child.name)].some((item) => normalizeAlias(item) === normalized)) {
+                childMatches.push({ parent, child });
+            }
+        }
+    }
+
+    if (childMatches.length === 1) {
+        return {
+            category1: cleanText(childMatches[0].parent.id),
+            category2: cleanText(childMatches[0].child.id),
+            label: cleanText(childMatches[0].child.name),
+        };
+    }
+    if (childMatches.length > 1) {
+        throw new ArgumentError(`qimao category is ambiguous: ${rawValue}. Use a numeric category id instead.`);
+    }
+    if (parentMatches.length === 1) {
+        return {
+            category1: cleanText(parentMatches[0].id),
+            category2: 'a',
+            label: cleanText(parentMatches[0].name),
+        };
+    }
+    throw new ArgumentError(`Unknown qimao category: ${rawValue}`);
+}
+
+export function normalizeBrowseOptionRows(metadata) {
+    const rows = [];
+    const pushFilterGroup = (group, list = []) => {
+        for (const item of list) {
+            rows.push({
+                group,
+                label: cleanText(item?.label),
+                value: cleanText(item?.value),
+                parent_label: '',
+                parent_value: '',
+            });
+        }
+    };
+
+    const filters = metadata?.filters ?? {};
+    pushFilterGroup('channel', filters.channel);
+    pushFilterGroup('words', filters.words);
+    pushFilterGroup('updated-within', filters.update_time);
+    pushFilterGroup('status', filters.is_over);
+    pushFilterGroup('sort', filters.order);
+
+    for (const category of Array.isArray(metadata?.category) ? metadata.category : []) {
+        const categoryId = cleanText(category?.id);
+        const categoryName = cleanText(category?.name);
+        rows.push({
+            group: 'category1',
+            label: categoryName,
+            value: categoryId,
+            parent_label: '',
+            parent_value: '',
+        });
+        for (const child of Array.isArray(category?.children) ? category.children : []) {
+            rows.push({
+                group: 'category2',
+                label: cleanText(child?.name),
+                value: cleanText(child?.id),
+                parent_label: categoryName,
+                parent_value: categoryId,
+            });
+        }
+    }
+    return rows;
+}
+
+export async function fetchBrowseMetadata(page) {
+    return qimaoFetchJson(
+        buildClassifySelectOptionApiUrl(),
+        'qimao browse options',
+        `${QIMAO_ORIGIN}/shuku/a-a-a-a-a-a-a-click-1/`,
+        page,
+    );
+}

--- a/clis/qimao/catalog.js
+++ b/clis/qimao/catalog.js
@@ -1,0 +1,48 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    QIMAO_ORIGIN,
+    QIMAO_DOMAIN,
+    buildBookUrl,
+    buildChapterListApiUrl,
+    normalizeCatalogChapter,
+    parseBookId,
+    qimaoFetchJson,
+    requireLimit,
+    requireNonNegativeInt,
+} from './utils.js';
+
+cli({
+    site: 'qimao',
+    name: 'catalog',
+    access: 'read',
+    description: 'List Qimao chapters for a book',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    navigateBefore: QIMAO_ORIGIN,
+    args: [
+        { name: 'book', positional: true, required: true, help: 'Qimao book id or book URL' },
+        { name: 'limit', type: 'int', default: 50, help: 'Max chapters to return (1-500)' },
+        { name: 'offset', type: 'int', default: 0, help: 'Zero-based chapter offset' },
+    ],
+    columns: ['index', 'chapter_id', 'title', 'words', 'is_vip', 'updated_at', 'url'],
+    func: async (page, args) => {
+        const bookId = parseBookId(args.book);
+        const limit = requireLimit(args.limit, 50, 500);
+        const offset = requireNonNegativeInt(args.offset, 0, 'offset');
+        const data = await qimaoFetchJson(
+            buildChapterListApiUrl(bookId),
+            `qimao catalog ${bookId}`,
+            buildBookUrl(bookId),
+            page,
+        );
+        const chapters = Array.isArray(data.chapters) ? data.chapters : [];
+        if (chapters.length === 0) {
+            throw new EmptyResultError('qimao catalog', `No chapters found for book ${bookId}.`);
+        }
+        return chapters
+            .slice(offset, offset + limit)
+            .map((chapter) => normalizeCatalogChapter(bookId, chapter));
+    },
+});

--- a/clis/qimao/qimao.test.js
+++ b/clis/qimao/qimao.test.js
@@ -1,0 +1,484 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './catalog.js';
+import './book.js';
+import './read.js';
+import './browse.js';
+import './browse-options.js';
+import './rank.js';
+import './rank-options.js';
+import { __test__ as bookTest } from './book.js';
+import { __test__ as readTest } from './read.js';
+import { __test__ as browseTest } from './browse.js';
+import { __test__ as rankTest } from './rank.js';
+import { parseBookId, parseChapterId, stripHtml } from './utils.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('qimao utils', () => {
+    it('parses qimao book and chapter identifiers from ids and urls', () => {
+        expect(parseBookId('1784909')).toBe('1784909');
+        expect(parseBookId('https://www.qimao.com/shuku/1784909/')).toBe('1784909');
+        expect(parseBookId('https://www.qimao.com/shuku/1784909-17059219630001/')).toBe('1784909');
+        expect(parseBookId('https://www.qimao.com/reader/index/1784909/')).toBe('1784909');
+        expect(parseChapterId('17059219630001')).toBe('17059219630001');
+        expect(parseChapterId('https://www.qimao.com/shuku/1784909-17059219630001/')).toBe('17059219630001');
+    });
+
+    it('decodes html fragments into plain text', () => {
+        expect(stripHtml('<p>Hello&nbsp;<b>World</b></p><p>&#x4F60;&#22909;</p>')).toBe('Hello World\n你好');
+    });
+});
+
+describe('qimao search command', () => {
+    const cmd = getRegistry().get('qimao/search');
+
+    it('rejects invalid query/limit/page before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const page = { evaluate: vi.fn() };
+        await expect(cmd.func(page, { query: '   ', limit: 10, page: 1 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func(page, { query: '凡人修仙传', limit: 0, page: 1 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func(page, { query: '凡人修仙传', limit: 10, page: 0 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns normalized search rows from the public api', async () => {
+        const payload = {
+            data: {
+                search_list: [{
+                    book_id: '1784909',
+                    title: '凡人修仙传（杨洋、金晨主演同名影视原著）',
+                    author: '忘语',
+                    category2_name: '古典仙侠',
+                    is_over_txt: '完结',
+                    words_num: '747.84万字',
+                    characters: '韩立',
+                    latest_chapter_title: '忘语新书《玄界之门》',
+                    update_time: '2024-01-24 09:51:50',
+                    read_url: 'https://www.qimao.com/shuku/1784909/',
+                    intro: '<p>一个普通山村小子。</p>',
+                }],
+            },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+        const page = {
+            evaluate: vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                text: JSON.stringify(payload),
+            }),
+        };
+        const rows = await cmd.func(page, { query: '凡人修仙传', limit: 5, page: 1 });
+        expect(rows).toHaveLength(1);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            book_id: '1784909',
+            author: '忘语',
+            category: '古典仙侠',
+            status: '完结',
+            words: '747.84万字',
+            latest_chapter: '忘语新书《玄界之门》',
+        });
+        expect(rows[0].intro).toBe('一个普通山村小子。');
+    });
+});
+
+describe('qimao catalog command', () => {
+    const cmd = getRegistry().get('qimao/catalog');
+
+    it('returns normalized chapter rows with limit/offset slicing', async () => {
+        const payload = {
+            data: {
+                chapters: [
+                    { id: '17059219630001', title: '第一章 山边小村', words: '2601', is_vip: '0', update_time: '1203482820', index: '1' },
+                    { id: '17059219630002', title: '第二章 青牛镇', words: '2134', is_vip: '0', update_time: '1203482880', index: '2' },
+                ],
+            },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 })));
+        const rows = await cmd.func({ evaluate: vi.fn() }, { book: '1784909', limit: 1, offset: 1 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            index: 2,
+            chapter_id: '17059219630002',
+            title: '第二章 青牛镇',
+            words: 2134,
+            is_vip: false,
+            url: 'https://www.qimao.com/shuku/1784909-17059219630002/',
+        });
+    });
+});
+
+describe('qimao book command', () => {
+    const cmd = getRegistry().get('qimao/book');
+
+    it('normalizes book snapshot fields', () => {
+        const row = bookTest.normalizeBookSnapshot({
+            title: '凡人修仙传（杨洋、金晨主演同名影视原著）',
+            author: '忘语',
+            category: '古典仙侠',
+            status: 1,
+            score: '9.4',
+            words: '747.84万字',
+            chapters: '2551',
+            characters: '韩立',
+            latest_chapter: '忘语新书《玄界之门》',
+            updated_at: '2024-01-24 09:51:50',
+            intro: '一个普通山村小子。',
+            cover: 'https://cdn.example.com/cover.jpg',
+            url: 'https://www.qimao.com/shuku/1784909/',
+        }, '1784909');
+        expect(row).toMatchObject({
+            book_id: '1784909',
+            title: '凡人修仙传（杨洋、金晨主演同名影视原著）',
+            status: '完结',
+            chapters: 2551,
+        });
+    });
+
+    it('uses browser extraction on the public book page', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                title: '凡人修仙传（杨洋、金晨主演同名影视原著）',
+                author: '忘语',
+                category: '古典仙侠',
+                status: 1,
+                score: '9.4',
+                words: '747.84万字',
+                chapters: '2551',
+                characters: '韩立',
+                latest_chapter: '忘语新书《玄界之门》',
+                updated_at: '2024-01-24 09:51:50',
+                intro: '一个普通山村小子。',
+                cover: 'https://cdn.example.com/cover.jpg',
+                url: 'https://www.qimao.com/shuku/1784909/',
+            }),
+        };
+        const rows = await cmd.func(page, { book: '1784909' });
+        expect(page.goto).toHaveBeenCalledWith('https://www.qimao.com/shuku/1784909/', { waitUntil: 'load', settleMs: 2000 });
+        expect(rows[0]).toMatchObject({
+            book_id: '1784909',
+            author: '忘语',
+            category: '古典仙侠',
+        });
+    });
+});
+
+describe('qimao read command', () => {
+    const cmd = getRegistry().get('qimao/read');
+
+    it('normalizes chapter content rows', () => {
+        const row = readTest.normalizeReadSnapshot({
+            book_id: '1784909',
+            book_title: '凡人修仙传（杨洋、金晨主演同名影视原著）',
+            author: '忘语',
+            chapter_id: '17059219630002',
+            chapter_title: '第二章 青牛镇',
+            words: '2134',
+            updated_at: '2008-02-20 12:48:00',
+            url: 'https://www.qimao.com/shuku/1784909-17059219630002/',
+            content: '这是一个小城。',
+        }, {
+            chapter_id: '17059219630002',
+            index: 2,
+            title: '第二章 青牛镇',
+            words: 2134,
+            updated_at: '2008-02-20 12:48:00',
+            url: 'https://www.qimao.com/shuku/1784909-17059219630002/',
+        });
+        expect(row).toMatchObject({
+            book_id: '1784909',
+            index: 2,
+            chapter_title: '第二章 青牛镇',
+            content: '这是一个小城。',
+        });
+    });
+
+    it('removes empty lines from chapter content', () => {
+        const row = readTest.normalizeReadSnapshot({
+            book_id: '1784909',
+            chapter_title: '第二章 青牛镇',
+            content: '第一段\n\n\n第二段\n   \n第三段',
+        }, {
+            chapter_id: '17059219630002',
+            index: 2,
+            title: '第二章 青牛镇',
+            words: 2134,
+            updated_at: '2008-02-20 12:48:00',
+            url: 'https://www.qimao.com/shuku/1784909-17059219630002/',
+        });
+        expect(row.content).toBe('第一段\n第二段\n第三段');
+    });
+
+    it('reads a target chapter resolved from the catalog api', async () => {
+        const payload = {
+            data: {
+                chapters: [
+                    { id: '17059219630001', title: '第一章 山边小村', words: '2601', is_vip: '0', update_time: '1203482820', index: '1' },
+                    { id: '17059219630002', title: '第二章 青牛镇', words: '2134', is_vip: '0', update_time: '1203482880', index: '2' },
+                ],
+            },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    text: JSON.stringify(payload),
+                })
+                .mockResolvedValueOnce({
+                    book_id: '1784909',
+                    book_title: '凡人修仙传（杨洋、金晨主演同名影视原著）',
+                    author: '忘语',
+                    chapter_id: '17059219630002',
+                    chapter_title: '第二章 青牛镇',
+                    words: '2134',
+                    updated_at: '2008-02-20 12:48:00',
+                    url: 'https://www.qimao.com/shuku/1784909-17059219630002/',
+                    content: '这是一个小城。',
+                }),
+        };
+        const rows = await cmd.func(page, { book: '1784909', 'chapter-index': 2 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.qimao.com/shuku/1784909-17059219630002/', { waitUntil: 'load', settleMs: 2000 });
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+        expect(rows[0]).toMatchObject({
+            chapter_id: '17059219630002',
+            chapter_title: '第二章 青牛镇',
+            content: '这是一个小城。',
+        });
+    });
+
+    it('throws when the requested chapter is missing', async () => {
+        const payload = {
+            data: {
+                chapters: [
+                    { id: '17059219630001', title: '第一章 山边小村', words: '2601', is_vip: '0', update_time: '1203482820', index: '1' },
+                ],
+            },
+        };
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 })));
+        const page = {
+            goto: vi.fn(),
+            wait: vi.fn(),
+            evaluate: vi.fn(),
+        };
+        await expect(cmd.func(page, { book: '1784909', 'chapter-index': 2 })).rejects.toThrow(EmptyResultError);
+    });
+});
+
+describe('qimao browse command', () => {
+    const cmd = getRegistry().get('qimao/browse');
+
+    it('resolves category ids from top-level and child categories', () => {
+        const categories = [
+            { id: '1', name: '现代言情', children: [{ id: '8', name: '总裁豪门' }] },
+            { id: '203', name: '都市', children: [{ id: '219', name: '都市高武' }] },
+        ];
+        expect(browseTest.resolveCategoryValue('现代言情', categories)).toMatchObject({ category1: '1', category2: 'a' });
+        expect(browseTest.resolveCategoryValue('总裁豪门', categories)).toMatchObject({ category1: '1', category2: '8' });
+        expect(browseTest.resolveCategoryValue('219', categories)).toMatchObject({ category1: '203', category2: '219' });
+    });
+
+    it('normalizes listing rows', () => {
+        expect(browseTest.normalizeBrowseRow({
+            book_id: '2062428',
+            title: '雾色京婚',
+            author: '栗子甜豆糕',
+            category2_name: '总裁豪门',
+            is_over_txt: '连载中',
+            words_num: '102.84万字',
+            latest_chapter_title: '第480章  另一个乔梨？',
+            update_time_txt: '2026-05-09 08:22:06',
+            read_url: 'https://www.qimao.com/shuku/2062428/',
+            intro: '第一段\n\n第二段',
+        }, 6)).toMatchObject({
+            rank: 6,
+            book_id: '2062428',
+            title: '雾色京婚',
+            category: '总裁豪门',
+            intro: '第一段\n第二段',
+        });
+    });
+
+    it('normalizes browse option rows', () => {
+        const rows = browseTest.normalizeBrowseOptionRows({
+            filters: {
+                channel: [{ label: '女生原创', value: '1' }],
+                words: [{ label: '100万-200万', value: '4' }],
+                update_time: [{ label: '7天内', value: '2' }],
+                is_over: [{ label: '连载中', value: '0' }],
+                order: [{ label: '最近更新', value: 'update_time' }],
+            },
+            category: [
+                { id: '1', name: '现代言情', children: [{ id: '8', name: '总裁豪门' }] },
+            ],
+        });
+        expect(rows).toEqual(expect.arrayContaining([
+            { group: 'channel', label: '女生原创', value: '1', parent_label: '', parent_value: '' },
+            { group: 'category1', label: '现代言情', value: '1', parent_label: '', parent_value: '' },
+            { group: 'category2', label: '总裁豪门', value: '8', parent_label: '现代言情', parent_value: '1' },
+        ]));
+    });
+
+    it('returns filtered category rows from classify APIs', async () => {
+        const payloads = [
+            {
+                data: {
+                    category: [
+                        { id: '1', name: '现代言情', children: [{ id: '8', name: '总裁豪门' }] },
+                        { id: '203', name: '都市', children: [{ id: '219', name: '都市高武' }] },
+                    ],
+                },
+            },
+            {
+                data: {
+                    book_list: [
+                        {
+                            book_id: '2062428',
+                            title: '雾色京婚',
+                            author: '栗子甜豆糕',
+                            category2_name: '总裁豪门',
+                            is_over_txt: '连载中',
+                            words_num: '102.84万字',
+                            latest_chapter_title: '第480章  另一个乔梨？',
+                            update_time_txt: '2026-05-09 08:22:06',
+                            read_url: 'https://www.qimao.com/shuku/2062428/',
+                            intro: '第一段\r\n\r\n第二段',
+                        },
+                    ],
+                },
+            },
+        ];
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(new Response(JSON.stringify(payloads[0]), { status: 200 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify(payloads[1]), { status: 200 })));
+        const rows = await cmd.func({ evaluate: vi.fn() }, {
+            category: '总裁豪门',
+            channel: '女生原创',
+            words: '100万-200万',
+            'updated-within': '7天内',
+            status: '连载中',
+            sort: '最近更新',
+            page: 1,
+            limit: 5,
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            book_id: '2062428',
+            title: '雾色京婚',
+            category: '总裁豪门',
+            intro: '第一段\n第二段',
+        });
+    });
+});
+
+describe('qimao browse-options command', () => {
+    const cmd = getRegistry().get('qimao/browse-options');
+
+    it('returns normalized filter metadata rows', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            data: {
+                filters: {
+                    channel: [{ label: '女生原创', value: '1' }],
+                    words: [{ label: '100万-200万', value: '4' }],
+                    update_time: [{ label: '7天内', value: '2' }],
+                    is_over: [{ label: '连载中', value: '0' }],
+                    order: [{ label: '最近更新', value: 'update_time' }],
+                },
+                category: [
+                    { id: '1', name: '现代言情', children: [{ id: '8', name: '总裁豪门' }] },
+                ],
+            },
+        }), { status: 200 })));
+        const rows = await cmd.func({ evaluate: vi.fn() }, { group: 'category2' });
+        expect(rows).toEqual([
+            { group: 'category2', label: '总裁豪门', value: '8', parent_label: '现代言情', parent_value: '1' },
+        ]);
+    });
+});
+
+describe('qimao rank command', () => {
+    const cmd = getRegistry().get('qimao/rank');
+
+    it('normalizes ranking rows', () => {
+        expect(rankTest.normalizeRankRow({
+            book_id: '1761978',
+            title: '葬神棺',
+            author: '浮生一诺',
+            category1_name: '玄幻奇幻',
+            category2_name: '东方玄幻',
+            is_over: 0,
+            words_num: '665.48万字',
+            latest_chapter_title: '第2549章 神墟第一魄，尸狗！',
+            update_time: '2026-05-07 23:32:22',
+            number: '64.0',
+            unit: '万热度',
+            book_url: 'https://www.qimao.com/shuku/1761978/',
+            intro: '第一段\r\n\r\n第二段',
+        }, 5)).toMatchObject({
+            rank: 5,
+            book_id: '1761978',
+            category1: '玄幻奇幻',
+            category: '东方玄幻',
+            status: '连载中',
+            intro: '第一段\n第二段',
+        });
+    });
+
+    it('returns ranking rows from page snapshot data', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                listData: [{
+                    book_id: '1761978',
+                    title: '葬神棺',
+                    author: '浮生一诺',
+                    category1_name: '玄幻奇幻',
+                    category2_name: '东方玄幻',
+                    is_over: 0,
+                    words_num: '665.48万字',
+                    latest_chapter_title: '第2549章 神墟第一魄，尸狗！',
+                    update_time: '2026-05-07 23:32:22',
+                    number: '64.0',
+                    unit: '万热度',
+                    book_url: 'https://www.qimao.com/shuku/1761978/',
+                    intro: '第一段\n第二段',
+                }],
+            }),
+        };
+        const rows = await cmd.func(page, { channel: '男生', type: '大热榜', period: '日榜', limit: 5 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.qimao.com/paihang/boy/hot/date/', { waitUntil: 'load', settleMs: 2000 });
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            book_id: '1761978',
+            title: '葬神棺',
+        });
+    });
+});
+
+describe('qimao rank-options command', () => {
+    const cmd = getRegistry().get('qimao/rank-options');
+
+    it('returns ranking dimension rows', async () => {
+        const rows = await cmd.func({}, { group: 'type' });
+        expect(rows).toEqual(expect.arrayContaining([
+            { group: 'type', label: '大热榜', value: 'hot' },
+            { group: 'type', label: '新书榜', value: 'new' },
+            { group: 'type', label: '完结榜', value: 'over' },
+        ]));
+    });
+});

--- a/clis/qimao/rank-options.js
+++ b/clis/qimao/rank-options.js
@@ -1,0 +1,47 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { QIMAO_DOMAIN, buildRankUrl, cleanText } from './utils.js';
+import { normalizeRankOptionRows } from './rank.shared.js';
+
+const GROUP_ALIASES = {
+    channel: ['channel', '频道'],
+    type: ['type', '榜单', '榜单类型'],
+    period: ['period', '时间', '周期', '时间范围'],
+};
+
+function normalizeGroup(value) {
+    const text = cleanText(value).toLowerCase();
+    if (!text) {
+        return '';
+    }
+    for (const [group, aliases] of Object.entries(GROUP_ALIASES)) {
+        if (aliases.some((alias) => cleanText(alias).toLowerCase() === text)) {
+            return group;
+        }
+    }
+    throw new ArgumentError(`qimao group must be one of: ${Object.keys(GROUP_ALIASES).join(', ')}`);
+}
+
+cli({
+    site: 'qimao',
+    name: 'rank-options',
+    access: 'read',
+    description: 'List Qimao ranking dimensions for programmatic use',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    navigateBefore: buildRankUrl(),
+    args: [
+        { name: 'group', help: 'Optional group: channel, type, period' },
+    ],
+    columns: ['group', 'label', 'value'],
+    func: async (_page, args) => {
+        const group = normalizeGroup(args.group);
+        const rows = normalizeRankOptionRows();
+        const filtered = group ? rows.filter((row) => row.group === group) : rows;
+        if (filtered.length === 0) {
+            throw new EmptyResultError('qimao rank-options', 'No ranking options found for the selected group.');
+        }
+        return filtered;
+    },
+});

--- a/clis/qimao/rank.js
+++ b/clis/qimao/rank.js
@@ -1,0 +1,76 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { QIMAO_DOMAIN, buildRankUrl, cleanText, requireLimit, stripHtml } from './utils.js';
+import { getRankChoiceOptions, normalizeRankOptionRows, resolveRankChoice } from './rank.shared.js';
+
+function firstDefined(...values) {
+    return values.find((value) => cleanText(value));
+}
+
+export function normalizeRankRow(item, rank) {
+    return {
+        rank,
+        book_id: cleanText(item?.book_id),
+        title: cleanText(item?.title),
+        author: cleanText(item?.author),
+        category1: cleanText(item?.category1_name),
+        category: cleanText(item?.category2_name),
+        status: String(item?.is_over) === '1' ? '完结' : '连载中',
+        words: cleanText(item?.words_num),
+        latest_chapter: cleanText(item?.latest_chapter_title),
+        updated_at: cleanText(item?.update_time),
+        hot_value: firstDefined(item?.number, item?.bonus),
+        hot_unit: cleanText(item?.unit),
+        url: cleanText(item?.book_url),
+        intro: stripHtml(item?.intro),
+    };
+}
+
+async function extractRankSnapshot(page) {
+    return page.evaluate(`(() => {
+      const root = (window.__NUXT__ && window.__NUXT__.fetch) || {};
+      const fetchKey = Object.keys(root).find((key) => key.includes('data-v-cca2d2e4'));
+      const payload = fetchKey ? root[fetchKey] : null;
+      return {
+        listData: Array.isArray(payload?.listData) ? payload.listData : [],
+      };
+    })()`);
+}
+
+cli({
+    site: 'qimao',
+    name: 'rank',
+    access: 'read',
+    description: 'Read Qimao ranking lists',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    navigateBefore: buildRankUrl(),
+    args: [
+        { name: 'channel', help: 'boy/girl or 男生/女生' },
+        { name: 'type', help: 'hot/new/over/collect/update or 大热榜/新书榜/完结榜/收藏榜/更新榜' },
+        { name: 'period', help: 'date/month or 日榜/月榜' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (1-50)' },
+    ],
+    columns: ['rank', 'book_id', 'title', 'author', 'category1', 'category', 'status', 'words', 'latest_chapter', 'updated_at', 'hot_value', 'hot_unit', 'url', 'intro'],
+    func: async (page, args) => {
+        const choices = getRankChoiceOptions();
+        const channel = resolveRankChoice(args.channel, choices.channel, 'boy', 'channel');
+        const type = resolveRankChoice(args.type, choices.type, 'hot', 'type');
+        const period = resolveRankChoice(args.period, choices.period, 'date', 'period');
+        const limit = requireLimit(args.limit, 20, 50);
+        await page.goto(buildRankUrl(channel, type, period), { waitUntil: 'load', settleMs: 2000 });
+        await page.wait({ time: 1 });
+        const snapshot = await extractRankSnapshot(page);
+        const list = Array.isArray(snapshot?.listData) ? snapshot.listData : [];
+        if (list.length === 0) {
+            throw new EmptyResultError('qimao rank', 'Qimao returned no ranking rows.');
+        }
+        return list.slice(0, limit).map((item, index) => normalizeRankRow(item, index + 1));
+    },
+});
+
+export const __test__ = {
+    normalizeRankRow,
+    normalizeRankOptionRows,
+};

--- a/clis/qimao/rank.shared.js
+++ b/clis/qimao/rank.shared.js
@@ -1,0 +1,51 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { cleanText } from './utils.js';
+
+const CHANNEL_OPTIONS = [
+    { value: 'boy', aliases: ['boy', 'male', '男生', '男生榜'] },
+    { value: 'girl', aliases: ['girl', 'female', '女生', '女生榜'] },
+];
+
+const RANK_OPTIONS = [
+    { value: 'hot', aliases: ['hot', '大热榜'] },
+    { value: 'new', aliases: ['new', '新书榜'] },
+    { value: 'over', aliases: ['over', '完结榜'] },
+    { value: 'collect', aliases: ['collect', '收藏榜'] },
+    { value: 'update', aliases: ['update', '更新榜'] },
+];
+
+const DATE_OPTIONS = [
+    { value: 'date', aliases: ['date', 'daily', '日榜'] },
+    { value: 'month', aliases: ['month', 'monthly', '月榜'] },
+];
+
+export function getRankChoiceOptions() {
+    return {
+        channel: CHANNEL_OPTIONS,
+        type: RANK_OPTIONS,
+        period: DATE_OPTIONS,
+    };
+}
+
+export function normalizeRankOptionRows() {
+    const rows = [];
+    for (const item of CHANNEL_OPTIONS) {
+        rows.push({ group: 'channel', label: item.aliases[item.aliases.length - 1], value: item.value });
+    }
+    for (const item of RANK_OPTIONS) {
+        rows.push({ group: 'type', label: item.aliases[item.aliases.length - 1], value: item.value });
+    }
+    for (const item of DATE_OPTIONS) {
+        rows.push({ group: 'period', label: item.aliases[item.aliases.length - 1], value: item.value });
+    }
+    return rows;
+}
+
+export function resolveRankChoice(rawValue, options, defaultValue, label) {
+    const value = cleanText(rawValue ?? defaultValue).toLowerCase();
+    const matched = options.find((option) => option.aliases.some((alias) => cleanText(alias).toLowerCase() === value));
+    if (!matched) {
+        throw new ArgumentError(`qimao ${label} must be one of: ${options.map((item) => item.aliases[0]).join(', ')}`);
+    }
+    return matched.value;
+}

--- a/clis/qimao/read.js
+++ b/clis/qimao/read.js
@@ -1,0 +1,205 @@
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    QIMAO_DOMAIN,
+    buildBookUrl,
+    buildChapterListApiUrl,
+    buildChapterUrl,
+    cleanText,
+    normalizeCatalogChapter,
+    parseBookId,
+    parseChapterId,
+    qimaoFetchJson,
+    requirePositiveInt,
+} from './utils.js';
+
+function selectTargetChapter(bookId, chapters, args) {
+    const chapterIdArg = args['chapter-id'];
+    const chapterIndexArg = args['chapter-index'];
+    if (chapterIdArg !== undefined && chapterIndexArg !== undefined) {
+        throw new ArgumentError('Use either --chapter-id or --chapter-index, not both.');
+    }
+    if (chapterIdArg !== undefined) {
+        const chapterId = parseChapterId(chapterIdArg);
+        const found = chapters.find((chapter) => chapter.chapter_id === chapterId);
+        if (!found) {
+            throw new EmptyResultError('qimao read', `Chapter ${chapterId} was not found for book ${bookId}.`);
+        }
+        return found;
+    }
+    if (chapterIndexArg !== undefined) {
+        const chapterIndex = requirePositiveInt(chapterIndexArg, 1, 'chapter-index');
+        const found = chapters.find((chapter) => chapter.index === chapterIndex);
+        if (!found) {
+            throw new EmptyResultError('qimao read', `Chapter index ${chapterIndex} was not found for book ${bookId}.`);
+        }
+        return found;
+    }
+    if (!chapters[0]) {
+        throw new EmptyResultError('qimao read', `No chapters found for book ${bookId}.`);
+    }
+    return chapters[0];
+}
+
+function normalizeContent(value) {
+    return String(value ?? '')
+        .replace(/\r/g, '')
+        .split('\n')
+        .map((line) => cleanText(line))
+        .filter(Boolean)
+        .join('\n');
+}
+
+export function normalizeReadSnapshot(snapshot, chapter) {
+    const content = normalizeContent(snapshot?.content);
+    if (!content) {
+        throw new EmptyResultError('qimao read', `Chapter content is empty for ${chapter.chapter_id}.`);
+    }
+    return {
+        book_id: cleanText(snapshot?.book_id) || '',
+        book_title: cleanText(snapshot?.book_title),
+        author: cleanText(snapshot?.author),
+        chapter_id: cleanText(snapshot?.chapter_id) || chapter.chapter_id,
+        index: chapter.index,
+        chapter_title: cleanText(snapshot?.chapter_title) || chapter.title,
+        words: Number.parseInt(String(snapshot?.words ?? ''), 10) || chapter.words,
+        updated_at: cleanText(snapshot?.updated_at) || chapter.updated_at,
+        url: cleanText(snapshot?.url) || chapter.url,
+        content,
+    };
+}
+
+async function extractReadSnapshot(page, attempts = 5) {
+    let lastSnapshot = null;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        lastSnapshot = await page.evaluate(`
+      (() => {
+        const clean = (value) => String(value ?? '').replace(/\\s+/g, ' ').trim();
+        const pathname = window.location.pathname || '';
+        const pathMatch = pathname.match(/^\\/shuku\\/(\\d+)-(\\d+)\\/?$/);
+        const reader = (window.__NUXT__ && window.__NUXT__.state && window.__NUXT__.state.reader && window.__NUXT__.state.reader.readerChapterInfo) || {};
+        const chapterInfo = reader.chapterInfo || {};
+        const bookSummary = reader.bookSummary || {};
+        const rawHtml = String(reader.chapterData || '');
+        const nuxtContainer = document.createElement('div');
+        nuxtContainer.innerHTML = rawHtml;
+        const nuxtParagraphs = Array.from(nuxtContainer.querySelectorAll('p'))
+          .map((node) => clean(node.textContent))
+          .filter(Boolean);
+        const domParagraphs = Array.from(document.querySelectorAll('h2 ~ p, article p, main p, [class*="chapter"] p, [class*="content"] p, [class*="read"] p'))
+          .map((node) => clean(node.textContent))
+          .filter(Boolean);
+        const content = nuxtParagraphs.length > 0
+          ? nuxtParagraphs.join('\\n\\n')
+          : domParagraphs.length > 0
+            ? domParagraphs.join('\\n\\n')
+            : clean(
+              document.querySelector('article, main, [class*="chapter"], [class*="content"], [class*="read"]')?.textContent ||
+              ''
+            );
+        const chapterTitle = clean(chapterInfo.title || document.querySelector('h2')?.textContent || '');
+        const titlePrefix = clean(document.title.replace(/最新章节[\\s\\S]*$/, ''));
+        const authorFromTitle = titlePrefix.startsWith(chapterTitle)
+          ? clean(titlePrefix.slice(chapterTitle.length))
+          : '';
+        const rawBookTitle = clean(bookSummary.book_title || chapterInfo.book_title || document.querySelector('h1')?.textContent || '');
+        return {
+          book_id: clean(bookSummary.book_id || chapterInfo.book_id || pathMatch?.[1] || ''),
+          book_title: rawBookTitle.replace(/\\s+(完结|连载)$/, ''),
+          author: clean(bookSummary.author || chapterInfo.author || document.querySelector('a[href*="/zuozhe/"]')?.textContent || authorFromTitle),
+          chapter_id: clean(chapterInfo.chapter_id || pathMatch?.[2] || ''),
+          chapter_title: chapterTitle,
+          words: clean(chapterInfo.words || ''),
+          updated_at: clean(chapterInfo.update_time || ''),
+          url: clean(window.location.href || ''),
+          content,
+        };
+      })()
+    `);
+        if (normalizeContent(lastSnapshot?.content)) {
+            return lastSnapshot;
+        }
+        if (attempt < attempts - 1) {
+            await page.wait({ time: 1 });
+        }
+    }
+    return lastSnapshot;
+}
+
+async function extractBookTitleFallback(page, bookId) {
+    if (!page?.evaluate) {
+        return '';
+    }
+    try {
+        return cleanText(await page.evaluate(`(async () => {
+          const response = await fetch(${JSON.stringify(buildBookUrl(bookId))}, {
+            headers: { accept: 'text/html' },
+            credentials: 'omit',
+          });
+          const html = await response.text();
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const title = String(
+            doc.querySelector('h1')?.textContent ||
+            doc.querySelector('meta[property="og:title"]')?.getAttribute('content') ||
+            doc.title ||
+            ''
+          )
+            .replace(/免费阅读[\\s\\S]*$/, '')
+            .replace(/最新章节[\\s\\S]*$/, '');
+          return title.replace(/\\s+(完结|连载)$/, '').trim();
+        })()`));
+    }
+    catch {
+        return '';
+    }
+}
+
+cli({
+    site: 'qimao',
+    name: 'read',
+    access: 'read',
+    description: 'Read a Qimao chapter by chapter id or chapter index',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    args: [
+        { name: 'book', positional: true, required: true, help: 'Qimao book id or book URL' },
+        { name: 'chapter-id', help: 'Specific Qimao chapter id or chapter URL' },
+        { name: 'chapter-index', type: 'int', help: '1-based chapter index from the catalog' },
+    ],
+    columns: [
+        'book_id',
+        'book_title',
+        'author',
+        'chapter_id',
+        'index',
+        'chapter_title',
+        'words',
+        'updated_at',
+        'url',
+        'content',
+    ],
+    func: async (page, args) => {
+        const bookId = parseBookId(args.book);
+        const data = await qimaoFetchJson(
+            buildChapterListApiUrl(bookId),
+            `qimao catalog ${bookId}`,
+            buildBookUrl(bookId),
+            page,
+        );
+        const chapters = (Array.isArray(data.chapters) ? data.chapters : [])
+            .map((chapter) => normalizeCatalogChapter(bookId, chapter));
+        const target = selectTargetChapter(bookId, chapters, args);
+        await page.goto(target.url || buildChapterUrl(bookId, target.chapter_id), { waitUntil: 'load', settleMs: 2000 });
+        await page.wait({ time: 1 });
+        const snapshot = await extractReadSnapshot(page);
+        if (!cleanText(snapshot?.book_title)) {
+            snapshot.book_title = await extractBookTitleFallback(page, bookId);
+        }
+        return [normalizeReadSnapshot(snapshot, target)];
+    },
+});
+
+export const __test__ = {
+    normalizeReadSnapshot,
+};

--- a/clis/qimao/search.js
+++ b/clis/qimao/search.js
@@ -1,0 +1,72 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    QIMAO_ORIGIN,
+    QIMAO_DOMAIN,
+    buildSearchApiUrl,
+    cleanText,
+    qimaoFetchJson,
+    requireLimit,
+    requirePositiveInt,
+    requireString,
+    stripHtml,
+} from './utils.js';
+
+cli({
+    site: 'qimao',
+    name: 'search',
+    access: 'read',
+    description: 'Search Qimao books by title, author, or character',
+    domain: QIMAO_DOMAIN,
+    strategy: Strategy.PUBLIC,
+    browser: true,
+    navigateBefore: QIMAO_ORIGIN,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Book title, author, or character keyword' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max rows to return (1-50)' },
+        { name: 'page', type: 'int', default: 1, help: 'Result page number (1-based)' },
+    ],
+    columns: [
+        'rank',
+        'book_id',
+        'title',
+        'author',
+        'category',
+        'status',
+        'words',
+        'characters',
+        'latest_chapter',
+        'updated_at',
+        'url',
+        'intro',
+    ],
+    func: async (page, args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireLimit(args.limit, 10, 50);
+        const pageNumber = requirePositiveInt(args.page, 1, 'page');
+        const data = await qimaoFetchJson(
+            buildSearchApiUrl(query, pageNumber, limit),
+            `qimao search ${query}`,
+            `${QIMAO_ORIGIN}/`,
+            page,
+        );
+        const list = Array.isArray(data.search_list) ? data.search_list : [];
+        if (list.length === 0) {
+            throw new EmptyResultError('qimao search', `Qimao returned no books matching "${query}".`);
+        }
+        return list.slice(0, limit).map((item, index) => ({
+            rank: index + 1,
+            book_id: cleanText(item?.book_id),
+            title: cleanText(item?.title),
+            author: cleanText(item?.author),
+            category: cleanText(item?.category2_name),
+            status: cleanText(item?.is_over_txt),
+            words: cleanText(item?.words_num),
+            characters: cleanText(item?.characters),
+            latest_chapter: cleanText(item?.latest_chapter_title),
+            updated_at: cleanText(item?.update_time),
+            url: cleanText(item?.read_url),
+            intro: stripHtml(item?.intro),
+        }));
+    },
+});

--- a/clis/qimao/utils.js
+++ b/clis/qimao/utils.js
@@ -1,0 +1,304 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const QIMAO_ORIGIN = 'https://www.qimao.com';
+export const QIMAO_DOMAIN = 'www.qimao.com';
+const QIMAO_UA = 'opencli-qimao-adapter (+https://github.com/jackwener/opencli)';
+
+const HTML_ENTITY_MAP = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    hellip: '...',
+    ldquo: '“',
+    rdquo: '”',
+    lsquo: '‘',
+    rsquo: '’',
+    mdash: '—',
+    ndash: '–',
+};
+
+export function cleanText(value) {
+    return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+export function decodeHtmlEntities(value) {
+    return String(value ?? '')
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+        const code = Number.parseInt(hex, 16);
+        return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+    })
+        .replace(/&#(\d+);/g, (_, dec) => {
+        const code = Number.parseInt(dec, 10);
+        return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+    })
+        .replace(/&([a-zA-Z]+);/g, (match, name) => HTML_ENTITY_MAP[name] ?? match);
+}
+
+export function stripHtml(value) {
+    if (value == null) {
+        return '';
+    }
+    const withLineBreaks = String(value)
+        .replace(/<\s*br\s*\/?>/gi, '\n')
+        .replace(/<\s*\/p\s*>/gi, '\n')
+        .replace(/<\s*p[^>]*>/gi, '');
+    return decodeHtmlEntities(withLineBreaks)
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/\r/g, '')
+        .split('\n')
+        .map((line) => cleanText(line))
+        .filter(Boolean)
+        .join('\n');
+}
+
+export function requireString(value, label) {
+    const text = cleanText(value);
+    if (!text) {
+        throw new ArgumentError(`qimao ${label} cannot be empty`);
+    }
+    return text;
+}
+
+export function requirePositiveInt(value, defaultValue, label) {
+    const raw = value ?? defaultValue;
+    const num = Number.parseInt(String(raw), 10);
+    if (!Number.isInteger(num) || num <= 0) {
+        throw new ArgumentError(`qimao ${label} must be a positive integer`);
+    }
+    return num;
+}
+
+export function requireNonNegativeInt(value, defaultValue, label) {
+    const raw = value ?? defaultValue;
+    const num = Number.parseInt(String(raw), 10);
+    if (!Number.isInteger(num) || num < 0) {
+        throw new ArgumentError(`qimao ${label} must be a non-negative integer`);
+    }
+    return num;
+}
+
+export function requireLimit(value, defaultValue = 20, maxValue = 50) {
+    const limit = requirePositiveInt(value, defaultValue, 'limit');
+    if (limit > maxValue) {
+        throw new ArgumentError(`qimao limit must be <= ${maxValue}`);
+    }
+    return limit;
+}
+
+export function normalizeStatus(value) {
+    if (value === '完结' || value === 1 || value === '1' || value === true) {
+        return '完结';
+    }
+    if (value === '连载' || value === 0 || value === '0' || value === false) {
+        return '连载';
+    }
+    return cleanText(value);
+}
+
+export function buildBookUrl(bookId) {
+    return `${QIMAO_ORIGIN}/shuku/${bookId}/`;
+}
+
+export function buildReaderUrl(bookId) {
+    return `${QIMAO_ORIGIN}/reader/index/${bookId}/`;
+}
+
+export function buildChapterUrl(bookId, chapterId) {
+    return `${QIMAO_ORIGIN}/shuku/${bookId}-${chapterId}/`;
+}
+
+export function buildSearchApiUrl(query, page = 1, pageSize = 15) {
+    const url = new URL('/qimaoapi/api/search/result', QIMAO_ORIGIN);
+    url.searchParams.set('keyword', query);
+    url.searchParams.set('count', '0');
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('page_size', String(pageSize));
+    return url.toString();
+}
+
+export function buildChapterListApiUrl(bookId) {
+    const url = new URL('/qimaoapi/api/book/chapter-list', QIMAO_ORIGIN);
+    url.searchParams.set('book_id', String(bookId));
+    return url.toString();
+}
+
+export function buildClassifySelectOptionApiUrl() {
+    return new URL('/qimaoapi/api/classify/select-option', QIMAO_ORIGIN).toString();
+}
+
+export function buildClassifyBookListApiUrl(filters = {}) {
+    const url = new URL('/qimaoapi/api/classify/book-list', QIMAO_ORIGIN);
+    url.searchParams.set('channel', String(filters.channel ?? 'a'));
+    url.searchParams.set('category1', String(filters.category1 ?? 'a'));
+    url.searchParams.set('category2', String(filters.category2 ?? 'a'));
+    url.searchParams.set('words', String(filters.words ?? 'a'));
+    url.searchParams.set('update_time', String(filters.updateTime ?? 'a'));
+    url.searchParams.set('is_vip', String(filters.isVip ?? 'a'));
+    url.searchParams.set('is_over', String(filters.isOver ?? 'a'));
+    url.searchParams.set('order', String(filters.order ?? 'click'));
+    url.searchParams.set('page', String(filters.page ?? 1));
+    return url.toString();
+}
+
+export function buildRankUrl(channelType = 'boy', rankType = 'hot', dateType = 'date') {
+    return `${QIMAO_ORIGIN}/paihang/${channelType}/${rankType}/${dateType}/`;
+}
+
+export function parseBookId(value) {
+    const raw = requireString(value, 'book');
+    if (/^\d+$/.test(raw)) {
+        return raw;
+    }
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    }
+    catch {
+        throw new ArgumentError(
+            `Unrecognized qimao book reference: ${raw}`,
+            'Use a numeric book id like 1784909 or a Qimao book/chapter URL.',
+        );
+    }
+    const matched = parsed.pathname.match(/^\/(?:shuku|reader\/index)\/(\d+)(?:-(\d+))?\/?$/);
+    if (!matched?.[1]) {
+        throw new ArgumentError(
+            `Unrecognized qimao book URL: ${raw}`,
+            'Supported URLs look like /shuku/<bookId>/, /shuku/<bookId>-<chapterId>/, or /reader/index/<bookId>/.',
+        );
+    }
+    return matched[1];
+}
+
+export function parseChapterId(value) {
+    const raw = requireString(value, 'chapter-id');
+    if (/^\d+$/.test(raw)) {
+        return raw;
+    }
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    }
+    catch {
+        throw new ArgumentError(
+            `Unrecognized qimao chapter reference: ${raw}`,
+            'Use a numeric chapter id or a Qimao chapter URL.',
+        );
+    }
+    const matched = parsed.pathname.match(/^\/shuku\/\d+-(\d+)\/?$/);
+    if (!matched?.[1]) {
+        throw new ArgumentError(
+            `Unrecognized qimao chapter URL: ${raw}`,
+            'Supported chapter URLs look like /shuku/<bookId>-<chapterId>/.',
+        );
+    }
+    return matched[1];
+}
+
+export function formatTimestamp(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num <= 0) {
+        return '';
+    }
+    const millis = num < 1e12 ? num * 1000 : num;
+    const date = new Date(millis);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    const pad = (part) => String(part).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function normalizeJsonBody(body, label) {
+    if (!body || typeof body !== 'object' || typeof body.data !== 'object') {
+        throw new CommandExecutionError(`${label} returned an unexpected payload shape`);
+    }
+    return body.data;
+}
+
+async function qimaoBrowserFetchJson(page, url, label, referer) {
+    if (!page?.evaluate) {
+        throw new CommandExecutionError(
+            `${label} request failed: browser fallback is unavailable`,
+            'Run this command with browser support enabled.',
+        );
+    }
+
+    const response = await page.evaluate(`(async () => {
+        const response = await fetch(${JSON.stringify(url)}, {
+            headers: {
+                accept: 'application/json',
+                referer: ${JSON.stringify(referer)},
+            },
+            credentials: 'omit',
+        });
+        return {
+            ok: response.ok,
+            status: response.status,
+            text: await response.text(),
+        };
+    })()`);
+
+    if (response.status === 404) {
+        throw new EmptyResultError(label, `Qimao returned 404 for ${url}.`);
+    }
+    if (!response.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${response.status}`);
+    }
+
+    try {
+        return normalizeJsonBody(JSON.parse(response.text), label);
+    }
+    catch (error) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${error?.message ?? error}`);
+    }
+}
+
+export async function qimaoFetchJson(url, label, referer = `${QIMAO_ORIGIN}/`, page) {
+    try {
+        const response = await fetch(url, {
+            headers: {
+                accept: 'application/json',
+                referer,
+                'user-agent': QIMAO_UA,
+            },
+        });
+        if (response.status === 404) {
+            throw new EmptyResultError(label, `Qimao returned 404 for ${url}.`);
+        }
+        if (!response.ok) {
+            throw new CommandExecutionError(`${label} returned HTTP ${response.status}`);
+        }
+
+        try {
+            return normalizeJsonBody(await response.json(), label);
+        }
+        catch (error) {
+            throw new CommandExecutionError(`${label} returned malformed JSON: ${error?.message ?? error}`);
+        }
+    }
+    catch (error) {
+        if (page?.evaluate) {
+            return qimaoBrowserFetchJson(page, url, label, referer);
+        }
+        throw new CommandExecutionError(
+            `${label} request failed: ${error?.message ?? error}`,
+            'Check that www.qimao.com is reachable from this network.',
+        );
+    }
+}
+
+export function normalizeCatalogChapter(bookId, chapter) {
+    const chapterId = cleanText(chapter?.id);
+    return {
+        index: Number.parseInt(String(chapter?.index ?? chapter?.chapter_sort ?? ''), 10) || null,
+        chapter_id: chapterId,
+        title: cleanText(chapter?.title),
+        words: Number.parseInt(String(chapter?.words ?? ''), 10) || null,
+        is_vip: String(chapter?.is_vip ?? '') === '1',
+        updated_at: formatTimestamp(chapter?.update_time),
+        url: chapterId ? buildChapterUrl(bookId, chapterId) : '',
+    };
+}


### PR DESCRIPTION
## Summary

This PR adds a new `qimao` site adapter for [七猫中文网](https://www.qimao.com/) and wires it into OpenCLI's built-in adapter registry.

New Qimao commands included in this PR:

- `opencli qimao search`
- `opencli qimao catalog`
- `opencli qimao book`
- `opencli qimao read`
- `opencli qimao browse`
- `opencli qimao browse-options`
- `opencli qimao rank`
- `opencli qimao rank-options`

## What’s Added

### Core book flow

Implemented the basic read pipeline for Qimao books:

- `search`: search books by title, author, or character
- `catalog`: list chapters for a book
- `book`: fetch book detail data
- `read`: read chapter content by chapter id or chapter index

### Category browsing

Added support for Qimao classification pages:

- `browse`: list books from category pages with filters
- `browse-options`: enumerate available filter values for programmatic use

Supported browse dimensions:

- channel
- category / subcategory
- word count range
- update time
- completion status
- sort order

### Ranking lists

Added support for Qimao ranking pages:

- `rank`: fetch ranking list results
- `rank-options`: enumerate ranking dimensions for programmatic use

Supported rank dimensions:

- channel: `boy` / `girl`
- type: `hot` / `new` / `over` / `collect` / `update`
- period: `date` / `month`

## Implementation Notes

### Data sources

The adapter uses a mix of public endpoints and browser-backed extraction depending on the page type:

- Search and catalog use Qimao public APIs
- Browse uses Qimao classify APIs
- Book and read use browser-backed extraction from page state / rendered content
- Rank uses browser-backed extraction from Qimao ranking pages

### Shared helpers

Added shared utilities for:

- Qimao URL construction
- ID parsing
- HTML/plain-text normalization
- filter metadata handling
- ranking metadata handling

### Text cleanup

Included normalization improvements for Qimao text fields:

- `read.content` removes empty lines
- `search.intro` removes empty lines
- `read.book_title` includes fallback extraction when the chapter page does not expose a stable title directly

## Tests

Added adapter tests for Qimao coverage in `clis/qimao/qimao.test.js`.

Covered areas:

- utils
- search
- catalog
- book
- read
- browse
- browse-options
- rank
- rank-options

Validation performed:

```bash
npx vitest run --project adapter clis/qimao/qimao.test.js
npm test
```

## Registry / Discovery

Updated `cli-manifest.json` so the new `qimao` commands are discoverable by OpenCLI.

## Notes

- This PR only contains Qimao-related adapter code and manifest updates.
- README changes were intentionally excluded from the submitted commit.