### PR TITLE
chore(release): 1.7.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Changelog
 
-## Unreleased
+## [1.7.18](https://github.com/jackwener/opencli/compare/v1.7.17...v1.7.18) (2026-05-12)
+
+Hotfix release for the 1.7.17 doctor regression: `opencli doctor` failed connectivity probe with `Browser session is required` because the doctor probe didn't pass a session to the new strict-session browser bridge. Also adds new adapters and adapter fixes that were ready immediately after 1.7.17.
 
 ### Bug Fixes
 
-* **doctor** — pass an internal browser session to the live connectivity probe so `opencli doctor` works with the explicit-session browser model.
+* **doctor** — pass an internal `__doctor__` browser session to the live connectivity probe so `opencli doctor` works again under the explicit-session browser model introduced in 1.7.17. ([#1485](https://github.com/jackwener/opencli/issues/1485))
+* **browser** — `--session <name>` is now declared as a `requiredOption` so Commander itself rejects calls missing the flag before runtime, and the help line is marked `(required)` instead of being hidden under `Options:`. ([#1485](https://github.com/jackwener/opencli/issues/1485))
+* **doubao/ask** — restore Assistant detection after the 2026-05 DOM refactor. ([#1484](https://github.com/jackwener/opencli/issues/1484))
+* **youtube** — request `srv3` format for caption URLs. ([#1422](https://github.com/jackwener/opencli/issues/1422))
+
+### Features
+
+* **rednote** — add `rednote.com` adapter mirroring xiaohongshu read commands. ([#1475](https://github.com/jackwener/opencli/issues/1475))
+* **reddit** — add `reply` command for replying to comments. ([#1428](https://github.com/jackwener/opencli/issues/1428))
 
 ## [1.7.17](https://github.com/jackwener/opencli/compare/v1.7.16...v1.7.17) (2026-05-12)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.17",
+  "version": "1.7.18",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Hotfix release for the 1.7.17 doctor regression + a few adapter fixes/features merged immediately after.

- **fix(doctor)** (#1485): doctor connectivity probe now passes an internal `__doctor__` session so it works under the strict-session browser model from 1.7.17
- **fix(browser)** (#1485): `--session` declared as `requiredOption` so Commander rejects missing flag at parse time + help marks `(required)`
- **fix(doubao/ask)** (#1484): restore Assistant detection after 2026-05 DOM refactor
- **fix(youtube)** (#1422): request srv3 format for caption URLs
- **feat(rednote)** (#1475): new rednote.com adapter
- **feat(reddit)** (#1428): reply command

Extension version unchanged (still 1.0.12).

Per @WAWQAQ msg=b5760678 directive: admin-merge immediately without CI wait — user-visible 1.7.17 regression.

## Test plan
- [x] CHANGELOG 1.7.18 entry covers 5 commits since v1.7.17
- [x] package.json 1.7.17 → 1.7.18
- [x] Admin merge — skip CI gate per directive
- [ ] Tag `v1.7.18` after merge triggers Release workflow