### PR TITLE
refactor(browser): split interactive and automation windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ⚠ BREAKING CHANGES
+
+* **browser lifecycle** — replace `--focus` / `OPENCLI_WINDOW_FOCUSED` with `--window foreground|background` / `OPENCLI_WINDOW`, and replace `--live` / `OPENCLI_LIVE` with `--keep-tab true|false` / `OPENCLI_KEEP_TAB`. `opencli browser *` defaults to a foreground window and keeps its tab; browser-backed adapter commands default to a background automation window and release their tab unless the adapter uses site-level reuse.
+
 ### Features
 
 * **help / browser** — `opencli browser --help -f yaml|json` now emits a structured, agent-ready index of all browser leaf commands (including nested `tab`, `get`, and `dialog` commands), their positionals, command options, namespace options, and root global options. Individual browser commands also support structured help, backed by a shared Commander option/argument spec extractor.

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ OpenCLI is not only for websites. It can also:
 |----------|---------|-------------|
 | `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge |
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
-| `OPENCLI_WINDOW_FOCUSED` | `false` | Set to `1` to open the automation container in the foreground (useful for debugging). The `--focus` flag sets this. |
-| `OPENCLI_LIVE` | `false` | Set to `1` to keep the automation lease open after an adapter command finishes (useful for inspection). The `--live` flag sets this. |
+| `OPENCLI_WINDOW` | command default | Set to `foreground` or `background` to override Browser Bridge window placement. Browser-backed commands also accept `--window <foreground\|background>`. |
+| `OPENCLI_KEEP_TAB` | command default | Set to `true` or `false` to keep or release the browser tab lease after a browser-backed command. Browser-backed commands also accept `--keep-tab <true\|false>`. |
 | `OPENCLI_BROWSER_REUSE` | adapter default | Set to `none` or `site` to override adapter browser tab reuse. The `--reuse <none\|site>` flag sets this. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
@@ -208,7 +208,7 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
-`--focus` works for both `opencli browser *` and browser-backed adapter commands. `--live` is mainly for adapter commands: browser subcommands already keep the automation lease open until you run `opencli browser close` or the idle timeout expires. Some interactive adapters default to `--reuse site` so repeated commands continue in the same site tab; pass `--reuse none` for a one-shot tab.
+`opencli browser *` uses a foreground browser window and keeps its tab lease by default. Browser-backed adapters use a background automation window and release one-shot tab leases by default. Some interactive adapters default to `--reuse site`, which also keeps the site tab lease; pass `--reuse none` for a one-shot tab.
 
 ## Update
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,8 +181,8 @@ OpenCLI 不只是网站 CLI，还可以：
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `OPENCLI_DAEMON_PORT` | `19825` | daemon-extension 通信端口 |
-| `OPENCLI_WINDOW_FOCUSED` | `false` | 设为 `1` 时 automation 窗口在前台打开（适合调试）。`--focus` 标志会设置此变量 |
-| `OPENCLI_LIVE` | `false` | 设为 `1` 时 adapter 命令执行完后保留 automation 窗口不关闭（适合检查页面）。`--live` 标志会设置此变量 |
+| `OPENCLI_WINDOW` | 命令默认值 | 设为 `foreground` 或 `background` 来覆盖 Browser Bridge 窗口位置。浏览器型命令也支持 `--window <foreground\|background>` |
+| `OPENCLI_KEEP_TAB` | 命令默认值 | 设为 `true` 或 `false` 来控制浏览器型命令结束后是否保留 tab lease。浏览器型命令也支持 `--keep-tab <true\|false>` |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | 浏览器连接超时（秒） |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |
@@ -190,7 +190,7 @@ OpenCLI 不只是网站 CLI，还可以：
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |
 | `DEBUG_SNAPSHOT` | — | 设为 `1` 输出 DOM 快照调试信息 |
 
-`--focus` 同时适用于 `opencli browser *` 和浏览器型 adapter 命令。`--live` 主要是给 adapter 命令用的：`browser` 子命令本来就会一直保留 automation window，直到你手动执行 `opencli browser close` 或等空闲超时。
+`opencli browser *` 默认使用前台窗口并保留 tab lease，直到你手动执行 `opencli browser close` 或等空闲超时。浏览器型 adapter 默认使用后台 automation 窗口并在命令结束后释放 tab lease；如果需要调试最终页面，可以传 `--window foreground --keep-tab true`。
 
 ## 更新
 

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -750,17 +750,21 @@ function scheduleReconnect() {
   }, delay);
 }
 const automationSessions = /* @__PURE__ */ new Map();
-let ownedContainerWindowId = null;
-let ownedContainerGroupId = null;
 const IDLE_TIMEOUT_DEFAULT = 3e4;
 const IDLE_TIMEOUT_INTERACTIVE = 6e5;
 const IDLE_TIMEOUT_NONE = -1;
-const REGISTRY_KEY = "opencli_target_lease_registry_v1";
+const REGISTRY_KEY = "opencli_target_lease_registry_v2";
 const LEASE_IDLE_ALARM_PREFIX = "opencli:lease-idle:";
-const AUTOMATION_TAB_GROUP_TITLE = "OpenCLI";
+const CONTAINER_TAB_GROUP_TITLE = {
+  interactive: "OpenCLI Browser",
+  automation: "OpenCLI Automation"
+};
 const AUTOMATION_TAB_GROUP_COLOR = "orange";
 let leaseMutationQueue = Promise.resolve();
-let ownedContainerWindowPromise = null;
+const ownedContainers = {
+  interactive: { windowId: null, groupId: null, promise: null },
+  automation: { windowId: null, groupId: null, promise: null }
+};
 class CommandFailure extends Error {
   constructor(code, message, hint) {
     super(message);
@@ -770,6 +774,7 @@ class CommandFailure extends Error {
   }
 }
 const workspaceTimeoutOverrides = /* @__PURE__ */ new Map();
+const workspaceWindowModeOverrides = /* @__PURE__ */ new Map();
 function getIdleTimeout(workspace) {
   if (workspace.startsWith("bound:")) return IDLE_TIMEOUT_NONE;
   const override = workspaceTimeoutOverrides.get(workspace);
@@ -779,7 +784,6 @@ function getIdleTimeout(workspace) {
   }
   return IDLE_TIMEOUT_DEFAULT;
 }
-let windowFocused = false;
 function getWorkspaceKey(workspace) {
   return workspace?.trim() || "default";
 }
@@ -787,6 +791,15 @@ function getLeaseLifecycle(workspace) {
   if (workspace.startsWith("bound:")) return "pinned";
   if (workspace.startsWith("browser:") || workspace.startsWith("operate:")) return "persistent";
   return "ephemeral";
+}
+function getOwnedWindowRole(workspace) {
+  return workspace.startsWith("browser:") || workspace.startsWith("operate:") ? "interactive" : "automation";
+}
+function getWindowRole(workspace, ownership) {
+  return ownership === "borrowed" ? "borrowed-user" : getOwnedWindowRole(workspace);
+}
+function getWindowMode(workspace) {
+  return workspaceWindowModeOverrides.get(workspace) ?? (getOwnedWindowRole(workspace) === "interactive" ? "foreground" : "background");
 }
 function makeAlarmName(workspace) {
   return `${LEASE_IDLE_ALARM_PREFIX}${encodeURIComponent(workspace)}`;
@@ -811,15 +824,23 @@ function makeSession(workspace, session) {
     contextId: currentContextId,
     ownership,
     lifecycle: getLeaseLifecycle(workspace),
-    surface: ownership === "owned" ? "dedicated-container" : "borrowed-user-tab"
+    windowRole: getWindowRole(workspace, ownership)
   };
 }
 function emptyRegistry() {
   return {
-    version: 1,
+    version: 2,
     contextId: currentContextId,
-    ownedContainerWindowId,
-    ownedContainerGroupId,
+    ownedContainers: {
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupId: ownedContainers.interactive.groupId
+      },
+      automation: {
+        windowId: ownedContainers.automation.windowId,
+        groupId: ownedContainers.automation.groupId
+      }
+    },
     leases: {}
   };
 }
@@ -829,12 +850,21 @@ async function readRegistry() {
     if (!local) return emptyRegistry();
     const raw = await local.get(REGISTRY_KEY);
     const stored = raw[REGISTRY_KEY];
-    if (!stored || stored.version !== 1 || typeof stored.leases !== "object") return emptyRegistry();
+    if (!stored || stored.version !== 2 || typeof stored.leases !== "object") return emptyRegistry();
+    const storedContainers = stored.ownedContainers && typeof stored.ownedContainers === "object" ? stored.ownedContainers : emptyRegistry().ownedContainers;
     return {
-      version: 1,
+      version: 2,
       contextId: currentContextId,
-      ownedContainerWindowId: typeof stored.ownedContainerWindowId === "number" ? stored.ownedContainerWindowId : null,
-      ownedContainerGroupId: typeof stored.ownedContainerGroupId === "number" ? stored.ownedContainerGroupId : null,
+      ownedContainers: {
+        interactive: {
+          windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null,
+          groupId: typeof storedContainers.interactive?.groupId === "number" ? storedContainers.interactive.groupId : null
+        },
+        automation: {
+          windowId: typeof storedContainers.automation?.windowId === "number" ? storedContainers.automation.windowId : null,
+          groupId: typeof storedContainers.automation?.groupId === "number" ? storedContainers.automation.groupId : null
+        }
+      },
       leases: stored.leases
     };
   } catch {
@@ -857,16 +887,24 @@ async function persistRuntimeState() {
       contextId: session.contextId,
       ownership: session.ownership,
       lifecycle: session.lifecycle,
-      surface: session.surface,
+      windowRole: session.windowRole,
       idleDeadlineAt: session.idleDeadlineAt,
       updatedAt: Date.now()
     };
   }
   await writeRegistry({
-    version: 1,
+    version: 2,
     contextId: currentContextId,
-    ownedContainerWindowId,
-    ownedContainerGroupId,
+    ownedContainers: {
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupId: ownedContainers.interactive.groupId
+      },
+      automation: {
+        windowId: ownedContainers.automation.windowId,
+        groupId: ownedContainers.automation.groupId
+      }
+    },
     leases
   });
 }
@@ -893,6 +931,7 @@ async function removeWorkspaceSession(workspace) {
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
   automationSessions.delete(workspace);
   workspaceTimeoutOverrides.delete(workspace);
+  workspaceWindowModeOverrides.delete(workspace);
   scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
   await persistRuntimeState();
 }
@@ -914,26 +953,27 @@ function resetWindowIdleTimer(workspace) {
     await releaseWorkspaceLease(workspace, "idle timeout");
   }, timeout);
 }
-async function getOwnedContainerGroupId(windowId) {
-  if (ownedContainerGroupId !== null) {
+async function getOwnedContainerGroupId(role, windowId) {
+  const container = ownedContainers[role];
+  if (container.groupId !== null) {
     try {
-      const group = await chrome.tabGroups.get(ownedContainerGroupId);
-      if (group.windowId === windowId) return ownedContainerGroupId;
+      const group = await chrome.tabGroups.get(container.groupId);
+      if (group.windowId === windowId) return container.groupId;
     } catch {
     }
-    ownedContainerGroupId = null;
+    container.groupId = null;
   }
-  const groups = await chrome.tabGroups.query({ windowId, title: AUTOMATION_TAB_GROUP_TITLE });
+  const groups = await chrome.tabGroups.query({ windowId, title: CONTAINER_TAB_GROUP_TITLE[role] });
   const existing = groups[0];
   if (!existing) return null;
-  ownedContainerGroupId = existing.id;
+  container.groupId = existing.id;
   return existing.id;
 }
-async function ensureOwnedContainerTabGroup(windowId, tabIds) {
+async function ensureOwnedContainerTabGroup(role, windowId, tabIds) {
   const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
   if (ids.length === 0) return;
   try {
-    const existingGroupId = await getOwnedContainerGroupId(windowId);
+    const existingGroupId = await getOwnedContainerGroupId(role, windowId);
     if (existingGroupId !== null) {
       const tabs = await chrome.tabs.query({ windowId });
       const alreadyGrouped = new Set(
@@ -943,48 +983,56 @@ async function ensureOwnedContainerTabGroup(windowId, tabIds) {
       if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
       return;
     }
-    ownedContainerGroupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-    await chrome.tabGroups.update(ownedContainerGroupId, {
+    const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
+    ownedContainers[role].groupId = groupId;
+    await chrome.tabGroups.update(groupId, {
       color: AUTOMATION_TAB_GROUP_COLOR,
-      title: AUTOMATION_TAB_GROUP_TITLE,
+      title: CONTAINER_TAB_GROUP_TITLE[role],
       collapsed: false
     });
   } catch (err) {
-    console.warn(`[opencli] Failed to mark automation tab group: ${err instanceof Error ? err.message : String(err)}`);
+    console.warn(`[opencli] Failed to mark ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
-async function ensureOwnedContainerWindow(initialUrl) {
-  if (ownedContainerWindowPromise) return ownedContainerWindowPromise;
-  ownedContainerWindowPromise = ensureOwnedContainerWindowUnlocked(initialUrl).finally(() => {
-    ownedContainerWindowPromise = null;
+async function ensureOwnedContainerWindow(role, initialUrl, mode = "background") {
+  const container = ownedContainers[role];
+  if (container.promise) return container.promise;
+  container.promise = ensureOwnedContainerWindowUnlocked(role, initialUrl, mode).finally(() => {
+    container.promise = null;
   });
-  return ownedContainerWindowPromise;
+  return container.promise;
 }
-async function ensureOwnedContainerWindowUnlocked(initialUrl) {
-  if (ownedContainerWindowId !== null) {
+async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "background") {
+  const container = ownedContainers[role];
+  if (container.windowId !== null) {
     try {
-      await chrome.windows.get(ownedContainerWindowId);
-      const initialTabId2 = await findReusableOwnedContainerTab(ownedContainerWindowId);
-      await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId2]);
+      await chrome.windows.get(container.windowId);
+      if (mode === "foreground") {
+        const updateWindow = chrome.windows.update;
+        if (typeof updateWindow === "function") await updateWindow(container.windowId, { focused: true }).catch(() => {
+        });
+      }
+      const initialTabId2 = await findReusableOwnedContainerTab(container.windowId);
+      await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId2]);
       return {
-        windowId: ownedContainerWindowId,
+        windowId: container.windowId,
         initialTabId: initialTabId2
       };
     } catch {
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
+      container.windowId = null;
+      container.groupId = null;
     }
   }
   const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
   const win = await chrome.windows.create({
     url: startUrl,
-    focused: windowFocused,
+    focused: mode === "foreground",
     width: 1280,
     height: 900,
     type: "normal"
   });
-  ownedContainerWindowId = win.id;
-  console.log(`[opencli] Created owned automation container window ${ownedContainerWindowId} (start=${startUrl})`);
+  container.windowId = win.id;
+  console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);
   const tabs = await chrome.tabs.query({ windowId: win.id });
   const initialTabId = tabs[0]?.id;
   if (initialTabId) {
@@ -1005,9 +1053,9 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl) {
       }
     });
   }
