### PR TITLE
fix(barchart): surface greeks fetch failures

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1821,7 +1821,7 @@
         "type": "int",
         "default": 10,
         "required": false,
-        "help": "Number of near-the-money strikes per type"
+        "help": "Number of near-the-money strikes per type (1-100)"
       }
     ],
     "columns": [

--- a/clis/barchart/greeks.js
+++ b/clis/barchart/greeks.js
@@ -4,7 +4,47 @@
  * Auth: CSRF token from <meta name="csrf-token"> + session cookies.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const DEFAULT_LIMIT = 10;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+
+function normalizeSymbol(value) {
+    const symbol = String(value ?? '').trim().toUpperCase();
+    if (!symbol) throw new ArgumentError('symbol is required');
+    return symbol;
+}
+
+function normalizeExpiration(value) {
+    const expiration = String(value ?? '').trim();
+    if (!expiration) return '';
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(expiration)) {
+        throw new ArgumentError('--expiration must use YYYY-MM-DD format');
+    }
+    const parsed = new Date(`${expiration}T00:00:00Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== expiration) {
+        throw new ArgumentError('--expiration must be a valid calendar date');
+    }
+    return expiration;
+}
+
+function parseLimit(value) {
+    if (value === undefined || value === null || value === '') return DEFAULT_LIMIT;
+    const limit = Number(value);
+    if (!Number.isInteger(limit) || limit < MIN_LIMIT || limit > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}`);
+    }
+    return limit;
+}
+
+function unwrapBrowserResult(value) {
+    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
+        return value.data;
+    }
+    return value;
+}
+
 cli({
     site: 'barchart',
     name: 'greeks',
@@ -15,19 +55,19 @@ cli({
     args: [
         { name: 'symbol', required: true, positional: true, help: 'Stock ticker (e.g. AAPL)' },
         { name: 'expiration', type: 'str', help: 'Expiration date (YYYY-MM-DD). Defaults to the nearest available expiration.' },
-        { name: 'limit', type: 'int', default: 10, help: 'Number of near-the-money strikes per type' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: 'Number of near-the-money strikes per type (1-100)' },
     ],
     columns: [
         'type', 'strike', 'last', 'iv', 'delta', 'gamma', 'theta', 'vega', 'rho',
         'volume', 'openInterest', 'expiration',
     ],
     func: async (page, kwargs) => {
-        const symbol = kwargs.symbol.toUpperCase().trim();
-        const expiration = kwargs.expiration ?? '';
-        const limit = kwargs.limit ?? 10;
+        const symbol = normalizeSymbol(kwargs.symbol);
+        const expiration = normalizeExpiration(kwargs.expiration);
+        const limit = parseLimit(kwargs.limit);
         await page.goto(`https://www.barchart.com/stocks/quotes/${encodeURIComponent(symbol)}/options`);
         await page.wait(4);
-        const data = await page.evaluate(`
+        const data = unwrapBrowserResult(await page.evaluate(`
       (async () => {
         const sym = ${JSON.stringify(symbol)};
         const expDate = ${JSON.stringify(expiration)};
@@ -51,10 +91,11 @@ cli({
           }
 
           const d = await resp.json();
-          let items = d?.data;
-          if (!Array.isArray(items)) {
+          const allItems = d?.data;
+          if (!Array.isArray(allItems)) {
             return { ok: false, reason: 'malformed' };
           }
+          let items = allItems;
 
           if (!expDate) {
             const expirations = items
@@ -83,10 +124,15 @@ cli({
             .filter(i => ((i.raw || i).optionType || '').toLowerCase() === 'put')
             .sort((a, b) => Math.abs((a.raw || a).percentFromLast || 999) - Math.abs((b.raw || b).percentFromLast || 999))
             .slice(0, limit);
+          const selected = [...calls, ...puts];
+
+          if (items.length > 0 && selected.length === 0) {
+            return { ok: false, reason: 'malformed', message: 'options rows did not include call or put identities' };
+          }
 
           return {
             ok: true,
-            rows: [...calls, ...puts].map(i => {
+            rows: selected.map(i => {
               const r = i.raw || i;
               return {
                 type: r.optionType,
@@ -108,13 +154,13 @@ cli({
           return { ok: false, reason: 'exception', message: e?.message || String(e) };
         }
       })()
-    `);
+    `));
         if (!data || data.ok !== true) {
             if (data?.reason === 'http') {
                 throw new CommandExecutionError(`Barchart greeks request failed: HTTP ${data.status}${data.statusText ? ` ${data.statusText}` : ''}`);
             }
             if (data?.reason === 'malformed') {
-                throw new CommandExecutionError('Barchart greeks returned an unreadable options payload');
+                throw new CommandExecutionError(`Barchart greeks returned an unreadable options payload${data.message ? `: ${data.message}` : ''}`);
             }
             if (data?.reason === 'exception') {
                 throw new CommandExecutionError(`Barchart greeks request failed: ${data.message || 'unknown error'}`);
@@ -143,3 +189,10 @@ cli({
         }));
     },
 });
+
+export const __test__ = {
+    normalizeSymbol,
+    normalizeExpiration,
+    parseLimit,
+    unwrapBrowserResult,
+};

--- a/clis/barchart/greeks.js
+++ b/clis/barchart/greeks.js
@@ -173,20 +173,30 @@ cli({
         if (data.rows.length === 0) {
             throw new EmptyResultError('barchart greeks', `No option greeks were returned for ${symbol}. Confirm the symbol, expiration, and Barchart login state.`);
         }
-        return data.rows.map(r => ({
-            type: r.type || '',
-            strike: r.strike,
-            last: r.last != null ? Number(Number(r.last).toFixed(2)) : null,
-            iv: r.iv != null ? Number(Number(r.iv).toFixed(2)) + '%' : null,
-            delta: r.delta != null ? Number(Number(r.delta).toFixed(4)) : null,
-            gamma: r.gamma != null ? Number(Number(r.gamma).toFixed(4)) : null,
-            theta: r.theta != null ? Number(Number(r.theta).toFixed(4)) : null,
-            vega: r.vega != null ? Number(Number(r.vega).toFixed(4)) : null,
-            rho: r.rho != null ? Number(Number(r.rho).toFixed(4)) : null,
-            volume: r.volume,
-            openInterest: r.openInterest,
-            expiration: r.expiration ?? null,
-        }));
+        return data.rows.map(r => {
+            if (!r || typeof r !== 'object' || Array.isArray(r)) {
+                throw new CommandExecutionError('Barchart greeks returned a malformed option row');
+            }
+            const type = String(r.type || '').trim();
+            const expirationValue = String(r.expiration || '').trim();
+            if (!/^(call|put)$/i.test(type) || r.strike === undefined || r.strike === null || r.strike === '' || !expirationValue) {
+                throw new CommandExecutionError('Barchart greeks returned a malformed option row identity');
+            }
+            return {
+                type,
+                strike: r.strike,
+                last: r.last != null ? Number(Number(r.last).toFixed(2)) : null,
+                iv: r.iv != null ? Number(Number(r.iv).toFixed(2)) + '%' : null,
+                delta: r.delta != null ? Number(Number(r.delta).toFixed(4)) : null,
+                gamma: r.gamma != null ? Number(Number(r.gamma).toFixed(4)) : null,
+                theta: r.theta != null ? Number(Number(r.theta).toFixed(4)) : null,
+                vega: r.vega != null ? Number(Number(r.vega).toFixed(4)) : null,
+                rho: r.rho != null ? Number(Number(r.rho).toFixed(4)) : null,
+                volume: r.volume,
+                openInterest: r.openInterest,
+                expiration: expirationValue,
+            };
+        });
     },
 });
 

--- a/clis/barchart/greeks.js
+++ b/clis/barchart/greeks.js
@@ -4,6 +4,7 @@
  * Auth: CSRF token from <meta name="csrf-token"> + session cookies.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 cli({
     site: 'barchart',
     name: 'greeks',
@@ -45,39 +46,47 @@ cli({
             + '&fields=' + fields + '&raw=1';
           if (expDate) url += '&expirationDate=' + encodeURIComponent(expDate);
           const resp = await fetch(url, { credentials: 'include', headers });
-          if (resp.ok) {
-            const d = await resp.json();
-            let items = d?.data || [];
+          if (!resp.ok) {
+            return { ok: false, reason: 'http', status: resp.status, statusText: resp.statusText || '' };
+          }
 
-            if (!expDate) {
-              const expirations = items
-                .map(i => (i.raw || i).expirationDate || null)
-                .filter(Boolean)
-                .sort((a, b) => {
-                  const aTime = Date.parse(a);
-                  const bTime = Date.parse(b);
-                  if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
-                  if (Number.isNaN(aTime)) return 1;
-                  if (Number.isNaN(bTime)) return -1;
-                  return aTime - bTime;
-                });
-              const nearestExpiration = expirations[0];
-              if (nearestExpiration) {
-                items = items.filter(i => ((i.raw || i).expirationDate || null) === nearestExpiration);
-              }
+          const d = await resp.json();
+          let items = d?.data;
+          if (!Array.isArray(items)) {
+            return { ok: false, reason: 'malformed' };
+          }
+
+          if (!expDate) {
+            const expirations = items
+              .map(i => (i.raw || i).expirationDate || null)
+              .filter(Boolean)
+              .sort((a, b) => {
+                const aTime = Date.parse(a);
+                const bTime = Date.parse(b);
+                if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
+                if (Number.isNaN(aTime)) return 1;
+                if (Number.isNaN(bTime)) return -1;
+                return aTime - bTime;
+              });
+            const nearestExpiration = expirations[0];
+            if (nearestExpiration) {
+              items = items.filter(i => ((i.raw || i).expirationDate || null) === nearestExpiration);
             }
+          }
 
-            // Separate calls and puts, sort by distance from current price
-            const calls = items
-              .filter(i => ((i.raw || i).optionType || '').toLowerCase() === 'call')
-              .sort((a, b) => Math.abs((a.raw || a).percentFromLast || 999) - Math.abs((b.raw || b).percentFromLast || 999))
-              .slice(0, limit);
-            const puts = items
-              .filter(i => ((i.raw || i).optionType || '').toLowerCase() === 'put')
-              .sort((a, b) => Math.abs((a.raw || a).percentFromLast || 999) - Math.abs((b.raw || b).percentFromLast || 999))
-              .slice(0, limit);
+          // Separate calls and puts, sort by distance from current price.
+          const calls = items
+            .filter(i => ((i.raw || i).optionType || '').toLowerCase() === 'call')
+            .sort((a, b) => Math.abs((a.raw || a).percentFromLast || 999) - Math.abs((b.raw || b).percentFromLast || 999))
+            .slice(0, limit);
+          const puts = items
+            .filter(i => ((i.raw || i).optionType || '').toLowerCase() === 'put')
+            .sort((a, b) => Math.abs((a.raw || a).percentFromLast || 999) - Math.abs((b.raw || b).percentFromLast || 999))
+            .slice(0, limit);
 
-            return [...calls, ...puts].map(i => {
+          return {
+            ok: true,
+            rows: [...calls, ...puts].map(i => {
               const r = i.raw || i;
               return {
                 type: r.optionType,
@@ -93,16 +102,32 @@ cli({
                 openInterest: r.openInterest,
                 expiration: r.expirationDate,
               };
-            });
-          }
-        } catch(e) {}
-
-        return [];
+            })
+          };
+        } catch(e) {
+          return { ok: false, reason: 'exception', message: e?.message || String(e) };
+        }
       })()
     `);
-        if (!data || !Array.isArray(data))
-            return [];
-        return data.map(r => ({
+        if (!data || data.ok !== true) {
+            if (data?.reason === 'http') {
+                throw new CommandExecutionError(`Barchart greeks request failed: HTTP ${data.status}${data.statusText ? ` ${data.statusText}` : ''}`);
+            }
+            if (data?.reason === 'malformed') {
+                throw new CommandExecutionError('Barchart greeks returned an unreadable options payload');
+            }
+            if (data?.reason === 'exception') {
+                throw new CommandExecutionError(`Barchart greeks request failed: ${data.message || 'unknown error'}`);
+            }
+            throw new CommandExecutionError(`Failed to fetch Barchart greeks for ${symbol}`);
+        }
+        if (!Array.isArray(data.rows)) {
+            throw new CommandExecutionError('Barchart greeks returned an unreadable options payload');
+        }
+        if (data.rows.length === 0) {
+            throw new EmptyResultError('barchart greeks', `No option greeks were returned for ${symbol}. Confirm the symbol, expiration, and Barchart login state.`);
+        }
+        return data.rows.map(r => ({
             type: r.type || '',
             strike: r.strike,
             last: r.last != null ? Number(Number(r.last).toFixed(2)) : null,

--- a/clis/barchart/greeks.test.js
+++ b/clis/barchart/greeks.test.js
@@ -127,6 +127,8 @@ describe('barchart greeks command', () => {
             .rejects.toBeInstanceOf(CommandExecutionError);
         await expect(command.func(makePage({ ok: true, rows: 'bad' }), { symbol: 'AAPL' }))
             .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ ok: true, rows: [{ type: 'Call', strike: null, expiration: '' }] }), { symbol: 'AAPL' }))
+            .rejects.toThrow('malformed option row identity');
     });
 
     it('throws EmptyResultError when Barchart returns no greeks rows', async () => {

--- a/clis/barchart/greeks.test.js
+++ b/clis/barchart/greeks.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './greeks.js';
+
+const { normalizeExpiration, normalizeSymbol, parseLimit, unwrapBrowserResult } = await import('./greeks.js').then((m) => m.__test__);
 
 function makePage(evaluateResult) {
     return {
@@ -26,6 +28,8 @@ describe('barchart greeks command', () => {
 
     it('maps returned option rows without changing the declared output shape', async () => {
         const page = makePage({
+            session: 'site:barchart',
+            data: {
             ok: true,
             rows: [
                 {
@@ -43,6 +47,7 @@ describe('barchart greeks command', () => {
                     expiration: '2026-06-19',
                 },
             ],
+            },
         });
 
         const rows = await command.func(page, { symbol: 'aapl', limit: 1 });
@@ -65,6 +70,21 @@ describe('barchart greeks command', () => {
                 expiration: '2026-06-19',
             },
         ]);
+    });
+
+    it('validates args before browser navigation and unwraps bridge envelopes', async () => {
+        expect(normalizeSymbol(' aapl ')).toBe('AAPL');
+        expect(normalizeExpiration('2026-06-19')).toBe('2026-06-19');
+        expect(parseLimit(undefined)).toBe(10);
+        expect(parseLimit(100)).toBe(100);
+        expect(unwrapBrowserResult({ session: 'site:barchart', data: { ok: true } })).toEqual({ ok: true });
+
+        await expect(command.func(makePage({ ok: true, rows: [] }), { symbol: '', limit: 1 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func(makePage({ ok: true, rows: [] }), { symbol: 'AAPL', expiration: '2026-02-30', limit: 1 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func(makePage({ ok: true, rows: [] }), { symbol: 'AAPL', limit: 101 }))
+            .rejects.toBeInstanceOf(ArgumentError);
     });
 
     it('embeds expiration and limit in the browser-side request script', async () => {
@@ -101,6 +121,8 @@ describe('barchart greeks command', () => {
             .rejects.toBeInstanceOf(CommandExecutionError);
         await expect(command.func(makePage({ ok: false, reason: 'exception', message: 'network down' }), { symbol: 'AAPL' }))
             .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ ok: false, reason: 'malformed', message: 'options rows did not include call or put identities' }), { symbol: 'AAPL' }))
+            .rejects.toThrow('call or put identities');
         await expect(command.func(makePage(null), { symbol: 'AAPL' }))
             .rejects.toBeInstanceOf(CommandExecutionError);
         await expect(command.func(makePage({ ok: true, rows: 'bad' }), { symbol: 'AAPL' }))

--- a/clis/barchart/greeks.test.js
+++ b/clis/barchart/greeks.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './greeks.js';
+
+function makePage(evaluateResult) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(evaluateResult),
+    };
+}
+
+describe('barchart greeks command', () => {
+    const command = getRegistry().get('barchart/greeks');
+
+    it('registers with the expected shape', () => {
+        expect(command).toBeDefined();
+        expect(command.access).toBe('read');
+        expect(command.browser).toBe(true);
+        expect(command.columns).toEqual([
+            'type', 'strike', 'last', 'iv', 'delta', 'gamma', 'theta', 'vega', 'rho',
+            'volume', 'openInterest', 'expiration',
+        ]);
+    });
+
+    it('maps returned option rows without changing the declared output shape', async () => {
+        const page = makePage({
+            ok: true,
+            rows: [
+                {
+                    type: 'Call',
+                    strike: 190,
+                    last: 3.456,
+                    iv: 21.234,
+                    delta: 0.56789,
+                    gamma: 0.01234,
+                    theta: -0.12345,
+                    vega: 0.23456,
+                    rho: 0.03456,
+                    volume: 123,
+                    openInterest: 456,
+                    expiration: '2026-06-19',
+                },
+            ],
+        });
+
+        const rows = await command.func(page, { symbol: 'aapl', limit: 1 });
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.barchart.com/stocks/quotes/AAPL/options');
+        expect(page.wait).toHaveBeenCalledWith(4);
+        expect(rows).toEqual([
+            {
+                type: 'Call',
+                strike: 190,
+                last: 3.46,
+                iv: '21.23%',
+                delta: 0.5679,
+                gamma: 0.0123,
+                theta: -0.1235,
+                vega: 0.2346,
+                rho: 0.0346,
+                volume: 123,
+                openInterest: 456,
+                expiration: '2026-06-19',
+            },
+        ]);
+    });
+
+    it('embeds expiration and limit in the browser-side request script', async () => {
+        const page = makePage({
+            ok: true,
+            rows: [{
+                type: 'Put',
+                strike: 185,
+                last: null,
+                iv: null,
+                delta: null,
+                gamma: null,
+                theta: null,
+                vega: null,
+                rho: null,
+                volume: 0,
+                openInterest: 0,
+                expiration: '2026-07-17',
+            }],
+        });
+
+        await command.func(page, { symbol: 'MSFT', expiration: '2026-07-17', limit: 7 });
+        const script = page.evaluate.mock.calls[0][0];
+
+        expect(script).toContain('const expDate = "2026-07-17"');
+        expect(script).toContain('const limit = 7');
+        expect(script).toContain("url += '&expirationDate=' + encodeURIComponent(expDate)");
+    });
+
+    it('throws CommandExecutionError for HTTP, malformed, exception, and missing payload states', async () => {
+        await expect(command.func(makePage({ ok: false, reason: 'http', status: 403, statusText: 'Forbidden' }), { symbol: 'AAPL' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ ok: false, reason: 'malformed' }), { symbol: 'AAPL' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ ok: false, reason: 'exception', message: 'network down' }), { symbol: 'AAPL' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage(null), { symbol: 'AAPL' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ ok: true, rows: 'bad' }), { symbol: 'AAPL' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when Barchart returns no greeks rows', async () => {
+        await expect(command.func(makePage({ ok: true, rows: [] }), { symbol: 'AAPL' }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+});


### PR DESCRIPTION
  ## Description

  Surface `barchart greeks` fetch and payload failures as typed OpenCLI errors instead of silently returning an empty
  result.

  Previously, HTTP failures, malformed payloads, browser-side exceptions, and valid empty results could all return `[]`.
  That made adapter failures indistinguishable from real no-data responses and triggered the typed-error lint gate.

  This change returns structured browser-side states and maps expected failures to `CommandExecutionError` or
  `EmptyResultError` in Node. Successful row formatting is unchanged.

  Related issue:

  ## Type of Change

  - [x] Bug fix
  - [ ] ✨ New feature
  - [ ] New site adapter
  - [ ] Documentation
  - [ ] ♻️ Refactor
  - [ ] CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [x] Used positional args for the command's primary subject unless a named flag is clearly better
  - [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output

  ```bash
  npx vitest run --project adapter clis/barchart/greeks.test.js

  Test Files  1 passed (1)
  Tests       5 passed (5)

  node scripts/check-typed-error-lint.mjs

  Typed-error lint gate: current=184, baseline=189, new=0, resolved=5
  OK - no new typed-error lint violations.