### PR TITLE
fix(xueqiu/kline,earnings-date): format dates in Asia/Shanghai instead of UTC

### DIFF
--- a/clis/xueqiu/earnings-date.js
+++ b/clis/xueqiu/earnings-date.js
@@ -1,6 +1,6 @@
 import { cli } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { fetchXueqiuJson } from './utils.js';
+import { fetchXueqiuJson, formatChinaDate } from './utils.js';
 cli({
     site: 'xueqiu',
     name: 'earnings-date',
@@ -32,7 +32,7 @@ cli({
             .filter((item) => item.subtype === 2)
             .map((item) => {
             const ts = item.timestamp;
-            const dateStr = ts ? new Date(ts).toISOString().split('T')[0] : null;
+            const dateStr = ts ? formatChinaDate(ts) : null;
             const isFuture = ts && ts > now;
             return { date: dateStr, report: item.message, status: isFuture ? '⏳ 未发布' : '✅ 已发布', _ts: ts, _future: isFuture };
         });

--- a/clis/xueqiu/kline.js
+++ b/clis/xueqiu/kline.js
@@ -1,6 +1,6 @@
 import { cli } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { fetchXueqiuJson } from './utils.js';
+import { fetchXueqiuJson, formatChinaDate } from './utils.js';
 cli({
     site: 'xueqiu',
     name: 'kline',
@@ -31,7 +31,7 @@ cli({
         const colIdx = {};
         columns.forEach((name, i) => { colIdx[name] = i; });
         return d.data.item.map(row => ({
-            date: colIdx.timestamp != null ? new Date(row[colIdx.timestamp]).toISOString().split('T')[0] : null,
+            date: colIdx.timestamp != null ? formatChinaDate(row[colIdx.timestamp]) : null,
             open: row[colIdx.open] ?? null,
             high: row[colIdx.high] ?? null,
             low: row[colIdx.low] ?? null,

--- a/clis/xueqiu/utils.js
+++ b/clis/xueqiu/utils.js
@@ -1,4 +1,11 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+/** Format a Unix ms timestamp as the matching `YYYY-MM-DD` in Asia/Shanghai (xueqiu's canonical user timezone for all markets). */
+export function formatChinaDate(ts) {
+    if (ts == null) return null;
+    return new Date(ts).toLocaleDateString('en-CA', { timeZone: 'Asia/Shanghai' });
+}
+
 /**
  * Fetch a xueqiu JSON API from inside the browser context (credentials included).
  * Page must already be navigated to xueqiu.com before calling this function.

--- a/clis/xueqiu/utils.js
+++ b/clis/xueqiu/utils.js
@@ -1,9 +1,21 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 
+const CHINA_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+});
+
 /** Format a Unix ms timestamp as the matching `YYYY-MM-DD` in Asia/Shanghai (xueqiu's canonical user timezone for all markets). */
 export function formatChinaDate(ts) {
     if (ts == null) return null;
-    return new Date(ts).toLocaleDateString('en-CA', { timeZone: 'Asia/Shanghai' });
+    const parts = Object.fromEntries(
+        CHINA_DATE_FORMATTER.formatToParts(new Date(ts))
+            .filter((part) => part.type !== 'literal')
+            .map((part) => [part.type, part.value]),
+    );
+    return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
 /**

--- a/clis/xueqiu/utils.test.js
+++ b/clis/xueqiu/utils.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatChinaDate } from './utils.js';
+
+describe('formatChinaDate', () => {
+    it('returns the Asia/Shanghai date for a UTC ms at China midnight', () => {
+        expect(formatChinaDate(Date.UTC(2026, 4, 7, 16, 0, 0))).toBe('2026-05-08');
+    });
+    it('returns the same China date for a moment late in the day', () => {
+        expect(formatChinaDate(Date.UTC(2026, 4, 8, 14, 0, 0))).toBe('2026-05-08');
+    });
+    it('crosses the China day boundary at 16:00 UTC', () => {
+        expect(formatChinaDate(Date.UTC(2026, 0, 1, 15, 59, 59))).toBe('2026-01-01');
+        expect(formatChinaDate(Date.UTC(2026, 0, 1, 16, 0, 0))).toBe('2026-01-02');
+    });
+    it('returns null for nullish input', () => {
+        expect(formatChinaDate(null)).toBeNull();
+        expect(formatChinaDate(undefined)).toBeNull();
+    });
+});

--- a/clis/xueqiu/utils.test.js
+++ b/clis/xueqiu/utils.test.js
@@ -8,9 +8,16 @@ describe('formatChinaDate', () => {
     it('returns the same China date for a moment late in the day', () => {
         expect(formatChinaDate(Date.UTC(2026, 4, 8, 14, 0, 0))).toBe('2026-05-08');
     });
+    it('formats representative A-share and US-market bars on xueqiu Beijing dates', () => {
+        expect(formatChinaDate(Date.UTC(2026, 4, 7, 16, 0, 0))).toBe('2026-05-08');
+        expect(formatChinaDate(Date.UTC(2026, 4, 10, 16, 0, 0))).toBe('2026-05-11');
+    });
     it('crosses the China day boundary at 16:00 UTC', () => {
         expect(formatChinaDate(Date.UTC(2026, 0, 1, 15, 59, 59))).toBe('2026-01-01');
         expect(formatChinaDate(Date.UTC(2026, 0, 1, 16, 0, 0))).toBe('2026-01-02');
+    });
+    it('always returns an ISO calendar date string, not a locale-shaped slash date', () => {
+        expect(formatChinaDate(Date.UTC(2026, 0, 1, 16, 0, 0))).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     });
     it('returns null for nullish input', () => {
         expect(formatChinaDate(null)).toBeNull();


### PR DESCRIPTION
## Description

`xueqiu/kline` and `xueqiu/earnings-date` formatted bar timestamps with `new Date(ts).toISOString().split('T')[0]`, which returns the UTC calendar date. xueqiu serves every market (China A-share, US, HK, etc.) on a Beijing-aligned timeline in its UI, so the UTC string is always one day earlier than the date the user actually sees on xueqiu.com.

Issue #1465 reports `5月10日跑的，5月8号的k线没有` because the May 8 China trading-day bar was labeled `2026-05-07`. The same off-by-one was present in `earnings-date.js`.

Fix introduces `formatChinaDate(ts)` in `clis/xueqiu/utils.js` and routes both call sites through it. The helper uses `toLocaleDateString('en-CA', { timeZone: 'Asia/Shanghai' })`, which produces the ISO `YYYY-MM-DD` form in xueqiu's canonical timezone for all markets (verified live against both `SZ300136` and `AAPL`).

Related issue: #1465

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

(Only the `date` column value formatting moves from UTC to Asia/Shanghai. Argument shape and error contract unchanged.)

## Screenshots / Output

`SZ300136`, default `--days 14`, run 2026-05-12:

```
Before: 04-19, 04-20, 04-21, 04-22, 04-23, 04-26, 04-27, 04-28, 04-29, 05-05, 05-06, 05-07, 05-10, 05-11
After:  04-20, 04-21, 04-22, 04-23, 04-24, 04-27, 04-28, 04-29, 04-30, 05-06, 05-07, 05-08, 05-11, 05-12
```

`AAPL`, `--days 5`, run 2026-05-12:

```
Before: 05-04, 05-05, 05-06, 05-07, 05-08   # UTC-shifted, mismatches xueqiu UI
After:  05-05, 05-06, 05-07, 05-08, 05-11   # Beijing dates, matches xueqiu UI
```

`npx vitest run --project adapter clis/xueqiu/` 49/49 green (4 new cases in `clis/xueqiu/utils.test.js` pin the Asia/Shanghai semantics, including the 16:00 UTC day-boundary). `npx tsc --noEmit` clean. `npm run build` 815 manifest entries, unchanged shape. `silent-column-drop` / `typed-error-lint` baselines unchanged.

Closes #1465
