### PR TITLE
feat(browser): add hover focus and dblclick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * **browser state** — add opt-in AX snapshot refs via `browser state --source ax`, including backend-node click resolution and role/name stale-ref recovery for the Phase 0 browser-agent runtime prototype.
 * **browser state** — AX snapshots now include same-origin iframe refs, and `browser state --compare-sources` prints DOM-vs-AX observation metrics for the Phase 1 default-source decision without dumping page contents.
 * **browser locators** — `browser find`, `browser click`, and `browser get text|value|attributes` now accept semantic locator flags (`--role`, `--name`, `--label`, `--text`, `--testid`) so agents can act on common controls without a separate state-ref lookup.
+* **browser actions** — add `browser hover`, `browser focus`, and `browser dblclick` primitives backed by the same target resolver and CDP input path as `browser click`.
 
 ### Bug Fixes
 

--- a/docs/design/browser-agent-runtime.md
+++ b/docs/design/browser-agent-runtime.md
@@ -343,7 +343,8 @@ Exit:
 
 Scope:
 
-- `hover`, `focus`, `check`, `uncheck`, `dblclick`, `drag`, `upload`,
+- `hover`, `focus`, `dblclick` (implemented first),
+- `check`, `uncheck`, `drag`, `upload`,
   `wait download`,
 - semantic locator options for role/name, label, text, testid,
 - structured ambiguity errors for write locators.

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -155,6 +155,9 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 |---------|-------|
 | `browser click <target> [--nth N]` | Returns `{clicked, target, matches_n, match_level}`. |
 | `browser click --role button --name Submit` | Semantic click. Write actions require a unique match; ambiguous locators return candidates instead of clicking the first match. |
+| `browser hover <target> [--nth N]` | Moves the mouse over an element. Use for hover menus/tooltips before taking `state` or clicking submenu items. Returns `{hovered, target, matches_n, match_level}`. |
+| `browser focus <target> [--nth N]` | Focuses an element without typing. Useful before `keys` or when a page reacts to focus/blur. Returns `{focused, target, matches_n, match_level}`. |
+| `browser dblclick <target> [--nth N]` | Double-clicks an element via native mouse events when available. Returns `{dblclicked, target, matches_n, match_level}`. |
 | `browser type <target> <text> [--nth N]` | Clicks first, then types. Returns `{typed, text, target, matches_n, match_level, autocomplete}`. `autocomplete: true` means a combobox/datalist popup appeared after typing — you almost always need `keys Enter` or a follow-up `click` on the suggestion to commit the value. |
 | `browser fill <target> <text> [--nth N]` | Exact replacement for input, textarea, and contenteditable targets. Returns `{filled, verified, text, actual, matches_n, match_level}`. Use this when you need raw text set and verified, not keyboard/autocomplete behavior. Pipeline form supports `{ fill: { ref, text, submit: true } }`. |
 | `browser select <target> <option> [--nth N]` | Matches option by label first, then value. Use `compound` from `find`/`state` to see exactly what labels are available. |

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -525,6 +525,61 @@ describe('BasePage native input routing', () => {
     expect(nativeClick).toHaveBeenNthCalledWith(2, 10, 20);
   });
 
