### PR TITLE
fix(ci): add Windows native binding lock entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.18",
+  "version": "1.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.7.18",
+      "version": "1.7.20",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -732,6 +732,23 @@
         "glibc"
       ]
     },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
@@ -768,6 +785,20 @@
       ],
       "libc": [
         "glibc"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@shikijs/core": {


### PR DESCRIPTION
## Summary
- add missing Windows x64 optional native binding lock entries for rolldown and rollup
- sync package-lock root version with package.json 1.7.20

## Why
Main CI Windows unit-test fails before tests start because Vitest imports rolldown and npm did not install `@rolldown/binding-win32-x64-msvc` from the incomplete lockfile.

## Test
- `npx -p npm@10 npm ci --ignore-scripts --dry-run`
- `npx tsc --noEmit`
- `npm run build`
- `npx vitest run --project unit src/external.test.ts src/help.test.ts src/cli.test.ts`
- `git diff --check`