### PR TITLE
fix(social): use ephemeral adapter site sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ External CLI surface cleanup + Browser Bridge WebSocket lifecycle hardening. Two
 
 ### Bug Fixes
 
+* **twitter, reddit** — default browser-backed social adapters back to ephemeral tab leases. Twitter/X and Reddit commands now release their site tab after each run while keeping the shared Adapter window available for reuse; persistent sessions remain reserved for AI/chat-style adapters that need long-lived conversation state.
 * **daemon** — report ambiguous browser command outcomes with a distinct `command_result_unknown` errorCode and `503` when the extension WebSocket drops between command dispatch and result delivery. `sendCommandRaw()` treats this code as hard non-retryable, so write-side commands (`navigate` / `click` / `type` / `eval`) won't be silently re-issued and double-executed. Daemon exposes a `commandResultUnknown` counter on `/status` for future observability. ([#1558](https://github.com/jackwener/opencli/issues/1558))
 * **extension** — keep active daemon WebSocket; stale sockets no longer clobber active connection (`onopen` / `onclose` / `onmessage` are all gated by `ws !== thisWs` short-circuit), and `safeSend` only fires when `readyState === OPEN`. ([#1540](https://github.com/jackwener/opencli/issues/1540))
 * **extension** — coalesce concurrent daemon WebSocket connects via an in-flight promise. Startup / keepalive / reconnect triggering `connect()` during the daemon-probe or context-lookup async gap no longer creates duplicate real WebSocket connections. ([#1554](https://github.com/jackwener/opencli/issues/1554))

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19118,8 +19118,7 @@
     "type": "js",
     "modulePath": "reddit/comment.js",
     "sourceFile": "reddit/comment.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19149,8 +19148,7 @@
     "type": "js",
     "modulePath": "reddit/frontpage.js",
     "sourceFile": "reddit/frontpage.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19182,8 +19180,7 @@
     "type": "js",
     "modulePath": "reddit/home.js",
     "sourceFile": "reddit/home.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19252,8 +19249,7 @@
     "type": "js",
     "modulePath": "reddit/popular.js",
     "sourceFile": "reddit/popular.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19330,8 +19326,7 @@
     "type": "js",
     "modulePath": "reddit/read.js",
     "sourceFile": "reddit/read.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19397,8 +19392,7 @@
     "type": "js",
     "modulePath": "reddit/save.js",
     "sourceFile": "reddit/save.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19427,8 +19421,7 @@
     "type": "js",
     "modulePath": "reddit/saved.js",
     "sourceFile": "reddit/saved.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19486,8 +19479,7 @@
     "type": "js",
     "modulePath": "reddit/search.js",
     "sourceFile": "reddit/search.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19537,8 +19529,7 @@
     "type": "js",
     "modulePath": "reddit/subreddit.js",
     "sourceFile": "reddit/subreddit.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19564,8 +19555,7 @@
     "type": "js",
     "modulePath": "reddit/subreddit-info.js",
     "sourceFile": "reddit/subreddit-info.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19598,8 +19588,7 @@
     "type": "js",
     "modulePath": "reddit/subscribe.js",
     "sourceFile": "reddit/subscribe.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19632,8 +19621,7 @@
     "type": "js",
     "modulePath": "reddit/upvote.js",
     "sourceFile": "reddit/upvote.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19662,8 +19650,7 @@
     "type": "js",
     "modulePath": "reddit/upvoted.js",
     "sourceFile": "reddit/upvoted.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19689,8 +19676,7 @@
     "type": "js",
     "modulePath": "reddit/user.js",
     "sourceFile": "reddit/user.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19725,8 +19711,7 @@
     "type": "js",
     "modulePath": "reddit/user-comments.js",
     "sourceFile": "reddit/user-comments.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19762,8 +19747,7 @@
     "type": "js",
     "modulePath": "reddit/user-posts.js",
     "sourceFile": "reddit/user-posts.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "reddit",
@@ -19781,8 +19765,7 @@
     "type": "js",
     "modulePath": "reddit/whoami.js",
     "sourceFile": "reddit/whoami.js",
-    "navigateBefore": "https://reddit.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://reddit.com"
   },
   {
     "site": "rednote",
@@ -22570,8 +22553,7 @@
     "type": "js",
     "modulePath": "twitter/article.js",
     "sourceFile": "twitter/article.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22671,8 +22653,7 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
     "sourceFile": "twitter/bookmark-folder.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22692,8 +22673,7 @@
     "type": "js",
     "modulePath": "twitter/bookmark-folders.js",
     "sourceFile": "twitter/bookmark-folders.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22734,8 +22714,7 @@
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
     "sourceFile": "twitter/bookmarks.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22809,8 +22788,7 @@
     "type": "js",
     "modulePath": "twitter/download.js",
     "sourceFile": "twitter/download.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -22870,8 +22848,7 @@
     "type": "js",
     "modulePath": "twitter/followers.js",
     "sourceFile": "twitter/followers.js",
-    "navigateBefore": true,
-    "siteSession": "persistent"
+    "navigateBefore": true
   },
   {
     "site": "twitter",
@@ -22906,8 +22883,7 @@
     "type": "js",
     "modulePath": "twitter/following.js",
     "sourceFile": "twitter/following.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23007,8 +22983,7 @@
     "type": "js",
     "modulePath": "twitter/likes.js",
     "sourceFile": "twitter/likes.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23128,8 +23103,7 @@
     "type": "js",
     "modulePath": "twitter/list-tweets.js",
     "sourceFile": "twitter/list-tweets.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23158,8 +23132,7 @@
     "type": "js",
     "modulePath": "twitter/lists.js",
     "sourceFile": "twitter/lists.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23188,8 +23161,7 @@
     "type": "js",
     "modulePath": "twitter/notifications.js",
     "sourceFile": "twitter/notifications.js",
-    "navigateBefore": true,
-    "siteSession": "persistent"
+    "navigateBefore": true
   },
   {
     "site": "twitter",
@@ -23259,8 +23231,7 @@
     "type": "js",
     "modulePath": "twitter/profile.js",
     "sourceFile": "twitter/profile.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23529,8 +23500,7 @@
     "type": "js",
     "modulePath": "twitter/search.js",
     "sourceFile": "twitter/search.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23576,8 +23546,7 @@
     "type": "js",
     "modulePath": "twitter/thread.js",
     "sourceFile": "twitter/thread.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23630,8 +23599,7 @@
     "type": "js",
     "modulePath": "twitter/timeline.js",
     "sourceFile": "twitter/timeline.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23658,8 +23626,7 @@
     "type": "js",
     "modulePath": "twitter/trending.js",
     "sourceFile": "twitter/trending.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",
@@ -23709,8 +23676,7 @@
     "type": "js",
     "modulePath": "twitter/tweets.js",
     "sourceFile": "twitter/tweets.js",
-    "navigateBefore": "https://x.com",
-    "siteSession": "persistent"
+    "navigateBefore": "https://x.com"
   },
   {
     "site": "twitter",

--- a/clis/reddit/comment.js
+++ b/clis/reddit/comment.js
@@ -8,7 +8,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
         { name: 'text', type: 'string', required: true, positional: true, help: 'Comment text' },

--- a/clis/reddit/frontpage.js
+++ b/clis/reddit/frontpage.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/reddit/home.js
+++ b/clis/reddit/home.js
@@ -23,7 +23,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 25, help: `Number of posts (1–${REDDIT_HOME_MAX_LIMIT})` },
     ],

--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -105,7 +105,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'post-id', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or full URL' },
         { name: 'sort', default: 'best', help: 'Comment sort: best, top, new, controversial, old, qa' },

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -78,9 +78,9 @@ function makeRuntimePage(fetchImpl) {
 describe('reddit read adapter', () => {
     const command = getRegistry().get('reddit/read');
 
-    it('opts into the Reddit persistent site session', () => {
+    it('uses an ephemeral Reddit site tab by default', () => {
         expect(command?.browser).toBe(true);
-        expect(command?.siteSession).toBe('persistent');
+        expect(command?.siteSession).toBeUndefined();
         expect(command?.columns).toEqual(['type', 'author', 'score', 'text']);
     });
 

--- a/clis/reddit/save.js
+++ b/clis/reddit/save.js
@@ -8,7 +8,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
         { name: 'undo', type: 'boolean', default: false, help: 'Unsave instead of save' },

--- a/clis/reddit/saved.js
+++ b/clis/reddit/saved.js
@@ -8,7 +8,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: 'Reddit search query' },
         {

--- a/clis/reddit/subreddit-info.js
+++ b/clis/reddit/subreddit-info.js
@@ -32,7 +32,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'name', type: 'string', required: true, positional: true, help: 'Subreddit name (no `r/` prefix needed)' },
     ],

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'name', type: 'string', required: true, positional: true, help: 'Subreddit name (no `r/` prefix; e.g. `python`)' },
         {

--- a/clis/reddit/subscribe.js
+++ b/clis/reddit/subscribe.js
@@ -8,7 +8,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'subreddit', type: 'string', required: true, positional: true, help: 'Subreddit name (e.g. python)' },
         { name: 'undo', type: 'boolean', default: false, help: 'Unsubscribe instead of subscribe' },

--- a/clis/reddit/upvote.js
+++ b/clis/reddit/upvote.js
@@ -8,7 +8,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'post-id', type: 'string', required: true, positional: true, help: 'Post ID (e.g. 1abc123) or fullname (t3_xxx)' },
         { name: 'direction', type: 'string', default: 'up', help: 'Vote direction: up, down, none' },

--- a/clis/reddit/upvoted.js
+++ b/clis/reddit/upvoted.js
@@ -8,7 +8,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],

--- a/clis/reddit/user-comments.js
+++ b/clis/reddit/user-comments.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
         { name: 'limit', type: 'int', default: 15 },

--- a/clis/reddit/user-posts.js
+++ b/clis/reddit/user-posts.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
         { name: 'limit', type: 'int', default: 15 },

--- a/clis/reddit/user.js
+++ b/clis/reddit/user.js
@@ -7,7 +7,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', required: true, positional: true, help: 'Reddit username (no `u/` prefix needed)' },
     ],

--- a/clis/reddit/whoami.js
+++ b/clis/reddit/whoami.js
@@ -9,7 +9,6 @@ cli({
     domain: 'reddit.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [],
     columns: ['field', 'value'],
     func: async (page) => {

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -11,7 +11,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'tweet-id', type: 'string', positional: true, required: true, help: 'Tweet ID or URL containing the article' },
     ],

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -124,7 +124,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'folder-id', positional: true, type: 'string', required: true, help: 'Folder id from `opencli twitter bookmark-folders`.' },
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },

