### PR TITLE
docs(readme): simplify Highlights from 9 to 5 bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,11 @@ It also works as a **CLI hub** for local tools such as `gh`, `docker`, `longbrid
 
 ## Highlights
 
-- **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT, etc.) directly from the terminal via CDP.
-- **Browser Automation for AI Agents** — Install the `opencli-adapter-author` skill, and your AI agent can operate any website: navigate, click, type/fill, extract, screenshot — all through your logged-in Chrome session.
-- **Multi-profile Browser Bridge** — Install the extension in each Chrome profile you want to use, then route commands with `--profile`, `OPENCLI_PROFILE`, or `opencli profile use`.
-- **Website → CLI** — Turn any website into a deterministic CLI: 100+ site surfaces are already registered, or write your own with the `opencli-adapter-author` skill + `opencli browser verify`.
-- **Account-safe** — Reuses Chrome/Chromium logged-in state; your credentials never leave the browser.
-- **AI Agent ready** — One skill takes you from site recon through API discovery, field decoding, adapter writing, and verification.
-- **CLI Hub** — Discover, auto-install, and passthrough commands to any external CLI (gh, docker, obsidian, tg, discord, wx, etc).
-- **Zero LLM cost** — No tokens consumed at runtime. Run 10,000 times and pay nothing.
-- **Deterministic** — Same command, same output schema, every time. Pipeable, scriptable, CI-friendly.
+- **Live Browser Automation** — Drive your logged-in Chrome from AI agents: navigate, fill forms, click, extract. Credentials stay in the browser.
+- **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT) directly via CDP.
+- **Multi-profile Browser Bridge** — Route commands to specific Chrome profiles via `--profile` or `OPENCLI_PROFILE`.
+- **100+ adapters + CLI Hub** — Built-in site commands (bilibili / xiaohongshu / twitter / hackernews / ...) plus external CLI passthrough (`gh`, `docker`, `ntn`, `longbridge`).
+- **Zero LLM cost at runtime** — Deterministic output, no tokens consumed.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,14 +19,11 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 
 ## 亮点
 
-- **桌面应用控制** — 通过 CDP 直接在终端驱动 Electron 应用（Cursor、Codex、ChatGPT 等）。
-- **AI Agent 浏览器自动化** — 安装 `opencli-adapter-author` skill，你的 AI Agent 就能操作任意网站：导航、点击、输入/填充、提取、截图——全部通过你的已登录 Chrome 会话完成。
-- **网站 → CLI** — 把任何网站变成确定性 CLI：100+ 站点能力已注册，或用 `opencli-adapter-author` skill + `opencli browser verify` 自己写。
-- **账号安全** — 复用 Chrome/Chromium 登录态，凭证永远不会离开浏览器。
-- **面向 AI Agent** — 一个 skill 带你走完站点侦察、API 发现、字段解码、适配器编写、验证的全流程。
-- **CLI 枢纽** — 统一发现、自动安装、纯透传任何外部 CLI（gh、docker、obsidian、tg、discord、wx 等）。
-- **零 LLM 成本** — 运行时不消耗模型 token，跑 10,000 次也不花一分钱。
-- **确定性输出** — 相同命令，相同输出结构，每次一致。可管道、可脚本、CI 友好。
+- **登录态浏览器自动化** — 让 AI Agent 驱动你的已登录 Chrome：导航、填表单、点击、提取。凭证永远不离开浏览器。
+- **桌面应用控制** — 通过 CDP 直接驱动 Electron 应用（Cursor、Codex、ChatGPT）。
+- **多 Profile 浏览器桥接** — 通过 `--profile` 或 `OPENCLI_PROFILE` 把命令路由到指定 Chrome profile。
+- **100+ 适配器 + CLI 枢纽** — 内置站点命令（B站 / 小红书 / Twitter / HackerNews / ...）加外部 CLI 透传（`gh`、`docker`、`ntn`、`longbridge`）。
+- **零 LLM 运行成本** — 确定性输出，运行时不消耗 token。
 
 ## 快速开始
 


### PR DESCRIPTION
## Summary

Per WAWQAQ: Highlights section was bloated with hollow marketing phrases and overlapping bullets. Cut to 5 concrete capability bullets, EN/ZH in sync.

## What changed

### Removed (hollow / overlapping)
- ~~AI Agent ready~~ — overlapped with "Browser Automation for AI Agents"
- ~~Account-safe~~ — folded into "Live Browser Automation"
- ~~Deterministic~~ — `Pipeable, scriptable, CI-friendly` was generic CLI filler; folded into "Zero LLM cost"
- ~~Website → CLI~~ + ~~CLI Hub~~ — merged into "100+ adapters + CLI Hub"

### Result: 5 bullets

```
- Live Browser Automation — Drive your logged-in Chrome from AI agents: navigate, fill forms, click, extract. Credentials stay in the browser.
- Desktop App Control — Drive Electron apps (Cursor, Codex, ChatGPT) directly via CDP.
- Multi-profile Browser Bridge — Route commands to specific Chrome profiles via `--profile` or `OPENCLI_PROFILE`.
- 100+ adapters + CLI Hub — Built-in site commands (bilibili / xiaohongshu / twitter / hackernews / ...) plus external CLI passthrough (`gh`, `docker`, `ntn`, `longbridge`).
- Zero LLM cost at runtime — Deterministic output, no tokens consumed.
```

## Test plan

- [x] Manual diff inspection on README.md + README.zh-CN.md
- [ ] Visual render on GitHub after merge