### PR TITLE
feat(external): add Longbridge CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **external** — add the Longbridge CLI as a built-in external CLI passthrough (`opencli longbridge ...`) for Longbridge OpenAPI market data, account, and trading commands.
+
 ## [1.7.21](https://github.com/jackwener/opencli/compare/v1.7.20...v1.7.21) (2026-05-14)
 
 Adapter polish release: new web search adapters, better Browser Bridge tab group reuse, and social adapters returning to one-shot tab leases. Extension package version is bumped to 1.0.15 for the Browser Bridge fix.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OpenCLI gives you one surface for three different kinds of automation:
 - **Let AI Agents operate any website** — install the `opencli-adapter-author` skill in your AI agent (Claude Code, Cursor, etc.), and it can navigate, click, type/fill, extract, and inspect any page through your logged-in browser via `opencli browser` primitives.
 - **Write new adapters** end-to-end with `opencli browser` + the `opencli-adapter-author` skill, which guides from first recon through field decoding, code, and `opencli browser verify`.
 
-It also works as a **CLI hub** for local tools such as `gh`, `docker`, `tg`, `discord`, `wx`, `ntn` (Notion), and other binaries you register yourself, plus **desktop app adapters** for Electron apps like Cursor, Codex, Antigravity, and ChatGPT.
+It also works as a **CLI hub** for local tools such as `gh`, `docker`, `longbridge`, `tg`, `discord`, `wx`, `ntn` (Notion), and other binaries you register yourself, plus **desktop app adapters** for Electron apps like Cursor, Codex, Antigravity, and ChatGPT.
 
 ## Highlights
 
@@ -290,6 +290,7 @@ OpenCLI acts as a universal hub for your existing command-line tools — unified
 | **gh** | GitHub CLI | `opencli gh pr list --limit 5` |
 | **obsidian** | Obsidian vault management | `opencli obsidian search query="AI"` |
 | **docker** | Docker | `opencli docker ps` |
+| **longbridge** | Longbridge CLI — market data, account management, and trading via Longbridge OpenAPI | `opencli longbridge quote TSLA.US --format json` |
 | **ntn** | Notion CLI — official Notion API CLI for pages, databases, blocks, search, comments | `opencli ntn pages list` |
 | **lark-cli** | Lark/Feishu — messages, docs, calendar, tasks, 200+ commands | `opencli lark-cli calendar +agenda` |
 | **dws** | DingTalk — cross-platform CLI for DingTalk's full suite, designed for humans and AI agents | `opencli dws msg send --to user "hello"` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 - **让 AI Agent 操作任意网站**：在你的 AI Agent（Claude Code、Cursor 等）中安装 `opencli-adapter-author` skill，Agent 就能用你的已登录浏览器导航、点击、输入/填充、提取任意网页内容。
 - **把新网站写成 CLI**：用 `opencli browser` 原语 + `opencli-adapter-author` skill，从站点侦察、API 发现、字段解码到 `opencli browser verify` 一条龙。
 
-除了网站能力，OpenCLI 还是一个 **CLI 枢纽**：你可以把 `gh`、`docker`、`tg`、`discord`、`wx`、`ntn`（Notion）等本地工具统一注册到 `opencli` 下，也可以通过桌面端适配器控制 Cursor、Codex、Antigravity、ChatGPT 等 Electron 应用。
+除了网站能力，OpenCLI 还是一个 **CLI 枢纽**：你可以把 `gh`、`docker`、`longbridge`、`tg`、`discord`、`wx`、`ntn`（Notion）等本地工具统一注册到 `opencli` 下，也可以通过桌面端适配器控制 Cursor、Codex、Antigravity、ChatGPT 等 Electron 应用。
 
 ## 亮点
 
@@ -332,6 +332,7 @@ OpenCLI 也可以作为你现有命令行工具的统一入口，负责发现、
 | **gh** | GitHub CLI | `opencli gh pr list --limit 5` |
 | **obsidian** | Obsidian 仓库管理 | `opencli obsidian search query="AI"` |
 | **docker** | Docker 命令行工具 | `opencli docker ps` |
