### PR TITLE
feat: add DuckDuckGo, Brave, and Yahoo web search adapters

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4041,6 +4041,7 @@
       }
     ],
     "columns": [
+      "rank",
       "title",
       "url",
       "snippet"
@@ -8788,6 +8789,7 @@
       }
     ],
     "columns": [
+      "rank",
       "title",
       "url",
       "snippet",
@@ -26857,6 +26859,7 @@
       }
     ],
     "columns": [
+      "rank",
       "title",
       "url",
       "snippet"

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4010,6 +4010,46 @@
     "navigateBefore": false
   },
   {
+    "site": "brave",
+    "name": "search",
+    "description": "Search Brave Search",
+    "access": "read",
+    "domain": "search.brave.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search query"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of results per page (max 18)"
+      },
+      {
+        "name": "offset",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Page offset (0, 1, 2...). Brave returns ~18 results per page"
+      }
+    ],
+    "columns": [
+      "title",
+      "url",
+      "snippet"
+    ],
+    "type": "js",
+    "modulePath": "brave/search.js",
+    "sourceFile": "brave/search.js"
+  },
+  {
     "site": "chaoxing",
     "name": "assignments",
     "description": "学习通作业列表",
@@ -8703,6 +8743,92 @@
     "modulePath": "douyin/videos.js",
     "sourceFile": "douyin/videos.js",
     "navigateBefore": "https://creator.douyin.com"
+  },
+  {
+    "site": "duckduckgo",
+    "name": "search",
+    "description": "Search DuckDuckGo",
+    "access": "read",
+    "domain": "html.duckduckgo.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search query"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of results per page (1-10). For multi-page, use --offset"
+      },
+      {
+        "name": "offset",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Result offset for pagination (0, 10, 20...). Uses XHR POST internally"
+      },
+      {
+        "name": "region",
+        "type": "str",
+        "required": false,
+        "help": "Region code (e.g. jp-jp, us-en, cn-zh). Default: all regions"
+      },
+      {
+        "name": "time",
+        "type": "str",
+        "required": false,
+        "help": "Time range: d (day), w (week), m (month), y (year)"
+      }
+    ],
+    "columns": [
+      "title",
+      "url",
+      "snippet",
+      "displayUrl",
+      "icon",
+      "resultType"
+    ],
+    "type": "js",
+    "modulePath": "duckduckgo/search.js",
+    "sourceFile": "duckduckgo/search.js"
+  },
+  {
+    "site": "duckduckgo",
+    "name": "suggest",
+    "description": "DuckDuckGo search suggestions",
+    "access": "read",
+    "domain": "duckduckgo.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search query prefix"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 8,
+        "required": false,
+        "help": "Max number of suggestions"
+      }
+    ],
+    "columns": [
+      "phrase"
+    ],
+    "type": "js",
+    "modulePath": "duckduckgo/suggest.js",
+    "sourceFile": "duckduckgo/suggest.js"
   },
   {
     "site": "eastmoney",
@@ -26698,6 +26824,46 @@
     "modulePath": "xueqiu/watchlist.js",
     "sourceFile": "xueqiu/watchlist.js",
     "navigateBefore": "https://xueqiu.com"
+  },
+  {
+    "site": "yahoo",
+    "name": "search",
+    "description": "Search Yahoo (powered by Bing)",
+    "access": "read",
+    "domain": "search.yahoo.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search query"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 7,
+        "required": false,
+        "help": "Number of results per page (max 7)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Page number (1, 2, 3...). Yahoo returns ~7 results per page"
+      }
+    ],
+    "columns": [
+      "title",
+      "url",
+      "snippet"
+    ],
+    "type": "js",
+    "modulePath": "yahoo/search.js",
+    "sourceFile": "yahoo/search.js"
   },
   {
     "site": "yahoo-finance",

--- a/clis/_shared/search-adapter.js
+++ b/clis/_shared/search-adapter.js
@@ -1,0 +1,70 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export function requireSearchQuery(value, label = 'keyword') {
+  const query = String(value ?? '').trim();
+  if (!query) {
+    throw new ArgumentError(`${label} cannot be empty`);
+  }
+  return query;
+}
+
+export function requireBoundedInteger(value, defaultValue, min, max, label) {
+  const raw = value ?? defaultValue;
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isInteger(parsed)) {
+    throw new ArgumentError(`${label} must be an integer between ${min} and ${max}, got ${JSON.stringify(value)}`);
+  }
+  if (parsed < min || parsed > max) {
+    throw new ArgumentError(`${label} must be between ${min} and ${max}, got ${parsed}`);
+  }
+  return parsed;
+}
+
+export function requireNonNegativeInteger(value, defaultValue, label) {
+  const raw = value ?? defaultValue;
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new ArgumentError(`${label} must be a non-negative integer, got ${JSON.stringify(value)}`);
+  }
+  return parsed;
+}
+
+export function unwrapBrowserResult(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value) && 'session' in value && 'data' in value) {
+    return value.data;
+  }
+  return value;
+}
+
+export function requireRows(value, label) {
+  const rows = unwrapBrowserResult(value);
+  if (!Array.isArray(rows)) {
+    throw new CommandExecutionError(`${label} returned an unexpected payload shape; expected an array of result rows.`);
+  }
+  return rows;
+}
+
+export function toHttpsUrl(value, baseUrl) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+  try {
+    const url = new URL(raw, baseUrl);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
+    return url.href;
+  } catch {
+    return '';
+  }
+}
+
+export function emptySearchResults(site, query) {
+  return new EmptyResultError(`${site} search`, `No ${site} results matched "${query}".`);
+}
+
+export async function runBrowserStep(label, fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    if (error?.code || error?.name === 'ArgumentError') throw error;
+    throw new CommandExecutionError(`${label} failed: ${error?.message ?? error}`);
+  }
+}

--- a/clis/brave/search.js
+++ b/clis/brave/search.js
@@ -22,9 +22,9 @@ function buildExtractorJs(limit) {
     if (!title || !href || seen[title]) continue;
     if (href.indexOf('/') === 0) continue;
     seen[title] = true;
-    results.push({ title: title, url: href, snippet: snippet });
+    results.push([title, href, snippet]);
   }
-  return { items: results };
+  return results;
 })()`;
 }
 
@@ -54,12 +54,14 @@ const command = cli({
     } catch {
       await page.wait(3).catch(function() {});
     }
-    const wrapper = await page.evaluate(buildExtractorJs(limit));
-    const results = (wrapper && wrapper.items) || [];
+    const raw = await page.evaluate(buildExtractorJs(limit));
+    const results = (raw && Array.isArray(raw)) ? raw : [];
     if (results.length === 0) {
       throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
     }
-    return results;
+    return results.map(function(r) {
+      return { title: r[0], url: r[1], snippet: r[2] };
+    });
   },
 });
 

--- a/clis/brave/search.js
+++ b/clis/brave/search.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
+import { clampInt } from '../_shared/common.js';
 
 function buildExtractorJs(limit) {
   return `
@@ -42,7 +43,7 @@ const command = cli({
   ],
   columns: ['title', 'url', 'snippet'],
   func: async (page, kwargs) => {
-    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 10, 18));
+    const limit = clampInt(kwargs.limit, 10, 1, 18);
     const keyword = encodeURIComponent(String(kwargs.keyword));
     const offset = Math.max(0, Number(kwargs.offset) || 0);
     let url = `https://search.brave.com/search?q=${keyword}`;

--- a/clis/brave/search.js
+++ b/clis/brave/search.js
@@ -1,0 +1,65 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+function buildExtractorJs(limit) {
+  return `
+(function() {
+  var results = [];
+  var seen = {};
+  var items = document.querySelectorAll('.snippet');
+  for (var i = 0; i < items.length; i++) {
+    if (results.length >= ${limit}) break;
+    var el = items[i];
+    if (el.classList.contains('standalone')) continue;
+    var titleEl = el.querySelector('.search-snippet-title');
+    var snippetEl = el.querySelector('.generic-snippet .content');
+    var linkEl = el.querySelector('.result-content a');
+    if (!titleEl) continue;
+    var title = titleEl.textContent.trim();
+    var href = linkEl ? linkEl.getAttribute('href') || '' : '';
+    var snippet = snippetEl ? snippetEl.textContent.trim() : '';
+    if (!title || !href || seen[title]) continue;
+    if (href.indexOf('/') === 0) continue;
+    seen[title] = true;
+    results.push({ title: title, url: href, snippet: snippet });
+  }
+  return { items: results };
+})()`;
+}
+
+const command = cli({
+  site: 'brave',
+  name: 'search',
+  access: 'read',
+  description: 'Search Brave Search',
+  domain: 'search.brave.com',
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    { name: 'keyword', positional: true, required: true, help: 'Search query' },
+    { name: 'limit', type: 'int', default: 10, help: 'Number of results per page (max 18)' },
+    { name: 'offset', type: 'int', default: 0, help: 'Page offset (0, 1, 2...). Brave returns ~18 results per page' },
+  ],
+  columns: ['title', 'url', 'snippet'],
+  func: async (page, kwargs) => {
+    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 10, 18));
+    const keyword = encodeURIComponent(String(kwargs.keyword));
+    const offset = Math.max(0, Number(kwargs.offset) || 0);
+    let url = `https://search.brave.com/search?q=${keyword}`;
+    if (offset > 0) url += `&offset=${offset}`;
+    await page.goto(url);
+    try {
+      await page.wait({ selector: '.snippet', timeout: 10 });
+    } catch {
+      await page.wait(3).catch(function() {});
+    }
+    const wrapper = await page.evaluate(buildExtractorJs(limit));
+    const results = (wrapper && wrapper.items) || [];
+    if (results.length === 0) {
+      throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
+    }
+    return results;
+  },
+});
+
+export const __test__ = { command };

