### PR TITLE
perf(twitter): enable browserSession reuse:site on 17 read-only adapters (PR B)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -22175,7 +22175,10 @@
     "type": "js",
     "modulePath": "twitter/article.js",
     "sourceFile": "twitter/article.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22273,7 +22276,10 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
     "sourceFile": "twitter/bookmark-folder.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22293,7 +22299,10 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folders.js",
     "sourceFile": "twitter/bookmark-folders.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22332,7 +22341,10 @@
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
     "sourceFile": "twitter/bookmarks.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22406,7 +22418,10 @@
     "type": "js",
     "modulePath": "twitter/download.js",
     "sourceFile": "twitter/download.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22466,7 +22481,10 @@
     "type": "js",
     "modulePath": "twitter/followers.js",
     "sourceFile": "twitter/followers.js",
-    "navigateBefore": true
+    "navigateBefore": true,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22501,7 +22519,10 @@
     "type": "js",
     "modulePath": "twitter/following.js",
     "sourceFile": "twitter/following.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22601,7 +22622,10 @@
     "type": "js",
     "modulePath": "twitter/likes.js",
     "sourceFile": "twitter/likes.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22719,7 +22743,10 @@
     "type": "js",
     "modulePath": "twitter/list-tweets.js",
     "sourceFile": "twitter/list-tweets.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22748,7 +22775,10 @@
     "type": "js",
     "modulePath": "twitter/lists.js",
     "sourceFile": "twitter/lists.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22777,7 +22807,10 @@
     "type": "js",
     "modulePath": "twitter/notifications.js",
     "sourceFile": "twitter/notifications.js",
-    "navigateBefore": true
+    "navigateBefore": true,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -22845,7 +22878,10 @@
     "type": "js",
     "modulePath": "twitter/profile.js",
     "sourceFile": "twitter/profile.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -23113,7 +23149,10 @@
     "type": "js",
     "modulePath": "twitter/search.js",
     "sourceFile": "twitter/search.js",
-    "navigateBefore": true
+    "navigateBefore": true,
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -23159,7 +23198,10 @@
     "type": "js",
     "modulePath": "twitter/thread.js",
     "sourceFile": "twitter/thread.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -23212,7 +23254,10 @@
     "type": "js",
     "modulePath": "twitter/timeline.js",
     "sourceFile": "twitter/timeline.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -23239,7 +23284,10 @@
     "type": "js",
     "modulePath": "twitter/trending.js",
     "sourceFile": "twitter/trending.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",
@@ -23289,7 +23337,10 @@
     "type": "js",
     "modulePath": "twitter/tweets.js",
     "sourceFile": "twitter/tweets.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "browserSession": {
+      "reuse": "site"
+    }
   },
   {
     "site": "twitter",

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -11,6 +11,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'tweet-id', type: 'string', positional: true, required: true, help: 'Tweet ID or URL containing the article' },
     ],

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -122,6 +122,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'folder-id', positional: true, type: 'string', required: true, help: 'Folder id from `opencli twitter bookmark-folders`.' },
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },

--- a/clis/twitter/bookmark-folders.js
+++ b/clis/twitter/bookmark-folders.js
@@ -77,6 +77,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [],
     columns: ['id', 'name', 'items', 'created_at'],
     func: async (page) => {

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -105,6 +105,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },

--- a/clis/twitter/download.js
+++ b/clis/twitter/download.js
@@ -15,6 +15,7 @@ cli({
     description: 'Download Twitter/X media (images and videos). Provide either <username> to scan a profile\'s media tab, or --tweet-url to download a single tweet.',
     domain: 'x.com',
     strategy: Strategy.COOKIE,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'username', positional: true, help: 'Twitter username (with or without @) to scan their /media tab. Either <username> or --tweet-url is required.' },
         { name: 'tweet-url', help: 'Single tweet URL to download. Use this OR <username>, not both required at once.' },

--- a/clis/twitter/followers.js
+++ b/clis/twitter/followers.js
@@ -83,6 +83,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.UI,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         {
             name: 'user',

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -139,6 +139,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         {
             name: 'user',

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -142,6 +142,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of liked tweets to return (default 20).' },

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -112,6 +112,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'listId', positional: true, type: 'string', required: true, help: 'Numeric ID of a Twitter/X list (e.g. from `opencli twitter lists`)' },
         { name: 'limit', type: 'int', default: 50 },

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -92,6 +92,7 @@ export const command = cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'limit', type: 'int', default: 50, help: 'Maximum number of lists to return (default 50).' },
     ],

