### PR TITLE
perf(deepseek): replace fixed-sleep waits with selector-based readiness

### DIFF
--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -3,7 +3,7 @@ import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/
 import {
     DEEPSEEK_DOMAIN, DEEPSEEK_URL, ensureOnDeepSeek, selectModel, setFeature,
     sendMessage, sendWithFile, getBubbleCount, waitForResponse, parseBoolFlag, withRetry,
-    pickResumeUrl,
+    pickResumeUrl, TEXTAREA_SELECTOR,
 } from './utils.js';
 
 export const askCommand = cli({
@@ -35,7 +35,13 @@ export const askCommand = cli({
 
         if (parseBoolFlag(kwargs.new)) {
             await page.goto(DEEPSEEK_URL);
-            await page.wait(3);
+            // Wait for the composer to mount instead of a fixed 3 s sleep.
+            try {
+                await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 8 });
+            } catch {
+                // Selector still missing → downstream selectModel/sendMessage
+                // will surface the failure with a typed error.
+            }
         } else {
             const navigated = await ensureOnDeepSeek(page);
             if (navigated) {
@@ -49,11 +55,14 @@ export const askCommand = cli({
                     );
                 }
                 await page.goto(resumeUrl);
-                await page.wait(2);
+                try {
+                    await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 5 });
+                } catch {
+                    // Conversation page may still be loading; subsequent steps
+                    // will retry or report.
+                }
             }
         }
-
-        await page.wait(2);
 
         // Model selector is only available on the new-chat page, not inside
         // an existing conversation. Skip it when we resumed a prior thread.
