### PR TITLE
fix(xiaohongshu/publish): invoke shadow-DOM publish handler directly

### DIFF
--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -22,6 +22,14 @@ const PUBLISH_URL = 'https://creator.xiaohongshu.com/publish/publish?from=menu_l
 const MAX_IMAGES = 9;
 const MAX_TITLE_LEN = 20;
 const UPLOAD_SETTLE_MS = 3000;
+/**
+ * XHS creator center wraps the publish/save button in an `<xhs-publish-btn>`
+ * web component backed by a CLOSED shadow root. Host-level `.click()` does
+ * not dispatch into the internal handler. Invoke these instance methods on
+ * the host element to trigger publish / save-draft directly (#1606).
+ */
+const PUBLISH_METHOD_NAMES = ['_onPublish', 'onPublish', '_onSubmit', '_handlePublish'];
+const DRAFT_METHOD_NAMES = ['_onSave', '_onSaveDraft', '_onDraft'];
 /** Selectors for the title field, ordered by priority across current UI variants. */
 const TITLE_SELECTORS = [
     // Some creator-center variants expose the title as contenteditable,
@@ -610,26 +618,58 @@ cli({
         }
         // ── Step 7: Publish or save draft ─────────────────────────────────────────
         const actionLabels = isDraft ? ['暂存离开', '存草稿'] : ['发布', '发布笔记'];
-        const btnClicked = await page.evaluate(`
-      (labels => {
+        const invokeResult = await page.evaluate(`
+      (cfg => {
+        const { isDraftMode, publishNames, draftNames, labels } = cfg;
+        const isVisible = (el) => {
+          if (!el || el.offsetParent === null) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        };
+        // Path 1: web component method invoke on <xhs-publish-btn>.
+        const hosts = Array.from(document.querySelectorAll('xhs-publish-btn')).filter(isVisible);
+        const wanted = isDraftMode ? draftNames : publishNames;
+        // Try every host + every candidate; do NOT bail on the first throw
+        // (multiple hosts can exist, and a later name may succeed).
+        let lastMethodError = null;
+        for (const host of hosts) {
+          for (const name of wanted) {
+            if (typeof host[name] !== 'function') continue;
+            try {
+              host[name]();
+              return { ok: true, via: 'method', name };
+            } catch (err) {
+              lastMethodError = String(err && err.message || err);
+            }
+          }
+        }
+        // Path 2: legacy <button>/[role=button] text-match click fallback.
         const buttons = document.querySelectorAll('button, [role="button"]');
         for (const btn of buttons) {
           const text = (btn.innerText || btn.textContent || '').trim();
           if (
             labels.some(l => text === l || text.includes(l)) &&
-            btn.offsetParent !== null &&
+            isVisible(btn) &&
             !btn.disabled
           ) {
             btn.click();
-            return true;
+            return { ok: true, via: 'click', text };
           }
         }
-        return false;
-      })(${JSON.stringify(actionLabels)})
+        return { ok: false, via: 'none', hosts: hosts.length, lastMethodError };
+      })(${JSON.stringify({
+            isDraftMode: isDraft,
+            publishNames: PUBLISH_METHOD_NAMES,
+            draftNames: DRAFT_METHOD_NAMES,
+            labels: actionLabels,
+        })})
     `);
-        if (!btnClicked) {
+        if (!invokeResult?.ok) {
             await page.screenshot({ path: '/tmp/xhs_publish_submit_debug.png' });
-            throw new Error(`Could not find "${actionLabels[0]}" button. ` +
+            const viaClause = invokeResult?.via ? ` (via=${invokeResult.via})` : '';
+            const errorClause = invokeResult?.error ? `, error=${invokeResult.error}` : '';
+            const lastMethodClause = invokeResult?.lastMethodError ? `, lastMethodError=${invokeResult.lastMethodError}` : '';
+            throw new Error(`Could not trigger "${actionLabels[0]}" action${viaClause}${errorClause}${lastMethodClause}. ` +
                 'Debug screenshot: /tmp/xhs_publish_submit_debug.png');
         }
         // ── Step 8: Verify success ─────────────────────────────────────────────────

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -76,8 +76,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '标题走原生输入' }
                     : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable', actual: '正文也走原生输入' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -128,8 +130,10 @@ describe('xiaohongshu publish', () => {
                 return { ok: false, actual: '' };
             if (code.includes('(function(selectors, text)'))
                 return { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '' };
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -177,8 +181,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, actual: '原生失败后回退' }
                     : { ok: true, actual: '正文也回退' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -227,8 +233,10 @@ describe('xiaohongshu publish', () => {
                 return code.includes('input[maxlength')
                     ? { ok: false, actual: '' }
                     : { ok: true, actual: '正文' };
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -259,7 +267,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: 'CDP上传优先' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: '优先走 setFileInput 主路径' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ], {
@@ -301,7 +309,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: 'CDP被拒后回退' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: 'DataTransfer fallback path' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ], {
@@ -366,7 +374,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: 'DeepSeek别乱问' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: '一篇真实一点的小红书正文' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ]);
@@ -389,6 +397,49 @@ describe('xiaohongshu publish', () => {
                 detail: '"DeepSeek别乱问" · 1张图片 · 发布成功',
             },
         ]);
+    });
+    it('uses the shadow-DOM method-invoke path when xhs-publish-btn handler succeeds', async () => {
+        // Mirrors the previous "selects the image-text tab and publishes successfully"
+        // mock sequence but returns `via: 'method', name: '_onPublish'` for the publish
+        // trigger evaluate, exercising the shadow-DOM web-component handler path
+        // (the primary #1606 fix). Without this case the fix's main path is uncovered.
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const page = createPageMock([
+            'https://creator.xiaohongshu.com/publish/publish?from=menu_left',
+            { ok: true, target: '上传图文', text: '上传图文' },
+            { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false },
+            { ok: true, count: 1 },
+            false,
+            true, // waitForEditForm: editor appeared
+            { ok: true, sel: 'input[maxlength="20"]', kind: 'input' },
+            { ok: true, actual: 'shadow-dom-test' },
+            { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
+            { ok: true, actual: '走 method-invoke 路径' },
+            { ok: true, via: 'method', name: '_onPublish' }, // shadow-DOM handler success
+            'https://creator.xiaohongshu.com/publish/success',
+            '发布成功',
+        ]);
+        const result = await cmd.func(page, {
+            title: 'shadow-dom-test',
+            content: '走 method-invoke 路径',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        });
+        expect(result).toEqual([
+            {
+                status: '✅ 发布成功',
+                detail: '"shadow-dom-test" · 1张图片 · 发布成功',
+            },
+        ]);
+        // The publish-trigger evaluate must have been the shadow-DOM probe (contains
+        // 'xhs-publish-btn'), not the legacy `button.click()` fallback alone.
+        const evaluateCalls = page.evaluate.mock.calls.map((args) => String(args[0]));
+        expect(evaluateCalls.some((code) => code.includes('xhs-publish-btn'))).toBe(true);
     });
     it('fails early with a clear error when still on the video page', async () => {
         const cmd = getRegistry().get('xiaohongshu/publish');
@@ -431,7 +482,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: '延迟切换也能过' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: '图文页切换慢一点也继续等' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ]);
@@ -479,8 +530,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, actual: '停留在发布页也算成功' }
                     : { ok: true, actual: '草稿成功提示' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll')) {
                 return code.includes('保存成功') ? '保存成功' : '';
             }
@@ -529,8 +582,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, actual: '发布提示不该复用草稿成功' }
                     : { ok: true, actual: '发布成功提示' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll')) {
                 return code.includes('保存成功') ? '保存成功' : '';
             }


### PR DESCRIPTION
## Description

XHS creator center now wraps the publish / save-draft button in an `<xhs-publish-btn>` web component backed by a CLOSED shadow root. Calling `.click()` on the host element does not dispatch into the internal handler, and CDP coordinate clicks cannot penetrate the shadow boundary. The previous text-match `button.click()` loop hit the host element, reported success, and yet the note silently stayed on the publish page as a draft. Adapter returned the soft `⚠️ 操作完成，请在浏览器中确认` status while nothing was posted.

Invoke the publish / save method directly on the `<xhs-publish-btn>` host (`_onPublish` / `_onSave` and a few candidate names XHS has shipped historically). Fall back to the legacy `<button>` / `[role="button"]` text-match click path for older creator-center variants that still expose plain buttons.

Patch shape suggested by the OpenCLI autofix report in #1606 from @chcc-funny (who verified an end-to-end real publish locally before filing the issue).

Closes #1606.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

New constants near the existing file-level constants:

```js
const PUBLISH_METHOD_NAMES = ['_onPublish', 'onPublish', '_onSubmit', '_handlePublish'];
const DRAFT_METHOD_NAMES = ['_onSave', '_onSaveDraft', '_onDraft'];
```

Step 7 of `func()` becomes a single `page.evaluate` that:

1. Queries `<xhs-publish-btn>` host elements; if any expose a matching method name (`_onPublish` etc., or `_onSave` etc. in `--draft` mode), invoke it directly on the host.
2. Falls back to the original visible-button text-match `.click()` if no host element / no candidate method was found, so older creator-center variants continue to work.

Returns a structured `{ ok, via, name | text }` result so callers and tests can tell which path was used.

## Screenshots / Output

Live run on macOS / opencli v1.7.22 / extension v1.0.15, creator center logged in:

```bash
$ node ./dist/src/main.js xiaohongshu publish "明洞测试..." \
    --title "明洞街景测试" \
    --images /tmp/xhs_test_myeongdong.jpg \
    --draft

- status: ✅ 暂存成功
  detail: '"明洞街景测试" · 1张图片 · 保存成功'
```

Creator center home then reads `草稿箱中有未发布的作品`. Sleep 10s, then real publish:

```bash
$ node ./dist/src/main.js xiaohongshu publish "明洞测试..." \
    --title "明洞街景测试" \
    --images /tmp/xhs_test_myeongdong.jpg

- status: ✅ 发布成功
  detail: '"明洞街景测试" · 1张图片 · 发布成功'
```

Note appeared on the account feed and was visible from the XHS mobile app (proving full publish path, not just web-side success acknowledgement). Test note deleted after verification.

## Test plan

- [x] `npx vitest run clis/xiaohongshu/publish.test.js`: 12 / 12 pass (mocks updated to return `{ ok, via, text }` instead of bare boolean for the publish-click step)
- [x] `npm run build`: manifest compiles, 821 entries, no path leaks
- [x] Live `--draft` against logged-in creator center: returns `✅ 暂存成功`, draft visible in creator-center home
- [x] Live real publish against logged-in creator center: returns `✅ 发布成功`, note visible on web feed and mobile app
- [ ] Reviewer: confirm legacy button-text fallback (Path 2) still triggers if `<xhs-publish-btn>` is absent. A creator-center A/B variant without the web component would exercise this code path.

## Out of scope (deliberately deferred)

The autofix report mentioned three additional defensive improvements the reporter included in their local repair: a secondary 二次确认 dialog poll, a 20s success-marker poll replacing the fixed 4s wait, and `note-id` extraction from the post-publish URL. Each is a nice-to-have but does NOT affect the primary "click was silently no-op" root cause and adds enough new `page.evaluate` calls to invalidate the sequence-based mocks in `publish.test.js`. Verified live without them. If real-world publishes start hitting the confirm dialog or the 4s timeout, those can ship as separate small follow-ups.

