### PR TITLE
fix(doubao/ask): restore Assistant detection after 2026-05 DOM refactor

### DIFF
--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -163,6 +163,19 @@ function getTurnsScript() {
         ) {
           return 'Assistant';
         }
+        // 2026-05 Doubao DOM refactor: no more receive-message / bg-g-receive-msg-bubble
+        // markers on assistant turns. Wrappers are now [class*="inner-item-"] /
+        // [class*="top-item-"] and the only reliable assistant signal is the
+        // .flow-markdown-body content container WITHOUT any send-bubble marker.
+        if (
+          (root.matches('[class*="inner-item-"], [class*="top-item-"]')
+            || root.closest('[class*="inner-item-"], [class*="top-item-"]'))
+          && (root.matches('.flow-markdown-body') || root.querySelector('.flow-markdown-body'))
+          && !root.matches('[class*="bg-g-send-msg-bubble"]')
+          && !root.querySelector('[class*="bg-g-send-msg-bubble"]')
+        ) {
+          return 'Assistant';
+        }
         return '';
       };
 
@@ -223,6 +236,10 @@ function getTurnsScript() {
       if (!messageList) return [];
 
       const itemSelectors = [
+        // 2026-05 Doubao DOM refactor wrappers (prepended; outer ones win via
+        // ancestor-keep dedup below).
+        '[class*="inner-item-"]',
+        '[class*="top-item-"]',
         '[class*="item-kDun2N"]',
         '[data-testid="union_message"]',
         '[data-testid="message-block-container"]',

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -157,6 +157,19 @@ describe('doubao receive strategy', () => {
         expect(turnsScript).toContain('[data-testid="message-block-container"]');
     });
 
+    it('includes the 2026-05 doubao DOM-refactor inner-item / top-item wrappers and the flow-markdown-body assistant fallback', () => {
+        const turnsScript = __test__.getTurnsScript();
+        // New wrappers added to itemSelectors so message roots resolve under the
+        // refactored DOM where the legacy item-kDun2N / union_message / message-block-container
+        // / data-message-id selectors no longer match.
+        expect(turnsScript).toContain('[class*="inner-item-"]');
+        expect(turnsScript).toContain('[class*="top-item-"]');
+        // Assistant fallback: post-refactor doubao no longer emits receive-message /
+        // bg-g-receive-msg-bubble markup. Only signal is .flow-markdown-body content
+        // container without send-bubble.
+        expect(turnsScript).toContain('.flow-markdown-body');
+    });
+
     it('extends transcript-noise cleanup for the current zh-CN chrome copy', () => {
         const transcriptScript = __test__.getTranscriptLinesScript();
         expect(transcriptScript).toContain('请仔细甄别');

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -1,3 +1,4 @@
+import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
@@ -145,6 +146,28 @@ describe('doubao send strategy', () => {
     });
 });
 describe('doubao receive strategy', () => {
+    function runTurnsScript(html) {
+        const dom = new JSDOM(html, { url: 'https://www.doubao.com/chat', runScripts: 'outside-only' });
+        Object.defineProperty(dom.window.HTMLElement.prototype, 'innerText', {
+            configurable: true,
+            get() {
+                return this.textContent || '';
+            },
+        });
+        dom.window.HTMLElement.prototype.getBoundingClientRect = () => ({
+            width: 100,
+            height: 24,
+            top: 0,
+            left: 0,
+            right: 100,
+            bottom: 24,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        });
+        return dom.window.eval(__test__.getTurnsScript());
+    }
+
     it('keeps both the new skin selectors and the older structural fallbacks in the turns script', () => {
         const turnsScript = __test__.getTurnsScript();
         expect(turnsScript).toContain('[class*="message-list-S2Fv2S"]');
@@ -168,6 +191,31 @@ describe('doubao receive strategy', () => {
         // bg-g-receive-msg-bubble markup. Only signal is .flow-markdown-body content
         // container without send-bubble.
         expect(turnsScript).toContain('.flow-markdown-body');
+    });
+
+    it('extracts clean assistant turns from the 2026-05 wrapper DOM without using whole-page chrome', () => {
+        const turns = runTurnsScript(`
+          <main>
+            <aside>历史对话</aside>
+            <section class="message-list-S2Fv2S">
+              <div class="top-item-user">
+                <div class="inner-item-user">
+                  <div class="bg-g-send-msg-bubble">测试一下，只回复OK</div>
+                </div>
+              </div>
+              <div class="top-item-assistant">
+                <div class="inner-item-assistant">
+                  <div class="flow-markdown-body"><p>OK</p></div>
+                </div>
+              </div>
+            </section>
+          </main>
+        `);
+
+        expect(turns).toEqual([
+            { Role: 'User', Text: '测试一下，只回复OK' },
+            { Role: 'Assistant', Text: 'OK' },
+        ]);
     });
 
     it('extends transcript-noise cleanup for the current zh-CN chrome copy', () => {


### PR DESCRIPTION
## Summary

Fixes #1478. Doubao reworked its message-item wrappers in 2026-05 and removed all `receive-message` / `bg-g-receive-msg-bubble` markers from assistant turns. Symptoms: `opencli doubao ask <text>` returned an Assistant `Text` field containing sidebar labels + history titles + adjacent conversations concatenated with the real reply — silent SELECTOR failure (no thrown error).

## Root cause

`getTurnsScript` in `clis/doubao/utils.js` had:
- 6 `itemSelectors` (`item-kDun2N`, `union_message`, `message-block-container`, `data-message-id`, `bg-g-send-msg-bubble`, `bg-g-receive-msg-bubble`) — all match **0** elements on the new DOM.
- `getRole` assistant branch relied entirely on `receive-message` / `bg-g-receive-msg-bubble` markers — none of which exist anymore.

When `getTurnsScript` returned `[]`, `getDoubaoTurns` fell through to the whole-page transcript scraper (`getTranscriptLinesScript`), which is by design last-resort and picks up sidebar chrome. `ask.js` then unconditionally labels the resulting snippet `Role: 'Assistant'`.

## Fix

Two minimal changes in `clis/doubao/utils.js` `getTurnsScript`:

1. **`itemSelectors`**: prepend `[class*="inner-item-"]` and `[class*="top-item-"]`. The existing ancestor-keep dedup downstream guarantees we end up with one root per turn (not one per nested chunk).
2. **`getRole` fallback branch**: if root matches `inner-item-*` / `top-item-*`, contains `.flow-markdown-body`, and has NO `bg-g-send-msg-bubble` marker (User detection unchanged), treat it as Assistant. `.flow-markdown-body` is already in `messageTextSelectors`, so text extraction works unchanged.

User detection (`bg-g-send-msg-bubble` etc.) is left intact because those markers are preserved on the new DOM.

## Test

Added a test asserting the new wrappers and assistant fallback selector are present in the generated `getTurnsScript`.

Test Files 3 passed / Tests 29 passed.

Audits unchanged:
- check:typed-error-lint — 189/189 baseline
- check:silent-column-drop — 103/103 baseline

## Credit

Diagnosis from the autofix issue body in #1478 (willzhqiang). Local-repair patch verified by the issue author before filing. This PR applies that patch with minor stylistic alignment to the existing getRole shape + a regression test.

## Test plan

- [x] Vitest 29/29 passing
- [x] typed-error-lint baseline preserved
- [x] silent-column-drop baseline preserved
- [ ] Live-verify on www.doubao.com/chat once a reviewer with a logged-in session can run opencli doubao ask "hello" — Assistant Text should be the clean reply only, not the concat.