### PR TITLE
fix(browser): clarify empty network captures

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1596,6 +1596,7 @@ describe('browser network command', () => {
       getActivePage: vi.fn().mockReturnValue('tab-1'),
       tabs: vi.fn().mockResolvedValue([{ page: 'tab-1', active: true }]),
       evaluate: vi.fn().mockResolvedValue(''),
+      startNetworkCapture: vi.fn().mockResolvedValue(true),
       readNetworkCapture: vi.fn().mockResolvedValue([
         {
           url: 'https://x.com/i/api/graphql/qid/UserTweets?v=1',
@@ -1623,12 +1624,78 @@ describe('browser network command', () => {
     await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'network']);
 
     const out = lastJsonLog();
+    expect(browserState.page?.startNetworkCapture).toHaveBeenCalledTimes(1);
     expect(out.count).toBe(1);
     expect(out.filtered_out).toBe(1);
     expect(out.entries[0].key).toBe('UserTweets');
     expect(out.entries[0].shape['$.data.user.rest_id']).toBe('string');
     expect(out.entries[0]).not.toHaveProperty('body');
     expect(fs.existsSync(getNetworkCachePath(cacheDir))).toBe(true);
+  });
+
+  it('installs the JS fallback and explains empty fallback captures when native capture is unsupported', async () => {
+    browserState.page!.startNetworkCapture = vi.fn().mockResolvedValue(false);
+    browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([]);
+    browserState.page!.evaluate = vi.fn().mockResolvedValue('[]');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'network']);
+
+    const out = lastJsonLog();
+    expect(browserState.page?.evaluate).toHaveBeenCalledWith(expect.stringContaining('__opencli_net'));
+    expect(out.count).toBe(0);
+    expect(out.empty_reason).toBe('capture_empty_fallback');
+    expect(out.empty_hint).toContain('Reload the page');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('falls back to the JS interceptor when native capture startup fails', async () => {
+    browserState.page!.startNetworkCapture = vi.fn().mockRejectedValue(new Error('Extension disconnected'));
+    browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([]);
+    browserState.page!.evaluate = vi.fn().mockResolvedValue('[]');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'network']);
+
+    const out = lastJsonLog();
+    expect(browserState.page?.evaluate).toHaveBeenCalledWith(expect.stringContaining('__opencli_net'));
+    expect(out.empty_reason).toBe('capture_empty_fallback');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('explains truly empty native captures without treating them as errors', async () => {
+    browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([]);
+    browserState.page!.evaluate = vi.fn().mockResolvedValue('[]');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(0);
+    expect(out.empty_reason).toBe('capture_empty');
+    expect(out.empty_hint).toContain('Trigger the page action');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('suggests --all when the default network filter removes every captured request', async () => {
+    browserState.page!.readNetworkCapture = vi.fn().mockResolvedValue([
+      {
+        url: 'https://cdn.example.com/app.js',
+        method: 'GET',
+        responseStatus: 200,
+        responseContentType: 'application/javascript',
+        responsePreview: '// js',
+      },
+    ]);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'network']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(0);
+    expect(out.filtered_out).toBe(1);
+    expect(out.empty_reason).toBe('default_filter_empty');
+    expect(out.empty_hint).toContain('--all');
   });
 
   it('uses the selected browser session for network cache scope', async () => {
@@ -1857,6 +1924,8 @@ describe('browser network command', () => {
       expect(out.entries).toEqual([]);
       expect(out.filter).toEqual(['author', 'followers']);
       expect(out.filter_dropped).toBe(3);
+      expect(out.empty_reason).toBe('filter_empty');
+      expect(out.empty_hint).toContain('without `--filter`');
     });
 
     it('returns empty entries (not an error) when nothing matches', async () => {
@@ -1866,6 +1935,7 @@ describe('browser network command', () => {
       const out = lastJsonLog();
       expect(out.count).toBe(0);
       expect(out.entries).toEqual([]);
+      expect(out.empty_reason).toBe('filter_empty');
       expect(out).not.toHaveProperty('error');
       expect(process.exitCode).toBeUndefined();
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,6 +144,8 @@ async function captureNetworkItems(page: import('./types.js').IPage): Promise<Br
   }
 }
 
+type NetworkCaptureMode = 'native' | 'fallback' | 'unavailable';
+
 /** Drop static-resource / telemetry noise so agents see only API-shaped traffic. */
 function filterNetworkItems(items: BrowserNetworkItem[]): BrowserNetworkItem[] {
   return items.filter((r) => {
@@ -154,6 +156,57 @@ function filterNetworkItems(items: BrowserNetworkItem[]): BrowserNetworkItem[] {
       !/analytics|tracking|telemetry|beacon|pixel|gtag|fbevents/i.test(r.url)
     );
   });
+}
+
+function buildEmptyNetworkHint(input: {
+  rawCount: number;
+  defaultVisibleCount: number;
+  visibleCount: number;
+  captureMode: NetworkCaptureMode;
+  hasFilter: boolean;
+  filterDropped: number;
+  hasFailed: boolean;
+  hasTimeWindow: boolean;
+}): { reason: string; hint: string } | null {
+  if (input.visibleCount > 0) return null;
+
+  if (input.rawCount === 0) {
+    if (input.captureMode === 'fallback') {
+      return {
+        reason: 'capture_empty_fallback',
+        hint: 'Native network capture is unavailable; JS fallback only captures fetch/XHR after it is installed. Reload the page, trigger the action again, then rerun `browser network`.',
+      };
+    }
+    if (input.captureMode === 'unavailable') {
+      return {
+        reason: 'capture_unavailable',
+        hint: 'Could not install native or JS network capture. Check that the browser tab is still reachable, then reload or reopen the page.',
+      };
+    }
+    return {
+      reason: 'capture_empty',
+      hint: 'Capture is active but no requests were observed yet. Trigger the page action or reload the page, then rerun `browser network`.',
+    };
+  }
+
+  if (input.hasFilter && input.defaultVisibleCount > 0 && input.filterDropped > 0) {
+    return {
+      reason: 'filter_empty',
+      hint: 'Requests were captured, but `--filter` removed every visible entry. Run without `--filter` to inspect shapes, or use `--all` if the target was classified as static/noise.',
+    };
+  }
+
+  if (input.hasFailed || input.hasTimeWindow) {
+    return {
+      reason: 'option_empty',
+      hint: 'Requests were captured, but the current options removed every entry. Relax `--failed`, `--since`, or `--until`, or run with `--all` to inspect the raw capture.',
+    };
+  }
+
+  return {
+    reason: 'default_filter_empty',
+    hint: 'Requests were captured, but the default API filter removed all of them. Retry with `browser network --all` to include static resources, telemetry, and non-API responses.',
+  };
 }
 
 /** Exit codes by network error code — usage errors vs runtime failures. */
@@ -2442,7 +2495,24 @@ Examples:
         }
       }
 
-      // Fresh capture path.
+      // Fresh capture path. Arm capture here too: `browser open` normally
+      // starts it before navigation, but agents often call `browser network`
+      // directly against an existing tab/session.
+      let captureMode: NetworkCaptureMode = 'native';
+      let hasSessionCapture = false;
+      try {
+        hasSessionCapture = await page.startNetworkCapture?.() ?? false;
+      } catch {
+        hasSessionCapture = false;
+      }
+      if (!hasSessionCapture) {
+        try {
+          await page.evaluate(NETWORK_INTERCEPTOR_JS);
+          captureMode = 'fallback';
+        } catch {
+          captureMode = 'unavailable';
+        }
+      }
       let rawItems: BrowserNetworkItem[];
       try {
         rawItems = await captureNetworkItems(page);
@@ -2451,7 +2521,8 @@ Examples:
         return;
       }
 
-      let items = opts.all ? rawItems : filterNetworkItems(rawItems);
+      const defaultVisibleItems = opts.all ? rawItems : filterNetworkItems(rawItems);
+      let items = defaultVisibleItems;
       items = filterByTimeWindow(items, { sinceMs, untilMs });
       if (opts.failed) items = items.filter((item) => item.status === 0 || item.status >= 400);
       const filteredOut = rawItems.length - items.length;
@@ -2502,6 +2573,21 @@ Examples:
         envelope.filter_dropped = filterDropped;
       }
       if (cacheWarning) envelope.cache_warning = cacheWarning;
+
+      const empty = buildEmptyNetworkHint({
+        rawCount: rawItems.length,
+        defaultVisibleCount: defaultVisibleItems.length,
+        visibleCount: visible.length,
+        captureMode,
+        hasFilter,
+        filterDropped,
+        hasFailed: opts.failed === true,
+        hasTimeWindow: Boolean(sinceMs || untilMs),
+      });
+      if (empty) {
+        envelope.empty_reason = empty.reason;
+        envelope.empty_hint = empty.hint;
+      }
 
       const truncatedCount = visible.filter((s) => s.entry.body_truncated).length;
       if (truncatedCount > 0) {


### PR DESCRIPTION
  ## Description

  Improves `browser network` behavior when a capture produces no visible entries.

  This PR adds structured `empty_reason` and `empty_hint` fields so users and agents can distinguish between:
  - no requests captured yet
  - JS fallback capture being installed after requests already fired
  - default filtering hiding all captured requests
  - `--filter`, `--failed`, `--since`, or `--until` removing all entries

  It also hardens the fresh capture path: if native network capture startup fails, `browser network` now attempts the JS interceptor fallback instead of failing before
  fallback is tried.

  Related issue: Partially addresses #1473

  ## Type of Change

  - [x] Bug fix
  - [ ] ✨ New feature
  - [ ] New site adapter
  - [ ] Documentation
  - [ ] ♻️ Refactor
  - [ ] CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [ ] Used positional args for the command's primary subject unless a named flag is clearly better
  - [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output

  ```bash
  npx vitest run --project unit src/cli.test.ts
  # 163 passed

  npm run typecheck
  # passed

  git diff --check
  # passed