--- a/clis/brave/search.js
+++ b/clis/brave/search.js
@@ -1,6 +1,13 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
-import { clampInt } from '../_shared/common.js';
+import {
+  emptySearchResults,
+  requireBoundedInteger,
+  requireNonNegativeInteger,
+  requireRows,
+  requireSearchQuery,
+  runBrowserStep,
+  toHttpsUrl,
+} from '../_shared/search-adapter.js';
 
 function buildExtractorJs(limit) {
   return `
@@ -11,7 +18,7 @@ function buildExtractorJs(limit) {
   for (var i = 0; i < items.length; i++) {
     if (results.length >= ${limit}) break;
     var el = items[i];
-    if (el.classList.contains('standalone')) continue;
+    if (el.classList.contains('standalone') || el.classList.contains('ad')) continue;
     var titleEl = el.querySelector('.search-snippet-title');
     var snippetEl = el.querySelector('.generic-snippet .content');
     var linkEl = el.querySelector('.result-content a');
@@ -19,9 +26,9 @@ function buildExtractorJs(limit) {
     var title = titleEl.textContent.trim();
     var href = linkEl ? linkEl.getAttribute('href') || '' : '';
     var snippet = snippetEl ? snippetEl.textContent.trim() : '';
-    if (!title || !href || seen[title]) continue;
+    if (!title || !href || seen[href]) continue;
     if (href.indexOf('/') === 0) continue;
-    seen[title] = true;
+    seen[href] = true;
     results.push([title, href, snippet]);
   }
   return results;
@@ -41,27 +48,32 @@ const command = cli({
     { name: 'limit', type: 'int', default: 10, help: 'Number of results per page (max 18)' },
     { name: 'offset', type: 'int', default: 0, help: 'Page offset (0, 1, 2...). Brave returns ~18 results per page' },
   ],
-  columns: ['title', 'url', 'snippet'],
+  columns: ['rank', 'title', 'url', 'snippet'],
   func: async (page, kwargs) => {
-    const limit = clampInt(kwargs.limit, 10, 1, 18);
-    const keyword = encodeURIComponent(String(kwargs.keyword));
-    const offset = Math.max(0, Number(kwargs.offset) || 0);
+    const limit = requireBoundedInteger(kwargs.limit, 10, 1, 18, '--limit');
+    const query = requireSearchQuery(kwargs.keyword);
+    const keyword = encodeURIComponent(query);
+    const offset = requireNonNegativeInteger(kwargs.offset, 0, '--offset');
     let url = `https://search.brave.com/search?q=${keyword}`;
     if (offset > 0) url += `&offset=${offset}`;
-    await page.goto(url);
+    await runBrowserStep('brave search navigation', () => page.goto(url));
     try {
       await page.wait({ selector: '.snippet', timeout: 10 });
     } catch {
       await page.wait(3).catch(function() {});
     }
-    const raw = await page.evaluate(buildExtractorJs(limit));
-    const results = (raw && Array.isArray(raw)) ? raw : [];
+    const raw = await runBrowserStep('brave search extraction', () => page.evaluate(buildExtractorJs(limit)));
+    const results = requireRows(raw, 'brave search');
     if (results.length === 0) {
-      throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
+      throw emptySearchResults('Brave', query);
     }
-    return results.map(function(r) {
-      return { title: r[0], url: r[1], snippet: r[2] };
-    });
+    const rows = results
+      .map(function(r, index) {
+        return { rank: index + 1 + offset * 18, title: r[0], url: toHttpsUrl(r[1], 'https://search.brave.com'), snippet: r[2] };
+      })
+      .filter((row) => row.url);
+    if (rows.length === 0) throw emptySearchResults('Brave', query);
+    return rows;
   },
 });
 

--- a/clis/brave/search.test.js
+++ b/clis/brave/search.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+
+const { __test__ } = await import('./search.js');
+const command = __test__.command;
+
+describe('brave search', () => {
+  it('should register as a valid command', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('brave');
+    expect(command.name).toBe('search');
+    expect(command.access).toBe('read');
+    expect(command.browser).toBe(true);
+    expect(command.strategy).toBe('public');
+    expect(command.domain).toBe('search.brave.com');
+  });
+
+  it('should define keyword positional arg', () => {
+    const kwArg = command.args.find(a => a.name === 'keyword');
+    expect(kwArg).toBeDefined();
+    expect(kwArg.positional).toBe(true);
+    expect(kwArg.required).toBe(true);
+  });
+
+  it('should define limit arg with default 10', () => {
+    const limitArg = command.args.find(a => a.name === 'limit');
+    expect(limitArg).toBeDefined();
+    expect(limitArg.type).toBe('int');
+    expect(limitArg.default).toBe(10);
+  });
+
+  it('should define output columns', () => {
+    expect(command.columns).toContain('title');
+    expect(command.columns).toContain('url');
+    expect(command.columns).toContain('snippet');
+  });
+});

--- a/clis/brave/search.test.js
+++ b/clis/brave/search.test.js
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const { __test__ } = await import('./search.js');
 const command = __test__.command;
