### PR TITLE
feat(browser): add semantic locator flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **help / browser** — `opencli browser --help -f yaml|json` now emits a structured, agent-ready index of all browser leaf commands (including nested `tab`, `get`, and `dialog` commands), their positionals, command options, namespace options, and root global options. Individual browser commands also support structured help, backed by a shared Commander option/argument spec extractor.
 * **browser state** — add opt-in AX snapshot refs via `browser state --source ax`, including backend-node click resolution and role/name stale-ref recovery for the Phase 0 browser-agent runtime prototype.
 * **browser state** — AX snapshots now include same-origin iframe refs, and `browser state --compare-sources` prints DOM-vs-AX observation metrics for the Phase 1 default-source decision without dumping page contents.
+* **browser locators** — `browser find`, `browser click`, and `browser get text|value|attributes` now accept semantic locator flags (`--role`, `--name`, `--label`, `--text`, `--testid`) so agents can act on common controls without a separate state-ref lookup.
 
 ### Bug Fixes
 

--- a/docs/design/browser-agent-runtime.md
+++ b/docs/design/browser-agent-runtime.md
@@ -345,8 +345,14 @@ Scope:
 
 - `hover`, `focus`, `check`, `uncheck`, `dblclick`, `drag`, `upload`,
   `wait download`,
-- semantic locator options for role/name, label, placeholder, text, testid,
+- semantic locator options for role/name, label, text, testid,
 - structured ambiguity errors for write locators.
+
+Implementation note: the first semantic-locator slice covers `browser find`,
+`browser click`, and `browser get text|value|attributes` with `--role`,
+`--name`, `--label`, `--text`, and `--testid`. Placeholder is folded into
+accessible-name matching for `--name`; a dedicated `--placeholder` flag can be
+added only if real usage shows the distinction matters.
 
 Exit:
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -133,6 +133,7 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 | `browser state --source ax` | Opt-in accessibility-tree snapshot. Use when custom controls, portals, or same-origin iframes are hard to identify in normal `state`. AX refs can recover stale React re-renders by role/name/nth. |
 | `browser state --compare-sources` | Metrics-only DOM vs AX comparison for deciding whether AX should become default. It prints counts and sizes, not page text, so it is safer to share for validation. |
 | `browser find --css <sel> [--limit N] [--text-max N]` | Run a CSS query and return one entry per match with `{nth, ref, tag, role, text, attrs, visible, compound?}`. Allocates refs for matches the prior snapshot didn't tag. Cheap alternative to `state` when you already know the selector. |
+| `browser find --role button --name Save` | Semantic locator query. Also supports `--label`, `--text`, and `--testid`. Use before raw CSS when a control has accessible labels. |
 | `browser frames` | List cross-origin iframe targets. Pass the index to `--frame` on `eval`. |
 | `browser screenshot [path]` | Viewport PNG. No path → base64 to stdout. Prefer `state` when you just need structure. |
 
@@ -145,6 +146,7 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 | `browser get text <target> [--nth N]` | `{value, matches_n, match_level}` |
 | `browser get value <target> [--nth N]` | `{value, matches_n, match_level}` |
 | `browser get attributes <target> [--nth N]` | `{value: {attr: val, ...}, matches_n, match_level}` |
+| `browser get text --role option --name Travel` | Semantic locator read without a prior `state` call. Same flags as `browser find`. |
 | `browser get html [--selector <css>] [--as html\|json] [--depth N] [--children-max N] [--text-max N] [--max N]` | Raw HTML, or structured tree. JSON tree nodes have `{tag, attrs, text, children[], compound?}`. Truncation reported via `truncated: {depth?, children_dropped?, text_truncated?}`. |
 
 ### Interact
@@ -152,6 +154,7 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 | command | notes |
 |---------|-------|
 | `browser click <target> [--nth N]` | Returns `{clicked, target, matches_n, match_level}`. |
+| `browser click --role button --name Submit` | Semantic click. Write actions require a unique match; ambiguous locators return candidates instead of clicking the first match. |
 | `browser type <target> <text> [--nth N]` | Clicks first, then types. Returns `{typed, text, target, matches_n, match_level, autocomplete}`. `autocomplete: true` means a combobox/datalist popup appeared after typing — you almost always need `keys Enter` or a follow-up `click` on the suggestion to commit the value. |
 | `browser fill <target> <text> [--nth N]` | Exact replacement for input, textarea, and contenteditable targets. Returns `{filled, verified, text, actual, matches_n, match_level}`. Use this when you need raw text set and verified, not keyboard/autocomplete behavior. Pipeline form supports `{ fill: { ref, text, submit: true } }`. |
 | `browser select <target> <option> [--nth N]` | Matches option by label first, then value. Use `compound` from `find`/`state` to see exactly what labels are available. |

