### PR TITLE
feat(xquik): add OpenCLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ To load the source Browser Bridge extension:
 | **tieba** | `hot` `posts` `search` `read` |
 | **hupu** | `hot` `search` `detail` `mentions` `reply` `like` `unlike` |
 | **twitter** | `trending` `search` `timeline` `tweets` `lists` `list-tweets` `list-add` `list-remove` `bookmarks` `post` `download` `profile` `article` `like` `likes` `notifications` `reply` `reply-dm` `thread` `follow` `unfollow` `followers` `following` `block` `unblock` `bookmark` `unbookmark` `delete` `hide-reply` `accept` |
+| **xquik** | `search` `tweet` `user` `user-search` `user-tweets` `trends` |
 | **reddit** | `hot` `frontpage` `popular` `search` `subreddit` `read` `user` `user-posts` `user-comments` `upvote` `upvoted` `save` `saved` `comment` `subscribe` |
 | **zhihu** | `hot` `search` `question` `download` `follow` `like` `favorite` `comment` `answer` |
 | **amazon** | `bestsellers` `search` `product` `offer` `discussion` `movers-shakers` `new-releases` `rankings` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -232,6 +232,7 @@ npm link
 | 站点 | 命令 | 模式 |
 |------|------|------|
 | **twitter** | `trending` `search` `timeline` `tweets` `lists` `list-tweets` `list-add` `list-remove` `bookmarks` `profile` `thread` `following` `followers` `notifications` `post` `reply` `delete` `like` `likes` `article` `follow` `unfollow` `bookmark` `unbookmark` `download` `accept` `reply-dm` `block` `unblock` `hide-reply` | 浏览器 |
