### PR TITLE
refactor(adapter): rename site browser reuse to persistent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### ⚠ BREAKING CHANGES
 
-* **browser session model** — replace the browser-facing `--workspace` model with explicit `--session <name>` on `opencli browser *`. Browser commands now require a session name, `browser bind`/`unbind` use `--session`, and bind no longer accepts `--domain`, `--path-prefix`, or `--allow-navigate-bound`. Browser primitives keep their session tab by design; the browser namespace no longer exposes `--keep-tab`. Adapter `--keep-tab` and `browserSession.reuse: 'site'` are unchanged.
+* **browser session model** — replace the browser-facing `--workspace` model with explicit `--session <name>` on `opencli browser *`. Browser commands now require a session name, `browser bind`/`unbind` use `--session`, and bind no longer accepts `--domain`, `--path-prefix`, or `--allow-navigate-bound`. Browser primitives keep their session tab by design; the browser namespace no longer exposes `--keep-tab`.
+* **adapter site sessions** — replace adapter metadata `browserSession: { reuse: 'site' }` with `siteSession: 'persistent'`, and replace the user override `--reuse <none|site>` / `OPENCLI_BROWSER_REUSE` with `--site-session <ephemeral|persistent>`. Persistent site sessions keep a stable site tab open without idle expiry.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW` | command default | Set to `foreground` or `background` to override Browser Bridge window placement. Browser-backed commands also accept `--window <foreground\|background>`. |
 | `OPENCLI_KEEP_TAB` | command default | Set to `true` or `false` to keep or release the browser tab lease after a browser-backed adapter command. Browser-backed adapter commands also accept `--keep-tab <true\|false>`. |
-| `OPENCLI_BROWSER_REUSE` | adapter default | Set to `none` or `site` to override adapter browser tab reuse. The `--reuse <none\|site>` flag sets this. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |
@@ -208,7 +207,7 @@ OpenCLI is not only for websites. It can also:
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
-`opencli browser *` requires an explicit `--session <name>`, uses a foreground browser window by default, and keeps that session's tab lease until `browser --session <name> close` or idle cleanup. Browser-backed adapters use a background adapter window and release one-shot tab leases by default. Some interactive adapters default to `--reuse site`, which keeps the site tab lease for continuity; pass `--reuse none` for a one-shot tab.
+`opencli browser *` requires an explicit `--session <name>`, uses a foreground browser window by default, and keeps that session's tab lease until `browser --session <name> close` or idle cleanup. Browser-backed adapters use a background adapter window and release one-shot tab leases by default. Interactive adapters can declare `siteSession: 'persistent'` to keep a stable site tab for continuity; pass `--site-session ephemeral` for a one-shot tab.
 
 ## Update
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4160,9 +4160,7 @@
     "modulePath": "chatgpt/ask.js",
     "sourceFile": "chatgpt/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4197,9 +4195,7 @@
     "modulePath": "chatgpt/detail.js",
     "sourceFile": "chatgpt/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4228,9 +4224,7 @@
     "modulePath": "chatgpt/history.js",
     "sourceFile": "chatgpt/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4279,9 +4273,7 @@
     "modulePath": "chatgpt/image.js",
     "sourceFile": "chatgpt/image.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4299,9 +4291,7 @@
     "modulePath": "chatgpt/new.js",
     "sourceFile": "chatgpt/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4329,9 +4319,7 @@
     "modulePath": "chatgpt/read.js",
     "sourceFile": "chatgpt/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4365,9 +4353,7 @@
     "modulePath": "chatgpt/send.js",
     "sourceFile": "chatgpt/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4387,9 +4373,7 @@
     "modulePath": "chatgpt/status.js",
     "sourceFile": "chatgpt/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt-app",
@@ -4824,9 +4808,7 @@
     "modulePath": "claude/ask.js",
     "sourceFile": "claude/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4854,9 +4836,7 @@
     "modulePath": "claude/detail.js",
     "sourceFile": "claude/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4885,9 +4865,7 @@
     "modulePath": "claude/history.js",
     "sourceFile": "claude/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4905,9 +4883,7 @@
     "modulePath": "claude/new.js",
     "sourceFile": "claude/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4927,9 +4903,7 @@
     "modulePath": "claude/read.js",
     "sourceFile": "claude/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4964,9 +4938,7 @@
     "modulePath": "claude/send.js",
     "sourceFile": "claude/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4986,9 +4958,7 @@
     "modulePath": "claude/status.js",
     "sourceFile": "claude/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "cnki",
@@ -6445,9 +6415,7 @@
     "modulePath": "deepseek/ask.js",
     "sourceFile": "deepseek/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6474,9 +6442,7 @@
     "modulePath": "deepseek/detail.js",
     "sourceFile": "deepseek/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6504,9 +6470,7 @@
     "modulePath": "deepseek/history.js",
     "sourceFile": "deepseek/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6524,9 +6488,7 @@
     "modulePath": "deepseek/new.js",
     "sourceFile": "deepseek/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6545,9 +6507,7 @@
     "modulePath": "deepseek/read.js",
     "sourceFile": "deepseek/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6588,9 +6548,7 @@
     "modulePath": "deepseek/send.js",
     "sourceFile": "deepseek/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6610,9 +6568,7 @@
     "modulePath": "deepseek/status.js",
     "sourceFile": "deepseek/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "defillama",
@@ -7703,9 +7659,7 @@
     "modulePath": "doubao/ask.js",
     "sourceFile": "doubao/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7732,9 +7686,7 @@
     "modulePath": "doubao/detail.js",
     "sourceFile": "doubao/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7763,9 +7715,7 @@
     "modulePath": "doubao/history.js",
     "sourceFile": "doubao/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7799,9 +7749,7 @@
     "modulePath": "doubao/meeting-summary.js",
     "sourceFile": "doubao/meeting-summary.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7835,9 +7783,7 @@
     "modulePath": "doubao/meeting-transcript.js",
     "sourceFile": "doubao/meeting-transcript.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7856,9 +7802,7 @@
     "modulePath": "doubao/new.js",
     "sourceFile": "doubao/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7877,9 +7821,7 @@
     "modulePath": "doubao/read.js",
     "sourceFile": "doubao/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7907,9 +7849,7 @@
     "modulePath": "doubao/send.js",
     "sourceFile": "doubao/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7930,9 +7870,7 @@
     "modulePath": "doubao/status.js",
     "sourceFile": "doubao/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "doubao-app",
@@ -9712,9 +9650,7 @@
     "modulePath": "gemini/ask.js",
     "sourceFile": "gemini/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9761,9 +9697,7 @@
     "modulePath": "gemini/deep-research.js",
     "sourceFile": "gemini/deep-research.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9808,9 +9742,7 @@
     "modulePath": "gemini/deep-research-result.js",
     "sourceFile": "gemini/deep-research-result.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9874,9 +9806,7 @@
     "modulePath": "gemini/image.js",
     "sourceFile": "gemini/image.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9895,9 +9825,7 @@
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "gitee",
@@ -10494,9 +10422,7 @@
     "modulePath": "grok/ask.js",
     "sourceFile": "grok/ask.js",
     "navigateBefore": "https://grok.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10530,9 +10456,7 @@
     "modulePath": "grok/detail.js",
     "sourceFile": "grok/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10560,9 +10484,7 @@
     "modulePath": "grok/history.js",
     "sourceFile": "grok/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10619,9 +10541,7 @@
     "modulePath": "grok/image.js",
     "sourceFile": "grok/image.js",
     "navigateBefore": "https://grok.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10639,9 +10559,7 @@
     "modulePath": "grok/new.js",
     "sourceFile": "grok/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10668,9 +10586,7 @@
     "modulePath": "grok/read.js",
     "sourceFile": "grok/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10704,9 +10620,7 @@
     "modulePath": "grok/send.js",
     "sourceFile": "grok/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10728,9 +10642,7 @@
     "modulePath": "grok/status.js",
     "sourceFile": "grok/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "hackernews",
@@ -18863,9 +18775,7 @@
     "modulePath": "qwen/ask.js",
     "sourceFile": "qwen/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18899,9 +18809,7 @@
     "modulePath": "qwen/detail.js",
     "sourceFile": "qwen/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18930,9 +18838,7 @@
     "modulePath": "qwen/history.js",
     "sourceFile": "qwen/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18989,9 +18895,7 @@
     "modulePath": "qwen/image.js",
     "sourceFile": "qwen/image.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -19009,9 +18913,7 @@
     "modulePath": "qwen/new.js",
     "sourceFile": "qwen/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -19038,9 +18940,7 @@
     "modulePath": "qwen/read.js",
     "sourceFile": "qwen/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -19088,9 +18988,7 @@
     "modulePath": "qwen/send.js",
     "sourceFile": "qwen/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -19112,9 +19010,7 @@
     "modulePath": "qwen/status.js",
     "sourceFile": "qwen/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19148,9 +19044,7 @@
     "modulePath": "reddit/comment.js",
     "sourceFile": "reddit/comment.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19181,9 +19075,7 @@
     "modulePath": "reddit/frontpage.js",
     "sourceFile": "reddit/frontpage.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19253,9 +19145,7 @@
     "modulePath": "reddit/popular.js",
     "sourceFile": "reddit/popular.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19319,9 +19209,7 @@
     "modulePath": "reddit/read.js",
     "sourceFile": "reddit/read.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19355,9 +19243,7 @@
     "modulePath": "reddit/save.js",
     "sourceFile": "reddit/save.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19387,9 +19273,7 @@
     "modulePath": "reddit/saved.js",
     "sourceFile": "reddit/saved.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19448,9 +19332,7 @@
     "modulePath": "reddit/search.js",
     "sourceFile": "reddit/search.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19501,9 +19383,7 @@
     "modulePath": "reddit/subreddit.js",
     "sourceFile": "reddit/subreddit.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19537,9 +19417,7 @@
     "modulePath": "reddit/subscribe.js",
     "sourceFile": "reddit/subscribe.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19573,9 +19451,7 @@
     "modulePath": "reddit/upvote.js",
     "sourceFile": "reddit/upvote.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19605,9 +19481,7 @@
     "modulePath": "reddit/upvoted.js",
     "sourceFile": "reddit/upvoted.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19634,9 +19508,7 @@
     "modulePath": "reddit/user.js",
     "sourceFile": "reddit/user.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19672,9 +19544,7 @@
     "modulePath": "reddit/user-comments.js",
     "sourceFile": "reddit/user-comments.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19711,9 +19581,7 @@
     "modulePath": "reddit/user-posts.js",
     "sourceFile": "reddit/user-posts.js",
     "navigateBefore": "https://reddit.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "rest-countries",
@@ -22255,9 +22123,7 @@
     "modulePath": "twitter/article.js",
     "sourceFile": "twitter/article.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22356,9 +22222,7 @@
     "modulePath": "twitter/bookmark-folder.js",
     "sourceFile": "twitter/bookmark-folder.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22379,9 +22243,7 @@
     "modulePath": "twitter/bookmark-folders.js",
     "sourceFile": "twitter/bookmark-folders.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22421,9 +22283,7 @@
     "modulePath": "twitter/bookmarks.js",
     "sourceFile": "twitter/bookmarks.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22498,9 +22358,7 @@
     "modulePath": "twitter/download.js",
     "sourceFile": "twitter/download.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22561,9 +22419,7 @@
     "modulePath": "twitter/followers.js",
     "sourceFile": "twitter/followers.js",
     "navigateBefore": true,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22599,9 +22455,7 @@
     "modulePath": "twitter/following.js",
     "sourceFile": "twitter/following.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22702,9 +22556,7 @@
     "modulePath": "twitter/likes.js",
     "sourceFile": "twitter/likes.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22823,9 +22675,7 @@
     "modulePath": "twitter/list-tweets.js",
     "sourceFile": "twitter/list-tweets.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22855,9 +22705,7 @@
     "modulePath": "twitter/lists.js",
     "sourceFile": "twitter/lists.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22887,9 +22735,7 @@
     "modulePath": "twitter/notifications.js",
     "sourceFile": "twitter/notifications.js",
     "navigateBefore": true,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22958,9 +22804,7 @@
     "modulePath": "twitter/profile.js",
     "sourceFile": "twitter/profile.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23229,9 +23073,7 @@
     "modulePath": "twitter/search.js",
     "sourceFile": "twitter/search.js",
     "navigateBefore": true,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23278,9 +23120,7 @@
     "modulePath": "twitter/thread.js",
     "sourceFile": "twitter/thread.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23334,9 +23174,7 @@
     "modulePath": "twitter/timeline.js",
     "sourceFile": "twitter/timeline.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23364,9 +23202,7 @@
     "modulePath": "twitter/trending.js",
     "sourceFile": "twitter/trending.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23417,9 +23253,7 @@
     "modulePath": "twitter/tweets.js",
     "sourceFile": "twitter/tweets.js",
     "navigateBefore": "https://x.com",
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -27674,9 +27508,7 @@
     "modulePath": "yuanbao/ask.js",
     "sourceFile": "yuanbao/ask.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27703,9 +27535,7 @@
     "modulePath": "yuanbao/detail.js",
     "sourceFile": "yuanbao/detail.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27735,9 +27565,7 @@
     "modulePath": "yuanbao/history.js",
     "sourceFile": "yuanbao/history.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27756,9 +27584,7 @@
     "modulePath": "yuanbao/new.js",
     "sourceFile": "yuanbao/new.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27777,9 +27603,7 @@
     "modulePath": "yuanbao/read.js",
     "sourceFile": "yuanbao/read.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27813,9 +27637,7 @@
     "modulePath": "yuanbao/send.js",
     "sourceFile": "yuanbao/send.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27839,9 +27661,7 @@
     "modulePath": "yuanbao/status.js",
     "sourceFile": "yuanbao/status.js",
     "navigateBefore": false,
-    "browserSession": {
-      "reuse": "site"
-    }
+    "siteSession": "persistent"
   },
   {
     "site": "zhihu",

--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -22,7 +22,7 @@ export const askCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -10,7 +10,7 @@ import './status.js';
 import './image.js';
 
 describe('chatgpt browser command registration', () => {
-    it('registers the baseline web chat commands with site-level reuse', () => {
+    it('registers the baseline web chat commands with persistent site sessions', () => {
         const expectedAccess = {
             ask: 'write',
             send: 'write',
@@ -29,7 +29,7 @@ describe('chatgpt browser command registration', () => {
             expect(cmd.domain).toBe('chatgpt.com');
             expect(cmd.strategy).toBe('cookie');
             expect(cmd.browser).toBe(true);
-            expect(cmd.browserSession).toEqual({ reuse: 'site' });
+            expect(cmd.siteSession).toBe('persistent');
             expect(cmd.navigateBefore).toBe(false);
             expect(cmd.access).toBe(access);
         }

--- a/clis/chatgpt/detail.js
+++ b/clis/chatgpt/detail.js
@@ -19,7 +19,7 @@ export const detailCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', positional: true, required: true, help: 'Conversation ID or full /c/<id> URL' },

--- a/clis/chatgpt/history.js
+++ b/clis/chatgpt/history.js
@@ -16,7 +16,7 @@ export const historyCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -49,7 +49,7 @@ export const imageCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/chatgpt/new.js
+++ b/clis/chatgpt/new.js
@@ -13,7 +13,7 @@ export const newCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/chatgpt/read.js
+++ b/clis/chatgpt/read.js
@@ -17,7 +17,7 @@ export const readCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },

--- a/clis/chatgpt/send.js
+++ b/clis/chatgpt/send.js
@@ -19,7 +19,7 @@ export const sendCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/chatgpt/status.js
+++ b/clis/chatgpt/status.js
@@ -13,7 +13,7 @@ export const statusCommand = cli({
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url'],

--- a/clis/claude/ask.js
+++ b/clis/claude/ask.js
@@ -15,7 +15,7 @@ export const askCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/claude/detail.js
+++ b/clis/claude/detail.js
@@ -10,7 +10,7 @@ export const detailCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', positional: true, required: true, help: 'Conversation ID (UUID from /chat/<id>)' },

--- a/clis/claude/history.js
+++ b/clis/claude/history.js
@@ -10,7 +10,7 @@ export const historyCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },

--- a/clis/claude/new.js
+++ b/clis/claude/new.js
@@ -9,7 +9,7 @@ export const newCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/claude/read.js
+++ b/clis/claude/read.js
@@ -10,7 +10,7 @@ export const readCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Index', 'Role', 'Text'],

--- a/clis/claude/send.js
+++ b/clis/claude/send.js
@@ -10,7 +10,7 @@ export const sendCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/claude/status.js
+++ b/clis/claude/status.js
@@ -9,7 +9,7 @@ export const statusCommand = cli({
     domain: CLAUDE_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url'],

--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -14,7 +14,7 @@ export const askCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },

--- a/clis/deepseek/detail.js
+++ b/clis/deepseek/detail.js
@@ -16,7 +16,7 @@ export const detailCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },

--- a/clis/deepseek/history.js
+++ b/clis/deepseek/history.js
@@ -9,7 +9,7 @@ export const historyCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },

--- a/clis/deepseek/new.js
+++ b/clis/deepseek/new.js
@@ -10,7 +10,7 @@ export const newCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/deepseek/read.js
+++ b/clis/deepseek/read.js
@@ -9,7 +9,7 @@ export const readCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Role', 'Text'],

--- a/clis/deepseek/send.js
+++ b/clis/deepseek/send.js
@@ -15,7 +15,7 @@ export const sendCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (UUID) or full /a/chat/s/<id> URL' },

--- a/clis/deepseek/status.js
+++ b/clis/deepseek/status.js
@@ -9,7 +9,7 @@ export const statusCommand = cli({
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url'],

--- a/clis/doubao/ask.js
+++ b/clis/doubao/ask.js
@@ -9,7 +9,7 @@ export const askCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'text', required: true, positional: true, help: 'Prompt to send' },

--- a/clis/doubao/detail.js
+++ b/clis/doubao/detail.js
@@ -8,7 +8,7 @@ export const detailCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },

--- a/clis/doubao/history.js
+++ b/clis/doubao/history.js
@@ -8,7 +8,7 @@ export const historyCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', required: false, help: 'Max number of conversations to show', default: '50' },

--- a/clis/doubao/meeting-summary.js
+++ b/clis/doubao/meeting-summary.js
@@ -8,7 +8,7 @@ export const meetingSummaryCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },

--- a/clis/doubao/meeting-transcript.js
+++ b/clis/doubao/meeting-transcript.js
@@ -8,7 +8,7 @@ export const meetingTranscriptCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Conversation ID (numeric or full URL)' },

--- a/clis/doubao/new.js
+++ b/clis/doubao/new.js
@@ -8,7 +8,7 @@ export const newCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Action'],

--- a/clis/doubao/read.js
+++ b/clis/doubao/read.js
@@ -8,7 +8,7 @@ export const readCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Role', 'Text'],

--- a/clis/doubao/send.js
+++ b/clis/doubao/send.js
@@ -8,7 +8,7 @@ export const sendCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [{ name: 'text', required: true, positional: true, help: 'Message to send' }],
     columns: ['Status', 'SubmittedBy', 'InjectedText'],

--- a/clis/doubao/status.js
+++ b/clis/doubao/status.js
@@ -8,7 +8,7 @@ export const statusCommand = cli({
     domain: DOUBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Url', 'Title'],

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -16,7 +16,7 @@ export const askCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/deep-research-result.js
+++ b/clis/gemini/deep-research-result.js
@@ -44,7 +44,7 @@ export const deepResearchResultCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/deep-research.js
+++ b/clis/gemini/deep-research.js
@@ -23,7 +23,7 @@ export const deepResearchCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/image.js
+++ b/clis/gemini/image.js
@@ -52,7 +52,7 @@ export const imageCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/gemini/new.js
+++ b/clis/gemini/new.js
@@ -8,7 +8,7 @@ export const newCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Action'],

--- a/clis/grok/ask.js
+++ b/clis/grok/ask.js
@@ -29,7 +29,7 @@ export const askCommand = cli({
     domain: 'grok.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'prompt', positional: true, type: 'string', required: true, help: 'Prompt to send to Grok' },
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response (default: 120)' },

--- a/clis/grok/detail.js
+++ b/clis/grok/detail.js
@@ -17,7 +17,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'id', positional: true, required: true, help: 'Session ID (UUID) or full https://grok.com/c/<id> URL' },
         { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },

--- a/clis/grok/history.js
+++ b/clis/grok/history.js
@@ -16,7 +16,7 @@ cli({
     domain: GROK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show (default 20, max 100)' },

--- a/clis/grok/image.js
+++ b/clis/grok/image.js
@@ -253,7 +253,7 @@ export const imageCommand = cli({
   domain: 'grok.com',
   strategy: Strategy.COOKIE,
   browser: true,
-  browserSession: { reuse: 'site' },
+  siteSession: 'persistent',
   args: [
     { name: 'prompt', positional: true, type: 'string', required: true, help: 'Image generation prompt' },
     { name: 'timeout', type: 'int', default: 240, help: 'Max seconds to wait for the image (default: 240)' },

--- a/clis/grok/new.js
+++ b/clis/grok/new.js
@@ -9,7 +9,7 @@ cli({
     domain: GROK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/grok/read.js
+++ b/clis/grok/read.js
@@ -15,7 +15,7 @@ cli({
     domain: GROK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },

--- a/clis/grok/send.js
+++ b/clis/grok/send.js
@@ -18,7 +18,7 @@ cli({
     domain: GROK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send to Grok' },

--- a/clis/grok/status.js
+++ b/clis/grok/status.js
@@ -15,7 +15,7 @@ cli({
     domain: GROK_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Model', 'SessionId', 'Url'],

--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -24,7 +24,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/qwen/detail.js
+++ b/clis/qwen/detail.js
@@ -18,7 +18,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'id', positional: true, required: true, help: 'Session ID (32-char hex) or full https://www.qianwen.com/chat/<id> URL' },
         { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },

--- a/clis/qwen/history.js
+++ b/clis/qwen/history.js
@@ -24,7 +24,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show (default 20, max 100)' },

--- a/clis/qwen/image.js
+++ b/clis/qwen/image.js
@@ -99,7 +99,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/qwen/new.js
+++ b/clis/qwen/new.js
@@ -9,7 +9,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status'],

--- a/clis/qwen/read.js
+++ b/clis/qwen/read.js
@@ -16,7 +16,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'markdown', type: 'boolean', default: false, help: 'Emit assistant replies as markdown' },

--- a/clis/qwen/send.js
+++ b/clis/qwen/send.js
@@ -20,7 +20,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send to Qianwen' },

--- a/clis/qwen/status.js
+++ b/clis/qwen/status.js
@@ -9,7 +9,7 @@ cli({
     domain: QIANWEN_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Model', 'SessionId', 'Url'],

--- a/clis/reddit/comment.js
+++ b/clis/reddit/comment.js
@@ -8,7 +8,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
         { name: 'text', type: 'string', required: true, positional: true, help: 'Comment text' },

--- a/clis/reddit/frontpage.js
+++ b/clis/reddit/frontpage.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -16,7 +16,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'post-id', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or full URL' },
         { name: 'sort', default: 'best', help: 'Comment sort: best, top, new, controversial, old, qa' },

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -3,9 +3,9 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import './read.js';
 describe('reddit read adapter', () => {
     const command = getRegistry().get('reddit/read');
-    it('opts into the Reddit site browser session lease', () => {
+    it('opts into the Reddit persistent site session', () => {
         expect(command?.browser).toBe(true);
-        expect(command?.browserSession).toEqual({ reuse: 'site' });
+        expect(command?.siteSession).toBe('persistent');
     });
     it('returns threaded rows from the browser-evaluated payload', async () => {
         const page = {

--- a/clis/reddit/save.js
+++ b/clis/reddit/save.js
@@ -8,7 +8,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
         { name: 'undo', type: 'boolean', default: false, help: 'Unsave instead of save' },

--- a/clis/reddit/saved.js
+++ b/clis/reddit/saved.js
@@ -8,7 +8,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: 'Reddit search query' },
         {

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'name', type: 'string', required: true, positional: true, help: 'Subreddit name (no `r/` prefix; e.g. `python`)' },
         {

--- a/clis/reddit/subscribe.js
+++ b/clis/reddit/subscribe.js
@@ -8,7 +8,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'subreddit', type: 'string', required: true, positional: true, help: 'Subreddit name (e.g. python)' },
         { name: 'undo', type: 'boolean', default: false, help: 'Unsubscribe instead of subscribe' },

--- a/clis/reddit/upvote.js
+++ b/clis/reddit/upvote.js
@@ -8,7 +8,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
         { name: 'direction', type: 'string', default: 'up', help: 'Vote direction: up, down, none' },

--- a/clis/reddit/upvoted.js
+++ b/clis/reddit/upvoted.js
@@ -8,7 +8,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/reddit/user-comments.js
+++ b/clis/reddit/user-comments.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
         { name: 'limit', type: 'int', default: 15 },

--- a/clis/reddit/user-posts.js
+++ b/clis/reddit/user-posts.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
         { name: 'limit', type: 'int', default: 15 },

--- a/clis/reddit/user.js
+++ b/clis/reddit/user.js
@@ -7,7 +7,7 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
     ],

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -11,7 +11,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'tweet-id', type: 'string', positional: true, required: true, help: 'Tweet ID or URL containing the article' },
     ],

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -122,7 +122,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'folder-id', positional: true, type: 'string', required: true, help: 'Folder id from `opencli twitter bookmark-folders`.' },
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },

--- a/clis/twitter/bookmark-folders.js
+++ b/clis/twitter/bookmark-folders.js
@@ -77,7 +77,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [],
     columns: ['id', 'name', 'items', 'created_at'],
     func: async (page) => {

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -105,7 +105,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },

--- a/clis/twitter/download.js
+++ b/clis/twitter/download.js
@@ -15,7 +15,7 @@ cli({
     description: 'Download Twitter/X media (images and videos). Provide either <username> to scan a profile\'s media tab, or --tweet-url to download a single tweet.',
     domain: 'x.com',
     strategy: Strategy.COOKIE,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', positional: true, help: 'Twitter username (with or without @) to scan their /media tab. Either <username> or --tweet-url is required.' },
         { name: 'tweet-url', help: 'Single tweet URL to download. Use this OR <username>, not both required at once.' },

--- a/clis/twitter/followers.js
+++ b/clis/twitter/followers.js
@@ -83,7 +83,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.UI,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         {
             name: 'user',

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -139,7 +139,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         {
             name: 'user',

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -142,7 +142,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of liked tweets to return (default 20).' },

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -112,7 +112,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'listId', positional: true, type: 'string', required: true, help: 'Numeric ID of a Twitter/X list (e.g. from `opencli twitter lists`)' },
         { name: 'limit', type: 'int', default: 50 },

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -92,7 +92,7 @@ export const command = cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 50, help: 'Maximum number of lists to return (default 50).' },
     ],

--- a/clis/twitter/notifications.js
+++ b/clis/twitter/notifications.js
@@ -8,7 +8,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.INTERCEPT,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of notifications to return (default 20).' },
     ],

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -11,7 +11,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
     ],

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -228,7 +228,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.INTERCEPT, // Use intercept strategy
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: 'Search query. Raw X operators (e.g. "exact phrase", #tag, OR, lang:en, since:YYYY-MM-DD, from:, since:) are passed through unchanged.' },
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'], help: 'Legacy alias for --product. Kept for backwards compatibility; if --product is set it wins.' },

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -100,7 +100,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'tweet-id', positional: true, type: 'string', required: true, help: 'Tweet numeric ID (e.g. 1234567890) or full status URL' },
         { name: 'limit', type: 'int', default: 50 },

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -141,7 +141,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         {
             name: 'type',

--- a/clis/twitter/trending.js
+++ b/clis/twitter/trending.js
@@ -17,7 +17,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of trends to show' },
     ],

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -149,7 +149,7 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (with or without @)' },
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },

--- a/clis/yuanbao/ask.js
+++ b/clis/yuanbao/ask.js
@@ -305,7 +305,7 @@ export const askCommand = cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [

--- a/clis/yuanbao/detail.js
+++ b/clis/yuanbao/detail.js
@@ -18,7 +18,7 @@ cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         {

--- a/clis/yuanbao/history.js
+++ b/clis/yuanbao/history.js
@@ -17,7 +17,7 @@ cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Max conversations to list (sidebar virtual scroll caps actual count)' },

--- a/clis/yuanbao/new.js
+++ b/clis/yuanbao/new.js
@@ -55,7 +55,7 @@ export const newCommand = cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Action'],

--- a/clis/yuanbao/read.js
+++ b/clis/yuanbao/read.js
@@ -14,7 +14,7 @@ cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Role', 'Text'],

--- a/clis/yuanbao/send.js
+++ b/clis/yuanbao/send.js
@@ -18,7 +18,7 @@ cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send to Yuanbao' },

--- a/clis/yuanbao/status.js
+++ b/clis/yuanbao/status.js
@@ -15,7 +15,7 @@ cli({
     domain: YUANBAO_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    browserSession: { reuse: 'site' },
+    siteSession: 'persistent',
     navigateBefore: false,
     args: [],
     columns: ['Status', 'Login', 'Model', 'ModelId', 'AgentId', 'SessionId', 'Url'],

--- a/docs/adapters/browser/chatgpt.md
+++ b/docs/adapters/browser/chatgpt.md
@@ -58,7 +58,7 @@ opencli chatgpt image "a tiny watercolor fox" --sd true
 
 ## Behavior
 
-- ChatGPT web commands use site-level browser tab reuse by default, so consecutive `ask` / `send` / `read` / `detail` commands continue in the same ChatGPT tab. Use `--reuse none` for one-shot isolated tabs.
+- ChatGPT web commands use persistent site sessions by default, so consecutive `ask` / `send` / `read` / `detail` commands continue in the same ChatGPT tab. Use `--site-session ephemeral` for one-shot isolated tabs.
 - `ask` waits for the first stable assistant response after sending. `send` submits only and returns immediately.
 - `history` reads visible `/c/<id>` links from the ChatGPT sidebar; it does not use private backend APIs.
 - `image` opens a fresh `chatgpt.com/new` page before sending the image prompt.

--- a/docs/adapters/browser/claude.md
+++ b/docs/adapters/browser/claude.md
@@ -61,7 +61,7 @@ opencli claude ask "hello" -f json
 ## Caveats
 
 - This adapter drives the Claude web UI in the browser, not an API
-- Claude commands default to site-level browser tab reuse, so consecutive `claude ask` / `claude read` / `claude detail` invocations continue in the same Claude page. Pass `--reuse none` for a one-shot tab.
+- Claude commands default to persistent site sessions, so consecutive `claude ask` / `claude read` / `claude detail` invocations continue in the same Claude page. Pass `--site-session ephemeral` for a one-shot tab.
 - `--model opus` requires a paid Claude plan; on a free-tier account the adapter surfaces a usage error rather than silently falling back
 - The default Sonnet 4.6 model uses Adaptive thinking by default; `--think` is the explicit switch but Claude may still invoke thinking for complex prompts even when not requested
 - Adaptive-thinking and file-thumbnail widgets render duplicated label paragraphs (`Thought process` / `View uploaded image`) at the top of the response; these are stripped automatically so the row value is the actual answer

--- a/docs/adapters/browser/deepseek.md
+++ b/docs/adapters/browser/deepseek.md
@@ -99,7 +99,7 @@ opencli deepseek send 749e6bbd-6a45-4440-beaa-ae5238bf06d8 "continue from the la
 ## Caveats
 
 - This adapter drives the DeepSeek web UI in the browser, not an API
-- DeepSeek commands default to site-level browser tab reuse, so consecutive `deepseek ask` / `deepseek read` / `deepseek detail` invocations continue in the same DeepSeek page. Pass `--reuse none` for a one-shot tab.
+- DeepSeek commands default to persistent site sessions, so consecutive `deepseek ask` / `deepseek read` / `deepseek detail` invocations continue in the same DeepSeek page. Pass `--site-session ephemeral` for a one-shot tab.
 - Default mode is Instant with DeepThink and Search disabled; each flag (`--model`, `--think`, `--search`) is synced on every invocation so omitting a flag resets it
 - Vision mode does not support `--search`; use `--model instant` or `--model expert` for web search
 - `send` requires an explicit conversation ID; use `history` to find a conversation URL or ID first

--- a/docs/adapters/browser/doubao.md
+++ b/docs/adapters/browser/doubao.md
@@ -35,6 +35,6 @@ opencli doubao ask "请写一个 Python 快速排序示例" --timeout 90
 ## Notes
 
 - The adapter targets the web chat page at `https://www.doubao.com/chat`