+| **longbridge** | Longbridge CLI — 通过 Longbridge OpenAPI 获取行情、账户和交易能力 | `opencli longbridge quote TSLA.US --format json` |
 | **ntn** | Notion CLI — 基于官方 Notion API 的页面、数据库、块、搜索、评论命令 | `opencli ntn pages list` |
 | **lark-cli** | 飞书 CLI — 消息、文档、日历、任务，200+ 命令 | `opencli lark-cli calendar +agenda` |
 | **dws** | 钉钉 CLI — 钉钉全套产品能力的跨平台命令行工具，支持人类和 AI Agent 使用 | `opencli dws msg send --to user "hello"` |

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -134,7 +134,7 @@ opencli gh pr list --limit 5   # passthrough; stdio is inherited, exit code prop
 opencli docker ps
 ```
 
-Built-in entries live in `src/external-clis.yaml`; user overrides and additions in `~/.opencli/external-clis.yaml`. Commonly shipped: `gh`, `docker`, `vercel`, `lark-cli`, `dws`, `wecom-cli`, `obsidian`, `ntn`, `tg(tg-cli)`, `discord(discord-cli)`, `wx(wx-cli)`.
+Built-in entries live in `src/external-clis.yaml`; user overrides and additions in `~/.opencli/external-clis.yaml`. Commonly shipped: `gh`, `docker`, `vercel`, `lark-cli`, `longbridge`, `dws`, `wecom-cli`, `obsidian`, `ntn`, `tg(tg-cli)`, `discord(discord-cli)`, `wx(wx-cli)`.
 
 Some official CLIs use shell-script installers instead of a shell-free package-manager command. Entries without an `install` config, such as `ntn`, must be installed manually from their homepage before passthrough use.
 

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -36,6 +36,15 @@
   install:
     default: "npm install -g @larksuite/cli"
 
+- name: longbridge
+  binary: longbridge
+  description: "Longbridge CLI — AI-native market data, account management and trading commands for Longbridge OpenAPI"
+  homepage: "https://open.longbridge.com/zh-CN/docs/cli/"
+  tags: [longbridge, finance, trading, market-data, openapi, ai-agent]
+  install:
+    mac: "brew install --cask longbridge/tap/longbridge-terminal"
+    windows: "scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json"
+
 - name: dws
   binary: dws
   description: "DingTalk Workspace CLI — messages, docs, calendar, contacts and more for humans and AI agents"

--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -59,6 +59,23 @@ describe('parseCommand', () => {
       }
     }
   });
+
+  it('registers Longbridge with safe package-manager installers only', () => {
+    const raw = fs.readFileSync(path.join(__dirname, 'external-clis.yaml'), 'utf8');
+    const entries = (yaml.load(raw) || []) as ExternalCliConfig[];
+    const longbridge = entries.find((entry) => entry.name === 'longbridge');
+
+    expect(longbridge).toMatchObject({
+      binary: 'longbridge',
+      homepage: 'https://open.longbridge.com/zh-CN/docs/cli/',
+      install: {
+        mac: 'brew install --cask longbridge/tap/longbridge-terminal',
+        windows: 'scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json',
+      },
+    });
+    expect(longbridge?.install?.linux).toBeUndefined();
+    expect(longbridge?.install?.default).toBeUndefined();
+  });
 });
 
 describe('formatExternalCliLabel', () => {


### PR DESCRIPTION
## Summary
- register Longbridge CLI as a built-in external CLI passthrough
- document \Usage: opencli [options] [command]

Make any website your CLI. Zero setup. AI-powered.

Options:
  -V, --version                        output the version number
  --profile <name>                     Chrome profile/context alias for Browser
                                       Bridge commands
  -h, --help                           display help for command

Commands:
  list [options]                       List all available CLI commands
  validate [target]                    Validate CLI definitions
  verify [options] [target]            Validate + smoke test
  convention-audit [options] [target]  Scan adapters for agent-native convention
                                       violations
  browser [options]                    analyze, back, bind, check, click, close,
                                       console, dblclick, dialog, drag, eval,
                                       extract, fill, find, focus, frames, get,
                                       hover, init, keys, network, open,
                                       screenshot, scroll, select, state, tab,
                                       type, unbind, uncheck, upload, verify,
                                       wait
  doctor [options]                     Diagnose opencli browser bridge
                                       connectivity
  completion <shell>                   Output shell completion script
  plugin                               create, install, list, uninstall, update
  adapter                              eject, reset, status
  profile                              list, rename, use
  daemon                               restart, status, stop
  external                             install, list, register

External CLIs (11):
  discord(discord-cli), docker, dws, gh, lark-cli, ntn, obsidian, tg(tg-cli), vercel, wecom-cli,
  wx(wx-cli)

App adapters (7):
  antigravity, chatgpt-app, chatwise, codex, cursor, discord-app, doubao-app

Site adapters (136):
  1688, 1point3acres, 36kr, 51job, aibase, amazon, apple-podcasts, arxiv, baidu-scholar, band,
  barchart, bbc, bilibili, binance, bloomberg, bluesky, boss, brave, chaoxing, chatgpt, claude,
  cnki, coingecko, coupang, crates, ctrip, dblp, deepseek, defillama, devto, dianping, dictionary,
  dockerhub, douban, doubao, douyin, duckduckgo, eastmoney, endoflife, facebook, flathub, gemini,
  gitee, google, google-scholar, goproxy, gov-law, gov-policy, grok, hackernews, hf, homebrew, hupu,
  imdb, indeed, instagram, jd, jianyu, jike, jimeng, ke, lesswrong, lichess, linkedin, linux-do,
  lobsters, maimai, maven, mdn, medium, mubu, notebooklm, nowcoder, npm, nuget, nvd, oeis, ones,
  openalex, openfda, openreview, osv, packagist, paperreview, pixiv, powerchina, producthunt,
  pubmed, pypi, quark, qwen, reddit, rednote, rest-countries, reuters, rfc, rubygems, sinablog,
  sinafinance, smzdm, spotify, stackoverflow, steam, substack, taobao, tdx, ths, tieba, tiktok,
  toutiao, tvmaze, twitter, uisdc, uiverse, v2ex, wanfang, web, weibo, weixin, weread, wikidata,
  wikipedia, wttr, xianyu, xiaoe, xiaohongshu, xiaoyuzhou, xueqiu, yahoo, yahoo-finance, yollomi,
  youtube, yuanbao, zhihu, zlibrary, zsxq

Run 'opencli list' for full command details, or 'opencli <site> --help' to inspect one site.
Agent tip: use 'opencli <site> --help -f yaml' for all command args/options in one structured response. in README / zh README / opencli-usage skill
- add regression coverage for the safe Homebrew/Scoop installers and intentionally omit shell-script installers

## Verification
- \
 RUN  v4.1.4 /Users/jakevin/.slock/agents/50984615-bae4-4353-8062-1791eeb9471f/opencli


 Test Files  3 passed (3)
      Tests  176 passed (176)
   Start at  16:23:21
   Duration  491ms (transform 359ms, setup 0ms, import 466ms, tests 131ms, environment 0ms)
- \
> @jackwener/opencli@1.7.21 build
> npm run clean-dist && npm run copy-yaml && npm run build-manifest


> @jackwener/opencli@1.7.21 clean-dist
> node scripts/clean-dist.cjs


> @jackwener/opencli@1.7.21 copy-yaml
> node scripts/copy-yaml.cjs


> @jackwener/opencli@1.7.21 prebuild-manifest
> tsc --build


> @jackwener/opencli@1.7.21 build-manifest
> tsx src/build-manifest.ts

✅ Manifest compiled: 813 entries → /Users/jakevin/.slock/agents/50984615-bae4-4353-8062-1791eeb9471f/opencli/cli-manifest.json
✅ Restored executable permission: dist/src/main.js
- \
> @jackwener/opencli@1.7.21 typecheck
> tsc --noEmit
- \
> @jackwener/opencli@1.7.21 docs:build
> vitepress build docs


  vitepress v1.6.4

build complete in 4.19s.
- clean-HOME help smoke: External CLIs includes \
- clean-HOME \[
  {
    "name": "discord",
    "package": "discord-cli",
    "binary": "discord",
    "installed": false,
    "description": "Discord CLI — local-first sync, search, export via SQLite for AI agents",
    "homepage": "https://github.com/jackwener/discord-cli",
    "tags": "discord, messaging, search, export, ai-agent"
  },
  {
    "name": "docker",
    "package": "",
    "binary": "docker",
    "installed": false,
    "description": "Docker command-line interface",
    "homepage": "https://docs.docker.com/engine/reference/commandline/cli/",
    "tags": "docker, containers, devops"
  },
  {
    "name": "dws",
    "package": "",
    "binary": "dws",
    "installed": false,
    "description": "DingTalk Workspace CLI — messages, docs, calendar, contacts and more for humans and AI agents",
    "homepage": "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli",
    "tags": "dingtalk, collaboration, productivity, ai-agent"
  },
  {
    "name": "gh",
    "package": "",
    "binary": "gh",
    "installed": true,
    "description": "GitHub CLI — repos, PRs, issues, releases, gists",
    "homepage": "https://cli.github.com",
    "tags": "github, git, dev"
  },
  {
    "name": "lark-cli",
    "package": "",
    "binary": "lark-cli",
    "installed": false,
    "description": "Lark/Feishu CLI — messages, documents, spreadsheets, calendar, tasks and 200+ commands for AI agents",
    "homepage": "https://github.com/larksuite/cli",
    "tags": "lark, feishu, collaboration, productivity, ai-agent"
  },
  {
    "name": "ntn",
    "package": "",
    "binary": "ntn",
    "installed": false,
    "description": "Notion CLI — official Notion API CLI for pages, databases, blocks, search, comments",
    "homepage": "https://ntn.dev",
    "tags": "notion, notes, knowledge, productivity"
  },
  {
    "name": "obsidian",
    "package": "",
    "binary": "obsidian",
    "installed": false,
    "description": "Obsidian vault management — notes, search, tags, tasks, sync",
    "homepage": "https://obsidian.md/help/cli",
    "tags": "notes, knowledge, markdown"
  },
  {
    "name": "tg",
    "package": "tg-cli",
    "binary": "tg",
    "installed": false,
    "description": "Telegram CLI — local-first sync, search, export via MTProto for AI agents",
    "homepage": "https://github.com/jackwener/tg-cli",
    "tags": "telegram, messaging, search, export, ai-agent"
  },
  {
    "name": "vercel",
    "package": "",
    "binary": "vercel",
    "installed": false,
    "description": "Vercel CLI — deploy projects, manage domains, env vars, logs and serverless functions",
    "homepage": "https://vercel.com/docs/cli",
    "tags": "vercel, deployment, serverless, frontend, devops"
  },
  {
    "name": "wecom-cli",
    "package": "",
    "binary": "wecom-cli",
    "installed": false,
    "description": "WeCom/企业微信 CLI — contacts, todos, meetings, messages, calendar, docs and smart sheets for AI agents",
    "homepage": "https://github.com/WecomTeam/wecom-cli",
    "tags": "wecom, wechat-work, collaboration, productivity, ai-agent"
  },
  {
    "name": "wx",
    "package": "wx-cli",
    "binary": "wx",
    "installed": false,
    "description": "WeChat local data CLI — sessions, messages, search, contacts, export for AI agents",
    "homepage": "https://github.com/jackwener/wx-cli",
    "tags": "wechat, messaging, search, export, ai-agent"
  }
] includes \
- \