### PR TITLE
fix(xiaohongshu,rednote): unwrap page.evaluate envelope in search adapter

### DIFF
--- a/clis/rednote/rednote.test.js
+++ b/clis/rednote/rednote.test.js
@@ -31,6 +31,14 @@ function createPageMock(evaluateResult) {
         getCookies: vi.fn().mockResolvedValue([{ name: 'sid', value: 'secret', domain: 'www.rednote.com' }]),
     };
 }
+function createSearchPageMock(evaluateResults) {
+    const page = createPageMock(undefined);
+    page.evaluate = vi.fn();
+    for (const result of evaluateResults) {
+        page.evaluate.mockResolvedValueOnce(result);
+    }
+    return page;
+}
 
 describe('rednote note URL identity', () => {
     const download = getRegistry().get('rednote/download');
@@ -127,6 +135,63 @@ describe('rednote argument validation', () => {
             message: expect.stringContaining('--type'),
         });
         expect(page.goto).not.toHaveBeenCalled();
+    });
+});
+
+describe('rednote search browser-bridge envelopes', () => {
+    const search = getRegistry().get('rednote/search');
+
+    it('unwraps login-wall wait result envelopes before auth handling', async () => {
+        const page = createSearchPageMock([
+            { session: 'site:rednote', data: 'login_wall' },
+        ]);
+
+        await expect(search.func(page, { query: 'tesla', limit: 5 })).rejects.toMatchObject({
+            code: 'AUTH_REQUIRED',
+            message: expect.stringContaining('blocked behind a login wall'),
+        });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('unwraps search extraction envelopes and preserves rednote row shape', async () => {
+        const url = 'https://www.rednote.com/search_result/68e90be80000000004022e66?xsec_token=test-token';
+        const page = createSearchPageMock([
+            'content',
+            1,
+            {
+                session: 'site:rednote',
+                data: [{
+                    title: 'rednote result',
+                    author: 'author',
+                    likes: '12',
+                    url,
+                    author_url: 'https://www.rednote.com/user/profile/u1',
+                }],
+            },
+        ]);
+
+        await expect(search.func(page, { query: 'tesla', limit: 1 })).resolves.toEqual([{
+            rank: 1,
+            title: 'rednote result',
+            author: 'author',
+            likes: '12',
+            published_at: '2025-10-10',
+            url,
+            author_url: 'https://www.rednote.com/user/profile/u1',
+        }]);
+    });
+
+    it('fails typed instead of silently returning [] for malformed extraction payloads', async () => {
+        const page = createSearchPageMock([
+            'content',
+            1,
+            { session: 'site:rednote', data: { rows: [] } },
+        ]);
+
+        await expect(search.func(page, { query: 'tesla', limit: 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('payload shape'),
+        });
     });
 });
 

--- a/clis/rednote/search.js
+++ b/clis/rednote/search.js
@@ -7,7 +7,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
-import { buildScrollUntilJs, buildSearchExtractJs, noteIdToDate } from '../xiaohongshu/search.js';
+import { buildScrollUntilJs, buildSearchExtractJs, noteIdToDate, unwrapEvaluateResult } from '../xiaohongshu/search.js';
 
 function parseLimit(raw) {
     const parsed = Number(raw);
@@ -87,7 +87,7 @@ cli({
         // `autoScroll({ times: 2 })` capped extraction at ~13 notes regardless
         // of `--limit`.
         await page.evaluate(buildScrollUntilJs(limit));
-        const payload = await page.evaluate(buildSearchExtractJs('www.rednote.com'));
+        const payload = unwrapEvaluateResult(await page.evaluate(buildSearchExtractJs('www.rednote.com')));
         const data = Array.isArray(payload) ? payload : [];
         return data
             .filter((item) => item.title)

--- a/clis/rednote/search.js
+++ b/clis/rednote/search.js
@@ -6,7 +6,7 @@
  * 1:1 comparison between the two frontends.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { buildScrollUntilJs, buildSearchExtractJs, noteIdToDate, unwrapEvaluateResult } from '../xiaohongshu/search.js';
 
 function parseLimit(raw) {
@@ -18,6 +18,13 @@ function parseLimit(raw) {
         throw new ArgumentError(`--limit must be between 1 and 100, got ${parsed}`);
     }
     return parsed;
+}
+function requireSearchRows(payload) {
+    const rows = unwrapEvaluateResult(payload);
+    if (!Array.isArray(rows)) {
+        throw new CommandExecutionError('Unexpected Rednote search extraction payload shape; expected an array of rows.');
+    }
+    return rows;
 }
 
 /**
@@ -78,7 +85,7 @@ cli({
         const limit = parseLimit(kwargs.limit ?? 20);
         const keyword = encodeURIComponent(kwargs.query);
         await page.goto(`https://www.rednote.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
-        const waitResult = await page.evaluate(WAIT_FOR_CONTENT_JS);
+        const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.rednote.com', 'Rednote search results are blocked behind a login wall');
         }
@@ -87,8 +94,7 @@ cli({
         // `autoScroll({ times: 2 })` capped extraction at ~13 notes regardless
         // of `--limit`.
         await page.evaluate(buildScrollUntilJs(limit));
-        const payload = unwrapEvaluateResult(await page.evaluate(buildSearchExtractJs('www.rednote.com')));
-        const data = Array.isArray(payload) ? payload : [];
+        const data = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.rednote.com')));
         return data
             .filter((item) => item.title)
             .slice(0, limit)

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -6,7 +6,7 @@
  * Ref: https://github.com/jackwener/opencli/issues/10
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, 'login_wall' if login gate
@@ -68,10 +68,17 @@ export function stripXhsAuthorDateSuffix(value) {
  * both shapes so callers can keep their Array.isArray checks unchanged.
  */
 export function unwrapEvaluateResult(payload) {
-    if (payload && !Array.isArray(payload) && typeof payload === 'object' && Array.isArray(payload.data)) {
+    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
         return payload.data;
     }
     return payload;
+}
+function requireSearchRows(payload, phase) {
+    const rows = unwrapEvaluateResult(payload);
+    if (!Array.isArray(rows)) {
+        throw new CommandExecutionError(`Unexpected Xiaohongshu search ${phase} payload shape; expected an array of rows.`);
+    }
+    return rows;
 }
 export function parseLimit(raw) {
     const parsed = Number(raw ?? 20);
@@ -280,7 +287,7 @@ export const command = cli({
         // Wait for search results to render (or login wall to appear).
         // Uses MutationObserver to resolve as soon as content appears,
         // instead of a fixed delay + blind retry.
-        const waitResult = await page.evaluate(WAIT_FOR_CONTENT_JS);
+        const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
         }
@@ -288,25 +295,23 @@ export const command = cli({
         // layout, so scrolling to the bottom can evict the initially visible
         // note cards from the DOM and make extraction return [] even though the
         // browser rendered results correctly.
-        const initialPayload = unwrapEvaluateResult(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')));
-        let payload = Array.isArray(initialPayload) ? initialPayload : [];
+        const initialPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'initial extraction');
+        const payload = [...initialPayload];
         if (payload.length < limit) {
             // Scroll until enough rows are rendered or the lazy-load plateaus.
             // Replaces the previous fixed `autoScroll({ times: 2 })` which capped
             // extraction at ~13 notes regardless of `--limit` (#1471).
             await page.evaluate(buildScrollUntilJs(limit));
-            const scrolledPayload = unwrapEvaluateResult(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')));
-            if (Array.isArray(scrolledPayload)) {
-                const seen = new Set(payload.map((item) => item.url).filter(Boolean));
-                for (const item of scrolledPayload) {
-                    if (item?.url && seen.has(item.url))
-                        continue;
-                    if (item?.url)
-                        seen.add(item.url);
-                    payload.push(item);
-                    if (payload.length >= limit)
-                        break;
-                }
+            const scrolledPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'post-scroll extraction');
+            const seen = new Set(payload.map((item) => item.url).filter(Boolean));
+            for (const item of scrolledPayload) {
+                if (item?.url && seen.has(item.url))
+                    continue;
+                if (item?.url)
+                    seen.add(item.url);
+                payload.push(item);
+                if (payload.length >= limit)
+                    break;
             }
         }
         const data = payload;

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -60,6 +60,19 @@ export function stripXhsAuthorDateSuffix(value) {
     const stripped = text.replace(/\s*(?:\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2})$/u, '').trim();
     return stripped || text;
 }
+/**
+ * `page.evaluate` may return either the raw IIFE value or a
+ * `{ session, data }` envelope depending on the browser-bridge version.
+ * Adapter code that called `Array.isArray(payload)` directly on the
+ * envelope silently received [] for every search. This helper normalizes
+ * both shapes so callers can keep their Array.isArray checks unchanged.
+ */
+export function unwrapEvaluateResult(payload) {
+    if (payload && !Array.isArray(payload) && typeof payload === 'object' && Array.isArray(payload.data)) {
+        return payload.data;
+    }
+    return payload;
+}
 export function parseLimit(raw) {
     const parsed = Number(raw ?? 20);
     if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
@@ -275,14 +288,14 @@ export const command = cli({
         // layout, so scrolling to the bottom can evict the initially visible
         // note cards from the DOM and make extraction return [] even though the
         // browser rendered results correctly.
-        const initialPayload = await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com'));
+        const initialPayload = unwrapEvaluateResult(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')));
         let payload = Array.isArray(initialPayload) ? initialPayload : [];
         if (payload.length < limit) {
             // Scroll until enough rows are rendered or the lazy-load plateaus.
             // Replaces the previous fixed `autoScroll({ times: 2 })` which capped
             // extraction at ~13 notes regardless of `--limit` (#1471).
             await page.evaluate(buildScrollUntilJs(limit));
-            const scrolledPayload = await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com'));
+            const scrolledPayload = unwrapEvaluateResult(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')));
             if (Array.isArray(scrolledPayload)) {
                 const seen = new Set(payload.map((item) => item.url).filter(Boolean));
                 for (const item of scrolledPayload) {

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { JSDOM } from 'jsdom';
-import { __test__, buildScrollUntilJs, noteIdToDate } from './search.js';
+import { __test__, buildScrollUntilJs, noteIdToDate, unwrapEvaluateResult } from './search.js';
 
 function markVisible(el) {
     el.getBoundingClientRect = () => ({ width: 100, height: 100 });
@@ -266,5 +266,28 @@ describe('noteIdToDate (ObjectID timestamp parsing)', () => {
     it('returns empty string when timestamp is out of range', () => {
         // All zeros → ts = 0
         expect(noteIdToDate('https://www.xiaohongshu.com/search_result/000000000000000000000000')).toBe('');
+    });
+});
+describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
+    it('returns the raw array unchanged when payload is already an array', () => {
+        const arr = [{ title: 'a' }, { title: 'b' }];
+        expect(unwrapEvaluateResult(arr)).toBe(arr);
+    });
+    it('unwraps { session, data: [...] } envelope to the inner array', () => {
+        const arr = [{ title: 'a' }];
+        const env = { session: 'site:xiaohongshu:abc', data: arr };
+        expect(unwrapEvaluateResult(env)).toBe(arr);
+    });
+    it('passes non-envelope objects through unchanged', () => {
+        const obj = { results: [], loginWall: true };
+        expect(unwrapEvaluateResult(obj)).toBe(obj);
+    });
+    it('handles null and undefined safely', () => {
+        expect(unwrapEvaluateResult(null)).toBe(null);
+        expect(unwrapEvaluateResult(undefined)).toBe(undefined);
+    });
+    it('does not unwrap when envelope.data is not an array', () => {
+        const env = { session: 'x', data: { not: 'an array' } };
+        expect(unwrapEvaluateResult(env)).toBe(env);
     });
 });

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -57,24 +57,37 @@ describe('xiaohongshu search', () => {
         expect(page.evaluate).toHaveBeenCalledTimes(1);
         expect(page.autoScroll).not.toHaveBeenCalled();
     });
+    it('unwraps a browser-bridge envelope before handling login-wall wait result', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([
+            { session: 'site:xiaohongshu', data: 'login_wall' },
+        ]);
+
+        await expect(cmd.func(page, { query: '特斯拉', limit: 5 })).rejects.toMatchObject({
+            code: 'AUTH_REQUIRED',
+            message: expect.stringContaining('blocked behind a login wall'),
+        });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
     it('returns ranked results with search_result url and author_url preserved', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         expect(cmd?.func).toBeTypeOf('function');
         const detailUrl = 'https://www.xiaohongshu.com/search_result/68e90be80000000004022e66?xsec_token=test-token&xsec_source=';
         const authorUrl = 'https://www.xiaohongshu.com/user/profile/635a9c720000000018028b40?xsec_token=user-token&xsec_source=pc_search';
+        const rows = [
+            {
+                title: '某鱼买FSD被坑了4万',
+                author: '随风',
+                likes: '261',
+                url: detailUrl,
+                author_url: authorUrl,
+            },
+        ];
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: initial DOM extraction (already enough results)
-            [
-                {
-                    title: '某鱼买FSD被坑了4万',
-                    author: '随风',
-                    likes: '261',
-                    url: detailUrl,
-                    author_url: authorUrl,
-                },
-            ],
+            // Second evaluate: initial DOM extraction (already enough results) through Browser Bridge envelope.
+            { session: 'site:xiaohongshu', data: rows },
         ]);
         const result = await cmd.func(page, { query: '特斯拉', limit: 1 });
         // Should only do one goto (the search page itself), no per-note detail navigation
@@ -90,6 +103,18 @@ describe('xiaohongshu search', () => {
                 author_url: authorUrl,
             },
         ]);
+    });
+    it('fails typed instead of silently returning [] for malformed extraction payloads', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([
+            'content',
+            { session: 'site:xiaohongshu', data: { rows: [] } },
+        ]);
+
+        await expect(cmd.func(page, { query: '测试', limit: 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('payload shape'),
+        });
     });
     it('filters out results with no title and respects the limit', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
@@ -134,6 +159,10 @@ describe('xiaohongshu search', () => {
             // First evaluate: MutationObserver wait (content appeared)
             'content',
             // Second evaluate: initial extraction (no rows rendered)
+            [],
+            // Third evaluate: scroll-until row count
+            0,
+            // Fourth evaluate: post-scroll extraction (still no rows)
             [],
         ]);
         const result = (await cmd.func(page, { query: '测试等待', limit: 5 }));
@@ -278,6 +307,9 @@ describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
         const env = { session: 'site:xiaohongshu:abc', data: arr };
         expect(unwrapEvaluateResult(env)).toBe(arr);
     });
+    it('unwraps primitive data from Browser Bridge envelopes', () => {
+        expect(unwrapEvaluateResult({ session: 'site:xiaohongshu:abc', data: 'login_wall' })).toBe('login_wall');
+    });
     it('passes non-envelope objects through unchanged', () => {
         const obj = { results: [], loginWall: true };
         expect(unwrapEvaluateResult(obj)).toBe(obj);
@@ -286,8 +318,8 @@ describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
         expect(unwrapEvaluateResult(null)).toBe(null);
         expect(unwrapEvaluateResult(undefined)).toBe(undefined);
     });
-    it('does not unwrap when envelope.data is not an array', () => {
+    it('unwraps non-array envelope data so callers can validate the payload shape', () => {
         const env = { session: 'x', data: { not: 'an array' } };
-        expect(unwrapEvaluateResult(env)).toBe(env);
+        expect(unwrapEvaluateResult(env)).toEqual({ not: 'an array' });
     });
 });


### PR DESCRIPTION
## Summary

`opencli xiaohongshu search <keyword>` silently returns `[]` for every query — even ones with results visible in a normal Chrome tab. `opencli rednote search` has the same bug. Exit code 0, `status: success` in trace, no console errors, no failed network — indistinguishable from "no matches."

Root cause: the browser bridge wraps `page.evaluate(...)` return values in a `{ session, data }` envelope. Both search adapters do `Array.isArray(payload) ? payload : []` directly on the envelope — that's always `false`, so every result is discarded.

This PR adds a shared `unwrapEvaluateResult(payload)` helper exported from `clis/xiaohongshu/search.js` and uses it at the three call sites (two in `xiaohongshu/search.js`, one in `rednote/search.js`). The helper is a defensive ternary: it unwraps when payload looks like `{ session, data: Array }`, otherwise passes through unchanged. Back-compat with bridge versions that return the raw value.

## Reproduction (before fix)

```bash
# Logged in to xiaohongshu.com; feed/note/comments all work
$ opencli xiaohongshu feed --limit 1 -f yaml
# ✅ feed works

$ opencli xiaohongshu search "补墙洞" -f yaml
[]
# ❌ search silently empty for every keyword

$ opencli xiaohongshu search "补墙洞" --trace on
# trace summary: status=success, no errors, ~3.7s runtime, no failed network
```

DOM is fine:
```bash
$ opencli browser --session xhs open "https://www.xiaohongshu.com/search_result?keyword=%E8%A1%A5%E5%A2%99%E6%B4%9E"
$ opencli browser --session xhs eval "document.querySelectorAll('section.note-item').length"
22
```

## Root cause evidence

Adding `process.stderr.write(JSON.stringify(payload))` before the `Array.isArray` check:

```
{"session":"site:xiaohongshu:<uuid>","data":[{"title":"...","author":"...",...},...]}
```

`Array.isArray({session, data: [...]})` is `false`, so every IIFE result is dropped.

### Why other commands are unaffected

`feed.js`, `note.js`, `comments.js` access nested fields (`data.results`, `data.note`, etc.) on the returned value, which by coincidence walks one level into the envelope's inner object. Only `search.js` (and its `rednote` mirror) returns a bare array from its IIFE and does a strict `Array.isArray` typecheck — there's no field name to coincidentally route around the envelope, so 100% of results are dropped.

The shared `buildSearchExtractJs` import means `rednote/search.js` inherited the same bug.

## Fix shape

```js
export function unwrapEvaluateResult(payload) {
    if (payload && !Array.isArray(payload) && typeof payload === 'object' && Array.isArray(payload.data)) {
        return payload.data;
    }
    return payload;
}
```

Used as `const initialPayload = unwrapEvaluateResult(await page.evaluate(...))` at the three sites. The `Array.isArray(initialPayload)` typecheck immediately after each call site is preserved unchanged.

## Verification

```bash
$ opencli xiaohongshu search "补墙洞" --limit 10 -f yaml
- rank: 1
  author: 梨枝糖姜
  likes: '1775'
  title: 黑洞消失术｜墙面打孔修复
  url: https://www.xiaohongshu.com/search_result/682739cb...
- rank: 2
  author: 小月想当农场主🌱
  likes: '599'
  title: 40秒分享补墙的大大大洞，新手容易踩哪些坑
...
```

All declared columns (`rank, title, author, likes, published_at, url`) populated.

Tests: 24 passed in `clis/xiaohongshu/search.test.js` (existing 19 + 5 new unit tests for `unwrapEvaluateResult`), 12 passed in `clis/rednote/rednote.test.js`. No existing test changes — the unwrap is invisible to existing mocks that already return raw arrays.

## Suggested follow-ups (not in this PR)

These came up during diagnosis. Happy to open separate issues:

1. **Silent `[]` from `WAIT_FOR_CONTENT_JS` timeout branch.** If neither `section.note-item` nor the login wall appears within 5s, the adapter currently continues and returns whatever's there (`[]`). Worth either widening the wait deadline (some sessions need >5s) or throwing an explicit `TimeoutError` so the empty result is distinguishable from "genuinely zero matches."

2. **The `{ session, data }` envelope is a hidden API contract.** Adapter authors have to either know to unwrap or coincidentally access a field on the inner object. Options:
   - A: Bridge returns raw value (revert envelope) — breaks any adapter that touches `.session` / `.data` from envelope; needs audit.
   - B: Add `page.evaluateValue(...)` that always returns the unwrapped value; keep `page.evaluate` for callers that want the envelope.
   - C: Add `page.evaluate(code, { unwrap: true })` option.
   This bug took ~8 diagnostic steps to find — the right move (Node-side `process.stderr.write(payload)`) would have been step 1 if the envelope shape were discoverable from docs/types.

## Test plan

- [x] `opencli xiaohongshu search "<query>"` returns non-empty list for known-good queries
- [x] All 24 tests in `clis/xiaohongshu/search.test.js` pass
- [x] All 12 tests in `clis/rednote/rednote.test.js` pass
- [ ] Reviewer to confirm `opencli rednote search "<query>"` works (requires rednote.com login; xiaohongshu.com login auto-bridges via `account_holder_country=US` redirect)
