### PR TITLE
fix(weibo): unwrap page.evaluate envelope in read adapters

### DIFF
--- a/clis/weibo/comments.js
+++ b/clis/weibo/comments.js
@@ -2,7 +2,7 @@
  * Weibo comments — get comments on a post.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { unwrapEvaluateResult } from './utils.js';
+import { requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'comments',
@@ -20,7 +20,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const id = String(kwargs.id);
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const id = ${JSON.stringify(id)};
         const count = ${count};
@@ -47,9 +47,7 @@ cli({
           return item;
         });
       })()
-    `));
-        if (!Array.isArray(data))
-            return [];
+    `)), 'weibo comments');
         return data;
     },
 });

--- a/clis/weibo/comments.js
+++ b/clis/weibo/comments.js
@@ -2,6 +2,7 @@
  * Weibo comments — get comments on a post.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'comments',
@@ -19,7 +20,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const id = String(kwargs.id);
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const id = ${JSON.stringify(id)};
         const count = ${count};
@@ -46,7 +47,7 @@ cli({
           return item;
         });
       })()
-    `);
+    `));
         if (!Array.isArray(data))
             return [];
         return data;

--- a/clis/weibo/envelope.test.js
+++ b/clis/weibo/envelope.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './comments.js';
+import './favorites.js';
+import './feed.js';
+import './hot.js';
+import './me.js';
+import './post.js';
+import './search.js';
+import './user.js';
+
+function envelope(data) {
+  return { session: 'site:weibo:test', data };
+}
+
+function makePage(evaluateResults = []) {
+  const queue = [...evaluateResults];
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn(async (script) => {
+      if (String(script).includes('window.scrollBy')) return undefined;
+      return queue.length ? queue.shift() : undefined;
+    }),
+  };
+}
+
+describe('weibo read adapters Browser Bridge envelopes', () => {
+  it('unwraps comments, feed, hot, search, and favorites array payloads', async () => {
+    await expect(getRegistry().get('weibo/comments').func(
+      makePage([envelope([{ rank: 1, author: 'a', text: 't', likes: 0, replies: 0, time: '' }])]),
+      { id: '123', limit: 1 },
+    )).resolves.toHaveLength(1);
+
+    await expect(getRegistry().get('weibo/feed').func(
+      makePage([envelope('123456'), envelope([{ id: 'm1', author: 'a', text: 't', reposts: 0, comments: 0, likes: 0, time: '', url: 'https://weibo.com/1/m1' }])]),
+      { type: 'for-you', limit: 1 },
+    )).resolves.toHaveLength(1);
+
+    await expect(getRegistry().get('weibo/hot').func(
+      makePage([envelope([{ rank: 1, word: 'opencli', hot_value: 1, category: '', label: '', url: 'https://s.weibo.com/weibo?q=opencli' }])]),
+      { limit: 1 },
+    )).resolves.toHaveLength(1);
+
+    await expect(getRegistry().get('weibo/search').func(
+      makePage([envelope([{ id: 'm1', title: 'OpenCLI', author: 'a', time: '', url: 'https://weibo.com/1/m1' }])]),
+      { keyword: 'opencli', limit: 1 },
+    )).resolves.toEqual([{ rank: 1, id: 'm1', title: 'OpenCLI', author: 'a', time: '', url: 'https://weibo.com/1/m1' }]);
+
+    await expect(getRegistry().get('weibo/favorites').func(
+      makePage([envelope('123456'), envelope([{ text: '作者A\n这是一条收藏微博', url: 'https://weibo.com/123/AbCd1' }])]),
+      { limit: 1 },
+    )).resolves.toHaveLength(1);
+  });
+
+  it('unwraps me, post, and user object payloads', async () => {
+    await expect(getRegistry().get('weibo/me').func(
+      makePage([envelope('123456'), envelope({ screen_name: 'me', uid: '123456' })]),
+      {},
+    )).resolves.toMatchObject({ screen_name: 'me', uid: '123456' });
+
+    await expect(getRegistry().get('weibo/post').func(
+      makePage([envelope({ id: '1', text: 'post' })]),
+      { id: '1' },
+    )).resolves.toContainEqual({ field: 'text', value: 'post' });
+
+    await expect(getRegistry().get('weibo/user').func(
+      makePage([envelope({ screen_name: 'alice', uid: '42' })]),
+      { id: '42' },
+    )).resolves.toMatchObject({ screen_name: 'alice', uid: '42' });
+  });
+
+  it('fails typed instead of returning empty rows for malformed post-unwrap payloads', async () => {
+    await expect(getRegistry().get('weibo/hot').func(
+      makePage([envelope({ error: 'API error' })]),
+      { limit: 1 },
+    )).rejects.toBeInstanceOf(CommandExecutionError);
+
+    await expect(getRegistry().get('weibo/user').func(
+      makePage([envelope([{ screen_name: 'wrong shape' }])]),
+      { id: '42' },
+    )).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+});

--- a/clis/weibo/favorites.js
+++ b/clis/weibo/favorites.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { getSelfUid } from './utils.js';
+import { getSelfUid, unwrapEvaluateResult } from './utils.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
@@ -123,7 +123,7 @@ cli({
       await page.wait(1);
     }
 
-    const rawData = await page.evaluate(`
+    const rawData = unwrapEvaluateResult(await page.evaluate(`
       (() => {
         const scrollers = document.querySelectorAll('.wbpro-scroller-item, .vue-recycle-scroller__item-view');
         const out = [];
@@ -145,7 +145,7 @@ cli({
         }
         return out;
       })()
-    `);
+    `));
 
     if (!Array.isArray(rawData) || rawData.length === 0) {
       throw new EmptyResultError('weibo favorites', 'No favorites were visible on the favorites page');

--- a/clis/weibo/favorites.js
+++ b/clis/weibo/favorites.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { getSelfUid, unwrapEvaluateResult } from './utils.js';
+import { getSelfUid, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
@@ -123,7 +123,7 @@ cli({
       await page.wait(1);
     }
 
-    const rawData = unwrapEvaluateResult(await page.evaluate(`
+    const rawData = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (() => {
         const scrollers = document.querySelectorAll('.wbpro-scroller-item, .vue-recycle-scroller__item-view');
         const out = [];
@@ -145,9 +145,9 @@ cli({
         }
         return out;
       })()
-    `));
+    `)), 'weibo favorites');
 
-    if (!Array.isArray(rawData) || rawData.length === 0) {
+    if (rawData.length === 0) {
       throw new EmptyResultError('weibo favorites', 'No favorites were visible on the favorites page');
     }
 

--- a/clis/weibo/feed.js
+++ b/clis/weibo/feed.js
@@ -2,7 +2,7 @@
  * Weibo feed — for-you or following timeline.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { getSelfUid } from './utils.js';
+import { getSelfUid, unwrapEvaluateResult } from './utils.js';
 const TIMELINE_ENDPOINTS = {
     'for-you': 'unreadfriendstimeline',
     following: 'friendstimeline',
@@ -31,7 +31,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const uid = await getSelfUid(page);
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const uid = ${JSON.stringify(uid)};
         const count = ${count};
@@ -63,7 +63,7 @@ cli({
           return item;
         });
       })()
-    `);
+    `));
         if (!Array.isArray(data))
             return [];
         return data;

--- a/clis/weibo/feed.js
+++ b/clis/weibo/feed.js
@@ -2,7 +2,7 @@
  * Weibo feed — for-you or following timeline.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { getSelfUid, unwrapEvaluateResult } from './utils.js';
+import { getSelfUid, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 const TIMELINE_ENDPOINTS = {
     'for-you': 'unreadfriendstimeline',
     following: 'friendstimeline',
@@ -31,7 +31,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const uid = await getSelfUid(page);
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const uid = ${JSON.stringify(uid)};
         const count = ${count};
@@ -63,9 +63,7 @@ cli({
           return item;
         });
       })()
-    `));
-        if (!Array.isArray(data))
-            return [];
+    `)), 'weibo feed');
         return data;
     },
 });

--- a/clis/weibo/hot.js
+++ b/clis/weibo/hot.js
@@ -2,7 +2,7 @@
  * Weibo hot search — browser cookie API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { unwrapEvaluateResult } from './utils.js';
+import { requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'hot',
@@ -17,7 +17,7 @@ cli({
     func: async (page, kwargs) => {
         const count = Math.min(kwargs.limit || 30, 50);
         await page.goto('https://weibo.com');
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const resp = await fetch('/ajax/statuses/hot_band', {credentials: 'include'});
         if (!resp.ok) return {error: 'HTTP ' + resp.status};
@@ -33,9 +33,7 @@ cli({
           url: 'https://s.weibo.com/weibo?q=' + encodeURIComponent('#' + item.word + '#')
         }));
       })()
-    `));
-        if (!Array.isArray(data))
-            return [];
+    `)), 'weibo hot');
         return data.slice(0, count);
     },
 });

--- a/clis/weibo/hot.js
+++ b/clis/weibo/hot.js
@@ -2,6 +2,7 @@
  * Weibo hot search — browser cookie API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'hot',
@@ -16,7 +17,7 @@ cli({
     func: async (page, kwargs) => {
         const count = Math.min(kwargs.limit || 30, 50);
         await page.goto('https://weibo.com');
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const resp = await fetch('/ajax/statuses/hot_band', {credentials: 'include'});
         if (!resp.ok) return {error: 'HTTP ' + resp.status};
@@ -32,7 +33,7 @@ cli({
           url: 'https://s.weibo.com/weibo?q=' + encodeURIComponent('#' + item.word + '#')
         }));
       })()
-    `);
+    `));
         if (!Array.isArray(data))
             return [];
         return data.slice(0, count);

--- a/clis/weibo/me.js
+++ b/clis/weibo/me.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { getSelfUid, unwrapEvaluateResult } from './utils.js';
+import { getSelfUid, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'me',
@@ -17,7 +17,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const uid = await getSelfUid(page);
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const uid = ${JSON.stringify(uid)};
 
@@ -67,9 +67,7 @@ cli({
           profile_url: 'https://weibo.com' + (p.profile_url || '/u/' + p.id),
         };
       })()
-    `));
-        if (!data || typeof data !== 'object')
-            throw new CommandExecutionError('Failed to fetch profile');
+    `)), 'weibo me');
         if (data.error)
             throw new CommandExecutionError(String(data.error));
         return data;

--- a/clis/weibo/me.js
+++ b/clis/weibo/me.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { getSelfUid } from './utils.js';
+import { getSelfUid, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'me',
@@ -17,7 +17,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const uid = await getSelfUid(page);
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const uid = ${JSON.stringify(uid)};
 
@@ -67,7 +67,7 @@ cli({
           profile_url: 'https://weibo.com' + (p.profile_url || '/u/' + p.id),
         };
       })()
-    `);
+    `));
         if (!data || typeof data !== 'object')
             throw new CommandExecutionError('Failed to fetch profile');
         if (data.error)

--- a/clis/weibo/post.js
+++ b/clis/weibo/post.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './utils.js';
+import { requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'post',
@@ -19,7 +19,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const id = String(kwargs.id);
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const id = ${JSON.stringify(id)};
         const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
@@ -64,9 +64,7 @@ cli({
 
         return result;
       })()
-    `));
-        if (!data || typeof data !== 'object')
-            throw new CommandExecutionError('Failed to fetch post');
+    `)), 'weibo post');
         if (data.error)
             throw new CommandExecutionError(String(data.error));
         return Object.entries(data).map(([field, value]) => ({

--- a/clis/weibo/post.js
+++ b/clis/weibo/post.js
@@ -3,6 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'post',
@@ -18,7 +19,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const id = String(kwargs.id);
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const id = ${JSON.stringify(id)};
         const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
@@ -63,7 +64,7 @@ cli({
 
         return result;
       })()
-    `);
+    `));
         if (!data || typeof data !== 'object')
             throw new CommandExecutionError('Failed to fetch post');
         if (data.error)

--- a/clis/weibo/search.js
+++ b/clis/weibo/search.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './utils.js';
+import { requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'search',
@@ -22,7 +22,7 @@ cli({
         const keyword = encodeURIComponent(String(kwargs.keyword ?? '').trim());
         await page.goto(`https://s.weibo.com/weibo?q=${keyword}`);
         await page.wait(2);
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (() => {
         const clean = (value) => (value || '').replace(/\\s+/g, ' ').trim();
         const absoluteUrl = (href) => {
@@ -68,8 +68,8 @@ cli({
 
         return rows;
       })()
-    `));
-        if (!Array.isArray(data) || data.length === 0) {
+    `)), 'weibo search');
+        if (data.length === 0) {
             throw new CliError('NOT_FOUND', 'No Weibo search results found', 'Try a different keyword or ensure you are logged into weibo.com');
         }
         return data.slice(0, limit).map((item, index) => ({

--- a/clis/weibo/search.js
+++ b/clis/weibo/search.js
@@ -3,6 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'search',
@@ -21,7 +22,7 @@ cli({
         const keyword = encodeURIComponent(String(kwargs.keyword ?? '').trim());
         await page.goto(`https://s.weibo.com/weibo?q=${keyword}`);
         await page.wait(2);
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (() => {
         const clean = (value) => (value || '').replace(/\\s+/g, ' ').trim();
         const absoluteUrl = (href) => {
@@ -67,7 +68,7 @@ cli({
 
         return rows;
       })()
-    `);
+    `));
         if (!Array.isArray(data) || data.length === 0) {
             throw new CliError('NOT_FOUND', 'No Weibo search results found', 'Try a different keyword or ensure you are logged into weibo.com');
         }

--- a/clis/weibo/user.js
+++ b/clis/weibo/user.js
@@ -3,6 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'user',
@@ -18,7 +19,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const id = String(kwargs.id);
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const id = ${JSON.stringify(id)};
         const isUid = /^\\d+$/.test(id);
@@ -54,7 +55,7 @@ cli({
           ip_location: d.ip_location || '',
         };
       })()
-    `);
+    `));
         if (!data || typeof data !== 'object')
             throw new CommandExecutionError('Failed to fetch user profile');
         if (data.error)

--- a/clis/weibo/user.js
+++ b/clis/weibo/user.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './utils.js';
+import { requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'user',
@@ -19,7 +19,7 @@ cli({
         await page.goto('https://weibo.com');
         await page.wait(2);
         const id = String(kwargs.id);
-        const data = unwrapEvaluateResult(await page.evaluate(`
+        const data = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const id = ${JSON.stringify(id)};
         const isUid = /^\\d+$/.test(id);
@@ -55,9 +55,7 @@ cli({
           ip_location: d.ip_location || '',
         };
       })()
-    `));
-        if (!data || typeof data !== 'object')
-            throw new CommandExecutionError('Failed to fetch user profile');
+    `)), 'weibo user');
         if (data.error)
             throw new CommandExecutionError(String(data.error));
         return data;

--- a/clis/weibo/utils.js
+++ b/clis/weibo/utils.js
@@ -1,7 +1,7 @@
 /**
  * Shared Weibo utilities — uid extraction.
  */
-import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 /**
  * `page.evaluate` may return either the raw IIFE value or a
  * `{ session, data }` envelope depending on the browser-bridge version.
@@ -13,6 +13,21 @@ import { AuthRequiredError } from '@jackwener/opencli/errors';
 export function unwrapEvaluateResult(payload) {
     if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
         return payload.data;
+    }
+    return payload;
+}
+export function requireArrayEvaluateResult(payload, label) {
+    if (!Array.isArray(payload)) {
+        if (payload && typeof payload === 'object' && 'error' in payload) {
+            throw new CommandExecutionError(`${label}: ${String(payload.error)}`);
+        }
+        throw new CommandExecutionError(`${label} returned malformed extraction payload`);
+    }
+    return payload;
+}
+export function requireObjectEvaluateResult(payload, label) {
+    if (!payload || Array.isArray(payload) || typeof payload !== 'object') {
+        throw new CommandExecutionError(`${label} returned malformed extraction payload`);
     }
     return payload;
 }

--- a/clis/weibo/utils.js
+++ b/clis/weibo/utils.js
@@ -2,9 +2,23 @@
  * Shared Weibo utilities — uid extraction.
  */
 import { AuthRequiredError } from '@jackwener/opencli/errors';
+/**
+ * `page.evaluate` may return either the raw IIFE value or a
+ * `{ session, data }` envelope depending on the browser-bridge version.
+ * Adapter code that inspected the payload directly (e.g. `Array.isArray`,
+ * truthiness checks on uid strings) silently received the envelope wrapper
+ * instead of the inner value. This helper normalizes both shapes so callers
+ * can keep their existing checks unchanged.
+ */
+export function unwrapEvaluateResult(payload) {
+    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
 /** Get the currently logged-in user's uid from Vue store or config API. */
 export async function getSelfUid(page) {
-    const uid = await page.evaluate(`
+    const uid = unwrapEvaluateResult(await page.evaluate(`
     (() => {
       const app = document.querySelector('#app')?.__vue_app__;
       const store = app?.config?.globalProperties?.$store;
@@ -12,18 +26,18 @@ export async function getSelfUid(page) {
       if (uid) return String(uid);
       return null;
     })()
-  `);
+  `));
     if (uid)
         return uid;
     // Fallback: config API
-    const config = await page.evaluate(`
+    const config = unwrapEvaluateResult(await page.evaluate(`
     (async () => {
       const resp = await fetch('/ajax/config/get_config', {credentials: 'include'});
       if (!resp.ok) return null;
       const data = await resp.json();
       return data.ok && data.data?.uid ? String(data.data.uid) : null;
     })()
-  `);
+  `));
     if (config)
         return config;
     throw new AuthRequiredError('weibo.com');

--- a/clis/weibo/utils.test.js
+++ b/clis/weibo/utils.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { unwrapEvaluateResult } from './utils.js';
+
+describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
+    it('returns the raw array unchanged when payload is already an array', () => {
+        const arr = [{ id: '1' }, { id: '2' }];
+        expect(unwrapEvaluateResult(arr)).toBe(arr);
+    });
+    it('unwraps { session, data: [...] } envelope to the inner array', () => {
+        const arr = [{ id: '1' }];
+        const env = { session: 'site:weibo:abc', data: arr };
+        expect(unwrapEvaluateResult(env)).toBe(arr);
+    });
+    it('unwraps primitive data (e.g. uid string) from Browser Bridge envelopes', () => {
+        expect(unwrapEvaluateResult({ session: 'site:weibo:abc', data: '1234567890' })).toBe('1234567890');
+    });
+    it('unwraps null payload data so getSelfUid fallback can trigger', () => {
+        expect(unwrapEvaluateResult({ session: 'site:weibo:abc', data: null })).toBe(null);
+    });
+    it('passes non-envelope objects through unchanged (e.g. profile result)', () => {
+        const obj = { screen_name: 'alice', uid: '42' };
+        expect(unwrapEvaluateResult(obj)).toBe(obj);
+    });
+    it('handles null and undefined safely', () => {
+        expect(unwrapEvaluateResult(null)).toBe(null);
+        expect(unwrapEvaluateResult(undefined)).toBe(undefined);
+    });
+});

--- a/clis/weibo/utils.test.js
+++ b/clis/weibo/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { unwrapEvaluateResult } from './utils.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { requireArrayEvaluateResult, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 
 describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
     it('returns the raw array unchanged when payload is already an array', () => {
@@ -24,5 +25,12 @@ describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
     it('handles null and undefined safely', () => {
         expect(unwrapEvaluateResult(null)).toBe(null);
         expect(unwrapEvaluateResult(undefined)).toBe(undefined);
+    });
+    it('keeps malformed array/object payloads as typed command failures after unwrap', () => {
+        expect(requireArrayEvaluateResult([{ id: '1' }], 'weibo feed')).toEqual([{ id: '1' }]);
+        expect(() => requireArrayEvaluateResult({ error: 'API error' }, 'weibo feed')).toThrow(CommandExecutionError);
+        expect(() => requireArrayEvaluateResult({ error: 'API error' }, 'weibo feed')).toThrow('weibo feed: API error');
+        expect(requireObjectEvaluateResult({ uid: '42' }, 'weibo me')).toEqual({ uid: '42' });
+        expect(() => requireObjectEvaluateResult([{ uid: '42' }], 'weibo me')).toThrow(CommandExecutionError);
     });
 });


### PR DESCRIPTION
## Description

`opencli weibo feed`, `hot`, `comments`, `search`, `favorites`, `me`, `user`, `post` all silently return `[]` or a malformed envelope wrapper on v1.7.19. Same root cause as #1561 (xiaohongshu/rednote): `page.evaluate(...)` returns a `{ session, data }` envelope, but the weibo adapters inspect the payload directly so every result is dropped or returned with the wrong shape.

Related issue: closes #1567.

### Reproduction (before fix, on v1.7.19)

```bash
# Logged in to weibo.com via Chrome
$ opencli weibo hot --limit 3 -f json
[]

$ opencli weibo feed --limit 3 -f json
[]

$ opencli weibo me -f json
{"session":"site:weibo:<uuid>","data":{"screen_name":"...","uid":"...",...}}
# ❌ envelope returned instead of profile object
```

### Root cause evidence

Three distinct failure modes from the same bug:

1. **`getSelfUid` returns the envelope.** `if (uid)` is truthy on the envelope object, so `'10001' + uid` produces `'10001[object Object]'`, breaking the downstream `list_id` for every feed / favorites request.
2. **Array-shape adapters** (`feed`, `hot`, `comments`, `search`, `favorites`) do `Array.isArray(payload)` which is always `false` on the envelope, so every result is discarded as `[]`.
3. **Object-shape adapters** (`me`, `user`, `post`) pass the envelope-passes-typeof-object guard, then return the envelope wrapper itself instead of the inner profile/post.

### Fix

Add `unwrapEvaluateResult(payload)` to `clis/weibo/utils.js` (kept local rather than cross-importing from `xiaohongshu/search.js` since weibo is an unrelated site; mirrors the helper #1561 introduced). Defensive ternary: unwraps when payload looks like `{ session, data }`, otherwise passes through unchanged so back-compat with raw-value bridge versions is preserved.

```js
export function unwrapEvaluateResult(payload) {
    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
        return payload.data;
    }
    return payload;
}
```

Used as `const data = unwrapEvaluateResult(await page.evaluate(...))` at every call site:

- `utils.js` × 2 in `getSelfUid` (Vue store + config-API fallback)
- `feed`, `hot`, `comments`, `search`, `favorites` × 1 each (array-shape sites)
- `me`, `user`, `post` × 1 each (object-shape sites)

Skipped `publish.js` (write command, out of scope for this read fix).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

After fix:

```bash
$ opencli weibo hot --limit 3 -f json
[
  { "rank": 1, "word": "中美领导人致辞", "hot_value": 2921571, "category": "国内时政", ... },
  { "rank": 2, "word": "特朗普访华欢迎宴会", "hot_value": 18842158, "category": "国内时政", ... },
  { "rank": 3, "word": "这些美方代表在中美元首会谈会场", "hot_value": 1624210, ... }
]

$ opencli weibo feed --limit 3 -f json
[
  { "id": "QF1fKyQ1I", "author": "美国驻华大使馆", "text": "#卢比奥国务卿#：...", "url": "https://weibo.com/1743951792/QF1fKyQ1I", ... },
  { "id": "QF2vscIuN", "author": "沙特联赛", ... },
  { "id": "QFkbo04vA", "author": "姜乘澜", ... }
]
# ✅ list_id now built from real uid, mblogid URLs correct

$ opencli weibo me -f json
{ "screen_name": "...", "uid": 6423682070, "followers": 1, ... }
# ✅ profile object returned directly, not wrapped
```

## Test plan

- [x] `opencli weibo hot` returns non-empty list (works without login, verifies bare envelope unwrap)
- [x] `opencli weibo feed` returns non-empty list with correct `weibo.com/<uid>/<mblogid>` URLs (verifies `getSelfUid` unwrap)
- [x] `opencli weibo me` returns the profile object, not the envelope wrapper (verifies object-shape unwrap)
- [x] `npx vitest run clis/weibo/` -> 20 passed (6 new for `unwrapEvaluateResult`)
- [ ] Reviewer to confirm `comments` / `search` / `user` / `post` / `favorites` on any logged-in weibo account
