### PR TITLE
fix(google-scholar/search): wrap evaluate return to fix serialization

### DIFF
--- a/clis/google-scholar/search.js
+++ b/clis/google-scholar/search.js
@@ -18,8 +18,12 @@ cli({
         const limit = clampInt(kwargs.limit, 10, 1, 20);
         const query = requireNonEmptyQuery(kwargs.query);
         await page.goto(`https://scholar.google.com/scholar?q=${encodeURIComponent(query)}&hl=zh-CN`);
-        await page.wait(3);
-        const data = await page.evaluate(`
+        try {
+            await page.wait({ selector: '.gs_r.gs_or.gs_scl', timeout: 5 });
+        } catch {
+            await page.wait(3);
+        }
+        const wrapper = await page.evaluate(`
       (() => {
         const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
         const results = [];
@@ -50,9 +54,10 @@ cli({
           });
           if (results.length >= ${limit}) break;
         }
-        return results;
+        return {items: results};
       })()
     `);
-        return Array.isArray(data) ? data : [];
+        const data = (wrapper && wrapper.items) || [];
+        return data;
     },
 });

--- a/clis/google-scholar/search.js
+++ b/clis/google-scholar/search.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { clampInt, requireNonEmptyQuery } from '../_shared/common.js';
 
 cli({
@@ -27,7 +28,8 @@ cli({
       (() => {
         const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
         const results = [];
-        for (const el of document.querySelectorAll('.gs_r.gs_or.gs_scl')) {
+        const resultCards = Array.from(document.querySelectorAll('.gs_r.gs_or.gs_scl'));
+        for (const el of resultCards) {
           const container = el.querySelector('.gs_ri') || el;
           const titleEl = container.querySelector('.gs_rt a, h3 a');
           const title = normalize(titleEl?.textContent);
@@ -54,10 +56,18 @@ cli({
           });
           if (results.length >= ${limit}) break;
         }
-        return {items: results};
+        return { items: results, resultCount: resultCards.length };
       })()
     `);
-        const data = (wrapper && wrapper.items) || [];
-        return data;
+        if (!wrapper || typeof wrapper !== 'object' || !Array.isArray(wrapper.items)) {
+            throw new CommandExecutionError('Google Scholar search returned an unexpected payload shape');
+        }
+        if (wrapper.items.length === 0) {
+            if (Number(wrapper.resultCount) > 0) {
+                throw new CommandExecutionError('Google Scholar result cards were present but no rows could be extracted');
+            }
+            throw new EmptyResultError('google-scholar/search', 'Try a different query or check whether Google Scholar returned a CAPTCHA.');
+        }
+        return wrapper.items;
     },
 });

--- a/clis/google-scholar/search.test.js
+++ b/clis/google-scholar/search.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './search.js';
 
@@ -25,14 +26,46 @@ describe('google-scholar search command', () => {
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue([]),
+            evaluate: vi.fn().mockResolvedValue({ items: [{ rank: 1, title: 'Paper' }], resultCount: 1 }),
         };
 
-        await command.func(page, { query: 'transformer' });
+        const rows = await command.func(page, { query: 'transformer' });
 
         const script = page.evaluate.mock.calls[0][0];
         expect(script).toContain("document.querySelectorAll('.gs_r.gs_or.gs_scl')");
         expect(script).not.toContain(".gs_r.gs_or.gs_scl, .gs_ri");
         expect(script).toContain("const container = el.querySelector('.gs_ri') || el");
+        expect(script).toContain('return { items: results, resultCount: resultCards.length }');
+        expect(rows).toEqual([{ rank: 1, title: 'Paper' }]);
+    });
+
+    it('throws typed empty when Scholar returns no result cards', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ items: [], resultCount: 0 }),
+        };
+
+        await expect(command.func(page, { query: 'no results expected' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('throws command execution when result cards exist but parser extracts no rows', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ items: [], resultCount: 2 }),
+        };
+
+        await expect(command.func(page, { query: 'parser drift' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws command execution for malformed evaluate payloads instead of treating them as empty', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ items: { rank: 1 }, resultCount: 1 }),
+        };
+
+        await expect(command.func(page, { query: 'bad payload' })).rejects.toThrow(CommandExecutionError);
     });
 });


### PR DESCRIPTION
## Summary

- `page.evaluate()` serializes JS arrays as plain objects across the CDP boundary, causing `Array.isArray()` to return `false` and the adapter to silently return `[]` instead of actual results
- Wrap the return value in `{items: results}` and extract via `wrapper.items` to avoid the type check issue
- Replace fixed `page.wait(3)` with selector-based wait for `.gs_r.gs_or.gs_scl` with a 3s fallback

## Root Cause

Same issue as #1523 (google/search). When a JS array crosses the CDP boundary via `page.evaluate()`, it becomes a plain object — `Array.isArray()` returns `false`. The existing check:

```js
return Array.isArray(data) ? data : [];
```

always returns `[]` because `Array.isArray` fails, even though the data is valid.

## Test plan

- [x] `opencli google-scholar search "deep learning" --limit 5` — returns results with correct title, authors, source, year, cited, url (previously returned `[]`)