+| **xquik** | `search` `tweet` `user` `user-search` `user-tweets` `trends` | 本地 API |
 | **reddit** | `hot` `frontpage` `popular` `search` `subreddit` `read` `user` `user-posts` `user-comments` `upvote` `save` `comment` `subscribe` `saved` `upvoted` | 浏览器 |
 | **tieba** | `hot` `posts` `search` `read` | 浏览器 |
 | **hupu** | `hot` `search` `detail` `mentions` `reply` `like` `unlike` | 浏览器 |

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -26428,6 +26428,269 @@
     "sourceFile": "xiaoyuzhou/transcript.js"
   },
   {
+    "site": "xquik",
+    "name": "search",
+    "description": "Search public X/Twitter posts through Xquik.",
+    "access": "read",
+    "domain": "xquik.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "X search query, including operators such as from:user or has:media"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max posts to return (1-200)"
+      },
+      {
+        "name": "queryType",
+        "type": "str",
+        "default": "Latest",
+        "required": false,
+        "help": "Search order: Latest or Top",
+        "choices": [
+          "Latest",
+          "Top"
+        ]
+      },
+      {
+        "name": "cursor",
+        "type": "str",
+        "required": false,
+        "help": "Pagination cursor from a prior response"
+      },
+      {
+        "name": "sinceTime",
+        "type": "str",
+        "required": false,
+        "help": "Only return posts after this ISO 8601 timestamp"
+      },
+      {
+        "name": "untilTime",
+        "type": "str",
+        "required": false,
+        "help": "Only return posts before this ISO 8601 timestamp"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "author",
+      "text",
+      "createdAt",
+      "likes",
+      "replies",
+      "retweets",
+      "views",
+      "url",
+      "nextCursor"
+    ],
+    "type": "js",
+    "modulePath": "xquik/search.js",
+    "sourceFile": "xquik/search.js"
+  },
+  {
+    "site": "xquik",
+    "name": "trends",
+    "description": "Get X/Twitter trending topics by WOEID through Xquik.",
+    "access": "read",
+    "domain": "xquik.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "woeid",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Region WOEID, for example 1 worldwide or 23424977 US"
+      },
+      {
+        "name": "count",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Number of trends to return (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "description",
+      "query",
+      "woeid"
+    ],
+    "type": "js",
+    "modulePath": "xquik/trends.js",
+    "sourceFile": "xquik/trends.js"
+  },
+  {
+    "site": "xquik",
+    "name": "tweet",
+    "description": "Look up one public X/Twitter post by ID through Xquik.",
+    "access": "read",
+    "domain": "xquik.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Numeric post ID"
+      }
+    ],
+    "columns": [
+      "id",
+      "author",
+      "text",
+      "createdAt",
+      "likes",
+      "replies",
+      "retweets",
+      "quotes",
+      "views",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "xquik/tweet.js",
+    "sourceFile": "xquik/tweet.js"
+  },
+  {
+    "site": "xquik",
+    "name": "user",
+    "description": "Look up an X/Twitter user profile by username or ID through Xquik.",
+    "access": "read",
+    "domain": "xquik.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Username without @, @username, or numeric user ID"
+      }
+    ],
+    "columns": [
+      "id",
+      "username",
+      "name",
+      "followers",
+      "following",
+      "verified",
+      "description",
+      "location",
+      "createdAt",
+      "profileUrl"
+    ],
+    "type": "js",
+    "modulePath": "xquik/user.js",
+    "sourceFile": "xquik/user.js"
+  },
+  {
+    "site": "xquik",
+    "name": "user-search",
+    "description": "Search X/Twitter users by name or username through Xquik.",
+    "access": "read",
+    "domain": "xquik.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "User search query"
+      },
+      {
+        "name": "cursor",
+        "type": "str",
+        "required": false,
+        "help": "Pagination cursor from a prior response"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "username",
+      "name",
+      "followers",
+      "following",
+      "verified",
+      "description",
+      "profileUrl"
+    ],
+    "type": "js",
+    "modulePath": "xquik/user-search.js",
+    "sourceFile": "xquik/user-search.js"
+  },
+  {
+    "site": "xquik",
+    "name": "user-tweets",
+    "description": "List recent posts from one X/Twitter user through Xquik.",
+    "access": "read",
+    "domain": "xquik.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Username without @, @username, or numeric user ID"
+      },
+      {
+        "name": "cursor",
+        "type": "str",
+        "required": false,
+        "help": "Pagination cursor from a prior response"
+      },
+      {
+        "name": "includeReplies",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Include reply posts"
+      },
+      {
+        "name": "includeParentTweet",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Include parent tweet details for replies"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "author",
+      "text",
+      "createdAt",
+      "likes",
+      "replies",
+      "retweets",
+      "views",
+      "url",
+      "nextCursor"
+    ],
+    "type": "js",
+    "modulePath": "xquik/user-tweets.js",
+    "sourceFile": "xquik/user-tweets.js"
+  },
+  {
     "site": "xueqiu",
     "name": "comments",
     "description": "获取单只股票的讨论动态",

--- a/clis/xquik/search.js
+++ b/clis/xquik/search.js
@@ -1,0 +1,32 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { XQUIK_BASE, addParam, normalizeTweet, paginatedRows, requireBoundedInt, requireString, xquikFetch } from './utils.js';
+
+cli({
+    site: 'xquik',
+    name: 'search',
+    access: 'read',
+    description: 'Search public X/Twitter posts through Xquik.',
+    domain: 'xquik.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'X search query, including operators such as from:user or has:media' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max posts to return (1-200)' },
+        { name: 'queryType', default: 'Latest', choices: ['Latest', 'Top'], help: 'Search order: Latest or Top' },
+        { name: 'cursor', required: false, help: 'Pagination cursor from a prior response' },
+        { name: 'sinceTime', required: false, help: 'Only return posts after this ISO 8601 timestamp' },
+        { name: 'untilTime', required: false, help: 'Only return posts before this ISO 8601 timestamp' },
+    ],
+    columns: ['rank', 'id', 'author', 'text', 'createdAt', 'likes', 'replies', 'retweets', 'views', 'url', 'nextCursor'],
+    func: async (args) => {
+        const url = new URL('/api/v1/x/tweets/search', XQUIK_BASE);
+        addParam(url, 'q', requireString(args.query, 'query'));
+        addParam(url, 'limit', requireBoundedInt(args.limit, 20, 200));
+        addParam(url, 'queryType', args.queryType ?? 'Latest');
+        addParam(url, 'cursor', args.cursor);
+        addParam(url, 'sinceTime', args.sinceTime);
+        addParam(url, 'untilTime', args.untilTime);
+        const body = await xquikFetch(url, 'xquik search');
+        return paginatedRows(body, 'tweets', 'xquik search', normalizeTweet);
+    },
+});

