### PR TITLE
fix(chatgpt): drop unused second arg from getChatGPTImageAssets evaluate

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -850,5 +850,5 @@ export async function getChatGPTImageAssets(page, urls) {
 
             return results;
         })(${urlsJson})
-    `, urls);
+    `);
 }


### PR DESCRIPTION
## Summary

`getChatGPTImageAssets` passes the URL list both ways:

```js
const urlsJson = JSON.stringify(urls);
return await page.evaluate(`
    (async (targetUrls) => { ... })(${urlsJson})   // ← inlined here
`, urls);                                          // ← also as a CDP arg
```

Browser bridge **1.7.x** rejects the second form for string scripts:

```
page.evaluate string input does not accept args; use page.evaluate(fn, ...args) instead
```

So any `opencli chatgpt image <prompt>` that actually downloads the asset (i.e. without `--sd true`) fails with `code: UNKNOWN`.

## Fix

Drop the trailing `, urls` argument. The URLs are already inlined via the `${urlsJson}` template substitution, so no semantic change — only the redundant + now-invalid CDP arg is removed.

## Root cause

The redundant arg was harmless in older bridge versions; the strict-mode guard was added in `browser/utils.ts`:

```js
if (args.length > 0) {
    throw new Error('page.evaluate string input does not accept args; ...');
}
```

## Validation

- `npx tsc --noEmit` clean
- `npx vitest run --project adapter clis/chatgpt/` — 25/25 pass (3 files)
- Live: `opencli chatgpt image "a fluffy orange cat" --op /tmp/x` succeeds end-to-end after the fix (fails before with the error above)

## Scope

Single-line change in `clis/chatgpt/utils.js`. No new tests — the existing `image.test.js` mocks `getChatGPTImageAssets`, so this codepath is only exercised against a live browser. Happy to add an integration-style assertion if the reviewer prefers.