@@ -76,7 +85,9 @@ export const askCommand = cli({
             if (!modelResult?.ok) {
                 throw new CommandExecutionError(`Could not switch to ${wantModel} model`);
             }
-            if (modelResult?.toggled) await page.wait(0.5);
+            // The 0.5 s settle previously here was redundant: each subsequent
+            // step (setFeature, sendMessage) issues a fresh CDP eval, giving
+            // React more than enough time to flush the toggle's state update.
         }
 
         const thinkResult = await withRetry(() => setFeature(page, 'DeepThink', wantThink));
@@ -102,7 +113,8 @@ export const askCommand = cli({
             }
         }
 
-        if (thinkResult?.toggled || searchResult?.toggled) await page.wait(0.5);
+        // No settle wait after toggles: the next CDP eval below already gives
+        // React time to flush the aria-checked state.
 
         if (kwargs.file) {
             const baseline = await withRetry(() => getBubbleCount(page));
@@ -115,7 +127,8 @@ export const askCommand = cli({
                 // SPA navigates after send; "Promise was collected" means send succeeded
                 if (!String(err?.message || err).includes('Promise was collected')) throw err;
             }
-            await page.wait(3);
+            // waitForResponse polls every 3 s for new bubbles, so the previous
+            // 3 s settle here was a redundant sleep on top of the first poll.
             const result = await waitForResponse(page, baseline, prompt, timeoutMs, wantThink);
             if (!result) {
                 return [{ response: `[NO RESPONSE] No reply within ${kwargs.timeout}s.` }];

--- a/clis/deepseek/detail.js
+++ b/clis/deepseek/detail.js
@@ -2,6 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
     DEEPSEEK_DOMAIN,
+    MESSAGE_SELECTOR,
     ensureOnDeepSeek,
     getVisibleMessages,
     parseDeepSeekConversationId,
@@ -25,7 +26,14 @@ export const detailCommand = cli({
         const id = parseDeepSeekConversationId(kwargs.id);
         await ensureOnDeepSeek(page);
         await page.goto(`https://chat.deepseek.com/a/chat/s/${id}`);
-        await page.wait(5);
+        // Wait for at least one rendered bubble instead of a fixed 5 s sleep.
+        // Empty / invalid conversations fall through to the EmptyResultError
+        // below.
+        try {
+            await page.wait({ selector: MESSAGE_SELECTOR, timeout: 10 });
+        } catch {
+            // No bubble mounted within 10 s; treated as empty by the check below.
+        }
         const messages = await getVisibleMessages(page);
         if (messages.length === 0) {
             throw new EmptyResultError(

--- a/clis/deepseek/new.js
+++ b/clis/deepseek/new.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { DEEPSEEK_DOMAIN, DEEPSEEK_URL } from './utils.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { DEEPSEEK_DOMAIN, DEEPSEEK_URL, TEXTAREA_SELECTOR } from './utils.js';
 
 export const newCommand = cli({
     site: 'deepseek',
@@ -16,7 +17,17 @@ export const newCommand = cli({
 
     func: async (page) => {
         await page.goto(DEEPSEEK_URL);
-        await page.wait(2);
+        // Confirm the composer mounted before reporting success. The previous
+        // 2 s blind sleep would return "New chat started" even when the page
+        // was still loading or the user was logged out.
+        try {
+            await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 8 });
+        } catch {
+            throw new CommandExecutionError(
+                'DeepSeek composer did not mount within 8 s',
+                'Verify you are logged into chat.deepseek.com.',
+            );
+        }
         return [{ Status: 'New chat started' }];
     },
 });

--- a/clis/deepseek/read.js
+++ b/clis/deepseek/read.js
@@ -15,8 +15,9 @@ export const readCommand = cli({
     columns: ['Role', 'Text'],
 
     func: async (page) => {
+        // ensureOnDeepSeek already waits for the composer to mount; the
+        // follow-up 5 s sleep was redundant.
         await ensureOnDeepSeek(page);
-        await page.wait(5);
         const messages = await getVisibleMessages(page);
         if (messages.length > 0) return messages;
         return [{ Role: 'system', Text: 'No visible messages found.' }];

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -43,7 +43,14 @@ export async function isOnDeepSeek(page) {
 export async function ensureOnDeepSeek(page) {
     if (await isOnDeepSeek(page)) return false;
     await page.goto(DEEPSEEK_URL);
-    await page.wait(3);
+    // Wait for the composer textarea instead of a fixed 3 s sleep. On the login
+    // page it never mounts; swallow the timeout so callers (status / read /
+    // history) can still inspect page state.
+    try {
+        await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 8 });
+    } catch {
+        // Login or error page — downstream will see hasTextarea=false / empty results.
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary

Proof template for the **D-LLM** sweep (#OpenCLI thread `3889b5cf`): convert deepseek's 18 `page.wait(N)` fixed-duration sleeps to event-based selector waits where the wait is genuinely tied to a DOM marker. Once this lands cleanly, PRs D2–D8 will copy the same pattern across claude / chatgpt / doubao / yuanbao / qwen / grok / gemini.

10 of 18 sites are touched here. The other 8 (in-loop polling ticks + send.js native-input flush) stay — they are already polling patterns and out of scope for D1.

### Changes

**Page-ready waits** — replaced `page.wait(N)` with `page.wait({ selector, timeout })` (MutationObserver, resolves as soon as the selector matches):

| Site | Old | New |
|------|-----|-----|
| `utils.js:46` (`ensureOnDeepSeek`) | `wait(3)` | wait for `TEXTAREA_SELECTOR`, timeout 8s, swallow on login page |
| `ask.js:38` (`--new` branch) | `wait(3)` | wait for `TEXTAREA_SELECTOR`, timeout 8s |
| `ask.js:52` (resume branch) | `wait(2)` | wait for `TEXTAREA_SELECTOR`, timeout 5s |
| `detail.js:28` | `wait(5)` | wait for `MESSAGE_SELECTOR`, timeout 10s |
| `new.js:19` | `wait(2)` | wait for `TEXTAREA_SELECTOR`, timeout 8s; throw `CommandExecutionError` on miss |

**Redundant settles deleted** (5 sites):

| Site | Reason |
|------|--------|
| `ask.js:56` standalone `wait(2)` | covered by the new selector waits in the if/else above |
| `ask.js:79` post-`selectModel` 0.5s settle | next CDP eval already gives React time to flush `aria-checked` |
| `ask.js:105` post-`setFeature` 0.5s settle | same as above |
| `ask.js:118` pre-`waitForResponse` 3s settle | `waitForResponse`'s first 3s tick already covers this |
| `read.js:19` post-`ensureOnDeepSeek` 5s settle | `ensureOnDeepSeek` now waits for the textarea selector itself |

**Behavior tightening**: `deepseek new` previously returned `Status: 'New chat started'` even when the composer never mounted (e.g., logged-out, network error). It now throws `CommandExecutionError` on timeout with a hint about login.

### What is **not** changed

8 remaining `page.wait(N)` calls in `clis/deepseek/` are kept:
- `utils.js:165` — `waitForResponse` 3s polling tick (response stream)
- `utils.js:281, 323` — sidebar mount polling (5×2s) in `getConversationList` / `pickResumeUrl`
- `utils.js:345` — `waitForFilePreview` polling (8×2s)
- `utils.js:388` — sidebar collapse settle (0.5s)
- `utils.js:452` — send-button-enable polling tick
- `send.js:61` — `nativeType` input flush (0.6s)
- `send.js:135` — `waitForTextareaReady` poll tick

These are already polling patterns or low-risk leaves; tightening them is follow-up work.

## Test plan

- [x] `npm test -- clis/deepseek` — 49/49 pass
- [x] `npm test -- src/browser` — 355/355 pass
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run check:typed-error-lint` — no new violations (baseline 189)
- [x] `npm run check:silent-column-drop` — no new violations (baseline 103)
- [ ] Live smoke: `opencli deepseek ask "ping"` and `opencli deepseek new` cold/warm — perf delta to be measured by reviewers (I do not currently have a reproducible deepseek login on this host)

## Why now

WAWQAQ's twitter-thread perf complaint (#OpenCLI thread `fa209a2c`) put the spotlight on the cookie-split / bare-domain-goto / fixed-wait anti-patterns across the codebase. opencli-user is taking the twitter side (PRs A/B/C); this PR is the deepseek-side proof template for the wait→event sweep. Once merged, D2–D8 follow.