--- a/src/browser/find.test.ts
+++ b/src/browser/find.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildFindJs, FIND_ATTR_WHITELIST, isFindError, type FindError } from './find.js';
+import { JSDOM } from 'jsdom';
+import { buildFindJs, buildSemanticFindJs, FIND_ATTR_WHITELIST, isFindError, type FindError } from './find.js';
 
 /**
  * These tests validate the shape and options of the generated JS string
@@ -130,5 +131,76 @@ describe('isFindError', () => {
     expect(isFindError(null)).toBe(false);
     expect(isFindError(undefined)).toBe(false);
     expect(isFindError('string')).toBe(false);
+  });
+});
+
+describe('buildSemanticFindJs', () => {
+  function runSemanticFind(html: string, opts: Parameters<typeof buildSemanticFindJs>[0]) {
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    return {
+      dom,
+      result: dom.window.eval(buildSemanticFindJs(opts)),
+    };
+  }
+
+  it('produces syntactically valid JS and embeds semantic criteria safely', () => {
+    const js = buildSemanticFindJs({ role: 'button', name: 'Save "now"', testid: 'submit' });
+    expect(() => new Function(`return (${js});`)).not.toThrow();
+    expect(js).toContain(JSON.stringify({
+      role: 'button',
+      name: 'Save "now"',
+      label: '',
+      text: '',
+      testid: 'submit',
+    }));
+  });
+
+  it('matches native roles, accessible name, labels, text, and test ids', () => {
+    const js = buildSemanticFindJs({ role: 'button', name: 'Save', label: 'Category', text: 'Travel', testid: 'category' });
+    expect(js).toContain('function nativeRole(el)');
+    expect(js).toContain('function accessibleName(el)');
+    expect(js).toContain('function labelText(el)');
+    expect(js).toContain('CRITERIA.role');
+    expect(js).toContain('CRITERIA.name');
+    expect(js).toContain('CRITERIA.label');
+    expect(js).toContain('CRITERIA.text');
+    expect(js).toContain('CRITERIA.testid');
+  });
+
+  it('allocates refs exactly like CSS find so downstream actions can click them', () => {
+    const js = buildSemanticFindJs({ role: 'button', name: 'Save' });
+    expect(js).toContain("el.setAttribute('data-opencli-ref'");
+    expect(js).toContain('__opencli_ref_identity');
+    expect(js).toContain("identity['' + refNum] = fingerprintOf(el)");
+    expect(js).toContain("document.querySelectorAll('[data-opencli-ref]')");
+  });
+
+  it('executes semantic role/name/testid matching and allocates a clickable ref', () => {
+    const { dom, result } = runSemanticFind(
+      '<button aria-label="Save expense" data-testid="save-button">Ignored copy</button>',
+      { role: 'button', name: 'Save', testid: 'save' },
+    );
+    expect(result).toMatchObject({
+      matches_n: 1,
+      entries: [
+        { nth: 0, ref: 1, tag: 'button', role: 'button', attrs: { 'aria-label': 'Save expense', 'data-testid': 'save-button' } },
+      ],
+    });
+    const button = dom.window.document.querySelector('button')!;
+    expect(button.getAttribute('data-opencli-ref')).toBe('1');
+    expect((dom.window as any).__opencli_ref_identity['1']).toMatchObject({ tag: 'button', ariaLabel: 'Save expense' });
+  });
+
+  it('matches associated labels and placeholders for form controls', () => {
+    const { result } = runSemanticFind(
+      '<label for="category">Category</label><input id="category" placeholder="Expense category" value="Travel" />',
+      { role: 'textbox', label: 'Category', name: 'Expense category' },
+    );
+    expect(result).toMatchObject({
+      matches_n: 1,
+      entries: [
+        { nth: 0, ref: 1, tag: 'input', role: 'textbox' },
+      ],
+    });
   });
 });

--- a/src/browser/find.ts
+++ b/src/browser/find.ts
@@ -74,7 +74,7 @@ export interface FindResult {
 
 export interface FindError {
   error: {
-    code: 'invalid_selector' | 'selector_not_found';
+    code: 'invalid_selector' | 'selector_not_found' | 'semantic_not_found';
     message: string;
     hint?: string;
   };
@@ -85,6 +85,14 @@ export interface FindOptions {
   limit?: number;
   /** Max chars of trimmed text per entry. Default 120. */
   textMax?: number;