+
+function createPageMock(evaluateResult = []) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+  };
+}
 
 describe('brave search', () => {
   it('should register as a valid command', () => {
@@ -29,8 +37,40 @@ describe('brave search', () => {
   });
 
   it('should define output columns', () => {
+    expect(command.columns).toContain('rank');
     expect(command.columns).toContain('title');
     expect(command.columns).toContain('url');
     expect(command.columns).toContain('snippet');
+  });
+
+  it('rejects empty query, invalid limit, and invalid offset before navigation', async () => {
+    const page = createPageMock();
+    await expect(command.func(page, { keyword: '', limit: 5 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func(page, { keyword: 'opencli', limit: 19 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func(page, { keyword: 'opencli', limit: 5, offset: -1 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('unwraps browser envelopes and returns ranked HTTPS rows', async () => {
+    const page = createPageMock({
+      session: 'site:brave',
+      data: [['OpenCLI', 'https://github.com/jackwener/OpenCLI', 'CLI browser tooling']],
+    });
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1, offset: 1 })).resolves.toEqual([{
+      rank: 19,
+      title: 'OpenCLI',
+      url: 'https://github.com/jackwener/OpenCLI',
+      snippet: 'CLI browser tooling',
+    }]);
+  });
+
+  it('fails typed instead of silently returning [] for malformed extraction payloads', async () => {
+    const page = createPageMock({ rows: [] });
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1 })).rejects.toMatchObject({
+      code: 'COMMAND_EXEC',
+      message: expect.stringContaining('payload shape'),
+    });
   });
 });

--- a/clis/duckduckgo/search.js
+++ b/clis/duckduckgo/search.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
+import { clampInt } from '../_shared/common.js';
 
 function decodeDdgUrl(href) {
   if (!href) return '';
@@ -77,7 +78,7 @@ const command = cli({
   ],
   columns: ['title', 'url', 'snippet', 'displayUrl', 'icon', 'resultType'],
   func: async (page, kwargs) => {
-    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 10, 10));
+    const limit = clampInt(kwargs.limit, 10, 1, 10);
     const keyword = String(kwargs.keyword);
     const offset = Math.max(0, Number(kwargs.offset) || 0);
     let url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(keyword)}`;

--- a/clis/duckduckgo/search.js
+++ b/clis/duckduckgo/search.js
@@ -1,16 +1,23 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
-import { clampInt } from '../_shared/common.js';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+  emptySearchResults,
+  requireBoundedInteger,
+  requireNonNegativeInteger,
+  requireRows,
+  requireSearchQuery,
+  runBrowserStep,
+  toHttpsUrl,
+} from '../_shared/search-adapter.js';
 
 function decodeDdgUrl(href) {
   if (!href) return '';
   try {
     const url = new URL(href, 'https://duckduckgo.com');
     const uddg = url.searchParams.get('uddg');
-    if (uddg) return decodeURIComponent(uddg);
-    return href;
+    return toHttpsUrl(uddg || href, 'https://duckduckgo.com');
   } catch {
-    return href;
+    return '';
   }
 }
 
@@ -23,6 +30,7 @@ function buildExtractFn(limit) {
     'var se=el.querySelector(".result__snippet");' +
     'var ue=el.querySelector(".result__url");' +
     'var ie=el.querySelector(".result__icon__img");' +
+    'if(cls.indexOf("result--ad")!==-1||cls.indexOf("result--ads")!==-1||cls.indexOf("badge--ad")!==-1)continue;' +
     'if(!te)continue;' +
     'var t=(te.textContent||"").trim();' +
     'var h=te.getAttribute("href")||"";' +
@@ -33,7 +41,7 @@ function buildExtractFn(limit) {
     'if(cls.indexOf("news-result")!==-1)rt="news";' +
     'else if(cls.indexOf("video-result")!==-1)rt="video";' +
     'else if(cls.indexOf("image-result")!==-1)rt="image";' +
-    'if(!t||seen[t])continue;seen[t]=true;' +
+    'if(!t||!h||seen[h])continue;seen[h]=true;' +
     'r.push([t,h,sn,du,ic,rt]);' +
     '}return r;}';
 }
@@ -53,9 +61,9 @@ function buildPaginateJs(limit, keyword, offset, region) {
     'x.onload=function(){' +
     'try{var d=new DOMParser().parseFromString(x.responseText,"text/html");' +
     '$r(' + buildExtractFn(limit) + '(d));' +
-    '}catch(e){$r([])}' +
+    '}catch(e){$r({error:"parse",message:String(e&&e.message||e)})}' +
     '};' +
-    'x.onerror=function(){$r([])};' +
+    'x.onerror=function(){$r({error:"network"})};' +
     'x.send("' + params + '");' +
     '})'
   );
@@ -76,15 +84,21 @@ const command = cli({
     { name: 'region', help: 'Region code (e.g. jp-jp, us-en, cn-zh). Default: all regions' },
     { name: 'time', help: 'Time range: d (day), w (week), m (month), y (year)' },
   ],
-  columns: ['title', 'url', 'snippet', 'displayUrl', 'icon', 'resultType'],
+  columns: ['rank', 'title', 'url', 'snippet', 'displayUrl', 'icon', 'resultType'],
   func: async (page, kwargs) => {
-    const limit = clampInt(kwargs.limit, 10, 1, 10);
-    const keyword = String(kwargs.keyword);
-    const offset = Math.max(0, Number(kwargs.offset) || 0);
+    const limit = requireBoundedInteger(kwargs.limit, 10, 1, 10, '--limit');
+    const keyword = requireSearchQuery(kwargs.keyword);
+    const offset = requireNonNegativeInteger(kwargs.offset, 0, '--offset');
+    if (offset % 10 !== 0) {
+      throw new ArgumentError('--offset must be a multiple of 10 for DuckDuckGo HTML pagination');
+    }
+    if (kwargs.time && !/^(d|w|m|y)$/.test(String(kwargs.time))) {
+      throw new ArgumentError('--time must be one of d, w, m, or y');
+    }
     let url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(keyword)}`;
     if (kwargs.region) url += `&kl=${encodeURIComponent(String(kwargs.region))}`;
     if (kwargs.time) url += `&df=${encodeURIComponent(String(kwargs.time))}`;
-    await page.goto(url);
+    await runBrowserStep('duckduckgo search navigation', () => page.goto(url));
     try {
       await page.wait({ selector: '.result', timeout: 8 });
     } catch {
@@ -92,15 +106,17 @@ const command = cli({
     }
     var raw;
     if (offset === 0) {
-      raw = await page.evaluate(buildExtractorJs(limit));
+      raw = await runBrowserStep('duckduckgo search extraction', () => page.evaluate(buildExtractorJs(limit)));
     } else {
-      raw = await page.evaluate(buildPaginateJs(limit, keyword, offset, kwargs.region));
+      raw = await runBrowserStep('duckduckgo search pagination extraction', () => page.evaluate(buildPaginateJs(limit, keyword, offset, kwargs.region)));
     }
-    if (!raw || raw.length === 0) {
-      throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
+    const rows = requireRows(raw, 'duckduckgo search');
+    if (rows.length === 0) {
+      throw emptySearchResults('DuckDuckGo', keyword);
     }
-    return raw.map(function(r) {
+    return rows.map(function(r, index) {
       return {
+        rank: index + 1 + offset,
         title: r[0],
         url: decodeDdgUrl(r[1]),
         snippet: r[2],
@@ -108,7 +124,7 @@ const command = cli({
         icon: r[4],
         resultType: r[5],
       };
-    });
+    }).filter((row) => row.url);
   },
 });
 

--- a/clis/duckduckgo/search.js
+++ b/clis/duckduckgo/search.js
@@ -30,6 +30,7 @@ function buildExtractFn(limit) {
     'var se=el.querySelector(".result__snippet");' +
     'var ue=el.querySelector(".result__url");' +
     'var ie=el.querySelector(".result__icon__img");' +
+    'var cls=el.className||"";var rt="web";' +
     'if(cls.indexOf("result--ad")!==-1||cls.indexOf("result--ads")!==-1||cls.indexOf("badge--ad")!==-1)continue;' +
     'if(!te)continue;' +
     'var t=(te.textContent||"").trim();' +
@@ -37,7 +38,6 @@ function buildExtractFn(limit) {
     'var sn=se?(se.textContent||"").trim():"";' +
     'var du=ue?(ue.textContent||"").trim():"";' +
     'var ic=ie?(ie.getAttribute("src")||""):"";' +
-    'var cls=el.className||"";var rt="web";' +
     'if(cls.indexOf("news-result")!==-1)rt="news";' +
     'else if(cls.indexOf("video-result")!==-1)rt="video";' +
     'else if(cls.indexOf("image-result")!==-1)rt="image";' +

--- a/clis/duckduckgo/search.js
+++ b/clis/duckduckgo/search.js
@@ -1,0 +1,114 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+function decodeDdgUrl(href) {
+  if (!href) return '';
+  try {
+    const url = new URL(href, 'https://duckduckgo.com');
+    const uddg = url.searchParams.get('uddg');
+    if (uddg) return decodeURIComponent(uddg);
+    return href;
+  } catch {
+    return href;
+  }
+}
+
+function buildExtractFn(limit) {
+  return 'function(doc){' +
+    'var r=[];var seen={};var items=doc.querySelectorAll(".result");' +
+    'for(var i=0;i<items.length;i++){' +
+    'if(r.length>=' + limit + ')break;' +
+    'var el=items[i];var te=el.querySelector(".result__a");' +
+    'var se=el.querySelector(".result__snippet");' +
+    'var ue=el.querySelector(".result__url");' +
+    'var ie=el.querySelector(".result__icon__img");' +
+    'if(!te)continue;' +
+    'var t=(te.textContent||"").trim();' +
+    'var h=te.getAttribute("href")||"";' +
+    'var sn=se?(se.textContent||"").trim():"";' +
+    'var du=ue?(ue.textContent||"").trim():"";' +
+    'var ic=ie?(ie.getAttribute("src")||""):"";' +
+    'var cls=el.className||"";var rt="web";' +
+    'if(cls.indexOf("news-result")!==-1)rt="news";' +
+    'else if(cls.indexOf("video-result")!==-1)rt="video";' +
+    'else if(cls.indexOf("image-result")!==-1)rt="image";' +
+    'if(!t||seen[t])continue;seen[t]=true;' +
+    'r.push([t,h,sn,du,ic,rt]);' +
+    '}return r;}';
+}
+
+function buildExtractorJs(limit) {
+  return '(' + buildExtractFn(limit) + '(document))';
+}
+
+function buildPaginateJs(limit, keyword, offset, region) {
+  var params = 'q=' + encodeURIComponent(keyword) + '&s=' + offset + '&v=l&o=json';
+  if (region) params += '&kl=' + encodeURIComponent(region);
+  return (
+    'new Promise(function($r){' +
+    'var x=new XMLHttpRequest();' +
+    'x.open("POST","/html/",true);' +
+    'x.setRequestHeader("Content-Type","application/x-www-form-urlencoded");' +
+    'x.onload=function(){' +
+    'try{var d=new DOMParser().parseFromString(x.responseText,"text/html");' +
+    '$r(' + buildExtractFn(limit) + '(d));' +
+    '}catch(e){$r([])}' +
+    '};' +
+    'x.onerror=function(){$r([])};' +
+    'x.send("' + params + '");' +
+    '})'
+  );
+}
+
+const command = cli({
+  site: 'duckduckgo',
+  name: 'search',
+  access: 'read',
+  description: 'Search DuckDuckGo',
+  domain: 'html.duckduckgo.com',
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    { name: 'keyword', positional: true, required: true, help: 'Search query' },
+    { name: 'limit', type: 'int', default: 10, help: 'Number of results per page (1-10). For multi-page, use --offset' },
+    { name: 'offset', type: 'int', default: 0, help: 'Result offset for pagination (0, 10, 20...). Uses XHR POST internally' },
+    { name: 'region', help: 'Region code (e.g. jp-jp, us-en, cn-zh). Default: all regions' },
+    { name: 'time', help: 'Time range: d (day), w (week), m (month), y (year)' },
+  ],
+  columns: ['title', 'url', 'snippet', 'displayUrl', 'icon', 'resultType'],
+  func: async (page, kwargs) => {
+    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 10, 10));
+    const keyword = String(kwargs.keyword);
+    const offset = Math.max(0, Number(kwargs.offset) || 0);
+    let url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(keyword)}`;
+    if (kwargs.region) url += `&kl=${encodeURIComponent(String(kwargs.region))}`;
+    if (kwargs.time) url += `&df=${encodeURIComponent(String(kwargs.time))}`;
+    await page.goto(url);
+    try {
+      await page.wait({ selector: '.result', timeout: 8 });
+    } catch {
+      await page.wait(3).catch(function() {});
+    }
+    var raw;
+    if (offset === 0) {
+      raw = await page.evaluate(buildExtractorJs(limit));
+    } else {
+      raw = await page.evaluate(buildPaginateJs(limit, keyword, offset, kwargs.region));
+    }
+    if (!raw || raw.length === 0) {
+      throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
+    }
+    return raw.map(function(r) {
+      return {
+        title: r[0],
+        url: decodeDdgUrl(r[1]),
+        snippet: r[2],
+        displayUrl: r[3],
+        icon: r[4],
+        resultType: r[5],
+      };
+    });
+  },
+});
+
+export const __test__ = { command };

--- a/clis/duckduckgo/search.test.js
+++ b/clis/duckduckgo/search.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+const { __test__ } = await import('./search.js');
+const command = __test__.command;
+
+describe('duckduckgo search', () => {
+  it('should register as a valid command', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('duckduckgo');
+    expect(command.name).toBe('search');
+    expect(command.access).toBe('read');
+    expect(command.browser).toBe(true);
+    expect(command.strategy).toBe('public');
+    expect(command.domain).toBe('html.duckduckgo.com');
+  });
+
+  it('should define keyword positional arg', () => {
+    const kwArg = command.args.find(a => a.name === 'keyword');
+    expect(kwArg).toBeDefined();
+    expect(kwArg.positional).toBe(true);
+    expect(kwArg.required).toBe(true);
+  });
+
+  it('should define limit arg with default 10', () => {
+    const limitArg = command.args.find(a => a.name === 'limit');
+    expect(limitArg).toBeDefined();
+    expect(limitArg.type).toBe('int');
+    expect(limitArg.default).toBe(10);
+  });
+
+  it('should define columns for output', () => {
+    expect(command.columns).toContain('title');
+    expect(command.columns).toContain('url');
+    expect(command.columns).toContain('snippet');
+    expect(command.columns).toContain('displayUrl');
+    expect(command.columns).toContain('icon');
+    expect(command.columns).toContain('resultType');
+  });
+});

--- a/clis/duckduckgo/search.test.js
+++ b/clis/duckduckgo/search.test.js
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const { __test__ } = await import('./search.js');
 const command = __test__.command;
+
+function createPageMock(evaluateResult = []) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+  };
+}
 
 describe('duckduckgo search', () => {
   it('should register as a valid command', () => {
@@ -29,11 +37,62 @@ describe('duckduckgo search', () => {
   });
 
   it('should define columns for output', () => {
+    expect(command.columns).toContain('rank');
     expect(command.columns).toContain('title');
     expect(command.columns).toContain('url');
     expect(command.columns).toContain('snippet');
     expect(command.columns).toContain('displayUrl');
     expect(command.columns).toContain('icon');
     expect(command.columns).toContain('resultType');
+  });
+
+  it('rejects empty query and out-of-range pagination before navigation', async () => {
+    const page = createPageMock();
+    await expect(command.func(page, { keyword: ' ', limit: 5 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func(page, { keyword: 'opencli', limit: 11 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func(page, { keyword: 'opencli', limit: 5, offset: 5 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('decodes DuckDuckGo redirect URLs and assigns listing rank', async () => {
+    const page = createPageMock([
+      [
+        'OpenCLI',
+        '/l/?uddg=https%3A%2F%2Fgithub.com%2Fjackwener%2FOpenCLI',
+        'CLI browser tooling',
+        'github.com/jackwener/OpenCLI',
+        '',
+        'web',
+      ],
+    ]);
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1 })).resolves.toEqual([{
+      rank: 1,
+      title: 'OpenCLI',
+      url: 'https://github.com/jackwener/OpenCLI',
+      snippet: 'CLI browser tooling',
+      displayUrl: 'github.com/jackwener/OpenCLI',
+      icon: '',
+      resultType: 'web',
+    }]);
+  });
+
+  it('unwraps browser envelopes for paginated extraction', async () => {
+    const page = createPageMock({ session: 'site:duckduckgo', data: [
+      ['Result', 'https://example.com/', 'snippet', 'example.com', '', 'web'],
+    ] });
+
+    const result = await command.func(page, { keyword: 'opencli', limit: 1, offset: 10 });
+
+    expect(result[0]).toMatchObject({ rank: 11, url: 'https://example.com/' });
+  });
+
+  it('fails typed instead of returning [] for malformed extraction payloads', async () => {
+    const page = createPageMock({ rows: [] });
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1 })).rejects.toMatchObject({
+      code: 'COMMAND_EXEC',
+      message: expect.stringContaining('payload shape'),
+    });
   });
 });

--- a/clis/duckduckgo/search.test.js
+++ b/clis/duckduckgo/search.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 
 const { __test__ } = await import('./search.js');
 const command = __test__.command;
@@ -73,6 +74,35 @@ describe('duckduckgo search', () => {
       snippet: 'CLI browser tooling',
       displayUrl: 'github.com/jackwener/OpenCLI',
       icon: '',
+      resultType: 'web',
+    }]);
+  });
+
+  it('executes the DOM extractor, filters ads, and returns canonical rows', async () => {
+    const dom = new JSDOM(`
+      <div class="result result--ad">
+        <a class="result__a" href="https://ads.example/">Sponsored result</a>
+      </div>
+      <div class="result">
+        <a class="result__a" href="/l/?uddg=https%3A%2F%2Fexample.com%2Farticle">Organic result</a>
+        <a class="result__snippet">Organic snippet</a>
+        <span class="result__url">example.com/article</span>
+        <img class="result__icon__img" src="https://icons.duckduckgo.com/ip3/example.com.ico">
+      </div>
+    `);
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn(async (source) => Function('document', `return ${source};`)(dom.window.document)),
+    };
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 5 })).resolves.toEqual([{
+      rank: 1,
+      title: 'Organic result',
+      url: 'https://example.com/article',
+      snippet: 'Organic snippet',
+      displayUrl: 'example.com/article',
+      icon: 'https://icons.duckduckgo.com/ip3/example.com.ico',
       resultType: 'web',
     }]);
   });

--- a/clis/duckduckgo/suggest.js
+++ b/clis/duckduckgo/suggest.js
@@ -1,0 +1,41 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+const command = cli({
+  site: 'duckduckgo',
+  name: 'suggest',
+  access: 'read',
+  description: 'DuckDuckGo search suggestions',
+  domain: 'duckduckgo.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'keyword', positional: true, required: true, help: 'Search query prefix' },
+    { name: 'limit', type: 'int', default: 8, help: 'Max number of suggestions' },
+  ],
+  columns: ['phrase'],
+  func: async (kwargs) => {
+    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 8, 20));
+    const keyword = encodeURIComponent(String(kwargs.keyword));
+    const url = `https://duckduckgo.com/ac/?q=${keyword}&type=list`;
+    let resp;
+    try {
+      resp = await fetch(url);
+    } catch (err) {
+      throw new CliError('NETWORK_ERROR', `Failed to fetch suggestions: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (!resp.ok) {
+      throw new CliError('HTTP_ERROR', `Suggest API returned ${resp.status}`);
+    }
+    let data;
+    try {
+      data = await resp.json();
+    } catch {
+      throw new CliError('PARSE_ERROR', 'Failed to parse suggestion response');
+    }
+    const phrases = Array.isArray(data) && data.length > 1 && Array.isArray(data[1]) ? data[1] : [];
+    return phrases.slice(0, limit).map(function(p) { return { phrase: p }; });
+  },
+});
+
+export const __test__ = { command };

--- a/clis/duckduckgo/suggest.js
+++ b/clis/duckduckgo/suggest.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
+import { clampInt } from '../_shared/common.js';
 
 const command = cli({
   site: 'duckduckgo',
@@ -15,7 +16,7 @@ const command = cli({
   ],
   columns: ['phrase'],
   func: async (kwargs) => {
-    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 8, 20));
+    const limit = clampInt(kwargs.limit, 8, 1, 20);
     const keyword = encodeURIComponent(String(kwargs.keyword));
     const url = `https://duckduckgo.com/ac/?q=${keyword}&type=list`;
     let resp;

--- a/clis/duckduckgo/suggest.js
+++ b/clis/duckduckgo/suggest.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
-import { clampInt } from '../_shared/common.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { requireBoundedInteger, requireSearchQuery } from '../_shared/search-adapter.js';
 
 const command = cli({
   site: 'duckduckgo',
@@ -16,26 +16,29 @@ const command = cli({
   ],
   columns: ['phrase'],
   func: async (kwargs) => {
-    const limit = clampInt(kwargs.limit, 8, 1, 20);
-    const keyword = encodeURIComponent(String(kwargs.keyword));
+    const limit = requireBoundedInteger(kwargs.limit, 8, 1, 20, '--limit');
+    const keyword = encodeURIComponent(requireSearchQuery(kwargs.keyword));
     const url = `https://duckduckgo.com/ac/?q=${keyword}&type=list`;
     let resp;
     try {
       resp = await fetch(url);
     } catch (err) {
-      throw new CliError('NETWORK_ERROR', `Failed to fetch suggestions: ${err instanceof Error ? err.message : String(err)}`);
+      throw new CommandExecutionError(`DuckDuckGo suggest request failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     if (!resp.ok) {
-      throw new CliError('HTTP_ERROR', `Suggest API returned ${resp.status}`);
+      throw new CommandExecutionError(`DuckDuckGo suggest returned HTTP ${resp.status}`);
     }
     let data;
     try {
       data = await resp.json();
-    } catch {
-      throw new CliError('PARSE_ERROR', 'Failed to parse suggestion response');
+    } catch (err) {
+      throw new CommandExecutionError(`DuckDuckGo suggest returned malformed JSON: ${err?.message ?? err}`);
     }
     const phrases = Array.isArray(data) && data.length > 1 && Array.isArray(data[1]) ? data[1] : [];
-    return phrases.slice(0, limit).map(function(p) { return { phrase: p }; });
+    return phrases
+      .filter((phrase) => typeof phrase === 'string' && phrase.trim())
+      .slice(0, limit)
+      .map(function(p) { return { phrase: p }; });
   },
 });
 

--- a/clis/duckduckgo/suggest.test.js
+++ b/clis/duckduckgo/suggest.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+const { __test__ } = await import('./suggest.js');
+const command = __test__.command;
+
+describe('duckduckgo suggest', () => {
+  it('should register as a valid command', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('duckduckgo');
+    expect(command.name).toBe('suggest');
+    expect(command.access).toBe('read');
+    expect(command.browser).toBe(false);
+    expect(command.strategy).toBe('public');
+  });
+
+  it('should define keyword positional arg', () => {
+    const kwArg = command.args.find(a => a.name === 'keyword');
+    expect(kwArg).toBeDefined();
+    expect(kwArg.positional).toBe(true);
+    expect(kwArg.required).toBe(true);
+  });
+
+  it('should define limit arg with default 8', () => {
+    const limitArg = command.args.find(a => a.name === 'limit');
+    expect(limitArg).toBeDefined();
+    expect(limitArg.default).toBe(8);
+  });
+
+  it('should define phrase column', () => {
+    expect(command.columns).toEqual(['phrase']);
+  });
+});

--- a/clis/duckduckgo/suggest.test.js
+++ b/clis/duckduckgo/suggest.test.js
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 
 const { __test__ } = await import('./suggest.js');
 const command = __test__.command;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('duckduckgo suggest', () => {
   it('should register as a valid command', () => {
@@ -28,5 +32,35 @@ describe('duckduckgo suggest', () => {
 
   it('should define phrase column', () => {
     expect(command.columns).toEqual(['phrase']);
+  });
+
+  it('rejects empty query and invalid limit before fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await expect(command.func({ keyword: '', limit: 5 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func({ keyword: 'opencli', limit: 21 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns filtered suggestion rows from the public API payload', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ['open', ['opencli', '', 'open source']],
+    });
+
+    await expect(command.func({ keyword: 'open', limit: 3 })).resolves.toEqual([
+      { phrase: 'opencli' },
+      { phrase: 'open source' },
+    ]);
+  });
+
+  it('maps fetch and malformed JSON failures to typed command errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('offline'));
+    await expect(command.func({ keyword: 'open', limit: 3 })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => { throw new Error('bad json'); },
+    });
+    await expect(command.func({ keyword: 'open', limit: 3 })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
   });
 });

--- a/clis/yahoo/search.js
+++ b/clis/yahoo/search.js
@@ -14,9 +14,9 @@ function decodeYahooUrl(href) {
     var match = href.match(/RU=([^/]+)\/RK=/);
     if (match && match[1]) {
       try {
-        return decodeURIComponent(match[1]);
+        return toHttpsUrl(decodeURIComponent(match[1]), 'https://search.yahoo.com');
       } catch {
-        return href;
+        return toHttpsUrl(href, 'https://search.yahoo.com');
       }
     }
   }

--- a/clis/yahoo/search.js
+++ b/clis/yahoo/search.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
+import { clampInt } from '../_shared/common.js';
 
 function decodeYahooUrl(href) {
   if (!href) return '';
@@ -55,7 +56,7 @@ const command = cli({
   ],
   columns: ['title', 'url', 'snippet'],
   func: async (page, kwargs) => {
-    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 7, 7));
+    const limit = clampInt(kwargs.limit, 7, 1, 7);
     const keyword = encodeURIComponent(String(kwargs.keyword));
     const pageNum = Math.max(1, Number(kwargs.page) || 1);
     var url = `https://search.yahoo.com/search?p=${keyword}`;

--- a/clis/yahoo/search.js
+++ b/clis/yahoo/search.js
@@ -1,6 +1,12 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
-import { clampInt } from '../_shared/common.js';
+import {
+  emptySearchResults,
+  requireBoundedInteger,
+  requireRows,
+  requireSearchQuery,
+  runBrowserStep,
+  toHttpsUrl,
+} from '../_shared/search-adapter.js';
 
 function decodeYahooUrl(href) {
   if (!href) return '';
@@ -14,7 +20,7 @@ function decodeYahooUrl(href) {
       }
     }
   }
-  return href;
+  return toHttpsUrl(href, 'https://search.yahoo.com');
 }
 
 function buildExtractorJs(limit) {
@@ -33,8 +39,8 @@ function buildExtractorJs(limit) {
     var title = h3.textContent.trim();
     var href = linkEl.getAttribute('href') || '';
     var snippet = snippetEl ? snippetEl.textContent.trim() : '';
-    if (!title || !href || seen[title]) continue;
-    seen[title] = true;
+    if (!title || !href || seen[href]) continue;
+    seen[href] = true;
     results.push([title, href, snippet]);
   }
   return results;
@@ -54,27 +60,32 @@ const command = cli({
     { name: 'limit', type: 'int', default: 7, help: 'Number of results per page (max 7)' },
     { name: 'page', type: 'int', default: 1, help: 'Page number (1, 2, 3...). Yahoo returns ~7 results per page' },
   ],
-  columns: ['title', 'url', 'snippet'],
+  columns: ['rank', 'title', 'url', 'snippet'],
   func: async (page, kwargs) => {
-    const limit = clampInt(kwargs.limit, 7, 1, 7);
-    const keyword = encodeURIComponent(String(kwargs.keyword));
-    const pageNum = Math.max(1, Number(kwargs.page) || 1);
+    const limit = requireBoundedInteger(kwargs.limit, 7, 1, 7, '--limit');
+    const query = requireSearchQuery(kwargs.keyword);
+    const keyword = encodeURIComponent(query);
+    const pageNum = requireBoundedInteger(kwargs.page, 1, 1, 100, '--page');
     var url = `https://search.yahoo.com/search?p=${keyword}`;
     if (pageNum > 1) url += `&b=${(pageNum - 1) * 7 + 1}`;
-    await page.goto(url);
+    await runBrowserStep('yahoo search navigation', () => page.goto(url));
     try {
       await page.wait({ selector: '.algo', timeout: 10 });
     } catch {
       await page.wait(3).catch(function() {});
     }
-    const raw = await page.evaluate(buildExtractorJs(limit));
-    const results = (raw && Array.isArray(raw)) ? raw : [];
+    const raw = await runBrowserStep('yahoo search extraction', () => page.evaluate(buildExtractorJs(limit)));
+    const results = requireRows(raw, 'yahoo search');
     if (results.length === 0) {
-      throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
+      throw emptySearchResults('Yahoo', query);
     }
-    return results.map(function(r) {
-      return { title: r[0], url: decodeYahooUrl(r[1]), snippet: r[2] };
-    });
+    const rows = results
+      .map(function(r, index) {
+        return { rank: index + 1 + (pageNum - 1) * 7, title: r[0], url: decodeYahooUrl(r[1]), snippet: r[2] };
+      })
+      .filter((row) => row.url);
+    if (rows.length === 0) throw emptySearchResults('Yahoo', query);
+    return rows;
   },
 });
 

--- a/clis/yahoo/search.js
+++ b/clis/yahoo/search.js
@@ -35,9 +35,9 @@ function buildExtractorJs(limit) {
     var snippet = snippetEl ? snippetEl.textContent.trim() : '';
     if (!title || !href || seen[title]) continue;
     seen[title] = true;
-    results.push({ title: title, url: href, snippet: snippet });
+    results.push([title, href, snippet]);
   }
-  return { items: results };
+  return results;
 })()`;
 }
 
@@ -67,13 +67,13 @@ const command = cli({
     } catch {
       await page.wait(3).catch(function() {});
     }
-    const wrapper = await page.evaluate(buildExtractorJs(limit));
-    const results = (wrapper && wrapper.items) || [];
+    const raw = await page.evaluate(buildExtractorJs(limit));
+    const results = (raw && Array.isArray(raw)) ? raw : [];
     if (results.length === 0) {
       throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
     }
     return results.map(function(r) {
-      return { title: r.title, url: decodeYahooUrl(r.url), snippet: r.snippet };
+      return { title: r[0], url: decodeYahooUrl(r[1]), snippet: r[2] };
     });
   },
 });

--- a/clis/yahoo/search.js
+++ b/clis/yahoo/search.js
@@ -1,0 +1,80 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+
+function decodeYahooUrl(href) {
+  if (!href) return '';
+  if (href.indexOf('RU=') !== -1 && href.indexOf('/RK=') !== -1) {
+    var match = href.match(/RU=([^/]+)\/RK=/);
+    if (match && match[1]) {
+      try {
+        return decodeURIComponent(match[1]);
+      } catch {
+        return href;
+      }
+    }
+  }
+  return href;
+}
+
+function buildExtractorJs(limit) {
+  return `
+(function() {
+  var results = [];
+  var seen = {};
+  var items = document.querySelectorAll('.algo');
+  for (var i = 0; i < items.length; i++) {
+    if (results.length >= ${limit}) break;
+    var el = items[i];
+    var h3 = el.querySelector('h3');
+    var linkEl = el.querySelector('.compTitle a');
+    var snippetEl = el.querySelector('.compText');
+    if (!h3 || !linkEl) continue;
+    var title = h3.textContent.trim();
+    var href = linkEl.getAttribute('href') || '';
+    var snippet = snippetEl ? snippetEl.textContent.trim() : '';
+    if (!title || !href || seen[title]) continue;
+    seen[title] = true;
+    results.push({ title: title, url: href, snippet: snippet });
+  }
+  return { items: results };
+})()`;
+}
+
+const command = cli({
+  site: 'yahoo',
+  name: 'search',
+  access: 'read',
+  description: 'Search Yahoo (powered by Bing)',
+  domain: 'search.yahoo.com',
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    { name: 'keyword', positional: true, required: true, help: 'Search query' },
+    { name: 'limit', type: 'int', default: 7, help: 'Number of results per page (max 7)' },
+    { name: 'page', type: 'int', default: 1, help: 'Page number (1, 2, 3...). Yahoo returns ~7 results per page' },
+  ],
+  columns: ['title', 'url', 'snippet'],
+  func: async (page, kwargs) => {
+    const limit = Math.max(1, Math.min(Number(kwargs.limit) || 7, 7));
+    const keyword = encodeURIComponent(String(kwargs.keyword));
+    const pageNum = Math.max(1, Number(kwargs.page) || 1);
+    var url = `https://search.yahoo.com/search?p=${keyword}`;
+    if (pageNum > 1) url += `&b=${(pageNum - 1) * 7 + 1}`;
+    await page.goto(url);
+    try {
+      await page.wait({ selector: '.algo', timeout: 10 });
+    } catch {
+      await page.wait(3).catch(function() {});
+    }
+    const wrapper = await page.evaluate(buildExtractorJs(limit));
+    const results = (wrapper && wrapper.items) || [];
+    if (results.length === 0) {
+      throw new CliError('NOT_FOUND', 'No search results found', 'Try a different keyword');
+    }
+    return results.map(function(r) {
+      return { title: r.title, url: decodeYahooUrl(r.url), snippet: r.snippet };
+    });
+  },
+});
+
+export const __test__ = { command };

--- a/clis/yahoo/search.test.js
+++ b/clis/yahoo/search.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+
+const { __test__ } = await import('./search.js');
+const command = __test__.command;
+
+describe('yahoo search', () => {
+  it('should register as a valid command', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('yahoo');
+    expect(command.name).toBe('search');
+    expect(command.access).toBe('read');
+    expect(command.browser).toBe(true);
+    expect(command.strategy).toBe('public');
+    expect(command.domain).toBe('search.yahoo.com');
+  });
+
+  it('should define keyword positional arg', () => {
+    const kwArg = command.args.find(a => a.name === 'keyword');
+    expect(kwArg).toBeDefined();
+    expect(kwArg.positional).toBe(true);
+    expect(kwArg.required).toBe(true);
+  });
+
+  it('should define limit arg with default 7', () => {
+    const limitArg = command.args.find(a => a.name === 'limit');
+    expect(limitArg).toBeDefined();
+    expect(limitArg.type).toBe('int');
+    expect(limitArg.default).toBe(7);
+  });
+
+  it('should define output columns', () => {
+    expect(command.columns).toContain('title');
+    expect(command.columns).toContain('url');
+    expect(command.columns).toContain('snippet');
+  });
+});

--- a/clis/yahoo/search.test.js
+++ b/clis/yahoo/search.test.js
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const { __test__ } = await import('./search.js');
 const command = __test__.command;
+
+function createPageMock(evaluateResult = []) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+  };
+}
 
 describe('yahoo search', () => {
   it('should register as a valid command', () => {
@@ -29,8 +37,44 @@ describe('yahoo search', () => {
   });
 
   it('should define output columns', () => {
+    expect(command.columns).toContain('rank');
     expect(command.columns).toContain('title');
     expect(command.columns).toContain('url');
     expect(command.columns).toContain('snippet');
+  });
+
+  it('rejects empty query, invalid limit, and invalid page before navigation', async () => {
+    const page = createPageMock();
+    await expect(command.func(page, { keyword: ' ', limit: 5 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func(page, { keyword: 'opencli', limit: 8 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    await expect(command.func(page, { keyword: 'opencli', limit: 5, page: 0 })).rejects.toMatchObject({ code: 'ARGUMENT' });
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('decodes Yahoo redirect URLs and assigns listing rank', async () => {
+    const page = createPageMock({
+      session: 'site:yahoo',
+      data: [[
+        'OpenCLI',
+        'https://r.search.yahoo.com/_ylt=x/RU=https%3A%2F%2Fgithub.com%2Fjackwener%2FOpenCLI/RK=2/RS=x',
+        'CLI browser tooling',
+      ]],
+    });
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1, page: 2 })).resolves.toEqual([{
+      rank: 8,
+      title: 'OpenCLI',
+      url: 'https://github.com/jackwener/OpenCLI',
+      snippet: 'CLI browser tooling',
+    }]);
+  });
+
+  it('fails typed instead of silently returning [] for malformed extraction payloads', async () => {
+    const page = createPageMock({ rows: [] });
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1 })).rejects.toMatchObject({
+      code: 'COMMAND_EXEC',
+      message: expect.stringContaining('payload shape'),
+    });
   });
 });

--- a/clis/yahoo/search.test.js
+++ b/clis/yahoo/search.test.js
@@ -69,6 +69,20 @@ describe('yahoo search', () => {
     }]);
   });
 
+  it('drops decoded Yahoo redirect targets that are not http(s) URLs', async () => {
+    const page = createPageMock([
+      [
+        'Bad redirect',
+        'https://r.search.yahoo.com/_ylt=x/RU=javascript%3Aalert(1)/RK=2/RS=x',
+        'should not be emitted',
+      ],
+    ]);
+
+    await expect(command.func(page, { keyword: 'opencli', limit: 1 })).rejects.toMatchObject({
+      code: 'EMPTY_RESULT',
+    });
+  });
+
   it('fails typed instead of silently returning [] for malformed extraction payloads', async () => {
     const page = createPageMock({ rows: [] });
 

--- a/docs/adapters/browser/brave.md
+++ b/docs/adapters/browser/brave.md
@@ -10,9 +10,10 @@
 
 ## What works today
 
-- Uses browser mode to search `search.brave.com` and extract results via DOM queries.
+- Uses browser mode to search `search.brave.com` and extract ranked results via DOM queries.
 - Supports `--offset` for GET-based pagination. Brave returns approximately 18 results per page.
-- Results include title, URL, and snippet.
+- Results include rank, title, URL, and snippet.
+- `--limit` must be between 1 and 18; `--offset` must be a non-negative page offset.
 
 ## Current limitations
 

--- a/docs/adapters/browser/brave.md
+++ b/docs/adapters/browser/brave.md
@@ -1,0 +1,46 @@
+# Brave Search
+
+**Mode**: 🌐 Public · **Domain**: `search.brave.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli brave search <keyword>` | Search Brave Search and extract results from the page |
+
+## What works today
+
+- Uses browser mode to search `search.brave.com` and extract results via DOM queries.
+- Supports `--offset` for GET-based pagination. Brave returns approximately 18 results per page.
+- Results include title, URL, and snippet.
+
+## Current limitations
+
+- Requires browser mode. Brave Search does not offer a public, no-auth search API.
+- DOM structure uses Svelte-generated class names that may change with updates.
+- Some results may have empty snippets depending on Brave's layout.
+
+## Usage Examples
+
+```bash
+# Basic search
+opencli brave search "machine learning"
+
+# Limit results
+opencli brave search "machine learning" --limit 5
+
+# Pagination (second page)
+opencli brave search "machine learning" --offset 1
+
+# JSON output
+opencli brave search "machine learning" -f json
+```
+
+## Prerequisites
+
+- Requires Chrome running (Standalone mode will auto-launch) or the [Browser Bridge extension](/guide/browser-bridge).
+
+## Notes
+
+- Brave Search renders results server-side; all results are present in the initial HTML (no lazy loading).
+- Brave also shows an AI-generated summary box as the first result. The adapter filters this out via the `.standalone` class check.

--- a/docs/adapters/browser/duckduckgo.md
+++ b/docs/adapters/browser/duckduckgo.md
@@ -1,0 +1,60 @@
+# DuckDuckGo
+
+**Mode**: 🌐 Public · **Domains**: `html.duckduckgo.com`, `duckduckgo.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli duckduckgo search <keyword>` | Search DuckDuckGo and extract results from the page |
+| `opencli duckduckgo suggest <keyword>` | Get DuckDuckGo search suggestions |
+
+## What works today
+
+- `duckduckgo search` uses browser mode to search `html.duckduckgo.com` and extract results.
+- `duckduckgo suggest` uses the public JSON API at `duckduckgo.com/ac/` — no browser needed.
+- `search` supports `--region` (e.g. `jp-jp`, `us-en`, `cn-zh`) and `--time` (`d`, `w`, `m`, `y`) filters.
+- `search` supports `--offset` for pagination via XHR POST (avoids page navigation issues with `form.submit()`).
+
+## Current limitations
+
+- `duckduckgo search` requires browser mode due to anti-bot protections on DuckDuckGo.
+- The HTML version returns a maximum of 10 results per page.
+- Pagination uses POST-based navigation; results may have some overlap at page boundaries.
+- Snippet extraction is based on the HTML version's DOM structure (`.result__snippet`).
+
+## Usage Examples
+
+```bash
+# Basic search
+opencli duckduckgo search "machine learning"
+
+# Limit results
+opencli duckduckgo search "machine learning" --limit 5
+
+# Region-specific search
+opencli duckduckgo search "machine learning" --region jp-jp
+
+# Time filter (past week)
+opencli duckduckgo search "machine learning" --time w
+
+# Pagination (second page)
+opencli duckduckgo search "machine learning" --offset 10
+
+# JSON output
+opencli duckduckgo search "machine learning" -f json
+
+# Search suggestions
+opencli duckduckgo suggest "machine" --limit 5
+```
+
+## Prerequisites
+
+- `suggest` does not require Chrome.
+- `search` requires Chrome running (Standalone mode will auto-launch) or the [Browser Bridge extension](/guide/browser-bridge).
+
+## Notes
+
+- DuckDuckGo uses `uddg=` URL redirects; the adapter automatically decodes them to return clean URLs.
+- The `ac/` suggest API returns phonetic suggestions for CJK queries, which may not always match expected results.
+- Region codes follow DuckDuckGo's format (e.g. `jp-jp`, `us-en`, `uk-en`). Default is all regions.

--- a/docs/adapters/browser/duckduckgo.md
+++ b/docs/adapters/browser/duckduckgo.md
@@ -11,7 +11,7 @@
 
 ## What works today
 
-- `duckduckgo search` uses browser mode to search `html.duckduckgo.com` and extract results.
+- `duckduckgo search` uses browser mode to search `html.duckduckgo.com` and extract ranked results.
 - `duckduckgo suggest` uses the public JSON API at `duckduckgo.com/ac/` — no browser needed.
 - `search` supports `--region` (e.g. `jp-jp`, `us-en`, `cn-zh`) and `--time` (`d`, `w`, `m`, `y`) filters.
 - `search` supports `--offset` for pagination via XHR POST (avoids page navigation issues with `form.submit()`).
@@ -19,7 +19,7 @@
 ## Current limitations
 
 - `duckduckgo search` requires browser mode due to anti-bot protections on DuckDuckGo.
-- The HTML version returns a maximum of 10 results per page.
+- The HTML version returns a maximum of 10 results per page; `--limit` must be between 1 and 10.
 - Pagination uses POST-based navigation; results may have some overlap at page boundaries.
 - Snippet extraction is based on the HTML version's DOM structure (`.result__snippet`).
 

--- a/docs/adapters/browser/yahoo.md
+++ b/docs/adapters/browser/yahoo.md
@@ -10,9 +10,10 @@
 
 ## What works today
 
-- Uses browser mode to search `search.yahoo.com` and extract results via DOM queries.
+- Uses browser mode to search `search.yahoo.com` and extract ranked results via DOM queries.
 - Supports `--page` for pagination. Yahoo returns approximately 7 results per page.
-- Results include title, URL, and snippet.
+- Results include rank, title, URL, and snippet.
+- `--limit` must be between 1 and 7; `--page` must be a positive integer.
 
 ## Current limitations
 

--- a/docs/adapters/browser/yahoo.md
+++ b/docs/adapters/browser/yahoo.md
@@ -1,0 +1,48 @@
+# Yahoo Search
+
+**Mode**: 🌐 Public · **Domain**: `search.yahoo.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli yahoo search <keyword>` | Search Yahoo (powered by Bing) and extract results from the page |
+
+## What works today
+
+- Uses browser mode to search `search.yahoo.com` and extract results via DOM queries.
+- Supports `--page` for pagination. Yahoo returns approximately 7 results per page.
+- Results include title, URL, and snippet.
+
+## Current limitations
+
+- Requires browser mode.
+- Yahoo returns fewer results per page (7) compared to other engines.
+- Page 2+ results may include lower-quality or less relevant matches.
+- Yahoo wraps URLs in a `RU=.../RK=` redirect structure; the adapter automatically decodes them.
+
+## Usage Examples
+
+```bash
+# Basic search
+opencli yahoo search "machine learning"
+
+# Limit results
+opencli yahoo search "machine learning" --limit 5
+
+# Pagination (second page)
+opencli yahoo search "machine learning" --page 2
+
+# JSON output
+opencli yahoo search "machine learning" -f json
+```
+
+## Prerequisites
+
+- Requires Chrome running (Standalone mode will auto-launch) or the [Browser Bridge extension](/guide/browser-bridge).
+
+## Notes
+
+- Yahoo Search is powered by Bing. Results are rendered server-side in the initial HTML.
+- Yahoo uses `RU=` redirect URLs to wrap search results; the adapter extracts the real URLs automatically.
+- Region/language filtering is not currently exposed as a parameter. Results depend on the browser session's locale.

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -411,7 +411,7 @@
     "rule": "silent-clamp",
     "command": "linkedin/search",
     "file": "clis/linkedin/search.js",
-    "line": 256,
+    "line": 249,
     "text": "const count = Math.min(MAX_BATCH, input.limit - allJobs.length);",
     "occurrence": 0
   },
@@ -483,7 +483,7 @@
     "rule": "silent-clamp",
     "command": "reddit/read",
     "file": "clis/reddit/read.js",
-    "line": 480,
+    "line": 157,
     "text": "for (var i = 0; i < Math.min(t1TopLevel.length, limit); i++) {",
     "occurrence": 0
   },
@@ -619,7 +619,7 @@
     "rule": "silent-clamp",
     "command": "twitter/bookmark-folder",
     "file": "clis/twitter/bookmark-folder.js",
-    "line": 164,
+    "line": 161,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -635,7 +635,7 @@
     "rule": "silent-clamp",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
-    "line": 228,
+    "line": 215,
     "text": "const fetchCount = Math.min(50, limit - allUsers.length + 10);",
     "occurrence": 0
   },
@@ -643,7 +643,7 @@
     "rule": "silent-clamp",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
-    "line": 208,
+    "line": 195,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -651,7 +651,7 @@
     "rule": "silent-clamp",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 175,
+    "line": 168,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -667,7 +667,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 287,
+    "line": 194,
     "text": "const fetchCount = Math.min(100, limit - all.length + 10);",
     "occurrence": 0
   },
@@ -675,7 +675,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 232,
+    "line": 159,
     "text": "const limit = Math.max(1, Math.min(200, kwargs.limit || 20));",
     "occurrence": 0
   },
@@ -1179,7 +1179,7 @@
     "rule": "silent-sentinel",
     "command": "reddit/saved",
     "file": "clis/reddit/saved.js",
-    "line": 34,
+    "line": 33,
     "text": "title: c.data.title || c.data.body?.slice(0, 100) || '-',",
     "occurrence": 0
   },
@@ -1187,7 +1187,7 @@
     "rule": "silent-sentinel",
     "command": "reddit/upvoted",
     "file": "clis/reddit/upvoted.js",
-    "line": 34,
+    "line": 33,
     "text": "title: c.data.title || '-',",
     "occurrence": 0
   },
@@ -1211,7 +1211,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/article",
     "file": "clis/twitter/article.js",
-    "line": 110,
+    "line": 105,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1219,16 +1219,8 @@
     "rule": "silent-sentinel",
     "command": "twitter/bookmarks",
     "file": "clis/twitter/bookmarks.js",
-    "line": 54,
+    "line": 53,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "twitter/following",
-    "file": "clis/twitter/following.js",
-    "line": 95,
-    "text": "name: core.name || legacy.name || 'unknown',",
     "occurrence": 0
   },
   {
@@ -1236,6 +1228,14 @@
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
     "line": 94,
+    "text": "name: core.name || legacy.name || 'unknown',",
+    "occurrence": 0
+  },
+  {
+    "rule": "silent-sentinel",
+    "command": "twitter/following",
+    "file": "clis/twitter/following.js",
+    "line": 93,
     "text": "screen_name: core.screen_name || legacy.screen_name || 'unknown',",
     "occurrence": 0
   },
