### PR TITLE
feat(extension): add opt-out flag to disable automation tab grouping

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -24,3 +24,29 @@ Suggested Chrome Web Store justification for `downloads`:
 > so agents can wait for downloads triggered during an automation workflow. The
 > command filters by a user-provided filename or URL pattern and timeout. We do
 > not modify, redirect, or persist user download history.
+
+## Configuration
+
+### `opencli_disable_automation_tab_group` (chrome.storage.local, boolean)
+
+When set to `true`, the extension stops placing owned tabs into a named tab
+group (`OpenCLI Browser` / `OpenCLI Adapter`). Tabs are still tracked
+internally by id, so adapters keep working — only the visual grouping is
+suppressed.
+
+Why this exists: Chrome 119+ ships a "Saved Tab Groups" feature that
+auto-saves any named/colored tab group to the user's sidebar and keeps it
+there even after the underlying window is closed. For automation-heavy
+workflows that spin up many short-lived owned windows, this causes
+`OpenCLI Adapter` (or `OpenCLI Browser`) entries to accumulate. The flag
+lets users opt out.
+
+To enable, open the extension's service worker DevTools console
+(`chrome://extensions` → OpenCLI → "Inspect views: service worker") and run:
+
+```js
+chrome.storage.local.set({ opencli_disable_automation_tab_group: true });
+```
+
+To revert, set the same key to `false` (or remove it) and reload the
+extension. The default behavior (tab grouping enabled) is unchanged.

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -755,6 +755,7 @@ const IDLE_TIMEOUT_INTERACTIVE = 6e5;
 const IDLE_TIMEOUT_NONE = -1;
 const REGISTRY_KEY = "opencli_target_lease_registry_v2";
 const LEASE_IDLE_ALARM_PREFIX = "opencli:lease-idle:";
