### PR TITLE
chore(release): 1.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## [1.7.15](https://github.com/jackwener/opencli/compare/v1.7.14...v1.7.15) (2026-05-10)
+
+Extension bumped to 1.0.9 (Accessibility.enable allowlist + downloads permission + cross-origin frame target attach for AX). Major Browser Agent Runtime release: full Phase 0/1/2 alignment with `vercel-labs/agent-browser` model — CDP-primary input, AX snapshot/refs with stale recovery, semantic locators across all primitives, full form toolbelt (hover/focus/dblclick/check/uncheck/upload/drag/wait-download), annotated screenshots, and same-origin iframe AX routing. Cross-origin OOPIF AX is best-effort (Chrome extension API limitation).
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- bump opencli to **1.7.15** (was 1.7.14)
- extension at **1.0.9** (already bumped during release cycle)
- finalize CHANGELOG for 1.7.15

## Major Release: Browser Agent Runtime

Full Phase 0/1/2 alignment with `vercel-labs/agent-browser` model.

**Phase 0** (Mercury MVP):
- CDP-primary `browser click` (#1412) — fixes Radix/MUI/shadcn dropdown failures
- AX snapshot prototype (#1413) with backendNodeId refs + role/name/nth stale recovery
- Accessibility.enable bug fix (#1417)

**Phase 1** (observation upgrade):
- Same-origin iframe AX refs (#1414)
- DOM vs AX metrics (#1415)
- Annotated screenshot (#1433)
- Cross-origin OOPIF AX routing — best-effort due to chrome.debugger API limitations (#1442/#1443)

**Phase 2** (toolbelt):
- Semantic locator (#1434/#1440/#1444): `--role/--name/--label/--text/--testid` across all primitives
- New primitives: hover/focus/dblclick (#1435), check/uncheck (#1437), upload (#1438), drag (#1439), wait --download (#1441)

**Quality**:
- Real Chrome AX smoke gate (#1445) catches platform-level regressions

**Extension 1.0.9**:
- Accessibility.enable allowlist
- downloads permission (justification in extension/README.md for Chrome Web Store)
- cross-origin frame target attach via chrome.debugger.attach({targetId})
- tabGroups marker

## Verification

- [x] `npm run build` clean (manifest 801 entries)
- [x] `npx tsc --noEmit` clean
- [ ] CI green (build / unit / adapter / audit / docs / e2e-headed)

## Release flow

After merge: tag `v1.7.15` triggers Release CI — npm publish + GitHub Release + extension 1.0.9 zip upload.

**Reminder**: Chrome Web Store submission of extension 1.0.9 needs `downloads` permission justification (template in `extension/README.md`).