### PR TITLE
perf(claude): replace fixed-sleep waits with selector-based readiness (D2)

### DIFF
--- a/clis/claude/ask.js
+++ b/clis/claude/ask.js
@@ -1,7 +1,8 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
-    CLAUDE_DOMAIN, CLAUDE_URL, ensureOnClaude, selectModel, setAdaptiveThinking,
+    CLAUDE_DOMAIN, CLAUDE_URL, COMPOSER_SELECTOR, MESSAGE_SELECTOR,
+    ensureOnClaude, selectModel, setAdaptiveThinking,
     sendMessage, sendWithFile, getBubbleCount, waitForResponse, parseBoolFlag, withRetry,
     ensureClaudeComposer, requireNonEmptyPrompt, requirePositiveInt,
 } from './utils.js';
@@ -38,7 +39,11 @@ export const askCommand = cli({
 
         if (parseBoolFlag(kwargs.new)) {
             await page.goto(CLAUDE_URL);
-            await page.wait(3);
+            try {
+                await page.wait({ selector: COMPOSER_SELECTOR, timeout: 8 });
+            } catch {
+                // Composer didn't mount; ensureClaudeComposer below surfaces a typed error.
+            }
         } else {
             const navigated = await ensureOnClaude(page);
             if (navigated) {
@@ -48,11 +53,18 @@ export const askCommand = cli({
                     var link = document.querySelector('a[href*="/chat/"]');
                     if (link) link.click();
                 })()`);
-                await page.wait(2);
+                // Wait for the resumed conversation to render messages, or
+                // fall through if the link click had no effect (no recents).
+                try {
+                    await page.wait({ selector: MESSAGE_SELECTOR, timeout: 5 });
+                } catch {
+                    // No prior conversation; ensureClaudeComposer still requires composer below.
+                }
             }
         }
 
-        await page.wait(2);
+        // ensureClaudeComposer reads composer presence directly via getPageState,
+        // so the previous standalone 2 s settle is redundant.
         await withRetry(() => ensureClaudeComposer(page, 'Claude ask requires a visible composer on the current page.'));
 
         // Model selector is only available on the new-chat page, not inside
@@ -80,14 +92,16 @@ export const askCommand = cli({
                 }
                 throw new CommandExecutionError(`Could not switch to ${wantModel} model`);
             }
-            if (modelResult?.toggled) await page.wait(0.5);
+            // Post-toggle settle dropped — the next CDP eval (setAdaptiveThinking) gives
+            // React enough time to flush aria-checked updates between rountrips.
         }
 
         const thinkResult = await withRetry(() => setAdaptiveThinking(page, wantThink));
         if (!thinkResult?.ok && wantThink) {
             throw new CommandExecutionError('Could not enable Adaptive thinking');
         }
-        if (thinkResult?.toggled) await page.wait(0.5);
+        // Post-toggle settle dropped — the next CDP eval (sendMessage / sendWithFile)
+        // gives React enough time to flush aria-checked updates.
 
         if (kwargs.file) {
             const baseline = await withRetry(() => getBubbleCount(page));
@@ -100,7 +114,8 @@ export const askCommand = cli({
                 // SPA navigates after send; "Promise was collected" means send succeeded
                 if (!String(err?.message || err).includes('Promise was collected')) throw err;
             }
-            await page.wait(3);
+            // Pre-waitForResponse settle dropped — waitForResponse's first 3 s polling
+            // tick covers the same window without an unconditional sleep.
             const result = await waitForResponse(page, baseline, prompt, timeoutMs);
             if (!result) {
                 throw new EmptyResultError(

--- a/clis/claude/detail.js
+++ b/clis/claude/detail.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { CLAUDE_DOMAIN, getVisibleMessages, ensureClaudeLogin, requireConversationId } from './utils.js';
+import { CLAUDE_DOMAIN, MESSAGE_SELECTOR, getVisibleMessages, ensureClaudeLogin, requireConversationId } from './utils.js';
 
 export const detailCommand = cli({
     site: 'claude',
@@ -21,7 +21,14 @@ export const detailCommand = cli({
         const id = requireConversationId(kwargs.id);
 
         await page.goto(`https://claude.ai/chat/${id}`);
-        await page.wait(4);
+        // Wait for the first assistant message bubble to render instead of a
+        // fixed 4 s sleep. Swallow the timeout so empty conversations and
+        // login redirects fall through to ensureClaudeLogin / EmptyResultError.
+        try {
+            await page.wait({ selector: MESSAGE_SELECTOR, timeout: 10 });
+        } catch {
+            // Empty conversation, missing access, or login redirect — handled below.
+        }
         await ensureClaudeLogin(page, 'Claude detail requires a logged-in Claude session.');
 
         const messages = await getVisibleMessages(page);

--- a/clis/claude/new.js
+++ b/clis/claude/new.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CLAUDE_DOMAIN, CLAUDE_URL, ensureClaudeComposer } from './utils.js';
+import { CLAUDE_DOMAIN, CLAUDE_URL, COMPOSER_SELECTOR, ensureClaudeComposer } from './utils.js';
 
 export const newCommand = cli({
     site: 'claude',
@@ -16,7 +16,13 @@ export const newCommand = cli({
 
     func: async (page) => {
         await page.goto(CLAUDE_URL);
-        await page.wait(2);
+        // Wait for the composer to mount instead of a fixed 2 s sleep. If it
+        // never mounts, swallow and let ensureClaudeComposer surface a typed error.
+        try {
+            await page.wait({ selector: COMPOSER_SELECTOR, timeout: 8 });
+        } catch {
+            // Login or error page — ensureClaudeComposer below throws AuthRequiredError / CommandExecutionError.
+        }
         await ensureClaudeComposer(page, 'Claude new requires a logged-in Claude session with a visible composer.');
         return [{ Status: 'New chat started' }];
     },

--- a/clis/claude/read.js
+++ b/clis/claude/read.js
@@ -16,8 +16,9 @@ export const readCommand = cli({
     columns: ['Index', 'Role', 'Text'],
 
     func: async (page) => {
+        // ensureOnClaude now waits for the composer selector; the previous post-nav
+        // 3 s settle is covered by that event-based wait.
         await ensureOnClaude(page);
-        await page.wait(3);
         await ensureClaudeLogin(page, 'Claude read requires a logged-in Claude session.');
         const messages = await getVisibleMessages(page);
         if (messages.length > 0) return messages;

--- a/clis/claude/send.js
+++ b/clis/claude/send.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { CLAUDE_DOMAIN, CLAUDE_URL, ensureOnClaude, sendMessage, parseBoolFlag, withRetry, ensureClaudeComposer, requireNonEmptyPrompt } from './utils.js';
+import { CLAUDE_DOMAIN, CLAUDE_URL, COMPOSER_SELECTOR, ensureOnClaude, sendMessage, parseBoolFlag, withRetry, ensureClaudeComposer, requireNonEmptyPrompt } from './utils.js';
 
 export const sendCommand = cli({
     site: 'claude',
@@ -23,10 +23,15 @@ export const sendCommand = cli({
 
         if (parseBoolFlag(kwargs.new)) {
             await page.goto(CLAUDE_URL);
-            await page.wait(3);
+            try {
+                await page.wait({ selector: COMPOSER_SELECTOR, timeout: 8 });
+            } catch {
+                // Composer didn't mount; ensureClaudeComposer below surfaces a typed error.
+            }
         } else {
+            // ensureOnClaude now waits for the composer selector; the previous
+            // post-nav 2 s settle is covered by that event-based wait.
             await ensureOnClaude(page);
-            await page.wait(2);
         }
         await withRetry(() => ensureClaudeComposer(page, 'Claude send requires a visible composer on the current page.'));
 

--- a/clis/claude/utils.js
+++ b/clis/claude/utils.js
@@ -26,7 +26,14 @@ export async function isOnClaude(page) {
 export async function ensureOnClaude(page) {
     if (await isOnClaude(page)) return false;
     await page.goto(CLAUDE_URL);
-    await page.wait(3);
+    // Wait for the composer textarea instead of a fixed 3 s sleep. On the login
+    // page it never mounts; swallow the timeout so callers (read / detail /
+    // send) can still inspect page state and produce typed errors.
+    try {
+        await page.wait({ selector: COMPOSER_SELECTOR, timeout: 8 });
+    } catch {
+        // Login or error page — downstream ensureClaudeLogin / ensureClaudeComposer surfaces a typed error.
+    }
     return true;
 }
 
@@ -111,7 +118,13 @@ export async function getVisibleMessages(page) {
 export async function getConversationList(page) {
     if (!(await isOnClaude(page)) || !(await page.evaluate('window.location.href') || '').includes('/recents')) {
         await page.goto('https://claude.ai/recents');
-        await page.wait(3);
+        // Recents list mounts <a href="/chat/...">; an empty history is also
+        // valid (returns []), so swallow the timeout instead of raising.
+        try {
+            await page.wait({ selector: 'a[href*="/chat/"]', timeout: 8 });
+        } catch {
+            // Empty history or login page — downstream evaluate returns [].
+        }
     }
     const items = await page.evaluate(`(() => {
         var links = Array.from(document.querySelectorAll('a[href*="/chat/"]'));
@@ -147,7 +160,12 @@ export async function selectModel(page, modelName) {
     if (!opened?.ok) return opened;
     if (!opened.opened) return opened;
 
-    await page.wait(0.6);
+    // Wait for the dropdown menu items to mount instead of a fixed 0.6 s sleep.
+    try {
+        await page.wait({ selector: 'div[role="menuitemradio"]', timeout: 3 });
+    } catch {
+        // Dropdown didn't open — next evaluate finds no target and returns { ok: false }.
+    }
 
     return page.evaluate(`(() => {
         var items = Array.from(document.querySelectorAll('div[role="menuitemradio"]'));
@@ -175,7 +193,12 @@ export async function setAdaptiveThinking(page, enabled) {
     })()`);
     if (!opened?.ok) return { ok: false };
 
-    await page.wait(0.6);
+    // Wait for the dropdown menu items to mount instead of a fixed 0.6 s sleep.
+    try {
+        await page.wait({ selector: 'div[role="menuitem"]', timeout: 3 });
+    } catch {
+        // Dropdown didn't open — next evaluate finds no target and returns { ok: false }.
+    }
 
     return page.evaluate(`(() => {
         var items = Array.from(document.querySelectorAll('div[role="menuitem"]'));


### PR DESCRIPTION
## Summary
- D2 in the LLM-adapter wait→event sweep started by deepseek (D1, #1449)
- Convert 9 of 18 \`page.wait(N)\` calls in \`clis/claude/\` from fixed-duration sleeps to event-based readiness checks (\`page.wait({ selector, timeout })\`)
- Drop 6 redundant settle waits whose function is already covered by the next CDP roundtrip or the new event waits
- Keep 3 in-loop polling / React-debounce slots out of scope

## Wait site classification (18 sites)

**Converted (9):**
| File | Site | New selector | Why |
|------|------|--------------|-----|
| utils.js:29 | \`ensureOnClaude\` post-goto | \`COMPOSER_SELECTOR\` | composer is the canonical "page is ready" signal |
| utils.js:114 | \`getConversationList\` post-goto-/recents | \`a[href*="/chat/"]\` | recents links mount when history loads |
| utils.js:150 | \`selectModel\` post-trigger.click() | \`div[role="menuitemradio"]\` | dropdown menuitems mount when open |
| utils.js:178 | \`setAdaptiveThinking\` post-trigger.click() | \`div[role="menuitem"]\` | same |
| ask.js:41 | \`--new\` path post-goto | \`COMPOSER_SELECTOR\` | matches \`ensureOnClaude\` semantics |
| ask.js:51 | resume-conversation post-link.click() | \`MESSAGE_SELECTOR\` | resumed conversation renders bubbles |
| new.js:19 | post-goto | \`COMPOSER_SELECTOR\` | downstream \`ensureClaudeComposer\` already throws if missing |
| detail.js:24 | post-goto-/chat/{id} | \`MESSAGE_SELECTOR\` | first assistant bubble |
| send.js:26 | \`--new\` path post-goto | \`COMPOSER_SELECTOR\` | same as ask.js:41 |

All wrapped in \`try { ... } catch { /* fall through */ }\` so login redirects, empty conversations, and missing access still produce the right typed error downstream (\`AuthRequiredError\` / \`CommandExecutionError\` / \`EmptyResultError\`).

**Deleted (6):**
| File | Site | Why dropping is safe |
|------|------|----------------------|
| ask.js:55 | standalone settle | \`ensureClaudeComposer\` reads composer presence directly via \`getPageState\` |
| ask.js:83 | post-\`selectModel\` toggle settle | next CDP eval (\`setAdaptiveThinking\`) gives React enough time to flush \`aria-checked\` between roundtrips |
| ask.js:90 | post-\`setAdaptiveThinking\` toggle settle | same — next CDP eval (\`sendMessage\`) flushes |
| ask.js:103 | pre-\`waitForResponse\` settle | the polling loop's first 3 s tick already covers this window |
| read.js:20 | post-\`ensureOnClaude\` sleep | \`ensureOnClaude\` now waits for the composer selector itself |
| send.js:29 | post-\`ensureOnClaude\` sleep | same |

**Kept (3):**
- \`utils.js:231\` post-input 1.2 s React debounce inside \`sendMessage\` — the ProseMirror editor needs a debounce window before the send button enables; reducing this risks silent send-button-disabled drops.
- \`utils.js:276\` 3 s polling tick inside \`waitForResponse\` — already a polling pattern.
- \`utils.js:330\` 1 s polling tick inside \`waitForFilePreview\` — same.

## Verifications
- \`npx vitest run clis/claude src/browser\`: 389/389 pass (28 files)
- \`npx tsc --noEmit\`: clean
- \`npm run build\`: 801 manifest entries, no errors
- \`npm run check:typed-error-lint\`: current=189, baseline=189, new=0
- \`npm run check:silent-column-drop\`: current=103, baseline=103, new=0

## Test plan
- [x] Targeted unit tests on clis/claude pass
- [x] Browser runtime tests on src/browser pass
- [x] No new typed-error / silent-column-drop violations
- [ ] Smoke: \`opencli claude read\` against an active session (manual; requires Claude login — happy to run on request)
- [ ] Smoke: \`opencli claude detail <id>\` against a real conversation