### PR TITLE
fix(doctor): pass session to connectivity probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **doctor** — pass an internal browser session to the live connectivity probe so `opencli doctor` works with the explicit-session browser model.
+
 ## [1.7.17](https://github.com/jackwener/opencli/compare/v1.7.16...v1.7.17) (2026-05-12)
 
 Extension bumped to 1.0.12 (workspace → session lease routing, drop `handleSessions` handler). Major simplification pass: browser/adapter session model rewrite, `--workspace` removed, doctor surface trimmed to its core job.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -383,6 +383,8 @@ describe('createProgram root help descriptions', () => {
           name: 'session',
           flags: '--session <name>',
           takes_value: 'required',
+          required: true,
+          help: expect.stringContaining('required'),
         }),
         expect.objectContaining({
           name: 'window',
@@ -961,12 +963,15 @@ describe('browser tab targeting commands', () => {
 
   it('requires an explicit session for browser commands', async () => {
     const program = createProgram('', '');
+    program.exitOverride((err) => { throw err; });
+    program.commands.find(cmd => cmd.name() === 'browser')?.exitOverride((err) => { throw err; });
 
-    await program.parseAsync(['node', 'opencli', 'browser', 'state']);
+    await expect(program.parseAsync(['node', 'opencli', 'browser', 'state'])).rejects.toMatchObject({
+      code: 'commander.missingMandatoryOptionValue',
+    });
 
     expect(mockBrowserConnect).not.toHaveBeenCalled();
-    expect(stderrSpy.mock.calls.flat().join('')).toContain('--session <name> is required');
-    expect(process.exitCode).toBeDefined();
+    expect(stderrSpy.mock.calls.flat().join('')).toContain("required option '--session <name>' not specified");
   });
 
   it('runs browser commands against an explicit session', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -686,7 +686,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   const browser = program
     .command('browser')
-    .option('--session <name>', 'Browser session to use')
+    .requiredOption('--session <name>', 'Browser session to use (required)')
     .option('--window <mode>', 'Browser window mode: foreground or background')
     .description('Browser control — navigate, click, type, extract, wait (no LLM needed)');
   const originalBrowserDescription = browser.description();
@@ -811,7 +811,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
   }
 
   browser.command('bind')
-    .option('--session <name>', 'Browser session name to bind')
+    .option('--session <name>', 'Browser session name to bind (required)')
     .description('Bind the current Chrome tab/window to a browser session')
     .action(async (optsOrCommand, maybeCommand?: Command) => {
       const command = optsOrCommand instanceof Command ? optsOrCommand : maybeCommand;
@@ -841,7 +841,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     });
 
   browser.command('unbind')
-    .option('--session <name>', 'Browser session name to detach')
+    .option('--session <name>', 'Browser session name to detach (required)')
     .description('Detach a bound browser session without closing the user tab/window')
     .action(async (optsOrCommand, maybeCommand?: Command) => {
       const command = optsOrCommand instanceof Command ? optsOrCommand : maybeCommand;

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -208,7 +208,7 @@ describe('doctor report rendering', () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     mockConnect.mockImplementationOnce(async (opts?: { timeout?: number; session?: string; surface?: string }) => {
       timeoutSeen = opts?.timeout;
-      expect(opts?.session).toBe('doctor');
+      expect(opts?.session).toBe('__doctor__');
       expect(opts?.surface).toBe('browser');
       return {
         evaluate: vi.fn().mockResolvedValue(2),

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -206,8 +206,10 @@ describe('doctor report rendering', () => {
   it('uses the fast default timeout for live connectivity checks', async () => {
     let timeoutSeen: number | undefined;
     const closeWindow = vi.fn().mockResolvedValue(undefined);
-    mockConnect.mockImplementationOnce(async (opts?: { timeout?: number }) => {
+    mockConnect.mockImplementationOnce(async (opts?: { timeout?: number; session?: string; surface?: string }) => {
       timeoutSeen = opts?.timeout;
+      expect(opts?.session).toBe('doctor');
+      expect(opts?.surface).toBe('browser');
       return {
         evaluate: vi.fn().mockResolvedValue(2),
         closeWindow,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -17,7 +17,7 @@ import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
-const DOCTOR_SESSION = 'doctor';
+const DOCTOR_SESSION = '__doctor__';
 
 /** Parse a semver string into [major, minor, patch]. Returns null on invalid input. */
 function parseSemver(v: string): [number, number, number] | null {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -17,6 +17,7 @@ import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
+const DOCTOR_SESSION = 'doctor';
 
 /** Parse a semver string into [major, minor, patch]. Returns null on invalid input. */
 function parseSemver(v: string): [number, number, number] | null {
@@ -81,7 +82,11 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   const start = Date.now();
   try {
     const bridge = new BrowserBridge();
-    const page = await bridge.connect({ timeout: opts?.timeout ?? DOCTOR_LIVE_TIMEOUT_SECONDS });
+    const page = await bridge.connect({
+      timeout: opts?.timeout ?? DOCTOR_LIVE_TIMEOUT_SECONDS,
+      session: DOCTOR_SESSION,
+      surface: 'browser',
+    });
     try {
       // Try a simple eval to verify end-to-end connectivity.
       await page.evaluate('1 + 1');


### PR DESCRIPTION
## Summary
- pass an internal `__doctor__` browser session to the doctor live connectivity probe
- keep the probe on the browser surface and release the lease after eval
- mark browser `--session` as a required CLI option and lock the structured help contract

## Verification
- `npx vitest run src/cli.test.ts --project unit -t "session|browser namespace structured help|binds the current Chrome tab"`
- `npx vitest run src/doctor.test.ts --project unit`
- `npx tsc --noEmit`
- `git diff --check`
