### PR TITLE
fix(chatgpt): unwrap page.evaluate envelope across browser commands

### DIFF
--- a/clis/chatgpt/envelope.test.js
+++ b/clis/chatgpt/envelope.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    requireArrayEvaluateResult,
+    requireObjectEvaluateResult,
+    unwrapEvaluateResult,
+} from './utils.js';
+
+describe('chatgpt page.evaluate envelope helpers', () => {
+    describe('unwrapEvaluateResult', () => {
+        it('unwraps a { session, data } envelope produced by the browser bridge', () => {
+            const envelope = { session: 'site:chatgpt:abc', data: [{ id: 'msg-1' }] };
+            expect(unwrapEvaluateResult(envelope)).toEqual([{ id: 'msg-1' }]);
+        });
+
+        it('passes raw arrays through unchanged (back-compat with older bridge versions)', () => {
+            const raw = [1, 2, 3];
+            expect(unwrapEvaluateResult(raw)).toBe(raw);
+        });
+
+        it('passes primitive return values (URL strings, booleans) through unchanged', () => {
+            expect(unwrapEvaluateResult('https://chatgpt.com/c/abc')).toBe('https://chatgpt.com/c/abc');
+            expect(unwrapEvaluateResult(true)).toBe(true);
+            expect(unwrapEvaluateResult(0)).toBe(0);
+        });
+
+        it('passes plain non-envelope objects through unchanged', () => {
+            const obj = { ok: true, reason: 'all good' };
+            expect(unwrapEvaluateResult(obj)).toBe(obj);
+        });
+
+        it('handles null and undefined defensively', () => {
+            expect(unwrapEvaluateResult(null)).toBe(null);
+            expect(unwrapEvaluateResult(undefined)).toBe(undefined);
+        });
+    });
+
+    describe('requireArrayEvaluateResult', () => {
+        it('returns the payload when it is an array', () => {
+            const rows = [{ id: 1 }, { id: 2 }];
+            expect(requireArrayEvaluateResult(rows, 'chatgpt test')).toBe(rows);
+        });
+
+        it('throws a typed CommandExecutionError when the payload is the raw envelope (caller forgot to unwrap)', () => {
+            const envelope = { session: 'site:chatgpt:abc', data: [{ id: 1 }] };
+            expect(() => requireArrayEvaluateResult(envelope, 'chatgpt visible image url extraction'))
+                .toThrowError(CommandExecutionError);
+            expect(() => requireArrayEvaluateResult(envelope, 'chatgpt visible image url extraction'))
+                .toThrow(/malformed extraction payload/);
+        });
+
+        it('surfaces the inner error message when the payload carries an `error` field', () => {
+            const errPayload = { error: 'image generator returned 500' };
+            expect(() => requireArrayEvaluateResult(errPayload, 'chatgpt image asset export'))
+                .toThrow(/chatgpt image asset export: image generator returned 500/);
+        });
+
+        it('throws when the payload is null or a primitive', () => {
+            expect(() => requireArrayEvaluateResult(null, 'chatgpt test')).toThrowError(CommandExecutionError);
+            expect(() => requireArrayEvaluateResult('a string', 'chatgpt test')).toThrowError(CommandExecutionError);
+        });
+    });
+
+    describe('requireObjectEvaluateResult', () => {
+        it('returns the payload when it is a plain object', () => {
+            const obj = { url: 'https://chatgpt.com', isLoggedIn: true };
+            expect(requireObjectEvaluateResult(obj, 'chatgpt page state')).toBe(obj);
+        });
+
+        it('throws when the payload is an array or a primitive', () => {
+            expect(() => requireObjectEvaluateResult([], 'chatgpt page state')).toThrowError(CommandExecutionError);
+            expect(() => requireObjectEvaluateResult('string', 'chatgpt page state')).toThrowError(CommandExecutionError);
+            expect(() => requireObjectEvaluateResult(null, 'chatgpt page state')).toThrowError(CommandExecutionError);
+        });
+    });
+
+    describe('end-to-end envelope sweep', () => {
+        // The bridge envelope is shaped like { session, data } where `session` is
+        // any string and `data` is the actual return value. Verify the helpers
+        // chain correctly: unwrap → require* yields the inner shape.
+        it('unwrap + requireArray pipes an envelope through to the underlying array', () => {
+            const envelope = {
+                session: 'site:chatgpt:img-export',
+                data: [
+                    { url: 'https://a.example/1.png', dataUrl: 'data:image/png;base64,xxx', mimeType: 'image/png' },
+                ],
+            };
+            expect(requireArrayEvaluateResult(unwrapEvaluateResult(envelope), 'chatgpt image asset export'))
+                .toEqual(envelope.data);
+        });
+
+        it('unwrap + requireObject pipes an envelope through to the underlying object', () => {
+            const envelope = { session: 'site:chatgpt:state', data: { url: 'https://chatgpt.com', isLoggedIn: true } };
+            expect(requireObjectEvaluateResult(unwrapEvaluateResult(envelope), 'chatgpt page state'))
+                .toEqual(envelope.data);
+        });
+    });
+});