--- a/clis/twitter/notifications.js
+++ b/clis/twitter/notifications.js
@@ -8,6 +8,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.INTERCEPT,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of notifications to return (default 20).' },
     ],

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -11,6 +11,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
     ],

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -228,6 +228,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.INTERCEPT, // Use intercept strategy
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: 'Search query. Raw X operators (e.g. "exact phrase", #tag, OR, lang:en, since:YYYY-MM-DD, from:, since:) are passed through unchanged.' },
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'], help: 'Legacy alias for --product. Kept for backwards compatibility; if --product is set it wins.' },

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -100,6 +100,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'tweet-id', positional: true, type: 'string', required: true, help: 'Tweet numeric ID (e.g. 1234567890) or full status URL' },
         { name: 'limit', type: 'int', default: 50 },

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -141,6 +141,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         {
             name: 'type',

--- a/clis/twitter/trending.js
+++ b/clis/twitter/trending.js
@@ -17,6 +17,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of trends to show' },
     ],

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -149,6 +149,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    browserSession: { reuse: 'site' },
     args: [
         { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (with or without @)' },
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },


### PR DESCRIPTION
## Summary

Read-only Twitter/X adapters now declare `browserSession: { reuse: 'site' }`, matching the LLM-site adapters (claude/gemini/yuanbao/etc.). This unblocks the perf wins WAWQAQ called out for the thread.js 35s→9s/3.4s progression (#OpenCLI:3889b5cf, msg=fa209a2c).

This is **PR B** in the agreed cookie-API/perf sweep:
- PR A #1450 (merged, `60dbbd4b`) — `document.cookie` → `page.getCookies({domain})` hoist
- PR C #1451 (merged, `ff7d741a`) — drop redundant `goto + wait` (framework auto pre-navs)
- **PR B (this) — `browserSession: { reuse: 'site' }` for read-only twitter**
- D-track (coding-claude-opus, parallel) — wait→event sweep across LLM sites

## What changes

- Tab lease shared across calls under `site:twitter` until idle expiry, so the second-and-later command pays no cold-start tab cost.
- Framework's domain-root pre-nav (`https://x.com`) is skipped on subsequent calls when the reused tab is already on x.com (`shouldRunPreNav` → `isDomainRootPreNav` + `urlMatchesDomain` short-circuit at `src/execution.ts:190`).

## Files (17 read-only adapters)

- **Strategy.COOKIE × 14**: article, bookmark-folder, bookmark-folders, bookmarks, download, following, likes, list-tweets, lists, profile, thread, timeline, trending, tweets
- **Strategy.UI × 1**: followers
- **Strategy.INTERCEPT × 2**: notifications, search

Insertion point in each file: after `browser: true,` (or after `strategy:` in download.js which omits the explicit `browser:` field), matching the convention used by yuanbao/read.js, claude/read.js, etc.

Manifest regenerated (`cli-manifest.json`: +85/-17 — 17 entries gain the `browserSession: { reuse: "site" }` block).

## Scope notes (intentionally NOT in this PR)

- **Write adapters** (post/reply/quote/like/retweet/bookmark/follow/list-add/list-remove/delete/hide-reply/block/accept/follow) are kept as one-shot by default — `reuse: 'site'` for write paths is a separate decision about action idempotency under tab reuse.
- **Comment polish on thread.js / timeline.js**: still says "Cookie context auto-established by framework pre-nav"; the deeper truth (CDP `getCookies({url})` is origin-independent — framing nit from coding-claude-opus on PR C) is left as a doc-only follow-up to keep this PR's diff focused on the perf gain.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run clis/twitter --reporter=dot` → 218/218 pass (25 files)
- [x] `npx vitest run src/convention-audit.test.ts --reporter=dot` → 8/8 pass
- [x] `node scripts/check-typed-error-lint.mjs` → 189/189 baseline, no new violations
- [x] `node scripts/check-silent-column-drop.mjs` → 103/103 baseline, no new violations
- [x] `npm run build-manifest` → 801 entries, 17 manifest entries gain the new field
- [ ] Live verify on a couple of read commands back-to-back to observe the cold-start saving (requires logged-in twitter session — leaving for human verification per PR C path)

Refs: #OpenCLI:3889b5cf (WAWQAQ msg=fa209a2c, msg=35c90460, msg=838128ef "你们继续做啊… 后面还有那么多其他的东西呢")