-- Doubao commands default to site-level browser tab reuse, so consecutive `doubao ask` / `doubao read` / `doubao detail` invocations continue in the same Doubao page. Pass `--reuse none` for a one-shot tab.
+- Doubao commands default to persistent site sessions, so consecutive `doubao ask` / `doubao read` / `doubao detail` invocations continue in the same Doubao page. Pass `--site-session ephemeral` for a one-shot tab.
 - `new` first tries the visible "New Chat / 新对话" button, then falls back to the new-thread route
 - `ask` uses DOM polling, so very long generations may need a larger `--timeout`

--- a/docs/adapters/browser/gemini.md
+++ b/docs/adapters/browser/gemini.md
@@ -70,6 +70,6 @@ opencli gemini image "A flat illustration of a robot" --op ~/tmp/gemini-images
 ## Caveats
 
 - This adapter drives the Gemini consumer web UI, not a public API.
-- Gemini commands default to site-level browser tab reuse, so consecutive `gemini ask` / `gemini image` / `gemini deep-research-result` invocations continue in the same Gemini page. Pass `--reuse none` for a one-shot tab.
+- Gemini commands default to persistent site sessions, so consecutive `gemini ask` / `gemini image` / `gemini deep-research-result` invocations continue in the same Gemini page. Pass `--site-session ephemeral` for a one-shot tab.
 - It depends on the current browser session and may fail if Gemini shows login, consent, challenge, quota, or other gating UI.
 - DOM or product changes on Gemini can break composer detection, new-chat handling, or image export behavior.

