### PR TITLE
ci(e2e): drop e2e-headed from pull_request trigger

### DIFF
--- a/.github/workflows/e2e-headed.yml
+++ b/.github/workflows/e2e-headed.yml
@@ -1,6 +1,10 @@
 name: E2E Headed Chrome
 
 on:
+  # E2E removed from `pull_request` to keep PR feedback under ~2 minutes; PR-time
+  # protection is the CI workflow (typecheck / unit / lint / adapter / build).
+  # E2E still guards `main` directly, runs nightly, and on release tag push so
+  # protocol/CDP/extension contract regressions are caught before they ship.
   push:
     branches: [main, dev]
     paths:
@@ -13,18 +17,11 @@ on:
       - 'tests/smoke/**'
       - '.github/actions/setup-chrome/**'
       - '.github/workflows/e2e-headed.yml'
-  pull_request:
-    branches: [main, dev]
-    paths:
-      - 'extension/**'
-      - 'src/browser/**'
-      - 'src/daemon.ts'
-      - 'src/execution.ts'
-      - 'src/interceptor.ts'
-      - 'tests/e2e/**'
-      - 'tests/smoke/**'
-      - '.github/actions/setup-chrome/**'
-      - '.github/workflows/e2e-headed.yml'
+    tags: ['v*']
+  schedule:
+    # Daily 08:00 UTC — catch flake / Chrome-version drift even when no commits
+    # touched the watched paths recently.
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Per @WAWQAQ direction (DM): per-PR e2e-headed Chrome (~10-15 min, 2 platforms) is the dominant PR wait, especially on fork PRs where it blocks behind maintainer approval. The actual regressions e2e caught in the last 30 days were e2e-test migrations missed by the authoring PR (#1461 / #1505 workspace→session migration), not real product regressions the unit tier missed.

## New PR feedback path

Per-PR (fast, ~2 min):
- typecheck / unit / lint / adapter / build (ci.yml)
- extension typecheck / build (build-extension.yml)
- docs build (doc-check.yml)
- security audit (security.yml)

E2E-headed Chrome guards (still strict):
- push to main / dev (watched paths)
- push v* tag (release)
- nightly cron 08:00 UTC (NEW — catches Chrome version drift / flake drift even when no commits touched watched paths)
- workflow_dispatch (manual when a PR really wants e2e signal)

smoke-test already gated on `schedule || workflow_dispatch` only (ci.yml), no change needed.

## Test plan

- [x] e2e-headed.yml workflow trigger change is the only diff
- [x] yaml syntax valid (preserves anchors, just edits `on:` block)
- [ ] After merge, next PR should NOT trigger E2E Headed Chrome check
- [ ] After this PR merges to main, e2e-headed should run via `push` trigger