### PR TITLE
perf(adapters): hoist cookie reads to page.getCookies (Tier 1, 25 files)

### DIFF
--- a/clis/linkedin/search.js
+++ b/clis/linkedin/search.js
@@ -245,23 +245,20 @@ async function fetchJobCards(page, input) {
     const MAX_BATCH = 25;
     const allJobs = [];
     let offset = input.start;
+    // Read JSESSIONID directly from the cookie store via CDP — zero page.evaluate round-trip
+    const cookies = await page.getCookies({ domain: '.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+        throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.');
+    }
+    const csrf = jsession.replace(/^"|"$/g, '');
     while (allJobs.length < input.limit) {
         const count = Math.min(MAX_BATCH, input.limit - allJobs.length);
         const apiPath = buildVoyagerUrl(input, offset, count);
         const batch = await page.evaluate(`(async () => {
-      const jsession = document.cookie.split(';').map(p => p.trim())
-        .find(p => p.startsWith('JSESSIONID='))?.slice('JSESSIONID='.length);
-      if (!jsession) {
-        return {
-          authRequired: true,
-          error: 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.'
-        };
-      }
-
-      const csrf = jsession.replace(/^"|"$/g, '');
       const res = await fetch(${JSON.stringify(apiPath)}, {
         credentials: 'include',
-        headers: { 'csrf-token': csrf, 'x-restli-protocol-version': '2.0.0' },
+        headers: { 'csrf-token': ${JSON.stringify(csrf)}, 'x-restli-protocol-version': '2.0.0' },
       });
       if (res.status === 401 || res.status === 403) {
         const text = await res.text();

--- a/clis/linkedin/search.js
+++ b/clis/linkedin/search.js
@@ -246,7 +246,7 @@ async function fetchJobCards(page, input) {
     const allJobs = [];
     let offset = input.start;
     // Read JSESSIONID directly from the cookie store via CDP — zero page.evaluate round-trip
-    const cookies = await page.getCookies({ domain: '.linkedin.com' });
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
     const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
     if (!jsession) {
         throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.');

--- a/clis/maimai/search-talents.js
+++ b/clis/maimai/search-talents.js
@@ -80,17 +80,21 @@ cli({
       },
     };
 
+    // Read csrftoken directly from the cookie store via CDP — zero page.evaluate round-trip
+    const cookies = await page.getCookies({ domain: '.maimai.cn' });
+    const csrftokenFromCookie = cookies.find((c) => c.name === 'csrftoken')?.value || '';
+
     // Execute the search API call in browser context
-    const data = await page.evaluate(async (body) => {
-      // Get CSRF token from cookie or meta tag
-      let csrftoken = document.cookie.split('; ')
-        .find(row => row.startsWith('csrftoken='))
-        ?.split('=')[1] || '';
+    const data = await page.evaluate(`async () => {
+      // Prefer cookie-derived csrftoken (hoisted from CDP); fall back to meta tag
+      let csrftoken = ${JSON.stringify(csrftokenFromCookie)};
 
       if (!csrftoken) {
         const meta = document.querySelector('meta[name="csrf-token"]');
         if (meta) csrftoken = meta.getAttribute('content') || '';
       }
+
+      const body = ${JSON.stringify(requestBody)};
 
       const res = await fetch('https://maimai.cn/api/ent/discover/search?channel=www&data_version=3.0&version=1.0.0', {
         method: 'POST',
@@ -117,7 +121,7 @@ cli({
       }
 
       return result;
-    }, requestBody);
+    }`);
 
     // Extract talent list from response
     const talentList = data.data?.list || data.data?.talent_list || data.list || data.talent_list || [];

--- a/clis/maimai/search-talents.js
+++ b/clis/maimai/search-talents.js
@@ -81,7 +81,7 @@ cli({
     };
 
     // Read csrftoken directly from the cookie store via CDP — zero page.evaluate round-trip
-    const cookies = await page.getCookies({ domain: '.maimai.cn' });
+    const cookies = await page.getCookies({ url: 'https://maimai.cn' });
     const csrftokenFromCookie = cookies.find((c) => c.name === 'csrftoken')?.value || '';
 
     // Execute the search API call in browser context

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -51,12 +51,16 @@ cli({
         // Navigate to the tweet page for cookie context
         await page.goto(`https://x.com/i/status/${tweetId}`);
         await page.wait(3);
+        // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
+        if (!ct0)
+            throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await resolveTwitterQueryId(page, 'TweetResultByRestId', TWEET_RESULT_BY_REST_ID_QUERY_ID);
         const result = await page.evaluate(`
       async () => {
         const tweetId = "${tweetId}";
-        const ct0 = document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1];
-        if (!ct0) return {error: 'No ct0 cookie — not logged into x.com'};
+        const ct0 = ${JSON.stringify(ct0)};
 
         const bearer = ${JSON.stringify(TWITTER_BEARER_TOKEN)};
         const headers = {
@@ -156,8 +160,6 @@ cli({
       }
     `);
         if (result?.error) {
-            if (String(result.error).includes('No ct0 cookie'))
-                throw new AuthRequiredError('x.com', result.error);
             throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
         }
         return result || [];

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -52,7 +52,7 @@ cli({
         await page.goto(`https://x.com/i/status/${tweetId}`);
         await page.wait(3);
         // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -142,9 +142,8 @@ cli({
 
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -142,7 +142,7 @@ cli({
 
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -309,6 +309,7 @@ describe('twitter bookmark-folder command (registry)', () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn().mockResolvedValue([]),
             evaluate: vi.fn().mockResolvedValue(null),
         };
         await expect(command.func(page, { 'folder-id': '12345', limit: 5 }))
@@ -321,14 +322,14 @@ describe('twitter bookmark-folder command (registry)', () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'ct0-token' }]),
             evaluate: vi.fn()
-                .mockResolvedValueOnce('ct0-token')
                 .mockResolvedValueOnce('queryX')
                 .mockResolvedValueOnce({ data: { bookmark_timeline_v2: { timeline: { instructions: [] } } } }),
         };
         const result = await command.func(page, { 'folder-id': 'folder_AbC-123', limit: 5 });
         expect(result).toEqual([]);
-        const fetchScript = page.evaluate.mock.calls[2][0];
+        const fetchScript = page.evaluate.mock.calls[1][0];
         expect(decodeURIComponent(fetchScript)).toContain('"bookmark_collection_id":"folder_AbC-123"');
     });
 });

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -315,6 +315,7 @@ describe('twitter bookmark-folder command (registry)', () => {
         await expect(command.func(page, { 'folder-id': '12345', limit: 5 }))
             .rejects
             .toThrow(/Not logged into x.com/);
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
     });
 
     it('accepts an opaque safe folder-id and sends it in the GraphQL variables', async () => {
@@ -329,6 +330,7 @@ describe('twitter bookmark-folder command (registry)', () => {
         };
         const result = await command.func(page, { 'folder-id': 'folder_AbC-123', limit: 5 });
         expect(result).toEqual([]);
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
         const fetchScript = page.evaluate.mock.calls[1][0];
         expect(decodeURIComponent(fetchScript)).toContain('"bookmark_collection_id":"folder_AbC-123"');
     });

--- a/clis/twitter/bookmark-folders.js
+++ b/clis/twitter/bookmark-folders.js
@@ -82,9 +82,8 @@ cli({
     func: async (page) => {
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 

--- a/clis/twitter/bookmark-folders.js
+++ b/clis/twitter/bookmark-folders.js
@@ -82,7 +82,7 @@ cli({
     func: async (page) => {
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/bookmark-folders.test.js
+++ b/clis/twitter/bookmark-folders.test.js
@@ -143,7 +143,8 @@ describe('twitter bookmark-folders command (registry)', () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue(null), // null cookie → AuthRequired
+            getCookies: vi.fn().mockResolvedValue([]), // no ct0 cookie → AuthRequired
+            evaluate: vi.fn().mockResolvedValue(null),
         };
         await expect(command.func(page, {})).rejects.toThrow(/Not logged into x.com/);
     });

--- a/clis/twitter/bookmark-folders.test.js
+++ b/clis/twitter/bookmark-folders.test.js
@@ -147,5 +147,6 @@ describe('twitter bookmark-folders command (registry)', () => {
             evaluate: vi.fn().mockResolvedValue(null),
         };
         await expect(command.func(page, {})).rejects.toThrow(/Not logged into x.com/);
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
     });
 });

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -114,9 +114,8 @@ cli({
         const limit = kwargs.limit || 20;
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-      return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-    }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await page.evaluate(`async () => {

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -114,7 +114,7 @@ cli({
         const limit = kwargs.limit || 20;
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -160,9 +160,8 @@ cli({
         await page.goto('https://x.com');
         await page.wait(3);
 
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -160,7 +160,7 @@ cli({
         await page.goto('https://x.com');
         await page.wait(3);
 
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/following.test.js
+++ b/clis/twitter/following.test.js
@@ -205,8 +205,8 @@ function createFollowingPage(followingResponses, { ct0 = 'token', userLookup = {
     const page = {
         goto: vi.fn().mockResolvedValue(undefined),
         wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn(async () => (ct0 ? [{ name: 'ct0', value: ct0 }] : [])),
         evaluate: vi.fn(async (script) => {
-            if (script.includes('document.cookie')) return ct0;
             if (script.includes('operationName')) return null;
             if (script.includes('/UserByScreenName')) return userLookup;
             if (script.includes('/Following')) return followingResponses.shift() || followingPayload([], null);

--- a/clis/twitter/following.test.js
+++ b/clis/twitter/following.test.js
@@ -228,6 +228,7 @@ describe('twitter following command', () => {
         const rows = await command.func(page, { user: '@elonmusk', limit: 3 });
 
         expect(rows.map((row) => row.screen_name)).toEqual(['alice', 'bob', 'carol']);
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
         const userLookupScript = page.evaluate.mock.calls.find(([script]) => script.includes('/UserByScreenName'))?.[0] || '';
         expect(decodeURIComponent(userLookupScript)).toContain('"screen_name":"elonmusk"');
         expect(decodeURIComponent(userLookupScript)).not.toContain('"screen_name":"@elonmusk"');

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -153,9 +153,8 @@ cli({
         let username = (kwargs.username || '').replace(/^@/, '');
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-      return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-    }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         // If no username provided, detect the logged-in user

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -153,7 +153,7 @@ cli({
         let username = (kwargs.username || '').replace(/^@/, '');
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/list-add.js
+++ b/clis/twitter/list-add.js
@@ -86,9 +86,8 @@ cli({
         }
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
         const userByScreenNameQueryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);

--- a/clis/twitter/list-add.js
+++ b/clis/twitter/list-add.js
@@ -86,7 +86,7 @@ cli({
         }
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 

--- a/clis/twitter/list-remove.js
+++ b/clis/twitter/list-remove.js
@@ -94,9 +94,8 @@ cli({
 
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
         const userByScreenNameQueryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);

--- a/clis/twitter/list-remove.js
+++ b/clis/twitter/list-remove.js
@@ -94,7 +94,7 @@ cli({
 
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -126,9 +126,8 @@ cli({
         const limit = kwargs.limit || 50;
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await page.evaluate(`async () => {

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -126,7 +126,7 @@ cli({
         const limit = kwargs.limit || 50;
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -100,9 +100,8 @@ export const command = cli({
         const limit = kwargs.limit || 50;
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await page.evaluate(`async () => {

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -100,7 +100,7 @@ export const command = cli({
         const limit = kwargs.limit || 50;
         await page.goto('https://x.com');
         await page.wait(3);
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -32,12 +32,16 @@ cli({
         // Navigate directly to the user's profile page (gives us cookie context)
         await page.goto(`https://x.com/${username}`);
         await page.wait(3);
+        // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
+        if (!ct0)
+            throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
         const result = await page.evaluate(`
       async () => {
         const screenName = "${username}";
-        const ct0 = document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1];
-        if (!ct0) return {error: 'No ct0 cookie — not logged into x.com'};
+        const ct0 = ${JSON.stringify(ct0)};
 
         const bearer = ${JSON.stringify(TWITTER_BEARER_TOKEN)};
         const headers = {
@@ -96,8 +100,6 @@ cli({
       }
     `);
         if (result?.error) {
-            if (String(result.error).includes('No ct0 cookie'))
-                throw new AuthRequiredError('x.com', result.error);
             throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
         }
         return result || [];

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -33,7 +33,7 @@ cli({
         await page.goto(`https://x.com/${username}`);
         await page.wait(3);
         // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -114,10 +114,9 @@ cli({
         // Navigate to x.com for cookie context
         await page.goto('https://x.com');
         await page.wait(3);
-        // Extract CSRF token — the only thing we need from the browser
-        const ct0 = await page.evaluate(`() => {
-      return document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1] || null;
-    }`);
+        // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         // Build auth headers in TypeScript

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -115,7 +115,7 @@ cli({
         await page.goto('https://x.com');
         await page.wait(3);
         // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -159,10 +159,9 @@ cli({
         // Navigate to x.com for cookie context
         await page.goto('https://x.com');
         await page.wait(3);
-        // Extract CSRF token
-        const ct0 = await page.evaluate(`() => {
-      return document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1] || null;
-    }`);
+        // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         // Dynamically resolve queryId for the selected endpoint

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -160,7 +160,7 @@ cli({
         await page.goto('https://x.com');
         await page.wait(3);
         // Read CSRF token directly from the cookie store via CDP — zero page.evaluate round-trip
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/trending.js
+++ b/clis/twitter/trending.js
@@ -26,10 +26,9 @@ cli({
         // Navigate to trending page
         await page.goto('https://x.com/explore/tabs/trending');
         await page.wait(3);
-        // Verify login via CSRF cookie
-        const ct0 = await page.evaluate(`(() => {
-      return document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1] || null;
-    })()`);
+        // Verify login via CSRF cookie (read directly from cookie store via CDP)
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         await page.wait(2);

--- a/clis/twitter/trending.js
+++ b/clis/twitter/trending.js
@@ -27,7 +27,7 @@ cli({
         await page.goto('https://x.com/explore/tabs/trending');
         await page.wait(3);
         // Verify login via CSRF cookie (read directly from cookie store via CDP)
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -163,9 +163,8 @@ cli({
         await page.goto('https://x.com');
         await page.wait(3);
 
-        const ct0 = await page.evaluate(`() => {
-      return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-    }`);
+        const cookies = await page.getCookies({ domain: '.x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
         const userTweetsQueryId = await resolveTwitterQueryId(page, 'UserTweets', USER_TWEETS_QUERY_ID);

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -163,7 +163,7 @@ cli({
         await page.goto('https://x.com');
         await page.wait(3);
 
-        const cookies = await page.getCookies({ domain: '.x.com' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 

--- a/clis/youtube/like.js
+++ b/clis/youtube/like.js
@@ -2,7 +2,7 @@
  * YouTube like — like a video via InnerTube like API (requires SAPISIDHASH auth).
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { parseVideoId, prepareYoutubeApiPage, SAPISID_HASH_FN } from './utils.js';
+import { parseVideoId, prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -19,6 +19,10 @@ cli({
     func: async (page, kwargs) => {
         const videoId = parseVideoId(String(kwargs.url));
         await prepareYoutubeApiPage(page);
+        // Read SAPISID directly from the cookie store via CDP — zero document.cookie round-trip
+        const sapisid = await readYoutubeSapisid(page);
+        if (!sapisid)
+            throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
         const result = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
@@ -28,7 +32,7 @@ cli({
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return { error: 'config', message: 'YouTube config not found' };
 
-        const authHash = await getSapisidHash('https://www.youtube.com');
+        const authHash = await getSapisidHash(${JSON.stringify(sapisid)}, 'https://www.youtube.com');
         if (!authHash) return { error: 'auth', message: 'Not logged in (SAPISID cookie missing)' };
 
         const resp = await fetch('/youtubei/v1/like/like?key=' + apiKey + '&prettyPrint=false', {

--- a/clis/youtube/subscribe.js
+++ b/clis/youtube/subscribe.js
@@ -2,7 +2,7 @@
  * YouTube subscribe — subscribe to a channel via InnerTube subscription API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { prepareYoutubeApiPage, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN } from './utils.js';
+import { prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -19,6 +19,10 @@ cli({
     func: async (page, kwargs) => {
         const channelInput = String(kwargs.channel);
         await prepareYoutubeApiPage(page);
+        // Read SAPISID directly from the cookie store via CDP — zero document.cookie round-trip
+        const sapisid = await readYoutubeSapisid(page);
+        if (!sapisid)
+            throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
         const result = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
@@ -28,7 +32,7 @@ cli({
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return { error: 'config', message: 'YouTube config not found' };
 
-        const authHash = await getSapisidHash('https://www.youtube.com');
+        const authHash = await getSapisidHash(${JSON.stringify(sapisid)}, 'https://www.youtube.com');
         if (!authHash) return { error: 'auth', message: 'Not logged in (SAPISID cookie missing)' };
 
         ${RESOLVE_CHANNEL_HANDLE_FN}

--- a/clis/youtube/unlike.js
+++ b/clis/youtube/unlike.js
@@ -2,7 +2,7 @@
  * YouTube unlike — remove like from a video via InnerTube like API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { parseVideoId, prepareYoutubeApiPage, SAPISID_HASH_FN } from './utils.js';
+import { parseVideoId, prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -19,6 +19,10 @@ cli({
     func: async (page, kwargs) => {
         const videoId = parseVideoId(String(kwargs.url));
         await prepareYoutubeApiPage(page);
+        // Read SAPISID directly from the cookie store via CDP — zero document.cookie round-trip
+        const sapisid = await readYoutubeSapisid(page);
+        if (!sapisid)
+            throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
         const result = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
@@ -28,7 +32,7 @@ cli({
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return { error: 'config', message: 'YouTube config not found' };
 
-        const authHash = await getSapisidHash('https://www.youtube.com');
+        const authHash = await getSapisidHash(${JSON.stringify(sapisid)}, 'https://www.youtube.com');
         if (!authHash) return { error: 'auth', message: 'Not logged in (SAPISID cookie missing)' };
 
         const resp = await fetch('/youtubei/v1/like/removelike?key=' + apiKey + '&prettyPrint=false', {

--- a/clis/youtube/unsubscribe.js
+++ b/clis/youtube/unsubscribe.js
@@ -2,7 +2,7 @@
  * YouTube unsubscribe — unsubscribe from a channel via InnerTube subscription API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { prepareYoutubeApiPage, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN } from './utils.js';
+import { prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -19,6 +19,10 @@ cli({
     func: async (page, kwargs) => {
         const channelInput = String(kwargs.channel);
         await prepareYoutubeApiPage(page);
+        // Read SAPISID directly from the cookie store via CDP — zero document.cookie round-trip
+        const sapisid = await readYoutubeSapisid(page);
+        if (!sapisid)
+            throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
         const result = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
@@ -28,7 +32,7 @@ cli({
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return { error: 'config', message: 'YouTube config not found' };
 
-        const authHash = await getSapisidHash('https://www.youtube.com');
+        const authHash = await getSapisidHash(${JSON.stringify(sapisid)}, 'https://www.youtube.com');
         if (!authHash) return { error: 'auth', message: 'Not logged in (SAPISID cookie missing)' };
 
         ${RESOLVE_CHANNEL_HANDLE_FN}

--- a/clis/youtube/utils.js
+++ b/clis/youtube/utils.js
@@ -189,21 +189,13 @@ async function resolveChannelHandle(input, apiKey, context) {
  * Inline SAPISIDHASH helper for use inside page.evaluate() strings.
  * YouTube write APIs (like, subscribe) require:
  *   Authorization: SAPISIDHASH {time}_{SHA1(time + " " + SAPISID + " " + origin)}
+ *
+ * The SAPISID cookie value must be hoisted from the cookie store on the Node side
+ * (via `readYoutubeSapisid(page)`) and passed in here — keeps `crypto.subtle.digest`
+ * (browser Web Crypto) call site, but no `document.cookie` round-trip.
  */
 export const SAPISID_HASH_FN = `
-async function getSapisidHash(origin) {
-  const cookies = document.cookie.split('; ');
-  let sapisid = '';
-  for (const c of cookies) {
-    const eq = c.indexOf('=');
-    if (eq === -1) continue;
-    const name = c.slice(0, eq);
-    const val = c.slice(eq + 1);
-    if (name === '__Secure-3PAPISID' || name === 'SAPISID') {
-      sapisid = val;
-      if (name === '__Secure-3PAPISID') break;
-    }
-  }
+async function getSapisidHash(sapisid, origin) {
   if (!sapisid) return null;
   const time = Math.floor(Date.now() / 1000);
   const msgBuffer = new TextEncoder().encode(time + ' ' + sapisid + ' ' + origin);
@@ -212,3 +204,17 @@ async function getSapisidHash(origin) {
   return 'SAPISIDHASH ' + time + '_' + hashHex;
 }
 `;
+
+/**
+ * Read the YouTube SAPISID cookie via CDP, preferring `__Secure-3PAPISID`
+ * (current first-party cookie) and falling back to the legacy `SAPISID` name.
+ * Returns the cookie value, or null if neither is present.
+ */
+export async function readYoutubeSapisid(page) {
+  const cookies = await page.getCookies({ domain: '.youtube.com' });
+  return (
+    cookies.find((c) => c.name === '__Secure-3PAPISID')?.value
+    || cookies.find((c) => c.name === 'SAPISID')?.value
+    || null
+  );
+}

--- a/clis/youtube/utils.js
+++ b/clis/youtube/utils.js
@@ -211,7 +211,7 @@ async function getSapisidHash(sapisid, origin) {
  * Returns the cookie value, or null if neither is present.
  */
 export async function readYoutubeSapisid(page) {
-  const cookies = await page.getCookies({ domain: '.youtube.com' });
+  const cookies = await page.getCookies({ url: 'https://www.youtube.com' });
   return (
     cookies.find((c) => c.name === '__Secure-3PAPISID')?.value
     || cookies.find((c) => c.name === 'SAPISID')?.value

--- a/clis/youtube/utils.test.js
+++ b/clis/youtube/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { extractJsonAssignmentFromHtml, extractSubscriptionChannel, prepareYoutubeApiPage } from './utils.js';
+import { extractJsonAssignmentFromHtml, extractSubscriptionChannel, prepareYoutubeApiPage, readYoutubeSapisid } from './utils.js';
 describe('youtube utils', () => {
     it('extractJsonAssignmentFromHtml parses bootstrap objects with nested braces in strings', () => {
         const html = `
@@ -33,6 +33,22 @@ describe('youtube utils', () => {
         await expect(prepareYoutubeApiPage(page)).resolves.toBeUndefined();
         expect(page.goto).toHaveBeenCalledWith('https://www.youtube.com', { waitUntil: 'none' });
         expect(page.wait).toHaveBeenCalledWith(2);
+    });
+    it('readYoutubeSapisid reads URL-scoped cookies and prefers secure SAPISID', async () => {
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([
+                { name: 'SAPISID', value: 'legacy' },
+                { name: '__Secure-3PAPISID', value: 'secure' },
+            ]),
+        };
+        await expect(readYoutubeSapisid(page)).resolves.toBe('secure');
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://www.youtube.com' });
+    });
+    it('readYoutubeSapisid falls back to legacy SAPISID', async () => {
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'SAPISID', value: 'legacy' }]),
+        };
+        await expect(readYoutubeSapisid(page)).resolves.toBe('legacy');
     });
     it('extractSubscriptionChannel prefers explicit handle and subscriber count fields', () => {
         expect(extractSubscriptionChannel({


### PR DESCRIPTION
## Summary

Replaces `page.evaluate(\`document.cookie.split…\`)` round-trips with direct CDP `page.getCookies({domain})` reads across **25 files** in 4 sites (twitter / linkedin / maimai / youtube). Part of the goto-and-wait audit follow-up per #OpenCLI msg=fa209a2c.

`twitter thread 2051987950200648006` cold-run profile breakdown (with framework pre-nav already in place) showed `goto + wait(3) + page.evaluate(document.cookie)` together accounted for ~20s of a 35s run; this PR is the first surgical cut — removing the `document.cookie` extraction path. Sibling PRs B (`browserSession: { reuse: 'site' }` for read-only twitter) and C (delete the redundant in-func `goto + wait`) are scoped separately.

## Patterns

| Site | Files | Pattern |
|---|---|---|
| twitter | 13 | Cookie was extracted *outside* `page.evaluate` — direct 4-line replacement: `await page.getCookies({domain:'.x.com'})` + `cookies.find((c) => c.name === 'ct0')?.value` |
| twitter | 2 (article, profile) | Cookie was extracted *inside* `page.evaluate` — hoisted out and `AuthRequiredError` is now thrown upfront on the Node side, dropping the unreachable in-evaluate `error: 'No ct0 cookie'` branch + its outside re-throw |
| linkedin | 1 (search) | `JSESSIONID` was read inside the per-batch fetch loop — hoisted once before the loop, `csrf` interpolated into the fetch template as `JSON.stringify(csrf)` |
| maimai | 1 (search-talents) | csrftoken cookie hoisted; meta-tag fallback preserved inside the template. Also converted the `page.evaluate(async (body) => …, body)` Playwright-style call (which doesn't match OpenCLI's `evaluate(js: string)` signature) to a template-string form so the helper actually runs |
| youtube | 5 (utils + like/unlike/subscribe/unsubscribe) | `SAPISID_HASH_FN` reshaped to take `sapisid` as a parameter; new `readYoutubeSapisid(page)` helper reads `__Secure-3PAPISID` (preferred) / `SAPISID` via CDP. HMAC-SHA1 compute still happens browser-side (Web Crypto); only the cookie read is hoisted |

## Tests

`twitter/following.test.js`, `twitter/bookmark-folder.test.js`, `twitter/bookmark-folders.test.js` had mocks specifically asserting `script.includes('document.cookie')` or returning ct0 from a generic `evaluate` — switched to mocking `getCookies` (returning `[{name:'ct0',value:'...'}]` or `[]`) which is now the actual call path.

## Lint / type checks

- `npx tsc --noEmit` clean
- `npx vitest run clis/twitter clis/linkedin clis/youtube` → **264/264 pass**
- `node scripts/check-typed-error-lint.mjs` → 189/189 (no new violations)
- `node scripts/check-silent-column-drop.mjs` → 103/103 (no new violations)

## Scope notes

This PR is intentionally minimal:
- **PR B (separate)** will roll out `browserSession: { reuse: 'site' }` to read-only twitter adapters.
- **PR C (separate)** will delete the now-redundant `await page.goto('https://x.com'); await page.wait(3)` calls that were retained here for blast-radius reasons.
- `document.cookie.match(...)` patterns (instagram 8 / xiaoe / qwen / hupu / tiktok / 1point3acres — ~13 files) are outside the original `document.cookie.split` audit scope; will follow as a Tier 1 expansion sweep.

## Test plan

- [x] `npx vitest run clis/twitter clis/linkedin clis/youtube` (264/264)
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-typed-error-lint.mjs`
- [x] `node scripts/check-silent-column-drop.mjs`
- [ ] Live verify: `opencli twitter thread <id>` end-to-end (covered separately by goto/reuse PRs since this PR alone is identity-preserving for the cookie code path)