### PR TITLE
feat(twitter/list-tweets): include media via extractMedia (parity with timeline/search)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -22669,7 +22669,9 @@
       "retweets",
       "replies",
       "created_at",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/list-tweets.js",

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { extractMedia } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 const LIST_TWEETS_QUERY_ID = 'RlZzktZY_9wJynoepm8ZsA';
@@ -70,6 +71,7 @@ export function extractTimelineTweet(result, seen) {
         replies: legacy.reply_count || 0,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(legacy),
     };
 }
 
@@ -118,7 +120,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -30,7 +30,55 @@ describe('twitter list-tweets parser', () => {
             replies: 2,
             created_at: 'Wed Apr 16 10:00:00 +0000 2026',
             url: 'https://x.com/bob/status/99',
+            has_media: false,
+            media_urls: [],
         });
+    });
+
+    it('includes photo media URLs from extended_entities', () => {
+        const tweet = extractTimelineTweet({
+            rest_id: '101',
+            legacy: {
+                full_text: 'pic post',
+                extended_entities: {
+                    media: [
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/abc.jpg' },
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/def.jpg' },
+                    ],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'dave' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls).toEqual([
+            'https://pbs.twimg.com/media/abc.jpg',
+            'https://pbs.twimg.com/media/def.jpg',
+        ]);
+    });
+
+    it('extracts mp4 variant URL for video media', () => {
+        const tweet = extractTimelineTweet({
+            rest_id: '102',
+            legacy: {
+                full_text: 'video post',
+                extended_entities: {
+                    media: [{
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/amplify_video_thumb/thumb.jpg',
+                        video_info: {
+                            variants: [
+                                { content_type: 'application/x-mpegURL', url: 'https://video.twimg.com/playlist.m3u8' },
+                                { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/low.mp4' },
+                                { content_type: 'video/mp4', bitrate: 2176000, url: 'https://video.twimg.com/high.mp4' },
+                            ],
+                        },
+                    }],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'erin' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls?.[0]).toMatch(/\.mp4$/);
     });
 
     it('prefers long-form note_tweet text over truncated legacy full_text', () => {


### PR DESCRIPTION
## Description

`list-tweets` was the only X recall path that dropped media. `timeline.js`
and `search.js` both call `extractMedia(legacy)` and emit `has_media`/`media_urls`;
`list-tweets` returned only text fields, so downstream consumers (e.g.
ml-scout's rate UI) couldn't render image/video thumbnails on tweets pulled
from a list timeline.

## Changes

- Import `extractMedia` from `./shared.js`
- Spread `extractMedia(legacy)` into `extractTimelineTweet` return
- Add `has_media`, `media_urls` to `columns` array (`--format columns` parity)
- Update unit test to assert the new shape; add coverage for photo and
  video extraction
- Rebuild `cli-manifest.json` (CI check)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR (`npx vitest run clis/twitter/list-tweets.test.js` → 7/7 pass; `npm run build` regenerates manifest)
- [x] I updated tests or docs if needed (added 2 new test cases for photo / video media extraction)
- [x] I included output or screenshots when useful

### Verification

Smoke test against a real X list (50 tweets) after the change:

```
$ opencli twitter list-tweets <list_id> --limit 50 --format json | jq '[.[] | select(.has_media)] | length'
13
```

13 of 50 tweets returned media URLs — photos as `pbs.twimg.com/media/*.jpg`,
videos as `video.twimg.com/.../*.mp4`. Before the change all 50 had
`has_media: false` (field was simply absent).