### PR TITLE
ci(adapter-test): gate off pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,12 @@ jobs:
       - name: Run unit tests under Bun
         run: bun vitest run --project unit --reporter=verbose
 
-  # Adapter tests are pure unit tests — OS doesn't affect results.
+  # Adapter tests are pure unit tests — OS doesn't affect results. Gated off
+  # `pull_request` to keep PR CI under ~2 minutes; adapter authors run focused
+  # tests locally before pushing, and `push` to main / nightly cron / manual
+  # dispatch still guard the merged state.
   adapter-test:
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
## Summary

Per @WAWQAQ direction (DM): gate `adapter-test` job off `pull_request` to keep PR CI under ~2 min. Same model as smoke-test and the just-shipped #1521 (e2e-headed).

## New PR-time CI surface

- typecheck / unit (~1 min, ci.yml `build` + `unit-test` + `bun-test`)
- lint gates (typed-error-lint / silent-column-drop, scripts run inside unit jobs)
- build × 3 platforms

## adapter-test still strict on

- push to main / dev
- nightly cron (08:00 UTC, configured at workflow `on:` level)
- `workflow_dispatch` (manual)

Same gate pattern as `smoke-test`:
```
if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
```

## Test plan
- [x] yaml syntax valid (single `if:` added)
- [ ] After merge, next PR should NOT trigger `adapter-test` check
- [ ] After push to main, adapter-test should run via `push` trigger