@@ -1243,7 +1243,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
-    "line": 91,
+    "line": 90,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1251,7 +1251,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 62,
+    "line": 60,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1259,7 +1259,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/notifications",
     "file": "clis/twitter/notifications.js",
-    "line": 83,
+    "line": 82,
     "text": "author = fromUser?.core?.screen_name || fromUser?.legacy?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1267,7 +1267,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/notifications",
     "file": "clis/twitter/notifications.js",
-    "line": 105,
+    "line": 104,
     "text": "author = tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1275,7 +1275,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/notifications",
     "file": "clis/twitter/notifications.js",
-    "line": 98,
+    "line": 97,
     "text": "author = tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown';",
     "occurrence": 1
   },
@@ -1291,7 +1291,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/search",
     "file": "clis/twitter/search.js",
-    "line": 217,
+    "line": 296,
     "text": "author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown',",
     "occurrence": 0
   },
@@ -1307,7 +1307,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/timeline",
     "file": "clis/twitter/timeline.js",
-    "line": 76,
+    "line": 75,
     "text": "const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1315,7 +1315,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 161,
+    "line": 92,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1403,7 +1403,7 @@
     "rule": "silent-sentinel",
     "command": "xiaohongshu/download",
     "file": "clis/xiaohongshu/download.js",
