### PR TITLE
feat(douyin): restore publish and delete flow

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8266,7 +8266,7 @@
   {
     "site": "douyin",
     "name": "delete",
-    "description": "删除作品",
+    "description": "删除作品（优先使用创作者后台作品管理；找不到时回退到旧删除接口）",
     "access": "write",
     "domain": "creator.douyin.com",
     "strategy": "cookie",
@@ -8277,7 +8277,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "作品 ID"
+        "help": "作品 ID / item_id"
       }
     ],
     "columns": [
@@ -8286,7 +8286,8 @@
     "type": "js",
     "modulePath": "douyin/delete.js",
     "sourceFile": "douyin/delete.js",
-    "navigateBefore": "https://creator.douyin.com"
+    "navigateBefore": "https://creator.douyin.com",
+    "siteSession": "persistent"
   },
   {
     "site": "douyin",

--- a/clis/douyin/_shared/browser-fetch.js
+++ b/clis/douyin/_shared/browser-fetch.js
@@ -6,18 +6,30 @@ import { CommandExecutionError } from '@jackwener/opencli/errors';
 export async function browserFetch(page, method, url, options = {}) {
     const js = `
     (async () => {
-      const res = await fetch(${JSON.stringify(url)}, {
-        method: ${JSON.stringify(method)},
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          ...${JSON.stringify(options.headers ?? {})}
-        },
-        ${options.body ? `body: JSON.stringify(${JSON.stringify(options.body)}),` : ''}
-      });
-      const text = await res.text();
-      if (!text) return null;
-      return JSON.parse(text);
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), ${Number(options.timeoutMs ?? 30000)});
+      try {
+        const res = await fetch(${JSON.stringify(url)}, {
+          method: ${JSON.stringify(method)},
+          credentials: 'include',
+          signal: controller.signal,
+          headers: {
+            'Content-Type': 'application/json',
+            ...${JSON.stringify(options.headers ?? {})}
+          },
+          ${options.body ? `body: JSON.stringify(${JSON.stringify(options.body)}),` : ''}
+        });
+        const text = await res.text();
+        try {
+          return JSON.parse(text);
+        } catch (error) {
+          return { status_code: res.ok ? 0 : res.status, status_msg: text.slice(0, 500) || String(error && error.message || error) };
+        }
+      } catch (error) {
+        return { status_code: -1, status_msg: String(error && error.message || error) };
+      } finally {
+        clearTimeout(timer);
+      }
     })()
   `;
     let result;
@@ -25,17 +37,16 @@ export async function browserFetch(page, method, url, options = {}) {
         result = await page.evaluate(js);
     }
     catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new CommandExecutionError(`Douyin API request failed: ${message}`);
+        throw new CommandExecutionError(`Douyin API request failed (${method} ${url}): ${error instanceof Error ? error.message : String(error)}`);
     }
-    if (result === null || result === undefined) {
-        throw new CommandExecutionError('Empty response from Douyin API');
+    if (result == null) {
+        throw new CommandExecutionError(`Empty response from Douyin API (${method} ${url})`);
     }
     if (result && typeof result === 'object' && 'status_code' in result) {
         const code = result.status_code;
         if (code !== 0) {
-            const msg = result.status_msg ?? 'unknown error';
-            throw new CommandExecutionError(`Douyin API error ${code}: ${msg}`);
+            const msg = result.status_msg ?? result.message ?? 'unknown error';
+            throw new CommandExecutionError(`Douyin API error ${code} at ${method} ${url}: ${msg}`);
         }
     }
     return result;

--- a/clis/douyin/_shared/browser-fetch.js
+++ b/clis/douyin/_shared/browser-fetch.js
@@ -1,4 +1,11 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './evaluate-result.js';
+
+function isAuthLikeError(code, message) {
+    const text = String(message ?? '');
+    return code === 401 || code === 403 || /login|cookie|auth|captcha|verify|forbidden|permission|登录|登陆|权限|验证|验证码/i.test(text);
+}
+
 /**
  * Execute a fetch() call inside the Chrome browser context via page.evaluate.
  * This ensures a_bogus signing and cookies are handled automatically by the browser.
@@ -23,7 +30,7 @@ export async function browserFetch(page, method, url, options = {}) {
         try {
           return JSON.parse(text);
         } catch (error) {
-          return { status_code: res.ok ? 0 : res.status, status_msg: text.slice(0, 500) || String(error && error.message || error) };
+          return { status_code: res.ok ? -2 : res.status, status_msg: \`JSON parse failed: \${text.slice(0, 500) || String(error && error.message || error)}\` };
         }
       } catch (error) {
         return { status_code: -1, status_msg: String(error && error.message || error) };
@@ -34,7 +41,7 @@ export async function browserFetch(page, method, url, options = {}) {
   `;
     let result;
     try {
-        result = await page.evaluate(js);
+        result = unwrapEvaluateResult(await page.evaluate(js));
     }
     catch (error) {
         throw new CommandExecutionError(`Douyin API request failed (${method} ${url}): ${error instanceof Error ? error.message : String(error)}`);
@@ -42,10 +49,16 @@ export async function browserFetch(page, method, url, options = {}) {
     if (result == null) {
         throw new CommandExecutionError(`Empty response from Douyin API (${method} ${url})`);
     }
+    if (Array.isArray(result) || typeof result !== 'object') {
+        throw new CommandExecutionError(`Malformed response from Douyin API (${method} ${url})`);
+    }
     if (result && typeof result === 'object' && 'status_code' in result) {
         const code = result.status_code;
         if (code !== 0) {
             const msg = result.status_msg ?? result.message ?? 'unknown error';
+            if (isAuthLikeError(code, msg)) {
+                throw new AuthRequiredError('creator.douyin.com', `Douyin API auth/permission error ${code} at ${method} ${url}: ${msg}`);
+            }
             throw new CommandExecutionError(`Douyin API error ${code} at ${method} ${url}: ${msg}`);
         }
     }

--- a/clis/douyin/_shared/browser-fetch.test.js
+++ b/clis/douyin/_shared/browser-fetch.test.js
@@ -38,6 +38,6 @@ describe('browserFetch', () => {
     it('wraps browser-side fetch or JSON parse failures', async () => {
         const page = makePage(null);
         page.evaluate.mockRejectedValueOnce(new SyntaxError('Unexpected token < in JSON'));
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Douyin API request failed: Unexpected token < in JSON');
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Douyin API request failed (GET https://creator.douyin.com/api/test): Unexpected token < in JSON');
     });
 });

--- a/clis/douyin/_shared/browser-fetch.test.js
+++ b/clis/douyin/_shared/browser-fetch.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { browserFetch } from './browser-fetch.js';
 function makePage(result) {
     return {
@@ -18,9 +19,19 @@ describe('browserFetch', () => {
         const result = await browserFetch(page, 'GET', 'https://creator.douyin.com/api/test');
         expect(result).toEqual({ status_code: 0, data: { ak: 'KEY' } });
     });
+    it('unwraps Browser Bridge {session,data} envelopes', async () => {
+        const page = makePage({ session: 'site:douyin:test', data: { status_code: 0, data: { ok: true } } });
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .resolves.toEqual({ status_code: 0, data: { ok: true } });
+    });
     it('throws when status_code is non-zero', async () => {
         const page = makePage({ status_code: 8, message: 'fail' });
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Douyin API error 8');
+    });
+    it('maps auth-like API errors to AuthRequiredError', async () => {
+        const page = makePage({ status_code: 401, status_msg: 'login required' });
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toBeInstanceOf(AuthRequiredError);
     });
     it('returns result even when no status_code field', async () => {
         const page = makePage({ some_field: 'value' });
@@ -34,6 +45,16 @@ describe('browserFetch', () => {
     it('throws on undefined response body', async () => {
         const page = makePage(undefined);
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Empty response from Douyin API');
+    });
+    it('throws typed on malformed primitive response body', async () => {
+        const page = makePage('not-json-object');
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+    it('throws typed when browser fetch returns a non-JSON body', async () => {
+        const page = makePage({ status_code: -2, status_msg: 'JSON parse failed: <html>not-json</html>' });
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toThrow('Douyin API error -2');
     });
     it('wraps browser-side fetch or JSON parse failures', async () => {
         const page = makePage(null);

--- a/clis/douyin/_shared/evaluate-result.js
+++ b/clis/douyin/_shared/evaluate-result.js
@@ -1,0 +1,16 @@
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+export function unwrapEvaluateResult(payload) {
+  if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+    return payload.data;
+  }
+  return payload;
+}
+
+export function requireObjectEvaluateResult(payload, context) {
+  const result = unwrapEvaluateResult(payload);
+  if (!result || Array.isArray(result) || typeof result !== 'object') {
+    throw new CommandExecutionError(`${context}: malformed evaluate payload`);
+  }
+  return result;
+}

--- a/clis/douyin/_shared/tos-upload.js
+++ b/clis/douyin/_shared/tos-upload.js
@@ -56,6 +56,31 @@ function sha256Hex(data) {
     }
     return hash.digest('hex');
 }
+const CRC32_TABLE = new Uint32Array(256).map((_, index) => {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+        value = (value & 1) ? (0xEDB88320 ^ (value >>> 1)) : (value >>> 1);
+    }
+    return value >>> 0;
+});
+function crc32Hex(data) {
+    let crc = 0xffffffff;
+    for (const byte of data) {
+        crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+    }
+    return ((crc ^ 0xffffffff) >>> 0).toString(16).padStart(8, '0');
+}
+function gatewayBaseUrl(tosUrl) {
+    const parsedUrl = new URL(tosUrl);
+    return `https://${parsedUrl.host}/upload/v1${parsedUrl.pathname}`;
+}
+function gatewayHeaders(auth, uploadHeader, userId = '') {
+    return {
+        Authorization: auth,
+        'X-Storage-U': encodeURIComponent(userId),
+        ...(uploadHeader ?? {}),
+    };
+}
 function extractRegionFromHost(host) {
     // e.g. "tos-cn-i-alisg.volces.com" → "cn-i-alisg"
     // e.g. "tos-cn-beijing.ivolces.com" → "cn-beijing"
@@ -129,6 +154,7 @@ async function tosRequest(opts) {
         method,
         headers,
         body: fetchBody,
+        signal: AbortSignal.timeout(60000),
     });
     const responseBody = await res.text();
     const responseHeaders = {};
@@ -140,86 +166,95 @@ async function tosRequest(opts) {
 function nowDatetime() {
     return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
 }
-// ── Phase 1: Init multipart upload ───────────────────────────────────────────
-async function initMultipartUpload(tosUrl, auth, credentials) {
-    const initUrl = `${tosUrl}?uploads`;
-    const datetime = nowDatetime();
-    // Use the pre-computed auth for INIT, as it comes from ApplyVideoUpload
-    const headers = {
-        Authorization: auth,
-        'x-amz-date': datetime,
-        'x-amz-security-token': credentials.session_token,
-        'content-type': 'application/octet-stream',
-    };
-    const res = await tosRequest({ method: 'POST', url: initUrl, headers });
-    if (res.status !== 200) {
-        throw new CommandExecutionError(`TOS init multipart upload failed with status ${res.status}: ${res.body}`, 'Check that TOS credentials are valid and not expired.');
+function extractUploadId(body) {
+    const xmlMatch = body.match(/<UploadId>([^<]+)<\/UploadId>/i);
+    if (xmlMatch) return xmlMatch[1];
+    try {
+        const json = JSON.parse(body);
+        return json?.payload?.uploadID
+            || json?.payload?.uploadId
+            || json?.payload?.UploadID
+            || json?.payload?.UploadId
+            || json?.data?.uploadid
+            || json?.data?.uploadID
+            || json?.data?.uploadId
+            || json?.data?.UploadID
+            || json?.data?.UploadId
+            || json?.UploadID
+            || json?.UploadId
+            || json?.uploadID
+            || json?.uploadId
+            || null;
     }
-    // Parse UploadId from XML: <UploadId>...</UploadId>
-    const match = res.body.match(/<UploadId>([^<]+)<\/UploadId>/);
-    if (!match) {
+    catch {
+        return null;
+    }
+}
+// ── Phase 1: Init multipart upload ───────────────────────────────────────────
+async function initMultipartUpload(tosUrl, auth, uploadHeader, userId) {
+    const initUrl = `${gatewayBaseUrl(tosUrl)}?uploadmode=part&phase=init`;
+    const res = await tosRequest({
+        method: 'POST',
+        url: initUrl,
+        headers: gatewayHeaders(auth, uploadHeader, userId),
+    });
+    if (res.status !== 200) {
+        throw new CommandExecutionError(`TOS init multipart upload failed with status ${res.status}: ${res.body}`, 'Check that TOS upload authorization is valid and not expired.');
+    }
+    const uploadId = extractUploadId(res.body);
+    if (!uploadId) {
         throw new CommandExecutionError(`TOS init response missing UploadId: ${res.body}`);
     }
-    return match[1];
+    return uploadId;
 }
 // ── Phase 2: Upload a single part ────────────────────────────────────────────
-async function uploadPart(tosUrl, partNumber, uploadId, data, credentials, region) {
-    const parsedUrl = new URL(tosUrl);
-    parsedUrl.searchParams.set('partNumber', String(partNumber));
-    parsedUrl.searchParams.set('uploadId', uploadId);
-    const url = parsedUrl.toString();
-    const datetime = nowDatetime();
-    const headers = computeAws4Headers({
-        method: 'PUT',
-        url,
-        headers: { 'content-type': 'application/octet-stream' },
-        body: data,
-        credentials,
-        service: 'tos',
-        region,
-        datetime,
-    });
-    const res = await tosRequest({ method: 'PUT', url, headers, body: data });
-    if (res.status !== 200) {
-        throw new CommandExecutionError(`TOS upload part ${partNumber} failed with status ${res.status}: ${res.body}`, 'Check that STS2 credentials are valid and not expired.');
+async function uploadPart(tosUrl, partNumber, uploadId, data, auth, uploadHeader, userId) {
+    const crc32 = crc32Hex(data);
+    const url = `${gatewayBaseUrl(tosUrl)}?uploadid=${encodeURIComponent(uploadId)}&part_number=${partNumber}&phase=transfer`;
+    const headers = {
+        ...gatewayHeaders(auth, uploadHeader, userId),
+        'Content-CRC32': crc32,
+        'Content-Type': 'application/octet-stream',
+        'X-Use-Init-Upload-Optimize': '1',
+        'X-Use-Large-Local-Cache': '1',
+    };
+    const res = await tosRequest({ method: 'POST', url, headers, body: data });
+    let parsed;
+    try {
+        parsed = JSON.parse(res.body);
     }
-    const etag = res.headers['etag'];
-    if (!etag) {
-        throw new CommandExecutionError(`TOS upload part ${partNumber} response missing ETag header`);
+    catch {
+        parsed = null;
     }
-    return etag;
+    if (res.status !== 200 || parsed?.code !== 2000) {
+        throw new CommandExecutionError(`TOS upload part ${partNumber} failed with status ${res.status}: ${res.body}`, 'Check that TOS upload authorization is valid and not expired.');
+    }
+    return parsed?.data?.crc32 || crc32;
 }
 // ── Phase 3: Complete multipart upload ───────────────────────────────────────
-async function completeMultipartUpload(tosUrl, uploadId, parts, credentials, region) {
-    const parsedUrl = new URL(tosUrl);
-    parsedUrl.searchParams.set('uploadId', uploadId);
-    const url = parsedUrl.toString();
-    const xmlBody = '<CompleteMultipartUpload>' +
-        parts
-            .sort((a, b) => a.partNumber - b.partNumber)
-            .map(p => `<Part><PartNumber>${p.partNumber}</PartNumber><ETag>${p.etag}</ETag></Part>`)
-            .join('') +
-        '</CompleteMultipartUpload>';
-    const datetime = nowDatetime();
-    const headers = computeAws4Headers({
-        method: 'POST',
-        url,
-        headers: { 'content-type': 'application/xml' },
-        body: xmlBody,
-        credentials,
-        service: 'tos',
-        region,
-        datetime,
-    });
+async function completeMultipartUpload(tosUrl, uploadId, parts, auth, uploadHeader, userId) {
+    const url = `${gatewayBaseUrl(tosUrl)}?uploadmode=part&phase=finish&uploadid=${encodeURIComponent(uploadId)}`;
+    const body = parts
+        .sort((a, b) => a.partNumber - b.partNumber)
+        .map(p => `${p.partNumber}:${p.crc32}`)
+        .join(',');
     const res = await tosRequest({
         method: 'POST',
         url,
-        headers,
-        body: xmlBody,
+        headers: gatewayHeaders(auth, uploadHeader, userId),
+        body,
     });
-    if (res.status !== 200) {
+    let parsed;
+    try {
+        parsed = JSON.parse(res.body);
+    }
+    catch {
+        parsed = null;
+    }
+    if (res.status !== 200 || parsed?.code !== 2000) {
         throw new CommandExecutionError(`TOS complete multipart upload failed with status ${res.status}: ${res.body}`, 'Check that all parts were uploaded successfully.');
     }
+    return parsed?.data?.key || null;
 }
 let _readSyncOverride = null;
 /** @internal — for testing only */
@@ -237,7 +272,7 @@ export async function tosUpload(options) {
     if (fileSize === 0) {
         throw new CommandExecutionError(`Video file is empty: ${filePath}`);
     }
-    const { tos_upload_url: tosUrl, auth } = uploadInfo;
+    const { tos_upload_url: tosUrl, auth, upload_header: uploadHeader, user_id: userId } = uploadInfo;
     const parsedTosUrl = new URL(tosUrl);
     const region = extractRegionFromHost(parsedTosUrl.host);
     const resumePath = getResumeFilePath(filePath);
@@ -251,7 +286,7 @@ export async function tosUpload(options) {
     }
     else {
         // Start fresh
-        uploadId = await initMultipartUpload(tosUrl, auth, credentials);
+        uploadId = await initMultipartUpload(tosUrl, auth, uploadHeader, userId);
         completedParts = [];
         saveResumeState(resumePath, { uploadId, fileSize, parts: completedParts });
     }
@@ -277,8 +312,8 @@ export async function tosUpload(options) {
             if (bytesRead !== chunkSize) {
                 throw new CommandExecutionError(`Short read on part ${partNumber}: expected ${chunkSize} bytes, got ${bytesRead}`);
             }
-            const etag = await uploadPart(tosUrl, partNumber, uploadId, buffer, credentials, region);
-            completedParts.push({ partNumber, etag });
+            const crc32 = await uploadPart(tosUrl, partNumber, uploadId, buffer, auth, uploadHeader, userId);
+            completedParts.push({ partNumber, crc32 });
             saveResumeState(resumePath, { uploadId, fileSize, parts: completedParts });
             uploadedBytes = Math.min(offset + chunkSize, fileSize);
             if (onProgress)
@@ -288,8 +323,9 @@ export async function tosUpload(options) {
     finally {
         fs.closeSync(fd);
     }
-    await completeMultipartUpload(tosUrl, uploadId, completedParts, credentials, region);
+    const completedKey = await completeMultipartUpload(tosUrl, uploadId, completedParts, auth, uploadHeader, userId);
     deleteResumeState(resumePath);
+    return completedKey;
 }
 // ── Internal exports for testing ─────────────────────────────────────────────
-export { PART_SIZE, RESUME_DIR, extractRegionFromHost, getResumeFilePath, loadResumeState, saveResumeState, deleteResumeState, computeAws4Headers, };
+export { PART_SIZE, RESUME_DIR, extractRegionFromHost, getResumeFilePath, loadResumeState, saveResumeState, deleteResumeState, computeAws4Headers, extractUploadId, crc32Hex, gatewayBaseUrl, gatewayHeaders, };

--- a/clis/douyin/_shared/vod-upload.js
+++ b/clis/douyin/_shared/vod-upload.js
@@ -1,0 +1,201 @@
+import * as crypto from 'node:crypto';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+const AUTH_V5_URL = 'https://creator.douyin.com/web/api/media/upload/auth/v5/';
+const VOD_UPLOAD_HOST = 'https://vod.bytedanceapi.com/';
+const VOD_SPACE_NAME = 'aweme';
+
+function hmacSha256(key, data) {
+  return crypto.createHmac('sha256', key).update(data, 'utf8').digest();
+}
+
+function sha256Hex(data) {
+  const hash = crypto.createHash('sha256');
+  if (Buffer.isBuffer(data) || data instanceof Uint8Array) {
+    hash.update(data);
+  } else {
+    hash.update(data ?? '', 'utf8');
+  }
+  return hash.digest('hex');
+}
+
+function nowDatetime() {
+  return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+}
+
+function canonicalQuery(url) {
+  return [...url.searchParams.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
+function computeAws4Headers(url, credentials, options = {}) {
+  const parsedUrl = new URL(url);
+  const datetime = nowDatetime();
+  const date = datetime.slice(0, 8);
+  const method = options.method ?? 'GET';
+  const body = options.body ?? '';
+  const bodyHash = sha256Hex(body);
+  const headers = {
+    ...(options.headers ?? {}),
+    host: parsedUrl.host,
+    'x-amz-content-sha256': bodyHash,
+    'x-amz-date': datetime,
+    'x-amz-security-token': credentials.session_token,
+  };
+  const sortedHeaderKeys = Object.keys(headers).sort((a, b) => a.localeCompare(b));
+  const canonicalHeaders = sortedHeaderKeys
+    .map((key) => `${key}:${String(headers[key]).trim()}`)
+    .join('\n') + '\n';
+  const signedHeaders = sortedHeaderKeys.join(';');
+  const canonicalRequest = [
+    method,
+    parsedUrl.pathname || '/',
+    canonicalQuery(parsedUrl),
+    canonicalHeaders,
+    signedHeaders,
+    bodyHash,
+  ].join('\n');
+  const service = 'vod';
+  const region = 'cn-north-1';
+  const credentialScope = `${date}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    datetime,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join('\n');
+  const kDate = hmacSha256(`AWS4${credentials.secret_access_key}`, date);
+  const kRegion = hmacSha256(kDate, region);
+  const kService = hmacSha256(kRegion, service);
+  const kSigning = hmacSha256(kService, 'aws4_request');
+  const signature = hmacSha256(kSigning, stringToSign).toString('hex');
+  return {
+    ...headers,
+    Authorization: `AWS4-HMAC-SHA256 Credential=${credentials.access_key_id}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+}
+
+function extractUserIdFromSessionToken(sessionToken) {
+  try {
+    const raw = sessionToken.startsWith('STS2') ? sessionToken.slice(4) : sessionToken;
+    const decoded = JSON.parse(Buffer.from(raw, 'base64').toString('utf8'));
+    const policy = JSON.parse(decoded.PolicyString || '{}');
+    const condition = policy?.Statement?.[0]?.Condition;
+    if (typeof condition === 'string') {
+      const parsedCondition = JSON.parse(condition);
+      return parsedCondition.UserId || '';
+    }
+  } catch {
+    return '';
+  }
+  return '';
+}
+
+export async function getUploadAuthV5Credentials(page) {
+  const result = await page.evaluate(`fetch(${JSON.stringify(AUTH_V5_URL)}, { credentials: 'include' }).then(r => r.json())`);
+  if (!result || typeof result !== 'object' || result.status_code !== 0 || !result.auth) {
+    throw new CommandExecutionError(`获取抖音上传授权失败: ${JSON.stringify(result)}`);
+  }
+  let auth;
+  try {
+    auth = JSON.parse(result.auth);
+  } catch (error) {
+    throw new CommandExecutionError(`解析抖音上传授权失败: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!auth.AccessKeyID || !auth.SecretAccessKey || !auth.SessionToken) {
+    throw new CommandExecutionError('抖音上传授权缺少 AccessKeyID/SecretAccessKey/SessionToken');
+  }
+  return {
+    access_key_id: auth.AccessKeyID,
+    secret_access_key: auth.SecretAccessKey,
+    session_token: auth.SessionToken,
+    user_id: extractUserIdFromSessionToken(auth.SessionToken),
+    expired_time: auth.ExpiredTime,
+    current_time: auth.CurrentTime,
+  };
+}
+
+export async function applyVideoUploadInner(fileSize, credentials) {
+  const params = new URLSearchParams({
+    Action: 'ApplyUploadInner',
+    Version: '2020-11-19',
+    SpaceName: VOD_SPACE_NAME,
+    FileType: 'video',
+    IsInner: '1',
+    FileSize: String(fileSize),
+  });
+  const url = `${VOD_UPLOAD_HOST}?${params.toString()}`;
+  const res = await fetch(url, { headers: computeAws4Headers(url, credentials), signal: AbortSignal.timeout(30000) });
+  const text = await res.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new CommandExecutionError(`申请抖音上传地址失败，非 JSON 响应: HTTP ${res.status} ${text.slice(0, 300)}`);
+  }
+  const error = payload?.ResponseMetadata?.Error;
+  if (!res.ok || error) {
+    throw new CommandExecutionError(`申请抖音上传地址失败: HTTP ${res.status} ${JSON.stringify(error ?? payload)}`);
+  }
+  const uploadNode = payload?.Result?.InnerUploadAddress?.UploadNodes?.[0];
+  const storeInfo = uploadNode?.StoreInfos?.[0];
+  const videoId = payload?.Result?.Vid || uploadNode?.Vid;
+  const sessionKey = uploadNode?.SessionKey ?? storeInfo?.SessionKey ?? payload?.Result?.SessionKey;
+  if (!uploadNode?.UploadHost || !storeInfo?.StoreUri || !storeInfo?.Auth || !videoId || !sessionKey) {
+    throw new CommandExecutionError(`申请抖音上传地址响应缺少必要字段: ${JSON.stringify(payload).slice(0, 500)}`);
+  }
+  return {
+    video_id: videoId,
+    tos_upload_url: `https://${uploadNode.UploadHost}/${storeInfo.StoreUri}`,
+    auth: storeInfo.Auth,
+    session_key: sessionKey,
+    upload_header: uploadNode.UploadHeader ?? {},
+    user_id: credentials.user_id ?? '',
+  };
+}
+
+
+export async function commitVideoUploadInner(uploadInfo, credentials) {
+  if (!uploadInfo?.session_key) {
+    throw new CommandExecutionError('抖音上传提交缺少 SessionKey');
+  }
+  const params = new URLSearchParams({
+    Action: 'CommitUploadInner',
+    Version: '2020-11-19',
+    SpaceName: VOD_SPACE_NAME,
+  });
+  const url = `${VOD_UPLOAD_HOST}?${params.toString()}`;
+  const body = JSON.stringify({ SessionKey: uploadInfo.session_key });
+  const headers = computeAws4Headers(url, credentials, {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/json;charset=UTF-8' },
+  });
+  const res = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(30000) });
+  const text = await res.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new CommandExecutionError(`提交抖音上传失败，非 JSON 响应: HTTP ${res.status} ${text.slice(0, 300)}`);
+  }
+  const error = payload?.ResponseMetadata?.Error;
+  if (!res.ok || error) {
+    throw new CommandExecutionError(`提交抖音上传失败: HTTP ${res.status} ${JSON.stringify(error ?? payload)}`);
+  }
+  const result = payload?.Result?.Results?.[0] ?? payload?.Result ?? {};
+  const videoId = result.Vid ?? result.VideoId ?? result.VideoID ?? result.vid ?? uploadInfo.video_id;
+  if (!videoId) {
+    throw new CommandExecutionError(`提交抖音上传响应缺少 video id: ${JSON.stringify(payload).slice(0, 500)}`);
+  }
+  const meta = result.Meta ?? result.VideoMeta ?? {};
+  return {
+    video_id: videoId,
+    poster_uri: result.PosterUri ?? result.PosterURI ?? result.SnapshotUri ?? result.SnapshotURI ?? '',
+    width: Number(meta.Width ?? meta.width ?? 720) || 720,
+    height: Number(meta.Height ?? meta.height ?? 1280) || 1280,
+    raw: result,
+  };
+}

--- a/clis/douyin/_shared/vod-upload.js
+++ b/clis/douyin/_shared/vod-upload.js
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './evaluate-result.js';
 
 const AUTH_V5_URL = 'https://creator.douyin.com/web/api/media/upload/auth/v5/';
 const VOD_UPLOAD_HOST = 'https://vod.bytedanceapi.com/';
@@ -94,8 +95,18 @@ function extractUserIdFromSessionToken(sessionToken) {
 }
 
 export async function getUploadAuthV5Credentials(page) {
-  const result = await page.evaluate(`fetch(${JSON.stringify(AUTH_V5_URL)}, { credentials: 'include' }).then(r => r.json())`);
-  if (!result || typeof result !== 'object' || result.status_code !== 0 || !result.auth) {
+  const result = unwrapEvaluateResult(await page.evaluate(`fetch(${JSON.stringify(AUTH_V5_URL)}, { credentials: 'include' }).then(r => r.json())`));
+  if (!result || Array.isArray(result) || typeof result !== 'object') {
+    throw new CommandExecutionError(`获取抖音上传授权失败: ${JSON.stringify(result)}`);
+  }
+  if (result.status_code !== 0) {
+    const message = result.status_msg ?? result.message ?? 'unknown error';
+    if (result.status_code === 401 || result.status_code === 403 || /login|cookie|auth|captcha|verify|forbidden|permission|登录|登陆|权限|验证|验证码/i.test(String(message))) {
+      throw new AuthRequiredError('creator.douyin.com', `获取抖音上传授权失败: ${message}`);
+    }
+    throw new CommandExecutionError(`获取抖音上传授权失败: ${JSON.stringify(result)}`);
+  }
+  if (!result.auth) {
     throw new CommandExecutionError(`获取抖音上传授权失败: ${JSON.stringify(result)}`);
   }
   let auth;

--- a/clis/douyin/_shared/vod-upload.test.js
+++ b/clis/douyin/_shared/vod-upload.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getUploadAuthV5Credentials, applyVideoUploadInner } from './vod-upload.js';
+
+describe('douyin vod upload helpers', () => {
+  it('parses creator upload auth v5 credentials', async () => {
+    const page = { evaluate: async () => ({ status_code: 0, auth: JSON.stringify({ AccessKeyID: 'ak', SecretAccessKey: 'sk', SessionToken: 'token', ExpiredTime: 123, CurrentTime: 100 }) }) };
+    await expect(getUploadAuthV5Credentials(page)).resolves.toEqual({ access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token', user_id: '', expired_time: 123, current_time: 100 });
+  });
+
+  it('maps ApplyUploadInner response to TOS upload info', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify({ ResponseMetadata: { RequestId: 'req' }, Result: { InnerUploadAddress: { UploadNodes: [{ Vid: 'video-id', SessionKey: 'session-key', UploadHost: 'tos.example.com', StoreInfos: [{ StoreUri: 'obj/key.mp4', Auth: 'space-auth' }] }] } } }) });
+    await expect(applyVideoUploadInner(1234, { access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token' })).resolves.toEqual({ video_id: 'video-id', tos_upload_url: 'https://tos.example.com/obj/key.mp4', auth: 'space-auth', session_key: 'session-key', upload_header: {}, user_id: '' });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('Action=ApplyUploadInner');
+    expect(String(url)).toContain('Version=2020-11-19');
+    expect(init.headers.Authorization).toContain('AWS4-HMAC-SHA256 Credential=ak/');
+    expect(init.headers['x-amz-security-token']).toBe('token');
+    fetchSpy.mockRestore();
+  });
+
+  it('surfaces VOD API errors with context', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify({ ResponseMetadata: { Error: { Code: 'AccessDenied', Message: 'denied' } } }) });
+    await expect(applyVideoUploadInner(1234, { access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token' })).rejects.toBeInstanceOf(CommandExecutionError);
+    fetchSpy.mockRestore();
+  });
+});

--- a/clis/douyin/_shared/vod-upload.test.js
+++ b/clis/douyin/_shared/vod-upload.test.js
@@ -1,11 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { getUploadAuthV5Credentials, applyVideoUploadInner } from './vod-upload.js';
 
 describe('douyin vod upload helpers', () => {
   it('parses creator upload auth v5 credentials', async () => {
     const page = { evaluate: async () => ({ status_code: 0, auth: JSON.stringify({ AccessKeyID: 'ak', SecretAccessKey: 'sk', SessionToken: 'token', ExpiredTime: 123, CurrentTime: 100 }) }) };
     await expect(getUploadAuthV5Credentials(page)).resolves.toEqual({ access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token', user_id: '', expired_time: 123, current_time: 100 });
+  });
+
+  it('unwraps browser bridge envelopes around upload auth payloads', async () => {
+    const payload = { status_code: 0, auth: JSON.stringify({ AccessKeyID: 'ak', SecretAccessKey: 'sk', SessionToken: 'token' }) };
+    const page = { evaluate: async () => ({ session: 'site:douyin:test', data: payload }) };
+    await expect(getUploadAuthV5Credentials(page)).resolves.toMatchObject({ access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token' });
+  });
+
+  it('maps upload auth permission errors to AuthRequiredError', async () => {
+    const page = { evaluate: async () => ({ status_code: 401, status_msg: 'login required' }) };
+    await expect(getUploadAuthV5Credentials(page)).rejects.toBeInstanceOf(AuthRequiredError);
   });
 
   it('maps ApplyUploadInner response to TOS upload info', async () => {

--- a/clis/douyin/delete.js
+++ b/clis/douyin/delete.js
@@ -1,19 +1,118 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { browserFetch } from './_shared/browser-fetch.js';
+
+const CREATOR_MANAGE_URL = 'https://creator.douyin.com/creator-micro/content/manage';
+const WORK_LIST_URL = '/janus/douyin/creator/pc/work_list?status=0&count=20&max_cursor=0&scene=star_atlas&device_platform=android&aid=1128';
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function deleteViaCreatorManage(page, workId) {
+    await page.goto(CREATOR_MANAGE_URL);
+    await sleep(3000);
+    await sleep(3000);
+    const result = await page.evaluate(`
+    (async () => {
+      const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const targetId = ${JSON.stringify(String(workId))};
+      const textOf = (node) => (node && (node.innerText || node.textContent) || '').trim();
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+
+      async function loadTarget() {
+        const res = await fetch(${JSON.stringify(WORK_LIST_URL)}, { credentials: 'include' });
+        const payload = await res.json();
+        const list = Array.isArray(payload.aweme_list) ? payload.aweme_list : [];
+        const matches = list
+          .map((entry, index) => ({ entry, index }))
+          .filter(({ entry }) => String(entry.aweme_id || '') === targetId || String(entry.item_id || '') === targetId);
+        if (matches.length === 0) {
+          return { ok: false, reason: 'not_found', status_code: payload.status_code, count: list.length };
+        }
+        if (matches.length !== 1) {
+          return { ok: false, reason: 'target_not_unique', count: matches.length };
+        }
+        const { entry: item, index } = matches[0];
+        const title = normalize(item.desc || item.caption || item.title || item.item_title || '');
+        return { ok: true, item, index, listCount: list.length, title };
+      }
+
+      function visibleWorkCards() {
+        const candidates = Array.from(document.querySelectorAll('[class*="video-card"]'))
+          .filter((element) => {
+            const text = normalize(textOf(element));
+            return text.includes('删除作品') && text.includes('继续编辑');
+          });
+        return candidates.filter((candidate) => !candidates.some((other) => other !== candidate && other.contains(candidate)));
+      }
+
+      const target = await loadTarget();
+      if (!target.ok) return target;
+
+      const allTab = Array.from(document.querySelectorAll('button,[role="button"],span,div'))
+        .find((element) => /^全部作品$/.test(normalize(textOf(element))));
+      allTab?.click();
+      await sleep(1000);
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const cards = visibleWorkCards();
+        if (cards.length >= target.listCount && cards[target.index]) {
+          const card = cards[target.index];
+          const deleteButton = Array.from(card.querySelectorAll('button,[role="button"],span,div'))
+            .find((element) => /^删除作品$/.test(normalize(textOf(element))));
+          if (!deleteButton) return { ok: false, reason: 'delete_button_not_found', aweme_id: target.item.aweme_id, item_id: target.item.item_id, index: target.index, cardCount: cards.length };
+          deleteButton.click();
+          await sleep(800);
+          const confirmButton = Array.from(document.querySelectorAll('button,[role="button"]'))
+            .find((element) => ['确定', '确认', '删除'].includes(normalize(textOf(element))));
+          if (!confirmButton) return { ok: false, reason: 'confirm_button_not_found', aweme_id: target.item.aweme_id, item_id: target.item.item_id };
+          confirmButton.click();
+          for (let wait = 0; wait < 20; wait += 1) {
+            await sleep(500);
+            const after = await loadTarget();
+            if (!after.ok && after.reason === 'not_found') {
+              return { ok: true, aweme_id: target.item.aweme_id, item_id: target.item.item_id, title: target.title };
+            }
+          }
+          return { ok: false, reason: 'delete_not_confirmed', aweme_id: target.item.aweme_id, item_id: target.item.item_id };
+        }
+        await sleep(500);
+      }
+      return { ok: false, reason: 'card_not_found', aweme_id: target.item.aweme_id, item_id: target.item.item_id, index: target.index, listCount: target.listCount };
+    })()
+  `);
+
+    if (!result?.ok) {
+        throw new CommandExecutionError(`抖音后台管理删除失败: ${JSON.stringify(result)}`);
+    }
+    return result;
+}
+
 cli({
     site: 'douyin',
     name: 'delete',
     access: 'write',
-    description: '删除作品',
+    description: '删除作品（优先使用创作者后台作品管理；找不到时回退到旧删除接口）',
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
     args: [
-        { name: 'aweme_id', required: true, positional: true, help: '作品 ID' },
+        { name: 'aweme_id', required: true, positional: true, help: '作品 ID / item_id' },
     ],
     columns: ['status'],
     func: async (page, kwargs) => {
+        try {
+            const deleted = await deleteViaCreatorManage(page, kwargs.aweme_id);
+            return [{ status: `✅ 已通过后台管理删除 ${deleted.aweme_id || kwargs.aweme_id}` }];
+        } catch (fallbackError) {
+            const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+            if (!fallbackMessage.includes('"reason":"not_found"')) {
+                throw fallbackError;
+            }
+        }
+
         const url = 'https://creator.douyin.com/web/api/media/aweme/delete/?aid=1128';
-        await browserFetch(page, 'POST', url, { body: { aweme_id: kwargs.aweme_id } });
+        await browserFetch(page, 'POST', url, { body: { aweme_id: kwargs.aweme_id }, timeoutMs: 8000 });
         return [{ status: `✅ 已删除 ${kwargs.aweme_id}` }];
     },
 });

--- a/clis/douyin/delete.js
+++ b/clis/douyin/delete.js
@@ -1,9 +1,21 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { browserFetch } from './_shared/browser-fetch.js';
+import { requireObjectEvaluateResult } from './_shared/evaluate-result.js';
 
 const CREATOR_MANAGE_URL = 'https://creator.douyin.com/creator-micro/content/manage';
 const WORK_LIST_URL = '/janus/douyin/creator/pc/work_list?status=0&count=20&max_cursor=0&scene=star_atlas&device_platform=android&aid=1128';
+
+function readAwemeId(raw) {
+    const value = String(raw ?? '').trim();
+    if (!value) {
+        throw new ArgumentError('douyin delete aweme_id cannot be empty');
+    }
+    if (!/^\d+$/.test(value)) {
+        throw new ArgumentError('douyin delete aweme_id must be a numeric id');
+    }
+    return value;
+}
 
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -13,7 +25,7 @@ async function deleteViaCreatorManage(page, workId) {
     await page.goto(CREATOR_MANAGE_URL);
     await sleep(3000);
     await sleep(3000);
-    const result = await page.evaluate(`
+    const result = requireObjectEvaluateResult(await page.evaluate(`
     (async () => {
       const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
       const targetId = ${JSON.stringify(String(workId))};
@@ -80,12 +92,21 @@ async function deleteViaCreatorManage(page, workId) {
       }
       return { ok: false, reason: 'card_not_found', aweme_id: target.item.aweme_id, item_id: target.item.item_id, index: target.index, listCount: target.listCount };
     })()
-  `);
+  `), '抖音后台管理删除响应异常');
 
     if (!result?.ok) {
         throw new CommandExecutionError(`抖音后台管理删除失败: ${JSON.stringify(result)}`);
     }
     return result;
+}
+
+async function findWorkListItem(page, workId) {
+    const data = await browserFetch(page, 'GET', `https://creator.douyin.com${WORK_LIST_URL}`, { timeoutMs: 8000 });
+    const list = data.data?.work_list ?? data.aweme_list ?? data.work_list ?? [];
+    if (!Array.isArray(list)) {
+        throw new CommandExecutionError('抖音作品列表响应缺少 work_list/aweme_list');
+    }
+    return list.find((entry) => String(entry.aweme_id || '') === workId || String(entry.item_id || '') === workId) || null;
 }
 
 cli({
@@ -101,9 +122,10 @@ cli({
     ],
     columns: ['status'],
     func: async (page, kwargs) => {
+        const awemeId = readAwemeId(kwargs.aweme_id);
         try {
-            const deleted = await deleteViaCreatorManage(page, kwargs.aweme_id);
-            return [{ status: `✅ 已通过后台管理删除 ${deleted.aweme_id || kwargs.aweme_id}` }];
+            const deleted = await deleteViaCreatorManage(page, awemeId);
+            return [{ status: `✅ 已通过后台管理删除 ${deleted.aweme_id || awemeId}` }];
         } catch (fallbackError) {
             const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
             if (!fallbackMessage.includes('"reason":"not_found"')) {
@@ -111,8 +133,20 @@ cli({
             }
         }
 
+        const before = await findWorkListItem(page, awemeId);
+        if (!before) {
+            throw new CommandExecutionError(`抖音作品 ${awemeId} 未在作品列表中找到，未执行删除`);
+        }
         const url = 'https://creator.douyin.com/web/api/media/aweme/delete/?aid=1128';
-        await browserFetch(page, 'POST', url, { body: { aweme_id: kwargs.aweme_id }, timeoutMs: 8000 });
-        return [{ status: `✅ 已删除 ${kwargs.aweme_id}` }];
+        await browserFetch(page, 'POST', url, { body: { aweme_id: awemeId }, timeoutMs: 8000 });
+        const deadline = Date.now() + 10_000;
+        while (Date.now() < deadline) {
+            await sleep(500);
+            const after = await findWorkListItem(page, awemeId);
+            if (!after) {
+                return [{ status: `✅ 已删除 ${awemeId}` }];
+            }
+        }
+        throw new CommandExecutionError(`抖音作品 ${awemeId} 删除后仍在作品列表中，删除未确认`);
     },
 });

--- a/clis/douyin/delete.test.js
+++ b/clis/douyin/delete.test.js
@@ -1,11 +1,21 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './delete.js';
+
 describe('douyin delete registration', () => {
     it('registers the delete command', () => {
         const registry = getRegistry();
         const values = [...registry.values()];
         const cmd = values.find(c => c.site === 'douyin' && c.name === 'delete');
         expect(cmd).toBeDefined();
+    });
+
+    it('uses work_list id/index matching instead of title matching for fallback deletion', () => {
+        const source = readFileSync(new URL('./delete.js', import.meta.url), 'utf8');
+        expect(source).toContain('target_not_unique');
+        expect(source).toContain("String(entry.aweme_id || '') === targetId");
+        expect(source).toContain('cards[target.index]');
+        expect(source).not.toContain('text.includes(target.title)');
     });
 });

--- a/clis/douyin/delete.test.js
+++ b/clis/douyin/delete.test.js
@@ -1,9 +1,44 @@
 import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
+
+const mocks = vi.hoisted(() => ({
+    browserFetch: vi.fn(),
+}));
+
+vi.mock('./_shared/browser-fetch.js', () => ({ browserFetch: mocks.browserFetch }));
+
 import './delete.js';
 
+function makePage({ evaluateResult, listBefore = [], listAfter = [] } = {}) {
+    let listCalls = 0;
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+        if (method === 'GET' && String(url).includes('/work_list?')) {
+            listCalls += 1;
+            return { aweme_list: listCalls === 1 ? listBefore : listAfter };
+        }
+        return { status_code: 0 };
+    });
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(evaluateResult ?? { ok: false, reason: 'not_found' }),
+        wait: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
 describe('douyin delete registration', () => {
+    const command = getRegistry().get('douyin/delete');
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('registers the delete command', () => {
         const registry = getRegistry();
         const values = [...registry.values()];
@@ -17,5 +52,49 @@ describe('douyin delete registration', () => {
         expect(source).toContain("String(entry.aweme_id || '') === targetId");
         expect(source).toContain('cards[target.index]');
         expect(source).not.toContain('text.includes(target.title)');
+    });
+
+    it('validates aweme_id before navigation', async () => {
+        const page = makePage();
+        await expect(command.func(page, { aweme_id: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func(page, { aweme_id: 'abc' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('does not treat a missing work as successful delete', async () => {
+        const page = makePage({ listBefore: [], listAfter: [] });
+        const promise = command.func(page, { aweme_id: '123' });
+        const assertion = expect(promise).rejects.toBeInstanceOf(CommandExecutionError);
+        await vi.advanceTimersByTimeAsync(7000);
+        await assertion;
+    });
+
+    it('unwraps Browser Bridge envelopes around creator manage delete results', async () => {
+        const page = makePage({ evaluateResult: { session: 'site:douyin:test', data: { ok: true, aweme_id: '123' } } });
+        const promise = command.func(page, { aweme_id: '123' });
+        const assertion = expect(promise).resolves.toEqual([{ status: '✅ 已通过后台管理删除 123' }]);
+        await vi.advanceTimersByTimeAsync(7000);
+        await assertion;
+        expect(mocks.browserFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws typed on malformed creator manage delete result', async () => {
+        const page = makePage({ evaluateResult: 'bad-shape' });
+        const promise = command.func(page, { aweme_id: '123' });
+        const assertion = expect(promise).rejects.toBeInstanceOf(CommandExecutionError);
+        await vi.advanceTimersByTimeAsync(7000);
+        await assertion;
+        expect(mocks.browserFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns success only after fallback delete postcondition removes the target', async () => {
+        const page = makePage({
+            listBefore: [{ aweme_id: '123' }],
+            listAfter: [],
+        });
+        const promise = command.func(page, { aweme_id: '123' });
+        const assertion = expect(promise).resolves.toEqual([{ status: '✅ 已删除 123' }]);
+        await vi.advanceTimersByTimeAsync(8000);
+        await assertion;
     });
 });

--- a/clis/douyin/publish-upload-id.test.js
+++ b/clis/douyin/publish-upload-id.test.js
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  browserFetch: vi.fn(),
+  getUploadAuthV5Credentials: vi.fn(),
+  applyVideoUploadInner: vi.fn(),
+  commitVideoUploadInner: vi.fn(),
+  tosUpload: vi.fn(),
+  pollTranscode: vi.fn(),
+  imagexUpload: vi.fn(),
+}));
+
+vi.mock('./_shared/browser-fetch.js', () => ({ browserFetch: mocks.browserFetch }));
+vi.mock('./_shared/vod-upload.js', () => ({
+  getUploadAuthV5Credentials: mocks.getUploadAuthV5Credentials,
+  applyVideoUploadInner: mocks.applyVideoUploadInner,
+  commitVideoUploadInner: mocks.commitVideoUploadInner,
+}));
+vi.mock('./_shared/tos-upload.js', () => ({ tosUpload: mocks.tosUpload }));
+vi.mock('./_shared/transcode.js', () => ({ pollTranscode: mocks.pollTranscode }));
+vi.mock('./_shared/imagex-upload.js', () => ({ imagexUpload: mocks.imagexUpload }));
+
+describe('douyin publish upload identifier handling', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.getUploadAuthV5Credentials.mockResolvedValue({ access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token' });
+    mocks.applyVideoUploadInner.mockResolvedValue({ video_id: 'apply-video-id', tos_upload_url: 'https://tos.example.com/bucket/key', auth: 'auth', session_key: 'session-key' });
+    mocks.commitVideoUploadInner.mockResolvedValue({ video_id: 'canonical-video-id', poster_uri: 'poster-uri' });
+    mocks.tosUpload.mockResolvedValue('object-key-returned-by-complete');
+    mocks.pollTranscode.mockResolvedValue({ width: 720, height: 1280, poster_uri: 'poster-uri' });
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+      if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { aweme_id: 'aweme-1' };
+      return { status_code: 0 };
+    });
+  });
+
+  it('uses CommitUploadInner Vid for create_v2, not the completed TOS object key', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-id-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await cmd.func({}, {
+      video,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      caption: '',
+      visibility: 'private',
+      no_safety_check: true,
+    });
+
+    expect(mocks.commitVideoUploadInner).toHaveBeenCalledWith(
+      { video_id: 'apply-video-id', tos_upload_url: 'https://tos.example.com/bucket/key', auth: 'auth', session_key: 'session-key' },
+      { access_key_id: 'ak', secret_access_key: 'sk', session_token: 'token' },
+    );
+    expect(mocks.pollTranscode).not.toHaveBeenCalled();
+    const createCall = mocks.browserFetch.mock.calls.find((call) => String(call[2]).includes('/aweme/create_v2/'));
+    expect(createCall?.[3]?.body.item.common.video_id).toBe('canonical-video-id');
+    expect(createCall?.[3]?.body.item.common.video_id).not.toBe('object-key-returned-by-complete');
+  });
+
+  it('continues to create_v2 when the legacy fast detect API returns an empty response', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-safety-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/pre_check')) {
+        throw new Error('Empty response from Douyin API (POST https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/pre_check)');
+      }
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/poll')) return { status: -1, has_done: true, detect_result: { reason_code: 0 }, detect_list: [] };
+      if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { item_id: 'item-1' };
+      return { status_code: 0 };
+    });
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await cmd.func({}, {
+      video,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      visibility: 'public',
+      caption: 'caption',
+      no_safety_check: false,
+    });
+
+    expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/post_assistant/fast_detect/pre_check'))).toBe(true);
+    expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/aweme/create_v2/'))).toBe(true);
+  });
+});

--- a/clis/douyin/publish-upload-id.test.js
+++ b/clis/douyin/publish-upload-id.test.js
@@ -99,4 +99,72 @@ describe('douyin publish upload identifier handling', () => {
     expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/post_assistant/fast_detect/pre_check'))).toBe(true);
     expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/aweme/create_v2/'))).toBe(true);
   });
+
+  it('unwraps Browser Bridge envelopes around cover ImageX evaluate results', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-cover-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    const cover = path.join(tmpDir, 'cover.jpg');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    fs.writeFileSync(cover, Buffer.from('fake-cover'));
+    mocks.imagexUpload.mockResolvedValue('cover-store-uri');
+
+    const page = {
+      evaluate: vi.fn()
+        .mockResolvedValueOnce({
+          session: 'site:douyin:test',
+          data: { Result: { UploadAddress: { StoreInfos: [{ UploadHost: 'imagex.example.com', StoreUri: 'cover/key.jpg' }] } } },
+        })
+        .mockResolvedValueOnce({ session: 'site:douyin:test', data: { Result: {} } }),
+    };
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await cmd.func(page, {
+      video,
+      cover,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      caption: '',
+      visibility: 'private',
+      no_safety_check: true,
+    });
+
+    expect(mocks.imagexUpload).toHaveBeenCalledWith(cover, {
+      upload_url: 'https://imagex.example.com/cover/key.jpg',
+      store_uri: 'cover/key.jpg',
+    });
+    const createCall = mocks.browserFetch.mock.calls.find((call) => String(call[2]).includes('/aweme/create_v2/'));
+    expect(createCall?.[3]?.body.item.cover.poster).toBe('cover-store-uri');
+  });
+
+  it('throws typed when cover ImageX apply returns the wrong shape', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-cover-bad-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    const cover = path.join(tmpDir, 'cover.jpg');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    fs.writeFileSync(cover, Buffer.from('fake-cover'));
+
+    const page = { evaluate: vi.fn().mockResolvedValueOnce({ session: 'site:douyin:test', data: { Result: { UploadAddress: { StoreInfos: [] } } } }) };
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await expect(cmd.func(page, {
+      video,
+      cover,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      caption: '',
+      visibility: 'private',
+      no_safety_check: true,
+    })).rejects.toThrow('UploadHost/StoreUri');
+    expect(mocks.imagexUpload).not.toHaveBeenCalled();
+  });
 });

--- a/clis/douyin/publish.js
+++ b/clis/douyin/publish.js
@@ -2,7 +2,7 @@
  * Douyin publish — 8-phase pipeline for scheduling video posts.
  *
  * Phases:
- *   1. STS2 credentials
+ *   1. upload auth v5 credentials
  *   2. Apply TOS upload URL
  *   3. TOS multipart upload
  *   4. Cover upload (optional, via ImageX)
@@ -15,10 +15,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { getSts2Credentials } from './_shared/sts2.js';
+import { getUploadAuthV5Credentials, applyVideoUploadInner, commitVideoUploadInner } from './_shared/vod-upload.js';
 import { tosUpload } from './_shared/tos-upload.js';
 import { imagexUpload } from './_shared/imagex-upload.js';
-import { pollTranscode } from './_shared/transcode.js';
 import { browserFetch } from './_shared/browser-fetch.js';
 import { generateCreationId } from './_shared/creation-id.js';
 import { validateTiming, toUnixSeconds } from './_shared/timing.js';
@@ -54,6 +53,30 @@ const DEFAULT_COVER_TOOLS_INFO = JSON.stringify({
     initial_cover_uri: '',
     cut_coordinate: '',
 });
+function isFastDetectRetryable(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes('post_assistant/fast_detect') && (message.includes('Empty response') || message.includes('404') || message.includes('Not Found') || message.includes('Timeout') || message.includes('timed out') || message.includes('Failed to fetch'));
+}
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function tryFastDetectFetch(page, method, url, options) {
+    let lastError;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+        try {
+            return { ok: true, value: await browserFetch(page, method, url, options) };
+        } catch (error) {
+            if (!isFastDetectRetryable(error)) {
+                throw error;
+            }
+            lastError = error;
+            if (attempt < 3) {
+                await sleep(500 * attempt);
+            }
+        }
+    }
+    return { ok: false, error: lastError };
+}
 cli({
     site: 'douyin',
     name: 'publish',
@@ -106,19 +129,13 @@ cli({
                 throw new ArgumentError(`封面文件不存在: ${path.resolve(coverPath)}`);
             }
         }
-        // ── Phase 1: STS2 credentials ───────────────────────────────────────
-        const credentials = await getSts2Credentials(page);
+        // ── Phase 1: upload credentials ────────────────────────────────────
+        const credentials = await getUploadAuthV5Credentials(page);
         // ── Phase 2: Apply TOS upload URL ───────────────────────────────────
-        const vodUrl = `https://vod.bytedanceapi.com/?Action=ApplyVideoUpload&ServiceId=1128&Version=2021-01-01&FileType=video&FileSize=${fileSize}`;
-        const vodJs = `fetch(${JSON.stringify(vodUrl)}, { credentials: 'include' }).then(r => r.json())`;
-        const vodRes = (await page.evaluate(vodJs));
-        const { VideoId: videoId, UploadHosts, StoreInfos } = vodRes.Result.UploadAddress;
-        const tosUrl = `https://${UploadHosts[0]}/${StoreInfos[0].StoreUri}`;
-        const tosUploadInfo = {
-            tos_upload_url: tosUrl,
-            auth: StoreInfos[0].Auth,
-            video_id: videoId,
-        };
+        const tosUploadInfo = await applyVideoUploadInner(fileSize, credentials);
+        let coverUri = '';
+        let coverWidth = 720;
+        let coverHeight = 1280;
         // ── Phase 3: TOS upload ─────────────────────────────────────────────
         await tosUpload({
             filePath: videoPath,
@@ -130,10 +147,16 @@ cli({
             },
         });
         process.stderr.write('\n');
+        process.stderr.write('  提交上传...\n');
+        const committedVideo = await commitVideoUploadInner(tosUploadInfo, credentials);
+        const videoId = committedVideo.video_id;
+        process.stderr.write(`  上传已提交: ${videoId}\n`);
+        coverWidth = committedVideo.width || coverWidth;
+        coverHeight = committedVideo.height || coverHeight;
+        if (!coverUri && committedVideo.poster_uri) {
+            coverUri = committedVideo.poster_uri;
+        }
         // ── Phase 4: Cover upload (optional) ────────────────────────────────
-        let coverUri = '';
-        let coverWidth = 720;
-        let coverHeight = 1280;
         if (kwargs.cover) {
             const resolvedCoverPath = path.resolve(kwargs.cover);
             // 4A: Apply ImageX upload
@@ -161,16 +184,9 @@ cli({
             await page.evaluate(commitJs);
             coverUri = coverStoreUri;
         }
-        // ── Phase 5: Enable video ───────────────────────────────────────────
-        const enableUrl = `https://creator.douyin.com/web/api/media/video/enable/?video_id=${videoId}&aid=1128`;
-        await browserFetch(page, 'GET', enableUrl);
-        // ── Phase 6: Poll transcode ─────────────────────────────────────────
-        const transResult = await pollTranscode(page, videoId);
-        coverWidth = transResult.width;
-        coverHeight = transResult.height;
-        if (!coverUri) {
-            coverUri = transResult.poster_uri;
-        }
+        // The gateway upload flow returns a committed VOD upload result; the legacy
+        // enable/transend endpoints can hang for that flow, so create_v2 consumes
+        // the committed video_id and poster metadata directly.
         // ── Phase 7: Content safety check ───────────────────────────────────
         if (!kwargs.no_safety_check) {
             const safetyUrl = 'https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/pre_check';
@@ -179,25 +195,42 @@ cli({
                 title,
                 desc: caption,
             };
-            await browserFetch(page, 'POST', safetyUrl, { body: safetyBody });
+            const preCheck = await tryFastDetectFetch(page, 'POST', safetyUrl, { body: safetyBody });
+            if (!preCheck.ok) {
+                process.stderr.write('  内容安全预检接口无响应，继续轮询检测结果。\n');
+            }
             const pollUrl = 'https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/poll';
             const deadline = Date.now() + 30_000;
             let safetyPassed = false;
+            let pollUnavailableCount = 0;
             while (Date.now() < deadline) {
-                const pollRes = (await browserFetch(page, 'POST', pollUrl, {
-                    body: safetyBody,
-                }));
-                if (pollRes.status === 0) {
+                const poll = await tryFastDetectFetch(page, 'POST', pollUrl, { body: safetyBody });
+                if (!poll.ok) {
+                    pollUnavailableCount += 1;
+                    if (!preCheck.ok && pollUnavailableCount >= 3) {
+                        break;
+                    }
+                    await sleep(2000);
+                    continue;
+                }
+                pollUnavailableCount = 0;
+                const pollRes = poll.value;
+                if (pollRes.status === 0 || (pollRes.has_done === true && pollRes.detect_result?.reason_code === 0 && (pollRes.detect_list?.length ?? 0) === 0)) {
                     safetyPassed = true;
                     break;
                 }
                 if (pollRes.status === 1) {
                     throw new CommandExecutionError('内容安全检测不通过，请修改后重试', '使用 --no_safety_check 跳过');
                 }
-                await new Promise((r) => setTimeout(r, 2000));
+                await sleep(2000);
             }
             if (!safetyPassed) {
-                throw new CommandExecutionError('内容安全检测超时（30s），请稍后重试', '使用 --no_safety_check 跳过');
+                if (!preCheck.ok && pollUnavailableCount >= 3) {
+                    process.stderr.write('  内容安全预检持续无响应，跳过本地预检，交由 create_v2 后的平台审核。\n');
+                }
+                else {
+                    throw new CommandExecutionError('内容安全检测超时（30s），请稍后重试', '如确认要跳过本地预检，可使用 --no_safety_check；提交后仍会走抖音平台审核');
+                }
             }
         }
         // ── Phase 8: create_v2 publish ──────────────────────────────────────
@@ -266,12 +299,13 @@ cli({
             },
         };
         const publishUrl = `https://creator.douyin.com/web/api/media/aweme/create_v2/?read_aid=2906&${DEVICE_PARAMS}`;
+        process.stderr.write('  创建定时发布...\n');
         const publishRes = (await browserFetch(page, 'POST', publishUrl, {
             body: publishBody,
         }));
-        const awemeId = publishRes.aweme_id;
+        const awemeId = publishRes.aweme_id ?? publishRes.item_id;
         if (!awemeId) {
-            throw new CommandExecutionError(`发布成功但未返回 aweme_id: ${JSON.stringify(publishRes)}`);
+            throw new CommandExecutionError(`发布成功但未返回 aweme_id/item_id: ${JSON.stringify(publishRes)}`);
         }
         const url = `https://www.douyin.com/video/${awemeId}`;
         const publishTimeStr = new Date(timingTs * 1000).toLocaleString('zh-CN', {

--- a/clis/douyin/publish.js
+++ b/clis/douyin/publish.js
@@ -19,6 +19,7 @@ import { getUploadAuthV5Credentials, applyVideoUploadInner, commitVideoUploadInn
 import { tosUpload } from './_shared/tos-upload.js';
 import { imagexUpload } from './_shared/imagex-upload.js';
 import { browserFetch } from './_shared/browser-fetch.js';
+import { requireObjectEvaluateResult } from './_shared/evaluate-result.js';
 import { generateCreationId } from './_shared/creation-id.js';
 import { validateTiming, toUnixSeconds } from './_shared/timing.js';
 import { parseTextExtra, extractHashtagNames } from './_shared/text-extra.js';
@@ -59,6 +60,12 @@ function isFastDetectRetryable(error) {
 }
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function throwIfImagexError(action, payload) {
+    const error = payload?.ResponseMetadata?.Error ?? payload?.Error;
+    if (error) {
+        throw new CommandExecutionError(`${action}失败: ${JSON.stringify(error)}`);
+    }
 }
 async function tryFastDetectFetch(page, method, url, options) {
     let lastError;
@@ -162,13 +169,17 @@ cli({
             // 4A: Apply ImageX upload
             const applyUrl = `${IMAGEX_BASE}/?Action=ApplyImageUpload&ServiceId=${IMAGEX_SERVICE_ID}&Version=2018-08-01&UploadNum=1`;
             const applyJs = `fetch(${JSON.stringify(applyUrl)}, { credentials: 'include' }).then(r => r.json())`;
-            const applyRes = (await page.evaluate(applyJs));
-            const { StoreInfos: imgStoreInfos } = applyRes.Result.UploadAddress;
-            const imgUploadUrl = `https://${imgStoreInfos[0].UploadHost}/${imgStoreInfos[0].StoreUri}`;
+            const applyRes = requireObjectEvaluateResult(await page.evaluate(applyJs), '抖音封面申请上传地址响应异常');
+            throwIfImagexError('抖音封面申请上传地址', applyRes);
+            const imgStoreInfo = applyRes.Result?.UploadAddress?.StoreInfos?.[0];
+            if (!imgStoreInfo?.UploadHost || !imgStoreInfo?.StoreUri) {
+                throw new CommandExecutionError(`抖音封面申请上传地址响应缺少 UploadHost/StoreUri: ${JSON.stringify(applyRes).slice(0, 500)}`);
+            }
+            const imgUploadUrl = `https://${imgStoreInfo.UploadHost}/${imgStoreInfo.StoreUri}`;
             // 4B: Upload image
             const coverStoreUri = await imagexUpload(resolvedCoverPath, {
                 upload_url: imgUploadUrl,
-                store_uri: imgStoreInfos[0].StoreUri,
+                store_uri: imgStoreInfo.StoreUri,
             });
             // 4C: Commit ImageX upload
             const commitUrl = `${IMAGEX_BASE}/?Action=CommitImageUpload&ServiceId=${IMAGEX_SERVICE_ID}&Version=2018-08-01`;
@@ -181,7 +192,8 @@ cli({
           body: ${JSON.stringify(commitBody)}
         }).then(r => r.json())
       `;
-            await page.evaluate(commitJs);
+            const commitRes = requireObjectEvaluateResult(await page.evaluate(commitJs), '抖音封面提交上传响应异常');
+            throwIfImagexError('抖音封面提交上传', commitRes);
             coverUri = coverStoreUri;
         }
         // The gateway upload flow returns a committed VOD upload result; the legacy


### PR DESCRIPTION
Replacement relay for #1574 because maintainer push to EasyMetaAu:feat/douyin-publish-restore is returning 403 despite maintainerCanModify=true.\n\nThis branch cherry-picks the contributor PR head c1e528d onto current main, then applies the reviewed hardening commit from codex-mini0/pr1574-hardening (8d783cbd).\n\nReviewed in Slock task #264: lead and aux validated the hardening commit, including browser evaluate envelope guards, typed API/auth/malformed boundaries, publish upload/create postconditions, and delete pre/post evidence.\n\nOriginal PR: #1574.