### PR TITLE
feat(browser): route AX refs through cross-origin frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * **browser upload** — add `browser upload <target> <file...>` to attach local files to `input[type=file]` targets through CDP `DOM.setFileInputFiles`, with local path validation and file-input verification.
 * **browser actions** — add `browser drag <source> <target>` for CDP mouse drag sequences between two resolved element centers.
 * **browser wait / extension 1.0.8** — add `browser wait download [pattern]` backed by Chrome's downloads lifecycle API, so agents can wait for file downloads by filename/URL pattern and receive completed/failed download metadata.
+* **browser state / extension 1.0.9** — AX snapshots can now include cross-origin iframe refs by routing CDP calls through frame target sessions, allowing `browser click <ref>` to act on accessible OOPIF controls without manual `--frame` selection.
 
 ### Bug Fixes
 

--- a/docs/design/browser-agent-runtime.md
+++ b/docs/design/browser-agent-runtime.md
@@ -333,6 +333,15 @@ Scope:
 - iframe-aware action routing,
 - annotated screenshot with the same ref ids and sidecar metadata.
 
+Status after implementation:
+
+- same-origin iframe AX refs route through `Accessibility.getFullAXTree`
+  `frameId` params,
+- cross-origin iframe AX refs route through Browser Bridge frame target sessions
+  when Chrome exposes an attachable OOPIF target,
+- unsupported frames degrade by omission or typed action failure rather than
+  requiring global manual frame switching.
+
 Exit:
 
 - Agent can act on iframe refs without manual frame selection in common cases.

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -7,6 +7,11 @@ const WS_RECONNECT_MAX_DELAY = 5e3;
 
 const attached = /* @__PURE__ */ new Set();
 const tabFrameContexts = /* @__PURE__ */ new Map();
+const frameSessions = /* @__PURE__ */ new Map();
+const sessionFrameKeys = /* @__PURE__ */ new Map();
+const pendingSessionCommands = /* @__PURE__ */ new Map();
+let sessionCommandId = 0;
+let frameSessionRoutingRegistered = false;
 const CDP_RESPONSE_BODY_CAPTURE_LIMIT = 8 * 1024 * 1024;
 const CDP_REQUEST_BODY_CAPTURE_LIMIT = 1 * 1024 * 1024;
 const networkCaptures = /* @__PURE__ */ new Map();
@@ -276,11 +281,95 @@ async function waitForDownload(pattern = "", timeoutMs = 3e4) {
     });
   });
 }
