### PR TITLE
fix(cli): show external CLI package aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * **notion** — remove the in-tree `clis/notion/` CDP-on-Desktop adapter (8 commands: status / search / read / new / write / sidebar / favorites / export). Notion has shipped an official CLI at <https://ntn.dev>, which is registered as a first-class external CLI in `external-clis.yaml`. Migration: install `ntn` from <https://ntn.dev> (`curl -fsSL https://ntn.dev | bash`), then use `opencli ntn <command>`. Auto-install is intentionally not configured because the official installer is a shell script while OpenCLI external installs run shell-free command strings. The official CLI uses the public Notion API rather than reverse-engineering the Desktop UI, so it survives Notion app updates and exposes a wider command surface (blocks / databases / properties / comments) than the reverse-engineered adapter could.
 
+### Bug Fixes
+
+* **external** — distinguish external CLI executable names from distribution/project names in root help. Built-in aliases such as `tg`, `discord`, and `wx` remain the callable `opencli <name> ...` entrypoints while help renders `tg(tg-cli)`, `discord(discord-cli)`, and `wx(wx-cli)` to show their package lineage.
+
 ## [1.7.19](https://github.com/jackwener/opencli/compare/v1.7.18...v1.7.19) (2026-05-14)
 
 Major hotfix + simplification batch. Extension bumped to 1.0.14. Node floor lowered to v20 so the long tail of Node v20–v21.6 users no longer crashes at module load. `opencli browser` user surface replaces required-flag `--session <name>` with a `<session>` positional. `page.evaluate(fn, ...args)` adds a type-safe alternative to the implicit auto-IIFE string form. Twitter cursor pagination no longer silently caps at ~500 items.

--- a/README.md
+++ b/README.md
@@ -294,9 +294,9 @@ OpenCLI acts as a universal hub for your existing command-line tools — unified
 | **lark-cli** | Lark/Feishu — messages, docs, calendar, tasks, 200+ commands | `opencli lark-cli calendar +agenda` |
 | **dws** | DingTalk — cross-platform CLI for DingTalk's full suite, designed for humans and AI agents | `opencli dws msg send --to user "hello"` |
 | **wecom-cli** | WeCom/企业微信 — CLI for WeCom open platform, for humans and AI agents | `opencli wecom-cli msg send --to user "hello"` |
-| **tg** | Telegram — local-first sync, search, and export via MTProto for AI agents | `opencli tg search "AI news" -f json` |
-| **discord** | Discord — local-first sync, search, and export via SQLite for AI agents | `opencli discord recent --channel general` |
-| **wx** | WeChat — query local WeChat data: sessions, messages, search, contacts, export | `opencli wx search "OpenCLI"` |
+| **tg(tg-cli)** | Telegram — local-first sync, search, and export via MTProto for AI agents | `opencli tg search "AI news" -f json` |
+| **discord(discord-cli)** | Discord — local-first sync, search, and export via SQLite for AI agents | `opencli discord recent --channel general` |
+| **wx(wx-cli)** | WeChat — query local WeChat data: sessions, messages, search, contacts, export | `opencli wx search "OpenCLI"` |
 | **vercel** | Vercel — deploy projects, manage domains, env vars, logs | `opencli vercel deploy --prod` |
 
 **Register your own** — add any local CLI so AI agents can discover it via `opencli list`:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -336,9 +336,9 @@ OpenCLI 也可以作为你现有命令行工具的统一入口，负责发现、
 | **lark-cli** | 飞书 CLI — 消息、文档、日历、任务，200+ 命令 | `opencli lark-cli calendar +agenda` |
 | **dws** | 钉钉 CLI — 钉钉全套产品能力的跨平台命令行工具，支持人类和 AI Agent 使用 | `opencli dws msg send --to user "hello"` |
 | **wecom-cli** | 企业微信 CLI — 企业微信开放平台命令行工具，支持人类和 AI Agent 使用 | `opencli wecom-cli msg send --to user "hello"` |