--- a/clis/chatgpt/envelope.test.js
+++ b/clis/chatgpt/envelope.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     requireArrayEvaluateResult,
+    requireBooleanEvaluateResult,
     requireObjectEvaluateResult,
     unwrapEvaluateResult,
 } from './utils.js';
@@ -71,6 +72,15 @@ describe('chatgpt page.evaluate envelope helpers', () => {
             expect(() => requireObjectEvaluateResult([], 'chatgpt page state')).toThrowError(CommandExecutionError);
             expect(() => requireObjectEvaluateResult('string', 'chatgpt page state')).toThrowError(CommandExecutionError);
             expect(() => requireObjectEvaluateResult(null, 'chatgpt page state')).toThrowError(CommandExecutionError);
+        });
+    });
+
+    describe('requireBooleanEvaluateResult', () => {
+        it('returns booleans and rejects wrong-shape values', () => {
+            expect(requireBooleanEvaluateResult(true, 'chatgpt generation state')).toBe(true);
+            expect(requireBooleanEvaluateResult(false, 'chatgpt generation state')).toBe(false);
+            expect(() => requireBooleanEvaluateResult({ ok: true }, 'chatgpt generation state'))
+                .toThrowError(CommandExecutionError);
         });
     });
 

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { clearChatGPTDraft, getChatGPTVisibleImageUrls, normalizeBooleanFlag, prepareChatGPTImagePaths, sendChatGPTMessage, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
+import { clearChatGPTDraft, getChatGPTVisibleImageUrls, normalizeBooleanFlag, prepareChatGPTImagePaths, sendChatGPTMessage, unwrapEvaluateResult, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
 
@@ -54,7 +54,7 @@ function buildPrompt(prompt, imageCount) {
 }
 
 async function currentChatGPTLink(page) {
-    const url = await page.evaluate('window.location.href').catch(() => '');
+    const url = unwrapEvaluateResult(await page.evaluate('window.location.href').catch(() => ''));
     return typeof url === 'string' && url ? url : 'https://chatgpt.com';
 }
 

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -24,6 +24,12 @@ vi.mock('./utils.js', () => ({
     },
     prepareChatGPTImagePaths: mocks.prepareChatGPTImagePaths,
     sendChatGPTMessage: mocks.sendChatGPTMessage,
+    unwrapEvaluateResult: (payload) => {
+        if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+            return payload.data;
+        }
+        return payload;
+    },
     uploadChatGPTImages: mocks.uploadChatGPTImages,
     waitForChatGPTImages: mocks.waitForChatGPTImages,
     getChatGPTImageAssets: mocks.getChatGPTImageAssets,

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -140,6 +140,13 @@ export function requireObjectEvaluateResult(payload, label) {
     return payload;
 }
 
+export function requireBooleanEvaluateResult(payload, label) {
+    if (typeof payload !== 'boolean') {
+        throw new CommandExecutionError(`${label} returned malformed extraction payload`);
+    }
+    return payload;
+}
+
 export function parseChatGPTConversationId(value) {
     const raw = String(value ?? '').trim();
     const match = raw.match(/(?:^|\/c\/)([A-Za-z0-9_-]{8,})(?:[/?#]|$)/);
@@ -198,7 +205,7 @@ export async function startNewChat(page) {
 }
 
 export async function getPageState(page) {
-    return unwrapEvaluateResult(await page.evaluate(`(() => {
+    return requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -224,7 +231,7 @@ export async function getPageState(page) {
             isLoggedIn: hasComposer || !!userMenu || !hasLoginGate,
             hasLoginGate,
         };
-    })()`));
+    })()`)), 'chatgpt page state');
 }
 
 export async function ensureChatGPTLogin(page, message = 'ChatGPT requires a logged-in browser session.') {
@@ -295,7 +302,7 @@ export async function sendChatGPTMessage(page, text) {
     // findComposer() retries inside a single CDP call, so no fixed sleep is
     // needed before reading the composer.
 
-    const typeResult = unwrapEvaluateResult(await page.evaluate(`
+    const typeResult = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (() => {
             ${buildComposerLocatorScript()}
             const composer = findComposer();
@@ -313,7 +320,7 @@ export async function sendChatGPTMessage(page, text) {
             composer.dispatchEvent(new Event('change', { bubbles: true }));
             return true;
         })()
-    `));
+    `)), 'chatgpt composer readiness');
 
     if (!typeResult) return false;
     
@@ -341,7 +348,7 @@ export async function sendChatGPTMessage(page, text) {
     let sent = null;
     for (let attempt = 0; attempt < 20; attempt += 1) {
         await page.wait(0.5);
-        sent = unwrapEvaluateResult(await page.evaluate(`
+        sent = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const isUsable = (button) => button
                     && !button.disabled
@@ -355,7 +362,7 @@ export async function sendChatGPTMessage(page, text) {
                     : btns.find(b => labels.includes(b.getAttribute('aria-label') || '') && isUsable(b));
                 return { sendBtnFound: !!sendBtn };
             })()
-        `));
+        `)), 'chatgpt send button readiness');
         if (sent?.sendBtnFound) break;
     }
 
@@ -376,7 +383,7 @@ export async function sendChatGPTMessage(page, text) {
 }
 
 export async function getVisibleMessages(page) {
-    const result = unwrapEvaluateResult(await page.evaluate(`(() => {
+    const result = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -422,8 +429,7 @@ export async function getVisibleMessages(page) {
             rows.push({ role, text, html });
         }
         return rows;
-    })()`));
-    if (!Array.isArray(result)) return [];
+    })()`)), 'chatgpt visible messages');
     return result.map((item, index) => ({
         Index: index + 1,
         Role: item?.role === 'Assistant' ? 'Assistant' : 'User',
@@ -485,7 +491,7 @@ export async function getConversationList(page) {
     // so the previous standalone 2 s settle is redundant.
     await ensureOnChatGPT(page);
 
-    const openSidebar = unwrapEvaluateResult(await page.evaluate(`(() => {
+    const openSidebar = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const button = Array.from(document.querySelectorAll('button'))
             .find((node) => /open sidebar/i.test(node.getAttribute('aria-label') || ''));
         if (button instanceof HTMLElement) {
@@ -493,7 +499,7 @@ export async function getConversationList(page) {
             return true;
         }
         return false;
-    })()`));
+    })()`)), 'chatgpt sidebar open state');
     if (openSidebar) {
         try {
             await page.wait({ selector: CONVERSATION_LINK_SELECTOR, timeout: 3 });
@@ -517,7 +523,7 @@ export async function getConversationList(page) {
 }
 
 async function extractConversationLinks(page) {
-    const items = unwrapEvaluateResult(await page.evaluate(`(() => {
+    const items = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -542,15 +548,13 @@ async function extractConversationLinks(page) {
             });
         }
         return rows;
-    })()`));
-    return Array.isArray(items)
-        ? items.map((item, index) => ({
+    })()`)), 'chatgpt conversation link extraction');
+    return items.map((item, index) => ({
             Index: index + 1,
             Id: String(item?.Id || ''),
             Title: String(item?.Title || '(untitled)').trim() || '(untitled)',
             Url: String(item?.Url || ''),
-        })).filter((item) => item.Id)
-        : [];
+        })).filter((item) => item.Id);
 }
 
 function imageMimeFromPath(filePath) {
@@ -593,7 +597,7 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
     const namesJson = JSON.stringify(fileNames);
     for (let attempt = 0; attempt < 10; attempt += 1) {
         await page.wait(1);
-        const ready = unwrapEvaluateResult(await page.evaluate(`
+        const ready = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const names = ${namesJson};
                 const text = document.body ? (document.body.innerText || '') : '';
@@ -609,7 +613,7 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
                 const previewNodes = scope.querySelectorAll('img[src], canvas, video, [style*="background-image"], [data-testid*="attachment"], [data-testid*="upload"], [class*="attachment"], [class*="upload"]');
                 return previewNodes.length >= names.length;
             })()
-        `));
+        `)), 'chatgpt upload preview detection');
         if (ready) return true;
     }
     return false;
@@ -643,7 +647,7 @@ export async function uploadChatGPTImages(page, imagePaths) {
             mime: imageMimeFromPath(absPath),
             base64: fs.default.readFileSync(absPath).toString('base64'),
         }));
-        const fallbackResult = unwrapEvaluateResult(await page.evaluate(`
+        const fallbackResult = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const files = ${JSON.stringify(files)};
                 const input = document.querySelector('input[type="file"]');
@@ -679,7 +683,7 @@ export async function uploadChatGPTImages(page, imagePaths) {
                 }
                 return { ok: true };
             })()
