### PR TITLE
chore(extension): rename adapter tab group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+* **extension 1.0.10** — rename the adapter-owned Chrome tab group from `OpenCLI Automation` to `OpenCLI Adapter`.
+
 ## [1.7.15](https://github.com/jackwener/opencli/compare/v1.7.14...v1.7.15) (2026-05-10)
 
 Extension bumped to 1.0.9 (Accessibility.enable allowlist + downloads permission + cross-origin frame target attach for AX). Major Browser Agent Runtime release: full Phase 0/1/2 alignment with `vercel-labs/agent-browser` model — CDP-primary input, AX snapshot/refs with stale recovery, semantic locators across all primitives, full form toolbelt (hover/focus/dblclick/check/uncheck/upload/drag/wait-download), annotated screenshots, and same-origin iframe AX routing. Cross-origin OOPIF AX is best-effort (Chrome extension API limitation).

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -757,7 +757,7 @@ const REGISTRY_KEY = "opencli_target_lease_registry_v2";
 const LEASE_IDLE_ALARM_PREFIX = "opencli:lease-idle:";
 const CONTAINER_TAB_GROUP_TITLE = {
   interactive: "OpenCLI Browser",
-  automation: "OpenCLI Automation"
+  automation: "OpenCLI Adapter"
 };
 const AUTOMATION_TAB_GROUP_COLOR = "orange";
 let leaseMutationQueue = Promise.resolve();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -867,7 +867,7 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).toHaveBeenCalledTimes(1);
   });
 
-  it('marks a newly created owned automation window with an OpenCLI Automation tab group', async () => {
+  it('marks a newly created owned automation window with an OpenCLI Adapter tab group', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -880,7 +880,7 @@ describe('background tab isolation', () => {
       expect.objectContaining({
         id: 100,
         windowId: 1,
-        title: 'OpenCLI Automation',
+        title: 'OpenCLI Adapter',
         color: 'orange',
         collapsed: false,
       }),
@@ -918,7 +918,7 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ focused: false }));
     expect(groups).toEqual(expect.arrayContaining([
       expect.objectContaining({ windowId: 20, title: 'OpenCLI Browser' }),
-      expect.objectContaining({ windowId: 21, title: 'OpenCLI Automation' }),
+      expect.objectContaining({ windowId: 21, title: 'OpenCLI Adapter' }),
     ]));
   });
 
@@ -969,12 +969,12 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [10] });
   });
 
-  it('discovers and reuses an existing OpenCLI Automation group after service worker restart', async () => {
+  it('discovers and reuses an existing OpenCLI Adapter group after service worker restart', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     groups.push({
       id: 99,
       windowId: 1,
-      title: 'OpenCLI Automation',
+      title: 'OpenCLI Adapter',
       color: 'orange',
       collapsed: true,
     });
@@ -1042,7 +1042,7 @@ describe('background tab isolation', () => {
     groups.push({
       id: 99,
       windowId: 1,
-      title: 'OpenCLI Automation',
+      title: 'OpenCLI Adapter',
       color: 'orange',
       collapsed: true,
     });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -955,7 +955,7 @@ describe('background tab isolation', () => {
     expect(chrome.windows.create).toHaveBeenCalledWith(expect.objectContaining({ focused: true }));
   });
 
-  it('reuses the existing automation tab group when adding another owned lease tab', async () => {
+  it('reuses the existing adapter tab group when adding another owned lease tab', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -199,7 +199,7 @@ const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
 const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
 const CONTAINER_TAB_GROUP_TITLE: Record<OwnedWindowRole, string> = {
   interactive: 'OpenCLI Browser',
-  automation: 'OpenCLI Automation',
+  automation: 'OpenCLI Adapter',
 };
 const AUTOMATION_TAB_GROUP_COLOR: chrome.tabGroups.ColorEnum = 'orange';
 let leaseMutationQueue: Promise<void> = Promise.resolve();


### PR DESCRIPTION
## Summary
- rename the adapter-owned Chrome tab group from `OpenCLI Automation` to `OpenCLI Adapter`
- bump Browser Bridge extension to 1.0.10 and rebuild `extension/dist/background.js`
- update extension tests and changelog

## Verification
- `npm test -- --run extension/src/background.test.ts`
- `npm run typecheck --prefix extension`
- `npm run build --prefix extension`
- `npm run package:release --prefix extension`
- `git diff --check`