--- a/docs/adapters/browser/grok.md
+++ b/docs/adapters/browser/grok.md
@@ -99,7 +99,7 @@ opencli grok image "a cyberpunk mechanical owl, neon purple and blue" --new true
 ## Notes
 
 - `read` works in the current tab even without an explicit ID; pair it with `status` to discover the active session ID first.
-- Grok commands default to site-level browser tab reuse, so consecutive `grok ask` / `grok read` / `grok detail` invocations continue in the same Grok page. Pass `--reuse none` for a one-shot tab.
+- Grok commands default to persistent site sessions, so consecutive `grok ask` / `grok read` / `grok detail` invocations continue in the same Grok page. Pass `--site-session ephemeral` for a one-shot tab.
 - `ask` waits for the streaming reply to stabilize; `send` returns immediately after submission.
 - `history` reads the visible sidebar — if Grok lazy-loads older conversations, scroll the sidebar in your browser before re-running, or use `detail <id>` directly.
 - `status` returns `Model` / `SessionId` as `null` when they cannot be detected (e.g. page still loading) rather than a string sentinel — branch on `null` in agent code.

--- a/docs/adapters/browser/qwen.md
+++ b/docs/adapters/browser/qwen.md
@@ -119,7 +119,7 @@ opencli qwen image "a tiny robot" --sd true
 ## Notes
 
 - `read` works without login (guest mode), but `history` and most `write` flows require an authenticated session