-  await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId]);
+  await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId]);
   await persistRuntimeState();
-  return { windowId: ownedContainerWindowId, initialTabId };
+  return { windowId: container.windowId, initialTabId };
 }
 async function findReusableOwnedContainerTab(windowId) {
   try {
@@ -1032,7 +1080,8 @@ async function createOwnedTabLease(workspace, initialUrl) {
 }
 async function createOwnedTabLeaseUnlocked(workspace, initialUrl) {
   const targetUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
-  const { windowId, initialTabId } = await ensureOwnedContainerWindow(targetUrl);
+  const role = getOwnedWindowRole(workspace);
+  const { windowId, initialTabId } = await ensureOwnedContainerWindow(role, targetUrl, getWindowMode(workspace));
   let tab;
   if (initialTabIsAvailable(initialTabId)) {
     tab = await chrome.tabs.get(initialTabId);
@@ -1045,7 +1094,7 @@ async function createOwnedTabLeaseUnlocked(workspace, initialUrl) {
     tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
   }
   if (!tab.id) throw new Error("Failed to create tab lease in automation container");
-  await ensureOwnedContainerTabGroup(windowId, [tab.id]);
+  await ensureOwnedContainerTabGroup(role, windowId, [tab.id]);
   setWorkspaceSession(workspace, {
     windowId,
     owned: true,
@@ -1083,12 +1132,15 @@ async function getAutomationWindow(workspace, initialUrl) {
       await removeWorkspaceSession(workspace);
     }
   }
-  return (await ensureOwnedContainerWindow(initialUrl)).windowId;
+  const role = getOwnedWindowRole(workspace);
+  return (await ensureOwnedContainerWindow(role, initialUrl, getWindowMode(workspace))).windowId;
 }
 chrome.windows.onRemoved.addListener(async (windowId) => {
-  if (ownedContainerWindowId === windowId) {
-    ownedContainerWindowId = null;
-    ownedContainerGroupId = null;
+  for (const container of Object.values(ownedContainers)) {
+    if (container.windowId === windowId) {
+      container.windowId = null;
+      container.groupId = null;
+    }
   }
   for (const [workspace, session] of automationSessions.entries()) {
     if (session.windowId === windowId) {
@@ -1096,6 +1148,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(workspace);
       workspaceTimeoutOverrides.delete(workspace);
+      workspaceWindowModeOverrides.delete(workspace);
       scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
     }
   }
@@ -1179,7 +1232,9 @@ async function fetchDaemonVersion() {
 }
 async function handleCommand(cmd) {
   const workspace = getWorkspaceKey(cmd.workspace);
-  windowFocused = cmd.windowFocused === true;
+  if (!workspace.startsWith("bound:") && (cmd.windowMode === "foreground" || cmd.windowMode === "background")) {
+    workspaceWindowModeOverrides.set(workspace, cmd.windowMode);
+  }
   if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
     workspaceTimeoutOverrides.set(workspace, cmd.idleTimeout * 1e3);
   }
@@ -1599,7 +1654,7 @@ async function handleTabs(cmd, workspace) {
       const windowId = await getAutomationWindow(workspace);
       const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
       if (!tab.id) return { id: cmd.id, ok: false, error: "Failed to create tab" };
-      await ensureOwnedContainerTabGroup(windowId, [tab.id]);
+      await ensureOwnedContainerTabGroup(getOwnedWindowRole(workspace), windowId, [tab.id]);
       setWorkspaceSession(workspace, {
         windowId: tab.windowId,
         owned: true,
@@ -1837,7 +1892,7 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
       } else {
         try {
           const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
-          await ensureOwnedContainerTabGroup(session.windowId, [tab.id ?? tabId]);
+          await ensureOwnedContainerTabGroup(getOwnedWindowRole(workspace), session.windowId, [tab.id ?? tabId]);
           console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (${workspace}, ${reason})`);
         } catch {
           await chrome.tabs.remove(tabId).catch(() => {
@@ -1854,18 +1909,22 @@ async function releaseWorkspaceLease(workspace, reason = "released") {
   }
   automationSessions.delete(workspace);
   workspaceTimeoutOverrides.delete(workspace);
+  workspaceWindowModeOverrides.delete(workspace);
   await persistRuntimeState();
 }
 async function reconcileTargetLeaseRegistry() {
   const registry = await readRegistry();
-  ownedContainerWindowId = registry.ownedContainerWindowId;
-  ownedContainerGroupId = registry.ownedContainerGroupId ?? null;
-  if (ownedContainerWindowId !== null) {
-    try {
-      await chrome.windows.get(ownedContainerWindowId);
-    } catch {
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
+  for (const role of Object.keys(ownedContainers)) {
+    ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
+    ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
+    const windowId = ownedContainers[role].windowId;
+    if (windowId !== null) {
+      try {
+        await chrome.windows.get(windowId);
+      } catch {
+        ownedContainers[role].windowId = null;
+        ownedContainers[role].groupId = null;
+      }
     }
   }
   automationSessions.clear();
@@ -1886,8 +1945,11 @@ async function reconcileTargetLeaseRegistry() {
         idleTimer: null,
         idleDeadlineAt: stored.idleDeadlineAt
       });
-      if (session.owned && ownedContainerWindowId === null) ownedContainerWindowId = tab.windowId;
-      if (session.owned) await ensureOwnedContainerTabGroup(tab.windowId, [tabId]);
+      if (session.owned) {
+        const role = getOwnedWindowRole(workspace);
+        if (ownedContainers[role].windowId === null) ownedContainers[role].windowId = tab.windowId;
+        await ensureOwnedContainerTabGroup(role, tab.windowId, [tabId]);
+      }
       const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
       if (timeout > 0) {
         if (remaining <= 0) {
@@ -1911,7 +1973,7 @@ async function handleSessions(cmd) {
     contextId: session.contextId,
     ownership: session.ownership,
     lifecycle: session.lifecycle,
-    surface: session.surface,
+    windowRole: session.windowRole,
     tabCount: session.preferredTabId !== null ? await chrome.tabs.get(session.preferredTabId).then((tab) => isDebuggableUrl(tab.url) ? 1 : 0).catch(() => 0) : (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,
     idleMsRemaining: session.idleDeadlineAt <= 0 ? null : Math.max(0, session.idleDeadlineAt - now)
   })));

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -725,10 +725,10 @@ describe('background tab isolation', () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
-      opencli_target_lease_registry_v1: {
-        version: 1,
+      opencli_target_lease_registry_v2: {
+        version: 2,
         contextId: 'user-default',
-        ownedContainerWindowId: 1,
+        ownedContainers: { interactive: { windowId: null }, automation: { windowId: 1 } },
         leases: {},
       },
     });
@@ -752,10 +752,10 @@ describe('background tab isolation', () => {
     const deadline = Date.now() + 30_000;
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
-      opencli_target_lease_registry_v1: {
-        version: 1,
+      opencli_target_lease_registry_v2: {
+        version: 2,
         contextId: 'user-default',
-        ownedContainerWindowId: 1,
+        ownedContainers: { interactive: { windowId: null }, automation: { windowId: 1 } },
         leases: {
           'site:restored': {
             windowId: 1,
@@ -764,7 +764,7 @@ describe('background tab isolation', () => {
             contextId: 'user-default',
             ownership: 'owned',
             lifecycle: 'ephemeral',
-            surface: 'dedicated-container',
+            windowRole: 'automation',
             idleDeadlineAt: deadline,
             updatedAt: Date.now(),
           },
@@ -775,7 +775,7 @@ describe('background tab isolation', () => {
             contextId: 'user-default',
             ownership: 'borrowed',
             lifecycle: 'pinned',
-            surface: 'borrowed-user-tab',
+            windowRole: 'borrowed-user',
             idleDeadlineAt: 0,
             updatedAt: Date.now(),
           },
@@ -790,14 +790,14 @@ describe('background tab isolation', () => {
       owned: true,
       ownership: 'owned',
       lifecycle: 'ephemeral',
-      surface: 'dedicated-container',
+      windowRole: 'automation',
       preferredTabId: 1,
     }));
     expect(mod.__test__.getSession('bound:restored')).toEqual(expect.objectContaining({
       owned: false,
       ownership: 'borrowed',
       lifecycle: 'pinned',
-      surface: 'borrowed-user-tab',
+      windowRole: 'borrowed-user',
       preferredTabId: 2,
       idleTimer: null,
       idleDeadlineAt: 0,
@@ -867,7 +867,7 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).toHaveBeenCalledTimes(1);
   });
 
-  it('marks a newly created owned automation window with an OpenCLI tab group', async () => {
+  it('marks a newly created owned automation window with an OpenCLI Automation tab group', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -880,12 +880,79 @@ describe('background tab isolation', () => {
       expect.objectContaining({
         id: 100,
         windowId: 1,
-        title: 'OpenCLI',
+        title: 'OpenCLI Automation',
         color: 'orange',
         collapsed: false,
       }),
     ]);
     expect(chrome.tabs.group).toHaveBeenCalledWith({ tabIds: [1], createProperties: { windowId: 1 } });
+  });
+
+  it('uses separate owned windows for browser and adapter workspaces', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    let nextWindowId = 20;
+    let nextTabId = 200;
+    chrome.windows.create = vi.fn(async ({ url, focused, width, height, type }: any) => {
+      const windowId = nextWindowId++;
+      const tab: MockTab = {
+        id: nextTabId++,
+        windowId,
+        url,
+        title: url ?? 'blank',
+        active: true,
+        status: 'complete',
+        groupId: -1,
+      };
+      tabs.push(tab);
+      return { id: windowId, url, focused, width, height, type };
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const browserTabId = await mod.__test__.resolveTabId(undefined, 'browser:default');
+    const adapterTabId = await mod.__test__.resolveTabId(undefined, 'site:twitter');
+
+    expect(tabs.find((tab) => tab.id === browserTabId)?.windowId).toBe(20);
+    expect(tabs.find((tab) => tab.id === adapterTabId)?.windowId).toBe(21);
+    expect(chrome.windows.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ focused: true }));
+    expect(chrome.windows.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ focused: false }));
+    expect(groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({ windowId: 20, title: 'OpenCLI Browser' }),
+      expect.objectContaining({ windowId: 21, title: 'OpenCLI Automation' }),
+    ]));
+  });
+
+  it('lets adapters explicitly request a foreground automation window', async () => {
+    const { chrome, tabs } = createChromeMock();
+    let nextWindowId = 30;
+    let nextTabId = 300;
+    chrome.windows.create = vi.fn(async ({ url, focused, width, height, type }: any) => {
+      const windowId = nextWindowId++;
+      tabs.push({
+        id: nextTabId++,
+        windowId,
+        url,
+        title: url ?? 'blank',
+        active: true,
+        status: 'complete',
+        groupId: -1,
+      });
+      return { id: windowId, url, focused, width, height, type };
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const result = await mod.__test__.handleCommand({
+      id: 'new-foreground',
+      action: 'tabs',
+      op: 'new',
+      workspace: 'site:twitter',
+      url: 'https://x.com',
+      windowMode: 'foreground',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true }));
+    expect(chrome.windows.create).toHaveBeenCalledWith(expect.objectContaining({ focused: true }));
   });
 
   it('reuses the existing automation tab group when adding another owned lease tab', async () => {
@@ -902,12 +969,12 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [10] });
   });
 
-  it('discovers and reuses an existing OpenCLI group after service worker restart', async () => {
+  it('discovers and reuses an existing OpenCLI Automation group after service worker restart', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     groups.push({
       id: 99,
       windowId: 1,
-      title: 'OpenCLI',
+      title: 'OpenCLI Automation',
       color: 'orange',
       collapsed: true,
     });
@@ -934,11 +1001,10 @@ describe('background tab isolation', () => {
     });
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
-      opencli_target_lease_registry_v1: {
-        version: 1,
+      opencli_target_lease_registry_v2: {
+        version: 2,
         contextId: 'user-default',
-        ownedContainerWindowId: 1,
-        ownedContainerGroupId: 99,
+        ownedContainers: { interactive: { windowId: null }, automation: { windowId: 1, groupId: 99 } },
         leases: {
           'site:restored-group': {
             windowId: 1,
@@ -947,7 +1013,7 @@ describe('background tab isolation', () => {
             contextId: 'user-default',
             ownership: 'owned',
             lifecycle: 'ephemeral',
-            surface: 'dedicated-container',
+            windowRole: 'automation',
             idleDeadlineAt: Date.now() + 30_000,
             updatedAt: Date.now(),
           },
@@ -976,17 +1042,16 @@ describe('background tab isolation', () => {
     groups.push({
       id: 99,
       windowId: 1,
-      title: 'OpenCLI',
+      title: 'OpenCLI Automation',
       color: 'orange',
       collapsed: true,
     });
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
-      opencli_target_lease_registry_v1: {
-        version: 1,
+      opencli_target_lease_registry_v2: {
+        version: 2,
         contextId: 'user-default',
-        ownedContainerWindowId: 1,
-        ownedContainerGroupId: 404,
+        ownedContainers: { interactive: { windowId: null }, automation: { windowId: 1, groupId: 404 } },
         leases: {
           'site:restored-group': {
             windowId: 1,
@@ -995,7 +1060,7 @@ describe('background tab isolation', () => {
             contextId: 'user-default',
             ownership: 'owned',
             lifecycle: 'ephemeral',
-            surface: 'dedicated-container',
+            windowRole: 'automation',
             idleDeadlineAt: Date.now() + 30_000,
             updatedAt: Date.now(),
           },

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -166,15 +166,18 @@ function scheduleReconnect(): void {
 
 // ─── Browser target leases ───────────────────────────────────────────
 // OpenCLI does not model workspace identity as a Chrome window. A workspace
-// owns or borrows a tab lease; owned leases share a dedicated container surface
-// and borrowed leases point at user-owned tabs.
+// owns or borrows a tab lease; owned leases live in either the interactive
+// browser window or the background automation window, while borrowed leases
+// point at user-owned tabs.
 // Interactive workspaces (browser:*, operate:*) get a longer timeout (10 min)
 // since users type commands manually; adapter workspaces keep a short 30s timeout.
 
 type BrowserContextId = string;
 type LeaseOwnership = 'owned' | 'borrowed';
 type LeaseLifecycle = 'ephemeral' | 'persistent' | 'pinned';
-type SurfacePolicy = 'dedicated-container' | 'borrowed-user-tab';
+type WindowRole = 'interactive' | 'automation' | 'borrowed-user';
+type OwnedWindowRole = Exclude<WindowRole, 'borrowed-user'>;
+type WindowMode = 'foreground' | 'background';
 
 type TargetLease = {
   windowId: number;
@@ -185,21 +188,29 @@ type TargetLease = {
   contextId: BrowserContextId;
   ownership: LeaseOwnership;
   lifecycle: LeaseLifecycle;
-  surface: SurfacePolicy;
+  windowRole: WindowRole;
 };
 
 const automationSessions = new Map<string, TargetLease>();
-let ownedContainerWindowId: number | null = null;
-let ownedContainerGroupId: number | null = null;
 const IDLE_TIMEOUT_DEFAULT = 30_000;      // 30s — adapter-driven automation
 const IDLE_TIMEOUT_INTERACTIVE = 600_000; // 10min — human-paced browser:* / operate:*
 const IDLE_TIMEOUT_NONE = -1;             // borrowed bound tabs stay bound until unbound/closed
-const REGISTRY_KEY = 'opencli_target_lease_registry_v1';
+const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
 const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
-const AUTOMATION_TAB_GROUP_TITLE = 'OpenCLI';
+const CONTAINER_TAB_GROUP_TITLE: Record<OwnedWindowRole, string> = {
+  interactive: 'OpenCLI Browser',
+  automation: 'OpenCLI Automation',
+};
 const AUTOMATION_TAB_GROUP_COLOR: chrome.tabGroups.ColorEnum = 'orange';
 let leaseMutationQueue: Promise<void> = Promise.resolve();
-let ownedContainerWindowPromise: Promise<{ windowId: number; initialTabId?: number }> | null = null;
+const ownedContainers: Record<OwnedWindowRole, {
+  windowId: number | null;
+  groupId: number | null;
+  promise: Promise<{ windowId: number; initialTabId?: number }> | null;
+}> = {
+  interactive: { windowId: null, groupId: null, promise: null },
+  automation: { windowId: null, groupId: null, promise: null },
+};
 
 type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
   idleDeadlineAt: number;
@@ -207,10 +218,9 @@ type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
 };
 
 type StoredRegistry = {
-  version: 1;
+  version: 2;
   contextId: BrowserContextId;
-  ownedContainerWindowId: number | null;
-  ownedContainerGroupId?: number | null;
+  ownedContainers: Record<OwnedWindowRole, { windowId: number | null; groupId?: number | null }>;
   leases: Record<string, StoredLease>;
 };
 
@@ -223,6 +233,7 @@ class CommandFailure extends Error {
 
 /** Per-workspace custom timeout overrides set via command.idleTimeout */
 const workspaceTimeoutOverrides = new Map<string, number>();
+const workspaceWindowModeOverrides = new Map<string, WindowMode>();
 
 function getIdleTimeout(workspace: string): number {
   if (workspace.startsWith('bound:')) return IDLE_TIMEOUT_NONE;
@@ -234,8 +245,6 @@ function getIdleTimeout(workspace: string): number {
   return IDLE_TIMEOUT_DEFAULT;
 }
 
-let windowFocused = false; // set per-command from daemon's OPENCLI_WINDOW_FOCUSED
-
 function getWorkspaceKey(workspace?: string): string {
   return workspace?.trim() || 'default';
 }
@@ -244,6 +253,19 @@ function getLeaseLifecycle(workspace: string): LeaseLifecycle {
   if (workspace.startsWith('bound:')) return 'pinned';
   if (workspace.startsWith('browser:') || workspace.startsWith('operate:')) return 'persistent';
   return 'ephemeral';
+}
+
+function getOwnedWindowRole(workspace: string): OwnedWindowRole {
+  return (workspace.startsWith('browser:') || workspace.startsWith('operate:')) ? 'interactive' : 'automation';
+}
+
+function getWindowRole(workspace: string, ownership: LeaseOwnership): WindowRole {
+  return ownership === 'borrowed' ? 'borrowed-user' : getOwnedWindowRole(workspace);
+}
+
+function getWindowMode(workspace: string): WindowMode {
+  return workspaceWindowModeOverrides.get(workspace)
+    ?? (getOwnedWindowRole(workspace) === 'interactive' ? 'foreground' : 'background');
 }
 
 function makeAlarmName(workspace: string): string {
@@ -267,7 +289,7 @@ function withLeaseMutation<T>(fn: () => Promise<T>): Promise<T> {
 
 function makeSession(
   workspace: string,
-  session: Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
+  session: Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'windowRole'>,
 ): Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> {
   const ownership = session.owned ? 'owned' : 'borrowed';
   return {
@@ -275,16 +297,24 @@ function makeSession(
     contextId: currentContextId,
     ownership,
     lifecycle: getLeaseLifecycle(workspace),
-    surface: ownership === 'owned' ? 'dedicated-container' : 'borrowed-user-tab',
+    windowRole: getWindowRole(workspace, ownership),
   };
 }
 
 function emptyRegistry(): StoredRegistry {
   return {
-    version: 1,
+    version: 2,
     contextId: currentContextId,
-    ownedContainerWindowId,
-    ownedContainerGroupId,
+    ownedContainers: {
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupId: ownedContainers.interactive.groupId,
+      },
+      automation: {
+        windowId: ownedContainers.automation.windowId,
+        groupId: ownedContainers.automation.groupId,
+      },
+    },
     leases: {},
   };
 }
@@ -295,12 +325,23 @@ async function readRegistry(): Promise<StoredRegistry> {
     if (!local) return emptyRegistry();
     const raw = await local.get(REGISTRY_KEY) as Record<string, unknown>;
     const stored = raw[REGISTRY_KEY] as Partial<StoredRegistry> | undefined;
-    if (!stored || stored.version !== 1 || typeof stored.leases !== 'object') return emptyRegistry();
+    if (!stored || stored.version !== 2 || typeof stored.leases !== 'object') return emptyRegistry();
+    const storedContainers = stored.ownedContainers && typeof stored.ownedContainers === 'object'
+      ? stored.ownedContainers
+      : emptyRegistry().ownedContainers;
     return {
-      version: 1,
+      version: 2,
       contextId: currentContextId,
-      ownedContainerWindowId: typeof stored.ownedContainerWindowId === 'number' ? stored.ownedContainerWindowId : null,
-      ownedContainerGroupId: typeof stored.ownedContainerGroupId === 'number' ? stored.ownedContainerGroupId : null,
+      ownedContainers: {
+        interactive: {
+          windowId: typeof storedContainers.interactive?.windowId === 'number' ? storedContainers.interactive.windowId : null,
+          groupId: typeof storedContainers.interactive?.groupId === 'number' ? storedContainers.interactive.groupId : null,
+        },
+        automation: {
+          windowId: typeof storedContainers.automation?.windowId === 'number' ? storedContainers.automation.windowId : null,
+          groupId: typeof storedContainers.automation?.groupId === 'number' ? storedContainers.automation.groupId : null,
+        },
+      },
       leases: stored.leases as Record<string, StoredLease>,
     };
   } catch {
@@ -326,16 +367,24 @@ async function persistRuntimeState(): Promise<void> {
       contextId: session.contextId,
       ownership: session.ownership,
       lifecycle: session.lifecycle,
-      surface: session.surface,
+      windowRole: session.windowRole,
       idleDeadlineAt: session.idleDeadlineAt,
       updatedAt: Date.now(),
     };
   }
   await writeRegistry({
-    version: 1,
+    version: 2,
     contextId: currentContextId,
-    ownedContainerWindowId,
-    ownedContainerGroupId,
+    ownedContainers: {
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupId: ownedContainers.interactive.groupId,
+      },
+      automation: {
+        windowId: ownedContainers.automation.windowId,
+        groupId: ownedContainers.automation.groupId,
+      },
+    },
     leases,
   });
 }
@@ -367,6 +416,7 @@ async function removeWorkspaceSession(workspace: string): Promise<void> {
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
   automationSessions.delete(workspace);
   workspaceTimeoutOverrides.delete(workspace);
+  workspaceWindowModeOverrides.delete(workspace);
   scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
   await persistRuntimeState();
 }
@@ -390,30 +440,31 @@ function resetWindowIdleTimer(workspace: string): void {
   }, timeout);
 }
 
-async function getOwnedContainerGroupId(windowId: number): Promise<number | null> {
-  if (ownedContainerGroupId !== null) {
+async function getOwnedContainerGroupId(role: OwnedWindowRole, windowId: number): Promise<number | null> {
+  const container = ownedContainers[role];
+  if (container.groupId !== null) {
     try {
-      const group = await chrome.tabGroups.get(ownedContainerGroupId);
-      if (group.windowId === windowId) return ownedContainerGroupId;
+      const group = await chrome.tabGroups.get(container.groupId);
+      if (group.windowId === windowId) return container.groupId;
     } catch {
       // Group IDs are browser-session state and can disappear when the last tab closes.
     }
-    ownedContainerGroupId = null;
+    container.groupId = null;
   }
 
-  const groups = await chrome.tabGroups.query({ windowId, title: AUTOMATION_TAB_GROUP_TITLE });
+  const groups = await chrome.tabGroups.query({ windowId, title: CONTAINER_TAB_GROUP_TITLE[role] });
   const existing = groups[0];
   if (!existing) return null;
-  ownedContainerGroupId = existing.id;
+  container.groupId = existing.id;
   return existing.id;
 }
 
-async function ensureOwnedContainerTabGroup(windowId: number, tabIds: Array<number | undefined>): Promise<void> {
+async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: number, tabIds: Array<number | undefined>): Promise<void> {
   const ids = [...new Set(tabIds.filter((id): id is number => id !== undefined))];
   if (ids.length === 0) return;
 
   try {
-    const existingGroupId = await getOwnedContainerGroupId(windowId);
+    const existingGroupId = await getOwnedContainerGroupId(role, windowId);
     if (existingGroupId !== null) {
       const tabs = await chrome.tabs.query({ windowId });
       const alreadyGrouped = new Set(
@@ -426,47 +477,63 @@ async function ensureOwnedContainerTabGroup(windowId: number, tabIds: Array<numb
       return;
     }
 
-    ownedContainerGroupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-    await chrome.tabGroups.update(ownedContainerGroupId, {
+    const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
+    ownedContainers[role].groupId = groupId;
+    await chrome.tabGroups.update(groupId, {
       color: AUTOMATION_TAB_GROUP_COLOR,
-      title: AUTOMATION_TAB_GROUP_TITLE,
+      title: CONTAINER_TAB_GROUP_TITLE[role],
       collapsed: false,
     });
   } catch (err) {
-    console.warn(`[opencli] Failed to mark automation tab group: ${err instanceof Error ? err.message : String(err)}`);
+    console.warn(`[opencli] Failed to mark ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
 /**
- * Ensure the shared owned automation surface exists.
+ * Ensure the owned window for the requested role exists.
  *
  * First-principles model:
  * - BrowserContext is the user's default Chrome profile.
  * - Workspace identity maps to a TargetLease (usually a tab), not a window.
- * - Owned TargetLeases are placed in the default dedicated-container surface.
+ * - Browser commands and adapters use separate owned windows so foreground
+ *   interactive work cannot drag background adapter automation into view.
  */
-async function ensureOwnedContainerWindow(initialUrl?: string): Promise<{ windowId: number; initialTabId?: number }> {
-  if (ownedContainerWindowPromise) return ownedContainerWindowPromise;
-  ownedContainerWindowPromise = ensureOwnedContainerWindowUnlocked(initialUrl)
+async function ensureOwnedContainerWindow(
+  role: OwnedWindowRole,
+  initialUrl?: string,
+  mode: WindowMode = 'background',
+): Promise<{ windowId: number; initialTabId?: number }> {
+  const container = ownedContainers[role];
+  if (container.promise) return container.promise;
+  container.promise = ensureOwnedContainerWindowUnlocked(role, initialUrl, mode)
     .finally(() => {
-      ownedContainerWindowPromise = null;
+      container.promise = null;
     });
-  return ownedContainerWindowPromise;
+  return container.promise;
 }
 
-async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<{ windowId: number; initialTabId?: number }> {
-  if (ownedContainerWindowId !== null) {
+async function ensureOwnedContainerWindowUnlocked(
+  role: OwnedWindowRole,
+  initialUrl?: string,
+  mode: WindowMode = 'background',
+): Promise<{ windowId: number; initialTabId?: number }> {
+  const container = ownedContainers[role];
+  if (container.windowId !== null) {
     try {
-      await chrome.windows.get(ownedContainerWindowId);
-      const initialTabId = await findReusableOwnedContainerTab(ownedContainerWindowId);
-      await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId]);
+      await chrome.windows.get(container.windowId);
+      if (mode === 'foreground') {
+        const updateWindow = (chrome.windows as unknown as { update?: (windowId: number, updateInfo: { focused?: boolean }) => Promise<unknown> }).update;
+        if (typeof updateWindow === 'function') await updateWindow(container.windowId, { focused: true }).catch(() => {});
+      }
+      const initialTabId = await findReusableOwnedContainerTab(container.windowId);
+      await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId]);
       return {
-        windowId: ownedContainerWindowId,
+        windowId: container.windowId,
         initialTabId,
       };
     } catch {
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
+      container.windowId = null;
+      container.groupId = null;
     }
   }
 
@@ -476,13 +543,13 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<
   // state value for windows.create(). The window defaults to 'normal' state anyway.
   const win = await chrome.windows.create({
     url: startUrl,
-    focused: windowFocused,
+    focused: mode === 'foreground',
     width: 1280,
     height: 900,
     type: 'normal',
   });
-  ownedContainerWindowId = win.id!;
-  console.log(`[opencli] Created owned automation container window ${ownedContainerWindowId} (start=${startUrl})`);
+  container.windowId = win.id!;
+  console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);
 
   // Wait for the initial tab to finish loading instead of a fixed 200ms sleep.
   const tabs = await chrome.tabs.query({ windowId: win.id! });
@@ -506,9 +573,9 @@ async function ensureOwnedContainerWindowUnlocked(initialUrl?: string): Promise<
       }
     });
   }
-  await ensureOwnedContainerTabGroup(ownedContainerWindowId, [initialTabId]);
+  await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId]);
   await persistRuntimeState();
-  return { windowId: ownedContainerWindowId, initialTabId };
+  return { windowId: container.windowId, initialTabId };
 }
 
 async function findReusableOwnedContainerTab(windowId: number): Promise<number | undefined> {
@@ -539,7 +606,8 @@ async function createOwnedTabLease(workspace: string, initialUrl?: string): Prom
 
 async function createOwnedTabLeaseUnlocked(workspace: string, initialUrl?: string): Promise<ResolvedTab> {
   const targetUrl = (initialUrl && isSafeNavigationUrl(initialUrl)) ? initialUrl : BLANK_PAGE;
-  const { windowId, initialTabId } = await ensureOwnedContainerWindow(targetUrl);
+  const role = getOwnedWindowRole(workspace);
+  const { windowId, initialTabId } = await ensureOwnedContainerWindow(role, targetUrl, getWindowMode(workspace));
   let tab: chrome.tabs.Tab;
 
   if (initialTabIsAvailable(initialTabId)) {
@@ -553,7 +621,7 @@ async function createOwnedTabLeaseUnlocked(workspace: string, initialUrl?: strin
     tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
   }
   if (!tab.id) throw new Error('Failed to create tab lease in automation container');
-  await ensureOwnedContainerTabGroup(windowId, [tab.id]);
+  await ensureOwnedContainerTabGroup(role, windowId, [tab.id]);
 
   setWorkspaceSession(workspace, {
     windowId,
@@ -600,14 +668,17 @@ async function getAutomationWindow(workspace: string, initialUrl?: string): Prom
     }
   }
 
-  return (await ensureOwnedContainerWindow(initialUrl)).windowId;
+  const role = getOwnedWindowRole(workspace);
+  return (await ensureOwnedContainerWindow(role, initialUrl, getWindowMode(workspace))).windowId;
 }
 
-// Clean up when the shared automation container window is closed
+// Clean up when an owned container window is closed
 chrome.windows.onRemoved.addListener(async (windowId) => {
-  if (ownedContainerWindowId === windowId) {
-    ownedContainerWindowId = null;
-    ownedContainerGroupId = null;
+  for (const container of Object.values(ownedContainers)) {
+    if (container.windowId === windowId) {
+      container.windowId = null;
+      container.groupId = null;
+    }
   }
   for (const [workspace, session] of automationSessions.entries()) {
     if (session.windowId === windowId) {
@@ -615,6 +686,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(workspace);
       workspaceTimeoutOverrides.delete(workspace);
+      workspaceWindowModeOverrides.delete(workspace);
       scheduleIdleAlarm(workspace, IDLE_TIMEOUT_NONE);
     }
   }
@@ -724,7 +796,9 @@ async function fetchDaemonVersion(): Promise<string | null> {
 
 async function handleCommand(cmd: Command): Promise<Result> {
   const workspace = getWorkspaceKey(cmd.workspace);
-  windowFocused = cmd.windowFocused === true;
+  if (!workspace.startsWith('bound:') && (cmd.windowMode === 'foreground' || cmd.windowMode === 'background')) {
+    workspaceWindowModeOverrides.set(workspace, cmd.windowMode);
+  }
   // Apply custom idle timeout if specified in the command
   if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
     workspaceTimeoutOverrides.set(workspace, cmd.idleTimeout * 1000);
@@ -879,7 +953,7 @@ function enumerateCrossOriginFrames(tree: any): Array<{ index: number; frameId: 
 
 function setWorkspaceSession(
   workspace: string,
-  session: Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'surface'>,
+  session: Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt' | 'contextId' | 'ownership' | 'lifecycle' | 'windowRole'>,
 ): void {
   const existing = automationSessions.get(workspace);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
@@ -1240,7 +1314,7 @@ async function handleTabs(cmd: Command, workspace: string): Promise<Result> {
       const windowId = await getAutomationWindow(workspace);
       const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
       if (!tab.id) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
-      await ensureOwnedContainerTabGroup(windowId, [tab.id]);
+      await ensureOwnedContainerTabGroup(getOwnedWindowRole(workspace), windowId, [tab.id]);
       setWorkspaceSession(workspace, {
         windowId: tab.windowId,
         owned: true,
@@ -1499,7 +1573,7 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
       } else {
         try {
           const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
-          await ensureOwnedContainerTabGroup(session.windowId, [tab.id ?? tabId]);
+          await ensureOwnedContainerTabGroup(getOwnedWindowRole(workspace), session.windowId, [tab.id ?? tabId]);
           console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (${workspace}, ${reason})`);
         } catch {
           await chrome.tabs.remove(tabId).catch(() => {});
@@ -1516,21 +1590,24 @@ async function releaseWorkspaceLease(workspace: string, reason: string = 'releas
 
   automationSessions.delete(workspace);
   workspaceTimeoutOverrides.delete(workspace);
+  workspaceWindowModeOverrides.delete(workspace);
 
   await persistRuntimeState();
 }
 
 async function reconcileTargetLeaseRegistry(): Promise<void> {
   const registry = await readRegistry();
-  ownedContainerWindowId = registry.ownedContainerWindowId;
-  ownedContainerGroupId = registry.ownedContainerGroupId ?? null;
-
-  if (ownedContainerWindowId !== null) {
-    try {
-      await chrome.windows.get(ownedContainerWindowId);
-    } catch {
-      ownedContainerWindowId = null;
-      ownedContainerGroupId = null;
+  for (const role of Object.keys(ownedContainers) as OwnedWindowRole[]) {
+    ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
+    ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
+    const windowId = ownedContainers[role].windowId;
+    if (windowId !== null) {
+      try {
+        await chrome.windows.get(windowId);
+      } catch {
+        ownedContainers[role].windowId = null;
+        ownedContainers[role].groupId = null;
+      }
     }
   }
 
@@ -1552,8 +1629,11 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
         idleTimer: null,
         idleDeadlineAt: stored.idleDeadlineAt,
       });
-      if (session.owned && ownedContainerWindowId === null) ownedContainerWindowId = tab.windowId;
-      if (session.owned) await ensureOwnedContainerTabGroup(tab.windowId, [tabId]);
+      if (session.owned) {
+        const role = getOwnedWindowRole(workspace);
+        if (ownedContainers[role].windowId === null) ownedContainers[role].windowId = tab.windowId;
+        await ensureOwnedContainerTabGroup(role, tab.windowId, [tabId]);
+      }
       const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
       if (timeout > 0) {
         if (remaining <= 0) {
@@ -1581,7 +1661,7 @@ async function handleSessions(cmd: Command): Promise<Result> {
     contextId: session.contextId,
     ownership: session.ownership,
     lifecycle: session.lifecycle,
-    surface: session.surface,
+    windowRole: session.windowRole,
     tabCount: session.preferredTabId !== null
       ? (await chrome.tabs.get(session.preferredTabId).then((tab) => isDebuggableUrl(tab.url) ? 1 : 0).catch(() => 0))
       : (await chrome.tabs.query({ windowId: session.windowId })).filter((tab) => isDebuggableUrl(tab.url)).length,

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -69,8 +69,8 @@ export interface Command {
   cdpMethod?: string;
   /** CDP method params for 'cdp' action */
   cdpParams?: Record<string, unknown>;
-  /** When true, the owned automation container is created in the foreground (focused) */
-  windowFocused?: boolean;
+  /** Window foreground/background policy for owned Browser Bridge containers. */
+  windowMode?: 'foreground' | 'background';
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
   /** Explicitly allow navigation inside a borrowed bound tab. */

--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash(opencli:*), Read, Edit, Write, Grep
 
 全程用现有工具：`opencli browser *` / `opencli doctor` / `opencli browser init` / `opencli browser verify`。没有新命令。
 
-调试浏览器型 adapter 时，优先直接带上 `--trace on --live --focus`。`--trace on` 每轮都落 trace artifact，`summary.md` 是失败/成功复盘入口；`--live --focus` 让 automation lease 保留且容器在前台，方便核对最终页面状态。
+调试浏览器型 adapter 时，优先直接带上 `--trace on --keep-tab true --window foreground`。`--trace on` 每轮都落 trace artifact，`summary.md` 是失败/成功复盘入口；`--keep-tab true --window foreground` 让 tab lease 保留且浏览器窗口在前台，方便核对最终页面状态。
 
 ---
 

--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -26,8 +26,8 @@ Until `doctor` is green, nothing else will work. Typical failures: Chrome not ru
 
 - `opencli browser *` commands keep an owned tab lease alive between calls. Owned leases share a dedicated automation container and are released with `opencli browser close` or when the idle timeout expires.
 - `opencli browser bind` binds a `bound:*` workspace to the Chrome tab you already have open. Use this for logged-in pages, SSO flows, or pages you manually positioned before handing control to the agent.
-- `--focus` (or `OPENCLI_WINDOW_FOCUSED=1`) opens the automation container in the foreground. Use it when you want to watch the page live.
-- `--live` (or `OPENCLI_LIVE=1`) is mainly for browser-backed adapter commands such as `opencli xiaohongshu note ...`. It keeps the adapter's automation lease open after the command returns so you can inspect the final page state.
+- `--window foreground|background` (or `OPENCLI_WINDOW=foreground|background`) chooses whether OpenCLI uses a foreground browser window or a background automation window.
+- `--keep-tab true|false` (or `OPENCLI_KEEP_TAB=true|false`) chooses whether the tab lease is kept after the command. `opencli browser *` defaults to `true`; browser-backed adapter commands default to `false` unless the adapter opts into site reuse.
 
 ### Bind Tab
 

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -82,7 +82,8 @@ A few commands override the default via `cmd.defaultFormat` (e.g. chat commands 
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Per-command timeout. |
 | `OPENCLI_CDP_ENDPOINT` | — | Manual CDP endpoint override (dev / remote Chrome / Electron). |
 | `OPENCLI_CACHE_DIR` | `~/.opencli/cache` | Network capture + browser-state cache. |
-| `OPENCLI_WINDOW_FOCUSED` | `false` | `1` → automation window opens in the foreground. |
+| `OPENCLI_WINDOW` | command-specific | `foreground` or `background` browser window mode. |
+| `OPENCLI_KEEP_TAB` | command-specific | `true` or `false`; controls whether browser tab leases are kept after a command. |
 | `OPENCLI_VERBOSE` | `false` | Verbose logging (also triggered by `-v`). |
 
 ## Self-repair

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -29,7 +29,7 @@ export class BrowserBridge implements IBrowserFactory {
     return this._state;
   }
 
-  async connect(opts: { timeout?: number; workspace?: string; idleTimeout?: number; contextId?: string } = {}): Promise<IPage> {
+  async connect(opts: { timeout?: number; workspace?: string; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background' } = {}): Promise<IPage> {
     if (this._state === 'connected' && this._page) return this._page;
     if (this._state === 'connecting') throw new Error('Already connecting');
     if (this._state === 'closing') throw new Error('Session is closing');
@@ -40,7 +40,7 @@ export class BrowserBridge implements IBrowserFactory {
     try {
       const contextId = opts.contextId ?? resolveProfileContextId();
       await this._ensureDaemon(opts.timeout, contextId);
-      this._page = new Page(opts.workspace, opts.idleTimeout, contextId);
+      this._page = new Page(opts.workspace, opts.idleTimeout, contextId, opts.windowMode);
       this._state = 'connected';
       return this._page;
     } catch (err) {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -53,7 +53,7 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background' }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -183,6 +183,19 @@ describe('daemon-client', () => {
     expect(body.contextId).toBe('work');
   });
 
+  it('sendCommand uses explicit windowMode before OPENCLI_WINDOW env fallback', async () => {
+    vi.stubEnv('OPENCLI_WINDOW', 'foreground');
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1 + 1', windowMode: 'background' });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { windowMode?: string };
+    expect(body.windowMode).toBe('background');
+  });
+
   it('sendCommand retries with a new id when daemon reports a duplicate pending id', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_123);
     const fetchMock = vi.mocked(fetch);

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -53,8 +53,8 @@ export interface DaemonCommand {
   timeoutMs?: number;
   cdpMethod?: string;
   cdpParams?: Record<string, unknown>;
-  /** When true, the owned automation container is created in the foreground */
-  windowFocused?: boolean;
+  /** Window foreground/background policy for owned Browser Bridge containers. */
+  windowMode?: 'foreground' | 'background';
   /** Custom idle timeout in seconds for this workspace session. Overrides the default. */
   idleTimeout?: number;
   /** Explicitly allow navigation inside a borrowed bound tab. */
@@ -181,10 +181,13 @@ async function sendCommandRaw(
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     const id = generateId();
-    const wf = process.env.OPENCLI_WINDOW_FOCUSED;
-    const windowFocused = (wf === '1' || wf === 'true') ? true : undefined;
+    const rawWindowMode = process.env.OPENCLI_WINDOW;
+    const envWindowMode = rawWindowMode === 'foreground' || rawWindowMode === 'background'
+      ? rawWindowMode
+      : undefined;
     const contextId = params.contextId ?? resolveProfileContextId();
-    const command: DaemonCommand = { id, action, ...params, ...(contextId && { contextId }), ...(windowFocused && { windowFocused }) };
+    const windowMode = params.windowMode ?? envWindowMode;
+    const command: DaemonCommand = { id, action, ...params, ...(contextId && { contextId }), ...(windowMode && { windowMode }) };
     try {
       const res = await requestDaemon('/command', {
         method: 'POST',

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -36,6 +36,7 @@ export class Page extends BasePage {
     private readonly workspace: string = 'default',
     idleTimeout?: number,
     public readonly contextId?: string,
+    private readonly windowMode?: 'foreground' | 'background',
   ) {
     super();
     this._idleTimeout = idleTimeout;
@@ -52,6 +53,7 @@ export class Page extends BasePage {
       workspace: this.workspace,
       ...(this.contextId && { contextId: this.contextId }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
+      ...(this.windowMode && { windowMode: this.windowMode }),
     };
   }
 
@@ -62,6 +64,7 @@ export class Page extends BasePage {
       ...(this.contextId && { contextId: this.contextId }),
       ...(this._page !== undefined && { page: this._page }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
+      ...(this.windowMode && { windowMode: this.windowMode }),
     };
   }
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -903,6 +903,7 @@ describe('browser tab targeting commands', () => {
 
     expect(browserState.page?.snapshot).toHaveBeenCalled();
     expect(browserState.page?.closeWindow).not.toHaveBeenCalled();
+    expect(stderrSpy.mock.calls.flat().join('')).toContain('--window/--keep-tab ignored for bound:* workspaces');
   });
 
   it('passes the opt-in AX source to browser state', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -378,13 +378,23 @@ describe('createProgram root help descriptions', () => {
       expect(data.command).toBe('opencli browser');
       expect(data.description).toBe('Browser control — navigate, click, type, extract, wait (no LLM needed)');
       expect(data.command_count).toBeGreaterThan(20);
-      expect(data.namespace_options).toMatchObject([
-        {
+      expect(data.namespace_options).toEqual(expect.arrayContaining([
+        expect.objectContaining({
           name: 'workspace',
           flags: '--workspace <name>',
           takes_value: 'required',
-        },
-      ]);
+        }),
+        expect.objectContaining({
+          name: 'window',
+          flags: '--window <mode>',
+          takes_value: 'required',
+        }),
+        expect.objectContaining({
+          name: 'keepTab',
+          flags: '--keep-tab <bool>',
+          takes_value: 'required',
+        }),
+      ]));
       expect(data.global_options).toEqual(expect.arrayContaining([
         expect.objectContaining({
           name: 'version',
@@ -455,7 +465,7 @@ describe('createProgram root help descriptions', () => {
         usage: 'opencli browser tab close [targetId] [options]',
         positionals: [{ name: 'targetId', help: 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"' }],
       });
-      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['workspace']);
+      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['workspace', 'window', 'keepTab']);
       expect(data.structured_help).toMatchObject({
         usage: 'opencli browser tab --help -f yaml',
       });
@@ -486,7 +496,7 @@ describe('createProgram root help descriptions', () => {
         },
       });
       expect(data.command_options.map((option: any) => option.name)).toEqual(['role', 'name', 'label', 'text', 'testid', 'nth', 'tab']);
-      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['workspace']);
+      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['workspace', 'window', 'keepTab']);
       expect(data.global_options.map((option: any) => option.name)).toContain('profile');
     } finally {
       process.argv = argv;
@@ -780,6 +790,8 @@ describe('browser tab targeting commands', () => {
     stderrSpy.mockClear();
     mockBrowserConnect.mockClear();
     mockBrowserClose.mockReset().mockResolvedValue(undefined);
+    delete process.env.OPENCLI_WINDOW;
+    delete process.env.OPENCLI_KEEP_TAB;
     mockBindTab.mockReset().mockResolvedValue({
       workspace: 'bound:default',
       page: 'tab-2',
@@ -811,6 +823,7 @@ describe('browser tab targeting commands', () => {
       ]),
       evaluateInFrame: vi.fn().mockResolvedValue('inside frame'),
       readNetworkCapture: vi.fn().mockResolvedValue([]),
+      closeWindow: vi.fn().mockResolvedValue(undefined),
       waitForDownload: vi.fn().mockResolvedValue({
         downloaded: true,
         filename: '/tmp/receipt.pdf',
@@ -861,8 +874,35 @@ describe('browser tab targeting commands', () => {
 
     await program.parseAsync(['node', 'opencli', 'browser', '--workspace', 'bound:default', 'state']);
 
-    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default' });
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'bound:default', windowMode: 'foreground' });
     expect(browserState.page?.snapshot).toHaveBeenCalled();
+  });
+
+  it('passes browser --window through Commander options without relying on env pre-processing', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--window', 'background', 'state']);
+
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 30, workspace: 'browser:default', windowMode: 'background' });
+    expect(browserState.page?.snapshot).toHaveBeenCalled();
+  });
+
+  it('releases non-bound browser tab leases when --keep-tab=false', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--keep-tab', 'false', 'state']);
+
+    expect(browserState.page?.snapshot).toHaveBeenCalled();
+    expect(browserState.page?.closeWindow).toHaveBeenCalled();
+  });
+
+  it('does not auto-release explicit bound workspaces when --keep-tab=false', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--workspace', 'bound:default', '--keep-tab', 'false', 'state']);
+
+    expect(browserState.page?.snapshot).toHaveBeenCalled();
+    expect(browserState.page?.closeWindow).not.toHaveBeenCalled();
   });
 
   it('passes the opt-in AX source to browser state', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './
 import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 import type { BrowserDownloadWaitResult, IPage, ScreenshotOptions } from './types.js';
+import type { BrowserWindowMode } from './runtime.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const DEFAULT_BROWSER_WORKSPACE = 'browser:default';
@@ -375,7 +376,12 @@ async function resolveStoredBrowserTarget(page: import('./types.js').IPage, scop
 }
 
 /** Create a browser page for browser commands. Uses a dedicated browser workspace for session persistence. */
-async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_BROWSER_WORKSPACE, contextId?: string): Promise<import('./types.js').IPage> {
+async function getBrowserPage(
+  targetPage?: string,
+  workspace: string = DEFAULT_BROWSER_WORKSPACE,
+  contextId?: string,
+  opts: { windowMode?: BrowserWindowMode } = {},
+): Promise<import('./types.js').IPage> {
   const { BrowserBridge } = await import('./browser/index.js');
   const bridge = new BrowserBridge();
   // Idle timeout: how long the browser workspace lease stays alive between commands
@@ -387,6 +393,7 @@ async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_B
     workspace,
     ...(contextId && { contextId }),
     ...(idleTimeout && idleTimeout > 0 && { idleTimeout }),
+    windowMode: opts.windowMode ?? getBrowserWindowMode(undefined, 'foreground'),
   });
   const targetScope = getBrowserScope(workspace, contextId);
   const resolvedTargetPage = targetPage
@@ -399,6 +406,33 @@ async function getBrowserPage(targetPage?: string, workspace: string = DEFAULT_B
     page.setActivePage(resolvedTargetPage);
   }
   return page;
+}
+
+function getBrowserWindowMode(command: Command | undefined, defaultMode: BrowserWindowMode): BrowserWindowMode {
+  const optionRaw = getCommandOption(command, 'window');
+  if (optionRaw !== undefined && optionRaw !== '') {
+    if (optionRaw === 'foreground' || optionRaw === 'background') return optionRaw;
+    throw new Error(`--window must be one of: foreground, background. Received: "${String(optionRaw)}"`);
+  }
+  const envRaw = process.env.OPENCLI_WINDOW;
+  if (envRaw !== undefined && envRaw !== '') {
+    if (envRaw === 'foreground' || envRaw === 'background') return envRaw;
+    throw new Error(`OPENCLI_WINDOW must be one of: foreground, background. Received: "${envRaw}"`);
+  }
+  return defaultMode;
+}
+
+function parseBrowserBoolean(name: string, raw: unknown): boolean | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  throw new Error(`${name} must be one of: true, false. Received: "${String(raw)}"`);
+}
+
+function getBrowserKeepTab(command: Command | undefined, defaultValue: boolean): boolean {
+  return parseBrowserBoolean('--keep-tab', getCommandOption(command, 'keepTab'))
+    ?? parseBrowserBoolean('OPENCLI_KEEP_TAB', process.env.OPENCLI_KEEP_TAB)
+    ?? defaultValue;
 }
 
 function addBrowserTabOption(command: Command): Command {
@@ -666,6 +700,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   const browser = program
     .command('browser')
     .option('--workspace <name>', 'Browser workspace to use (default: browser:default; bound tabs use bound:<name>)')
+    .option('--window <mode>', 'Browser window mode: foreground or background')
+    .option('--keep-tab <bool>', 'Keep the browser tab lease after the command finishes')
     .description('Browser control — navigate, click, type, extract, wait (no LLM needed)');
   const originalBrowserDescription = browser.description();
 
@@ -740,12 +776,17 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   /** Wrap browser actions with error handling and optional --json output */
   function browserAction(fn: (page: Awaited<ReturnType<typeof getBrowserPage>>, ...args: any[]) => Promise<unknown>) {
     return async (...args: any[]) => {
+      let page: Awaited<ReturnType<typeof getBrowserPage>> | null = null;
+      let shouldReleasePage = false;
       try {
         const command = args.at(-1) instanceof Command ? args.at(-1) as Command : undefined;
         const targetPage = getBrowserTargetId(command);
         const workspace = getBrowserWorkspace(command);
         const contextId = getBrowserContextId(command);
-        const page = await getBrowserPage(targetPage, workspace, contextId);
+        const windowMode = getBrowserWindowMode(command, 'foreground');
+        const keepTab = getBrowserKeepTab(command, true);
+        shouldReleasePage = !keepTab && !workspace.startsWith('bound:');
+        page = await getBrowserPage(targetPage, workspace, contextId, { windowMode });
         await fn(page, ...args);
       } catch (err) {
         if (err instanceof BrowserConnectError) {
@@ -782,6 +823,12 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           }
         }
         process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      } finally {
+        if (shouldReleasePage && page?.closeWindow) {
+          await page.closeWindow().catch((err) => {
+            if (process.env.OPENCLI_VERBOSE) log.warn(`[browser] Failed to release tab lease: ${getErrorMessage(err)}`);
+          });
+        }
       }
     };
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -435,6 +435,16 @@ function getBrowserKeepTab(command: Command | undefined, defaultValue: boolean):
     ?? defaultValue;
 }
 
+function hasExplicitBrowserWindowOption(command: Command | undefined): boolean {
+  const raw = getCommandOption(command, 'window');
+  return raw !== undefined && raw !== '';
+}
+
+function hasExplicitBrowserKeepTabOption(command: Command | undefined): boolean {
+  const raw = getCommandOption(command, 'keepTab');
+  return raw !== undefined && raw !== '';
+}
+
 function addBrowserTabOption(command: Command): Command {
   return command.option('--tab <targetId>', BROWSER_TAB_OPTION_DESCRIPTION);
 }
@@ -786,6 +796,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         const windowMode = getBrowserWindowMode(command, 'foreground');
         const keepTab = getBrowserKeepTab(command, true);
         shouldReleasePage = !keepTab && !workspace.startsWith('bound:');
+        if (workspace.startsWith('bound:') && (hasExplicitBrowserWindowOption(command) || hasExplicitBrowserKeepTabOption(command))) {
+          log.warn('--window/--keep-tab ignored for bound:* workspaces; bound tabs are user-owned.');
+        }
         page = await getBrowserPage(targetPage, workspace, contextId, { windowMode });
         await fn(page, ...args);
       } catch (err) {

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -61,6 +61,11 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
     .option('-f, --format <fmt>', 'Output format: table, plain, json, yaml, md, csv', 'table')
     .option('--trace <mode>', 'Trace capture: off, on, retain-on-failure', 'off')
     .option('-v, --verbose', 'Debug output', false);
+  if (cmd.browser) {
+    subCmd
+      .option('--window <mode>', 'Browser window mode: foreground or background')
+      .option('--keep-tab <bool>', 'Keep the browser tab lease after the command finishes');
+  }
 
   const originalHelpInformation = subCmd.helpInformation.bind(subCmd);
   subCmd.helpInformation = ((contextOptions?: unknown) => {
@@ -112,6 +117,8 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         prepared: true,
         ...(typeof globals.profile === 'string' && globals.profile.trim() ? { profile: globals.profile.trim() } : {}),
         ...(typeof optionsRecord.trace === 'string' && optionsRecord.trace !== 'off' ? { trace: optionsRecord.trace } : {}),
+        ...(cmd.browser && typeof optionsRecord.window === 'string' ? { windowMode: optionsRecord.window } : {}),
+        ...(cmd.browser && typeof optionsRecord.keepTab === 'string' ? { keepTab: optionsRecord.keepTab } : {}),
       });
       if (result === null || result === undefined) {
         return;

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -138,14 +138,14 @@ describe('doctor report rendering', () => {
           windowId: 2,
           preferredTabId: 42,
           ownership: 'borrowed',
-          surface: 'borrowed-user-tab',
+          windowRole: 'borrowed-user',
           tabCount: 1,
           idleMsRemaining: null,
         },
       ],
     }));
 
-    expect(text).toContain('bound:default → tab 42, mode=borrowed, surface=borrowed-user-tab, tabs=1, idle=none');
+    expect(text).toContain('bound:default → tab 42, mode=borrowed, window=borrowed-user, tabs=1, idle=none');
   });
 
   it('renders connected profiles and groups sessions by profile', () => {
@@ -164,7 +164,7 @@ describe('doctor report rendering', () => {
           windowId: 2,
           preferredTabId: 42,
           ownership: 'borrowed',
-          surface: 'borrowed-user-tab',
+          windowRole: 'borrowed-user',
           tabCount: 1,
           idleMsRemaining: null,
         },
@@ -174,7 +174,7 @@ describe('doctor report rendering', () => {
           windowId: 1,
           preferredTabId: 10,
           ownership: 'owned',
-          surface: 'dedicated-container',
+          windowRole: 'automation',
           tabCount: 1,
           idleMsRemaining: 1000,
         },

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -322,8 +322,8 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
           ? `tab ${session.preferredTabId}`
           : `window ${session.windowId ?? 'unknown'}`;
         const mode = session.ownership ?? (session.owned === false ? 'borrowed' : 'owned');
-        const surface = session.surface ? `, surface=${session.surface}` : '';
-        lines.push(styleText('dim', `  • ${session.workspace ?? 'default'} → ${target}, mode=${mode}${surface}, tabs=${session.tabCount ?? 0}, idle=${idle}`));
+        const windowRole = session.windowRole ? `, window=${session.windowRole}` : '';
+        lines.push(styleText('dim', `  • ${session.workspace ?? 'default'} → ${target}, mode=${mode}${windowRole}, tabs=${session.tabCount ?? 0}, idle=${idle}`));
       }
       }
     }

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -168,7 +168,7 @@ describe('executeCommand — non-browser timeout', () => {
   it('reuses a site-scoped browser workspace and keeps the tab lease open', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
-    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number }> = [];
+    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number; windowMode?: string }> = [];
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
@@ -190,8 +190,8 @@ describe('executeCommand — non-browser timeout', () => {
     await executeCommand(cmd, {});
 
     expect(sessionOpts).toHaveLength(2);
-    expect(sessionOpts[0]).toMatchObject({ workspace: 'site:test-execution', idleTimeout: 600 });
-    expect(sessionOpts[1]).toMatchObject({ workspace: 'site:test-execution', idleTimeout: 600 });
+    expect(sessionOpts[0]).toMatchObject({ workspace: 'site:test-execution', idleTimeout: 600, windowMode: 'background' });
+    expect(sessionOpts[1]).toMatchObject({ workspace: 'site:test-execution', idleTimeout: 600, windowMode: 'background' });
     expect(closeWindow).not.toHaveBeenCalled();
     vi.restoreAllMocks();
   });
@@ -199,7 +199,7 @@ describe('executeCommand — non-browser timeout', () => {
   it('keeps default browser commands on one-shot workspaces', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
-    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number }> = [];
+    const sessionOpts: Array<{ workspace?: string; idleTimeout?: number; windowMode?: string }> = [];
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
@@ -225,6 +225,8 @@ describe('executeCommand — non-browser timeout', () => {
     expect(sessionOpts[0]?.workspace).not.toBe(sessionOpts[1]?.workspace);
     expect(sessionOpts[0]?.idleTimeout).toBeUndefined();
     expect(sessionOpts[1]?.idleTimeout).toBeUndefined();
+    expect(sessionOpts[0]?.windowMode).toBe('background');
+    expect(sessionOpts[1]?.windowMode).toBe('background');
     expect(closeWindow).toHaveBeenCalledTimes(2);
     vi.restoreAllMocks();
   });
@@ -440,20 +442,20 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
-  it('skips closeWindow when OPENCLI_LIVE=1 (success path)', async () => {
+  it('skips closeWindow when OPENCLI_KEEP_TAB=true (success path)', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
 
-    const prev = process.env.OPENCLI_LIVE;
-    process.env.OPENCLI_LIVE = '1';
+    const prev = process.env.OPENCLI_KEEP_TAB;
+    process.env.OPENCLI_KEEP_TAB = 'true';
     try {
       const cmd = cli({
         site: 'test-execution',
-        name: 'browser-live-success', access: 'read',
-        description: 'test closeWindow skipped with --live on success',
+        name: 'browser-keep-tab-success', access: 'read',
+        description: 'test closeWindow skipped with --keep-tab on success',
         browser: true,
         strategy: Strategy.PUBLIC,
         func: async () => [{ ok: true }],
@@ -462,26 +464,26 @@ describe('executeCommand — non-browser timeout', () => {
       await executeCommand(cmd, {});
       expect(closeWindow).not.toHaveBeenCalled();
     } finally {
-      if (prev === undefined) delete process.env.OPENCLI_LIVE;
-      else process.env.OPENCLI_LIVE = prev;
+      if (prev === undefined) delete process.env.OPENCLI_KEEP_TAB;
+      else process.env.OPENCLI_KEEP_TAB = prev;
       vi.restoreAllMocks();
     }
   });
 
-  it('skips closeWindow when OPENCLI_LIVE=1 (failure path)', async () => {
+  it('skips closeWindow when OPENCLI_KEEP_TAB=true (failure path)', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
 
-    const prev = process.env.OPENCLI_LIVE;
-    process.env.OPENCLI_LIVE = '1';
+    const prev = process.env.OPENCLI_KEEP_TAB;
+    process.env.OPENCLI_KEEP_TAB = 'true';
     try {
       const cmd = cli({
         site: 'test-execution',
-        name: 'browser-live-failure', access: 'read',
-        description: 'test closeWindow skipped with --live on failure',
+        name: 'browser-keep-tab-failure', access: 'read',
+        description: 'test closeWindow skipped with --keep-tab on failure',
         browser: true,
         strategy: Strategy.PUBLIC,
         func: async () => { throw new Error('adapter failure'); },
@@ -490,10 +492,40 @@ describe('executeCommand — non-browser timeout', () => {
       await expect(executeCommand(cmd, {})).rejects.toThrow('adapter failure');
       expect(closeWindow).not.toHaveBeenCalled();
     } finally {
-      if (prev === undefined) delete process.env.OPENCLI_LIVE;
-      else process.env.OPENCLI_LIVE = prev;
+      if (prev === undefined) delete process.env.OPENCLI_KEEP_TAB;
+      else process.env.OPENCLI_KEEP_TAB = prev;
       vi.restoreAllMocks();
     }
+  });
+
+  it('lets browser common options override adapter window and keep-tab defaults', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+    const sessionOpts: Array<{ windowMode?: string }> = [];
+
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
+      sessionOpts.push(opts ?? {});
+      return fn(mockPage);
+    });
+
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'browser-window-options', access: 'read',
+      description: 'test browser common options',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {}, false, {
+      windowMode: 'foreground',
+      keepTab: 'true',
+    });
+
+    expect(sessionOpts[0]).toMatchObject({ windowMode: 'foreground' });
+    expect(closeWindow).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 
   it('does not re-run custom validation when args are already prepared', async () => {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -28,7 +28,7 @@ import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
 import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceReceipt, getErrorMessage } from './errors.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
-import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT } from './runtime.js';
+import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
 import { resolveProfileContextId } from './browser/profile.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
@@ -202,6 +202,8 @@ export async function executeCommand(
     prepared?: boolean;
     profile?: string;
     trace?: string;
+    keepTab?: string;
+    windowMode?: string;
     onTraceExport?: (trace: ObservationExportResult) => void;
   } = {},
 ): Promise<unknown> {
@@ -252,6 +254,8 @@ export async function executeCommand(
       const browserReuse = resolveBrowserSessionReuse(cmd);
       const workspace = resolveBrowserWorkspace(cmd, browserReuse);
       const idleTimeout = browserReuse === 'site' ? INTERACTIVE_BROWSER_IDLE_TIMEOUT_SECONDS : undefined;
+      const keepTab = resolveKeepTab(browserReuse, opts.keepTab);
+      const windowMode = resolveBrowserWindowMode('background', opts.windowMode);
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
           ? null
@@ -320,9 +324,6 @@ export async function executeCommand(
             throw wrapped;
           }
         }
-        // --live / OPENCLI_LIVE=1 keeps the current automation tab lease after
-        // the command finishes, so agents (or humans) can inspect the page state.
-        const keepOpen = browserReuse !== 'none' || process.env.OPENCLI_LIVE === '1' || process.env.OPENCLI_LIVE === 'true';
         try {
           const browserTimeout = userTimeoutSec !== null
             ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
@@ -343,7 +344,7 @@ export async function executeCommand(
           // Adapter commands are one-shot — release the current tab lease immediately
           // instead of waiting for the 30s idle timeout. The automation container
           // window stays open for reuse.
-          if (!keepOpen) await page.closeWindow?.().catch(() => {});
+          if (!keepTab) await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
           if (observation) {
@@ -366,10 +367,10 @@ export async function executeCommand(
           // Release the tab lease on failure too — without this, the lease lingers
           // until the extension's idle timer fires (unreliable on Windows where
           // MV3 service workers may be suspended before setTimeout triggers).
-          if (!keepOpen) await page.closeWindow?.().catch(() => {});
+          if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { workspace, cdpEndpoint, contextId, idleTimeout });
+      }, { workspace, cdpEndpoint, contextId, idleTimeout, windowMode });
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that
@@ -501,6 +502,31 @@ function resolveBrowserSessionReuse(cmd: CliCommand): BrowserSessionReuse {
 function resolveBrowserWorkspace(cmd: CliCommand, reuse: BrowserSessionReuse): string {
   if (reuse === 'site') return `site:${cmd.site}`;
   return `site:${cmd.site}:${crypto.randomUUID()}`;
+}
+
+function normalizeBooleanOption(name: string, raw: unknown): boolean | null {
+  if (raw === undefined || raw === '') return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  throw new ArgumentError(`${name} must be one of: true, false. Received: "${String(raw)}"`);
+}
+
+function resolveKeepTab(reuse: BrowserSessionReuse, rawOption?: unknown): boolean {
+  return normalizeBooleanOption('--keep-tab', rawOption)
+    ?? normalizeBooleanOption('OPENCLI_KEEP_TAB', process.env.OPENCLI_KEEP_TAB)
+    ?? reuse !== 'none';
+}
+
+function normalizeWindowMode(name: string, raw: unknown): BrowserWindowMode | null {
+  if (raw === undefined || raw === '') return null;
+  if (raw === 'foreground' || raw === 'background') return raw;
+  throw new ArgumentError(`${name} must be one of: foreground, background. Received: "${String(raw)}"`);
+}
+
+function resolveBrowserWindowMode(defaultMode: BrowserWindowMode = 'background', rawOption?: unknown): BrowserWindowMode {
+  return normalizeWindowMode('--window', rawOption)
+    ?? normalizeWindowMode('OPENCLI_WINDOW', process.env.OPENCLI_WINDOW)
+    ?? defaultMode;
 }
 
 /**

--- a/src/help.ts
+++ b/src/help.ts
@@ -54,6 +54,21 @@ const COMMON_OPTIONS = [
   },
 ] as const;
 
+const BROWSER_COMMON_OPTIONS = [
+  {
+    flags: '--window <mode>',
+    name: 'window',
+    help: 'Browser window mode: foreground or background',
+    choices: ['foreground', 'background'],
+  },
+  {
+    flags: '--keep-tab <bool>',
+    name: 'keep-tab',
+    help: 'Keep the browser tab lease after the command finishes',
+    choices: ['true', 'false'],
+  },
+] as const;
+
 function normalizeStructuredHelpFormat(value: string | undefined): StructuredHelpFormat | undefined {
   const normalized = value?.toLowerCase();
   if (normalized === 'yaml' || normalized === 'yml') return 'yaml';
@@ -168,7 +183,7 @@ function compactArg(arg: Arg): Record<string, unknown> {
   };
 }
 
-function compactCommonOption(option: typeof COMMON_OPTIONS[number]): Record<string, unknown> {
+function compactCommonOption(option: typeof COMMON_OPTIONS[number] | typeof BROWSER_COMMON_OPTIONS[number]): Record<string, unknown> {
   return {
     name: option.name,
     flags: option.flags,
@@ -396,6 +411,7 @@ function compactCommand(cmd: CliCommand): Record<string, unknown> {
     ...(cmd.aliases?.length ? { aliases: cmd.aliases } : {}),
     positionals: positionals(cmd).map(compactArg),
     command_options: commandOptions(cmd).map(compactArg),
+    ...(cmd.browser ? { browser_common_options: BROWSER_COMMON_OPTIONS.map(compactCommonOption) } : {}),
     example: formatCommandExample(cmd),
     ...(cmd.browserSession ? { browserSession: cmd.browserSession } : {}),
     ...(cmd.defaultFormat ? { defaultFormat: cmd.defaultFormat } : {}),
@@ -445,6 +461,7 @@ export function siteHelpData(site: string, commands: readonly CliCommand[]): Rec
     command_count: unique.length,
     commands: unique.map(cmd => compactCommand(cmd)),
     common_options: COMMON_OPTIONS.map(compactCommonOption),
+    ...(unique.some(cmd => cmd.browser) ? { browser_common_options: BROWSER_COMMON_OPTIONS.map(compactCommonOption) } : {}),
     next: [
       `opencli ${site} <command> --help -f yaml`,
       `opencli ${site} <command> -f yaml`,
@@ -457,6 +474,7 @@ export function commandHelpData(cmd: CliCommand): Record<string, unknown> {
     site: cmd.site,
     ...compactCommand(cmd),
     common_options: COMMON_OPTIONS.map(compactCommonOption),
+    ...(cmd.browser ? { browser_common_options: BROWSER_COMMON_OPTIONS.map(compactCommonOption) } : {}),
     output_formats: ['table', 'plain', 'yaml', 'json', 'md', 'csv'],
   };
 }
@@ -485,6 +503,15 @@ export function formatCommonOptionsHelpText(): string {
   return ['Common options:', ...formatRows(rows)].join('\n');
 }
 
+export function formatBrowserCommonOptionsHelpText(): string {
+  const rows = BROWSER_COMMON_OPTIONS.map(option => {
+    const details: string[] = [option.help];
+    if ('choices' in option) details.push(`choices: ${option.choices.join(', ')}`);
+    return [option.flags, details.join('  ')] as [string, string];
+  });
+  return ['Browser common options:', ...formatRows(rows)].join('\n');
+}
+
 export function formatSiteHelpText(site: string, commands: readonly CliCommand[]): string {
   const unique = [...new Map(commands.map(cmd => [fullName(cmd), cmd])).values()]
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -497,6 +524,7 @@ export function formatSiteHelpText(site: string, commands: readonly CliCommand[]
     ...formatRows(unique.map(cmd => [formatCommandListTerm(cmd), formatSiteCommandDescription(cmd)])),
     '',
     formatCommonOptionsHelpText(),
+    ...(unique.some(cmd => cmd.browser) ? ['', formatBrowserCommonOptionsHelpText()] : []),
     '',
     `Agent tip: use 'opencli ${site} --help -f yaml' to get all command args/options in one structured response.`,
     '',
@@ -529,6 +557,7 @@ export function formatCommandHelpText(cmd: CliCommand): string {
   }
 
   lines.push(formatCommonOptionsHelpText(), '');
+  if (cmd.browser) lines.push(formatBrowserCommonOptionsHelpText(), '');
 
   const meta: string[] = [];
   meta.push(`Access: ${cmd.access}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,21 +30,11 @@ const __dirname = path.dirname(__filename);
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 
-// ── Session lifecycle flags ──────────────────────────────────────────────
-// `--live` / `--focus` / `--reuse` are top-level-ish toggles that tweak the automation
-// window's lifecycle. We strip them from argv before Commander runs so they
-// can be placed anywhere and work on any subcommand (adapter or browser).
+// ── Browser reuse flag ───────────────────────────────────────────────────
+// `--reuse` is a runtime-level browser session override rather than an adapter
+// arg. Strip it before Commander runs and expose it through an explicit env
+// name. Window/keep-tab are registered on browser-backed commands directly.
 {
-  const liveIdx = process.argv.indexOf('--live');
-  if (liveIdx !== -1) {
-    process.env.OPENCLI_LIVE = '1';
-    process.argv.splice(liveIdx, 1);
-  }
-  const focusIdx = process.argv.indexOf('--focus');
-  if (focusIdx !== -1) {
-    process.env.OPENCLI_WINDOW_FOCUSED = '1';
-    process.argv.splice(focusIdx, 1);
-  }
   const reuseIdx = process.argv.findIndex(arg => arg === '--reuse' || arg.startsWith('--reuse='));
   if (reuseIdx !== -1) {
     const arg = process.argv[reuseIdx];

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -27,6 +27,8 @@ function parseEnvTimeout(envVar: string, fallback: number): number {
 export const DEFAULT_BROWSER_CONNECT_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_CONNECT_TIMEOUT', 30);
 export const DEFAULT_BROWSER_COMMAND_TIMEOUT = parseEnvTimeout('OPENCLI_BROWSER_COMMAND_TIMEOUT', 60);
 
+export type BrowserWindowMode = 'foreground' | 'background';
+
 /**
  * Timeout with seconds unit. Used for high-level command timeouts.
  */
@@ -63,14 +65,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number }): Promise<IPage>;
+  connect(opts?: { timeout?: number; workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number } = {},
+  opts: { workspace?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -80,6 +82,7 @@ export async function browserSession<T>(
       cdpEndpoint: opts.cdpEndpoint,
       contextId: opts.contextId,
       idleTimeout: opts.idleTimeout,
+      windowMode: opts.windowMode,
     });
     return await fn(page);
   } finally {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface BrowserSessionInfo {
   owned?: boolean;
   ownership?: 'owned' | 'borrowed';
   lifecycle?: 'ephemeral' | 'persistent' | 'pinned';
-  surface?: 'dedicated-container' | 'borrowed-user-tab';
+  windowRole?: 'interactive' | 'automation' | 'borrowed-user';
   contextId?: string;
   tabCount?: number;
   idleMsRemaining?: number | null;


### PR DESCRIPTION
## Summary
- replace `--live` / `OPENCLI_LIVE` with `--keep-tab true|false` / `OPENCLI_KEEP_TAB`
- replace `--focus` / `OPENCLI_WINDOW_FOCUSED` with `--window foreground|background` / `OPENCLI_WINDOW`
- scope these as browser runtime common options for `opencli browser` and browser-backed adapters, not global common options
- split Browser Bridge owned containers into separate `interactive` (`opencli browser`) and `automation` (adapter) windows
- keep `bound:*` explicit and user-owned; window mode does not auto-bind or take over user tabs

## Defaults
- `opencli browser *`: foreground window, keep tab lease
- browser-backed adapters: background automation window, release tab lease
- `browserSession.reuse: 'site'`: keep tab lease by default

## Verification
- `npm test -- --run src/browser/daemon-client.test.ts src/execution.test.ts src/cli.test.ts src/doctor.test.ts extension/src/background.test.ts`
- `npm run typecheck`
- `npm run typecheck --prefix extension`
- `npm run build --prefix extension`
- `npm run docs:build`
- `npm run build`
- `git diff --check`
