### PR TITLE
feat(chatgpt): support local image uploads

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4159,8 +4159,7 @@
     "type": "js",
     "modulePath": "chatgpt/ask.js",
     "sourceFile": "chatgpt/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4194,8 +4193,7 @@
     "type": "js",
     "modulePath": "chatgpt/detail.js",
     "sourceFile": "chatgpt/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4223,8 +4221,7 @@
     "type": "js",
     "modulePath": "chatgpt/history.js",
     "sourceFile": "chatgpt/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4241,6 +4238,12 @@
         "required": true,
         "positional": true,
         "help": "Image prompt to send to ChatGPT"
+      },
+      {
+        "name": "image",
+        "type": "str",
+        "required": false,
+        "help": "Local image path to attach before prompting; comma-separated paths are supported"
       },
       {
         "name": "op",
@@ -4272,8 +4275,7 @@
     "type": "js",
     "modulePath": "chatgpt/image.js",
     "sourceFile": "chatgpt/image.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4290,8 +4292,7 @@
     "type": "js",
     "modulePath": "chatgpt/new.js",
     "sourceFile": "chatgpt/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4318,8 +4319,7 @@
     "type": "js",
     "modulePath": "chatgpt/read.js",
     "sourceFile": "chatgpt/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4352,8 +4352,7 @@
     "type": "js",
     "modulePath": "chatgpt/send.js",
     "sourceFile": "chatgpt/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -4372,8 +4371,7 @@
     "type": "js",
     "modulePath": "chatgpt/status.js",
     "sourceFile": "chatgpt/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "chatgpt-app",
@@ -4807,8 +4805,7 @@
     "type": "js",
     "modulePath": "claude/ask.js",
     "sourceFile": "claude/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "claude",
@@ -4835,8 +4832,7 @@
     "type": "js",
     "modulePath": "claude/detail.js",
     "sourceFile": "claude/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "claude",
@@ -4864,8 +4860,7 @@
     "type": "js",
     "modulePath": "claude/history.js",
     "sourceFile": "claude/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "claude",
@@ -4882,8 +4877,7 @@
     "type": "js",
     "modulePath": "claude/new.js",
     "sourceFile": "claude/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "claude",
@@ -4902,8 +4896,7 @@
     "type": "js",
     "modulePath": "claude/read.js",
     "sourceFile": "claude/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "claude",
@@ -4937,8 +4930,7 @@
     "type": "js",
     "modulePath": "claude/send.js",
     "sourceFile": "claude/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "claude",
@@ -4957,8 +4949,7 @@
     "type": "js",
     "modulePath": "claude/status.js",
     "sourceFile": "claude/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "cnki",
@@ -6414,8 +6405,7 @@
     "type": "js",
     "modulePath": "deepseek/ask.js",
     "sourceFile": "deepseek/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "deepseek",
@@ -6441,8 +6431,7 @@
     "type": "js",
     "modulePath": "deepseek/detail.js",
     "sourceFile": "deepseek/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "deepseek",
@@ -6469,8 +6458,7 @@
     "type": "js",
     "modulePath": "deepseek/history.js",
     "sourceFile": "deepseek/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "deepseek",
@@ -6487,8 +6475,7 @@
     "type": "js",
     "modulePath": "deepseek/new.js",
     "sourceFile": "deepseek/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "deepseek",
@@ -6506,8 +6493,7 @@
     "type": "js",
     "modulePath": "deepseek/read.js",
     "sourceFile": "deepseek/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "deepseek",
@@ -6547,8 +6533,7 @@
     "type": "js",
     "modulePath": "deepseek/send.js",
     "sourceFile": "deepseek/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "deepseek",
@@ -6567,8 +6552,7 @@
     "type": "js",
     "modulePath": "deepseek/status.js",
     "sourceFile": "deepseek/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "defillama",
@@ -7658,8 +7642,7 @@
     "type": "js",
     "modulePath": "doubao/ask.js",
     "sourceFile": "doubao/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7685,8 +7668,7 @@
     "type": "js",
     "modulePath": "doubao/detail.js",
     "sourceFile": "doubao/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7714,8 +7696,7 @@
     "type": "js",
     "modulePath": "doubao/history.js",
     "sourceFile": "doubao/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7748,8 +7729,7 @@
     "type": "js",
     "modulePath": "doubao/meeting-summary.js",
     "sourceFile": "doubao/meeting-summary.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7782,8 +7762,7 @@
     "type": "js",
     "modulePath": "doubao/meeting-transcript.js",
     "sourceFile": "doubao/meeting-transcript.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7801,8 +7780,7 @@
     "type": "js",
     "modulePath": "doubao/new.js",
     "sourceFile": "doubao/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7820,8 +7798,7 @@
     "type": "js",
     "modulePath": "doubao/read.js",
     "sourceFile": "doubao/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7848,8 +7825,7 @@
     "type": "js",
     "modulePath": "doubao/send.js",
     "sourceFile": "doubao/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao",
@@ -7869,8 +7845,7 @@
     "type": "js",
     "modulePath": "doubao/status.js",
     "sourceFile": "doubao/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "doubao-app",
@@ -9649,8 +9624,7 @@
     "type": "js",
     "modulePath": "gemini/ask.js",
     "sourceFile": "gemini/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "gemini",
@@ -9696,8 +9670,7 @@
     "type": "js",
     "modulePath": "gemini/deep-research.js",
     "sourceFile": "gemini/deep-research.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "gemini",
@@ -9741,8 +9714,7 @@
     "type": "js",
     "modulePath": "gemini/deep-research-result.js",
     "sourceFile": "gemini/deep-research-result.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "gemini",
@@ -9805,8 +9777,7 @@
     "type": "js",
     "modulePath": "gemini/image.js",
     "sourceFile": "gemini/image.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "gemini",
@@ -9824,8 +9795,7 @@
     "type": "js",
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "gitee",
@@ -10421,8 +10391,7 @@
     "type": "js",
     "modulePath": "grok/ask.js",
     "sourceFile": "grok/ask.js",
-    "navigateBefore": "https://grok.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://grok.com"
   },
   {
     "site": "grok",
@@ -10455,8 +10424,7 @@
     "type": "js",
     "modulePath": "grok/detail.js",
     "sourceFile": "grok/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "grok",
@@ -10483,8 +10451,7 @@
     "type": "js",
     "modulePath": "grok/history.js",
     "sourceFile": "grok/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "grok",
@@ -10540,8 +10507,7 @@
     "type": "js",
     "modulePath": "grok/image.js",
     "sourceFile": "grok/image.js",
-    "navigateBefore": "https://grok.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://grok.com"
   },
   {
     "site": "grok",
@@ -10558,8 +10524,7 @@
     "type": "js",
     "modulePath": "grok/new.js",
     "sourceFile": "grok/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "grok",
@@ -10585,8 +10550,7 @@
     "type": "js",
     "modulePath": "grok/read.js",
     "sourceFile": "grok/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "grok",
@@ -10619,8 +10583,7 @@
     "type": "js",
     "modulePath": "grok/send.js",
     "sourceFile": "grok/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "grok",
@@ -10641,8 +10604,7 @@
     "type": "js",
     "modulePath": "grok/status.js",
     "sourceFile": "grok/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "hackernews",
@@ -18774,8 +18736,7 @@
     "type": "js",
     "modulePath": "qwen/ask.js",
     "sourceFile": "qwen/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -18808,8 +18769,7 @@
     "type": "js",
     "modulePath": "qwen/detail.js",
     "sourceFile": "qwen/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -18837,8 +18797,7 @@
     "type": "js",
     "modulePath": "qwen/history.js",
     "sourceFile": "qwen/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -18894,8 +18853,7 @@
     "type": "js",
     "modulePath": "qwen/image.js",
     "sourceFile": "qwen/image.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -18912,8 +18870,7 @@
     "type": "js",
     "modulePath": "qwen/new.js",
     "sourceFile": "qwen/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -18939,8 +18896,7 @@
     "type": "js",
     "modulePath": "qwen/read.js",
     "sourceFile": "qwen/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -18987,8 +18943,7 @@
     "type": "js",
     "modulePath": "qwen/send.js",
     "sourceFile": "qwen/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -19009,8 +18964,7 @@
     "type": "js",
     "modulePath": "qwen/status.js",
     "sourceFile": "qwen/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "reddit",
@@ -19043,8 +18997,7 @@
     "type": "js",
     "modulePath": "reddit/comment.js",
     "sourceFile": "reddit/comment.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19074,8 +19027,7 @@
     "type": "js",
     "modulePath": "reddit/frontpage.js",
     "sourceFile": "reddit/frontpage.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19144,8 +19096,7 @@
     "type": "js",
     "modulePath": "reddit/popular.js",
     "sourceFile": "reddit/popular.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19208,8 +19159,7 @@
     "type": "js",
     "modulePath": "reddit/read.js",
     "sourceFile": "reddit/read.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19242,8 +19192,7 @@
     "type": "js",
     "modulePath": "reddit/save.js",
     "sourceFile": "reddit/save.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19272,8 +19221,7 @@
     "type": "js",
     "modulePath": "reddit/saved.js",
     "sourceFile": "reddit/saved.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19331,8 +19279,7 @@
     "type": "js",
     "modulePath": "reddit/search.js",
     "sourceFile": "reddit/search.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19382,8 +19329,7 @@
     "type": "js",
     "modulePath": "reddit/subreddit.js",
     "sourceFile": "reddit/subreddit.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19416,8 +19362,7 @@
     "type": "js",
     "modulePath": "reddit/subscribe.js",
     "sourceFile": "reddit/subscribe.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19450,8 +19395,7 @@
     "type": "js",
     "modulePath": "reddit/upvote.js",
     "sourceFile": "reddit/upvote.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19480,8 +19424,7 @@
     "type": "js",
     "modulePath": "reddit/upvoted.js",
     "sourceFile": "reddit/upvoted.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19507,8 +19450,7 @@
     "type": "js",
     "modulePath": "reddit/user.js",
     "sourceFile": "reddit/user.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19543,8 +19485,7 @@
     "type": "js",
     "modulePath": "reddit/user-comments.js",
     "sourceFile": "reddit/user-comments.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19580,8 +19521,7 @@
     "type": "js",
     "modulePath": "reddit/user-posts.js",
     "sourceFile": "reddit/user-posts.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "rest-countries",
@@ -22122,8 +22062,7 @@
     "type": "js",
     "modulePath": "twitter/article.js",
     "sourceFile": "twitter/article.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22221,8 +22160,7 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
     "sourceFile": "twitter/bookmark-folder.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22242,8 +22180,7 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folders.js",
     "sourceFile": "twitter/bookmark-folders.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22282,8 +22219,7 @@
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
     "sourceFile": "twitter/bookmarks.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22357,8 +22293,7 @@
     "type": "js",
     "modulePath": "twitter/download.js",
     "sourceFile": "twitter/download.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22418,8 +22353,7 @@
     "type": "js",
     "modulePath": "twitter/followers.js",
     "sourceFile": "twitter/followers.js",
-    "navigateBefore": true,
-    "siteSession": "persistent"
+    "navigateBefore": true
   },
   {
     "site": "twitter",
@@ -22454,8 +22388,7 @@
     "type": "js",
     "modulePath": "twitter/following.js",
     "sourceFile": "twitter/following.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22555,8 +22488,7 @@
     "type": "js",
     "modulePath": "twitter/likes.js",
     "sourceFile": "twitter/likes.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22674,8 +22606,7 @@
     "type": "js",
     "modulePath": "twitter/list-tweets.js",
     "sourceFile": "twitter/list-tweets.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22704,8 +22635,7 @@
     "type": "js",
     "modulePath": "twitter/lists.js",
     "sourceFile": "twitter/lists.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22734,8 +22664,7 @@
     "type": "js",
     "modulePath": "twitter/notifications.js",
     "sourceFile": "twitter/notifications.js",
-    "navigateBefore": true,
-    "siteSession": "persistent"
+    "navigateBefore": true
   },
   {
     "site": "twitter",
@@ -22803,8 +22732,7 @@
     "type": "js",
     "modulePath": "twitter/profile.js",
     "sourceFile": "twitter/profile.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23072,8 +23000,7 @@
     "type": "js",
     "modulePath": "twitter/search.js",
     "sourceFile": "twitter/search.js",
-    "navigateBefore": true,
-    "siteSession": "persistent"
+    "navigateBefore": true
   },
   {
     "site": "twitter",
@@ -23119,8 +23046,7 @@
     "type": "js",
     "modulePath": "twitter/thread.js",
     "sourceFile": "twitter/thread.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23173,8 +23099,7 @@
     "type": "js",
     "modulePath": "twitter/timeline.js",
     "sourceFile": "twitter/timeline.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23201,8 +23126,7 @@
     "type": "js",
     "modulePath": "twitter/trending.js",
     "sourceFile": "twitter/trending.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23252,8 +23176,7 @@
     "type": "js",
     "modulePath": "twitter/tweets.js",
     "sourceFile": "twitter/tweets.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -27507,8 +27430,7 @@
     "type": "js",
     "modulePath": "yuanbao/ask.js",
     "sourceFile": "yuanbao/ask.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "yuanbao",
@@ -27534,8 +27456,7 @@
     "type": "js",
     "modulePath": "yuanbao/detail.js",
     "sourceFile": "yuanbao/detail.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "yuanbao",
@@ -27564,8 +27485,7 @@
     "type": "js",
     "modulePath": "yuanbao/history.js",
     "sourceFile": "yuanbao/history.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "yuanbao",
@@ -27583,8 +27503,7 @@
     "type": "js",
     "modulePath": "yuanbao/new.js",
     "sourceFile": "yuanbao/new.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "yuanbao",
@@ -27602,8 +27521,7 @@
     "type": "js",
     "modulePath": "yuanbao/read.js",
     "sourceFile": "yuanbao/read.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "yuanbao",
@@ -27636,8 +27554,7 @@
     "type": "js",
     "modulePath": "yuanbao/send.js",
     "sourceFile": "yuanbao/send.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "yuanbao",
@@ -27660,8 +27577,7 @@
     "type": "js",
     "modulePath": "yuanbao/status.js",
     "sourceFile": "yuanbao/status.js",
-    "navigateBefore": false,
-    "siteSession": "persistent"
+    "navigateBefore": false
   },
   {
     "site": "zhihu",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4159,7 +4159,8 @@
     "type": "js",
     "modulePath": "chatgpt/ask.js",
     "sourceFile": "chatgpt/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4193,7 +4194,8 @@
     "type": "js",
     "modulePath": "chatgpt/detail.js",
     "sourceFile": "chatgpt/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4221,7 +4223,8 @@
     "type": "js",
     "modulePath": "chatgpt/history.js",
     "sourceFile": "chatgpt/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4275,7 +4278,8 @@
     "type": "js",
     "modulePath": "chatgpt/image.js",
     "sourceFile": "chatgpt/image.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4292,7 +4296,8 @@
     "type": "js",
     "modulePath": "chatgpt/new.js",
     "sourceFile": "chatgpt/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4319,7 +4324,8 @@
     "type": "js",
     "modulePath": "chatgpt/read.js",
     "sourceFile": "chatgpt/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4352,7 +4358,8 @@
     "type": "js",
     "modulePath": "chatgpt/send.js",
     "sourceFile": "chatgpt/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -4371,7 +4378,8 @@
     "type": "js",
     "modulePath": "chatgpt/status.js",
     "sourceFile": "chatgpt/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt-app",
@@ -4805,7 +4813,8 @@
     "type": "js",
     "modulePath": "claude/ask.js",
     "sourceFile": "claude/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4832,7 +4841,8 @@
     "type": "js",
     "modulePath": "claude/detail.js",
     "sourceFile": "claude/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4860,7 +4870,8 @@
     "type": "js",
     "modulePath": "claude/history.js",
     "sourceFile": "claude/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4877,7 +4888,8 @@
     "type": "js",
     "modulePath": "claude/new.js",
     "sourceFile": "claude/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4896,7 +4908,8 @@
     "type": "js",
     "modulePath": "claude/read.js",
     "sourceFile": "claude/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4930,7 +4943,8 @@
     "type": "js",
     "modulePath": "claude/send.js",
     "sourceFile": "claude/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "claude",
@@ -4949,7 +4963,8 @@
     "type": "js",
     "modulePath": "claude/status.js",
     "sourceFile": "claude/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "cnki",
@@ -6405,7 +6420,8 @@
     "type": "js",
     "modulePath": "deepseek/ask.js",
     "sourceFile": "deepseek/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6431,7 +6447,8 @@
     "type": "js",
     "modulePath": "deepseek/detail.js",
     "sourceFile": "deepseek/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6458,7 +6475,8 @@
     "type": "js",
     "modulePath": "deepseek/history.js",
     "sourceFile": "deepseek/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6475,7 +6493,8 @@
     "type": "js",
     "modulePath": "deepseek/new.js",
     "sourceFile": "deepseek/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6493,7 +6512,8 @@
     "type": "js",
     "modulePath": "deepseek/read.js",
     "sourceFile": "deepseek/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6533,7 +6553,8 @@
     "type": "js",
     "modulePath": "deepseek/send.js",
     "sourceFile": "deepseek/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "deepseek",
@@ -6552,7 +6573,8 @@
     "type": "js",
     "modulePath": "deepseek/status.js",
     "sourceFile": "deepseek/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "defillama",
@@ -7642,7 +7664,8 @@
     "type": "js",
     "modulePath": "doubao/ask.js",
     "sourceFile": "doubao/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7668,7 +7691,8 @@
     "type": "js",
     "modulePath": "doubao/detail.js",
     "sourceFile": "doubao/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7696,7 +7720,8 @@
     "type": "js",
     "modulePath": "doubao/history.js",
     "sourceFile": "doubao/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7729,7 +7754,8 @@
     "type": "js",
     "modulePath": "doubao/meeting-summary.js",
     "sourceFile": "doubao/meeting-summary.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7762,7 +7788,8 @@
     "type": "js",
     "modulePath": "doubao/meeting-transcript.js",
     "sourceFile": "doubao/meeting-transcript.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7780,7 +7807,8 @@
     "type": "js",
     "modulePath": "doubao/new.js",
     "sourceFile": "doubao/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7798,7 +7826,8 @@
     "type": "js",
     "modulePath": "doubao/read.js",
     "sourceFile": "doubao/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7825,7 +7854,8 @@
     "type": "js",
     "modulePath": "doubao/send.js",
     "sourceFile": "doubao/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -7845,7 +7875,8 @@
     "type": "js",
     "modulePath": "doubao/status.js",
     "sourceFile": "doubao/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao-app",
@@ -9624,7 +9655,8 @@
     "type": "js",
     "modulePath": "gemini/ask.js",
     "sourceFile": "gemini/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9670,7 +9702,8 @@
     "type": "js",
     "modulePath": "gemini/deep-research.js",
     "sourceFile": "gemini/deep-research.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9714,7 +9747,8 @@
     "type": "js",
     "modulePath": "gemini/deep-research-result.js",
     "sourceFile": "gemini/deep-research-result.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9777,7 +9811,8 @@
     "type": "js",
     "modulePath": "gemini/image.js",
     "sourceFile": "gemini/image.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -9795,7 +9830,8 @@
     "type": "js",
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gitee",
@@ -10391,7 +10427,8 @@
     "type": "js",
     "modulePath": "grok/ask.js",
     "sourceFile": "grok/ask.js",
-    "navigateBefore": "https://grok.com"
+    "navigateBefore": "https://grok.com",
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10424,7 +10461,8 @@
     "type": "js",
     "modulePath": "grok/detail.js",
     "sourceFile": "grok/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10451,7 +10489,8 @@
     "type": "js",
     "modulePath": "grok/history.js",
     "sourceFile": "grok/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10507,7 +10546,8 @@
     "type": "js",
     "modulePath": "grok/image.js",
     "sourceFile": "grok/image.js",
-    "navigateBefore": "https://grok.com"
+    "navigateBefore": "https://grok.com",
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10524,7 +10564,8 @@
     "type": "js",
     "modulePath": "grok/new.js",
     "sourceFile": "grok/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10550,7 +10591,8 @@
     "type": "js",
     "modulePath": "grok/read.js",
     "sourceFile": "grok/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10583,7 +10625,8 @@
     "type": "js",
     "modulePath": "grok/send.js",
     "sourceFile": "grok/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "grok",
@@ -10604,7 +10647,8 @@
     "type": "js",
     "modulePath": "grok/status.js",
     "sourceFile": "grok/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "hackernews",
@@ -18736,7 +18780,8 @@
     "type": "js",
     "modulePath": "qwen/ask.js",
     "sourceFile": "qwen/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18769,7 +18814,8 @@
     "type": "js",
     "modulePath": "qwen/detail.js",
     "sourceFile": "qwen/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18797,7 +18843,8 @@
     "type": "js",
     "modulePath": "qwen/history.js",
     "sourceFile": "qwen/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18853,7 +18900,8 @@
     "type": "js",
     "modulePath": "qwen/image.js",
     "sourceFile": "qwen/image.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18870,7 +18918,8 @@
     "type": "js",
     "modulePath": "qwen/new.js",
     "sourceFile": "qwen/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18896,7 +18945,8 @@
     "type": "js",
     "modulePath": "qwen/read.js",
     "sourceFile": "qwen/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18943,7 +18993,8 @@
     "type": "js",
     "modulePath": "qwen/send.js",
     "sourceFile": "qwen/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -18964,7 +19015,8 @@
     "type": "js",
     "modulePath": "qwen/status.js",
     "sourceFile": "qwen/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -18997,7 +19049,8 @@
     "type": "js",
     "modulePath": "reddit/comment.js",
     "sourceFile": "reddit/comment.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19027,7 +19080,8 @@
     "type": "js",
     "modulePath": "reddit/frontpage.js",
     "sourceFile": "reddit/frontpage.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19096,7 +19150,8 @@
     "type": "js",
     "modulePath": "reddit/popular.js",
     "sourceFile": "reddit/popular.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19159,7 +19214,8 @@
     "type": "js",
     "modulePath": "reddit/read.js",
     "sourceFile": "reddit/read.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19192,7 +19248,8 @@
     "type": "js",
     "modulePath": "reddit/save.js",
     "sourceFile": "reddit/save.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19221,7 +19278,8 @@
     "type": "js",
     "modulePath": "reddit/saved.js",
     "sourceFile": "reddit/saved.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19279,7 +19337,8 @@
     "type": "js",
     "modulePath": "reddit/search.js",
     "sourceFile": "reddit/search.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19329,7 +19388,8 @@
     "type": "js",
     "modulePath": "reddit/subreddit.js",
     "sourceFile": "reddit/subreddit.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19362,7 +19422,8 @@
     "type": "js",
     "modulePath": "reddit/subscribe.js",
     "sourceFile": "reddit/subscribe.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19395,7 +19456,8 @@
     "type": "js",
     "modulePath": "reddit/upvote.js",
     "sourceFile": "reddit/upvote.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19424,7 +19486,8 @@
     "type": "js",
     "modulePath": "reddit/upvoted.js",
     "sourceFile": "reddit/upvoted.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19450,7 +19513,8 @@
     "type": "js",
     "modulePath": "reddit/user.js",
     "sourceFile": "reddit/user.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19485,7 +19549,8 @@
     "type": "js",
     "modulePath": "reddit/user-comments.js",
     "sourceFile": "reddit/user-comments.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -19521,7 +19586,8 @@
     "type": "js",
     "modulePath": "reddit/user-posts.js",
     "sourceFile": "reddit/user-posts.js",
-    "navigateBefore": "https://reddit.com"
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
   },
   {
     "site": "rest-countries",
@@ -22062,7 +22128,8 @@
     "type": "js",
     "modulePath": "twitter/article.js",
     "sourceFile": "twitter/article.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22160,7 +22227,8 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
     "sourceFile": "twitter/bookmark-folder.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22180,7 +22248,8 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folders.js",
     "sourceFile": "twitter/bookmark-folders.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22219,7 +22288,8 @@
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
     "sourceFile": "twitter/bookmarks.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22293,7 +22363,8 @@
     "type": "js",
     "modulePath": "twitter/download.js",
     "sourceFile": "twitter/download.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22353,7 +22424,8 @@
     "type": "js",
     "modulePath": "twitter/followers.js",
     "sourceFile": "twitter/followers.js",
-    "navigateBefore": true
+    "navigateBefore": true,
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22388,7 +22460,8 @@
     "type": "js",
     "modulePath": "twitter/following.js",
     "sourceFile": "twitter/following.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22488,7 +22561,8 @@
     "type": "js",
     "modulePath": "twitter/likes.js",
     "sourceFile": "twitter/likes.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22606,7 +22680,8 @@
     "type": "js",
     "modulePath": "twitter/list-tweets.js",
     "sourceFile": "twitter/list-tweets.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22635,7 +22710,8 @@
     "type": "js",
     "modulePath": "twitter/lists.js",
     "sourceFile": "twitter/lists.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22664,7 +22740,8 @@
     "type": "js",
     "modulePath": "twitter/notifications.js",
     "sourceFile": "twitter/notifications.js",
-    "navigateBefore": true
+    "navigateBefore": true,
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -22732,7 +22809,8 @@
     "type": "js",
     "modulePath": "twitter/profile.js",
     "sourceFile": "twitter/profile.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23000,7 +23078,8 @@
     "type": "js",
     "modulePath": "twitter/search.js",
     "sourceFile": "twitter/search.js",
-    "navigateBefore": true
+    "navigateBefore": true,
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23046,7 +23125,8 @@
     "type": "js",
     "modulePath": "twitter/thread.js",
     "sourceFile": "twitter/thread.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23099,7 +23179,8 @@
     "type": "js",
     "modulePath": "twitter/timeline.js",
     "sourceFile": "twitter/timeline.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23126,7 +23207,8 @@
     "type": "js",
     "modulePath": "twitter/trending.js",
     "sourceFile": "twitter/trending.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -23176,7 +23258,8 @@
     "type": "js",
     "modulePath": "twitter/tweets.js",
     "sourceFile": "twitter/tweets.js",
-    "navigateBefore": "https://x.com"
+    "navigateBefore": "https://x.com",
+    "siteSession": "persistent"
   },
   {
     "site": "twitter",
@@ -27430,7 +27513,8 @@
     "type": "js",
     "modulePath": "yuanbao/ask.js",
     "sourceFile": "yuanbao/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27456,7 +27540,8 @@
     "type": "js",
     "modulePath": "yuanbao/detail.js",
     "sourceFile": "yuanbao/detail.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27485,7 +27570,8 @@
     "type": "js",
     "modulePath": "yuanbao/history.js",
     "sourceFile": "yuanbao/history.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27503,7 +27589,8 @@
     "type": "js",
     "modulePath": "yuanbao/new.js",
     "sourceFile": "yuanbao/new.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27521,7 +27608,8 @@
     "type": "js",
     "modulePath": "yuanbao/read.js",
     "sourceFile": "yuanbao/read.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27554,7 +27642,8 @@
     "type": "js",
     "modulePath": "yuanbao/send.js",
     "sourceFile": "yuanbao/send.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -27577,7 +27666,8 @@
     "type": "js",
     "modulePath": "yuanbao/status.js",
     "sourceFile": "yuanbao/status.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "zhihu",

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { getChatGPTVisibleImageUrls, normalizeBooleanFlag, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets } from './utils.js';
+import { getChatGPTVisibleImageUrls, normalizeBooleanFlag, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
 
@@ -36,6 +36,23 @@ export function nextAvailablePath(dir, baseName, ext, existsSync = fs.existsSync
     return candidate;
 }
 
+export function parseImagePaths(value) {
+    if (Array.isArray(value)) {
+        return value.flatMap(item => parseImagePaths(item));
+    }
+    return String(value ?? '')
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+}
+
+function buildPrompt(prompt, imageCount) {
+    if (imageCount > 0) {
+        return `Edit the attached image${imageCount === 1 ? '' : 's'}: ${prompt}`;
+    }
+    return `Generate an image of: ${prompt}`;
+}
+
 async function currentChatGPTLink(page) {
     const url = await page.evaluate('window.location.href').catch(() => '');
     return typeof url === 'string' && url ? url : 'https://chatgpt.com';
@@ -54,6 +71,7 @@ export const imageCommand = cli({
     defaultFormat: 'plain',
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to ChatGPT' },
+        { name: 'image', help: 'Local image path to attach before prompting; comma-separated paths are supported' },
         { name: 'op', help: 'Output directory (default: ~/Pictures/chatgpt)' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show ChatGPT link' },
         { name: 'timeout', type: 'int', required: false, default: 240, help: 'Max seconds for the overall command (default: 240)' },
@@ -61,6 +79,7 @@ export const imageCommand = cli({
     columns: ['status', 'file', 'link'],
     func: async (page, kwargs) => {
         const prompt = kwargs.prompt;
+        const imagePaths = parseImagePaths(kwargs.image);
         const outputDir = resolveOutputDir(kwargs.op);
         const skipDownloadRaw = kwargs.sd;
         const skipDownload = skipDownloadRaw === '' || skipDownloadRaw === true || normalizeBooleanFlag(skipDownloadRaw);
@@ -74,8 +93,15 @@ export const imageCommand = cli({
 
         const beforeUrls = await getChatGPTVisibleImageUrls(page);
 
-        // Send the image generation prompt - must be explicit
-        const sent = await sendChatGPTMessage(page, `Generate an image of: ${prompt}`);
+        if (imagePaths.length) {
+            const upload = await uploadChatGPTImages(page, imagePaths);
+            if (!upload?.ok) {
+                throw new CommandExecutionError(upload?.reason || 'Failed to upload image to ChatGPT');
+            }
+        }
+
+        // Send an explicit generation/editing prompt so ChatGPT returns image assets.
+        const sent = await sendChatGPTMessage(page, buildPrompt(prompt, imagePaths.length));
         if (!sent) {
             throw new CommandExecutionError(
                 'Failed to send image prompt to ChatGPT',

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { getChatGPTVisibleImageUrls, normalizeBooleanFlag, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
+import { clearChatGPTDraft, getChatGPTVisibleImageUrls, normalizeBooleanFlag, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
 
@@ -90,6 +90,7 @@ export const imageCommand = cli({
 
         // Navigate to chatgpt.com/new with full reload to clear React sidebar state
         await page.goto(`https://${CHATGPT_DOMAIN}/new`, { settleMs: 2000 });
+        await clearChatGPTDraft(page);
 
         const beforeUrls = await getChatGPTVisibleImageUrls(page);
 

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { clearChatGPTDraft, getChatGPTVisibleImageUrls, normalizeBooleanFlag, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
+import { clearChatGPTDraft, getChatGPTVisibleImageUrls, normalizeBooleanFlag, prepareChatGPTImagePaths, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
 
@@ -87,19 +87,26 @@ export const imageCommand = cli({
         if (!Number.isInteger(timeout) || timeout < 1) {
             throw new ArgumentError('--timeout must be a positive integer (seconds)');
         }
+        const preparedImages = imagePaths.length ? await prepareChatGPTImagePaths(imagePaths) : { ok: true, paths: [] };
+        if (!preparedImages.ok) {
+            throw new ArgumentError(preparedImages.reason);
+        }
 
         // Navigate to chatgpt.com/new with full reload to clear React sidebar state
         await page.goto(`https://${CHATGPT_DOMAIN}/new`, { settleMs: 2000 });
         await clearChatGPTDraft(page);
 
-        const beforeUrls = await getChatGPTVisibleImageUrls(page);
-
         if (imagePaths.length) {
-            const upload = await uploadChatGPTImages(page, imagePaths);
-            if (!upload?.ok) {
-                throw new CommandExecutionError(upload?.reason || 'Failed to upload image to ChatGPT');
+            let upload;
+            try {
+                upload = await uploadChatGPTImages(page, preparedImages.paths);
+            } catch (err) {
+                throw new CommandExecutionError(`Failed to upload image to ChatGPT: ${err instanceof Error ? err.message : String(err)}`);
             }
+            if (!upload?.ok) throw new CommandExecutionError(upload?.reason || 'Failed to upload image to ChatGPT');
         }
+
+        const beforeUrls = await getChatGPTVisibleImageUrls(page);
 
         // Send an explicit generation/editing prompt so ChatGPT returns image assets.
         const sent = await sendChatGPTMessage(page, buildPrompt(prompt, imagePaths.length));

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
     getChatGPTVisibleImageUrls: vi.fn(),
     sendChatGPTMessage: vi.fn(),
+    uploadChatGPTImages: vi.fn(),
     waitForChatGPTImages: vi.fn(),
     getChatGPTImageAssets: vi.fn(),
     saveBase64ToFile: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock('./utils.js', () => ({
         return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
     },
     sendChatGPTMessage: mocks.sendChatGPTMessage,
+    uploadChatGPTImages: mocks.uploadChatGPTImages,
     waitForChatGPTImages: mocks.waitForChatGPTImages,
     getChatGPTImageAssets: mocks.getChatGPTImageAssets,
 }));
@@ -27,7 +29,7 @@ vi.mock('@jackwener/opencli/utils', () => ({
     saveBase64ToFile: mocks.saveBase64ToFile,
 }));
 
-const { imageCommand, nextAvailablePath, resolveOutputDir } = await import('./image.js');
+const { imageCommand, nextAvailablePath, parseImagePaths, resolveOutputDir } = await import('./image.js');
 
 function createPage() {
     return {
@@ -41,6 +43,7 @@ beforeEach(() => {
     vi.restoreAllMocks();
     mocks.getChatGPTVisibleImageUrls.mockReset().mockResolvedValue([]);
     mocks.sendChatGPTMessage.mockReset().mockResolvedValue(true);
+    mocks.uploadChatGPTImages.mockReset().mockResolvedValue({ ok: true });
     mocks.waitForChatGPTImages.mockReset().mockResolvedValue(['https://images.example/generated.png']);
     mocks.getChatGPTImageAssets.mockReset().mockResolvedValue([{
         url: 'https://images.example/generated.png',
@@ -65,6 +68,41 @@ describe('chatgpt image output paths', () => {
         ]);
 
         expect(nextAvailablePath(dir, 'chatgpt_123', '.png', (file) => taken.has(file))).toBe(path.join(dir, 'chatgpt_123_2.png'));
+    });
+
+    it('parses comma-separated image paths', () => {
+        expect(parseImagePaths('/tmp/a.png, /tmp/b.jpg')).toEqual(['/tmp/a.png', '/tmp/b.jpg']);
+        expect(parseImagePaths([' /tmp/a.png ', '/tmp/b.jpg,/tmp/c.webp'])).toEqual(['/tmp/a.png', '/tmp/b.jpg', '/tmp/c.webp']);
+    });
+});
+
+describe('chatgpt image upload flow', () => {
+    it('uploads local images before sending an edit prompt', async () => {
+        await imageCommand.func(createPage(), {
+            prompt: 'make the background blue',
+            image: '/tmp/cat.png,/tmp/dog.jpg',
+            op: '',
+            sd: true,
+            timeout: 240,
+        });
+
+        expect(mocks.uploadChatGPTImages).toHaveBeenCalledWith(expect.anything(), ['/tmp/cat.png', '/tmp/dog.jpg']);
+        expect(mocks.sendChatGPTMessage).toHaveBeenCalledWith(expect.anything(), 'Edit the attached images: make the background blue');
+    });
+
+    it('surfaces upload failures as command execution errors', async () => {
+        mocks.uploadChatGPTImages.mockResolvedValue({ ok: false, reason: 'image upload preview did not appear' });
+
+        await expect(imageCommand.func(createPage(), {
+            prompt: 'make the background blue',
+            image: '/tmp/cat.png',
+            op: '',
+            sd: false,
+            timeout: 240,
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('image upload preview did not appear'),
+        });
     });
 });
 

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
     getChatGPTVisibleImageUrls: vi.fn(),
     clearChatGPTDraft: vi.fn(),
+    prepareChatGPTImagePaths: vi.fn(),
     sendChatGPTMessage: vi.fn(),
     uploadChatGPTImages: vi.fn(),
     waitForChatGPTImages: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock('./utils.js', () => ({
         const normalized = String(value).trim().toLowerCase();
         return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
     },
+    prepareChatGPTImagePaths: mocks.prepareChatGPTImagePaths,
     sendChatGPTMessage: mocks.sendChatGPTMessage,
     uploadChatGPTImages: mocks.uploadChatGPTImages,
     waitForChatGPTImages: mocks.waitForChatGPTImages,
@@ -44,6 +46,7 @@ function createPage() {
 beforeEach(() => {
     vi.restoreAllMocks();
     mocks.clearChatGPTDraft.mockReset().mockResolvedValue(undefined);
+    mocks.prepareChatGPTImagePaths.mockReset().mockImplementation(async (paths) => ({ ok: true, paths }));
     mocks.getChatGPTVisibleImageUrls.mockReset().mockResolvedValue([]);
     mocks.sendChatGPTMessage.mockReset().mockResolvedValue(true);
     mocks.uploadChatGPTImages.mockReset().mockResolvedValue({ ok: true });
@@ -81,6 +84,7 @@ describe('chatgpt image output paths', () => {
 
 describe('chatgpt image upload flow', () => {
     it('uploads local images before sending an edit prompt', async () => {
+        mocks.prepareChatGPTImagePaths.mockResolvedValue({ ok: true, paths: ['/abs/cat.png', '/abs/dog.jpg'] });
         await imageCommand.func(createPage(), {
             prompt: 'make the background blue',
             image: '/tmp/cat.png,/tmp/dog.jpg',
@@ -90,8 +94,29 @@ describe('chatgpt image upload flow', () => {
         });
 
         expect(mocks.clearChatGPTDraft).toHaveBeenCalled();
-        expect(mocks.uploadChatGPTImages).toHaveBeenCalledWith(expect.anything(), ['/tmp/cat.png', '/tmp/dog.jpg']);
+        expect(mocks.uploadChatGPTImages).toHaveBeenCalledWith(expect.anything(), ['/abs/cat.png', '/abs/dog.jpg']);
+        expect(mocks.uploadChatGPTImages.mock.invocationCallOrder[0]).toBeLessThan(
+            mocks.getChatGPTVisibleImageUrls.mock.invocationCallOrder[0],
+        );
         expect(mocks.sendChatGPTMessage).toHaveBeenCalledWith(expect.anything(), 'Edit the attached images: make the background blue');
+    });
+
+    it('rejects invalid local image paths before browser navigation', async () => {
+        mocks.prepareChatGPTImagePaths.mockResolvedValue({ ok: false, reason: 'Image not found: /tmp/missing.png' });
+        const page = createPage();
+
+        await expect(imageCommand.func(page, {
+            prompt: 'make the background blue',
+            image: '/tmp/missing.png',
+            op: '',
+            sd: false,
+            timeout: 240,
+        })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('Image not found'),
+        });
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(mocks.uploadChatGPTImages).not.toHaveBeenCalled();
     });
 
     it('surfaces upload failures as command execution errors', async () => {

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
     getChatGPTVisibleImageUrls: vi.fn(),
+    clearChatGPTDraft: vi.fn(),
     sendChatGPTMessage: vi.fn(),
     uploadChatGPTImages: vi.fn(),
     waitForChatGPTImages: vi.fn(),
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('./utils.js', () => ({
+    clearChatGPTDraft: mocks.clearChatGPTDraft,
     getChatGPTVisibleImageUrls: mocks.getChatGPTVisibleImageUrls,
     normalizeBooleanFlag: (value, fallback = false) => {
         if (typeof value === 'boolean') return value;
@@ -41,6 +43,7 @@ function createPage() {
 
 beforeEach(() => {
     vi.restoreAllMocks();
+    mocks.clearChatGPTDraft.mockReset().mockResolvedValue(undefined);
     mocks.getChatGPTVisibleImageUrls.mockReset().mockResolvedValue([]);
     mocks.sendChatGPTMessage.mockReset().mockResolvedValue(true);
     mocks.uploadChatGPTImages.mockReset().mockResolvedValue({ ok: true });
@@ -86,6 +89,7 @@ describe('chatgpt image upload flow', () => {
             timeout: 240,
         });
 
+        expect(mocks.clearChatGPTDraft).toHaveBeenCalled();
         expect(mocks.uploadChatGPTImages).toHaveBeenCalledWith(expect.anything(), ['/tmp/cat.png', '/tmp/dog.jpg']);
         expect(mocks.sendChatGPTMessage).toHaveBeenCalledWith(expect.anything(), 'Edit the attached images: make the background blue');
     });

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -20,6 +20,9 @@ const COMPOSER_SELECTORS = [
     '[contenteditable="true"][role="textbox"]',
 ];
 const SEND_BUTTON_SELECTOR = 'button[data-testid="send-button"]:not([disabled])';
+const SEND_BUTTON_FALLBACK_SELECTORS = [
+    '#composer-submit-button:not([disabled])',
+];
 const SEND_BUTTON_LABELS = [
     'Send prompt',
     'Send message',
@@ -307,7 +310,7 @@ export async function sendChatGPTMessage(page, text) {
                     && !button.disabled
                     && button.getAttribute('aria-disabled') !== 'true';
                 const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)})
-                    || document.querySelector('#composer-submit-button:not([disabled])');
+                    || ${JSON.stringify(SEND_BUTTON_FALLBACK_SELECTORS)}.map(selector => document.querySelector(selector)).find(Boolean);
                 const btns = Array.from(document.querySelectorAll('button'));
                 const labels = ${JSON.stringify(SEND_BUTTON_LABELS)};
                 const sendBtn = isUsable(primary)
@@ -325,7 +328,8 @@ export async function sendChatGPTMessage(page, text) {
     
     await page.evaluate(`
         (() => {
-            const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)});
+            const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)})
+                || ${JSON.stringify(SEND_BUTTON_FALLBACK_SELECTORS)}.map(selector => document.querySelector(selector)).find(Boolean);
             const labels = ${JSON.stringify(SEND_BUTTON_LABELS)};
             const sendBtn = primary || Array.from(document.querySelectorAll('button')).find(b => labels.includes(b.getAttribute('aria-label') || '') && !b.disabled);
             if (sendBtn) sendBtn.click();
@@ -759,6 +763,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
 export const __test__ = {
     COMPOSER_SELECTORS,
     SEND_BUTTON_SELECTOR,
+    SEND_BUTTON_FALLBACK_SELECTORS,
     SEND_BUTTON_LABELS,
     CLOSE_SIDEBAR_LABELS,
     isSameChatGPTConversation,

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -522,6 +522,32 @@ function imageMimeFromPath(filePath) {
     return 'image/jpeg';
 }
 
+export async function prepareChatGPTImagePaths(imagePaths) {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const absPaths = imagePaths.map(filePath => path.default.resolve(filePath));
+    const allowedExts = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.heic', '.heif']);
+
+    for (const absPath of absPaths) {
+        if (!fs.default.existsSync(absPath)) {
+            return { ok: false, reason: `Image not found: ${absPath}` };
+        }
+        const stat = fs.default.statSync(absPath);
+        if (!stat.isFile()) {
+            return { ok: false, reason: `Not a file: ${absPath}` };
+        }
+        if (stat.size > 25 * 1024 * 1024) {
+            return { ok: false, reason: `Image too large (${(stat.size / 1024 / 1024).toFixed(1)} MB). Max: 25 MB` };
+        }
+        const ext = path.default.extname(absPath).toLowerCase();
+        if (!allowedExts.has(ext)) {
+            return { ok: false, reason: `Unsupported image type: ${absPath}` };
+        }
+    }
+
+    return { ok: true, paths: absPaths };
+}
+
 async function waitForChatGPTUploadPreview(page, fileNames) {
     const namesJson = JSON.stringify(fileNames);
     for (let attempt = 0; attempt < 10; attempt += 1) {
@@ -551,25 +577,9 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
 export async function uploadChatGPTImages(page, imagePaths) {
     const fs = await import('node:fs');
     const path = await import('node:path');
-    const absPaths = imagePaths.map(filePath => path.default.resolve(filePath));
-    const allowedExts = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.heic', '.heif']);
-
-    for (const absPath of absPaths) {
-        if (!fs.default.existsSync(absPath)) {
-            return { ok: false, reason: `Image not found: ${absPath}` };
-        }
-        const stat = fs.default.statSync(absPath);
-        if (!stat.isFile()) {
-            return { ok: false, reason: `Not a file: ${absPath}` };
-        }
-        if (stat.size > 25 * 1024 * 1024) {
-            return { ok: false, reason: `Image too large (${(stat.size / 1024 / 1024).toFixed(1)} MB). Max: 25 MB` };
-        }
-        const ext = path.default.extname(absPath).toLowerCase();
-        if (!allowedExts.has(ext)) {
-            return { ok: false, reason: `Unsupported image type: ${absPath}` };
-        }
-    }
+    const prepared = await prepareChatGPTImagePaths(imagePaths);
+    if (!prepared.ok) return prepared;
+    const absPaths = prepared.paths;
 
     const fileNames = absPaths.map(filePath => path.default.basename(filePath));
 

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -203,6 +203,40 @@ export async function ensureChatGPTComposer(page, message = 'ChatGPT composer is
     return state;
 }
 
+export async function clearChatGPTDraft(page) {
+    await page.evaluate(`
+        (() => {
+            const removeLabels = [/^remove file/i, /^移除文件/];
+            for (let pass = 0; pass < 10; pass += 1) {
+                const button = Array.from(document.querySelectorAll('button')).find((node) => {
+                    const label = node.getAttribute('aria-label') || '';
+                    return removeLabels.some((pattern) => pattern.test(label));
+                });
+                if (!button) break;
+                button.click();
+            }
+
+            const selectors = ${JSON.stringify(COMPOSER_SELECTORS)};
+            for (const selector of selectors) {
+                for (const node of document.querySelectorAll(selector)) {
+                    if (!(node instanceof HTMLElement)) continue;
+                    if (node instanceof HTMLTextAreaElement || node instanceof HTMLInputElement) {
+                        node.value = '';
+                    } else if (node.isContentEditable) {
+                        node.textContent = '';
+                        node.innerHTML = '<p><br></p>';
+                    } else {
+                        node.textContent = '';
+                    }
+                    node.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward', data: null }));
+                    node.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            }
+        })()
+    `);
+    await page.wait(0.5);
+}
+
 /**
  * Send a message to the ChatGPT composer and submit it.
  * Returns true if the message was sent successfully.
@@ -227,7 +261,16 @@ export async function sendChatGPTMessage(page, text) {
             const composer = findComposer();
             if (!composer) return false;
             composer.focus();
-            composer.textContent = '';
+            if (composer instanceof HTMLTextAreaElement || composer instanceof HTMLInputElement) {
+                composer.value = '';
+            } else if (composer.isContentEditable) {
+                composer.textContent = '';
+                composer.innerHTML = '<p><br></p>';
+            } else {
+                composer.textContent = '';
+            }
+            composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward', data: null }));
+            composer.dispatchEvent(new Event('change', { bubbles: true }));
             return true;
         })()
     `);
@@ -255,21 +298,28 @@ export async function sendChatGPTMessage(page, text) {
         `);
     }
     
-    // Wait for send button to appear (it only shows when there's text)
-    await page.wait(1.5);
+    let sent = null;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        await page.wait(0.5);
+        sent = await page.evaluate(`
+            (() => {
+                const isUsable = (button) => button
+                    && !button.disabled
+                    && button.getAttribute('aria-disabled') !== 'true';
+                const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)})
+                    || document.querySelector('#composer-submit-button:not([disabled])');
+                const btns = Array.from(document.querySelectorAll('button'));
+                const labels = ${JSON.stringify(SEND_BUTTON_LABELS)};
+                const sendBtn = isUsable(primary)
+                    ? primary
+                    : btns.find(b => labels.includes(b.getAttribute('aria-label') || '') && isUsable(b));
+                return { sendBtnFound: !!sendBtn };
+            })()
+        `);
+        if (sent?.sendBtnFound) break;
+    }
 
-    // Click send button
-    const sent = await page.evaluate(`
-        (() => {
-            const primary = document.querySelector(${JSON.stringify(SEND_BUTTON_SELECTOR)});
-            const btns = Array.from(document.querySelectorAll('button'));
-            const labels = ${JSON.stringify(SEND_BUTTON_LABELS)};
-            const sendBtn = primary || btns.find(b => labels.includes(b.getAttribute('aria-label') || '') && !b.disabled);
-            return { sendBtnFound: !!sendBtn };
-        })()
-    `);
-    
-    if (!sent || !sent.sendBtnFound) {
+    if (!sent?.sendBtnFound) {
         return false;
     }
     
@@ -561,7 +611,17 @@ export async function uploadChatGPTImages(page, imagePaths) {
 
                 const propsKey = Object.keys(input).find(key => key.startsWith('__reactProps$'));
                 if (propsKey && input[propsKey] && typeof input[propsKey].onChange === 'function') {
-                    input[propsKey].onChange({ target: { files: input.files }, currentTarget: input });
+                    const nativeEvent = new Event('change', { bubbles: true });
+                    input[propsKey].onChange({
+                        target: input,
+                        currentTarget: input,
+                        nativeEvent,
+                        preventDefault() {},
+                        stopPropagation() {},
+                        isDefaultPrevented() { return false; },
+                        isPropagationStopped() { return false; },
+                        persist() {},
+                    });
                 } else {
                     input.dispatchEvent(new Event('input', { bubbles: true }));
                     input.dispatchEvent(new Event('change', { bubbles: true }));

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -462,6 +462,122 @@ async function extractConversationLinks(page) {
         : [];
 }
 
+function imageMimeFromPath(filePath) {
+    const lower = String(filePath || '').toLowerCase();
+    if (lower.endsWith('.png')) return 'image/png';
+    if (lower.endsWith('.webp')) return 'image/webp';
+    if (lower.endsWith('.gif')) return 'image/gif';
+    if (lower.endsWith('.heic')) return 'image/heic';
+    if (lower.endsWith('.heif')) return 'image/heif';
+    return 'image/jpeg';
+}
+
+async function waitForChatGPTUploadPreview(page, fileNames) {
+    const namesJson = JSON.stringify(fileNames);
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+        await page.wait(1);
+        const ready = await page.evaluate(`
+            (() => {
+                const names = ${namesJson};
+                const text = document.body ? (document.body.innerText || '') : '';
+                const matchedNames = names.filter(name => text.includes(name)).length;
+                if (matchedNames >= names.length) return true;
+
+                const composer = document.querySelector('[aria-label="Chat with ChatGPT"], [placeholder="Ask anything"], #prompt-textarea');
+                let root = composer;
+                for (let i = 0; i < 6 && root && root.parentElement; i += 1) root = root.parentElement;
+                const scope = root || document.body;
+                if (!scope) return false;
+
+                const previewNodes = scope.querySelectorAll('img[src], canvas, video, [style*="background-image"], [data-testid*="attachment"], [data-testid*="upload"], [class*="attachment"], [class*="upload"]');
+                return previewNodes.length >= names.length;
+            })()
+        `);
+        if (ready) return true;
+    }
+    return false;
+}
+
+export async function uploadChatGPTImages(page, imagePaths) {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const absPaths = imagePaths.map(filePath => path.default.resolve(filePath));
+    const allowedExts = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.heic', '.heif']);
+
+    for (const absPath of absPaths) {
+        if (!fs.default.existsSync(absPath)) {
+            return { ok: false, reason: `Image not found: ${absPath}` };
+        }
+        const stat = fs.default.statSync(absPath);
+        if (!stat.isFile()) {
+            return { ok: false, reason: `Not a file: ${absPath}` };
+        }
+        if (stat.size > 25 * 1024 * 1024) {
+            return { ok: false, reason: `Image too large (${(stat.size / 1024 / 1024).toFixed(1)} MB). Max: 25 MB` };
+        }
+        const ext = path.default.extname(absPath).toLowerCase();
+        if (!allowedExts.has(ext)) {
+            return { ok: false, reason: `Unsupported image type: ${absPath}` };
+        }
+    }
+
+    const fileNames = absPaths.map(filePath => path.default.basename(filePath));
+
+    let uploaded = false;
+    if (page.setFileInput) {
+        try {
+            await page.setFileInput(absPaths, 'input[type="file"]');
+            uploaded = true;
+        } catch (err) {
+            const msg = String(err?.message || err);
+            if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed') && !msg.includes('No element found')) {
+                throw err;
+            }
+        }
+    }
+
+    if (!uploaded) {
+        const files = absPaths.map(absPath => ({
+            name: path.default.basename(absPath),
+            mime: imageMimeFromPath(absPath),
+            base64: fs.default.readFileSync(absPath).toString('base64'),
+        }));
+        const fallbackResult = await page.evaluate(`
+            (() => {
+                const files = ${JSON.stringify(files)};
+                const input = document.querySelector('input[type="file"]');
+                if (!(input instanceof HTMLInputElement)) {
+                    return { ok: false, reason: 'file input not found' };
+                }
+
+                const dt = new DataTransfer();
+                for (const item of files) {
+                    const binary = atob(item.base64);
+                    const bytes = new Uint8Array(binary.length);
+                    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+                    dt.items.add(new File([bytes], item.name, { type: item.mime }));
+                }
+                input.files = dt.files;
+
+                const propsKey = Object.keys(input).find(key => key.startsWith('__reactProps$'));
+                if (propsKey && input[propsKey] && typeof input[propsKey].onChange === 'function') {
+                    input[propsKey].onChange({ target: { files: input.files }, currentTarget: input });
+                } else {
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                return { ok: true };
+            })()
+        `);
+        if (fallbackResult && !fallbackResult.ok) return fallbackResult;
+    }
+
+    const ready = await waitForChatGPTUploadPreview(page, fileNames);
+    if (!ready) return { ok: false, reason: 'image upload preview did not appear' };
+
+    return { ok: true, files: absPaths };
+}
+
 /**
  * Check if ChatGPT is still generating a response.
  */
@@ -577,6 +693,7 @@ export const __test__ = {
     CLOSE_SIDEBAR_LABELS,
     isSameChatGPTConversation,
     parseChatGPTConversationId,
+    imageMimeFromPath,
 };
 
 /**

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -174,6 +174,30 @@ describe('chatgpt image upload helper', () => {
         expect(page.setFileInput).not.toHaveBeenCalled();
     });
 
+    it('passes a React-compatible change event in fallback upload', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'cat.png');
+        fs.writeFileSync(filePath, 'fake-png');
+
+        const page = {
+            setFileInput: vi.fn().mockRejectedValue(new Error('No element found')),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                return Promise.resolve({ ok: true });
+            }),
+        };
+
+        const result = await uploadChatGPTImages(page, [filePath]);
+
+        expect(result).toEqual({ ok: true, files: [filePath] });
+        const fallbackScript = page.evaluate.mock.calls
+            .map(([script]) => String(script))
+            .find(script => script.includes('new DataTransfer()'));
+        expect(fallbackScript).toContain('preventDefault()');
+        expect(fallbackScript).toContain('stopPropagation()');
+    });
+
     it('exposes image MIME inference for fallback upload', () => {
         expect(__test__.imageMimeFromPath('/tmp/a.png')).toBe('image/png');
         expect(__test__.imageMimeFromPath('/tmp/a.webp')).toBe('image/webp');

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { __test__, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTImages } from './utils.js';
+import { __test__, prepareChatGPTImagePaths, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTImages } from './utils.js';
 
 const tempDirs = [];
 
@@ -123,6 +123,19 @@ describe('chatgpt send selectors', () => {
 });
 
 describe('chatgpt image upload helper', () => {
+    it('validates local images without a browser page', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'cat.png');
+        fs.writeFileSync(filePath, 'fake-png');
+
+        await expect(prepareChatGPTImagePaths([filePath])).resolves.toEqual({ ok: true, paths: [filePath] });
+        await expect(prepareChatGPTImagePaths([path.join(dir, 'missing.png')])).resolves.toMatchObject({
+            ok: false,
+            reason: expect.stringContaining('Image not found'),
+        });
+    });
+
     it('prefers Browser Bridge file input upload and waits for a preview', async () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
         tempDirs.push(dir);

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -108,6 +108,26 @@ describe('chatgpt send selectors', () => {
         await expect(sendChatGPTMessage(page, 'hello')).resolves.toBe(true);
     });
 
+    it('uses the composer submit fallback consistently for readiness and click', async () => {
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            nativeType: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                if (script.includes('findComposer')) return Promise.resolve(true);
+                if (script.includes('sendBtnFound')) {
+                    expect(script).toContain('#composer-submit-button:not([disabled])');
+                    return Promise.resolve({ sendBtnFound: true });
+                }
+                if (script.includes('if (sendBtn) sendBtn.click')) {
+                    expect(script).toContain('#composer-submit-button:not([disabled])');
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        await expect(sendChatGPTMessage(page, 'hello')).resolves.toBe(true);
+    });
+
     it('keeps zh-CN aria and placeholder fallbacks without replacing English selectors', () => {
         expect(__test__.COMPOSER_SELECTORS).toEqual(expect.arrayContaining([
             '[aria-label="Chat with ChatGPT"]',
@@ -117,6 +137,7 @@ describe('chatgpt send selectors', () => {
             '[data-testid="prompt-textarea"]',
         ]));
         expect(__test__.SEND_BUTTON_SELECTOR).toBe('button[data-testid="send-button"]:not([disabled])');
+        expect(__test__.SEND_BUTTON_FALLBACK_SELECTORS).toContain('#composer-submit-button:not([disabled])');
         expect(__test__.SEND_BUTTON_LABELS).toEqual(expect.arrayContaining(['Send prompt', 'Send message', 'Send', '发送提示']));
         expect(__test__.CLOSE_SIDEBAR_LABELS).toEqual(expect.arrayContaining(['Close sidebar', '关闭边栏']));
     });

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1,5 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
-import { __test__, sendChatGPTMessage, waitForChatGPTImages } from './utils.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { __test__, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTImages } from './utils.js';
+
+const tempDirs = [];
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    while (tempDirs.length) {
+        fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+});
 
 function createPageMock({ location = '', generating = [], imageUrls = [] } = {}) {
     let generatingIndex = 0;
@@ -107,5 +119,64 @@ describe('chatgpt send selectors', () => {
         expect(__test__.SEND_BUTTON_SELECTOR).toBe('button[data-testid="send-button"]:not([disabled])');
         expect(__test__.SEND_BUTTON_LABELS).toEqual(expect.arrayContaining(['Send prompt', 'Send message', 'Send', '发送提示']));
         expect(__test__.CLOSE_SIDEBAR_LABELS).toEqual(expect.arrayContaining(['Close sidebar', '关闭边栏']));
+    });
+});
+
+describe('chatgpt image upload helper', () => {
+    it('prefers Browser Bridge file input upload and waits for a preview', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'cat.png');
+        fs.writeFileSync(filePath, 'fake-png');
+
+        const page = {
+            setFileInput: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(true),
+        };
+
+        const result = await uploadChatGPTImages(page, [filePath]);
+
+        expect(result).toEqual({ ok: true, files: [filePath] });
+        expect(page.setFileInput).toHaveBeenCalledWith([filePath], 'input[type="file"]');
+    });
+
+    it('rejects missing files before touching the page', async () => {
+        const page = {
+            setFileInput: vi.fn(),
+            wait: vi.fn(),
+            evaluate: vi.fn(),
+        };
+
+        const result = await uploadChatGPTImages(page, ['/no/such/cat.png']);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('Image not found');
+        expect(page.setFileInput).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-image extensions', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'report.pdf');
+        fs.writeFileSync(filePath, 'fake');
+
+        const page = {
+            setFileInput: vi.fn(),
+            wait: vi.fn(),
+            evaluate: vi.fn(),
+        };
+
+        const result = await uploadChatGPTImages(page, [filePath]);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('Unsupported image type');
+        expect(page.setFileInput).not.toHaveBeenCalled();
+    });
+
+    it('exposes image MIME inference for fallback upload', () => {
+        expect(__test__.imageMimeFromPath('/tmp/a.png')).toBe('image/png');
+        expect(__test__.imageMimeFromPath('/tmp/a.webp')).toBe('image/webp');
+        expect(__test__.imageMimeFromPath('/tmp/a.jpg')).toBe('image/jpeg');
     });
 });

--- a/docs/adapters/browser/chatgpt.md
+++ b/docs/adapters/browser/chatgpt.md
@@ -37,6 +37,12 @@ opencli chatgpt new
 # Generate an image and save it to the default directory
 opencli chatgpt image "a cyberpunk city at night"
 
+# Upload a local image, ask ChatGPT to edit it, and save the result
+opencli chatgpt image "make the background blue" --image ./cat.png
+
+# Upload multiple local images for a combined edit
+opencli chatgpt image "combine these into a poster" --image ./cat.png,./logo.png
+
 # Save to a custom output directory
 opencli chatgpt image "a robot sketching on paper" --op ~/Downloads/chatgpt-images
 
@@ -53,6 +59,7 @@ opencli chatgpt image "a tiny watercolor fox" --sd true
 | `--new` | Start a new conversation before `ask` / `send` |
 | `--markdown` | Convert assistant message HTML to Markdown for `read` / `detail` |
 | `--limit` | Max visible history conversations to return (default: `20`) |
+| `--image` | Local image path to attach before prompting; comma-separated paths are supported |
 | `--op` | Output directory for downloaded images (default: `~/Pictures/chatgpt`) |
 | `--sd` | Skip download and only print the ChatGPT conversation link |
 
@@ -62,6 +69,7 @@ opencli chatgpt image "a tiny watercolor fox" --sd true
 - `ask` waits for the first stable assistant response after sending. `send` submits only and returns immediately.
 - `history` reads visible `/c/<id>` links from the ChatGPT sidebar; it does not use private backend APIs.
 - `image` opens a fresh `chatgpt.com/new` page before sending the image prompt.
+- When `--image` is provided, local images are uploaded first and the prompt is sent as an image edit request.
 - `image` output is plain `status / file / link`, not a markdown table.
 - When `--sd` is enabled, the command does not download files and only prints the ChatGPT link.
 - Downloaded files are named with a timestamp to avoid overwriting prior runs.


### PR DESCRIPTION
## Type of Change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 🌐 New site adapter
  - [x] 📝 Documentation
  - [ ] ♻️ Refactor
  - [ ] 🔧 CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [ ] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under docs/adapters/ (if new adapter)
  - [ ] Updated docs/adapters/index.md table (if new adapter)
  - [ ] Updated sidebar in docs/.vitepress/config.mts (if new adapter)
  - [ ] Updated README.md / README.zh-CN.md when command discoverability changed
  - [x] Used positional args for the command's primary subject unless a named flag is clearly better
  - [x] Normalized expected adapter failures to CliError subclasses instead of raw Error

  ## Screenshots / Output

  Validation run:

  npm test -- clis/chatgpt/image.test.js clis/chatgpt/utils.test.js
  npm run typecheck
  npm run check:typed-error-lint
  npm run check:silent-column-drop
  npm run build-manifest

  Implementation notes:

  - Supports one image path or comma-separated multiple image paths.
  - Validates existence, regular file type, allowed image extensions, and 25 MB max size.
  - Prefers Browser Bridge setFileInput; falls back to DataTransfer when needed.
  - Waits for upload preview before sending the prompt, so upload failures fail fast.
  - Keeps existing image detection and local save behavior unchanged.