### PR TITLE
feat: add Flomo memos reader adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9766,7 +9766,7 @@
     "type": "js",
     "modulePath": "flomo/memos.js",
     "sourceFile": "flomo/memos.js",
-    "navigateBefore": "https://flomoapp.com/mine"
+    "navigateBefore": "https://v.flomoapp.com/"
   },
   {
     "site": "gemini",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9739,8 +9739,8 @@
     "description": "List your Flomo memos",
     "access": "read",
     "domain": "flomoapp.com",
-    "strategy": "public",
-    "browser": false,
+    "strategy": "cookie",
+    "browser": true,
     "args": [
       {
         "name": "limit",
@@ -9754,19 +9754,6 @@
         "type": "str",
         "required": false,
         "help": "Pagination cursor: slug of the last memo from previous page"
-      },
-      {
-        "name": "tz",
-        "type": "str",
-        "default": "8:0",
-        "required": false,
-        "help": "Timezone offset (e.g. 8:0 for Beijing)"
-      },
-      {
-        "name": "token",
-        "type": "str",
-        "required": false,
-        "help": "Flomo API token. Falls back to FLOMO_ACCESS_TOKEN env var"
       }
     ],
     "columns": [
@@ -9778,7 +9765,8 @@
     ],
     "type": "js",
     "modulePath": "flomo/memos.js",
-    "sourceFile": "flomo/memos.js"
+    "sourceFile": "flomo/memos.js",
+    "navigateBefore": "https://flomoapp.com/mine"
   },
   {
     "site": "gemini",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9761,6 +9761,12 @@
         "default": "8:0",
         "required": false,
         "help": "Timezone offset (e.g. 8:0 for Beijing)"
+      },
+      {
+        "name": "token",
+        "type": "str",
+        "required": false,
+        "help": "Flomo API token. Falls back to FLOMO_ACCESS_TOKEN env var"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9747,13 +9747,19 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of memos to fetch (max 200)"
+        "help": "Number of memos (max 200). Use --limit 200 to fetch all"
+      },
+      {
+        "name": "since",
+        "type": "int",
+        "required": false,
+        "help": "Only memos updated after this Unix timestamp (e.g. 1735689600 for 2025)"
       },
       {
         "name": "slug",
         "type": "str",
         "required": false,
-        "help": "Pagination cursor: slug of the last memo from previous page"
+        "help": "[Experimental] Pagination cursor from previous response"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9766,6 +9766,7 @@
       "content",
       "slug",
       "tags",
+      "images",
       "created_at",
       "updated_at"
     ],

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9734,6 +9734,47 @@
     "sourceFile": "flathub/search.js"
   },
   {
+    "site": "flomo",
+    "name": "memos",
+    "description": "List your Flomo memos",
+    "access": "read",
+    "domain": "flomoapp.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of memos to fetch (max 200)"
+      },
+      {
+        "name": "slug",
+        "type": "str",
+        "required": false,
+        "help": "Pagination cursor: slug of the last memo from previous page"
+      },
+      {
+        "name": "tz",
+        "type": "str",
+        "default": "8:0",
+        "required": false,
+        "help": "Timezone offset (e.g. 8:0 for Beijing)"
+      }
+    ],
+    "columns": [
+      "content",
+      "slug",
+      "tags",
+      "created_at",
+      "updated_at"
+    ],
+    "type": "js",
+    "modulePath": "flomo/memos.js",
+    "sourceFile": "flomo/memos.js"
+  },
+  {
     "site": "gemini",
     "name": "ask",
     "description": "Send a prompt to Gemini and return only the assistant response",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9747,22 +9747,24 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of memos (max 200). Use --limit 200 to fetch all"
+        "help": "Number of memos to fetch (1-200)"
       },
       {
         "name": "since",
         "type": "int",
         "required": false,
-        "help": "Only memos updated after this Unix timestamp (e.g. 1735689600 for 2025)"
+        "help": "Only memos updated after this Unix timestamp in seconds"
       },
       {
         "name": "slug",
         "type": "str",
         "required": false,
-        "help": "[Experimental] Pagination cursor from previous response"
+        "help": "Pagination cursor from a previous memo page"
       }
     ],
     "columns": [
+      "id",
+      "url",
       "content",
       "slug",
       "tags",

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -1,12 +1,68 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
+import {
+  ArgumentError,
+  AuthRequiredError,
+  CommandExecutionError,
+  EmptyResultError,
+} from '@jackwener/opencli/errors';
 import { createHash } from 'node:crypto';
-import { clampInt } from '../_shared/common.js';
+
+const FLOMO_APP_DOMAIN = 'v.flomoapp.com';
+const FLOMO_API_DOMAIN = 'flomoapp.com';
+const MAX_LIMIT = 200;
+
+function unwrapBrowserResult(value) {
+  if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
+    return value.data;
+  }
+  return value;
+}
+
+function parsePositiveIntArg(value, name, fallback, max) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) {
+    throw new ArgumentError(`flomo memos --${name} must be a positive integer`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > max) {
+    throw new ArgumentError(`flomo memos --${name} must be between 1 and ${max}`);
+  }
+  return parsed;
+}
+
+function parseSinceArg(value) {
+  if (value === undefined || value === null || value === '') {
+    return 0;
+  }
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) {
+    throw new ArgumentError('flomo memos --since must be a non-negative Unix timestamp in seconds');
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new ArgumentError('flomo memos --since must be a safe integer Unix timestamp in seconds');
+  }
+  return parsed;
+}
+
+function parseSlugArg(value) {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+  const slug = String(value).trim();
+  if (!/^[A-Za-z0-9_-]{1,256}$/.test(slug)) {
+    throw new ArgumentError('flomo memos --slug must be an opaque memo cursor containing only letters, numbers, _ or -');
+  }
+  return slug;
+}
 
 function buildSignedUrl(limit, since, slug) {
-  var params = {
+  const params = {
     limit: String(limit),
-    latest_updated_at: String(since != null ? since : 0),
+    latest_updated_at: String(since),
     tz: '8:0',
     timestamp: String(Math.floor(Date.now() / 1000)),
     api_key: 'flomo_web',
@@ -15,76 +71,158 @@ function buildSignedUrl(limit, since, slug) {
     webp: '1',
   };
   if (slug) params.latest_slug = slug;
-  var keys = Object.keys(params).sort();
-  var s = keys.map(function(k) { return k + '=' + params[k]; }).join('&');
-  params.sign = createHash('md5').update(s + 'dbbc3dd73364b4084c3a69346e0ce2b2').digest('hex');
+  const keys = Object.keys(params).sort();
+  const signBase = keys.map((key) => `${key}=${params[key]}`).join('&');
+  params.sign = createHash('md5').update(signBase + 'dbbc3dd73364b4084c3a69346e0ce2b2').digest('hex');
   return 'https://flomoapp.com/api/v1/memo/updated/?' + new URLSearchParams(params).toString();
 }
 
 function buildGetTokenJs() {
-  return '(function(){try{var m=JSON.parse(localStorage.getItem("me"));return m&&m.access_token?m.access_token:null;}catch(e){return null;}})()';
+  return `
+    (() => {
+      try {
+        const raw = localStorage.getItem('me');
+        if (!raw) return null;
+        const me = JSON.parse(raw);
+        const token = me?.access_token || me?.data?.access_token || '';
+        return typeof token === 'string' && token.trim() ? token.trim() : null;
+      } catch {
+        return null;
+      }
+    })()
+  `;
 }
 
-var command = cli({
+function isAuthFailureMessage(message) {
+  return /auth|unauth|login|token|permission|forbidden|unauthorized|登录|登陆|鉴权|权限/i.test(String(message || ''));
+}
+
+function normalizeTags(tags) {
+  if (!Array.isArray(tags)) return '';
+  return tags
+    .map((tag) => {
+      if (typeof tag === 'string') return tag;
+      return tag?.name || tag?.tag || tag?.content || '';
+    })
+    .map((tag) => String(tag).trim())
+    .filter(Boolean)
+    .join(', ');
+}
+
+function normalizeImages(files) {
+  if (!Array.isArray(files)) return '';
+  return files
+    .map((file) => file?.thumbnail_url || file?.url || '')
+    .map((url) => String(url).trim())
+    .filter(Boolean)
+    .join(' | ');
+}
+
+function memoUrl(slug) {
+  return slug ? `https://${FLOMO_APP_DOMAIN}/mine/?memo_id=${encodeURIComponent(slug)}` : '';
+}
+
+function normalizeMemo(memo) {
+  if (!memo || typeof memo !== 'object' || Array.isArray(memo)) {
+    throw new CommandExecutionError('Flomo API returned a malformed memo entry');
+  }
+  const slug = String(memo.slug || memo.id || '').trim();
+  if (!slug) {
+    throw new CommandExecutionError('Flomo API returned a memo without slug/id');
+  }
+  return {
+    id: slug,
+    url: memoUrl(slug),
+    content: String(memo.content || '').trim(),
+    slug,
+    tags: normalizeTags(memo.tags),
+    images: normalizeImages(memo.files),
+    created_at: String(memo.created_at || ''),
+    updated_at: String(memo.updated_at || ''),
+  };
+}
+
+async function fetchFlomoJson(url, token) {
+  let resp;
+  try {
+    resp = await fetch(url, {
+      headers: {
+        Authorization: 'Bearer ' + token,
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+        Accept: 'application/json',
+      },
+    });
+  } catch (err) {
+    throw new CommandExecutionError(`Failed to fetch Flomo memos: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (resp.status === 401 || resp.status === 403) {
+    throw new AuthRequiredError(FLOMO_API_DOMAIN, `Flomo API returned HTTP ${resp.status}; please refresh your Flomo login session`);
+  }
+  if (!resp.ok) {
+    throw new CommandExecutionError(`Flomo API returned HTTP ${resp.status}`);
+  }
+  try {
+    return await resp.json();
+  } catch (err) {
+    throw new CommandExecutionError(`Flomo API returned malformed JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function readAccessToken(page) {
+  const token = unwrapBrowserResult(await page.evaluate(buildGetTokenJs()));
+  if (typeof token !== 'string' || !token.trim()) {
+    throw new AuthRequiredError(FLOMO_API_DOMAIN, 'Flomo memos requires an active signed-in Flomo browser session');
+  }
+  return token.trim();
+}
+
+const command = cli({
   site: 'flomo',
   name: 'memos',
   access: 'read',
   description: 'List your Flomo memos',
-  domain: 'flomoapp.com',
+  domain: FLOMO_API_DOMAIN,
   strategy: Strategy.COOKIE,
   browser: true,
-  navigateBefore: 'https://v.flomoapp.com/',
+  navigateBefore: `https://${FLOMO_APP_DOMAIN}/`,
   args: [
-    { name: 'limit', type: 'int', default: 20, help: 'Number of memos (max 200). Use --limit 200 to fetch all' },
-    { name: 'since', type: 'int', help: 'Only memos updated after this Unix timestamp (e.g. 1735689600 for 2025)' },
-    { name: 'slug', help: '[Experimental] Pagination cursor from previous response' },
+    { name: 'limit', type: 'int', default: 20, help: 'Number of memos to fetch (1-200)' },
+    { name: 'since', type: 'int', help: 'Only memos updated after this Unix timestamp in seconds' },
+    { name: 'slug', help: 'Pagination cursor from a previous memo page' },
   ],
-  columns: ['content', 'slug', 'tags', 'images', 'created_at', 'updated_at'],
-  func: async function(page, kwargs) {
-    var limit = clampInt(kwargs.limit, 20, 1, 200);
-    await page.wait(3).catch(function() {});
-    var token = await page.evaluate(buildGetTokenJs());
-    if (!token) {
-      throw new CliError('AUTH_REQUIRED', 'Not logged in to Flomo', 'Open https://v.flomoapp.com in this browser and log in first');
-    }
-    var url = buildSignedUrl(limit, kwargs.since, kwargs.slug);
-    var resp;
-    try {
-      resp = await fetch(url, {
-        headers: {
-          'Authorization': 'Bearer ' + token,
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-          'Accept': 'application/json',
-        },
-      });
-    } catch (err) {
-      throw new CliError('NETWORK_ERROR', 'Failed to fetch memos: ' + (err instanceof Error ? err.message : String(err)));
-    }
-    if (!resp.ok) {
-      throw new CliError('HTTP_ERROR', 'API returned ' + resp.status);
-    }
-    var body;
-    try {
-      body = await resp.json();
-    } catch (_) {
-      throw new CliError('PARSE_ERROR', 'Failed to parse API response');
+  columns: ['id', 'url', 'content', 'slug', 'tags', 'images', 'created_at', 'updated_at'],
+  func: async (page, kwargs) => {
+    const limit = parsePositiveIntArg(kwargs.limit, 'limit', 20, MAX_LIMIT);
+    const since = parseSinceArg(kwargs.since);
+    const slug = parseSlugArg(kwargs.slug);
+    await page.wait(3).catch(() => {});
+    const token = await readAccessToken(page);
+    const body = await fetchFlomoJson(buildSignedUrl(limit, since, slug), token);
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw new CommandExecutionError('Flomo API returned a malformed response');
     }
     if (body.code !== 0) {
-      throw new CliError('API_ERROR', body.message || 'API error code ' + body.code);
+      const message = body.message || `Flomo API error code ${body.code}`;
+      if (isAuthFailureMessage(message)) {
+        throw new AuthRequiredError(FLOMO_API_DOMAIN, message);
+      }
+      throw new CommandExecutionError(message);
     }
-    var memos = Array.isArray(body.data) ? body.data : [];
-    return memos.map(function(m) {
-      var images = Array.isArray(m.files) ? m.files.map(function(f) { return f.thumbnail_url || f.url || ''; }).filter(Boolean) : [];
-      return {
-        content: (m.content || '').trim(),
-        slug: m.slug || '',
-        tags: Array.isArray(m.tags) ? m.tags.join(', ') : '',
-        images: images.join(' | '),
-        created_at: m.created_at || '',
-        updated_at: m.updated_at || '',
-      };
-    });
+    if (!Array.isArray(body.data)) {
+      throw new CommandExecutionError('Flomo API returned malformed memo data');
+    }
+    if (body.data.length === 0) {
+      throw new EmptyResultError('flomo memos', 'No Flomo memos matched the requested filters.');
+    }
+    return body.data.map(normalizeMemo);
   },
 });
 
-export var __test__ = { command: command };
+export const __test__ = {
+  buildSignedUrl,
+  command,
+  normalizeMemo,
+  parsePositiveIntArg,
+  parseSinceArg,
+  parseSlugArg,
+};

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -2,10 +2,10 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
 import { createHash } from 'node:crypto';
 
-function buildSignedUrl(limit, slug) {
+function buildSignedUrl(limit, since, slug) {
   var params = {
     limit: String(limit),
-    latest_updated_at: '0',
+    latest_updated_at: String(since != null ? since : 0),
     tz: '8:0',
     timestamp: String(Math.floor(Date.now() / 1000)),
     api_key: 'flomo_web',
@@ -34,8 +34,9 @@ var command = cli({
   browser: true,
   navigateBefore: 'https://v.flomoapp.com/',
   args: [
-    { name: 'limit', type: 'int', default: 20, help: 'Number of memos to fetch (max 200)' },
-    { name: 'slug', help: 'Pagination cursor: slug of the last memo from previous page' },
+    { name: 'limit', type: 'int', default: 20, help: 'Number of memos (max 200). Use --limit 200 to fetch all' },
+    { name: 'since', type: 'int', help: 'Only memos updated after this Unix timestamp (e.g. 1735689600 for 2025)' },
+    { name: 'slug', help: '[Experimental] Pagination cursor from previous response' },
   ],
   columns: ['content', 'slug', 'tags', 'created_at', 'updated_at'],
   func: async function(page, kwargs) {
@@ -45,7 +46,7 @@ var command = cli({
     if (!token) {
       throw new CliError('AUTH_REQUIRED', 'Not logged in to Flomo', 'Open https://v.flomoapp.com in this browser and log in first');
     }
-    var url = buildSignedUrl(limit, kwargs.slug);
+    var url = buildSignedUrl(limit, kwargs.since, kwargs.slug);
     var resp;
     try {
       resp = await fetch(url, {

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -20,22 +20,8 @@ function buildSignedUrl(limit, slug) {
   return 'https://flomoapp.com/api/v1/memo/updated/?' + new URLSearchParams(params).toString();
 }
 
-function buildTokenCheckJs() {
-  return '(function(){var t=window.localStorage.getItem("flomo_token");return t?{ok:true}:{ok:false};})()';
-}
-
-function buildFetchJs(url) {
-  return (
-    '(function(){try{' +
-    'var tkn=window.localStorage.getItem("flomo_token");' +
-    'if(!tkn)return{error:"no_token"};' +
-    'return fetch("' + url + '",{' +
-    'headers:{"Authorization":"Bearer "+tkn,"Accept":"application/json"}' +
-    '}).then(function(r){return r.json();}).then(function(j){' +
-    'if(j.code!==0)return{error:j.message||"err_"+j.code};' +
-    'return{items:j.data||[]};' +
-    '});}catch(e){return Promise.resolve({error:e.message});}})()'
-  );
+function buildGetTokenJs() {
+  return '(function(){try{var m=JSON.parse(localStorage.getItem("me"));return m&&m.access_token?m.access_token:null;}catch(e){return null;}})()';
 }
 
 var command = cli({
@@ -46,7 +32,7 @@ var command = cli({
   domain: 'flomoapp.com',
   strategy: Strategy.COOKIE,
   browser: true,
-  navigateBefore: 'https://flomoapp.com/mine',
+  navigateBefore: 'https://v.flomoapp.com/',
   args: [
     { name: 'limit', type: 'int', default: 20, help: 'Number of memos to fetch (max 200)' },
     { name: 'slug', help: 'Pagination cursor: slug of the last memo from previous page' },
@@ -55,16 +41,36 @@ var command = cli({
   func: async function(page, kwargs) {
     var limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 200));
     await page.wait(3).catch(function() {});
-    var check = await page.evaluate(buildTokenCheckJs());
-    if (!check || !check.ok) {
-      throw new CliError('AUTH_REQUIRED', 'Not logged in to Flomo', 'Open https://flomoapp.com in your browser, log in, then run this command again');
+    var token = await page.evaluate(buildGetTokenJs());
+    if (!token) {
+      throw new CliError('AUTH_REQUIRED', 'Not logged in to Flomo', 'Open https://v.flomoapp.com in this browser and log in first');
     }
     var url = buildSignedUrl(limit, kwargs.slug);
-    var data = await page.evaluate(buildFetchJs(url));
-    if (!data || data.error) {
-      throw new CliError('API_ERROR', 'Failed to fetch memos: ' + ((data && data.error) || 'unknown'));
+    var resp;
+    try {
+      resp = await fetch(url, {
+        headers: {
+          'Authorization': 'Bearer ' + token,
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+          'Accept': 'application/json',
+        },
+      });
+    } catch (err) {
+      throw new CliError('NETWORK_ERROR', 'Failed to fetch memos: ' + (err instanceof Error ? err.message : String(err)));
     }
-    var memos = Array.isArray(data.items) ? data.items : [];
+    if (!resp.ok) {
+      throw new CliError('HTTP_ERROR', 'API returned ' + resp.status);
+    }
+    var body;
+    try {
+      body = await resp.json();
+    } catch (_) {
+      throw new CliError('PARSE_ERROR', 'Failed to parse API response');
+    }
+    if (body.code !== 0) {
+      throw new CliError('API_ERROR', body.message || 'API error code ' + body.code);
+    }
+    var memos = Array.isArray(body.data) ? body.data : [];
     return memos.map(function(m) {
       return {
         content: (m.content || '').trim(),

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -38,7 +38,7 @@ var command = cli({
     { name: 'since', type: 'int', help: 'Only memos updated after this Unix timestamp (e.g. 1735689600 for 2025)' },
     { name: 'slug', help: '[Experimental] Pagination cursor from previous response' },
   ],
-  columns: ['content', 'slug', 'tags', 'created_at', 'updated_at'],
+  columns: ['content', 'slug', 'tags', 'images', 'created_at', 'updated_at'],
   func: async function(page, kwargs) {
     var limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 200));
     await page.wait(3).catch(function() {});
@@ -73,10 +73,12 @@ var command = cli({
     }
     var memos = Array.isArray(body.data) ? body.data : [];
     return memos.map(function(m) {
+      var images = Array.isArray(m.files) ? m.files.map(function(f) { return f.thumbnail_url || f.url || ''; }).filter(Boolean) : [];
       return {
         content: (m.content || '').trim(),
         slug: m.slug || '',
         tags: Array.isArray(m.tags) ? m.tags.join(', ') : '',
+        images: images.join(' | '),
         created_at: m.created_at || '',
         updated_at: m.updated_at || '',
       };

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -1,0 +1,87 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
+import { createHash } from 'node:crypto';
+
+function signParams(params, secret) {
+  var keys = Object.keys(params).sort();
+  var s = keys.map(function(k) { return k + '=' + params[k]; }).join('&');
+  return createHash('md5').update(s + secret).digest('hex');
+}
+
+function buildUrl(limit, slug, updatedAt, tz) {
+  var params = {
+    limit: String(limit),
+    latest_updated_at: String(updatedAt != null ? updatedAt : 0),
+    tz: tz || '8:0',
+    timestamp: String(Math.floor(Date.now() / 1000)),
+    api_key: 'flomo_web',
+    app_version: '4.0',
+    platform: 'web',
+    webp: '1',
+  };
+  if (slug) params.latest_slug = slug;
+  var secret = 'dbbc3dd73364b4084c3a69346e0ce2b2';
+  params.sign = signParams(params, secret);
+  return 'https://flomoapp.com/api/v1/memo/updated/?' + new URLSearchParams(params).toString();
+}
+
+var command = cli({
+  site: 'flomo',
+  name: 'memos',
+  access: 'read',
+  description: 'List your Flomo memos',
+  domain: 'flomoapp.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 20, help: 'Number of memos to fetch (max 200)' },
+    { name: 'slug', help: 'Pagination cursor: slug of the last memo from previous page' },
+    { name: 'tz', default: '8:0', help: 'Timezone offset (e.g. 8:0 for Beijing)' },
+  ],
+  columns: ['content', 'slug', 'tags', 'created_at', 'updated_at'],
+  func: async function(kwargs) {
+    var limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 200));
+    var token = process.env.FLOMO_ACCESS_TOKEN || '';
+    if (!token) {
+      throw new CliError('AUTH_REQUIRED', 'FLOMO_ACCESS_TOKEN is not set', 'Set the FLOMO_ACCESS_TOKEN environment variable. You can find your token in the browser DevTools > Application > Local Storage > flomoapp.com > flomo_token');
+    }
+    var url = buildUrl(limit, kwargs.slug, null, kwargs.tz);
+    var resp;
+    try {
+      resp = await fetch(url, {
+        headers: {
+          'Authorization': 'Bearer ' + token,
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+          'Referer': 'https://flomoapp.com/',
+          'Accept': 'application/json',
+        },
+      });
+    } catch (err) {
+      throw new CliError('NETWORK_ERROR', 'Failed to fetch memos: ' + (err instanceof Error ? err.message : String(err)));
+    }
+    if (!resp.ok) {
+      throw new CliError('HTTP_ERROR', 'API returned ' + resp.status + ' ' + resp.statusText);
+    }
+    var body;
+    try {
+      body = await resp.json();
+    } catch (_) {
+      throw new CliError('PARSE_ERROR', 'Failed to parse API response');
+    }
+    if (body.code !== 0) {
+      throw new CliError('API_ERROR', 'API error: ' + (body.message || 'code ' + body.code));
+    }
+    var memos = Array.isArray(body.data) ? body.data : [];
+    return memos.map(function(m) {
+      return {
+        content: (m.content || '').trim(),
+        slug: m.slug || '',
+        tags: Array.isArray(m.tags) ? m.tags.join(', ') : '',
+        created_at: m.created_at || '',
+        updated_at: m.updated_at || '',
+      };
+    });
+  },
+});
+
+export var __test__ = { command: command };

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -37,13 +37,14 @@ var command = cli({
     { name: 'limit', type: 'int', default: 20, help: 'Number of memos to fetch (max 200)' },
     { name: 'slug', help: 'Pagination cursor: slug of the last memo from previous page' },
     { name: 'tz', default: '8:0', help: 'Timezone offset (e.g. 8:0 for Beijing)' },
+    { name: 'token', help: 'Flomo API token. Falls back to FLOMO_ACCESS_TOKEN env var' },
   ],
   columns: ['content', 'slug', 'tags', 'created_at', 'updated_at'],
   func: async function(kwargs) {
     var limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 200));
-    var token = process.env.FLOMO_ACCESS_TOKEN || '';
+    var token = kwargs.token || process.env.FLOMO_ACCESS_TOKEN || '';
     if (!token) {
-      throw new CliError('AUTH_REQUIRED', 'FLOMO_ACCESS_TOKEN is not set', 'Set the FLOMO_ACCESS_TOKEN environment variable. You can find your token in the browser DevTools > Application > Local Storage > flomoapp.com > flomo_token');
+      throw new CliError('AUTH_REQUIRED', 'Flomo token is required', 'Pass --token <token> or set FLOMO_ACCESS_TOKEN env var. Find your token in browser DevTools > Application > Local Storage > flomoapp.com > flomo_token');
     }
     var url = buildUrl(limit, kwargs.slug, null, kwargs.tz);
     var resp;

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -1,6 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
 import { createHash } from 'node:crypto';
+import { clampInt } from '../_shared/common.js';
 
 function buildSignedUrl(limit, since, slug) {
   var params = {
@@ -40,7 +41,7 @@ var command = cli({
   ],
   columns: ['content', 'slug', 'tags', 'images', 'created_at', 'updated_at'],
   func: async function(page, kwargs) {
-    var limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 200));
+    var limit = clampInt(kwargs.limit, 20, 1, 200);
     await page.wait(3).catch(function() {});
     var token = await page.evaluate(buildGetTokenJs());
     if (!token) {

--- a/clis/flomo/memos.js
+++ b/clis/flomo/memos.js
@@ -2,17 +2,11 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
 import { createHash } from 'node:crypto';
 
-function signParams(params, secret) {
-  var keys = Object.keys(params).sort();
-  var s = keys.map(function(k) { return k + '=' + params[k]; }).join('&');
-  return createHash('md5').update(s + secret).digest('hex');
-}
-
-function buildUrl(limit, slug, updatedAt, tz) {
+function buildSignedUrl(limit, slug) {
   var params = {
     limit: String(limit),
-    latest_updated_at: String(updatedAt != null ? updatedAt : 0),
-    tz: tz || '8:0',
+    latest_updated_at: '0',
+    tz: '8:0',
     timestamp: String(Math.floor(Date.now() / 1000)),
     api_key: 'flomo_web',
     app_version: '4.0',
@@ -20,9 +14,28 @@ function buildUrl(limit, slug, updatedAt, tz) {
     webp: '1',
   };
   if (slug) params.latest_slug = slug;
-  var secret = 'dbbc3dd73364b4084c3a69346e0ce2b2';
-  params.sign = signParams(params, secret);
+  var keys = Object.keys(params).sort();
+  var s = keys.map(function(k) { return k + '=' + params[k]; }).join('&');
+  params.sign = createHash('md5').update(s + 'dbbc3dd73364b4084c3a69346e0ce2b2').digest('hex');
   return 'https://flomoapp.com/api/v1/memo/updated/?' + new URLSearchParams(params).toString();
+}
+
+function buildTokenCheckJs() {
+  return '(function(){var t=window.localStorage.getItem("flomo_token");return t?{ok:true}:{ok:false};})()';
+}
+
+function buildFetchJs(url) {
+  return (
+    '(function(){try{' +
+    'var tkn=window.localStorage.getItem("flomo_token");' +
+    'if(!tkn)return{error:"no_token"};' +
+    'return fetch("' + url + '",{' +
+    'headers:{"Authorization":"Bearer "+tkn,"Accept":"application/json"}' +
+    '}).then(function(r){return r.json();}).then(function(j){' +
+    'if(j.code!==0)return{error:j.message||"err_"+j.code};' +
+    'return{items:j.data||[]};' +
+    '});}catch(e){return Promise.resolve({error:e.message});}})()'
+  );
 }
 
 var command = cli({
@@ -31,48 +44,27 @@ var command = cli({
   access: 'read',
   description: 'List your Flomo memos',
   domain: 'flomoapp.com',
-  strategy: Strategy.PUBLIC,
-  browser: false,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: 'https://flomoapp.com/mine',
   args: [
     { name: 'limit', type: 'int', default: 20, help: 'Number of memos to fetch (max 200)' },
     { name: 'slug', help: 'Pagination cursor: slug of the last memo from previous page' },
-    { name: 'tz', default: '8:0', help: 'Timezone offset (e.g. 8:0 for Beijing)' },
-    { name: 'token', help: 'Flomo API token. Falls back to FLOMO_ACCESS_TOKEN env var' },
   ],
   columns: ['content', 'slug', 'tags', 'created_at', 'updated_at'],
-  func: async function(kwargs) {
+  func: async function(page, kwargs) {
     var limit = Math.max(1, Math.min(Number(kwargs.limit) || 20, 200));
-    var token = kwargs.token || process.env.FLOMO_ACCESS_TOKEN || '';
-    if (!token) {
-      throw new CliError('AUTH_REQUIRED', 'Flomo token is required', 'Pass --token <token> or set FLOMO_ACCESS_TOKEN env var. Find your token in browser DevTools > Application > Local Storage > flomoapp.com > flomo_token');
+    await page.wait(3).catch(function() {});
+    var check = await page.evaluate(buildTokenCheckJs());
+    if (!check || !check.ok) {
+      throw new CliError('AUTH_REQUIRED', 'Not logged in to Flomo', 'Open https://flomoapp.com in your browser, log in, then run this command again');
     }
-    var url = buildUrl(limit, kwargs.slug, null, kwargs.tz);
-    var resp;
-    try {
-      resp = await fetch(url, {
-        headers: {
-          'Authorization': 'Bearer ' + token,
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-          'Referer': 'https://flomoapp.com/',
-          'Accept': 'application/json',
-        },
-      });
-    } catch (err) {
-      throw new CliError('NETWORK_ERROR', 'Failed to fetch memos: ' + (err instanceof Error ? err.message : String(err)));
+    var url = buildSignedUrl(limit, kwargs.slug);
+    var data = await page.evaluate(buildFetchJs(url));
+    if (!data || data.error) {
+      throw new CliError('API_ERROR', 'Failed to fetch memos: ' + ((data && data.error) || 'unknown'));
     }
-    if (!resp.ok) {
-      throw new CliError('HTTP_ERROR', 'API returned ' + resp.status + ' ' + resp.statusText);
-    }
-    var body;
-    try {
-      body = await resp.json();
-    } catch (_) {
-      throw new CliError('PARSE_ERROR', 'Failed to parse API response');
-    }
-    if (body.code !== 0) {
-      throw new CliError('API_ERROR', 'API error: ' + (body.message || 'code ' + body.code));
-    }
-    var memos = Array.isArray(body.data) ? body.data : [];
+    var memos = Array.isArray(data.items) ? data.items : [];
     return memos.map(function(m) {
       return {
         content: (m.content || '').trim(),

--- a/clis/flomo/memos.test.js
+++ b/clis/flomo/memos.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+const { __test__ } = await import('./memos.js');
+var command = __test__.command;
+
+describe('flomo memos', function() {
+  it('should register as a valid command', function() {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('flomo');
+    expect(command.name).toBe('memos');
+    expect(command.access).toBe('read');
+    expect(command.browser).toBe(false);
+    expect(command.strategy).toBe('public');
+  });
+
+  it('should define limit arg with default 20', function() {
+    var arg = command.args.find(function(a) { return a.name === 'limit'; });
+    expect(arg).toBeDefined();
+    expect(arg.type).toBe('int');
+    expect(arg.default).toBe(20);
+  });
+
+  it('should define slug arg for pagination', function() {
+    var arg = command.args.find(function(a) { return a.name === 'slug'; });
+    expect(arg).toBeDefined();
+  });
+
+  it('should define output columns', function() {
+    expect(command.columns).toContain('content');
+    expect(command.columns).toContain('slug');
+    expect(command.columns).toContain('tags');
+    expect(command.columns).toContain('created_at');
+    expect(command.columns).toContain('updated_at');
+  });
+});

--- a/clis/flomo/memos.test.js
+++ b/clis/flomo/memos.test.js
@@ -1,41 +1,144 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ArgumentError,
+  AuthRequiredError,
+  CommandExecutionError,
+  EmptyResultError,
+} from '@jackwener/opencli/errors';
 
 const { __test__ } = await import('./memos.js');
-var command = __test__.command;
+const { command, normalizeMemo, parsePositiveIntArg, parseSinceArg, parseSlugArg } = __test__;
 
-describe('flomo memos', function() {
-  it('should register as a valid command', function() {
-    expect(command).toBeDefined();
+function createPage(token = 'token-123') {
+  return {
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue({ session: 'browser:default', data: token }),
+  };
+}
+
+function mockFetchJson(body, status = 200) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  }));
+}
+
+describe('flomo memos registration', () => {
+  it('registers as a browser cookie read command with stable columns', () => {
     expect(command.site).toBe('flomo');
     expect(command.name).toBe('memos');
     expect(command.access).toBe('read');
     expect(command.browser).toBe(true);
     expect(command.strategy).toBe('cookie');
+    expect(command.columns).toEqual(['id', 'url', 'content', 'slug', 'tags', 'images', 'created_at', 'updated_at']);
+  });
+});
+
+describe('flomo memos argument validation', () => {
+  it('rejects invalid limits instead of silently clamping', () => {
+    expect(() => parsePositiveIntArg('0', 'limit', 20, 200)).toThrow(ArgumentError);
+    expect(() => parsePositiveIntArg('201', 'limit', 20, 200)).toThrow(ArgumentError);
+    expect(() => parsePositiveIntArg('10.5', 'limit', 20, 200)).toThrow(ArgumentError);
+    expect(() => parsePositiveIntArg('abc', 'limit', 20, 200)).toThrow(ArgumentError);
+    expect(parsePositiveIntArg(undefined, 'limit', 20, 200)).toBe(20);
+    expect(parsePositiveIntArg('200', 'limit', 20, 200)).toBe(200);
   });
 
-  it('should define limit arg with default 20', function() {
-    var arg = command.args.find(function(a) { return a.name === 'limit'; });
-    expect(arg).toBeDefined();
-    expect(arg.type).toBe('int');
-    expect(arg.default).toBe(20);
+  it('rejects invalid since and slug arguments', () => {
+    expect(parseSinceArg(undefined)).toBe(0);
+    expect(parseSinceArg('1735689600')).toBe(1735689600);
+    expect(() => parseSinceArg('-1')).toThrow(ArgumentError);
+    expect(() => parseSinceArg('1.5')).toThrow(ArgumentError);
+    expect(parseSlugArg(undefined)).toBe('');
+    expect(parseSlugArg('abc_DEF-123')).toBe('abc_DEF-123');
+    expect(() => parseSlugArg('bad/slash')).toThrow(ArgumentError);
+    expect(() => parseSlugArg('bad space')).toThrow(ArgumentError);
+  });
+});
+
+describe('flomo memo normalization', () => {
+  it('emits string-safe id/url fields and normalizes tags/images', () => {
+    expect(normalizeMemo({
+      slug: 'memo_12345678901234567890',
+      content: ' <p>Hello</p> ',
+      tags: [{ name: 'work' }, 'idea'],
+      files: [{ thumbnail_url: 'https://img/thumb.jpg' }, { url: 'https://img/full.jpg' }],
+      created_at: '2026-01-01T00:00:00+08:00',
+      updated_at: '2026-01-02T00:00:00+08:00',
+    })).toEqual({
+      id: 'memo_12345678901234567890',
+      url: 'https://v.flomoapp.com/mine/?memo_id=memo_12345678901234567890',
+      content: '<p>Hello</p>',
+      slug: 'memo_12345678901234567890',
+      tags: 'work, idea',
+      images: 'https://img/thumb.jpg | https://img/full.jpg',
+      created_at: '2026-01-01T00:00:00+08:00',
+      updated_at: '2026-01-02T00:00:00+08:00',
+    });
   });
 
-  it('should define since arg for time filter', function() {
-    var arg = command.args.find(function(a) { return a.name === 'since'; });
-    expect(arg).toBeDefined();
-    expect(arg.type).toBe('int');
+  it('fails typed on malformed memo entries', () => {
+    expect(() => normalizeMemo(null)).toThrow(CommandExecutionError);
+    expect(() => normalizeMemo({ content: 'missing slug' })).toThrow(CommandExecutionError);
+  });
+});
+
+describe('flomo memos command', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it('should define slug arg for pagination', function() {
-    var arg = command.args.find(function(a) { return a.name === 'slug'; });
-    expect(arg).toBeDefined();
+  it('reads token from Browser Bridge envelope and returns memo rows', async () => {
+    mockFetchJson({
+      code: 0,
+      data: [{
+        slug: 'memo_1',
+        content: 'hello',
+        tags: ['tag'],
+        files: [],
+        created_at: '2026-01-01',
+        updated_at: '2026-01-02',
+      }],
+    });
+
+    const rows = await command.func(createPage(), { limit: '1' });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('limit=1'), expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer token-123' }),
+    }));
+    expect(rows).toEqual([{
+      id: 'memo_1',
+      url: 'https://v.flomoapp.com/mine/?memo_id=memo_1',
+      content: 'hello',
+      slug: 'memo_1',
+      tags: 'tag',
+      images: '',
+      created_at: '2026-01-01',
+      updated_at: '2026-01-02',
+    }]);
   });
 
-  it('should define output columns', function() {
-    expect(command.columns).toContain('content');
-    expect(command.columns).toContain('slug');
-    expect(command.columns).toContain('tags');
-    expect(command.columns).toContain('created_at');
-    expect(command.columns).toContain('updated_at');
+  it('throws AuthRequiredError when the browser session has no token', async () => {
+    await expect(command.func(createPage(null), {})).rejects.toBeInstanceOf(AuthRequiredError);
+  });
+
+  it('maps Flomo auth failures to AuthRequiredError', async () => {
+    mockFetchJson({ code: 401, message: 'unauthorized' });
+    await expect(command.func(createPage(), {})).rejects.toBeInstanceOf(AuthRequiredError);
+  });
+
+  it('maps HTTP, malformed JSON, malformed data, and empty results to typed errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: vi.fn() }));
+    await expect(command.func(createPage(), {})).rejects.toBeInstanceOf(CommandExecutionError);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200, json: vi.fn().mockRejectedValue(new Error('bad json')) }));
+    await expect(command.func(createPage(), {})).rejects.toBeInstanceOf(CommandExecutionError);
+
+    mockFetchJson({ code: 0, data: {} });
+    await expect(command.func(createPage(), {})).rejects.toBeInstanceOf(CommandExecutionError);
+
+    mockFetchJson({ code: 0, data: [] });
+    await expect(command.func(createPage(), {})).rejects.toBeInstanceOf(EmptyResultError);
   });
 });

--- a/clis/flomo/memos.test.js
+++ b/clis/flomo/memos.test.js
@@ -20,6 +20,12 @@ describe('flomo memos', function() {
     expect(arg.default).toBe(20);
   });
 
+  it('should define since arg for time filter', function() {
+    var arg = command.args.find(function(a) { return a.name === 'since'; });
+    expect(arg).toBeDefined();
+    expect(arg.type).toBe('int');
+  });
+
   it('should define slug arg for pagination', function() {
     var arg = command.args.find(function(a) { return a.name === 'slug'; });
     expect(arg).toBeDefined();

--- a/clis/flomo/memos.test.js
+++ b/clis/flomo/memos.test.js
@@ -9,8 +9,8 @@ describe('flomo memos', function() {
     expect(command.site).toBe('flomo');
     expect(command.name).toBe('memos');
     expect(command.access).toBe('read');
-    expect(command.browser).toBe(false);
-    expect(command.strategy).toBe('public');
+    expect(command.browser).toBe(true);
+    expect(command.strategy).toBe('cookie');
   });
 
   it('should define limit arg with default 20', function() {

--- a/docs/adapters/browser/flomo.md
+++ b/docs/adapters/browser/flomo.md
@@ -12,9 +12,10 @@
 
 - Lists memos from your Flomo account using the browser login session.
 - Reads the access token automatically from `localStorage.me.access_token` — no manual token setup required.
-- Supports `--limit` (up to 200 — enough to fetch all memos in one call).
+- Supports `--limit` from 1 to 200. Invalid values fail instead of being silently clamped.
 - Supports `--since <unix_ts>` to filter by update time.
-- Returns memo content (HTML), slug, tags, image URLs, and timestamps.
+- Supports `--slug <cursor>` for pagination from a previous memo page.
+- Returns stable `id` / `url` fields plus memo content (HTML), slug, tags, image URLs, and timestamps.
 
 ## Current limitations
 
@@ -36,6 +37,9 @@ opencli flomo memos --limit 200
 # Filter by time (Unix timestamp)
 opencli flomo memos --since 1735689600
 
+# Continue from a memo cursor
+opencli flomo memos --slug memo_abc123 --limit 50
+
 # JSON output
 opencli flomo memos --limit 200 -f json
 ```
@@ -51,3 +55,4 @@ opencli flomo memos --limit 200 -f json
 - Memo content is stored as HTML (including formatting tags like `<p>`, `<ul>`, `<strong>`, etc.).
 - Image attachments are returned as thumbnail URLs from Flomo's CDN (`static.flomoapp.com`).
 - The `--since` parameter expects a Unix timestamp in seconds (e.g. `1735689600` = 2025-01-01 00:00:00 UTC).
+- `id` is the memo slug returned by Flomo and `url` opens the memo in Flomo's web app when the session has access.

--- a/docs/adapters/browser/flomo.md
+++ b/docs/adapters/browser/flomo.md
@@ -1,0 +1,53 @@
+# Flomo
+
+**Mode**: 🌐 Cookie · **Domain**: `flomoapp.com`, `v.flomoapp.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli flomo memos` | List your Flomo memos |
+
+## What works today
+
+- Lists memos from your Flomo account using the browser login session.
+- Reads the access token automatically from `localStorage.me.access_token` — no manual token setup required.
+- Supports `--limit` (up to 200 — enough to fetch all memos in one call).
+- Supports `--since <unix_ts>` to filter by update time.
+- Returns memo content (HTML), slug, tags, image URLs, and timestamps.
+
+## Current limitations
+
+- Requires browser mode with an active Flomo login session.
+- The Flomo API uses a custom MD5 signing mechanism with a fixed secret key (embedded in the adapter). If the signing key changes, the adapter will break.
+- `--slug` pagination is experimental and may not work reliably.
+- Image URLs have expiration timestamps in the query string; they may expire after some time.
+- Rate limited to 360 requests per hour.
+
+## Usage Examples
+
+```bash
+# List recent memos
+opencli flomo memos
+
+# Fetch all memos
+opencli flomo memos --limit 200
+
+# Filter by time (Unix timestamp)
+opencli flomo memos --since 1735689600
+
+# JSON output
+opencli flomo memos --limit 200 -f json
+```
+
+## Prerequisites
+
+- Requires Chrome running with an active Flomo session at `v.flomoapp.com`.
+- Standalone mode will auto-launch Chrome; use the [Browser Bridge extension](/guide/browser-bridge) for an established session.
+
+## Notes
+
+- The adapter authenticates via `Strategy.COOKIE` — it reads the Bearer token from `localStorage` in the browser context, then calls the signed API from Node.js.
+- Memo content is stored as HTML (including formatting tags like `<p>`, `<ul>`, `<strong>`, etc.).
+- Image attachments are returned as thumbnail URLs from Flomo's CDN (`static.flomoapp.com`).
+- The `--since` parameter expects a Unix timestamp in seconds (e.g. `1735689600` = 2025-01-01 00:00:00 UTC).


### PR DESCRIPTION
## Summary
Add a new adapter for reading memos from [Flomo](https://flomoapp.com/), a popular card-based note-taking app. The adapter accesses the user's memos via Flomo's internal signed API, with authentication handled through the browser login session.

## Commands

| Command | Description |
|---------|-------------|
| `opencli flomo memos [options]` | List memos from your Flomo account |

## Technical Details

**Auth strategy**: `Strategy.COOKIE` with `browser: true`. The adapter navigates to `v.flomoapp.com` (the Flomo SPA) and reads the access token from `localStorage.me.access_token`. No manual token setup or environment variables needed.

**API integration**: Flomo's internal API at `flomoapp.com/api/v1/memo/updated/` uses a custom MD5 signing mechanism. Parameters are sorted alphabetically and hashed with a static secret key. The adapter implements this signing in Node.js using the built-in `crypto` module.

**Arguments**:
- `--limit` (default: 20, max: 200) — number of memos to fetch. Use `--limit 200` to fetch all memos in one call
- `--since <unix_ts>` — only return memos updated after this timestamp (experimentally verified to work)
- `--slug <cursor>` — experimental cursor-based pagination

**Output columns**: `content`, `slug`, `tags`, `images`, `created_at`, `updated_at`

## Testing
- 5 unit tests (command registration, args validation, columns)
- Verified with real Flomo account data (173 memos, 17 with image attachments)
- Verified `--since` date filtering returns correct results
- Rate limit confirmed: 360 requests/hour

## Files Changed
- `clis/flomo/memos.js` — main adapter implementation
- `clis/flomo/memos.test.js` — unit tests (5 tests)
- `cli-manifest.json` — regenerated

Closes #1548