### PR TITLE
fix(twitter): dynamic pagination limit for bookmarks and likes

### DIFF
--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -150,7 +150,8 @@ cli({
         const allTweets = [];
         const seen = new Set();
         let cursor = null;
-        for (let i = 0; i < 5 && allTweets.length < limit; i++) {
+        const maxPages = Math.ceil(limit / 100) + 2;
+        for (let i = 0; i < maxPages && allTweets.length < limit; i++) {
             const fetchCount = Math.min(100, limit - allTweets.length + 10);
             const apiUrl = buildBookmarksUrl(fetchCount, cursor).replace(BOOKMARKS_QUERY_ID, queryId);
             const data = await page.evaluate(`async () => {

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -189,7 +189,8 @@ cli({
         const allTweets = [];
         const seen = new Set();
         let cursor = null;
-        for (let i = 0; i < 5 && allTweets.length < limit; i++) {
+        const maxPages = Math.ceil(limit / 100) + 2;
+        for (let i = 0; i < maxPages && allTweets.length < limit; i++) {
             const fetchCount = Math.min(100, limit - allTweets.length + 10);
             const apiUrl = buildLikesUrl(likesQueryId, userId, fetchCount, cursor);
             const data = await page.evaluate(`async () => {


### PR DESCRIPTION
## Summary

- Replace hardcoded `i < 5` pagination loop in `bookmarks.js` and `likes.js` with dynamic limit based on `--limit` argument
- Old behavior: max 5 pages × 100 items = ~500 items regardless of `--limit` value
- New behavior: `maxPages = Math.ceil(limit / 100) + 2`, allowing full fetch up to any limit

## Problem

When using `opencli twitter bookmarks --limit 5000`, only ~500 bookmarks were returned because the pagination loop was hardcoded to `for (let i = 0; i < 5; ...)`. The same issue affected `likes`.

## Fix

```diff
-        for (let i = 0; i < 5 && allTweets.length < limit; i++) {
+        const maxPages = Math.ceil(limit / 100) + 2;
+        for (let i = 0; i < maxPages && allTweets.length < limit; i++) {
```

The `+ 2` provides a small buffer for empty pages and deduplication, while still respecting the user's `--limit` parameter.

## Testing

- `opencli twitter bookmarks --limit 1000` → returned 1000 items (previously capped at ~500)
- `opencli twitter likes --limit 1000` → returned 1000 items  
- `opencli twitter bookmarks --limit 20` → still returns 20 items (default behavior unchanged)
- Data dates back to 2023-03, confirming full pagination works

## Files Changed

- `clis/twitter/bookmarks.js` — line 153
- `clis/twitter/likes.js` — line 192