### PR TITLE
perf(chatgpt): replace fixed-sleep waits with selector-based readiness (D3)

### DIFF
--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -43,7 +43,8 @@ export const askCommand = cli({
         } else {
             await ensureOnChatGPT(page);
         }
-        await page.wait(2);
+        // startNewChat / ensureOnChatGPT now wait for the composer selector
+        // after navigating, so the previous standalone 2 s settle is redundant.
         await ensureChatGPTComposer(page, 'ChatGPT ask requires a logged-in ChatGPT session with a visible composer.');
 
         const baseline = await getBubbleCount(page);

--- a/clis/chatgpt/detail.js
+++ b/clis/chatgpt/detail.js
@@ -3,6 +3,7 @@ import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
     CHATGPT_DOMAIN,
     CHATGPT_URL,
+    CONVERSATION_MESSAGE_SELECTOR,
     ensureChatGPTLogin,
     getVisibleMessages,
     messageHtmlToMarkdown,
@@ -29,7 +30,11 @@ export const detailCommand = cli({
         const id = parseChatGPTConversationId(kwargs.id);
         const wantMarkdown = normalizeBooleanFlag(kwargs.markdown, false);
         await page.goto(`${CHATGPT_URL}/c/${id}`, { settleMs: 2000 });
-        await page.wait(4);
+        try {
+            await page.wait({ selector: CONVERSATION_MESSAGE_SELECTOR, timeout: 10 });
+        } catch {
+            // Empty conversation, missing access, or login redirect — handled by ensureChatGPTLogin / EmptyResultError below.
+        }
         await ensureChatGPTLogin(page, 'ChatGPT detail requires a logged-in ChatGPT session.');
         const messages = await getVisibleMessages(page);
         if (!messages.length) {

--- a/clis/chatgpt/read.js
+++ b/clis/chatgpt/read.js
@@ -25,8 +25,9 @@ export const readCommand = cli({
     columns: ['Index', 'Role', 'Text'],
     func: async (page, kwargs) => {
         const wantMarkdown = normalizeBooleanFlag(kwargs.markdown, false);
+        // ensureOnChatGPT now waits for the composer selector after navigating,
+        // so the previous standalone 2 s settle is redundant.
         await ensureOnChatGPT(page);
-        await page.wait(2);
         await ensureChatGPTLogin(page, 'ChatGPT read requires a logged-in ChatGPT session.');
         const messages = await getVisibleMessages(page);
         if (!messages.length) {

--- a/clis/chatgpt/send.js
+++ b/clis/chatgpt/send.js
@@ -34,7 +34,8 @@ export const sendCommand = cli({
         } else {
             await ensureOnChatGPT(page);
         }
-        await page.wait(2);
+        // startNewChat / ensureOnChatGPT now wait for the composer selector
+        // after navigating, so the previous standalone 2 s settle is redundant.
         await ensureChatGPTComposer(page, 'ChatGPT send requires a logged-in ChatGPT session with a visible composer.');
 
         const sent = await sendChatGPTMessage(page, prompt);

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -127,16 +127,34 @@ export async function isOnChatGPT(page) {
     }
 }
 
+// Comma-joined CSS selector list passed to page.wait({ selector }) so the
+// wait succeeds as soon as any composer flavour mounts (querySelectorAll
+// matches all of them). Tracks the most stable subset of COMPOSER_SELECTORS;
+// we only need to know "the composer is ready", not which variant rendered.
+const COMPOSER_WAIT_SELECTOR = '#prompt-textarea, [data-testid="prompt-textarea"]';
+const CONVERSATION_LINK_SELECTOR = 'a[href*="/c/"]';
+// Selector used by detail.js to wait for at least one rendered message bubble
+// after navigating to /c/<id>; mirrors the markup queried by getVisibleMessages.
+export const CONVERSATION_MESSAGE_SELECTOR = '[data-message-author-role], article[data-testid*="conversation-turn"]';
+
 export async function ensureOnChatGPT(page) {
     if (await isOnChatGPT(page)) return false;
     await page.goto(CHATGPT_URL, { settleMs: 2000 });
-    await page.wait(2);
+    try {
+        await page.wait({ selector: COMPOSER_WAIT_SELECTOR, timeout: 8 });
+    } catch {
+        // Composer didn't mount; downstream ensureChatGPTLogin / ensureChatGPTComposer surfaces a typed error.
+    }
     return true;
 }
 
 export async function startNewChat(page) {
     await page.goto(`${CHATGPT_URL}/new`, { settleMs: 2000 });
-    await page.wait(2);
+    try {
+        await page.wait({ selector: COMPOSER_WAIT_SELECTOR, timeout: 8 });
+    } catch {
+        // Composer didn't mount; downstream ensureChatGPTComposer surfaces a typed error.
+    }
 }
 
 export async function getPageState(page) {
@@ -198,11 +216,11 @@ export async function sendChatGPTMessage(page, text) {
             if (closeBtn) closeBtn.click();
         })()
     `);
-    await page.wait(0.5);
+    // The previous 0.5 s + 1.5 s pre-composer settles are dropped: the next
+    // page.evaluate roundtrip flushes the close-sidebar React update and
+    // findComposer() retries inside a single CDP call, so no fixed sleep is
+    // needed before reading the composer.
 
-    // Wait for composer to be ready and use Playwright's type()
-    await page.wait(1.5);
-    
     const typeResult = await page.evaluate(`
         (() => {
             ${buildComposerLocatorScript()}
@@ -372,8 +390,9 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
 }
 
 export async function getConversationList(page) {
+    // ensureOnChatGPT already waits for the composer selector after navigation,
+    // so the previous standalone 2 s settle is redundant.
     await ensureOnChatGPT(page);
-    await page.wait(2);
 
     const openSidebar = await page.evaluate(`(() => {
         const button = Array.from(document.querySelectorAll('button'))
@@ -384,12 +403,22 @@ export async function getConversationList(page) {
         }
         return false;
     })()`);
-    if (openSidebar) await page.wait(1);
+    if (openSidebar) {
+        try {
+            await page.wait({ selector: CONVERSATION_LINK_SELECTOR, timeout: 3 });
+        } catch {
+            // Sidebar slide-in didn't surface conversation links; extractConversationLinks below tolerates empty and falls back to home goto.
+        }
+    }
 
     let items = await extractConversationLinks(page);
     if (!items.length) {
         await page.goto(CHATGPT_URL, { settleMs: 2000 });
-        await page.wait(2);
+        try {
+            await page.wait({ selector: CONVERSATION_LINK_SELECTOR, timeout: 8 });
+        } catch {
+            // No conversation links visible after fallback goto; extractConversationLinks returns empty.
+        }
         items = await extractConversationLinks(page);
     }
 


### PR DESCRIPTION
## Summary

Continues the wait→event sweep started in #1449 (deepseek) and #1452 (claude). Same 3-bucket classification across 5 chatgpt adapter files.

## Changes by bucket

### CONVERT (5) — fixed sleep → `page.wait({selector, timeout})`
| Site | Before | After |
|---|---|---|
| `utils.js` `ensureOnChatGPT` | 2s settle after `goto(/)` | wait composer 8s |
| `utils.js` `startNewChat` | 2s settle after `goto(/new)` | wait composer 8s |
| `utils.js` `getConversationList` openSidebar | 1.5s | wait `a[href*="/c/"]` 3s |
| `utils.js` `getConversationList` fallback goto | 2.5s | wait composer 8s |
| `detail.js` post-`/c/<id>` goto | 2s | wait `[data-message-author-role]` 10s |

### DELETE (6) — redundant settles after helpers that now wait internally
- `ask.js` / `send.js` / `read.js`: standalone 2s settle after `ensureOnChatGPT` / `startNewChat`
- `utils.js sendChatGPTMessage`: 0.5s post-closeBtn wait + 1.5s pre-composer-focus wait (composer is already focused; the focus call itself is the readiness signal)
- `utils.js getConversationList`: 2s settle after `ensureOnChatGPT`

### KEEP (6) — legitimate polling cadence
- `sendChatGPTMessage` ProseMirror React debounce ticks
- `waitForChatGPTResponse` streaming response polling

## Risk

Low. Per-call cost: warm path (composer already mounted) drops from fixed 2s → ≤16ms (one selector poll). Cold path (composer mounting) caps at the same 8s the implicit-mount window already needed; if composer never mounts, downstream `ensureChatGPTComposer` / `ensureChatGPTLogin` still surface the typed error — try/catch around the `wait()` is intentional and matches D1/D2 precedent.

No typed-error harmonization needed in this PR — chatgpt's existing helpers already gate through `ensureChatGPTLogin` (AuthRequiredError) and `ensureChatGPTComposer` (CommandExecutionError) correctly. The deferred D1/D2 backport remains its own follow-up.

## Verification

| Check | Result |
|---|---|
| `npx vitest run clis/chatgpt` | 20/20 (4 files) |
| Full vitest | 3379 pass / 1 skip / 2 errors (`background.test.ts` + `daemon.test.ts` EADDRINUSE — unrelated, also seen on #1449/#1452/#1454/#1455) |
| `tsc --noEmit` | clean |
| `npm run check:typed-error-lint` | 189/189 unchanged |
| `npm run check:silent-column-drop` | 103/103 unchanged |
| `npm run build` | 802 manifest entries |

## Diff stat
+50 / -13 across 5 files (`ask.js`, `detail.js`, `read.js`, `send.js`, `utils.js`).

## Test plan
- [ ] CI green
- [ ] Cross-review by @opencli-user (per WAWQAQ msg=af5b5367 互 review 授权)