### PR TITLE
feat(linkedin): add messaging commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14345,6 +14345,182 @@
   },
   {
     "site": "linkedin",
+    "name": "connect",
+    "description": "Fail-closed LinkedIn connection request sender that verifies the exact profile before optionally sending a note",
+    "access": "write",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "profile-url",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Exact LinkedIn profile URL to open and verify"
+      },
+      {
+        "name": "expected-name",
+        "type": "string",
+        "required": true,
+        "help": "Expected visible profile name"
+      },
+      {
+        "name": "note",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Optional connection note, max 300 chars"
+      },
+      {
+        "name": "send",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Actually click Send. Default is dry-run verification only."
+      }
+    ],
+    "columns": [
+      "status",
+      "recipient",
+      "reason",
+      "profile_url",
+      "note_chars",
+      "expected",
+      "actual",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/connect.js",
+    "sourceFile": "linkedin/connect.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
+    "name": "inbox",
+    "description": "List LinkedIn messaging inbox conversations and unread messages",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 40,
+        "required": false,
+        "help": "Maximum conversations to return (max 200)"
+      },
+      {
+        "name": "max-scrolls",
+        "type": "int",
+        "default": 18,
+        "required": false,
+        "help": "Maximum inbox scroll/pagination passes"
+      },
+      {
+        "name": "unread-only",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Return only conversations detected as unread"
+      }
+    ],
+    "columns": [
+      "rank",
+      "thread_url",
+      "thread_id",
+      "person_name",
+      "last_message_preview",
+      "unread",
+      "timestamp"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/inbox.js",
+    "sourceFile": "linkedin/inbox.js",
+    "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin",
+    "name": "safe-send",
+    "description": "Fail-closed LinkedIn message sender that verifies exact thread, recipient, and latest message before filling/sending",
+    "access": "write",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "thread-url",
+        "type": "str",
+        "required": true,
+        "help": "Exact LinkedIn messaging thread URL to open and verify"
+      },
+      {
+        "name": "expected-name",
+        "type": "str",
+        "required": true,
+        "help": "Expected visible recipient name in the active thread header"
+      },
+      {
+        "name": "message",
+        "type": "str",
+        "required": true,
+        "help": "Message body to send or dry-run"
+      },
+      {
+        "name": "expected-last-text",
+        "type": "str",
+        "required": false,
+        "help": "Substring expected in the currently visible latest conversation context"
+      },
+      {
+        "name": "expected-last-hash",
+        "type": "str",
+        "required": false,
+        "help": "SHA-256 hash of expected latest visible message text"
+      },
+      {
+        "name": "send",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Actually click Send. Default is dry-run verification only."
+      },
+      {
+        "name": "screenshot",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Capture a screenshot during verification"
+      }
+    ],
+    "columns": [
+      "status",
+      "recipient",
+      "reason",
+      "thread_url",
+      "message_chars",
+      "expected",
+      "actual",
+      "url",
+      "screenshot",
+      "authRequired",
+      "bodyText",
+      "composerFound",
+      "composerText",
+      "headerNames",
+      "latestMessageHash",
+      "latestMessageText",
+      "searchFailure",
+      "title"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/safe-send.js",
+    "sourceFile": "linkedin/safe-send.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
     "name": "search",
     "description": "Search LinkedIn jobs",
     "access": "read",
@@ -14430,6 +14606,48 @@
     "modulePath": "linkedin/search.js",
     "sourceFile": "linkedin/search.js",
     "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin",
+    "name": "thread-snapshot",
+    "description": "Load a LinkedIn messaging thread, scroll for available history, and return a full context snapshot",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "thread-url",
+        "type": "str",
+        "required": true,
+        "help": "Exact LinkedIn messaging thread URL to open and snapshot"
+      },
+      {
+        "name": "max-scrolls",
+        "type": "number",
+        "default": 30,
+        "required": false,
+        "help": "Maximum upward scroll attempts to load older messages"
+      },
+      {
+        "name": "json",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Return only JSON snapshot string in the snapshot_json field"
+      }
+    ],
+    "columns": [
+      "thread_url",
+      "recipient",
+      "message_count",
+      "latest_text",
+      "snapshot_json"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/thread-snapshot.js",
+    "sourceFile": "linkedin/thread-snapshot.js",
+    "navigateBefore": true
   },
   {
     "site": "linkedin",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14385,10 +14385,7 @@
       "recipient",
       "reason",
       "profile_url",
-      "note_chars",
-      "expected",
-      "actual",
-      "url"
+      "note_chars"
     ],
     "type": "js",
     "modulePath": "linkedin/connect.js",
@@ -14495,19 +14492,7 @@
       "reason",
       "thread_url",
       "message_chars",
-      "expected",
-      "actual",
-      "url",
-      "screenshot",
-      "authRequired",
-      "bodyText",
-      "composerFound",
-      "composerText",
-      "headerNames",
-      "latestMessageHash",
-      "latestMessageText",
-      "searchFailure",
-      "title"
+      "screenshot"
     ],
     "type": "js",
     "modulePath": "linkedin/safe-send.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14409,21 +14409,14 @@
         "type": "int",
         "default": 40,
         "required": false,
-        "help": "Maximum conversations to return (max 200)"
-      },
-      {
-        "name": "max-scrolls",
-        "type": "int",
-        "default": 18,
-        "required": false,
-        "help": "Maximum inbox scroll/pagination passes"
+        "help": "Maximum conversations to return (1-100)"
       },
       {
         "name": "unread-only",
         "type": "bool",
         "default": false,
         "required": false,
-        "help": "Return only conversations detected as unread"
+        "help": "Return only conversations with unread messages"
       }
     ],
     "columns": [
@@ -14433,6 +14426,8 @@
       "person_name",
       "last_message_preview",
       "unread",
+      "counterparty_type",
+      "category",
       "timestamp"
     ],
     "type": "js",

--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -1,0 +1,216 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+
+function normalizeWhitespace(value) {
+    return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeName(value) {
+    return normalizeWhitespace(value)
+        .replace(/\s*[•·]\s*(?:1st|2nd|3rd\+?|degree connection).*$/i, '')
+        .replace(/\s+LinkedIn.*$/i, '')
+        .toLowerCase();
+}
+
+function canonicalizeLinkedInProfileUrl(value) {
+    const raw = normalizeWhitespace(value);
+    if (!raw) return '';
+    try {
+        const url = new URL(raw);
+        if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+        url.hash = '';
+        url.search = '';
+        if (!url.pathname.endsWith('/')) url.pathname += '/';
+        return url.toString();
+    }
+    catch {
+        return raw;
+    }
+}
+
+function requireStringArg(args, key, label = key) {
+    const value = normalizeWhitespace(args[key]);
+    if (!value) throw new ArgumentError(`${label} is required`);
+    return value;
+}
+
+function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+    return payload;
+}
+
+function clampNote(note) {
+    const value = normalizeWhitespace(note);
+    if (value.length > 300) throw new ArgumentError('--note must be 300 characters or fewer for LinkedIn connection requests');
+    return value;
+}
+
+function assessProfileSafety(probe, expectedName, expectedProfileUrl) {
+    const expected = normalizeWhitespace(expectedName);
+    const actual = normalizeWhitespace(probe?.name || '');
+    const expectedUrl = canonicalizeLinkedInProfileUrl(expectedProfileUrl);
+    const actualUrl = canonicalizeLinkedInProfileUrl(probe?.url || '');
+    if (probe?.authRequired) return { ok: false, reason: 'auth_required', expected, actual, url: actualUrl };
+    if (!actual) return { ok: false, reason: 'profile_name_not_found', expected, actual, url: actualUrl };
+    if (expected && normalizeName(actual) !== normalizeName(expected)) {
+        return { ok: false, reason: 'profile_name_mismatch', expected, actual, url: actualUrl };
+    }
+    if (expectedUrl && actualUrl && expectedUrl !== actualUrl) {
+        return { ok: false, reason: 'profile_url_mismatch', expected: expectedUrl, actual: actualUrl, url: actualUrl };
+    }
+    if (probe?.alreadyConnected) return { ok: false, reason: 'already_connected', expected, actual, url: actualUrl };
+    if (probe?.pending) return { ok: false, reason: 'connection_pending', expected, actual, url: actualUrl };
+    if (!probe?.connectAvailable) return { ok: false, reason: 'connect_button_not_found', expected, actual, url: actualUrl };
+    return { ok: true, reason: 'verified', expected, actual, url: actualUrl };
+}
+
+function buildProfileProbeScript() {
+    return String.raw`(() => {
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const text = document.body ? (document.body.innerText || '') : '';
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
+      || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
+      || /captcha|verification required/i.test(text);
+    const main = document.querySelector('main') || document.body;
+    const h1 = main?.querySelector('h1');
+    const name = clean(h1?.innerText || h1?.textContent || document.querySelector('.text-heading-xlarge')?.textContent || '');
+    const buttons = Array.from(document.querySelectorAll('button, [role="button"]')).filter((el) => el.offsetParent !== null);
+    const buttonLabels = buttons.map((button) => clean(button.innerText || button.textContent || button.getAttribute('aria-label'))).filter(Boolean);
+    const lowerLabels = buttonLabels.map((label) => label.toLowerCase());
+    const alreadyConnected = lowerLabels.some((label) => label === 'message' || label.includes('1st degree connection'));
+    const pending = lowerLabels.some((label) => label === 'pending' || label.includes('pending'));
+    const connectAvailable = lowerLabels.some((label) => label === 'connect' || label.startsWith('connect ') || label.includes(' invite '));
+    return {
+      url: location.href,
+      title: document.title || '',
+      name,
+      authRequired,
+      alreadyConnected,
+      pending,
+      connectAvailable,
+      buttonLabels: buttonLabels.slice(0, 30),
+      bodyText: text,
+    };
+  })()`;
+}
+
+function buildConnectionRequestScript(note) {
+    return String.raw`(async () => {
+    const note = ${JSON.stringify(note)};
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const jitter = async (min = 350, max = 950) => sleep(min + Math.floor(Math.random() * (max - min + 1)));
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const visible = (el) => el && el.offsetParent !== null && !el.closest('[aria-hidden="true"]');
+    const label = (el) => clean(el?.innerText || el?.textContent || el?.getAttribute('aria-label'));
+    const buttons = () => Array.from(document.querySelectorAll('button, [role="button"]')).filter(visible);
+    const findButton = (patterns) => buttons().find((button) => patterns.some((pattern) => pattern.test(label(button))));
+
+    let connect = findButton([/^connect$/i, /^connect\s+/i]);
+    if (!connect) {
+      const more = findButton([/^more$/i, /more actions/i]);
+      if (more) {
+        more.scrollIntoView({ block: 'center' });
+        await jitter();
+        more.click();
+        await jitter(800, 1400);
+        connect = findButton([/^connect$/i, /^connect\s+/i]);
+      }
+    }
+    if (!connect) return { ok: false, status: 'blocked', reason: 'connect_button_not_found' };
+
+    connect.scrollIntoView({ block: 'center' });
+    await jitter();
+    connect.click();
+    await jitter(900, 1700);
+
+    if (note) {
+      const addNote = findButton([/add a note/i, /^add note$/i]);
+      if (!addNote) return { ok: false, status: 'blocked', reason: 'add_note_button_not_found' };
+      addNote.click();
+      await jitter(700, 1300);
+      const textarea = Array.from(document.querySelectorAll('textarea')).find(visible);
+      if (!textarea) return { ok: false, status: 'blocked', reason: 'note_textarea_not_found' };
+      textarea.focus();
+      textarea.value = note;
+      textarea.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: note }));
+      textarea.dispatchEvent(new Event('change', { bubbles: true }));
+      await jitter(500, 1000);
+    }
+
+    const send = findButton([/^send$/i, /^send now$/i, /^done$/i]);
+    if (!send) return { ok: false, status: 'blocked', reason: 'send_button_not_found' };
+    if (send.disabled || send.getAttribute('aria-disabled') === 'true') return { ok: false, status: 'blocked', reason: 'send_button_disabled' };
+    send.click();
+    await jitter(1200, 2200);
+    return { ok: true, status: 'sent', reason: 'connection_request_sent' };
+  })()`;
+}
+
+async function probeProfile(page) {
+    return unwrapEvaluateResult(await page.evaluate(buildProfileProbeScript()));
+}
+
+cli({
+    site: 'linkedin',
+    name: 'connect',
+    access: 'write',
+    description: 'Fail-closed LinkedIn connection request sender that verifies the exact profile before optionally sending a note',
+    domain: LINKEDIN_DOMAIN,
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'profile-url', type: 'string', required: true, positional: true, help: 'Exact LinkedIn profile URL to open and verify' },
+        { name: 'expected-name', type: 'string', required: true, help: 'Expected visible profile name' },
+        { name: 'note', type: 'string', required: false, default: '', help: 'Optional connection note, max 300 chars' },
+        { name: 'send', type: 'bool', required: false, default: false, help: 'Actually click Send. Default is dry-run verification only.' },
+    ],
+    columns: ['status', 'recipient', 'reason', 'profile_url', 'note_chars', 'expected', 'actual', 'url'],
+    func: async (page, args) => {
+        if (!page) throw new CommandExecutionError('Browser session required for linkedin connect');
+        const profileUrl = canonicalizeLinkedInProfileUrl(requireStringArg(args, 'profile-url', '--profile-url'));
+        const expectedName = requireStringArg(args, 'expected-name', '--expected-name');
+        const note = clampNote(args.note || '');
+
+        await page.goto(profileUrl);
+        await page.wait(5);
+        let probe = await probeProfile(page);
+        for (let attempt = 0; attempt < 5 && !probe?.name; attempt += 1) {
+            await page.wait(2);
+            probe = await probeProfile(page);
+        }
+        const safety = assessProfileSafety(probe, expectedName, profileUrl);
+        if (safety.reason === 'auth_required') {
+            throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn connect requires an active signed-in LinkedIn browser session.');
+        }
+        if (!safety.ok) {
+            throw new CommandExecutionError(
+                `LinkedIn connect blocked: ${safety.reason}`,
+                `Expected ${safety.expected}; actual ${safety.actual || 'not_visible'} at ${safety.url || 'url_not_available'}\nButtons: ${(probe?.buttonLabels || []).join(' | ')}`,
+            );
+        }
+        if (!args.send) {
+            return [{ status: 'verified_dry_run', recipient: safety.actual, reason: safety.reason, profile_url: safety.url, note_chars: note.length }];
+        }
+        const result = unwrapEvaluateResult(await page.evaluate(buildConnectionRequestScript(note)));
+        if (!result?.ok) throw new CommandExecutionError(`LinkedIn connect blocked: ${result?.reason || 'send_failed'}`);
+        const after = await probeProfile(page);
+        return [{
+            status: result.status || 'sent',
+            recipient: safety.actual,
+            reason: result.reason || 'connection_request_sent',
+            profile_url: canonicalizeLinkedInProfileUrl(after?.url || safety.url),
+            note_chars: note.length,
+        }];
+    },
+});
+
+export const __test__ = {
+    normalizeWhitespace,
+    normalizeName,
+    canonicalizeLinkedInProfileUrl,
+    unwrapEvaluateResult,
+    clampNote,
+    assessProfileSafety,
+};