--- a/clis/xquik/trends.js
+++ b/clis/xquik/trends.js
@@ -1,0 +1,31 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { XQUIK_BASE, addParam, requireBoundedInt, xquikFetch } from './utils.js';
+
+cli({
+    site: 'xquik',
+    name: 'trends',
+    access: 'read',
+    description: 'Get X/Twitter trending topics by WOEID through Xquik.',
+    domain: 'xquik.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'woeid', type: 'int', default: 1, help: 'Region WOEID, for example 1 worldwide or 23424977 US' },
+        { name: 'count', type: 'int', default: 30, help: 'Number of trends to return (1-50)' },
+    ],
+    columns: ['rank', 'name', 'description', 'query', 'woeid'],
+    func: async (args) => {
+        const url = new URL('/api/v1/x/trends', XQUIK_BASE);
+        addParam(url, 'woeid', requireBoundedInt(args.woeid, 1, Number.MAX_SAFE_INTEGER, 'woeid'));
+        addParam(url, 'count', requireBoundedInt(args.count, 30, 50, 'count'));
+        const body = await xquikFetch(url, 'xquik trends');
+        const trends = Array.isArray(body?.trends) ? body.trends : [];
+        return trends.map((trend, index) => ({
+            rank: trend?.rank ?? index + 1,
+            name: String(trend?.name ?? ''),
+            description: String(trend?.description ?? ''),
+            query: String(trend?.query ?? ''),
+            woeid: body?.woeid ?? args.woeid ?? 1,
+        }));
+    },
+});

--- a/clis/xquik/tweet.js
+++ b/clis/xquik/tweet.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { normalizeTweet, requireString, xquikFetch } from './utils.js';
+
+cli({
+    site: 'xquik',
+    name: 'tweet',
+    access: 'read',
+    description: 'Look up one public X/Twitter post by ID through Xquik.',
+    domain: 'xquik.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Numeric post ID' },
+    ],
+    columns: ['id', 'author', 'text', 'createdAt', 'likes', 'replies', 'retweets', 'quotes', 'views', 'url'],
+    func: async (args) => {
+        const id = encodeURIComponent(requireString(args.id, 'id'));
+        const body = await xquikFetch(`/x/tweets/${id}`, 'xquik tweet');
+        return [normalizeTweet(body?.tweet, 0, { author: body?.author })];
+    },
+});

--- a/clis/xquik/user-search.js
+++ b/clis/xquik/user-search.js
@@ -1,0 +1,24 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { XQUIK_BASE, addParam, normalizeUser, paginatedRows, requireString, xquikFetch } from './utils.js';
+
+cli({
+    site: 'xquik',
+    name: 'user-search',
+    access: 'read',
+    description: 'Search X/Twitter users by name or username through Xquik.',
+    domain: 'xquik.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'User search query' },
+        { name: 'cursor', required: false, help: 'Pagination cursor from a prior response' },
+    ],
+    columns: ['rank', 'id', 'username', 'name', 'followers', 'following', 'verified', 'description', 'profileUrl'],
+    func: async (args) => {
+        const url = new URL('/api/v1/x/users/search', XQUIK_BASE);
+        addParam(url, 'q', requireString(args.query, 'query'));
+        addParam(url, 'cursor', args.cursor);
+        const body = await xquikFetch(url, 'xquik user-search');
+        return paginatedRows(body, 'users', 'xquik user-search', normalizeUser);
+    },
+});

