### PR TITLE
feat(bilibili): add comment command and --parent reply-thread reading

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2298,7 +2298,7 @@
   {
     "site": "bilibili",
     "name": "comment",
-    "description": "在 B站视频下发表评论/回复（官方 API，需登录；发「@AI视频小助理 总结一下」可召唤AI总结视频）",
+    "description": "在 B站视频下发表评论或回复（官方 API，需登录；消息里的 @用户 会被解析为真实提及）",
     "access": "write",
     "domain": "www.bilibili.com",
     "strategy": "cookie",
@@ -2316,7 +2316,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "Comment text. Post \"@AI视频小助理 总结一下\" to summon the AI assistant"
+        "help": "Comment text. Any @username in it is resolved to a real mention"
       },
       {
         "name": "parent",
@@ -2346,7 +2346,7 @@
   {
     "site": "bilibili",
     "name": "comments",
-    "description": "获取 B站视频评论（使用官方 API + WBI 签名）",
+    "description": "获取 B站视频评论（官方 API；用 --parent <rpid> 读取某条评论下的「楼中楼」回复）",
     "access": "read",
     "domain": "www.bilibili.com",
     "strategy": "cookie",
@@ -2358,6 +2358,12 @@
         "required": true,
         "positional": true,
         "help": "Video BV ID (e.g. BV1WtAGzYEBm)"
+      },
+      {
+        "name": "parent",
+        "type": "int",
+        "required": false,
+        "help": "rpid of a comment — fetch the replies under it instead of top-level comments"
       },
       {
         "name": "limit",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2297,6 +2297,54 @@
   },
   {
     "site": "bilibili",
+    "name": "comment",
+    "description": "在 B站视频下发表评论/回复（官方 API，需登录；发「@AI视频小助理 总结一下」可召唤AI总结视频）",
+    "access": "write",
+    "domain": "www.bilibili.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "bvid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Video BV ID / URL / b23.tv short link"
+      },
+      {
+        "name": "message",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Comment text. Post \"@AI视频小助理 总结一下\" to summon the AI assistant"
+      },
+      {
+        "name": "parent",
+        "type": "int",
+        "required": false,
+        "help": "rpid of an existing comment to reply under (omit for a top-level comment)"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually post the comment. Without it the command refuses to write."
+      }
+    ],
+    "columns": [
+      "rpid",
+      "bvid",
+      "oid",
+      "message",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bilibili/comment.js",
+    "sourceFile": "bilibili/comment.js",
+    "navigateBefore": "https://www.bilibili.com"
+  },
+  {
+    "site": "bilibili",
     "name": "comments",
     "description": "获取 B站视频评论（使用官方 API + WBI 签名）",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2322,7 +2322,7 @@
         "name": "parent",
         "type": "int",
         "required": false,
-        "help": "rpid of an existing comment to reply under (omit for a top-level comment)"
+        "help": "top-level/root rpid to reply under (omit for a top-level comment)"
       },
       {
         "name": "execute",
@@ -2375,6 +2375,7 @@
     ],
     "columns": [
       "rank",
+      "rpid",
       "author",
       "text",
       "likes",

--- a/clis/bilibili/comment.js
+++ b/clis/bilibili/comment.js
@@ -4,7 +4,35 @@
  * @username mentions in the message are resolved to real mentions (at_name_to_mid).
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { apiGet, apiPost, resolveBvid, resolveUid } from './utils.js';
+
+function isAuthLikeBilibiliError(code, message) {
+    return code === -101 || code === -111 || code === -403 || /csrf|登录|账号|权限|forbidden|permission|login/i.test(String(message ?? ''));
+}
+
+function requireOkPayload(payload, label) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload) || !Object.hasOwn(payload, 'code')) {
+        throw new CommandExecutionError(`Bilibili ${label} API returned a malformed payload`);
+    }
+    if (payload.code !== 0) {
+        const message = payload.message ?? 'unknown error';
+        if (isAuthLikeBilibiliError(payload.code, message)) {
+            throw new AuthRequiredError('bilibili.com', `Bilibili ${label} API requires login or permission: ${message} (${payload.code})`);
+        }
+        throw new CommandExecutionError(`Bilibili ${label} API failed: ${message} (${payload.code})`);
+    }
+    return payload.data;
+}
+
+function readPositiveInteger(value, label) {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`bilibili comment ${label} must be a positive integer`);
+    }
+    return n;
+}
+
 cli({
     site: 'bilibili',
     name: 'comment',
@@ -15,23 +43,34 @@ cli({
     args: [
         { name: 'bvid', required: true, positional: true, help: 'Video BV ID / URL / b23.tv short link' },
         { name: 'message', required: true, positional: true, help: 'Comment text. Any @username in it is resolved to a real mention' },
-        { name: 'parent', type: 'int', help: 'rpid of an existing comment to reply under (omit for a top-level comment)' },
+        { name: 'parent', type: 'int', help: 'top-level/root rpid to reply under (omit for a top-level comment)' },
         { name: 'execute', type: 'boolean', help: 'Actually post the comment. Without it the command refuses to write.' },
     ],
     columns: ['rpid', 'bvid', 'oid', 'message', 'url'],
     func: async (page, kwargs) => {
+        if (!page) {
+            throw new CommandExecutionError('Browser session required for bilibili comment');
+        }
         const message = String(kwargs.message ?? '').trim();
         if (!message)
-            throw new Error('Comment message cannot be empty');
+            throw new ArgumentError('bilibili comment message cannot be empty');
         // Write guard: posting is public and irreversible-ish, so require an explicit opt-in.
         if (!kwargs.execute)
-            throw new Error('Refusing to post: pass --execute to actually publish this comment');
-        const bvid = await resolveBvid(kwargs.bvid);
+            throw new ArgumentError('Refusing to post: pass --execute to actually publish this comment');
+        const parent = kwargs.parent != null ? readPositiveInteger(kwargs.parent, 'parent') : null;
+        let bvid;
+        try {
+            bvid = await resolveBvid(kwargs.bvid);
+        }
+        catch (error) {
+            throw new ArgumentError(`Cannot resolve Bilibili BV ID from input: ${String(kwargs.bvid ?? '')}`, error instanceof Error ? error.message : String(error));
+        }
         // Resolve bvid → aid (the reply API addresses videos by aid, as `oid`)
         const view = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
-        const oid = view?.data?.aid;
+        const viewData = requireOkPayload(view, 'view');
+        const oid = viewData?.aid;
         if (!oid)
-            throw new Error(`Cannot resolve aid for bvid: ${bvid}`);
+            throw new CommandExecutionError(`Cannot resolve aid for bvid: ${bvid}`);
         // Resolve @username mentions to uids. Bilibili only turns "@name" into a real
         // mention — one that notifies the mentioned user — when the request carries
         // at_name_to_mid; a plain-text "@name" is otherwise inert and notifies nobody.
@@ -44,7 +83,10 @@ cli({
             try {
                 atNameToMid[name] = Number(await resolveUid(page, name));
             }
-            catch {
+            catch (error) {
+                if (!(error instanceof EmptyResultError)) {
+                    throw error;
+                }
                 // Unresolvable @name (typo, or not a user) — leave it as plain text.
             }
         }
@@ -55,17 +97,19 @@ cli({
             type: 1,
             message,
             plat: 1,
-            ...(kwargs.parent != null
-                ? { root: Number(kwargs.parent), parent: Number(kwargs.parent) }
+            ...(parent != null
+                ? { root: parent, parent }
                 : {}),
             ...(Object.keys(atNameToMid).length > 0
                 ? { at_name_to_mid: JSON.stringify(atNameToMid) }
                 : {}),
         };
         const payload = await apiPost(page, '/x/v2/reply/add', { params });
-        if (payload?.code !== 0)
-            throw new Error(`Bilibili rejected the comment (code ${payload?.code}): ${payload?.message ?? 'unknown error'}`);
-        const rpid = payload?.data?.rpid ?? '';
+        const postData = requireOkPayload(payload, 'reply add');
+        const rpid = postData?.rpid;
+        if (!rpid) {
+            throw new CommandExecutionError('Bilibili reply add API did not return rpid for the posted comment');
+        }
         return [{
             rpid: String(rpid),
             bvid,

--- a/clis/bilibili/comment.js
+++ b/clis/bilibili/comment.js
@@ -81,7 +81,11 @@ cli({
             if (name in atNameToMid)
                 continue;
             try {
-                atNameToMid[name] = Number(await resolveUid(page, name));
+                const mid = Number(await resolveUid(page, name));
+                if (!Number.isInteger(mid) || mid <= 0) {
+                    throw new CommandExecutionError(`Bilibili user search returned malformed mid for @${name}`);
+                }
+                atNameToMid[name] = mid;
             }
             catch (error) {
                 if (!(error instanceof EmptyResultError)) {

--- a/clis/bilibili/comment.js
+++ b/clis/bilibili/comment.js
@@ -1,0 +1,77 @@
+/**
+ * Bilibili comment — posts a top-level comment or a reply on a video via the official API.
+ * Uses /x/v2/reply/add, authenticated by the logged-in cookie + bili_jct CSRF token.
+ * @username mentions in the message are resolved to real mentions (at_name_to_mid).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { apiGet, apiPost, resolveBvid, resolveUid } from './utils.js';
+cli({
+    site: 'bilibili',
+    name: 'comment',
+    access: 'write',
+    description: '在 B站视频下发表评论或回复（官方 API，需登录；消息里的 @用户 会被解析为真实提及）',
+    domain: 'www.bilibili.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'bvid', required: true, positional: true, help: 'Video BV ID / URL / b23.tv short link' },
+        { name: 'message', required: true, positional: true, help: 'Comment text. Any @username in it is resolved to a real mention' },
+        { name: 'parent', type: 'int', help: 'rpid of an existing comment to reply under (omit for a top-level comment)' },
+        { name: 'execute', type: 'boolean', help: 'Actually post the comment. Without it the command refuses to write.' },
+    ],
+    columns: ['rpid', 'bvid', 'oid', 'message', 'url'],
+    func: async (page, kwargs) => {
+        const message = String(kwargs.message ?? '').trim();
+        if (!message)
+            throw new Error('Comment message cannot be empty');
+        // Write guard: posting is public and irreversible-ish, so require an explicit opt-in.
+        if (!kwargs.execute)
+            throw new Error('Refusing to post: pass --execute to actually publish this comment');
+        const bvid = await resolveBvid(kwargs.bvid);
+        // Resolve bvid → aid (the reply API addresses videos by aid, as `oid`)
+        const view = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
+        const oid = view?.data?.aid;
+        if (!oid)
+            throw new Error(`Cannot resolve aid for bvid: ${bvid}`);
+        // Resolve @username mentions to uids. Bilibili only turns "@name" into a real
+        // mention — one that notifies the mentioned user — when the request carries
+        // at_name_to_mid; a plain-text "@name" is otherwise inert and notifies nobody.
+        /** @type {Record<string, number>} */
+        const atNameToMid = {};
+        for (const match of message.matchAll(/@([^\s@]+)/g)) {
+            const name = match[1];
+            if (name in atNameToMid)
+                continue;
+            try {
+                atNameToMid[name] = Number(await resolveUid(page, name));
+            }
+            catch {
+                // Unresolvable @name (typo, or not a user) — leave it as plain text.
+            }
+        }
+        // For a reply, Bilibili needs both `root` (top-level comment) and `parent`.
+        // Replying to a top-level comment means root === parent.
+        const params = {
+            oid,
+            type: 1,
+            message,
+            plat: 1,
+            ...(kwargs.parent != null
+                ? { root: Number(kwargs.parent), parent: Number(kwargs.parent) }
+                : {}),
+            ...(Object.keys(atNameToMid).length > 0
+                ? { at_name_to_mid: JSON.stringify(atNameToMid) }
+                : {}),
+        };
+        const payload = await apiPost(page, '/x/v2/reply/add', { params });
+        if (payload?.code !== 0)
+            throw new Error(`Bilibili rejected the comment (code ${payload?.code}): ${payload?.message ?? 'unknown error'}`);
+        const rpid = payload?.data?.rpid ?? '';
+        return [{
+            rpid: String(rpid),
+            bvid,
+            oid: String(oid),
+            message,
+            url: `https://www.bilibili.com/video/${bvid}#reply${rpid}`,
+        }];
+    },
+});

--- a/clis/bilibili/comment.test.js
+++ b/clis/bilibili/comment.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 const { mockApiGet, mockApiPost, mockResolveUid } = vi.hoisted(() => ({
     mockApiGet: vi.fn(),
@@ -40,7 +41,7 @@ describe('bilibili comment', () => {
     });
 
     it('posts a top-level comment, resolving @mentions to at_name_to_mid', async () => {
-        mockApiGet.mockResolvedValueOnce({ data: { aid: 12345 } });
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 12345 } });
         mockResolveUid.mockResolvedValueOnce('1141159409'); // @AI视频小助理 → mid
         mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 99887766 } });
 
@@ -69,8 +70,8 @@ describe('bilibili comment', () => {
     });
 
     it('still posts when an @mention cannot be resolved, leaving it as plain text', async () => {
-        mockApiGet.mockResolvedValueOnce({ data: { aid: 7 } });
-        mockResolveUid.mockRejectedValueOnce(new Error('user not found'));
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 7 } });
+        mockResolveUid.mockRejectedValueOnce(new EmptyResultError('bilibili user search'));
         mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 5 } });
 
         await command.func({}, { bvid: 'BV1xxx', message: '@幽灵用户zzz hi', execute: true });
@@ -80,8 +81,18 @@ describe('bilibili comment', () => {
         });
     });
 
+    it('fails closed when mention resolution has parser or transport errors', async () => {
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 7 } });
+        mockResolveUid.mockRejectedValueOnce(new CommandExecutionError('search API drift'));
+
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: '@用户 hi', execute: true }),
+        ).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(mockApiPost).not.toHaveBeenCalled();
+    });
+
     it('posts a reply under an existing comment when --parent is given', async () => {
-        mockApiGet.mockResolvedValueOnce({ data: { aid: 1 } });
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 1 } });
         mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 2 } });
 
         await command.func({}, { bvid: 'BV1xxx', message: 'thanks', parent: 555, execute: true });
