### PR TITLE
docs(skill/adapter-author): aria-label / placeholder / title are locale-dependent (#1474)

### DIFF
--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -186,7 +186,7 @@ DONE
 | `references/adapter-template.md` | Step 9 文件结构 + 活例子 `convertible.js` |
 | `references/site-memory.md` | 总览：in-repo 种子 + 本地 `~/.opencli/sites/` 的两层结构 |
 | `references/site-memory/<site>.md` | Step 2 读站点公共知识（eastmoney / xueqiu / bilibili / tonghuashun 已铺） |
-| `references/success-rate-pitfalls.md` | Step 7 / 11 踩坑前翻：10 种"verify 能过但数据是错的"静默失败 |
+| `references/success-rate-pitfalls.md` | Step 7 / 11 踩坑前翻：11 种"verify 能过但数据是错的"静默失败（含 aria-label locale-dependence） |
 | `references/jsdom-fixture-pattern.md` | 当 adapter 走 `page.evaluate` 内 DOM 抽取、且 mocked-evaluate 单测漏 silent bug 时——把 HTML 冻进 `clis/<site>/__fixtures__/` 用 JSDOM 跑（含 fixture 创建 mandatory `awk 'NF>0'` 收紧 + reverse-validate 纪律） |
 | `references/typed-errors.md` | 写 `func` 主体之前必读：5 类 typed error 落点表（ArgumentError / EmptyResultError / CommandExecutionError / AuthRequiredError / TimeoutError）+ 三大 silent anti-pattern（silent-clamp / sentinel-row / generic CliError）的反例修法 |
 

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -282,29 +282,37 @@ issue #1474 触发：同一个发送按钮在英文 Chrome 是 `aria-label="Subm
 
 | 类 | 例子 | locale 切换会变吗 | 用作 primary selector？ |
 |----|------|----------------|---------------------|
-| **locale-stable 标识** | `id`、`class`、`data-testid`、`data-*`、`role` | 不变（开发者内部 ID） | ✅ 首选 |
+| **locale-stable 标识** | `data-testid`、`data-*`、稳定 `id` / `class` | 通常不变（开发者内部 ID） | ✅ 首选，但要先确认不是 hash / A-B test |
+| **semantic / scope anchor** | `role`、结构关系、邻近稳定容器 | 不按 locale 翻译，但常常不唯一 | ⚠️ 只作 scope/filter；不要单独用 `button[role="button"]` |
 | **locale-dependent 文本** | `aria-label`、`title`、`placeholder`、`alt`、`textContent` | 变（被 i18n 框架翻译） | ❌ 仅当 stable 选择器全都不存在时的兜底 |
 
-ChatGPT 的 web 端就是反例驱动的——它 *只* 暴露 `aria-label`，没给稳定 class / data-testid。这种站只能多语言 fallback list：
+ChatGPT 的 web 端就是反例驱动的：有些 controls 暴露稳定 `data-testid`，有些 surfaces 只暴露 `aria-label` / `placeholder`。这种站必须先用 stable selector，再用多语言 fallback list：
 
 ```javascript
-// clis/chatgpt/utils.js（活例）
+// clis/chatgpt/utils.js（简化活例）
 const COMPOSER_SELECTORS = [
+  '#prompt-textarea',
+  '[data-testid="composer"] [contenteditable="true"]',
   '[aria-label="Chat with ChatGPT"]',   // en
   '[aria-label="与 ChatGPT 聊天"]',      // zh-CN
   '[placeholder="Ask anything"]',
   '[placeholder="有问题，尽管问"]',       // zh-CN
-  '#prompt-textarea',                    // stable fallback（如果有就放最前）
 ];
-const SEND_BUTTON_LABELS = ['Send prompt', 'Send message', 'Send', '发送提示'];
+const SEND_BUTTON_SELECTORS = [
+  'button[data-testid="send-button"]:not([disabled])',
+  'button[aria-label="Send prompt"]:not([disabled])',
+  'button[aria-label="发送提示"]:not([disabled])',
+];
 ```
 
 写 fallback list 的纪律：
 
 1. **stable selector 放最前**（`#prompt-textarea` / `[data-testid="send-button"]`），locale-dependent 的放后面当兜底
-2. **每种 locale 至少列一条**（en + zh-CN 是底线；扩到 ja / ko / ar 看站点用户分布）
-3. **commit 前 grep `aria-label=` 看是不是漏了哪种 locale**——见 success-rate-pitfalls.md §11
-4. **不要给 framework 加 `--i18n "zh:提交,ja:送信"` 这种 flag** —— 等于把 fallback list 从 adapter 挪到 CLI，多一层 indirection 还要维护翻译字典。这是 over-engineering，已经在评审时被否
+2. **`role` 只能当 semantic / scope filter**：`dialog [role="textbox"]` 可以；裸 `button` / `[role="button"]` 不够，因为同页可能有多个按钮
+3. **每种 locale 至少列一条**（en + zh-CN 是底线；扩到 ja / ko / ar 看站点用户分布）
+4. **commit 前 grep `aria-label=` / `placeholder=` / `title=` 看是不是漏了 fallback locale**——见 success-rate-pitfalls.md §11
+5. **失败要 typed fail-fast**：找不到 control 应该 `CommandExecutionError` / send-failed，不要返回空 rows 或假成功
+6. **不要给 framework 加 `--i18n "zh:提交,ja:送信"` 这种 flag** —— 等于把 fallback list 从 adapter 挪到 CLI，多一层 indirection 还要维护翻译字典。这是 over-engineering，已经在评审时被否
 
 为什么不在 daemon 端固定 Chrome locale？因为 opencli **不启动 Chrome**——daemon 是连用户已经在跑的 Chrome（CDP via extension），用户可能就是中文 UI / 中文资料检索需求。强制 en-US 会破坏用户的正当工作流。
 

--- a/skills/opencli-adapter-author/references/adapter-template.md
+++ b/skills/opencli-adapter-author/references/adapter-template.md
@@ -274,6 +274,40 @@ const data = await page.fetchJson(`${BASE}/api/list`, {
 
 **规则**：JSON 型浏览器接口用 `page.fetchJson()`；HTML 型 COOKIE adapter 一律 Node 侧 `fetch`，浏览器只当 cookie jar 用。
 
+### Selector 稳定性 — 不要 select 用户可见文本
+
+issue #1474 触发：同一个发送按钮在英文 Chrome 是 `aria-label="Submit"`，在中文 Chrome（`chrome://settings/languages` 设中文）变 `aria-label="提交"`，CSS 选择器 `button[aria-label="Submit"]` 在中文环境下直接 0 匹配，silent empty result。
+
+根因不是 i18n bug，是**选择器的 anchor 选错了**。把页面 DOM 属性按 "locale-stable vs locale-dependent" 分两类：
+
+| 类 | 例子 | locale 切换会变吗 | 用作 primary selector？ |
+|----|------|----------------|---------------------|
+| **locale-stable 标识** | `id`、`class`、`data-testid`、`data-*`、`role` | 不变（开发者内部 ID） | ✅ 首选 |
+| **locale-dependent 文本** | `aria-label`、`title`、`placeholder`、`alt`、`textContent` | 变（被 i18n 框架翻译） | ❌ 仅当 stable 选择器全都不存在时的兜底 |
+
+ChatGPT 的 web 端就是反例驱动的——它 *只* 暴露 `aria-label`，没给稳定 class / data-testid。这种站只能多语言 fallback list：
+
+```javascript
+// clis/chatgpt/utils.js（活例）
+const COMPOSER_SELECTORS = [
+  '[aria-label="Chat with ChatGPT"]',   // en
+  '[aria-label="与 ChatGPT 聊天"]',      // zh-CN
+  '[placeholder="Ask anything"]',
+  '[placeholder="有问题，尽管问"]',       // zh-CN
+  '#prompt-textarea',                    // stable fallback（如果有就放最前）
+];
+const SEND_BUTTON_LABELS = ['Send prompt', 'Send message', 'Send', '发送提示'];
+```
+
+写 fallback list 的纪律：
+
+1. **stable selector 放最前**（`#prompt-textarea` / `[data-testid="send-button"]`），locale-dependent 的放后面当兜底
+2. **每种 locale 至少列一条**（en + zh-CN 是底线；扩到 ja / ko / ar 看站点用户分布）
+3. **commit 前 grep `aria-label=` 看是不是漏了哪种 locale**——见 success-rate-pitfalls.md §11
+4. **不要给 framework 加 `--i18n "zh:提交,ja:送信"` 这种 flag** —— 等于把 fallback list 从 adapter 挪到 CLI，多一层 indirection 还要维护翻译字典。这是 over-engineering，已经在评审时被否
+
+为什么不在 daemon 端固定 Chrome locale？因为 opencli **不启动 Chrome**——daemon 是连用户已经在跑的 Chrome（CDP via extension），用户可能就是中文 UI / 中文资料检索需求。强制 en-US 会破坏用户的正当工作流。
+
 ### Cookie 域的双查
 
 ```javascript

--- a/skills/opencli-adapter-author/references/success-rate-pitfalls.md
+++ b/skills/opencli-adapter-author/references/success-rate-pitfalls.md
@@ -1,6 +1,6 @@
 # Success-Rate Pitfalls
 
-10 个**静默失败**（adapter 看起来能跑、verify 能过，但数据是错的）的坑。每条给：现象 → 根因 → 防御手段。
+11 个**静默失败**（adapter 看起来能跑、verify 能过，但数据是错的）的坑。每条给：现象 → 根因 → 防御手段。
 
 不是风格建议。每条都对应过一次真实翻车。
 
@@ -142,9 +142,11 @@
 **根因**：`aria-label` / `title` / `placeholder` / `alt` / `textContent` 都是页面的**用户可见文本**，被站点 i18n 框架翻译。用它们当 selector anchor 等于 "select by visible text"，locale 一动整个选择器就废。
 
 **防御**：
-- 优先用 locale-stable 标识：`id` / `class` / `data-testid` / `data-*` / `role`（开发者内部 ID，不被翻译）
-- 站点只暴露 `aria-label`（典型如 ChatGPT web）时，写 fallback list，至少 en + zh-CN：`'[aria-label="Send"], [aria-label="发送"]'`
-- commit 前 grep `aria-label=` / `placeholder=` 的硬编码字符串，确认每条都有兜底 locale
+- 优先用 locale-stable 标识：`data-testid` / `data-*` / 稳定 `id` / `class`。先确认不是 hash / A-B test 产物
+- `role` 不按 locale 翻译，但通常不唯一；只能当 semantic / scope filter，不能用裸 `[role="button"]` 当 primary
+- 站点只暴露 `aria-label`（典型如 ChatGPT web 某些 control）时，写 fallback list，至少 en + zh-CN：`'[aria-label="Send"], [aria-label="发送"]'`
+- commit 前 grep `aria-label=` / `placeholder=` / `title=` 的硬编码字符串，确认每条都有兜底 locale
+- 找不到 control 要 typed fail-fast（例如 `CommandExecutionError` / send-failed），不要把 selector miss 变成空 rows 或假成功
 - 详细 framework + 活例见 `adapter-template.md §Selector 稳定性`
 
 不要去给 framework 加 `--i18n` flag 自动展开——多一层 indirection 还要维护翻译字典，纯 over-engineering。

--- a/skills/opencli-adapter-author/references/success-rate-pitfalls.md
+++ b/skills/opencli-adapter-author/references/success-rate-pitfalls.md
@@ -135,10 +135,26 @@
 
 ---
 
+## 11. `aria-label` / `placeholder` / `title` 是 locale-dependent 文本
+
+**现象**：你本地英文 Chrome 测 `button[aria-label="Submit"]` 一切正常，verify fixture 也是英文环境抓的。用户把 `chrome://settings/languages` 切中文，同一个按钮变 `aria-label="提交"`，adapter silent 0 匹配——退化成 `notEmpty` / `types` 都没法 fire 的"adapter 跑完返 0 行"。
+
+**根因**：`aria-label` / `title` / `placeholder` / `alt` / `textContent` 都是页面的**用户可见文本**，被站点 i18n 框架翻译。用它们当 selector anchor 等于 "select by visible text"，locale 一动整个选择器就废。
+
+**防御**：
+- 优先用 locale-stable 标识：`id` / `class` / `data-testid` / `data-*` / `role`（开发者内部 ID，不被翻译）
+- 站点只暴露 `aria-label`（典型如 ChatGPT web）时，写 fallback list，至少 en + zh-CN：`'[aria-label="Send"], [aria-label="发送"]'`
+- commit 前 grep `aria-label=` / `placeholder=` 的硬编码字符串，确认每条都有兜底 locale
+- 详细 framework + 活例见 `adapter-template.md §Selector 稳定性`
+
+不要去给 framework 加 `--i18n` flag 自动展开——多一层 indirection 还要维护翻译字典，纯 over-engineering。
+
+---
+
 ## 总结：静默失败的共同特征
 
 1. **verify 绿 ≠ 数据对**。verify 只能证"结构没坏"，证不出"值对不对"。Step 11 肉眼比对是必须的。
 2. **"字段有值"是个比"字段为空"更危险的失败态**。空你会去查，有值你会 fallthrough。
 3. **fixture 四件套一起上**：`patterns` + `notEmpty` + `mustNotContain` + `mustBeTruthy`——每件挡一类问题，缺一个就漏。
 
-回写 `notes.md` 时把你踩的新坑写进去。下次就有第 11 条了。
+回写 `notes.md` 时把你踩的新坑写进去。下次就有第 12 条了。


### PR DESCRIPTION
## Summary

Closes #1474. The reporter hit a silent zero-match selector when their Chrome UI was set to Chinese: `button[aria-label="Submit"]` doesn't match `<button aria-label="提交">`.

## First-principles take

This isn't really an i18n bug — it's an instance of a broader anti-pattern: **selecting on user-facing text is fragile by definition**, because the page's i18n framework translates that text. The fix is to teach adapter authors to anchor selectors on developer-internal identifiers (`id` / `class` / `data-testid` / `data-*` / `role`), and only fall back to `aria-label` / `placeholder` / `title` when the site (looking at you, ChatGPT web) genuinely exposes nothing else.

The three options the issue proposed:

1. **Doc note in adapter-template** ✅ — done. New "Selector 稳定性" section with locale-stable vs locale-dependent attribute taxonomy, the activie `clis/chatgpt/utils.js` fallback-list as the escape-hatch pattern, and an explicit "don't add `--i18n` flag" note so the next agent doesn't re-propose this.
2. **i18n section in SKILL doc** ✅ — done via new pitfall #11 in `success-rate-pitfalls.md` (linked from the SKILL.md reference table) so it surfaces during Step 7 / Step 11 of the runbook.
3. **`find --role button --name "Submit" --i18n "zh:提交,ja:送信"` flag** ❌ — explicitly **not** done. It's the same data flow as a fallback list (cartesian-product of selectors) but with an extra indirection and a centralized translation dictionary to maintain forever. Same risk profile as the #1297 listing-id-pairing CI gate we walked back: "let's build a thing" trap.

Also considered + rejected: **locking Chrome's locale at launch**. OpenCLI doesn't launch Chrome — `src/daemon.ts` + `src/browser/daemon-lifecycle.ts` proxy CDP into the user's already-running browser. Forcing `--lang=en-US` would (a) require changing the launch path we don't own, and (b) break users who intentionally run Chinese Chrome for their day job.

## What this PR adds

- `skills/opencli-adapter-author/references/adapter-template.md` — new "Selector 稳定性" section with the 2-class taxonomy, the chatgpt fallback-list activie example, the 4-point fallback-list discipline, and the explicit non-goals (no `--i18n` flag, no locale lock)
- `skills/opencli-adapter-author/references/success-rate-pitfalls.md` — new pitfall #11 for the agent runbook
- `skills/opencli-adapter-author/SKILL.md` — reference table now says "11 种" instead of "10 种" and tags the aria-label coverage

## Test plan

- [x] Doc-only change — no test impact
- [x] Both existing `aria-label`-using adapters in `clis/` (chatgpt, claude, grok, gemini, instagram, facebook) already follow the recommended pattern, so the doc reflects activie practice rather than introducing aspirational rules

## Out of scope

Refactoring the existing aria-label users in `clis/` is left to future Boy-Scout passes — they already work; the doc is the leverage point for the next 100 adapters.