### PR TITLE
test(plugin): cover options-only command args

### DIFF
--- a/tests/e2e/plugin-command-args.test.ts
+++ b/tests/e2e/plugin-command-args.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression coverage for plugin commands registered through real discovery
+ * and Commander parsing.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { parseJsonOutput, runCli } from './helpers.js';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-plugin-args-e2e-'));
+const PLUGIN_NAME = 'options-only';
+const PLUGIN_DIR = path.join(TEST_HOME, '.opencli', 'plugins', PLUGIN_NAME);
+
+function runPluginCli(args: string[]) {
+  return runCli(args, {
+    env: {
+      HOME: TEST_HOME,
+      USERPROFILE: TEST_HOME,
+    },
+  });
+}
+
+describe('plugin command args E2E', () => {
+  beforeAll(() => {
+    fs.mkdirSync(PLUGIN_DIR, { recursive: true });
+    fs.writeFileSync(
+      path.join(PLUGIN_DIR, 'capture.js'),
+      `
+import { cli } from '@jackwener/opencli/registry';
+
+cli({
+  site: '${PLUGIN_NAME}',
+  name: 'capture',
+  access: 'read',
+  browser: false,
+  description: 'Capture parsed kwargs',
+  args: [
+    { name: 'message', required: true, valueRequired: true, help: 'Message text' },
+    { name: 'enabled', type: 'boolean', default: false, help: 'Enable mode' },
+    { name: 'limit', type: 'number', default: 5, help: 'Limit' },
+  ],
+  func: async (kwargs) => kwargs,
+});
+`,
+      'utf-8',
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('preserves string and valueless boolean options for options-only plugin commands', async () => {
+    const result = await runPluginCli([
+      PLUGIN_NAME,
+      'capture',
+      '--message',
+      'hello',
+      '--enabled',
+      '-f',
+      'json',
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(parseJsonOutput(result.stdout)).toMatchObject({
+      message: 'hello',
+      enabled: true,
+      limit: 5,
+    });
+  });
+
+  it('preserves explicit numeric options and default boolean values for options-only plugin commands', async () => {
+    const result = await runPluginCli([
+      PLUGIN_NAME,
+      'capture',
+      '--message',
+      'counted',
+      '--limit',
+      '12',
+      '-f',
+      'json',
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(parseJsonOutput(result.stdout)).toMatchObject({
+      message: 'counted',
+      enabled: false,
+      limit: 12,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             'tests/e2e/public-commands.test.ts',
             'tests/e2e/management.test.ts',
             'tests/e2e/output-formats.test.ts',
+            'tests/e2e/plugin-command-args.test.ts',
             'tests/e2e/plugin-management.test.ts',
             'tests/e2e/browser-tabs.test.ts',
             'tests/e2e/article-download-pipeline.test.ts',


### PR DESCRIPTION

  ## Description

  Adds regression coverage for options-only plugin commands to ensure command-line options are preserved through real
  plugin discovery, Commander parsing, command execution, and JSON output.

  The reported issue could not be reproduced on current main, so this PR locks the expected behavior with an E2E test
  using a local synthetic plugin. The test covers:

  - required string options
  - valueless boolean options
  - default boolean values
  - explicit numeric options
  - default numeric values

  Related issue: https://github.com/jackwener/OpenCLI/issues/1501

  ## Type of Change

  - [ ]  Bug fix
  - [ ] ✨ New feature
  - [ ]  New site adapter
  - [ ]  Documentation
  - [ ] ♻️ Refactor
  - [x]  CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [ ] Used positional args for the command's primary subject unless a named flag is clearly better
  - [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output

  Checks run:

  ```bash
  npm run build
  npx vitest run --project e2e tests/e2e/plugin-command-args.test.ts
  npx vitest run --project unit src/commanderAdapter.test.ts
  npm run typecheck

  Result:

  - build passed
  - e2e: 2 tests passed
  - unit: 17 tests passed
  - typecheck passed