-    "line": 53,
+    "line": 65,
     "text": "result.author = authorEl?.textContent?.trim() || 'unknown';",
     "occurrence": 0
   },

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -411,7 +411,7 @@
     "rule": "silent-clamp",
     "command": "linkedin/search",
     "file": "clis/linkedin/search.js",
-    "line": 249,
+    "line": 256,
     "text": "const count = Math.min(MAX_BATCH, input.limit - allJobs.length);",
     "occurrence": 0
   },
@@ -483,7 +483,7 @@
     "rule": "silent-clamp",
     "command": "reddit/read",
     "file": "clis/reddit/read.js",
-    "line": 157,
+    "line": 480,
     "text": "for (var i = 0; i < Math.min(t1TopLevel.length, limit); i++) {",
     "occurrence": 0
   },
@@ -619,7 +619,7 @@
     "rule": "silent-clamp",
     "command": "twitter/bookmark-folder",
     "file": "clis/twitter/bookmark-folder.js",
-    "line": 161,
+    "line": 164,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -635,7 +635,7 @@
     "rule": "silent-clamp",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
-    "line": 215,
+    "line": 228,
     "text": "const fetchCount = Math.min(50, limit - allUsers.length + 10);",
     "occurrence": 0
   },
@@ -643,7 +643,7 @@
     "rule": "silent-clamp",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