-        `));
+        `)), 'chatgpt image upload fallback');
         if (fallbackResult && !fallbackResult.ok) return fallbackResult;
     }
 
@@ -693,14 +697,14 @@ export async function uploadChatGPTImages(page, imagePaths) {
  * Check if ChatGPT is still generating a response.
  */
 export async function isGenerating(page) {
-    return unwrapEvaluateResult(await page.evaluate(`
+    return requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (() => {
             return Array.from(document.querySelectorAll('button')).some(b => {
                 const label = b.getAttribute('aria-label') || '';
                 return label === 'Stop generating' || label.includes('Thinking');
             });
         })()
-    `));
+    `)), 'chatgpt generation state');
 }
 
 /**

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -103,6 +103,43 @@ export function requirePositiveInt(value, flagLabel, hint) {
     return value;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// page.evaluate envelope helpers.
+//
+// The browser bridge wraps every `page.evaluate(...)` return value in a
+// `{ session, data }` envelope. Adapters that read `.length` or
+// `Array.isArray(payload)` directly on the envelope silently see "no data" —
+// this matches the failure mode fixed for xiaohongshu/rednote (#1561) and
+// weibo (#1568).
+//
+// `unwrapEvaluateResult` is a defensive ternary: it unwraps when the payload
+// looks like an envelope, otherwise passes the value through unchanged so
+// older bridge versions and primitive return values still work.
+// ─────────────────────────────────────────────────────────────────────────────
+export function unwrapEvaluateResult(payload) {
+    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
+
+export function requireArrayEvaluateResult(payload, label) {
+    if (!Array.isArray(payload)) {
+        if (payload && typeof payload === 'object' && 'error' in payload) {
+            throw new CommandExecutionError(`${label}: ${String(payload.error)}`);
+        }
+        throw new CommandExecutionError(`${label} returned malformed extraction payload`);
+    }
+    return payload;
+}
+
+export function requireObjectEvaluateResult(payload, label) {
+    if (!payload || Array.isArray(payload) || typeof payload !== 'object') {
+        throw new CommandExecutionError(`${label} returned malformed extraction payload`);
+    }
+    return payload;
+}
+
 export function parseChatGPTConversationId(value) {
     const raw = String(value ?? '').trim();
     const match = raw.match(/(?:^|\/c\/)([A-Za-z0-9_-]{8,})(?:[/?#]|$)/);
@@ -115,7 +152,7 @@ export function parseChatGPTConversationId(value) {
 }
 
 export async function currentChatGPTUrl(page) {
-    const url = await page.evaluate('window.location.href').catch(() => '');
+    const url = unwrapEvaluateResult(await page.evaluate('window.location.href').catch(() => ''));
     return typeof url === 'string' ? url : '';
 }
 
@@ -161,7 +198,7 @@ export async function startNewChat(page) {
 }
 
 export async function getPageState(page) {
-    return await page.evaluate(`(() => {
+    return unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -187,7 +224,7 @@ export async function getPageState(page) {
             isLoggedIn: hasComposer || !!userMenu || !hasLoginGate,
             hasLoginGate,
         };
-    })()`);
+    })()`));
 }
 
 export async function ensureChatGPTLogin(page, message = 'ChatGPT requires a logged-in browser session.') {
@@ -258,7 +295,7 @@ export async function sendChatGPTMessage(page, text) {
     // findComposer() retries inside a single CDP call, so no fixed sleep is
     // needed before reading the composer.
 
-    const typeResult = await page.evaluate(`
+    const typeResult = unwrapEvaluateResult(await page.evaluate(`
         (() => {
             ${buildComposerLocatorScript()}
             const composer = findComposer();
@@ -276,8 +313,8 @@ export async function sendChatGPTMessage(page, text) {
             composer.dispatchEvent(new Event('change', { bubbles: true }));
             return true;
         })()
-    `);
-    
+    `));
+
     if (!typeResult) return false;
     
     // Use page.type() which is Playwright's native method
@@ -304,7 +341,7 @@ export async function sendChatGPTMessage(page, text) {
     let sent = null;
     for (let attempt = 0; attempt < 20; attempt += 1) {
         await page.wait(0.5);
-        sent = await page.evaluate(`
+        sent = unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const isUsable = (button) => button
                     && !button.disabled
@@ -318,7 +355,7 @@ export async function sendChatGPTMessage(page, text) {
                     : btns.find(b => labels.includes(b.getAttribute('aria-label') || '') && isUsable(b));
                 return { sendBtnFound: !!sendBtn };
             })()
-        `);
+        `));
         if (sent?.sendBtnFound) break;
     }
 
@@ -339,7 +376,7 @@ export async function sendChatGPTMessage(page, text) {
 }
 
 export async function getVisibleMessages(page) {
-    const result = await page.evaluate(`(() => {
+    const result = unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -385,7 +422,7 @@ export async function getVisibleMessages(page) {
             rows.push({ role, text, html });
         }
         return rows;
-    })()`);
+    })()`));
     if (!Array.isArray(result)) return [];
     return result.map((item, index) => ({
         Index: index + 1,
@@ -448,7 +485,7 @@ export async function getConversationList(page) {
     // so the previous standalone 2 s settle is redundant.
     await ensureOnChatGPT(page);
 
-    const openSidebar = await page.evaluate(`(() => {
+    const openSidebar = unwrapEvaluateResult(await page.evaluate(`(() => {
         const button = Array.from(document.querySelectorAll('button'))
             .find((node) => /open sidebar/i.test(node.getAttribute('aria-label') || ''));
         if (button instanceof HTMLElement) {
@@ -456,7 +493,7 @@ export async function getConversationList(page) {
             return true;
         }
         return false;
-    })()`);
+    })()`));
     if (openSidebar) {
         try {
             await page.wait({ selector: CONVERSATION_LINK_SELECTOR, timeout: 3 });
@@ -480,7 +517,7 @@ export async function getConversationList(page) {
 }
 
 async function extractConversationLinks(page) {
-    const items = await page.evaluate(`(() => {
+    const items = unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -505,7 +542,7 @@ async function extractConversationLinks(page) {
             });
         }
         return rows;
-    })()`);
+    })()`));
     return Array.isArray(items)
         ? items.map((item, index) => ({
             Index: index + 1,
@@ -556,7 +593,7 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
     const namesJson = JSON.stringify(fileNames);
     for (let attempt = 0; attempt < 10; attempt += 1) {
         await page.wait(1);
-        const ready = await page.evaluate(`
+        const ready = unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const names = ${namesJson};
                 const text = document.body ? (document.body.innerText || '') : '';
@@ -572,7 +609,7 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
                 const previewNodes = scope.querySelectorAll('img[src], canvas, video, [style*="background-image"], [data-testid*="attachment"], [data-testid*="upload"], [class*="attachment"], [class*="upload"]');
                 return previewNodes.length >= names.length;
             })()
-        `);
+        `));
         if (ready) return true;
     }
     return false;
@@ -606,7 +643,7 @@ export async function uploadChatGPTImages(page, imagePaths) {
             mime: imageMimeFromPath(absPath),
             base64: fs.default.readFileSync(absPath).toString('base64'),
         }));