-| **tg** | Telegram CLI — 基于 MTProto 的本地优先同步、搜索、导出，面向 AI Agent | `opencli tg search "AI news" -f json` |
-| **discord** | Discord CLI — 基于 SQLite 的本地优先同步、搜索、导出，面向 AI Agent | `opencli discord recent --channel general` |
-| **wx** | 微信本地数据 CLI — 会话、聊天记录、搜索、联系人、导出 | `opencli wx search "OpenCLI"` |
+| **tg(tg-cli)** | Telegram CLI — 基于 MTProto 的本地优先同步、搜索、导出，面向 AI Agent | `opencli tg search "AI news" -f json` |
+| **discord(discord-cli)** | Discord CLI — 基于 SQLite 的本地优先同步、搜索、导出，面向 AI Agent | `opencli discord recent --channel general` |
+| **wx(wx-cli)** | 微信本地数据 CLI — 会话、聊天记录、搜索、联系人、导出 | `opencli wx search "OpenCLI"` |
 | **vercel** | Vercel — 部署项目、管理域名、环境变量、日志 | `opencli vercel deploy --prod` |
 
 **零配置透传**：OpenCLI 会把你的输入原样转发给底层二进制，保留原生 stdout / stderr 行为。

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -134,7 +134,7 @@ opencli gh pr list --limit 5   # passthrough; stdio is inherited, exit code prop
 opencli docker ps
 ```
 
-Built-in entries live in `src/external-clis.yaml`; user overrides and additions in `~/.opencli/external-clis.yaml`. Commonly shipped: `gh`, `docker`, `vercel`, `lark-cli`, `dws`, `wecom-cli`, `obsidian`, `ntn`, `tg`, `discord`, `wx`.
+Built-in entries live in `src/external-clis.yaml`; user overrides and additions in `~/.opencli/external-clis.yaml`. Commonly shipped: `gh`, `docker`, `vercel`, `lark-cli`, `dws`, `wecom-cli`, `obsidian`, `ntn`, `tg(tg-cli)`, `discord(discord-cli)`, `wx(wx-cli)`.
 
 Some official CLIs use shell-script installers instead of a shell-free package-manager command. Entries without an `install` config, such as `ntn`, must be installed manually from their homepage before passthrough use.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -192,6 +192,7 @@ describe('createProgram root help descriptions', () => {
       expect(data.site_adapters.sites).toEqual(['bilibili']);
       expect(data.external_clis.count).toBeGreaterThanOrEqual(0);
       expect(Array.isArray(data.external_clis.clis)).toBe(true);
+      expect(Array.isArray(data.external_clis.display)).toBe(true);
       // Adapters must NOT leak into the core commands list
       const commandNames = data.commands.map((cmd: any) => cmd.name);
       expect(commandNames).not.toContain('bilibili');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import { serializeCommand, formatArgSummary } from './serialization.js';
 import { render as renderOutput } from './output.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
-import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled } from './external.js';
+import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceStructuredHelp, installStructuredHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
@@ -3239,6 +3239,7 @@ cli({
     .action((opts) => {
       const rows = loadExternalClis().map((ext) => ({
         name: ext.name,
+        package: ext.package ?? '',
         binary: ext.binary,
         installed: isBinaryInstalled(ext.binary),
         description: ext.description ?? '',
@@ -3247,7 +3248,7 @@ cli({
       }));
       renderOutput(rows, {
         fmt: opts.format,
-        columns: ['name', 'binary', 'installed', 'description', 'homepage', 'tags'],
+        columns: ['name', 'package', 'binary', 'installed', 'description', 'homepage', 'tags'],
         title: 'opencli/external/list',
         source: 'opencli external list',
       });
@@ -3306,6 +3307,10 @@ cli({
   // Classification derives from each adapter's `domain` field — see classifyAdapter.
   // External CLIs are taken from the externalClis registry (passthrough binaries).
   const externalNames = externalClis.map(ext => ext.name);
+  const externalHelpEntries = externalClis.map(ext => ({
+    name: ext.name,
+    label: formatExternalCliLabel(ext),
+  }));
   const siteDomains = new Map<string, string | undefined>();
   for (const [, cmd] of getRegistry()) {
     if (!siteDomains.has(cmd.site)) siteDomains.set(cmd.site, cmd.domain);
@@ -3316,7 +3321,7 @@ cli({
     if (classifyAdapter(siteDomains.get(site)) === 'app') apps.push(site);
     else sites.push(site);
   }
-  const adapterGroups: RootAdapterGroups = { external: externalNames, apps, sites };
+  const adapterGroups: RootAdapterGroups = { external: externalHelpEntries, apps, sites };
   const adapterNameSet = new Set<string>([...externalNames, ...siteNames]);
   installCommanderNamespaceStructuredHelp(browser, { globalCommand: program, description: originalBrowserDescription });
   installCommanderNamespaceStructuredHelp(daemonCmd, { globalCommand: program, description: originalDaemonDescription });

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -63,6 +63,7 @@
 
 - name: tg
   binary: tg
+  package: tg-cli
   description: "Telegram CLI — local-first sync, search, export via MTProto for AI agents"
   homepage: "https://github.com/jackwener/tg-cli"
   tags: [telegram, messaging, search, export, ai-agent]
@@ -71,6 +72,7 @@
 
 - name: discord
   binary: discord
+  package: discord-cli
   description: "Discord CLI — local-first sync, search, export via SQLite for AI agents"
   homepage: "https://github.com/jackwener/discord-cli"
   tags: [discord, messaging, search, export, ai-agent]
@@ -79,6 +81,7 @@
 
 - name: wx
   binary: wx
+  package: wx-cli
   description: "WeChat local data CLI — sessions, messages, search, contacts, export for AI agents"
   homepage: "https://github.com/jackwener/wx-cli"
   tags: [wechat, messaging, search, export, ai-agent]

--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -22,7 +22,7 @@ vi.mock('node:os', async () => {
   };
 });
 
-import { installExternalCli, parseCommand, type ExternalCliConfig } from './external.js';
+import { formatExternalCliLabel, installExternalCli, parseCommand, type ExternalCliConfig } from './external.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -58,6 +58,16 @@ describe('parseCommand', () => {
         if (command) expect(() => parseCommand(command)).not.toThrow();
       }
     }
+  });
+});
+
+describe('formatExternalCliLabel', () => {
+  it('shows the package name when the executable name differs', () => {
+    expect(formatExternalCliLabel({ name: 'wx', binary: 'wx', package: 'wx-cli' })).toBe('wx(wx-cli)');
+  });
+
+  it('keeps the label compact when package and name match', () => {
+    expect(formatExternalCliLabel({ name: 'docker', binary: 'docker', package: 'docker' })).toBe('docker');
   });
 });
 

--- a/src/external.ts
+++ b/src/external.ts
@@ -17,8 +17,11 @@ export interface ExternalCliInstall {
 }
 
 export interface ExternalCliConfig {
+  /** User-facing OpenCLI subcommand and, by default, the executable name. */
   name: string;
   binary: string;
+  /** Distribution/project name when it differs from the executable name. */
+  package?: string;
   description?: string;
   homepage?: string;
   tags?: string[];
@@ -84,6 +87,10 @@ export function getInstallCmd(installConfig?: ExternalCliInstall): string | null
   if (platform === 'win32' && installConfig.windows) return installConfig.windows;
   if (installConfig.default) return installConfig.default;
   return null;
+}
+
+export function formatExternalCliLabel(cli: ExternalCliConfig): string {
+  return cli.package && cli.package !== cli.name ? `${cli.name}(${cli.package})` : cli.name;
 }
 
 /**

--- a/src/help.test.ts
+++ b/src/help.test.ts
@@ -25,13 +25,17 @@ describe('classifyAdapter', () => {
 describe('formatRootAdapterHelpText', () => {
   it('renders all three sections in External / App / Site order when populated', () => {
     const text = formatRootAdapterHelpText({
-      external: ['gh', 'docker'],
+      external: [
+        { name: 'gh', label: 'gh' },
+        { name: 'wx', label: 'wx(wx-cli)' },
+      ],
       apps: ['chatwise', 'codex'],
       sites: ['bilibili'],
     });
     expect(text).toContain('External CLIs (2):');
     expect(text).toContain('App adapters (2):');
     expect(text).toContain('Site adapters (1):');
+    expect(text).toContain('wx(wx-cli)');
     expect(text.indexOf('External CLIs')).toBeLessThan(text.indexOf('App adapters'));
     expect(text.indexOf('App adapters')).toBeLessThan(text.indexOf('Site adapters'));
   });

--- a/src/help.ts
+++ b/src/help.ts
@@ -147,11 +147,16 @@ export function classifyAdapter(domain: string | undefined): AdapterKind {
 
 export interface RootAdapterGroups {
   /** Externally-registered CLIs (docker, gh, vercel, ...) — passthrough binaries */
-  external: readonly string[];
+  external: readonly RootExternalCli[];
   /** Desktop-app adapters (chatgpt-app, chatwise, codex, ...) */
   apps: readonly string[];
   /** Web-site adapters (bilibili, dianping, ...) */
   sites: readonly string[];
+}
+
+export interface RootExternalCli {
+  name: string;
+  label: string;
 }
 
 function formatGroupSection(label: string, names: readonly string[]): string[] {
@@ -167,7 +172,7 @@ export function formatRootAdapterHelpText(groups: RootAdapterGroups): string {
   const total = groups.external.length + groups.apps.length + groups.sites.length;
   if (total === 0) return '';
   const lines: string[] = [''];
-  lines.push(...formatGroupSection('External CLIs', groups.external));
+  lines.push(...formatGroupSection('External CLIs', groups.external.map(cli => cli.label)));
   lines.push(...formatGroupSection('App adapters', groups.apps));
   lines.push(...formatGroupSection('Site adapters', groups.sites));
   lines.push("Run 'opencli list' for full command details, or 'opencli <site> --help' to inspect one site.");
@@ -468,7 +473,7 @@ function compactCommand(cmd: CliCommand): Record<string, unknown> {
 }
 
 export function rootHelpData(program: Command, groups: RootAdapterGroups): Record<string, unknown> {
-  const adapterNames = new Set<string>([...groups.external, ...groups.apps, ...groups.sites]);
+  const adapterNames = new Set<string>([...groups.external.map(cli => cli.name), ...groups.apps, ...groups.sites]);
   const commands = program.commands
     .filter(command => !adapterNames.has(command.name()))
     .map(command => ({
@@ -483,7 +488,8 @@ export function rootHelpData(program: Command, groups: RootAdapterGroups): Recor
     commands,
     external_clis: {
       count: groups.external.length,
-      clis: [...groups.external].sort(sortLocale),
+      clis: groups.external.map(cli => cli.name).sort(sortLocale),
+      display: groups.external.map(cli => cli.label).sort(sortLocale),
     },
     app_adapters: {
       count: groups.apps.length,


### PR DESCRIPTION
## Summary
- keep external CLI command names as the executable/user-facing OpenCLI subcommands
- add optional package/project metadata and render root help as command(package), e.g. tg(tg-cli), discord(discord-cli), wx(wx-cli)
- expose package in `opencli external list` and preserve structured help `external_clis.clis` as command names while adding `display`

## Notes
- I checked upstream `kabi-discord-cli`: the console script is `discord`; `dc` is a second-level `discord dc ...` command in its README, so this PR does not change the OpenCLI top-level command to `dc`.

## Test
- `npx vitest run --project unit src/help.test.ts src/cli.test.ts src/external.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `npm run docs:build`
- clean-HOME smoke: `node dist/src/main.js --help` shows `discord(discord-cli) ... tg(tg-cli) ... wx(wx-cli)`
- `git diff --check`