-    "line": 195,
+    "line": 208,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -651,7 +651,7 @@
     "rule": "silent-clamp",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 168,
+    "line": 175,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -667,7 +667,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 194,
+    "line": 287,
     "text": "const fetchCount = Math.min(100, limit - all.length + 10);",
     "occurrence": 0
   },
@@ -675,7 +675,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 159,
+    "line": 232,
     "text": "const limit = Math.max(1, Math.min(200, kwargs.limit || 20));",
     "occurrence": 0
   },
@@ -1179,7 +1179,7 @@
     "rule": "silent-sentinel",
     "command": "reddit/saved",
     "file": "clis/reddit/saved.js",
-    "line": 33,
+    "line": 34,
     "text": "title: c.data.title || c.data.body?.slice(0, 100) || '-',",
     "occurrence": 0
   },
@@ -1187,7 +1187,7 @@
     "rule": "silent-sentinel",
     "command": "reddit/upvoted",
     "file": "clis/reddit/upvoted.js",
-    "line": 33,
+    "line": 34,
     "text": "title: c.data.title || '-',",
     "occurrence": 0
   },
@@ -1211,7 +1211,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/article",
     "file": "clis/twitter/article.js",
-    "line": 105,
+    "line": 110,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1219,7 +1219,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/bookmarks",
     "file": "clis/twitter/bookmarks.js",
