### PR TITLE
fix(doctor): clarify connected profile status

### DIFF
--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   BrowserCommandError,
+  connectedProfileCount,
   fetchDaemonStatus,
+  getDaemonExtensionState,
   getDaemonHealth,
   requestDaemonShutdown,
   sendCommand,
@@ -128,6 +130,66 @@ describe('daemon-client', () => {
     } as Response);
 
     await expect(getDaemonHealth()).resolves.toEqual({ state: 'profile-required', status });
+  });
+
+  it('classifies extension route state without collapsing connected profiles into disconnected', () => {
+    expect(getDaemonExtensionState({
+      ok: true,
+      pid: 1,
+      uptime: 0,
+      extensionConnected: false,
+      pending: 0,
+      memoryMB: 1,
+      port: 19825,
+    })).toBe('no-extension');
+
+    expect(getDaemonExtensionState({
+      ok: true,
+      pid: 1,
+      uptime: 0,
+      extensionConnected: false,
+      profileRequired: true,
+      profiles: [
+        { contextId: 'work', extensionConnected: true, pending: 0 },
+        { contextId: 'personal', extensionConnected: true, pending: 0 },
+      ],
+      pending: 0,
+      memoryMB: 1,
+      port: 19825,
+    })).toBe('profile-required');
+
+    expect(getDaemonExtensionState({
+      ok: true,
+      pid: 1,
+      uptime: 0,
+      extensionConnected: false,
+      profileDisconnected: true,
+      contextId: 'default',
+      profiles: [{ contextId: 'work', extensionConnected: true, pending: 0 }],
+      pending: 0,
+      memoryMB: 1,
+      port: 19825,
+    })).toBe('profile-disconnected');
+
+    expect(getDaemonExtensionState({
+      ok: true,
+      pid: 1,
+      uptime: 0,
+      extensionConnected: true,
+      extensionVersion: '1.2.3',
+      pending: 0,
+      memoryMB: 1,
+      port: 19825,
+    })).toBe('connected');
+  });
+
+  it('counts only connected profile entries', () => {
+    expect(connectedProfileCount({
+      profiles: [
+        { contextId: 'work', extensionConnected: true, pending: 0 },
+        { contextId: 'closed', extensionConnected: false, pending: 0 },
+      ],
+    })).toBe(1);
   });
 
   it('fetchDaemonStatus includes contextId in the status query', async () => {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -108,6 +108,23 @@ export interface BrowserProfileStatus {
   lastSeenAt?: number;
 }
 
+export type DaemonExtensionState =
+  | 'connected'
+  | 'no-extension'
+  | 'profile-required'
+  | 'profile-disconnected';
+
+export function connectedProfileCount(status: Pick<DaemonStatus, 'profiles'>): number {
+  return status.profiles?.filter((profile) => profile.extensionConnected).length ?? 0;
+}
+
+export function getDaemonExtensionState(status: DaemonStatus): DaemonExtensionState {
+  if (status.profileRequired) return 'profile-required';
+  if (status.profileDisconnected) return 'profile-disconnected';
+  if (status.extensionConnected) return 'connected';
+  return 'no-extension';
+}
+
 async function requestDaemon(pathname: string, init?: RequestInit & { timeout?: number }): Promise<Response> {
   const { timeout = 2000, headers, ...rest } = init ?? {};
   const controller = new AbortController();
@@ -148,9 +165,10 @@ export type DaemonHealth =
 export async function getDaemonHealth(opts?: { timeout?: number; contextId?: string }): Promise<DaemonHealth> {
   const status = await fetchDaemonStatus(opts);
   if (!status) return { state: 'stopped', status: null };
-  if (status.profileRequired) return { state: 'profile-required', status };
-  if (status.profileDisconnected) return { state: 'profile-disconnected', status };
-  if (!status.extensionConnected) return { state: 'no-extension', status };
+  const extensionState = getDaemonExtensionState(status);
+  if (extensionState === 'profile-required') return { state: 'profile-required', status };
+  if (extensionState === 'profile-disconnected') return { state: 'profile-disconnected', status };
+  if (extensionState === 'no-extension') return { state: 'no-extension', status };
   return { state: 'ready', status };
 }
 

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -4,19 +4,29 @@ const {
   fetchDaemonStatusMock,
   requestDaemonShutdownMock,
   restartDaemonMock,
+  resolveProfileContextIdMock,
 } = vi.hoisted(() => ({
   fetchDaemonStatusMock: vi.fn(),
   requestDaemonShutdownMock: vi.fn(),
   restartDaemonMock: vi.fn(),
+  resolveProfileContextIdMock: vi.fn(),
 }));
 
-vi.mock('../browser/daemon-client.js', () => ({
-  fetchDaemonStatus: fetchDaemonStatusMock,
-  requestDaemonShutdown: requestDaemonShutdownMock,
-}));
+vi.mock('../browser/daemon-client.js', async () => {
+  const actual = await vi.importActual<typeof import('../browser/daemon-client.js')>('../browser/daemon-client.js');
+  return {
+    ...actual,
+    fetchDaemonStatus: fetchDaemonStatusMock,
+    requestDaemonShutdown: requestDaemonShutdownMock,
+  };
+});
 
 vi.mock('../browser/daemon-lifecycle.js', () => ({
   restartDaemon: restartDaemonMock,
+}));
+
+vi.mock('../browser/profile.js', () => ({
+  resolveProfileContextId: resolveProfileContextIdMock,
 }));
 
 import { daemonRestart, daemonStatus, daemonStop } from './daemon.js';
@@ -29,6 +39,8 @@ describe('daemonStatus', () => {
     stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     fetchDaemonStatusMock.mockReset();
     requestDaemonShutdownMock.mockReset();
+    resolveProfileContextIdMock.mockReset();
+    resolveProfileContextIdMock.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -83,6 +95,55 @@ describe('daemonStatus', () => {
     await daemonStatus();
 
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('disconnected'));
+  });
+
+  it('shows profile selection required when profiles are connected but no default is selected', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 99,
+      uptime: 120,
+      daemonVersion: PKG_VERSION,
+      extensionConnected: false,
+      profileRequired: true,
+      profiles: [
+        { contextId: 'work', extensionConnected: true, extensionVersion: '1.0.14', pending: 0 },
+        { contextId: 'personal', extensionConnected: true, extensionVersion: '1.0.14', pending: 0 },
+      ],
+      pending: 0,
+      memoryMB: 32,
+      port: 19825,
+    });
+
+    await daemonStatus();
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('2 profiles connected, none selected'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('opencli profile use <name>'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringMatching(/^Extension: disconnected$/));
+  });
+
+  it('queries the selected default profile and reports when it is disconnected', async () => {
+    resolveProfileContextIdMock.mockReturnValue('default');
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 99,
+      uptime: 120,
+      daemonVersion: PKG_VERSION,
+      extensionConnected: false,
+      profileDisconnected: true,
+      contextId: 'default',
+      profiles: [
+        { contextId: 'work', extensionConnected: true, extensionVersion: '1.0.14', pending: 0 },
+      ],
+      pending: 0,
+      memoryMB: 32,
+      port: 19825,
+    });
+
+    await daemonStatus();
+
+    expect(fetchDaemonStatusMock).toHaveBeenCalledWith({ contextId: 'default' });
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('selected profile "default" disconnected'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 other profile connected'));
   });
 
   it('shows version unknown when the connected extension does not report one', async () => {

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -5,32 +5,57 @@
  *   opencli daemon restart — graceful shutdown, then start a fresh daemon
  */
 
-import { fetchDaemonStatus, requestDaemonShutdown } from '../browser/daemon-client.js';
+import {
+  connectedProfileCount,
+  fetchDaemonStatus,
+  getDaemonExtensionState,
+  requestDaemonShutdown,
+  type DaemonStatus,
+} from '../browser/daemon-client.js';
 import { restartDaemon } from '../browser/daemon-lifecycle.js';
+import { resolveProfileContextId } from '../browser/profile.js';
 import { formatDuration } from '../download/progress.js';
 import { log } from '../logger.js';
 import { PKG_VERSION } from '../version.js';
 import { formatDaemonVersion, isDaemonStale } from '../browser/daemon-version.js';
 
+function pluralizeProfile(count: number): string {
+  return count === 1 ? 'profile' : 'profiles';
+}
+
+function formatExtensionLabel(status: DaemonStatus): string {
+  const extensionState = getDaemonExtensionState(status);
+  const profileCount = connectedProfileCount(status);
+
+  if (extensionState === 'profile-required') {
+    return `${profileCount} ${pluralizeProfile(profileCount)} connected, none selected (run: opencli profile use <name>)`;
+  }
+  if (extensionState === 'profile-disconnected') {
+    const selected = status.contextId ? `selected profile "${status.contextId}"` : 'selected profile';
+    const connected = profileCount > 0
+      ? `; ${profileCount} other ${pluralizeProfile(profileCount)} connected`
+      : '';
+    return `${selected} disconnected${connected}`;
+  }
+  if (extensionState === 'no-extension') return 'disconnected';
+  return status.extensionVersion
+    ? `connected (v${status.extensionVersion})`
+    : 'connected (version unknown)';
+}
+
 export async function daemonStatus(): Promise<void> {
-  const status = await fetchDaemonStatus();
+  const status = await fetchDaemonStatus({ contextId: resolveProfileContextId() });
   if (!status) {
     console.log('Daemon: not running');
     return;
   }
-
-  const extensionLabel = !status.extensionConnected
-    ? 'disconnected'
-    : status.extensionVersion
-      ? `connected (v${status.extensionVersion})`
-      : 'connected (version unknown)';
 
   const daemonVersion = formatDaemonVersion(status);
   const stale = isDaemonStale(status, PKG_VERSION);
   console.log(`Daemon: ${stale ? 'stale' : 'running'} (PID ${status.pid})`);
   console.log(`Version: ${daemonVersion}${stale ? ` (CLI v${PKG_VERSION}; run: opencli daemon restart)` : ''}`);
   console.log(`Uptime: ${formatDuration(Math.round(status.uptime * 1000))}`);
-  console.log(`Extension: ${extensionLabel}`);
+  console.log(`Extension: ${formatExtensionLabel(status)}`);
   if (status.profiles && status.profiles.length > 0) {
     console.log(`Profiles: ${status.profiles.map((profile) => {
       const version = profile.extensionVersion ? ` v${profile.extensionVersion}` : '';

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetDaemonHealth, mockConnect, mockClose, mockFindShadowedUserAdapters } = vi.hoisted(() => ({
+const { mockGetDaemonHealth, mockConnect, mockClose, mockFindShadowedUserAdapters, mockResolveProfileContextId } = vi.hoisted(() => ({
   mockGetDaemonHealth: vi.fn(),
   mockConnect: vi.fn(),
   mockClose: vi.fn(),
   mockFindShadowedUserAdapters: vi.fn(),
+  mockResolveProfileContextId: vi.fn(),
 }));
 
-vi.mock('./browser/daemon-client.js', () => ({
-  getDaemonHealth: mockGetDaemonHealth,
-}));
+vi.mock('./browser/daemon-client.js', async () => {
+  const actual = await vi.importActual<typeof import('./browser/daemon-client.js')>('./browser/daemon-client.js');
+  return {
+    ...actual,
+    getDaemonHealth: mockGetDaemonHealth,
+  };
+});
 
 vi.mock('./browser/index.js', () => ({
   BrowserBridge: class {
@@ -23,6 +28,14 @@ vi.mock('./adapter-shadow.js', async () => {
   return {
     ...actual,
     findShadowedUserAdapters: mockFindShadowedUserAdapters,
+  };
+});
+
+vi.mock('./browser/profile.js', async () => {
+  const actual = await vi.importActual<typeof import('./browser/profile.js')>('./browser/profile.js');
+  return {
+    ...actual,
+    resolveProfileContextId: mockResolveProfileContextId,
   };
 });
 
@@ -40,6 +53,7 @@ describe('doctor report rendering', () => {
       closeWindow: vi.fn().mockResolvedValue(undefined),
     });
     mockClose.mockResolvedValue(undefined);
+    mockResolveProfileContextId.mockReturnValue(undefined);
   });
 
   it('renders OK-style report when daemon and extension connected', () => {
@@ -125,6 +139,7 @@ describe('doctor report rendering', () => {
     const text = strip(renderBrowserDoctorReport({
       daemonRunning: true,
       extensionConnected: false,
+      extensionState: 'profile-required',
       profiles: [
         { contextId: 'work', extensionConnected: true, extensionVersion: '1.2.3', pending: 0 },
         { contextId: 'personal', extensionConnected: true, extensionVersion: '1.2.3', pending: 0 },
@@ -132,9 +147,27 @@ describe('doctor report rendering', () => {
       issues: [],
     }));
 
+    expect(text).toContain('[WARN] Extension: 2 profiles connected, none selected');
     expect(text).toContain('Profiles:');
     expect(text).toContain('work: connected v1.2.3');
     expect(text).toContain('personal: connected v1.2.3');
+    expect(text).not.toContain('[MISSING] Extension: not connected');
+  });
+
+  it('renders selected profile disconnected separately from no extension', () => {
+    const text = strip(renderBrowserDoctorReport({
+      daemonRunning: true,
+      extensionConnected: false,
+      extensionState: 'profile-disconnected',
+      profiles: [
+        { contextId: 'work', extensionConnected: true, extensionVersion: '1.2.3', pending: 0 },
+      ],
+      issues: ['Selected browser profile is not connected: default.'],
+    }));
+
+    expect(text).toContain('[WARN] Extension: selected profile not connected');
+    expect(text).toContain('work: connected v1.2.3');
+    expect(text).not.toContain('[MISSING] Extension: not connected');
   });
 
   it('renders unstable extension state when live connectivity and status disagree', () => {
@@ -305,8 +338,38 @@ describe('doctor report rendering', () => {
     const report = await runBrowserDoctor();
 
     expect(report.profiles).toHaveLength(2);
+    expect(report.extensionState).toBe('profile-required');
+    expect(report.extensionFlaky).toBe(false);
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('Multiple Chrome profiles are connected'),
+    ]));
+  });
+
+  it('reports a disconnected selected default profile without treating other profiles as no extension', async () => {
+    mockResolveProfileContextId.mockReturnValue('default');
+    const status = {
+      state: 'profile-disconnected' as const,
+      status: {
+        extensionConnected: false,
+        profileDisconnected: true,
+        contextId: 'default',
+        profiles: [
+          { contextId: 'work', extensionConnected: true, pending: 0 },
+        ],
+      },
+    };
+    mockGetDaemonHealth.mockResolvedValue(status);
+    mockConnect.mockRejectedValueOnce(new Error('profile disconnected'));
+
+    const report = await runBrowserDoctor();
+
+    expect(mockGetDaemonHealth).toHaveBeenCalledWith({ contextId: 'default' });
+    expect(report.extensionState).toBe('profile-disconnected');
+    expect(report.extensionConnected).toBe(false);
+    expect(report.extensionFlaky).toBe(false);
+    expect(report.profiles).toHaveLength(1);
+    expect(report.issues).toEqual(expect.arrayContaining([
+      expect.stringContaining('Selected browser profile is not connected: default'),
     ]));
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -6,12 +6,12 @@
 
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
-import { getDaemonHealth } from './browser/daemon-client.js';
+import { connectedProfileCount, getDaemonExtensionState, getDaemonHealth } from './browser/daemon-client.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
-import type { BrowserProfileStatus } from './browser/daemon-client.js';
-import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
+import type { BrowserProfileStatus, DaemonExtensionState } from './browser/daemon-client.js';
+import { aliasForContextId, loadProfileConfig, resolveProfileContextId } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
@@ -65,6 +65,7 @@ export type DoctorReport = {
   daemonStale?: boolean;
   daemonVersion?: string;
   extensionConnected: boolean;
+  extensionState?: DaemonExtensionState;
   extensionFlaky?: boolean;
   extensionVersion?: string;
   latestExtensionVersion?: string;
@@ -105,11 +106,12 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const connectivity = await checkConnectivity();
 
   // Single status read *after* connectivity side-effects settle.
-  const health = await getDaemonHealth();
+  const health = await getDaemonHealth({ contextId: resolveProfileContextId() });
   const daemonRunning = health.state !== 'stopped';
+  const extensionState = health.status ? getDaemonExtensionState(health.status) : 'no-extension';
   const extensionConnected = health.state === 'ready';
   const daemonFlaky = connectivity.ok && !daemonRunning;
-  const extensionFlaky = connectivity.ok && daemonRunning && !extensionConnected;
+  const extensionFlaky = connectivity.ok && daemonRunning && (health.state === 'no-extension' || health.state === 'profile-disconnected');
   const daemonStale = isDaemonStale(health.status, opts.cliVersion);
   const profiles = health.status?.profiles;
   const extensionVersion = health.status?.extensionVersion;
@@ -204,6 +206,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     daemonStale,
     daemonVersion: health.status?.daemonVersion,
     extensionConnected,
+    extensionState,
     extensionFlaky,
     extensionVersion,
     latestExtensionVersion,
@@ -233,7 +236,11 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
   lines.push(`${daemonIcon} Daemon: ${daemonLabel}`);
 
   // Extension status
-  const extIcon = report.extensionFlaky || (report.extensionConnected && !report.extensionVersion)
+  const extState = report.extensionState ?? (report.extensionConnected ? 'connected' : 'no-extension');
+  const extIcon = report.extensionFlaky
+    || extState === 'profile-required'
+    || extState === 'profile-disconnected'
+    || (report.extensionConnected && !report.extensionVersion)
     ? '[WARN]'
     : report.extensionConnected ? '[OK]' : '[MISSING]';
   const extUpdateHint = report.extensionVersion && report.latestExtensionVersion && isNewerVersion(report.latestExtensionVersion, report.extensionVersion)
@@ -244,9 +251,14 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
     : report.extensionVersion
       ? ` (v${report.extensionVersion})` + extUpdateHint
       : ' (version unknown)';
+  const profileCount = connectedProfileCount({ profiles: report.profiles });
   const extLabel = report.extensionFlaky
     ? 'unstable (connected during live check, then disconnected)'
-    : report.extensionConnected ? 'connected' : 'not connected';
+    : extState === 'profile-required'
+      ? `${profileCount} ${profileCount === 1 ? 'profile' : 'profiles'} connected, none selected`
+      : extState === 'profile-disconnected'
+        ? 'selected profile not connected'
+        : report.extensionConnected ? 'connected' : 'not connected';
   lines.push(`${extIcon} Extension: ${extLabel}${extVersion}`);
 
   if (report.profiles && report.profiles.length > 0) {


### PR DESCRIPTION
  ## Description

  Clarifies daemon/browser extension status reporting when Browser Bridge profiles are connected but the active/default
  profile is missing or disconnected.

  Previously, doctor/status output could collapse profile routing states into a generic `Extension: not connected`
  message. This made multi-profile setups misleading: the extension could be connected in one or more profiles while the
  selected/default profile was not usable.

  This PR centralizes daemon extension state classification and updates doctor/status rendering to distinguish:

  - no extension/profile connected
  - multiple profiles connected but no profile selected
  - selected profile disconnected
  - extension connected normally

  Related issue: https://github.com/jackwener/OpenCLI/issues/1575

  ## Type of Change

  - [x]  Bug fix
  - [ ] ✨ New feature
  - [ ]  New site adapter
  - [ ]  Documentation
  - [ ] ♻️ Refactor
  - [ ]  CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [ ] Used positional args for the command's primary subject unless a named flag is clearly better
  - [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output

  Checks run:

  ```bash
  npx vitest run --project unit src/browser/daemon-client.test.ts src/commands/daemon.test.ts src/doctor.test.ts
  npm run typecheck

  Result:

  - 3 test files passed
  - 46 tests passed
  - typecheck passed