### PR TITLE
chore(release): 1.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## Unreleased
+## [1.7.22](https://github.com/jackwener/opencli/compare/v1.7.21...v1.7.22) (2026-05-15)
+
+External CLI ergonomics + two adapter envelope/auth fixes. New `longbridge` external CLI entry; `opencli list` / root help now render human-readable brand labels for executables whose bare name is ambiguous.
 
 ### Features
 
-* **external** — add the Longbridge CLI as a built-in external CLI passthrough (`opencli longbridge ...`) for Longbridge OpenAPI market data, account, and trading commands.
-* **external-cli** — render brand alias `name(package)` in `opencli list` and root help when the bare executable name is ambiguous. Built-in entries `ntn` → `ntn(notion)`, `dws` → `dws(DingTalk Workspace)`, `wecom-cli` → `wecom-cli(企业微信)` now self-explain in help output. `package` field is repurposed to cover both upstream distribution names (e.g. `tg-cli`) and human-readable brand labels (e.g. `notion`, `企业微信`).
+* **external** — add the Longbridge CLI as a built-in external CLI passthrough (`opencli longbridge ...`) for Longbridge OpenAPI market data, account, and trading commands. ([#1584](https://github.com/jackwener/opencli/issues/1584))
+* **external-cli** — render brand alias `name(package)` in `opencli list` and root help when the bare executable name is ambiguous. Built-in entries `ntn` → `ntn(notion)`, `dws` → `dws(DingTalk Workspace)`, `wecom-cli` → `wecom-cli(企业微信)` now self-explain in help output. `package` field is repurposed to cover both upstream distribution names (e.g. `tg-cli`) and human-readable brand labels (e.g. `notion`, `企业微信`). ([#1585](https://github.com/jackwener/opencli/issues/1585))
+
+### Bug Fixes
+
+* **boss** — map `code=24` (identity mismatch) to `AuthRequiredError` so re-login is signaled instead of surfacing as a generic API error. ([#1573](https://github.com/jackwener/opencli/issues/1573))
+* **weibo** — unwrap Browser Bridge `page.evaluate` envelopes in read adapters. ([#1568](https://github.com/jackwener/opencli/issues/1568))
 
 ## [1.7.21](https://github.com/jackwener/opencli/compare/v1.7.20...v1.7.21) (2026-05-14)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.21",
+  "version": "1.7.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.7.21",
+      "version": "1.7.22",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.7.21",
+  "version": "1.7.22",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

External CLI ergonomics + two adapter envelope/auth fixes. No BREAKING changes, no extension version bump.

## Included PRs (4 since 1.7.21)

### Features
- #1584 **external**: longbridge CLI passthrough
- #1585 **external-cli**: brand alias rendering — `ntn(notion)`, `dws(DingTalk Workspace)`, `wecom-cli(企业微信)`

### Bug Fixes
- #1573 **boss**: map code=24 (identity mismatch) → AuthRequiredError
- #1568 **weibo**: unwrap page.evaluate envelope in read adapters

## Version

- `package.json` / `package-lock.json`: 1.7.21 → 1.7.22
- `extension/manifest.json`: 1.0.15 (unchanged — no extension changes in this release)

## Test plan

- [ ] CI green (build / unit-test / bun-test / audit / doc / extension build across 3 OS)
- [ ] After merge: tag `v1.7.22`, Release CI auto-publishes to npm + GitHub Release