@@ -92,17 +103,41 @@ describe('bilibili comment', () => {
     });
 
     it('throws when the bvid cannot be resolved to an aid', async () => {
-        mockApiGet.mockResolvedValueOnce({ data: {} });
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: {} });
         await expect(
             command.func({}, { bvid: 'BVbroken', message: 'hi', execute: true }),
-        ).rejects.toThrow('Cannot resolve aid for bvid: BVbroken');
+        ).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('throws with the API code and message when Bilibili rejects the comment', async () => {
-        mockApiGet.mockResolvedValueOnce({ data: { aid: 9 } });
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 9 } });
         mockApiPost.mockResolvedValueOnce({ code: 12025, message: '评论字数过多' });
         await expect(
             command.func({}, { bvid: 'BV1xxx', message: 'x', execute: true }),
-        ).rejects.toThrow(/12025.*评论字数过多/);
+        ).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps login/csrf failures from the write API to AuthRequiredError', async () => {
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 9 } });
+        mockApiPost.mockResolvedValueOnce({ code: -111, message: 'csrf 校验失败' });
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: 'x', execute: true }),
+        ).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects invalid parent ids before posting', async () => {
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: 'x', parent: 0, execute: true }),
+        ).rejects.toBeInstanceOf(ArgumentError);
+        expect(mockApiGet).not.toHaveBeenCalled();
+        expect(mockApiPost).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the write API omits rpid', async () => {
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 9 } });
+        mockApiPost.mockResolvedValueOnce({ code: 0, data: {} });
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: 'x', execute: true }),
+        ).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/bilibili/comment.test.js
+++ b/clis/bilibili/comment.test.js
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApiGet, mockApiPost, mockResolveUid } = vi.hoisted(() => ({
+    mockApiGet: vi.fn(),
+    mockApiPost: vi.fn(),
+    mockResolveUid: vi.fn(),
+}));
+
+vi.mock('./utils.js', async (importOriginal) => ({
+    ...(await importOriginal()),
+    apiGet: mockApiGet,
+    apiPost: mockApiPost,
+    resolveUid: mockResolveUid,
+}));
+
+import { getRegistry } from '@jackwener/opencli/registry';
+import './comment.js';
+
+describe('bilibili comment', () => {
+    const command = getRegistry().get('bilibili/comment');
+
+    beforeEach(() => {
+        mockApiGet.mockReset();
+        mockApiPost.mockReset();
+        mockResolveUid.mockReset();
+    });
+
+    it('refuses to post without --execute', async () => {
+        await expect(
+            command.func({}, { bvid: 'BV1WtAGzYEBm', message: 'hi' }),
+        ).rejects.toThrow(/--execute/);
+        expect(mockApiPost).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty message before calling the API', async () => {
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: '   ', execute: true }),
+        ).rejects.toThrow(/empty/i);
+        expect(mockApiGet).not.toHaveBeenCalled();
+    });
+
+    it('posts a top-level comment, resolving @mentions to at_name_to_mid', async () => {
+        mockApiGet.mockResolvedValueOnce({ data: { aid: 12345 } });
+        mockResolveUid.mockResolvedValueOnce('1141159409'); // @AI视频小助理 → mid
+        mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 99887766 } });
+
+        const result = await command.func({}, {
+            bvid: 'BV1WtAGzYEBm', message: '@AI视频小助理 总结一下', execute: true,
+        });
+
+        expect(mockApiGet).toHaveBeenNthCalledWith(1, {}, '/x/web-interface/view', { params: { bvid: 'BV1WtAGzYEBm' } });
+        expect(mockResolveUid).toHaveBeenCalledWith({}, 'AI视频小助理');
+        expect(mockApiPost).toHaveBeenCalledWith({}, '/x/v2/reply/add', {
+            params: {
+                oid: 12345,
+                type: 1,
+                message: '@AI视频小助理 总结一下',
+                plat: 1,
+                at_name_to_mid: '{"AI视频小助理":1141159409}',
+            },
+        });
+        expect(result).toEqual([{
+            rpid: '99887766',
+            bvid: 'BV1WtAGzYEBm',
+            oid: '12345',
+            message: '@AI视频小助理 总结一下',
+            url: 'https://www.bilibili.com/video/BV1WtAGzYEBm#reply99887766',
+        }]);
+    });
+
+    it('still posts when an @mention cannot be resolved, leaving it as plain text', async () => {
+        mockApiGet.mockResolvedValueOnce({ data: { aid: 7 } });
+        mockResolveUid.mockRejectedValueOnce(new Error('user not found'));
+        mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 5 } });
+
+        await command.func({}, { bvid: 'BV1xxx', message: '@幽灵用户zzz hi', execute: true });
+
+        expect(mockApiPost).toHaveBeenCalledWith({}, '/x/v2/reply/add', {
+            params: { oid: 7, type: 1, message: '@幽灵用户zzz hi', plat: 1 },
+        });
+    });
+
+    it('posts a reply under an existing comment when --parent is given', async () => {
+        mockApiGet.mockResolvedValueOnce({ data: { aid: 1 } });
+        mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 2 } });
+
+        await command.func({}, { bvid: 'BV1xxx', message: 'thanks', parent: 555, execute: true });
+
+        expect(mockApiPost).toHaveBeenCalledWith({}, '/x/v2/reply/add', {
+            params: { oid: 1, type: 1, message: 'thanks', plat: 1, root: 555, parent: 555 },
+        });
+    });
+
+    it('throws when the bvid cannot be resolved to an aid', async () => {
+        mockApiGet.mockResolvedValueOnce({ data: {} });
+        await expect(
+            command.func({}, { bvid: 'BVbroken', message: 'hi', execute: true }),
+        ).rejects.toThrow('Cannot resolve aid for bvid: BVbroken');
+    });
+
+    it('throws with the API code and message when Bilibili rejects the comment', async () => {
+        mockApiGet.mockResolvedValueOnce({ data: { aid: 9 } });
+        mockApiPost.mockResolvedValueOnce({ code: 12025, message: '评论字数过多' });
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: 'x', execute: true }),
+        ).rejects.toThrow(/12025.*评论字数过多/);
+    });
+});