+}
+
+export interface SemanticFindOptions extends FindOptions {
+  role?: string;
+  name?: string;
+  label?: string;
+  text?: string;
+  testid?: string;
 }
 
 /**
@@ -215,6 +223,227 @@ export function buildFindJs(selector: string, opts: FindOptions = {}): string {
 
       return {
         matches_n: matches.length,
+        entries,
+      };
+    })()
+  `;
+}
+
+export function buildSemanticFindJs(opts: SemanticFindOptions): string {
+  const criteria = JSON.stringify({
+    role: opts.role ?? '',
+    name: opts.name ?? '',
+    label: opts.label ?? '',
+    text: opts.text ?? '',
+    testid: opts.testid ?? '',
+  });
+  const limit = opts.limit ?? 50;
+  const textMax = opts.textMax ?? 120;
+  const whitelist = JSON.stringify(FIND_ATTR_WHITELIST);
+
+  return `
+    (() => {
+      const CRITERIA = ${criteria};
+      const LIMIT = ${limit};
+      const TEXT_MAX = ${textMax};
+      const ATTR_WHITELIST = ${whitelist};
+
+      ${COMPOUND_INFO_JS}
+
+      function normalize(value) {
+        return String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+      }
+
+      function includesNeedle(value, needle) {
+        const n = normalize(needle);
+        if (!n) return true;
+        return normalize(value).includes(n);
+      }
+
+      function nativeRole(el) {
+        const explicit = el.getAttribute('role');
+        if (explicit) return explicit;
+        const tag = el.tagName.toLowerCase();
+        const type = (el.getAttribute('type') || '').toLowerCase();
+        if (tag === 'button') return 'button';
+        if (tag === 'a' && el.getAttribute('href')) return 'link';
+        if (tag === 'textarea') return 'textbox';
+        if (tag === 'select') return 'combobox';
+        if (tag === 'option') return 'option';
+        if (tag === 'input') {
+          if (type === 'button' || type === 'submit' || type === 'reset') return 'button';
+          if (type === 'checkbox') return 'checkbox';
+          if (type === 'radio') return 'radio';
+          if (type === 'range') return 'slider';
+          if (type === 'search') return 'searchbox';
+          return 'textbox';
+        }
+        return '';
+      }
+
+      function labelText(el) {
+        const parts = [];
+        function cssEscape(value) {
+          try {
+            if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
+          } catch (_) {}
+          return String(value).replace(/["\\\\]/g, '\\\\$&');
+        }
+        if (el.id) {
+          try {
+            const label = document.querySelector('label[for="' + cssEscape(el.id) + '"]');
+            if (label) parts.push(label.textContent || '');
+          } catch (_) {}
+        }
+        const parentLabel = el.closest?.('label');
+        if (parentLabel) parts.push(parentLabel.textContent || '');
+        return parts.join(' ');
+      }
+
+      function byIdText(ids) {
+        if (!ids) return '';
+        const parts = [];
+        for (const id of String(ids).split(/\\s+/)) {
+          if (!id) continue;
+          try {
+            const el = document.getElementById(id);
+            if (el) parts.push(el.textContent || '');
+          } catch (_) {}
+        }
+        return parts.join(' ');
+      }
+
+      function accessibleName(el) {
+        return [
+          el.getAttribute('aria-label') || '',
+          byIdText(el.getAttribute('aria-labelledby')),
+          labelText(el),
+          el.getAttribute('alt') || '',
+          el.getAttribute('title') || '',
+          el.getAttribute('placeholder') || '',
+          el.getAttribute('value') || '',
+          el.textContent || '',
+        ].filter(Boolean).join(' ');
+      }
+
+      function pickAttrs(el) {
+        const out = {};
+        for (const key of ATTR_WHITELIST) {
+          const v = el.getAttribute(key);
+          if (v != null && v !== '') out[key] = v;
+        }
+        return out;
+      }
+
+      function isVisible(el) {
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) return false;
+        try {
+          const style = getComputedStyle(el);
+          if (style.display === 'none' || style.visibility === 'hidden') return false;
+          if (parseFloat(style.opacity || '1') === 0) return false;
+        } catch (_) {}
+        return true;
+      }
+
+      function fingerprintOf(el) {
+        return {
+          tag: el.tagName.toLowerCase(),
+          role: el.getAttribute('role') || '',
+          text: (el.textContent || '').trim().slice(0, 30),
+          ariaLabel: el.getAttribute('aria-label') || '',
+          id: el.id || '',
+          testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
+        };
+      }
+
+      function matches(el) {
+        const role = nativeRole(el);
+        const name = accessibleName(el);
+        const label = labelText(el);
+        const text = el.textContent || '';
+        const testid = el.getAttribute('data-testid') || el.getAttribute('data-test') || el.getAttribute('test-id') || '';
+        if (CRITERIA.role && normalize(role) !== normalize(CRITERIA.role)) return false;
+        if (CRITERIA.name && !includesNeedle(name, CRITERIA.name)) return false;
+        if (CRITERIA.label && !includesNeedle(label, CRITERIA.label)) return false;
+        if (CRITERIA.text && !includesNeedle(text, CRITERIA.text)) return false;
+        if (CRITERIA.testid && !includesNeedle(testid, CRITERIA.testid)) return false;
+        return true;
+      }
+
+      const candidates = Array.from(document.querySelectorAll([
+        'a[href]',
+        'button',
+        'input',
+        'textarea',
+        'select',
+        'option',
+        '[role]',
+        '[aria-label]',
+        '[aria-labelledby]',
+        '[data-testid]',
+        '[data-test]',
+        '[test-id]',
+        'label',
+        '[contenteditable="true"]',
+      ].join(',')));
+      const matchesList = candidates.filter(matches);
+
+      if (matchesList.length === 0) {
+        return {
+          error: {
+            code: 'semantic_not_found',
+            message: 'Semantic locator matched 0 elements',
+            hint: 'Try browser state, --source ax, or relax --role/--name/--label/--text/--testid.',
+          },
+        };
+      }
+
+      const identity = (window.__opencli_ref_identity = window.__opencli_ref_identity || {});
+      let maxRef = 0;
+      for (const k in identity) {
+        const n = parseInt(k, 10);
+        if (!isNaN(n) && n > maxRef) maxRef = n;
+      }
+      try {
+        const tagged = document.querySelectorAll('[data-opencli-ref]');
+        for (let t = 0; t < tagged.length; t++) {
+          const v = tagged[t].getAttribute('data-opencli-ref');
+          const n = v != null && /^\\d+$/.test(v) ? parseInt(v, 10) : NaN;
+          if (!isNaN(n) && n > maxRef) maxRef = n;
+        }
+      } catch (_) {}
+
+      const take = Math.min(matchesList.length, LIMIT);
+      const entries = [];
+      for (let i = 0; i < take; i++) {
+        const el = matchesList[i];
+        const refAttr = el.getAttribute('data-opencli-ref');
+        let refNum = refAttr != null && /^\\d+$/.test(refAttr) ? parseInt(refAttr, 10) : null;
+        if (refNum === null) {
+          refNum = ++maxRef;
+          try { el.setAttribute('data-opencli-ref', '' + refNum); } catch (_) {}
+          identity['' + refNum] = fingerprintOf(el);
+        } else if (!identity['' + refNum]) {
+          identity['' + refNum] = fingerprintOf(el);
+        }
+        const text = (el.textContent || '').trim();
+        const entry = {
+          nth: i,
+          ref: refNum,
+          tag: el.tagName.toLowerCase(),
+          role: nativeRole(el),
+          text: text.length > TEXT_MAX ? text.slice(0, TEXT_MAX) : text,
+          attrs: pickAttrs(el),
+          visible: isVisible(el),
+        };
+        const compound = compoundInfoOf(el);
+        if (compound) entry.compound = compound;
+        entries.push(entry);
+      }
+
+      return {
+        matches_n: matchesList.length,
         entries,
       };
     })()

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -400,10 +400,10 @@ describe('createProgram root help descriptions', () => {
       const click = data.commands.find((cmd: any) => cmd.name === 'click');
       expect(click).toMatchObject({
         command: 'opencli browser click',
-        usage: 'opencli browser click <target> [options]',
-        positionals: [{ name: 'target', required: true }],
+        usage: 'opencli browser click [target] [options]',
+        positionals: [{ name: 'target' }],
       });
-      expect(click.command_options.map((option: any) => option.name)).toEqual(['nth', 'tab']);
+      expect(click.command_options.map((option: any) => option.name)).toEqual(['role', 'name', 'label', 'text', 'testid', 'nth', 'tab']);
 
       const tabList = data.commands.find((cmd: any) => cmd.name === 'tab list');
       expect(tabList).toMatchObject({
@@ -415,7 +415,7 @@ describe('createProgram root help descriptions', () => {
       const getText = data.commands.find((cmd: any) => cmd.name === 'get text');
       expect(getText).toMatchObject({
         command: 'opencli browser get text',
-        positionals: [{ name: 'target', required: true }],
+        positionals: [{ name: 'target' }],
       });
       expect(data.structured_help).toMatchObject({
         formats: ['yaml', 'json'],
@@ -479,13 +479,13 @@ describe('createProgram root help descriptions', () => {
         namespace: 'browser',
         name: 'click',
         command: 'opencli browser click',
-        usage: 'opencli browser click <target> [options]',
-        positionals: [{ name: 'target', required: true }],
+        usage: 'opencli browser click [target] [options]',
+        positionals: [{ name: 'target' }],
         structured_help: {
           usage: 'opencli browser click --help -f yaml',
         },
       });
-      expect(data.command_options.map((option: any) => option.name)).toEqual(['nth', 'tab']);
+      expect(data.command_options.map((option: any) => option.name)).toEqual(['role', 'name', 'label', 'text', 'testid', 'nth', 'tab']);
       expect(data.namespace_options.map((option: any) => option.name)).toEqual(['workspace']);
       expect(data.global_options.map((option: any) => option.name)).toContain('profile');
     } finally {
@@ -2136,6 +2136,28 @@ describe('browser find command', () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it('finds elements by semantic role/name without requiring CSS', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      matches_n: 1,
+      entries: [
+        { nth: 0, ref: 9, tag: 'button', role: 'button', text: 'Save', attrs: {}, visible: true },
+      ],
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'find', '--role', 'button', '--name', 'Save']);
+
+    const js = (browserState.page!.evaluate as any).mock.calls[0][0] as string;
+    expect(js).toContain('CRITERIA');
+    expect(js).toContain('function accessibleName');
+    expect(lastJsonLog()).toEqual({
+      matches_n: 1,
+      entries: [
+        { nth: 0, ref: 9, tag: 'button', role: 'button', text: 'Save', attrs: {}, visible: true },
+      ],
+    });
+  });
+
   it('forwards --limit / --text-max into the generated JS', async () => {
     (browserState.page!.evaluate as any).mockResolvedValueOnce({ matches_n: 0, entries: [] });
     const program = createProgram('', '');
@@ -2208,6 +2230,25 @@ describe('browser get text/value/attributes commands', () => {
     await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '7']);
 
     expect(lastJsonLog()).toEqual({ value: 'Hello world', matches_n: 1, match_level: 'exact' });
+  });
+
+  it('resolves a semantic locator to a ref before get text', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({
+      matches_n: 1,
+      entries: [
+        { nth: 0, ref: 12, tag: 'button', role: 'button', text: 'Save', attrs: {}, visible: true },
+      ],
+    });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
+    evalMock.mockResolvedValueOnce('Save');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '--role', 'button', '--name', 'Save']);
+
+    expect(evalMock.mock.calls[0][0]).toContain('function accessibleName');
+    expect(evalMock.mock.calls[1][0]).toContain('const ref = "12"');
+    expect(lastJsonLog()).toEqual({ value: 'Save', matches_n: 1, match_level: 'exact' });
   });
 
   it('reports matches_n on multi-match CSS (read path: first match wins)', async () => {
@@ -2302,6 +2343,41 @@ describe('browser click/type commands', () => {
 
     expect(browserState.page!.click).toHaveBeenCalledWith('#save', {});
     expect(lastJsonLog()).toEqual({ clicked: true, target: '#save', matches_n: 1, match_level: 'exact' });
+  });
+
+  it('clicks a unique semantic locator without a prior state call', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      matches_n: 1,
+      entries: [
+        { nth: 0, ref: 23, tag: 'button', role: 'button', text: 'Submit', attrs: {}, visible: true },
+      ],
+    });
+    (browserState.page!.click as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '--role', 'button', '--name', 'Submit']);
+
+    expect(browserState.page!.click).toHaveBeenCalledWith('23', {});
+    expect(lastJsonLog()).toEqual({ clicked: true, target: '23', matches_n: 1, match_level: 'exact' });
+  });
+
+  it('rejects ambiguous semantic locators before write actions', async () => {
+    (browserState.page!.evaluate as any).mockResolvedValueOnce({
+      matches_n: 2,
+      entries: [
+        { nth: 0, ref: 1, tag: 'button', role: 'button', text: 'Save', attrs: {}, visible: true },
+        { nth: 1, ref: 2, tag: 'button', role: 'button', text: 'Save draft', attrs: {}, visible: true },
+      ],
+    });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'click', '--role', 'button', '--name', 'Save']);
+
+    const err = lastJsonLog().error;
+    expect(err.code).toBe('semantic_ambiguous');
+    expect(err.matches_n).toBe(2);
+    expect(browserState.page!.click).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
   });
 
   it('surfaces match_level=stable when resolver falls back to fingerprint match', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2251,6 +2251,27 @@ describe('browser get text/value/attributes commands', () => {
     expect(lastJsonLog()).toEqual({ value: 'Save', matches_n: 1, match_level: 'exact' });
   });
 
+  it('reports total_matches when semantic get reads the first of multiple matches', async () => {
+    const evalMock = browserState.page!.evaluate as any;
+    evalMock.mockResolvedValueOnce({
+      matches_n: 3,
+      entries: [
+        { nth: 0, ref: 12, tag: 'button', role: 'button', text: 'Save', attrs: {}, visible: true },
+        { nth: 1, ref: 13, tag: 'button', role: 'button', text: 'Save draft', attrs: {}, visible: true },
+        { nth: 2, ref: 14, tag: 'button', role: 'button', text: 'Save copy', attrs: {}, visible: true },
+      ],
+    });
+    evalMock.mockResolvedValueOnce({ ok: true, matches_n: 1, match_level: 'exact' });
+    evalMock.mockResolvedValueOnce('Save');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'get', 'text', '--role', 'button', '--name', 'Save']);
+
+    expect(evalMock.mock.calls[0][0]).toContain('const LIMIT = 6');
+    expect(evalMock.mock.calls[1][0]).toContain('const ref = "12"');
+    expect(lastJsonLog()).toEqual({ value: 'Save', matches_n: 1, match_level: 'exact', total_matches: 3 });
+  });
+
   it('reports matches_n on multi-match CSS (read path: first match wins)', async () => {
     const evalMock = browserState.page!.evaluate as any;
     evalMock.mockResolvedValueOnce({ ok: true, matches_n: 3, match_level: 'exact' });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceSt
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
-import { buildFindJs, isFindError, type FindResult, type FindError } from './browser/find.js';
+import { buildFindJs, buildSemanticFindJs, isFindError, type FindResult, type FindError, type SemanticFindOptions } from './browser/find.js';
 import { inferShape } from './browser/shape.js';
 import { assignKeys } from './browser/network-key.js';
 import { DEFAULT_TTL_MS, findEntry, loadNetworkCache, saveNetworkCache, type CachedNetworkEntry } from './browser/network-cache.js';
@@ -1214,20 +1214,107 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   // `browser find --css <sel>` lets agents jump straight from a semantic
   // selector to a JSON list of matching elements, without having to parse
   // the free-text state snapshot to recover indices.
+  const addSemanticLocatorOptions = (cmd: Command): Command => cmd
+    .option('--role <role>', 'Semantic role (button, link, textbox, option, etc.)')
+    .option('--name <text>', 'Accessible name contains text (aria-label, label, title, placeholder, or visible text)')
+    .option('--label <text>', 'Associated label contains text')
+    .option('--text <text>', 'Visible text contains text')
+    .option('--testid <id>', 'data-testid / data-test / test-id contains id');
+
+  const semanticLocatorFromOptions = (opts: Record<string, unknown>): SemanticFindOptions | null => {
+    const locator: SemanticFindOptions = {};
+    for (const key of ['role', 'name', 'label', 'text', 'testid'] as const) {
+      const value = opts[key];
+      if (typeof value === 'string' && value.trim()) locator[key] = value.trim();
+    }
+    return Object.keys(locator).length > 0 ? locator : null;
+  };
+
+  const semanticTargetFromOptions = async (
+    page: Awaited<ReturnType<typeof getBrowserPage>>,
+    opts: Record<string, unknown>,
+    mode: 'read' | 'write',
+  ): Promise<string | { error: { code: string; message: string; hint?: string; matches_n?: number; entries?: FindResult['entries'] } } | null> => {
+    const locator = semanticLocatorFromOptions(opts);
+    if (!locator) return null;
+    const result = await page.evaluate(buildSemanticFindJs({ ...locator, limit: mode === 'write' ? 6 : 1 })) as FindResult | FindError;
+    if (isFindError(result)) return result;
+    if (mode === 'write' && result.matches_n !== 1) {
+      return {
+        error: {
+          code: 'semantic_ambiguous',
+          message: `Semantic locator matched ${result.matches_n} elements; write actions require a unique target.`,
+          hint: 'Add --name/--label/--text/--testid or use browser find with a narrower locator.',
+          matches_n: result.matches_n,
+          entries: result.entries,
+        },
+      };
+    }
+    const first = result.entries[0];
+    if (!first) {
+      return {
+        error: {
+          code: 'semantic_not_found',
+          message: 'Semantic locator matched 0 elements',
+          hint: 'Try browser state, --source ax, or relax the semantic locator.',
+        },
+      };
+    }
+    return String(first.ref);
+  };
+
+  const resolveExplicitOrSemanticTarget = async (
+    page: Awaited<ReturnType<typeof getBrowserPage>>,
+    target: unknown,
+    opts: Record<string, unknown>,
+    mode: 'read' | 'write',
+  ): Promise<string | { error: { code: string; message: string; hint?: string; matches_n?: number; entries?: FindResult['entries'] } }> => {
+    const explicit = typeof target === 'string' && target.trim() ? target.trim() : '';
+    const hasSemantic = !!semanticLocatorFromOptions(opts);
+    if (explicit && hasSemantic) {
+      return {
+        error: {
+          code: 'usage_error',
+          message: 'Pass either <target> or semantic locator flags, not both.',
+        },
+      };
+    }
+    if (explicit) return explicit;
+    const semantic = await semanticTargetFromOptions(page, opts, mode);
+    if (semantic) return semantic;
+    return {
+      error: {
+        code: 'usage_error',
+        message: 'Missing target. Pass a numeric ref/CSS selector, or semantic flags like --role button --name Submit.',
+      },
+    };
+  };
+
   addBrowserTabOption(
-    browser.command('find')
+    addSemanticLocatorOptions(browser.command('find'))
       .option('--css <selector>', 'CSS selector (required)')
       .option('--limit <n>', 'Max entries returned', '50')
       .option('--text-max <n>', 'Max chars of trimmed text per entry', '120')
-      .description('Find DOM elements by CSS selector — returns JSON {matches_n, entries[]}'),
+      .description('Find DOM elements by CSS or semantic locator — returns JSON {matches_n, entries[]}'),
   )
     .action(browserAction(async (page, opts) => {
-      if (!opts.css || typeof opts.css !== 'string') {
+      const locator = semanticLocatorFromOptions(opts);
+      if ((!opts.css || typeof opts.css !== 'string') && !locator) {
         console.log(JSON.stringify({
           error: {
             code: 'usage_error',
-            message: '--css <selector> is required',
-            hint: 'Example: opencli browser find --css ".btn.primary"',
+            message: '--css <selector> or a semantic locator flag is required',
+            hint: 'Examples: opencli browser find --css ".btn.primary"; opencli browser find --role button --name Save',
+          },
+        }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      if (opts.css && locator) {
+        console.log(JSON.stringify({
+          error: {
+            code: 'usage_error',
+            message: 'Pass either --css or semantic locator flags, not both.',
           },
         }, null, 2));
         process.exitCode = EXIT_CODES.USAGE_ERROR;
@@ -1245,10 +1332,18 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         process.exitCode = EXIT_CODES.USAGE_ERROR;
         return;
       }
-      const result = await page.evaluate(buildFindJs(opts.css, {
-        limit: limit as number | null ?? undefined,
-        textMax: textMax as number | null ?? undefined,
-      })) as FindResult | FindError;
+      const result = await page.evaluate(
+        locator
+          ? buildSemanticFindJs({
+              ...locator,
+              limit: limit as number | null ?? undefined,
+              textMax: textMax as number | null ?? undefined,
+            })
+          : buildFindJs(opts.css, {
+              limit: limit as number | null ?? undefined,
+              textMax: textMax as number | null ?? undefined,
+            }),
+      ) as FindResult | FindError;
       if (isFindError(result)) {
         console.log(JSON.stringify(result, null, 2));
         process.exitCode = EXIT_CODES.GENERIC_ERROR;
@@ -1281,18 +1376,24 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   // match count is exposed via `matches_n`; `--nth <n>` picks a specific one.
   const runGetCommand = async (
     page: Awaited<ReturnType<typeof getBrowserPage>>,
-    target: string,
-    opts: { nth?: string },
+    target: string | undefined,
+    opts: Record<string, unknown> & { nth?: string },
     evalJs: string,
     field: 'text' | 'value' | 'attributes',
   ): Promise<void> => {
+    const resolvedTarget = await resolveExplicitOrSemanticTarget(page, target, opts, 'read');
+    if (typeof resolvedTarget !== 'string') {
+      console.log(JSON.stringify(resolvedTarget, null, 2));
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
+      return;
+    }
     const nth = parseNthFlag(opts.nth);
     if (nth && typeof nth === 'object' && 'error' in nth) {
       console.log(JSON.stringify({ error: { code: 'usage_error', message: nth.error } }, null, 2));
       process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
-    const { matches_n, match_level } = await resolveRef(page, String(target), {
+    const { matches_n, match_level } = await resolveRef(page, resolvedTarget, {
       firstOnMulti: nth === null,
       ...(typeof nth === 'number' ? { nth } : {}),
     });
@@ -1310,22 +1411,22 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   };
 
   addBrowserTabOption(
-    get.command('text')
-      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+    addSemanticLocatorOptions(get.command('text'))
+      .argument('[target]', 'Numeric ref (from browser state / find), CSS selector, or omit when using --role/--name/etc.')
       .option('--nth <n>', 'Pick the nth match (0-based) when <target> is a multi-match CSS selector')
       .description('Element text content — JSON envelope {value, matches_n}'),
   )
     .action(browserAction(async (page, target, opts) =>
-      runGetCommand(page, String(target), opts ?? {}, getTextResolvedJs(), 'text')));
+      runGetCommand(page, target, opts ?? {}, getTextResolvedJs(), 'text')));
 
   addBrowserTabOption(
-    get.command('value')
-      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+    addSemanticLocatorOptions(get.command('value'))
+      .argument('[target]', 'Numeric ref (from browser state / find), CSS selector, or omit when using --role/--name/etc.')
       .option('--nth <n>', 'Pick the nth match (0-based) when <target> is a multi-match CSS selector')
       .description('Input/textarea value — JSON envelope {value, matches_n}'),
   )
     .action(browserAction(async (page, target, opts) =>
-      runGetCommand(page, String(target), opts ?? {}, getValueResolvedJs(), 'value')));
+      runGetCommand(page, target, opts ?? {}, getValueResolvedJs(), 'value')));
 
   addBrowserTabOption(
     get.command('html')
@@ -1450,13 +1551,13 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     }));
 
   addBrowserTabOption(
-    get.command('attributes')
-      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+    addSemanticLocatorOptions(get.command('attributes'))
+      .argument('[target]', 'Numeric ref (from browser state / find), CSS selector, or omit when using --role/--name/etc.')
       .option('--nth <n>', 'Pick the nth match (0-based) when <target> is a multi-match CSS selector')
       .description('Element attributes — JSON envelope {value, matches_n}'),
   )
     .action(browserAction(async (page, target, opts) =>
-      runGetCommand(page, String(target), opts ?? {}, getAttributesResolvedJs(), 'attributes')));
+      runGetCommand(page, target, opts ?? {}, getAttributesResolvedJs(), 'attributes')));
 
   // ── Interact ──
   //
@@ -1481,20 +1582,26 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   }
 
   addBrowserTabOption(
-    browser.command('click')
-      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+    addSemanticLocatorOptions(browser.command('click'))
+      .argument('[target]', 'Numeric ref (from browser state / find), CSS selector, or omit when using --role/--name/etc.')
       .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
       .description('Click element — JSON envelope {clicked, target, matches_n}'),
   )
     .action(browserAction(async (page, target, opts) => {
+      const resolvedTarget = await resolveExplicitOrSemanticTarget(page, target, opts ?? {}, 'write');
+      if (typeof resolvedTarget !== 'string') {
+        console.log(JSON.stringify(resolvedTarget, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
       const parsed = nthToResolveOpts(opts?.nth);
       if ('error' in parsed) {
         console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
         process.exitCode = EXIT_CODES.USAGE_ERROR;
         return;
       }
-      const { matches_n, match_level } = await page.click(String(target), parsed.opts);
-      console.log(JSON.stringify({ clicked: true, target: String(target), matches_n, match_level }, null, 2));
+      const { matches_n, match_level } = await page.click(resolvedTarget, parsed.opts);
+      console.log(JSON.stringify({ clicked: true, target: resolvedTarget, matches_n, match_level }, null, 2));
     }));
 
   addBrowserTabOption(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1234,10 +1234,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     page: Awaited<ReturnType<typeof getBrowserPage>>,
     opts: Record<string, unknown>,
     mode: 'read' | 'write',
-  ): Promise<string | { error: { code: string; message: string; hint?: string; matches_n?: number; entries?: FindResult['entries'] } } | null> => {
+  ): Promise<string | { target: string; total_matches?: number } | { error: { code: string; message: string; hint?: string; matches_n?: number; entries?: FindResult['entries'] } } | null> => {
     const locator = semanticLocatorFromOptions(opts);
     if (!locator) return null;
-    const result = await page.evaluate(buildSemanticFindJs({ ...locator, limit: mode === 'write' ? 6 : 1 })) as FindResult | FindError;
+    const result = await page.evaluate(buildSemanticFindJs({ ...locator, limit: 6 })) as FindResult | FindError;
     if (isFindError(result)) return result;
     if (mode === 'write' && result.matches_n !== 1) {
       return {
@@ -1260,7 +1260,14 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         },
       };
     }
-    return String(first.ref);
+    const target = String(first.ref);
+    if (mode === 'read') {
+      return {
+        target,
+        ...(result.matches_n > 1 ? { total_matches: result.matches_n } : {}),
+      };
+    }
+    return target;
   };
 
   const resolveExplicitOrSemanticTarget = async (
@@ -1268,7 +1275,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     target: unknown,
     opts: Record<string, unknown>,
     mode: 'read' | 'write',
-  ): Promise<string | { error: { code: string; message: string; hint?: string; matches_n?: number; entries?: FindResult['entries'] } }> => {
+  ): Promise<string | { target: string; total_matches?: number } | { error: { code: string; message: string; hint?: string; matches_n?: number; entries?: FindResult['entries'] } }> => {
     const explicit = typeof target === 'string' && target.trim() ? target.trim() : '';
     const hasSemantic = !!semanticLocatorFromOptions(opts);
     if (explicit && hasSemantic) {
@@ -1382,18 +1389,20 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     field: 'text' | 'value' | 'attributes',
   ): Promise<void> => {
     const resolvedTarget = await resolveExplicitOrSemanticTarget(page, target, opts, 'read');
-    if (typeof resolvedTarget !== 'string') {
+    if (typeof resolvedTarget !== 'string' && 'error' in resolvedTarget) {
       console.log(JSON.stringify(resolvedTarget, null, 2));
       process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
+    const targetRef = typeof resolvedTarget === 'string' ? resolvedTarget : resolvedTarget.target;
+    const totalMatches = typeof resolvedTarget === 'string' ? undefined : resolvedTarget.total_matches;
     const nth = parseNthFlag(opts.nth);
     if (nth && typeof nth === 'object' && 'error' in nth) {
       console.log(JSON.stringify({ error: { code: 'usage_error', message: nth.error } }, null, 2));
       process.exitCode = EXIT_CODES.USAGE_ERROR;
       return;
     }
-    const { matches_n, match_level } = await resolveRef(page, resolvedTarget, {
+    const { matches_n, match_level } = await resolveRef(page, targetRef, {
       firstOnMulti: nth === null,
       ...(typeof nth === 'number' ? { nth } : {}),
     });
@@ -1407,7 +1416,12 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     } else {
       value = raw ?? null;
     }
-    console.log(JSON.stringify({ value, matches_n, match_level }, null, 2));
+    console.log(JSON.stringify({
+      value,
+      matches_n,
+      match_level,
+      ...(totalMatches && totalMatches > 1 ? { total_matches: totalMatches } : {}),
+    }, null, 2));
   };
 
   addBrowserTabOption(


### PR DESCRIPTION
## Summary
- Add semantic locator flags to `browser find`: `--role`, `--name`, `--label`, `--text`, `--testid`.
- Allow `browser click` and `browser get text|value|attributes` to omit `<target>` when semantic locator flags are provided.
- Reuse the existing `data-opencli-ref` / `window.__opencli_ref_identity` ref system so semantic finds feed downstream actions directly.
- Reject ambiguous semantic write locators before clicking, returning candidate entries instead of clicking the first match.
- Report `total_matches` when semantic reads take the first of multiple matches, so agents can decide whether to disambiguate.
- Update browser skill, design roadmap, changelog, and structured help expectations.

## Verification
- `npm test -- --run src/browser/find.test.ts src/cli.test.ts` (153/153)
- `npm run typecheck`
- `npm run build` (801 manifest entries)
- `npm run docs:build`
- `git diff --check`
