### PR TITLE
feat(reddit): add post_hint / url / preview / gallery columns

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19075,7 +19075,11 @@
       "author",
       "upvotes",
       "comments",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/frontpage.js",
@@ -19115,7 +19119,11 @@
       "comments",
       "postId",
       "author",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/hot.js",
@@ -19145,7 +19153,11 @@
       "subreddit",
       "score",
       "comments",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/popular.js",
@@ -19209,7 +19221,11 @@
       "type",
       "author",
       "score",
-      "text"
+      "text",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/read.js",
@@ -19332,7 +19348,11 @@
       "author",
       "score",
       "comments",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/search.js",
@@ -19383,7 +19403,11 @@
       "author",
       "upvotes",
       "comments",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/subreddit.js",

--- a/clis/reddit/extract-media.test.js
+++ b/clis/reddit/extract-media.test.js
@@ -1,0 +1,149 @@
+/**
+ * Behavioral tests for the extractRedditMedia helper.
+ *
+ * The helper is duplicated inline inside each adapter's browser-side evaluate()
+ * source (see popular.js / hot.js / search.js / frontpage.js / subreddit.js /
+ * read.js). Per-adapter tests grep that the same function-name + spread call
+ * is present. This file pins the helper's behavior against representative
+ * Reddit-JSON fixtures.
+ */
+import { describe, expect, it } from 'vitest';
+
+function decodeHtml(s) {
+  if (typeof s !== 'string' || !s) return '';
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&#39;/g, "'");
+}
+function extractRedditMedia(d) {
+  const post_hint = d?.post_hint || '';
+  const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+  const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+  const gallery_urls = [];
+  const items = d?.gallery_data?.items;
+  const meta = d?.media_metadata;
+  if (Array.isArray(items) && meta) {
+    for (const it of items) {
+      const m = it && meta[it.media_id];
+      const u = m?.s?.u;
+      if (u) gallery_urls.push(decodeHtml(u));
+    }
+  }
+  return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+}
+
+describe('extractRedditMedia', () => {
+  it('returns empty fields for a plain text/self post', () => {
+    expect(extractRedditMedia({ is_self: true, selftext: 'hi' })).toEqual({
+      post_hint: '',
+      url_overridden_by_dest: '',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+  });
+
+  it('extracts post_hint, url_overridden_by_dest, preview_image_url for a single-image post', () => {
+    const post = {
+      post_hint: 'image',
+      url_overridden_by_dest: 'https://i.redd.it/abc.jpg',
+      preview: {
+        images: [{ source: { url: 'https://preview.redd.it/abc.jpg?width=640&amp;s=xyz' } }],
+      },
+    };
+    expect(extractRedditMedia(post)).toEqual({
+      post_hint: 'image',
+      url_overridden_by_dest: 'https://i.redd.it/abc.jpg',
+      preview_image_url: 'https://preview.redd.it/abc.jpg?width=640&s=xyz',
+      gallery_urls: [],
+    });
+  });
+
+  it('extracts gallery_urls in gallery_data.items order, HTML-decoded', () => {
+    const post = {
+      post_hint: '',
+      url_overridden_by_dest: 'https://www.reddit.com/gallery/xyz',
+      gallery_data: {
+        items: [{ media_id: 'idB' }, { media_id: 'idA' }, { media_id: 'idC' }],
+      },
+      media_metadata: {
+        idA: { s: { u: 'https://preview.redd.it/idA.jpg?width=1&amp;a=1' } },
+        idB: { s: { u: 'https://preview.redd.it/idB.jpg?width=1&amp;a=2' } },
+        idC: { s: { u: 'https://preview.redd.it/idC.jpg?width=1&amp;a=3' } },
+      },
+    };
+    const out = extractRedditMedia(post);
+    expect(out.gallery_urls).toEqual([
+      'https://preview.redd.it/idB.jpg?width=1&a=2',
+      'https://preview.redd.it/idA.jpg?width=1&a=1',
+      'https://preview.redd.it/idC.jpg?width=1&a=3',
+    ]);
+    expect(out.url_overridden_by_dest).toBe('https://www.reddit.com/gallery/xyz');
+  });
+
+  it('extracts post_hint for a hosted:video post', () => {
+    const post = {
+      post_hint: 'hosted:video',
+      url_overridden_by_dest: 'https://v.redd.it/xyz',
+      preview: { images: [{ source: { url: 'https://preview.redd.it/thumb.jpg' } }] },
+    };
+    const out = extractRedditMedia(post);
+    expect(out.post_hint).toBe('hosted:video');
+    expect(out.url_overridden_by_dest).toBe('https://v.redd.it/xyz');
+    expect(out.preview_image_url).toBe('https://preview.redd.it/thumb.jpg');
+    expect(out.gallery_urls).toEqual([]);
+  });
+
+  it('extracts post_hint for an external link post', () => {
+    const post = {
+      post_hint: 'link',
+      url_overridden_by_dest: 'https://example.com/article',
+    };
+    expect(extractRedditMedia(post)).toEqual({
+      post_hint: 'link',
+      url_overridden_by_dest: 'https://example.com/article',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+  });
+
+  it('HTML-decodes preview URLs that arrive with &amp; separators', () => {
+    const post = {
+      preview: {
+        images: [{ source: { url: 'https://x/?a=1&amp;b=2&amp;c=3' } }],
+      },
+    };
+    expect(extractRedditMedia(post).preview_image_url).toBe('https://x/?a=1&b=2&c=3');
+  });
+
+  it('skips gallery entries whose media_metadata is missing', () => {
+    const post = {
+      gallery_data: { items: [{ media_id: 'present' }, { media_id: 'orphan' }] },
+      media_metadata: {
+        present: { s: { u: 'https://preview.redd.it/present.jpg' } },
+        // 'orphan' intentionally absent
+      },
+    };
+    expect(extractRedditMedia(post).gallery_urls).toEqual([
+      'https://preview.redd.it/present.jpg',
+    ]);
+  });
+
+  it('tolerates null/undefined input without throwing', () => {
+    expect(extractRedditMedia(null)).toEqual({
+      post_hint: '',
+      url_overridden_by_dest: '',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+    expect(extractRedditMedia(undefined)).toEqual({
+      post_hint: '',
+      url_overridden_by_dest: '',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+  });
+});

--- a/clis/reddit/frontpage.js
+++ b/clis/reddit/frontpage.js
@@ -11,22 +11,60 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['title', 'subreddit', 'author', 'upvotes', 'comments', 'url'],
+    columns: ['title', 'subreddit', 'author', 'upvotes', 'comments', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const res = await fetch('/r/all.json?limit=\${{ args.limit }}', { credentials: 'include' });
   const j = await res.json();
-  return j?.data?.children || [];
+  return (j?.data?.children || []).map(c => ({
+    title: c.data.title,
+    subreddit: c.data.subreddit_name_prefixed,
+    author: c.data.author,
+    upvotes: c.data.score,
+    comments: c.data.num_comments,
+    url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
+  }));
 })()
 ` },
         { map: {
-                title: '${{ item.data.title }}',
-                subreddit: '${{ item.data.subreddit_name_prefixed }}',
-                author: '${{ item.data.author }}',
-                upvotes: '${{ item.data.score }}',
-                comments: '${{ item.data.num_comments }}',
-                url: 'https://www.reddit.com${{ item.data.permalink }}',
+                title: '${{ item.title }}',
+                subreddit: '${{ item.subreddit }}',
+                author: '${{ item.author }}',
+                upvotes: '${{ item.upvotes }}',
+                comments: '${{ item.comments }}',
+                url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/frontpage.test.js
+++ b/clis/reddit/frontpage.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './frontpage.js';
+
+describe('reddit frontpage adapter', () => {
+  const command = getRegistry().get('reddit/frontpage');
+
+  it('exposes the full frontpage shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'title', 'subreddit', 'author', 'upvotes', 'comments', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('shapes children into the intermediate-object pattern with media spread in', () => {
+    // Refactored from item.data.* templating to a uniform pre-shaped object
+    // so gallery_urls (array-valued) can be set directly in evaluate.
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      title: '${{ item.title }}',
+      subreddit: '${{ item.subreddit }}',
+      author: '${{ item.author }}',
+      upvotes: '${{ item.upvotes }}',
+      comments: '${{ item.comments }}',
+      url: '${{ item.url }}',
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});

--- a/clis/reddit/hot.js
+++ b/clis/reddit/hot.js
@@ -13,10 +13,36 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20, help: 'Number of posts' },
     ],
-    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url'],
+    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const sub = \${{ args.subreddit | json }};
   const path = sub ? '/r/' + sub + '/hot.json' : '/hot.json';
   const limit = \${{ args.limit }};
@@ -32,6 +58,7 @@ cli({
     author: c.data.author,
     postId: c.data.id,
     url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
   }));
 })()
 ` },
@@ -44,6 +71,10 @@ cli({
                 postId: '${{ item.postId }}',
                 author: '${{ item.author }}',
                 url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/hot.test.js
+++ b/clis/reddit/hot.test.js
@@ -6,13 +6,27 @@ describe('reddit hot adapter', () => {
   const command = getRegistry().get('reddit/hot');
 
   it('registers postId, author, and url columns in the hot-list shape', () => {
-    expect(command?.columns).toEqual(['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url']);
+    expect(command?.columns).toEqual([
+      'rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
     expect(command?.pipeline?.[1]?.evaluate).toContain('postId: c.data.id');
     expect(command?.pipeline?.[1]?.evaluate).toContain("'https://www.reddit.com' + c.data.permalink");
     expect(command?.pipeline?.[2]?.map).toMatchObject({
       postId: '${{ item.postId }}',
       author: '${{ item.author }}',
       url: '${{ item.url }}',
+    });
+  });
+
+  it('surfaces post_hint, url_overridden_by_dest, preview_image_url, gallery_urls via extractRedditMedia', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
     });
   });
 });

--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -11,10 +11,36 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'url'],
+    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const limit = \${{ args.limit }};
   const res = await fetch('/r/popular.json?limit=' + limit + '&raw_json=1', {
     credentials: 'include'
@@ -27,6 +53,7 @@ cli({
     comments: c.data.num_comments,
     author: c.data.author,
     url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
   }));
 })()
 ` },
@@ -37,6 +64,10 @@ cli({
                 score: '${{ item.score }}',
                 comments: '${{ item.comments }}',
                 url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/popular.test.js
+++ b/clis/reddit/popular.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './popular.js';
+
+describe('reddit popular adapter', () => {
+  const command = getRegistry().get('reddit/popular');
+
+  it('exposes the full post-list shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'rank', 'title', 'subreddit', 'score', 'comments', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('surfaces media via extractRedditMedia in evaluate + map', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -25,7 +25,7 @@ cli({
         { name: 'replies', type: 'int', default: 5, help: 'Max replies shown per comment at each level (sorted by score)' },
         { name: 'max-length', type: 'int', default: 2000, help: 'Max characters per comment body (min 100)' },
     ],
-    columns: ['type', 'author', 'score', 'text'],
+    columns: ['type', 'author', 'score', 'text', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     func: async (page, kwargs) => {
         const sort = kwargs.sort ?? 'best';
         const limit = Math.max(1, kwargs.limit ?? 25);
@@ -35,6 +35,40 @@ cli({
         await page.goto('https://www.reddit.com');
         const data = await page.evaluate(`
       (async function() {
+        function decodeHtml(s) {
+          if (typeof s !== 'string' || !s) return '';
+          return s
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#x27;/gi, "'")
+            .replace(/&#39;/g, "'");
+        }
+        function extractRedditMedia(d) {
+          var post_hint = (d && d.post_hint) || '';
+          var url_overridden_by_dest = (d && d.url_overridden_by_dest) || '';
+          var preview_image_url = decodeHtml(
+            (d && d.preview && d.preview.images && d.preview.images[0] && d.preview.images[0].source && d.preview.images[0].source.url) || ''
+          );
+          var gallery_urls = [];
+          var items = d && d.gallery_data && d.gallery_data.items;
+          var meta = d && d.media_metadata;
+          if (Array.isArray(items) && meta) {
+            for (var gi = 0; gi < items.length; gi++) {
+              var it = items[gi];
+              var m = it && meta[it.media_id];
+              var u = m && m.s && m.s.u;
+              if (u) gallery_urls.push(decodeHtml(u));
+            }
+          }
+          return {
+            post_hint: post_hint,
+            url_overridden_by_dest: url_overridden_by_dest,
+            preview_image_url: preview_image_url,
+            gallery_urls: gallery_urls,
+          };
+        }
         var postId = ${JSON.stringify(kwargs['post-id'])};
         var urlMatch = postId.match(/comments\\/([a-z0-9]+)/);
         if (urlMatch) postId = urlMatch[1];
@@ -65,11 +99,16 @@ cli({
         if (post) {
           var body = post.selftext || '';
           if (body.length > maxLength) body = body.slice(0, maxLength) + '\\n... [truncated]';
+          var postMedia = extractRedditMedia(post);
           results.push({
             type: 'POST',
             author: post.author || '[deleted]',
             score: post.score || 0,
             text: post.title + (body ? '\\n\\n' + body : '') + (post.url && !post.is_self ? '\\n' + post.url : ''),
+            post_hint: postMedia.post_hint,
+            url_overridden_by_dest: postMedia.url_overridden_by_dest,
+            preview_image_url: postMedia.preview_image_url,
+            gallery_urls: postMedia.gallery_urls,
           });
         }
 
@@ -95,6 +134,10 @@ cli({
             author: d.author || '[deleted]',
             score: d.score || 0,
             text: indentedBody,
+            post_hint: '',
+            url_overridden_by_dest: '',
+            preview_image_url: '',
+            gallery_urls: [],
           });
 
           // Count all available replies (for accurate "more" count)
@@ -122,6 +165,10 @@ cli({
                 author: '',
                 score: '',
                 text: cutoffIndent + '[+' + totalHidden + ' more replies]',
+                post_hint: '',
+                url_overridden_by_dest: '',
+                preview_image_url: '',
+                gallery_urls: [],
               });
             }
             return;
@@ -144,6 +191,10 @@ cli({
               author: '',
               score: '',
               text: moreIndent + '[+' + hidden + ' more replies]',
+              post_hint: '',
+              url_overridden_by_dest: '',
+              preview_image_url: '',
+              gallery_urls: [],
             });
           }
         }
@@ -170,6 +221,10 @@ cli({
             author: '',
             score: '',
             text: '[+' + hiddenTopLevel + ' more top-level comments]',
+            post_hint: '',
+            url_overridden_by_dest: '',
+            preview_image_url: '',
+            gallery_urls: [],
           });
         }
 

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -7,19 +7,43 @@ describe('reddit read adapter', () => {
         expect(command?.browser).toBe(true);
         expect(command?.siteSession).toBe('persistent');
     });
+    it('exposes the threaded shape including the 4 media columns', () => {
+        expect(command?.columns).toEqual([
+            'type', 'author', 'score', 'text',
+            'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+        ]);
+    });
+    it('embeds extractRedditMedia in the browser-evaluated source and applies it to the POST row', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue([]),
+        };
+        await command.func(page, { 'post-id': 'abc123', limit: 5 });
+        const src = page.evaluate.mock.calls[0][0];
+        expect(src).toContain('function extractRedditMedia');
+        expect(src).toContain('var postMedia = extractRedditMedia(post)');
+    });
     it('returns threaded rows from the browser-evaluated payload', async () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn().mockResolvedValue([
-                { type: 'POST', author: 'alice', score: 10, text: 'Title' },
-                { type: 'L0', author: 'bob', score: 5, text: 'Comment' },
+                { type: 'POST', author: 'alice', score: 10, text: 'Title',
+                  post_hint: 'image', url_overridden_by_dest: 'https://i.redd.it/a.jpg',
+                  preview_image_url: 'https://preview.redd.it/a.jpg?width=640',
+                  gallery_urls: [] },
+                { type: 'L0', author: 'bob', score: 5, text: 'Comment',
+                  post_hint: '', url_overridden_by_dest: '', preview_image_url: '', gallery_urls: [] },
             ]),
         };
         const result = await command.func(page, { 'post-id': 'abc123', limit: 5 });
         expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
         expect(result).toEqual([
-            { type: 'POST', author: 'alice', score: 10, text: 'Title' },
-            { type: 'L0', author: 'bob', score: 5, text: 'Comment' },
+            { type: 'POST', author: 'alice', score: 10, text: 'Title',
+              post_hint: 'image', url_overridden_by_dest: 'https://i.redd.it/a.jpg',
+              preview_image_url: 'https://preview.redd.it/a.jpg?width=640',
+              gallery_urls: [] },
+            { type: 'L0', author: 'bob', score: 5, text: 'Comment',
+              post_hint: '', url_overridden_by_dest: '', preview_image_url: '', gallery_urls: [] },
         ]);
     });
     it('surfaces adapter-level API errors clearly', async () => {

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -30,10 +30,36 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['title', 'subreddit', 'author', 'score', 'comments', 'url'],
+    columns: ['title', 'subreddit', 'author', 'score', 'comments', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const q = encodeURIComponent(\${{ args.query | json }});
   const sub = \${{ args.subreddit | json }};
   const sort = \${{ args.sort | json }};
@@ -51,6 +77,7 @@ cli({
     score: c.data.score,
     comments: c.data.num_comments,
     url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
   }));
 })()
 ` },
@@ -61,6 +88,10 @@ cli({
                 score: '${{ item.score }}',
                 comments: '${{ item.comments }}',
                 url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/search.test.js
+++ b/clis/reddit/search.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+
+describe('reddit search adapter', () => {
+  const command = getRegistry().get('reddit/search');
+
+  it('exposes the full search-result shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'title', 'subreddit', 'author', 'score', 'comments', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('surfaces media via extractRedditMedia in evaluate + map', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -24,10 +24,36 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['title', 'author', 'upvotes', 'comments', 'url'],
+    columns: ['title', 'author', 'upvotes', 'comments', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   let sub = \${{ args.name | json }};
   if (sub.startsWith('r/')) sub = sub.slice(2);
   const sort = \${{ args.sort | json }};
@@ -39,15 +65,26 @@ cli({
   }
   const res = await fetch(url, { credentials: 'include' });
   const j = await res.json();
-  return j?.data?.children || [];
+  return (j?.data?.children || []).map(c => ({
+    title: c.data.title,
+    author: c.data.author,
+    upvotes: c.data.score,
+    comments: c.data.num_comments,
+    url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
+  }));
 })()
 ` },
         { map: {
-                title: '${{ item.data.title }}',
-                author: '${{ item.data.author }}',
-                upvotes: '${{ item.data.score }}',
-                comments: '${{ item.data.num_comments }}',
-                url: 'https://www.reddit.com${{ item.data.permalink }}',
+                title: '${{ item.title }}',
+                author: '${{ item.author }}',
+                upvotes: '${{ item.upvotes }}',
+                comments: '${{ item.comments }}',
+                url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/subreddit.test.js
+++ b/clis/reddit/subreddit.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './subreddit.js';
+
+describe('reddit subreddit adapter', () => {
+  const command = getRegistry().get('reddit/subreddit');
+
+  it('exposes the full subreddit-list shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'title', 'author', 'upvotes', 'comments', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('shapes children into the intermediate-object pattern with media spread in', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      title: '${{ item.title }}',
+      author: '${{ item.author }}',
+      upvotes: '${{ item.upvotes }}',
+      comments: '${{ item.comments }}',
+      url: '${{ item.url }}',
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add 4 additive columns — `post_hint`, `url_overridden_by_dest`, `preview_image_url`, `gallery_urls` — to `popular`, `hot`, `frontpage`, `search`, `subreddit`, and `read` so downstream consumers can route image / gallery / hosted:video / link posts without scraping `selftext`. Preview and gallery URLs are HTML-decoded (Reddit returns `&amp;` in those URLs even with `raw_json=1`). `frontpage` and `subreddit` are refactored to the intermediate-object shape used by `popular`/`hot`/`search` so the array-valued `gallery_urls` can be set directly in `evaluate`. `read`'s POST row carries real values; comment and synthetic rows get empty placeholders to keep the table rectangular.

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [x] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Verification:
- `npx vitest run clis/reddit/ --project adapter` → 23/23 pass (8 behavioral fixtures in `extract-media.test.js` cover plain/image/gallery/hosted-video/link/HTML-decode/missing-metadata/nullish-input)
- `npm test` → 3301 passed, 1 skipped (unrelated `daemon.test.ts` port-conflict)
- `npm run check:silent-column-drop` → no new violations (baseline 103, current 103)
- `npm run typecheck` → clean

Output contract is strictly additive — existing field names, ordering, and values are unchanged.