### PR TITLE
fix(browser): handle daemon returning { session, data } wrapper from screenshot

### DIFF
--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -216,14 +216,18 @@ export class Page extends BasePage {
    * Capture a screenshot via CDP Page.captureScreenshot.
    */
   async screenshot(options: ScreenshotOptions = {}): Promise<string> {
-    const base64 = await sendCommand('screenshot', {
+    const raw = await sendCommand('screenshot', {
       ...this._cmdOpts(),
       format: options.format,
       quality: options.quality,
       fullPage: options.fullPage,
       width: options.width,
       height: options.height,
-    }) as string;
+    });
+
+    const base64 = typeof raw === 'object' && raw !== null && typeof (raw as Record<string, unknown>).data === 'string'
+      ? (raw as Record<string, unknown>).data as string
+      : raw as string;
 
     if (options.path) {
       await saveBase64ToFile(base64, options.path);


### PR DESCRIPTION
## Description

The daemon'"'"'s screenshot command returns the base64 data wrapped in an object with session info (`{ session, data }`), but `page.screenshot()` passes the return value directly to `saveBase64ToFile()` which calls `Buffer.from(base64, '"'"'base64'"'"')`.

When the value is an object instead of a string, this causes `TypeError: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object`.

## Fix

Extract the `data` field when the return value is an object with a string `data` property, matching the pattern already used in `cdp.ts`. Falls back to treating the return value as a string for backward compatibility.

## Tested

- `opencli browser --session test screenshot output.png` — saves PNG file correctly
- `opencli browser --session test screenshot` — returns base64 string in console
- Both with and without `--full-page` flag

## Related

This follows the same defensive pattern used in `src/browser/cdp.ts:246`.