### PR TITLE
Fix YouTube transcript caption fetching

### DIFF
--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -1,9 +1,9 @@
 /**
- * YouTube transcript — extracts caption tracks from watch page bootstrap data.
+ * YouTube transcript — extracts caption tracks through the watch player.
  *
- * The old Android InnerTube client path stopped reliably returning captions.
- * We now match youtube/video.js: fetch watch HTML with the browser session and
- * parse ytInitialPlayerResponse.captions.playerCaptionsTracklistRenderer.
+ * YouTube timedtext URLs can require player-generated PO tokens. Load the
+ * watch page, ask the player captions module to select a track, then reuse the
+ * generated json3 timedtext URL before falling back to watch HTML captions.
  *
  * Modes:
  *   --mode grouped (default): sentences merged, speaker detection, chapters
@@ -13,6 +13,97 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage } from './utils.js';
 import { groupTranscriptSegments, formatGroupedTranscript, } from './transcript-group.js';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+function unwrapBrowserResult(value) {
+    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
+        return value.data;
+    }
+    return value;
+}
+
+function normalizeSegmentsPayload(value, source, { allowNull = false } = {}) {
+    const payload = unwrapBrowserResult(value);
+    if (payload == null && allowNull)
+        return null;
+    if (Array.isArray(payload))
+        return payload;
+    if (payload && typeof payload === 'object' && payload.error) {
+        throw new CommandExecutionError(String(payload.error));
+    }
+    throw new CommandExecutionError(`Malformed ${source} payload`);
+}
+
+function parseJson3Segments(text) {
+    let data;
+    try {
+        data = JSON.parse(text);
+    }
+    catch (err) {
+        throw new CommandExecutionError(`Malformed json3 timedtext response: ${err?.message || err}`);
+    }
+    if (!Array.isArray(data?.events)) {
+        throw new CommandExecutionError('Malformed json3 timedtext response: missing events array');
+    }
+    const rows = [];
+    for (const event of data.events) {
+        const startMs = Number(event?.tStartMs || 0);
+        const durMs = Number(event?.dDurationMs || 0);
+        const segs = Array.isArray(event?.segs) ? event.segs : [];
+        const line = segs.map(seg => seg?.utf8 || '').join('').replace(/\s+/g, ' ').trim();
+        if (!line)
+            continue;
+        rows.push({
+            start: startMs / 1000,
+            end: (startMs + durMs) / 1000,
+            text: line,
+        });
+    }
+    return rows;
+}
+
+function extractSegmentsFromNetworkCapture(entries, lang) {
+    const payload = unwrapBrowserResult(entries);
+    if (!Array.isArray(payload) || payload.length === 0)
+        return { segments: [] };
+    const wanted = String(lang || '').toLowerCase();
+    const wantedBase = wanted.split('-')[0];
+    const timedtext = payload
+        .filter((entry) => {
+        const url = String(entry?.url || '');
+        if (!url.includes('/api/timedtext'))
+            return false;
+        if (!url.includes('fmt=json3') || !url.includes('pot='))
+            return false;
+        if (!wanted)
+            return true;
+        try {
+            const u = new URL(url);
+            const got = String(u.searchParams.get('lang') || '').toLowerCase();
+            const gotBase = got.split('-')[0];
+            return got === wanted || gotBase === wantedBase || wantedBase === got;
+        }
+        catch {
+            return false;
+        }
+    })
+        .reverse();
+    let malformed = '';
+    for (const entry of timedtext) {
+        const body = typeof entry?.responsePreview === 'string' ? entry.responsePreview : '';
+        if (!body)
+            continue;
+        try {
+            const parsed = parseJson3Segments(body);
+            if (parsed.length > 0)
+                return { segments: parsed };
+        }
+        catch (err) {
+            malformed = err?.message || String(err);
+        }
+    }
+    return malformed ? { error: malformed } : { segments: [] };
+}
+
 cli({
     site: 'youtube',
     name: 'transcript',
@@ -29,11 +120,247 @@ cli({
     // so we let the renderer auto-detect columns from the data keys.
     func: async (page, kwargs) => {
         const videoId = parseVideoId(kwargs.url);
-        await prepareYoutubeApiPage(page);
         const lang = kwargs.lang || '';
         const mode = kwargs.mode || 'grouped';
-        // Step 1: Get caption track URL from watch page HTML
-        const captionData = await page.evaluate(`
+        const watchUrl = 'https://www.youtube.com/watch?v=' + encodeURIComponent(videoId);
+        const canCapture = typeof page.startNetworkCapture === 'function' && typeof page.readNetworkCapture === 'function';
+        if (canCapture) {
+            try {
+                await page.startNetworkCapture('/api/timedtext');
+            }
+            catch {
+                // Best-effort only. The in-page capture and XML fallback still run.
+            }
+        }
+        await page.goto(watchUrl, { waitUntil: 'none' });
+        await page.wait(3);
+        const playerResult = await page.evaluate(`
+      (async () => {
+        const langPref = ${JSON.stringify(lang)};
+        const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+        function textFromJson3Event(event) {
+          if (!Array.isArray(event?.segs)) return '';
+          return event.segs.map(seg => seg?.utf8 || '').join('').replace(/\\s+/g, ' ').trim();
+        }
+
+        function parseJson3(text) {
+          let data;
+          try {
+            data = JSON.parse(text);
+          } catch (err) {
+            return { error: 'Malformed json3 timedtext response: ' + (err?.message || String(err)) };
+          }
+          if (!Array.isArray(data.events)) {
+            return { error: 'Malformed json3 timedtext response: missing events array' };
+          }
+          const rows = [];
+          for (const event of data.events) {
+            const startMs = Number(event.tStartMs || 0);
+            const durMs = Number(event.dDurationMs || 0);
+            const text = textFromJson3Event(event);
+            if (!text) continue;
+            rows.push({
+              start: startMs / 1000,
+              end: (startMs + durMs) / 1000,
+              text,
+            });
+          }
+          return { rows };
+        }
+
+        function captionTrackToPlayerTrack(track) {
+          if (!track?.languageCode) return null;
+          const name = track.name?.simpleText
+            || (Array.isArray(track.name?.runs) ? track.name.runs.map(run => run?.text || '').join('') : '')
+            || track.languageCode;
+          return {
+            displayName: name,
+            id: null,
+            is_default: false,
+            is_servable: false,
+            is_translateable: !!track.isTranslatable,
+            kind: track.kind || '',
+            languageCode: track.languageCode,
+            languageName: name,
+            name: '',
+            vss_id: track.vssId || ((track.kind === 'asr' ? 'a.' : '.') + track.languageCode),
+          };
+        }
+
+        function getTrackCandidates(player) {
+          const tracklist = player?.getOption?.('captions', 'tracklist');
+          if (Array.isArray(tracklist) && tracklist.length > 0) return tracklist;
+          const captionTracks = player?.getPlayerResponse?.()
+            ?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+          if (!Array.isArray(captionTracks)) return [];
+          return captionTracks.map(captionTrackToPlayerTrack).filter(Boolean);
+        }
+
+        function pickTrack(tracklist) {
+          if (!Array.isArray(tracklist) || tracklist.length === 0) return null;
+          if (langPref) {
+            return tracklist.find(t => t.languageCode === langPref)
+              || tracklist.find(t => t.languageCode?.startsWith(langPref));
+          }
+          return tracklist.find(t => t.languageCode === 'en' && t.kind !== 'asr')
+            || tracklist.find(t => t.languageCode === 'en')
+            || tracklist.find(t => t.kind !== 'asr')
+            || tracklist[0];
+        }
+
+        function findTimedtextUrl(track) {
+          const urls = performance.getEntriesByType('resource')
+            .map(entry => entry.name)
+            .filter(url => url.includes('/api/timedtext') && url.includes('fmt=json3') && url.includes('pot='));
+          if (!urls.length) return '';
+          if (track?.languageCode) {
+            const wanted = String(track.languageCode || '').toLowerCase();
+            const wantedBase = wanted.split('-')[0];
+            const match = [...urls].reverse().find((rawUrl) => {
+              try {
+                const u = new URL(rawUrl, location.origin);
+                const got = String(u.searchParams.get('lang') || '').toLowerCase();
+                const gotBase = got.split('-')[0];
+                return got === wanted || gotBase === wantedBase || wantedBase === got;
+              } catch {
+                return false;
+              }
+            });
+            if (match) return match;
+          }
+          return urls[urls.length - 1];
+        }
+
+        function isJson3TimedtextUrl(url, track) {
+          if (!url || !url.includes('/api/timedtext')) return false;
+          if (!url.includes('fmt=json3')) return false;
+          if (!url.includes('pot=')) return false;
+          if (!track?.languageCode) return true;
+          try {
+            const u = new URL(url, location.origin);
+            const got = String(u.searchParams.get('lang') || '').toLowerCase();
+            const wanted = String(track.languageCode || '').toLowerCase();
+            const gotBase = got.split('-')[0];
+            const wantedBase = wanted.split('-')[0];
+            return got === wanted || gotBase === wantedBase || wantedBase === got;
+          } catch {
+            return false;
+          }
+        }
+
+        const player = document.getElementById('movie_player');
+        if (!player?.getOption || !player?.setOption) {
+          return null;
+        }
+
+        let track = null;
+        for (let i = 0; i < 20; i++) {
+          track = pickTrack(getTrackCandidates(player));
+          if (track) break;
+          await sleep(500);
+        }
+        if (!track) return null;
+
+        const originalFetch = globalThis.fetch;
+        const boundOriginalFetch = originalFetch?.bind(globalThis);
+        const OriginalXHR = globalThis.XMLHttpRequest;
+        let capturedJson3Text = '';
+        try {
+          if (boundOriginalFetch) {
+            globalThis.fetch = async (...args) => {
+              const response = await boundOriginalFetch(...args);
+              try {
+                const req = args[0];
+                const reqUrl = typeof req === 'string' ? req : req?.url || '';
+                if (isJson3TimedtextUrl(reqUrl, track) && response?.ok) {
+                  const text = await response.clone().text();
+                  if (text && !capturedJson3Text) {
+                    capturedJson3Text = text;
+                  }
+                }
+              } catch {}
+              return response;
+            };
+          }
+          if (OriginalXHR) {
+            globalThis.XMLHttpRequest = class TimedtextCaptureXHR extends OriginalXHR {
+              open(method, url, ...rest) {
+                this.__opencliTimedtextUrl = typeof url === 'string' ? url : '';
+                return super.open(method, url, ...rest);
+              }
+              send(...args) {
+                this.addEventListener('load', () => {
+                  try {
+                    const url = this.__opencliTimedtextUrl || this.responseURL || '';
+                    if (!isJson3TimedtextUrl(url, track)) return;
+                    if (this.status < 200 || this.status >= 300) return;
+                    const text = typeof this.responseText === 'string' ? this.responseText : '';
+                    if (text && !capturedJson3Text) {
+                      capturedJson3Text = text;
+                    }
+                  } catch {}
+                });
+                return super.send(...args);
+              }
+            };
+          }
+
+          // Do not clear resource timings: some videos emit a valid timedtext URL
+          // before our polling loop starts; keeping existing entries avoids misses.
+          try { player.loadModule?.('captions'); } catch {}
+          await sleep(500);
+          try { player.setOption('captions', 'track', track); } catch {}
+          try { player.playVideo?.(); } catch {}
+
+          for (let i = 0; i < 30; i++) {
+            await sleep(500);
+            if (capturedJson3Text) {
+              const parsed = parseJson3(capturedJson3Text);
+              if (parsed.error) return { error: parsed.error };
+              if (parsed.rows.length > 0) return parsed.rows;
+            }
+            const url = findTimedtextUrl(track);
+            if (!url) continue;
+            const resp = await fetch(url, { credentials: 'include' });
+            if (!resp.ok) continue;
+            const text = await resp.text();
+            if (!text) continue;
+            const parsed = parseJson3(text);
+            if (parsed.error) return { error: parsed.error };
+            if (parsed.rows.length > 0) return parsed.rows;
+          }
+
+          return null;
+        } finally {
+          try { player?.pauseVideo?.(); } catch {}
+          if (originalFetch) globalThis.fetch = originalFetch;
+          if (OriginalXHR) globalThis.XMLHttpRequest = OriginalXHR;
+        }
+      })()
+    `);
+        let segments = normalizeSegmentsPayload(playerResult, 'player caption extraction', { allowNull: true });
+        if (!segments && canCapture) {
+            try {
+                const captured = extractSegmentsFromNetworkCapture(await page.readNetworkCapture(), lang);
+                if (captured.error) {
+                    throw new CommandExecutionError(captured.error);
+                }
+                if (captured.segments.length > 0) {
+                    segments = captured.segments;
+                }
+            }
+            catch (err) {
+                if (err instanceof CommandExecutionError)
+                    throw err;
+                // Keep existing fallback path when capture is unavailable.
+            }
+        }
+        if (!segments) {
+            await prepareYoutubeApiPage(page);
+        }
+        // Fallback: get caption track URL from watch page HTML
+        const captionData = segments ? null : unwrapBrowserResult(await page.evaluate(`
       (async () => {
         const extractJsonAssignmentFromHtml = ${extractJsonAssignmentFromHtml.toString()};
 
@@ -74,26 +401,27 @@ cli({
           langPrefixMatched: !!(langPref && track.languageCode !== langPref && track.languageCode.startsWith(langPref))
         };
       })()
-    `);
-        if (!captionData || typeof captionData === 'string') {
+    `));
+        if (!segments && (!captionData || typeof captionData === 'string')) {
             throw new CommandExecutionError(`Failed to get caption info: ${typeof captionData === 'string' ? captionData : 'null response'}`);
         }
-        if (captionData.error) {
+        if (captionData?.error) {
             throw new CommandExecutionError(`${captionData.error}${captionData.available ? ' (available: ' + captionData.available.join(', ') + ')' : ''}`);
         }
         // Warn if --lang was specified but not matched
-        if (captionData.requestedLang && !captionData.langMatched && !captionData.langPrefixMatched) {
+        if (captionData?.requestedLang && !captionData.langMatched && !captionData.langPrefixMatched) {
             console.error(`Warning: --lang "${captionData.requestedLang}" not found. Using "${captionData.language}" instead. Available: ${captionData.available.join(', ')}`);
         }
         // Step 2: Fetch caption XML and parse segments
         // Ensure caption URL requests srv3 XML format — YouTube may return empty
         // responses when no explicit format is specified.
-        const originalCaptionUrl = captionData.captionUrl;
-        let captionUrl = originalCaptionUrl;
-        if (!/[&?]fmt=/.test(originalCaptionUrl)) {
-            captionUrl = originalCaptionUrl + (originalCaptionUrl.includes('?') ? '&' : '?') + 'fmt=srv3';
-        }
-        const segments = await page.evaluate(`
+        if (!segments) {
+            const originalCaptionUrl = captionData.captionUrl;
+            let captionUrl = originalCaptionUrl;
+            if (!/[&?]fmt=/.test(originalCaptionUrl)) {
+                captionUrl = originalCaptionUrl + (originalCaptionUrl.includes('?') ? '&' : '?') + 'fmt=srv3';
+            }
+            segments = normalizeSegmentsPayload(await page.evaluate(`
       (async () => {
         async function fetchCaptionXml(url) {
           const resp = await fetch(url);
@@ -181,9 +509,7 @@ cli({
 
         return results;
       })()
-    `);
-        if (!Array.isArray(segments)) {
-            throw new CommandExecutionError(segments?.error || 'Failed to parse caption segments');
+    `), 'caption XML extraction');
         }
         if (segments.length === 0) {
             throw new EmptyResultError('youtube transcript');
@@ -192,7 +518,7 @@ cli({
         let chapters = [];
         if (mode === 'grouped') {
             try {
-                const chapterData = await page.evaluate(`
+                const chapterData = unwrapBrowserResult(await page.evaluate(`
           (async () => {
             const cfg = window.ytcfg?.data_ || {};
             const apiKey = cfg.INNERTUBE_API_KEY;
@@ -256,7 +582,7 @@ cli({
             }
             return chapters;
           })()
-        `);
+        `));
                 if (Array.isArray(chapterData)) {
                     chapters = chapterData;
                 }

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -402,11 +402,14 @@ cli({
         };
       })()
     `));
-        if (!segments && (!captionData || typeof captionData === 'string')) {
-            throw new CommandExecutionError(`Failed to get caption info: ${typeof captionData === 'string' ? captionData : 'null response'}`);
+        if (!segments && (!captionData || typeof captionData !== 'object' || Array.isArray(captionData))) {
+            throw new CommandExecutionError(`Failed to get caption info: ${typeof captionData === 'string' ? captionData : 'malformed response'}`);
         }
         if (captionData?.error) {
             throw new CommandExecutionError(`${captionData.error}${captionData.available ? ' (available: ' + captionData.available.join(', ') + ')' : ''}`);
+        }
+        if (!segments && typeof captionData?.captionUrl !== 'string') {
+            throw new CommandExecutionError('Malformed caption info payload');
         }
         // Warn if --lang was specified but not matched
         if (captionData?.requestedLang && !captionData.langMatched && !captionData.langPrefixMatched) {

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -179,6 +179,19 @@ describe('youtube transcript caption fetch', () => {
         });
     });
 
+    it('fails typed on malformed caption info payloads before URL construction', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+        page.evaluate.mockReset();
+        page.evaluate
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ session: 'browser:default', data: { rows: [] } });
+
+        await expect(command.func(page, { url: 'abc', mode: 'raw' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Malformed caption info payload'),
+        });
+    });
+
     it('fails typed on malformed captured timedtext json3', async () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -15,6 +15,7 @@ function createPageMock(captionUrl) {
         evaluate: vi.fn(),
     };
     page.evaluate
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({
         captionUrl,
         language: 'en',
@@ -33,7 +34,10 @@ afterEach(() => {
 });
 
 describe('youtube transcript source contract', () => {
-    it('gets caption tracks from watch page bootstrap data, not Android InnerTube', () => {
+    it('uses the watch player captions module before falling back to watch HTML, not Android InnerTube', () => {
+        expect(transcriptSource).toContain("player.loadModule?.('captions')");
+        expect(transcriptSource).toContain("player.setOption('captions', 'track', track)");
+        expect(transcriptSource).toContain("url.includes('pot=')");
         expect(transcriptSource).toContain("fetch('/watch?v='");
         expect(transcriptSource).toContain("extractJsonAssignmentFromHtml(html, 'ytInitialPlayerResponse')");
         expect(transcriptSource).toContain('playerCaptionsTracklistRenderer');
@@ -48,6 +52,12 @@ describe('youtube transcript source contract', () => {
     it('checks HTTP status before reading caption response body', () => {
         expect(transcriptSource).toContain('resp.ok');
     });
+
+    it('restores page fetch and XHR hooks even when caption probing exits early', () => {
+        expect(transcriptSource).toContain('} finally {');
+        expect(transcriptSource).toContain('globalThis.fetch = originalFetch');
+        expect(transcriptSource).toContain('globalThis.XMLHttpRequest = OriginalXHR');
+    });
 });
 
 describe('youtube transcript caption fetch', () => {
@@ -58,9 +68,51 @@ describe('youtube transcript caption fetch', () => {
 
         const rows = await command.func(page, { url: 'abc', mode: 'raw' });
 
-        expect(page.evaluate.mock.calls[1][0]).toContain('const primaryUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=srv3"');
-        expect(page.evaluate.mock.calls[1][0]).toContain('const originalUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en"');
+        expect(page.evaluate.mock.calls[2][0]).toContain('const primaryUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=srv3"');
+        expect(page.evaluate.mock.calls[2][0]).toContain('const originalUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en"');
         expect(rows).toEqual([{ index: 1, start: '1.00s', end: '3.00s', text: 'hello & world' }]);
+    });
+
+    it('uses Browser Bridge envelope-wrapped player caption segments without fallback', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValueOnce({
+                session: 'browser:default',
+                data: [{ start: 2, end: 4.5, text: 'from player captions' }],
+            }),
+        };
+
+        const rows = await command.func(page, { url: 'abc', mode: 'raw' });
+
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        expect(rows).toEqual([{ index: 1, start: '2.00s', end: '4.50s', text: 'from player captions' }]);
+    });
+
+    it('uses captured timedtext json3 when player selection returns no segments', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            startNetworkCapture: vi.fn().mockResolvedValue(undefined),
+            readNetworkCapture: vi.fn().mockResolvedValue({
+                session: 'browser:default',
+                data: [{
+                    url: 'https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=json3&pot=token',
+                    responsePreview: JSON.stringify({
+                        events: [
+                            { tStartMs: 1000, dDurationMs: 1500, segs: [{ utf8: 'hello ' }, { utf8: 'capture' }] },
+                        ],
+                    }),
+                }],
+            }),
+            evaluate: vi.fn().mockResolvedValueOnce(null),
+        };
+
+        const rows = await command.func(page, { url: 'abc', mode: 'raw', lang: 'en' });
+
+        expect(page.startNetworkCapture).toHaveBeenCalledWith('/api/timedtext');
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        expect(rows).toEqual([{ index: 1, start: '1.00s', end: '2.50s', text: 'hello capture' }]);
     });
 
     it('does not override an existing caption format', async () => {
@@ -68,8 +120,8 @@ describe('youtube transcript caption fetch', () => {
 
         await command.func(page, { url: 'abc', mode: 'raw' });
 
-        expect(page.evaluate.mock.calls[1][0]).toContain('const primaryUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt"');
-        expect(page.evaluate.mock.calls[1][0]).toContain('const originalUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt"');
+        expect(page.evaluate.mock.calls[2][0]).toContain('const primaryUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt"');
+        expect(page.evaluate.mock.calls[2][0]).toContain('const originalUrl = "https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=vtt"');
     });
 
     it('falls back to the original URL only after an empty successful srv3 response', async () => {
@@ -77,7 +129,7 @@ describe('youtube transcript caption fetch', () => {
 
         await command.func(page, { url: 'abc', mode: 'raw' });
 
-        const script = page.evaluate.mock.calls[1][0];
+        const script = page.evaluate.mock.calls[2][0];
         expect(script).toContain('if (!result.xml.length && originalUrl !== primaryUrl)');
         expect(script).toContain('result = await fetchCaptionXml(originalUrl)');
         expect(script).toContain('if (result.error) {');
@@ -87,6 +139,7 @@ describe('youtube transcript caption fetch', () => {
         const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
         page.evaluate.mockReset();
         page.evaluate
+            .mockResolvedValueOnce(null)
             .mockResolvedValueOnce({
             captionUrl: 'https://www.youtube.com/api/timedtext?v=abc&lang=en',
             language: 'en',
@@ -101,6 +154,48 @@ describe('youtube transcript caption fetch', () => {
         await expect(command.func(page, { url: 'abc', mode: 'raw' })).rejects.toMatchObject({
             code: 'COMMAND_EXEC',
             message: expect.stringContaining('HTTP 503'),
+        });
+    });
+
+    it('fails typed on malformed browser extraction payloads', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+        page.evaluate.mockReset();
+        page.evaluate
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({
+                captionUrl: 'https://www.youtube.com/api/timedtext?v=abc&lang=en',
+                language: 'en',
+                kind: 'manual',
+                available: ['en'],
+                requestedLang: null,
+                langMatched: false,
+                langPrefixMatched: false,
+            })
+            .mockResolvedValueOnce({ session: 'browser:default', data: { rows: [] } });
+
+        await expect(command.func(page, { url: 'abc', mode: 'raw' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Malformed caption XML extraction payload'),
+        });
+    });
+
+    it('fails typed on malformed captured timedtext json3', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            startNetworkCapture: vi.fn().mockResolvedValue(undefined),
+            readNetworkCapture: vi.fn().mockResolvedValue([
+                {
+                    url: 'https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=json3&pot=token',
+                    responsePreview: '{"events":',
+                },
+            ]),
+            evaluate: vi.fn().mockResolvedValueOnce(null),
+        };
+
+        await expect(command.func(page, { url: 'abc', mode: 'raw', lang: 'en' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Malformed json3 timedtext response'),
         });
     });
 });


### PR DESCRIPTION
## Description

  Fix YouTube transcript failures where caption URLs return an empty response.

  **Root cause:**
  YouTube’s /api/timedtext caption URLs now require player-generated PO tokens. The old implementation parsed
  ytInitialPlayerResponse.captions.captionTracks[].baseUrl from watch HTML and fetched it directly with fmt=srv3. That URL does not include the player-
  generated pot parameter, so YouTube returns HTTP 200 with an empty body, causing Caption URL returned empty response.

  **Changes:**

  - Open the real YouTube watch page and wait for the player to initialize.
  - Use the YouTube player captions module to select the requested caption track.
  - Read the player-generated fmt=json3&pot=... timedtext URL from performance.getEntriesByType('resource').
  - Fetch and parse JSON3 captions into the existing { start, end, text } segment shape.
  - Handle auto-caption-only videos where player.getOption('captions', 'tracklist') is empty by constructing a compatible player track from
    player.getPlayerResponse().captions.captionTracks.
  - Keep the old watch HTML captionTracks -> srv3 XML path as a fallback.
  - Update tests to cover both the new player captions path and the legacy fallback path.

  **Verification:**

  - npx vitest run --project adapter clis/youtube/transcript.test.js clis/youtube/transcript-group.test.js
  - Manually verified with:
      - https://www.youtube.com/watch?v=dQw4w9WgXcQ
      - https://www.youtube.com/watch?v=XLyKB-0-GEA

Related issue: #1376 #1420 

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```bash
node dist/src/main.js youtube transcript -f json https://www.youtube.com/watch\?v\=Lj4LMlGr4og
[
  {
    "timestamp": "0:00",
    "speaker": "",
    "text": "Does using your phone while charging hurt the battery?"
  },
  {
    "timestamp": "0:02",
    "speaker": "",
    "text": "Two years ago we took apart 16 phones to see if fast charging hurts the battery The answer was No After that people started asking Does using your phone while charging hurt the battery?"
  },
  {
    "timestamp": "0:11",
    "speaker": "",
    "text": "Does heat or cold hurt the battery?"
  },
  {
    "timestamp": "0:14",
    "speaker": "",
    "text": "Is wireless charging bad for the battery?"
  },
  {
    "timestamp": "0:15",
    "speaker": "",
    "text": "It feels like people won’t relax until they find a way to break their battery Also is the last 1% of battery extra durable?"
  },
  {
    "timestamp": "0:22",
    "speaker": "",
    "text": "Is the battery health number on your phone even real?"
  },
  {
    "timestamp": "0:25",
    "speaker": "",
    "text": "How much do batteries hurt the environment?"
  },
  {
    "timestamp": "0:27",
    "speaker": "",
    "text": "To answer these questions we did a very long test First we set up 4 phones for normal charging When the battery dropped to 5%, a relay turned on and started charging When it hit 100% the relay cut off and our app started draining the battery down to 5% again This loop kept going To test if using the phone while charging is bad we prepared another 4 phones These phones did the same 5%-100% charging loop But while charging the discharge app was also running — just like using your phone while it’s charging"
  },
  {
    "timestamp": "0:58",
    "speaker": "",
    "text": "Besides that we had 16 more phones in the room Some were put in a hot box some on wireless chargers Each group had their own tests To keep the results fair All phones were bought by us through official stores just like last time To show time passing we planted some plants…"
  },
  {
    "timestamp": "1:41",
    "speaker": "",
    "text": "Time flew by After 193 days we grew 76 cucumbers And all phones finished 2000 hours of discharging The normal charging group did 750 charge cycles Their batteries lost about 9.0% capacity on average The \"charging while using\" group did only 380 cycles because charging while using is slower and their batteries lost about 3.5%."
  },
  {
    "timestamp": "2:04",
    "speaker": "",
    "text": "We then checked how much normal phones dropped after around 400 cycles — about 3.7%."
  },
  {
    "timestamp": "2:09",
    "speaker": "",
    "text": "Very close So in our test what really affects battery life is the number of cycles Using your phone while charging does not hurt the battery more But this result feels strange When you use your phone while charging the temperature is higher In our test Just charging makes battery warms up to 33°C（91.4℉） Charging while using makes battery warms up to 37°C（98.6℉） 1°C（33.8℉）hotter than playing games Isn’t higher temperature supposed to hurt the battery?"
  },
  {
    "timestamp": "2:34",
    "speaker": "",
    "text": "That’s what we tested next We put 4 phones in a hot box at around 35°C（95℉） During charging they heated up to 45°C（113℉） We also put 4 phones into a cold box around 0°C（32℉） Their max temperature was only 3°C（37.4℉） After 2000 hours In the hot box batteries dropped about 9.6% A little more than normal but not much In the cold box 3 phones dropped about 7.8%, but one phone suddenly dropped 45%."
  },
  {
    "timestamp": "2:58",
    "speaker": "",
    "text": "This made the cold test results unreliable Overall As long as you use your phone within the normal temperature range battery life is fine Still I don’t recommend using your phone while charging — it just feels bad when the phone gets too hot But you know when I do worry about battery life?"
  },
  {
    "timestamp": "3:13",
    "speaker": "",
    "text": "When my phone hits 1%."
  },
  {
    "timestamp": "3:15",
    "speaker": "",
    "text": "A lot of people feel like the last 1% of battery and the 100%-99% drop last a long time Is it true?"
  },
  {
    "timestamp": "3:22",
    "speaker": "",
    "text": "We charged 3 phones to 100%, ran our discharge app and used a shortcut to record battery every 5 seconds After 15 tests From 99% to 1%, each percent lasted about 110 seconds pretty even But from 100% to 99%, it lasted more than 350 seconds — 3 to 5 times longer!"
  },
  {
    "timestamp": "3:41",
    "speaker": "",
    "text": "Turns out people’s feeling was right We tested other phone models too Same result Our friends at ChargerLab told us: Phones might \"show\" 100% before they are fully full Because the closer you get to 100%, the slower the charging If they waited for true 100%, it would take longer and once you unplug and start using it you’d immediately drop to 99%, which would feel bad As for 1% battery to shutdown: After 15 tests the phones lasted between 120 and 300 seconds So it could die fast or last a few minutes — it’s random"
  },
  {
    "timestamp": "4:14",
    "speaker": "",
    "text": "Best way?"
  },
  {
    "timestamp": "4:15",
    "speaker": "",
    "text": "Just plug it in as soon as possible Also a lot of my coworkers kept a wireless charger on their desk When they work they just pick up the phone when needed and put it back down to charge when done It keeps the battery level high But does frequent charging hurt the battery?"
  },
  {
    "timestamp": "4:28",
    "speaker": "",
    "text": "Is wireless charging worse than wired?"
  },
  {
    "timestamp": "4:31",
    "speaker": "",
    "text": "We tested 8 phones: One group charged wirelessly from 5% to 100% One group charged from 80% to 95% wirelessly Results after 2000 hours: 5%-100% group lost about 9.0% — same as normal wired charging 80%-95% group only lost about 3.9% — much better!"
  },
  {
    "timestamp": "4:48",
    "speaker": "",
    "text": "So: Wireless charging does not hurt more than wired charging Avoiding deep discharge helps keep your battery healthy So charge whenever you want Pick up whenever you want It might even make your battery last longer Finally is the battery health number on your iPhone accurate?"
  },
  {
    "timestamp": "5:02",
    "speaker": "",
    "text": "In the test we checked battery health every 200 hours and physically measured the battery Result The iPhone’s battery health reading is roughly accurate It shows the general trend But it’s not exact Sometimes it’s off by less than 1%, but sometimes over 4%."
  },
  {
    "timestamp": "5:17",
    "speaker": "",
    "text": "That’s because it’s based on estimated data like cycle count voltage current, not a real measurement Still you can trust it for a general idea And that’s everything we found We spent so much time and effort on this test because first many viewers were truly curious and second because when I got my first phone I treated it like the most precious thing I had I hope this video helps you use your phone more freely — without worry Just like last time we have replaced the batteries of all 24 phones used in the experiment with brand-new ones and gave them away"
  },
  {
    "timestamp": "5:48",
    "speaker": "",
    "text": "we gave all the old batteries to recycling Why can't you just throw old phone batteries in the trash?"
  },
  {
    "timestamp": "5:53",
    "speaker": "",
    "text": "We put some battery chemicals into soil planted some plants and here’s what happened"
  }
]
```