### PR TITLE
feat(external-cli): render brand alias for ambiguous executable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **external** — add the Longbridge CLI as a built-in external CLI passthrough (`opencli longbridge ...`) for Longbridge OpenAPI market data, account, and trading commands.
+* **external-cli** — render brand alias `name(package)` in `opencli list` and root help when the bare executable name is ambiguous. Built-in entries `ntn` → `ntn(notion)`, `dws` → `dws(DingTalk Workspace)`, `wecom-cli` → `wecom-cli(企业微信)` now self-explain in help output. `package` field is repurposed to cover both upstream distribution names (e.g. `tg-cli`) and human-readable brand labels (e.g. `notion`, `企业微信`).
 
 ## [1.7.21](https://github.com/jackwener/opencli/compare/v1.7.20...v1.7.21) (2026-05-14)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -626,7 +626,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         for (const ext of externalClis) {
           const isInstalled = isBinaryInstalled(ext.binary);
           const tag = isInstalled ? '[installed]' : '[auto-install]';
-          console.log(`    ${ext.name} ${tag}${ext.description ? ` — ${ext.description}` : ''}`);
+          console.log(`    ${formatExternalCliLabel(ext)} ${tag}${ext.description ? ` — ${ext.description}` : ''}`);
         }
         console.log();
       }

--- a/src/external-clis.yaml
+++ b/src/external-clis.yaml
@@ -16,6 +16,7 @@
 
 - name: ntn
   binary: ntn
+  package: notion
   description: "Notion CLI — official Notion API CLI for pages, databases, blocks, search, comments"
   homepage: "https://ntn.dev"
   tags: [notion, notes, knowledge, productivity]
@@ -47,6 +48,7 @@
 
 - name: dws
   binary: dws
+  package: DingTalk Workspace
   description: "DingTalk Workspace CLI — messages, docs, calendar, contacts and more for humans and AI agents"
   homepage: "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
   tags: [dingtalk, collaboration, productivity, ai-agent]
@@ -56,6 +58,7 @@
 
 - name: wecom-cli
   binary: wecom-cli
+  package: 企业微信
   description: "WeCom/企业微信 CLI — contacts, todos, meetings, messages, calendar, docs and smart sheets for AI agents"
   homepage: "https://github.com/WecomTeam/wecom-cli"
   tags: [wecom, wechat-work, collaboration, productivity, ai-agent]

--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -86,6 +86,13 @@ describe('formatExternalCliLabel', () => {
   it('keeps the label compact when package and name match', () => {
     expect(formatExternalCliLabel({ name: 'docker', binary: 'docker', package: 'docker' })).toBe('docker');
   });
+
+  it('renders a human-readable brand alias for ambiguous executable names', () => {
+    expect(formatExternalCliLabel({ name: 'ntn', binary: 'ntn', package: 'notion' })).toBe('ntn(notion)');
+    expect(formatExternalCliLabel({ name: 'wecom-cli', binary: 'wecom-cli', package: '企业微信' })).toBe(
+      'wecom-cli(企业微信)',
+    );
+  });
 });
 
 describe('installExternalCli', () => {

--- a/src/external.ts
+++ b/src/external.ts
@@ -20,7 +20,12 @@ export interface ExternalCliConfig {
   /** User-facing OpenCLI subcommand and, by default, the executable name. */
   name: string;
   binary: string;
-  /** Distribution/project name when it differs from the executable name. */
+  /**
+   * Display alias rendered alongside `name` in help/listing as `name(package)`.
+   * Use either the upstream distribution/project name (e.g. `tg-cli`, `discord-cli`)
+   * or a human-readable brand label (e.g. `notion`, `企业微信`) when the bare
+   * executable name is ambiguous.
+   */
   package?: string;
   description?: string;
   homepage?: string;


### PR DESCRIPTION
## Summary

`ntn`, `dws`, and `wecom-cli` are opaque executable names — users seeing them in `opencli list` or root help have no way to know they correspond to Notion, DingTalk Workspace, and 企业微信. This PR repurposes the existing `package` field to double as a human-readable brand label so help output self-explains:

- `ntn` → `ntn(notion)`
- `dws` → `dws(DingTalk Workspace)`
- `wecom-cli` → `wecom-cli(企业微信)`

The `name(package)` rendering function `formatExternalCliLabel` already existed and was already used by root help. This PR:
- adds `package:` to the three ambiguous YAML entries
- expands the JSDoc on `package` so future entries know the field covers both upstream distribution names (`tg-cli`, `discord-cli`) and brand labels (`notion`, `企业微信`)
- threads `formatExternalCliLabel` into `opencli list` at `src/cli.ts:629` so listing and root help stay consistent

Co-developed with PR #1584 (Longbridge entry) per @WAWQAQ's request — same `name(package)` convention is now available for Longbridge and future external CLIs.

## Test plan

- [x] `npx vitest run --project unit src/external.test.ts` — 9/9 pass (incl. new regression test for brand aliases)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — 813 manifest entries unchanged
- [x] Smoke: `opencli list` and `opencli --help` render `ntn(notion)` / `dws(DingTalk Workspace)` / `wecom-cli(企业微信)`