### PR TITLE
fix(xiaohongshu): parseLikes should handle 2.1w / 1.5万 / 1.2k shortforms

### DIFF
--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -14,12 +14,33 @@ export function parseCommentLimit(raw, fallback = 20) {
         return fallback;
     return Math.max(1, Math.min(Math.floor(n), 50));
 }
+
+export function parseXhsLikeCountText(value) {
+    const integerRe = /^(?:\d+|\d{1,3}(?:[,，]\d{3})+)\+?$/u;
+    const shortformRe = /^((?:\d+|\d{1,3}(?:[,，]\d{3})+)(?:\.\d+)?)([wWkK万千])\+?$/u;
+    const raw = String(value ?? '').replace(/\s+/g, '');
+    if (!raw)
+        return 0;
+    if (integerRe.test(raw))
+        return Number(raw.replace(/[,+，]/g, ''));
+    const short = raw.match(shortformRe);
+    if (!short)
+        return 0;
+    const numeric = Number(short[1].replace(/[,，]/g, ''));
+    if (!Number.isFinite(numeric))
+        return 0;
+    const unit = short[2].toLowerCase();
+    const multiplier = unit === 'w' || unit === '万' ? 10000 : 1000;
+    return Math.round(numeric * multiplier);
+}
+
 /**
  * Host-agnostic IIFE that scrolls a note's comment list and extracts
  * top-level comments (and optionally nested 楼中楼 replies). Exported so
  * the rednote adapter can reuse the exact same selector chain.
  */
 export function buildCommentsExtractJs(withReplies) {
+    const parseLikeCountText = parseXhsLikeCountText.toString();
     return `
       (async () => {
         const wait = (ms) => new Promise(r => setTimeout(r, ms))
@@ -44,20 +65,9 @@ export function buildCommentsExtractJs(withReplies) {
         }
 
         const clean = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim()
+        const parseLikeCountText = ${parseLikeCountText}
         const parseLikes = (el) => {
-          const raw = clean(el)
-          if (!raw) return 0
-          if (/^\\d+$/.test(raw)) return Number(raw)
-          // Handle Xiaohongshu's shortform like-count text: "2.1w" / "1.5万" -> *10000;
-          // "1.2k" / "3千" -> *1000; trailing "+" tolerated. Falls back to 0 on unknown shapes.
-          const m = raw.match(/^([\\d.]+)\\s*([wk万千]?)\\+?$/i)
-          if (!m) return 0
-          const num = parseFloat(m[1])
-          if (!Number.isFinite(num)) return 0
-          const unit = m[2].toLowerCase()
-          if (unit === 'w' || unit === '万') return Math.round(num * 10000)
-          if (unit === 'k' || unit === '千') return Math.round(num * 1000)
-          return Math.round(num)
+          return parseLikeCountText(clean(el))
         }
         const expandReplyThreads = async (root) => {
           if (!withReplies || !root) return

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -46,7 +46,18 @@ export function buildCommentsExtractJs(withReplies) {
         const clean = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim()
         const parseLikes = (el) => {
           const raw = clean(el)
-          return /^\\d+$/.test(raw) ? Number(raw) : 0
+          if (!raw) return 0
+          if (/^\\d+$/.test(raw)) return Number(raw)
+          // Handle Xiaohongshu's shortform like-count text: "2.1w" / "1.5万" -> *10000;
+          // "1.2k" / "3千" -> *1000; trailing "+" tolerated. Falls back to 0 on unknown shapes.
+          const m = raw.match(/^([\\d.]+)\\s*([wk万千]?)\\+?$/i)
+          if (!m) return 0
+          const num = parseFloat(m[1])
+          if (!Number.isFinite(num)) return 0
+          const unit = m[2].toLowerCase()
+          if (unit === 'w' || unit === '万') return Math.round(num * 10000)
+          if (unit === 'k' || unit === '千') return Math.round(num * 1000)
+          return Math.round(num)
         }
         const expandReplyThreads = async (root) => {
           if (!withReplies || !root) return

--- a/clis/xiaohongshu/comments.test.js
+++ b/clis/xiaohongshu/comments.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
-import './comments.js';
+import { buildCommentsExtractJs, parseXhsLikeCountText } from './comments.js';
 function createPageMock(evaluateResult) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -25,6 +26,41 @@ function createPageMock(evaluateResult) {
         waitForCapture: vi.fn().mockResolvedValue(undefined),
     };
 }
+
+async function runCommentsExtract(html) {
+    const dom = new JSDOM(html, { url: 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok' });
+    const previousDocument = globalThis.document;
+    const previousLocation = globalThis.location;
+    globalThis.document = dom.window.document;
+    globalThis.location = dom.window.location;
+    try {
+        return await eval(buildCommentsExtractJs(false));
+    } finally {
+        globalThis.document = previousDocument;
+        globalThis.location = previousLocation;
+    }
+}
+
+describe('parseXhsLikeCountText', () => {
+    it('parses exact integer and shortform like counts', () => {
+        expect(parseXhsLikeCountText('0')).toBe(0);
+        expect(parseXhsLikeCountText('42')).toBe(42);
+        expect(parseXhsLikeCountText('1,234')).toBe(1234);
+        expect(parseXhsLikeCountText('1，234+')).toBe(1234);
+        expect(parseXhsLikeCountText('2.1w')).toBe(21000);
+        expect(parseXhsLikeCountText('1.5万')).toBe(15000);
+        expect(parseXhsLikeCountText('1.2k')).toBe(1200);
+        expect(parseXhsLikeCountText('3千')).toBe(3000);
+        expect(parseXhsLikeCountText(' 2.1 w + ')).toBe(21000);
+    });
+
+    it('returns 0 for unknown shapes without overparsing arbitrary text', () => {
+        for (const raw of ['', null, undefined, '赞', 'likes 2.1w', '2w人', '1,23', '1.2.3k', '.', '1.5']) {
+            expect(parseXhsLikeCountText(raw)).toBe(0);
+        }
+    });
+});
+
 describe('xiaohongshu comments', () => {
     const command = getRegistry().get('xiaohongshu/comments');
     it('returns ranked comment rows for signed full URLs', async () => {
@@ -119,6 +155,32 @@ describe('xiaohongshu comments', () => {
         expect(script).toContain("const beforeCount = scroller.querySelectorAll('.parent-comment').length");
         expect(script).toContain("const afterCount = scroller.querySelectorAll('.parent-comment').length");
         expect(script).toContain('if (afterCount <= beforeCount) break');
+    });
+    it('extracts shortform like counts from the shared xiaohongshu/rednote DOM script', async () => {
+        const data = await runCommentsExtract(`
+          <main>
+            <section class="parent-comment">
+              <div class="comment-item">
+                <div class="author-wrapper"><span class="name">Alice</span></div>
+                <div class="content">Great note</div>
+                <span class="count">2.1w</span>
+                <span class="date">today</span>
+              </div>
+            </section>
+            <section class="parent-comment">
+              <div class="comment-item">
+                <span class="user-name">Bob</span>
+                <div class="note-text">Malformed count</div>
+                <span class="count">likes 2.1w</span>
+              </div>
+            </section>
+          </main>
+        `);
+
+        expect(data.results).toEqual([
+            { author: 'Alice', text: 'Great note', likes: 21000, time: 'today', is_reply: false, reply_to: '' },
+            { author: 'Bob', text: 'Malformed count', likes: 0, time: '', is_reply: false, reply_to: '' },
+        ]);
     });
     it('respects the limit for top-level comments', async () => {
         const manyComments = Array.from({ length: 10 }, (_, i) => ({


### PR DESCRIPTION
## Description

Fix `parseLikes` in `clis/xiaohongshu/comments.js` so it correctly parses Xiaohongshu's shortform like-count rendering (`2.1w`, `1.5万`, `1.2k`, `3千`). The previous implementation only matched bare digits (`/^\d+$/`) and silently returned `0` for any shortform string, which **inverts the ranking**: the most-liked top-level comments (typically 10k+) end up with `likes: 0` while mid-tier comments with plain numeric counts (e.g. 7569) bubble up to the top.

This affects both top-level comments and 楼中楼 sub-replies (same helper).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Repro

On any popular Xiaohongshu thread where the top comment has more than ~10 000 likes, run:

```bash
opencli xiaohongshu comments "<full signed URL>" --limit 50 --with-replies true --format json
```

Sort the resulting JSON by `likes` desc — the actual most-liked rows show `"likes": 0` because their rendered count is `2.1w` / `1.1万` / etc., which the old regex rejected.

After this patch the same output puts the real top comments at rank 1.

## Patch summary

Keep the fast path for bare integers, then add a single regex covering the well-known shortform suffixes:

| Input | Parsed |
|---|---|
| `7569` | `7569` |
| `2.1w` / `1.5万` | `21000` / `15000` |
| `1.2k` / `3千` | `1200` / `3000` |
| `999+` | `999` (trailing `+` tolerated) |
| anything else | `0` (unchanged fallback) |

## Notes on testing

`parseLikes` lives inside the IIFE that gets serialized into a string and passed to `page.evaluate()`. The existing `comments.test.js` mocks `page.evaluate`'s return value directly, so it does not exercise the IIFE-internal helpers — there is no current way to unit-test `parseLikes` in isolation without exporting it. Refactoring to make it directly importable would be a meaningful change in surface area, so I've intentionally kept this PR scoped to the bug fix.

I verified the fix manually against a thread with a 21k-liked top comment; ranking now matches the in-app order.

## Checklist

- [x] I ran the checks relevant to this PR (manual verification on a live thread; existing tests untouched and still mock at the boundary above this helper)
- [ ] I updated tests or docs if needed (see "Notes on testing")
- [x] I included output or screenshots when useful (see "Repro" / table above)
