### PR TITLE
feat(browser): add annotated screenshot refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * **browser actions** — add `browser drag <source> <target>` for CDP mouse drag sequences between two resolved element centers.
 * **browser wait / extension 1.0.8** — add `browser wait download [pattern]` backed by Chrome's downloads lifecycle API, so agents can wait for file downloads by filename/URL pattern and receive completed/failed download metadata.
 * **browser state / extension 1.0.9** — AX snapshots can now route same-origin iframe refs through `frameId`. Cross-origin OOPIF AX routing is best-effort because real Chrome extension smoke tests show `chrome.debugger` may not expose attachable iframe targets to extensions.
+* **browser screenshot** — add `browser screenshot --annotate`, which refreshes DOM refs and overlays visible `[N]` labels on the screenshot so visual inspection maps back to `browser click <ref>` targets.
 
 ### Bug Fixes
 

--- a/docs/design/browser-agent-runtime.md
+++ b/docs/design/browser-agent-runtime.md
@@ -344,6 +344,11 @@ Status after implementation:
 - unsupported frames degrade by omission or typed action failure rather than
   requiring global manual frame switching.
 
+Implementation note: Phase 1 also includes a DOM-ref visual slice via
+`browser screenshot --annotate`. It refreshes current DOM refs and overlays
+visible `[N]` labels on the captured image. AX-side visual labels and richer
+sidecar metadata remain follow-up work.
+
 Exit:
 
 - Agent can act on iframe refs without manual frame selection in common cases.

--- a/docs/design/mercury-fix-mvp.md
+++ b/docs/design/mercury-fix-mvp.md
@@ -192,6 +192,8 @@ Status after implementation:
   session routing remains deferred.
 - Phase 1 metrics shipped as `browser state --compare-sources` so AX default
   promotion can be decided from measured DOM-vs-AX data.
+- Phase 1 visual refs shipped as `browser screenshot --annotate`, giving agents
+  a screenshot whose visible labels map back to normal DOM `[N]` refs.
 
 ## Phase 1 Follow-Up
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -136,6 +136,7 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 | `browser find --role button --name Save` | Semantic locator query. Also supports `--label`, `--text`, and `--testid`. Use before raw CSS when a control has accessible labels. |
 | `browser frames` | List cross-origin iframe targets. Pass the index to `--frame` on `eval`. |
 | `browser screenshot [path]` | Viewport PNG. No path → base64 to stdout. Prefer `state` when you just need structure. |
+| `browser screenshot --annotate [path]` | Visual ref map. Refreshes DOM refs and overlays visible `[N]` labels so the screenshot maps back to `browser click <ref>` targets. Use for icon-only controls, visual layouts, charts, or when text state is ambiguous. |
 
 ### Get (read-only)
 

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CliError } from '../errors.js';
 import { BasePage } from './base-page.js';
 import { TargetError } from './target-errors.js';