-    "line": 53,
+    "line": 54,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1227,7 +1227,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
-    "line": 94,
+    "line": 95,
     "text": "name: core.name || legacy.name || 'unknown',",
     "occurrence": 0
   },
@@ -1235,7 +1235,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
-    "line": 93,
+    "line": 94,
     "text": "screen_name: core.screen_name || legacy.screen_name || 'unknown',",
     "occurrence": 0
   },
@@ -1243,7 +1243,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
-    "line": 90,
+    "line": 91,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1251,7 +1251,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 60,
+    "line": 62,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1259,7 +1259,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/notifications",
     "file": "clis/twitter/notifications.js",
-    "line": 82,
+    "line": 83,
     "text": "author = fromUser?.core?.screen_name || fromUser?.legacy?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1267,7 +1267,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/notifications",
     "file": "clis/twitter/notifications.js",
-    "line": 104,
+    "line": 105,
     "text": "author = tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1275,7 +1275,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/notifications",
     "file": "clis/twitter/notifications.js",
-    "line": 97,
+    "line": 98,
     "text": "author = tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown';",
     "occurrence": 1
   },
@@ -1291,7 +1291,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/search",
     "file": "clis/twitter/search.js",
-    "line": 296,
+    "line": 217,
     "text": "author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown',",
     "occurrence": 0
   },