+const DISABLE_TAB_GROUP_KEY = "opencli_disable_automation_tab_group";
 const CONTAINER_TAB_GROUP_TITLE = {
   interactive: "OpenCLI Browser",
   automation: "OpenCLI Adapter"
@@ -810,7 +811,8 @@ function getSessionFromKey(key) {
 function getIdleTimeout(key) {
   const session = automationSessions.get(key);
   if (session?.kind === "bound") return IDLE_TIMEOUT_NONE;
-  if (getSurfaceFromKey(key) === "adapter" && (session?.lifecycle === "persistent" || sessionLifecycleOverrides.get(key) === "persistent")) return IDLE_TIMEOUT_NONE;
+  const adapterPersistent = getSurfaceFromKey(key) === "adapter" && (session?.lifecycle === "persistent" || sessionLifecycleOverrides.get(key) === "persistent");
+  if (adapterPersistent) return IDLE_TIMEOUT_NONE;
   const override = sessionTimeoutOverrides.get(key);
   if (override !== void 0) return override;
   return getSurfaceFromKey(key) === "browser" ? IDLE_TIMEOUT_INTERACTIVE : IDLE_TIMEOUT_DEFAULT;
@@ -1002,9 +1004,20 @@ async function getOwnedContainerGroupId(role, windowId) {
   container.groupId = existing.id;
   return existing.id;
 }
+async function isAutomationTabGroupDisabled() {
+  try {
+    const local = chrome.storage?.local;
+    if (!local) return false;
+    const raw = await local.get(DISABLE_TAB_GROUP_KEY);
+    return raw[DISABLE_TAB_GROUP_KEY] === true;
+  } catch {
+    return false;
+  }
+}
 async function ensureOwnedContainerTabGroup(role, windowId, tabIds) {
   const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
   if (ids.length === 0) return;
+  if (await isAutomationTabGroupDisabled()) return;
   try {
     const existingGroupId = await getOwnedContainerGroupId(role, windowId);
     if (existingGroupId !== null) {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -901,6 +901,23 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ tabIds: [1], createProperties: { windowId: 1 } });
   });
 
+  it('skips tab grouping when opencli_disable_automation_tab_group is set in storage', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    // Pre-set the opt-out flag before background.ts loads.
+    await chrome.storage.local.set({ opencli_disable_automation_tab_group: true });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    // The tab is still created and resolvable — only the visual grouping is suppressed.
+    expect(tabId).toBe(1);
+    expect(tabs[0].groupId).toBe(-1);
+    expect(groups).toHaveLength(0);
+    expect(chrome.tabs.group).not.toHaveBeenCalled();
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+  });
+
   it('uses separate owned windows for browser and adapter sessions', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     let nextWindowId = 20;

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -200,6 +200,12 @@ const IDLE_TIMEOUT_INTERACTIVE = 600_000; // 10min — human-paced browser:* / o
 const IDLE_TIMEOUT_NONE = -1;             // borrowed bound tabs stay bound until unbound/closed
 const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
 const LEASE_IDLE_ALARM_PREFIX = 'opencli:lease-idle:';
+// Storage flag (chrome.storage.local) — when set to `true`, the extension stops
+// placing owned tabs into a named tab group. Useful on Chrome 119+ where the
+// "Saved Tab Groups" feature persists every named group's metadata across
+// sessions, causing OpenCLI entries to accumulate in the user's sidebar for
+// automation-heavy workflows.
+const DISABLE_TAB_GROUP_KEY = 'opencli_disable_automation_tab_group';
 const CONTAINER_TAB_GROUP_TITLE: Record<OwnedWindowRole, string> = {
   interactive: 'OpenCLI Browser',
   automation: 'OpenCLI Adapter',
@@ -501,9 +507,21 @@ async function getOwnedContainerGroupId(role: OwnedWindowRole, windowId: number)
   return existing.id;
 }
 
+async function isAutomationTabGroupDisabled(): Promise<boolean> {
+  try {
+    const local = chrome.storage?.local;
+    if (!local) return false;
+    const raw = await local.get(DISABLE_TAB_GROUP_KEY) as Record<string, unknown>;
+    return raw[DISABLE_TAB_GROUP_KEY] === true;
+  } catch {
+    return false;
+  }
+}
+
 async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: number, tabIds: Array<number | undefined>): Promise<void> {
   const ids = [...new Set(tabIds.filter((id): id is number => id !== undefined))];
   if (ids.length === 0) return;
+  if (await isAutomationTabGroupDisabled()) return;
 
   try {
     const existingGroupId = await getOwnedContainerGroupId(role, windowId);


### PR DESCRIPTION
## Summary

Adds a `chrome.storage.local` boolean (`opencli_disable_automation_tab_group`) that, when set to `true`, makes the extension skip grouping owned tabs into a named tab group (`OpenCLI Browser` / `OpenCLI Adapter`). Default behavior is unchanged.

## Motivation

Chrome 119+ ships a "Saved Tab Groups" feature that auto-saves any named/colored tab group to the user's sidebar and keeps it there even after the underlying window is closed. For workflows that repeatedly spin up short-lived owned windows (e.g. periodic adapter calls from a scheduled job), entries accumulate in the saved-groups list with no API surface to remove them — `chrome.tabGroups.*` doesn't expose deletion of saved entries, and the three related Chrome flags (`tab group sync` / `tab groups save` / `saved tab groups`) have all been removed.

Closing tabs / windows / ungrouping via `chrome.tabs.remove`, `chrome.windows.remove`, or `chrome.tabs.ungroup` all leave the saved entry behind. The only effective mitigation is **never to name/color the group in the first place**.

Rather than remove the existing grouping behavior — which other users explicitly requested (see #1043) for visual organisation — this PR adds an opt-out flag so users running automation-heavy workflows can suppress it without affecting anyone else.

## What changes

- `extension/src/background.ts`:
  - New constant `DISABLE_TAB_GROUP_KEY = 'opencli_disable_automation_tab_group'`
  - New helper `isAutomationTabGroupDisabled()` reading `chrome.storage.local`
  - Early-return added to `ensureOwnedContainerTabGroup` when the flag is set
- `extension/src/background.test.ts`: new test covering the opt-out path (asserts neither `chrome.tabs.group` nor `chrome.tabGroups.update` is called when the flag is set; tab id is still resolvable)
- `extension/README.md`: new "Configuration" section documenting the flag, the rationale (Chrome 119+ saved tab groups), and how to enable/revert from the service worker DevTools console
- `extension/dist/background.js`: rebuilt via `npm run build`

## How tabs stay tracked without grouping

The extension already tracks owned tabs by id via the `automationSessions` map plus persisted state in `chrome.storage.local[REGISTRY_KEY]`. The tab group is purely a visual marker — disabling it does not affect adapter functionality, lease lifecycle, or tab reuse logic. The flag only skips `chrome.tabs.group` + `chrome.tabGroups.update`; everything else is unchanged.

## Test plan

- [x] `cd extension && npx tsc --noEmit` — passes
- [x] `npx tsc --noEmit` (repo root) — passes
- [x] `npx vitest run extension/src/background.test.ts` — 51/51 pass (50 existing + 1 new)
- [x] `cd extension && npm run build` — produces updated `dist/background.js`
- [ ] Manual smoke: load patched extension, set the flag, run an adapter command, confirm no new entry appears in Chrome's saved tab groups sidebar