### PR TITLE
fix(extension): keep active daemon websocket

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -671,11 +671,21 @@ const _origLog = console.log.bind(console);
 const _origWarn = console.warn.bind(console);
 const _origError = console.error.bind(console);
 function forwardLog(level, args) {
-  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   try {
     const msg = args.map((a) => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
-    ws.send(JSON.stringify({ type: "log", level, msg, ts: Date.now() }));
+    safeSend(ws, { type: "log", level, msg, ts: Date.now() });
   } catch {
+  }
+}
+function safeSend(socket, payload) {
+  if (!socket || socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
+    return false;
+  }
+  try {
+    socket.send(JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
   }
 }
 console.log = (...args) => {
@@ -698,44 +708,48 @@ async function connect() {
   } catch {
     return;
   }
+  let thisWs;
   try {
     const contextId = await getCurrentContextId();
-    ws = new WebSocket(DAEMON_WS_URL);
+    thisWs = new WebSocket(DAEMON_WS_URL);
+    ws = thisWs;
     currentContextId = contextId;
   } catch {
     scheduleReconnect();
     return;
   }
-  ws.onopen = () => {
+  thisWs.onopen = () => {
+    if (ws !== thisWs) return;
     console.log("[opencli] Connected to daemon");
     reconnectAttempts = 0;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
-    ws?.send(JSON.stringify({
+    safeSend(thisWs, {
       type: "hello",
       contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
       compatRange: ">=1.7.0"
-    }));
+    });
   };
-  ws.onmessage = async (event) => {
+  thisWs.onmessage = async (event) => {
     try {
       const command = JSON.parse(event.data);
       const result = await handleCommand(command);
-      ws?.send(JSON.stringify(result));
+      safeSend(thisWs, result);
     } catch (err) {
       console.error("[opencli] Message handling error:", err);
     }
   };
-  ws.onclose = () => {
+  thisWs.onclose = () => {
+    if (ws !== thisWs) return;
     console.log("[opencli] Disconnected from daemon");
     ws = null;
     scheduleReconnect();
   };
-  ws.onerror = () => {
-    ws?.close();
+  thisWs.onerror = () => {
+    thisWs.close();
   };
 }
 const MAX_EAGER_ATTEMPTS = 6;

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -678,9 +678,7 @@ function forwardLog(level, args) {
   }
 }
 function safeSend(socket, payload) {
-  if (!socket || socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
-    return false;
-  }
+  if (!socket || socket.readyState !== WebSocket.OPEN) return false;
   try {
     socket.send(JSON.stringify(payload));
     return true;
@@ -734,9 +732,11 @@ async function connect() {
     });
   };
   thisWs.onmessage = async (event) => {
+    if (ws !== thisWs) return;
     try {
       const command = JSON.parse(event.data);
       const result = await handleCommand(command);
+      if (ws !== thisWs) return;
       safeSend(thisWs, result);
     } catch (err) {
       console.error("[opencli] Message handling error:", err);

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -31,6 +31,7 @@ const adapterKey = (session: string): string => leaseKey('adapter', session);
 class MockWebSocket {
   static OPEN = 1;
   static CONNECTING = 0;
+  static CLOSED = 3;
   static instances: MockWebSocket[] = [];
   readyState = MockWebSocket.CONNECTING;
   sent: string[] = [];
@@ -46,6 +47,7 @@ class MockWebSocket {
     this.sent.push(data);
   }
   close(): void {
+    this.readyState = MockWebSocket.CLOSED;
     this.onclose?.();
   }
 }
@@ -674,6 +676,7 @@ describe('background tab isolation', () => {
       expect(MockWebSocket.instances).toHaveLength(2);
     });
     const secondWs = MockWebSocket.instances[1];
+    secondWs.readyState = MockWebSocket.OPEN;
 
     firstWs.onclose?.();
     secondWs.onmessage?.({
@@ -689,6 +692,39 @@ describe('background tab isolation', () => {
     await vi.waitFor(() => {
       expect(secondWs.sent.some((entry) => entry.includes('sessions-after-stale-close'))).toBe(true);
     });
+  });
+
+  it('ignores daemon commands delivered to a superseded WebSocket', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+
+    await import('./background');
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    const firstWs = MockWebSocket.instances[0];
+    firstWs.readyState = MockWebSocket.OPEN;
+
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    firstWs.readyState = MockWebSocket.CLOSED;
+    await onAlarmListener({ name: 'keepalive' });
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+    firstWs.readyState = MockWebSocket.OPEN;
+
+    await firstWs.onmessage?.({
+      data: JSON.stringify({
+        id: 'stale-command',
+        action: 'tabs',
+        op: 'list',
+        session: 'work',
+        surface: 'browser',
+      }),
+    });
+
+    expect(firstWs.sent.some((entry) => entry.includes('stale-command'))).toBe(false);
   });
 
   it('can execute concurrently on two pages in the same session', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -31,14 +31,20 @@ const adapterKey = (session: string): string => leaseKey('adapter', session);
 class MockWebSocket {
   static OPEN = 1;
   static CONNECTING = 0;
+  static instances: MockWebSocket[] = [];
   readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
-  constructor(_url: string) {}
-  send(_data: string): void {}
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this);
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
   close(): void {
     this.onclose?.();
   }
@@ -194,6 +200,7 @@ describe('background tab isolation', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.useRealTimers();
+    MockWebSocket.instances = [];
     vi.stubGlobal('WebSocket', MockWebSocket);
   });
 
@@ -646,6 +653,41 @@ describe('background tab isolation', () => {
       expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({
         contextId: 'abc123xy',
       }));
+    });
+  });
+
+  it('keeps the active daemon connection when a superseded WebSocket closes later', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+
+    await import('./background');
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    const firstWs = MockWebSocket.instances[0];
+    firstWs.readyState = 3;
+
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    await onAlarmListener({ name: 'keepalive' });
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+    const secondWs = MockWebSocket.instances[1];
+
+    firstWs.onclose?.();
+    secondWs.onmessage?.({
+      data: JSON.stringify({
+        id: 'sessions-after-stale-close',
+        action: 'tabs',
+        op: 'list',
+        session: 'work',
+        surface: 'browser',
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(secondWs.sent.some((entry) => entry.includes('sessions-after-stale-close'))).toBe(true);
     });
   });
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -70,11 +70,22 @@ const _origWarn = console.warn.bind(console);
 const _origError = console.error.bind(console);
 
 function forwardLog(level: 'info' | 'warn' | 'error', args: unknown[]): void {
-  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   try {
     const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
-    ws.send(JSON.stringify({ type: 'log', level, msg, ts: Date.now() }));
+    safeSend(ws, { type: 'log', level, msg, ts: Date.now() });
   } catch { /* don't recurse */ }
+}
+
+function safeSend(socket: WebSocket | null | undefined, payload: unknown): boolean {
+  if (!socket || socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
+    return false;
+  }
+  try {
+    socket.send(JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 console.log = (...args: unknown[]) => { _origLog(...args); forwardLog('info', args); };
@@ -100,16 +111,19 @@ async function connect(): Promise<void> {
     return; // daemon not running — skip WebSocket to avoid console noise
   }
 
+  let thisWs: WebSocket;
   try {
     const contextId = await getCurrentContextId();
-    ws = new WebSocket(DAEMON_WS_URL);
+    thisWs = new WebSocket(DAEMON_WS_URL);
+    ws = thisWs;
     currentContextId = contextId;
   } catch {
     scheduleReconnect();
     return;
   }
 
-  ws.onopen = () => {
+  thisWs.onopen = () => {
+    if (ws !== thisWs) return;
     console.log('[opencli] Connected to daemon');
     reconnectAttempts = 0; // Reset on successful connection
     if (reconnectTimer) {
@@ -117,32 +131,33 @@ async function connect(): Promise<void> {
       reconnectTimer = null;
     }
     // Send version + compatibility range so the daemon can report mismatches to the CLI
-    ws?.send(JSON.stringify({
+    safeSend(thisWs, {
       type: 'hello',
       contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
       compatRange: __OPENCLI_COMPAT_RANGE__,
-    }));
+    });
   };
 
-  ws.onmessage = async (event) => {
+  thisWs.onmessage = async (event) => {
     try {
       const command = JSON.parse(event.data as string) as Command;
       const result = await handleCommand(command);
-      ws?.send(JSON.stringify(result));
+      safeSend(thisWs, result);
     } catch (err) {
       console.error('[opencli] Message handling error:', err);
     }
   };
 
-  ws.onclose = () => {
+  thisWs.onclose = () => {
+    if (ws !== thisWs) return;
     console.log('[opencli] Disconnected from daemon');
     ws = null;
     scheduleReconnect();
   };
 
-  ws.onerror = () => {
-    ws?.close();
+  thisWs.onerror = () => {
+    thisWs.close();
   };
 }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -77,9 +77,7 @@ function forwardLog(level: 'info' | 'warn' | 'error', args: unknown[]): void {
 }
 
 function safeSend(socket: WebSocket | null | undefined, payload: unknown): boolean {
-  if (!socket || socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
-    return false;
-  }
+  if (!socket || socket.readyState !== WebSocket.OPEN) return false;
   try {
     socket.send(JSON.stringify(payload));
     return true;
@@ -140,9 +138,11 @@ async function connect(): Promise<void> {
   };
 
   thisWs.onmessage = async (event) => {
+    if (ws !== thisWs) return;
     try {
       const command = JSON.parse(event.data as string) as Command;
       const result = await handleCommand(command);
+      if (ws !== thisWs) return;
       safeSend(thisWs, result);
     } catch (err) {
       console.error('[opencli] Message handling error:', err);


### PR DESCRIPTION
## Summary

- capture each Browser Bridge WebSocket instance locally so stale close events cannot clear a newer active connection
- route hello/result/log sends through `safeSend()` so closing/closed sockets do not throw
- add extension coverage for a superseded WebSocket closing after a replacement connection is active

Fixes #1537.
Related to #569, #1229, and #1075. This is a small scoped service-worker WebSocket fix and does not replace the broader offscreen-document design in #569.

## Verification

- `npm --prefix extension run build`
- `npx vitest run --project extension extension/src/background.test.ts`
- `npm --prefix extension run typecheck`
