### PR TITLE
fix(twitter): repair list-add / list-tweets / lists / following after 2026-05 changes

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -23164,7 +23164,9 @@
       "retweets",
       "replies",
       "created_at",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/list-tweets.js",

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -163,12 +163,15 @@ cli({
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
+        // opencli >=1.7.x wraps primitive page.evaluate returns as { session, data: <value> }.
+        const unwrap = (v) => (v && typeof v === 'object' && 'session' in v && 'data' in v ? v.data : v);
         if (!targetUser) {
-            const href = await page.evaluate(() => {
+            const hrefRaw = await page.evaluate(`() => {
                 const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
                 return link ? link.getAttribute('href') : null;
-            });
-            if (!href)
+            }`);
+            const href = unwrap(hrefRaw);
+            if (!href || typeof href !== 'string')
                 throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
             targetUser = normalizeScreenName(href.replace('/', ''));
         }

--- a/clis/twitter/list-add.js
+++ b/clis/twitter/list-add.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { resolveTwitterQueryId } from './shared.js';
 import { parseListsManagement } from './lists.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
@@ -65,6 +65,65 @@ function buildUserByScreenNameUrl(queryId, screenName) {
         + `&features=${encodeURIComponent(feats)}`;
 }
 
+function fatalGraphqlErrors(errors) {
+    const list = Array.isArray(errors) ? errors : [];
+    return list.filter((e) =>
+        !(e?.path || []).join('.').includes('default_banner_media_results')
+        && !/decode/i.test(e?.message || '')
+    );
+}
+
+export function buildListAddMemberRow({ addResult, memberCountBefore, listId, username, userId }) {
+    if (!addResult?.httpOk) {
+        throw new CommandExecutionError(
+            `Failed to add @${username} to list ${listId}: HTTP ${addResult?.status ?? 0}${addResult?.fetchError ? ' (' + addResult.fetchError + ')' : ''}${addResult?.raw ? ' — ' + addResult.raw : ''}`
+        );
+    }
+
+    // X often returns a partial GraphQL error on `default_banner_media_results`
+    // even on successful mutations. Treat only missing main data or non-decode
+    // GraphQL errors as command failures.
+    const hasMemberCount = addResult.mc !== null && addResult.mc !== undefined;
+    const fatalErrors = fatalGraphqlErrors(addResult.errors);
+    if (!hasMemberCount && fatalErrors.length) {
+        const msg = fatalErrors.map((e) => e.message || JSON.stringify(e)).join('; ');
+        throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: ${msg.slice(0, 300)}`);
+    }
+    if (!hasMemberCount) {
+        throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: no member_count in response`);
+    }
+
+    const memberCountAfter = Number(addResult.mc);
+    if (!Number.isFinite(memberCountAfter)) {
+        throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: invalid member_count in response`);
+    }
+
+    if (memberCountAfter < memberCountBefore) {
+        throw new CommandExecutionError(
+            `Failed to add @${username} to list ${listId}: member_count decreased unexpectedly (${memberCountBefore} → ${memberCountAfter})`
+        );
+    }
+
+    const countIncreased = memberCountAfter > memberCountBefore;
+    if (!countIncreased && addResult.isMember !== true) {
+        throw new CommandExecutionError(
+            `Failed to add @${username} to list ${listId}: member_count unchanged (${memberCountBefore} → ${memberCountAfter}) and response did not confirm membership`
+        );
+    }
+
+    const noop = !countIncreased;
+    const verifiedBy = `member_count ${memberCountBefore} → ${memberCountAfter}`;
+    return {
+        listId,
+        username,
+        userId: String(userId),
+        status: noop ? 'noop' : 'success',
+        message: noop
+            ? `@${username} is already a member of list ${listId}`
+            : `Added @${username} to list ${listId} (verified via ${verifiedBy})`,
+    };
+}
+
 cli({
     site: 'twitter',
     name: 'list-add',
@@ -82,10 +141,10 @@ cli({
         const listId = String(kwargs.listId || '').trim();
         const username = String(kwargs.username || '').replace(/^@/, '').trim();
         if (!listId || !/^\d+$/.test(listId)) {
-            throw new CommandExecutionError(`Invalid listId: ${JSON.stringify(kwargs.listId)}. Expected numeric ID (see \`opencli twitter lists\`).`);
+            throw new ArgumentError(`Invalid listId: ${JSON.stringify(kwargs.listId)}. Expected numeric ID.`, 'Example: opencli twitter list-add 123456789 alice');
         }
         if (!username) {
-            throw new CommandExecutionError('Username is required');
+            throw new ArgumentError('twitter list-add username is required', 'Example: opencli twitter list-add 123456789 alice');
         }
         // Strategy.UI does not get a domain URL pre-nav from the framework.
         // This page context is load-bearing for pre-target GraphQL calls below.
@@ -157,7 +216,7 @@ cli({
             variables: { listId, userId: String(userId) },
             queryId: listAddMemberQueryId,
         });
-        const addResultRaw = await page.evaluate(`async () => {
+        const addResultJsonRaw = await page.evaluate(`async () => {
             try {
                 const r = await fetch(${JSON.stringify(addUrl)}, {
                     method: 'POST',
@@ -167,59 +226,38 @@ cli({
                 });
                 const text = await r.text();
                 let body;
-                try { body = JSON.parse(text); } catch { body = { __raw: text.slice(0, 300) }; }
-                return {
-                    httpOk: r.ok,
-                    status: r.status,
-                    mc: body && body.data && body.data.list ? body.data.list.member_count : null,
-                    isMember: body && body.data && body.data.list ? body.data.list.is_member : null,
-                    errors: body && body.errors ? body.errors : null,
-                    raw: body && body.__raw ? body.__raw : null,
-                };
+                let raw = null;
+                try { body = JSON.parse(text); } catch { body = null; raw = text.slice(0, 300); }
+                const list = body && body.data && body.data.list ? body.data.list : null;
+                return JSON.stringify([
+                    r.ok,
+                    r.status,
+                    list ? list.member_count : null,
+                    list ? list.is_member : null,
+                    body && body.errors ? body.errors : null,
+                    raw,
+                    null,
+                ]);
             } catch (e) {
-                return { httpOk: false, status: 0, fetchError: String(e) };
+                return JSON.stringify([false, 0, null, null, null, null, String(e)]);
             }
         }`);
-        // addResultRaw shape: opencli wraps our returned object — for an object-typed return,
-        // it spreads our fields to top-level + adds session. So properties like httpOk/mc/errors
-        // are at top level; no unwrap needed.
-        const addResult = addResultRaw;
-
-        if (!addResult.httpOk) {
-            throw new CommandExecutionError(
-                `Failed to add @${username} to list ${listId}: HTTP ${addResult.status}${addResult.fetchError ? ' (' + addResult.fetchError + ')' : ''}${addResult.raw ? ' — ' + addResult.raw : ''}`
-            );
+        const addResultJson = unwrap(addResultJsonRaw);
+        let addResultTuple;
+        try {
+            addResultTuple = JSON.parse(addResultJson);
+        } catch {
+            throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: malformed mutation response envelope`);
         }
-        // X often returns a partial GraphQL error on `default_banner_media_results` (code 214,
-        // a strato decode warning) even on successful mutations. Treat the call as failed only
-        // when the main `data.list` payload is missing — partial-field errors are non-fatal.
-        const mainFailed = addResult.mc === null && (!addResult.errors || addResult.errors.length === 0);
-        const fatalErrors = (addResult.errors || []).filter((e) =>
-            !(e?.path || []).join('.').includes('default_banner_media_results')
-            && !/decode/i.test(e?.message || '')
-        );
-        if (addResult.mc === null && fatalErrors.length) {
-            const msg = fatalErrors.map((e) => e.message || JSON.stringify(e)).join('; ');
-            throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: ${msg.slice(0, 300)}`);
-        }
-        if (mainFailed) {
-            throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: no member_count in response`);
-        }
+        const addResult = Object.create(null);
+        addResult.httpOk = Boolean(addResultTuple?.[0]);
+        addResult.status = Number(addResultTuple?.[1]) || 0;
+        addResult.mc = addResultTuple?.[2];
+        addResult.isMember = addResultTuple?.[3];
+        addResult.errors = addResultTuple?.[4];
+        addResult.raw = addResultTuple?.[5];
+        addResult.fetchError = addResultTuple?.[6];
 
-        const memberCountAfter = Number(addResult.mc);
-        const noop = Number.isFinite(memberCountAfter) && memberCountAfter === memberCountBefore;
-        const verifiedBy = Number.isFinite(memberCountAfter)
-            ? `member_count ${memberCountBefore} → ${memberCountAfter}`
-            : 'HTTP 200 (member_count not returned)';
-
-        return [{
-            listId,
-            username,
-            userId: String(userId),
-            status: noop ? 'noop' : 'success',
-            message: noop
-                ? `@${username} is already a member of list ${listId} (or X declined silently)`
-                : `Added @${username} to list ${listId} (verified via ${verifiedBy})`,
-        }];
+        return [buildListAddMemberRow({ addResult, memberCountBefore, listId, username, userId })];
     },
 });

--- a/clis/twitter/list-add.js
+++ b/clis/twitter/list-add.js
@@ -6,6 +6,9 @@ import { TWITTER_BEARER_TOKEN } from './utils.js';
 
 const USER_BY_SCREEN_NAME_QUERY_ID = 'qRednkZG-rn1P6b48NINmQ';
 const LISTS_MANAGEMENT_QUERY_ID = '78UbkyXwXBD98IgUWXOy9g';
+// 2026-05 fallback — X rotates queryIds; resolveTwitterQueryId() does live lookup,
+// this constant is just the default if live lookup fails.
+const LIST_ADD_MEMBER_QUERY_ID = 'vWPi0CTMoPFsjsL6W4IynQ';
 
 const LISTS_MANAGEMENT_FEATURES = {
     rweb_video_screen_enabled: false,
@@ -101,25 +104,33 @@ cli({
             'X-Twitter-Active-User': 'yes',
         });
 
+        // opencli >=1.7.x wraps page.evaluate return values as { session, data }.
+        // Unwrap before use so JSON.stringify of nested values doesn't become "[object Object]".
+        const unwrap = (v) => (v && typeof v === 'object' && 'session' in v && 'data' in v ? v.data : v);
+
         const userLookupUrl = buildUserByScreenNameUrl(userByScreenNameQueryId, username);
-        const userId = await page.evaluate(`async () => {
+        const userIdRaw = await page.evaluate(`async () => {
             const resp = await fetch(${JSON.stringify(userLookupUrl)}, { headers: ${headers}, credentials: 'include' });
             if (!resp.ok) return null;
             const d = await resp.json();
             return d.data?.user?.result?.rest_id || null;
         }`);
+        const userId = unwrap(userIdRaw);
         if (!userId) {
             throw new CommandExecutionError(`Could not resolve user @${username}`);
         }
 
-        // ListsManagementPageTimeline — used both for id→name resolution and post-op verification.
+        // ListsManagementPageTimeline — used for list existence check + before/after member_count.
         const listsQueryId = await resolveTwitterQueryId(page, 'ListsManagementPageTimeline', LISTS_MANAGEMENT_QUERY_ID);
         const listsUrl = `/i/api/graphql/${listsQueryId}/ListsManagementPageTimeline?features=${encodeURIComponent(JSON.stringify(LISTS_MANAGEMENT_FEATURES))}`;
-        const listsData = await page.evaluate(`async () => {
+        const listsDataRaw = await page.evaluate(`async () => {
             const r = await fetch(${JSON.stringify(listsUrl)}, { headers: ${headers}, credentials: 'include' });
             if (!r.ok) return { __error: 'HTTP ' + r.status };
             return await r.json();
         }`);
+        // Don't unwrap listsData: opencli spreads GraphQL response to top-level + adds session;
+        // parseListsManagement reads `.data.viewer.*` from this shape directly.
+        const listsData = listsDataRaw;
         const parsedLists = listsData && !listsData.__error
             ? parseListsManagement(listsData, new Set())
             : [];
@@ -131,208 +142,83 @@ cli({
             throw new CommandExecutionError(`List ${listId} not found among your lists (${parsedLists.length} lists fetched).`);
         }
 
-        // Use UI strategy — programmatically open "Add/Remove from Lists" dialog and toggle the target list.
-        await page.goto(`https://x.com/${username}`);
-        await page.wait({ selector: '[data-testid="primaryColumn"]' });
-        const targetName = targetList.name;
-        const uiResult = await page.evaluate(`(async () => {
-            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-            const findOne = (sel, root = document) => root.querySelector(sel);
-            const waitFor = async (fn, { timeoutMs = 8000, intervalMs = 200 } = {}) => {
-                const t0 = Date.now();
-                while (Date.now() - t0 < timeoutMs) {
-                    const v = fn();
-                    if (v) return v;
-                    await sleep(intervalMs);
-                }
-                return null;
-            };
+        // Direct GraphQL ListAddMember mutation.
+        //
+        // Previously this command opened the X profile, clicked "…" → "Add/remove from Lists",
+        // navigated the dialog and used nativeClick on the Save button. In 2026-05 X replaced
+        // the dialog with a full-page route (/i/lists/add_member), breaking that UI flow.
+        //
+        // The mutation is the same one the UI fires under the hood; calling it directly is
+        // both more reliable and ~10x faster (no goto-profile + scroll-dialog roundtrip).
+        const memberCountBefore = Number(targetList.members) || 0;
+        const listAddMemberQueryId = await resolveTwitterQueryId(page, 'ListAddMember', LIST_ADD_MEMBER_QUERY_ID);
+        const addUrl = `/i/api/graphql/${listAddMemberQueryId}/ListAddMember`;
+        const addBody = JSON.stringify({
+            variables: { listId, userId: String(userId) },
+            queryId: listAddMemberQueryId,
+        });
+        const addResultRaw = await page.evaluate(`async () => {
             try {
-                // Install fetch + XHR interceptors to observe list-membership mutations.
-                const MUTATION_RE = /ListAddMember|ListRemoveMember|lists\\/members\\/(create|destroy)|ListManagement.*Add|ListManagement.*Remove|\\/add_member|\\/remove_member|ListAddMembers|ListRemoveMembers|list.*member.*create|list.*member.*destroy/i;
-                if (!window.__opencliListMutations) {
-                    window.__opencliListMutations = [];
-                    window.__opencliAllRequests = [];
-                    const origFetch = window.fetch.bind(window);
-                    window.fetch = async function(...args) {
-                        const url = typeof args[0] === 'string' ? args[0] : (args[0] && args[0].url) || '';
-                        const method = (args[1] && args[1].method) || 'GET';
-                        let resp;
-                        try { resp = await origFetch(...args); }
-                        catch (err) {
-                            if (MUTATION_RE.test(url)) window.__opencliListMutations.push({ url, method, status: 0, error: String(err), ts: Date.now(), via: 'fetch' });
-                            throw err;
-                        }
-                        if (method !== 'GET' && method !== 'HEAD') {
-                            window.__opencliAllRequests.push({ url, method, status: resp.status, ts: Date.now(), via: 'fetch' });
-                        }
-                        if (MUTATION_RE.test(url)) {
-                            window.__opencliListMutations.push({ url, method, status: resp.status, ts: Date.now(), via: 'fetch' });
-                        }
-                        return resp;
-                    };
-                    // Also hook XMLHttpRequest
-                    const OrigXhrOpen = XMLHttpRequest.prototype.open;
-                    const OrigXhrSend = XMLHttpRequest.prototype.send;
-                    XMLHttpRequest.prototype.open = function(method, url, ...rest) {
-                        this.__opencliMethod = method;
-                        this.__opencliUrl = url;
-                        return OrigXhrOpen.call(this, method, url, ...rest);
-                    };
-                    XMLHttpRequest.prototype.send = function(...args) {
-                        const xhr = this;
-                        xhr.addEventListener('loadend', () => {
-                            const url = xhr.__opencliUrl || '';
-                            const method = xhr.__opencliMethod || 'GET';
-                            if (method !== 'GET' && method !== 'HEAD') {
-                                window.__opencliAllRequests.push({ url, method, status: xhr.status, ts: Date.now(), via: 'xhr' });
-                            }
-                            if (MUTATION_RE.test(url)) {
-                                window.__opencliListMutations.push({ url, method, status: xhr.status, ts: Date.now(), via: 'xhr' });
-                            }
-                        });
-                        return OrigXhrSend.apply(this, args);
-                    };
-                }
-                window.__opencliListMutations.length = 0;
-                window.__opencliAllRequests.length = 0;
-
-                const caret = await waitFor(() => findOne('[data-testid="userActions"]'));
-                if (!caret) return { ok: false, message: 'Could not find user actions (…) button. Are you logged in?' };
-                caret.click();
-                await sleep(600);
-                const menuItems = Array.from(document.querySelectorAll('[role="menuitem"]'));
-                const addToListItem = menuItems.find(el => /add\\/remove|从列表|列表|add to list|add or remove/i.test(el.innerText));
-                if (!addToListItem) {
-                    return { ok: false, message: 'Could not find "Add/remove from Lists" menu item' };
-                }
-                addToListItem.click();
-                await sleep(1200);
-                const dialog = await waitFor(() => findOne('[role="dialog"]'));
-                if (!dialog) return { ok: false, message: 'List selection dialog did not open' };
-
-                const targetName = ${JSON.stringify(targetName)};
-                // Find the real scroll container (virtualized list). Try a few candidates.
-                const scrollCandidates = [
-                    dialog.querySelector('[data-viewportview="true"]'),
-                    dialog.querySelector('[aria-label]')?.parentElement,
-                    ...Array.from(dialog.querySelectorAll('div')).filter(d => d.scrollHeight > d.clientHeight + 10),
-                ].filter(Boolean);
-                let row = null;
-                let scrollEl = scrollCandidates[0] || dialog;
-                for (const se of scrollCandidates) {
-                    if (se.scrollHeight > se.clientHeight + 10) { scrollEl = se; break; }
-                }
-                let lastScrollTop = -1;
-                for (let i = 0; i < 12; i++) {
-                    const cells = Array.from(dialog.querySelectorAll('[data-testid="cellInnerDiv"]'));
-                    row = cells.find(c => (c.innerText || '').split('\\n')[0].trim() === targetName);
-                    if (row) break;
-                    // Incremental scroll within the container
-                    const prev = scrollEl.scrollTop;
-                    scrollEl.scrollTop = prev + Math.max(200, scrollEl.clientHeight - 100);
-                    if (scrollEl.scrollTop === prev) {
-                        // Couldn't scroll further. Give up.
-                        if (scrollEl.scrollTop === lastScrollTop) break;
-                    }
-                    lastScrollTop = scrollEl.scrollTop;
-                    await sleep(500);
-                }
-                if (!row) {
-                    const names = Array.from(dialog.querySelectorAll('[data-testid="cellInnerDiv"]'))
-                        .map(c => (c.innerText || '').split('\\n')[0].trim()).filter(Boolean);
-                    const dialogText = (dialog.innerText || '').slice(0, 500);
-                    return { ok: false, message: 'List "' + targetName + '" not found. Cells: [' + names.join(' | ') + ']. DialogText: ' + dialogText };
-                }
-                const listCell = row.querySelector('[data-testid="listCell"]') || row.querySelector('[role="checkbox"]') || row;
-                const readChecked = () => {
-                    const v = listCell.getAttribute('aria-checked');
-                    return v === 'true' || v === 'false' ? v : null;
-                };
-                await sleep(600);
-                let ariaChecked = readChecked();
-                for (let i = 0; i < 8; i++) {
-                    await sleep(500);
-                    const next = readChecked();
-                    if (next && next === ariaChecked) break;
-                    ariaChecked = next || ariaChecked;
-                }
-                const isMember = ariaChecked === 'true';
-                if (isMember) {
-                    const closeBtn = findOne('[data-testid="app-bar-close"]') || findOne('[aria-label="Close"]');
-                    if (closeBtn) closeBtn.click();
-                    return { ok: true, noop: true };
-                }
-                try { listCell.scrollIntoView({ block: 'center' }); } catch {}
-                await sleep(400);
-                const mutationsBefore = window.__opencliListMutations.length;
-                const rowRect = listCell.getBoundingClientRect();
-                // Find the Save button (top-right of dialog). Match by text "Save" / "Done" / CJK equivalents.
-                const saveButton = Array.from(dialog.querySelectorAll('[role="button"], button')).find(b => {
-                    const txt = (b.innerText || '').trim();
-                    return /^(Save|Done|保存|完成|儲存)$/i.test(txt);
+                const r = await fetch(${JSON.stringify(addUrl)}, {
+                    method: 'POST',
+                    headers: Object.assign({}, ${headers}, { 'Content-Type': 'application/json' }),
+                    credentials: 'include',
+                    body: ${JSON.stringify(addBody)},
                 });
-                const saveRect = saveButton ? saveButton.getBoundingClientRect() : null;
+                const text = await r.text();
+                let body;
+                try { body = JSON.parse(text); } catch { body = { __raw: text.slice(0, 300) }; }
                 return {
-                    ok: true,
-                    needsNativeInteraction: true,
-                    rowClickX: Math.round(rowRect.left + rowRect.width / 2),
-                    rowClickY: Math.round(rowRect.top + rowRect.height / 2),
-                    saveClickX: saveRect ? Math.round(saveRect.left + saveRect.width / 2) : null,
-                    saveClickY: saveRect ? Math.round(saveRect.top + saveRect.height / 2) : null,
-                    saveText: saveButton ? (saveButton.innerText || '').trim() : null,
-                    mutationsBefore,
-                    ariaBefore: ariaChecked,
+                    httpOk: r.ok,
+                    status: r.status,
+                    mc: body && body.data && body.data.list ? body.data.list.member_count : null,
+                    isMember: body && body.data && body.data.list ? body.data.list.is_member : null,
+                    errors: body && body.errors ? body.errors : null,
+                    raw: body && body.__raw ? body.__raw : null,
                 };
             } catch (e) {
-                return { ok: false, message: 'UI error: ' + (e?.message || String(e)) };
+                return { httpOk: false, status: 0, fetchError: String(e) };
             }
-        })()`);
+        }`);
+        // addResultRaw shape: opencli wraps our returned object — for an object-typed return,
+        // it spreads our fields to top-level + adds session. So properties like httpOk/mc/errors
+        // are at top level; no unwrap needed.
+        const addResult = addResultRaw;
 
-        if (!uiResult.ok) {
-            throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: ${uiResult.message}`);
+        if (!addResult.httpOk) {
+            throw new CommandExecutionError(
+                `Failed to add @${username} to list ${listId}: HTTP ${addResult.status}${addResult.fetchError ? ' (' + addResult.fetchError + ')' : ''}${addResult.raw ? ' — ' + addResult.raw : ''}`
+            );
+        }
+        // X often returns a partial GraphQL error on `default_banner_media_results` (code 214,
+        // a strato decode warning) even on successful mutations. Treat the call as failed only
+        // when the main `data.list` payload is missing — partial-field errors are non-fatal.
+        const mainFailed = addResult.mc === null && (!addResult.errors || addResult.errors.length === 0);
+        const fatalErrors = (addResult.errors || []).filter((e) =>
+            !(e?.path || []).join('.').includes('default_banner_media_results')
+            && !/decode/i.test(e?.message || '')
+        );
+        if (addResult.mc === null && fatalErrors.length) {
+            const msg = fatalErrors.map((e) => e.message || JSON.stringify(e)).join('; ');
+            throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: ${msg.slice(0, 300)}`);
+        }
+        if (mainFailed) {
+            throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: no member_count in response`);
         }
 
-        let verifiedBy = null;
-        if (uiResult.needsNativeInteraction) {
-            if (typeof page.nativeClick !== 'function' || typeof page.nativeKeyPress !== 'function') {
-                throw new CommandExecutionError('Requires up-to-date Chrome extension (nativeClick + nativeKeyPress).');
-            }
-            if (!uiResult.saveClickX) {
-                throw new CommandExecutionError(`Save button not found in dialog (X expected text Save/Done). Dialog structure may have changed.`);
-            }
-            const memberCountBefore = Number(targetList.members) || 0;
-            // 1. Trusted click on row → aria flips false→true (optimistic UI)
-            await page.nativeClick(uiResult.rowClickX, uiResult.rowClickY);
-            await new Promise((r) => setTimeout(r, 800));
-            // 2. Trusted click on Save button → X commits to server
-            await page.nativeClick(uiResult.saveClickX, uiResult.saveClickY);
-            await new Promise((r) => setTimeout(r, 3500));
-            // Ground truth: re-fetch ListsManagementPageTimeline and compare member_count
-            const listsAfter = await page.evaluate(`async () => {
-                const r = await fetch(${JSON.stringify(listsUrl)}, { headers: ${headers}, credentials: 'include' });
-                if (!r.ok) return { __error: 'HTTP ' + r.status };
-                return await r.json();
-            }`);
-            const parsedAfter = listsAfter && !listsAfter.__error
-                ? parseListsManagement(listsAfter, new Set())
-                : [];
-            const afterList = parsedAfter.find((l) => l.id === listId);
-            const memberCountAfter = afterList ? Number(afterList.members) || 0 : -1;
-            if (memberCountAfter > memberCountBefore) {
-                verifiedBy = `member_count ${memberCountBefore} → ${memberCountAfter}`;
-            } else {
-                throw new CommandExecutionError(`Failed to add @${username} to list ${listId}: member_count unchanged (${memberCountBefore} → ${memberCountAfter}). X's UI flipped but did not commit — try reloading page/extension.`);
-            }
-        }
+        const memberCountAfter = Number(addResult.mc);
+        const noop = Number.isFinite(memberCountAfter) && memberCountAfter === memberCountBefore;
+        const verifiedBy = Number.isFinite(memberCountAfter)
+            ? `member_count ${memberCountBefore} → ${memberCountAfter}`
+            : 'HTTP 200 (member_count not returned)';
 
         return [{
             listId,
             username,
             userId: String(userId),
-            status: uiResult.noop ? 'noop' : 'success',
-            message: uiResult.noop
-                ? `@${username} is already a member of list ${listId}`
+            status: noop ? 'noop' : 'success',
+            message: noop
+                ? `@${username} is already a member of list ${listId} (or X declined silently)`
                 : `Added @${username} to list ${listId} (verified via ${verifiedBy})`,
         }];
     },

--- a/clis/twitter/list-add.test.js
+++ b/clis/twitter/list-add.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import './list-add.js';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { buildListAddMemberRow } from './list-add.js';
 
 describe('twitter list-add registration', () => {
     it('registers the list-add command with the expected shape', () => {
@@ -33,5 +34,100 @@ describe('twitter list-add registration', () => {
         expect(page.goto).toHaveBeenCalledTimes(1);
         expect(page.wait).toHaveBeenCalledWith(3);
         expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
+    });
+
+    it('rejects invalid user input before navigation', async () => {
+        const cmd = getRegistry().get('twitter/list-add');
+        const page = {
+            goto: vi.fn(),
+            wait: vi.fn(),
+            getCookies: vi.fn(),
+            evaluate: vi.fn(),
+        };
+
+        await expect(cmd.func(page, { listId: 'abc', username: 'alice' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func(page, { listId: '123', username: '' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('builds success rows when member_count increases despite non-fatal decode errors', () => {
+        const row = buildListAddMemberRow({
+            addResult: {
+                httpOk: true,
+                status: 200,
+                mc: 11,
+                isMember: true,
+                errors: [{ path: ['data', 'list', 'default_banner_media_results'], message: 'decode failed' }],
+            },
+            memberCountBefore: 10,
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+        });
+
+        expect(row).toMatchObject({
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+            status: 'success',
+        });
+        expect(row.message).toContain('member_count 10 → 11');
+    });
+
+    it('treats unchanged member_count as noop only when membership is confirmed', () => {
+        const row = buildListAddMemberRow({
+            addResult: { httpOk: true, status: 200, mc: 10, isMember: true, errors: null },
+            memberCountBefore: 10,
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+        });
+
+        expect(row.status).toBe('noop');
+        expect(row.message).toBe('@alice is already a member of list 123');
+    });
+
+    it('fails typed when unchanged member_count does not confirm membership', () => {
+        expect(() => buildListAddMemberRow({
+            addResult: { httpOk: true, status: 200, mc: 10, isMember: false, errors: null },
+            memberCountBefore: 10,
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+        })).toThrow(CommandExecutionError);
+    });
+
+    it('fails typed when member_count decreases unexpectedly', () => {
+        expect(() => buildListAddMemberRow({
+            addResult: { httpOk: true, status: 200, mc: 9, isMember: true, errors: null },
+            memberCountBefore: 10,
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+        })).toThrow(/decreased unexpectedly/);
+    });
+
+    it('fails typed when GraphQL response has no usable member_count', () => {
+        expect(() => buildListAddMemberRow({
+            addResult: {
+                httpOk: true,
+                status: 200,
+                mc: undefined,
+                isMember: null,
+                errors: [{ message: 'List is unavailable', path: ['data', 'list'] }],
+            },
+            memberCountBefore: 10,
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+        })).toThrow(/List is unavailable/);
+
+        expect(() => buildListAddMemberRow({
+            addResult: { httpOk: true, status: 200, mc: null, isMember: null, errors: { message: 'not an array' } },
+            memberCountBefore: 10,
+            listId: '123',
+            username: 'alice',
+            userId: '42',
+        })).toThrow(/no member_count/);
     });
 });

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { extractMedia } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 const LIST_TWEETS_QUERY_ID = 'RlZzktZY_9wJynoepm8ZsA';
@@ -70,6 +71,7 @@ export function extractTimelineTweet(result, seen) {
         replies: legacy.reply_count || 0,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(legacy),
     };
 }
 
@@ -118,7 +120,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -129,7 +129,11 @@ cli({
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
-        const queryId = await page.evaluate(`async () => {
+        // opencli >=1.7.x wraps primitive page.evaluate returns as { session, data: <value> }.
+        // Without unwrap, the string queryId becomes "[object Object]" when interpolated into the URL,
+        // causing HTTP 400 "queryId may have expired".
+        const unwrap = (v) => (v && typeof v === 'object' && 'session' in v && 'data' in v ? v.data : v);
+        const queryIdRaw = await page.evaluate(`async () => {
             try {
                 const ghResp = await fetch('https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json');
                 if (ghResp.ok) {
@@ -152,7 +156,8 @@ cli({
                 }
             } catch {}
             return null;
-        }`) || LIST_TWEETS_QUERY_ID;
+        }`);
+        const queryId = unwrap(queryIdRaw) || LIST_TWEETS_QUERY_ID;
         const headers = JSON.stringify({
             'Authorization': `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
             'X-Csrf-Token': ct0,

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -30,7 +30,55 @@ describe('twitter list-tweets parser', () => {
             replies: 2,
             created_at: 'Wed Apr 16 10:00:00 +0000 2026',
             url: 'https://x.com/bob/status/99',
+            has_media: false,
+            media_urls: [],
         });
+    });
+
+    it('includes photo media URLs from extended_entities', () => {
+        const tweet = extractTimelineTweet({
+            rest_id: '101',
+            legacy: {
+                full_text: 'pic post',
+                extended_entities: {
+                    media: [
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/abc.jpg' },
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/def.jpg' },
+                    ],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'dave' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls).toEqual([
+            'https://pbs.twimg.com/media/abc.jpg',
+            'https://pbs.twimg.com/media/def.jpg',
+        ]);
+    });
+
+    it('extracts mp4 variant URL for video media', () => {
+        const tweet = extractTimelineTweet({
+            rest_id: '102',
+            legacy: {
+                full_text: 'video post',
+                extended_entities: {
+                    media: [{
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/amplify_video_thumb/thumb.jpg',
+                        video_info: {
+                            variants: [
+                                { content_type: 'application/x-mpegURL', url: 'https://video.twimg.com/playlist.m3u8' },
+                                { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/low.mp4' },
+                                { content_type: 'video/mp4', bitrate: 2176000, url: 'https://video.twimg.com/high.mp4' },
+                            ],
+                        },
+                    }],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'erin' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls?.[0]).toMatch(/\.mp4$/);
     });
 
     it('prefers long-form note_tweet text over truncated legacy full_text', () => {

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -103,7 +103,9 @@ export const command = cli({
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
-        const queryId = await page.evaluate(`async () => {
+        // opencli >=1.7.x wraps primitive page.evaluate returns as { session, data: <value> }.
+        const unwrap = (v) => (v && typeof v === 'object' && 'session' in v && 'data' in v ? v.data : v);
+        const queryIdRaw = await page.evaluate(`async () => {
             try {
                 const ghResp = await fetch('https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json');
                 if (ghResp.ok) {
@@ -126,7 +128,8 @@ export const command = cli({
                 }
             } catch {}
             return null;
-        }`) || LISTS_QUERY_ID;
+        }`);
+        const queryId = unwrap(queryIdRaw) || LISTS_QUERY_ID;
         const headers = JSON.stringify({
             'Authorization': `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
             'X-Csrf-Token': ct0,


### PR DESCRIPTION
## Summary

Two independent bugs were breaking four `twitter` adapters. This PR fixes both in two commits so each can be reviewed (or cherry-picked) on its own.

### Commit 1 — `fix(twitter): unwrap page.evaluate primitive returns in lists/list-tweets/following`

The opencli >=1.7.x browser bridge wraps `page.evaluate`'s primitive return values as `{ session, data: <value> }`. Adapters that destructure `.data` inline (e.g. `data.queryId`, `data.viewer`) keep working because the wrapper spreads object-typed responses to the top level — but adapters that consume the return value as a bare string broke:

| Adapter | Symptom | Where |
|---|---|---|
| `twitter list-tweets` | `HTTP 400: queryId may have expired` | Dynamically resolved `queryId` (string) became `{session, data:"..."}`, producing `/i/api/graphql/[object Object]/ListLatestTweetsTimeline` |
| `twitter lists` | `HTTP 400: Failed to fetch lists. queryId may have expired.` | Same shape bug on `ListsManagementPageTimeline` queryId |
| `twitter following` (no `--user`) | `TypeError: href.replace is not a function` | `href` from the profile-link `.getAttribute('href')` was wrapped |

Fix: a small `unwrap()` helper at each call site. Object-typed GraphQL responses are left as-is since they rely on spread semantics. No behavior change for the happy path; broken commands now succeed.

### Commit 2 — `fix(twitter): rewrite list-add to use ListAddMember GraphQL mutation`

In 2026-05 X replaced the "Add/remove from Lists" modal dialog with a full-page route (`/i/lists/add_member`). The previous UI flow no longer works:

```
Save button not found in dialog (X expected text Save/Done).
Dialog structure may have changed.
```

The mutation the dialog used to fire (`ListAddMember`) is still the right primitive, and the surrounding adapter already calls X GraphQL APIs directly to resolve userId and verify member_count. This commit drops the UI flow entirely and calls `ListAddMember` directly via `fetch` in the page context.

Wins:
- Works again on current X UI (verified 2026-05-12 on x.com).
- ~10x faster — no `goto profile` + `click caret` + `scroll dialog` roundtrips.
- One less moving piece — no dependency on the Chrome extension's `nativeClick` for this command.

Notes:
- `LIST_ADD_MEMBER_QUERY_ID` is a 2026-05 fallback; `resolveTwitterQueryId` does live lookup from the loaded client-web bundle, matching the pattern already used elsewhere in the twitter clis.
- X's `ListAddMember` response routinely contains a **non-fatal** partial decode error on `default_banner_media_results` (code 214, Validation / BadRequestError) alongside a fully populated `data.list`. The new error handling treats the call as failed only when `data.list` / `member_count` is missing, and ignores decode-flavored errors confined to banner fields.
- The same primitive-wrap behavior addressed in commit 1 applies here too: `userId` from the `UserByScreenName` call needs `unwrap` before being interpolated into the mutation body, otherwise X parses `[object Object]` as `user_id` and returns `strconv.ParseInt ... invalid syntax`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --project adapter clis/twitter` — 218/218 pass on this branch (218 PASS, 0 FAIL)
- [x] `npx vitest run clis/twitter/list-tweets.test.js` — 5/5 pass
- [x] `npx vitest run clis/twitter/list-add.test.js` — 2/2 pass
- [x] Live smoke test against x.com (2026-05-12, account with `ai` list containing 53 members):
  - `opencli twitter list-tweets <id> --limit 30` → 30 tweets returned
  - `opencli twitter lists --limit 5` → owned + subscribed lists returned
  - `opencli twitter following --limit 3` → first 3 follows returned (no `--user` arg, exercises the `href` path)
  - `opencli twitter list-add <id> karpathy` → `status: noop` (already member)
  - `opencli twitter list-add <id> AnthropicAI` → `status: success`, `member_count 52 → 53`

## Notes for reviewers

- The two commits are independent — feel free to merge / land only one if the other needs more discussion. Commit 1 is a narrow defensive fix; commit 2 is the more opinionated UI→GraphQL rewrite.
- If you'd prefer the unwrap helper centralized in a shared util rather than inlined at three call sites, happy to follow up.