-- Qwen commands default to site-level browser tab reuse, so consecutive `qwen ask` / `qwen read` / `qwen image` invocations continue in the same Qwen page. Pass `--reuse none` for a one-shot tab.
+- Qwen commands default to persistent site sessions, so consecutive `qwen ask` / `qwen read` / `qwen image` invocations continue in the same Qwen page. Pass `--site-session ephemeral` for a one-shot tab.
 - `ask` waits for the streaming reply to finish; `send` returns immediately after submission
 - DeepThink (`--think`) and DeepResearch (`--research`) toggle the corresponding composer chips before submitting
 - Generated image files are timestamped to avoid overwriting prior runs

--- a/docs/adapters/browser/yuanbao.md
+++ b/docs/adapters/browser/yuanbao.md
@@ -102,7 +102,7 @@ opencli yuanbao detail "naQivTmsDa/b1118732-15ca-42cc-bc9a-e40090ccfb8c"
 ## Caveats
 
 - This adapter drives the Yuanbao web UI, not a public API.
-- Yuanbao commands default to site-level browser tab reuse, so consecutive Yuanbao invocations continue in the same Yuanbao page. Pass `--reuse none` for a one-shot tab.
+- Yuanbao commands default to persistent site sessions, so consecutive Yuanbao invocations continue in the same Yuanbao page. Pass `--site-session ephemeral` for a one-shot tab.
 - Yuanbao chat URLs encode both an agent slug and a conversation UUID (`/chat/<agentId>/<convId>`). `detail` requires both — passing only a UUID is rejected with an actionable error to avoid silently opening a different agent's chat.
 - It depends on the current browser session and may fail if Yuanbao shows login, consent, challenge, or other gating UI.
 - DOM or product changes on Yuanbao can break composer detection, submit behavior, or transcript extraction.

--- a/docs/developer/ts-adapter.md
+++ b/docs/developer/ts-adapter.md
@@ -89,21 +89,23 @@ for context, the full pattern table, and how to add an id to a listing.
 
 Browser-backed commands are one-shot by default: each execution gets a fresh
 tab lease and releases it when the command returns. For interactive sites where