+function frameSessionKey(tabId, frameId) {
+  return `${tabId}:${frameId}`;
+}
+function registerFrameSessionRouting() {
+  if (frameSessionRoutingRegistered) return;
+  frameSessionRoutingRegistered = true;
+  chrome.debugger.onEvent.addListener((_source, method, params) => {
+    if (method === "Target.receivedMessageFromTarget") {
+      const sessionId = String(params?.sessionId || "");
+      const raw = typeof params?.message === "string" ? params.message : "";
+      if (!sessionId || !raw) return;
+      let message;
+      try {
+        message = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      if (typeof message.id !== "number") return;
+      const sessionPending = pendingSessionCommands.get(sessionId);
+      const pending = sessionPending?.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      sessionPending.delete(message.id);
+      if (sessionPending.size === 0) pendingSessionCommands.delete(sessionId);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        pending.resolve(message.result);
+      }
+    }
+    if (method === "Target.detachedFromTarget") {
+      const sessionId = String(params?.sessionId || "");
+      const key = sessionFrameKeys.get(sessionId);
+      if (key) frameSessions.delete(key);
+      sessionFrameKeys.delete(sessionId);
+      const sessionPending = pendingSessionCommands.get(sessionId);
+      if (sessionPending) {
+        for (const pending of sessionPending.values()) {
+          clearTimeout(pending.timer);
+          pending.reject(new Error(`Frame target session ${sessionId} detached`));
+        }
+        pendingSessionCommands.delete(sessionId);
+      }
+    }
+  });
+}
+async function ensureFrameSession(tabId, frameId, aggressiveRetry = false) {
+  registerFrameSessionRouting();
+  await ensureAttached(tabId, aggressiveRetry);
+  const key = frameSessionKey(tabId, frameId);
+  const existing = frameSessions.get(key);
+  if (existing) return existing;
+  const result = await chrome.debugger.sendCommand({ tabId }, "Target.attachToTarget", {
+    targetId: frameId,
+    flatten: false
+  });
+  const sessionId = result.sessionId;
+  if (!sessionId) {
+    throw new Error(`Frame ${frameId} did not return a CDP session id`);
+  }
+  frameSessions.set(key, sessionId);
+  sessionFrameKeys.set(sessionId, key);
+  return sessionId;
+}
+async function sendCommandInFrameTarget(tabId, frameId, method, params = {}, aggressiveRetry = false, timeoutMs = 3e4) {
+  const sessionId = await ensureFrameSession(tabId, frameId, aggressiveRetry);
+  const id = ++sessionCommandId;
+  const sessionPending = pendingSessionCommands.get(sessionId) ?? /* @__PURE__ */ new Map();
+  pendingSessionCommands.set(sessionId, sessionPending);
+  const command = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      sessionPending.delete(id);
+      if (sessionPending.size === 0) pendingSessionCommands.delete(sessionId);
+      reject(new Error(`Frame CDP command '${method}' timed out after ${timeoutMs / 1e3}s`));
+    }, timeoutMs);
+    sessionPending.set(id, { resolve, reject, timer });
+  });
+  await chrome.debugger.sendCommand({ tabId }, "Target.sendMessageToTarget", {
+    sessionId,
+    message: JSON.stringify({ id, method, params })
+  });
+  return command;
+}
 async function insertText(tabId, text) {
   await ensureAttached(tabId);
   await chrome.debugger.sendCommand({ tabId }, "Input.insertText", { text });
 }
 function registerFrameTracking() {
+  registerFrameSessionRouting();
   chrome.debugger.onEvent.addListener((source, method, params) => {
     const tabId = source.tabId;
     if (!tabId) return;
@@ -324,7 +413,17 @@ async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = fal
   const contexts = tabFrameContexts.get(tabId);
   const contextId = contexts?.get(frameId);
   if (contextId === void 0) {
-    throw new Error(`No execution context found for frame ${frameId}. The frame may not be loaded yet.`);
+    await sendCommandInFrameTarget(tabId, frameId, "Runtime.enable", {}, aggressiveRetry).catch(() => void 0);
+    const result2 = await sendCommandInFrameTarget(tabId, frameId, "Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true
+    }, aggressiveRetry);
+    if (result2.exceptionDetails) {
+      const errMsg = result2.exceptionDetails.exception?.description || result2.exceptionDetails.text || "Eval error";
+      throw new Error(errMsg);
+    }
+    return result2.result?.value;
   }
   const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
     expression,
@@ -394,7 +493,23 @@ async function readNetworkCapture(tabId) {
 function hasActiveNetworkCapture(tabId) {
   return networkCaptures.has(tabId);
 }
+function clearFrameSessionsForTab(tabId, reason) {
+  for (const [key, sessionId] of [...frameSessions.entries()]) {
+    if (!key.startsWith(`${tabId}:`)) continue;
+    frameSessions.delete(key);
+    sessionFrameKeys.delete(sessionId);
+    const sessionPending = pendingSessionCommands.get(sessionId);
+    if (sessionPending) {
+      for (const pending of sessionPending.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error(reason));
+      }
+      pendingSessionCommands.delete(sessionId);
+    }
+  }
+}
 async function detach(tabId) {
+  clearFrameSessionsForTab(tabId, `Tab ${tabId} detached`);
   if (!attached.has(tabId)) return;
   attached.delete(tabId);
   networkCaptures.delete(tabId);
@@ -409,12 +524,14 @@ function registerListeners() {
     attached.delete(tabId);
     networkCaptures.delete(tabId);
     tabFrameContexts.delete(tabId);
+    clearFrameSessionsForTab(tabId, `Tab ${tabId} removed`);
   });
   chrome.debugger.onDetach.addListener((source) => {
     if (source.tabId) {
       attached.delete(source.tabId);
       networkCaptures.delete(source.tabId);
       tabFrameContexts.delete(source.tabId);
+      clearFrameSessionsForTab(source.tabId, `Tab ${source.tabId} detached`);
     }
   });
   chrome.tabs.onUpdated.addListener(async (tabId, info) => {
@@ -1641,15 +1758,22 @@ async function handleCdp(cmd, workspace) {
   try {
     const aggressive = workspace.startsWith("browser:") || workspace.startsWith("operate:");
     await ensureAttached(tabId, aggressive);
-    const data = await chrome.debugger.sendCommand(
+    const params = cmd.cdpParams ?? {};
+    const routeFrameId = typeof params.frameId === "string" && params.sessionId === "target" ? params.frameId : void 0;
+    const data = routeFrameId ? await sendCommandInFrameTarget(tabId, routeFrameId, cmd.cdpMethod, stripOpenCliFrameRoutingParams(params, true), aggressive) : await chrome.debugger.sendCommand(
       { tabId },
       cmd.cdpMethod,
-      cmd.cdpParams ?? {}
+      stripOpenCliFrameRoutingParams(params, false)
     );
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+}
+function stripOpenCliFrameRoutingParams(params, stripFrameId) {
+  const { sessionId, frameId, ...rest } = params;
+  if (!stripFrameId && frameId !== void 0) return { ...rest, frameId };
+  return rest;
 }
 async function handleCloseWindow(cmd, workspace) {
   await releaseWorkspaceLease(workspace, "explicit close");

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -288,6 +288,47 @@ describe('background tab isolation', () => {
     );
   });
 
+  it('routes frame-target CDP passthrough calls through Target session messaging', async () => {
+    const { chrome } = createChromeMock();
+    chrome.debugger.sendCommand = vi.fn(async (_target: unknown, method: string, params?: Record<string, unknown>) => {
+      if (method === 'Runtime.evaluate') return { result: { value: 1 } };
+      if (method === 'Target.attachToTarget') return { sessionId: 'session-1' };
+      if (method === 'Target.sendMessageToTarget') return {};
+      return {};
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const sendCommandInFrameTarget = vi.fn(async () => ({ nodes: [] }));
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      ensureAttached: vi.fn(async () => {}),
+      sendCommandInFrameTarget,
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId('site:twitter', 1);
+
+    const result = await mod.__test__.handleCommand({
+      id: 'frame-ax',
+      action: 'cdp',
+      workspace: 'site:twitter',
+      cdpMethod: 'Accessibility.getFullAXTree',
+      cdpParams: { frameId: 'cross-frame', sessionId: 'target' },
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, data: { nodes: [] } }));
+    expect(sendCommandInFrameTarget).toHaveBeenCalledWith(
+      1,
+      'cross-frame',
+      'Accessibility.getFullAXTree',
+      {},
+      false,
+    );
+  });
+
   it('routes wait-download commands to the download observer', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1372,15 +1372,27 @@ async function handleCdp(cmd: Command, workspace: string): Promise<Result> {
   try {
     const aggressive = workspace.startsWith('browser:') || workspace.startsWith('operate:');
     await executor.ensureAttached(tabId, aggressive);
-    const data = await chrome.debugger.sendCommand(
-      { tabId },
-      cmd.cdpMethod,
-      cmd.cdpParams ?? {},
-    );
+    const params = cmd.cdpParams ?? {};
+    const routeFrameId = typeof params.frameId === 'string' && params.sessionId === 'target'
+      ? params.frameId
+      : undefined;
+    const data = routeFrameId
+      ? await executor.sendCommandInFrameTarget(tabId, routeFrameId, cmd.cdpMethod, stripOpenCliFrameRoutingParams(params, true), aggressive)
+      : await chrome.debugger.sendCommand(
+        { tabId },
+        cmd.cdpMethod,
+        stripOpenCliFrameRoutingParams(params, false),
+      );
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+function stripOpenCliFrameRoutingParams(params: Record<string, unknown>, stripFrameId: boolean): Record<string, unknown> {
+  const { sessionId, frameId, ...rest } = params;
+  if (!stripFrameId && frameId !== undefined) return { ...rest, frameId };
+  return rest;
 }
 
 async function handleCloseWindow(cmd: Command, workspace: string): Promise<Result> {

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -70,17 +70,19 @@ describe('cdp attach recovery', () => {
     const mod = await import('./cdp');
     mod.registerFrameTracking();
 
-    expect(debuggerEventListeners).toHaveLength(1);
-    debuggerEventListeners[0](
-      { tabId: 1 },
-      'Runtime.executionContextCreated',
-      { context: { id: 11, auxData: { frameId: 'frame-1', isDefault: false } } },
-    );
-    debuggerEventListeners[0](
-      { tabId: 1 },
-      'Runtime.executionContextCreated',
-      { context: { id: 22, auxData: { frameId: 'frame-1', isDefault: true } } },
-    );
+    expect(debuggerEventListeners.length).toBeGreaterThanOrEqual(1);
+    for (const listener of debuggerEventListeners) {
+      listener(
+        { tabId: 1 },
+        'Runtime.executionContextCreated',
+        { context: { id: 11, auxData: { frameId: 'frame-1', isDefault: false } } },
+      );
+      listener(
+        { tabId: 1 },
+        'Runtime.executionContextCreated',
+        { context: { id: 22, auxData: { frameId: 'frame-1', isDefault: true } } },
+      );
+    }
 
     await mod.evaluateInFrame(1, 'document.title', 'frame-1');
 
@@ -88,6 +90,57 @@ describe('cdp attach recovery', () => {
       { tabId: 1 },
       'Runtime.evaluate',
       expect.objectContaining({ contextId: 22 }),
+    );
+  });
+
+  it('falls back to a frame target session when no same-target execution context exists', async () => {
+    const { chrome, debuggerApi, debuggerEventListeners } = createChromeMock();
+    debuggerApi.sendCommand = vi.fn(async (_target: unknown, method: string, params?: any) => {
+      if (method === 'Runtime.evaluate') return { result: { value: 'root-ok' } };
+      if (method === 'Target.attachToTarget') return { sessionId: 'session-1' };
+      if (method === 'Target.sendMessageToTarget') {
+        const message = JSON.parse(String(params.message));
+        queueMicrotask(() => {
+          for (const listener of debuggerEventListeners) {
+            listener(
+              { tabId: 1 },
+              'Target.receivedMessageFromTarget',
+              {
+                sessionId: params.sessionId,
+                message: JSON.stringify({
+                  id: message.id,
+                  result: message.method === 'Runtime.evaluate'
+                    ? { result: { value: 'frame-ok' } }
+                    : {},
+                }),
+              },
+            );
+          }
+        });
+        return {};
+      }
+      return {};
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    mod.registerFrameTracking();
+
+    const result = await mod.evaluateInFrame(1, 'document.title', 'oopif-frame');
+
+    expect(result).toBe('frame-ok');
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith(
+      { tabId: 1 },
+      'Target.attachToTarget',
+      { targetId: 'oopif-frame', flatten: false },
+    );
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith(
+      { tabId: 1 },
+      'Target.sendMessageToTarget',
+      expect.objectContaining({
+        sessionId: 'session-1',
+        message: expect.stringContaining('"Runtime.evaluate"'),
+      }),
     );
   });
 

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -9,6 +9,15 @@
 const attached = new Set<number>();
 
 const tabFrameContexts = new Map<number, Map<string, number>>();
+const frameSessions = new Map<string, string>();
+const sessionFrameKeys = new Map<string, string>();
+const pendingSessionCommands = new Map<string, Map<number, {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}>>();
+let sessionCommandId = 0;
+let frameSessionRoutingRegistered = false;
 
 // Large cap so agents stop hitting silent JSON.parse failures on real API bodies.
 // See src/browser/cdp.ts CDP_RESPONSE_BODY_CAPTURE_LIMIT for the matching constant
@@ -410,6 +419,100 @@ export async function waitForDownload(pattern: string = '', timeoutMs: number = 
   });
 }
 
+function frameSessionKey(tabId: number, frameId: string): string {
+  return `${tabId}:${frameId}`;
+}
+
+function registerFrameSessionRouting(): void {
+  if (frameSessionRoutingRegistered) return;
+  frameSessionRoutingRegistered = true;
+  chrome.debugger.onEvent.addListener((_source, method, params: any) => {
+    if (method === 'Target.receivedMessageFromTarget') {
+      const sessionId = String(params?.sessionId || '');
+      const raw = typeof params?.message === 'string' ? params.message : '';
+      if (!sessionId || !raw) return;
+      let message: any;
+      try { message = JSON.parse(raw); } catch { return; }
+      if (typeof message.id !== 'number') return;
+      const sessionPending = pendingSessionCommands.get(sessionId);
+      const pending = sessionPending?.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      sessionPending!.delete(message.id);
+      if (sessionPending!.size === 0) pendingSessionCommands.delete(sessionId);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        pending.resolve(message.result);
+      }
+    }
+
+    if (method === 'Target.detachedFromTarget') {
+      const sessionId = String(params?.sessionId || '');
+      const key = sessionFrameKeys.get(sessionId);
+      if (key) frameSessions.delete(key);
+      sessionFrameKeys.delete(sessionId);
+      const sessionPending = pendingSessionCommands.get(sessionId);
+      if (sessionPending) {
+        for (const pending of sessionPending.values()) {
+          clearTimeout(pending.timer);
+          pending.reject(new Error(`Frame target session ${sessionId} detached`));
+        }
+        pendingSessionCommands.delete(sessionId);
+      }
+    }
+  });
+}
+
+async function ensureFrameSession(tabId: number, frameId: string, aggressiveRetry: boolean = false): Promise<string> {
+  registerFrameSessionRouting();
+  await ensureAttached(tabId, aggressiveRetry);
+  const key = frameSessionKey(tabId, frameId);
+  const existing = frameSessions.get(key);
+  if (existing) return existing;
+
+  const result = await chrome.debugger.sendCommand({ tabId }, 'Target.attachToTarget', {
+    targetId: frameId,
+    flatten: false,
+  }) as { sessionId?: string };
+  const sessionId = result.sessionId;
+  if (!sessionId) {
+    throw new Error(`Frame ${frameId} did not return a CDP session id`);
+  }
+  frameSessions.set(key, sessionId);
+  sessionFrameKeys.set(sessionId, key);
+  return sessionId;
+}
+
+export async function sendCommandInFrameTarget(
+  tabId: number,
+  frameId: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  aggressiveRetry: boolean = false,
+  timeoutMs: number = 30_000,
+): Promise<unknown> {
+  const sessionId = await ensureFrameSession(tabId, frameId, aggressiveRetry);
+  const id = ++sessionCommandId;
+  const sessionPending = pendingSessionCommands.get(sessionId) ?? new Map();
+  pendingSessionCommands.set(sessionId, sessionPending);
+
+  const command = new Promise<unknown>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      sessionPending.delete(id);
+      if (sessionPending.size === 0) pendingSessionCommands.delete(sessionId);
+      reject(new Error(`Frame CDP command '${method}' timed out after ${timeoutMs / 1000}s`));
+    }, timeoutMs);
+    sessionPending.set(id, { resolve, reject, timer });
+  });
+
+  await chrome.debugger.sendCommand({ tabId }, 'Target.sendMessageToTarget', {
+    sessionId,
+    message: JSON.stringify({ id, method, params }),
+  });
+  return command;
+}
+
 export async function insertText(
   tabId: number,
   text: string,
@@ -419,6 +522,7 @@ export async function insertText(
 }
 
 export function registerFrameTracking(): void {
+  registerFrameSessionRouting();
   chrome.debugger.onEvent.addListener((source, method, params: any) => {
     const tabId = source.tabId;
     if (!tabId) return;
@@ -472,7 +576,24 @@ export async function evaluateInFrame(
   const contextId = contexts?.get(frameId);
 
   if (contextId === undefined) {
-    throw new Error(`No execution context found for frame ${frameId}. The frame may not be loaded yet.`);
+    await sendCommandInFrameTarget(tabId, frameId, 'Runtime.enable', {}, aggressiveRetry).catch(() => undefined);
+    const result = await sendCommandInFrameTarget(tabId, frameId, 'Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    }, aggressiveRetry) as {
+      result?: { type: string; value?: unknown; description?: string; subtype?: string };
+      exceptionDetails?: { exception?: { description?: string }; text?: string };
+    };
+
+    if (result.exceptionDetails) {
+      const errMsg = result.exceptionDetails.exception?.description
+        || result.exceptionDetails.text
+        || 'Eval error';
+      throw new Error(errMsg);
+    }
+
+    return result.result?.value;
   }
 
   const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
@@ -568,7 +689,24 @@ export function hasActiveNetworkCapture(tabId: number): boolean {
   return networkCaptures.has(tabId);
 }
 
+function clearFrameSessionsForTab(tabId: number, reason: string): void {
+  for (const [key, sessionId] of [...frameSessions.entries()]) {
+    if (!key.startsWith(`${tabId}:`)) continue;
+    frameSessions.delete(key);
+    sessionFrameKeys.delete(sessionId);
+    const sessionPending = pendingSessionCommands.get(sessionId);
+    if (sessionPending) {
+      for (const pending of sessionPending.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error(reason));
+      }
+      pendingSessionCommands.delete(sessionId);
+    }
+  }
+}
+
 export async function detach(tabId: number): Promise<void> {
+  clearFrameSessionsForTab(tabId, `Tab ${tabId} detached`);
   if (!attached.has(tabId)) return;
   attached.delete(tabId);
   networkCaptures.delete(tabId);
@@ -581,12 +719,14 @@ export function registerListeners(): void {
     attached.delete(tabId);
     networkCaptures.delete(tabId);
     tabFrameContexts.delete(tabId);
+    clearFrameSessionsForTab(tabId, `Tab ${tabId} removed`);
   });
   chrome.debugger.onDetach.addListener((source) => {
     if (source.tabId) {
       attached.delete(source.tabId);
       networkCaptures.delete(source.tabId);
       tabFrameContexts.delete(source.tabId);
+      clearFrameSessionsForTab(source.tabId, `Tab ${source.tabId} detached`);
     }
   });
   // Invalidate attached cache when tab URL changes to non-debuggable

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -130,7 +130,7 @@ Error envelope always includes `error.code` and `error.message`. Target errors (
 | command | purpose |
 |---------|---------|
 | `browser state` | Snapshot: text tree with `[N]` refs, scroll hints, hidden-interactive hints, `compounds (N):` sidecar for date/select/file refs. |
-| `browser state --source ax` | Opt-in accessibility-tree snapshot. Use when custom controls, portals, or same-origin iframes are hard to identify in normal `state`. AX refs can recover stale React re-renders by role/name/nth. |
+| `browser state --source ax` | Opt-in accessibility-tree snapshot. Use when custom controls, portals, or iframe contents are hard to identify in normal `state`. AX refs can recover stale React re-renders by role/name/nth and can route same-origin plus attachable cross-origin iframe refs. |
 | `browser state --compare-sources` | Metrics-only DOM vs AX comparison for deciding whether AX should become default. It prints counts and sizes, not page text, so it is safer to share for validation. |
 | `browser find --css <sel> [--limit N] [--text-max N]` | Run a CSS query and return one entry per match with `{nth, ref, tag, role, text, attrs, visible, compound?}`. Allocates refs for matches the prior snapshot didn't tag. Cheap alternative to `state` when you already know the selector. |
 | `browser find --role button --name Save` | Semantic locator query. Also supports `--label`, `--text`, and `--testid`. Use before raw CSS when a control has accessible labels. |

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -330,6 +330,14 @@ describe('BasePage native input routing', () => {
           ],
         };
       }
+      if (method === 'Accessibility.getFullAXTree' && params?.frameId === 'cross-frame') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, name: { value: 'Cross' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Cross Save' }, backendDOMNodeId: 30 },
+          ],
+        };
+      }
       if (method === 'Accessibility.getFullAXTree') {
         return {
           nodes: [
@@ -359,13 +367,53 @@ describe('BasePage native input routing', () => {
     expect(snapshot).toContain('[1]button "Main Save"');
     expect(snapshot).toContain('frame "https://app.example/embed":');
     expect(snapshot).toContain('[2]button "Frame Save"');
+    expect(snapshot).toContain('frame "https://other.example/embed":');
+    expect(snapshot).toContain('[3]button "Cross Save"');
 
     await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
 
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
-    expect(page.cdp).not.toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame' });
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target' });
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 20 });
     expect(page.nativeClick).toHaveBeenCalledWith(120, 210);
+  });
+
+  it('clicks cross-origin AX refs through a frame-target CDP route', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    page.cdp = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'Page.getFrameTree') {
+        return {
+          frameTree: {
+            frame: { id: 'root', url: 'https://app.example/' },
+            childFrames: [{ frame: { id: 'cross-frame', url: 'https://other.example/embed' } }],
+          },
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree' && params?.sessionId === 'target') {
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Cross Save' }, backendDOMNodeId: 99 },
+          ],
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree') {
+        return { nodes: [{ nodeId: '1', role: { value: 'RootWebArea' } }] };
+      }
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [300, 400, 340, 400, 340, 420, 300, 420] } };
+      }
+      return {};
+    });
+
+    const snapshot = await page.snapshot({ source: 'ax' }) as string;
+    expect(snapshot).toContain('[1]button "Cross Save"');
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target' });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 99, frameId: 'cross-frame', sessionId: 'target' });
+    expect(page.nativeClick).toHaveBeenCalledWith(320, 410);
   });
 
   it('recovers stale iframe AX refs inside the original frame', async () => {

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -382,7 +382,7 @@ export abstract class BasePage implements IPage {
     if (typeof cdp !== 'function') return null;
 
     if (entry.backendNodeId != null) {
-      const point = await this.axBoxCenter(entry.backendNodeId).catch(() => null);
+      const point = await this.axBoxCenter(entry.backendNodeId, entry.frame).catch(() => null);
       if (point) return { ...point, matchLevel: 'exact' };
     }
 
@@ -391,14 +391,17 @@ export abstract class BasePage implements IPage {
     const recovered = findAxRefReplacement(axTree, entry);
     if (!recovered?.backendNodeId) return null;
     this._axRefs.set(entry.ref, recovered);
-    const point = await this.axBoxCenter(recovered.backendNodeId).catch(() => null);
+    const point = await this.axBoxCenter(recovered.backendNodeId, recovered.frame).catch(() => null);
     return point ? { ...point, matchLevel: 'reidentified' } : null;
   }
 
-  private async axBoxCenter(backendNodeId: number): Promise<{ x: number; y: number } | null> {
+  private async axBoxCenter(backendNodeId: number, frame?: BrowserRef['frame']): Promise<{ x: number; y: number } | null> {
     const cdp = (this as IPage).cdp;
     if (typeof cdp !== 'function') return null;
-    const result = await cdp.call(this, 'DOM.getBoxModel', { backendNodeId }) as
+    const result = await cdp.call(this, 'DOM.getBoxModel', {
+      backendNodeId,
+      ...(frame?.sessionId ? { frameId: frame.frameId, sessionId: frame.sessionId } : {}),
+    }) as
       | { model?: { content?: unknown[]; border?: unknown[] } }
       | null;
     const quad = Array.isArray(result?.model?.content) && result.model.content.length >= 8
@@ -1091,9 +1094,9 @@ export abstract class BasePage implements IPage {
     const trees: AxSnapshotTree[] = [{ tree: rootTree }];
 
     const frameTreeResult = await cdp.call(this, 'Page.getFrameTree', {}).catch(() => null);
-    const frames = collectSameOriginFrameRefs(frameTreeResult);
+    const frames = collectAxFrameRefs(frameTreeResult);
     for (const frame of frames) {
-      const tree = await cdp.call(this, 'Accessibility.getFullAXTree', { frameId: frame.frameId }).catch(() => null);
+      const tree = await cdp.call(this, 'Accessibility.getFullAXTree', axTreeParams(frame)).catch(() => null);
       if (tree) trees.push({ tree, frame });
     }
 
@@ -1171,10 +1174,12 @@ export abstract class BasePage implements IPage {
 }
 
 function axTreeParams(frame: BrowserRef['frame'] | undefined): Record<string, unknown> {
-  return frame?.frameId ? { frameId: frame.frameId } : {};
+  return frame?.frameId
+    ? { frameId: frame.frameId, ...(frame.sessionId ? { sessionId: frame.sessionId } : {}) }
+    : {};
 }
 
-function collectSameOriginFrameRefs(frameTreeResult: unknown): Array<NonNullable<BrowserRef['frame']>> {
+function collectAxFrameRefs(frameTreeResult: unknown): Array<NonNullable<BrowserRef['frame']>> {
   const root = (frameTreeResult as { frameTree?: CdpFrameTreeNode } | null)?.frameTree;
   const rootUrl = root?.frame?.url || root?.frame?.unreachableUrl || '';
   const rootOrigin = urlOrigin(rootUrl);
@@ -1187,9 +1192,12 @@ function collectSameOriginFrameRefs(frameTreeResult: unknown): Array<NonNullable
       const frameId = frame?.id;
       const frameUrl = frame?.url || frame?.unreachableUrl || '';
       const origin = urlOrigin(frameUrl);
-      if (frameId && origin === rootOrigin) {
+      if (!frameId) continue;
+      if (origin === rootOrigin) {
         frames.push({ frameId, url: frameUrl });
         collect(child);
+      } else {
+        frames.push({ frameId, url: frameUrl, sessionId: 'target' });
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add Browser Bridge frame-target CDP routing for AX snapshot/actions in cross-origin iframe targets.
- Include attachable cross-origin iframe AX refs in `browser state --source ax` alongside existing same-origin iframe refs.
- Route cross-origin AX ref click geometry through the frame target session before dispatching the normal native click.
- Bump Browser Bridge extension to `1.0.9` because this changes extension runtime behavior.

## Design Notes

Same-origin iframe refs keep the existing parent-session `frameId` path. Cross-origin frames are marked internally with `sessionId: "target"`; the extension strips that OpenCLI marker and sends CDP commands through `Target.attachToTarget` / `Target.sendMessageToTarget` for the frame target. If Chrome does not expose an attachable frame target, the AX frame query is skipped or the action fails instead of requiring a global manual frame switch.

This intentionally does not make DOM `state` cross-origin-aware and does not add a public frame session API. It only completes the AX ref route promised by the Agent Browser alignment plan.

## Verification

- `npm test -- --run src/browser/base-page.test.ts extension/src/cdp.test.ts extension/src/background.test.ts` → 96 passed
- `npm run typecheck`
- `cd extension && npm run typecheck`
- `cd extension && npm run build`
- `npm run build`
- `npm run docs:build`
- `cd extension && npm run package:release`
- `git diff --check origin/main...HEAD`
