### PR TITLE
fix(e2e): unstick e2e-headed by matching fake daemon version

### DIFF
--- a/tests/e2e/browser-tabs.test.ts
+++ b/tests/e2e/browser-tabs.test.ts
@@ -3,7 +3,23 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseJsonOutput, runCli } from './helpers.js';
+
+// Match the running CLI's package version so BrowserBridge does not classify
+// this fake daemon as stale (PR #1399 auto-restarts daemons whose
+// daemonVersion does not match PKG_VERSION; the fake daemon does not implement
+// /shutdown, so a mismatch makes every test exit with code 1).
+const PKG_VERSION: string = (() => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // tests/e2e -> repo root: ../..
+  const pkgPath = path.resolve(here, '..', '..', 'package.json');
+  try {
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  } catch {
+    return '0.0.0';
+  }
+})();
 
 type FakeTab = {
   page: string;
@@ -50,7 +66,7 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
         ok: true,
         pid: process.pid,
         uptime: 1,
-        daemonVersion: 'test',
+        daemonVersion: PKG_VERSION,
         extensionConnected: true,
         extensionVersion: 'test',
         pending: 0,


### PR DESCRIPTION
## Problem

E2E Headed Chrome workflow has been failing on every main push since PR #1399. All 4 tests in \`tests/e2e/browser-tabs.test.ts\` fail with:

\`\`\`
AssertionError: expected 1 to be +0 // Object.is equality
\`\`\`

i.e. the CLI exits with code 1.

## Root Cause

PR #1399 introduced auto-restart of stale daemons in \`src/browser/bridge.ts\`:

\`\`\`ts
const daemonVersion = health.status?.daemonVersion;
const isStale = !!health.status && (!daemonVersion || daemonVersion !== PKG_VERSION);
if (isStale) {
  // ... try /shutdown, then throw if it fails
}
\`\`\`

The browser-tabs fake daemon at \`tests/e2e/browser-tabs.test.ts:53\` hardcodes:

\`\`\`ts
daemonVersion: 'test',
\`\`\`

\`'test' !== PKG_VERSION\` always, so every test:
1. Trips the stale-daemon path
2. Bridge tries \`requestDaemonShutdown()\`
3. Fake daemon has no \`/shutdown\` endpoint → fails
4. Bridge throws \`BrowserConnectError('Stale daemon could not be replaced')\`
5. CLI exits with code 1

## Fix

Read \`PKG_VERSION\` from \`package.json\` once at module load and feed it to the fake \`/status\` response. The fake daemon now matches the running CLI, so the stale-daemon path is not triggered.

## Verification

- \`npx tsc --noEmit\` clean
- \`npm run build\` clean
- \`npx vitest run --project e2e tests/e2e/browser-tabs.test.ts\` → 4/4 pass (was 0/4 on main)

## Test plan

- [ ] CI green on this PR
- [ ] After merge: confirm \`e2e-headed\` workflow goes green on the next main push