### PR TITLE
fix(google/search): wrap evaluate return to fix Array.isArray check

### DIFF
--- a/clis/google/search.js
+++ b/clis/google/search.js
@@ -39,12 +39,12 @@ cli({
         catch {
             await page.wait(2);
         }
-        const results = await page.evaluate(`
+        const wrapper = await page.evaluate(`
       (function() {
         var results = [];
         var seenUrls = {};
         var rso = document.querySelector('#rso');
-        if (!rso) return results;
+        if (!rso) return {items: results};
 
         // -- Featured snippet (scoped to #rso to avoid matching unrelated elements) --
         var featuredEl = rso.querySelector('.xpdopen .hgKElc')
@@ -126,10 +126,11 @@ cli({
           }
         }
 
-        return results;
+        return {items: results};
       })()
     `);
-        if (!Array.isArray(results) || results.length === 0) {
+        const results = (wrapper && wrapper.items) || [];
+        if (results.length === 0) {
             throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword or check for CAPTCHA');
         }
         return results;


### PR DESCRIPTION
## Summary

- `page.evaluate()` serializes JS arrays as plain objects across the CDP boundary, causing `Array.isArray()` to return `false` and the adapter to throw `NOT_FOUND` even when results exist
- Wrap the return value in `{items: results}` and extract via `wrapper.items` to avoid the type check issue

## Root Cause

`page.evaluate()` returns serialized data from the browser context. When a JS array crosses this boundary, it becomes a plain object — `Array.isArray()` returns `false`. The existing check:

```js
if (!Array.isArray(results) || results.length === 0)
```

always takes the error branch because `Array.isArray` fails, even though the data is valid and `.length` would be correct.

## Test plan

- [x] `opencli google search "how to write a paper" --lang en --limit 5` — returns results (previously NOT_FOUND)
- [x] `opencli google search "怎么写论文呢" --lang zh --limit 5` — returns results (previously NOT_FOUND)
- [x] Verified results contain correct title, url, and snippet fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)