### PR TITLE
fix(extension): coalesce daemon websocket connects

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -626,6 +626,7 @@ let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = "opencli_context_id_v1";
 let currentContextId = "default";
 let contextIdPromise = null;
+let connectInFlight = null;
 async function getCurrentContextId() {
   if (contextIdPromise) return contextIdPromise;
   contextIdPromise = (async () => {
@@ -698,17 +699,30 @@ console.error = (...args) => {
   _origError(...args);
   forwardLog("error", args);
 };
-async function connect() {
-  if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+function isDaemonSocketActive(socket = ws) {
+  return socket?.readyState === WebSocket.OPEN || socket?.readyState === WebSocket.CONNECTING;
+}
+function connect() {
+  if (isDaemonSocketActive()) return Promise.resolve();
+  if (connectInFlight) return connectInFlight;
+  connectInFlight = connectAttempt().finally(() => {
+    connectInFlight = null;
+  });
+  return connectInFlight;
+}
+async function connectAttempt() {
+  if (isDaemonSocketActive()) return;
   try {
     const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1e3) });
     if (!res.ok) return;
   } catch {
     return;
   }
+  if (isDaemonSocketActive()) return;
   let thisWs;
   try {
     const contextId = await getCurrentContextId();
+    if (isDaemonSocketActive()) return;
     thisWs = new WebSocket(DAEMON_WS_URL);
     ws = thisWs;
     currentContextId = contextId;

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -52,6 +52,16 @@ class MockWebSocket {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function createChromeMock() {
   let nextTabId = 10;
   let nextGroupId = 100;
@@ -691,6 +701,31 @@ describe('background tab isolation', () => {
 
     await vi.waitFor(() => {
       expect(secondWs.sent.some((entry) => entry.includes('sessions-after-stale-close'))).toBe(true);
+    });
+  });
+
+  it('coalesces concurrent daemon connection attempts while the probe is in flight', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    const ping = deferred<{ ok: boolean }>();
+    const fetchMock = vi.fn(() => ping.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('./background');
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    await onAlarmListener({ name: 'keepalive' });
+    await onAlarmListener({ name: 'keepalive' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.instances).toHaveLength(0);
+
+    ping.resolve({ ok: true });
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
     });
   });
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -18,6 +18,7 @@ let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = 'opencli_context_id_v1';
 let currentContextId = 'default';
 let contextIdPromise: Promise<string> | null = null;
+let connectInFlight: Promise<void> | null = null;
 
 async function getCurrentContextId(): Promise<string> {
   if (contextIdPromise) return contextIdPromise;
@@ -92,6 +93,10 @@ console.error = (...args: unknown[]) => { _origError(...args); forwardLog('error
 
 // ─── WebSocket connection ────────────────────────────────────────────
 
+function isDaemonSocketActive(socket: WebSocket | null | undefined = ws): boolean {
+  return socket?.readyState === WebSocket.OPEN || socket?.readyState === WebSocket.CONNECTING;
+}
+
 /**
  * Probe the daemon via its /ping HTTP endpoint before attempting a WebSocket
  * connection.  fetch() failures are silently catchable; new WebSocket() is not
@@ -99,8 +104,17 @@ console.error = (...args: unknown[]) => { _origError(...args); forwardLog('error
  * JS handler can intercept it.  By keeping the probe inside connect() every
  * call site remains unchanged and the guard can never be accidentally skipped.
  */
-async function connect(): Promise<void> {
-  if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+function connect(): Promise<void> {
+  if (isDaemonSocketActive()) return Promise.resolve();
+  if (connectInFlight) return connectInFlight;
+  connectInFlight = connectAttempt().finally(() => {
+    connectInFlight = null;
+  });
+  return connectInFlight;
+}
+
+async function connectAttempt(): Promise<void> {
+  if (isDaemonSocketActive()) return;
 
   try {
     const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1000) });
@@ -108,10 +122,12 @@ async function connect(): Promise<void> {
   } catch {
     return; // daemon not running — skip WebSocket to avoid console noise
   }
+  if (isDaemonSocketActive()) return;
 
   let thisWs: WebSocket;
   try {
     const contextId = await getCurrentContextId();
+    if (isDaemonSocketActive()) return;
     thisWs = new WebSocket(DAEMON_WS_URL);
     ws = thisWs;
     currentContextId = contextId;


### PR DESCRIPTION
## Summary
- add a Browser Bridge connect in-flight lock so startup / keepalive / reconnect callers share one daemon connection attempt
- re-check active WebSocket state after async daemon probe and context lookup before constructing a socket
- add a regression test that repeated keepalive calls during the probe produce only one WebSocket

Fixes #1552

## Validation
- npx vitest run --project extension extension/src/background.test.ts
- npm --prefix extension run typecheck
- npm --prefix extension run build
- git diff --check