-successive commands should continue in the same page, opt into site-level reuse:
+successive commands should continue in the same page, opt into a persistent site
+session:
 
 ```typescript
 cli({
   site: 'mysite',
   name: 'ask',
   strategy: Strategy.COOKIE,
-  browserSession: { reuse: 'site' },
+  siteSession: 'persistent',
   // ...
 });
 ```
 
-`reuse: 'site'` makes commands for the same site share `site:<site>` and use the
-interactive idle timeout. Users can override the adapter default with
-`--reuse none` or force reuse with `--reuse site`.
+`siteSession: 'persistent'` makes commands for the same site share a stable
+adapter site tab and keeps that tab open until it is explicitly closed. Users
+can override the adapter default with `--site-session ephemeral` or force
+persistence with `--site-session persistent`.
 
 ## The `page` Object
 

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -775,6 +775,7 @@ class CommandFailure extends Error {
 }
 const sessionTimeoutOverrides = /* @__PURE__ */ new Map();
 const sessionWindowModeOverrides = /* @__PURE__ */ new Map();
+const sessionLifecycleOverrides = /* @__PURE__ */ new Map();
 const LEASE_KEY_SEPARATOR = "\0";
 function getLeaseKey(session, surface) {
   return `${surface}${LEASE_KEY_SEPARATOR}${encodeURIComponent(session)}`;
@@ -809,12 +810,15 @@ function getSessionFromKey(key) {
 function getIdleTimeout(key) {
   const session = automationSessions.get(key);
   if (session?.kind === "bound") return IDLE_TIMEOUT_NONE;
+  if (getSurfaceFromKey(key) === "adapter" && (session?.lifecycle === "persistent" || sessionLifecycleOverrides.get(key) === "persistent")) return IDLE_TIMEOUT_NONE;
   const override = sessionTimeoutOverrides.get(key);
   if (override !== void 0) return override;
   return getSurfaceFromKey(key) === "browser" ? IDLE_TIMEOUT_INTERACTIVE : IDLE_TIMEOUT_DEFAULT;
 }
 function getLeaseLifecycle(key, kind) {
   if (kind === "bound") return "pinned";
+  const override = sessionLifecycleOverrides.get(key);
+  if (override) return override;
   return getSurfaceFromKey(key) === "browser" ? "persistent" : "ephemeral";
 }
 function getOwnedWindowRole(key) {
@@ -960,6 +964,7 @@ async function removeLeaseSession(leaseKey) {
   automationSessions.delete(leaseKey);
   sessionTimeoutOverrides.delete(leaseKey);
   sessionWindowModeOverrides.delete(leaseKey);
+  sessionLifecycleOverrides.delete(leaseKey);
   scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
   await persistRuntimeState();
 }
@@ -1173,6 +1178,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
       automationSessions.delete(leaseKey);
       sessionTimeoutOverrides.delete(leaseKey);
       sessionWindowModeOverrides.delete(leaseKey);
+      sessionLifecycleOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     }
   }
@@ -1185,6 +1191,8 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(leaseKey);
       sessionTimeoutOverrides.delete(leaseKey);
+      sessionWindowModeOverrides.delete(leaseKey);
+      sessionLifecycleOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
       console.log(`[opencli] Session ${session.session} detached from tab ${tabId} (tab closed)`);
     }
