### PR TITLE
feat(ctrip): add hotel-search + flight browser-mode commands (#1481)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5844,6 +5844,122 @@
   },
   {
     "site": "ctrip",
+    "name": "flight",
+    "description": "搜索携程一程机票（按出发/到达 IATA 三字码 + 日期）",
+    "access": "read",
+    "domain": "flights.ctrip.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "from",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Departure IATA code (e.g. BJS / PEK)"
+      },
+      {
+        "name": "to",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Arrival IATA code (e.g. SHA / PVG)"
+      },
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "help": "Departure date (YYYY-MM-DD)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of flights (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "airline",
+      "flightNo",
+      "aircraft",
+      "departureTime",
+      "departureAirport",
+      "arrivalTime",
+      "arrivalAirport",
+      "terminal",
+      "price",
+      "currency",
+      "cabin",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "ctrip/flight.js",
+    "sourceFile": "ctrip/flight.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "ctrip",
+    "name": "hotel-search",
+    "description": "搜索携程酒店列表（按城市 + 入住/离店日期）",
+    "access": "read",
+    "domain": "hotels.ctrip.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "city",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Numeric Ctrip city ID (use `ctrip search` or `ctrip hotel-suggest` to discover)"
+      },
+      {
+        "name": "checkin",
+        "type": "str",
+        "required": true,
+        "help": "Check-in date (YYYY-MM-DD)"
+      },
+      {
+        "name": "checkout",
+        "type": "str",
+        "required": true,
+        "help": "Check-out date (YYYY-MM-DD)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of hotels (1-30); SSR first page returns ~13 entries"
+      }
+    ],
+    "columns": [
+      "rank",
+      "hotelId",
+      "name",
+      "enName",
+      "star",
+      "score",
+      "scoreLabel",
+      "reviewCount",
+      "cityName",
+      "district",
+      "address",
+      "lat",
+      "lon",
+      "price",
+      "currency",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "ctrip/hotel-search.js",
+    "sourceFile": "ctrip/hotel-search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "ctrip",
     "name": "hotel-suggest",
     "description": "搜索携程酒店上下文联想：城市、商圈、单酒店匹配",
     "access": "read",

--- a/clis/ctrip/ctrip.test.js
+++ b/clis/ctrip/ctrip.test.js
@@ -5,6 +5,7 @@ import './search.js';
 import './hotel-suggest.js';
 import './hotel-search.js';
 import './flight.js';
+import { __test__ as hotelSearchTest } from './hotel-search.js';
 import {
     buildFlightExtractJs,
     buildScrollUntilJs,
@@ -452,6 +453,18 @@ describe('ctrip hotel-search command (registry-level)', () => {
             .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
     });
 
+    it('waits for an empty SSR hotelList so empty results do not become timeout failures', async () => {
+        const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+            url: 'https://hotels.ctrip.com/hotels/list?city=9999',
+            runScripts: 'outside-only',
+        });
+        dom.window.__NEXT_DATA__ = {
+            props: { pageProps: { initListData: { hotelList: [] } } },
+        };
+        await expect(dom.window.Function(`return (${hotelSearchTest.WAIT_FOR_SSR_JS})`)())
+            .resolves.toBe('content');
+    });
+
     it('throws CommandExecutionError when SSR state times out or is malformed', async () => {
         await expect(cmd.func(createPageMock(['timeout']), { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
             .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('did not expose SSR hotel list') });
@@ -543,6 +556,15 @@ describe('ctrip flight command (registry-level)', () => {
         const page = createPageMock(['content', 0, []]);
         await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
             .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+
+    it('throws CommandExecutionError when visible cards render but parser finds no flight anchors', async () => {
+        const page = createPageMock(['content', 2, []]);
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('parser did not find required flight anchors'),
+            });
     });
 
     it('throws CommandExecutionError when flight render waits timeout or extraction is malformed', async () => {

--- a/clis/ctrip/ctrip.test.js
+++ b/clis/ctrip/ctrip.test.js
@@ -452,6 +452,13 @@ describe('ctrip hotel-search command (registry-level)', () => {
             .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
     });
 
+    it('throws CommandExecutionError when SSR state times out or is malformed', async () => {
+        await expect(cmd.func(createPageMock(['timeout']), { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('did not expose SSR hotel list') });
+        await expect(cmd.func(createPageMock(['content', { hotelList: [] }]), { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed SSR hotel list') });
+    });
+
     it('maps SSR rows and respects --limit', async () => {
         const page = createPageMock([
             'content',
@@ -477,6 +484,13 @@ describe('ctrip hotel-search command (registry-level)', () => {
         const rows = await cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 });
         expect(rows).toHaveLength(1);
         expect(rows[0].hotelId).toBe('106876528');
+    });
+
+    it('throws CommandExecutionError when all SSR rows miss required anchors', async () => {
+        const incomplete = { hotelInfo: { summary: {}, nameInfo: { name: 'No-id' } }, roomInfo: [] };
+        const page = createPageMock(['content', [incomplete]]);
+        await expect(cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('required hotelId/name anchors') });
     });
 });
 
@@ -531,6 +545,13 @@ describe('ctrip flight command (registry-level)', () => {
             .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
     });
 
+    it('throws CommandExecutionError when flight render waits timeout or extraction is malformed', async () => {
+        await expect(cmd.func(createPageMock(['timeout']), { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('did not render flight cards') });
+        await expect(cmd.func(createPageMock(['content', 1, { rows: [] }]), { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed rows') });
+    });
+
     it('builds URL with lowercase IATA codes and Y_S_C_F cabin', async () => {
         const page = createPageMock(['content', 1, [FLIGHT_RAW]]);
         await cmd.func(page, { from: 'pek', to: 'sha', date: '2026-06-15', limit: 1 });
@@ -570,6 +591,12 @@ describe('ctrip flight command (registry-level)', () => {
         expect(rows).toHaveLength(1);
         expect(rows[0].departureTime).toBe('07:50');
     });
+
+    it('throws CommandExecutionError when every flight row misses core anchors', async () => {
+        const page = createPageMock(['content', 2, [{ ...FLIGHT_RAW, departureAirport: '' }, { ...FLIGHT_RAW, flightNo: null }]]);
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('required airline/flight/time/airport anchors') });
+    });
 });
 
 describe('ctrip buildScrollUntilJs', () => {
@@ -579,11 +606,19 @@ describe('ctrip buildScrollUntilJs', () => {
         expect(js).toContain('countItems() >= 20');
         expect(js).toContain('i < 8');
         expect(js).toContain('plateauRounds');
+        expect(js).toContain('getBoundingClientRect');
+        expect(js).toContain('getComputedStyle');
     });
     it('respects a custom maxScrolls override', () => {
         const js = buildScrollUntilJs('.hotel-card', 50, 3);
         expect(js).toContain('countItems() >= 50');
         expect(js).toContain('i < 3');
+    });
+    it('rejects unsafe target / maxScrolls values before interpolation', () => {
+        expect(() => buildScrollUntilJs('.hotel-card', 0)).toThrow('targetCount');
+        expect(() => buildScrollUntilJs('.hotel-card', 101)).toThrow('targetCount');
+        expect(() => buildScrollUntilJs('.hotel-card', 10, 0)).toThrow('maxScrolls');
+        expect(() => buildScrollUntilJs('.hotel-card', 10, 31)).toThrow('maxScrolls');
     });
 });
 
@@ -645,5 +680,18 @@ describe('ctrip buildFlightExtractJs (JSDOM)', () => {
     it('returns empty array when there are no flight cards (not a sentinel row)', () => {
         const rows = runExtract('<div class="flight-list"></div>');
         expect(rows).toEqual([]);
+    });
+
+    it('does not fabricate rows from non-flight cards with two times', () => {
+        const html = `
+          <div class="flight-list"><span>
+            <div>
+              <span>筛选</span><span>价格排序</span><span>推荐</span>
+              <span>08:00</span><span>出发</span><span>10:00</span><span>到达</span>
+              <span>¥</span><span>520</span><span>经济舱</span>
+            </div>
+          </span></div>
+        `;
+        expect(runExtract(html)).toEqual([]);
     });
 });

--- a/clis/ctrip/ctrip.test.js
+++ b/clis/ctrip/ctrip.test.js
@@ -1,8 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './search.js';
 import './hotel-suggest.js';
-import { buildUrl, mapSuggestRow, parseLimit, pickCoords } from './utils.js';
+import './hotel-search.js';
+import './flight.js';
+import {
+    buildFlightExtractJs,
+    buildScrollUntilJs,
+    buildUrl,
+    mapHotelRow,
+    mapSuggestRow,
+    parseCityId,
+    parseIataCode,
+    parseIsoDate,
+    parseLimit,
+    pickCoords,
+    pickHotelMapCoords,
+} from './utils.js';
+
+function createPageMock(evaluateResults) {
+    const evaluate = vi.fn();
+    for (const result of evaluateResults) {
+        evaluate.mockResolvedValueOnce(result);
+    }
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate,
+        wait: vi.fn().mockResolvedValue(undefined),
+        scroll: vi.fn().mockResolvedValue(undefined),
+        autoScroll: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue([]),
+    };
+}
 
 function ok(payload) {
     return new Response(JSON.stringify(payload), { status: 200 });
@@ -230,5 +260,390 @@ describe('ctrip hotel-suggest command (registry-level)', () => {
             Result: true, ErrorCode: 0, Response: { searchResults: [] },
         }))));
         await expect(cmd.func({ query: 'zzz', limit: 5 })).rejects.toThrow('ctrip hotel-suggest returned no data');
+    });
+});
+
+describe('ctrip parseIsoDate', () => {
+    it('accepts well-formed dates', () => {
+        expect(parseIsoDate('checkin', '2026-06-15')).toBe('2026-06-15');
+        expect(parseIsoDate('date', '2030-12-31')).toBe('2030-12-31');
+    });
+    it('rejects missing/blank with required-arg message', () => {
+        expect(() => parseIsoDate('checkin', '')).toThrow(/--checkin is required/);
+        expect(() => parseIsoDate('date', undefined)).toThrow(/--date is required/);
+    });
+    it('rejects malformed strings', () => {
+        expect(() => parseIsoDate('checkin', '2026/06/15')).toThrow(/must be YYYY-MM-DD/);
+        expect(() => parseIsoDate('checkin', 'tomorrow')).toThrow(/must be YYYY-MM-DD/);
+    });
+    it('rejects out-of-range month/day before Date math', () => {
+        expect(() => parseIsoDate('checkin', '2026-13-01')).toThrow(/invalid month\/day/);
+        expect(() => parseIsoDate('checkin', '2026-06-32')).toThrow(/invalid month\/day/);
+    });
+    it('rejects impossible calendar dates (Feb 30) via UTC cross-check', () => {
+        expect(() => parseIsoDate('checkin', '2026-02-30')).toThrow(/not a real calendar date/);
+        expect(() => parseIsoDate('checkin', '2025-02-29')).toThrow(/not a real calendar date/); // 2025 not leap
+    });
+});
+
+describe('ctrip parseIataCode', () => {
+    it('uppercases and accepts 3-letter codes', () => {
+        expect(parseIataCode('from', 'pek')).toBe('PEK');
+        expect(parseIataCode('from', 'BJS')).toBe('BJS');
+        expect(parseIataCode('to', '  sha  ')).toBe('SHA');
+    });
+    it('rejects non-3-letter / mixed inputs', () => {
+        expect(() => parseIataCode('from', 'PE')).toThrow(/3-letter IATA/);
+        expect(() => parseIataCode('from', 'PEKK')).toThrow(/3-letter IATA/);
+        expect(() => parseIataCode('from', '123')).toThrow(/3-letter IATA/);
+        expect(() => parseIataCode('from', '')).toThrow(/required/);
+    });
+});
+
+describe('ctrip parseCityId', () => {
+    it('accepts positive integer city IDs (numeric and string)', () => {
+        expect(parseCityId(2)).toBe(2);
+        expect(parseCityId('1')).toBe(1);
+        expect(parseCityId('12345')).toBe(12345);
+    });
+    it('rejects zero / negative / non-integer / empty', () => {
+        expect(() => parseCityId(0)).toThrow(/positive integer/);
+        expect(() => parseCityId(-1)).toThrow(/positive integer/);
+        expect(() => parseCityId(2.5)).toThrow(/positive integer/);
+        expect(() => parseCityId('shanghai')).toThrow(/positive integer/);
+        expect(() => parseCityId('')).toThrow(/--city is required/);
+    });
+});
+
+describe('ctrip pickHotelMapCoords', () => {
+    it('prefers WGS84 (coordinateType=1) when multiple available', () => {
+        const coords = [
+            { coordinateType: 3, latitude: '31.25', longitude: '121.51' },
+            { coordinateType: 1, latitude: '31.23', longitude: '121.47' },
+            { coordinateType: 2, latitude: '31.24', longitude: '121.49' },
+        ];
+        expect(pickHotelMapCoords(coords)).toEqual({ lat: 31.23, lon: 121.47 });
+    });
+    it('falls through to GCJ02 then BD09 if WGS84 missing', () => {
+        const onlyBD09 = [{ coordinateType: 3, latitude: '31.25', longitude: '121.51' }];
+        expect(pickHotelMapCoords(onlyBD09)).toEqual({ lat: 31.25, lon: 121.51 });
+    });
+    it('returns null/null on empty / non-array / all-zero coords', () => {
+        expect(pickHotelMapCoords([])).toEqual({ lat: null, lon: null });
+        expect(pickHotelMapCoords(null)).toEqual({ lat: null, lon: null });
+        expect(pickHotelMapCoords([{ coordinateType: 1, latitude: '0', longitude: '0' }])).toEqual({ lat: null, lon: null });
+    });
+});
+
+describe('ctrip mapHotelRow', () => {
+    const HOTEL_FIXTURE = {
+        hotelInfo: {
+            summary: { hotelId: '106876528' },
+            nameInfo: { name: '上海外滩滨江珍宝酒店', enName: 'Shanghai Bund Riverside Treasury Hotel' },
+            hotelStar: { star: 4 },
+            commentInfo: { commentScore: '4.7', commentDescription: '超棒', commenterNumber: '13,966条点评' },
+            positionInfo: {
+                cityName: '上海',
+                positionDesc: '北外滩地区 · 近北外滩来福士',
+                address: '东大名路988号',
+                mapCoordinate: [{ coordinateType: 3, latitude: '31.25693033446487', longitude: '121.51336547497098' }],
+            },
+        },
+        roomInfo: [{ priceInfo: { price: 548, currency: 'RMB', displayPrice: '¥548' } }],
+    };
+
+    it('projects every declared column key (no silent drop)', () => {
+        const row = mapHotelRow(HOTEL_FIXTURE, 0);
+        expect(row).toEqual({
+            rank: 1,
+            hotelId: '106876528',
+            name: '上海外滩滨江珍宝酒店',
+            enName: 'Shanghai Bund Riverside Treasury Hotel',
+            star: 4,
+            score: 4.7,
+            scoreLabel: '超棒',
+            reviewCount: 13966,
+            cityName: '上海',
+            district: '北外滩地区 · 近北外滩来福士',
+            address: '东大名路988号',
+            lat: 31.25693033446487,
+            lon: 121.51336547497098,
+            price: 548,
+            currency: 'RMB',
+            url: 'https://hotels.ctrip.com/hotels/detail/?hotelid=106876528',
+        });
+    });
+
+    it('returns null (not 0 / "") for missing optional fields', () => {
+        const sparse = { hotelInfo: { summary: { hotelId: '999' }, nameInfo: { name: 'X' } }, roomInfo: [] };
+        const row = mapHotelRow(sparse, 4);
+        expect(row.rank).toBe(5);
+        expect(row.star).toBeNull();
+        expect(row.score).toBeNull();
+        expect(row.reviewCount).toBeNull();
+        expect(row.price).toBeNull();
+        expect(row.currency).toBeNull();
+        expect(row.lat).toBeNull();
+        expect(row.lon).toBeNull();
+        expect(row.address).toBeNull();
+    });
+
+    it('parses reviewCount from "13,966条点评" / "999 reviews" by stripping non-digits', () => {
+        const a = mapHotelRow({ hotelInfo: { summary: { hotelId: '1' }, nameInfo: { name: 'A' }, commentInfo: { commenterNumber: '13,966条点评' } }, roomInfo: [] }, 0);
+        expect(a.reviewCount).toBe(13966);
+        const b = mapHotelRow({ hotelInfo: { summary: { hotelId: '2' }, nameInfo: { name: 'B' }, commentInfo: { commenterNumber: '999 reviews' } }, roomInfo: [] }, 0);
+        expect(b.reviewCount).toBe(999);
+    });
+});
+
+describe('ctrip hotel-search command (registry-level)', () => {
+    const cmd = getRegistry().get('ctrip/hotel-search');
+
+    const SHANGHAI_HOTEL = {
+        hotelInfo: {
+            summary: { hotelId: '106876528' },
+            nameInfo: { name: '上海外滩滨江珍宝酒店' },
+            hotelStar: { star: 4 },
+            commentInfo: { commentScore: '4.7', commentDescription: '超棒', commenterNumber: '13,966条点评' },
+            positionInfo: { cityName: '上海', address: '东大名路988号', mapCoordinate: [{ coordinateType: 1, latitude: '31.25', longitude: '121.51' }] },
+        },
+        roomInfo: [{ priceInfo: { price: 548, currency: 'RMB' } }],
+    };
+
+    it('declares Strategy.COOKIE + browser:true + navigateBefore:false + access:read', () => {
+        expect(cmd.access).toBe('read');
+        expect(cmd.browser).toBe(true);
+        expect(String(cmd.strategy)).toContain('cookie');
+        expect(cmd.navigateBefore).toBe(false);
+        expect(cmd.domain).toBe('hotels.ctrip.com');
+    });
+
+    it('rejects invalid city / date / limit before browser navigation', async () => {
+        const page = createPageMock([]);
+        await expect(cmd.func(page, { city: 'shanghai', checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--city') });
+        await expect(cmd.func(page, { city: 2, checkin: 'tomorrow', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--checkin') });
+        await expect(cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 0 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--limit') });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('rejects checkin >= checkout before navigation', async () => {
+        const page = createPageMock([]);
+        await expect(cmd.func(page, { city: 2, checkin: '2026-06-17', checkout: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--checkin must be earlier') });
+        await expect(cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--checkin must be earlier') });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthRequired when captcha gate is detected', async () => {
+        const page = createPageMock(['captcha']);
+        await expect(cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toThrow('Ctrip is asking for a captcha');
+        // No extract call when captcha caught early
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws EmptyResultError when SSR hotelList is empty', async () => {
+        const page = createPageMock(['content', []]);
+        await expect(cmd.func(page, { city: 9999, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+
+    it('maps SSR rows and respects --limit', async () => {
+        const page = createPageMock([
+            'content',
+            [SHANGHAI_HOTEL, { ...SHANGHAI_HOTEL, hotelInfo: { ...SHANGHAI_HOTEL.hotelInfo, summary: { hotelId: '2' } } }],
+        ]);
+        const rows = await cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 1 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ rank: 1, hotelId: '106876528', name: '上海外滩滨江珍宝酒店', star: 4, price: 548 });
+        // Every declared column appears on every row
+        for (const row of rows) {
+            for (const col of cmd.columns) expect(row).toHaveProperty(col);
+        }
+        // Single goto, single URL
+        expect(page.goto).toHaveBeenCalledTimes(1);
+        expect(page.goto.mock.calls[0][0]).toContain('city=2');
+        expect(page.goto.mock.calls[0][0]).toContain('checkin=2026-06-15');
+        expect(page.goto.mock.calls[0][0]).toContain('checkout=2026-06-17');
+    });
+
+    it('filters out SSR rows missing hotelId or name (no silent partial rows)', async () => {
+        const incomplete = { hotelInfo: { summary: {}, nameInfo: { name: 'No-id' } }, roomInfo: [] };
+        const page = createPageMock(['content', [incomplete, SHANGHAI_HOTEL]]);
+        const rows = await cmd.func(page, { city: 2, checkin: '2026-06-15', checkout: '2026-06-17', limit: 5 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].hotelId).toBe('106876528');
+    });
+});
+
+describe('ctrip flight command (registry-level)', () => {
+    const cmd = getRegistry().get('ctrip/flight');
+
+    const FLIGHT_RAW = {
+        airline: '厦门航空',
+        flightNo: 'MF8561',
+        aircraft: '空客321(中)',
+        departureTime: '07:50',
+        departureAirport: '大兴国际机场',
+        arrivalTime: '09:45',
+        arrivalAirport: '浦东国际机场',
+        terminal: 'T2',
+        price: 487,
+        currency: '¥',
+        cabin: '经济舱',
+    };
+
+    it('declares Strategy.COOKIE + browser:true + navigateBefore:false + access:read', () => {
+        expect(cmd.access).toBe('read');
+        expect(cmd.browser).toBe(true);
+        expect(String(cmd.strategy)).toContain('cookie');
+        expect(cmd.navigateBefore).toBe(false);
+        expect(cmd.domain).toBe('flights.ctrip.com');
+    });
+
+    it('rejects invalid IATA / date / from==to / limit before browser navigation', async () => {
+        const page = createPageMock([]);
+        await expect(cmd.func(page, { from: 'PE', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('IATA') });
+        await expect(cmd.func(page, { from: 'PEK', to: 'PEK', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('must differ') });
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '06/15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--date') });
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 0 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--limit') });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthRequired when captcha gate is detected', async () => {
+        const page = createPageMock(['captcha']);
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toThrow('Ctrip is asking for a captcha');
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws EmptyResultError when DOM extraction returns no flights', async () => {
+        const page = createPageMock(['content', 0, []]);
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+
+    it('builds URL with lowercase IATA codes and Y_S_C_F cabin', async () => {
+        const page = createPageMock(['content', 1, [FLIGHT_RAW]]);
+        await cmd.func(page, { from: 'pek', to: 'sha', date: '2026-06-15', limit: 1 });
+        const url = page.goto.mock.calls[0][0];
+        expect(url).toContain('oneway-pek-sha');
+        expect(url).toContain('depdate=2026-06-15');
+        expect(url).toContain('cabin=Y_S_C_F');
+        expect(url).toContain('adult=1');
+    });
+
+    it('maps DOM-extracted rows and respects --limit', async () => {
+        const page = createPageMock([
+            'content',
+            2,
+            [FLIGHT_RAW, { ...FLIGHT_RAW, flightNo: 'CA1234', airline: '国航' }],
+        ]);
+        const rows = await cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 1 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            airline: '厦门航空',
+            flightNo: 'MF8561',
+            departureTime: '07:50',
+            arrivalTime: '09:45',
+            price: 487,
+            currency: '¥',
+            cabin: '经济舱',
+        });
+        for (const row of rows) {
+            for (const col of cmd.columns) expect(row).toHaveProperty(col);
+        }
+    });
+
+    it('filters out flight rows missing core anchors (no silent partial rows)', async () => {
+        const page = createPageMock(['content', 2, [{ ...FLIGHT_RAW, departureTime: '' }, FLIGHT_RAW]]);
+        const rows = await cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].departureTime).toBe('07:50');
+    });
+});
+
+describe('ctrip buildScrollUntilJs', () => {
+    it('inlines the row selector + target count + default maxScrolls', () => {
+        const js = buildScrollUntilJs('.flight-list > span > div', 20);
+        expect(js).toContain('"\.flight-list > span > div"'.replace('\\.', '.')); // selector literal
+        expect(js).toContain('countItems() >= 20');
+        expect(js).toContain('i < 8');
+        expect(js).toContain('plateauRounds');
+    });
+    it('respects a custom maxScrolls override', () => {
+        const js = buildScrollUntilJs('.hotel-card', 50, 3);
+        expect(js).toContain('countItems() >= 50');
+        expect(js).toContain('i < 3');
+    });
+});
+
+describe('ctrip buildFlightExtractJs (JSDOM)', () => {
+    function runExtract(html) {
+        const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`,
+            { url: 'https://flights.ctrip.com/' });
+        const js = buildFlightExtractJs();
+        return Function('document', `return (${js})`)(dom.window.document);
+    }
+
+    it('extracts a single ordered card via position-anchored chunks', () => {
+        const html = `
+          <div class="flight-list"><span>
+            <div>
+              <span>厦门航空</span><span>MF8561</span><span>空客321(中)</span>
+              <span>当日低价</span>
+              <span>07:50</span><span>大兴国际机场</span>
+              <span>09:45</span><span>浦东国际机场</span><span>T2</span>
+              <span>已减¥3</span><span>惊喜低价</span>
+              <span>¥</span><span>487</span><span>起</span>
+              <span>经济舱</span><span>订票</span>
+            </div>
+          </span></div>
+        `;
+        const rows = runExtract(html);
+        expect(rows).toEqual([{
+            airline: '厦门航空',
+            flightNo: 'MF8561',
+            aircraft: '空客321(中)',
+            departureTime: '07:50',
+            departureAirport: '大兴国际机场',
+            arrivalTime: '09:45',
+            arrivalAirport: '浦东国际机场',
+            terminal: 'T2',
+            price: 487,
+            currency: '¥',
+            cabin: '经济舱',
+        }]);
+    });
+
+    it('omits terminal when not present after arrAirport', () => {
+        const html = `
+          <div class="flight-list"><span>
+            <div>
+              <span>国航</span><span>CA1234</span><span>波音737</span>
+              <span>08:00</span><span>首都国际机场</span>
+              <span>10:00</span><span>虹桥国际机场</span>
+              <span>¥</span><span>520</span><span>起</span><span>经济舱</span>
+            </div>
+          </span></div>
+        `;
+        const rows = runExtract(html);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].terminal).toBeNull();
+        expect(rows[0].arrivalAirport).toBe('虹桥国际机场');
+    });
+
+    it('returns empty array when there are no flight cards (not a sentinel row)', () => {
+        const rows = runExtract('<div class="flight-list"></div>');
+        expect(rows).toEqual([]);
     });
 });

--- a/clis/ctrip/flight.js
+++ b/clis/ctrip/flight.js
@@ -96,13 +96,16 @@ cli({
             throw new CommandExecutionError(`Ctrip flight page did not render flight cards (state=${String(waitResult)})`);
         }
         // Scroll until enough flight cards rendered (Ctrip lazy-loads beyond ~8).
-        await page.evaluate(buildScrollUntilJs('.flight-list > span > div', limit));
+        const renderedCardCount = await page.evaluate(buildScrollUntilJs('.flight-list > span > div', limit));
         const raw = await page.evaluate(buildFlightExtractJs());
         if (!Array.isArray(raw)) {
             throw new CommandExecutionError('Ctrip flight DOM extraction returned malformed rows');
         }
         const rows = raw;
         if (rows.length === 0) {
+            if (Number(renderedCardCount) > 0) {
+                throw new CommandExecutionError('Ctrip flight cards rendered but parser did not find required flight anchors');
+            }
             throw new EmptyResultError('ctrip flight', `No flights for ${fromCode}→${toCode} on ${date}`);
         }
         const completeRows = rows

--- a/clis/ctrip/flight.js
+++ b/clis/ctrip/flight.js
@@ -10,7 +10,7 @@
  * Round-trip + advanced filters (airline whitelist, cabin selection beyond
  * 全舱位) are out of scope for v1 — track in #1481 follow-up if requested.
  */
-import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { buildFlightExtractJs, buildScrollUntilJs, parseIataCode, parseIsoDate } from './utils.js';
 
@@ -92,15 +92,21 @@ cli({
         if (waitResult === 'captcha') {
             throw new AuthRequiredError('flights.ctrip.com', 'Ctrip is asking for a captcha; complete it in your browser session and retry');
         }
+        if (waitResult !== 'content') {
+            throw new CommandExecutionError(`Ctrip flight page did not render flight cards (state=${String(waitResult)})`);
+        }
         // Scroll until enough flight cards rendered (Ctrip lazy-loads beyond ~8).
         await page.evaluate(buildScrollUntilJs('.flight-list > span > div', limit));
         const raw = await page.evaluate(buildFlightExtractJs());
-        const rows = Array.isArray(raw) ? raw : [];
+        if (!Array.isArray(raw)) {
+            throw new CommandExecutionError('Ctrip flight DOM extraction returned malformed rows');
+        }
+        const rows = raw;
         if (rows.length === 0) {
             throw new EmptyResultError('ctrip flight', `No flights for ${fromCode}→${toCode} on ${date}`);
         }
-        return rows
-            .filter((r) => r.departureTime && r.arrivalTime && r.airline)
+        const completeRows = rows
+            .filter((r) => r.departureTime && r.departureAirport && r.arrivalTime && r.arrivalAirport && r.airline && r.flightNo)
             .slice(0, limit)
             .map((r, i) => ({
                 rank: i + 1,
@@ -117,6 +123,10 @@ cli({
                 cabin: r.cabin,
                 url: searchUrl,
             }));
+        if (completeRows.length === 0) {
+            throw new CommandExecutionError('Ctrip flight rows were missing required airline/flight/time/airport anchors');
+        }
+        return completeRows;
     },
 });
 

--- a/clis/ctrip/flight.js
+++ b/clis/ctrip/flight.js
@@ -1,0 +1,123 @@
+/**
+ * 携程机票 oneway search — domestic + international flight search by route + date.
+ *
+ * Unlike `hotel-search`, the flight rows are NOT in `__NEXT_DATA__` — they
+ * arrive via a post-load XHR that the daemon network buffer currently can't
+ * capture (see MEMORY `daemon_capture_pipeline_bug_2026_05_07`). We instead
+ * extract from the rendered `.flight-list > span > div` cards using a
+ * position-anchored innerText parser (see `buildFlightExtractJs` in utils).
+ *
+ * Round-trip + advanced filters (airline whitelist, cabin selection beyond
+ * 全舱位) are out of scope for v1 — track in #1481 follow-up if requested.
+ */
+import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildFlightExtractJs, buildScrollUntilJs, parseIataCode, parseIsoDate } from './utils.js';
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 20;
+
+function parseFlightLimit(raw) {
+    if (raw === undefined || raw === null || raw === '') return DEFAULT_LIMIT;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+        throw new ArgumentError(`--limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}, got ${JSON.stringify(raw)}`);
+    }
+    if (parsed < MIN_LIMIT || parsed > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be between ${MIN_LIMIT} and ${MAX_LIMIT}, got ${parsed}`);
+    }
+    return parsed;
+}
+
+/**
+ * Wait for `.flight-list > span > div` to render (the post-load XHR settles
+ * 1-3s after navigation), or detect a captcha/login redirect.
+ */
+const WAIT_FOR_FLIGHTS_JS = `
+  new Promise((resolve) => {
+    const detect = () => {
+      if (location.pathname.includes('captcha') || /验证码|verify the human/i.test(document.body?.innerText || '')) return 'captcha';
+      if (document.querySelector('.flight-list > span > div')) return 'content';
+      return null;
+    };
+    const found = detect();
+    if (found) return resolve(found);
+    const observer = new MutationObserver(() => {
+      const result = detect();
+      if (result) { observer.disconnect(); resolve(result); }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    setTimeout(() => { observer.disconnect(); resolve('timeout'); }, 8000);
+  })
+`;
+
+cli({
+    site: 'ctrip',
+    name: 'flight',
+    access: 'read',
+    description: '搜索携程一程机票（按出发/到达 IATA 三字码 + 日期）',
+    domain: 'flights.ctrip.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'from', required: true, positional: true, help: 'Departure IATA code (e.g. BJS / PEK)' },
+        { name: 'to', required: true, positional: true, help: 'Arrival IATA code (e.g. SHA / PVG)' },
+        { name: 'date', required: true, help: 'Departure date (YYYY-MM-DD)' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of flights (${MIN_LIMIT}-${MAX_LIMIT})` },
+    ],
+    columns: [
+        'rank',
+        'airline', 'flightNo', 'aircraft',
+        'departureTime', 'departureAirport',
+        'arrivalTime', 'arrivalAirport', 'terminal',
+        'price', 'currency', 'cabin',
+        'url',
+    ],
+    func: async (page, kwargs) => {
+        const fromCode = parseIataCode('from', kwargs.from);
+        const toCode = parseIataCode('to', kwargs.to);
+        if (fromCode === toCode) {
+            throw new ArgumentError(`--from and --to must differ (got ${fromCode})`);
+        }
+        const date = parseIsoDate('date', kwargs.date);
+        const limit = parseFlightLimit(kwargs.limit);
+
+        const searchUrl =
+            `https://flights.ctrip.com/online/list/oneway-${fromCode.toLowerCase()}-${toCode.toLowerCase()}` +
+            `?depdate=${date}&cabin=Y_S_C_F&adult=1&child=0&infant=0`;
+        await page.goto(searchUrl);
+        const waitResult = await page.evaluate(WAIT_FOR_FLIGHTS_JS);
+        if (waitResult === 'captcha') {
+            throw new AuthRequiredError('flights.ctrip.com', 'Ctrip is asking for a captcha; complete it in your browser session and retry');
+        }
+        // Scroll until enough flight cards rendered (Ctrip lazy-loads beyond ~8).
+        await page.evaluate(buildScrollUntilJs('.flight-list > span > div', limit));
+        const raw = await page.evaluate(buildFlightExtractJs());
+        const rows = Array.isArray(raw) ? raw : [];
+        if (rows.length === 0) {
+            throw new EmptyResultError('ctrip flight', `No flights for ${fromCode}→${toCode} on ${date}`);
+        }
+        return rows
+            .filter((r) => r.departureTime && r.arrivalTime && r.airline)
+            .slice(0, limit)
+            .map((r, i) => ({
+                rank: i + 1,
+                airline: r.airline,
+                flightNo: r.flightNo,
+                aircraft: r.aircraft,
+                departureTime: r.departureTime,
+                departureAirport: r.departureAirport,
+                arrivalTime: r.arrivalTime,
+                arrivalAirport: r.arrivalAirport,
+                terminal: r.terminal,
+                price: r.price,
+                currency: r.currency,
+                cabin: r.cabin,
+                url: searchUrl,
+            }));
+    },
+});
+
+export const __test__ = { parseFlightLimit, WAIT_FOR_FLIGHTS_JS };

--- a/clis/ctrip/hotel-search.js
+++ b/clis/ctrip/hotel-search.js
@@ -13,7 +13,7 @@
  *
  * Anti-bot: not detected on first-page navigation (PR #1481 recon 2026-05-12).
  */
-import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { mapHotelRow, parseCityId, parseIsoDate } from './utils.js';
 
@@ -108,14 +108,24 @@ cli({
         if (waitResult === 'captcha') {
             throw new AuthRequiredError('hotels.ctrip.com', 'Ctrip is asking for a captcha; complete it in your browser session and retry');
         }
+        if (waitResult !== 'content') {
+            throw new CommandExecutionError(`Ctrip hotel-search page did not expose SSR hotel list (state=${String(waitResult)})`);
+        }
         const raw = await page.evaluate(EXTRACT_HOTELS_JS);
-        if (!Array.isArray(raw) || raw.length === 0) {
+        if (!Array.isArray(raw)) {
+            throw new CommandExecutionError('Ctrip hotel-search returned malformed SSR hotel list');
+        }
+        if (raw.length === 0) {
             throw new EmptyResultError('ctrip hotel-search', `No hotels for city=${cityId} on ${checkin} → ${checkout}`);
         }
-        return raw
+        const rows = raw
             .map((entry, i) => mapHotelRow(entry, i))
             .filter((row) => row.hotelId && row.name)
             .slice(0, limit);
+        if (rows.length === 0) {
+            throw new CommandExecutionError('Ctrip hotel-search SSR rows were missing required hotelId/name anchors');
+        }
+        return rows;
     },
 });
 

--- a/clis/ctrip/hotel-search.js
+++ b/clis/ctrip/hotel-search.js
@@ -45,7 +45,7 @@ const WAIT_FOR_SSR_JS = `
     const detect = () => {
       if (location.pathname.includes('captcha') || /验证码|verify the human/i.test(document.body?.innerText || '')) return 'captcha';
       const hotels = window.__NEXT_DATA__?.props?.pageProps?.initListData?.hotelList;
-      if (Array.isArray(hotels) && hotels.length > 0) return 'content';
+      if (Array.isArray(hotels)) return 'content';
       return null;
     };
     const found = detect();

--- a/clis/ctrip/hotel-search.js
+++ b/clis/ctrip/hotel-search.js
@@ -1,0 +1,122 @@
+/**
+ * 携程酒店 list — search hotels by city + date range.
+ *
+ * Reads `window.__NEXT_DATA__.props.pageProps.initListData.hotelList` directly
+ * from the SSR-rendered hotel listing page. Ctrip serves first 13 hotels
+ * (10 organic + ~3 promoted) inline; `&pageSize=N` URL params are ignored
+ * server-side so we cap default limit accordingly (see
+ * `~/.opencli/sites/ctrip/notes.md`).
+ *
+ * Reuses the existing `mapHotelRow` + `pickHotelMapCoords` helpers from utils.js
+ * so the column shape stays consistent if future variants (hotel-detail) also
+ * project from the same `hotelInfo` shape.
+ *
+ * Anti-bot: not detected on first-page navigation (PR #1481 recon 2026-05-12).
+ */
+import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { mapHotelRow, parseCityId, parseIsoDate } from './utils.js';
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 30;
+const DEFAULT_LIMIT = 10;
+
+function parseHotelLimit(raw) {
+    if (raw === undefined || raw === null || raw === '') return DEFAULT_LIMIT;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+        throw new ArgumentError(`--limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}, got ${JSON.stringify(raw)}`);
+    }
+    if (parsed < MIN_LIMIT || parsed > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be between ${MIN_LIMIT} and ${MAX_LIMIT}, got ${parsed}`);
+    }
+    return parsed;
+}
+
+/**
+ * Wait for SSR state to be populated, or detect a login/captcha gate.
+ *
+ * Ctrip occasionally serves a captcha redirect (`/captcha`) when traffic
+ * looks bot-like; we catch that as AuthRequired so the agent can pop a
+ * human session instead of looping on an empty extract.
+ */
+const WAIT_FOR_SSR_JS = `
+  new Promise((resolve) => {
+    const detect = () => {
+      if (location.pathname.includes('captcha') || /验证码|verify the human/i.test(document.body?.innerText || '')) return 'captcha';
+      const hotels = window.__NEXT_DATA__?.props?.pageProps?.initListData?.hotelList;
+      if (Array.isArray(hotels) && hotels.length > 0) return 'content';
+      return null;
+    };
+    const found = detect();
+    if (found) return resolve(found);
+    const observer = new MutationObserver(() => {
+      const result = detect();
+      if (result) { observer.disconnect(); resolve(result); }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    setTimeout(() => { observer.disconnect(); resolve('timeout'); }, 5000);
+  })
+`;
+
+const EXTRACT_HOTELS_JS = `
+  (() => {
+    const list = window.__NEXT_DATA__?.props?.pageProps?.initListData?.hotelList;
+    if (!Array.isArray(list)) return null;
+    return list;
+  })()
+`;
+
+function assertCheckinBeforeCheckout(checkin, checkout) {
+    if (Date.parse(checkin + 'T00:00:00Z') >= Date.parse(checkout + 'T00:00:00Z')) {
+        throw new ArgumentError(`--checkin must be earlier than --checkout (got ${checkin} >= ${checkout})`);
+    }
+}
+
+cli({
+    site: 'ctrip',
+    name: 'hotel-search',
+    access: 'read',
+    description: '搜索携程酒店列表（按城市 + 入住/离店日期）',
+    domain: 'hotels.ctrip.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'city', required: true, positional: true, help: 'Numeric Ctrip city ID (use `ctrip search` or `ctrip hotel-suggest` to discover)' },
+        { name: 'checkin', required: true, help: 'Check-in date (YYYY-MM-DD)' },
+        { name: 'checkout', required: true, help: 'Check-out date (YYYY-MM-DD)' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of hotels (${MIN_LIMIT}-${MAX_LIMIT}); SSR first page returns ~13 entries` },
+    ],
+    columns: [
+        'rank', 'hotelId', 'name', 'enName',
+        'star', 'score', 'scoreLabel', 'reviewCount',
+        'cityName', 'district', 'address',
+        'lat', 'lon',
+        'price', 'currency', 'url',
+    ],
+    func: async (page, kwargs) => {
+        const cityId = parseCityId(kwargs.city);
+        const checkin = parseIsoDate('checkin', kwargs.checkin);
+        const checkout = parseIsoDate('checkout', kwargs.checkout);
+        assertCheckinBeforeCheckout(checkin, checkout);
+        const limit = parseHotelLimit(kwargs.limit);
+
+        const url = `https://hotels.ctrip.com/hotels/list?city=${cityId}&checkin=${checkin}&checkout=${checkout}`;
+        await page.goto(url);
+        const waitResult = await page.evaluate(WAIT_FOR_SSR_JS);
+        if (waitResult === 'captcha') {
+            throw new AuthRequiredError('hotels.ctrip.com', 'Ctrip is asking for a captcha; complete it in your browser session and retry');
+        }
+        const raw = await page.evaluate(EXTRACT_HOTELS_JS);
+        if (!Array.isArray(raw) || raw.length === 0) {
+            throw new EmptyResultError('ctrip hotel-search', `No hotels for city=${cityId} on ${checkin} → ${checkout}`);
+        }
+        return raw
+            .map((entry, i) => mapHotelRow(entry, i))
+            .filter((row) => row.hotelId && row.name)
+            .slice(0, limit);
+    },
+});
+
+export const __test__ = { parseHotelLimit, assertCheckinBeforeCheckout, WAIT_FOR_SSR_JS, EXTRACT_HOTELS_JS };

--- a/clis/ctrip/utils.js
+++ b/clis/ctrip/utils.js
@@ -336,6 +336,7 @@ export function buildFlightExtractJs() {
         const isTime = (s) => /^([01]?\\d|2[0-3]):[0-5]\\d$/.test(s);
         const isCurrency = (s) => /^[¥$€£]$/.test(s);
         const isPriceDigits = (s) => /^\\d+([.,]\\d+)?$/.test(s);
+        const isFlightNo = (s) => /^[A-Z0-9]{2}\\d{3,4}[A-Z]?$/.test(s);
 
         const rows = [];
         document.querySelectorAll('.flight-list > span > div').forEach((card) => {
@@ -359,6 +360,7 @@ export function buildFlightExtractJs() {
           if (firstTimeIdx < 1) return;
           const airline = chunks[0];
           const flightNo = chunks[1] || null;
+          if (!airline || !isFlightNo(flightNo)) return;
           const aircraft = chunks[2] && !isTime(chunks[2]) ? chunks[2] : null;
 
           const depTime = chunks[firstTimeIdx];
@@ -368,6 +370,7 @@ export function buildFlightExtractJs() {
           if (arrTimeIdx < 0) return;
           const arrTime = chunks[arrTimeIdx];
           const arrAirport = chunks[arrTimeIdx + 1] || null;
+          if (!depAirport || !arrAirport) return;
           // Optional terminal chunk right after arrAirport (matches /^T\\d$/ or single letter)
           let terminal = null;
           if (arrTimeIdx + 2 < chunks.length && /^T\\d$/.test(chunks[arrTimeIdx + 2])) {
@@ -419,10 +422,22 @@ export function buildFlightExtractJs() {
  * `section.note-item`; this generic version takes a selector.)
  */
 export function buildScrollUntilJs(rowSelector, targetCount, maxScrolls = 8) {
+    if (!Number.isInteger(targetCount) || targetCount < 1 || targetCount > 100) {
+        throw new ArgumentError(`targetCount must be an integer between 1 and 100, got ${JSON.stringify(targetCount)}`);
+    }
+    if (!Number.isInteger(maxScrolls) || maxScrolls < 1 || maxScrolls > 30) {
+        throw new ArgumentError(`maxScrolls must be an integer between 1 and 30, got ${JSON.stringify(maxScrolls)}`);
+    }
     return `
       (async () => {
         const sel = ${JSON.stringify(rowSelector)};
-        const countItems = () => document.querySelectorAll(sel).length;
+        const isVisible = (el) => {
+          const style = window.getComputedStyle(el);
+          if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        };
+        const countItems = () => Array.from(document.querySelectorAll(sel)).filter(isVisible).length;
         let lastCount = countItems();
         let plateauRounds = 0;
         for (let i = 0; i < ${maxScrolls}; i++) {

--- a/clis/ctrip/utils.js
+++ b/clis/ctrip/utils.js
@@ -172,4 +172,287 @@ export function mapSuggestRow(item, index) {
     };
 }
 
+/* --------- Helpers shared by hotel-search / flight (browser-context) ---------- */
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Validate YYYY-MM-DD and return the canonical string. Rejects out-of-range
+ * month/day, malformed input, and silent NaN. Does NOT coerce or shift timezones.
+ */
+export function parseIsoDate(name, raw) {
+    if (raw === undefined || raw === null || raw === '') {
+        throw new ArgumentError(`--${name} is required (YYYY-MM-DD)`);
+    }
+    const value = String(raw).trim();
+    const m = ISO_DATE_RE.exec(value);
+    if (!m) {
+        throw new ArgumentError(`--${name} must be YYYY-MM-DD, got ${JSON.stringify(raw)}`);
+    }
+    const year = Number(m[1]);
+    const month = Number(m[2]);
+    const day = Number(m[3]);
+    if (month < 1 || month > 12 || day < 1 || day > 31) {
+        throw new ArgumentError(`--${name} has invalid month/day: ${value}`);
+    }
+    // Cross-check via UTC date math so 2026-02-30 doesn't pass.
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (parsed.getUTCFullYear() !== year || parsed.getUTCMonth() !== month - 1 || parsed.getUTCDate() !== day) {
+        throw new ArgumentError(`--${name} is not a real calendar date: ${value}`);
+    }
+    return value;
+}
+
+/**
+ * Validate a 3-letter IATA airport / metro code, return uppercase.
+ * Ctrip URL accepts both single-airport (PEK / PVG) and metro-group (BJS / SHA) codes.
+ */
+export function parseIataCode(name, raw) {
+    if (raw === undefined || raw === null || raw === '') {
+        throw new ArgumentError(`--${name} is required (3-letter IATA code, e.g. PEK, SHA)`);
+    }
+    const value = String(raw).trim().toUpperCase();
+    if (!/^[A-Z]{3}$/.test(value)) {
+        throw new ArgumentError(`--${name} must be a 3-letter IATA code, got ${JSON.stringify(raw)}`);
+    }
+    return value;
+}
+
+/**
+ * Validate a numeric Ctrip city ID (returned by `ctrip search` / `ctrip hotel-suggest`).
+ */
+export function parseCityId(raw) {
+    if (raw === undefined || raw === null || raw === '') {
+        throw new ArgumentError('--city is required (numeric city ID from `ctrip search` or `ctrip hotel-suggest`)');
+    }
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+        throw new ArgumentError(`--city must be a positive integer city ID, got ${JSON.stringify(raw)}`);
+    }
+    return parsed;
+}
+
+/**
+ * Pick the best lat/lon from a Ctrip hotel `positionInfo.mapCoordinate` array.
+ *
+ * Each entry has a `coordinateType` (1=WGS84, 2=GCJ02, 3=BD09 / Baidu). We prefer
+ * WGS84 when present (most portable), then fall through. All coordinates are
+ * strings in the API, so we Number() and reject NaN.
+ */
+export function pickHotelMapCoords(mapCoordinate) {
+    if (!Array.isArray(mapCoordinate) || mapCoordinate.length === 0) {
+        return { lat: null, lon: null };
+    }
+    // Order: WGS84 (1) → GCJ02 (2) → BD09 (3) → whatever exists
+    const ranking = (entry) => {
+        const t = Number(entry?.coordinateType);
+        if (t === 1) return 0;
+        if (t === 2) return 1;
+        if (t === 3) return 2;
+        return 3;
+    };
+    const sorted = [...mapCoordinate].sort((a, b) => ranking(a) - ranking(b));
+    for (const entry of sorted) {
+        const lat = Number(entry?.latitude);
+        const lon = Number(entry?.longitude);
+        if (Number.isFinite(lat) && Number.isFinite(lon) && (lat !== 0 || lon !== 0)) {
+            return { lat, lon };
+        }
+    }
+    return { lat: null, lon: null };
+}
+
+/**
+ * Project a single Ctrip hotel row from `__NEXT_DATA__.props.pageProps.initListData.hotelList[*]`
+ * into stable adapter column shape.
+ *
+ * No silent fallbacks — every field is `string|number|null`, never `''` masquerading
+ * as "no data" (see typed-errors.md §"scalar sentinels are anti-pattern").
+ */
+export function mapHotelRow(entry, index) {
+    const hotelInfo = entry?.hotelInfo ?? {};
+    const rooms = Array.isArray(entry?.roomInfo) ? entry.roomInfo : [];
+    const summary = hotelInfo.summary ?? {};
+    const nameInfo = hotelInfo.nameInfo ?? {};
+    const hotelStar = hotelInfo.hotelStar ?? {};
+    const commentInfo = hotelInfo.commentInfo ?? {};
+    const positionInfo = hotelInfo.positionInfo ?? {};
+    const firstRoom = rooms[0] ?? {};
+    const priceInfo = firstRoom.priceInfo ?? {};
+
+    const hotelId = summary.hotelId ? String(summary.hotelId) : null;
+    const { lat, lon } = pickHotelMapCoords(positionInfo.mapCoordinate);
+
+    // commenterNumber arrives as "13,966条点评" — strip non-digits to int, else null.
+    let reviewCount = null;
+    if (commentInfo.commenterNumber) {
+        const digits = String(commentInfo.commenterNumber).replace(/[^\d]/g, '');
+        if (digits) reviewCount = Number(digits);
+    }
+    const score = commentInfo.commentScore ? Number(commentInfo.commentScore) : null;
+
+    const star = Number.isFinite(hotelStar.star) && hotelStar.star > 0 ? hotelStar.star : null;
+    const price = Number.isFinite(priceInfo.price) && priceInfo.price > 0 ? priceInfo.price : null;
+
+    return {
+        rank: index + 1,
+        hotelId,
+        name: nameInfo.name ? String(nameInfo.name).trim() : null,
+        enName: nameInfo.enName ? String(nameInfo.enName).trim() : null,
+        star,
+        score: Number.isFinite(score) && score > 0 ? score : null,
+        scoreLabel: commentInfo.commentDescription ? String(commentInfo.commentDescription).trim() : null,
+        reviewCount,
+        cityName: positionInfo.cityName ? String(positionInfo.cityName).trim() : null,
+        district: positionInfo.positionDesc ? String(positionInfo.positionDesc).trim() : null,
+        address: positionInfo.address ? String(positionInfo.address).trim() : null,
+        lat,
+        lon,
+        price,
+        currency: priceInfo.currency ? String(priceInfo.currency).trim() : null,
+        url: hotelId ? `https://hotels.ctrip.com/hotels/detail/?hotelid=${hotelId}` : null,
+    };
+}
+
+/**
+ * Build the browser-context IIFE that extracts flight rows from `.flight-list`.
+ *
+ * Flights are rendered as `.flight-list > span > div` cards. Each card's innerText
+ * has a stable ordering (verified 2026-05-12 on bjs→sha route):
+ *
+ *   [airline, flightNo, aircraft, lowPriceTag?, depTime, depAirport,
+ *    arrTime, arrAirport, terminal?, savings?, promo?, currency, price,
+ *    priceSuffix, cabin, cta]
+ *
+ * `lowPriceTag` (e.g. "当日低价") + `terminal` (e.g. "T2") + `savings` + `promo`
+ * are optional — we use position-of-first-time-match to anchor and parse around it.
+ *
+ * The host is baked in so `normalizeUrl` for booking links resolves on the calling site.
+ */
+export function buildFlightExtractJs() {
+    return `
+      (() => {
+        const cleanText = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+        const isTime = (s) => /^([01]?\\d|2[0-3]):[0-5]\\d$/.test(s);
+        const isCurrency = (s) => /^[¥$€£]$/.test(s);
+        const isPriceDigits = (s) => /^\\d+([.,]\\d+)?$/.test(s);
+
+        const rows = [];
+        document.querySelectorAll('.flight-list > span > div').forEach((card) => {
+          // Collect ordered text chunks (text nodes only, skip whitespace-only).
+          const chunks = [];
+          const walk = (node) => {
+            for (const c of node.childNodes) {
+              if (c.nodeType === 3) {
+                const t = cleanText(c.textContent);
+                if (t) chunks.push(t);
+              } else if (c.nodeType === 1) {
+                walk(c);
+              }
+            }
+          };
+          walk(card);
+          if (chunks.length < 8) return;
+
+          // Anchor on first HH:MM — that's depTime; depAirport is immediately after.
+          const firstTimeIdx = chunks.findIndex(isTime);
+          if (firstTimeIdx < 1) return;
+          const airline = chunks[0];
+          const flightNo = chunks[1] || null;
+          const aircraft = chunks[2] && !isTime(chunks[2]) ? chunks[2] : null;
+
+          const depTime = chunks[firstTimeIdx];
+          const depAirport = chunks[firstTimeIdx + 1] || null;
+          // Second HH:MM after depTime is arrTime
+          const arrTimeIdx = chunks.findIndex((c, i) => i > firstTimeIdx && isTime(c));
+          if (arrTimeIdx < 0) return;
+          const arrTime = chunks[arrTimeIdx];
+          const arrAirport = chunks[arrTimeIdx + 1] || null;
+          // Optional terminal chunk right after arrAirport (matches /^T\\d$/ or single letter)
+          let terminal = null;
+          if (arrTimeIdx + 2 < chunks.length && /^T\\d$/.test(chunks[arrTimeIdx + 2])) {
+            terminal = chunks[arrTimeIdx + 2];
+          }
+
+          // Price: scan for currency symbol then a digit-only chunk
+          let price = null;
+          let currency = null;
+          for (let i = 0; i < chunks.length - 1; i++) {
+            if (isCurrency(chunks[i]) && isPriceDigits(chunks[i + 1])) {
+              currency = chunks[i];
+              price = Number(chunks[i + 1].replace(',', ''));
+              break;
+            }
+          }
+          // Cabin: scan from end for first non-CTA Chinese chunk ending in "舱"
+          let cabin = null;
+          for (let i = chunks.length - 1; i >= 0; i--) {
+            if (/舱$/.test(chunks[i])) { cabin = chunks[i]; break; }
+          }
+
+          rows.push({
+            airline,
+            flightNo,
+            aircraft,
+            departureTime: depTime,
+            departureAirport: depAirport,
+            arrivalTime: arrTime,
+            arrivalAirport: arrAirport,
+            terminal,
+            price,
+            currency,
+            cabin,
+          });
+        });
+        return rows;
+      })()
+    `;
+}
+
+/**
+ * Build a scroll-until-enough IIFE for flights/hotels DOM-card pagination.
+ *
+ * Mirrors `clis/xiaohongshu/search.js#buildScrollUntilJs` (PR #1487) — counts a
+ * caller-supplied row selector, scrolls until count >= target / DOM plateau /
+ * maxScrolls. Returns final row count so the caller can decide whether to
+ * surface an EmptyResultError. (xiaohongshu's helper hardcodes
+ * `section.note-item`; this generic version takes a selector.)
+ */
+export function buildScrollUntilJs(rowSelector, targetCount, maxScrolls = 8) {
+    return `
+      (async () => {
+        const sel = ${JSON.stringify(rowSelector)};
+        const countItems = () => document.querySelectorAll(sel).length;
+        let lastCount = countItems();
+        let plateauRounds = 0;
+        for (let i = 0; i < ${maxScrolls}; i++) {
+          if (countItems() >= ${targetCount}) break;
+          const lastHeight = document.body.scrollHeight;
+          window.scrollTo(0, lastHeight);
+          await new Promise((resolve) => {
+            let to;
+            const ob = new MutationObserver(() => {
+              if (document.body.scrollHeight > lastHeight) {
+                clearTimeout(to);
+                ob.disconnect();
+                setTimeout(resolve, 200);
+              }
+            });
+            ob.observe(document.body, { childList: true, subtree: true });
+            to = setTimeout(() => { ob.disconnect(); resolve(null); }, 2500);
+          });
+          const newCount = countItems();
+          if (newCount === lastCount) {
+            plateauRounds++;
+            if (plateauRounds >= 2) break;
+          } else {
+            plateauRounds = 0;
+            lastCount = newCount;
+          }
+        }
+        return countItems();
+      })()
+    `;
+}
+
 export const __test__ = { ENDPOINT, MIN_LIMIT, MAX_LIMIT };

--- a/docs/adapters/browser/ctrip.md
+++ b/docs/adapters/browser/ctrip.md
@@ -1,17 +1,21 @@
 # Ctrip (携程)
 
-**Mode**: 🌐 Public · **Domain**: `ctrip.com`
+**Mode**: 🌐 Public (`search`, `hotel-suggest`) · 🖥️ Browser + Cookie (`hotel-search`, `flight`)
+**Domain**: `ctrip.com`
 
 Public destination + hotel-context suggestion lookup against the
-`m.ctrip.com/restapi/soa2/21881/json/gaHotelSearchEngine` endpoint. No browser
-or login required.
+`m.ctrip.com/restapi/soa2/21881/json/gaHotelSearchEngine` endpoint plus
+browser-driven hotel listing and one-way flight search on `hotels.ctrip.com`
+and `flights.ctrip.com`.
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `opencli ctrip search` | Suggest cities, scenic spots, railway stations and landmarks |
-| `opencli ctrip hotel-suggest` | Suggest cities, business areas and individual hotels |
+| Command | Mode | Description |
+|---------|------|-------------|
+| `opencli ctrip search` | Public | Suggest cities, scenic spots, railway stations and landmarks |
+| `opencli ctrip hotel-suggest` | Public | Suggest cities, business areas and individual hotels |
+| `opencli ctrip hotel-search` | Browser (cookie) | List hotels for a city + check-in/out date range |
+| `opencli ctrip flight` | Browser (cookie) | One-way flight search by IATA route + departure date |
 
 ## Usage Examples
 
@@ -22,13 +26,19 @@ opencli ctrip search 苏州 --limit 10
 # Hotel-context suggest (cities / business areas / hotels)
 opencli ctrip hotel-suggest 陆家嘴 --limit 5
 
+# Hotel listing (city ID from `search` / `hotel-suggest`)
+opencli ctrip hotel-search 2 --checkin 2026-05-20 --checkout 2026-05-21 --limit 10
+
+# One-way flight search
+opencli ctrip flight BJS SHA --date 2026-05-20 --limit 20
+
 # JSON output
 opencli ctrip search 上海 -f json
 ```
 
-## Columns
+## Suggest Columns (`search` / `hotel-suggest`)
 
-Both commands share a uniform column shape:
+Both suggest commands share a uniform column shape:
 
 | Column | Notes |
 |--------|-------|
@@ -46,11 +56,68 @@ Both commands share a uniform column shape:
 `--limit` accepts integers in `[1, 50]`. Out-of-range values raise
 `ArgumentError` (no silent clamp).
 
+## Hotel Listing Columns (`hotel-search`)
+
+| Column | Notes |
+|--------|-------|
+| `rank` | 1-based position in upstream list |
+| `hotelId` | Round-trips into `https://hotels.ctrip.com/hotels/detail/?hotelid=…` |
+| `name`, `enName` | Localised + English (English may be `null`) |
+| `star` | `1`-`5`, `null` for unrated / 客栈 entries |
+| `score`, `scoreLabel` | e.g. `4.8` / `"超棒"`; both `null` if unrated |
+| `reviewCount` | Integer parsed from `"13,966条点评"` |
+| `cityName`, `district`, `address` | Geo context |
+| `lat`, `lon` | WGS84 (1) > GCJ02 (2) > BD09 (3) selection; `null` if all are 0 |
+| `price`, `currency` | First room's quote; `null` when no rooms remain at the searched date |
+| `url` | Canonical detail URL or `null` if `hotelId` is missing |
+
+Args:
+- `<city>` (positional, required) — numeric Ctrip city ID (discover via `ctrip search` / `ctrip hotel-suggest`).
+- `--checkin`, `--checkout` (required) — `YYYY-MM-DD`, validated as real calendar dates with `checkin < checkout`.
+- `--limit` (1-30, default 10) — Ctrip's SSR first page ships ~13 entries (10 organic + ~3 promoted). Larger limits are not currently supported because the server ignores the URL `pageSize` param.
+
+## Flight Columns (`flight`)
+
+| Column | Notes |
+|--------|-------|
+| `rank` | 1-based position after filtering incomplete rows |
+| `airline`, `flightNo`, `aircraft` | Free-text from the rendered card; `aircraft` may be `null` |
+| `departureTime`, `arrivalTime` | `HH:MM` strings |
+| `departureAirport`, `arrivalAirport`, `terminal` | Airport names + optional `T1`/`T2` chunk |
+| `price`, `currency`, `cabin` | First quoted fare; `cabin` is the Chinese suffix (e.g. `经济舱`) |
+| `url` | The search URL (Ctrip's flight cards don't expose per-row stable deeplinks) |
+
+Args:
+- `<from>`, `<to>` (positional, required) — 3-letter IATA codes; `BJS`/`SHA` metro codes work alongside single-airport codes like `PEK`/`PVG`.
+- `--date` (required) — `YYYY-MM-DD`.
+- `--limit` (1-50, default 20).
+
+Rows are extracted from `.flight-list > span > div` cards because Ctrip's
+post-load XHR is not currently captured by the daemon network buffer (see
+"Caveats" below). Cards with missing departure/arrival/airline are dropped
+rather than emitted with sentinel values.
+
 ## Notes
 
-- Endpoint discriminator: `searchType=D` (search) vs `searchType=H`
+- Suggest endpoint discriminator: `searchType=D` (search) vs `searchType=H`
   (hotel-suggest). Hotel and BusinessArea rows only appear in the `H` flavour.
-- Mainland China rows ship `gdLat`/`gdLon` (gaode). International rows ship
-  `gLat`/`gLon` (wgs84). The adapter picks the first non-zero pair.
-- In-band `Result: false` envelopes are surfaced as `COMMAND_EXEC` typed
-  errors; HTTP non-2xx becomes `FETCH_ERROR`.
+- Mainland China suggest rows ship `gdLat`/`gdLon` (gaode). International rows
+  ship `gLat`/`gLon` (wgs84). The adapter picks the first non-zero pair.
+- Suggest in-band `Result: false` envelopes are surfaced as `COMMAND_EXEC`
+  typed errors; HTTP non-2xx becomes `FETCH_ERROR`.
+
+## Caveats (browser-mode commands)
+
+- **Cookie required**: `hotel-search` / `flight` use `Strategy.COOKIE` against
+  `hotels.ctrip.com` / `flights.ctrip.com`. If Ctrip serves a captcha redirect
+  (suspected bot), an `AuthRequiredError` is raised — complete the captcha in
+  your live browser session and retry.
+- **No per-flight deeplink**: Ctrip's flight cards funnel every row through a
+  shared booking handoff. Until a stable per-flight `bookingId` surfaces, all
+  rows share the search URL.
+- **Round-trip + airline-filter unsupported**: `flight` is one-way only and
+  passes `cabin=Y_S_C_F` (all cabins) in v1. Round-trip + advanced filters
+  tracked in the `#1481` follow-up.
+- **Hotel SSR page size is server-fixed**: passing `&pageSize=N` is ignored
+  upstream — first page returns ~13 rows. Larger result sets would need
+  scroll-paginated DOM extraction (not implemented in v1).


### PR DESCRIPTION
Closes #1481.

## Summary

Two new browser-mode commands on top of the existing public `search` / `hotel-suggest` pair:

- **`ctrip hotel-search <city> --checkin --checkout [--limit]`** — reads `window.__NEXT_DATA__.props.pageProps.initListData.hotelList` on `hotels.ctrip.com/hotels/list`. SSR first page ships ~13 entries; server ignores `&pageSize=N` so limit caps at 30, default 10. Surfaces `AuthRequiredError` on the captcha redirect.
- **`ctrip flight <from> <to> --date [--limit]`** — one-way flight search on `flights.ctrip.com/online/list/oneway-…`. Rows extracted from `.flight-list > span > div` cards via position-anchored innerText parser (the post-load XHR is not currently captured by the daemon network buffer — known daemon-side bug per agent memory). Round-trip + airline filters out of scope for v1.

All argument validation (IATA / ISO date / city ID / limit range) fires upfront before any `page.goto`, per PR #1387's validation-before-navigation boundary. No silent clamps, no sentinel rows — rows missing required fields are dropped, and end-state failures raise `ArgumentError` / `AuthRequiredError` / `EmptyResultError`.

New helpers in `clis/ctrip/utils.js`:
- `parseIsoDate(name, raw)` — UTC cross-check rejects Feb 30 / non-leap Feb 29
- `parseIataCode(name, raw)` — 3-letter uppercase
- `parseCityId(raw)` — positive integer
- `pickHotelMapCoords(mapCoordinate)` — WGS84 (1) > GCJ02 (2) > BD09 (3), filters all-zero
- `mapHotelRow(entry, index)` — 16-column projection with explicit `null` for missing data
- `buildFlightExtractJs()` — position-anchored card parser
- `buildScrollUntilJs(rowSelector, targetCount, maxScrolls=8)` — generic version of PR #1487's xiaohongshu helper, selector parameterised

Docs at `docs/adapters/browser/ctrip.md` now distinguish the public suggest commands from the new browser-mode commands and document columns + caveats for each.

## Test plan
- [x] `npx vitest run clis/ctrip/` — 61/61 passing (includes JSDOM exercises of `buildFlightExtractJs` + full `mapHotelRow` shape parity)
- [x] `npm run check:typed-error-lint` — 189/189 (0 new)
- [x] `npm run check:silent-column-drop` — 103/103 (0 new)
- [x] `npm run build-manifest` — 812 entries (was 810)
- [ ] Live browser-mode verification deferred to reviewer (hotel-search would be sufficient since flights need an active live Ctrip session anyway)