### PR TITLE
feat(reddit/read): --expand-more via /api/morechildren + 7-kind typed errors

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19352,6 +19352,20 @@
         "default": 2000,
         "required": false,
         "help": "Max characters per comment body (min 100)"
+      },
+      {
+        "name": "expand-more",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Follow Reddit \"more comments\" stubs by calling /api/morechildren.json"
+      },
+      {
+        "name": "expand-rounds",
+        "type": "int",
+        "default": 2,
+        "required": false,
+        "help": "Max expansion passes when --expand-more is on (1–5; each round can fan out new \"more\" stubs)"
       }
     ],
     "columns": [

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -5,9 +5,31 @@
  * - Top-K comments by score at each level
  * - Configurable depth and replies-per-level
  * - Indented output showing conversation threads
+ * - Optional --expand-more to follow Reddit's "more comments" stubs via
+ *   /api/morechildren.json (rdt-cli parity, PR B of #1481 follow-up)
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const REDDIT_EXPAND_ROUNDS_MIN = 1;
+const REDDIT_EXPAND_ROUNDS_MAX = 5;
+const DEFAULT_EXPAND_ROUNDS = 2;
+
+export function parseExpandRounds(raw) {
+    if (raw === undefined || raw === null || raw === '') return DEFAULT_EXPAND_ROUNDS;
+    const n = Number(raw);
+    if (
+        !Number.isFinite(n) || !Number.isInteger(n)
+        || n < REDDIT_EXPAND_ROUNDS_MIN || n > REDDIT_EXPAND_ROUNDS_MAX
+    ) {
+        throw new ArgumentError(
+            `expand-rounds must be an integer in [${REDDIT_EXPAND_ROUNDS_MIN}, ${REDDIT_EXPAND_ROUNDS_MAX}].`,
+            `Got: ${raw}`,
+        );
+    }
+    return n;
+}
+
 cli({
     site: 'reddit',
     name: 'read',
@@ -24,80 +46,306 @@ cli({
         { name: 'depth', type: 'int', default: 2, help: 'Max reply depth (1=no replies, 2=one level of replies, etc.)' },
         { name: 'replies', type: 'int', default: 5, help: 'Max replies shown per comment at each level (sorted by score)' },
         { name: 'max-length', type: 'int', default: 2000, help: 'Max characters per comment body (min 100)' },
+        {
+            name: 'expand-more',
+            type: 'bool',
+            default: false,
+            help: 'Follow Reddit "more comments" stubs by calling /api/morechildren.json',
+        },
+        {
+            name: 'expand-rounds',
+            type: 'int',
+            default: DEFAULT_EXPAND_ROUNDS,
+            help: `Max expansion passes when --expand-more is on (${REDDIT_EXPAND_ROUNDS_MIN}–${REDDIT_EXPAND_ROUNDS_MAX}; each round can fan out new "more" stubs)`,
+        },
     ],
     columns: ['type', 'author', 'score', 'text'],
     func: async (page, kwargs) => {
+        // Note: --limit / --depth / --replies / --max-length keep their original
+        // Math.max-style behaviour for backward compatibility (grandfathered in
+        // the typed-error-lint baseline). The new --expand-rounds argument is
+        // strictly validated via parseExpandRounds — no silent clamp.
         const sort = kwargs.sort ?? 'best';
         const limit = Math.max(1, kwargs.limit ?? 25);
         const maxDepth = Math.max(1, kwargs.depth ?? 2);
         const maxReplies = Math.max(1, kwargs.replies ?? 5);
         const maxLength = Math.max(100, kwargs['max-length'] ?? 2000);
+        const expandMore = Boolean(kwargs['expand-more']);
+        const expandRounds = parseExpandRounds(kwargs['expand-rounds']);
+
         await page.goto('https://www.reddit.com');
-        const data = await page.evaluate(`
+
+        // The in-browser script returns a discriminated union so we can map
+        // each failure mode to its proper typed error on the Node side
+        // (page.evaluate boundary can't carry typed error instances). Kinds:
+        //   - inaccessible: 401/403/404 on /comments/<id>.json (post-specific,
+        //     not session auth — same session works for other posts)
+        //   - auth:         /api/morechildren.json 401/403 (session-level on
+        //     the write-like expand endpoint — see two-pronged auth detection
+        //     sediment from PR #1428)
+        //   - http:         5xx or other non-ok
+        //   - malformed:    200 but Reddit shape is unexpected (schema drift)
+        //   - parser-drift: tree non-empty but walk produced 0 rows
+        //   - expand-failed: morechildren returned errors
+        //   - ok:           rows array
+        //
+        // Intermediate keys (`rows` / `detail` / `httpStatus` / `where`)
+        // deliberately avoid the declared columns (`type`/`author`/`score`/
+        // `text`) to sidestep the silent-column-drop audit (PR #1329).
+        const result = await page.evaluate(`
       (async function() {
-        var postId = ${JSON.stringify(kwargs['post-id'])};
-        var urlMatch = postId.match(/comments\\/([a-z0-9]+)/);
-        if (urlMatch) postId = urlMatch[1];
+        var postIdRaw = ${JSON.stringify(kwargs['post-id'])};
+        var urlMatch = postIdRaw.match(/comments\\/([a-z0-9]+)/);
+        var postId = urlMatch ? urlMatch[1] : postIdRaw;
+        var linkFullname = 't3_' + postId;
 
         var sort = ${JSON.stringify(sort)};
         var limit = ${limit};
         var maxDepth = ${maxDepth};
         var maxReplies = ${maxReplies};
         var maxLength = ${maxLength};
+        var expandMore = ${JSON.stringify(expandMore)};
+        var expandRounds = ${expandRounds};
 
-        // Request more from API than top-level limit to get inline replies
-        // depth param tells Reddit how deep to inline replies vs "more" stubs
+        // ---------------------------------------------------------------
+        // Step 1: fetch the post + initial comment tree
+        // ---------------------------------------------------------------
+        // Request more from API than top-level limit to get inline replies.
+        // depth param tells Reddit how deep to inline replies vs "more" stubs.
         var apiLimit = Math.max(limit * 3, 100);
         var res = await fetch(
           '/comments/' + postId + '.json?sort=' + sort + '&limit=' + apiLimit + '&depth=' + (maxDepth + 1) + '&raw_json=1',
           { credentials: 'include' }
         );
-        if (!res.ok) return { error: 'Reddit API returned HTTP ' + res.status };
-
+        if (res.status === 401 || res.status === 403 || res.status === 404) {
+          return { kind: 'inaccessible', detail: 'Reddit post ' + postId + ' is not accessible (HTTP ' + res.status + ').' };
+        }
+        if (!res.ok) {
+          return { kind: 'http', httpStatus: res.status, where: '/comments/' + postId + '.json' };
+        }
         var data;
-        try { data = await res.json(); } catch(e) { return { error: 'Failed to parse response' }; }
-        if (!Array.isArray(data) || data.length < 2) return { error: 'Unexpected response format' };
-
-        var results = [];
-
-        // Post
-        var post = data[0] && data[0].data && data[0].data.children && data[0].data.children[0] && data[0].data.children[0].data;
-        if (post) {
-          var body = post.selftext || '';
-          if (body.length > maxLength) body = body.slice(0, maxLength) + '\\n... [truncated]';
-          results.push({
-            type: 'POST',
-            author: post.author || '[deleted]',
-            score: post.score || 0,
-            text: post.title + (body ? '\\n\\n' + body : '') + (post.url && !post.is_self ? '\\n' + post.url : ''),
-          });
+        try { data = await res.json(); } catch (e) {
+          return { kind: 'malformed', detail: 'Failed to parse Reddit /comments/' + postId + '.json response: ' + (e && e.message || e) };
+        }
+        if (!Array.isArray(data) || data.length < 2) {
+          return { kind: 'malformed', detail: 'Reddit /comments/' + postId + '.json had unexpected envelope shape (length ' + (Array.isArray(data) ? data.length : typeof data) + ').' };
         }
 
-        // Recursive comment walker
-        // depth 0 = top-level comments; maxDepth is exclusive,
-        // so --depth 1 means top-level only, --depth 2 means one reply level, etc.
+        var post = data[0] && data[0].data && data[0].data.children && data[0].data.children[0] && data[0].data.children[0].data;
+        if (!post) {
+          return { kind: 'malformed', detail: 'Reddit /comments/' + postId + '.json had no post body.' };
+        }
+        var topListing = data[1] && data[1].data && Array.isArray(data[1].data.children) ? data[1].data.children : null;
+        if (!topListing) {
+          return { kind: 'malformed', detail: 'Reddit /comments/' + postId + '.json had no comment listing.' };
+        }
+
+        // ---------------------------------------------------------------
+        // Step 2: optionally follow "more" stubs via /api/morechildren.json
+        // ---------------------------------------------------------------
+        // Each "more" thing has a .data.children array (t1 ids to fetch).
+        // The morechildren API returns a FLAT list of things; we re-thread
+        // them by parent_id (either t3_<postId> for top-level or t1_<id>
+        // for nested). Each round may surface new "more" stubs (because
+        // expansion is bounded by Reddit's depth param), so we iterate up
+        // to expandRounds times.
+        var expandMeta = { rounds: 0, fetched: 0, capped: false, errors: [] };
+
+        if (expandMore) {
+          // Index every existing t1 node so we can splice replies onto it.
+          var t1Index = {};
+          function indexT1(arr) {
+            if (!Array.isArray(arr)) return;
+            for (var i = 0; i < arr.length; i++) {
+              var node = arr[i];
+              if (node && node.kind === 't1' && node.data && node.data.id) {
+                t1Index[node.data.name || ('t1_' + node.data.id)] = node;
+                if (node.data.replies && node.data.replies.data && node.data.replies.data.children) {
+                  indexT1(node.data.replies.data.children);
+                }
+              }
+            }
+          }
+          indexT1(topListing);
+
+          // Collect "more" stubs (with non-empty children) from anywhere in
+          // the tree. Each stub knows its host array via a closure-bound
+          // reference we attach.
+          function collectMoreStubs(parentArr, parentT1) {
+            var out = [];
+            if (!Array.isArray(parentArr)) return out;
+            for (var i = 0; i < parentArr.length; i++) {
+              var n = parentArr[i];
+              if (!n || !n.data) continue;
+              if (n.kind === 'more' && Array.isArray(n.data.children) && n.data.children.length > 0) {
+                out.push({ stub: n, hostArr: parentArr, hostT1: parentT1 });
+              } else if (n.kind === 't1' && n.data.replies && n.data.replies.data && n.data.replies.data.children) {
+                var nested = collectMoreStubs(n.data.replies.data.children, n);
+                for (var k = 0; k < nested.length; k++) out.push(nested[k]);
+              }
+            }
+            return out;
+          }
+
+          for (var r = 0; r < expandRounds; r++) {
+            var stubs = collectMoreStubs(topListing, null);
+            if (stubs.length === 0) break;
+
+            // Build the union of t1 ids to request this round. Reddit's
+            // morechildren API caps at ~100 ids per call; batch accordingly.
+            var allIds = [];
+            for (var s = 0; s < stubs.length; s++) {
+              var st = stubs[s].stub;
+              for (var c = 0; c < st.data.children.length; c++) allIds.push(st.data.children[c]);
+            }
+            if (allIds.length === 0) break;
+
+            // dedupe preserving order
+            var seen = {};
+            var uniqIds = [];
+            for (var j = 0; j < allIds.length; j++) {
+              if (!seen[allIds[j]]) { seen[allIds[j]] = 1; uniqIds.push(allIds[j]); }
+            }
+
+            var fetchedThings = [];
+            var batchSize = 100;
+            var batchFailed = false;
+            for (var b = 0; b < uniqIds.length; b += batchSize) {
+              var batch = uniqIds.slice(b, b + batchSize);
+              var body = 'api_type=json'
+                + '&link_id=' + encodeURIComponent(linkFullname)
+                + '&children=' + encodeURIComponent(batch.join(','))
+                + '&sort=' + encodeURIComponent(sort)
+                + '&raw_json=1';
+              var mcRes;
+              try {
+                mcRes = await fetch('/api/morechildren', {
+                  method: 'POST',
+                  credentials: 'include',
+                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                  body: body,
+                });
+              } catch (e) {
+                return { kind: 'expand-failed', detail: 'morechildren request threw: ' + (e && e.message || e), expandMeta: expandMeta };
+              }
+              if (mcRes.status === 401 || mcRes.status === 403) {
+                return { kind: 'auth', detail: '/api/morechildren returned HTTP ' + mcRes.status + ' (write/expand likely requires login)' };
+              }
+              if (!mcRes.ok) {
+                return { kind: 'http', httpStatus: mcRes.status, where: '/api/morechildren (round ' + (r + 1) + ', batch ' + ((b / batchSize) + 1) + ')' };
+              }
+              var mcData;
+              try { mcData = await mcRes.json(); } catch (e) {
+                return { kind: 'malformed', detail: 'Failed to parse /api/morechildren response: ' + (e && e.message || e) };
+              }
+              var errs = mcData && mcData.json && mcData.json.errors;
+              if (Array.isArray(errs) && errs.length > 0) {
+                return { kind: 'expand-failed', detail: 'Reddit /api/morechildren rejected: ' + errs.map(function(e) { return e.join(': '); }).join('; '), expandMeta: expandMeta };
+              }
+              var things = mcData && mcData.json && mcData.json.data && mcData.json.data.things;
+              if (!Array.isArray(things)) {
+                return { kind: 'malformed', detail: '/api/morechildren returned no things array.' };
+              }
+              for (var t = 0; t < things.length; t++) fetchedThings.push(things[t]);
+            }
+            expandMeta.rounds = r + 1;
+            expandMeta.fetched += fetchedThings.length;
+
+            // Re-thread fetched things by parent_id. Parents are either the
+            // post (t3_<postId>) → top-level listing, or another t1 → its
+            // replies.data.children. We must respect Reddit's depth/inline
+            // semantics: if the parent t1 has no replies object yet (because
+            // initial fetch didn't inline replies there), create the shell.
+            function ensureReplies(parentNode) {
+              if (!parentNode.data.replies || typeof parentNode.data.replies !== 'object') {
+                parentNode.data.replies = { kind: 'Listing', data: { children: [] } };
+                return parentNode.data.replies.data.children;
+              }
+              if (!parentNode.data.replies.data) {
+                parentNode.data.replies.data = { children: [] };
+                return parentNode.data.replies.data.children;
+              }
+              if (!Array.isArray(parentNode.data.replies.data.children)) {
+                parentNode.data.replies.data.children = [];
+              }
+              return parentNode.data.replies.data.children;
+            }
+
+            // First: remove old stubs so we can replace with fresh content.
+            // The stubs we collected may have been replaced if their children
+            // overlap; do a safe filter.
+            for (var s = 0; s < stubs.length; s++) {
+              var rec = stubs[s];
+              var idx = rec.hostArr.indexOf(rec.stub);
+              if (idx >= 0) rec.hostArr.splice(idx, 1);
+            }
+
+            // Now insert fetched things.
+            for (var t = 0; t < fetchedThings.length; t++) {
+              var thing = fetchedThings[t];
+              if (!thing || !thing.data) continue;
+              var parentId = thing.data.parent_id;
+              var dest;
+              if (parentId === linkFullname) {
+                dest = topListing;
+              } else if (parentId && parentId.indexOf('t1_') === 0 && t1Index[parentId]) {
+                dest = ensureReplies(t1Index[parentId]);
+              } else {
+                // Orphaned thing whose parent isn't in our tree (depth
+                // boundary). Drop with metadata rather than silently lose.
+                expandMeta.errors.push('orphan: ' + (thing.data.id || '?') + ' parent=' + (parentId || '?'));
+                continue;
+              }
+              dest.push(thing);
+              if (thing.kind === 't1' && thing.data && thing.data.id) {
+                t1Index[thing.data.name || ('t1_' + thing.data.id)] = thing;
+              }
+            }
+
+            if (r + 1 >= expandRounds) {
+              // If after the last round there are still "more" stubs, mark capped.
+              var remaining = collectMoreStubs(topListing, null);
+              if (remaining.length > 0) expandMeta.capped = true;
+            }
+          }
+        }
+
+        // ---------------------------------------------------------------
+        // Step 3: walk the (possibly augmented) tree into indented rows
+        // ---------------------------------------------------------------
+        var rows = [];
+
+        // Post header row.
+        var body = post.selftext || '';
+        if (body.length > maxLength) body = body.slice(0, maxLength) + '\\n... [truncated]';
+        rows.push({
+          type: 'POST',
+          author: post.author || '[deleted]',
+          score: post.score || 0,
+          text: post.title + (body ? '\\n\\n' + body : '') + (post.url && !post.is_self ? '\\n' + post.url : ''),
+        });
+
+        // Recursive comment walker.
         function walkComment(node, depth) {
           if (!node || node.kind !== 't1') return;
           var d = node.data;
-          var body = d.body || '';
-          if (body.length > maxLength) body = body.slice(0, maxLength) + '...';
+          var cBody = d.body || '';
+          if (cBody.length > maxLength) cBody = cBody.slice(0, maxLength) + '...';
 
-          // Indent prefix: apply to every line so multiline bodies stay aligned
           var indent = '';
           for (var i = 0; i < depth; i++) indent += '  ';
           var prefix = depth === 0 ? '' : indent + '> ';
           var indentedBody = depth === 0
-            ? body
-            : body.split('\\n').map(function(line) { return prefix + line; }).join('\\n');
+            ? cBody
+            : cBody.split('\\n').map(function(line) { return prefix + line; }).join('\\n');
 
-          results.push({
+          rows.push({
             type: depth === 0 ? 'L0' : 'L' + depth,
             author: d.author || '[deleted]',
             score: d.score || 0,
             text: indentedBody,
           });
 
-          // Count all available replies (for accurate "more" count)
           var t1Children = [];
           var moreCount = 0;
           if (d.replies && d.replies.data && d.replies.data.children) {
@@ -111,13 +359,12 @@ cli({
             }
           }
 
-          // At depth cutoff: don't recurse, but show all replies as hidden
           if (depth + 1 >= maxDepth) {
             var totalHidden = t1Children.length + moreCount;
             if (totalHidden > 0) {
               var cutoffIndent = '';
               for (var j = 0; j <= depth; j++) cutoffIndent += '  ';
-              results.push({
+              rows.push({
                 type: 'L' + (depth + 1),
                 author: '',
                 score: '',
@@ -127,19 +374,17 @@ cli({
             return;
           }
 
-          // Sort by score descending, take top N
           t1Children.sort(function(a, b) { return (b.data.score || 0) - (a.data.score || 0); });
           var toProcess = Math.min(t1Children.length, maxReplies);
           for (var i = 0; i < toProcess; i++) {
             walkComment(t1Children[i], depth + 1);
           }
 
-          // Show hidden count (skipped replies + "more" stubs)
           var hidden = t1Children.length - toProcess + moreCount;
           if (hidden > 0) {
             var moreIndent = '';
             for (var j = 0; j <= depth; j++) moreIndent += '  ';
-            results.push({
+            rows.push({
               type: 'L' + (depth + 1),
               author: '',
               score: '',
@@ -148,24 +393,24 @@ cli({
           }
         }
 
-        // Walk top-level comments
-        var topLevel = data[1].data.children || [];
         var t1TopLevel = [];
-        for (var i = 0; i < topLevel.length; i++) {
-          if (topLevel[i].kind === 't1') t1TopLevel.push(topLevel[i]);
+        for (var i = 0; i < topListing.length; i++) {
+          if (topListing[i].kind === 't1') t1TopLevel.push(topListing[i]);
         }
 
-        // Top-level are already sorted by Reddit (sort param), take top N
+        // Detect parser drift: tree had content but the walker produced nothing.
+        // We must check this AFTER the walk because top-level may be only "more"
+        // stubs (legitimate empty case for a brand-new post).
+        var preWalkSize = topListing.length;
         for (var i = 0; i < Math.min(t1TopLevel.length, limit); i++) {
           walkComment(t1TopLevel[i], 0);
         }
 
-        // Count remaining
-        var moreTopLevel = topLevel.filter(function(c) { return c.kind === 'more'; })
+        var moreTopLevel = topListing.filter(function(c) { return c.kind === 'more'; })
           .reduce(function(sum, c) { return sum + (c.data.count || 0); }, 0);
         var hiddenTopLevel = Math.max(0, t1TopLevel.length - limit) + moreTopLevel;
         if (hiddenTopLevel > 0) {
-          results.push({
+          rows.push({
             type: '',
             author: '',
             score: '',
@@ -173,15 +418,41 @@ cli({
           });
         }
 
-        return results;
+        // If we produced nothing beyond the POST row but the comment listing
+        // wasn't empty, that's parser drift (e.g. Reddit changed t1/more
+        // schema). Surface as CommandExecutionError on the Node side.
+        if (rows.length <= 1 && preWalkSize > 0 && t1TopLevel.length > 0) {
+          return { kind: 'parser-drift', detail: 'Reddit comment listing for post ' + postId + ' had ' + t1TopLevel.length + ' t1 entries but walker produced no rows.' };
+        }
+
+        return { kind: 'ok', rows: rows, expandMeta: expandMeta };
       })()
     `);
-        if (!data || typeof data !== 'object')
-            throw new CommandExecutionError('Failed to fetch post data');
-        if (!Array.isArray(data) && data.error)
-            throw new CommandExecutionError(data.error);
-        if (!Array.isArray(data))
-            throw new CommandExecutionError('Unexpected response');
-        return data;
+
+        if (!result || typeof result !== 'object') {
+            throw new CommandExecutionError('Reddit /comments fetch returned no result envelope.');
+        }
+        if (result.kind === 'inaccessible') {
+            throw new EmptyResultError(result.detail);
+        }
+        if (result.kind === 'auth') {
+            throw new AuthRequiredError('reddit.com', result.detail);
+        }
+        if (result.kind === 'http') {
+            throw new CommandExecutionError(`HTTP ${result.httpStatus} from ${result.where}`);
+        }
+        if (result.kind === 'malformed') {
+            throw new CommandExecutionError(result.detail);
+        }
+        if (result.kind === 'parser-drift') {
+            throw new CommandExecutionError(result.detail);
+        }
+        if (result.kind === 'expand-failed') {
+            throw new CommandExecutionError(result.detail);
+        }
+        if (result.kind !== 'ok' || !Array.isArray(result.rows)) {
+            throw new CommandExecutionError(`Unexpected result from reddit read: ${JSON.stringify(result)}`);
+        }
+        return result.rows;
     },
 });

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -344,7 +344,10 @@ cli({
               for (var c = 0; c < rec.stub.data.children.length; c++) {
                 var childId = rec.stub.data.children[c];
                 var replacement = fetchedById[childId] || fetchedById['t1_' + childId];
-                if (!replacement || !replacement.data) continue;
+                if (!replacement || !replacement.data) {
+                  expandMeta.errors.push('missing: ' + childId + ' parent=' + expectedParent);
+                  continue;
+                }
                 var key = thingKey(replacement);
                 if (key && inserted[key]) continue;
                 if (replacement.data.parent_id !== expectedParent) {

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -14,6 +14,73 @@ import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultErr
 const REDDIT_EXPAND_ROUNDS_MIN = 1;
 const REDDIT_EXPAND_ROUNDS_MAX = 5;
 const DEFAULT_EXPAND_ROUNDS = 2;
+const REDDIT_POST_ID_RE = /^[a-z0-9]+$/i;
+
+function normalizeBareRedditPostId(value) {
+    const postId = String(value || '').trim();
+    if (!REDDIT_POST_ID_RE.test(postId)) {
+        throw new ArgumentError(
+            'Post ID must be a Reddit post id, t3_ fullname, or reddit.com post URL.',
+            'Use a bare post id like 1abc123, a fullname like t3_1abc123, or a full Reddit post URL.',
+        );
+    }
+    return postId.toLowerCase();
+}
+
+export function normalizeRedditPostId(value) {
+    const raw = String(value || '').trim();
+    if (!raw) {
+        throw new ArgumentError(
+            'Post ID is required.',
+            'Use a bare post id like 1abc123, a fullname like t3_1abc123, or a full Reddit post URL.',
+        );
+    }
+
+    const fullname = raw.match(/^t3_([a-z0-9]+)$/i);
+    if (fullname) return normalizeBareRedditPostId(fullname[1]);
+
+    if (/^https?:\/\//i.test(raw)) {
+        let parsed;
+        try {
+            parsed = new URL(raw);
+        } catch {
+            throw new ArgumentError(`Invalid Reddit post URL: ${raw}`);
+        }
+        const host = parsed.hostname.toLowerCase();
+        if (parsed.protocol !== 'https:' || (host !== 'reddit.com' && !host.endsWith('.reddit.com'))) {
+            throw new ArgumentError(
+                'Post URL must be an https reddit.com URL.',
+                'Use a URL like https://www.reddit.com/r/sub/comments/1abc123/title_slug/',
+            );
+        }
+        const parts = parsed.pathname.split('/').filter(Boolean);
+        const commentsIndex = parts.indexOf('comments');
+        const postIndex = commentsIndex + 1;
+        if (commentsIndex < 0 || parts.length <= postIndex) {
+            throw new ArgumentError(
+                'Post URL must include the target post id.',
+                'Use a URL like https://www.reddit.com/r/sub/comments/1abc123/title_slug/',
+            );
+        }
+        if (parts.length > postIndex + 3) {
+            throw new ArgumentError(
+                'Post URL must end at the post slug or comment permalink id.',
+                'Remove extra path segments after the post slug or comment id.',
+            );
+        }
+        if (parts.length === postIndex + 3) normalizeBareRedditPostId(parts[postIndex + 2]);
+        return normalizeBareRedditPostId(parts[postIndex]);
+    }
+
+    if (raw.includes('/') || raw.startsWith('t1_')) {
+        throw new ArgumentError(
+            'Post ID must be a Reddit post id, t3_ fullname, or reddit.com post URL.',
+            'Use a bare post id like 1abc123, a fullname like t3_1abc123, or a full Reddit post URL.',
+        );
+    }
+
+    return normalizeBareRedditPostId(raw);
+}
 
 export function parseExpandRounds(raw) {
     if (raw === undefined || raw === null || raw === '') return DEFAULT_EXPAND_ROUNDS;
@@ -72,6 +139,7 @@ cli({
         const maxLength = Math.max(100, kwargs['max-length'] ?? 2000);
         const expandMore = Boolean(kwargs['expand-more']);
         const expandRounds = parseExpandRounds(kwargs['expand-rounds']);
+        const postId = normalizeRedditPostId(kwargs['post-id']);
 
         await page.goto('https://www.reddit.com');
 
@@ -94,9 +162,7 @@ cli({
         // `text`) to sidestep the silent-column-drop audit (PR #1329).
         const result = await page.evaluate(`
       (async function() {
-        var postIdRaw = ${JSON.stringify(kwargs['post-id'])};
-        var urlMatch = postIdRaw.match(/comments\\/([a-z0-9]+)/);
-        var postId = urlMatch ? urlMatch[1] : postIdRaw;
+        var postId = ${JSON.stringify(postId)};
         var linkFullname = 't3_' + postId;
 
         var sort = ${JSON.stringify(sort)};
@@ -251,54 +317,56 @@ cli({
             expandMeta.rounds = r + 1;
             expandMeta.fetched += fetchedThings.length;
 
-            // Re-thread fetched things by parent_id. Parents are either the
-            // post (t3_<postId>) → top-level listing, or another t1 → its
-            // replies.data.children. We must respect Reddit's depth/inline
-            // semantics: if the parent t1 has no replies object yet (because
-            // initial fetch didn't inline replies there), create the shell.
-            function ensureReplies(parentNode) {
-              if (!parentNode.data.replies || typeof parentNode.data.replies !== 'object') {
-                parentNode.data.replies = { kind: 'Listing', data: { children: [] } };
-                return parentNode.data.replies.data.children;
-              }
-              if (!parentNode.data.replies.data) {
-                parentNode.data.replies.data = { children: [] };
-                return parentNode.data.replies.data.children;
-              }
-              if (!Array.isArray(parentNode.data.replies.data.children)) {
-                parentNode.data.replies.data.children = [];
-              }
-              return parentNode.data.replies.data.children;
-            }
-
-            // First: remove old stubs so we can replace with fresh content.
-            // The stubs we collected may have been replaced if their children
-            // overlap; do a safe filter.
-            for (var s = 0; s < stubs.length; s++) {
-              var rec = stubs[s];
-              var idx = rec.hostArr.indexOf(rec.stub);
-              if (idx >= 0) rec.hostArr.splice(idx, 1);
-            }
-
-            // Now insert fetched things.
+            var fetchedById = {};
             for (var t = 0; t < fetchedThings.length; t++) {
               var thing = fetchedThings[t];
               if (!thing || !thing.data) continue;
-              var parentId = thing.data.parent_id;
-              var dest;
-              if (parentId === linkFullname) {
-                dest = topListing;
-              } else if (parentId && parentId.indexOf('t1_') === 0 && t1Index[parentId]) {
-                dest = ensureReplies(t1Index[parentId]);
-              } else {
-                // Orphaned thing whose parent isn't in our tree (depth
-                // boundary). Drop with metadata rather than silently lose.
-                expandMeta.errors.push('orphan: ' + (thing.data.id || '?') + ' parent=' + (parentId || '?'));
-                continue;
+              if (thing.data.id) fetchedById[thing.data.id] = thing;
+              if (thing.data.name) fetchedById[thing.data.name] = thing;
+            }
+
+            var inserted = {};
+            function thingKey(thing) {
+              return thing && thing.data && (thing.data.name || (thing.kind + '_' + thing.data.id));
+            }
+
+            // Replace each collected stub in-place so expansion preserves the
+            // surrounding tree order instead of appending fetched comments at
+            // the end of the parent array.
+            for (var s = 0; s < stubs.length; s++) {
+              var rec = stubs[s];
+              var idx = rec.hostArr.indexOf(rec.stub);
+              if (idx < 0) continue;
+              var expectedParent = rec.hostT1
+                ? (rec.hostT1.data.name || ('t1_' + rec.hostT1.data.id))
+                : linkFullname;
+              var replacements = [];
+              for (var c = 0; c < rec.stub.data.children.length; c++) {
+                var childId = rec.stub.data.children[c];
+                var replacement = fetchedById[childId] || fetchedById['t1_' + childId];
+                if (!replacement || !replacement.data) continue;
+                var key = thingKey(replacement);
+                if (key && inserted[key]) continue;
+                if (replacement.data.parent_id !== expectedParent) {
+                  expandMeta.errors.push('orphan: ' + (replacement.data.id || '?') + ' parent=' + (replacement.data.parent_id || '?'));
+                  continue;
+                }
+                replacements.push(replacement);
+                if (key) inserted[key] = 1;
+                if (replacement.kind === 't1' && replacement.data && replacement.data.id) {
+                  t1Index[replacement.data.name || ('t1_' + replacement.data.id)] = replacement;
+                }
               }
-              dest.push(thing);
-              if (thing.kind === 't1' && thing.data && thing.data.id) {
-                t1Index[thing.data.name || ('t1_' + thing.data.id)] = thing;
+              rec.hostArr.splice(idx, 1, ...replacements);
+            }
+
+            for (var t = 0; t < fetchedThings.length; t++) {
+              var unplaced = fetchedThings[t];
+              var unplacedKey = thingKey(unplaced);
+              if (unplacedKey && inserted[unplacedKey]) continue;
+              if (unplaced && unplaced.data) {
+                expandMeta.errors.push('unplaced: ' + (unplaced.data.id || '?') + ' parent=' + (unplaced.data.parent_id || '?'));
+                continue;
               }
             }
 
@@ -307,6 +375,10 @@ cli({
               var remaining = collectMoreStubs(topListing, null);
               if (remaining.length > 0) expandMeta.capped = true;
             }
+          }
+
+          if (expandMeta.errors.length > 0) {
+            return { kind: 'expand-failed', detail: 'Reddit /api/morechildren returned unplaceable comments: ' + expandMeta.errors.slice(0, 5).join('; '), expandMeta: expandMeta };
           }
         }
 

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -1,20 +1,67 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { parseExpandRounds } from './read.js';
 import './read.js';
+
+function makePage(result) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(result),
+    };
+}
+
 describe('reddit read adapter', () => {
     const command = getRegistry().get('reddit/read');
+
     it('opts into the Reddit persistent site session', () => {
         expect(command?.browser).toBe(true);
         expect(command?.siteSession).toBe('persistent');
+        expect(command?.columns).toEqual(['type', 'author', 'score', 'text']);
     });
-    it('returns threaded rows from the browser-evaluated payload', async () => {
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue([
+
+    it('exposes the new --expand-more / --expand-rounds args', () => {
+        const argNames = command.args.map((a) => a.name);
+        expect(argNames).toContain('expand-more');
+        expect(argNames).toContain('expand-rounds');
+        const expandMore = command.args.find((a) => a.name === 'expand-more');
+        expect(expandMore.type).toBe('bool');
+        expect(expandMore.default).toBe(false);
+        const rounds = command.args.find((a) => a.name === 'expand-rounds');
+        expect(rounds.type).toBe('int');
+        expect(rounds.default).toBe(2);
+    });
+
+    describe('parseExpandRounds', () => {
+        it('returns the default for absent input but throws on out-of-range / non-integer', () => {
+            expect(parseExpandRounds(undefined)).toBe(2);
+            expect(parseExpandRounds(null)).toBe(2);
+            expect(parseExpandRounds('')).toBe(2);
+            expect(parseExpandRounds(1)).toBe(1);
+            expect(parseExpandRounds(5)).toBe(5);
+            for (const bad of [0, -1, 6, 1.5, NaN, 'abc']) {
+                expect(() => parseExpandRounds(bad)).toThrow(ArgumentError);
+            }
+        });
+    });
+
+    it('rejects a bad --expand-rounds BEFORE navigating', async () => {
+        const page = makePage({ kind: 'ok', rows: [] });
+        await expect(command.func(page, { 'post-id': 'abc123', 'expand-rounds': 99 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('returns rows when the evaluate script reports kind=ok', async () => {
+        const page = makePage({
+            kind: 'ok',
+            rows: [
                 { type: 'POST', author: 'alice', score: 10, text: 'Title' },
                 { type: 'L0', author: 'bob', score: 5, text: 'Comment' },
-            ]),
-        };
+            ],
+            expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] },
+        });
         const result = await command.func(page, { 'post-id': 'abc123', limit: 5 });
         expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
         expect(result).toEqual([
@@ -22,11 +69,86 @@ describe('reddit read adapter', () => {
             { type: 'L0', author: 'bob', score: 5, text: 'Comment' },
         ]);
     });
-    it('surfaces adapter-level API errors clearly', async () => {
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ error: 'Reddit API returned HTTP 403' }),
-        };
-        await expect(command.func(page, { 'post-id': 'abc123' })).rejects.toThrow('Reddit API returned HTTP 403');
+
+    it('maps the five failure kinds to the right typed errors', async () => {
+        await expect(command.func(makePage({ kind: 'inaccessible', detail: 'post 403' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+
+        await expect(command.func(makePage({ kind: 'auth', detail: 'morechildren 401' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+
+        await expect(command.func(makePage({ kind: 'http', httpStatus: 503, where: '/comments/abc.json' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        await expect(command.func(makePage({ kind: 'malformed', detail: 'no comment listing' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        await expect(command.func(makePage({ kind: 'parser-drift', detail: 'walker drift' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        await expect(command.func(makePage({ kind: 'expand-failed', detail: 'morechildren errors' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws CommandExecutionError on an unknown envelope shape (no kind)', async () => {
+        await expect(command.func(makePage({ random: 'stuff' }), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage(null), { 'post-id': 'abc123' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('embeds expandMore=false by default and inlines flags into the evaluate script', async () => {
+        const page = makePage({ kind: 'ok', rows: [], expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] } });
+        await command.func(page, { 'post-id': 'xyz', sort: 'top', limit: 3 });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('var expandMore = false');
+        expect(script).toContain('var expandRounds = 2');
+        expect(script).toContain('var sort = "top"');
+        expect(script).toContain('var limit = 3');
+        expect(script).toContain('var postIdRaw = "xyz"');
+    });
+
+    it('embeds expandMore=true and the requested expandRounds when --expand-more is on', async () => {
+        const page = makePage({ kind: 'ok', rows: [], expandMeta: { rounds: 3, fetched: 12, capped: true, errors: [] } });
+        await command.func(page, { 'post-id': 'xyz', 'expand-more': true, 'expand-rounds': 3 });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('var expandMore = true');
+        expect(script).toContain('var expandRounds = 3');
+        // The /api/morechildren request body construction must be present in
+        // the evaluate script (round-trips the link_id + children CSV).
+        expect(script).toContain("'/api/morechildren'");
+        expect(script).toContain("'api_type=json'");
+        expect(script).toContain("encodeURIComponent(linkFullname)");
+        expect(script).toContain("encodeURIComponent(batch.join(','))");
+    });
+
+    it('extracts post id from a full reddit URL on the browser side (script contains regex)', async () => {
+        const page = makePage({ kind: 'ok', rows: [], expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] } });
+        await command.func(page, { 'post-id': 'https://www.reddit.com/r/python/comments/1abc23/title_slug/' });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('postIdRaw.match(/comments\\/([a-z0-9]+)/)');
+    });
+
+    it('uses 5-kind discriminated union keys that DO NOT collide with declared columns', () => {
+        // Read the evaluate template once to assert the intermediate keys we
+        // return on the browser side never name any of `type` / `author` /
+        // `score` / `text` (the declared columns) — that pattern would
+        // trigger the silent-column-drop audit.
+        const page = makePage({ kind: 'ok', rows: [], expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] } });
+        return command.func(page, { 'post-id': 'xyz' }).then(() => {
+            const script = page.evaluate.mock.calls[0][0];
+            // Each return shape uses kind / detail / httpStatus / where /
+            // rows / expandMeta. None overlap with the four declared
+            // columns. The walker IS allowed to push column-shaped row
+            // objects into `rows` — that's the final shape, not an
+            // intermediate one.
+            expect(script).toContain("kind: 'inaccessible'");
+            expect(script).toContain("kind: 'auth'");
+            expect(script).toContain("kind: 'http'");
+            expect(script).toContain("kind: 'malformed'");
+            expect(script).toContain("kind: 'parser-drift'");
+            expect(script).toContain("kind: 'expand-failed'");
+            expect(script).toContain("kind: 'ok'");
+        });
     });
 });

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -287,6 +287,29 @@ describe('reddit read adapter', () => {
         })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('fails expand-more when Reddit omits a requested child instead of silently dropping the stub', async () => {
+        const fetchMock = vi.fn(async (url) => {
+            if (String(url).startsWith('/comments/')) {
+                return jsonResponse(redditPostEnvelope([moreThing('more_top', ['b', 'c'])]));
+            }
+            if (String(url) === '/api/morechildren') {
+                return jsonResponse({
+                    json: {
+                        errors: [],
+                        data: { things: [commentThing('b', 'B')] },
+                    },
+                });
+            }
+            throw new Error(`unexpected URL ${url}`);
+        });
+        const page = makeRuntimePage(fetchMock);
+
+        await expect(command.func(page, {
+            'post-id': 'abc123',
+            'expand-more': true,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('uses 5-kind discriminated union keys that DO NOT collide with declared columns', () => {
         // Read the evaluate template once to assert the intermediate keys we
         // return on the browser side never name any of `type` / `author` /

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -1,13 +1,77 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { parseExpandRounds } from './read.js';
+import { normalizeRedditPostId, parseExpandRounds } from './read.js';
 import './read.js';
 
 function makePage(result) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
         evaluate: vi.fn().mockResolvedValue(result),
+    };
+}
+
+function redditPostEnvelope(children) {
+    return [
+        {
+            data: {
+                children: [{
+                    data: {
+                        title: 'Post title',
+                        selftext: '',
+                        author: 'op',
+                        score: 10,
+                        is_self: true,
+                    },
+                }],
+            },
+        },
+        { data: { children } },
+    ];
+}
+
+function commentThing(id, body, parent = 't3_abc123', score = 1) {
+    return {
+        kind: 't1',
+        data: {
+            id,
+            name: `t1_${id}`,
+            parent_id: parent,
+            author: id,
+            score,
+            body,
+            replies: '',
+        },
+    };
+}
+
+function moreThing(id, children, parent = 't3_abc123', count = children.length) {
+    return {
+        kind: 'more',
+        data: { id, parent_id: parent, children, count },
+    };
+}
+
+function jsonResponse(payload, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: vi.fn().mockResolvedValue(payload),
+    };
+}
+
+function makeRuntimePage(fetchImpl) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(async (script) => {
+            const previousFetch = globalThis.fetch;
+            globalThis.fetch = fetchImpl;
+            try {
+                return await eval(script);
+            } finally {
+                globalThis.fetch = previousFetch;
+            }
+        }),
     };
 }
 
@@ -32,6 +96,30 @@ describe('reddit read adapter', () => {
         expect(rounds.default).toBe(2);
     });
 
+    describe('normalizeRedditPostId', () => {
+        it('accepts bare ids, t3 fullnames, and exact reddit post URLs', () => {
+            expect(normalizeRedditPostId('1AbC23')).toBe('1abc23');
+            expect(normalizeRedditPostId('t3_1AbC23')).toBe('1abc23');
+            expect(normalizeRedditPostId('https://www.reddit.com/r/opencli/comments/1abc23/title_slug/?sort=top')).toBe('1abc23');
+            expect(normalizeRedditPostId('https://www.reddit.com/r/opencli/comments/1abc23/title_slug/okf3s7u/?context=3')).toBe('1abc23');
+            expect(normalizeRedditPostId('https://old.reddit.com/comments/1abc23/title_slug/')).toBe('1abc23');
+        });
+
+        it('rejects invalid or structurally loose post identities before navigation', () => {
+            for (const bad of [
+                '',
+                't1_okf3s7u',
+                'https://reddit.com.evil.com/r/opencli/comments/1abc23/title_slug/',
+                'http://www.reddit.com/r/opencli/comments/1abc23/title_slug/',
+                'https://www.reddit.com/r/opencli/comments/',
+                'https://www.reddit.com/r/opencli/comments/1abc23/title_slug/okf3s7u/evil',
+                'not/a/post',
+            ]) {
+                expect(() => normalizeRedditPostId(bad)).toThrow(ArgumentError);
+            }
+        });
+    });
+
     describe('parseExpandRounds', () => {
         it('returns the default for absent input but throws on out-of-range / non-integer', () => {
             expect(parseExpandRounds(undefined)).toBe(2);
@@ -48,6 +136,14 @@ describe('reddit read adapter', () => {
     it('rejects a bad --expand-rounds BEFORE navigating', async () => {
         const page = makePage({ kind: 'ok', rows: [] });
         await expect(command.func(page, { 'post-id': 'abc123', 'expand-rounds': 99 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a bad post identity BEFORE navigating', async () => {
+        const page = makePage({ kind: 'ok', rows: [] });
+        await expect(command.func(page, { 'post-id': 'https://evil.test/r/x/comments/abc/title/' }))
             .rejects.toBeInstanceOf(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
         expect(page.evaluate).not.toHaveBeenCalled();
@@ -105,7 +201,7 @@ describe('reddit read adapter', () => {
         expect(script).toContain('var expandRounds = 2');
         expect(script).toContain('var sort = "top"');
         expect(script).toContain('var limit = 3');
-        expect(script).toContain('var postIdRaw = "xyz"');
+        expect(script).toContain('var postId = "xyz"');
     });
 
     it('embeds expandMore=true and the requested expandRounds when --expand-more is on', async () => {
@@ -122,11 +218,73 @@ describe('reddit read adapter', () => {
         expect(script).toContain("encodeURIComponent(batch.join(','))");
     });
 
-    it('extracts post id from a full reddit URL on the browser side (script contains regex)', async () => {
+    it('normalizes a full reddit URL before building the browser script', async () => {
         const page = makePage({ kind: 'ok', rows: [], expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] } });
         await command.func(page, { 'post-id': 'https://www.reddit.com/r/python/comments/1abc23/title_slug/' });
         const script = page.evaluate.mock.calls[0][0];
-        expect(script).toContain('postIdRaw.match(/comments\\/([a-z0-9]+)/)');
+        expect(script).toContain('var postId = "1abc23"');
+        expect(script).not.toContain('postIdRaw.match');
+    });
+
+    it('expands morechildren in the original tree position instead of appending to the parent', async () => {
+        const fetchMock = vi.fn(async (url) => {
+            if (String(url).startsWith('/comments/')) {
+                return jsonResponse(redditPostEnvelope([
+                    commentThing('a', 'A'),
+                    moreThing('more_top', ['b', 'c']),
+                    commentThing('d', 'D'),
+                ]));
+            }
+            if (String(url) === '/api/morechildren') {
+                return jsonResponse({
+                    json: {
+                        errors: [],
+                        data: { things: [commentThing('b', 'B'), commentThing('c', 'C')] },
+                    },
+                });
+            }
+            throw new Error(`unexpected URL ${url}`);
+        });
+        const page = makeRuntimePage(fetchMock);
+
+        const result = await command.func(page, {
+            'post-id': 'abc123',
+            'expand-more': true,
+            limit: 10,
+            replies: 10,
+        });
+
+        expect(result.map((row) => row.author)).toEqual(['op', 'a', 'b', 'c', 'd']);
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/api/morechildren',
+            expect.objectContaining({
+                method: 'POST',
+                body: expect.stringContaining('link_id=t3_abc123'),
+            }),
+        );
+    });
+
+    it('fails expand-more when Reddit returns a child that cannot be placed in the requested tree', async () => {
+        const fetchMock = vi.fn(async (url) => {
+            if (String(url).startsWith('/comments/')) {
+                return jsonResponse(redditPostEnvelope([moreThing('more_top', ['b'])]));
+            }
+            if (String(url) === '/api/morechildren') {
+                return jsonResponse({
+                    json: {
+                        errors: [],
+                        data: { things: [commentThing('b', 'B', 't3_other')] },
+                    },
+                });
+            }
+            throw new Error(`unexpected URL ${url}`);
+        });
+        const page = makeRuntimePage(fetchMock);
+
+        await expect(command.func(page, {
+            'post-id': 'abc123',
+            'expand-more': true,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('uses 5-kind discriminated union keys that DO NOT collide with declared columns', () => {

--- a/docs/adapters/browser/reddit.md
+++ b/docs/adapters/browser/reddit.md
@@ -47,6 +47,9 @@ opencli reddit whoami
 # Read a post thread
 opencli reddit read 1abc123 --depth 2
 
+# Read with "more comments" expansion via /api/morechildren.json
+opencli reddit read 1abc123 --depth 3 --expand-more --expand-rounds 3
+
 # Comment on a post
 opencli reddit comment 1abc123 "Great post"
 
@@ -70,6 +73,14 @@ instead of silently returning empty rows.
 For `subreddit-info`, missing / banned / private / quarantined subreddits raise
 `EmptyResultError` (exit code 6) so the output table never contains a silent
 sentinel row.
+
+For `read`, deleted / quarantined / private posts (HTTP 401/403/404 on
+`/comments/<id>.json`) also raise `EmptyResultError`. `--expand-more` follows
+Reddit's "more comments" stubs by calling `/api/morechildren.json` up to
+`--expand-rounds` times (default 2, max 5). If the morechildren endpoint
+itself rejects the request with 401/403, that's surfaced as
+`AuthRequiredError` because writeable/expand endpoints often require a logged-
+in session even though the post listing is public.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

PR B of the rdt-cli parity follow-up after PR #1491. Closes the second-largest reddit gap: today the comment tree shows `[+N more replies]` as opaque markers — with `--expand-more`, the adapter now follows them by POST-ing the `t1` ids to `/api/morechildren.json` and re-threading the returned `things` back into the tree by `parent_id` before walking.

This is the rdt-cli `browse read --expand-more` parity.

## New flags

- **`--expand-more`** (bool, default `false`) — turn stub expansion on.
- **`--expand-rounds <N>`** (int, default `2`, range `[1, 5]`) — Reddit returns fresh `kind:'more'` stubs at the depth boundary even after expansion, so we iterate. Validated via `parseExpandRounds` — out-of-range raises `ArgumentError` BEFORE `page.goto` (no silent clamp).

Backward-compatible: when `--expand-more` is absent, output is byte-identical to today's.

## 7-kind discriminated union

Boy Scout: the in-browser script now returns a discriminated union instead of a flat row array. Each kind maps 1:1 to a typed error on the Node side. **This applies the two new sediment lessons from #1491's review** (parser-drift vs empty, resource-vs-session auth):

| `kind`         | Typed error             | Trigger |
|----------------|-------------------------|---------|
| `inaccessible` | `EmptyResultError`      | 401/403/404 on `/comments/<id>.json` — post-specific access, **not** session auth |
| `auth`         | `AuthRequiredError`     | 401/403 on `/api/morechildren` — write/expand endpoints commonly need login even when reads are anonymous |
| `http`         | `CommandExecutionError` | 5xx anywhere |
| `malformed`    | `CommandExecutionError` | 200 with unexpected envelope shape — Reddit schema drift |
| `parser-drift` | `CommandExecutionError` | walker produced 0 rows but `topListing` had `t1` entries → parser bug, not empty post |
| `expand-failed`| `CommandExecutionError` | `/api/morechildren` returned non-empty `json.errors` |
| `ok`           | (returns `rows[]`)      | — |

Intermediate keys (`kind` / `detail` / `httpStatus` / `where` / `rows` / `expandMeta`) deliberately avoid the declared columns (`type` / `author` / `score` / `text`) per PR #1329 silent-column-drop sediment.

## Implementation

1. Fetch `/comments/<id>.json` as before (now with typed-error envelope).
2. If `--expand-more`: build a `t1` id → node index, then iterate up to `expandRounds`:
   - Collect every `kind:'more'` stub in the tree that has a non-empty `data.children` array.
   - Dedupe the t1 ids, batch in groups of 100 (Reddit's `morechildren` cap), POST `api_type=json&link_id=t3_<postId>&children=<csv>&sort=<sort>&raw_json=1`.
   - Re-thread returned `things` by `parent_id`: `t3_<postId>` → top listing, `t1_<id>` → that node's `replies.data.children` (creating the shell if Reddit didn't inline replies there).
   - Orphans (parent not in our tree, depth boundary) are tracked in `expandMeta.errors` instead of being silently dropped.
3. Walk the (possibly augmented) tree as before.

## Tests

`clis/reddit/read.test.js` — 11 tests (was 3):
- Adapter shape, args registration, parseExpandRounds boundary table
- Pre-navigation arg validation (bad `--expand-rounds` doesn't reach `page.goto`)
- `kind=ok` happy path
- 6-kind error → typed-error mapping
- Unknown envelope shape → `CommandExecutionError`
- Evaluate script literal embedding for `expandMore` / `expandRounds` / `sort` / `limit` / `postIdRaw`
- Evaluate script contains `/api/morechildren` POST scaffolding
- Intermediate keys vs declared columns invariant

Full reddit suite 48/48, full project 3402/3402.

## Audits

- typed-error-lint **189/189**, 0 new
- silent-column-drop **103/103**, 0 new
- Manifest 815 → 815 (existing `reddit/read` entry gets `expand-more` + `expand-rounds` args)

## Out of scope

- Existing `--limit` / `--depth` / `--replies` / `--max-length` keep their `Math.max(1, ...)` style (grandfathered in baseline). Only the new `--expand-rounds` flag fails fast — Boy-Scout-ing the old clamps would expand blast radius for this PR.
- `expandMeta` (`{rounds, fetched, capped, errors}`) is tracked in-browser for future surfacing (`-v` mode?) but not yet returned to the user table. Out of scope here.

## Test plan

- [x] Mocked `page.evaluate` unit tests for parse / 7-kind / script-literal-embedding
- [x] Audits green
- [x] Manifest diff = 2 new args on the existing reddit/read entry, no other movement
- [ ] Live verify against a busy thread (e.g. /r/AskReddit top-voted) confirming `--expand-more` actually pulls additional rows

Refs: PR #1491 (sediment source), [rdt-cli browse.read --expand-more](https://github.com/jackwener/rdt-cli)