### PR TITLE
feat(twitter): add extractMedia parity to bookmarks + bookmark-folder

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -22711,7 +22711,9 @@
       "retweets",
       "bookmarks",
       "created_at",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
@@ -22772,7 +22774,9 @@
       "retweets",
       "bookmarks",
       "created_at",
-      "url"
+      "url",
+      "has_media",
+      "media_urls"
     ],
     "type": "js",
     "modulePath": "twitter/bookmarks.js",

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
-import { resolveTwitterQueryId } from './shared.js';
+import { extractMedia, resolveTwitterQueryId } from './shared.js';
 
 // Companion to bookmark-folders.js: reads tweets inside a single folder.
 // X exposes folder contents through a separate timeline operation
@@ -54,7 +54,7 @@ function buildFolderTimelineUrl(queryId, folderId, count, cursor) {
         + `&features=${encodeURIComponent(JSON.stringify(FEATURES))}`;
 }
 
-function extractFolderTweet(result, seen) {
+export function extractFolderTweet(result, seen) {
     if (!result) return null;
     const tw = result.tweet || result;
     const legacy = tw.legacy || {};
@@ -72,6 +72,7 @@ function extractFolderTweet(result, seen) {
         bookmarks: legacy.bookmark_count || 0,
         created_at: legacy.created_at || '',
         url: screenName ? `https://x.com/${screenName}/status/${tw.rest_id}` : `https://x.com/i/status/${tw.rest_id}`,
+        ...extractMedia(legacy),
     };
 }
 
@@ -129,7 +130,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the folder by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const folderId = String(kwargs['folder-id'] || '').trim();
         if (!folderId || !FOLDER_ID_PATTERN.test(folderId)) {
@@ -184,6 +185,7 @@ cli({
 
 export const __test__ = {
     parseBookmarkFolderTimeline,
+    extractFolderTweet,
     buildFolderTimelineUrl,
     FOLDER_ID_PATTERN,
 };

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './bookmark-folder.js';
 
-const { parseBookmarkFolderTimeline, buildFolderTimelineUrl, FOLDER_ID_PATTERN } = __test__;
+const { parseBookmarkFolderTimeline, extractFolderTweet, buildFolderTimelineUrl, FOLDER_ID_PATTERN } = __test__;
 
 describe('twitter bookmark-folder URL builder', () => {
     it('embeds the folder id and count in the variables payload', () => {
@@ -97,6 +97,8 @@ describe('twitter bookmark-folder timeline parser', () => {
                 bookmarks: 3,
                 created_at: 'Tue Mar 17 09:00:00 +0000 2026',
                 url: 'https://x.com/alice/status/1',
+                has_media: false,
+                media_urls: [],
             },
         ]);
         expect(nextCursor).toBe('NEXT_CURSOR');
@@ -246,6 +248,62 @@ describe('twitter bookmark-folder timeline parser', () => {
 
     it('returns empty array + null cursor for unknown envelope', () => {
         expect(parseBookmarkFolderTimeline({}, new Set())).toEqual({ tweets: [], nextCursor: null });
+    });
+
+    it('includes photo media URLs from extended_entities', () => {
+        const tweet = extractFolderTweet({
+            rest_id: '101',
+            legacy: {
+                full_text: 'pic folder tweet',
+                extended_entities: {
+                    media: [
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/abc.jpg' },
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/def.jpg' },
+                    ],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'eve' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls).toEqual([
+            'https://pbs.twimg.com/media/abc.jpg',
+            'https://pbs.twimg.com/media/def.jpg',
+        ]);
+    });
+
+    it('extracts mp4 variant URL for video media', () => {
+        const tweet = extractFolderTweet({
+            rest_id: '102',
+            legacy: {
+                full_text: 'video folder tweet',
+                extended_entities: {
+                    media: [{
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/amplify_video_thumb/thumb.jpg',
+                        video_info: {
+                            variants: [
+                                { content_type: 'application/x-mpegURL', url: 'https://video.twimg.com/playlist.m3u8' },
+                                { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/low.mp4' },
+                                { content_type: 'video/mp4', bitrate: 2176000, url: 'https://video.twimg.com/high.mp4' },
+                            ],
+                        },
+                    }],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'frank' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls?.[0]).toMatch(/\.mp4$/);
+    });
+
+    it('returns has_media false / media_urls empty when no media present', () => {
+        const tweet = extractFolderTweet({
+            rest_id: '103',
+            legacy: { full_text: 'text only', favorite_count: 0, retweet_count: 0, bookmark_count: 0 },
+            core: { user_results: { result: { legacy: { screen_name: 'gail' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(false);
+        expect(tweet?.media_urls).toEqual([]);
     });
 });
 

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { extractMedia } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const BOOKMARKS_QUERY_ID = 'Fy0QMy4q_aZCpkO0PnyLYw';
 const MAX_PAGINATION_PAGES = 100;
@@ -42,7 +43,7 @@ function buildBookmarksUrl(count, cursor) {
         + `?variables=${encodeURIComponent(JSON.stringify(vars))}`
         + `&features=${encodeURIComponent(JSON.stringify(FEATURES))}`;
 }
-function extractBookmarkTweet(result, seen) {
+export function extractBookmarkTweet(result, seen) {
     if (!result)
         return null;
     const tw = result.tweet || result;
@@ -64,9 +65,10 @@ function extractBookmarkTweet(result, seen) {
         bookmarks: legacy.bookmark_count || 0,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        ...extractMedia(legacy),
     };
 }
-function parseBookmarks(data, seen) {
+export function parseBookmarks(data, seen) {
     const tweets = [];
     let nextCursor = null;
     const instructions = data?.data?.bookmark_timeline_v2?.timeline?.instructions
@@ -111,7 +113,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const cookies = await page.getCookies({ url: 'https://x.com' });
@@ -174,3 +176,7 @@ cli({
         return applyTopByEngagement(trimmed, kwargs['top-by-engagement']);
     },
 });
+export const __test__ = {
+    parseBookmarks,
+    extractBookmarkTweet,
+};

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './bookmarks.js';
+
+const { parseBookmarks, extractBookmarkTweet } = __test__;
+
+describe('twitter bookmarks parser', () => {
+    it('extracts a baseline tweet with no media (has_media false, media_urls empty)', () => {
+        const tweet = extractBookmarkTweet({
+            rest_id: '1',
+            legacy: {
+                full_text: 'plain bookmark',
+                favorite_count: 5,
+                retweet_count: 1,
+                bookmark_count: 2,
+                created_at: 'Wed Apr 16 10:00:00 +0000 2026',
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'alice', name: 'Alice' } } } },
+        }, new Set());
+        expect(tweet).toEqual({
+            id: '1',
+            author: 'alice',
+            name: 'Alice',
+            text: 'plain bookmark',
+            likes: 5,
+            retweets: 1,
+            bookmarks: 2,
+            created_at: 'Wed Apr 16 10:00:00 +0000 2026',
+            url: 'https://x.com/alice/status/1',
+            has_media: false,
+            media_urls: [],
+        });
+    });
+
+    it('includes photo media URLs from extended_entities', () => {
+        const tweet = extractBookmarkTweet({
+            rest_id: '101',
+            legacy: {
+                full_text: 'pic bookmark',
+                extended_entities: {
+                    media: [
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/abc.jpg' },
+                        { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/def.jpg' },
+                    ],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'bob' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls).toEqual([
+            'https://pbs.twimg.com/media/abc.jpg',
+            'https://pbs.twimg.com/media/def.jpg',
+        ]);
+    });
+
+    it('extracts mp4 variant URL for video media', () => {
+        const tweet = extractBookmarkTweet({
+            rest_id: '102',
+            legacy: {
+                full_text: 'video bookmark',
+                extended_entities: {
+                    media: [{
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/amplify_video_thumb/thumb.jpg',
+                        video_info: {
+                            variants: [
+                                { content_type: 'application/x-mpegURL', url: 'https://video.twimg.com/playlist.m3u8' },
+                                { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/low.mp4' },
+                                { content_type: 'video/mp4', bitrate: 2176000, url: 'https://video.twimg.com/high.mp4' },
+                            ],
+                        },
+                    }],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'carol' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls?.[0]).toMatch(/\.mp4$/);
+    });
+
+    it('falls back to entities.media when extended_entities is absent', () => {
+        const tweet = extractBookmarkTweet({
+            rest_id: '103',
+            legacy: {
+                full_text: 'entities-only media',
+                entities: {
+                    media: [{ type: 'photo', media_url_https: 'https://pbs.twimg.com/media/legacy.jpg' }],
+                },
+            },
+            core: { user_results: { result: { legacy: { screen_name: 'dave' } } } },
+        }, new Set());
+        expect(tweet?.has_media).toBe(true);
+        expect(tweet?.media_urls).toEqual(['https://pbs.twimg.com/media/legacy.jpg']);
+    });
+
+    it('prefers note_tweet text over truncated full_text', () => {
+        const tweet = extractBookmarkTweet({
+            rest_id: '2',
+            legacy: { full_text: 'short text…', favorite_count: 0, retweet_count: 0, bookmark_count: 0 },
+            note_tweet: { note_tweet_results: { result: { text: 'full long-form text body' } } },
+            core: { user_results: { result: { core: { screen_name: 'erin' } } } },
+        }, new Set());
+        expect(tweet?.text).toBe('full long-form text body');
+    });
+
+    it('deduplicates tweets across the seen Set', () => {
+        const data = {
+            data: {
+                bookmark_timeline_v2: {
+                    timeline: {
+                        instructions: [{
+                            entries: [
+                                {
+                                    entryId: 'tweet-3',
+                                    content: {
+                                        itemContent: {
+                                            tweet_results: {
+                                                result: {
+                                                    rest_id: '3',
+                                                    legacy: { full_text: 'first', favorite_count: 0, retweet_count: 0, bookmark_count: 0 },
+                                                    core: { user_results: { result: { legacy: { screen_name: 'frank' } } } },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                                {
+                                    entryId: 'tweet-3-dup',
+                                    content: {
+                                        itemContent: {
+                                            tweet_results: {
+                                                result: {
+                                                    rest_id: '3',
+                                                    legacy: { full_text: 'duplicate' },
+                                                    core: { user_results: { result: { legacy: { screen_name: 'frank' } } } },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        }],
+                    },
+                },
+            },
+        };
+        const seen = new Set();
+        const { tweets } = parseBookmarks(data, seen);
+        expect(tweets).toHaveLength(1);
+        expect(tweets[0].text).toBe('first');
+    });
+
+    it('extracts cursor + tweets from the bookmark_timeline_v2 envelope', () => {
+        const data = {
+            data: {
+                bookmark_timeline_v2: {
+                    timeline: {
+                        instructions: [
+                            {
+                                type: 'TimelineAddEntries',
+                                entries: [
+                                    {
+                                        entryId: 'tweet-4',
+                                        content: {
+                                            itemContent: {
+                                                tweet_results: {
+                                                    result: {
+                                                        rest_id: '4',
+                                                        legacy: {
+                                                            full_text: 'envelope tweet',
+                                                            favorite_count: 1,
+                                                            retweet_count: 0,
+                                                            bookmark_count: 0,
+                                                            extended_entities: {
+                                                                media: [{ type: 'photo', media_url_https: 'https://pbs.twimg.com/media/x.jpg' }],
+                                                            },
+                                                        },
+                                                        core: { user_results: { result: { legacy: { screen_name: 'gina' } } } },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                    {
+                                        entryId: 'cursor-bottom-Y',
+                                        content: { __typename: 'TimelineTimelineCursor', cursorType: 'Bottom', value: 'NEXT' },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        };
+        const { tweets, nextCursor } = parseBookmarks(data, new Set());
+        expect(tweets).toHaveLength(1);
+        expect(tweets[0].id).toBe('4');
+        expect(tweets[0].has_media).toBe(true);
+        expect(tweets[0].media_urls).toEqual(['https://pbs.twimg.com/media/x.jpg']);
+        expect(nextCursor).toBe('NEXT');
+    });
+
+    it('returns empty tweets + null cursor for unknown envelope', () => {
+        expect(parseBookmarks({}, new Set())).toEqual({ tweets: [], nextCursor: null });
+    });
+});


### PR DESCRIPTION
## Summary

Mirror of PR #1464 (`twitter/list-tweets`) for the two remaining read adapters in the bookmarks family. Brings `has_media` + `media_urls` to `twitter/bookmarks` and `twitter/bookmark-folder`, matching the timeline / search / tweets / likes / thread / list-tweets family that already exposes them via `extractMedia(legacy)`.

Pure parity — no behavior change for existing callers. `extractMedia` is null-safe (returns `{has_media:false, media_urls:[]}` when neither `extended_entities.media` nor `entities.media` is populated), and the two new keys do not collide with any existing columns, so the silent-column-drop audit baseline stays unchanged.

## Why now

After #1464 merged, bookmarks/bookmark-folder were the only read adapters in the Twitter family still missing the media columns — an inconsistency callers would hit as soon as they cross between `twitter likes` (has media) and `twitter bookmarks` (didn't). The fix is mechanical and reuses the helper already shipped in `clis/twitter/shared.js`.

## Changes

- `clis/twitter/bookmarks.js` — import `extractMedia` from `./shared.js`, spread into `extractBookmarkTweet` row, add `has_media`/`media_urls` to `columns`, export `__test__ = { parseBookmarks, extractBookmarkTweet }`.
- `clis/twitter/bookmark-folder.js` — same change on `extractFolderTweet`, expose `extractFolderTweet` through the existing `__test__`.
- `clis/twitter/bookmarks.test.js` (new) — 8 tests: baseline (no media), photo, video (mp4 variant), `entities.media` fallback, long-form `note_tweet`, dedup, full envelope walk with media, empty envelope.
- `clis/twitter/bookmark-folder.test.js` — update existing baseline `toEqual(...)` to include `has_media:false, media_urls:[]`; add 3 new media tests (photo, mp4 variant, no-media).
- `cli-manifest.json` — regenerated; only the two `columns` entries change.

## Reverse-validation

Before committing, restored `bookmarks.js` and `bookmark-folder.js` to `main` and re-ran the new tests — 4 expected failures (the new media + baseline expectations), then restored and re-ran with all 28 tests green. So the tests actually exercise the change, not just rubber-stamp it.

## Audits

- `npm run check:typed-error-lint` → 189/189, no delta.
- `npm run check:silent-column-drop` → 102 violations vs baseline 103 (one upstream resolution on `twitter/list-add`, **not** introduced by this PR; left untouched to keep scope minimal).
- `npx vitest run clis/twitter/` → 262 passed (28 in the two touched suites).

## Test plan

- [ ] `npm run build` regenerates the manifest with only the two `columns` updates.
- [ ] `npx vitest run clis/twitter/bookmarks.test.js clis/twitter/bookmark-folder.test.js` → 28 passed.
- [ ] `npx vitest run clis/twitter/` → 262 passed (no other twitter suites broken).
- [ ] `npm run check:typed-error-lint` → no new violations.
- [ ] `npm run check:silent-column-drop` → no new violations.
- [ ] Live-verify (once a reviewer has an x.com session): `opencli twitter bookmarks --limit 5 -f json` and `opencli twitter bookmark-folder <id> --limit 5 -f json` surface `has_media`/`media_urls` consistently with `twitter likes` / `twitter list-tweets`.

## Out of scope

- `twitter/list-add` baseline shrink — pre-existing upstream resolution surfaced by the audit, orthogonal to this PR.
- Live-verify on x.com (no cookie session available in this run; same caveat as #1464's review note).

cc @WAWQAQ (DM authorize), follow-up to #1464.