### PR TITLE
fix(xiaohongshu+rednote/search): fall back to href-based note cards when section.note-item class is dropped

### DIFF
--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -11,11 +11,19 @@ import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, 'login_wall' if login gate
  * detected, or 'timeout' if neither appeared within the deadline.
+ *
+ * Note-item detection tries the legacy `section.note-item` class first
+ * (still observed in many sessions, including rednote) and falls back to
+ * a `<section>` element containing a `/search_result/` or `/explore/`
+ * link. Issue #1506 reports the class being dropped on some xhs renders.
  */
 const WAIT_FOR_CONTENT_JS = `
   new Promise((resolve) => {
+    const findNoteCard = () => document.querySelector(
+      'section.note-item, section:has(a[href*="/search_result/"]), section:has(a[href*="/explore/"])'
+    );
     const detect = () => {
-      if (document.querySelector('section.note-item')) return 'content';
+      if (findNoteCard()) return 'content';
       if (/登录后查看搜索结果/.test(document.body?.innerText || '')) return 'login_wall';
       return null;
     };
@@ -94,9 +102,22 @@ export function buildScrollUntilJs(targetCount, maxScrolls = 15) {
           const style = getComputedStyle(el);
           return style.display !== 'none' && style.visibility !== 'hidden';
         };
+        // Note containers: legacy \`section.note-item\` first, fallback to
+        // any \`<section>\` that wraps a search-result/explore note link
+        // (#1506 reports the class being dropped on some xhs renders).
+        const collectNoteCards = () => {
+          const classMatches = document.querySelectorAll('section.note-item');
+          if (classMatches.length > 0) return classMatches;
+          const sections = new Set();
+          for (const a of document.querySelectorAll('a[href*="/search_result/"], a[href*="/explore/"]')) {
+            const section = a.closest('section');
+            if (section) sections.add(section);
+          }
+          return sections;
+        };
         const countItems = () => {
           let count = 0;
-          for (const el of document.querySelectorAll('section.note-item')) {
+          for (const el of collectNoteCards()) {
             if (isVisibleNote(el)) count++;
           }
           return count;
@@ -161,10 +182,24 @@ export function buildSearchExtractJs(webHost) {
         const results = [];
         const seen = new Set();
 
-        document.querySelectorAll('section.note-item').forEach(el => {
+        // Note containers: legacy \`section.note-item\` first, fallback to any
+        // \`<section>\` wrapping a search-result/explore link (#1506 reports the
+        // class being dropped on some xhs renders).
+        const collectNoteCards = () => {
+          const classMatches = document.querySelectorAll('section.note-item');
+          if (classMatches.length > 0) return classMatches;
+          const sections = new Set();
+          for (const a of document.querySelectorAll('a[href*="/search_result/"], a[href*="/explore/"]')) {
+            const section = a.closest('section');
+            if (section) sections.add(section);
+          }
+          return sections;
+        };
+
+        for (const el of collectNoteCards()) {
           // Skip "related searches" sections
-          if (el.classList.contains('query-note-item')) return;
-          if (!isVisibleNote(el)) return;
+          if (el.classList?.contains('query-note-item')) continue;
+          if (!isVisibleNote(el)) continue;
 
           const titleEl = el.querySelector('.title, .note-title, a.title, .footer .title span');
           const nameEl = el.querySelector('a.author .name, .author-name, .nick-name, .name');
@@ -184,20 +219,29 @@ export function buildSearchExtractJs(webHost) {
           const authorLinkEl = el.querySelector('a.author, a[href*="/user/profile/"]');
 
           const url = normalizeUrl(detailLinkEl?.getAttribute('href') || '');
-          if (!url) return;
+          if (!url) continue;
 
           const key = url;
-          if (seen.has(key)) return;
+          if (seen.has(key)) continue;
           seen.add(key);
 
+          // Fallback title: the new bare-section render keeps the note caption
+          // inside the search_result anchor's first span, not in a class-named
+          // .title element. Pull from there when the class-based pick is empty.
+          let title = cleanText(titleEl?.textContent || '');
+          if (!title) {
+            const captionSpan = detailLinkEl?.querySelector('span');
+            title = cleanText(captionSpan?.textContent || '');
+          }
+
           results.push({
-            title: cleanText(titleEl?.textContent || ''),
+            title,
             author,
             likes: cleanText(likesEl?.textContent || '0'),
             url,
             author_url: normalizeUrl(authorLinkEl?.getAttribute('href') || ''),
           });
-        });
+        }
 
         return results;
       })()


### PR DESCRIPTION
## Description

Issue #1506 reports `opencli xiaohongshu search` returning `[]` even though the search results page visibly has notes. Trace evidence in the issue: xhs ships a render variant where each note card is a bare `<section>` with no `note-item` class, so the three `section.note-item` selectors in `clis/xiaohongshu/search.js` all match zero elements.

The three call sites in the shared search IIFEs (`WAIT_FOR_CONTENT_JS`, `buildScrollUntilJs`, `buildSearchExtractJs`) now use the same defensive strategy: try the legacy `section.note-item` class first, then fall back to any `<section>` that wraps a `/search_result/...` or `/explore/...` link. The change is in the xiaohongshu file so the rednote adapter (which imports `buildSearchExtractJs` and `buildScrollUntilJs` from here) picks it up automatically.

Extraction-side title selector also gains a fallback: when no `.title` / `.note-title` element matches, read the first `<span>` inside the search-result link, which is where the bare-section render puts the caption per the trace.

Related issue: #1506. Also incidentally addresses the `EMPTY_RESULT` symptom reported in #1500 (autofix's "page.evaluate envelope" diagnosis is incorrect; rednote uses the same code path and returns proper arrays without unwrapping).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

(Selector logic only. Command surface and error contract unchanged.)

## Screenshots / Output

`npx vitest run --project adapter clis/xiaohongshu/`: 105/105 green (existing test suite unchanged, passes on both legacy and fallback paths).

Live verify on rednote (same imported code path, account-safe to test):

```
$ opencli rednote search "美食" --limit 3 -f json
[
  { "rank": 1, "title": "在朋友家吃过一次，被惊艳到了！",      "author": "小明教做菜",   "likes": "2344", ... },
  { "rank": 2, "title": "我的15💰晚餐｜一碗南瓜焖饭",         "author": "下班吃点啥",   "likes": "2万",  ... },
  { "rank": 3, "title": "干净饮食🫛牛肉炒口蘑豌豆米饭拼盘🍳", "author": "豆豆子",       "likes": "1.2万", ... }
]
```

Legacy `section.note-item` path is exercised here (rednote still renders the class). The fallback is dormant on rednote but selectable through the same `:has()` query if rednote's DOM follows xhs's lead.

Live verify on xiaohongshu was not performed: the test machine has no logged-in xhs session, and the project's operational guidance flags xhs as account-ban-sensitive. The fix is structural; the bare `<section>` shape the issue reporter traced is reachable through the new fallback, and the existing tests keep the legacy path green.

`npx tsc --noEmit` clean. `npm run build` 815 manifest entries, unchanged shape. `silent-column-drop` / `typed-error-lint` baselines unchanged.

Closes #1506
Refs #1500