@@ -1260,6 +1268,9 @@ async function handleCommand(cmd) {
   const leaseKey = getLeaseKey(session, surface);
   if (cmd.windowMode === "foreground" || cmd.windowMode === "background") {
     sessionWindowModeOverrides.set(leaseKey, cmd.windowMode);
+  }
+  if (surface === "adapter" && (cmd.siteSession === "persistent" || cmd.siteSession === "ephemeral")) {
+    sessionLifecycleOverrides.set(leaseKey, cmd.siteSession);
   }
   if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
     sessionTimeoutOverrides.set(leaseKey, cmd.idleTimeout * 1e3);
@@ -1859,6 +1870,8 @@ async function releaseLease(leaseKey, reason = "released") {
   const session = automationSessions.get(leaseKey);
   if (!session) {
     sessionTimeoutOverrides.delete(leaseKey);
+    sessionWindowModeOverrides.delete(leaseKey);
+    sessionLifecycleOverrides.delete(leaseKey);
     scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     await persistRuntimeState();
     return;
@@ -1898,6 +1911,7 @@ async function releaseLease(leaseKey, reason = "released") {
   automationSessions.delete(leaseKey);
   sessionTimeoutOverrides.delete(leaseKey);
   sessionWindowModeOverrides.delete(leaseKey);
+  sessionLifecycleOverrides.delete(leaseKey);
   await persistRuntimeState();
 }
 async function reconcileTargetLeaseRegistry() {
@@ -1922,6 +1936,9 @@ async function reconcileTargetLeaseRegistry() {
     try {
       const tab = await chrome.tabs.get(tabId);
       if (!isDebuggableUrl(tab.url)) continue;
+      if (stored.lifecycle === "ephemeral" || stored.lifecycle === "persistent" || stored.lifecycle === "pinned") {
+        sessionLifecycleOverrides.set(leaseKey, stored.lifecycle);
+      }
       const session = makeSession(leaseKey, {
         session: typeof stored.session === "string" ? stored.session : getSessionFromKey(leaseKey),
         surface: stored.surface === "adapter" ? "adapter" : getSurfaceFromKey(leaseKey),

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1176,6 +1176,52 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getSession(adapterKey('twitter'))).toBeNull();
   });
 
+  it('keeps persistent adapter site sessions alive across adapter idle timeout', async () => {
+    const { chrome, tabs } = createChromeMock();
+    tabs[0].url = 'https://chatgpt.com/';
+    tabs[0].title = 'ChatGPT';
+    tabs[0].active = true;
+
+    vi.useFakeTimers();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+
+    const first = await mod.__test__.handleCommand({
+      id: 'persistent-nav-1',
+      action: 'navigate',
+      session: 'chatgpt',
+      surface: 'adapter',
+      siteSession: 'persistent',
+      url: 'https://chatgpt.com/',
+    });
+    expect(first.ok).toBe(true);
+    const page = first.page;
+
+    const session = mod.__test__.getSession(adapterKey('chatgpt'));
+    expect(session).toEqual(expect.objectContaining({
+      lifecycle: 'persistent',
+      surface: 'adapter',
+      session: 'chatgpt',
+    }));
+    expect(mod.__test__.getIdleTimeout(adapterKey('chatgpt'))).toBe(-1);
+
+    await vi.advanceTimersByTimeAsync(60001);
+    expect(mod.__test__.getSession(adapterKey('chatgpt'))).not.toBeNull();
+
+    const second = await mod.__test__.handleCommand({
+      id: 'persistent-nav-2',
+      action: 'navigate',
+      session: 'chatgpt',
+      surface: 'adapter',
+      siteSession: 'persistent',
+      url: 'https://chatgpt.com/',
+    });
+    expect(second.ok).toBe(true);
+    expect(second.page).toBe(page);
+    expect(mod.__test__.getSession(adapterKey('chatgpt'))).not.toBeNull();
+  });
+
   it('uses 10-minute timeout for browser:* sessions', async () => {
     const { chrome } = createChromeMock();
     vi.useFakeTimers();

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -237,6 +237,7 @@ class CommandFailure extends Error {
 /** Per-session custom timeout overrides set via command.idleTimeout */
 const sessionTimeoutOverrides = new Map<string, number>();
 const sessionWindowModeOverrides = new Map<string, WindowMode>();
+const sessionLifecycleOverrides = new Map<string, LeaseLifecycle>();
 const LEASE_KEY_SEPARATOR = '\u0000';
 
 function getLeaseKey(session: string, surface: BrowserSurface): string {
@@ -277,6 +278,9 @@ function getSessionFromKey(key: string): string {
 function getIdleTimeout(key: string): number {
   const session = automationSessions.get(key);
   if (session?.kind === 'bound') return IDLE_TIMEOUT_NONE;
+  const adapterPersistent = getSurfaceFromKey(key) === 'adapter'
+    && (session?.lifecycle === 'persistent' || sessionLifecycleOverrides.get(key) === 'persistent');
+  if (adapterPersistent) return IDLE_TIMEOUT_NONE;
   const override = sessionTimeoutOverrides.get(key);
   if (override !== undefined) return override;
   return getSurfaceFromKey(key) === 'browser' ? IDLE_TIMEOUT_INTERACTIVE : IDLE_TIMEOUT_DEFAULT;
@@ -284,6 +288,8 @@ function getIdleTimeout(key: string): number {
 
 function getLeaseLifecycle(key: string, kind: LeaseKind): LeaseLifecycle {
   if (kind === 'bound') return 'pinned';
+  const override = sessionLifecycleOverrides.get(key);
+  if (override) return override;
   return getSurfaceFromKey(key) === 'browser' ? 'persistent' : 'ephemeral';
 }
 
@@ -452,6 +458,7 @@ async function removeLeaseSession(leaseKey: string): Promise<void> {
   automationSessions.delete(leaseKey);
   sessionTimeoutOverrides.delete(leaseKey);
   sessionWindowModeOverrides.delete(leaseKey);
+  sessionLifecycleOverrides.delete(leaseKey);
   scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
   await persistRuntimeState();
 }
@@ -718,6 +725,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
       automationSessions.delete(leaseKey);
       sessionTimeoutOverrides.delete(leaseKey);
       sessionWindowModeOverrides.delete(leaseKey);
+      sessionLifecycleOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     }
   }
@@ -732,6 +740,8 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(leaseKey);
       sessionTimeoutOverrides.delete(leaseKey);
+      sessionWindowModeOverrides.delete(leaseKey);
+      sessionLifecycleOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
       console.log(`[opencli] Session ${session.session} detached from tab ${tabId} (tab closed)`);
     }
@@ -831,6 +841,9 @@ async function handleCommand(cmd: Command): Promise<Result> {
   const leaseKey = getLeaseKey(session, surface);
   if (cmd.windowMode === 'foreground' || cmd.windowMode === 'background') {
     sessionWindowModeOverrides.set(leaseKey, cmd.windowMode);
+  }
+  if (surface === 'adapter' && (cmd.siteSession === 'persistent' || cmd.siteSession === 'ephemeral')) {
+    sessionLifecycleOverrides.set(leaseKey, cmd.siteSession);
   }
   // Apply custom idle timeout if specified in the command
   if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
@@ -1542,6 +1555,8 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
   const session = automationSessions.get(leaseKey);
   if (!session) {
     sessionTimeoutOverrides.delete(leaseKey);
+    sessionWindowModeOverrides.delete(leaseKey);
+    sessionLifecycleOverrides.delete(leaseKey);
     scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     await persistRuntimeState();
     return;
@@ -1585,6 +1600,7 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
   automationSessions.delete(leaseKey);
   sessionTimeoutOverrides.delete(leaseKey);
   sessionWindowModeOverrides.delete(leaseKey);
+  sessionLifecycleOverrides.delete(leaseKey);
 
   await persistRuntimeState();
 }
@@ -1612,6 +1628,9 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
     try {
       const tab = await chrome.tabs.get(tabId);
       if (!isDebuggableUrl(tab.url)) continue;
+      if (stored.lifecycle === 'ephemeral' || stored.lifecycle === 'persistent' || stored.lifecycle === 'pinned') {
+        sessionLifecycleOverrides.set(leaseKey, stored.lifecycle);
+      }
       const session = makeSession(leaseKey, {
         session: typeof stored.session === 'string' ? stored.session : getSessionFromKey(leaseKey),
         surface: stored.surface === 'adapter' ? 'adapter' : getSurfaceFromKey(leaseKey),

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -35,6 +35,8 @@ export interface Command {
   session?: string;
   /** Runtime surface selecting owned container policy. */
   surface?: 'browser' | 'adapter';
+  /** Adapter site session lifecycle. Persistent site sessions do not idle-expire. */
+  siteSession?: 'ephemeral' | 'persistent';
   /** URL to navigate to (navigate action) */
   url?: string;
   /** Sub-operation for tabs: list, new, close, select */

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -29,7 +29,7 @@ export class BrowserBridge implements IBrowserFactory {
     return this._state;
   }
 
-  async connect(opts: { timeout?: number; session?: string; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter' } = {}): Promise<IPage> {
+  async connect(opts: { timeout?: number; session?: string; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' } = {}): Promise<IPage> {
     if (this._state === 'connected' && this._page) return this._page;
     if (this._state === 'connecting') throw new Error('Already connecting');
     if (this._state === 'closing') throw new Error('Session is closing');
@@ -41,7 +41,7 @@ export class BrowserBridge implements IBrowserFactory {
       const contextId = opts.contextId ?? resolveProfileContextId();
       await this._ensureDaemon(opts.timeout, contextId);
       if (!opts.session?.trim()) throw new Error('Browser session is required');
-      this._page = new Page(opts.session.trim(), opts.idleTimeout, contextId, opts.windowMode, opts.surface);
+      this._page = new Page(opts.session.trim(), opts.idleTimeout, contextId, opts.windowMode, opts.surface, opts.siteSession);
       this._state = 'connected';
       return this._page;
     } catch (err) {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -53,7 +53,7 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter' }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -28,6 +28,8 @@ export interface DaemonCommand {
   code?: string;
   session?: string;
   surface?: 'browser' | 'adapter';
+  /** Adapter site session lifecycle. Persistent site sessions do not idle-expire. */
+  siteSession?: 'ephemeral' | 'persistent';
   url?: string;
   op?: string;
   index?: number;

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -50,6 +50,28 @@ describe('Page.getCurrentUrl', () => {
 
     expect(sendCommandMock).toHaveBeenCalledTimes(1);
   });
+
+  it('passes adapter site session lifecycle through daemon commands', async () => {
+    sendCommandFullMock.mockResolvedValueOnce({ page: 'page-1', data: { url: 'https://chatgpt.com/' } });
+    sendCommandMock.mockResolvedValueOnce(null);
+
+    const page = new Page('site:chatgpt', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await page.goto('https://chatgpt.com/', { waitUntil: 'none' });
+    await page.evaluate('document.title');
+
+    expect(sendCommandFullMock).toHaveBeenCalledWith('navigate', expect.objectContaining({
+      session: 'site:chatgpt',
+      surface: 'adapter',
+      siteSession: 'persistent',
+    }));
+    expect(sendCommandMock).toHaveBeenCalledWith('exec', expect.objectContaining({
+      session: 'site:chatgpt',
+      surface: 'adapter',
+      siteSession: 'persistent',
+      page: 'page-1',
+    }));
+  });
 });
 
 describe('Page.evaluate', () => {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -38,6 +38,7 @@ export class Page extends BasePage {
     public readonly contextId?: string,
     private readonly windowMode?: 'foreground' | 'background',
     private readonly surface: 'browser' | 'adapter' = 'browser',
+    private readonly siteSession?: 'ephemeral' | 'persistent',
   ) {
     super();
     this._idleTimeout = idleTimeout;
@@ -49,13 +50,14 @@ export class Page extends BasePage {
   private _networkCaptureWarned = false;
 
   /** Helper: spread session into command params */
-  private _sessionOpts(): { session: string; surface: 'browser' | 'adapter'; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background' } {
+  private _sessionOpts(): { session: string; surface: 'browser' | 'adapter'; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background'; siteSession?: 'ephemeral' | 'persistent' } {
     return {
       session: this.session,
       surface: this.surface,
       ...(this.contextId && { contextId: this.contextId }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
       ...(this.windowMode && { windowMode: this.windowMode }),
+      ...(this.siteSession && { siteSession: this.siteSession }),
     };
   }
 
@@ -68,6 +70,7 @@ export class Page extends BasePage {
       ...(this._page !== undefined && { page: this._page }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
       ...(this.windowMode && { windowMode: this.windowMode }),
+      ...(this.siteSession && { siteSession: this.siteSession }),
     };
   }
 

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -126,7 +126,7 @@ function toManifestEntry(cmd: CliCommand, modulePath: string, sourceFile?: strin
     modulePath,
     sourceFile,
     navigateBefore: cmd.navigateBefore,
-    browserSession: cmd.browserSession,
+    siteSession: cmd.siteSession,
   };
 }
 

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -64,6 +64,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
   if (cmd.browser) {
     subCmd
       .option('--window <mode>', 'Browser window mode: foreground or background')
+      .option('--site-session <mode>', 'Adapter site session lifecycle: ephemeral or persistent')
       .option('--keep-tab <bool>', 'Keep the browser tab lease after the command finishes');
   }
 
@@ -118,6 +119,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         ...(typeof globals.profile === 'string' && globals.profile.trim() ? { profile: globals.profile.trim() } : {}),
         ...(typeof optionsRecord.trace === 'string' && optionsRecord.trace !== 'off' ? { trace: optionsRecord.trace } : {}),
         ...(cmd.browser && typeof optionsRecord.window === 'string' ? { windowMode: optionsRecord.window } : {}),
+        ...(cmd.browser && typeof optionsRecord.siteSession === 'string' ? { siteSession: optionsRecord.siteSession } : {}),
         ...(cmd.browser && typeof optionsRecord.keepTab === 'string' ? { keepTab: optionsRecord.keepTab } : {}),
       });
       if (result === null || result === undefined) {

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -134,7 +134,7 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
         pipeline: entry.pipeline,
         source: entry.sourceFile ? path.resolve(clisDir, entry.sourceFile) : modulePath,
         navigateBefore: entry.navigateBefore,
-        browserSession: entry.browserSession,
+        siteSession: entry.siteSession,
         _lazy: true,
         _modulePath: modulePath,
       };

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -168,7 +168,7 @@ describe('executeCommand — non-browser timeout', () => {
   it('reuses a persistent site browser session and keeps the tab lease open', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
-    const sessionOpts: Array<{ session?: string; idleTimeout?: number; windowMode?: string }> = [];
+    const sessionOpts: Array<{ session?: string; idleTimeout?: number; windowMode?: string; siteSession?: string }> = [];
 
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn, opts) => {
@@ -178,20 +178,22 @@ describe('executeCommand — non-browser timeout', () => {
 
     const cmd = cli({
       site: 'test-execution',
-      name: 'browser-reuse-site', access: 'read',
-      description: 'test site-scoped browser reuse',
+      name: 'site-session-persistent', access: 'read',
+      description: 'test persistent site session',
       browser: true,
       strategy: Strategy.PUBLIC,
-      browserSession: { reuse: 'site' },
+      siteSession: 'persistent',
       func: async () => [{ ok: true }],
     });
 
     await executeCommand(cmd, {});
-    await executeCommand(cmd, {});
+    await executeCommand(cmd, {}, false, { keepTab: 'false' });
 
     expect(sessionOpts).toHaveLength(2);
-    expect(sessionOpts[0]).toMatchObject({ session: 'site:test-execution', idleTimeout: 600, windowMode: 'background' });
-    expect(sessionOpts[1]).toMatchObject({ session: 'site:test-execution', idleTimeout: 600, windowMode: 'background' });
+    expect(sessionOpts[0]).toMatchObject({ session: 'site:test-execution', windowMode: 'background', siteSession: 'persistent' });
+    expect(sessionOpts[1]).toMatchObject({ session: 'site:test-execution', windowMode: 'background', siteSession: 'persistent' });
+    expect(sessionOpts[0]?.idleTimeout).toBeUndefined();
+    expect(sessionOpts[1]?.idleTimeout).toBeUndefined();
     expect(closeWindow).not.toHaveBeenCalled();
     vi.restoreAllMocks();
   });
@@ -209,7 +211,7 @@ describe('executeCommand — non-browser timeout', () => {
 
     const cmd = cli({
       site: 'test-execution',
-      name: 'browser-reuse-default', access: 'read',
+      name: 'site-session-default', access: 'read',
       description: 'test default one-shot browser session',
       browser: true,
       strategy: Strategy.PUBLIC,
@@ -231,7 +233,7 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
-  it('lets user --reuse none override adapter reuse metadata', async () => {
+  it('lets user --site-session ephemeral override adapter persistent metadata', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;
     const sessionOpts: Array<{ session?: string; idleTimeout?: number }> = [];
@@ -242,33 +244,29 @@ describe('executeCommand — non-browser timeout', () => {
       return fn(mockPage);
     });
 
-    const prev = process.env.OPENCLI_BROWSER_REUSE;
-    process.env.OPENCLI_BROWSER_REUSE = 'none';
     try {
       const cmd = cli({
         site: 'test-execution',
-        name: 'browser-reuse-override-none', access: 'read',
-        description: 'test user reuse override',
+        name: 'site-session-override-ephemeral', access: 'read',
+        description: 'test user site-session override',
         browser: true,
         strategy: Strategy.PUBLIC,
-        browserSession: { reuse: 'site' },
+        siteSession: 'persistent',
         func: async () => [{ ok: true }],
       });
 
-      await executeCommand(cmd, {});
+      await executeCommand(cmd, {}, false, { siteSession: 'ephemeral' });
 
       expect(sessionOpts).toHaveLength(1);
       expect(sessionOpts[0]?.session).toMatch(/^site:test-execution:/);
       expect(sessionOpts[0]?.idleTimeout).toBeUndefined();
       expect(closeWindow).toHaveBeenCalledTimes(1);
     } finally {
-      if (prev === undefined) delete process.env.OPENCLI_BROWSER_REUSE;
-      else process.env.OPENCLI_BROWSER_REUSE = prev;
       vi.restoreAllMocks();
     }
   });
 
-  it('skips repeated domain pre-navigation for site-reused browser sessions', async () => {
+  it('skips repeated domain pre-navigation for persistent site sessions', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const goto = vi.fn().mockResolvedValue(undefined);
     const mockPage = {
@@ -282,12 +280,12 @@ describe('executeCommand — non-browser timeout', () => {
 
     const cmd = cli({
       site: 'test-execution',
-      name: 'browser-reuse-skip-prenav', access: 'read',
+      name: 'site-session-skip-prenav', access: 'read',
       description: 'test reused same-domain tabs do not reset conversation state',
       browser: true,
       strategy: Strategy.COOKIE,
       domain: 'grok.com',
-      browserSession: { reuse: 'site' },
+      siteSession: 'persistent',
       func: async () => [{ ok: true }],
     });
 
@@ -298,7 +296,7 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
-  it('keeps explicit path pre-navigation for site-reused browser sessions', async () => {
+  it('keeps explicit path pre-navigation for persistent site sessions', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const goto = vi.fn().mockResolvedValue(undefined);
     const mockPage = {
@@ -312,13 +310,13 @@ describe('executeCommand — non-browser timeout', () => {
 
     const cmd = cli({
       site: 'test-execution',
-      name: 'browser-reuse-path-prenav', access: 'read',
+      name: 'site-session-path-prenav', access: 'read',
       description: 'test explicit path pre-navigation still runs',
       browser: true,
       strategy: Strategy.COOKIE,
       domain: 'example.com',
       navigateBefore: 'https://example.com/dashboard',
-      browserSession: { reuse: 'site' },
+      siteSession: 'persistent',
       func: async () => [{ ok: true }],
     });
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -14,7 +14,7 @@ import {
   type BrowserCliCommand,
   type CliCommand,
   type InternalCliCommand,
-  type BrowserSessionReuse,
+  type SiteSessionMode,
   type Arg,
   type CommandArgs,
   getRegistry,
@@ -41,7 +41,6 @@ const _loadedModules = new Map<string, Promise<void>>();
 /** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
 const _moduleMtimes = new Map<string, number>();
 const _userClisDir = `${os.homedir()}/.opencli/clis/`;
-const INTERACTIVE_BROWSER_IDLE_TIMEOUT_SECONDS = 600;
 
 type TraceMode = 'off' | 'on' | 'retain-on-failure';
 
@@ -187,8 +186,8 @@ function isDomainRootPreNav(preNavUrl: string, domain: string | undefined): bool
   }
 }
 
-async function shouldRunPreNav(cmd: CliCommand, page: IPage, reuse: BrowserSessionReuse, preNavUrl: string): Promise<boolean> {
-  if (reuse !== 'site' || !cmd.domain) return true;
+async function shouldRunPreNav(cmd: CliCommand, page: IPage, siteSession: SiteSessionMode, preNavUrl: string): Promise<boolean> {
+  if (siteSession !== 'persistent' || !cmd.domain) return true;
   if (!isDomainRootPreNav(preNavUrl, cmd.domain)) return true;
   const currentUrl = await page.getCurrentUrl?.().catch(() => null);
   return !urlMatchesDomain(currentUrl, cmd.domain);
@@ -204,6 +203,7 @@ export async function executeCommand(
     trace?: string;
     keepTab?: string;
     windowMode?: string;
+    siteSession?: string;
     onTraceExport?: (trace: ObservationExportResult) => void;
   } = {},
 ): Promise<unknown> {
@@ -251,10 +251,9 @@ export async function executeCommand(
       const BrowserFactory = getBrowserFactory(cmd.site);
       const contextId = resolveProfileContextId(opts.profile);
       const internal = cmd as InternalCliCommand;
-      const browserReuse = resolveBrowserSessionReuse(cmd);
-      const session = resolveAdapterBrowserSession(cmd, browserReuse);
-      const idleTimeout = browserReuse === 'site' ? INTERACTIVE_BROWSER_IDLE_TIMEOUT_SECONDS : undefined;
-      const keepTab = resolveKeepTab(browserReuse, opts.keepTab);
+      const siteSession = resolveSiteSession(cmd, opts.siteSession);
+      const session = resolveAdapterBrowserSession(cmd, siteSession);
+      const keepTab = resolveKeepTab(siteSession, opts.keepTab);
       const windowMode = resolveBrowserWindowMode('background', opts.windowMode);
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
@@ -279,7 +278,7 @@ export async function executeCommand(
           await page.startNetworkCapture?.().catch(() => false);
         }
         const preNavUrl = resolvePreNav(cmd);
-        if (preNavUrl && await shouldRunPreNav(cmd, page, browserReuse, preNavUrl)) {
+        if (preNavUrl && await shouldRunPreNav(cmd, page, siteSession, preNavUrl)) {
           observation?.record({
             stream: 'action',
             name: 'pre_navigate',
@@ -370,7 +369,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, contextId, idleTimeout, windowMode, surface: 'adapter' });
+      }, { session, cdpEndpoint, contextId, windowMode, surface: 'adapter', siteSession });
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that
@@ -488,19 +487,18 @@ export function prepareCommandArgs(
  */
 const RUNTIME_TIMEOUT_PADDING_SECONDS = 30;
 
-function readEnvBrowserSessionReuse(): BrowserSessionReuse | null {
-  const raw = process.env.OPENCLI_BROWSER_REUSE;
-  if (raw === undefined || raw === '') return null;
-  if (raw === 'none' || raw === 'site') return raw;
-  throw new ArgumentError(`--reuse must be one of: none, site. Received: "${raw}"`);
+function normalizeSiteSession(raw: unknown): SiteSessionMode | null {
+  if (raw === undefined || raw === null || raw === '') return null;
+  if (raw === 'ephemeral' || raw === 'persistent') return raw;
+  throw new ArgumentError(`--site-session must be one of: ephemeral, persistent. Received: "${String(raw)}"`);
 }
 
-function resolveBrowserSessionReuse(cmd: CliCommand): BrowserSessionReuse {
-  return readEnvBrowserSessionReuse() ?? cmd.browserSession?.reuse ?? 'none';
+function resolveSiteSession(cmd: CliCommand, rawOption?: unknown): SiteSessionMode {
+  return normalizeSiteSession(rawOption) ?? cmd.siteSession ?? 'ephemeral';
 }
 
-function resolveAdapterBrowserSession(cmd: CliCommand, reuse: BrowserSessionReuse): string {
-  if (reuse === 'site') return `site:${cmd.site}`;
+function resolveAdapterBrowserSession(cmd: CliCommand, siteSession: SiteSessionMode): string {
+  if (siteSession === 'persistent') return `site:${cmd.site}`;
   return `site:${cmd.site}:${crypto.randomUUID()}`;
 }
 
@@ -511,10 +509,11 @@ function normalizeBooleanOption(name: string, raw: unknown): boolean | null {
   throw new ArgumentError(`${name} must be one of: true, false. Received: "${String(raw)}"`);
 }
 
-function resolveKeepTab(reuse: BrowserSessionReuse, rawOption?: unknown): boolean {
+function resolveKeepTab(siteSession: SiteSessionMode, rawOption?: unknown): boolean {
+  if (siteSession === 'persistent') return true;
   return normalizeBooleanOption('--keep-tab', rawOption)
     ?? normalizeBooleanOption('OPENCLI_KEEP_TAB', process.env.OPENCLI_KEEP_TAB)
-    ?? reuse !== 'none';
+    ?? false;
 }
 
 function normalizeWindowMode(name: string, raw: unknown): BrowserWindowMode | null {

--- a/src/help.ts
+++ b/src/help.ts
@@ -62,6 +62,12 @@ const BROWSER_COMMON_OPTIONS = [
     choices: ['foreground', 'background'],
   },
   {
+    flags: '--site-session <mode>',
+    name: 'site-session',
+    help: 'Adapter site session lifecycle: ephemeral or persistent',
+    choices: ['ephemeral', 'persistent'],
+  },
+  {
     flags: '--keep-tab <bool>',
     name: 'keep-tab',
     help: 'Keep the browser tab lease after the command finishes',
@@ -413,7 +419,7 @@ function compactCommand(cmd: CliCommand): Record<string, unknown> {
     command_options: commandOptions(cmd).map(compactArg),
     ...(cmd.browser ? { browser_common_options: BROWSER_COMMON_OPTIONS.map(compactCommonOption) } : {}),
     example: formatCommandExample(cmd),
-    ...(cmd.browserSession ? { browserSession: cmd.browserSession } : {}),
+    ...(cmd.siteSession ? { siteSession: cmd.siteSession } : {}),
     ...(cmd.defaultFormat ? { defaultFormat: cmd.defaultFormat } : {}),
     ...(cmd.columns?.length ? { columns: cmd.columns } : {}),
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,26 +30,6 @@ const __dirname = path.dirname(__filename);
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), '.opencli', 'clis');
 
-// ── Browser reuse flag ───────────────────────────────────────────────────
-// `--reuse` is a runtime-level browser session override rather than an adapter
-// arg. Strip it before Commander runs and expose it through an explicit env
-// name. Window/keep-tab are registered on browser-backed commands directly.
-{
-  const reuseIdx = process.argv.findIndex(arg => arg === '--reuse' || arg.startsWith('--reuse='));
-  if (reuseIdx !== -1) {
-    const arg = process.argv[reuseIdx];
-    const value = arg.startsWith('--reuse=')
-      ? arg.slice('--reuse='.length)
-      : process.argv[reuseIdx + 1];
-    if (value !== 'none' && value !== 'site') {
-      process.stderr.write(`--reuse must be one of: none, site. Received: "${value ?? ''}"\n`);
-      process.exit(EXIT_CODES.USAGE_ERROR);
-    }
-    process.env.OPENCLI_BROWSER_REUSE = value;
-    process.argv.splice(reuseIdx, arg.startsWith('--reuse=') ? 1 : 2);
-  }
-}
-
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.
 const argv = process.argv.slice(2);

--- a/src/manifest-types.ts
+++ b/src/manifest-types.ts
@@ -37,8 +37,6 @@ export interface ManifestEntry {
   sourceFile?: string;
   /** Pre-navigation control — see CliCommand.navigateBefore */
   navigateBefore?: boolean | string;
-  /** Browser session lifecycle defaults — see CliCommand.browserSession */
-  browserSession?: {
-    reuse?: 'none' | 'site';
-  };
+  /** Site session lifecycle defaults — see CliCommand.siteSession */
+  siteSession?: 'ephemeral' | 'persistent';
 }

--- a/src/registry-api.ts
+++ b/src/registry-api.ts
@@ -8,7 +8,7 @@
  */
 
 export { cli, Strategy, getRegistry, fullName, registerCommand } from './registry.js';
-export type { CliCommand, Arg, CliOptions, CommandArgs, BrowserSessionOptions, BrowserSessionReuse } from './registry.js';
+export type { CliCommand, Arg, CliOptions, CommandArgs, SiteSessionMode } from './registry.js';
 export type { IPage } from './types.js';
 export { onStartup, onBeforeExecute, onAfterExecute } from './hooks.js';
 export type { HookFn, HookContext, HookName } from './hooks.js';

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -27,17 +27,7 @@ export type CommandArgs = Record<string, any>;
 export type BrowserCommandFunc = (page: IPage, kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
 export type NonBrowserCommandFunc = (kwargs: CommandArgs, debug?: boolean) => Promise<unknown>;
 export type CommandAccess = 'read' | 'write';
-export type BrowserSessionReuse = 'none' | 'site';
-
-export interface BrowserSessionOptions {
-  /**
-   * Control whether browser-backed adapter commands reuse a stable tab lease.
-   *
-   * - `none`: one-shot adapter browser session per command execution (default)
-   * - `site`: all commands for this site share one adapter browser session until idle expiry
-   */
-  reuse?: BrowserSessionReuse;
-}
+export type SiteSessionMode = 'ephemeral' | 'persistent';
 
 interface BaseCliCommand {
   site: string;
@@ -72,8 +62,8 @@ interface BaseCliCommand {
    * Adapter authors can set this explicitly to override the strategy-based default.
    */
   navigateBefore?: boolean | string;
-  /** Browser session lifecycle defaults for adapter commands. */
-  browserSession?: BrowserSessionOptions;
+  /** Site session lifecycle for adapter commands. */
+  siteSession?: SiteSessionMode;
   /** Override the default CLI output format when the user does not pass -f/--format. */
   defaultFormat?: 'table' | 'plain' | 'json' | 'yaml' | 'yml' | 'md' | 'markdown' | 'csv';
 }
@@ -146,7 +136,7 @@ export function cli(opts: CliOptions): CliCommand {
     pipeline: opts.pipeline,
     footerExtra: opts.footerExtra,
     navigateBefore: opts.navigateBefore,
-    browserSession: opts.browserSession,
+    siteSession: opts.siteSession,
     defaultFormat: opts.defaultFormat,
   };
 
@@ -181,7 +171,7 @@ export function strategyLabel(cmd: CliCommand): string {
  */
 function normalizeCommand(cmd: RawCliCommand): CliCommand {
   assertCommandAccess(cmd);
-  assertBrowserSessionOptions(cmd);
+  assertSiteSession(cmd);
 
   const strategy = cmd.strategy ?? (cmd.browser === false ? Strategy.PUBLIC : Strategy.COOKIE);
   const browser = cmd.browser ?? (strategy !== Strategy.PUBLIC && strategy !== Strategy.LOCAL);
@@ -209,15 +199,11 @@ function assertCommandAccess(cmd: Pick<RawCliCommand, 'site' | 'name'> & { acces
   throw new Error(`Command ${key} must declare access: 'read' | 'write'`);
 }
 
-function assertBrowserSessionOptions(cmd: Pick<RawCliCommand, 'site' | 'name'> & { browserSession?: unknown }): void {
-  if (cmd.browserSession === undefined) return;
+function assertSiteSession(cmd: Pick<RawCliCommand, 'site' | 'name'> & { siteSession?: unknown }): void {
+  if (cmd.siteSession === undefined) return;
   const key = `${cmd.site}/${cmd.name}`;
-  if (cmd.browserSession === null || typeof cmd.browserSession !== 'object' || Array.isArray(cmd.browserSession)) {
-    throw new Error(`Command ${key} browserSession must be an object`);
-  }
-  const reuse = (cmd.browserSession as BrowserSessionOptions).reuse;
-  if (reuse !== undefined && reuse !== 'none' && reuse !== 'site') {
-    throw new Error(`Command ${key} browserSession.reuse must be one of: none, site`);
+  if (cmd.siteSession !== 'ephemeral' && cmd.siteSession !== 'persistent') {
+    throw new Error(`Command ${key} siteSession must be one of: ephemeral, persistent`);
   }
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -66,14 +66,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface }): Promise<IPage>;
+  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface } = {},
+  opts: { session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -85,6 +85,7 @@ export async function browserSession<T>(
       idleTimeout: opts.idleTimeout,
       windowMode: opts.windowMode,
       surface: opts.surface,
+      siteSession: opts.siteSession,
     });
     return await fn(page);
   } finally {

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -51,7 +51,7 @@ export function serializeCommand(cmd: CliCommand) {
     domain: cmd.domain ?? null,
     example: formatCommandExample(cmd),
     defaultFormat: cmd.defaultFormat ?? null,
-    browserSession: cmd.browserSession ?? null,
+    siteSession: cmd.siteSession ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- replace adapter metadata `browserSession: { reuse: 'site' }` with `siteSession: 'persistent'` across source adapters and manifest
- replace the old `--reuse <none|site>` / `OPENCLI_BROWSER_REUSE` override with explicit `--site-session <ephemeral|persistent>` on browser-backed adapter commands
- carry `siteSession` through CLI/runtime/Page/protocol into Browser Bridge so the extension stores adapter persistent leases as `lifecycle: 'persistent'`
- make persistent site sessions semantic: stable site tab, keep-tab is forced on, no idle expiry, and root pre-nav is skipped when already on-domain
- update docs/tests/changelog for the new naming

## Verification
- `npx tsc --noEmit`
- `npm run typecheck --prefix extension`
- `npm run build`
- `npm run build --prefix extension`
- `npx vitest run --project extension extension/src/background.test.ts`
- `npm test -- --run src/execution.test.ts src/cli.test.ts src/browser/page.test.ts clis/chatgpt/commands.test.js clis/reddit/read.test.js src/registry.test.ts src/help.test.ts`
- `npm run test:adapter`
- `npm run docs:build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `git diff --check`