+import type { ScreenshotOptions } from '../types.js';
 
 class TestPage extends BasePage {
   result: unknown;
@@ -24,6 +25,7 @@ class ActionPage extends BasePage {
   withArgsResults: unknown[] = [];
   scripts: string[] = [];
   withArgs: Record<string, unknown>[] = [];
+  screenshotCalls: ScreenshotOptions[] = [];
   nativeType?: (text: string) => Promise<void>;
   insertText?: (text: string) => Promise<void>;
   nativeKeyPress?: (key: string, modifiers?: string[]) => Promise<void>;
@@ -42,7 +44,10 @@ class ActionPage extends BasePage {
     return this.withArgsResults.shift() ?? null;
   }
   async getCookies(): Promise<[]> { return []; }
-  async screenshot(): Promise<string> { return ''; }
+  async screenshot(options: ScreenshotOptions = {}): Promise<string> {
+    this.screenshotCalls.push(options);
+    return 'shot';
+  }
   async tabs(): Promise<unknown[]> { return []; }
   async selectTab(): Promise<void> {}
 }
@@ -110,6 +115,26 @@ describe('BasePage.fetchJson', () => {
       code: 'FETCH_ERROR',
       message: expect.stringContaining('The operation was aborted.'),
     });
+  });
+});
+
+describe('BasePage annotatedScreenshot', () => {
+  it('refreshes DOM refs, captures with a temporary visual overlay, and cleans up', async () => {
+    const page = new ActionPage();
+    page.results = [
+      'snapshot',
+      '["hash"]',
+      { annotated: 1, truncated: false },
+      true,
+    ];
+
+    await expect(page.annotatedScreenshot({ path: '/tmp/opencli.png', annotate: true })).resolves.toBe('shot');
+
+    expect(page.scripts[0]).toContain('const VIEWPORT_EXPAND = 0');
+    expect(page.scripts[2]).toContain('__opencli_visual_ref_overlay');
+    expect(page.scripts[2]).toContain('[data-opencli-ref]');
+    expect(page.scripts[3]).toContain('__opencli_visual_ref_overlay');
+    expect(page.screenshotCalls).toEqual([{ path: '/tmp/opencli.png', annotate: false }]);
   });
 });
 

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -37,6 +37,7 @@ import {
 import { TargetError, type TargetErrorCode } from './target-errors.js';
 import { CliError } from '../errors.js';
 import { formatSnapshot } from '../snapshotFormatter.js';
+import { installVisualRefOverlayJs, removeVisualRefOverlayJs } from './visual-refs.js';
 
 export interface ResolveSuccess {
   matches_n: number;
@@ -261,6 +262,17 @@ export abstract class BasePage implements IPage {
 
   abstract getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   abstract screenshot(options?: ScreenshotOptions): Promise<string>;
+
+  async annotatedScreenshot(options: ScreenshotOptions = {}): Promise<string> {
+    // Refresh DOM refs first so visual labels map to immediate `browser click <ref>` targets.
+    await this.snapshot({ source: 'dom', viewportExpand: 0 });
+    try {
+      await this.evaluate(installVisualRefOverlayJs());
+      return await this.screenshot({ ...options, annotate: false });
+    } finally {
+      await this.evaluate(removeVisualRefOverlayJs()).catch(() => {});
+    }
+  }
   abstract tabs(): Promise<unknown[]>;
   abstract selectTab(target: number | string): Promise<void>;
 

--- a/src/browser/visual-refs.ts
+++ b/src/browser/visual-refs.ts
@@ -1,0 +1,111 @@
+/**
+ * Visual ref overlay for annotated screenshots.
+ *
+ * The overlay is intentionally DOM-side and temporary. It reuses the same
+ * `data-opencli-ref` attributes produced by the DOM snapshot path so the
+ * screenshot labels map back to normal `browser click <ref>` targets.
+ */
+
+const OVERLAY_ID = '__opencli_visual_ref_overlay';
+
+export function installVisualRefOverlayJs(opts: { maxRefs?: number } = {}): string {
+  const maxRefs = Math.max(1, Math.min(opts.maxRefs ?? 120, 500));
+  return `
+    (() => {
+      const OVERLAY_ID = ${JSON.stringify(OVERLAY_ID)};
+      const MAX_REFS = ${maxRefs};
+      document.getElementById(OVERLAY_ID)?.remove();
+
+      const overlay = document.createElement('div');
+      overlay.id = OVERLAY_ID;
+      overlay.setAttribute('aria-hidden', 'true');
+      Object.assign(overlay.style, {
+        position: 'fixed',
+        inset: '0',
+        zIndex: '2147483647',
+        pointerEvents: 'none',
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      });
+
+      const refs = Array.from(document.querySelectorAll('[data-opencli-ref]'))
+        .map((el) => {
+          const rawRef = el.getAttribute('data-opencli-ref') || '';
+          const ref = Number(rawRef);
+          const rect = el.getBoundingClientRect();
+          const visible = Number.isFinite(ref)
+            && rect.width >= 2
+            && rect.height >= 2
+            && rect.bottom >= 0
+            && rect.right >= 0
+            && rect.top <= window.innerHeight
+            && rect.left <= window.innerWidth;
+          return { el, rawRef, ref, rect, visible };
+        })
+        .filter((entry) => entry.visible)
+        .sort((a, b) => a.ref - b.ref)
+        .slice(0, MAX_REFS);
+
+      for (const entry of refs) {
+        const left = Math.max(0, Math.min(window.innerWidth - 1, entry.rect.left));
+        const top = Math.max(0, Math.min(window.innerHeight - 1, entry.rect.top));
+        const right = Math.max(0, Math.min(window.innerWidth, entry.rect.right));
+        const bottom = Math.max(0, Math.min(window.innerHeight, entry.rect.bottom));
+        const width = Math.max(2, right - left);
+        const height = Math.max(2, bottom - top);
+
+        const box = document.createElement('div');
+        Object.assign(box.style, {
+          position: 'fixed',
+          left: left + 'px',
+          top: top + 'px',
+          width: width + 'px',
+          height: height + 'px',
+          border: '2px solid #ff3b30',
+          borderRadius: '4px',
+          boxSizing: 'border-box',
+          boxShadow: '0 0 0 1px rgba(255,255,255,.9), 0 4px 16px rgba(0,0,0,.25)',
+          background: 'rgba(255,59,48,.08)',
+        });
+
+        const badge = document.createElement('div');
+        badge.textContent = entry.rawRef;
+        Object.assign(badge.style, {
+          position: 'fixed',
+          left: left + 'px',
+          top: Math.max(0, top - 20) + 'px',
+          minWidth: '18px',
+          height: '18px',
+          padding: '0 5px',
+          borderRadius: '999px',
+          border: '1px solid rgba(255,255,255,.95)',
+          background: '#ff3b30',
+          color: '#fff',
+          fontSize: '12px',
+          fontWeight: '700',
+          lineHeight: '18px',
+          textAlign: 'center',
+          textShadow: '0 1px 1px rgba(0,0,0,.25)',
+          boxShadow: '0 2px 8px rgba(0,0,0,.35)',
+        });
+
+        overlay.appendChild(box);
+        overlay.appendChild(badge);
+      }
+
+      document.documentElement.appendChild(overlay);
+      return {
+        annotated: refs.length,
+        truncated: refs.length >= MAX_REFS,
+      };
+    })()
+  `.trim();
+}
+
+export function removeVisualRefOverlayJs(): string {
+  return `
+    (() => {
+      document.getElementById(${JSON.stringify(OVERLAY_ID)})?.remove();
+      return true;
+    })()
+  `.trim();
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -810,6 +810,8 @@ describe('browser tab targeting commands', () => {
         { index: 0, frameId: 'frame-1', url: 'https://x.example/embed', name: 'x-embed' },
       ]),
       evaluateInFrame: vi.fn().mockResolvedValue('inside frame'),
+      screenshot: vi.fn().mockResolvedValue('base64-shot'),
+      annotatedScreenshot: vi.fn().mockResolvedValue('annotated-base64-shot'),
       readNetworkCapture: vi.fn().mockResolvedValue([]),
       waitForDownload: vi.fn().mockResolvedValue({
         downloaded: true,
@@ -924,6 +926,22 @@ describe('browser tab targeting commands', () => {
     const out = lastJsonLog();
     expect(out.error.code).toBe('invalid_source');
     expect(process.exitCode).toBeDefined();
+  });
+
+  it('captures annotated screenshots through the visual ref overlay path', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'screenshot', '--annotate']);
+
+    expect(browserState.page?.annotatedScreenshot).toHaveBeenCalledWith({
+      fullPage: false,
+      annotate: true,
+      width: undefined,
+      height: undefined,
+      format: 'png',
+    });
+    expect(browserState.page?.screenshot).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenLastCalledWith('annotated-base64-shot');
   });
 
   it('blocks history navigation on bound workspaces unless explicitly allowed', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1053,20 +1053,25 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   addBrowserTabOption(browser.command('screenshot').argument('[path]', 'Save to file (base64 if omitted)'))
     .option('--full-page', 'Capture the full scrollable page, not just the viewport', false)
+    .option('--annotate', 'Overlay visible browser state ref labels on the screenshot', false)
     .option('--width <n>', 'Override viewport width in CSS pixels for this screenshot only', (v: string) => parseScreenshotDim(v, 'width'))
     .option('--height <n>', 'Override viewport height in CSS pixels for this screenshot only (ignored with --full-page)', (v: string) => parseScreenshotDim(v, 'height'))
     .description('Take screenshot')
     .action(browserAction(async (page, path, opts) => {
       const shotOpts: ScreenshotOptions = {
         fullPage: opts.fullPage === true,
+        annotate: opts.annotate === true,
         width: opts.width,
         height: opts.height,
       };
+      const capture = opts.annotate === true
+        ? (page.annotatedScreenshot ?? page.screenshot).bind(page)
+        : page.screenshot.bind(page);
       if (path) {
-        await page.screenshot({ ...shotOpts, path });
+        await capture({ ...shotOpts, path });
         console.log(`Screenshot saved to: ${path}`);
       } else {
-        console.log(await page.screenshot({ ...shotOpts, format: 'png' }));
+        console.log(await capture({ ...shotOpts, format: 'png' }));
       }
     }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,8 @@ export interface ScreenshotOptions {
   format?: 'png' | 'jpeg';
   quality?: number;
   fullPage?: boolean;
+  /** Overlay current browser-state refs on visible interactive elements. */
+  annotate?: boolean;
   /** Override viewport width in CSS pixels for the screenshot only (cleared after). */
   width?: number;
   /** Override viewport height in CSS pixels for the screenshot only (ignored when fullPage). */
@@ -128,6 +130,7 @@ export interface IPage {
   getInterceptedRequests(): Promise<any[]>;
   waitForCapture(timeout?: number): Promise<void>;
   screenshot(options?: ScreenshotOptions): Promise<string>;
+  annotatedScreenshot?(options?: ScreenshotOptions): Promise<string>;
   startNetworkCapture?(pattern?: string): Promise<boolean>;
   readNetworkCapture?(): Promise<unknown[]>;
   /**


### PR DESCRIPTION
## Summary
- Add `browser screenshot --annotate` to refresh DOM refs and overlay visible `[N]` labels before capture.
- Implement a temporary visual overlay that maps screenshot labels back to normal `browser click <ref>` targets.
- Update browser skill, design docs, changelog, and tests.

## Verification
- `npm test -- --run src/browser/base-page.test.ts src/cli.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run docs:build`
- `git diff --check`