--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -20,6 +20,10 @@ function canonicalizeLinkedInProfileUrl(value) {
     try {
         const url = new URL(raw);
         if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+        // LinkedIn redirects country subdomains (ca./uk./...) to www.; normalize the
+        // host so an expected `ca.linkedin.com/in/x` matches the landed `www.linkedin.com/in/x`.
+        url.protocol = 'https:';
+        url.hostname = 'www.linkedin.com';
         url.hash = '';
         url.search = '';
         if (!url.pathname.endsWith('/')) url.pathname += '/';
@@ -74,14 +78,25 @@ function buildProfileProbeScript() {
       || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
       || /captcha|verification required/i.test(text);
     const main = document.querySelector('main') || document.body;
-    const h1 = main?.querySelector('h1');
-    const name = clean(h1?.innerText || h1?.textContent || document.querySelector('.text-heading-xlarge')?.textContent || '');
-    const buttons = Array.from(document.querySelectorAll('button, [role="button"]')).filter((el) => el.offsetParent !== null);
+    // LinkedIn profile pages no longer expose the name in an <h1>; the heading
+    // markup churns, but document.title is a stable "Name | LinkedIn" pattern.
+    const heading = main?.querySelector('h1, .text-heading-xlarge, [class*="heading-xlarge"]');
+    const titleName = clean((document.title || '')
+      .replace(/^\(\d+\+?\)\s*/, '')
+      .replace(/\s*[|｜]\s*LinkedIn\s*$/i, ''));
+    const name = clean(heading?.innerText || heading?.textContent || '') || titleName;
+    const buttons = Array.from(document.querySelectorAll('button, [role="button"], a')).filter((el) => el.offsetParent !== null);
     const buttonLabels = buttons.map((button) => clean(button.innerText || button.textContent || button.getAttribute('aria-label'))).filter(Boolean);
     const lowerLabels = buttonLabels.map((label) => label.toLowerCase());
     const alreadyConnected = lowerLabels.some((label) => label === 'message' || label.includes('1st degree connection'));
     const pending = lowerLabels.some((label) => label === 'pending' || label.includes('pending'));
     const connectAvailable = lowerLabels.some((label) => label === 'connect' || label.startsWith('connect ') || label.includes(' invite '));
+    // The Connect control is an <a> linking to LinkedIn's invitation route
+    // (/preload/custom-invite/?vanityName=...). Capture it so the sender can
+    // navigate straight to the invite dialog.
+    const connectAnchor = buttons.find((el) => el.tagName === 'A'
+      && /^connect$/i.test(clean(el.innerText || el.textContent || el.getAttribute('aria-label'))));
+    const connectHref = connectAnchor ? (connectAnchor.getAttribute('href') || '') : '';
     return {
       url: location.href,
       title: document.title || '',
@@ -90,61 +105,68 @@ function buildProfileProbeScript() {
       alreadyConnected,
       pending,
       connectAvailable,
+      connectHref,
       buttonLabels: buttonLabels.slice(0, 30),
       bodyText: text,
     };
   })()`;
 }
 
-function buildConnectionRequestScript(note) {
+// Runs in-page on LinkedIn's invitation route (/preload/custom-invite/...),
+// where the "Add a note to your invitation?" dialog is already open.
+function buildInviteScript(note) {
     return String.raw`(async () => {
     const note = ${JSON.stringify(note)};
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-    const jitter = async (min = 350, max = 950) => sleep(min + Math.floor(Math.random() * (max - min + 1)));
+    const jitter = async (min = 450, max = 1150) => sleep(min + Math.floor(Math.random() * (max - min + 1)));
     const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
-    const visible = (el) => el && el.offsetParent !== null && !el.closest('[aria-hidden="true"]');
+    const visible = (el) => el && el.offsetParent !== null;
     const label = (el) => clean(el?.innerText || el?.textContent || el?.getAttribute('aria-label'));
-    const buttons = () => Array.from(document.querySelectorAll('button, [role="button"]')).filter(visible);
-    const findButton = (patterns) => buttons().find((button) => patterns.some((pattern) => pattern.test(label(button))));
+    const dialog = () => document.querySelector('[role="dialog"]');
+    const dialogButton = (pattern) => {
+      const dlg = dialog();
+      if (!dlg) return null;
+      return Array.from(dlg.querySelectorAll('button, [role="button"]')).filter(visible)
+        .find((button) => pattern.test(label(button)));
+    };
 
-    let connect = findButton([/^connect$/i, /^connect\s+/i]);
-    if (!connect) {
-      const more = findButton([/^more$/i, /more actions/i]);
-      if (more) {
-        more.scrollIntoView({ block: 'center' });
-        await jitter();
-        more.click();
-        await jitter(800, 1400);
-        connect = findButton([/^connect$/i, /^connect\s+/i]);
-      }
+    if (!dialog()) return { ok: false, status: 'blocked', reason: 'invite_dialog_not_found' };
+
+    if (!note) {
+      const sendDirect = dialogButton(/^send without a note$/i) || dialogButton(/^send$/i);
+      if (!sendDirect) return { ok: false, status: 'blocked', reason: 'send_button_not_found' };
+      await jitter();
+      sendDirect.click();
+      await jitter(1400, 2400);
+      return { ok: true, status: 'sent', reason: 'invitation_sent_without_note' };
     }
-    if (!connect) return { ok: false, status: 'blocked', reason: 'connect_button_not_found' };
 
-    connect.scrollIntoView({ block: 'center' });
+    const addNote = dialogButton(/^add a note$/i);
+    if (!addNote) return { ok: false, status: 'blocked', reason: 'add_note_button_not_found' };
     await jitter();
-    connect.click();
-    await jitter(900, 1700);
+    addNote.click();
+    await jitter(800, 1400);
 
-    if (note) {
-      const addNote = findButton([/add a note/i, /^add note$/i]);
-      if (!addNote) return { ok: false, status: 'blocked', reason: 'add_note_button_not_found' };
-      addNote.click();
-      await jitter(700, 1300);
-      const textarea = Array.from(document.querySelectorAll('textarea')).find(visible);
-      if (!textarea) return { ok: false, status: 'blocked', reason: 'note_textarea_not_found' };
-      textarea.focus();
-      textarea.value = note;
-      textarea.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: note }));
-      textarea.dispatchEvent(new Event('change', { bubbles: true }));
-      await jitter(500, 1000);
-    }
+    const textarea = document.querySelector('#custom-message')
+      || Array.from(document.querySelectorAll('textarea')).find(visible);
+    if (!textarea) return { ok: false, status: 'blocked', reason: 'note_textarea_not_found' };
+    textarea.focus();
+    // React tracks textarea values through the native setter; assigning .value
+    // directly would leave component state (and the Send button) unchanged.
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+    nativeSetter.call(textarea, note);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(new Event('change', { bubbles: true }));
+    await jitter(700, 1300);
 
-    const send = findButton([/^send$/i, /^send now$/i, /^done$/i]);
+    const send = dialogButton(/^send$/i);
     if (!send) return { ok: false, status: 'blocked', reason: 'send_button_not_found' };
-    if (send.disabled || send.getAttribute('aria-disabled') === 'true') return { ok: false, status: 'blocked', reason: 'send_button_disabled' };
+    if (send.disabled || send.getAttribute('aria-disabled') === 'true') {
+      return { ok: false, status: 'blocked', reason: 'send_button_disabled' };
+    }
     send.click();
-    await jitter(1200, 2200);
-    return { ok: true, status: 'sent', reason: 'connection_request_sent' };
+    await jitter(1400, 2400);
+    return { ok: true, status: 'sent', reason: 'invitation_sent_with_note' };
   })()`;
 }
 
@@ -174,9 +196,15 @@ cli({
         const note = clampNote(args.note || '');
 
         await page.goto(profileUrl);
-        await page.wait(5);
+        await page.wait(6);
         let probe = await probeProfile(page);
-        for (let attempt = 0; attempt < 5 && !probe?.name; attempt += 1) {
+        // The name resolves early (from document.title), but the profile action
+        // buttons (Connect / Message / Pending) render later. Keep probing until
+        // the action state has resolved, not merely until the name is visible.
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+            const resolved = probe?.name
+                && (probe.connectAvailable || probe.alreadyConnected || probe.pending);
+            if (resolved) break;
             await page.wait(2);
             probe = await probeProfile(page);
         }
@@ -193,11 +221,24 @@ cli({
         if (!args.send) {
             return [{ status: 'verified_dry_run', recipient: safety.actual, reason: safety.reason, profile_url: safety.url, note_chars: note.length }];
         }
-        const result = unwrapEvaluateResult(await page.evaluate(buildConnectionRequestScript(note)));
+        const inviteHref = probe?.connectHref || '';
+        if (!inviteHref) {
+            throw new CommandExecutionError('LinkedIn connect blocked: connect_link_not_found');
+        }
+        const inviteUrl = new URL(inviteHref, 'https://www.linkedin.com').toString();
+        await page.goto(inviteUrl);
+        await page.wait(6);
+        let result = unwrapEvaluateResult(await page.evaluate(buildInviteScript(note)));
+        if (result?.reason === 'invite_dialog_not_found') {
+            await page.wait(5);
+            result = unwrapEvaluateResult(await page.evaluate(buildInviteScript(note)));
+        }
         if (!result?.ok) throw new CommandExecutionError(`LinkedIn connect blocked: ${result?.reason || 'send_failed'}`);
+        await page.goto(profileUrl);
+        await page.wait(5);
         const after = await probeProfile(page);
         return [{
-            status: result.status || 'sent',
+            status: after?.pending ? 'sent' : (result.status || 'sent'),
             recipient: safety.actual,
             reason: result.reason || 'connection_request_sent',
             profile_url: canonicalizeLinkedInProfileUrl(after?.url || safety.url),

--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -14,15 +14,21 @@ function normalizeName(value) {
         .toLowerCase();
 }
 
+function isLinkedInHost(hostname) {
+    const host = String(hostname || '').toLowerCase();
+    return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
 function canonicalizeLinkedInProfileUrl(value) {
     const raw = normalizeWhitespace(value);
     if (!raw) return '';
     try {
         const url = new URL(raw);
-        if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+        if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
+        const match = url.pathname.match(/^\/in\/([^/]+)\/?$/i);
+        if (!match || !match[1]) return '';
         // LinkedIn redirects country subdomains (ca./uk./...) to www.; normalize the
         // host so an expected `ca.linkedin.com/in/x` matches the landed `www.linkedin.com/in/x`.
-        url.protocol = 'https:';
         url.hostname = 'www.linkedin.com';
         url.hash = '';
         url.search = '';
@@ -30,7 +36,7 @@ function canonicalizeLinkedInProfileUrl(value) {
         return url.toString();
     }
     catch {
-        return raw;
+        return '';
     }
 }
 
@@ -38,6 +44,12 @@ function requireStringArg(args, key, label = key) {
     const value = normalizeWhitespace(args[key]);
     if (!value) throw new ArgumentError(`${label} is required`);
     return value;
+}
+
+function requireLinkedInProfileUrl(value, label) {
+    const url = canonicalizeLinkedInProfileUrl(value);
+    if (!url) throw new ArgumentError(`${label} must be an exact https://www.linkedin.com/in/<profile>/ URL`);
+    return url;
 }
 
 function unwrapEvaluateResult(payload) {
@@ -51,23 +63,38 @@ function clampNote(note) {
     return value;
 }
 
+function canonicalizeLinkedInInviteUrl(value) {
+    try {
+        const url = new URL(normalizeWhitespace(value), 'https://www.linkedin.com');
+        if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
+        if (!/^\/preload\/custom-invite\/?$/i.test(url.pathname)) return '';
+        url.hostname = 'www.linkedin.com';
+        url.hash = '';
+        if (!url.pathname.endsWith('/')) url.pathname += '/';
+        return url.toString();
+    }
+    catch {
+        return '';
+    }
+}
+
 function assessProfileSafety(probe, expectedName, expectedProfileUrl) {
     const expected = normalizeWhitespace(expectedName);
     const actual = normalizeWhitespace(probe?.name || '');
     const expectedUrl = canonicalizeLinkedInProfileUrl(expectedProfileUrl);
     const actualUrl = canonicalizeLinkedInProfileUrl(probe?.url || '');
-    if (probe?.authRequired) return { ok: false, reason: 'auth_required', expected, actual, url: actualUrl };
-    if (!actual) return { ok: false, reason: 'profile_name_not_found', expected, actual, url: actualUrl };
+    if (probe?.authRequired) return { ok: false, blockReason: 'auth_required', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (!actual) return { ok: false, blockReason: 'profile_name_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
     if (expected && normalizeName(actual) !== normalizeName(expected)) {
-        return { ok: false, reason: 'profile_name_mismatch', expected, actual, url: actualUrl };
+        return { ok: false, blockReason: 'profile_name_mismatch', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
     }
     if (expectedUrl && actualUrl && expectedUrl !== actualUrl) {
-        return { ok: false, reason: 'profile_url_mismatch', expected: expectedUrl, actual: actualUrl, url: actualUrl };
+        return { ok: false, blockReason: 'profile_url_mismatch', expectedValue: expectedUrl, actualValue: actualUrl, observedUrl: actualUrl };
     }
-    if (probe?.alreadyConnected) return { ok: false, reason: 'already_connected', expected, actual, url: actualUrl };
-    if (probe?.pending) return { ok: false, reason: 'connection_pending', expected, actual, url: actualUrl };
-    if (!probe?.connectAvailable) return { ok: false, reason: 'connect_button_not_found', expected, actual, url: actualUrl };
-    return { ok: true, reason: 'verified', expected, actual, url: actualUrl };
+    if (probe?.alreadyConnected) return { ok: false, blockReason: 'already_connected', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (probe?.pending) return { ok: false, blockReason: 'connection_pending', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (!probe?.connectAvailable) return { ok: false, blockReason: 'connect_button_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    return { ok: true, blockReason: 'verified', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
 }
 
 function buildProfileProbeScript() {
@@ -188,10 +215,10 @@ cli({
         { name: 'note', type: 'string', required: false, default: '', help: 'Optional connection note, max 300 chars' },
         { name: 'send', type: 'bool', required: false, default: false, help: 'Actually click Send. Default is dry-run verification only.' },
     ],
-    columns: ['status', 'recipient', 'reason', 'profile_url', 'note_chars', 'expected', 'actual', 'url'],
+    columns: ['status', 'recipient', 'reason', 'profile_url', 'note_chars'],
     func: async (page, args) => {
         if (!page) throw new CommandExecutionError('Browser session required for linkedin connect');
-        const profileUrl = canonicalizeLinkedInProfileUrl(requireStringArg(args, 'profile-url', '--profile-url'));
+        const profileUrl = requireLinkedInProfileUrl(requireStringArg(args, 'profile-url', '--profile-url'), '--profile-url');
         const expectedName = requireStringArg(args, 'expected-name', '--expected-name');
         const note = clampNote(args.note || '');
 
@@ -209,23 +236,26 @@ cli({
             probe = await probeProfile(page);
         }
         const safety = assessProfileSafety(probe, expectedName, profileUrl);
-        if (safety.reason === 'auth_required') {
+        if (safety.blockReason === 'auth_required') {
             throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn connect requires an active signed-in LinkedIn browser session.');
         }
         if (!safety.ok) {
             throw new CommandExecutionError(
-                `LinkedIn connect blocked: ${safety.reason}`,
-                `Expected ${safety.expected}; actual ${safety.actual || 'not_visible'} at ${safety.url || 'url_not_available'}\nButtons: ${(probe?.buttonLabels || []).join(' | ')}`,
+                `LinkedIn connect blocked: ${safety.blockReason}`,
+                `Expected ${safety.expectedValue}; actual ${safety.actualValue || 'not_visible'} at ${safety.observedUrl || 'url_not_available'}\nButtons: ${(probe?.buttonLabels || []).join(' | ')}`,
             );
         }
         if (!args.send) {
-            return [{ status: 'verified_dry_run', recipient: safety.actual, reason: safety.reason, profile_url: safety.url, note_chars: note.length }];
+            return [{ status: 'verified_dry_run', recipient: safety.actualValue, reason: safety.blockReason, profile_url: safety.observedUrl, note_chars: note.length }];
         }
         const inviteHref = probe?.connectHref || '';
         if (!inviteHref) {
             throw new CommandExecutionError('LinkedIn connect blocked: connect_link_not_found');
         }
-        const inviteUrl = new URL(inviteHref, 'https://www.linkedin.com').toString();
+        const inviteUrl = canonicalizeLinkedInInviteUrl(inviteHref);
+        if (!inviteUrl) {
+            throw new CommandExecutionError('LinkedIn connect blocked: invalid_connect_link');
+        }
         await page.goto(inviteUrl);
         await page.wait(6);
         let result = unwrapEvaluateResult(await page.evaluate(buildInviteScript(note)));
@@ -239,9 +269,9 @@ cli({
         const after = await probeProfile(page);
         return [{
             status: after?.pending ? 'sent' : (result.status || 'sent'),
-            recipient: safety.actual,
+            recipient: safety.actualValue,
             reason: result.reason || 'connection_request_sent',
-            profile_url: canonicalizeLinkedInProfileUrl(after?.url || safety.url),
+            profile_url: canonicalizeLinkedInProfileUrl(after?.url || safety.observedUrl),
             note_chars: note.length,
         }];
     },
@@ -251,6 +281,7 @@ export const __test__ = {
     normalizeWhitespace,
     normalizeName,
     canonicalizeLinkedInProfileUrl,
+    canonicalizeLinkedInInviteUrl,
     unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import './connect.js';
+
+const {
+    normalizeName,
+    canonicalizeLinkedInProfileUrl,
+    unwrapEvaluateResult,
+    clampNote,
+    assessProfileSafety,
+} = await import('./connect.js').then((m) => m.__test__);
+
+function makeFakePage(probe, sendResult = { ok: true, status: 'sent', reason: 'connection_request_sent' }) {
+    return {
+        goto: vi.fn(async () => undefined),
+        wait: vi.fn(async () => undefined),
+        evaluate: vi.fn(async (script) => {
+            const text = String(script);
+            if (text.includes('connection_request_sent')) return sendResult;
+            return probe;
+        }),
+    };
+}
+
+describe('linkedin connect helpers', () => {
+    it('normalizes names and profile URLs', () => {
+        expect(normalizeName('Jane Doe • 2nd degree connection')).toBe('jane doe');
+        expect(canonicalizeLinkedInProfileUrl('https://www.linkedin.com/in/jane/?mini=true#x'))
+            .toBe('https://www.linkedin.com/in/jane/');
+    });
+
+    it('unwraps browser bridge evaluate envelopes', () => {
+        expect(unwrapEvaluateResult({ session: 'site:linkedin:1', data: { ok: true } })).toEqual({ ok: true });
+        const raw = { ok: true };
+        expect(unwrapEvaluateResult(raw)).toBe(raw);
+    });
+
+    it('enforces LinkedIn note length', () => {
+        expect(clampNote(' hello\nthere ')).toBe('hello there');
+        expect(() => clampNote('x'.repeat(301))).toThrow('--note must be 300 characters or fewer');
+    });
+
+    it('fails closed on wrong profile name, pending state, or missing connect button', () => {
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true }, 'Janet Doe', 'https://www.linkedin.com/in/jane/').reason)
+            .toBe('profile_name_mismatch');
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', pending: true, connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/').reason)
+            .toBe('connection_pending');
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/' }, 'Jane Doe', 'https://www.linkedin.com/in/jane/').reason)
+            .toBe('connect_button_not_found');
+    });
+
+    it('passes only when profile url, name, and connect affordance all match', () => {
+        const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/?mini=true', connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
+        expect(result).toMatchObject({ ok: true, reason: 'verified', actual: 'Jane Doe' });
+    });
+});
+
+describe('linkedin connect command', () => {
+    it('registers as a write command and dry-runs by default', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        expect(command).toBeDefined();
+        expect(command.access).toBe('write');
+        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, buttonLabels: ['Connect'] });
+        const rows = await command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            note: 'quick note',
+        });
+        expect(rows[0]).toMatchObject({ status: 'verified_dry_run', recipient: 'Jane Doe', reason: 'verified' });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send when recipient verification fails', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeFakePage({ name: 'Wrong Person', url: 'https://www.linkedin.com/in/wrong/', connectAvailable: true, buttonLabels: ['Connect'] });
+        await expect(command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            note: 'quick note',
+            send: true,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends only when --send is true after verification', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, buttonLabels: ['Connect'] });
+        const rows = await command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            note: 'quick note',
+            send: true,
+        });
+        expect(rows[0]).toMatchObject({ status: 'sent', recipient: 'Jane Doe', reason: 'connection_request_sent' });
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+    });
+});

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -17,7 +17,7 @@ function makeFakePage(probe, sendResult = { ok: true, status: 'sent', reason: 'c
         wait: vi.fn(async () => undefined),
         evaluate: vi.fn(async (script) => {
             const text = String(script);
-            if (text.includes('connection_request_sent')) return sendResult;
+            if (text.includes('custom-message') || text.includes('invite_dialog_not_found')) return sendResult;
             return probe;
         }),
     };
@@ -61,7 +61,7 @@ describe('linkedin connect command', () => {
         const command = getRegistry().get('linkedin/connect');
         expect(command).toBeDefined();
         expect(command.access).toBe('write');
-        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, buttonLabels: ['Connect'] });
+        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: '/preload/custom-invite/?vanityName=jane', buttonLabels: ['Connect'] });
         const rows = await command.func(page, {
             'profile-url': 'https://www.linkedin.com/in/jane/',
             'expected-name': 'Jane Doe',
@@ -85,7 +85,7 @@ describe('linkedin connect command', () => {
 
     it('sends only when --send is true after verification', async () => {
         const command = getRegistry().get('linkedin/connect');
-        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, buttonLabels: ['Connect'] });
+        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: '/preload/custom-invite/?vanityName=jane', buttonLabels: ['Connect'] });
         const rows = await command.func(page, {
             'profile-url': 'https://www.linkedin.com/in/jane/',
             'expected-name': 'Jane Doe',

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './connect.js';
 
 const {
     normalizeName,
     canonicalizeLinkedInProfileUrl,
+    canonicalizeLinkedInInviteUrl,
     unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,
@@ -28,6 +29,18 @@ describe('linkedin connect helpers', () => {
         expect(normalizeName('Jane Doe • 2nd degree connection')).toBe('jane doe');
         expect(canonicalizeLinkedInProfileUrl('https://www.linkedin.com/in/jane/?mini=true#x'))
             .toBe('https://www.linkedin.com/in/jane/');
+        expect(canonicalizeLinkedInProfileUrl('https://ca.linkedin.com/in/jane/?mini=true#x'))
+            .toBe('https://www.linkedin.com/in/jane/');
+        expect(canonicalizeLinkedInProfileUrl('https://www.linkedin.com/company/opencli/')).toBe('');
+        expect(canonicalizeLinkedInProfileUrl('https://evil-linkedin.com/in/jane/')).toBe('');
+        expect(canonicalizeLinkedInProfileUrl('http://www.linkedin.com/in/jane/')).toBe('');
+    });
+
+    it('only accepts LinkedIn invitation route hrefs for sending', () => {
+        expect(canonicalizeLinkedInInviteUrl('/preload/custom-invite/?vanityName=jane'))
+            .toBe('https://www.linkedin.com/preload/custom-invite/?vanityName=jane');
+        expect(canonicalizeLinkedInInviteUrl('https://www.linkedin.com/feed/')).toBe('');
+        expect(canonicalizeLinkedInInviteUrl('https://evil-linkedin.com/preload/custom-invite/?vanityName=jane')).toBe('');
     });
 
     it('unwraps browser bridge evaluate envelopes', () => {
@@ -42,17 +55,17 @@ describe('linkedin connect helpers', () => {
     });
 
     it('fails closed on wrong profile name, pending state, or missing connect button', () => {
-        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true }, 'Janet Doe', 'https://www.linkedin.com/in/jane/').reason)
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true }, 'Janet Doe', 'https://www.linkedin.com/in/jane/').blockReason)
             .toBe('profile_name_mismatch');
-        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', pending: true, connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/').reason)
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', pending: true, connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/').blockReason)
             .toBe('connection_pending');
-        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/' }, 'Jane Doe', 'https://www.linkedin.com/in/jane/').reason)
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/' }, 'Jane Doe', 'https://www.linkedin.com/in/jane/').blockReason)
             .toBe('connect_button_not_found');
     });
 
     it('passes only when profile url, name, and connect affordance all match', () => {
         const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/?mini=true', connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
-        expect(result).toMatchObject({ ok: true, reason: 'verified', actual: 'Jane Doe' });
+        expect(result).toMatchObject({ ok: true, blockReason: 'verified', actualValue: 'Jane Doe' });
     });
 });
 
@@ -81,6 +94,29 @@ describe('linkedin connect command', () => {
             send: true,
         })).rejects.toBeInstanceOf(CommandExecutionError);
         expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects non-profile URLs before navigating', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeFakePage({});
