### PR TITLE
feat(external): register tg-cli, discord-cli, wx-cli

### DIFF
--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -135,7 +135,7 @@ opencli gh pr list --limit 5   # passthrough; stdio is inherited, exit code prop
 opencli docker ps
 ```
 
-Built-in entries live in `src/external-clis.yaml`; user overrides and additions in `~/.opencli/external-clis.yaml`. Commonly shipped: `gh`, `docker`, `vercel`, `lark-cli`, `dws`, `wecom-cli`, `obsidian`.
+Built-in entries live in `src/external-clis.yaml`; user overrides and additions in `~/.opencli/external-clis.yaml`. Commonly shipped: `gh`, `docker`, `vercel`, `lark-cli`, `dws`, `wecom-cli`, `obsidian`, `tg-cli`, `discord-cli`, `wx-cli`.
 
 ## Shell completion
 

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -54,3 +54,27 @@
   tags: [vercel, deployment, serverless, frontend, devops]
   install:
     default: "npm install -g vercel"
+
+- name: tg-cli
+  binary: tg
+  description: "Telegram CLI — local-first sync, search, export via MTProto for AI agents"
+  homepage: "https://github.com/jackwener/tg-cli"
+  tags: [telegram, messaging, search, export, ai-agent]
+  install:
+    default: "uv tool install kabi-tg-cli"
+
+- name: discord-cli
+  binary: discord
+  description: "Discord CLI — local-first sync, search, export via SQLite for AI agents"
+  homepage: "https://github.com/jackwener/discord-cli"
+  tags: [discord, messaging, search, export, ai-agent]
+  install:
+    default: "uv tool install kabi-discord-cli"
+
+- name: wx-cli
+  binary: wx
+  description: "WeChat local data CLI — sessions, messages, search, contacts, export for AI agents"
+  homepage: "https://github.com/jackwener/wx-cli"
+  tags: [wechat, messaging, search, export, ai-agent]
+  install:
+    default: "npm install -g @jackwener/wx-cli"


### PR DESCRIPTION
## Summary
- Register three local-first messaging CLIs in the External CLI registry: `tg-cli` (Telegram), `discord-cli` (Discord), `wx-cli` (WeChat).
- After install, agents can use `opencli tg ...` / `opencli discord ...` / `opencli wx ...` like any other external binary.
- Updates skills/opencli-usage/SKILL.md so the listed common External CLIs stay in sync.

## Why these three
All three are agent-friendly local-data CLIs with structured (YAML/JSON) output and SQLite caches — same shape as `lark-cli` / `dws` / `wecom-cli` already shipped in the registry, just for personal-account messengers (Telegram, Discord, WeChat) rather than enterprise IM.

## Entries
| name | binary | install | source |
|------|--------|---------|--------|
| `tg-cli` | `tg` | `uv tool install kabi-tg-cli` | <https://github.com/jackwener/tg-cli> |
| `discord-cli` | `discord` | `uv tool install kabi-discord-cli` | <https://github.com/jackwener/discord-cli> |
| `wx-cli` | `wx` | `npm install -g @jackwener/wx-cli` | <https://github.com/jackwener/wx-cli> |

Binary names verified from each repo's `[project.scripts]` / `[[bin]]` table. Install commands match each repo's README.

## Test plan
- [x] `node -e` parse roundtrip on `src/external-clis.yaml` — all 10 entries load, three new entries match expected shape.
- [x] `npm test -- --run src/external.test.ts` — 5/5 pass.
- [x] `npm run docs:build` — clean.