--- a/clis/xquik/user-tweets.js
+++ b/clis/xquik/user-tweets.js
@@ -1,0 +1,28 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { XQUIK_BASE, addParam, normalizeTweet, paginatedRows, requireString, xquikFetch } from './utils.js';
+
+cli({
+    site: 'xquik',
+    name: 'user-tweets',
+    access: 'read',
+    description: 'List recent posts from one X/Twitter user through Xquik.',
+    domain: 'xquik.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Username without @, @username, or numeric user ID' },
+        { name: 'cursor', required: false, help: 'Pagination cursor from a prior response' },
+        { name: 'includeReplies', type: 'boolean', default: false, help: 'Include reply posts' },
+        { name: 'includeParentTweet', type: 'boolean', default: false, help: 'Include parent tweet details for replies' },
+    ],
+    columns: ['rank', 'id', 'author', 'text', 'createdAt', 'likes', 'replies', 'retweets', 'views', 'url', 'nextCursor'],
+    func: async (args) => {
+        const id = encodeURIComponent(requireString(args.id, 'id').replace(/^@+/, ''));
+        const url = new URL(`/api/v1/x/users/${id}/tweets`, XQUIK_BASE);
+        addParam(url, 'cursor', args.cursor);
+        addParam(url, 'includeReplies', Boolean(args.includeReplies));
+        addParam(url, 'includeParentTweet', Boolean(args.includeParentTweet));
+        const body = await xquikFetch(url, 'xquik user-tweets');
+        return paginatedRows(body, 'tweets', 'xquik user-tweets', normalizeTweet);
+    },
+});

--- a/clis/xquik/user.js
+++ b/clis/xquik/user.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { normalizeUser, requireString, xquikFetch } from './utils.js';
+
+cli({
+    site: 'xquik',
+    name: 'user',
+    access: 'read',
+    description: 'Look up an X/Twitter user profile by username or ID through Xquik.',
+    domain: 'xquik.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Username without @, @username, or numeric user ID' },
+    ],
+    columns: ['id', 'username', 'name', 'followers', 'following', 'verified', 'description', 'location', 'createdAt', 'profileUrl'],
+    func: async (args) => {
+        const id = encodeURIComponent(requireString(args.id, 'id').replace(/^@+/, ''));
+        const body = await xquikFetch(`/x/users/${id}`, 'xquik user');
+        return [normalizeUser(body, 0)];
+    },
+});

