### PR TITLE
fix(browser): enable AX in cross-origin frame targets

### DIFF
--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -373,6 +373,7 @@ describe('BasePage native input routing', () => {
     await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
 
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', { frameId: 'cross-frame', sessionId: 'target' });
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target' });
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 20 });
     expect(page.nativeClick).toHaveBeenCalledWith(120, 210);
@@ -411,8 +412,52 @@ describe('BasePage native input routing', () => {
     expect(snapshot).toContain('[1]button "Cross Save"');
     await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
 
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', { frameId: 'cross-frame', sessionId: 'target' });
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target' });
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 99, frameId: 'cross-frame', sessionId: 'target' });
+    expect(page.nativeClick).toHaveBeenCalledWith(320, 410);
+  });
+
+  it('enables Accessibility in cross-origin frame target sessions before stale AX recovery', async () => {
+    const page = new ActionPage();
+    page.nativeClick = vi.fn().mockResolvedValue(undefined);
+    let crossAxCalls = 0;
+    page.cdp = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'Page.getFrameTree') {
+        return {
+          frameTree: {
+            frame: { id: 'root', url: 'https://app.example/' },
+            childFrames: [{ frame: { id: 'cross-frame', url: 'https://other.example/embed' } }],
+          },
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree' && params?.sessionId === 'target') {
+        crossAxCalls++;
+        const backendDOMNodeId = crossAxCalls === 1 ? 99 : 100;
+        return {
+          nodes: [
+            { nodeId: '1', role: { value: 'RootWebArea' }, childIds: ['2'] },
+            { nodeId: '2', role: { value: 'button' }, name: { value: 'Cross Save' }, backendDOMNodeId },
+          ],
+        };
+      }
+      if (method === 'Accessibility.getFullAXTree') {
+        return { nodes: [{ nodeId: '1', role: { value: 'RootWebArea' } }] };
+      }
+      if (method === 'DOM.getBoxModel') {
+        if (params?.backendNodeId === 99) throw new Error('No node with given id found');
+        return { model: { content: [300, 400, 340, 400, 340, 420, 300, 420] } };
+      }
+      return {};
+    });
+
+    await page.snapshot({ source: 'ax' });
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', { frameId: 'cross-frame', sessionId: 'target' });
+    expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target' });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 99, frameId: 'cross-frame', sessionId: 'target' });
+    expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 100, frameId: 'cross-frame', sessionId: 'target' });
     expect(page.nativeClick).toHaveBeenCalledWith(320, 410);
   });
 

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -386,7 +386,7 @@ export abstract class BasePage implements IPage {
       if (point) return { ...point, matchLevel: 'exact' };
     }
 
-    await cdp.call(this, 'Accessibility.enable', {});
+    await cdp.call(this, 'Accessibility.enable', axEnableParams(entry.frame));
     const axTree = await cdp.call(this, 'Accessibility.getFullAXTree', axTreeParams(entry.frame)).catch(() => null);
     const recovered = findAxRefReplacement(axTree, entry);
     if (!recovered?.backendNodeId) return null;
@@ -1096,6 +1096,9 @@ export abstract class BasePage implements IPage {
     const frameTreeResult = await cdp.call(this, 'Page.getFrameTree', {}).catch(() => null);
     const frames = collectAxFrameRefs(frameTreeResult);
     for (const frame of frames) {
+      if (frame.sessionId) {
+        await cdp.call(this, 'Accessibility.enable', axEnableParams(frame)).catch(() => null);
+      }
       const tree = await cdp.call(this, 'Accessibility.getFullAXTree', axTreeParams(frame)).catch(() => null);
       if (tree) trees.push({ tree, frame });
     }
@@ -1176,6 +1179,12 @@ export abstract class BasePage implements IPage {
 function axTreeParams(frame: BrowserRef['frame'] | undefined): Record<string, unknown> {
   return frame?.frameId
     ? { frameId: frame.frameId, ...(frame.sessionId ? { sessionId: frame.sessionId } : {}) }
+    : {};
+}
+
+function axEnableParams(frame: BrowserRef['frame'] | undefined): Record<string, unknown> {
+  return frame?.frameId && frame.sessionId
+    ? { frameId: frame.frameId, sessionId: frame.sessionId }
     : {};
 }
 


### PR DESCRIPTION
## Summary
- enable the Accessibility domain inside cross-origin frame target sessions before fetching their AX tree
- enable the same frame target session before stale AX ref recovery re-queries
- add regression coverage for cross-origin frame AX snapshot and stale recovery

## Why
#1442 routed AX CDP calls through attachable cross-origin frame targets, but only enabled Accessibility on the parent session. We already saw real Chrome return empty AX trees when Accessibility is not enabled; frame targets need the same enable step.

## Verification
- npm test -- --run src/browser/base-page.test.ts
- npm run typecheck
- npm run build
- git diff --check