@@ -1307,7 +1307,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/timeline",
     "file": "clis/twitter/timeline.js",
-    "line": 75,
+    "line": 76,
     "text": "const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1315,7 +1315,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 92,
+    "line": 161,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1403,7 +1403,7 @@
     "rule": "silent-sentinel",
     "command": "xiaohongshu/download",
     "file": "clis/xiaohongshu/download.js",
-    "line": 65,
+    "line": 53,
     "text": "result.author = authorEl?.textContent?.trim() || 'unknown';",
     "occurrence": 0
   },


### PR DESCRIPTION
## Summary
Add three new search engine adapters with browser-based DOM extraction. These adapters allow users to search the web directly from the terminal.

## Adapters Added

### DuckDuckGo (2 commands)
| Command | Strategy | Description |
|---|---|---|
| `duckduckgo search <keyword>` | PUBLIC + browser | Web search via `html.duckduckgo.com`. Supports `--region` (e.g. `jp-jp`, `us-en`), `--time` (`d`, `w`, `m`, `y`), and `--offset` for pagination |
| `duckduckgo suggest <keyword>` | PUBLIC (no browser) | Autocomplete suggestions via `duckduckgo.com/ac/` JSON API |

### Brave Search (1 command)
| Command | Strategy | Description |
|---|---|---|
| `brave search <keyword>` | PUBLIC + browser | Web search via `search.brave.com`. Supports `--offset` for pagination (GET-based, ~18 results/page) |

### Yahoo Search (1 command)
| Command | Strategy | Description |
|---|---|---|
| `yahoo search <keyword>` | PUBLIC + browser | Web search via `search.yahoo.com` (Bing-powered). Supports `--page` for pagination (~7 results/page) |

## Technical Highlights

**DuckDuckGo pagination**: Uses XHR POST + `DOMParser` to fetch subsequent pages without triggering page navigation. This avoids the issue where `form.submit()` causes page context loss and empty DOM results.

**Brave DOM selectors**: The current `.snippet > .title` selectors from other open-source implementations are outdated. Our implementation uses the actual current selectors (`.search-snippet-title`, `.generic-snippet .content`) discovered by inspecting Braves live DOM.

**Yahoo URL decoding**: Extracts real URLs from Yahoos `RU=.../RK=` redirect wrapper structure.

## Testing
- 16 unit tests across 4 test files
- All tests pass
- Verified with real-world queries (e.g. "特朗普访华", "test")
- Verified pagination returns distinct results across pages

## Files Changed
- `clis/duckduckgo/search.js` — DuckDuckGo web search adapter
- `clis/duckduckgo/suggest.js` — DuckDuckGo autocomplete adapter
- `clis/duckduckgo/search.test.js` + `suggest.test.js`
- `clis/brave/search.js` — Brave Search adapter
- `clis/brave/search.test.js`
- `clis/yahoo/search.js` — Yahoo Search adapter
- `clis/yahoo/search.test.js`
- `cli-manifest.json` — regenerated (821 entries)

Closes #1545