--- a/clis/xquik/utils.js
+++ b/clis/xquik/utils.js
@@ -1,0 +1,148 @@
+import { ArgumentError, CommandExecutionError, ConfigError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const XQUIK_BASE = 'https://xquik.com/api/v1';
+const USER_AGENT = 'opencli-xquik/1.0 (+https://github.com/jackwener/OpenCLI)';
+
+export function requireString(value, name) {
+    const text = String(value ?? '').trim();
+    if (!text) {
+        throw new ArgumentError(`xquik --${name} is required`);
+    }
+    return text;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, name = 'limit') {
+    const raw = value == null || value === '' ? defaultValue : value;
+    const parsed = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > maxValue) {
+        throw new ArgumentError(`xquik --${name} must be an integer between 1 and ${maxValue}`);
+    }
+    return parsed;
+}
+
+function requireApiKey() {
+    const apiKey = String(process.env.XQUIK_API_KEY ?? '').trim();
+    if (!apiKey) {
+        throw new ConfigError(
+            'xquik requires XQUIK_API_KEY',
+            'Set XQUIK_API_KEY in the environment before running xquik commands.',
+        );
+    }
+    return apiKey;
+}
+
+export function addParam(url, name, value) {
+    if (value == null || value === '') return;
+    url.searchParams.set(name, String(value));
+}
+
+function errorCode(body) {
+    if (!body || typeof body !== 'object') return '';
+    const error = body.error;
+    if (typeof error === 'string') return error;
+    if (error && typeof error === 'object' && typeof error.code === 'string') return error.code;
+    return '';
+}
+
+export async function xquikFetch(path, label) {
+    const url = path instanceof URL ? path : new URL(String(path).replace(/^\/+/, ''), `${XQUIK_BASE}/`);
+    const apiKey = requireApiKey();
+    let response;
+    try {
+        response = await fetch(url, {
+            headers: {
+                accept: 'application/json',
+                'user-agent': USER_AGENT,
+                'x-api-key': apiKey,
+            },
+        });
+    } catch (error) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${error?.message ?? error}`,
+            'Check that xquik.com is reachable from this network.',
+        );
+    }
+
+    let body = null;
+    try {
+        body = await response.json();
+    } catch (error) {
+        if (response.ok) {
+            throw new CommandExecutionError(`${label} returned malformed JSON: ${error?.message ?? error}`);
+        }
+    }
+
+    if (response.status === 401) {
+        throw new ConfigError('xquik rejected XQUIK_API_KEY', 'Check that XQUIK_API_KEY is valid.');
+    }
+    if (response.status === 404) {
+        throw new EmptyResultError(label, `${label} returned 404.`);
+    }
+    if (response.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429`, 'Wait briefly and retry.');
+    }
+    if (!response.ok) {
+        const code = errorCode(body);
+        const suffix = code ? ` (${code})` : '';
+        throw new CommandExecutionError(`${label} returned HTTP ${response.status}${suffix}`);
+    }
+    return body;
+}
+
+function numberOrNull(value) {
+    if (value == null || value === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function authorName(tweet, fallbackAuthor) {
+    return tweet?.author?.username ?? fallbackAuthor?.username ?? '';
+}
+
+function tweetUrl(id) {
+    return id ? `https://x.com/i/web/status/${id}` : '';
+}
+
+export function normalizeTweet(tweet, index, options = {}) {
+    const id = String(tweet?.id ?? '');
+    return {
+        rank: index + 1,
+        id,
+        author: authorName(tweet, options.author),
+        text: String(tweet?.text ?? ''),
+        createdAt: String(tweet?.createdAt ?? ''),
+        likes: numberOrNull(tweet?.likeCount),
+        replies: numberOrNull(tweet?.replyCount),
+        retweets: numberOrNull(tweet?.retweetCount),
+        quotes: numberOrNull(tweet?.quoteCount),
+        views: numberOrNull(tweet?.viewCount),
+        url: tweet?.url || tweetUrl(id),
+        nextCursor: options.nextCursor ?? '',
+    };
+}
+
+export function normalizeUser(user, index) {
+    const username = String(user?.username ?? '').replace(/^@+/, '');
+    return {
+        rank: index + 1,
+        id: String(user?.id ?? ''),
+        username,
+        name: String(user?.name ?? ''),
+        followers: numberOrNull(user?.followers),
+        following: numberOrNull(user?.following),
+        verified: Boolean(user?.verified),
+        description: String(user?.description ?? ''),
+        location: String(user?.location ?? ''),
+        createdAt: String(user?.createdAt ?? ''),
+        profileUrl: username ? `https://x.com/${username}` : '',
+    };
+}
+
+export function paginatedRows(body, field, label, normalizer) {
+    const list = Array.isArray(body?.[field]) ? body[field] : [];
+    if (!list.length) {
+        throw new EmptyResultError(label, `Xquik returned no ${field}.`);
+    }
+    const nextCursor = body?.next_cursor || body?.nextCursor || '';
+    return list.map((item, index) => normalizer(item, index, { nextCursor }));
+}

--- a/clis/xquik/xquik.test.js
+++ b/clis/xquik/xquik.test.js
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ConfigError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+import './tweet.js';
+import './trends.js';
+import './user-search.js';
+import './user-tweets.js';
+import './user.js';
+
+const originalFetch = global.fetch;
+const originalKey = process.env.XQUIK_API_KEY;
+
+afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalKey == null) delete process.env.XQUIK_API_KEY;
+    else process.env.XQUIK_API_KEY = originalKey;
+    vi.restoreAllMocks();
+});
+
+function command(name) {
+    return getRegistry().get(`xquik/${name}`);
+}
+
+function mockJson(payload, status = 200) {
+    global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify(payload), { status })));
+}
+
+describe('xquik adapters', () => {
+    it('requires XQUIK_API_KEY before requests', async () => {
+        delete process.env.XQUIK_API_KEY;
+        await expect(command('search').func({ query: 'opencli' })).rejects.toBeInstanceOf(ConfigError);
+    });
+
+    it('search maps paginated tweets and sends the API key header', async () => {
+        process.env.XQUIK_API_KEY = 'test-key';
+        mockJson({
+            tweets: [
+                {
+                    id: '123',
+                    text: 'OpenCLI adapter',
+                    createdAt: '2026-05-14T12:00:00Z',
+                    likeCount: 7,
+                    replyCount: 1,
+                    retweetCount: 2,
+                    viewCount: 90,
+                    author: { username: 'xquikcom' },
+                },
+            ],
+            has_next_page: true,
+            next_cursor: 'cursor-1',
+        });
+
+        const rows = await command('search').func({ query: 'opencli', limit: 1, queryType: 'Top' });
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            id: '123',
+            author: 'xquikcom',
+            text: 'OpenCLI adapter',
+            likes: 7,
+            nextCursor: 'cursor-1',
+        });
+        expect(global.fetch.mock.calls[0][1].headers['x-api-key']).toBe('test-key');
+        expect(String(global.fetch.mock.calls[0][0])).toContain('/api/v1/x/tweets/search');
+        expect(String(global.fetch.mock.calls[0][0])).toContain('queryType=Top');
+    });
+
+    it('tweet lookup combines tweet and author payloads', async () => {
+        process.env.XQUIK_API_KEY = 'test-key';
+        mockJson({
+            tweet: { id: '456', text: 'single post', likeCount: 3 },
+            author: { username: 'alice' },
+        });
+
+        const rows = await command('tweet').func({ id: '456' });
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ id: '456', author: 'alice', text: 'single post', likes: 3 });
+    });
+
+    it('user lookup normalizes profile URLs', async () => {
+        process.env.XQUIK_API_KEY = 'test-key';
+        mockJson({ id: 'u1', username: 'alice', name: 'Alice', followers: 42, verified: true });
+
+        const rows = await command('user').func({ id: '@alice' });
+
+        expect(rows[0]).toMatchObject({
+            id: 'u1',
+            username: 'alice',
+            name: 'Alice',
+            followers: 42,
+            verified: true,
+            profileUrl: 'https://x.com/alice',
+        });
+        expect(String(global.fetch.mock.calls[0][0])).toContain('/api/v1/x/users/alice');
+    });
+
+    it('user-search promotes empty result arrays', async () => {
+        process.env.XQUIK_API_KEY = 'test-key';
+        mockJson({ users: [], has_next_page: false, next_cursor: '' });
+
+        await expect(command('user-search').func({ query: 'nobody' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('user-tweets forwards reply flags', async () => {
+        process.env.XQUIK_API_KEY = 'test-key';
+        mockJson({
+            tweets: [{ id: '789', text: 'reply included', author: { username: 'alice' } }],
+            has_next_page: false,
+            next_cursor: '',
+        });
+
+        const rows = await command('user-tweets').func({ id: 'alice', includeReplies: true, includeParentTweet: true });
+
+        expect(rows[0]).toMatchObject({ id: '789', author: 'alice' });
+        const url = String(global.fetch.mock.calls[0][0]);
+        expect(url).toContain('includeReplies=true');
+        expect(url).toContain('includeParentTweet=true');
+    });
+
+    it('trends maps topic rows', async () => {
+        process.env.XQUIK_API_KEY = 'test-key';
+        mockJson({
+            woeid: 1,
+            trends: [{ name: '#AI', description: 'Artificial intelligence', query: '%23AI', rank: 1 }],
+        });
+
+        const rows = await command('trends').func({ count: 1 });
+
+        expect(rows).toEqual([
+            { rank: 1, name: '#AI', description: 'Artificial intelligence', query: '%23AI', woeid: 1 },
+        ]);
+    });
+});

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -137,6 +137,7 @@ export default defineConfig({
                 { text: 'LessWrong', link: '/adapters/browser/lesswrong' },
                 { text: 'Lobsters', link: '/adapters/browser/lobsters' },
                 { text: 'Steam', link: '/adapters/browser/steam' },
+                { text: 'Xquik', link: '/adapters/browser/xquik' },
               ],
             },
             {

--- a/docs/adapters/browser/xquik.md
+++ b/docs/adapters/browser/xquik.md
@@ -1,0 +1,95 @@
+# Xquik
+
+**Mode**: Local API key - **Domain**: `xquik.com`
+
+Xquik provides read-only X/Twitter data endpoints for post search, post lookup, user lookup, user timelines, user search, and regional trends. Set `XQUIK_API_KEY` in the shell before running these commands.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli xquik search <query>` | Search public X/Twitter posts with X search operators |
+| `opencli xquik tweet <id>` | Look up one public post by ID |
+| `opencli xquik user <id>` | Look up a user profile by username or ID |
+| `opencli xquik user-search <query>` | Search users by name or username |
+| `opencli xquik user-tweets <id>` | List recent posts from one user |
+| `opencli xquik trends` | Get trending topics by region WOEID |
+
+## Usage Examples
+
+```bash
+export XQUIK_API_KEY=...
+
+opencli xquik search "opencli from:xquikcom" --limit 5
+opencli xquik search "AI has:media" --queryType Top --limit 10
+opencli xquik tweet 1234567890
+opencli xquik user xquikcom
+opencli xquik user-search "xquik"
+opencli xquik user-tweets xquikcom --includeReplies true
+opencli xquik trends --woeid 1 --count 10
+```
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, id, author, text, createdAt, likes, replies, retweets, views, url, nextCursor` |
+| `tweet` | `id, author, text, createdAt, likes, replies, retweets, quotes, views, url` |
+| `user` | `id, username, name, followers, following, verified, description, location, createdAt, profileUrl` |
+| `user-search` | `rank, id, username, name, followers, following, verified, description, profileUrl` |
+| `user-tweets` | `rank, id, author, text, createdAt, likes, replies, retweets, views, url, nextCursor` |
+| `trends` | `rank, name, description, query, woeid` |
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | X search query, including operators such as `from:user`, `has:media`, or `since:YYYY-MM-DD` |
+| `--limit` | Max posts to return, 1 to 200, default 20 |
+| `--queryType` | `Latest` or `Top`, default `Latest` |
+| `--cursor` | Cursor returned from a prior page |
+| `--sinceTime` | ISO 8601 lower bound |
+| `--untilTime` | ISO 8601 upper bound |
+
+### `tweet`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Numeric post ID |
+
+### `user`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Username with or without `@`, or numeric user ID |
+
+### `user-search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | User search query |
+| `--cursor` | Cursor returned from a prior page |
+
+### `user-tweets`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Username with or without `@`, or numeric user ID |
+| `--cursor` | Cursor returned from a prior page |
+| `--includeReplies` | Include reply posts |
+| `--includeParentTweet` | Include parent tweet details for replies |
+
+### `trends`
+
+| Option | Description |
+|--------|-------------|
+| `--woeid` | Region WOEID, default `1` for worldwide |
+| `--count` | Number of trends to return, 1 to 50, default 30 |
+
+## Notes
+
+- The adapter reads the API key from `XQUIK_API_KEY` and sends it as `x-api-key`.
+- Commands are read-only. They do not post, like, follow, send DMs, or request X login material.
+- Paginated commands return `nextCursor` so you can pass it back with `--cursor`.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -138,6 +138,7 @@ Run `opencli list` for the live registry.
 | **[oeis](./browser/oeis.md)**                     | `search` `sequence`                                                                                                                            | 🌐 Public    |
 | **[wttr](./browser/wttr.md)**                     | `current` `forecast`                                                                                                                           | 🌐 Public    |
 | **[openfda](./browser/openfda.md)**               | `drug-label` `food-recall`                                                                                                                     | 🌐 Public    |
+| **[xquik](./browser/xquik.md)**                   | `search` `tweet` `user` `user-search` `user-tweets` `trends`                                                                                   | 🔑 Local API |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
## Description

Adds a read-only Xquik local API adapter for public X/Twitter data lookup through `XQUIK_API_KEY`.

Commands:
- `opencli xquik search <query>`
- `opencli xquik tweet <id>`
- `opencli xquik user <id>`
- `opencli xquik user-search <query>`
- `opencli xquik user-tweets <id>`
- `opencli xquik trends`

Related issue: N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] New site adapter
- [x] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Added doc page under `docs/adapters/` (if new adapter)
- [x] Updated `docs/adapters/index.md` table (if new adapter)
- [x] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [x] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Validation run:

```text
npm run build
npx vitest run --project adapter clis/xquik/xquik.test.js
npm run docs:build
npm run check:typed-error-lint
npm run check:silent-column-drop
npm run advise:listing-id-pairing
node -e "JSON.parse(require('fs').readFileSync('cli-manifest.json','utf8'))"
git diff --check
```

Notes:
- `docs:build` passed with the existing VitePress chunk-size advisory.
- `check:silent-column-drop` reported no new violations.
- `advise:listing-id-pairing` is advisory only.
- Duplicate checks for `Xquik`, `x-twitter-scraper`, `Xquik-dev`, `xquik.com`, and `xquik-docs` found no existing OpenCLI code, PRs, or issues.