+
+        await expect(command.func(page, {
+            'profile-url': 'https://www.linkedin.com/company/opencli/',
+            'expected-name': 'Jane Doe',
+            send: true,
+        })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('blocks send when the connect link is not LinkedIn invitation route', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: 'https://www.linkedin.com/feed/', buttonLabels: ['Connect'] });
+
+        await expect(command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            send: true,
+        })).rejects.toThrow('invalid_connect_link');
     });
 
     it('sends only when --send is true after verification', async () => {

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -92,6 +92,9 @@ function parseConversations(normalized, mailboxUrn) {
   for (const conv of included) {
     if (!conv || conv.$type !== 'com.linkedin.messenger.Conversation') continue;
     const threadId = String(conv.backendUrn || '').replace(/^urn:li:messagingThread:/, '');
+    if (!threadId) {
+      throw new CommandExecutionError('LinkedIn messaging API returned a conversation without thread id');
+    }
 
     const others = [];
     let counterpartyKind = '';

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -1,312 +1,125 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
-function normalizeWhitespace(value) {
-  return String(value ?? '').replace(/\s+/g, ' ').trim();
-}
+const LINKEDIN_DOMAIN = 'linkedin.com';
+const MESSAGING_URL = 'https://www.linkedin.com/messaging/';
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 40;
+
+// ── Why this command reads an API response instead of scraping the DOM ──
+//
+// LinkedIn's messaging UI is a realtime, virtualized SPA. Scraping the rendered
+// conversation list is brittle: rows lazy-render, the list virtualizes, and the
+// markup churns. Instead we let the page load /messaging/ exactly as a human
+// would, which makes the page fire its own `messengerConversations` GraphQL
+// call. We then re-issue that same request (URL lifted from the Performance API,
+// so the rotating queryId is always current) and parse LinkedIn's normalized
+// JSON. Same session, same origin, same request the page already makes.
 
 function unwrapEvaluateResult(payload) {
   if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
   return payload;
 }
 
-function normalizeUrl(url) {
-  const raw = normalizeWhitespace(url);
-  if (!raw) return '';
+function threadUrl(threadId) {
+  return threadId ? `https://www.linkedin.com/messaging/thread/${threadId}/` : '';
+}
+
+// Runs in-page: locate the messengerConversations request the page already fired.
+// Prefers the category-scoped query (the primary inbox) over the sync-token query.
+function findMessagingApiUrl() {
+  if (/\/(login|checkpoint|authwall|uas)/i.test(location.pathname)) return { loginRequired: true };
+  const urls = performance.getEntriesByType('resource').map((e) => e.name);
+  const matches = (re) => urls.find((u) => /messengerConversations\.[a-f0-9]+/i.test(u) && re.test(u));
+  const url =
+    matches(/PRIMARY_INBOX/i) ||
+    matches(/conversationCategoryPredicate/i) ||
+    urls.find((u) => /messengerConversations\.[a-f0-9]+/i.test(u) && /mailboxUrn/i.test(u));
+  if (!url) return { url: null };
+  const mb = url.match(/mailboxUrn:(urn[^,)&]+)/i);
+  return { url, mailboxUrn: mb ? decodeURIComponent(mb[1]) : '' };
+}
+
+// Runs in-page: re-issue the messaging request with the session's csrf token.
+async function fetchMessagingApi(url, csrf) {
   try {
-    const parsed = new URL(raw, 'https://www.linkedin.com');
-    parsed.hash = '';
-    // LinkedIn often appends tracking/search params; keep the canonical thread URL stable.
-    if (parsed.pathname.includes('/messaging/thread/')) {
-      return `https://www.linkedin.com${parsed.pathname}`;
+    const res = await fetch(url, {
+      credentials: 'include',
+      headers: {
+        'csrf-token': csrf,
+        accept: 'application/vnd.linkedin.normalized+json+2.1',
+        'x-restli-protocol-version': '2.0.0',
+      },
+    });
+    if (res.status === 401 || res.status === 403) return { authRequired: true, error: 'HTTP ' + res.status };
+    if (!res.ok) return { error: 'HTTP ' + res.status };
+    return { json: await res.json() };
+  } catch (e) {
+    return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+  }
+}
+
+// Parse LinkedIn's normalized messaging JSON into plain conversation rows.
+// `included` is a flat entity array; conversations reference participants and
+// messages by URN, which we resolve through a urn->entity index. Exported for
+// unit testing against a captured fixture.
+function parseConversations(normalized, mailboxUrn) {
+  const included = Array.isArray(normalized && normalized.included) ? normalized.included : [];
+  const byUrn = new Map();
+  for (const o of included) {
+    if (o && o.entityUrn) byUrn.set(o.entityUrn, o);
+  }
+  const norm = (s) => String(s == null ? '' : s).replace(/\s+/g, ' ').trim();
+
+  const participantInfo = (p) => {
+    if (!p) return { name: '', kind: '' };
+    const pt = p.participantType || {};
+    if (pt.organization && pt.organization.name) return { name: norm(pt.organization.name.text), kind: 'organization' };
+    if (pt.member) {
+      const fn = pt.member.firstName && pt.member.firstName.text;
+      const ln = pt.member.lastName && pt.member.lastName.text;
+      return { name: norm([fn, ln].filter(Boolean).join(' ')), kind: 'member' };
     }
-    return parsed.toString();
-  } catch {
-    return raw;
-  }
-}
-
-function extractThreadId(url) {
-  const raw = normalizeWhitespace(url);
-  const match = raw.match(/\/messaging\/thread\/([^/?#]+)/i) || raw.match(/urn:li:fsd_conversation:([^\s"')]+)/i);
-  return match ? decodeURIComponent(match[1]) : '';
-}
-
-function looksLikeChromeOrNav(text) {
-  return /^(messaging|focused|other|inmail|sponsored|compose|search messages|new message|settings|message requests)$/i.test(normalizeWhitespace(text));
-}
-
-function compactPreview(value, personName = '') {
-  let text = normalizeWhitespace(value)
-    .replace(/^(unread|未读)\s+/i, '')
-    .replace(/\s+(mark as read|标记为已读)$/i, '')
-    .replace(/\s+sent from linkedin for (iphone|android).*$/i, '')
-    .trim();
-  if (personName) {
-    const escaped = personName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    text = text.replace(new RegExp(`^${escaped}\\s+`, 'i'), '').trim();
-  }
-  return text.slice(0, 500);
-}
-
-function inferTimestamp(text) {
-  const clean = normalizeWhitespace(text);
-  const patterns = [
-    /\b(?:now|just now)\b/i,
-    /\b\d+\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|wk|wks|week|weeks|mo|month|months|y|yr|yrs|year|years)\b/i,
-    /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{1,2}\b/i,
-    /\b\d{1,2}:\d{2}\s*(?:am|pm)?\b/i,
-  ];
-  for (const pattern of patterns) {
-    const match = clean.match(pattern);
-    if (match) return match[0];
-  }
-  return '';
-}
-
-function inferUnread(root) {
-  const blob = `${root.className || ''} ${root.getAttribute?.('aria-label') || ''} ${root.getAttribute?.('data-view-name') || ''} ${root.textContent || ''}`;
-  if (/\bunread\b|未读/i.test(blob)) return true;
-  const unreadEl = root.querySelector?.('[aria-label*="Unread" i], [class*="unread" i], [data-test-icon="unread"]');
-  if (unreadEl) return true;
-  const boldish = Array.from(root.querySelectorAll?.('*') || []).some((el) => {
-    const style = globalThis.getComputedStyle ? globalThis.getComputedStyle(el) : null;
-    const weight = Number(style?.fontWeight || 0);
-    return weight >= 600 && /\S/.test(el.textContent || '');
-  });
-  return Boolean(boldish && /\b(message|sent|you:|you sent|replied|accepted|connected)\b/i.test(blob));
-}
-
-function personFromRoot(root) {
-  const selectors = [
-    '.msg-conversation-card__participant-names',
-    '.msg-conversation-listitem__participant-names',
-    '[data-anonymize="person-name"]',
-    'span[dir="ltr"]',
-    'h3',
-    'a[href*="/in/"]',
-  ];
-  for (const selector of selectors) {
-    const value = normalizeWhitespace(root.querySelector?.(selector)?.textContent || '');
-    if (value && !looksLikeChromeOrNav(value) && !/^(you|sponsored)$/i.test(value)) return value;
-  }
-  const lines = normalizeWhitespace(root.innerText || root.textContent || '').split(/\s{2,}|\n/).map(normalizeWhitespace).filter(Boolean);
-  return lines.find((line) => !looksLikeChromeOrNav(line) && !inferTimestamp(line) && line.length <= 80) || '';
-}
-
-function extractConversationFromRoot(root, currentUrl = '') {
-  const link = root.querySelector?.('a[href*="/messaging/thread/"], a[href*="/messaging/compose"], a[href*="/in/"]');
-  let threadUrl = normalizeUrl(link?.href || link?.getAttribute?.('href') || '');
-  const currentThread = /\/messaging\/thread\//i.test(currentUrl || '') ? normalizeUrl(currentUrl) : '';
-  // LinkedIn sometimes omits a row-level thread anchor for the active conversation.
-  if (!threadUrl && /active conversation/i.test(root.getAttribute?.('aria-label') || root.textContent || '') && currentThread) {
-    threadUrl = currentThread;
-  }
-  if (!/\/messaging\/thread\//i.test(threadUrl) && currentThread && root.matches?.('[aria-current="true"], .active, [class*="active"]')) {
-    threadUrl = currentThread;
-  }
-  const text = normalizeWhitespace(root.innerText || root.textContent || '');
-  const person = personFromRoot(root);
-  const timestamp = normalizeWhitespace(root.querySelector?.('time')?.textContent || root.querySelector?.('.msg-conversation-card__time-stamp, .msg-conversation-listitem__time-stamp')?.textContent || inferTimestamp(text));
-  let preview = normalizeWhitespace(root.querySelector?.('.msg-conversation-card__message-snippet, .msg-conversation-listitem__message-snippet, [class*="message-snippet"]')?.textContent || '');
-  if (!preview) preview = compactPreview(text, person);
-  const threadId = extractThreadId(threadUrl);
-  const unread = inferUnread(root);
-  if (!threadUrl && !person && !preview) return null;
-  if (!threadUrl && preview.length < 2) return null;
-  return {
-    thread_url: threadUrl,
-    thread_id: threadId,
-    person_name: person,
-    last_message_preview: preview,
-    unread,
-    timestamp,
+    if (pt.agent && pt.agent.name) return { name: norm(pt.agent.name.text), kind: 'agent' };
+    return { name: '', kind: '' };
   };
-}
 
-function extractInboxConversationsFromDocument(doc = globalThis.document, currentUrl = globalThis.location?.href || '') {
-  const loginRequired = /\/login|\/checkpoint/i.test(String(currentUrl || ''))
-    || Boolean(doc.querySelector('input[name="session_key"], form.login__form'));
-  const selectors = [
-    '.msg-conversation-listitem',
-    '.msg-conversation-card',
-    'li[id*="conversation" i]',
-    '[data-view-name*="conversation" i]',
-    '[role="listitem"]',
-  ];
-  const roots = [];
-  const seen = new Set();
-  for (const selector of selectors) {
-    for (const el of Array.from(doc.querySelectorAll(selector))) {
-      const text = normalizeWhitespace(el.innerText || el.textContent || '');
-      const hasThread = Boolean(el.querySelector('a[href*="/messaging/thread/"]')) || /\/messaging\/thread\//i.test(text);
-      const looksConversation = hasThread || /\b(unread|you:|sent|accepted|message|active conversation)\b/i.test(`${el.className || ''} ${el.getAttribute('aria-label') || ''} ${text}`);
-      if (!looksConversation) continue;
-      if (text.length < 2) continue;
-      if (seen.has(el)) continue;
-      seen.add(el);
-      roots.push(el);
-    }
-  }
-  const conversations = [];
-  const dedupe = new Set();
-  for (const root of roots) {
-    const conv = extractConversationFromRoot(root, currentUrl);
-    if (!conv) continue;
-    const key = conv.thread_url || `${conv.person_name}::${conv.last_message_preview.slice(0, 80)}`;
-    if (dedupe.has(key)) continue;
-    dedupe.add(key);
-    conversations.push(conv);
-  }
-  return { loginRequired, conversations };
-}
+  const rows = [];
+  for (const conv of included) {
+    if (!conv || conv.$type !== 'com.linkedin.messenger.Conversation') continue;
+    const threadId = String(conv.backendUrn || '').replace(/^urn:li:messagingThread:/, '');
 
-function mergeConversations(existing, batch) {
-  const byKey = new Map();
-  for (const conv of existing) {
-    const key = conv.thread_url || conv.thread_id || `${conv.person_name}::${conv.last_message_preview.slice(0, 80)}`;
-    byKey.set(key, conv);
-  }
-  for (const conv of batch) {
-    const normalized = {
-      thread_url: normalizeWhitespace(conv.thread_url),
-      thread_id: normalizeWhitespace(conv.thread_id || extractThreadId(conv.thread_url)),
-      person_name: normalizeWhitespace(conv.person_name),
-      last_message_preview: normalizeWhitespace(conv.last_message_preview),
-      unread: Boolean(conv.unread),
-      timestamp: normalizeWhitespace(conv.timestamp),
-    };
-    const key = normalized.thread_url || normalized.thread_id || `${normalized.person_name}::${normalized.last_message_preview.slice(0, 80)}`;
-    if (!key.trim()) continue;
-    const prior = byKey.get(key);
-    byKey.set(key, prior ? { ...prior, ...normalized, unread: prior.unread || normalized.unread } : normalized);
-  }
-  return Array.from(byKey.values());
-}
+    const others = [];
+    let counterpartyKind = '';
+    for (const urn of conv['*conversationParticipants'] || []) {
+      const p = byUrn.get(urn);
+      if (!p) continue;
+      if (mailboxUrn && p.hostIdentityUrn === mailboxUrn) continue; // exclude the inbox owner
+      const info = participantInfo(p);
+      if (info.name) {
+        others.push(info.name);
+        if (!counterpartyKind) counterpartyKind = info.kind;
+      }
+    }
 
-async function extractVisibleInbox(page) {
-  return unwrapEvaluateResult(await page.evaluate(`(() => {
-    const normalizeWhitespace = ${normalizeWhitespace.toString()};
-    const normalizeUrl = ${normalizeUrl.toString()};
-    const extractThreadId = ${extractThreadId.toString()};
-    const looksLikeChromeOrNav = ${looksLikeChromeOrNav.toString()};
-    const compactPreview = ${compactPreview.toString()};
-    const inferTimestamp = ${inferTimestamp.toString()};
-    const inferUnread = ${inferUnread.toString()};
-    const personFromRoot = ${personFromRoot.toString()};
-    const extractConversationFromRoot = ${extractConversationFromRoot.toString()};
-    const extractInboxConversationsFromDocument = ${extractInboxConversationsFromDocument.toString()};
-    const result = extractInboxConversationsFromDocument(document, location.href);
-    if (result.conversations.length < 2) {
-      const manual = Array.from(document.querySelectorAll('.msg-conversation-listitem, .msg-conversation-card')).map((root) => extractConversationFromRoot(root, location.href)).filter(Boolean);
-      result.conversations = (${mergeConversations.toString()})(result.conversations, manual);
-    }
-    return result;
-  })()`));
-}
+    const msgUrns = (conv.messages && conv.messages['*elements']) || [];
+    const lastMsg = byUrn.get(msgUrns[0]);
+    let preview = lastMsg && lastMsg.body ? norm(lastMsg.body.text) : '';
+    if (!preview) preview = norm(conv.descriptionText || '');
 
-async function scrollInboxList(page) {
-  return unwrapEvaluateResult(await page.evaluate(`(() => {
-    function scrollableScore(el) {
-      if (!el) return 0;
-      return Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
-    }
-    const candidates = Array.from(document.querySelectorAll('main aside, aside, .msg-conversations-container__conversations-list, .msg-conversations-container, [role="main"], div'))
-      .filter(el => scrollableScore(el) > 40)
-      .sort((a, b) => scrollableScore(b) - scrollableScore(a));
-    const target = candidates.find(el => /conversation|message|messaging/i.test(el.className || el.getAttribute('aria-label') || el.innerText || '')) || candidates[0] || document.scrollingElement || document.documentElement;
-    const before = target.scrollTop || window.scrollY || 0;
-    if (target === document.scrollingElement || target === document.documentElement || target === document.body) {
-      window.scrollBy(0, Math.max(500, window.innerHeight * 0.85));
-      return { before, after: window.scrollY || document.documentElement.scrollTop || 0, target: 'window' };
-    }
-    target.scrollTop = Math.min(target.scrollHeight, (target.scrollTop || 0) + Math.max(400, target.clientHeight * 0.85));
-    return { before, after: target.scrollTop || 0, target: target.className || target.getAttribute('aria-label') || target.tagName };
-  })()`));
-}
-
-async function clickLoadMoreOrNext(page) {
-  return unwrapEvaluateResult(await page.evaluate(`(() => {
-    const candidates = Array.from(document.querySelectorAll('button, a[role="button"], a[href]'));
-    const el = candidates.find((node) => {
-      const text = String(node.innerText || node.textContent || node.getAttribute('aria-label') || '').replace(/\\s+/g, ' ').trim();
-      return /^(show more|load more|see more|next)$/i.test(text) || /load more conversations|next page|show more conversations/i.test(text);
-    });
-    if (!el) return false;
-    el.click();
-    return true;
-  })()`));
-}
-
-async function hydrateVisibleThreadUrls(page, conversations) {
-  const hydrated = [];
-  for (const conv of conversations) {
-    if (conv.thread_url || !conv.person_name) {
-      hydrated.push(conv);
-      continue;
-    }
-    const targetName = conv.person_name;
-    const clicked = unwrapEvaluateResult(await page.evaluate(`((targetName) => {
-      const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim();
-      const rows = Array.from(document.querySelectorAll('.msg-conversation-listitem, .msg-conversation-card'));
-      const row = rows.find((el) => norm(el.querySelector('.msg-conversation-card__participant-names, .msg-conversation-listitem__participant-names, [data-anonymize="person-name"], span[dir="ltr"], h3')?.textContent) === targetName)
-        || rows.find((el) => norm(el.innerText || el.textContent).includes(targetName));
-      const clickable = row?.querySelector('.msg-conversation-listitem__link, [tabindex="0"], a, button') || row;
-      if (!clickable) return false;
-      clickable.click();
-      return true;
-    })(${JSON.stringify(targetName)})`));
-    if (!clicked) {
-      hydrated.push(conv);
-      continue;
-    }
-    await page.wait(2);
-    const url = unwrapEvaluateResult(await page.evaluate(`location.href`));
-    const threadUrl = /\/messaging\/thread\//i.test(String(url || '')) ? normalizeUrl(url) : '';
-    hydrated.push({
-      ...conv,
-      thread_url: conv.thread_url || threadUrl,
-      thread_id: conv.thread_id || extractThreadId(threadUrl),
+    rows.push({
+      thread_id: threadId,
+      person_name: conv.title ? norm(conv.title) : others.join(', '),
+      last_message_preview: preview.slice(0, 300),
+      unread: Number(conv.unreadCount || 0) > 0 || conv.read === false,
+      counterparty_type: counterpartyKind,
+      category: Array.isArray(conv.categories) ? conv.categories.join(',') : '',
+      timestamp_ms: Number(conv.lastActivityAt || 0),
     });
   }
-  return hydrated;
-}
-
-async function clickUnreadFilter(page) {
-  return unwrapEvaluateResult(await page.evaluate(`(() => {
-    const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="tab"]'));
-    const el = candidates.find((node) => String(node.innerText || node.textContent || node.getAttribute('aria-label') || '').replace(/\\s+/g, ' ').trim().toLowerCase() === 'unread');
-    if (!el) return false;
-    el.click();
-    return true;
-  })()`));
-}
-
-async function collectInboxView(page, url, limit, maxScrolls, options = {}) {
-  await page.goto(url);
-  await page.wait(5);
-  let filterApplied = false;
-  if (options.unreadFilter) {
-    filterApplied = Boolean(await clickUnreadFilter(page));
-    await page.wait(3);
-  }
-  let conversations = [];
-  let sawLoginWall = false;
-  let stablePasses = 0;
-  for (let i = 0; i < maxScrolls && conversations.length < limit; i += 1) {
-    const batch = await extractVisibleInbox(page);
-    if (batch?.loginRequired) sawLoginWall = true;
-    const before = conversations.length;
-    conversations = mergeConversations(conversations, Array.isArray(batch?.conversations) ? batch.conversations : []);
-    if (conversations.length === before) stablePasses += 1;
-    else stablePasses = 0;
-    if (conversations.length >= limit) break;
-    const clicked = await clickLoadMoreOrNext(page);
-    const scroll = await scrollInboxList(page);
-    await page.wait(clicked ? 2 : 1);
-    if (stablePasses >= 4 && scroll?.before === scroll?.after && !clicked) break;
-  }
-  return { sawLoginWall, conversations, filterApplied };
+  rows.sort((a, b) => b.timestamp_ms - a.timestamp_ms);
+  return rows;
 }
 
 cli({
@@ -318,45 +131,86 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'limit', type: 'int', default: 40, help: 'Maximum conversations to return (max 200)' },
-    { name: 'max-scrolls', type: 'int', default: 18, help: 'Maximum inbox scroll/pagination passes' },
-    { name: 'unread-only', type: 'bool', default: false, help: 'Return only conversations detected as unread' },
+    { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: 'Maximum conversations to return (1-100)' },
+    { name: 'unread-only', type: 'bool', default: false, help: 'Return only conversations with unread messages' },
   ],
-  columns: ['rank', 'thread_url', 'thread_id', 'person_name', 'last_message_preview', 'unread', 'timestamp'],
+  columns: [
+    'rank',
+    'thread_url',
+    'thread_id',
+    'person_name',
+    'last_message_preview',
+    'unread',
+    'counterparty_type',
+    'category',
+    'timestamp',
+  ],
   func: async (page, kwargs) => {
-    const limit = Math.max(1, Math.min(kwargs.limit ?? 40, 200));
-    const maxScrolls = Math.max(1, Math.min(kwargs['max-scrolls'] ?? 18, 80));
+    const limit = Math.max(MIN_LIMIT, Math.min(Number(kwargs.limit) || DEFAULT_LIMIT, MAX_LIMIT));
     const unreadOnly = Boolean(kwargs['unread-only']);
-    const allView = await collectInboxView(page, 'https://www.linkedin.com/messaging/', limit, maxScrolls);
-    // LinkedIn's normal inbox can hide unread rows; also sample the unread-filtered view and merge.
-    const unreadView = await collectInboxView(page, 'https://www.linkedin.com/messaging/', limit, Math.max(6, Math.ceil(maxScrolls / 2)), { unreadFilter: true });
-    if ((allView.sawLoginWall || unreadView.sawLoginWall) && allView.conversations.length === 0 && unreadView.conversations.length === 0) {
-      throw new AuthRequiredError('linkedin.com', 'LinkedIn inbox requires an active signed-in browser session');
+
+    await page.goto(MESSAGING_URL);
+    await page.wait(10);
+
+    // Locate the messaging API request the page fired on load; retry once if the
+    // SPA was slow to issue it.
+    let located = unwrapEvaluateResult(await page.evaluate(`(${findMessagingApiUrl.toString()})()`));
+    if (located && located.loginRequired) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn requires an active signed-in browser session.');
     }
-    let conversations = mergeConversations(
-      allView.conversations,
-      unreadView.conversations.map((conv) => ({ ...conv, unread: unreadView.filterApplied ? true : conv.unread }))
+    if (!located || !located.url) {
+      await page.wait(6);
+      located = unwrapEvaluateResult(await page.evaluate(`(${findMessagingApiUrl.toString()})()`));
+    }
+    if (!located || !located.url) {
+      throw new CommandExecutionError(
+        'LinkedIn did not issue a messaging API request; the inbox may have failed to load.',
+      );
+    }
+
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+    }
+    const csrf = jsession.replace(/^"|"$/g, '');
+
+    // Widen the page size to the requested limit where the query supports it.
+    const targetUrl = located.url.replace(/count:\d+/, 'count:' + limit);
+    const fetched = unwrapEvaluateResult(
+      await page.evaluate(`(${fetchMessagingApi.toString()})(${JSON.stringify(targetUrl)}, ${JSON.stringify(csrf)})`),
     );
-    if (unreadOnly) conversations = conversations.filter((conv) => conv.unread);
-    if (!unreadOnly && conversations.some((conv) => !conv.thread_url && conv.person_name)) {
-      await page.goto('https://www.linkedin.com/messaging/');
-      await page.wait(3);
-      conversations = await hydrateVisibleThreadUrls(page, conversations);
+    if (fetched && fetched.authRequired) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn messaging API authentication failed: ' + fetched.error);
     }
+    if (!fetched || fetched.error || !fetched.json) {
+      throw new CommandExecutionError(
+        'LinkedIn messaging API returned an unexpected response: ' + ((fetched && fetched.error) || 'no data'),
+      );
+    }
+
+    let conversations = parseConversations(fetched.json, located.mailboxUrn || '');
+    if (unreadOnly) conversations = conversations.filter((c) => c.unread);
     if (conversations.length === 0) {
-      throw new EmptyResultError('linkedin inbox', 'No LinkedIn conversations were visible after scrolling/pagination.');
+      if (unreadOnly) return [];
+      throw new EmptyResultError('linkedin inbox', 'No LinkedIn conversations were found in the inbox.');
     }
-    return conversations.slice(0, limit).map((conv, index) => ({ rank: index + 1, ...conv }));
+
+    return conversations.slice(0, limit).map((c, index) => ({
+      rank: index + 1,
+      thread_url: threadUrl(c.thread_id),
+      thread_id: c.thread_id,
+      person_name: c.person_name,
+      last_message_preview: c.last_message_preview,
+      unread: c.unread,
+      counterparty_type: c.counterparty_type,
+      category: c.category,
+      timestamp: c.timestamp_ms ? new Date(c.timestamp_ms).toISOString() : '',
+    }));
   },
 });
 
 export const __test__ = {
-  normalizeWhitespace,
-  normalizeUrl,
-  extractThreadId,
-  inferTimestamp,
-  inferUnread,
-  extractConversationFromRoot,
-  extractInboxConversationsFromDocument,
-  mergeConversations,
+  parseConversations,
+  threadUrl,
 };

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 const LINKEDIN_DOMAIN = 'linkedin.com';
 const MESSAGING_URL = 'https://www.linkedin.com/messaging/';
@@ -151,7 +151,14 @@ cli({
     'timestamp',
   ],
   func: async (page, kwargs) => {
-    const limit = Math.max(MIN_LIMIT, Math.min(Number(kwargs.limit) || DEFAULT_LIMIT, MAX_LIMIT));
+    // Validate --limit explicitly rather than silently clamping an out-of-range value.
+    let limit = DEFAULT_LIMIT;
+    if (kwargs.limit !== undefined && kwargs.limit !== null && kwargs.limit !== '') {
+      limit = Number(kwargs.limit);
+      if (!Number.isInteger(limit) || limit < MIN_LIMIT || limit > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}`);
+      }
+    }
     const unreadOnly = Boolean(kwargs['unread-only']);
 
     await page.goto(MESSAGING_URL);

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -85,7 +85,7 @@ function parseConversations(normalized, mailboxUrn) {
     return { name: '', kind: '' };
   };
 
-  const rows = [];
+  const entries = [];
   for (const conv of included) {
     if (!conv || conv.$type !== 'com.linkedin.messenger.Conversation') continue;
     const threadId = String(conv.backendUrn || '').replace(/^urn:li:messagingThread:/, '');
@@ -108,18 +108,23 @@ function parseConversations(normalized, mailboxUrn) {
     let preview = lastMsg && lastMsg.body ? norm(lastMsg.body.text) : '';
     if (!preview) preview = norm(conv.descriptionText || '');
 
-    rows.push({
-      thread_id: threadId,
-      person_name: conv.title ? norm(conv.title) : others.join(', '),
-      last_message_preview: preview.slice(0, 300),
-      unread: Number(conv.unreadCount || 0) > 0 || conv.read === false,
-      counterparty_type: counterpartyKind,
-      category: Array.isArray(conv.categories) ? conv.categories.join(',') : '',
-      timestamp_ms: Number(conv.lastActivityAt || 0),
+    const activityMs = Number(conv.lastActivityAt || 0);
+    entries.push({
+      activityMs,
+      row: {
+        thread_id: threadId,
+        person_name: conv.title ? norm(conv.title) : others.join(', '),
+        last_message_preview: preview.slice(0, 300),
+        unread: Number(conv.unreadCount || 0) > 0 || conv.read === false,
+        counterparty_type: counterpartyKind,
+        category: Array.isArray(conv.categories) ? conv.categories.join(',') : '',
+        timestamp: activityMs ? new Date(activityMs).toISOString() : '',
+      },
     });
   }
-  rows.sort((a, b) => b.timestamp_ms - a.timestamp_ms);
-  return rows;
+  // Most-recent first; the sort key is kept off the returned row.
+  entries.sort((a, b) => b.activityMs - a.activityMs);
+  return entries.map((entry) => entry.row);
 }
 
 cli({
@@ -205,7 +210,7 @@ cli({
       unread: c.unread,
       counterparty_type: c.counterparty_type,
       category: c.category,
-      timestamp: c.timestamp_ms ? new Date(c.timestamp_ms).toISOString() : '',
+      timestamp: c.timestamp,
     }));
   },
 });

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -65,7 +65,10 @@ async function fetchMessagingApi(url, csrf) {
 // messages by URN, which we resolve through a urn->entity index. Exported for
 // unit testing against a captured fixture.
 function parseConversations(normalized, mailboxUrn) {
-  const included = Array.isArray(normalized && normalized.included) ? normalized.included : [];
+  if (!normalized || typeof normalized !== 'object' || Array.isArray(normalized) || !Array.isArray(normalized.included)) {
+    throw new CommandExecutionError('LinkedIn messaging API returned malformed normalized payload: missing included array');
+  }
+  const included = normalized.included;
   const byUrn = new Map();
   for (const o of included) {
     if (o && o.entityUrn) byUrn.set(o.entityUrn, o);

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -1,0 +1,362 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function normalizeUrl(url) {
+  const raw = normalizeWhitespace(url);
+  if (!raw) return '';
+  try {
+    const parsed = new URL(raw, 'https://www.linkedin.com');
+    parsed.hash = '';
+    // LinkedIn often appends tracking/search params; keep the canonical thread URL stable.
+    if (parsed.pathname.includes('/messaging/thread/')) {
+      return `https://www.linkedin.com${parsed.pathname}`;
+    }
+    return parsed.toString();
+  } catch {
+    return raw;
+  }
+}
+
+function extractThreadId(url) {
+  const raw = normalizeWhitespace(url);
+  const match = raw.match(/\/messaging\/thread\/([^/?#]+)/i) || raw.match(/urn:li:fsd_conversation:([^\s"')]+)/i);
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+function looksLikeChromeOrNav(text) {
+  return /^(messaging|focused|other|inmail|sponsored|compose|search messages|new message|settings|message requests)$/i.test(normalizeWhitespace(text));
+}
+
+function compactPreview(value, personName = '') {
+  let text = normalizeWhitespace(value)
+    .replace(/^(unread|未读)\s+/i, '')
+    .replace(/\s+(mark as read|标记为已读)$/i, '')
+    .replace(/\s+sent from linkedin for (iphone|android).*$/i, '')
+    .trim();
+  if (personName) {
+    const escaped = personName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    text = text.replace(new RegExp(`^${escaped}\\s+`, 'i'), '').trim();
+  }
+  return text.slice(0, 500);
+}
+
+function inferTimestamp(text) {
+  const clean = normalizeWhitespace(text);
+  const patterns = [
+    /\b(?:now|just now)\b/i,
+    /\b\d+\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|wk|wks|week|weeks|mo|month|months|y|yr|yrs|year|years)\b/i,
+    /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{1,2}\b/i,
+    /\b\d{1,2}:\d{2}\s*(?:am|pm)?\b/i,
+  ];
+  for (const pattern of patterns) {
+    const match = clean.match(pattern);
+    if (match) return match[0];
+  }
+  return '';
+}
+
+function inferUnread(root) {
+  const blob = `${root.className || ''} ${root.getAttribute?.('aria-label') || ''} ${root.getAttribute?.('data-view-name') || ''} ${root.textContent || ''}`;
+  if (/\bunread\b|未读/i.test(blob)) return true;
+  const unreadEl = root.querySelector?.('[aria-label*="Unread" i], [class*="unread" i], [data-test-icon="unread"]');
+  if (unreadEl) return true;
+  const boldish = Array.from(root.querySelectorAll?.('*') || []).some((el) => {
+    const style = globalThis.getComputedStyle ? globalThis.getComputedStyle(el) : null;
+    const weight = Number(style?.fontWeight || 0);
+    return weight >= 600 && /\S/.test(el.textContent || '');
+  });
+  return Boolean(boldish && /\b(message|sent|you:|you sent|replied|accepted|connected)\b/i.test(blob));
+}
+
+function personFromRoot(root) {
+  const selectors = [
+    '.msg-conversation-card__participant-names',
+    '.msg-conversation-listitem__participant-names',
+    '[data-anonymize="person-name"]',
+    'span[dir="ltr"]',
+    'h3',
+    'a[href*="/in/"]',
+  ];
+  for (const selector of selectors) {
+    const value = normalizeWhitespace(root.querySelector?.(selector)?.textContent || '');
+    if (value && !looksLikeChromeOrNav(value) && !/^(you|sponsored)$/i.test(value)) return value;
+  }
+  const lines = normalizeWhitespace(root.innerText || root.textContent || '').split(/\s{2,}|\n/).map(normalizeWhitespace).filter(Boolean);
+  return lines.find((line) => !looksLikeChromeOrNav(line) && !inferTimestamp(line) && line.length <= 80) || '';
+}
+
+function extractConversationFromRoot(root, currentUrl = '') {
+  const link = root.querySelector?.('a[href*="/messaging/thread/"], a[href*="/messaging/compose"], a[href*="/in/"]');
+  let threadUrl = normalizeUrl(link?.href || link?.getAttribute?.('href') || '');
+  const currentThread = /\/messaging\/thread\//i.test(currentUrl || '') ? normalizeUrl(currentUrl) : '';
+  // LinkedIn sometimes omits a row-level thread anchor for the active conversation.
+  if (!threadUrl && /active conversation/i.test(root.getAttribute?.('aria-label') || root.textContent || '') && currentThread) {
+    threadUrl = currentThread;
+  }
+  if (!/\/messaging\/thread\//i.test(threadUrl) && currentThread && root.matches?.('[aria-current="true"], .active, [class*="active"]')) {
+    threadUrl = currentThread;
+  }
+  const text = normalizeWhitespace(root.innerText || root.textContent || '');
+  const person = personFromRoot(root);
+  const timestamp = normalizeWhitespace(root.querySelector?.('time')?.textContent || root.querySelector?.('.msg-conversation-card__time-stamp, .msg-conversation-listitem__time-stamp')?.textContent || inferTimestamp(text));
+  let preview = normalizeWhitespace(root.querySelector?.('.msg-conversation-card__message-snippet, .msg-conversation-listitem__message-snippet, [class*="message-snippet"]')?.textContent || '');
+  if (!preview) preview = compactPreview(text, person);
+  const threadId = extractThreadId(threadUrl);
+  const unread = inferUnread(root);
+  if (!threadUrl && !person && !preview) return null;
+  if (!threadUrl && preview.length < 2) return null;
+  return {
+    thread_url: threadUrl,
+    thread_id: threadId,
+    person_name: person,
+    last_message_preview: preview,
+    unread,
+    timestamp,
+  };
+}
+
+function extractInboxConversationsFromDocument(doc = globalThis.document, currentUrl = globalThis.location?.href || '') {
+  const loginRequired = /\/login|\/checkpoint/i.test(String(currentUrl || ''))
+    || Boolean(doc.querySelector('input[name="session_key"], form.login__form'));
+  const selectors = [
+    '.msg-conversation-listitem',
+    '.msg-conversation-card',
+    'li[id*="conversation" i]',
+    '[data-view-name*="conversation" i]',
+    '[role="listitem"]',
+  ];
+  const roots = [];
+  const seen = new Set();
+  for (const selector of selectors) {
+    for (const el of Array.from(doc.querySelectorAll(selector))) {
+      const text = normalizeWhitespace(el.innerText || el.textContent || '');
+      const hasThread = Boolean(el.querySelector('a[href*="/messaging/thread/"]')) || /\/messaging\/thread\//i.test(text);
+      const looksConversation = hasThread || /\b(unread|you:|sent|accepted|message|active conversation)\b/i.test(`${el.className || ''} ${el.getAttribute('aria-label') || ''} ${text}`);
+      if (!looksConversation) continue;
+      if (text.length < 2) continue;
+      if (seen.has(el)) continue;
+      seen.add(el);
+      roots.push(el);
+    }
+  }
+  const conversations = [];
+  const dedupe = new Set();
+  for (const root of roots) {
+    const conv = extractConversationFromRoot(root, currentUrl);
+    if (!conv) continue;
+    const key = conv.thread_url || `${conv.person_name}::${conv.last_message_preview.slice(0, 80)}`;
+    if (dedupe.has(key)) continue;
+    dedupe.add(key);
+    conversations.push(conv);
+  }
+  return { loginRequired, conversations };
+}
+
+function mergeConversations(existing, batch) {
+  const byKey = new Map();
+  for (const conv of existing) {
+    const key = conv.thread_url || conv.thread_id || `${conv.person_name}::${conv.last_message_preview.slice(0, 80)}`;
+    byKey.set(key, conv);
+  }
+  for (const conv of batch) {
+    const normalized = {
+      thread_url: normalizeWhitespace(conv.thread_url),
+      thread_id: normalizeWhitespace(conv.thread_id || extractThreadId(conv.thread_url)),
+      person_name: normalizeWhitespace(conv.person_name),
+      last_message_preview: normalizeWhitespace(conv.last_message_preview),
+      unread: Boolean(conv.unread),
+      timestamp: normalizeWhitespace(conv.timestamp),
+    };
+    const key = normalized.thread_url || normalized.thread_id || `${normalized.person_name}::${normalized.last_message_preview.slice(0, 80)}`;
+    if (!key.trim()) continue;
+    const prior = byKey.get(key);
+    byKey.set(key, prior ? { ...prior, ...normalized, unread: prior.unread || normalized.unread } : normalized);
+  }
+  return Array.from(byKey.values());
+}
+
+async function extractVisibleInbox(page) {
+  return unwrapEvaluateResult(await page.evaluate(`(() => {
+    const normalizeWhitespace = ${normalizeWhitespace.toString()};
+    const normalizeUrl = ${normalizeUrl.toString()};
+    const extractThreadId = ${extractThreadId.toString()};
+    const looksLikeChromeOrNav = ${looksLikeChromeOrNav.toString()};
+    const compactPreview = ${compactPreview.toString()};
+    const inferTimestamp = ${inferTimestamp.toString()};
+    const inferUnread = ${inferUnread.toString()};
+    const personFromRoot = ${personFromRoot.toString()};
+    const extractConversationFromRoot = ${extractConversationFromRoot.toString()};
+    const extractInboxConversationsFromDocument = ${extractInboxConversationsFromDocument.toString()};
+    const result = extractInboxConversationsFromDocument(document, location.href);
+    if (result.conversations.length < 2) {
+      const manual = Array.from(document.querySelectorAll('.msg-conversation-listitem, .msg-conversation-card')).map((root) => extractConversationFromRoot(root, location.href)).filter(Boolean);
+      result.conversations = (${mergeConversations.toString()})(result.conversations, manual);
+    }
+    return result;
+  })()`));
+}
+
+async function scrollInboxList(page) {
+  return unwrapEvaluateResult(await page.evaluate(`(() => {
+    function scrollableScore(el) {
+      if (!el) return 0;
+      return Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
+    }
+    const candidates = Array.from(document.querySelectorAll('main aside, aside, .msg-conversations-container__conversations-list, .msg-conversations-container, [role="main"], div'))
+      .filter(el => scrollableScore(el) > 40)
+      .sort((a, b) => scrollableScore(b) - scrollableScore(a));
+    const target = candidates.find(el => /conversation|message|messaging/i.test(el.className || el.getAttribute('aria-label') || el.innerText || '')) || candidates[0] || document.scrollingElement || document.documentElement;
+    const before = target.scrollTop || window.scrollY || 0;
+    if (target === document.scrollingElement || target === document.documentElement || target === document.body) {
+      window.scrollBy(0, Math.max(500, window.innerHeight * 0.85));
+      return { before, after: window.scrollY || document.documentElement.scrollTop || 0, target: 'window' };
+    }
+    target.scrollTop = Math.min(target.scrollHeight, (target.scrollTop || 0) + Math.max(400, target.clientHeight * 0.85));
+    return { before, after: target.scrollTop || 0, target: target.className || target.getAttribute('aria-label') || target.tagName };
+  })()`));
+}
+
+async function clickLoadMoreOrNext(page) {
+  return unwrapEvaluateResult(await page.evaluate(`(() => {
+    const candidates = Array.from(document.querySelectorAll('button, a[role="button"], a[href]'));
+    const el = candidates.find((node) => {
+      const text = String(node.innerText || node.textContent || node.getAttribute('aria-label') || '').replace(/\\s+/g, ' ').trim();
+      return /^(show more|load more|see more|next)$/i.test(text) || /load more conversations|next page|show more conversations/i.test(text);
+    });
+    if (!el) return false;
+    el.click();
+    return true;
+  })()`));
+}
+
+async function hydrateVisibleThreadUrls(page, conversations) {
+  const hydrated = [];
+  for (const conv of conversations) {
+    if (conv.thread_url || !conv.person_name) {
+      hydrated.push(conv);
+      continue;
+    }
+    const targetName = conv.person_name;
+    const clicked = unwrapEvaluateResult(await page.evaluate(`((targetName) => {
+      const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim();
+      const rows = Array.from(document.querySelectorAll('.msg-conversation-listitem, .msg-conversation-card'));
+      const row = rows.find((el) => norm(el.querySelector('.msg-conversation-card__participant-names, .msg-conversation-listitem__participant-names, [data-anonymize="person-name"], span[dir="ltr"], h3')?.textContent) === targetName)
+        || rows.find((el) => norm(el.innerText || el.textContent).includes(targetName));
+      const clickable = row?.querySelector('.msg-conversation-listitem__link, [tabindex="0"], a, button') || row;
+      if (!clickable) return false;
+      clickable.click();
+      return true;
+    })(${JSON.stringify(targetName)})`));
+    if (!clicked) {
+      hydrated.push(conv);
+      continue;
+    }
+    await page.wait(2);
+    const url = unwrapEvaluateResult(await page.evaluate(`location.href`));
+    const threadUrl = /\/messaging\/thread\//i.test(String(url || '')) ? normalizeUrl(url) : '';
+    hydrated.push({
+      ...conv,
+      thread_url: conv.thread_url || threadUrl,
+      thread_id: conv.thread_id || extractThreadId(threadUrl),
+    });
+  }
+  return hydrated;
+}
+
+async function clickUnreadFilter(page) {
+  return unwrapEvaluateResult(await page.evaluate(`(() => {
+    const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="tab"]'));
+    const el = candidates.find((node) => String(node.innerText || node.textContent || node.getAttribute('aria-label') || '').replace(/\\s+/g, ' ').trim().toLowerCase() === 'unread');
+    if (!el) return false;
+    el.click();
+    return true;
+  })()`));
+}
+
+async function collectInboxView(page, url, limit, maxScrolls, options = {}) {
+  await page.goto(url);
+  await page.wait(5);
+  let filterApplied = false;
+  if (options.unreadFilter) {
+    filterApplied = Boolean(await clickUnreadFilter(page));
+    await page.wait(3);
+  }
+  let conversations = [];
+  let sawLoginWall = false;
+  let stablePasses = 0;
+  for (let i = 0; i < maxScrolls && conversations.length < limit; i += 1) {
+    const batch = await extractVisibleInbox(page);
+    if (batch?.loginRequired) sawLoginWall = true;
+    const before = conversations.length;
+    conversations = mergeConversations(conversations, Array.isArray(batch?.conversations) ? batch.conversations : []);
+    if (conversations.length === before) stablePasses += 1;
+    else stablePasses = 0;
+    if (conversations.length >= limit) break;
+    const clicked = await clickLoadMoreOrNext(page);
+    const scroll = await scrollInboxList(page);
+    await page.wait(clicked ? 2 : 1);
+    if (stablePasses >= 4 && scroll?.before === scroll?.after && !clicked) break;
+  }
+  return { sawLoginWall, conversations, filterApplied };
+}
+
+cli({
+  site: 'linkedin',
+  name: 'inbox',
+  access: 'read',
+  description: 'List LinkedIn messaging inbox conversations and unread messages',
+  domain: 'www.linkedin.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'limit', type: 'int', default: 40, help: 'Maximum conversations to return (max 200)' },
+    { name: 'max-scrolls', type: 'int', default: 18, help: 'Maximum inbox scroll/pagination passes' },
+    { name: 'unread-only', type: 'bool', default: false, help: 'Return only conversations detected as unread' },
+  ],
+  columns: ['rank', 'thread_url', 'thread_id', 'person_name', 'last_message_preview', 'unread', 'timestamp'],
+  func: async (page, kwargs) => {
+    const limit = Math.max(1, Math.min(kwargs.limit ?? 40, 200));
+    const maxScrolls = Math.max(1, Math.min(kwargs['max-scrolls'] ?? 18, 80));
+    const unreadOnly = Boolean(kwargs['unread-only']);
+    const allView = await collectInboxView(page, 'https://www.linkedin.com/messaging/', limit, maxScrolls);
+    // LinkedIn's normal inbox can hide unread rows; also sample the unread-filtered view and merge.
+    const unreadView = await collectInboxView(page, 'https://www.linkedin.com/messaging/', limit, Math.max(6, Math.ceil(maxScrolls / 2)), { unreadFilter: true });
+    if ((allView.sawLoginWall || unreadView.sawLoginWall) && allView.conversations.length === 0 && unreadView.conversations.length === 0) {
+      throw new AuthRequiredError('linkedin.com', 'LinkedIn inbox requires an active signed-in browser session');
+    }
+    let conversations = mergeConversations(
+      allView.conversations,
+      unreadView.conversations.map((conv) => ({ ...conv, unread: unreadView.filterApplied ? true : conv.unread }))
+    );
+    if (unreadOnly) conversations = conversations.filter((conv) => conv.unread);
+    if (!unreadOnly && conversations.some((conv) => !conv.thread_url && conv.person_name)) {
+      await page.goto('https://www.linkedin.com/messaging/');
+      await page.wait(3);
+      conversations = await hydrateVisibleThreadUrls(page, conversations);
+    }
+    if (conversations.length === 0) {
+      throw new EmptyResultError('linkedin inbox', 'No LinkedIn conversations were visible after scrolling/pagination.');
+    }
+    return conversations.slice(0, limit).map((conv, index) => ({ rank: index + 1, ...conv }));
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  normalizeUrl,
+  extractThreadId,
+  inferTimestamp,
+  inferUnread,
+  extractConversationFromRoot,
+  extractInboxConversationsFromDocument,
+  mergeConversations,
+};

--- a/clis/linkedin/inbox.test.js
+++ b/clis/linkedin/inbox.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import './inbox.js';
 
 const { parseConversations, threadUrl } = await import('./inbox.js').then((m) => m.__test__);
@@ -132,9 +133,12 @@ describe('linkedin inbox adapter', () => {
     expect(c3.person_name).toBe('Cohort 2 group');
   });
 
-  it('returns an empty array when the payload has no conversations', () => {
+  it('returns an empty array when a valid payload has no conversations', () => {
     expect(parseConversations({ included: [] }, SELF)).toEqual([]);
-    expect(parseConversations({}, SELF)).toEqual([]);
-    expect(parseConversations(null, SELF)).toEqual([]);
+  });
+
+  it('fails typed when the normalized payload shape is malformed', () => {
+    expect(() => parseConversations({}, SELF)).toThrow(CommandExecutionError);
+    expect(() => parseConversations(null, SELF)).toThrow(CommandExecutionError);
   });
 });

--- a/clis/linkedin/inbox.test.js
+++ b/clis/linkedin/inbox.test.js
@@ -1,18 +1,81 @@
 import { describe, expect, it } from 'vitest';
-import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './inbox.js';
 
-const {
-  extractInboxConversationsFromDocument,
-  extractThreadId,
-  mergeConversations,
-} = await import('./inbox.js').then((m) => m.__test__);
+const { parseConversations, threadUrl } = await import('./inbox.js').then((m) => m.__test__);
+
+const SELF = 'urn:li:fsd_profile:SELF';
+
+// Minimal normalized messaging payload mirroring LinkedIn's real response shape:
+// a flat `included` entity array where conversations reference participants and
+// messages by URN.
+function fixture() {
+  return {
+    included: [
+      {
+        $type: 'com.linkedin.messenger.MessagingParticipant',
+        entityUrn: 'urn:li:msg_messagingParticipant:SELF',
+        hostIdentityUrn: SELF,
+        participantType: { member: { firstName: { text: 'Hanzi' }, lastName: { text: 'Li' } } },
+      },
+      {
+        $type: 'com.linkedin.messenger.MessagingParticipant',
+        entityUrn: 'urn:li:msg_messagingParticipant:P1',
+        hostIdentityUrn: 'urn:li:fsd_profile:P1',
+        participantType: { member: { firstName: { text: 'Olga' }, lastName: { text: 'Magere' } } },
+      },
+      {
+        $type: 'com.linkedin.messenger.MessagingParticipant',
+        entityUrn: 'urn:li:msg_messagingParticipant:ORG',
+        hostIdentityUrn: 'urn:li:fsd_company:99',
+        participantType: { organization: { name: { text: 'American Express' } } },
+      },
+      { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M1', body: { text: 'hey, are you around   this week?' } },
+      { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M2', body: { text: 'Sponsored offer' } },
+      {
+        $type: 'com.linkedin.messenger.Conversation',
+        entityUrn: 'urn:li:msg_conversation:C1',
+        backendUrn: 'urn:li:messagingThread:2-aaa==',
+        unreadCount: 2,
+        read: false,
+        categories: ['INBOX', 'PRIMARY_INBOX'],
+        lastActivityAt: 2000,
+        '*conversationParticipants': ['urn:li:msg_messagingParticipant:P1', 'urn:li:msg_messagingParticipant:SELF'],
+        messages: { '*elements': ['urn:li:msg_message:M1'] },
+        title: null,
+      },
+      {
+        $type: 'com.linkedin.messenger.Conversation',
+        entityUrn: 'urn:li:msg_conversation:C2',
+        backendUrn: 'urn:li:messagingThread:2-bbb==',
+        unreadCount: 0,
+        read: true,
+        categories: ['INBOX', 'PRIMARY_INBOX', 'INMAIL'],
+        lastActivityAt: 3000,
+        '*conversationParticipants': ['urn:li:msg_messagingParticipant:ORG', 'urn:li:msg_messagingParticipant:SELF'],
+        messages: { '*elements': ['urn:li:msg_message:M2'] },
+        title: null,
+      },
+      {
+        $type: 'com.linkedin.messenger.Conversation',
+        entityUrn: 'urn:li:msg_conversation:C3',
+        backendUrn: 'urn:li:messagingThread:2-ccc==',
+        unreadCount: 0,
+        read: true,
+        categories: ['INBOX', 'PRIMARY_INBOX'],
+        lastActivityAt: 1000,
+        '*conversationParticipants': ['urn:li:msg_messagingParticipant:P1', 'urn:li:msg_messagingParticipant:SELF'],
+        messages: { '*elements': [] },
+        title: 'Cohort 2 group',
+      },
+    ],
+  };
+}
 
 describe('linkedin inbox adapter', () => {
   const command = getRegistry().get('linkedin/inbox');
 
-  it('registers the command with correct shape', () => {
+  it('registers the command with the expected shape', () => {
     expect(command).toBeDefined();
     expect(command.site).toBe('linkedin');
     expect(command.name).toBe('inbox');
@@ -22,105 +85,56 @@ describe('linkedin inbox adapter', () => {
     expect(typeof command.func).toBe('function');
   });
 
-  it('includes channel-safe structured columns', () => {
-    expect(command.columns).toEqual(expect.arrayContaining([
-      'thread_url',
-      'thread_id',
-      'person_name',
-      'last_message_preview',
-      'unread',
-      'timestamp',
-    ]));
-  });
-});
-
-describe('extractThreadId', () => {
-  it('extracts encoded LinkedIn thread IDs', () => {
-    expect(extractThreadId('https://www.linkedin.com/messaging/thread/2-YzEyMzQ=/')).toBe('2-YzEyMzQ=');
-  });
-});
-
-describe('extractInboxConversationsFromDocument', () => {
-  it('extracts visible read and unread conversations from an HTML fixture', () => {
-    const html = `<!doctype html>
-      <main>
-        <ul class="msg-conversations-container__conversations-list">
-          <li class="msg-conversation-listitem msg-conversation-listitem--unread">
-            <a href="/messaging/thread/2-abc123/">
-              <span class="msg-conversation-card__participant-names">Jane Champion</span>
-              <time>2h</time>
-              <p class="msg-conversation-card__message-snippet">Could you send the compliance checklist?</p>
-            </a>
-          </li>
-          <li class="msg-conversation-listitem">
-            <a href="https://www.linkedin.com/messaging/thread/2-def456/?lipi=tracking">
-              <span class="msg-conversation-card__participant-names">Bob Buyer</span>
-              <time>May 14</time>
-              <p class="msg-conversation-card__message-snippet">You: thanks, happy to show the workflow</p>
-            </a>
-          </li>
-        </ul>
-      </main>`;
-    const dom = new JSDOM(html, { url: 'https://www.linkedin.com/messaging/' });
-    const result = extractInboxConversationsFromDocument(dom.window.document, dom.window.location.href);
-    expect(result.loginRequired).toBe(false);
-    expect(result.conversations).toHaveLength(2);
-    expect(result.conversations[0]).toMatchObject({
-      thread_url: 'https://www.linkedin.com/messaging/thread/2-abc123/',
-      thread_id: '2-abc123',
-      person_name: 'Jane Champion',
-      last_message_preview: 'Could you send the compliance checklist?',
-      unread: true,
-      timestamp: '2h',
-    });
-    expect(result.conversations[1]).toMatchObject({
-      thread_url: 'https://www.linkedin.com/messaging/thread/2-def456/',
-      thread_id: '2-def456',
-      person_name: 'Bob Buyer',
-      unread: false,
-      timestamp: 'May 14',
-    });
+  it('exposes channel-safe structured columns', () => {
+    expect(command.columns).toEqual(
+      expect.arrayContaining([
+        'thread_url',
+        'thread_id',
+        'person_name',
+        'last_message_preview',
+        'unread',
+        'counterparty_type',
+        'category',
+        'timestamp',
+      ]),
+    );
   });
 
-  it('uses current thread URL for active conversation rows with no row-level link', () => {
-    const html = `<!doctype html>
-      <main>
-        <div role="listitem" aria-label="Active conversation Unread">
-          <span class="msg-conversation-card__participant-names">Active Router</span>
-          <p class="msg-conversation-card__message-snippet">Can you ask our QA manager?</p>
-          <time>now</time>
-        </div>
-      </main>`;
-    const currentUrl = 'https://www.linkedin.com/messaging/thread/2-active789/';
-    const dom = new JSDOM(html, { url: currentUrl });
-    const result = extractInboxConversationsFromDocument(dom.window.document, currentUrl);
-    expect(result.conversations).toHaveLength(1);
-    expect(result.conversations[0]).toMatchObject({
-      thread_url: currentUrl,
-      thread_id: '2-active789',
-      person_name: 'Active Router',
-      unread: true,
-    });
+  it('builds a thread URL from a thread id', () => {
+    expect(threadUrl('2-aaa==')).toBe('https://www.linkedin.com/messaging/thread/2-aaa==/');
+    expect(threadUrl('')).toBe('');
   });
 
-  it('detects login/checkpoint pages', () => {
-    const dom = new JSDOM('<form class="login__form"><input name="session_key" /></form>', {
-      url: 'https://www.linkedin.com/login',
-    });
-    const result = extractInboxConversationsFromDocument(dom.window.document, dom.window.location.href);
-    expect(result.loginRequired).toBe(true);
+  it('parses conversations and sorts them by most recent activity', () => {
+    const rows = parseConversations(fixture(), SELF);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.thread_id)).toEqual(['2-bbb==', '2-aaa==', '2-ccc==']);
   });
-});
 
-describe('mergeConversations', () => {
-  it('deduplicates by thread url and preserves unread truthiness', () => {
-    const result = mergeConversations([
-      { thread_url: 'https://www.linkedin.com/messaging/thread/2-a/', person_name: 'A', last_message_preview: 'old', unread: true, timestamp: '1h' },
-    ], [
-      { thread_url: 'https://www.linkedin.com/messaging/thread/2-a/', person_name: 'A', last_message_preview: 'new', unread: false, timestamp: '2h' },
-      { thread_url: 'https://www.linkedin.com/messaging/thread/2-b/', person_name: 'B', last_message_preview: 'hi', unread: false, timestamp: '3h' },
-    ]);
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ unread: true, last_message_preview: 'new' });
+  it('resolves the member counterparty, excludes the inbox owner, and reports unread state', () => {
+    const c1 = parseConversations(fixture(), SELF).find((r) => r.thread_id === '2-aaa==');
+    expect(c1.person_name).toBe('Olga Magere');
+    expect(c1.counterparty_type).toBe('member');
+    expect(c1.unread).toBe(true);
+    expect(c1.last_message_preview).toBe('hey, are you around this week?');
+  });
+
+  it('flags organization counterparties and read conversations', () => {
+    const c2 = parseConversations(fixture(), SELF).find((r) => r.thread_id === '2-bbb==');
+    expect(c2.person_name).toBe('American Express');
+    expect(c2.counterparty_type).toBe('organization');
+    expect(c2.unread).toBe(false);
+    expect(c2.category).toBe('INBOX,PRIMARY_INBOX,INMAIL');
+  });
+
+  it('uses the group title as the conversation name', () => {
+    const c3 = parseConversations(fixture(), SELF).find((r) => r.thread_id === '2-ccc==');
+    expect(c3.person_name).toBe('Cohort 2 group');
+  });
+
+  it('returns an empty array when the payload has no conversations', () => {
+    expect(parseConversations({ included: [] }, SELF)).toEqual([]);
+    expect(parseConversations({}, SELF)).toEqual([]);
+    expect(parseConversations(null, SELF)).toEqual([]);
   });
 });

--- a/clis/linkedin/inbox.test.js
+++ b/clis/linkedin/inbox.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './inbox.js';
+
+const {
+  extractInboxConversationsFromDocument,
+  extractThreadId,
+  mergeConversations,
+} = await import('./inbox.js').then((m) => m.__test__);
+
+describe('linkedin inbox adapter', () => {
+  const command = getRegistry().get('linkedin/inbox');
+
+  it('registers the command with correct shape', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('linkedin');
+    expect(command.name).toBe('inbox');
+    expect(command.domain).toBe('www.linkedin.com');
+    expect(command.strategy).toBe('cookie');
+    expect(command.browser).toBe(true);
+    expect(typeof command.func).toBe('function');
+  });
+
+  it('includes channel-safe structured columns', () => {
+    expect(command.columns).toEqual(expect.arrayContaining([
+      'thread_url',
+      'thread_id',
+      'person_name',
+      'last_message_preview',
+      'unread',
+      'timestamp',
+    ]));
+  });
+});
+
+describe('extractThreadId', () => {
+  it('extracts encoded LinkedIn thread IDs', () => {
+    expect(extractThreadId('https://www.linkedin.com/messaging/thread/2-YzEyMzQ=/')).toBe('2-YzEyMzQ=');
+  });
+});
+
+describe('extractInboxConversationsFromDocument', () => {
+  it('extracts visible read and unread conversations from an HTML fixture', () => {
+    const html = `<!doctype html>
+      <main>
+        <ul class="msg-conversations-container__conversations-list">
+          <li class="msg-conversation-listitem msg-conversation-listitem--unread">
+            <a href="/messaging/thread/2-abc123/">
+              <span class="msg-conversation-card__participant-names">Jane Champion</span>
+              <time>2h</time>
+              <p class="msg-conversation-card__message-snippet">Could you send the compliance checklist?</p>
+            </a>
+          </li>
+          <li class="msg-conversation-listitem">
+            <a href="https://www.linkedin.com/messaging/thread/2-def456/?lipi=tracking">
+              <span class="msg-conversation-card__participant-names">Bob Buyer</span>
+              <time>May 14</time>
+              <p class="msg-conversation-card__message-snippet">You: thanks, happy to show the workflow</p>
+            </a>
+          </li>
+        </ul>
+      </main>`;
+    const dom = new JSDOM(html, { url: 'https://www.linkedin.com/messaging/' });
+    const result = extractInboxConversationsFromDocument(dom.window.document, dom.window.location.href);
+    expect(result.loginRequired).toBe(false);
+    expect(result.conversations).toHaveLength(2);
+    expect(result.conversations[0]).toMatchObject({
+      thread_url: 'https://www.linkedin.com/messaging/thread/2-abc123/',
+      thread_id: '2-abc123',
+      person_name: 'Jane Champion',
+      last_message_preview: 'Could you send the compliance checklist?',
+      unread: true,
+      timestamp: '2h',
+    });
+    expect(result.conversations[1]).toMatchObject({
+      thread_url: 'https://www.linkedin.com/messaging/thread/2-def456/',
+      thread_id: '2-def456',
+      person_name: 'Bob Buyer',
+      unread: false,
+      timestamp: 'May 14',
+    });
+  });
+
+  it('uses current thread URL for active conversation rows with no row-level link', () => {
+    const html = `<!doctype html>
+      <main>
+        <div role="listitem" aria-label="Active conversation Unread">
+          <span class="msg-conversation-card__participant-names">Active Router</span>
+          <p class="msg-conversation-card__message-snippet">Can you ask our QA manager?</p>
+          <time>now</time>
+        </div>
+      </main>`;
+    const currentUrl = 'https://www.linkedin.com/messaging/thread/2-active789/';
+    const dom = new JSDOM(html, { url: currentUrl });
+    const result = extractInboxConversationsFromDocument(dom.window.document, currentUrl);
+    expect(result.conversations).toHaveLength(1);
+    expect(result.conversations[0]).toMatchObject({
+      thread_url: currentUrl,
+      thread_id: '2-active789',
+      person_name: 'Active Router',
+      unread: true,
+    });
+  });
+
+  it('detects login/checkpoint pages', () => {
+    const dom = new JSDOM('<form class="login__form"><input name="session_key" /></form>', {
+      url: 'https://www.linkedin.com/login',
+    });
+    const result = extractInboxConversationsFromDocument(dom.window.document, dom.window.location.href);
+    expect(result.loginRequired).toBe(true);
+  });
+});
+
+describe('mergeConversations', () => {
+  it('deduplicates by thread url and preserves unread truthiness', () => {
+    const result = mergeConversations([
+      { thread_url: 'https://www.linkedin.com/messaging/thread/2-a/', person_name: 'A', last_message_preview: 'old', unread: true, timestamp: '1h' },
+    ], [
+      { thread_url: 'https://www.linkedin.com/messaging/thread/2-a/', person_name: 'A', last_message_preview: 'new', unread: false, timestamp: '2h' },
+      { thread_url: 'https://www.linkedin.com/messaging/thread/2-b/', person_name: 'B', last_message_preview: 'hi', unread: false, timestamp: '3h' },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ unread: true, last_message_preview: 'new' });
+  });
+});

--- a/clis/linkedin/inbox.test.js
+++ b/clis/linkedin/inbox.test.js
@@ -140,5 +140,13 @@ describe('linkedin inbox adapter', () => {
   it('fails typed when the normalized payload shape is malformed', () => {
     expect(() => parseConversations({}, SELF)).toThrow(CommandExecutionError);
     expect(() => parseConversations(null, SELF)).toThrow(CommandExecutionError);
+    const malformed = fixture();
+    malformed.included.push({
+      $type: 'com.linkedin.messenger.Conversation',
+      entityUrn: 'urn:li:msg_conversation:MALFORMED',
+      '*conversationParticipants': [],
+      messages: { '*elements': [] },
+    });
+    expect(() => parseConversations(malformed, SELF)).toThrow(CommandExecutionError);
   });
 });

--- a/clis/linkedin/safe-send.js
+++ b/clis/linkedin/safe-send.js
@@ -20,18 +20,26 @@ function normalizeName(value) {
     .toLowerCase();
 }
 
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
 function canonicalizeLinkedInThreadUrl(value) {
   const raw = normalizeWhitespace(value);
   if (!raw) return '';
   try {
     const url = new URL(raw);
-    if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
+    const match = url.pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i);
+    if (!match || !match[1]) return '';
+    url.hostname = 'www.linkedin.com';
     url.hash = '';
     url.search = '';
     if (!url.pathname.endsWith('/')) url.pathname += '/';
     return url.toString();
   } catch {
-    return raw;
+    return '';
   }
 }
 
@@ -61,42 +69,48 @@ function assessThreadSafety(probe, expected) {
   const bodyText = String(probe?.bodyText || '');
 
   if (probe?.authRequired) {
-    return { ok: false, reason: 'auth_required', expected: expectedName, actual: actualName, url: actualThreadUrl };
+    return { ok: false, blockReason: 'auth_required', expectedValue: expectedName, actualValue: actualName, observedUrl: actualThreadUrl };
   }
 
   if (probe?.searchFailure || /we didn't find anything|no results found|no results for/i.test(bodyText)) {
-    return { ok: false, reason: 'search_failure_visible', expected: expectedName, actual: actualName, url: actualThreadUrl };
+    return { ok: false, blockReason: 'search_failure_visible', expectedValue: expectedName, actualValue: actualName, observedUrl: actualThreadUrl };
   }
 
   if (expectedThreadUrl && actualThreadUrl && expectedThreadUrl !== actualThreadUrl) {
-    return { ok: false, reason: 'thread_url_mismatch', expected: expectedThreadUrl, actual: actualThreadUrl, url: actualThreadUrl };
+    return { ok: false, blockReason: 'thread_url_mismatch', expectedValue: expectedThreadUrl, actualValue: actualThreadUrl, observedUrl: actualThreadUrl };
   }
 
   if (!actualName || normalizeName(actualName) !== normalizeName(expectedName)) {
-    return { ok: false, reason: 'recipient_header_mismatch', expected: expectedName, actual: actualName, url: actualThreadUrl };
+    return { ok: false, blockReason: 'recipient_header_mismatch', expectedValue: expectedName, actualValue: actualName, observedUrl: actualThreadUrl };
   }
 
   if (!probe?.composerFound) {
-    return { ok: false, reason: 'composer_not_found', expected: expectedName, actual: actualName, url: actualThreadUrl };
+    return { ok: false, blockReason: 'composer_not_found', expectedValue: expectedName, actualValue: actualName, observedUrl: actualThreadUrl };
   }
 
   const expectedLastHash = normalizeWhitespace(expected.expectedLastHash);
   if (expectedLastHash && expectedLastHash !== probe?.latestMessageHash) {
-    return { ok: false, reason: 'latest_message_mismatch', expected: expectedLastHash, actual: probe?.latestMessageHash || '', url: actualThreadUrl };
+    return { ok: false, blockReason: 'latest_message_mismatch', expectedValue: expectedLastHash, actualValue: probe?.latestMessageHash || '', observedUrl: actualThreadUrl };
   }
 
   const expectedLastText = normalizeWhitespace(expected.expectedLastText);
   if (expectedLastText && !textContainsNormalized(bodyText, expectedLastText)) {
-    return { ok: false, reason: 'latest_message_mismatch', expected: expectedLastText, actual: '', url: actualThreadUrl };
+    return { ok: false, blockReason: 'latest_message_mismatch', expectedValue: expectedLastText, actualValue: '', observedUrl: actualThreadUrl };
   }
 
-  return { ok: true, reason: 'verified', expected: expectedName, actual: actualName, url: actualThreadUrl };
+  return { ok: true, blockReason: 'verified', expectedValue: expectedName, actualValue: actualName, observedUrl: actualThreadUrl };
 }
 
 function requireStringArg(args, key, label = key) {
   const value = normalizeWhitespace(args[key]);
   if (!value) throw new ArgumentError(`${label} is required`);
   return value;
+}
+
+function requireLinkedInThreadUrl(value, label) {
+  const url = canonicalizeLinkedInThreadUrl(value);
+  if (!url) throw new ArgumentError(`${label} must be an exact https://www.linkedin.com/messaging/thread/<id>/ URL`);
+  return url;
 }
 
 function buildThreadProbeScript() {
@@ -227,11 +241,11 @@ cli({
     { name: 'send', type: 'bool', default: false, help: 'Actually click Send. Default is dry-run verification only.' },
     { name: 'screenshot', type: 'bool', default: false, help: 'Capture a screenshot during verification' },
   ],
-  columns: ['status', 'recipient', 'reason', 'thread_url', 'message_chars', 'expected', 'actual', 'url', 'screenshot', 'authRequired', 'bodyText', 'composerFound', 'composerText', 'headerNames', 'latestMessageHash', 'latestMessageText', 'searchFailure', 'title'],
+  columns: ['status', 'recipient', 'reason', 'thread_url', 'message_chars', 'screenshot'],
   func: async (page, args) => {
     if (!page) throw new CommandExecutionError('Browser session required for linkedin safe-send');
 
-    const threadUrl = requireStringArg(args, 'thread-url', '--thread-url');
+    const threadUrl = requireLinkedInThreadUrl(requireStringArg(args, 'thread-url', '--thread-url'), '--thread-url');
     const expectedName = requireStringArg(args, 'expected-name', '--expected-name');
     const message = requireStringArg(args, 'message', '--message');
 
@@ -258,19 +272,19 @@ cli({
       expectedLastHash: args['expected-last-hash'],
     });
 
-    if (safety.reason === 'auth_required') {
+    if (safety.blockReason === 'auth_required') {
       throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn safe-send requires an active signed-in LinkedIn browser session.');
     }
 
     if (!safety.ok) {
       const observed = [
-        `Expected ${safety.expected}; actual ${safety.actual || 'not_visible'} at ${safety.url || 'url_not_available'}`,
+        `Expected ${safety.expectedValue}; actual ${safety.actualValue || 'not_visible'} at ${safety.observedUrl || 'url_not_available'}`,
         `Observed headers: ${(beforeProbe.headerNames || []).join(' | ') || 'no_visible_headers'}`,
         `Title: ${beforeProbe.title || 'title_not_available'}`,
         `Body: ${normalizeWhitespace(beforeProbe.bodyText || '').slice(0, 500)}`,
       ].join('\n');
       throw new CommandExecutionError(
-        `LinkedIn safe-send blocked: ${safety.reason}`,
+        `LinkedIn safe-send blocked: ${safety.blockReason}`,
         observed,
       );
     }
@@ -283,9 +297,9 @@ cli({
     if (!args.send) {
       return [{
         status: 'verified_dry_run',
-        recipient: safety.actual,
-        reason: safety.reason,
-        thread_url: safety.url,
+        recipient: safety.actualValue,
+        reason: safety.blockReason,
+        thread_url: safety.observedUrl,
         message_chars: message.length,
         screenshot: screenshot ? 'captured' : '',
       }];
@@ -313,7 +327,7 @@ cli({
       expectedLastHash: args['expected-last-hash'],
     });
     if (!afterFillSafety.ok) {
-      throw new CommandExecutionError(`LinkedIn safe-send blocked after fill: ${afterFillSafety.reason}`);
+      throw new CommandExecutionError(`LinkedIn safe-send blocked after fill: ${afterFillSafety.blockReason}`);
     }
 
     const sent = unwrapEvaluateResult(await page.evaluate(buildClickSendScript()));
@@ -324,9 +338,9 @@ cli({
     await page.wait(0.8 + Math.random() * 1.2);
     return [{
       status: 'sent',
-      recipient: safety.actual,
-      reason: safety.reason,
-      thread_url: safety.url,
+      recipient: safety.actualValue,
+      reason: safety.blockReason,
+      thread_url: safety.observedUrl,
       message_chars: message.length,
       screenshot: screenshot ? 'captured' : '',
     }];

--- a/clis/linkedin/safe-send.js
+++ b/clis/linkedin/safe-send.js
@@ -1,0 +1,343 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { createHash } from 'node:crypto';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function normalizeName(value) {
+  return normalizeWhitespace(value)
+    .replace(/\s*[•·]\s*(?:1st|2nd|3rd\+?|degree connection).*$/i, '')
+    .replace(/\s+LinkedIn.*$/i, '')
+    .toLowerCase();
+}
+
+function canonicalizeLinkedInThreadUrl(value) {
+  const raw = normalizeWhitespace(value);
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+    url.hash = '';
+    url.search = '';
+    if (!url.pathname.endsWith('/')) url.pathname += '/';
+    return url.toString();
+  } catch {
+    return raw;
+  }
+}
+
+function hashText(value) {
+  return createHash('sha256').update(normalizeWhitespace(value)).digest('hex');
+}
+
+function textContainsNormalized(haystack, needle) {
+  const h = normalizeWhitespace(haystack).toLowerCase();
+  const n = normalizeWhitespace(needle).toLowerCase();
+  return !n || h.includes(n);
+}
+
+function selectBestHeaderName(headerNames, expectedName) {
+  const expected = normalizeName(expectedName);
+  const names = (Array.isArray(headerNames) ? headerNames : [])
+    .map(normalizeWhitespace)
+    .filter(Boolean);
+  return names.find((name) => normalizeName(name) === expected) || names[0] || '';
+}
+
+function assessThreadSafety(probe, expected) {
+  const expectedName = normalizeWhitespace(expected.expectedName);
+  const actualName = selectBestHeaderName(probe?.headerNames, expectedName);
+  const expectedThreadUrl = canonicalizeLinkedInThreadUrl(expected.threadUrl);
+  const actualThreadUrl = canonicalizeLinkedInThreadUrl(probe?.url || '');
+  const bodyText = String(probe?.bodyText || '');
+
+  if (probe?.authRequired) {
+    return { ok: false, reason: 'auth_required', expected: expectedName, actual: actualName, url: actualThreadUrl };
+  }
+
+  if (probe?.searchFailure || /we didn't find anything|no results found|no results for/i.test(bodyText)) {
+    return { ok: false, reason: 'search_failure_visible', expected: expectedName, actual: actualName, url: actualThreadUrl };
+  }
+
+  if (expectedThreadUrl && actualThreadUrl && expectedThreadUrl !== actualThreadUrl) {
+    return { ok: false, reason: 'thread_url_mismatch', expected: expectedThreadUrl, actual: actualThreadUrl, url: actualThreadUrl };
+  }
+
+  if (!actualName || normalizeName(actualName) !== normalizeName(expectedName)) {
+    return { ok: false, reason: 'recipient_header_mismatch', expected: expectedName, actual: actualName, url: actualThreadUrl };
+  }
+
+  if (!probe?.composerFound) {
+    return { ok: false, reason: 'composer_not_found', expected: expectedName, actual: actualName, url: actualThreadUrl };
+  }
+
+  const expectedLastHash = normalizeWhitespace(expected.expectedLastHash);
+  if (expectedLastHash && expectedLastHash !== probe?.latestMessageHash) {
+    return { ok: false, reason: 'latest_message_mismatch', expected: expectedLastHash, actual: probe?.latestMessageHash || '', url: actualThreadUrl };
+  }
+
+  const expectedLastText = normalizeWhitespace(expected.expectedLastText);
+  if (expectedLastText && !textContainsNormalized(bodyText, expectedLastText)) {
+    return { ok: false, reason: 'latest_message_mismatch', expected: expectedLastText, actual: '', url: actualThreadUrl };
+  }
+
+  return { ok: true, reason: 'verified', expected: expectedName, actual: actualName, url: actualThreadUrl };
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function buildThreadProbeScript() {
+  return String.raw`(() => {
+    const marker = '__OPENCLI_LINKEDIN_PROBE__';
+    void marker;
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const text = document.body ? (document.body.innerText || '') : '';
+    const lower = text.toLowerCase();
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
+      || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
+      || /captcha|verification required/i.test(text);
+    const searchFailure = /we didn't find anything|no results found|no results for/i.test(text);
+
+    const headerCandidates = [];
+    const selectors = [
+      '.msg-thread__link-to-profile',
+      '.msg-thread__link-to-profile span[aria-hidden="true"]',
+      '.msg-entity-lockup__entity-title',
+      '.msg-conversation-card__participant-names',
+      'main h1',
+      'main h2',
+      '[data-anonymize="person-name"]',
+      'a[href*="/in/"] span[aria-hidden="true"]',
+      'a[href*="/in/"]'
+    ];
+    for (const selector of selectors) {
+      for (const el of Array.from(document.querySelectorAll(selector)).slice(0, 8)) {
+        const value = clean(el.innerText || el.textContent || el.getAttribute('aria-label'));
+        if (value && value.length <= 120 && !/^(message|messaging|send|profile|view profile)$/i.test(value)) {
+          headerCandidates.push(value);
+        }
+      }
+    }
+
+    const composer = Array.from(document.querySelectorAll('[contenteditable="true"][role="textbox"], div.msg-form__contenteditable[contenteditable="true"], [aria-label*="Write a message" i]'))
+      .find((el) => !el.closest('[aria-hidden="true"]') && el.offsetParent !== null);
+
+    const messageText = Array.from(document.querySelectorAll('.msg-s-message-list__event, .msg-s-event-listitem, [data-event-urn], .msg-s-message-group__meta, .msg-s-message-list-content'))
+      .map((el) => clean(el.innerText || el.textContent))
+      .filter(Boolean)
+      .join('\n');
+    const sourceText = messageText || text;
+    const sourceLines = sourceText.split(/\n+/).map(clean).filter(Boolean);
+    const lastMeaningfulLine = [...sourceLines].reverse().find((line) => !/^(send|reply|write a message|press enter to send)$/i.test(line)) || '';
+
+    return {
+      url: location.href,
+      title: document.title || '',
+      headerNames: Array.from(new Set(headerCandidates)).slice(0, 10),
+      bodyText: text,
+      composerFound: Boolean(composer),
+      composerText: composer ? clean(composer.innerText || composer.textContent) : '',
+      authRequired,
+      searchFailure,
+      latestMessageText: lastMeaningfulLine,
+      latestMessageHash: '',
+    };
+  })()`;
+}
+
+function buildFocusComposerScript() {
+  return String.raw`(() => {
+    const marker = '__OPENCLI_LINKEDIN_FOCUS_COMPOSER__';
+    void marker;
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const composer = Array.from(document.querySelectorAll('[contenteditable="true"][role="textbox"], div.msg-form__contenteditable[contenteditable="true"], [aria-label*="Write a message" i]'))
+      .find((el) => !el.closest('[aria-hidden="true"]') && el.offsetParent !== null);
+    if (!composer) return { ok: false, error: 'composer_not_found', composerText: '' };
+    composer.focus();
+    composer.innerHTML = '';
+    composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward', data: null }));
+    return { ok: true, composerText: clean(composer.innerText || composer.textContent) };
+  })()`;
+}
+
+function buildReadComposerScript() {
+  return String.raw`(() => {
+    const marker = '__OPENCLI_LINKEDIN_READ_COMPOSER__';
+    void marker;
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const composer = Array.from(document.querySelectorAll('[contenteditable="true"][role="textbox"], div.msg-form__contenteditable[contenteditable="true"], [aria-label*="Write a message" i]'))
+      .find((el) => !el.closest('[aria-hidden="true"]') && el.offsetParent !== null);
+    return { ok: Boolean(composer), composerText: composer ? clean(composer.innerText || composer.textContent) : '' };
+  })()`;
+}
+
+function buildClickSendScript() {
+  return String.raw`(() => {
+    const marker = '__OPENCLI_LINKEDIN_CLICK_SEND__';
+    void marker;
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const send = buttons.find((button) => {
+      const text = (button.innerText || button.textContent || button.getAttribute('aria-label') || '').trim().toLowerCase();
+      return text === 'send' || text === 'send message';
+    });
+    if (!send) return { ok: false, error: 'send_button_not_found', sent: false };
+    if (send.disabled || send.getAttribute('aria-disabled') === 'true') return { ok: false, error: 'send_button_disabled', sent: false };
+    send.click();
+    return { ok: true, sent: true };
+  })()`;
+}
+
+async function probeThread(page) {
+  const result = unwrapEvaluateResult(await page.evaluate(buildThreadProbeScript()));
+  const latestText = normalizeWhitespace(result?.latestMessageText || '');
+  return {
+    ...(result || {}),
+    latestMessageText: latestText,
+    latestMessageHash: latestText ? hashText(latestText) : '',
+  };
+}
+
+cli({
+  site: 'linkedin',
+  name: 'safe-send',
+  access: 'write',
+  description: 'Fail-closed LinkedIn message sender that verifies exact thread, recipient, and latest message before filling/sending',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'thread-url', required: true, help: 'Exact LinkedIn messaging thread URL to open and verify' },
+    { name: 'expected-name', required: true, help: 'Expected visible recipient name in the active thread header' },
+    { name: 'message', required: true, help: 'Message body to send or dry-run' },
+    { name: 'expected-last-text', help: 'Substring expected in the currently visible latest conversation context' },
+    { name: 'expected-last-hash', help: 'SHA-256 hash of expected latest visible message text' },
+    { name: 'send', type: 'bool', default: false, help: 'Actually click Send. Default is dry-run verification only.' },
+    { name: 'screenshot', type: 'bool', default: false, help: 'Capture a screenshot during verification' },
+  ],
+  columns: ['status', 'recipient', 'reason', 'thread_url', 'message_chars', 'expected', 'actual', 'url', 'screenshot', 'authRequired', 'bodyText', 'composerFound', 'composerText', 'headerNames', 'latestMessageHash', 'latestMessageText', 'searchFailure', 'title'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin safe-send');
+
+    const threadUrl = requireStringArg(args, 'thread-url', '--thread-url');
+    const expectedName = requireStringArg(args, 'expected-name', '--expected-name');
+    const message = requireStringArg(args, 'message', '--message');
+
+    await page.goto('https://www.linkedin.com/messaging/');
+    await page.wait(4);
+    await page.goto(threadUrl);
+    // LinkedIn messaging often renders the shell first and hydrates the active
+    // thread header/messages a few seconds later. Wait long enough for the
+    // recipient header to appear so we fail closed on a real mismatch, not on
+    // a premature blank DOM snapshot.
+    await page.wait(12);
+
+    let beforeProbe = await probeThread(page);
+    const expectedLastText = normalizeWhitespace(args['expected-last-text']);
+    for (let attempt = 0; expectedLastText && attempt < 6 && !textContainsNormalized(beforeProbe.bodyText, expectedLastText); attempt += 1) {
+      await page.wait(2);
+      beforeProbe = await probeThread(page);
+    }
+
+    const safety = assessThreadSafety(beforeProbe, {
+      expectedName,
+      threadUrl,
+      expectedLastText: args['expected-last-text'],
+      expectedLastHash: args['expected-last-hash'],
+    });
+
+    if (safety.reason === 'auth_required') {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn safe-send requires an active signed-in LinkedIn browser session.');
+    }
+
+    if (!safety.ok) {
+      const observed = [
+        `Expected ${safety.expected}; actual ${safety.actual || 'not_visible'} at ${safety.url || 'url_not_available'}`,
+        `Observed headers: ${(beforeProbe.headerNames || []).join(' | ') || 'no_visible_headers'}`,
+        `Title: ${beforeProbe.title || 'title_not_available'}`,
+        `Body: ${normalizeWhitespace(beforeProbe.bodyText || '').slice(0, 500)}`,
+      ].join('\n');
+      throw new CommandExecutionError(
+        `LinkedIn safe-send blocked: ${safety.reason}`,
+        observed,
+      );
+    }
+
+    let screenshot = '';
+    if (args.screenshot && typeof page.screenshot === 'function') {
+      screenshot = await page.screenshot({ fullPage: false });
+    }
+
+    if (!args.send) {
+      return [{
+        status: 'verified_dry_run',
+        recipient: safety.actual,
+        reason: safety.reason,
+        thread_url: safety.url,
+        message_chars: message.length,
+        screenshot: screenshot ? 'captured' : '',
+      }];
+    }
+
+    const focus = unwrapEvaluateResult(await page.evaluate(buildFocusComposerScript()));
+    if (!focus?.ok) throw new CommandExecutionError(`LinkedIn safe-send blocked: ${focus?.error || 'composer_focus_failed'}`);
+
+    await page.insertText(message);
+    await page.wait(0.6 + Math.random() * 0.8);
+
+    const composer = unwrapEvaluateResult(await page.evaluate(buildReadComposerScript()));
+    if (!composer?.ok || normalizeWhitespace(composer.composerText) !== normalizeWhitespace(message)) {
+      throw new CommandExecutionError(
+        'LinkedIn safe-send blocked: composer_text_mismatch',
+        `Composer text did not exactly match intended message for ${expectedName}.`,
+      );
+    }
+
+    const afterFillProbe = await probeThread(page);
+    const afterFillSafety = assessThreadSafety(afterFillProbe, {
+      expectedName,
+      threadUrl,
+      expectedLastText: args['expected-last-text'],
+      expectedLastHash: args['expected-last-hash'],
+    });
+    if (!afterFillSafety.ok) {
+      throw new CommandExecutionError(`LinkedIn safe-send blocked after fill: ${afterFillSafety.reason}`);
+    }
+
+    const sent = unwrapEvaluateResult(await page.evaluate(buildClickSendScript()));
+    if (!sent?.ok || !sent.sent) {
+      throw new CommandExecutionError(`LinkedIn safe-send blocked: ${sent?.error || 'send_click_failed'}`);
+    }
+
+    await page.wait(0.8 + Math.random() * 1.2);
+    return [{
+      status: 'sent',
+      recipient: safety.actual,
+      reason: safety.reason,
+      thread_url: safety.url,
+      message_chars: message.length,
+      screenshot: screenshot ? 'captured' : '',
+    }];
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  unwrapEvaluateResult,
+  normalizeName,
+  canonicalizeLinkedInThreadUrl,
+  hashText,
+  assessThreadSafety,
+};

--- a/clis/linkedin/safe-send.test.js
+++ b/clis/linkedin/safe-send.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './safe-send.js';
 
 const {
@@ -12,6 +12,7 @@ const {
 } = await import('./safe-send.js').then((m) => m.__test__);
 
 function makeFakePage(probe) {
+  let composerText = probe.composerText || '';
   return {
     goto: vi.fn(async () => undefined),
     wait: vi.fn(async () => undefined),
@@ -19,11 +20,13 @@ function makeFakePage(probe) {
       const text = String(script);
       if (text.includes('__OPENCLI_LINKEDIN_PROBE__')) return probe;
       if (text.includes('__OPENCLI_LINKEDIN_FOCUS_COMPOSER__')) return { ok: true, composerText: '' };
-      if (text.includes('__OPENCLI_LINKEDIN_READ_COMPOSER__')) return { ok: true, composerText: probe.composerText || '' };
+      if (text.includes('__OPENCLI_LINKEDIN_READ_COMPOSER__')) return { ok: true, composerText };
       if (text.includes('__OPENCLI_LINKEDIN_CLICK_SEND__')) return { ok: true, sent: true };
       return undefined;
     }),
-    insertText: vi.fn(async () => undefined),
+    insertText: vi.fn(async (text) => {
+      composerText = text;
+    }),
     pressKey: vi.fn(async () => undefined),
     screenshot: vi.fn(async () => 'base64-screenshot'),
   };
@@ -38,6 +41,9 @@ describe('linkedin safe-send helpers', () => {
   it('canonicalizes thread URLs while dropping query and hash noise', () => {
     expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/?foo=1#bar'))
       .toBe('https://www.linkedin.com/messaging/thread/abc/');
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/extra')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('https://evil-linkedin.com/messaging/thread/abc/')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('http://www.linkedin.com/messaging/thread/abc/')).toBe('');
   });
 
   it('fails closed when LinkedIn search produced no results even if a composer is visible', () => {
@@ -55,7 +61,7 @@ describe('linkedin safe-send helpers', () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('search_failure_visible');
+    expect(result.blockReason).toBe('search_failure_visible');
   });
 
   it('fails closed on recipient header mismatch', () => {
@@ -71,8 +77,8 @@ describe('linkedin safe-send helpers', () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('recipient_header_mismatch');
-    expect(result.actual).toBe('Bora Nicholson');
+    expect(result.blockReason).toBe('recipient_header_mismatch');
+    expect(result.actualValue).toBe('Bora Nicholson');
   });
 
   it('fails closed when the stored latest message is no longer visible', () => {
@@ -88,7 +94,7 @@ describe('linkedin safe-send helpers', () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('latest_message_mismatch');
+    expect(result.blockReason).toBe('latest_message_mismatch');
   });
 
   it('passes only when recipient, thread, latest text, and composer are all verified', () => {
@@ -105,7 +111,7 @@ describe('linkedin safe-send helpers', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.reason).toBe('verified');
+    expect(result.blockReason).toBe('verified');
   });
 });
 
@@ -138,6 +144,21 @@ describe('linkedin safe-send command', () => {
     expect(page.pressKey).not.toHaveBeenCalled();
   });
 
+  it('rejects non-thread URLs before navigating or typing', async () => {
+    const command = getRegistry().get('linkedin/safe-send');
+    const page = makeFakePage({});
+
+    await expect(command.func(page, {
+      'thread-url': 'https://www.linkedin.com/feed/',
+      'expected-name': 'Victoria Munoz',
+      message: 'hello victoria',
+      send: true,
+    })).rejects.toBeInstanceOf(ArgumentError);
+
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(page.insertText).not.toHaveBeenCalled();
+  });
+
   it('dry-runs by default after verification without filling or sending', async () => {
     const command = getRegistry().get('linkedin/safe-send');
     const page = makeFakePage({
@@ -167,7 +188,6 @@ describe('linkedin safe-send command', () => {
       bodyText: 'Lokesh Ramesh\nprovider doc follow ups',
       composerFound: true,
       searchFailure: false,
-      composerText: 'both, but starting hands on',
     });
 
     const rows = await command.func(page, {

--- a/clis/linkedin/safe-send.test.js
+++ b/clis/linkedin/safe-send.test.js
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import './safe-send.js';
+
+const {
+  normalizeWhitespace,
+  normalizeName,
+  canonicalizeLinkedInThreadUrl,
+  hashText,
+  assessThreadSafety,
+} = await import('./safe-send.js').then((m) => m.__test__);
+
+function makeFakePage(probe) {
+  return {
+    goto: vi.fn(async () => undefined),
+    wait: vi.fn(async () => undefined),
+    evaluate: vi.fn(async (script) => {
+      const text = String(script);
+      if (text.includes('__OPENCLI_LINKEDIN_PROBE__')) return probe;
+      if (text.includes('__OPENCLI_LINKEDIN_FOCUS_COMPOSER__')) return { ok: true, composerText: '' };
+      if (text.includes('__OPENCLI_LINKEDIN_READ_COMPOSER__')) return { ok: true, composerText: probe.composerText || '' };
+      if (text.includes('__OPENCLI_LINKEDIN_CLICK_SEND__')) return { ok: true, sent: true };
+      return undefined;
+    }),
+    insertText: vi.fn(async () => undefined),
+    pressKey: vi.fn(async () => undefined),
+    screenshot: vi.fn(async () => 'base64-screenshot'),
+  };
+}
+
+describe('linkedin safe-send helpers', () => {
+  it('normalizes whitespace and LinkedIn names for exact-ish comparisons', () => {
+    expect(normalizeWhitespace('  Lokesh\n\tRamesh  ')).toBe('Lokesh Ramesh');
+    expect(normalizeName('Lokesh Ramesh • 1st')).toBe('lokesh ramesh');
+  });
+
+  it('canonicalizes thread URLs while dropping query and hash noise', () => {
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/?foo=1#bar'))
+      .toBe('https://www.linkedin.com/messaging/thread/abc/');
+  });
+
+  it('fails closed when LinkedIn search produced no results even if a composer is visible', () => {
+    const result = assessThreadSafety({
+      url: 'https://www.linkedin.com/messaging/thread/bora/',
+      headerNames: ['Bora Nicholson'],
+      bodyText: "We didn't find anything for Victoria Munoz\nBora Nicholson",
+      searchFailure: true,
+      composerFound: true,
+      latestMessageHash: hashText('hello'),
+    }, {
+      expectedName: 'Victoria Munoz',
+      threadUrl: 'https://www.linkedin.com/messaging/thread/victoria/',
+      expectedLastText: 'hello',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('search_failure_visible');
+  });
+
+  it('fails closed on recipient header mismatch', () => {
+    const result = assessThreadSafety({
+      url: 'https://www.linkedin.com/messaging/thread/bora/',
+      headerNames: ['Bora Nicholson'],
+      bodyText: 'Bora Nicholson\nhello',
+      composerFound: true,
+      latestMessageHash: hashText('hello'),
+    }, {
+      expectedName: 'Victoria Munoz',
+      expectedLastText: 'hello',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('recipient_header_mismatch');
+    expect(result.actual).toBe('Bora Nicholson');
+  });
+
+  it('fails closed when the stored latest message is no longer visible', () => {
+    const result = assessThreadSafety({
+      url: 'https://www.linkedin.com/messaging/thread/lokesh/',
+      headerNames: ['Lokesh Ramesh'],
+      bodyText: 'Lokesh Ramesh\na newer inbound arrived',
+      composerFound: true,
+      latestMessageHash: hashText('a newer inbound arrived'),
+    }, {
+      expectedName: 'Lokesh Ramesh',
+      expectedLastText: 'old inbound text',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('latest_message_mismatch');
+  });
+
+  it('passes only when recipient, thread, latest text, and composer are all verified', () => {
+    const result = assessThreadSafety({
+      url: 'https://www.linkedin.com/messaging/thread/lokesh/?mini=true',
+      headerNames: ['Lokesh Ramesh'],
+      bodyText: 'Lokesh Ramesh\nI think outside help would fit best for provider doc follow ups',
+      composerFound: true,
+      latestMessageHash: hashText('I think outside help would fit best for provider doc follow ups'),
+    }, {
+      expectedName: 'Lokesh Ramesh',
+      threadUrl: 'https://www.linkedin.com/messaging/thread/lokesh/',
+      expectedLastText: 'provider doc follow ups',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('verified');
+  });
+});
+
+describe('linkedin safe-send command', () => {
+  it('registers as a write command with safe output columns', () => {
+    const command = getRegistry().get('linkedin/safe-send');
+    expect(command).toBeDefined();
+    expect(command.access).toBe('write');
+    expect(command.columns).toEqual(expect.arrayContaining(['status', 'recipient', 'reason']));
+  });
+
+  it('does not type or send when verification fails', async () => {
+    const command = getRegistry().get('linkedin/safe-send');
+    const page = makeFakePage({
+      url: 'https://www.linkedin.com/messaging/thread/bora/',
+      headerNames: ['Bora Nicholson'],
+      bodyText: 'Bora Nicholson',
+      composerFound: true,
+      searchFailure: false,
+    });
+
+    await expect(command.func(page, {
+      'thread-url': 'https://www.linkedin.com/messaging/thread/victoria/',
+      'expected-name': 'Victoria Munoz',
+      message: 'hello victoria',
+      send: true,
+    })).rejects.toBeInstanceOf(CommandExecutionError);
+
+    expect(page.insertText).not.toHaveBeenCalled();
+    expect(page.pressKey).not.toHaveBeenCalled();
+  });
+
+  it('dry-runs by default after verification without filling or sending', async () => {
+    const command = getRegistry().get('linkedin/safe-send');
+    const page = makeFakePage({
+      url: 'https://www.linkedin.com/messaging/thread/lokesh/',
+      headerNames: ['Lokesh Ramesh'],
+      bodyText: 'Lokesh Ramesh\nprovider doc follow ups',
+      composerFound: true,
+      searchFailure: false,
+    });
+
+    const rows = await command.func(page, {
+      'thread-url': 'https://www.linkedin.com/messaging/thread/lokesh/',
+      'expected-name': 'Lokesh Ramesh',
+      message: 'both, but starting hands on',
+    });
+
+    expect(rows[0]).toMatchObject({ status: 'verified_dry_run', recipient: 'Lokesh Ramesh', reason: 'verified' });
+    expect(page.insertText).not.toHaveBeenCalled();
+    expect(page.pressKey).not.toHaveBeenCalled();
+  });
+
+  it('fills and sends only when --send is explicitly true and post-fill verification matches exactly', async () => {
+    const command = getRegistry().get('linkedin/safe-send');
+    const page = makeFakePage({
+      url: 'https://www.linkedin.com/messaging/thread/lokesh/',
+      headerNames: ['Lokesh Ramesh'],
+      bodyText: 'Lokesh Ramesh\nprovider doc follow ups',
+      composerFound: true,
+      searchFailure: false,
+      composerText: 'both, but starting hands on',
+    });
+
+    const rows = await command.func(page, {
+      'thread-url': 'https://www.linkedin.com/messaging/thread/lokesh/',
+      'expected-name': 'Lokesh Ramesh',
+      message: 'both, but starting hands on',
+      send: true,
+    });
+
+    expect(rows[0]).toMatchObject({ status: 'sent', recipient: 'Lokesh Ramesh', reason: 'verified' });
+    expect(page.insertText).toHaveBeenCalledWith('both, but starting hands on');
+    expect(page.pressKey).not.toHaveBeenCalled();
+  });
+});

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -12,18 +12,26 @@ function unwrapEvaluateResult(payload) {
   return payload;
 }
 
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
 function canonicalizeLinkedInThreadUrl(value) {
   const raw = normalizeWhitespace(value);
   if (!raw) return '';
   try {
     const url = new URL(raw);
-    if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
+    const match = url.pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i);
+    if (!match || !match[1]) return '';
+    url.hostname = 'www.linkedin.com';
     url.hash = '';
     url.search = '';
     if (!url.pathname.endsWith('/')) url.pathname += '/';
     return url.toString();
   } catch {
-    return raw;
+    return '';
   }
 }
 
@@ -33,8 +41,23 @@ function requireStringArg(args, key, label = key) {
   return value;
 }
 
+function requireLinkedInThreadUrl(value, label) {
+  const url = canonicalizeLinkedInThreadUrl(value);
+  if (!url) throw new ArgumentError(`${label} must be an exact https://www.linkedin.com/messaging/thread/<id>/ URL`);
+  return url;
+}
+
+function parseMaxScrolls(value) {
+  if (value === undefined || value === null || value === '') return 30;
+  const scrolls = Number(value);
+  if (!Number.isInteger(scrolls) || scrolls < 0 || scrolls > 80) {
+    throw new ArgumentError('--max-scrolls must be an integer between 0 and 80');
+  }
+  return scrolls;
+}
+
 function buildThreadSnapshotScript(maxScrolls) {
-  const scrolls = Number.isFinite(Number(maxScrolls)) ? Math.max(0, Math.min(80, Number(maxScrolls))) : 30;
+  const scrolls = maxScrolls;
   return String.raw`(async () => {
     const marker = '__OPENCLI_LINKEDIN_THREAD_SNAPSHOT__';
     void marker;
@@ -141,16 +164,20 @@ cli({
   columns: ['thread_url', 'recipient', 'message_count', 'latest_text', 'snapshot_json'],
   func: async (page, args) => {
     if (!page) throw new CommandExecutionError('Browser session required for linkedin thread-snapshot');
-    const threadUrl = canonicalizeLinkedInThreadUrl(requireStringArg(args, 'thread-url', '--thread-url'));
+    const threadUrl = requireLinkedInThreadUrl(requireStringArg(args, 'thread-url', '--thread-url'), '--thread-url');
+    const maxScrolls = parseMaxScrolls(args['max-scrolls']);
 
     await page.goto('https://www.linkedin.com/messaging/');
     await page.wait(4);
     await page.goto(threadUrl);
     await page.wait(10);
 
-    const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(args['max-scrolls'])));
+    const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(maxScrolls)));
     if (snapshot?.authRequired) {
       throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn thread-snapshot requires an active signed-in LinkedIn browser session.');
+    }
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot) || !Array.isArray(snapshot.headerNames) || !Array.isArray(snapshot.messages)) {
+      throw new CommandExecutionError('LinkedIn thread-snapshot returned malformed snapshot payload');
     }
 
     const actualUrl = canonicalizeLinkedInThreadUrl(snapshot?.url || '');
@@ -158,14 +185,14 @@ cli({
       throw new CommandExecutionError('LinkedIn thread-snapshot blocked: thread_url_mismatch', `Expected ${threadUrl}; actual ${actualUrl}`);
     }
 
-    const recipient = normalizeWhitespace((snapshot?.headerNames || [])[0] || '');
-    const messageCount = Array.isArray(snapshot?.messages) ? snapshot.messages.length : 0;
+    const recipient = normalizeWhitespace(snapshot.headerNames[0] || '');
+    const messageCount = snapshot.messages.length;
     const normalized = {
-      ...(snapshot || {}),
+      ...snapshot,
       url: actualUrl || threadUrl,
-      headerNames: snapshot?.headerNames || [],
+      headerNames: snapshot.headerNames,
       latestMessageText: normalizeWhitespace(snapshot?.latestMessageText || ''),
-      messages: Array.isArray(snapshot?.messages) ? snapshot.messages : [],
+      messages: snapshot.messages,
     };
 
     return [{
@@ -181,6 +208,7 @@ cli({
 export const __test__ = {
   normalizeWhitespace,
   canonicalizeLinkedInThreadUrl,
+  parseMaxScrolls,
   unwrapEvaluateResult,
   buildThreadSnapshotScript,
 };

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -1,0 +1,186 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function canonicalizeLinkedInThreadUrl(value) {
+  const raw = normalizeWhitespace(value);
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    if (!/linkedin\.com$/i.test(url.hostname) && !/\.linkedin\.com$/i.test(url.hostname)) return raw;
+    url.hash = '';
+    url.search = '';
+    if (!url.pathname.endsWith('/')) url.pathname += '/';
+    return url.toString();
+  } catch {
+    return raw;
+  }
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function buildThreadSnapshotScript(maxScrolls) {
+  const scrolls = Number.isFinite(Number(maxScrolls)) ? Math.max(0, Math.min(80, Number(maxScrolls))) : 30;
+  return String.raw`(async () => {
+    const marker = '__OPENCLI_LINKEDIN_THREAD_SNAPSHOT__';
+    void marker;
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const text = document.body ? (document.body.innerText || '') : '';
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
+      || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
+      || /captcha|verification required/i.test(text);
+
+    const selectors = [
+      '.msg-s-message-list',
+      '.msg-s-message-list-scrollable',
+      '.msg-thread',
+      'main [role="main"]',
+      'main'
+    ];
+    let scroller = null;
+    for (const selector of selectors) {
+      const el = document.querySelector(selector);
+      if (el && (el.scrollHeight > el.clientHeight || selector === 'main')) { scroller = el; break; }
+    }
+    scroller = scroller || document.scrollingElement || document.documentElement;
+    let previousHeight = -1;
+    let stable = 0;
+    for (let i = 0; i < ${scrolls}; i += 1) {
+      scroller.scrollTop = 0;
+      window.scrollTo(0, 0);
+      await sleep(750);
+      const height = scroller.scrollHeight || document.body.scrollHeight || 0;
+      if (height === previousHeight) stable += 1; else stable = 0;
+      previousHeight = height;
+      if (stable >= 3) break;
+    }
+    await sleep(1000);
+
+    const headerCandidates = [];
+    const headerSelectors = [
+      '.msg-thread__link-to-profile',
+      '.msg-thread__link-to-profile span[aria-hidden="true"]',
+      '.msg-entity-lockup__entity-title',
+      '.msg-conversation-card__participant-names',
+      'main h1',
+      'main h2',
+      '[data-anonymize="person-name"]',
+      'a[href*="/in/"] span[aria-hidden="true"]',
+      'a[href*="/in/"]'
+    ];
+    for (const selector of headerSelectors) {
+      for (const el of Array.from(document.querySelectorAll(selector)).slice(0, 8)) {
+        const value = clean(el.innerText || el.textContent || el.getAttribute('aria-label'));
+        if (value && value.length <= 120 && !/^(message|messaging|send|profile|view profile)$/i.test(value)) {
+          headerCandidates.push(value);
+        }
+      }
+    }
+
+    const seen = new Set();
+    const messages = [];
+    const nodes = Array.from(document.querySelectorAll('.msg-s-message-list__event, .msg-s-event-listitem, [data-event-urn], .msg-s-message-list-content'));
+    for (const [nodeIndex, el] of nodes.entries()) {
+      const raw = clean(el.innerText || el.textContent);
+      if (!raw || seen.has(raw)) continue;
+      seen.add(raw);
+      const lines = raw.split(/\n+/).map(clean).filter(Boolean);
+      const speaker = lines.length > 1 && lines[0].length <= 120 ? lines[0] : '';
+      messages.push({ index: messages.length, nodeIndex, speaker, text: raw });
+    }
+
+    const refreshedText = document.body ? (document.body.innerText || '') : '';
+    const fallbackLines = refreshedText.split(/\n+/).map(clean).filter(Boolean);
+    const latestMessageText = messages.length
+      ? messages[messages.length - 1].text
+      : ([...fallbackLines].reverse().find((line) => !/^(send|reply|write a message|press enter to send)$/i.test(line)) || '');
+
+    return {
+      url: location.href,
+      title: document.title || '',
+      headerNames: Array.from(new Set(headerCandidates)).slice(0, 10),
+      bodyText: refreshedText,
+      latestMessageText,
+      messages,
+      messageCount: messages.length,
+      authRequired,
+      extractedAt: new Date().toISOString(),
+      maxScrolls: ${scrolls}
+    };
+  })()`;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'thread-snapshot',
+  access: 'read',
+  description: 'Load a LinkedIn messaging thread, scroll for available history, and return a full context snapshot',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'thread-url', required: true, help: 'Exact LinkedIn messaging thread URL to open and snapshot' },
+    { name: 'max-scrolls', type: 'number', default: 30, help: 'Maximum upward scroll attempts to load older messages' },
+    { name: 'json', type: 'bool', default: false, help: 'Return only JSON snapshot string in the snapshot_json field' },
+  ],
+  columns: ['thread_url', 'recipient', 'message_count', 'latest_text', 'snapshot_json'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin thread-snapshot');
+    const threadUrl = canonicalizeLinkedInThreadUrl(requireStringArg(args, 'thread-url', '--thread-url'));
+
+    await page.goto('https://www.linkedin.com/messaging/');
+    await page.wait(4);
+    await page.goto(threadUrl);
+    await page.wait(10);
+
+    const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(args['max-scrolls'])));
+    if (snapshot?.authRequired) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn thread-snapshot requires an active signed-in LinkedIn browser session.');
+    }
+
+    const actualUrl = canonicalizeLinkedInThreadUrl(snapshot?.url || '');
+    if (threadUrl && actualUrl && threadUrl !== actualUrl) {
+      throw new CommandExecutionError('LinkedIn thread-snapshot blocked: thread_url_mismatch', `Expected ${threadUrl}; actual ${actualUrl}`);
+    }
+
+    const recipient = normalizeWhitespace((snapshot?.headerNames || [])[0] || '');
+    const messageCount = Array.isArray(snapshot?.messages) ? snapshot.messages.length : 0;
+    const normalized = {
+      ...(snapshot || {}),
+      url: actualUrl || threadUrl,
+      headerNames: snapshot?.headerNames || [],
+      latestMessageText: normalizeWhitespace(snapshot?.latestMessageText || ''),
+      messages: Array.isArray(snapshot?.messages) ? snapshot.messages : [],
+    };
+
+    return [{
+      thread_url: normalized.url,
+      recipient,
+      message_count: messageCount,
+      latest_text: normalized.latestMessageText,
+      snapshot_json: JSON.stringify(normalized),
+    }];
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  canonicalizeLinkedInThreadUrl,
+  unwrapEvaluateResult,
+  buildThreadSnapshotScript,
+};

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './thread-snapshot.js';
+
+function makeFakePage(snapshot) {
+  return {
+    goto: vi.fn(async () => undefined),
+    wait: vi.fn(async () => undefined),
+    evaluate: vi.fn(async () => snapshot),
+  };
+}
+
+describe('linkedin thread-snapshot command', () => {
+  it('registers as a read command for loading full thread context', () => {
+    const command = getRegistry().get('linkedin/thread-snapshot');
+    expect(command).toBeDefined();
+    expect(command.access).toBe('read');
+    expect(command.columns).toEqual(expect.arrayContaining(['thread_url', 'recipient', 'message_count', 'latest_text']));
+  });
+
+  it('opens messaging first, then exact thread, and returns extracted messages', async () => {
+    const command = getRegistry().get('linkedin/thread-snapshot');
+    const page = makeFakePage({
+      url: 'https://www.linkedin.com/messaging/thread/abc/',
+      headerNames: ['Neha Rudraraju'],
+      latestMessageText: 'safe-send test from hermes. pls ignore :)',
+      messages: [
+        { index: 0, speaker: 'Neha Rudraraju', text: 'damn i just saw ur msg sry sry' },
+        { index: 1, speaker: 'Me', text: 'safe-send test from hermes. pls ignore :)' },
+      ],
+    });
+
+    const rows = await command.func(page, {
+      'thread-url': 'https://www.linkedin.com/messaging/thread/abc/',
+      'max-scrolls': 8,
+      json: false,
+    });
+
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://www.linkedin.com/messaging/');
+    expect(page.goto).toHaveBeenNthCalledWith(2, 'https://www.linkedin.com/messaging/thread/abc/');
+    expect(rows[0]).toMatchObject({
+      thread_url: 'https://www.linkedin.com/messaging/thread/abc/',
+      recipient: 'Neha Rudraraju',
+      message_count: 2,
+      latest_text: 'safe-send test from hermes. pls ignore :)',
+    });
+    expect(rows[0].snapshot_json).toContain('damn i just saw ur msg sry sry');
+  });
+});

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
+
+const { canonicalizeLinkedInThreadUrl, parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
 
 function makeFakePage(snapshot) {
   return {
@@ -11,6 +14,22 @@ function makeFakePage(snapshot) {
 }
 
 describe('linkedin thread-snapshot command', () => {
+  it('accepts only exact LinkedIn messaging thread URLs', () => {
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/2-abc==/?mini=true#x'))
+      .toBe('https://www.linkedin.com/messaging/thread/2-abc==/');
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/2-abc==/extra')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('https://evil-linkedin.com/messaging/thread/2-abc==/')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('http://www.linkedin.com/messaging/thread/2-abc==/')).toBe('');
+  });
+
+  it('validates max-scrolls without silent clamping', () => {
+    expect(parseMaxScrolls(undefined)).toBe(30);
+    expect(parseMaxScrolls(0)).toBe(0);
+    expect(parseMaxScrolls(80)).toBe(80);
+    expect(() => parseMaxScrolls(81)).toThrow('--max-scrolls must be an integer between 0 and 80');
+    expect(() => parseMaxScrolls(1.5)).toThrow('--max-scrolls must be an integer between 0 and 80');
+  });
+
   it('registers as a read command for loading full thread context', () => {
     const command = getRegistry().get('linkedin/thread-snapshot');
     expect(command).toBeDefined();
@@ -45,5 +64,26 @@ describe('linkedin thread-snapshot command', () => {
       latest_text: 'safe-send test from hermes. pls ignore :)',
     });
     expect(rows[0].snapshot_json).toContain('damn i just saw ur msg sry sry');
+  });
+
+  it('rejects invalid thread URL before navigation', async () => {
+    const command = getRegistry().get('linkedin/thread-snapshot');
+    const page = makeFakePage({});
+
+    await expect(command.func(page, {
+      'thread-url': 'https://www.linkedin.com/feed/',
+      'max-scrolls': 8,
+    })).rejects.toBeInstanceOf(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('fails typed on malformed snapshot payloads', async () => {
+    const command = getRegistry().get('linkedin/thread-snapshot');
+    const page = makeFakePage({ url: 'https://www.linkedin.com/messaging/thread/abc/', headerNames: ['Neha Rudraraju'] });
+
+    await expect(command.func(page, {
+      'thread-url': 'https://www.linkedin.com/messaging/thread/abc/',
+      'max-scrolls': 8,
+    })).rejects.toBeInstanceOf(CommandExecutionError);
   });
 });

--- a/docs/adapters/browser/linkedin.md
+++ b/docs/adapters/browser/linkedin.md
@@ -6,7 +6,11 @@
 
 | Command | Description |
 |---------|-------------|
+| `opencli linkedin connect` | Send a fail-closed connection request after verifying the exact profile |
+| `opencli linkedin inbox` | List LinkedIn messaging inbox conversations and unread status |
+| `opencli linkedin safe-send` | Verify exact recipient/thread context before optionally sending a message |
 | `opencli linkedin search` | Search LinkedIn jobs (Voyager API), with optional `--details` enrichment |
+| `opencli linkedin thread-snapshot` | Load a LinkedIn messaging thread and return available context |
 | `opencli linkedin timeline` | Read posts from your LinkedIn home feed |
 
 ## Usage Examples
@@ -23,6 +27,16 @@ opencli linkedin search "data scientist" --limit 3 --details
 
 # Read your home timeline
 opencli linkedin timeline --limit 5
+
+# List recent inbox conversations, including unread status
+opencli linkedin inbox --limit 20 -f json
+
+# Verify a profile before sending a connection request; add --send to actually send
+opencli linkedin connect https://www.linkedin.com/in/example/ --expected-name "Jane Doe" --note "quick note" --send
+
+# Snapshot a thread, then safe-send only if exact recipient/thread context still matches
+opencli linkedin thread-snapshot --thread-url https://www.linkedin.com/messaging/thread/abc/ -f json
+opencli linkedin safe-send --thread-url https://www.linkedin.com/messaging/thread/abc/ --expected-name "Jane Doe" --message "thanks" --send
 
 # JSON output
 opencli linkedin search -f json
@@ -46,6 +60,14 @@ When `--details` is set, each row additionally has:
 Previously the adapter returned `description: '', apply_url: ''` for both the missing-url path and the silent-catch path — callers couldn't tell upstream gaps apart from fetch failures. The current shape preserves backward compatibility on success and surfaces failures with `null` + a typed reason on `detail_error`. Per-row failures still don't abort the batch.
 
 `--limit` must be between 1 and 100, and `--start` must be a non-negative integer. LinkedIn login/auth walls abort with `AuthRequiredError` instead of being folded into `detail_error`.
+
+### Messaging commands
+
+`inbox` returns `rank`, `thread_url`, `thread_id`, `person_name`, `last_message_preview`, `unread`, and `timestamp`. It scrolls/paginates the inbox and also checks LinkedIn's unread filter because unread threads are not always visible in the default list.
+
+`connect` and `safe-send` are write commands but dry-run by default. They only click LinkedIn write actions when `--send` is explicitly passed. `connect` verifies the canonical profile URL and visible profile name before sending. `safe-send` verifies the canonical thread URL, visible recipient name, composer presence, and optional latest-message guard before filling or sending.
+
+`thread-snapshot` opens an exact messaging thread URL, scrolls for available history, and returns a JSON snapshot suitable for caller-side recipient safety checks.
 
 ## Prerequisites
 

--- a/docs/adapters/browser/linkedin.md
+++ b/docs/adapters/browser/linkedin.md
@@ -63,11 +63,11 @@ Previously the adapter returned `description: '', apply_url: ''` for both the mi
 
 ### Messaging commands
 
-`inbox` returns `rank`, `thread_url`, `thread_id`, `person_name`, `last_message_preview`, `unread`, and `timestamp`. It scrolls/paginates the inbox and also checks LinkedIn's unread filter because unread threads are not always visible in the default list.
+`inbox` returns `rank`, `thread_url`, `thread_id`, `person_name`, `last_message_preview`, `unread`, and `timestamp`. It loads the LinkedIn messaging page with your browser session, then reuses the page's own `messengerConversations` API request as the row source instead of scraping the virtualized inbox DOM.
 
-`connect` and `safe-send` are write commands but dry-run by default. They only click LinkedIn write actions when `--send` is explicitly passed. `connect` verifies the canonical profile URL and visible profile name before sending. `safe-send` verifies the canonical thread URL, visible recipient name, composer presence, and optional latest-message guard before filling or sending.
+`connect` and `safe-send` are write commands but dry-run by default. They only click LinkedIn write actions when `--send` is explicitly passed. `connect` requires an exact `https://www.linkedin.com/in/<profile>/` URL and verifies the landed profile plus visible name before sending. `safe-send` requires an exact `https://www.linkedin.com/messaging/thread/<id>/` URL and verifies the landed thread, visible recipient name, composer presence, and optional latest-message guard before filling or sending.
 
-`thread-snapshot` opens an exact messaging thread URL, scrolls for available history, and returns a JSON snapshot suitable for caller-side recipient safety checks.
+`thread-snapshot` opens an exact messaging thread URL, validates `--max-scrolls` before navigation, scrolls for available history, and returns a JSON snapshot suitable for caller-side recipient safety checks.
 
 ## Prerequisites
 

--- a/scripts/silent-column-drop-baseline.json
+++ b/scripts/silent-column-drop-baseline.json
@@ -531,21 +531,6 @@
     ]
   },
   {
-    "command": "linkedin/connect",
-    "file": "clis/linkedin/connect.js",
-    "missing": [
-      "alreadyConnected",
-      "authRequired",
-      "bodyText",
-      "buttonLabels",
-      "connectAvailable",
-      "connectHref",
-      "name",
-      "pending",
-      "title"
-    ]
-  },
-  {
     "command": "linkedin/timeline",
     "file": "clis/linkedin/timeline.js",
     "missing": [

--- a/scripts/silent-column-drop-baseline.json
+++ b/scripts/silent-column-drop-baseline.json
@@ -531,6 +531,21 @@
     ]
   },
   {
+    "command": "linkedin/connect",
+    "file": "clis/linkedin/connect.js",
+    "missing": [
+      "alreadyConnected",
+      "authRequired",
+      "bodyText",
+      "buttonLabels",
+      "connectAvailable",
+      "connectHref",
+      "name",
+      "pending",
+      "title"
+    ]
+  },
+  {
     "command": "linkedin/timeline",
     "file": "clis/linkedin/timeline.js",
     "missing": [
@@ -625,16 +640,6 @@
     "file": "clis/twitter/download.js",
     "missing": [
       "url"
-    ]
-  },
-  {
-    "command": "twitter/list-add",
-    "file": "clis/twitter/list-add.js",
-    "missing": [
-      "method",
-      "ts",
-      "url",
-      "via"
     ]
   },
   {


### PR DESCRIPTION
## Description

Adds four LinkedIn browser-adapter commands:

- `linkedin inbox`: reads LinkedIn's own `messengerConversations` GraphQL response in-page and returns normalized conversations with unread state, counterparty type, last-message preview, and timestamp.
- `linkedin connect`: fail-closed profile connection flow for the current LinkedIn UI, where Connect opens the `/preload/custom-invite/` route. It verifies the exact profile name and URL first, dry-runs by default, and only sends with `--send`.
- `linkedin safe-send`: fail-closed message sender with thread/header/latest-message verification before typing or sending.
- `linkedin thread-snapshot`: captures verified conversation context before replying.

`inbox` and `connect` were verified end to end on the real LinkedIn account during development. `connect` successfully sent a real invitation and was confirmed on LinkedIn's Sent Invitations page.

This supersedes #1421. PR #1421 covered only `safe-send` and `thread-snapshot`; this branch is the cleaner all-in-one contribution with `inbox` and `connect` included too.

Related issue: none

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
RUN  v4.1.4 /home/hanzi/projects/opencli-pr-work/OpenCLI-linkedin-pr

 ✓  adapter  clis/linkedin/inbox.test.js (8 tests) 4ms
 ✓  adapter  clis/linkedin/thread-snapshot.test.js (2 tests) 5ms
 ✓  adapter  clis/linkedin/connect.test.js (8 tests) 6ms
 ✓  adapter  clis/linkedin/safe-send.test.js (10 tests) 8ms

 Test Files  4 passed (4)
      Tests  28 passed (28)
```