+  it('hovers via native CDP mouseMoved when coordinates are available', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn().mockResolvedValue({});
+    page.results = [resolveOk, { x: 70, y: 80, w: 100, h: 20, visible: true }];
+
+    await expect(page.hover('#menu')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenCalledWith('Input.dispatchMouseEvent', { type: 'mouseMoved', x: 70, y: 80 });
+    expect(page.scripts.at(-1)).toContain('getBoundingClientRect');
+  });
+
+  it('focuses through CDP DOM.focus when available', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn(async (method: string) => {
+      if (method === 'DOM.getDocument') return { root: { nodeId: 1 } };
+      if (method === 'DOM.querySelector') return { nodeId: 9 };
+      return {};
+    });
+    page.results = [resolveOk, true];
+    page.withArgsResults = [{ ok: true }, undefined];
+
+    await expect(page.focus('#email')).resolves.toEqual({ focused: true, matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenCalledWith('DOM.focus', { nodeId: 9 });
+  });
+
+  it('verifies CDP focus and falls back to DOM focus when focus did not stick', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn(async (method: string) => {
+      if (method === 'DOM.getDocument') return { root: { nodeId: 1 } };
+      if (method === 'DOM.querySelector') return { nodeId: 9 };
+      return {};
+    });
+    page.results = [resolveOk, false, true];
+    page.withArgsResults = [{ ok: true }, undefined];
+
+    await expect(page.focus('#email')).resolves.toEqual({ focused: true, matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenCalledWith('DOM.focus', { nodeId: 9 });
+    expect(page.scripts.at(-2)).toContain('document.activeElement === el');
+    expect(page.scripts.at(-1)).toContain('el.focus');
+  });
+
+  it('double-clicks via native CDP mouse events', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn().mockResolvedValue({});
+    page.results = [resolveOk, { x: 20, y: 30, w: 100, h: 20, visible: true }];
+
+    await expect(page.dblClick('#row')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenCalledWith('Input.dispatchMouseEvent', { type: 'mouseMoved', x: 20, y: 30 });
+    expect(page.cdp).toHaveBeenCalledWith('Input.dispatchMouseEvent', { type: 'mousePressed', x: 20, y: 30, button: 'left', clickCount: 2 });
+    expect(page.cdp).toHaveBeenCalledWith('Input.dispatchMouseEvent', { type: 'mouseReleased', x: 20, y: 30, button: 'left', clickCount: 2 });
+  });
+
   it('presses key chords through native CDP key events when available', async () => {
     const page = new ActionPage();
     page.nativeKeyPress = vi.fn().mockResolvedValue(undefined);

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -292,6 +292,32 @@ export abstract class BasePage implements IPage {
     }
   }
 
+  protected async tryNativeMouseMove(x: number, y: number): Promise<boolean> {
+    const cdp = (this as IPage).cdp;
+    if (typeof cdp !== 'function') return false;
+    try {
+      await cdp.call(this, 'Input.dispatchMouseEvent', { type: 'mouseMoved', x, y });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  protected async tryNativeDoubleClick(x: number, y: number): Promise<boolean> {
+    const cdp = (this as IPage).cdp;
+    if (typeof cdp !== 'function') return false;
+    try {
+      await cdp.call(this, 'Input.dispatchMouseEvent', { type: 'mouseMoved', x, y });
+      await cdp.call(this, 'Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1 });
+      await cdp.call(this, 'Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 });
+      await cdp.call(this, 'Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 2 });
+      await cdp.call(this, 'Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 2 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   protected async tryClickAxRef(ref: string): Promise<ResolveSuccess | null> {
     if (!/^\d+$/.test(ref)) return null;
     const entry = this._axRefs.get(ref);
@@ -376,6 +402,19 @@ export abstract class BasePage implements IPage {
     try {
       await nativeKeyPress.call(this, key, modifiers);
       return true;
+    } catch {
+      return false;
+    }
+  }
+
+  protected async isResolvedFocused(): Promise<boolean> {
+    try {
+      return await this.evaluate(`
+        (() => {
+          const el = window.__resolved;
+          return !!el && (document.activeElement === el || (typeof el.matches === 'function' && el.matches(':focus')));
+        })()
+      `) as boolean;
     } catch {
       return false;
     }
@@ -466,6 +505,81 @@ export abstract class BasePage implements IPage {
     if (!typed) {
       await this.evaluate(typeResolvedJs(text));
     }
+    return resolved;
+  }
+
+  async hover(ref: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
+    const resolved = await runResolve(this, ref, opts);
+    const nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
+    const rect = await this.evaluate(boundingRectResolvedJs({ skipScroll: nativeScrolled })) as
+      | { x: number; y: number; w: number; h: number; visible: boolean }
+      | null;
+    if (rect?.visible === true && await this.tryNativeMouseMove(rect.x, rect.y)) return resolved;
+
+    await this.evaluate(`
+      (() => {
+        const el = window.__resolved;
+        if (!el) throw new Error('No resolved element');
+        if (${nativeScrolled ? 'false' : 'true'}) el.scrollIntoView({ behavior: 'instant', block: 'center' });
+        const rect = el.getBoundingClientRect();
+        const init = {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: Math.round(rect.left + rect.width / 2),
+          clientY: Math.round(rect.top + rect.height / 2),
+        };
+        try { el.dispatchEvent(new PointerEvent('pointerover', init)); } catch (_) {}
+        try { el.dispatchEvent(new PointerEvent('pointermove', init)); } catch (_) {}
+        el.dispatchEvent(new MouseEvent('mouseover', init));
+        el.dispatchEvent(new MouseEvent('mousemove', init));
+      })()
+    `);
+    return resolved;
+  }
+
+  async focus(ref: string, opts: ResolveOptions = {}): Promise<ResolveSuccess & { focused: boolean }> {
+    const resolved = await runResolve(this, ref, opts);
+    let focused = await this.tryCdpOnResolvedElement('DOM.focus') && await this.isResolvedFocused();
+    if (!focused) {
+      focused = await this.evaluate(`
+        (() => {
+          const el = window.__resolved;
+          if (!el || typeof el.focus !== 'function') return false;
+          try { el.focus({ preventScroll: true }); } catch (_) { try { el.focus(); } catch (_) {} }
+          return document.activeElement === el || (typeof el.matches === 'function' && el.matches(':focus'));
+        })()
+      `) as boolean;
+    }
+    return { ...resolved, focused: !!focused };
+  }
+
+  async dblClick(ref: string, opts: ResolveOptions = {}): Promise<ResolveSuccess> {
+    const resolved = await runResolve(this, ref, opts);
+    const nativeScrolled = await this.tryCdpOnResolvedElement('DOM.scrollIntoViewIfNeeded');
+    const rect = await this.evaluate(boundingRectResolvedJs({ skipScroll: nativeScrolled })) as
+      | { x: number; y: number; w: number; h: number; visible: boolean }
+      | null;
+    if (rect?.visible === true && await this.tryNativeDoubleClick(rect.x, rect.y)) return resolved;
+
+    await this.evaluate(`
+      (() => {
+        const el = window.__resolved;
+        if (!el) throw new Error('No resolved element');
+        if (${nativeScrolled ? 'false' : 'true'}) el.scrollIntoView({ behavior: 'instant', block: 'center' });
+        const rect = el.getBoundingClientRect();
+        const init = {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: Math.round(rect.left + rect.width / 2),
+          clientY: Math.round(rect.top + rect.height / 2),
+          button: 0,
+          detail: 2,
+        };
+        el.dispatchEvent(new MouseEvent('dblclick', init));
+      })()
+    `);
     return resolved;
   }
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2342,6 +2342,9 @@ describe('browser click/type commands', () => {
   const { lastJsonLog } = installSelectorFirstTestHarness('click-type', () => ({
     evaluate: vi.fn().mockResolvedValue(false),
     click: vi.fn().mockResolvedValue({ matches_n: 1, match_level: 'exact' }),
+    dblClick: vi.fn().mockResolvedValue({ matches_n: 1, match_level: 'exact' }),
+    hover: vi.fn().mockResolvedValue({ matches_n: 1, match_level: 'exact' }),
+    focus: vi.fn().mockResolvedValue({ focused: true, matches_n: 1, match_level: 'exact' }),
     typeText: vi.fn().mockResolvedValue({ matches_n: 1, match_level: 'exact' }),
     fillText: vi.fn().mockResolvedValue({
       filled: true,
@@ -2460,6 +2463,36 @@ describe('browser click/type commands', () => {
     expect(lastJsonLog().error.code).toBe('usage_error');
     expect(browserState.page!.click).not.toHaveBeenCalled();
     expect(process.exitCode).toBeDefined();
+  });
+
+  it('hover: delegates to page.hover and emits a structured envelope', async () => {
+    (browserState.page!.hover as any).mockResolvedValueOnce({ matches_n: 2, match_level: 'exact' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'hover', '.menu', '--nth', '1']);
+
+    expect(browserState.page!.hover).toHaveBeenCalledWith('.menu', { nth: 1 });
+    expect(lastJsonLog()).toEqual({ hovered: true, target: '.menu', matches_n: 2, match_level: 'exact' });
+  });
+
+  it('focus: delegates to page.focus and reports whether the element took focus', async () => {
+    (browserState.page!.focus as any).mockResolvedValueOnce({ focused: true, matches_n: 1, match_level: 'stable' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'focus', '7']);
+
+    expect(browserState.page!.focus).toHaveBeenCalledWith('7', {});
+    expect(lastJsonLog()).toEqual({ focused: true, target: '7', matches_n: 1, match_level: 'stable' });
+  });
+
+  it('dblclick: delegates to page.dblClick and emits a structured envelope', async () => {
+    (browserState.page!.dblClick as any).mockResolvedValueOnce({ matches_n: 1, match_level: 'exact' });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', 'dblclick', '#row']);
+
+    expect(browserState.page!.dblClick).toHaveBeenCalledWith('#row', {});
+    expect(lastJsonLog()).toEqual({ dblclicked: true, target: '#row', matches_n: 1, match_level: 'exact' });
   });
 
   it('type: clicks, waits, then typeText — emits {typed, text, target, matches_n, match_level, autocomplete}', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1650,6 +1650,60 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     }));
 
   addBrowserTabOption(
+    browser.command('hover')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Move the mouse over an element — JSON envelope {hovered, target, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) => {
+      if (typeof page.hover !== 'function') throw new Error('browser hover is not supported by this browser backend');
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const { matches_n, match_level } = await page.hover(String(target), parsed.opts);
+      console.log(JSON.stringify({ hovered: true, target: String(target), matches_n, match_level }, null, 2));
+    }));
+
+  addBrowserTabOption(
+    browser.command('focus')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Focus an element — JSON envelope {focused, target, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) => {
+      if (typeof page.focus !== 'function') throw new Error('browser focus is not supported by this browser backend');
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const { focused, matches_n, match_level } = await page.focus(String(target), parsed.opts);
+      console.log(JSON.stringify({ focused, target: String(target), matches_n, match_level }, null, 2));
+    }));
+
+  addBrowserTabOption(
+    browser.command('dblclick')
+      .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
+      .option('--nth <n>', 'When <target> is a multi-match CSS selector, pick the nth match (0-based)')
+      .description('Double-click element — JSON envelope {dblclicked, target, matches_n}'),
+  )
+    .action(browserAction(async (page, target, opts) => {
+      if (typeof page.dblClick !== 'function') throw new Error('browser dblclick is not supported by this browser backend');
+      const parsed = nthToResolveOpts(opts?.nth);
+      if ('error' in parsed) {
+        console.log(JSON.stringify({ error: { code: 'usage_error', message: parsed.error } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const { matches_n, match_level } = await page.dblClick(String(target), parsed.opts);
+      console.log(JSON.stringify({ dblclicked: true, target: String(target), matches_n, match_level }, null, 2));
+    }));
+
+  addBrowserTabOption(
     browser.command('fill')
       .argument('<target>', 'Numeric ref (from browser state / find) or CSS selector')
       .argument('<text>', 'Text to set exactly')

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,9 @@ export interface IPage {
   getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   snapshot(opts?: SnapshotOptions): Promise<any>;
   click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
+  dblClick?(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
+  hover?(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
+  focus?(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ focused: boolean; matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
   typeText(ref: string, text: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
   fillText(ref: string, text: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{
     filled: boolean;


### PR DESCRIPTION
## Summary
- Add Phase 2 browser action primitives: `browser hover`, `browser focus`, and `browser dblclick`.
- Reuse the existing target resolver, `--nth` behavior, `matches_n`, and `match_level` envelope semantics.
- Use CDP `Input.dispatchMouseEvent` / `DOM.focus` when available, with DOM event/focus fallbacks for older backends.
- Verify `DOM.focus` actually changed focus before reporting `focused: true`.
- Update browser skill, design roadmap, changelog, and tests.

## Verification
- `npm test -- --run src/browser/base-page.test.ts src/cli.test.ts` (165/165)
- `npm run typecheck`
- `npm run build` (801 manifest entries)
- `npm run docs:build`
- `git diff --check origin/main...HEAD`