--- a/clis/bilibili/comment.test.js
+++ b/clis/bilibili/comment.test.js
@@ -91,6 +91,16 @@ describe('bilibili comment', () => {
         expect(mockApiPost).not.toHaveBeenCalled();
     });
 
+    it('fails closed when mention resolution returns a malformed mid', async () => {
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 7 } });
+        mockResolveUid.mockResolvedValueOnce('not-a-mid');
+
+        await expect(
+            command.func({}, { bvid: 'BV1xxx', message: '@用户 hi', execute: true }),
+        ).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(mockApiPost).not.toHaveBeenCalled();
+    });
+
     it('posts a reply under an existing comment when --parent is given', async () => {
         mockApiGet.mockResolvedValueOnce({ code: 0, data: { aid: 1 } });
         mockApiPost.mockResolvedValueOnce({ code: 0, data: { rpid: 2 } });

--- a/clis/bilibili/comments.js
+++ b/clis/bilibili/comments.js
@@ -1,6 +1,7 @@
 /**
- * Bilibili comments — fetches top-level replies via the official API with WBI signing.
- * Uses the /x/v2/reply/main endpoint which is stable and doesn't depend on DOM structure.
+ * Bilibili comments — fetches comments via the official API.
+ * Top-level comments come from /x/v2/reply/main (WBI-signed); with --parent,
+ * the replies nested under a given comment come from /x/v2/reply/reply.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { apiGet, resolveBvid } from './utils.js';
@@ -8,11 +9,12 @@ cli({
     site: 'bilibili',
     name: 'comments',
     access: 'read',
-    description: '获取 B站视频评论（使用官方 API + WBI 签名）',
+    description: '获取 B站视频评论（官方 API；用 --parent <rpid> 读取某条评论下的「楼中楼」回复）',
     domain: 'www.bilibili.com',
     strategy: Strategy.COOKIE,
     args: [
         { name: 'bvid', required: true, positional: true, help: 'Video BV ID (e.g. BV1WtAGzYEBm)' },
+        { name: 'parent', type: 'int', help: 'rpid of a comment — fetch the replies under it instead of top-level comments' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of comments (max 50)' },
     ],
     columns: ['rank', 'author', 'text', 'likes', 'replies', 'time'],
@@ -24,10 +26,14 @@ cli({
         const aid = view?.data?.aid;
         if (!aid)
             throw new Error(`Cannot resolve aid for bvid: ${bvid}`);
-        const payload = await apiGet(page, '/x/v2/reply/main', {
-            params: { oid: aid, type: 1, mode: 3, ps: limit },
-            signed: true,
-        });
+        const payload = kwargs.parent != null
+            ? await apiGet(page, '/x/v2/reply/reply', {
+                params: { oid: aid, type: 1, root: Number(kwargs.parent), pn: 1, ps: limit },
+            })
+            : await apiGet(page, '/x/v2/reply/main', {
+                params: { oid: aid, type: 1, mode: 3, ps: limit },
+                signed: true,
+            });
         const replies = payload?.data?.replies ?? [];
         return replies.slice(0, limit).map((r, i) => ({
             rank: i + 1,

--- a/clis/bilibili/comments.js
+++ b/clis/bilibili/comments.js
@@ -4,7 +4,88 @@
  * the replies nested under a given comment come from /x/v2/reply/reply.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { apiGet, resolveBvid } from './utils.js';
+
+const MAX_LIMIT = 50;
+
+function isAuthLikeBilibiliError(code, message) {
+    return code === -101 || code === -403 || /登录|账号|权限|forbidden|permission|login/i.test(String(message ?? ''));
+}
+
+function parseLimit(value) {
+    const raw = value == null ? 20 : value;
+    const limit = Number(raw);
+    if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_LIMIT) {
+        throw new ArgumentError(`bilibili comments limit must be an integer between 1 and ${MAX_LIMIT}`);
+    }
+    return limit;
+}
+
+function parseParent(value) {
+    if (value == null) {
+        return null;
+    }
+    const parent = Number(value);
+    if (!Number.isInteger(parent) || parent <= 0) {
+        throw new ArgumentError('bilibili comments parent must be a positive integer rpid');
+    }
+    return parent;
+}
+
+function requireOkPayload(payload, label) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload) || !Object.hasOwn(payload, 'code')) {
+        throw new CommandExecutionError(`Bilibili ${label} API returned a malformed payload`);
+    }
+    if (payload.code !== 0) {
+        const message = payload.message ?? 'unknown error';
+        if (isAuthLikeBilibiliError(payload.code, message)) {
+            throw new AuthRequiredError('bilibili.com', `Bilibili ${label} API requires login or permission: ${message} (${payload.code})`);
+        }
+        throw new CommandExecutionError(`Bilibili ${label} API failed: ${message} (${payload.code})`);
+    }
+    return payload.data;
+}
+
+function requireReplies(data, label) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new CommandExecutionError(`Bilibili ${label} API returned malformed data`);
+    }
+    if (!Object.hasOwn(data, 'replies')) {
+        throw new CommandExecutionError(`Bilibili ${label} API did not return replies`);
+    }
+    if (data.replies === null) {
+        return [];
+    }
+    if (!Array.isArray(data.replies)) {
+        throw new CommandExecutionError(`Bilibili ${label} API returned malformed replies`);
+    }
+    return data.replies;
+}
+
+function formatReplyRow(reply, index) {
+    if (!reply || typeof reply !== 'object' || Array.isArray(reply)) {
+        throw new CommandExecutionError(`Bilibili comments reply ${index + 1} was malformed`);
+    }
+    const rpid = String(reply.rpid ?? '').trim();
+    if (!rpid) {
+        throw new CommandExecutionError(`Bilibili comments reply ${index + 1} was missing rpid`);
+    }
+    const ctime = Number(reply.ctime);
+    if (!Number.isFinite(ctime)) {
+        throw new CommandExecutionError(`Bilibili comments reply ${index + 1} was missing ctime`);
+    }
+    return {
+        rank: index + 1,
+        rpid,
+        author: String(reply.member?.uname ?? ''),
+        text: String(reply.content?.message ?? '').replace(/\n/g, ' ').trim(),
+        likes: reply.like ?? 0,
+        replies: reply.rcount ?? 0,
+        time: new Date(ctime * 1000).toISOString().slice(0, 16).replace('T', ' '),
+    };
+}
+
 cli({
     site: 'bilibili',
     name: 'comments',
@@ -17,31 +98,39 @@ cli({
         { name: 'parent', type: 'int', help: 'rpid of a comment — fetch the replies under it instead of top-level comments' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of comments (max 50)' },
     ],
-    columns: ['rank', 'author', 'text', 'likes', 'replies', 'time'],
+    columns: ['rank', 'rpid', 'author', 'text', 'likes', 'replies', 'time'],
     func: async (page, kwargs) => {
-        const bvid = await resolveBvid(kwargs.bvid);
-        const limit = Math.min(Number(kwargs.limit) || 20, 50);
+        if (!page) {
+            throw new CommandExecutionError('Browser session required for bilibili comments');
+        }
+        let bvid;
+        try {
+            bvid = await resolveBvid(kwargs.bvid);
+        }
+        catch (error) {
+            throw new ArgumentError(`Cannot resolve Bilibili BV ID from input: ${String(kwargs.bvid ?? '')}`, error instanceof Error ? error.message : String(error));
+        }
+        const limit = parseLimit(kwargs.limit);
+        const parent = parseParent(kwargs.parent);
         // Resolve bvid → aid (required by reply API)
         const view = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
-        const aid = view?.data?.aid;
+        const viewData = requireOkPayload(view, 'view');
+        const aid = viewData?.aid;
         if (!aid)
-            throw new Error(`Cannot resolve aid for bvid: ${bvid}`);
-        const payload = kwargs.parent != null
+            throw new CommandExecutionError(`Cannot resolve aid for bvid: ${bvid}`);
+        const payload = parent != null
             ? await apiGet(page, '/x/v2/reply/reply', {
-                params: { oid: aid, type: 1, root: Number(kwargs.parent), pn: 1, ps: limit },
+                params: { oid: aid, type: 1, root: parent, pn: 1, ps: limit },
             })
             : await apiGet(page, '/x/v2/reply/main', {
                 params: { oid: aid, type: 1, mode: 3, ps: limit },
                 signed: true,
             });
-        const replies = payload?.data?.replies ?? [];
-        return replies.slice(0, limit).map((r, i) => ({
-            rank: i + 1,
-            author: r.member?.uname ?? '',
-            text: (r.content?.message ?? '').replace(/\n/g, ' ').trim(),
-            likes: r.like ?? 0,
-            replies: r.rcount ?? 0,
-            time: new Date(r.ctime * 1000).toISOString().slice(0, 16).replace('T', ' '),
-        }));
+        const label = parent != null ? 'reply thread' : 'reply main';
+        const replies = requireReplies(requireOkPayload(payload, label), label);
+        if (replies.length === 0) {
+            throw new EmptyResultError(parent != null ? `bilibili comment replies: ${parent}` : `bilibili comments: ${bvid}`);
+        }
+        return replies.slice(0, limit).map(formatReplyRow);
     },
 });

--- a/clis/bilibili/comments.test.js
+++ b/clis/bilibili/comments.test.js
@@ -46,6 +46,30 @@ describe('bilibili comments', () => {
             },
         ]);
     });
+    it('fetches replies under a comment via /x/v2/reply/reply when --parent is given', async () => {
+        mockApiGet
+            .mockResolvedValueOnce({ data: { aid: 12345 } }) // view endpoint
+            .mockResolvedValueOnce({
+            data: {
+                replies: [
+                    {
+                        member: { uname: 'AI视频小助理' },
+                        content: { message: '视频总结：作者开了一家咖啡馆' },
+                        like: 8,
+                        rcount: 0,
+                        ctime: 1700000000,
+                    },
+                ],
+            },
+        });
+        const result = await command.func({}, { bvid: 'BV1WtAGzYEBm', parent: 777, limit: 5 });
+        expect(mockApiGet).toHaveBeenNthCalledWith(1, {}, '/x/web-interface/view', { params: { bvid: 'BV1WtAGzYEBm' } });
+        expect(mockApiGet).toHaveBeenNthCalledWith(2, {}, '/x/v2/reply/reply', {
+            params: { oid: 12345, type: 1, root: 777, pn: 1, ps: 5 },
+        });
+        expect(result[0].author).toBe('AI视频小助理');
+        expect(result[0].text).toBe('视频总结：作者开了一家咖啡馆');
+    });
     it('throws when aid cannot be resolved', async () => {
         mockApiGet.mockResolvedValueOnce({ data: {} }); // no aid
         await expect(command.func({}, { bvid: 'BVinvalid123', limit: 5 })).rejects.toThrow('Cannot resolve aid for bvid: BVinvalid123');

--- a/clis/bilibili/comments.test.js
+++ b/clis/bilibili/comments.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 const { mockApiGet } = vi.hoisted(() => ({
     mockApiGet: vi.fn(),
 }));
@@ -15,11 +16,13 @@ describe('bilibili comments', () => {
     });
     it('resolves bvid to aid and fetches replies', async () => {
         mockApiGet
-            .mockResolvedValueOnce({ data: { aid: 12345 } }) // view endpoint
+            .mockResolvedValueOnce({ code: 0, data: { aid: 12345 } }) // view endpoint
             .mockResolvedValueOnce({
+            code: 0,
             data: {
                 replies: [
                     {
+                        rpid: 777,
                         member: { uname: 'Alice' },
                         content: { message: 'Great video!' },
                         like: 42,
@@ -38,6 +41,7 @@ describe('bilibili comments', () => {
         expect(result).toEqual([
             {
                 rank: 1,
+                rpid: '777',
                 author: 'Alice',
                 text: 'Great video!',
                 likes: 42,
@@ -48,11 +52,13 @@ describe('bilibili comments', () => {
     });
     it('fetches replies under a comment via /x/v2/reply/reply when --parent is given', async () => {
         mockApiGet
-            .mockResolvedValueOnce({ data: { aid: 12345 } }) // view endpoint
+            .mockResolvedValueOnce({ code: 0, data: { aid: 12345 } }) // view endpoint
             .mockResolvedValueOnce({
+            code: 0,
             data: {
                 replies: [
                     {
+                        rpid: 888,
                         member: { uname: 'AI视频小助理' },
                         content: { message: '视频总结：作者开了一家咖啡馆' },
                         like: 8,
@@ -68,40 +74,69 @@ describe('bilibili comments', () => {
             params: { oid: 12345, type: 1, root: 777, pn: 1, ps: 5 },
         });
         expect(result[0].author).toBe('AI视频小助理');
+        expect(result[0].rpid).toBe('888');
         expect(result[0].text).toBe('视频总结：作者开了一家咖啡馆');
     });
     it('throws when aid cannot be resolved', async () => {
-        mockApiGet.mockResolvedValueOnce({ data: {} }); // no aid
-        await expect(command.func({}, { bvid: 'BVinvalid123', limit: 5 })).rejects.toThrow('Cannot resolve aid for bvid: BVinvalid123');
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: {} }); // no aid
+        await expect(command.func({}, { bvid: 'BVinvalid123', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
-    it('returns empty array when replies is missing', async () => {
+    it('throws CommandExecutionError when replies is missing', async () => {
         mockApiGet
-            .mockResolvedValueOnce({ data: { aid: 99 } })
-            .mockResolvedValueOnce({ data: {} }); // no replies key
-        const result = await command.func({}, { bvid: 'BV1xxx', limit: 5 });
-        expect(result).toEqual([]);
+            .mockResolvedValueOnce({ code: 0, data: { aid: 99 } })
+            .mockResolvedValueOnce({ code: 0, data: {} }); // no replies key
+        await expect(command.func({}, { bvid: 'BV1xxx', limit: 5 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
-    it('caps limit at 50', async () => {
+    it('rejects out-of-range limits instead of silently clamping', async () => {
+        await expect(command.func({}, { bvid: 'BV1xxx', limit: 999 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(mockApiGet).not.toHaveBeenCalled();
+    });
+    it('rejects invalid parent ids before fetching comments', async () => {
+        await expect(command.func({}, { bvid: 'BV1xxx', parent: 0, limit: 5 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(mockApiGet).not.toHaveBeenCalled();
+    });
+    it('maps auth-like API errors to AuthRequiredError', async () => {
         mockApiGet
-            .mockResolvedValueOnce({ data: { aid: 1 } })
-            .mockResolvedValueOnce({ data: { replies: [] } });
-        await command.func({}, { bvid: 'BV1xxx', limit: 999 });
-        expect(mockApiGet).toHaveBeenNthCalledWith(2, {}, '/x/v2/reply/main', {
-            params: { oid: 1, type: 1, mode: 3, ps: 50 },
-            signed: true,
-        });
+            .mockResolvedValueOnce({ code: -101, message: '账号未登录', data: null });
+        await expect(command.func({}, { bvid: 'BV1xxx', limit: 5 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+    it('throws EmptyResultError for explicit empty comments', async () => {
+        mockApiGet
+            .mockResolvedValueOnce({ code: 0, data: { aid: 1 } })
+            .mockResolvedValueOnce({ code: 0, data: { replies: [] } });
+        await expect(command.func({}, { bvid: 'BV1xxx', limit: 5 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
     });
     it('collapses newlines in comment text', async () => {
         mockApiGet
-            .mockResolvedValueOnce({ data: { aid: 1 } })
+            .mockResolvedValueOnce({ code: 0, data: { aid: 1 } })
             .mockResolvedValueOnce({
+            code: 0,
             data: {
                 replies: [
-                    { member: { uname: 'Bob' }, content: { message: 'line1\nline2\nline3' }, like: 0, rcount: 0, ctime: 0 },
+                    { rpid: 123, member: { uname: 'Bob' }, content: { message: 'line1\nline2\nline3' }, like: 0, rcount: 0, ctime: 0 },
                 ],
             },
         });
         const result = (await command.func({}, { bvid: 'BV1xxx', limit: 5 }));
         expect(result[0].text).toBe('line1 line2 line3');
+    });
+    it('throws CommandExecutionError when a comment row lacks rpid', async () => {
+        mockApiGet
+            .mockResolvedValueOnce({ code: 0, data: { aid: 1 } })
+            .mockResolvedValueOnce({
+            code: 0,
+            data: {
+                replies: [
+                    { member: { uname: 'Bob' }, content: { message: 'hi' }, like: 0, rcount: 0, ctime: 0 },
+                ],
+            },
+        });
+        await expect(command.func({}, { bvid: 'BV1xxx', limit: 5 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/bilibili/utils.js
+++ b/clis/bilibili/utils.js
@@ -2,7 +2,7 @@
  * Bilibili shared helpers: WBI signing, authenticated fetch, nav data, UID resolution.
  */
 import https from 'node:https';
-import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 /**
  * Resolve Bilibili short URL / short code to BV ID.
  * Supports: BV1MV9NBtENN, XYzsqGa, b23.tv/XYzsqGa, https://b23.tv/XYzsqGa
@@ -166,8 +166,19 @@ export async function resolveUid(page, input) {
         params: { search_type: 'bili_user', keyword: input },
         signed: true,
     });
-    const results = payload?.data?.result ?? [];
-    if (results.length > 0)
-        return String(results[0].mid);
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload) || !payload.data || typeof payload.data !== 'object' || Array.isArray(payload.data) || !Object.hasOwn(payload.data, 'result')) {
+        throw new CommandExecutionError(`Bilibili user search returned malformed result for ${input}`);
+    }
+    const results = payload.data.result;
+    if (!Array.isArray(results)) {
+        throw new CommandExecutionError(`Bilibili user search returned malformed result for ${input}`);
+    }
+    if (results.length > 0) {
+        const mid = String(results[0]?.mid ?? '').trim();
+        if (!mid) {
+            throw new CommandExecutionError(`Bilibili user search returned malformed mid for ${input}`);
+        }
+        return mid;
+    }
     throw new EmptyResultError(`bilibili user search: ${input}`, 'User may not exist or username may have changed.');
 }

--- a/clis/bilibili/utils.js
+++ b/clis/bilibili/utils.js
@@ -12,7 +12,22 @@ export function resolveBvid(input) {
     if (/^BV[A-Za-z0-9]+$/i.test(trimmed)) {
         return Promise.resolve(trimmed);
     }
+    try {
+        const parsed = new URL(trimmed);
+        if (/(\.|^)bilibili\.com$/i.test(parsed.hostname)) {
+            const match = parsed.pathname.match(/\/(?:video|bangumi\/play)\/(BV[A-Za-z0-9]+)/i);
+            if (match) {
+                return Promise.resolve(match[1]);
+            }
+        }
+    }
+    catch {
+        // Non-URL inputs fall through to b23.tv short-code resolution.
+    }
     const shortCode = trimmed.replace(/^https?:\/\//, '').replace(/^(www\.)?b23\.tv\//, '');
+    if (!/^[A-Za-z0-9]+$/.test(shortCode)) {
+        return Promise.reject(new Error(`Cannot resolve BV ID from invalid b23.tv short code: ${trimmed}`));
+    }
     const url = 'https://b23.tv/' + shortCode;
     return new Promise((resolve, reject) => {
         const req = https.get(url, (res) => {
@@ -29,7 +44,7 @@ export function resolveBvid(input) {
             reject(new Error(`Cannot resolve BV ID from short URL: ${trimmed}`));
         });
         req.on('error', reject);
-        req.setTimeout(5000, () => { req.destroy(); reject(new Error(`Timeout resolving short URL: ${trimmed}`)); });
+        req.setTimeout(4000, () => { req.destroy(); reject(new Error(`Timeout resolving short URL: ${trimmed}`)); });
     });
 }
 const MIXIN_KEY_ENC_TAB = [

--- a/clis/bilibili/utils.js
+++ b/clis/bilibili/utils.js
@@ -104,6 +104,38 @@ export async function fetchJson(page, url) {
     }
   `);
 }
+/**
+ * POST form-encoded params to a Bilibili API endpoint.
+ * Runs inside the logged-in browser context and auto-attaches the bili_jct CSRF token,
+ * which Bilibili requires on every authenticated write request.
+ */
+export async function apiPost(page, path, opts = {}) {
+    const params = opts.params ?? {};
+    const stringified = Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)]));
+    const paramsJs = JSON.stringify(stringified);
+    const urlJs = JSON.stringify(`https://api.bilibili.com${path}`);
+    return page.evaluate(`
+    async () => {
+      const csrf = (document.cookie.match(/bili_jct=([^;]+)/) || [])[1] || "";
+      const body = new URLSearchParams(${paramsJs});
+      body.set("csrf", csrf);
+      const res = await fetch(${urlJs}, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      });
+      // Bilibili write endpoints can return an HTML risk-control page (e.g. HTTP 412)
+      // instead of JSON. Surface that as a structured error rather than a parse crash.
+      const text = await res.text();
+      try {
+        return JSON.parse(text);
+      } catch {
+        return { code: -1, message: "Non-JSON response (HTTP " + res.status + "): " + text.slice(0, 200) };
+      }
+    }
+  `);
+}
 export async function getSelfUid(page) {
     const nav = await getNavData(page);
     const mid = nav?.data?.mid;

--- a/clis/bilibili/utils.test.js
+++ b/clis/bilibili/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { resolveBvid } from './utils.js';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { resolveBvid, resolveUid } from './utils.js';
 describe('resolveBvid', () => {
     it('passes through a valid BV ID', async () => {
         expect(await resolveBvid('BV1MV9NBtENN')).toBe('BV1MV9NBtENN');
@@ -17,5 +18,44 @@ describe('resolveBvid', () => {
     it('rejects invalid input that cannot be resolved', async () => {
         // A random string that b23.tv won't resolve — should timeout or fail
         await expect(resolveBvid('not-a-valid-code-99999')).rejects.toThrow();
+    });
+});
+
+describe('resolveUid', () => {
+    function pageWithUserSearchResult(result) {
+        return {
+            evaluate: async (script) => {
+                if (String(script).includes('/x/web-interface/nav')) {
+                    return {
+                        data: {
+                            wbi_img: {
+                                img_url: 'https://i0.hdslb.com/bfs/wbi/abcdefghijklmnopqrstuvwxyz123456.png',
+                                sub_url: 'https://i0.hdslb.com/bfs/wbi/ABCDEFGHIJKLMNOPQRSTUVWXYZ123456.png',
+                            },
+                        },
+                    };
+                }
+                return result;
+            },
+        };
+    }
+
+    it('returns numeric uid input without searching', async () => {
+        expect(await resolveUid({}, '12345')).toBe('12345');
+    });
+
+    it('fails closed when user search payload lacks result', async () => {
+        await expect(resolveUid(pageWithUserSearchResult({ code: 0, data: {} }), 'missing'))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('fails closed when user search result row lacks mid', async () => {
+        await expect(resolveUid(pageWithUserSearchResult({ code: 0, data: { result: [{}] } }), 'missing-mid'))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('keeps explicit no-user result as EmptyResultError', async () => {
+        await expect(resolveUid(pageWithUserSearchResult({ code: 0, data: { result: [] } }), 'nobody'))
+            .rejects.toBeInstanceOf(EmptyResultError);
     });
 });

--- a/clis/bilibili/utils.test.js
+++ b/clis/bilibili/utils.test.js
@@ -10,6 +10,10 @@ describe('resolveBvid', () => {
     it('handles non-string input via String() coercion', async () => {
         expect(await resolveBvid('BV123abc')).toBe('BV123abc');
     });
+    it('extracts BV IDs from bilibili video URLs', async () => {
+        expect(await resolveBvid('https://www.bilibili.com/video/BV1xx411c7mD/?spm_id_from=333.1007')).toBe('BV1xx411c7mD');
+        expect(await resolveBvid('https://m.bilibili.com/video/BV1Je9EBnEha')).toBe('BV1Je9EBnEha');
+    });
     it('rejects invalid input that cannot be resolved', async () => {
         // A random string that b23.tv won't resolve — should timeout or fail
         await expect(resolveBvid('not-a-valid-code-99999')).rejects.toThrow();

--- a/docs/adapters/browser/bilibili.md
+++ b/docs/adapters/browser/bilibili.md
@@ -16,6 +16,8 @@
 | `opencli bilibili subtitle` | |
 | `opencli bilibili video` | Get one video's metadata (title, author, duration, stats) by BV / URL / b23.tv link |
 | `opencli bilibili summary` | Get the official AI video summary and timestamped outline by BV / URL / b23.tv link |
+| `opencli bilibili comments` | Read top-level comments, or read replies under a top-level comment with `--parent` |
+| `opencli bilibili comment` | Post a top-level comment or reply under a top-level comment (requires `--execute`) |
 | `opencli bilibili dynamic` | |
 | `opencli bilibili ranking` | |
 | `opencli bilibili following` | |
@@ -63,6 +65,14 @@ opencli bilibili video https://www.bilibili.com/video/BV1xx411c7mD/
 opencli bilibili summary BV1xx411c7mD
 opencli bilibili summary https://www.bilibili.com/video/BV1xx411c7mD/
 
+# Read comments and a reply thread under a top-level rpid
+opencli bilibili comments BV1xx411c7mD --limit 10
+opencli bilibili comments BV1xx411c7mD --parent 123456789 --limit 10
+
+# Post a comment or reply. The write only happens with --execute.
+opencli bilibili comment BV1xx411c7mD "这条评论来自 OpenCLI" --execute
+opencli bilibili comment BV1xx411c7mD "回复楼主" --parent 123456789 --execute
+
 # JSON output
 opencli bilibili hot -f json
 
@@ -81,3 +91,7 @@ opencli bilibili hot -v
 - `opencli bilibili feed <uid-or-name>` reads a specific user's dynamics
 - `opencli bilibili favorite` defaults to the first favorite folder when `--fid` is omitted
 - `feed-detail` expects the dynamic ID from a `https://t.bilibili.com/<id>` URL
+- `comments` emits `rpid`; pass a top-level row's `rpid` to `comments --parent` to read its reply thread
+- `comments --limit` accepts `1..50`; empty comment lists raise `EmptyResultError`
+- `comment` is a write command and refuses to post unless `--execute` is passed
+- `comment --parent` expects the top-level/root `rpid`; nested reply-to-reply targeting is not inferred


### PR DESCRIPTION
## What

Rounds out the `bilibili` adapter's comment capabilities with two related changes:

1. **`bilibili comment <bvid> <message>`** (new) — posts a top-level comment, or a reply with `--parent <rpid>`, on a video.
2. **`bilibili comments <bvid> --parent <rpid>`** (enhancement) — reads the replies nested under a given comment (the 楼中楼 thread), not just top-level comments.

## comment — posting (write)

- Posts via the official `/x/v2/reply/add`, authenticated by the logged-in cookie + `bili_jct` CSRF token.
- New `apiPost()` helper in `bilibili/utils.js`: form-encoded authenticated POST that auto-attaches the CSRF token, and degrades to a structured error on a non-JSON risk-control response.
- `@username` mentions in the message are resolved to uids and sent as `at_name_to_mid`, so they become real mentions that notify the user — a plain-text `@name` is otherwise inert.
- Write guard: requires `--execute` to actually publish, consistent with the existing write adapters (`zhihu/comment`, `twitter/post`, …).

## comments --parent — reading reply threads (read)

- Without `--parent`, behavior is unchanged (`/x/v2/reply/main`, WBI-signed).
- With `--parent <rpid>`, fetches that comment's nested reply thread via `/x/v2/reply/reply`.

## Testing

- `clis/bilibili/comment.test.js` (7 cases) and `clis/bilibili/comments.test.js` (6 cases).
- `npx tsc --noEmit` clean · `npm run test:adapter` green · `opencli validate` PASS.
- Verified live: `comment` posts persist (control-tested with a normal comment); `comments --parent` reads a real reply thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
