### PR TITLE
fix: tighten internal callback types

### DIFF
--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for browser operations
  */
 
-type EvaluateFunction = (...args: any[]) => unknown;
+type EvaluateFunction = (...args: never[]) => unknown;
 
 function describeJsonError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -776,8 +776,8 @@ Examples:
   }
 
   /** Wrap browser actions with error handling and optional --json output */
-  function browserAction(fn: (page: Awaited<ReturnType<typeof getBrowserPage>>, ...args: any[]) => Promise<unknown>) {
-    return async (...args: any[]) => {
+  function browserAction<Args extends unknown[]>(fn: (page: Awaited<ReturnType<typeof getBrowserPage>>, ...args: Args) => Promise<unknown>) {
+    return async (...args: Args) => {
       let page: Awaited<ReturnType<typeof getBrowserPage>> | null = null;
       try {
         const command = args.at(-1) instanceof Command ? args.at(-1) as Command : undefined;


### PR DESCRIPTION

  ## Description

  Tighten two internal callback type definitions to avoid unnecessary `any[]` usage without changing runtime behavior or public APIs.
  - Narrow the local browser eval helper function type from `any[]` to `never[]`, since the function is serialized rather than invoked in Node.

  - [ ] CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [ ] Used positional args for the command's primary subject unless a named flag is clearly better
  - [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output
  Result: typecheck passed; 3 test files passed, 186 tests passed.