### PR TITLE
fix(xiaohongshu+rednote): scroll until enough rows for --limit > 13 (#1471)

### DIFF
--- a/clis/rednote/search.js
+++ b/clis/rednote/search.js
@@ -7,7 +7,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
-import { buildSearchExtractJs, noteIdToDate } from '../xiaohongshu/search.js';
+import { buildScrollUntilJs, buildSearchExtractJs, noteIdToDate } from '../xiaohongshu/search.js';
 
 function parseLimit(raw) {
     const parsed = Number(raw);
@@ -82,7 +82,11 @@ cli({
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.rednote.com', 'Rednote search results are blocked behind a login wall');
         }
-        await page.autoScroll({ times: 2 });
+        // Scroll until enough rows are rendered or the lazy-load plateaus.
+        // Same fix as xiaohongshu/search (#1471): the previous fixed
+        // `autoScroll({ times: 2 })` capped extraction at ~13 notes regardless
+        // of `--limit`.
+        await page.evaluate(buildScrollUntilJs(limit));
         const payload = await page.evaluate(buildSearchExtractJs('www.rednote.com'));
         const data = Array.isArray(payload) ? payload : [];
         return data

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -6,7 +6,7 @@
  * Ref: https://github.com/jackwener/opencli/issues/10
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, 'login_wall' if login gate
@@ -52,6 +52,16 @@ export function stripXhsAuthorDateSuffix(value) {
     const stripped = text.replace(/\s*(?:\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2})$/u, '').trim();
     return stripped || text;
 }
+export function parseLimit(raw) {
+    const parsed = Number(raw ?? 20);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+        throw new ArgumentError(`--limit must be an integer between 1 and 100, got ${JSON.stringify(raw)}`);
+    }
+    if (parsed < 1 || parsed > 100) {
+        throw new ArgumentError(`--limit must be between 1 and 100, got ${parsed}`);
+    }
+    return parsed;
+}
 /**
  * Build a "scroll until enough or plateaued" IIFE used in place of a fixed
  * `autoScroll({ times: N })`. Xiaohongshu's search results page lazy-loads
@@ -69,12 +79,25 @@ export function stripXhsAuthorDateSuffix(value) {
  * Exported so the rednote adapter (same DOM shape) can reuse it.
  */
 export function buildScrollUntilJs(targetCount, maxScrolls = 15) {
+    if (!Number.isSafeInteger(targetCount) || targetCount < 1) {
+        throw new ArgumentError(`targetCount must be a positive integer, got ${JSON.stringify(targetCount)}`);
+    }
+    if (!Number.isSafeInteger(maxScrolls) || maxScrolls < 1) {
+        throw new ArgumentError(`maxScrolls must be a positive integer, got ${JSON.stringify(maxScrolls)}`);
+    }
     return `
       (async () => {
+        const isVisibleNote = (el) => {
+          if (el.classList.contains('query-note-item')) return false;
+          const rect = el.getBoundingClientRect();
+          if (rect.width <= 0 || rect.height <= 0) return false;
+          const style = getComputedStyle(el);
+          return style.display !== 'none' && style.visibility !== 'hidden';
+        };
         const countItems = () => {
           let count = 0;
           for (const el of document.querySelectorAll('section.note-item')) {
-            if (!el.classList.contains('query-note-item')) count++;
+            if (isVisibleNote(el)) count++;
           }
           return count;
         };
@@ -128,6 +151,12 @@ export function buildSearchExtractJs(webHost) {
 
         const cleanText = (value) => (value || '').replace(/\\s+/g, ' ').trim();
         const stripXhsAuthorDateSuffix = ${stripXhsAuthorDateSuffix.toString()};
+        const isVisibleNote = (el) => {
+          const rect = el.getBoundingClientRect();
+          if (rect.width <= 0 || rect.height <= 0) return false;
+          const style = getComputedStyle(el);
+          return style.display !== 'none' && style.visibility !== 'hidden';
+        };
 
         const results = [];
         const seen = new Set();
@@ -135,6 +164,7 @@ export function buildSearchExtractJs(webHost) {
         document.querySelectorAll('section.note-item').forEach(el => {
           // Skip "related searches" sections
           if (el.classList.contains('query-note-item')) return;
+          if (!isVisibleNote(el)) return;
 
           const titleEl = el.querySelector('.title, .note-title, a.title, .footer .title span');
           const nameEl = el.querySelector('a.author .name, .author-name, .nick-name, .name');
@@ -187,6 +217,7 @@ export const command = cli({
     ],
     columns: ['rank', 'title', 'author', 'likes', 'published_at', 'url'],
     func: async (page, kwargs) => {
+        const limit = parseLimit(kwargs.limit);
         const keyword = encodeURIComponent(kwargs.query);
         await page.goto(`https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
         // Wait for search results to render (or login wall to appear).
@@ -199,12 +230,12 @@ export const command = cli({
         // Scroll until enough rows are rendered or the lazy-load plateaus.
         // Replaces the previous fixed `autoScroll({ times: 2 })` which capped
         // extraction at ~13 notes regardless of `--limit` (#1471).
-        await page.evaluate(buildScrollUntilJs(kwargs.limit));
+        await page.evaluate(buildScrollUntilJs(limit));
         const payload = await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com'));
         const data = Array.isArray(payload) ? payload : [];
         return data
             .filter((item) => item.title)
-            .slice(0, kwargs.limit)
+            .slice(0, limit)
             .map((item, i) => ({
             rank: i + 1,
             ...item,

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -53,6 +53,64 @@ export function stripXhsAuthorDateSuffix(value) {
     return stripped || text;
 }
 /**
+ * Build a "scroll until enough or plateaued" IIFE used in place of a fixed
+ * `autoScroll({ times: N })`. Xiaohongshu's search results page lazy-loads
+ * ~5-7 notes per scroll, so the previous `times: 2` capped extraction at
+ * ~13 items regardless of `--limit` (see #1471). This helper drives scrolls
+ * dynamically:
+ *
+ *   - count visible `section.note-item` rows (excluding related-search
+ *     `.query-note-item` rows)
+ *   - if count >= targetCount → break (got enough)
+ *   - if two consecutive scrolls add no new rows → break (DOM plateaued,
+ *     no more lazy-load available)
+ *   - hard cap at `maxScrolls` iterations (default 15) to bound runtime
+ *
+ * Exported so the rednote adapter (same DOM shape) can reuse it.
+ */
+export function buildScrollUntilJs(targetCount, maxScrolls = 15) {
+    return `
+      (async () => {
+        const countItems = () => {
+          let count = 0;
+          for (const el of document.querySelectorAll('section.note-item')) {
+            if (!el.classList.contains('query-note-item')) count++;
+          }
+          return count;
+        };
+
+        let lastCount = countItems();
+        let plateauRounds = 0;
+        for (let i = 0; i < ${maxScrolls}; i++) {
+          if (countItems() >= ${targetCount}) break;
+          const lastHeight = document.body.scrollHeight;
+          window.scrollTo(0, lastHeight);
+          await new Promise((resolve) => {
+            let to;
+            const ob = new MutationObserver(() => {
+              if (document.body.scrollHeight > lastHeight) {
+                clearTimeout(to);
+                ob.disconnect();
+                setTimeout(resolve, 200);
+              }
+            });
+            ob.observe(document.body, { childList: true, subtree: true });
+            to = setTimeout(() => { ob.disconnect(); resolve(null); }, 2500);
+          });
+          const newCount = countItems();
+          if (newCount === lastCount) {
+            plateauRounds++;
+            if (plateauRounds >= 2) break;
+          } else {
+            plateauRounds = 0;
+            lastCount = newCount;
+          }
+        }
+        return countItems();
+      })()
+    `;
+}
+/**
  * Build the search-result extraction IIFE. The web host is baked into the
  * `normalizeUrl` fallback so relative `/explore/...` hrefs resolve to a full
  * URL on the calling site. Exported so the rednote adapter can call it with
@@ -138,8 +196,10 @@ export const command = cli({
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
         }
-        // Scroll a couple of times to load more results
-        await page.autoScroll({ times: 2 });
+        // Scroll until enough rows are rendered or the lazy-load plateaus.
+        // Replaces the previous fixed `autoScroll({ times: 2 })` which capped
+        // extraction at ~13 notes regardless of `--limit` (#1471).
+        await page.evaluate(buildScrollUntilJs(kwargs.limit));
         const payload = await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com'));
         const data = Array.isArray(payload) ? payload : [];
         return data

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { JSDOM } from 'jsdom';
-import { __test__, noteIdToDate } from './search.js';
+import { __test__, buildScrollUntilJs, noteIdToDate } from './search.js';
 function createPageMock(evaluateResults) {
     const evaluate = vi.fn();
     for (const result of evaluateResults) {
@@ -39,7 +39,8 @@ describe('xiaohongshu search', () => {
             'login_wall',
         ]);
         await expect(cmd.func(page, { query: '特斯拉', limit: 5 })).rejects.toThrow('Xiaohongshu search results are blocked behind a login wall');
-        // autoScroll must NOT be called when a login wall is detected early
+        // No scroll-until / autoScroll call when a login wall is detected early.
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
         expect(page.autoScroll).not.toHaveBeenCalled();
     });
     it('returns ranked results with search_result url and author_url preserved', async () => {
@@ -50,7 +51,9 @@ describe('xiaohongshu search', () => {
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: main DOM extraction (returns array directly)
+            // Second evaluate: scroll-until-enough (returns final note count)
+            1,
+            // Third evaluate: main DOM extraction (returns array directly)
             [
                 {
                     title: '某鱼买FSD被坑了4万',
@@ -82,7 +85,9 @@ describe('xiaohongshu search', () => {
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: main DOM extraction (returns array directly)
+            // Second evaluate: scroll-until-enough (returns final note count)
+            3,
+            // Third evaluate: main DOM extraction (returns array directly)
             [
                 {
                     title: 'Result A',
@@ -118,15 +123,17 @@ describe('xiaohongshu search', () => {
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: extraction (returns empty array)
+            // Second evaluate: scroll-until-enough (no rows rendered)
+            0,
+            // Third evaluate: extraction (returns empty array)
             [],
         ]);
         const result = (await cmd.func(page, { query: '测试等待', limit: 5 }));
         expect(result).toHaveLength(0);
         // Only one navigation, no retry
         expect(page.goto).toHaveBeenCalledTimes(1);
-        // Two evaluate calls: wait + extraction
-        expect(page.evaluate).toHaveBeenCalledTimes(2);
+        // Three evaluate calls: wait + scroll-until + extraction
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
     });
     it('separates fallback author text from appended relative date', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
@@ -143,6 +150,8 @@ describe('xiaohongshu search', () => {
         `, { url: 'https://www.xiaohongshu.com/search_result?keyword=test' });
         const page = createPageMock([]);
         page.evaluate.mockImplementationOnce(async () => 'content');
+        // scroll-until-enough returns the final visible row count
+        page.evaluate.mockImplementationOnce(async () => 1);
         page.evaluate.mockImplementationOnce(async (script) => Function('document', `return (${script})`)(dom.window.document));
 
         const result = await cmd.func(page, { query: '测试', limit: 1 });
@@ -153,6 +162,25 @@ describe('xiaohongshu search', () => {
             likes: '8',
             author_url: 'https://www.xiaohongshu.com/user/profile/author123',
         });
+    });
+});
+describe('buildScrollUntilJs', () => {
+    it('inlines the target count and default maxScrolls into the generated IIFE', () => {
+        const js = buildScrollUntilJs(40);
+        // Target count must drive the early-exit check (#1471: --limit > 13 was capped).
+        expect(js).toContain('countItems() >= 40');
+        // Default safety cap of 15 to bound runtime on infinite-scroll pages.
+        expect(js).toContain('i < 15');
+        // Plateau detection so the loop exits early when XHS stops lazy-loading
+        // instead of spinning all 15 iterations against an exhausted feed.
+        expect(js).toContain('plateauRounds');
+        // Related-search rows must not count toward the target.
+        expect(js).toContain("classList.contains('query-note-item')");
+    });
+    it('respects a custom maxScrolls override', () => {
+        const js = buildScrollUntilJs(100, 5);
+        expect(js).toContain('countItems() >= 100');
+        expect(js).toContain('i < 5');
     });
 });
 describe('stripXhsAuthorDateSuffix', () => {

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { JSDOM } from 'jsdom';
 import { __test__, buildScrollUntilJs, noteIdToDate } from './search.js';
+
+function markVisible(el) {
+    el.getBoundingClientRect = () => ({ width: 100, height: 100 });
+}
 function createPageMock(evaluateResults) {
     const evaluate = vi.fn();
     for (const result of evaluateResults) {
@@ -31,6 +35,16 @@ function createPageMock(evaluateResults) {
     };
 }
 describe('xiaohongshu search', () => {
+    it('rejects invalid limit before browser navigation', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([]);
+
+        await expect(cmd.func(page, { query: '特斯拉', limit: 0 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('--limit'),
+        });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
     it('throws a clear error when the search page is blocked by a login wall', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         expect(cmd?.func).toBeTypeOf('function');
@@ -148,11 +162,12 @@ describe('xiaohongshu search', () => {
             <span class="count">8</span>
           </section>
         `, { url: 'https://www.xiaohongshu.com/search_result?keyword=test' });
+        markVisible(dom.window.document.querySelector('section.note-item'));
         const page = createPageMock([]);
         page.evaluate.mockImplementationOnce(async () => 'content');
         // scroll-until-enough returns the final visible row count
         page.evaluate.mockImplementationOnce(async () => 1);
-        page.evaluate.mockImplementationOnce(async (script) => Function('document', `return (${script})`)(dom.window.document));
+        page.evaluate.mockImplementationOnce(async (script) => Function('document', 'getComputedStyle', `return (${script})`)(dom.window.document, dom.window.getComputedStyle.bind(dom.window)));
 
         const result = await cmd.func(page, { query: '测试', limit: 1 });
 
@@ -181,6 +196,24 @@ describe('buildScrollUntilJs', () => {
         const js = buildScrollUntilJs(100, 5);
         expect(js).toContain('countItems() >= 100');
         expect(js).toContain('i < 5');
+    });
+    it('counts only visible real note rows', async () => {
+        const dom = new JSDOM(`
+          <section class="note-item" id="visible"></section>
+          <section class="note-item query-note-item" id="query"></section>
+          <section class="note-item" id="hidden" style="display:none"></section>
+        `, { url: 'https://www.xiaohongshu.com/search_result?keyword=test' });
+        markVisible(dom.window.document.querySelector('#visible'));
+        markVisible(dom.window.document.querySelector('#query'));
+        markVisible(dom.window.document.querySelector('#hidden'));
+
+        const result = await Function('document', 'window', 'MutationObserver', 'getComputedStyle', `return (${buildScrollUntilJs(1)})`)(dom.window.document, dom.window, dom.window.MutationObserver, dom.window.getComputedStyle.bind(dom.window));
+
+        expect(result).toBe(1);
+    });
+    it('rejects unsafe helper arguments instead of interpolating them into code', () => {
+        expect(() => buildScrollUntilJs(0)).toThrow(/targetCount/);
+        expect(() => buildScrollUntilJs(10, 0)).toThrow(/maxScrolls/);
     });
 });
 describe('stripXhsAuthorDateSuffix', () => {


### PR DESCRIPTION
## Summary

Fixes #1471. `xiaohongshu/search` (and the `rednote/search` mirror) hard-capped at ~13 results regardless of `--limit` because the previous implementation called `page.autoScroll({ times: 2 })` after the search page loaded. XHS lazy-loads ~5-7 notes per scroll round, so two scrolls only ever yielded ~13 visible \`section.note-item\` nodes; the rest of the requested limit returned nothing.

Replace the fixed scroll with a dynamic \`buildScrollUntilJs(targetCount, maxScrolls=15)\` helper that:

- counts visible \`section.note-item\` rows (excluding \`.query-note-item\` related-search rows)
- breaks early when count >= target (we have enough)
- breaks early after 2 consecutive scrolls add no new rows (DOM plateaued — feed actually exhausted, don't waste 15 rounds)
- hard caps at 15 iterations to bound runtime

The helper is exported from \`clis/xiaohongshu/search.js\` and reused by \`clis/rednote/search.js\` (same DOM shape, Boy Scout fix for the same root cause) instead of duplicating the IIFE.

## Why scroll-until-enough vs just `times: 15`?

Three reasons:
1. **Bounded waste on small limits.** With \`--limit 5\` we don't need to scroll 15 times — first count check exits immediately.
2. **Bounded waste on exhausted feeds.** Some niche keywords return < 20 total results. Plateau detection (2 rounds with no growth) exits early instead of spinning 15 times against a frozen feed.
3. **Bounded total runtime.** maxScrolls=15 is the hard ceiling; each scroll waits up to 2.5s for new content via MutationObserver, then 200ms settle. Worst case ~40s for a `--limit 100` on a slow feed, vs unbounded.

## Test plan

- [x] 15/15 unit tests pass in \`clis/xiaohongshu/search.test.js\` (added 2 tests covering \`buildScrollUntilJs\` IIFE shape: target-count inlining + maxScrolls override)
- [x] 4/4 unit tests pass in \`clis/rednote/rednote.test.js\` (unchanged — they test note URL identity, not scroll behavior)
- [x] typed-error-lint baseline unchanged (189)
- [x] silent-column-drop baseline unchanged (103)
- [ ] Live verify `opencli xiaohongshu/search --query 特斯拉 --limit 40` returns 40 rows (reviewer to confirm in actual browser session)