### PR TITLE
feat(reddit): add whoami, home, subreddit-info read commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19201,6 +19201,39 @@
   },
   {
     "site": "reddit",
+    "name": "home",
+    "description": "Reddit personalized home feed (Best, requires login)",
+    "access": "read",
+    "domain": "reddit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Number of posts (1–100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "title",
+      "subreddit",
+      "score",
+      "comments",
+      "postId",
+      "author",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "reddit/home.js",
+    "sourceFile": "reddit/home.js",
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
+  },
+  {
+    "site": "reddit",
     "name": "hot",
     "description": "Reddit 热门帖子",
     "access": "read",
@@ -19542,6 +19575,33 @@
   },
   {
     "site": "reddit",
+    "name": "subreddit-info",
+    "description": "Show metadata for a Reddit subreddit (subscribers, description, created date, NSFW)",
+    "access": "read",
+    "domain": "reddit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "name",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Subreddit name (no `r/` prefix needed)"
+      }
+    ],
+    "columns": [
+      "field",
+      "value"
+    ],
+    "type": "js",
+    "modulePath": "reddit/subreddit-info.js",
+    "sourceFile": "reddit/subreddit-info.js",
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
+  },
+  {
+    "site": "reddit",
     "name": "subscribe",
     "description": "Subscribe or unsubscribe to a subreddit",
     "access": "write",
@@ -19735,6 +19795,25 @@
     "type": "js",
     "modulePath": "reddit/user-posts.js",
     "sourceFile": "reddit/user-posts.js",
+    "navigateBefore": "https://reddit.com",
+    "siteSession": "persistent"
+  },
+  {
+    "site": "reddit",
+    "name": "whoami",
+    "description": "Show the currently logged-in Reddit user",
+    "access": "read",
+    "domain": "reddit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "field",
+      "value"
+    ],
+    "type": "js",
+    "modulePath": "reddit/whoami.js",
+    "sourceFile": "reddit/whoami.js",
     "navigateBefore": "https://reddit.com",
     "siteSession": "persistent"
   },

--- a/clis/reddit/home.js
+++ b/clis/reddit/home.js
@@ -4,6 +4,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 const REDDIT_HOME_MAX_LIMIT = 100;
 
 export function parseRedditHomeLimit(raw) {
+    if (raw === undefined || raw === null || raw === '') return 25;
     const n = Number(raw);
     if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1 || n > REDDIT_HOME_MAX_LIMIT) {
         throw new ArgumentError(
@@ -106,6 +107,9 @@ cli({
             });
         }
         if (rows.length === 0) {
+            if (entries.length > 0) {
+                throw new CommandExecutionError('Reddit home feed entries were missing required post id anchors');
+            }
             throw new EmptyResultError('Reddit returned no posts in the personalized home feed.');
         }
         return rows;

--- a/clis/reddit/home.js
+++ b/clis/reddit/home.js
@@ -1,0 +1,113 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+const REDDIT_HOME_MAX_LIMIT = 100;
+
+export function parseRedditHomeLimit(raw) {
+    const n = Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1 || n > REDDIT_HOME_MAX_LIMIT) {
+        throw new ArgumentError(
+            `limit must be an integer in [1, ${REDDIT_HOME_MAX_LIMIT}].`,
+            `Got: ${raw}`,
+        );
+    }
+    return n;
+}
+
+cli({
+    site: 'reddit',
+    name: 'home',
+    access: 'read',
+    description: 'Reddit personalized home feed (Best, requires login)',
+    domain: 'reddit.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    args: [
+        { name: 'limit', type: 'int', default: 25, help: `Number of posts (1–${REDDIT_HOME_MAX_LIMIT})` },
+    ],
+    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url'],
+    func: async (page, kwargs) => {
+        const limit = parseRedditHomeLimit(kwargs.limit);
+        await page.goto('https://www.reddit.com');
+        // The Best feed is personalized only when logged in — for anonymous
+        // sessions Reddit returns a generic listing that overlaps with /r/all.
+        // To make `home` semantically meaningful (vs the public `frontpage`
+        // command) we require auth and surface the logged-out case via
+        // AuthRequiredError instead of silently returning the public feed.
+        //
+        // Two-pronged auth detection: HTTP 401/403 OR `me.data.name` missing
+        // on 200 (stale anonymous cookie session). See PR #1428 sediment.
+        //
+        // Intermediate object keys avoid `rank`/`title`/`subreddit`/etc. to
+        // sidestep the silent-column-drop audit; we use `entries` for the
+        // raw payload. See PR #1329 sediment "中间解析对象 key 不能跟
+        // columns 任一项重叠".
+        const result = await page.evaluate(`(async () => {
+      try {
+        const meRes = await fetch('/api/me.json', { credentials: 'include' });
+        if (meRes.status === 401 || meRes.status === 403) {
+          return { kind: 'auth', detail: 'Reddit /api/me.json returned HTTP ' + meRes.status };
+        }
+        if (!meRes.ok) {
+          return { kind: 'http', httpStatus: meRes.status, where: '/api/me.json' };
+        }
+        const me = await meRes.json();
+        if (!me?.data?.name) {
+          return { kind: 'auth', detail: 'Not logged in to reddit.com (no identity in /api/me.json)' };
+        }
+
+        const limit = ${JSON.stringify(limit)};
+        const res = await fetch('/best.json?limit=' + limit + '&raw_json=1', { credentials: 'include' });
+        if (res.status === 401 || res.status === 403) {
+          return { kind: 'auth', detail: 'Reddit /best.json returned HTTP ' + res.status };
+        }
+        if (!res.ok) {
+          return { kind: 'http', httpStatus: res.status, where: '/best.json' };
+        }
+        const j = await res.json();
+        const entries = j?.data?.children;
+        if (!Array.isArray(entries)) {
+          return { kind: 'http', httpStatus: 200, where: '/best.json (no data.children array)' };
+        }
+        return { kind: 'ok', entries };
+      } catch (e) {
+        return { kind: 'exception', detail: String(e && e.message || e) };
+      }
+    })()`);
+
+        if (result?.kind === 'auth') {
+            throw new AuthRequiredError('reddit.com', result.detail);
+        }
+        if (result?.kind === 'http') {
+            throw new CommandExecutionError(`HTTP ${result.httpStatus} from ${result.where}`);
+        }
+        if (result?.kind === 'exception') {
+            throw new CommandExecutionError(`home failed: ${result.detail}`);
+        }
+        if (result?.kind !== 'ok') {
+            throw new CommandExecutionError(`Unexpected result from reddit home: ${JSON.stringify(result)}`);
+        }
+
+        const rows = [];
+        const entries = result.entries.slice(0, limit);
+        for (let i = 0; i < entries.length; i++) {
+            const d = entries[i]?.data;
+            if (!d || !d.id) continue;
+            rows.push({
+                rank: i + 1,
+                title: typeof d.title === 'string' ? d.title : null,
+                subreddit: typeof d.subreddit_name_prefixed === 'string' ? d.subreddit_name_prefixed : null,
+                score: typeof d.score === 'number' ? d.score : null,
+                comments: typeof d.num_comments === 'number' ? d.num_comments : null,
+                postId: d.id,
+                author: typeof d.author === 'string' ? d.author : null,
+                url: d.permalink ? 'https://www.reddit.com' + d.permalink : null,
+            });
+        }
+        if (rows.length === 0) {
+            throw new EmptyResultError('Reddit returned no posts in the personalized home feed.');
+        }
+        return rows;
+    },
+});

