### PR TITLE
chore(scripts): auto-refresh dist/ before build-manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dev": "tsx src/main.ts",
     "dev:bun": "bun src/main.ts",
     "build": "npm run clean-dist && npm run copy-yaml && npm run build-manifest",
-    "prebuild-manifest": "tsc --build --force",
+    "prebuild-manifest": "tsc --build",
     "build-manifest": "tsx src/build-manifest.ts",
     "clean-dist": "node scripts/clean-dist.cjs",
     "copy-yaml": "node scripts/copy-yaml.cjs",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dev": "tsx src/main.ts",
     "dev:bun": "bun src/main.ts",
     "build": "npm run clean-dist && tsc && npm run copy-yaml && npm run build-manifest",
+    "prebuild-manifest": "tsc --build",
     "build-manifest": "tsx src/build-manifest.ts",
     "clean-dist": "node scripts/clean-dist.cjs",
     "copy-yaml": "node scripts/copy-yaml.cjs",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "scripts": {
     "dev": "tsx src/main.ts",
     "dev:bun": "bun src/main.ts",
-    "build": "npm run clean-dist && tsc && npm run copy-yaml && npm run build-manifest",
-    "prebuild-manifest": "tsc --build",
+    "build": "npm run clean-dist && npm run copy-yaml && npm run build-manifest",
+    "prebuild-manifest": "tsc --build --force",
     "build-manifest": "tsx src/build-manifest.ts",
     "clean-dist": "node scripts/clean-dist.cjs",
     "copy-yaml": "node scripts/copy-yaml.cjs",


### PR DESCRIPTION
## Summary

`npm run build-manifest` runs `build-manifest.ts` via tsx (so its OWN imports go to TS source), but the adapter `.js` files it dynamic-imports use `@jackwener/opencli/registry` via package exports → resolves to `dist/src/registry-api.js`. When `dist/` is stale relative to `src/`, the stale compiled registry drops registry fields (e.g. `siteSession`) from the rebuilt manifest.

CI catches the resulting diff via the "cli-manifest.json is up-to-date" gate, but locally it surfaces as mystery diff lines on adapter entries a contributor never touched. I hit this myself while working on PR #1489 (ctrip flight + hotel-search) — bare `npm run build-manifest` produced a noisy diff that vanished after `npm run build`.

Fix: add `prebuild-manifest: tsc --build` so `npm run build-manifest` is safe to invoke standalone. `tsc --build` is incremental (~0.6s when warm) and a no-op when invoked transitively from `npm run build` (TS is already compiled by then).

## Test plan
- [x] `rm -rf dist && npm run build-manifest` — pre-hook restores dist, manifest diff is 0 lines
- [x] `npm run build` still produces clean output (no manifest drift)
- [ ] CI manifest-up-to-date gate still passes