### PR TITLE
[codex] Fix ChatGPT browser adapter extraction

### DIFF
--- a/clis/chatgpt/detail.js
+++ b/clis/chatgpt/detail.js
@@ -3,12 +3,13 @@ import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
     CHATGPT_DOMAIN,
     CHATGPT_URL,
-    CONVERSATION_MESSAGE_SELECTOR,
+    CONVERSATION_TURN_SELECTOR,
     ensureChatGPTLogin,
     getVisibleMessages,
     messageHtmlToMarkdown,
     normalizeBooleanFlag,
     parseChatGPTConversationId,
+    revealChatGPTConversation,
 } from './utils.js';
 
 export const detailCommand = cli({
@@ -31,12 +32,16 @@ export const detailCommand = cli({
         const wantMarkdown = normalizeBooleanFlag(kwargs.markdown, false);
         await page.goto(`${CHATGPT_URL}/c/${id}`, { settleMs: 2000 });
         try {
-            await page.wait({ selector: CONVERSATION_MESSAGE_SELECTOR, timeout: 10 });
+            await page.wait({ selector: CONVERSATION_TURN_SELECTOR, timeout: 10 });
         } catch {
             // Empty conversation, missing access, or login redirect — handled by ensureChatGPTLogin / EmptyResultError below.
         }
         await ensureChatGPTLogin(page, 'ChatGPT detail requires a logged-in ChatGPT session.');
-        const messages = await getVisibleMessages(page);
+        let messages = await getVisibleMessages(page);
+        if (!messages.length) {
+            await revealChatGPTConversation(page);
+            messages = await getVisibleMessages(page);
+        }
         if (!messages.length) {
             throw new EmptyResultError('chatgpt detail', `No visible ChatGPT messages were found for conversation ${id}.`);
         }

--- a/clis/chatgpt/read.js
+++ b/clis/chatgpt/read.js
@@ -2,11 +2,15 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
     CHATGPT_DOMAIN,
+    CHATGPT_URL,
+    CONVERSATION_TURN_SELECTOR,
     ensureChatGPTLogin,
     ensureOnChatGPT,
+    getConversationList,
     getVisibleMessages,
     messageHtmlToMarkdown,
     normalizeBooleanFlag,
+    revealChatGPTConversation,
 } from './utils.js';
 
 export const readCommand = cli({
@@ -29,7 +33,32 @@ export const readCommand = cli({
         // so the previous standalone 2 s settle is redundant.
         await ensureOnChatGPT(page);
         await ensureChatGPTLogin(page, 'ChatGPT read requires a logged-in ChatGPT session.');
-        const messages = await getVisibleMessages(page);
+        let messages = await getVisibleMessages(page);
+        if (!messages.length) {
+            await revealChatGPTConversation(page);
+            messages = await getVisibleMessages(page);
+        }
+        if (!messages.length) {
+            const currentUrl = await page.evaluate('window.location.href').catch(() => '');
+            if (!String(currentUrl).includes('/c/')) {
+                const conversations = await getConversationList(page);
+                for (const conversation of conversations.slice(0, 5)) {
+                    if (!conversation?.Id) continue;
+                    await page.goto(`${CHATGPT_URL}/c/${conversation.Id}`, { settleMs: 2000 });
+                    try {
+                        await page.wait({ selector: CONVERSATION_TURN_SELECTOR, timeout: 10 });
+                    } catch {
+                        // Empty conversation, access issue, or DOM drift — getVisibleMessages may still use snapshot fallback.
+                    }
+                    messages = await getVisibleMessages(page);
+                    if (!messages.length) {
+                        await revealChatGPTConversation(page);
+                        messages = await getVisibleMessages(page);
+                    }
+                    if (messages.length) break;
+                }
+            }
+        }
         if (!messages.length) {
             throw new EmptyResultError('chatgpt read', 'No visible ChatGPT messages were found in the current conversation.');
         }

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -136,9 +136,11 @@ export async function isOnChatGPT(page) {
 // we only need to know "the composer is ready", not which variant rendered.
 const COMPOSER_WAIT_SELECTOR = '#prompt-textarea, [data-testid="prompt-textarea"]';
 const CONVERSATION_LINK_SELECTOR = 'a[href*="/c/"]';
+const OPEN_SIDEBAR_LABELS = ['Open sidebar', '開啟側邊欄', '打开边栏'];
 // Selector used by detail.js to wait for at least one rendered message bubble
 // after navigating to /c/<id>; mirrors the markup queried by getVisibleMessages.
 export const CONVERSATION_MESSAGE_SELECTOR = '[data-message-author-role], article[data-testid*="conversation-turn"]';
+export const CONVERSATION_TURN_SELECTOR = '[data-message-author-role], article[data-testid*="conversation-turn"], section[data-testid*="conversation-turn"]';
 
 export async function ensureOnChatGPT(page) {
     if (await isOnChatGPT(page)) return false;
@@ -340,12 +342,14 @@ export async function sendChatGPTMessage(page, text) {
 
 export async function getVisibleMessages(page) {
     const result = await page.evaluate(`(() => {
+        const isElement = (el) => el && el.nodeType === Node.ELEMENT_NODE;
         const isVisible = (el) => {
-            if (!(el instanceof HTMLElement)) return false;
+            if (!isElement(el)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
             const rect = el.getBoundingClientRect();
-            return rect.width > 0 && rect.height > 0;
+            if (rect.width > 0 && rect.height > 0) return true;
+            return Array.from(el.children || []).some((child) => isVisible(child));
         };
         const normalize = (value) => String(value || '').replace(/\\u00a0/g, ' ').replace(/[ \\t]+\\n/g, '\\n').replace(/\\n{3,}/g, '\\n\\n').trim();
         const roleOf = (node) => {
@@ -358,11 +362,14 @@ export async function getVisibleMessages(page) {
             const label = node.getAttribute('aria-label') || '';
             if (/assistant|chatgpt/i.test(label)) return 'Assistant';
             if (/you|user/i.test(label)) return 'User';
+            const heading = (node.querySelector('h1,h2,h3,h4,h5,h6')?.textContent || '').trim();
+            if (/chatgpt|assistant|助理|助手/i.test(heading)) return 'Assistant';
+            if (/^(you|user|你|您)\s*(said|說|说)?[：:]?$/i.test(heading)) return 'User';
             return '';
         };
 
-        let nodes = Array.from(document.querySelectorAll('[data-message-author-role], article[data-testid*="conversation-turn"]'));
-        nodes = nodes.filter((node) => node instanceof HTMLElement && isVisible(node));
+        let nodes = Array.from(document.querySelectorAll(${JSON.stringify(CONVERSATION_TURN_SELECTOR)}));
+        nodes = nodes.filter((node) => isElement(node) && isVisible(node));
 
         const rows = [];
         const seen = new Set();
@@ -386,13 +393,107 @@ export async function getVisibleMessages(page) {
         }
         return rows;
     })()`);
-    if (!Array.isArray(result)) return [];
-    return result.map((item, index) => ({
+    const messages = Array.isArray(result) ? result.map((item, index) => ({
         Index: index + 1,
         Role: item?.role === 'Assistant' ? 'Assistant' : 'User',
         Text: String(item?.text || '').trim(),
         Html: String(item?.html || ''),
-    })).filter((item) => item.Text);
+    })).filter((item) => item.Text) : [];
+    if (messages.length) return messages;
+    return await extractMessagesFromSnapshot(page);
+}
+
+export async function revealChatGPTConversation(page) {
+    await page.evaluate(`(() => {
+        const scrollables = [document.scrollingElement, document.documentElement, document.body]
+            .concat(Array.from(document.querySelectorAll('*')))
+            .filter((node) => node && node.scrollHeight > node.clientHeight + 80);
+        for (const node of scrollables) {
+            try { node.scrollTop = 0; } catch {}
+        }
+    })()`);
+    await page.wait(1);
+}
+
+async function extractMessagesFromSnapshot(page) {
+    if (!page || typeof page.snapshot !== 'function') return [];
+    try {
+        const snapshot = await page.snapshot({ viewportExpand: 2000 });
+        return parseMessagesFromSnapshot(snapshot);
+    } catch {
+        return [];
+    }
+}
+
+function parseMessagesFromSnapshot(snapshot) {
+    const text = snapshotText(snapshot);
+    const lines = text.split(/\r?\n/);
+    const turns = [];
+    let current = null;
+
+    const finish = () => {
+        if (!current) return;
+        const body = normalizeSnapshotMessageText(current.lines.join('\n'));
+        if (current.role && body) {
+            turns.push({
+                Index: turns.length + 1,
+                Role: current.role,
+                Text: body,
+                Html: '',
+            });
+        }
+        current = null;
+    };
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (/<section\b[^>]*data-testid=conversation-turn/i.test(line)) {
+            finish();
+            current = { role: '', lines: [] };
+            continue;
+        }
+        if (!current) continue;
+        if (/<div\b[^>]*id=thread-bottom-container/i.test(line) || /aria-label=回覆操作/.test(line)) {
+            finish();
+            continue;
+        }
+        if (/<h[1-6]>\s*ChatGPT\s*(說|说|said)?[：:]?\s*<\/h[1-6]>/i.test(line)) {
+            current.role = 'Assistant';
+            continue;
+        }
+        if (/<h[1-6]>\s*(你|您|You|User)\s*(說|说|said)?[：:]?\s*<\/h[1-6]>/i.test(line)) {
+            current.role = 'User';
+            continue;
+        }
+        const item = snapshotLineText(line);
+        if (item) current.lines.push(item);
+    }
+    finish();
+    return turns;
+}
+
+function snapshotLineText(line) {
+    let text = String(line || '').trim();
+    if (!text) return '';
+    if (/^---$/.test(text) || /^compounds\b/.test(text) || /^interactive:/.test(text)) return '';
+    if (/<(svg|input|button|label|iframe|dialog)\b/i.test(text)) return '';
+    if (/(顯示更多|顯示較少|已思考|複製回應|更多動作|切換模型|資料來源)/.test(text)) return '';
+    text = text.replace(/^\[\d+\]/, '').trim();
+    text = text.replace(/^\|table\|\s*/, '').trim();
+    text = text.replace(/<[^>]+\/>/g, ' ').replace(/<[^>]+>/g, ' ').trim();
+    text = text.replace(/\s+/g, ' ').trim();
+    if (!text || text === '---') return '';
+    return text;
+}
+
+function normalizeSnapshotMessageText(text) {
+    return String(text || '')
+        .split(/\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
 }
 
 export function messageHtmlToMarkdown(html) {
@@ -449,8 +550,12 @@ export async function getConversationList(page) {
     await ensureOnChatGPT(page);
 
     const openSidebar = await page.evaluate(`(() => {
+        const labels = ${JSON.stringify(OPEN_SIDEBAR_LABELS)};
         const button = Array.from(document.querySelectorAll('button'))
-            .find((node) => /open sidebar/i.test(node.getAttribute('aria-label') || ''));
+            .find((node) => {
+                const label = node.getAttribute('aria-label') || '';
+                return /open sidebar/i.test(label) || labels.includes(label);
+            });
         if (button instanceof HTMLElement) {
             button.click();
             return true;
@@ -465,7 +570,10 @@ export async function getConversationList(page) {
         }
     }
 
-    let items = await extractConversationLinks(page);
+    let items = await waitForConversationLinks(page, 5);
+    if (!items.length) {
+        items = await extractConversationLinksFromSnapshot(page);
+    }
     if (!items.length) {
         await page.goto(CHATGPT_URL, { settleMs: 2000 });
         try {
@@ -473,23 +581,39 @@ export async function getConversationList(page) {
         } catch {
             // No conversation links visible after fallback goto; extractConversationLinks returns empty.
         }
-        items = await extractConversationLinks(page);
+        items = await waitForConversationLinks(page, 8);
+        if (!items.length) {
+            items = await extractConversationLinksFromSnapshot(page);
+        }
     }
 
     return items;
 }
 
+async function waitForConversationLinks(page, timeoutSeconds) {
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    do {
+        const items = await extractConversationLinks(page);
+        if (items.length) return items;
+        await page.wait(0.25);
+    } while (Date.now() < deadline);
+    return [];
+}
+
 async function extractConversationLinks(page) {
     const items = await page.evaluate(`(() => {
+        const isElement = (el) => el && el.nodeType === Node.ELEMENT_NODE;
         const isVisible = (el) => {
-            if (!(el instanceof HTMLElement)) return false;
+            if (!isElement(el)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
             const rect = el.getBoundingClientRect();
-            return rect.width > 0 && rect.height > 0;
+            if (rect.width > 0 && rect.height > 0) return true;
+            return Array.from(el.children || []).some((child) => isVisible(child));
         };
         const links = Array.from(document.querySelectorAll('a[href*="/c/"]'))
-            .filter((link) => link instanceof HTMLAnchorElement && isVisible(link));
+            .filter((link) => link?.tagName?.toLowerCase() === 'a' && isVisible(link));
+        const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
         const seen = new Set();
         const rows = [];
         for (const link of links) {
@@ -497,11 +621,11 @@ async function extractConversationLinks(page) {
             const match = href.match(/\\/c\\/([^/?#]+)/);
             if (!match || seen.has(match[1])) continue;
             seen.add(match[1]);
-            const title = (link.innerText || link.textContent || '').replace(/\\s+/g, ' ').trim() || '(untitled)';
+            const title = normalize(link.getAttribute('aria-label') || link.innerText || link.textContent) || '(untitled)';
             rows.push({
                 Id: match[1],
                 Title: title,
-                Url: href.startsWith('http') ? href : ('${CHATGPT_URL}' + href),
+                Url: link.href || (href.startsWith('http') ? href : ('${CHATGPT_URL}' + href)),
             });
         }
         return rows;
@@ -514,6 +638,54 @@ async function extractConversationLinks(page) {
             Url: String(item?.Url || ''),
         })).filter((item) => item.Id)
         : [];
+}
+
+async function extractConversationLinksFromSnapshot(page) {
+    if (!page || typeof page.snapshot !== 'function') return [];
+    try {
+        const snapshot = await page.snapshot({ viewportExpand: 2000 });
+        return parseConversationLinksFromSnapshot(snapshot);
+    } catch {
+        return [];
+    }
+}
+
+function parseConversationLinksFromSnapshot(snapshot) {
+    const text = snapshotText(snapshot);
+    const rows = [];
+    const seen = new Set();
+    const linkPattern = /<a\b[^>]*\bhref=(?:"([^"]+)"|'([^']+)'|([^\s>]+))[^>]*>/g;
+    let match;
+    while ((match = linkPattern.exec(text)) !== null) {
+        const tag = match[0] || '';
+        const href = match[1] || match[2] || match[3] || '';
+        const idMatch = href.match(/\/c\/([^/?#\s]+)/);
+        if (!idMatch || seen.has(idMatch[1])) continue;
+        seen.add(idMatch[1]);
+        const title = String(readSnapshotAttribute(tag, 'aria-label') || '(untitled)')
+            .replace(/\s+/g, ' ')
+            .trim() || '(untitled)';
+        rows.push({
+            Index: rows.length + 1,
+            Id: idMatch[1],
+            Title: title,
+            Url: href.startsWith('http') ? href : (`${CHATGPT_URL}${href}`),
+        });
+    }
+    return rows;
+}
+
+function snapshotText(snapshot) {
+    if (typeof snapshot === 'string') return snapshot.replace(/\\n/g, '\n');
+    if (typeof snapshot?.data === 'string') return snapshot.data;
+    return JSON.stringify(snapshot || '').replace(/\\n/g, '\n');
+}
+
+function readSnapshotAttribute(tag, name) {
+    const quoted = tag.match(new RegExp(`\\b${name}=(?:"([^"]*)"|'([^']*)')`));
+    if (quoted) return quoted[1] || quoted[2] || '';
+    const unquoted = tag.match(new RegExp(`\\b${name}=([^>]*?)(?=\\s+[\\w:-]+=|\\s*/?>|$)`));
+    return unquoted?.[1] || '';
 }
 
 function imageMimeFromPath(filePath) {
@@ -766,9 +938,15 @@ export const __test__ = {
     SEND_BUTTON_FALLBACK_SELECTORS,
     SEND_BUTTON_LABELS,
     CLOSE_SIDEBAR_LABELS,
+    OPEN_SIDEBAR_LABELS,
     isSameChatGPTConversation,
     parseChatGPTConversationId,
     imageMimeFromPath,
+    extractConversationLinks,
+    parseMessagesFromSnapshot,
+    parseConversationLinksFromSnapshot,
+    snapshotText,
+    readSnapshotAttribute,
 };
 
 /**

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { __test__, prepareChatGPTImagePaths, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTImages } from './utils.js';
+import { __test__, getVisibleMessages, prepareChatGPTImagePaths, revealChatGPTConversation, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTImages } from './utils.js';
 
 const tempDirs = [];
 
@@ -140,6 +141,154 @@ describe('chatgpt send selectors', () => {
         expect(__test__.SEND_BUTTON_FALLBACK_SELECTORS).toContain('#composer-submit-button:not([disabled])');
         expect(__test__.SEND_BUTTON_LABELS).toEqual(expect.arrayContaining(['Send prompt', 'Send message', 'Send', '发送提示']));
         expect(__test__.CLOSE_SIDEBAR_LABELS).toEqual(expect.arrayContaining(['Close sidebar', '关闭边栏']));
+        expect(__test__.OPEN_SIDEBAR_LABELS).toEqual(expect.arrayContaining(['Open sidebar', '開啟側邊欄', '打开边栏']));
+    });
+});
+
+describe('chatgpt history extraction', () => {
+    it('accepts sidebar links whose visible box is on a child node', async () => {
+        const dom = new JSDOM(`
+            <nav aria-label="聊天歷程紀錄">
+              <div id="history">
+                <a href="/c/6a0522ba-89b4-83a2-9bc2-7a10eb6559c3" aria-label="Synology macOS App統計">
+                  <span>Synology macOS App統計</span>
+                </a>
+              </div>
+            </nav>
+        `, { url: 'https://chatgpt.com/', runScripts: 'dangerously' });
+        const anchor = dom.window.document.querySelector('a');
+        const span = dom.window.document.querySelector('span');
+        anchor.getBoundingClientRect = () => ({ x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, bottom: 0, right: 0 });
+        span.getBoundingClientRect = () => ({ x: 12, y: 20, width: 180, height: 24, top: 20, left: 12, bottom: 44, right: 192 });
+
+        const page = {
+            evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(script))),
+        };
+
+        await expect(__test__.extractConversationLinks(page)).resolves.toEqual([{
+            Index: 1,
+            Id: '6a0522ba-89b4-83a2-9bc2-7a10eb6559c3',
+            Title: 'Synology macOS App統計',
+            Url: 'https://chatgpt.com/c/6a0522ba-89b4-83a2-9bc2-7a10eb6559c3',
+        }]);
+    });
+
+    it('parses ChatGPT conversation links from OpenCLI snapshots', () => {
+        const snapshot = `
+            <div id=history />
+              <ul />
+                <li />
+                  [47]<a tabindex=0 aria-label=Synology macOS App統計 href=/c/6a0522ba-89b4-83a2-9bc2-7a10eb6559c3 />
+                <li />
+                  [48]<a tabindex=0 aria-label="MTP vs DFlash 性能" href=/c/6a0447bb-a1dc-8320-a8bd-0902d2068dea />
+        `;
+
+        expect(__test__.parseConversationLinksFromSnapshot(snapshot)).toEqual([
+            {
+                Index: 1,
+                Id: '6a0522ba-89b4-83a2-9bc2-7a10eb6559c3',
+                Title: 'Synology macOS App統計',
+                Url: 'https://chatgpt.com/c/6a0522ba-89b4-83a2-9bc2-7a10eb6559c3',
+            },
+            {
+                Index: 2,
+                Id: '6a0447bb-a1dc-8320-a8bd-0902d2068dea',
+                Title: 'MTP vs DFlash 性能',
+                Url: 'https://chatgpt.com/c/6a0447bb-a1dc-8320-a8bd-0902d2068dea',
+            },
+        ]);
+    });
+});
+
+describe('chatgpt visible message extraction', () => {
+    it('reads section-based ChatGPT conversation turns in localized UI', async () => {
+        const dom = new JSDOM(`
+            <main>
+              <section data-testid="conversation-turn-1">
+                <h4>你說：</h4>
+                <div data-testid="collapsible-user-message-content">搜尋 synology 官網的下載頁面.</div>
+              </section>
+              <section data-testid="conversation-turn-2">
+                <h4>ChatGPT 說：</h4>
+                <div>
+                  <p>統計結果：23 種 macOS native app</p>
+                  <button aria-label="複製回應">copy</button>
+                </div>
+              </section>
+            </main>
+        `, { url: 'https://chatgpt.com/c/demo', runScripts: 'dangerously' });
+        for (const node of dom.window.document.querySelectorAll('section')) {
+            node.getBoundingClientRect = () => ({ x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, bottom: 0, right: 0 });
+        }
+        for (const node of dom.window.document.querySelectorAll('[data-testid="collapsible-user-message-content"], p')) {
+            node.getBoundingClientRect = () => ({ x: 0, y: 0, width: 300, height: 20, top: 0, left: 0, bottom: 20, right: 300 });
+        }
+
+        const page = {
+            evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(script))),
+        };
+
+        await expect(getVisibleMessages(page)).resolves.toMatchObject([
+            { Index: 1, Role: 'User', Text: expect.stringContaining('搜尋 synology') },
+            { Index: 2, Role: 'Assistant', Text: expect.stringContaining('統計結果') },
+        ]);
+    });
+
+    it('parses localized conversation turns from OpenCLI snapshots', () => {
+        const snapshot = { data: `
+            <section data-testid=conversation-turn-1 />
+              <h4>你說：</h4>
+              <div>搜尋 synology 官網的下載頁面.</div>
+            <section data-testid=conversation-turn-2 />
+              <h4>ChatGPT 說：</h4>
+              <p>判斷標準：最新版本目錄中有 macOS 安裝檔。</p>
+              |table|
+              | # | macOS native app |
+              | 1 | Synology Drive Client |
+              <div aria-label=回覆操作 role=group tabindex=-1 />
+            <div id=thread-bottom-container />
+        ` };
+
+        expect(__test__.parseMessagesFromSnapshot(snapshot)).toEqual([
+            {
+                Index: 1,
+                Role: 'User',
+                Text: '搜尋 synology 官網的下載頁面.',
+                Html: '',
+            },
+            {
+                Index: 2,
+                Role: 'Assistant',
+                Text: [
+                    '判斷標準：最新版本目錄中有 macOS 安裝檔。',
+                    '| # | macOS native app |',
+                    '| 1 | Synology Drive Client |',
+                ].join('\n'),
+                Html: '',
+            },
+        ]);
+    });
+
+    it('scrolls chat containers back to the top when a conversation opens below rendered turns', async () => {
+        const dom = new JSDOM(`
+            <main style="height: 100px; overflow: auto">
+              <div style="height: 1000px"></div>
+            </main>
+        `, { url: 'https://chatgpt.com/c/demo', runScripts: 'dangerously' });
+        const main = dom.window.document.querySelector('main');
+        Object.defineProperty(main, 'clientHeight', { value: 100 });
+        Object.defineProperty(main, 'scrollHeight', { value: 1000 });
+        main.scrollTop = 900;
+
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(script))),
+        };
+
+        await revealChatGPTConversation(page);
+
+        expect(main.scrollTop).toBe(0);
+        expect(page.wait).toHaveBeenCalledWith(1);
     });
 });
 


### PR DESCRIPTION
## Summary
- support ChatGPT section-based conversation turns and localized message/sidebar labels
- add snapshot extraction fallbacks for history and message reads
- recover read/detail when conversations open at the bottom or the current page has no visible turns

## Root cause
ChatGPT changed visible conversation markup and localized UI labels, while the adapter only looked for older `[data-message-author-role]` / `article[data-testid*=conversation-turn]` nodes and the English `Open sidebar` label. Some conversations also opened with the scroll container positioned below the rendered turns, leaving no visible messages for the old extractor.

## Validation
- `npx vitest run --project adapter clis/chatgpt/utils.test.js clis/chatgpt/image.test.js clis/chatgpt/commands.test.js`
- `opencli chatgpt status -f yaml --window background`
- `opencli chatgpt history -f yaml --window background --limit 3`
- `opencli chatgpt read -f yaml --window background`
- `opencli chatgpt detail 69fea772-227c-8323-b7a1-98777b64edad -f yaml --window background`