--- a/clis/reddit/home.test.js
+++ b/clis/reddit/home.test.js
@@ -37,11 +37,14 @@ describe('reddit home command', () => {
     });
 
     it('parseRedditHomeLimit accepts [1,100] and rejects out-of-range / non-integer without silent clamp', () => {
+        expect(parseRedditHomeLimit(undefined)).toBe(25);
+        expect(parseRedditHomeLimit(null)).toBe(25);
+        expect(parseRedditHomeLimit('')).toBe(25);
         expect(parseRedditHomeLimit(1)).toBe(1);
         expect(parseRedditHomeLimit(25)).toBe(25);
         expect(parseRedditHomeLimit(100)).toBe(100);
 
-        for (const bad of [0, -1, 101, 1.5, NaN, 'abc', '']) {
+        for (const bad of [0, -1, 101, 1.5, NaN, 'abc']) {
             expect(() => parseRedditHomeLimit(bad)).toThrow(ArgumentError);
         }
     });
@@ -104,6 +107,15 @@ describe('reddit home command', () => {
         const entries = [makeEntry('keep1'), { data: { title: 'no id' } }, makeEntry('keep2')];
         const rows = await command.func(makePage({ kind: 'ok', entries }), { limit: 25 });
         expect(rows.map((r) => r.postId)).toEqual(['keep1', 'keep2']);
+    });
+
+    it('throws CommandExecutionError when all home entries are missing post ids', async () => {
+        const entries = [{ data: { title: 'no id' } }, { data: { title: 'also no id' } }];
+        await expect(command.func(makePage({ kind: 'ok', entries }), { limit: 25 }))
+            .rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('required post id anchors'),
+            });
     });
 
     it('embeds the requested limit literally inside the evaluate script', async () => {

--- a/clis/reddit/home.test.js
+++ b/clis/reddit/home.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { parseRedditHomeLimit } from './home.js';
+import './home.js';
+
+function makePage(result) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(result),
+    };
+}
+
+function makeEntry(id, overrides = {}) {
+    return {
+        data: {
+            id,
+            title: `Title for ${id}`,
+            subreddit_name_prefixed: 'r/dummy',
+            score: 100,
+            num_comments: 10,
+            author: 'someone',
+            permalink: `/r/dummy/comments/${id}/title/`,
+            ...overrides,
+        },
+    };
+}
+
+describe('reddit home command', () => {
+    const command = getRegistry().get('reddit/home');
+
+    it('registers with the expected shape', () => {
+        expect(command).toBeDefined();
+        expect(command.access).toBe('read');
+        expect(command.browser).toBe(true);
+        expect(command.columns).toEqual(['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url']);
+    });
+
+    it('parseRedditHomeLimit accepts [1,100] and rejects out-of-range / non-integer without silent clamp', () => {
+        expect(parseRedditHomeLimit(1)).toBe(1);
+        expect(parseRedditHomeLimit(25)).toBe(25);
+        expect(parseRedditHomeLimit(100)).toBe(100);
+
+        for (const bad of [0, -1, 101, 1.5, NaN, 'abc', '']) {
+            expect(() => parseRedditHomeLimit(bad)).toThrow(ArgumentError);
+        }
+    });
+
+    it('rejects a bad limit BEFORE navigating', async () => {
+        const page = makePage({ kind: 'ok', entries: [] });
+        await expect(command.func(page, { limit: 101 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthRequiredError when logged out (401/403 or missing identity)', async () => {
+        await expect(command.func(makePage({ kind: 'auth', detail: 'login required' }), { limit: 25 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('throws CommandExecutionError on HTTP / exception failure modes', async () => {
+        await expect(command.func(makePage({ kind: 'http', httpStatus: 503, where: '/best.json' }), { limit: 25 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ kind: 'exception', detail: 'network' }), { limit: 25 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when Reddit returns no posts', async () => {
+        await expect(command.func(makePage({ kind: 'ok', entries: [] }), { limit: 25 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('maps entries to row shape with 1-based rank, full URLs, and typed numbers', async () => {
+        const entries = [makeEntry('a1'), makeEntry('b2', { score: 250, num_comments: 42 })];
+        const rows = await command.func(makePage({ kind: 'ok', entries }), { limit: 25 });
+
+        expect(rows).toEqual([
+            {
+                rank: 1, title: 'Title for a1', subreddit: 'r/dummy', score: 100, comments: 10,
+                postId: 'a1', author: 'someone', url: 'https://www.reddit.com/r/dummy/comments/a1/title/',
+            },
+            {
+                rank: 2, title: 'Title for b2', subreddit: 'r/dummy', score: 250, comments: 42,
+                postId: 'b2', author: 'someone', url: 'https://www.reddit.com/r/dummy/comments/b2/title/',
+            },
+        ]);
+        // Row shape must match declared columns exactly.
+        for (const row of rows) {
+            expect(Object.keys(row).sort()).toEqual(
+                ['author', 'comments', 'postId', 'rank', 'score', 'subreddit', 'title', 'url'],
+            );
+        }
+    });
+
+    it('applies the post-fetch limit slice (defence in depth vs Reddit overshoot)', async () => {
+        const entries = Array.from({ length: 30 }, (_, i) => makeEntry(`p${i}`));
+        const rows = await command.func(makePage({ kind: 'ok', entries }), { limit: 5 });
+        expect(rows).toHaveLength(5);
+        expect(rows[0].postId).toBe('p0');
+        expect(rows[4].postId).toBe('p4');
+    });
+
+    it('drops entries with no data.id rather than silently emitting sentinels', async () => {
+        const entries = [makeEntry('keep1'), { data: { title: 'no id' } }, makeEntry('keep2')];
+        const rows = await command.func(makePage({ kind: 'ok', entries }), { limit: 25 });
+        expect(rows.map((r) => r.postId)).toEqual(['keep1', 'keep2']);
+    });
+
+    it('embeds the requested limit literally inside the evaluate script', async () => {
+        const page = makePage({ kind: 'ok', entries: [makeEntry('x')] });
+        await command.func(page, { limit: 7 });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('const limit = 7');
+    });
+});

--- a/clis/reddit/subreddit-info.js
+++ b/clis/reddit/subreddit-info.js
@@ -1,4 +1,4 @@
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 
 // Reddit subreddit names: 3–21 chars, letters/digits/underscore, must start
@@ -48,11 +48,8 @@ cli({
       try {
         const sub = ${JSON.stringify(sub)};
         const res = await fetch('/r/' + encodeURIComponent(sub) + '/about.json?raw_json=1', { credentials: 'include' });
-        if (res.status === 401 || res.status === 403) {
-          return { kind: 'auth', detail: 'Reddit /r/' + sub + '/about.json returned HTTP ' + res.status };
-        }
-        if (res.status === 404) {
-          return { kind: 'missing', detail: 'Subreddit r/' + sub + ' was not found (404).' };
+        if (res.status === 401 || res.status === 403 || res.status === 404) {
+          return { kind: 'missing', detail: 'Subreddit r/' + sub + ' was not found or is not accessible (HTTP ' + res.status + ').' };
         }
         if (!res.ok) {
           return { kind: 'http', httpStatus: res.status, where: '/r/' + sub + '/about.json' };
@@ -77,9 +74,6 @@ cli({
       }
     })()`);
 
-        if (result?.kind === 'auth') {
-            throw new AuthRequiredError('reddit.com', result.detail);
-        }
         if (result?.kind === 'missing') {
             throw new EmptyResultError(result.detail);
         }

--- a/clis/reddit/subreddit-info.js
+++ b/clis/reddit/subreddit-info.js
@@ -69,7 +69,7 @@ cli({
         }
         const info = j?.data;
         if (!info || !info.display_name) {
-          return { kind: 'missing', detail: 'Reddit returned no subreddit info for r/' + sub + '.' };
+          return { kind: 'malformed', detail: 'Reddit returned malformed subreddit info for r/' + sub + ' (missing data.display_name).' };
         }
         return { kind: 'ok', info };
       } catch (e) {
@@ -85,6 +85,9 @@ cli({
         }
         if (result?.kind === 'http') {
             throw new CommandExecutionError(`HTTP ${result.httpStatus} from ${result.where}`);
+        }
+        if (result?.kind === 'malformed') {
+            throw new CommandExecutionError(result.detail);
         }
         if (result?.kind === 'exception') {
             throw new CommandExecutionError(`subreddit-info failed: ${result.detail}`);

--- a/clis/reddit/subreddit-info.js
+++ b/clis/reddit/subreddit-info.js
@@ -1,0 +1,120 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+// Reddit subreddit names: 3–21 chars, letters/digits/underscore, must start
+// with a letter. Accept an optional `r/` prefix and normalise it off.
+const SUBREDDIT_NAME_RE = /^[A-Za-z][A-Za-z0-9_]{2,20}$/;
+
+export function parseSubredditName(raw) {
+    let name = String(raw || '').trim();
+    if (!name) {
+        throw new ArgumentError(
+            'Subreddit name is required.',
+            'Pass a subreddit name like `python` (or `r/python`).',
+        );
+    }
+    if (name.startsWith('/r/')) name = name.slice(3);
+    else if (name.startsWith('r/')) name = name.slice(2);
+    if (!SUBREDDIT_NAME_RE.test(name)) {
+        throw new ArgumentError(
+            'Invalid subreddit name.',
+            'Subreddit names are 3–21 characters, start with a letter, and contain only letters, digits, and underscores.',
+        );
+    }
+    return name;
+}
+
+cli({
+    site: 'reddit',
+    name: 'subreddit-info',
+    access: 'read',
+    description: 'Show metadata for a Reddit subreddit (subscribers, description, created date, NSFW)',
+    domain: 'reddit.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    args: [
+        { name: 'name', type: 'string', required: true, positional: true, help: 'Subreddit name (no `r/` prefix needed)' },
+    ],
+    columns: ['field', 'value'],
+    func: async (page, kwargs) => {
+        const sub = parseSubredditName(kwargs.name);
+        await page.goto('https://www.reddit.com');
+        // Banned / private / non-existent subreddits return a 404 envelope
+        // ({"error":404,"reason":"banned"|"private"|null,"message":"Not Found"}).
+        // We surface those as EmptyResultError so the table never contains a
+        // silent sentinel row. Intermediate keys avoid `field`/`value`.
+        const result = await page.evaluate(`(async () => {
+      try {
+        const sub = ${JSON.stringify(sub)};
+        const res = await fetch('/r/' + encodeURIComponent(sub) + '/about.json?raw_json=1', { credentials: 'include' });
+        if (res.status === 401 || res.status === 403) {
+          return { kind: 'auth', detail: 'Reddit /r/' + sub + '/about.json returned HTTP ' + res.status };
+        }
+        if (res.status === 404) {
+          return { kind: 'missing', detail: 'Subreddit r/' + sub + ' was not found (404).' };
+        }
+        if (!res.ok) {
+          return { kind: 'http', httpStatus: res.status, where: '/r/' + sub + '/about.json' };
+        }
+        const j = await res.json();
+        // Reddit may return an envelope-style 200 with {"kind":"Listing"} or
+        // an error body for quarantined / private subs. Identify "subreddit
+        // not found / not accessible" by the absence of data.display_name.
+        if (j?.error) {
+          if (j.error === 404 || j.reason === 'banned' || j.reason === 'private' || j.reason === 'quarantined') {
+            return { kind: 'missing', detail: 'Subreddit r/' + sub + ' is ' + (j.reason || 'unavailable') + '.' };
+          }
+          return { kind: 'http', httpStatus: j.error, where: '/r/' + sub + '/about.json (' + (j.reason || 'error') + ')' };
+        }
+        const info = j?.data;
+        if (!info || !info.display_name) {
+          return { kind: 'missing', detail: 'Reddit returned no subreddit info for r/' + sub + '.' };
+        }
+        return { kind: 'ok', info };
+      } catch (e) {
+        return { kind: 'exception', detail: String(e && e.message || e) };
+      }
+    })()`);
+
+        if (result?.kind === 'auth') {
+            throw new AuthRequiredError('reddit.com', result.detail);
+        }
+        if (result?.kind === 'missing') {
+            throw new EmptyResultError(result.detail);
+        }
+        if (result?.kind === 'http') {
+            throw new CommandExecutionError(`HTTP ${result.httpStatus} from ${result.where}`);
+        }
+        if (result?.kind === 'exception') {
+            throw new CommandExecutionError(`subreddit-info failed: ${result.detail}`);
+        }
+        if (result?.kind !== 'ok') {
+            throw new CommandExecutionError(`Unexpected result from reddit subreddit-info: ${JSON.stringify(result)}`);
+        }
+
+        const s = result.info;
+        const created = s.created_utc
+            ? new Date(s.created_utc * 1000).toISOString().split('T')[0]
+            : null;
+        const subscribers = typeof s.subscribers === 'number' ? s.subscribers : null;
+        const activeNow = typeof s.active_user_count === 'number'
+            ? s.active_user_count
+            : (typeof s.accounts_active === 'number' ? s.accounts_active : null);
+        const description = typeof s.public_description === 'string'
+            ? s.public_description.trim()
+            : '';
+
+        return [
+            { field: 'Name', value: s.display_name_prefixed || ('r/' + s.display_name) },
+            { field: 'Title', value: typeof s.title === 'string' ? s.title : null },
+            { field: 'Subscribers', value: subscribers != null ? String(subscribers) : null },
+            { field: 'Active Now', value: activeNow != null ? String(activeNow) : null },
+            { field: 'NSFW', value: s.over18 ? 'Yes' : 'No' },
+            { field: 'Type', value: typeof s.subreddit_type === 'string' ? s.subreddit_type : null },
+            { field: 'Description', value: description || null },
+            { field: 'Created', value: created },
+            { field: 'URL', value: s.url ? 'https://www.reddit.com' + s.url : null },
+        ];
+    },
+});

--- a/clis/reddit/subreddit-info.test.js
+++ b/clis/reddit/subreddit-info.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { parseSubredditName } from './subreddit-info.js';
 import './subreddit-info.js';
 
@@ -51,15 +51,29 @@ describe('reddit subreddit-info command', () => {
         expect(page.evaluate).not.toHaveBeenCalled();
     });
 
-    it('throws AuthRequiredError on 401/403', async () => {
-        await expect(command.func(makePage({ kind: 'auth', detail: 'login' }), { name: 'python' }))
-            .rejects.toBeInstanceOf(AuthRequiredError);
-    });
-
     it('throws EmptyResultError for missing / banned / private / quarantined subreddits', async () => {
         for (const detail of ['not found', 'banned', 'private', 'quarantined']) {
             await expect(command.func(makePage({ kind: 'missing', detail }), { name: 'python' }))
                 .rejects.toBeInstanceOf(EmptyResultError);
+        }
+    });
+
+    it('treats HTTP 401/403/404 about.json responses as inaccessible subreddit, not auth-required', async () => {
+        for (const status of [401, 403, 404]) {
+            const scriptResults = [];
+            const page = {
+                goto: vi.fn().mockResolvedValue(undefined),
+                evaluate: vi.fn(async (script) => {
+                    const result = await (new Function('fetch', `return (${script})`))(vi.fn(async () => ({
+                        status,
+                        ok: false,
+                    })));
+                    scriptResults.push(result);
+                    return result;
+                }),
+            };
+            await expect(command.func(page, { name: 'python' })).rejects.toBeInstanceOf(EmptyResultError);
+            expect(scriptResults[0]).toMatchObject({ kind: 'missing' });
         }
     });
 

--- a/clis/reddit/subreddit-info.test.js
+++ b/clis/reddit/subreddit-info.test.js
@@ -70,6 +70,17 @@ describe('reddit subreddit-info command', () => {
             .rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('throws CommandExecutionError for malformed 200 subreddit payloads', async () => {
+        await expect(command.func(makePage({
+            kind: 'malformed',
+            detail: 'Reddit returned malformed subreddit info for r/python (missing data.display_name).',
+        }), { name: 'python' }))
+            .rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('malformed subreddit info'),
+            });
+    });
+
     it('maps a normal subreddit payload into typed field/value rows', async () => {
         const info = {
             display_name: 'python',

--- a/clis/reddit/subreddit-info.test.js
+++ b/clis/reddit/subreddit-info.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { parseSubredditName } from './subreddit-info.js';
+import './subreddit-info.js';
+
+function makePage(result) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(result),
+    };
+}
+
+describe('reddit subreddit-info command', () => {
+    const command = getRegistry().get('reddit/subreddit-info');
+
+    it('registers with the expected shape', () => {
+        expect(command).toBeDefined();
+        expect(command.access).toBe('read');
+        expect(command.browser).toBe(true);
+        expect(command.columns).toEqual(['field', 'value']);
+    });
+
+    it('parseSubredditName strips prefixes and validates the name shape', () => {
+        expect(parseSubredditName('python')).toBe('python');
+        expect(parseSubredditName('r/python')).toBe('python');
+        expect(parseSubredditName('/r/python')).toBe('python');
+        expect(parseSubredditName('  AskReddit  ')).toBe('AskReddit');
+        expect(parseSubredditName('aw3some_sub')).toBe('aw3some_sub');
+    });
+
+    it('parseSubredditName rejects invalid names without silent fallback', () => {
+        for (const bad of [
+            '',
+            '  ',
+            'py',                   // too short
+            '1abc',                 // must start with letter
+            '_sub',                 // must start with letter
+            'has space',            // no spaces
+            'has-dash',             // no dashes
+            'way_too_long_subreddit_name_here', // too long (>21)
+        ]) {
+            expect(() => parseSubredditName(bad)).toThrow(ArgumentError);
+        }
+    });
+
+    it('rejects bad subreddit names BEFORE navigating', async () => {
+        const page = makePage({ kind: 'ok', info: {} });
+        await expect(command.func(page, { name: 'has space' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthRequiredError on 401/403', async () => {
+        await expect(command.func(makePage({ kind: 'auth', detail: 'login' }), { name: 'python' }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('throws EmptyResultError for missing / banned / private / quarantined subreddits', async () => {
+        for (const detail of ['not found', 'banned', 'private', 'quarantined']) {
+            await expect(command.func(makePage({ kind: 'missing', detail }), { name: 'python' }))
+                .rejects.toBeInstanceOf(EmptyResultError);
+        }
+    });
+
+    it('throws CommandExecutionError on HTTP and exception failure modes', async () => {
+        await expect(command.func(makePage({ kind: 'http', httpStatus: 500, where: 'about.json' }), { name: 'python' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ kind: 'exception', detail: 'bad' }), { name: 'python' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps a normal subreddit payload into typed field/value rows', async () => {
+        const info = {
+            display_name: 'python',
+            display_name_prefixed: 'r/python',
+            title: 'Python',
+            public_description: '  News about the programming language Python.  ',
+            subscribers: 1234567,
+            active_user_count: 4321,
+            over18: false,
+            subreddit_type: 'public',
+            created_utc: 1201881600, // 2008-02-01
+            url: '/r/python/',
+        };
+        const rows = await command.func(makePage({ kind: 'ok', info }), { name: 'python' });
+        const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+
+        expect(byField.Name).toBe('r/python');
+        expect(byField.Title).toBe('Python');
+        expect(byField.Subscribers).toBe('1234567');
+        expect(byField['Active Now']).toBe('4321');
+        expect(byField.NSFW).toBe('No');
+        expect(byField.Type).toBe('public');
+        expect(byField.Description).toBe('News about the programming language Python.');
+        expect(byField.Created).toBe('2008-02-01');
+        expect(byField.URL).toBe('https://www.reddit.com/r/python/');
+
+        for (const row of rows) {
+            expect(Object.keys(row).sort()).toEqual(['field', 'value']);
+        }
+    });
+
+    it('falls back to accounts_active when active_user_count is missing', async () => {
+        const info = {
+            display_name: 'sub',
+            display_name_prefixed: 'r/sub',
+            accounts_active: 99,
+            url: '/r/sub/',
+        };
+        const rows = await command.func(makePage({ kind: 'ok', info }), { name: 'sub' });
+        const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+        expect(byField['Active Now']).toBe('99');
+    });
+
+    it('emits typed null (not "-" sentinel) when subscribers / activity / created are missing', async () => {
+        const info = {
+            display_name: 'sparse',
+            display_name_prefixed: 'r/sparse',
+            url: '/r/sparse/',
+        };
+        const rows = await command.func(makePage({ kind: 'ok', info }), { name: 'sparse' });
+        const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+        expect(byField.Subscribers).toBeNull();
+        expect(byField['Active Now']).toBeNull();
+        expect(byField.Created).toBeNull();
+        expect(byField.Description).toBeNull();
+        expect(byField.Title).toBeNull();
+        expect(byField.Type).toBeNull();
+    });
+
+    it('encodes the subreddit name into the fetch URL embedded in evaluate', async () => {
+        const page = makePage({ kind: 'ok', info: { display_name: 'python', display_name_prefixed: 'r/python', url: '/r/python/' } });
+        await command.func(page, { name: 'r/python' });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('const sub = "python"');
+    });
+});

--- a/clis/reddit/whoami.js
+++ b/clis/reddit/whoami.js
@@ -1,0 +1,84 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+cli({
+    site: 'reddit',
+    name: 'whoami',
+    access: 'read',
+    description: 'Show the currently logged-in Reddit user',
+    domain: 'reddit.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    args: [],
+    columns: ['field', 'value'],
+    func: async (page) => {
+        await page.goto('https://www.reddit.com');
+        // Probe identity via /api/me.json. Reddit returns 200 with an empty
+        // body for stale anonymous sessions, so 401/403 alone is not a
+        // sufficient logged-out signal — we also verify `data.name` exists
+        // (two-pronged auth detection from PR #1428).
+        //
+        // Intermediate object keys deliberately avoid `field` / `value` to
+        // sidestep the silent-column-drop audit (columns are ['field',
+        // 'value']) — see PR #1329 sediment "中间解析对象 key 不能跟 columns
+        // 任一项重叠".
+        const result = await page.evaluate(`(async () => {
+      try {
+        const res = await fetch('/api/me.json?raw_json=1', { credentials: 'include' });
+        if (res.status === 401 || res.status === 403) {
+          return { kind: 'auth', detail: 'Reddit /api/me.json returned HTTP ' + res.status };
+        }
+        if (!res.ok) {
+          return { kind: 'http', httpStatus: res.status, where: '/api/me.json' };
+        }
+        const d = await res.json();
+        const me = d?.data;
+        if (!me?.name) {
+          return { kind: 'auth', detail: 'Not logged in to reddit.com (no identity in /api/me.json)' };
+        }
+        return { kind: 'ok', identity: me };
+      } catch (e) {
+        return { kind: 'exception', detail: String(e && e.message || e) };
+      }
+    })()`);
+
+        if (result?.kind === 'auth') {
+            throw new AuthRequiredError('reddit.com', result.detail);
+        }
+        if (result?.kind === 'http') {
+            throw new CommandExecutionError(`HTTP ${result.httpStatus} from ${result.where}`);
+        }
+        if (result?.kind === 'exception') {
+            throw new CommandExecutionError(`whoami failed: ${result.detail}`);
+        }
+        if (result?.kind !== 'ok') {
+            throw new CommandExecutionError(`Unexpected result from reddit whoami: ${JSON.stringify(result)}`);
+        }
+
+        const u = result.identity;
+        const created = u.created_utc
+            ? new Date(u.created_utc * 1000).toISOString().split('T')[0]
+            : null;
+        const linkKarma = typeof u.link_karma === 'number' ? u.link_karma : null;
+        const commentKarma = typeof u.comment_karma === 'number' ? u.comment_karma : null;
+        const totalKarma = typeof u.total_karma === 'number'
+            ? u.total_karma
+            : (linkKarma != null && commentKarma != null ? linkKarma + commentKarma : null);
+        const inboxCount = typeof u.inbox_count === 'number' ? u.inbox_count : null;
+
+        return [
+            { field: 'Username', value: 'u/' + u.name },
+            { field: 'ID', value: u.id ? 't2_' + u.id : null },
+            { field: 'Post Karma', value: linkKarma != null ? String(linkKarma) : null },
+            { field: 'Comment Karma', value: commentKarma != null ? String(commentKarma) : null },
+            { field: 'Total Karma', value: totalKarma != null ? String(totalKarma) : null },
+            { field: 'Account Created', value: created },
+            { field: 'Gold', value: u.is_gold ? 'Yes' : 'No' },
+            { field: 'Mod', value: u.is_mod ? 'Yes' : 'No' },
+            { field: 'Verified Email', value: u.has_verified_email ? 'Yes' : 'No' },
+            { field: 'Has Mail', value: u.has_mail ? 'Yes' : 'No' },
+            { field: 'Inbox Count', value: inboxCount != null ? String(inboxCount) : null },
+        ];
+    },
+});

--- a/clis/reddit/whoami.test.js
+++ b/clis/reddit/whoami.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './whoami.js';
+
+function makePage(result) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(result),
+    };
+}
+
+describe('reddit whoami command', () => {
+    const command = getRegistry().get('reddit/whoami');
+
+    it('registers with the expected shape', () => {
+        expect(command).toBeDefined();
+        expect(command.access).toBe('read');
+        expect(command.browser).toBe(true);
+        expect(command.columns).toEqual(['field', 'value']);
+        expect(command.args).toEqual([]);
+    });
+
+    it('throws AuthRequiredError on 401/403 from /api/me.json', async () => {
+        const page = makePage({ kind: 'auth', detail: 'Reddit /api/me.json returned HTTP 401' });
+        await expect(command.func(page, {})).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
+    });
+
+    it('throws AuthRequiredError on 200 with missing data.name (stale anon session)', async () => {
+        const page = makePage({ kind: 'auth', detail: 'Not logged in to reddit.com (no identity in /api/me.json)' });
+        await expect(command.func(page, {})).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('throws CommandExecutionError on HTTP / exception failure modes', async () => {
+        await expect(command.func(makePage({ kind: 'http', httpStatus: 500, where: '/api/me.json' }), {}))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ kind: 'exception', detail: 'bad json' }), {}))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps a full identity payload into the field/value rows', async () => {
+        const identity = {
+            name: 'alice',
+            id: 'abcdef',
+            link_karma: 1234,
+            comment_karma: 5678,
+            total_karma: 6912,
+            created_utc: 1577836800, // 2020-01-01
+            is_gold: true,
+            is_mod: false,
+            has_verified_email: true,
+            has_mail: false,
+            inbox_count: 0,
+        };
+        const page = makePage({ kind: 'ok', identity });
+        const rows = await command.func(page, {});
+
+        const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+        expect(byField.Username).toBe('u/alice');
+        expect(byField.ID).toBe('t2_abcdef');
+        expect(byField['Post Karma']).toBe('1234');
+        expect(byField['Comment Karma']).toBe('5678');
+        expect(byField['Total Karma']).toBe('6912');
+        expect(byField['Account Created']).toBe('2020-01-01');
+        expect(byField.Gold).toBe('Yes');
+        expect(byField.Mod).toBe('No');
+        expect(byField['Verified Email']).toBe('Yes');
+        expect(byField['Has Mail']).toBe('No');
+        expect(byField['Inbox Count']).toBe('0');
+
+        // Row shape must match the declared columns exactly so the
+        // silent-column-drop audit can't be triggered.
+        for (const row of rows) {
+            expect(Object.keys(row).sort()).toEqual(['field', 'value']);
+        }
+    });
+
+    it('falls back to null for missing numeric karma fields rather than 0 sentinels', async () => {
+        const identity = {
+            name: 'bob',
+            id: 'xyz',
+            created_utc: null,
+            is_gold: false,
+            is_mod: false,
+            has_verified_email: false,
+            has_mail: false,
+        };
+        const page = makePage({ kind: 'ok', identity });
+        const rows = await command.func(page, {});
+        const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+        expect(byField['Post Karma']).toBeNull();
+        expect(byField['Comment Karma']).toBeNull();
+        expect(byField['Total Karma']).toBeNull();
+        expect(byField['Account Created']).toBeNull();
+        expect(byField['Inbox Count']).toBeNull();
+    });
+
+    it('does not throw on `data.name` present even if optional booleans are missing', async () => {
+        const identity = { name: 'carol', id: 'i1' };
+        const page = makePage({ kind: 'ok', identity });
+        const rows = await command.func(page, {});
+        expect(rows[0]).toEqual({ field: 'Username', value: 'u/carol' });
+    });
+});

--- a/docs/adapters/browser/reddit.md
+++ b/docs/adapters/browser/reddit.md
@@ -6,22 +6,25 @@
 
 | Command | Description |
 |---------|-------------|
-| `opencli reddit hot` | |
-| `opencli reddit frontpage` | |
-| `opencli reddit popular` | |
-| `opencli reddit search` | |
-| `opencli reddit subreddit` | |
-| `opencli reddit read` | |
-| `opencli reddit user` | |
-| `opencli reddit user-posts` | |
-| `opencli reddit user-comments` | |
-| `opencli reddit upvote` | |
-| `opencli reddit save` | |
-| `opencli reddit comment` | |
-| `opencli reddit reply` | |
-| `opencli reddit subscribe` | |
-| `opencli reddit saved` | |
-| `opencli reddit upvoted` | |
+| `opencli reddit hot` | Hot posts from a subreddit (or frontpage if none) |
+| `opencli reddit frontpage` | Frontpage / r/all listing |
+| `opencli reddit home` | **Personalized Best feed (requires login)** |
+| `opencli reddit popular` | Trending posts on /r/popular |
+| `opencli reddit search` | Search posts |
+| `opencli reddit subreddit` | Posts from a specific subreddit, with sort and time filters |
+| `opencli reddit subreddit-info` | **Subreddit metadata (subscribers, active, NSFW, created, description)** |
+| `opencli reddit read` | Read a post thread with comments |
+| `opencli reddit user` | View a user profile |
+| `opencli reddit user-posts` | A user's submitted posts |
+| `opencli reddit user-comments` | A user's comments |
+| `opencli reddit whoami` | **Show the currently logged-in Reddit identity** |
+| `opencli reddit upvote` | Vote on a post or comment |
+| `opencli reddit save` | Save / unsave a post or comment |
+| `opencli reddit comment` | Comment on a post |
+| `opencli reddit reply` | Reply to a comment |
+| `opencli reddit subscribe` | Join / leave a subreddit |
+| `opencli reddit saved` | List your saved items |
+| `opencli reddit upvoted` | List your upvoted posts |
 
 ## Usage Examples
 
@@ -31,6 +34,15 @@ opencli reddit hot --limit 5
 
 # Read one subreddit
 opencli reddit subreddit python --limit 10
+
+# Subreddit metadata (subscribers / active / NSFW / created / description)
+opencli reddit subreddit-info AskReddit
+
+# Personalized Best feed (requires login)
+opencli reddit home --limit 10
+
+# Who am I logged in as?
+opencli reddit whoami
 
 # Read a post thread
 opencli reddit read 1abc123 --depth 2
@@ -47,6 +59,17 @@ opencli reddit hot -f json
 # Verbose mode
 opencli reddit hot -v
 ```
+
+## Auth-required commands
+
+`whoami`, `home`, `saved`, `upvoted`, `subscribe`, `upvote`, `save`, `comment`,
+and `reply` all require a logged-in `reddit.com` cookie session. When the
+session is missing or expired they raise `AuthRequiredError` (exit code 5)
+instead of silently returning empty rows.
+
+For `subreddit-info`, missing / banned / private / quarantined subreddits raise
+`EmptyResultError` (exit code 6) so the output table never contains a silent
+sentinel row.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

WAWQAQ pointed to [jackwener/rdt-cli](https://github.com/jackwener/rdt-cli) and noted opencli reddit's commands are "一点都不充足，一点都不完善". After running the opencli-adapter-author skill recon against rdt-cli's 22-command catalog, three high-priority gaps stood out — covered by this PR (PR A in a planned A/B/C split):

- **`reddit whoami`** — show the currently logged-in identity. Closes the obvious "am I authed?" hole; rdt-cli has `auth status`.
- **`reddit home`** — personalized **Best** feed (`/best.json`). The existing `frontpage`/`hot` commands are the public unauthenticated feed; `home` is the algorithmic feed Reddit shows logged-in users.
- **`reddit subreddit-info`** — subreddit metadata (subscribers / active / NSFW / created / description / type). Existing `subreddit` returns *posts* from a subreddit; this returns the sub's *metadata*. rdt-cli has `social subreddit-info`.

Lower-priority follow-ups (`read --expand-more`, `subscriptions`, `search --type sr`) are NOT in this PR — they'll be PR B / PR C per WAWQAQ's "解决完一个就可以继续了" protocol from msg=eba01f34.

## Design highlights

- All three are read commands using `Strategy.COOKIE`, `browser: true`, `siteSession: 'persistent'`, matching the existing 17 reddit adapters.
- **Two-pronged auth detection** (PR #1428 sediment): 401/403 from `/api/me.json` OR `data.name` missing on a 200. Reddit returns 200 with an empty body for stale anonymous cookie sessions — single-pronged 401-only would silently mis-classify those as "logged in".
- **5-kind discriminated union** from page.evaluate → typed-error mapping on the Node side (`auth`/`http`/`missing`/`exception`/`ok`). Mirrors PR #1428 reddit/reply.
- **Intermediate keys ≠ declared columns** (PR #1329 sediment): page.evaluate returns `{ kind, identity }` / `{ kind, entries }` / `{ kind, info }`, never `{ field, value, rank, ... }` literal column keys, so the silent-column-drop audit can't false-positive.
- **No silent clamp** on `home --limit`: parses to a strict int in [1, 100] (Reddit's per-listing cap), out-of-range raises `ArgumentError` BEFORE `page.goto`.
- **`subreddit-info` 404 → `EmptyResultError`**: banned / private / quarantined / non-existent subs raise typed errors instead of returning a sentinel row.
- **Typed `null` over `'-'` sentinels** for missing optional fields (`Post Karma`, `Subscribers`, `Created`, etc.). The existing user.js still emits `'-'` as a grandfathered pattern; not in scope to refactor here.

## Tests

```
clis/reddit/whoami.test.js          6 tests
clis/reddit/home.test.js            9 tests
clis/reddit/subreddit-info.test.js 13 tests
```

Full reddit suite 38/38, full project 3392/3392 (1 environmental EADDRINUSE on daemon.test.ts unrelated to this PR — port 19825 held by another local process).

## Audits

- typed-error-lint **189/189**, 0 new
- silent-column-drop **103/103**, 0 new
- listing-id-pairing — none of the 3 new commands are listings that pair with a detail command (whoami & subreddit-info return field/value scalar tables; home is itself a listing whose detail is the existing `read` command keyed on `postId`)
- Manifest 812 → 815

## Test plan

- [x] Mocked `page.evaluate` unit tests for each adapter's auth / http / empty / exception / ok path
- [x] Argument validators (`parseRedditHomeLimit`, `parseSubredditName`) tested independently against bad-input matrix
- [x] All three audits green
- [x] `npm run build` from clean state produces clean manifest diff (only +3 entries)
- [ ] Live verify (next: run `opencli reddit whoami` / `home --limit 5` / `subreddit-info AskReddit` against a logged-in Chrome session after review)