--- a/clis/twitter/bookmark-folders.js
+++ b/clis/twitter/bookmark-folders.js
@@ -77,7 +77,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [],
     columns: ['id', 'name', 'items', 'created_at'],
     func: async (page) => {

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -108,7 +108,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },

--- a/clis/twitter/download.js
+++ b/clis/twitter/download.js
@@ -15,7 +15,6 @@ cli({
     description: 'Download Twitter/X media (images and videos). Provide either <username> to scan a profile\'s media tab, or --tweet-url to download a single tweet.',
     domain: 'x.com',
     strategy: Strategy.COOKIE,
-    siteSession: 'persistent',
     args: [
         { name: 'username', positional: true, help: 'Twitter username (with or without @) to scan their /media tab. Either <username> or --tweet-url is required.' },
         { name: 'tweet-url', help: 'Single tweet URL to download. Use this OR <username>, not both required at once.' },

--- a/clis/twitter/followers.js
+++ b/clis/twitter/followers.js
@@ -84,7 +84,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.UI,
     browser: true,
-    siteSession: 'persistent',
     args: [
         {
             name: 'user',

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -140,7 +140,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         {
             name: 'user',

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -143,7 +143,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of liked tweets to return (default 20).' },

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -115,7 +115,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'listId', positional: true, type: 'string', required: true, help: 'Numeric ID of a Twitter/X list (e.g. from `opencli twitter lists`)' },
         { name: 'limit', type: 'int', default: 50 },

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -92,7 +92,6 @@ export const command = cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 50, help: 'Maximum number of lists to return (default 50).' },
     ],

--- a/clis/twitter/notifications.js
+++ b/clis/twitter/notifications.js
@@ -8,7 +8,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.INTERCEPT,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of notifications to return (default 20).' },
     ],

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -11,7 +11,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
     ],

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -261,7 +261,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: 'Search query. Raw X operators (e.g. "exact phrase", #tag, OR, lang:en, since:YYYY-MM-DD, from:, since:) are passed through unchanged.' },
         { name: 'filter', type: 'string', default: 'top', choices: ['top', 'live'], help: 'Legacy alias for --product. Kept for backwards compatibility; if --product is set it wins.' },

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -100,7 +100,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'tweet-id', positional: true, type: 'string', required: true, help: 'Tweet numeric ID (e.g. 1234567890) or full status URL' },
         { name: 'limit', type: 'int', default: 50 },

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -142,7 +142,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         {
             name: 'type',

--- a/clis/twitter/trending.js
+++ b/clis/twitter/trending.js
@@ -17,7 +17,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of trends to show' },
     ],

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -221,7 +221,6 @@ cli({
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },


### PR DESCRIPTION
## Summary
- remove `siteSession: 'persistent'` from Twitter/X and Reddit adapters
- keep persistent adapter sessions limited to AI/chat-style sites
- rebuild `cli-manifest.json` and update changelog

## Validation
- `npm run build-manifest`
- `npx vitest run --project unit src/execution.test.ts`
- `npx vitest run --project adapter clis/twitter/*.test.js clis/reddit/*.test.js`
- `npm run build`
- `git diff --check`

After this change, Twitter/Reddit adapter commands release their tab lease after each run while the shared Adapter window remains available for reuse.