-        const fallbackResult = await page.evaluate(`
+        const fallbackResult = unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const files = ${JSON.stringify(files)};
                 const input = document.querySelector('input[type="file"]');
@@ -642,7 +679,7 @@ export async function uploadChatGPTImages(page, imagePaths) {
                 }
                 return { ok: true };
             })()
-        `);
+        `));
         if (fallbackResult && !fallbackResult.ok) return fallbackResult;
     }
 
@@ -656,21 +693,21 @@ export async function uploadChatGPTImages(page, imagePaths) {
  * Check if ChatGPT is still generating a response.
  */
 export async function isGenerating(page) {
-    return await page.evaluate(`
+    return unwrapEvaluateResult(await page.evaluate(`
         (() => {
             return Array.from(document.querySelectorAll('button')).some(b => {
                 const label = b.getAttribute('aria-label') || '';
                 return label === 'Stop generating' || label.includes('Thinking');
             });
         })()
-    `);
+    `));
 }
 
 /**
  * Get visible image URLs from the ChatGPT page (excluding profile/avatar images).
  */
 export async function getChatGPTVisibleImageUrls(page) {
-    return await page.evaluate(`
+    return requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (() => {
             const isVisible = (el) => {
                 if (!(el instanceof HTMLElement)) return false;
@@ -705,7 +742,7 @@ export async function getChatGPTVisibleImageUrls(page) {
             }
             return urls;
         })()
-    `);
+    `)), 'chatgpt visible image url extraction');
 }
 
 /**
@@ -723,7 +760,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
 
         let currentUrl = '';
         if (convUrl && convUrl.includes('/c/')) {
-            currentUrl = await page.evaluate('window.location.href').catch(() => '');
+            currentUrl = unwrapEvaluateResult(await page.evaluate('window.location.href').catch(() => ''));
             if (currentUrl && !isSameChatGPTConversation(currentUrl, convUrl)) {
                 await page.goto(convUrl);
                 await page.wait(3);
@@ -776,7 +813,7 @@ export const __test__ = {
  */
 export async function getChatGPTImageAssets(page, urls) {
     const urlsJson = JSON.stringify(urls);
-    return await page.evaluate(`
+    return requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (async (targetUrls) => {
             const blobToDataUrl = (blob) => new Promise((resolve, reject) => {
                 const reader = new FileReader();
@@ -850,5 +887,5 @@ export async function getChatGPTImageAssets(page, urls) {
 
             return results;
         })(${urlsJson})
-    `, urls);
+    `)), 'chatgpt image asset export');
 }

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -218,7 +218,10 @@ describe('chatgpt image upload helper', () => {
             setFileInput: vi.fn().mockRejectedValue(new Error('No element found')),
             wait: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn((script) => {
-                return Promise.resolve({ ok: true });
+                if (String(script).includes('new DataTransfer()')) {
+                    return Promise.resolve({ ok: true });
+                }
+                return Promise.resolve(true);
             }),
         };
 


### PR DESCRIPTION
## Summary

The browser bridge wraps every `page.evaluate(...)` return value in a `{ session, data }` envelope. Adapters that read `.length` or `Array.isArray(payload)` directly on the envelope silently see "no data" — same failure mode addressed for `xiaohongshu` / `rednote` in #1561 and `weibo` in #1568.

This sweep applies the same `unwrapEvaluateResult` helper across **every** chatgpt `page.evaluate` consumer site, plus typed shape guards on the critical extraction paths so envelope misses fail loud (typed `CommandExecutionError`) instead of silently returning empty.

## Sites wrapped

`clis/chatgpt/utils.js`:

- `currentChatGPTUrl` — string URL probe
- `getPageState` — login / composer page state object
- `sendChatGPTMessage` — composer write + send-button readiness probes
- `getVisibleMessages` — conversation transcript array
- `getConversationList` / `extractConversationLinks` — sidebar items
- `waitForChatGPTUploadPreview` — image upload readiness
- `uploadChatGPTImages` fallback — DataTransfer upload result
- `isGenerating` — boolean "still generating?" probe
- `getChatGPTVisibleImageUrls` — visible image URL array (also wrapped with `requireArrayEvaluateResult`)
- `waitForChatGPTImages` — inline `window.location.href` poll
- `getChatGPTImageAssets` — exported asset array (also wrapped with `requireArrayEvaluateResult`)

`clis/chatgpt/image.js`:

- `currentChatGPTLink` — used for error hints + conversation link reporting

## Helpers added

Three small exports in `clis/chatgpt/utils.js`, mirroring the weibo signatures from #1568:

- \`unwrapEvaluateResult(payload)\` — defensive ternary; unwraps when payload looks like an envelope, otherwise passes through (back-compat with bridge versions that return raw values, and with primitive returns like booleans / URL strings)
- \`requireArrayEvaluateResult(payload, label)\` — array-shape guard with named context; surfaces inner \`{error: ...}\` payloads
- \`requireObjectEvaluateResult(payload, label)\` — plain-object-shape guard

## Drive-by fix

\`getChatGPTImageAssets\` was passing a redundant \`urls\` second arg to \`page.evaluate(string, urls)\`. The IIFE inside the string already receives the list via the \`\${urlsJson}\` template substitution, and the browser bridge guard in \`browser/utils.ts\` rejects the second form for string scripts:

\`\`\`
page.evaluate string input does not accept args;
use page.evaluate(fn, ...args) instead
\`\`\`

So \`opencli chatgpt image <prompt>\` blows up at the download step without \`--sd true\`. Drop the trailing arg as part of the asset-export cleanup.

(**This supersedes #1556** — that PR's one-line fix is bundled here as a natural part of the envelope wrap.)

## Validation

- \`npx tsc --noEmit\` — clean
- \`npx vitest run --project adapter clis/chatgpt/\` — **38/38 pass** (25 existing + 13 new in \`envelope.test.js\` covering the helpers' contract end-to-end)
- \`npm test\` — **3644 passing** across 364 files (1 pre-existing skip)
- Live smoke (browser bridge, ChatGPT logged in): \`opencli chatgpt image \"<prompt>\"\` end-to-end generate + download succeeds; the wrap is defensive in 1.7.19 (no envelope observed yet there), but pre-empts the same silent-failure mode that hit the merged xiaohongshu / weibo PRs.

## Backwards compatibility

\`unwrapEvaluateResult\` is a defensive ternary — payloads that aren't envelopes (raw arrays, primitives, plain objects) pass through unchanged. The \`require*\` guards only fire on shapes that would have caused silent failures or downstream TypeErrors anyway; they convert those into typed \`CommandExecutionError\` with a context label.

## Related

Closes #1556 (superseded). Same pattern as merged #1561 (xiaohongshu/rednote) and #1568 (weibo).