### PR TITLE
fix(boss): map code=24 (identity mismatch) to AuthRequiredError

### DIFF
--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -5,6 +5,7 @@ const BOSS_DOMAIN = 'www.zhipin.com';
 const CHAT_URL = `https://${BOSS_DOMAIN}/web/chat/index`;
 const COOKIE_EXPIRED_CODES = new Set([7, 37]);
 const COOKIE_EXPIRED_MSG = 'Cookie 已过期！请在当前 Chrome 浏览器中重新登录 BOSS 直聘。';
+const RECRUITER_ONLY_MSG = '该命令仅支持招聘端（BOSS 端）账号，请使用招聘者账号登录后重试。';
 const DEFAULT_TIMEOUT = 15_000;
 // ── Core helpers ────────────────────────────────────────────────────────────
 /**
@@ -56,8 +57,22 @@ export function checkAuth(data) {
     }
 }
 /**
+ * Map BOSS code=24 ("请切换身份后再试") to a typed AuthRequiredError.
+ * Recruiter-only commands (recommend, joblist, stats, resume, mark,
+ * exchange, invite, greet, batchgreet) have no geek-side equivalent;
+ * surfacing this as a generic COMMAND_EXEC hides what the user must do.
+ * chatlist / chatmsg avoid this path by using `allowNonZero: true` and
+ * branching to the geek-side fetch when they see code 24.
+ */
+function checkRecruiterSide(data) {
+    if (data.code === IDENTITY_MISMATCH_CODE) {
+        throw new AuthRequiredError(BOSS_DOMAIN, RECRUITER_ONLY_MSG);
+    }
+}
+/**
  * Throw if the API response is not code 0.
- * Checks for cookie expiry first, then throws with the provided message.
+ * Checks for cookie expiry first, then identity mismatch, then throws
+ * with the provided message.
  */
 export function assertOk(data, errorPrefix) {
     if (!data || typeof data !== 'object') {
@@ -66,6 +81,7 @@ export function assertOk(data, errorPrefix) {
     if (data.code === 0)
         return;
     checkAuth(data);
+    checkRecruiterSide(data);
     const prefix = errorPrefix ? `${errorPrefix}: ` : '';
     throw new CommandExecutionError(`${prefix}${data.message || 'Unknown error'} (code=${data.code})`);
 }

--- a/clis/boss/utils.test.js
+++ b/clis/boss/utils.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { assertOk } from './utils.js';
+
+describe('assertOk', () => {
+    it('returns silently on code 0', () => {
+        expect(() => assertOk({ code: 0 })).not.toThrow();
+    });
+
+    it('maps expired cookie codes (7, 37) to AuthRequiredError', () => {
+        expect(() => assertOk({ code: 7, message: 'expired' })).toThrow(AuthRequiredError);
+        expect(() => assertOk({ code: 37, message: 'expired' })).toThrow(AuthRequiredError);
+    });
+
+    it('maps code 24 (identity mismatch) to AuthRequiredError with recruiter-only hint', () => {
+        try {
+            assertOk({ code: 24, message: '请切换身份后再试' });
+            throw new Error('assertOk should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(AuthRequiredError);
+            expect(String(err.message)).toContain('招聘端');
+        }
+    });
+
+    it('falls through to CommandExecutionError for other non-zero codes', () => {
+        expect(() => assertOk({ code: 99, message: 'something else' }))
+            .toThrow(CommandExecutionError);
+    });
+
+    it('throws CommandExecutionError on malformed (non-object) response', () => {
+        expect(() => assertOk(null)).toThrow(CommandExecutionError);
+        expect(() => assertOk('not-an-object')).toThrow(CommandExecutionError);
+    });
+});


### PR DESCRIPTION
## Description

Recruiter-only BOSS commands (`recommend`, `joblist`, `stats`, `resume`, `mark`, `exchange`, `invite`, `greet`, `batchgreet`) returned a generic `COMMAND_EXEC: 请切换身份后再试 (code=24)` when called from a job-seeker account. The original error hid the actionable bit: this command set needs a recruiter (BOSS-side) account.

`chatlist` / `chatmsg` already special-case code=24 by falling back to the geek-side fetch when `--side auto`. Recruiter-only commands have no geek-side equivalent and were leaking the raw API code as a generic exec failure.

Closes #1572.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

Single change in `clis/boss/utils.js`: add a `checkRecruiterSide(data)` helper that throws `AuthRequiredError` on code=24, called from `assertOk` between the existing `checkAuth` (cookie-expired) check and the generic `CommandExecutionError` fallthrough.

```js
function checkRecruiterSide(data) {
    if (data.code === 24) {
        throw new AuthRequiredError(BOSS_DOMAIN, RECRUITER_ONLY_MSG);
    }
}
```

All 9 recruiter-only commands inherit the behaviour through their existing `bossFetch` calls (which call `assertOk` in the auto-error path). No adapter-level edits needed. `chatlist` / `chatmsg` are unaffected because they use `allowNonZero: true` and never reach the auto-error path.

## Screenshots / Output

Before, on a job-seeker account:

```bash
$ opencli boss recommend --limit 3
ok: false
error:
  code: COMMAND_EXEC
  message: 请切换身份后再试 (code=24)
  exitCode: 1
```

After:

```bash
$ opencli boss recommend --limit 3
ok: false
error:
  code: AUTH_REQUIRED
  message: 该命令仅支持招聘端（BOSS 端）账号，请使用招聘者账号登录后重试。
  help: Please open Chrome or Chromium and log in to https://www.zhipin.com
  exitCode: 77
```

## Test plan

- [x] `npx vitest run clis/boss/`: 31 passed (26 existing + 5 new for `assertOk` covering code=0 / code=7 / code=24 / generic non-zero / malformed input)
- [x] Live verify on geek account: `opencli boss recommend --limit 3` now emits `AUTH_REQUIRED` with the recruiter-only hint, exit 77
- [x] `chatlist` / `chatmsg` unit tests still pass (their `allowNonZero: true` path bypasses the new check)
- [ ] Reviewer to confirm the recruiter happy path on a BOSS-side account (no geek-side reproducer available locally).