### PR TITLE
feat(xiaohongshu): add delete-note command to remove published notes

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -26329,6 +26329,32 @@
   },
   {
     "site": "xiaohongshu",
+    "name": "delete-note",
+    "description": "删除小红书已发布笔记 (creator center UI automation)",
+    "access": "write",
+    "domain": "creator.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "note-id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Note ID (e.g. 6a08ba0b000000000702a893 from xiaohongshu creator-notes / URL)"
+      }
+    ],
+    "columns": [
+      "status",
+      "note_id"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/delete-note.js",
+    "sourceFile": "xiaohongshu/delete-note.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "xiaohongshu",
     "name": "download",
     "description": "下载小红书笔记中的图片和视频",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -26342,11 +26342,19 @@
         "required": true,
         "positional": true,
         "help": "Note ID (e.g. 6a08ba0b000000000702a893 from xiaohongshu creator-notes / URL)"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually click delete + confirm. Default is dry-run target verification only."
       }
     ],
     "columns": [
       "status",
-      "note_id"
+      "note_id",
+      "message"
     ],
     "type": "js",
     "modulePath": "xiaohongshu/delete-note.js",

--- a/clis/xiaohongshu/delete-note.js
+++ b/clis/xiaohongshu/delete-note.js
@@ -26,9 +26,38 @@ function unwrapEvaluateResult(payload) {
     }
     return payload;
 }
+function requireEvaluateString(payload, context) {
+    if (typeof payload !== 'string') {
+        throw new CommandExecutionError(`xiaohongshu/delete-note: malformed ${context} payload`);
+    }
+    return payload;
+}
+function requireEvaluateBoolean(payload, context) {
+    if (typeof payload !== 'boolean') {
+        throw new CommandExecutionError(`xiaohongshu/delete-note: malformed ${context} payload`);
+    }
+    return payload;
+}
+function requireEvaluateObject(payload, context) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new CommandExecutionError(`xiaohongshu/delete-note: malformed ${context} payload`);
+    }
+    return payload;
+}
+function requireActionResult(payload, context) {
+    const result = requireEvaluateObject(payload, context);
+    if (typeof result.ok !== 'boolean') {
+        throw new CommandExecutionError(`xiaohongshu/delete-note: malformed ${context} payload`);
+    }
+    return result;
+}
 function isXiaohongshuHost(hostname) {
     const host = String(hostname || '').toLowerCase();
     return host === 'xiaohongshu.com' || host.endsWith('.xiaohongshu.com');
+}
+function isSupportedQueryNoteUrl(url) {
+    return url.hostname.toLowerCase() === 'creator.xiaohongshu.com'
+        && url.pathname.replace(/\/+$/, '') === '/statistics/note-detail';
 }
 function normalizeNoteId(input) {
     const raw = String(input ?? '').trim();
@@ -51,7 +80,7 @@ function normalizeNoteId(input) {
         throw new ArgumentError('xiaohongshu/delete-note: note URL must be an exact https://*.xiaohongshu.com URL');
     }
     const queryId = url.searchParams.get('noteId') || url.searchParams.get('note_id');
-    if (queryId && NOTE_ID_RE.test(queryId))
+    if (queryId && NOTE_ID_RE.test(queryId) && isSupportedQueryNoteUrl(url))
         return queryId.toLowerCase();
     const pathMatch = url.pathname.match(/^\/(?:explore|note|search_result|discovery\/item)\/([0-9a-f]{24})\/?$/i)
         || url.pathname.match(/^\/user\/profile\/[^/?#]+\/([0-9a-f]{24})\/?$/i);
@@ -141,12 +170,12 @@ cli({
             await page.goto(NOTE_MANAGER_URL);
             await page.wait({ time: ROW_SETTLE_MS / 1000 });
             // Detect login redirect (creator.xiaohongshu.com bounces to /login on auth failure)
-            const currentUrl = unwrapEvaluateResult(await page.evaluate('() => location.href'));
+            const currentUrl = requireEvaluateString(unwrapEvaluateResult(await page.evaluate('() => location.href')), 'current-url');
             if (typeof currentUrl === 'string' && /\/login(?:[/?#]|$)/i.test(new URL(currentUrl).pathname + new URL(currentUrl).search)) {
                 throw new AuthRequiredError('creator.xiaohongshu.com');
             }
             // Step 1: ensure 已发布 tab is active (delete only exposed there).
-            const tabClicked = unwrapEvaluateResult(await page.evaluate(`
+            const tabClicked = requireEvaluateBoolean(unwrapEvaluateResult(await page.evaluate(`
       () => {
         const isVisible = (el) => !!el && el.offsetParent !== null;
         for (const el of document.querySelectorAll('a, button, [role="tab"], div')) {
@@ -158,7 +187,7 @@ cli({
         }
         return false;
       }
-    `));
+    `)), 'published-tab');
             if (!tabClicked) {
                 throw new CommandExecutionError('xiaohongshu/delete-note: 已发布 tab not found on note-manager; xhs creator UI may have changed.');
             }
@@ -168,7 +197,7 @@ cli({
             // Substring matching on the raw attribute would risk matching unrelated
             // fields whose values happen to share the noteId prefix, so parse the JSON
             // and compare `noteTarget.value.noteId` explicitly.
-            const initResult = unwrapEvaluateResult(await page.evaluate(buildLocateAndMaybeDeleteScript(noteId, execute)));
+            const initResult = requireActionResult(unwrapEvaluateResult(await page.evaluate(buildLocateAndMaybeDeleteScript(noteId, execute))), 'locate-note');
             if (!initResult?.ok) {
                 if (initResult?.kind === 'not_found') {
                     throw new EmptyResultError('xiaohongshu/delete-note', `Note ${noteId} not visible in the 已发布 tab. Verify the note belongs to the logged-in account and has cleared review (审核中 / 未通过 rows have no web delete entry).`);
@@ -183,7 +212,7 @@ cli({
             }
             await page.wait({ time: MODAL_SETTLE_MS / 1000 });
             // Step 3: click "确定" in the `.d-modal-footer` confirmation modal.
-            const confirmResult = unwrapEvaluateResult(await page.evaluate(`
+            const confirmResult = requireActionResult(unwrapEvaluateResult(await page.evaluate(`
       () => {
         const isVisible = (el) => !!el && el.offsetParent !== null;
         const footer = Array.from(document.querySelectorAll('.d-modal-footer')).find(isVisible);
@@ -194,7 +223,7 @@ cli({
         confirmBtn.click();
         return { ok: true };
       }
-    `));
+    `)), 'confirm-modal');
             if (!confirmResult?.ok) {
                 throw new CommandExecutionError(`xiaohongshu/delete-note: confirmation modal step failed (${confirmResult?.kind ?? 'unknown'})`);
             }
@@ -206,7 +235,7 @@ cli({
             let stillPresent = true;
             for (let i = 0; i < VERIFY_ITERATIONS; i++) {
                 await page.wait({ time: VERIFY_POLL_MS / 1000 });
-                const probe = unwrapEvaluateResult(await page.evaluate(buildVerifyGoneScript(noteId)));
+                const probe = requireEvaluateBoolean(unwrapEvaluateResult(await page.evaluate(buildVerifyGoneScript(noteId))), 'verify-gone');
                 if (probe === false) {
                     stillPresent = false;
                     break;

--- a/clis/xiaohongshu/delete-note.js
+++ b/clis/xiaohongshu/delete-note.js
@@ -1,0 +1,162 @@
+/**
+ * Xiaohongshu delete-note: remove a published note via creator center UI.
+ *
+ * Flow:
+ *   1. Navigate to creator note-manager
+ *   2. Switch to "已发布" tab (delete is only available on published notes;
+ *      "审核中" and "未通过" rows do not expose a web delete entry, only mobile)
+ *   3. Locate the row whose `data-impression` JSON contains the target noteId
+ *   4. Click the inline `<span class="control data-del">` action
+ *   5. Click "确定" in the `.d-modal-footer` confirmation modal
+ *   6. Poll for the row disappearing from the list
+ *
+ * Requires: logged into creator.xiaohongshu.com in Chrome.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+const NOTE_MANAGER_URL = 'https://creator.xiaohongshu.com/new/note-manager';
+const ROW_SETTLE_MS = 3000;
+const MODAL_SETTLE_MS = 2000;
+const VERIFY_TIMEOUT_MS = 10_000;
+const VERIFY_POLL_MS = 1000;
+cli({
+    site: 'xiaohongshu',
+    name: 'delete-note',
+    access: 'write',
+    description: '删除小红书已发布笔记 (creator center UI automation)',
+    domain: 'creator.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    navigateBefore: false,
+    browser: true,
+    args: [
+        {
+            name: 'note-id',
+            required: true,
+            positional: true,
+            help: 'Note ID (e.g. 6a08ba0b000000000702a893 from xiaohongshu creator-notes / URL)',
+        },
+    ],
+    columns: ['status', 'note_id'],
+    func: async (page, kwargs) => {
+        const noteId = String(kwargs['note-id'] ?? '').trim();
+        if (!noteId) {
+            throw new ArgumentError('xiaohongshu/delete-note: note-id cannot be empty');
+        }
+        await page.goto(NOTE_MANAGER_URL);
+        await page.wait({ time: ROW_SETTLE_MS / 1000 });
+        // Detect login redirect (creator.xiaohongshu.com bounces to /login on auth failure)
+        const currentUrl = await page.evaluate('() => location.href');
+        if (typeof currentUrl === 'string' && /\/login(\?|$)/i.test(currentUrl)) {
+            throw new AuthRequiredError('creator.xiaohongshu.com');
+        }
+        // Step 1: ensure 已发布 tab is active (delete only exposed there).
+        const tabClicked = await page.evaluate(`
+      () => {
+        const isVisible = (el) => !!el && el.offsetParent !== null;
+        for (const el of document.querySelectorAll('a, button, [role="tab"], div')) {
+          const text = (el.innerText || el.textContent || '').trim();
+          if (text === '已发布' && isVisible(el)) {
+            el.click();
+            return true;
+          }
+        }
+        return false;
+      }
+    `);
+        if (!tabClicked) {
+            throw new CommandExecutionError('xiaohongshu/delete-note: 已发布 tab not found on note-manager; xhs creator UI may have changed.');
+        }
+        await page.wait({ time: ROW_SETTLE_MS / 1000 });
+        // Step 2: locate the .note row whose data-impression JSON carries the
+        // exact `noteId` field, and click its `<span class="control data-del">`
+        // action. Substring matching on the raw attribute would risk matching
+        // unrelated fields whose values happen to share the noteId prefix, so
+        // parse the JSON and compare `noteTarget.value.noteId` explicitly.
+        const initResult = await page.evaluate(`
+      (targetId => {
+        const isVisible = (el) => !!el && el.offsetParent !== null;
+        const matchesNoteId = (impressionRaw) => {
+          if (!impressionRaw) return false;
+          try {
+            const parsed = JSON.parse(impressionRaw);
+            const id = parsed && parsed.noteTarget && parsed.noteTarget.value && parsed.noteTarget.value.noteId;
+            return typeof id === 'string' && id === targetId;
+          } catch {
+            return false;
+          }
+        };
+        const notes = Array.from(document.querySelectorAll('.note')).filter(isVisible);
+        for (const note of notes) {
+          if (matchesNoteId(note.getAttribute('data-impression'))) {
+            const del = note.querySelector('span.control.data-del');
+            if (!del || !isVisible(del)) {
+              return { ok: false, kind: 'no_delete_action', visibleRows: notes.length };
+            }
+            del.click();
+            return { ok: true };
+          }
+        }
+        return { ok: false, kind: 'not_found', visibleRows: notes.length };
+      })(${JSON.stringify(noteId)})
+    `);
+        if (!initResult?.ok) {
+            if (initResult?.kind === 'not_found') {
+                throw new EmptyResultError('xiaohongshu/delete-note', `Note ${noteId} not visible in the 已发布 tab. Verify the note belongs to the logged-in account and has cleared review (审核中 / 未通过 rows have no web delete entry).`);
+            }
+            if (initResult?.kind === 'no_delete_action') {
+                throw new CommandExecutionError(`xiaohongshu/delete-note: note ${noteId} row found but no delete action visible; xhs creator UI may have changed.`);
+            }
+            throw new CommandExecutionError('xiaohongshu/delete-note: failed to locate note row');
+        }
+        await page.wait({ time: MODAL_SETTLE_MS / 1000 });
+        // Step 3: click "确定" in the `.d-modal-footer` confirmation modal.
+        const confirmResult = await page.evaluate(`
+      () => {
+        const isVisible = (el) => !!el && el.offsetParent !== null;
+        const footer = Array.from(document.querySelectorAll('.d-modal-footer')).find(isVisible);
+        if (!footer) return { ok: false, kind: 'no_modal' };
+        const buttons = Array.from(footer.querySelectorAll('button, [role="button"]')).filter(isVisible);
+        const confirmBtn = buttons.find((b) => (b.innerText || b.textContent || '').trim() === '确定');
+        if (!confirmBtn) return { ok: false, kind: 'no_confirm', labels: buttons.map(b => (b.innerText || '').trim()) };
+        confirmBtn.click();
+        return { ok: true };
+      }
+    `);
+        if (!confirmResult?.ok) {
+            throw new CommandExecutionError(`xiaohongshu delete-note: confirmation modal step failed (${confirmResult?.kind ?? 'unknown'})`);
+        }
+        // Step 4: poll for row removal (proves the delete actually committed,
+        // not just the modal was clicked). Iteration-bounded rather than
+        // wall-clock so tests with a mocked `page.wait` exhaust the loop
+        // quickly instead of stalling on real time.
+        const VERIFY_ITERATIONS = Math.ceil(VERIFY_TIMEOUT_MS / VERIFY_POLL_MS);
+        let stillPresent = true;
+        for (let i = 0; i < VERIFY_ITERATIONS; i++) {
+            await page.wait({ time: VERIFY_POLL_MS / 1000 });
+            const probe = await page.evaluate(`
+        (targetId => {
+          const matchesNoteId = (impressionRaw) => {
+            if (!impressionRaw) return false;
+            try {
+              const parsed = JSON.parse(impressionRaw);
+              const id = parsed && parsed.noteTarget && parsed.noteTarget.value && parsed.noteTarget.value.noteId;
+              return typeof id === 'string' && id === targetId;
+            } catch {
+              return false;
+            }
+          };
+          const notes = Array.from(document.querySelectorAll('.note'));
+          return notes.some((n) => matchesNoteId(n.getAttribute('data-impression')));
+        })(${JSON.stringify(noteId)})
+      `);
+            if (probe === false) {
+                stillPresent = false;
+                break;
+            }
+        }
+        if (stillPresent) {
+            throw new CommandExecutionError(`xiaohongshu/delete-note: note ${noteId} still visible after confirm click; deletion may not have committed.`);
+        }
+        return [{ status: 'deleted', note_id: noteId }];
+    },
+});

--- a/clis/xiaohongshu/delete-note.js
+++ b/clis/xiaohongshu/delete-note.js
@@ -13,67 +13,56 @@
  * Requires: logged into creator.xiaohongshu.com in Chrome.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 const NOTE_MANAGER_URL = 'https://creator.xiaohongshu.com/new/note-manager';
 const ROW_SETTLE_MS = 3000;
 const MODAL_SETTLE_MS = 2000;
 const VERIFY_TIMEOUT_MS = 10_000;
 const VERIFY_POLL_MS = 1000;
-cli({
-    site: 'xiaohongshu',
-    name: 'delete-note',
-    access: 'write',
-    description: '删除小红书已发布笔记 (creator center UI automation)',
-    domain: 'creator.xiaohongshu.com',
-    strategy: Strategy.COOKIE,
-    navigateBefore: false,
-    browser: true,
-    args: [
-        {
-            name: 'note-id',
-            required: true,
-            positional: true,
-            help: 'Note ID (e.g. 6a08ba0b000000000702a893 from xiaohongshu creator-notes / URL)',
-        },
-    ],
-    columns: ['status', 'note_id'],
-    func: async (page, kwargs) => {
-        const noteId = String(kwargs['note-id'] ?? '').trim();
-        if (!noteId) {
-            throw new ArgumentError('xiaohongshu/delete-note: note-id cannot be empty');
-        }
-        await page.goto(NOTE_MANAGER_URL);
-        await page.wait({ time: ROW_SETTLE_MS / 1000 });
-        // Detect login redirect (creator.xiaohongshu.com bounces to /login on auth failure)
-        const currentUrl = await page.evaluate('() => location.href');
-        if (typeof currentUrl === 'string' && /\/login(\?|$)/i.test(currentUrl)) {
-            throw new AuthRequiredError('creator.xiaohongshu.com');
-        }
-        // Step 1: ensure 已发布 tab is active (delete only exposed there).
-        const tabClicked = await page.evaluate(`
-      () => {
-        const isVisible = (el) => !!el && el.offsetParent !== null;
-        for (const el of document.querySelectorAll('a, button, [role="tab"], div')) {
-          const text = (el.innerText || el.textContent || '').trim();
-          if (text === '已发布' && isVisible(el)) {
-            el.click();
-            return true;
-          }
-        }
-        return false;
-      }
-    `);
-        if (!tabClicked) {
-            throw new CommandExecutionError('xiaohongshu/delete-note: 已发布 tab not found on note-manager; xhs creator UI may have changed.');
-        }
-        await page.wait({ time: ROW_SETTLE_MS / 1000 });
-        // Step 2: locate the .note row whose data-impression JSON carries the
-        // exact `noteId` field, and click its `<span class="control data-del">`
-        // action. Substring matching on the raw attribute would risk matching
-        // unrelated fields whose values happen to share the noteId prefix, so
-        // parse the JSON and compare `noteTarget.value.noteId` explicitly.
-        const initResult = await page.evaluate(`
-      (targetId => {
+const NOTE_ID_RE = /^[0-9a-f]{24}$/i;
+function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
+function isXiaohongshuHost(hostname) {
+    const host = String(hostname || '').toLowerCase();
+    return host === 'xiaohongshu.com' || host.endsWith('.xiaohongshu.com');
+}
+function normalizeNoteId(input) {
+    const raw = String(input ?? '').trim();
+    if (!raw) {
+        throw new ArgumentError('xiaohongshu/delete-note: note-id cannot be empty');
+    }
+    if (NOTE_ID_RE.test(raw))
+        return raw.toLowerCase();
+    if (!/^https:\/\//i.test(raw)) {
+        throw new ArgumentError('xiaohongshu/delete-note: note-id must be a 24-character Xiaohongshu note ID or an exact Xiaohongshu note URL');
+    }
+    let url;
+    try {
+        url = new URL(raw);
+    }
+    catch {
+        throw new ArgumentError('xiaohongshu/delete-note: invalid note URL');
+    }
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isXiaohongshuHost(url.hostname)) {
+        throw new ArgumentError('xiaohongshu/delete-note: note URL must be an exact https://*.xiaohongshu.com URL');
+    }
+    const queryId = url.searchParams.get('noteId') || url.searchParams.get('note_id');
+    if (queryId && NOTE_ID_RE.test(queryId))
+        return queryId.toLowerCase();
+    const pathMatch = url.pathname.match(/^\/(?:explore|note|search_result|discovery\/item)\/([0-9a-f]{24})\/?$/i)
+        || url.pathname.match(/^\/user\/profile\/[^/?#]+\/([0-9a-f]{24})\/?$/i);
+    if (pathMatch)
+        return pathMatch[1].toLowerCase();
+    throw new ArgumentError('xiaohongshu/delete-note: note URL must contain a 24-character note ID');
+}
+function buildLocateAndMaybeDeleteScript(noteId, shouldClick) {
+    return `
+      (cfg => {
+        const { targetId, shouldClick } = cfg;
         const isVisible = (el) => !!el && el.offsetParent !== null;
         const matchesNoteId = (impressionRaw) => {
           if (!impressionRaw) return false;
@@ -92,48 +81,19 @@ cli({
             if (!del || !isVisible(del)) {
               return { ok: false, kind: 'no_delete_action', visibleRows: notes.length };
             }
+            if (!shouldClick) {
+              return { ok: true, clicked: false };
+            }
             del.click();
-            return { ok: true };
+            return { ok: true, clicked: true };
           }
         }
         return { ok: false, kind: 'not_found', visibleRows: notes.length };
-      })(${JSON.stringify(noteId)})
-    `);
-        if (!initResult?.ok) {
-            if (initResult?.kind === 'not_found') {
-                throw new EmptyResultError('xiaohongshu/delete-note', `Note ${noteId} not visible in the 已发布 tab. Verify the note belongs to the logged-in account and has cleared review (审核中 / 未通过 rows have no web delete entry).`);
-            }
-            if (initResult?.kind === 'no_delete_action') {
-                throw new CommandExecutionError(`xiaohongshu/delete-note: note ${noteId} row found but no delete action visible; xhs creator UI may have changed.`);
-            }
-            throw new CommandExecutionError('xiaohongshu/delete-note: failed to locate note row');
-        }
-        await page.wait({ time: MODAL_SETTLE_MS / 1000 });
-        // Step 3: click "确定" in the `.d-modal-footer` confirmation modal.
-        const confirmResult = await page.evaluate(`
-      () => {
-        const isVisible = (el) => !!el && el.offsetParent !== null;
-        const footer = Array.from(document.querySelectorAll('.d-modal-footer')).find(isVisible);
-        if (!footer) return { ok: false, kind: 'no_modal' };
-        const buttons = Array.from(footer.querySelectorAll('button, [role="button"]')).filter(isVisible);
-        const confirmBtn = buttons.find((b) => (b.innerText || b.textContent || '').trim() === '确定');
-        if (!confirmBtn) return { ok: false, kind: 'no_confirm', labels: buttons.map(b => (b.innerText || '').trim()) };
-        confirmBtn.click();
-        return { ok: true };
-      }
-    `);
-        if (!confirmResult?.ok) {
-            throw new CommandExecutionError(`xiaohongshu delete-note: confirmation modal step failed (${confirmResult?.kind ?? 'unknown'})`);
-        }
-        // Step 4: poll for row removal (proves the delete actually committed,
-        // not just the modal was clicked). Iteration-bounded rather than
-        // wall-clock so tests with a mocked `page.wait` exhaust the loop
-        // quickly instead of stalling on real time.
-        const VERIFY_ITERATIONS = Math.ceil(VERIFY_TIMEOUT_MS / VERIFY_POLL_MS);
-        let stillPresent = true;
-        for (let i = 0; i < VERIFY_ITERATIONS; i++) {
-            await page.wait({ time: VERIFY_POLL_MS / 1000 });
-            const probe = await page.evaluate(`
+      })(${JSON.stringify({ targetId: noteId, shouldClick })})
+    `;
+}
+function buildVerifyGoneScript(noteId) {
+    return `
         (targetId => {
           const matchesNoteId = (impressionRaw) => {
             if (!impressionRaw) return false;
@@ -148,15 +108,124 @@ cli({
           const notes = Array.from(document.querySelectorAll('.note'));
           return notes.some((n) => matchesNoteId(n.getAttribute('data-impression')));
         })(${JSON.stringify(noteId)})
-      `);
-            if (probe === false) {
-                stillPresent = false;
-                break;
+      `;
+}
+cli({
+    site: 'xiaohongshu',
+    name: 'delete-note',
+    access: 'write',
+    description: '删除小红书已发布笔记 (creator center UI automation)',
+    domain: 'creator.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    navigateBefore: false,
+    browser: true,
+    args: [
+        {
+            name: 'note-id',
+            required: true,
+            positional: true,
+            help: 'Note ID (e.g. 6a08ba0b000000000702a893 from xiaohongshu creator-notes / URL)',
+        },
+        {
+            name: 'execute',
+            type: 'boolean',
+            default: false,
+            help: 'Actually click delete + confirm. Default is dry-run target verification only.',
+        },
+    ],
+    columns: ['status', 'note_id', 'message'],
+    func: async (page, kwargs) => {
+        try {
+            const noteId = normalizeNoteId(kwargs['note-id']);
+            const execute = kwargs.execute === true;
+            await page.goto(NOTE_MANAGER_URL);
+            await page.wait({ time: ROW_SETTLE_MS / 1000 });
+            // Detect login redirect (creator.xiaohongshu.com bounces to /login on auth failure)
+            const currentUrl = unwrapEvaluateResult(await page.evaluate('() => location.href'));
+            if (typeof currentUrl === 'string' && /\/login(?:[/?#]|$)/i.test(new URL(currentUrl).pathname + new URL(currentUrl).search)) {
+                throw new AuthRequiredError('creator.xiaohongshu.com');
             }
+            // Step 1: ensure 已发布 tab is active (delete only exposed there).
+            const tabClicked = unwrapEvaluateResult(await page.evaluate(`
+      () => {
+        const isVisible = (el) => !!el && el.offsetParent !== null;
+        for (const el of document.querySelectorAll('a, button, [role="tab"], div')) {
+          const text = (el.innerText || el.textContent || '').trim();
+          if (text === '已发布' && isVisible(el)) {
+            el.click();
+            return true;
+          }
         }
-        if (stillPresent) {
-            throw new CommandExecutionError(`xiaohongshu/delete-note: note ${noteId} still visible after confirm click; deletion may not have committed.`);
+        return false;
+      }
+    `));
+            if (!tabClicked) {
+                throw new CommandExecutionError('xiaohongshu/delete-note: 已发布 tab not found on note-manager; xhs creator UI may have changed.');
+            }
+            await page.wait({ time: ROW_SETTLE_MS / 1000 });
+            // Step 2: locate the .note row whose data-impression JSON carries the
+            // exact `noteId` field. Dry-run stops here; execute clicks delete.
+            // Substring matching on the raw attribute would risk matching unrelated
+            // fields whose values happen to share the noteId prefix, so parse the JSON
+            // and compare `noteTarget.value.noteId` explicitly.
+            const initResult = unwrapEvaluateResult(await page.evaluate(buildLocateAndMaybeDeleteScript(noteId, execute)));
+            if (!initResult?.ok) {
+                if (initResult?.kind === 'not_found') {
+                    throw new EmptyResultError('xiaohongshu/delete-note', `Note ${noteId} not visible in the 已发布 tab. Verify the note belongs to the logged-in account and has cleared review (审核中 / 未通过 rows have no web delete entry).`);
+                }
+                if (initResult?.kind === 'no_delete_action') {
+                    throw new CommandExecutionError(`xiaohongshu/delete-note: note ${noteId} row found but no delete action visible; xhs creator UI may have changed.`);
+                }
+                throw new CommandExecutionError('xiaohongshu/delete-note: failed to locate note row');
+            }
+            if (!execute) {
+                return [{ status: 'dry-run', note_id: noteId, message: 'Target note row and delete action verified. Re-run with --execute to delete.' }];
+            }
+            await page.wait({ time: MODAL_SETTLE_MS / 1000 });
+            // Step 3: click "确定" in the `.d-modal-footer` confirmation modal.
+            const confirmResult = unwrapEvaluateResult(await page.evaluate(`
+      () => {
+        const isVisible = (el) => !!el && el.offsetParent !== null;
+        const footer = Array.from(document.querySelectorAll('.d-modal-footer')).find(isVisible);
+        if (!footer) return { ok: false, kind: 'no_modal' };
+        const buttons = Array.from(footer.querySelectorAll('button, [role="button"]')).filter(isVisible);
+        const confirmBtn = buttons.find((b) => (b.innerText || b.textContent || '').trim() === '确定');
+        if (!confirmBtn) return { ok: false, kind: 'no_confirm', labels: buttons.map(b => (b.innerText || '').trim()) };
+        confirmBtn.click();
+        return { ok: true };
+      }
+    `));
+            if (!confirmResult?.ok) {
+                throw new CommandExecutionError(`xiaohongshu/delete-note: confirmation modal step failed (${confirmResult?.kind ?? 'unknown'})`);
+            }
+            // Step 4: poll for row removal (proves the delete actually committed,
+            // not just the modal was clicked). Iteration-bounded rather than
+            // wall-clock so tests with a mocked `page.wait` exhaust the loop
+            // quickly instead of stalling on real time.
+            const VERIFY_ITERATIONS = Math.ceil(VERIFY_TIMEOUT_MS / VERIFY_POLL_MS);
+            let stillPresent = true;
+            for (let i = 0; i < VERIFY_ITERATIONS; i++) {
+                await page.wait({ time: VERIFY_POLL_MS / 1000 });
+                const probe = unwrapEvaluateResult(await page.evaluate(buildVerifyGoneScript(noteId)));
+                if (probe === false) {
+                    stillPresent = false;
+                    break;
+                }
+            }
+            if (stillPresent) {
+                throw new CommandExecutionError(`xiaohongshu/delete-note: note ${noteId} still visible after confirm click; deletion may not have committed.`);
+            }
+            return [{ status: 'deleted', note_id: noteId, message: 'Delete confirmed and note row disappeared.' }];
         }
-        return [{ status: 'deleted', note_id: noteId }];
+        catch (err) {
+            if (err instanceof CliError)
+                throw err;
+            throw new CommandExecutionError(`xiaohongshu/delete-note failed: ${err?.message ?? String(err)}`);
+        }
     },
 });
+export const __test__ = {
+    normalizeNoteId,
+    buildLocateAndMaybeDeleteScript,
+    buildVerifyGoneScript,
+};

--- a/clis/xiaohongshu/delete-note.test.js
+++ b/clis/xiaohongshu/delete-note.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+import './delete-note.js';
+
+function makePage(evaluateResults = []) {
+  const evaluate = vi.fn();
+  for (const r of evaluateResults) evaluate.mockResolvedValueOnce(r);
+  evaluate.mockResolvedValue(undefined);
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate,
+  };
+}
+
+describe('xiaohongshu delete-note command', () => {
+  const getCommand = () => getRegistry().get('xiaohongshu/delete-note');
+
+  it('returns deleted status when delete + confirm + verify all succeed', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',  // currentUrl
+      true,                                                 // 已发布 tab click
+      { ok: true },                                         // initResult: row found + delete clicked
+      { ok: true },                                         // confirmResult
+      false,                                                // verify probe: row gone
+    ]);
+    const result = await getCommand().func(page, { 'note-id': '6a08ba0b000000000702a893' });
+    expect(result).toEqual([
+      { status: 'deleted', note_id: '6a08ba0b000000000702a893' },
+    ]);
+    expect(page.goto).toHaveBeenCalledWith('https://creator.xiaohongshu.com/new/note-manager');
+  });
+
+  it('throws ArgumentError when note-id is empty or whitespace', async () => {
+    const page = makePage();
+    await expect(getCommand().func(page, { 'note-id': '' })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(getCommand().func(page, { 'note-id': '   ' })).rejects.toBeInstanceOf(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('throws AuthRequiredError when redirected to login', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/login?redirectReason=401',
+    ]);
+    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toBeInstanceOf(AuthRequiredError);
+  });
+
+  it('throws CommandExecutionError when 已发布 tab cannot be clicked (UI drift)', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      false, // tab click returns false
+    ]);
+    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/已发布 tab not found/);
+  });
+
+  it('throws EmptyResultError when the note row is not in the 已发布 tab', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      true,
+      { ok: false, kind: 'not_found', visibleRows: 0 },
+    ]);
+    await expect(getCommand().func(page, { 'note-id': 'missing-id' })).rejects.toBeInstanceOf(EmptyResultError);
+  });
+
+  it('throws CommandExecutionError when the row has no visible delete action', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      true,
+      { ok: false, kind: 'no_delete_action', visibleRows: 1 },
+    ]);
+    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/no delete action/i);
+  });
+
+  it('throws CommandExecutionError when the confirmation modal does not appear', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      true,
+      { ok: true },
+      { ok: false, kind: 'no_modal' },
+    ]);
+    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/no_modal/);
+  });
+
+  it('throws CommandExecutionError when row stays visible after confirm (delete did not commit)', async () => {
+    // verify probes return true (note still present) for the entire poll window.
+    const probes = Array(15).fill(true);
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      true,
+      { ok: true },
+      { ok: true },
+      ...probes,
+    ]);
+    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/still visible after confirm/i);
+  });
+});

--- a/clis/xiaohongshu/delete-note.test.js
+++ b/clis/xiaohongshu/delete-note.test.js
@@ -73,7 +73,25 @@ describe('xiaohongshu delete-note command', () => {
     await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toBeInstanceOf(ArgumentError);
     await expect(getCommand().func(page, { 'note-id': 'https://evil.com/explore/6a08ba0b000000000702a893' })).rejects.toBeInstanceOf(ArgumentError);
     await expect(getCommand().func(page, { 'note-id': 'https://xhslink.com/abc' })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(getCommand().func(page, { 'note-id': `https://www.xiaohongshu.com/anything?noteId=${validId}` })).rejects.toBeInstanceOf(ArgumentError);
     expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('throws CommandExecutionError for malformed evaluate payloads instead of trusting truthy objects', async () => {
+    await expect(getCommand().func(makePage([
+      { session: 's', data: { href: 'https://creator.xiaohongshu.com/new/note-manager' } },
+    ]), { 'note-id': validId })).rejects.toThrowError(/malformed current-url payload/);
+
+    await expect(getCommand().func(makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      { session: 's', data: { ok: true } },
+    ]), { 'note-id': validId })).rejects.toThrowError(/malformed published-tab payload/);
+
+    await expect(getCommand().func(makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      true,
+      { session: 's', data: { ok: 'yes', clicked: false } },
+    ]), { 'note-id': validId })).rejects.toThrowError(/malformed locate-note payload/);
   });
 
   it('throws AuthRequiredError when redirected to login', async () => {

--- a/clis/xiaohongshu/delete-note.test.js
+++ b/clis/xiaohongshu/delete-note.test.js
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
-import './delete-note.js';
+import { __test__ } from './delete-note.js';
 
 function makePage(evaluateResults = []) {
   const evaluate = vi.fn();
@@ -17,26 +18,61 @@ function makePage(evaluateResults = []) {
 
 describe('xiaohongshu delete-note command', () => {
   const getCommand = () => getRegistry().get('xiaohongshu/delete-note');
+  const validId = '6a08ba0b000000000702a893';
 
   it('returns deleted status when delete + confirm + verify all succeed', async () => {
     const page = makePage([
       'https://creator.xiaohongshu.com/new/note-manager',  // currentUrl
       true,                                                 // 已发布 tab click
-      { ok: true },                                         // initResult: row found + delete clicked
+      { ok: true, clicked: true },                          // initResult: row found + delete clicked
       { ok: true },                                         // confirmResult
       false,                                                // verify probe: row gone
     ]);
-    const result = await getCommand().func(page, { 'note-id': '6a08ba0b000000000702a893' });
+    const result = await getCommand().func(page, { 'note-id': validId, execute: true });
     expect(result).toEqual([
-      { status: 'deleted', note_id: '6a08ba0b000000000702a893' },
+      { status: 'deleted', note_id: validId, message: 'Delete confirmed and note row disappeared.' },
     ]);
     expect(page.goto).toHaveBeenCalledWith('https://creator.xiaohongshu.com/new/note-manager');
   });
 
-  it('throws ArgumentError when note-id is empty or whitespace', async () => {
+  it('dry-runs by default after verifying the exact target and delete affordance', async () => {
+    const page = makePage([
+      'https://creator.xiaohongshu.com/new/note-manager',
+      true,
+      { ok: true, clicked: false },
+    ]);
+    const result = await getCommand().func(page, { 'note-id': validId });
+    expect(result).toEqual([
+      { status: 'dry-run', note_id: validId, message: 'Target note row and delete action verified. Re-run with --execute to delete.' },
+    ]);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
+  });
+
+  it('unwraps browser bridge envelopes at every evaluate boundary', async () => {
+    const page = makePage([
+      { session: 's', data: 'https://creator.xiaohongshu.com/new/note-manager' },
+      { session: 's', data: true },
+      { session: 's', data: { ok: true, clicked: true } },
+      { session: 's', data: { ok: true } },
+      { session: 's', data: false },
+    ]);
+    const result = await getCommand().func(page, { 'note-id': validId, execute: true });
+    expect(result[0]).toMatchObject({ status: 'deleted', note_id: validId });
+  });
+
+  it('normalizes exact Xiaohongshu note IDs from supported URL forms', () => {
+    expect(__test__.normalizeNoteId(validId.toUpperCase())).toBe(validId);
+    expect(__test__.normalizeNoteId(`https://www.xiaohongshu.com/explore/${validId}?xsec_token=t`)).toBe(validId);
+    expect(__test__.normalizeNoteId(`https://creator.xiaohongshu.com/statistics/note-detail?noteId=${validId}`)).toBe(validId);
+  });
+
+  it('throws ArgumentError for missing or ambiguous note identity before navigation', async () => {
     const page = makePage();
     await expect(getCommand().func(page, { 'note-id': '' })).rejects.toBeInstanceOf(ArgumentError);
     await expect(getCommand().func(page, { 'note-id': '   ' })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(getCommand().func(page, { 'note-id': 'https://evil.com/explore/6a08ba0b000000000702a893' })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(getCommand().func(page, { 'note-id': 'https://xhslink.com/abc' })).rejects.toBeInstanceOf(ArgumentError);
     expect(page.goto).not.toHaveBeenCalled();
   });
 
@@ -44,7 +80,7 @@ describe('xiaohongshu delete-note command', () => {
     const page = makePage([
       'https://creator.xiaohongshu.com/login?redirectReason=401',
     ]);
-    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toBeInstanceOf(AuthRequiredError);
+    await expect(getCommand().func(page, { 'note-id': validId })).rejects.toBeInstanceOf(AuthRequiredError);
   });
 
   it('throws CommandExecutionError when 已发布 tab cannot be clicked (UI drift)', async () => {
@@ -52,7 +88,7 @@ describe('xiaohongshu delete-note command', () => {
       'https://creator.xiaohongshu.com/new/note-manager',
       false, // tab click returns false
     ]);
-    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/已发布 tab not found/);
+    await expect(getCommand().func(page, { 'note-id': validId })).rejects.toThrowError(/已发布 tab not found/);
   });
 
   it('throws EmptyResultError when the note row is not in the 已发布 tab', async () => {
@@ -61,7 +97,7 @@ describe('xiaohongshu delete-note command', () => {
       true,
       { ok: false, kind: 'not_found', visibleRows: 0 },
     ]);
-    await expect(getCommand().func(page, { 'note-id': 'missing-id' })).rejects.toBeInstanceOf(EmptyResultError);
+    await expect(getCommand().func(page, { 'note-id': validId })).rejects.toBeInstanceOf(EmptyResultError);
   });
 
   it('throws CommandExecutionError when the row has no visible delete action', async () => {
@@ -70,7 +106,7 @@ describe('xiaohongshu delete-note command', () => {
       true,
       { ok: false, kind: 'no_delete_action', visibleRows: 1 },
     ]);
-    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/no delete action/i);
+    await expect(getCommand().func(page, { 'note-id': validId })).rejects.toThrowError(/no delete action/i);
   });
 
   it('throws CommandExecutionError when the confirmation modal does not appear', async () => {
@@ -80,7 +116,7 @@ describe('xiaohongshu delete-note command', () => {
       { ok: true },
       { ok: false, kind: 'no_modal' },
     ]);
-    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/no_modal/);
+    await expect(getCommand().func(page, { 'note-id': validId, execute: true })).rejects.toThrowError(/no_modal/);
   });
 
   it('throws CommandExecutionError when row stays visible after confirm (delete did not commit)', async () => {
@@ -93,6 +129,26 @@ describe('xiaohongshu delete-note command', () => {
       { ok: true },
       ...probes,
     ]);
-    await expect(getCommand().func(page, { 'note-id': 'x' })).rejects.toThrowError(/still visible after confirm/i);
+    await expect(getCommand().func(page, { 'note-id': validId, execute: true })).rejects.toThrowError(/still visible after confirm/i);
+  });
+
+  it('executes the generated row locator without substring-matching other impression fields', () => {
+    const otherId = '6a08ba0b000000000702a894';
+    const dom = new JSDOM(`
+      <div class="note" data-impression='{"noteTarget":{"value":{"noteId":"${otherId}"}},"title":"${validId}"}'>
+        <span class="control data-del">删除</span>
+      </div>
+      <div class="note" data-impression='{"noteTarget":{"value":{"noteId":"${validId}"}}}'>
+        <span class="control data-del">删除</span>
+      </div>
+    `, { runScripts: 'outside-only' });
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get() {
+        return this.ownerDocument.body;
+      },
+    });
+    const result = dom.window.eval(__test__.buildLocateAndMaybeDeleteScript(validId, false));
+    expect(result).toEqual({ ok: true, clicked: false });
   });
 });

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -22,6 +22,14 @@ const PUBLISH_URL = 'https://creator.xiaohongshu.com/publish/publish?from=menu_l
 const MAX_IMAGES = 9;
 const MAX_TITLE_LEN = 20;
 const UPLOAD_SETTLE_MS = 3000;
+/**
+ * XHS creator center wraps the publish/save button in an `<xhs-publish-btn>`
+ * web component backed by a CLOSED shadow root. Host-level `.click()` does
+ * not dispatch into the internal handler. Invoke these instance methods on
+ * the host element to trigger publish / save-draft directly (#1606).
+ */
+const PUBLISH_METHOD_NAMES = ['_onPublish', 'onPublish', '_onSubmit', '_handlePublish'];
+const DRAFT_METHOD_NAMES = ['_onSave', '_onSaveDraft', '_onDraft'];
 /** Selectors for the title field, ordered by priority across current UI variants. */
 const TITLE_SELECTORS = [
     // Some creator-center variants expose the title as contenteditable,
@@ -610,26 +618,58 @@ cli({
         }
         // ── Step 7: Publish or save draft ─────────────────────────────────────────
         const actionLabels = isDraft ? ['暂存离开', '存草稿'] : ['发布', '发布笔记'];
-        const btnClicked = await page.evaluate(`
-      (labels => {
+        const invokeResult = await page.evaluate(`
+      (cfg => {
+        const { isDraftMode, publishNames, draftNames, labels } = cfg;
+        const isVisible = (el) => {
+          if (!el || el.offsetParent === null) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        };
+        // Path 1: web component method invoke on <xhs-publish-btn>.
+        const hosts = Array.from(document.querySelectorAll('xhs-publish-btn')).filter(isVisible);
+        const wanted = isDraftMode ? draftNames : publishNames;
+        // Try every host + every candidate; do NOT bail on the first throw
+        // (multiple hosts can exist, and a later name may succeed).
+        let lastMethodError = null;
+        for (const host of hosts) {
+          for (const name of wanted) {
+            if (typeof host[name] !== 'function') continue;
+            try {
+              host[name]();
+              return { ok: true, via: 'method', name };
+            } catch (err) {
+              lastMethodError = String(err && err.message || err);
+            }
+          }
+        }
+        // Path 2: legacy <button>/[role=button] text-match click fallback.
         const buttons = document.querySelectorAll('button, [role="button"]');
         for (const btn of buttons) {
           const text = (btn.innerText || btn.textContent || '').trim();
           if (
             labels.some(l => text === l || text.includes(l)) &&
-            btn.offsetParent !== null &&
+            isVisible(btn) &&
             !btn.disabled
           ) {
             btn.click();
-            return true;
+            return { ok: true, via: 'click', text };
           }
         }
-        return false;
-      })(${JSON.stringify(actionLabels)})
+        return { ok: false, via: 'none', hosts: hosts.length, lastMethodError };
+      })(${JSON.stringify({
+            isDraftMode: isDraft,
+            publishNames: PUBLISH_METHOD_NAMES,
+            draftNames: DRAFT_METHOD_NAMES,
+            labels: actionLabels,
+        })})
     `);
-        if (!btnClicked) {
+        if (!invokeResult?.ok) {
             await page.screenshot({ path: '/tmp/xhs_publish_submit_debug.png' });
-            throw new Error(`Could not find "${actionLabels[0]}" button. ` +
+            const viaClause = invokeResult?.via ? ` (via=${invokeResult.via})` : '';
+            const errorClause = invokeResult?.error ? `, error=${invokeResult.error}` : '';
+            const lastMethodClause = invokeResult?.lastMethodError ? `, lastMethodError=${invokeResult.lastMethodError}` : '';
+            throw new Error(`Could not trigger "${actionLabels[0]}" action${viaClause}${errorClause}${lastMethodClause}. ` +
                 'Debug screenshot: /tmp/xhs_publish_submit_debug.png');
         }
         // ── Step 8: Verify success ─────────────────────────────────────────────────

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -76,8 +76,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '标题走原生输入' }
                     : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable', actual: '正文也走原生输入' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -128,8 +130,10 @@ describe('xiaohongshu publish', () => {
                 return { ok: false, actual: '' };
             if (code.includes('(function(selectors, text)'))
                 return { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '' };
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -177,8 +181,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, actual: '原生失败后回退' }
                     : { ok: true, actual: '正文也回退' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -227,8 +233,10 @@ describe('xiaohongshu publish', () => {
                 return code.includes('input[maxlength')
                     ? { ok: false, actual: '' }
                     : { ok: true, actual: '正文' };
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
@@ -259,7 +267,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: 'CDP上传优先' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: '优先走 setFileInput 主路径' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ], {
@@ -301,7 +309,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: 'CDP被拒后回退' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: 'DataTransfer fallback path' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ], {
@@ -366,7 +374,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: 'DeepSeek别乱问' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: '一篇真实一点的小红书正文' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ]);
@@ -389,6 +397,49 @@ describe('xiaohongshu publish', () => {
                 detail: '"DeepSeek别乱问" · 1张图片 · 发布成功',
             },
         ]);
+    });
+    it('uses the shadow-DOM method-invoke path when xhs-publish-btn handler succeeds', async () => {
+        // Mirrors the previous "selects the image-text tab and publishes successfully"
+        // mock sequence but returns `via: 'method', name: '_onPublish'` for the publish
+        // trigger evaluate, exercising the shadow-DOM web-component handler path
+        // (the primary #1606 fix). Without this case the fix's main path is uncovered.
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const page = createPageMock([
+            'https://creator.xiaohongshu.com/publish/publish?from=menu_left',
+            { ok: true, target: '上传图文', text: '上传图文' },
+            { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false },
+            { ok: true, count: 1 },
+            false,
+            true, // waitForEditForm: editor appeared
+            { ok: true, sel: 'input[maxlength="20"]', kind: 'input' },
+            { ok: true, actual: 'shadow-dom-test' },
+            { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
+            { ok: true, actual: '走 method-invoke 路径' },
+            { ok: true, via: 'method', name: '_onPublish' }, // shadow-DOM handler success
+            'https://creator.xiaohongshu.com/publish/success',
+            '发布成功',
+        ]);
+        const result = await cmd.func(page, {
+            title: 'shadow-dom-test',
+            content: '走 method-invoke 路径',
+            images: imagePath,
+            topics: '',
+            draft: false,
+        });
+        expect(result).toEqual([
+            {
+                status: '✅ 发布成功',
+                detail: '"shadow-dom-test" · 1张图片 · 发布成功',
+            },
+        ]);
+        // The publish-trigger evaluate must have been the shadow-DOM probe (contains
+        // 'xhs-publish-btn'), not the legacy `button.click()` fallback alone.
+        const evaluateCalls = page.evaluate.mock.calls.map((args) => String(args[0]));
+        expect(evaluateCalls.some((code) => code.includes('xhs-publish-btn'))).toBe(true);
     });
     it('fails early with a clear error when still on the video page', async () => {
         const cmd = getRegistry().get('xiaohongshu/publish');
@@ -431,7 +482,7 @@ describe('xiaohongshu publish', () => {
             { ok: true, actual: '延迟切换也能过' },
             { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' },
             { ok: true, actual: '图文页切换慢一点也继续等' },
-            true,
+            { ok: true, via: 'click', text: '发布' },
             'https://creator.xiaohongshu.com/publish/success',
             '发布成功',
         ]);
@@ -479,8 +530,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, actual: '停留在发布页也算成功' }
                     : { ok: true, actual: '草稿成功提示' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll')) {
                 return code.includes('保存成功') ? '保存成功' : '';
             }
@@ -529,8 +582,10 @@ describe('xiaohongshu publish', () => {
                     ? { ok: true, actual: '发布提示不该复用草稿成功' }
                     : { ok: true, actual: '发布成功提示' };
             }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('labels.some'))
-                return true;
+                return false;
             if (code.includes('for (const el of document.querySelectorAll')) {
                 return code.includes('保存成功') ? '保存成功' : '';
             }

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -14,6 +14,7 @@
 | `opencli xiaohongshu user` | Get public notes from a user profile |
 | `opencli xiaohongshu download` | Download images and videos from a note |
 | `opencli xiaohongshu publish` | Publish image-text notes (creator center UI automation) |
+| `opencli xiaohongshu delete-note` | Verify or delete a published creator-center note by exact note ID |
 | `opencli xiaohongshu creator-notes` | Creator's note list with per-note metrics |
 | `opencli xiaohongshu creator-note-detail` | Detailed analytics for a single creator note |
 | `opencli xiaohongshu creator-notes-summary` | Combined note list + detail analytics summary |
@@ -40,9 +41,16 @@ opencli xiaohongshu feed
 opencli xiaohongshu notifications
 opencli xiaohongshu download "https://www.xiaohongshu.com/search_result/<id>?xsec_token=..."
 opencli xiaohongshu download "https://xhslink.com/..."
+
+# Verify a published creator note without deleting it (default dry-run)
+opencli xiaohongshu delete-note 6a08ba0b000000000702a893
+
+# Actually delete after the target row and delete action are verified
+opencli xiaohongshu delete-note 6a08ba0b000000000702a893 --execute
 ```
 
 > Note: `note` and `comments` now require a full signed note URL with `xsec_token`. `download` accepts either a signed note URL or an `xhslink` short link. Bare note IDs are no longer reliable on xiaohongshu.
+> `delete-note` operates in creator center and accepts a 24-character note ID or exact Xiaohongshu note URL; it defaults to dry-run verification and only deletes with `--execute`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Adds `opencli xiaohongshu delete-note <note-id>` so the workflow that creates a note can also remove one without leaving the CLI, mirroring the `weibo delete` shape (#1619 / #1620).

The creator-center HTTP delete API requires the `X-S-Common` signature header that `clis/xiaohongshu/publish.js` deliberately avoids, so this command follows the same UI automation route through `creator.xiaohongshu.com`.

Closes #1623.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

UI automation against the creator note-manager:

1. `page.goto('https://creator.xiaohongshu.com/new/note-manager')`. If creator center bounces to `/login`, throw `AuthRequiredError`.
2. Click the "已发布" tab. Delete is only exposed there: "审核中" and "未通过" rows expose no web delete entry (mobile app only).
3. Locate the `.note` row whose `data-impression` JSON contains the target noteId. Throw `EmptyResultError` with a hint about review state if not found.
4. Click the inline `<span class="control data-del">` action.
5. Click "确定" in the `.d-modal-footer` confirmation modal. Throw `CommandExecutionError` if the modal or button is missing (xhs UI drift).
6. Poll up to ~10s for the row to disappear (iteration-bounded so tests with mocked `page.wait` finish quickly). Throw `CommandExecutionError` if it stays visible, indicating the confirm click did not actually commit.

## Screenshots / Output

Live run on macOS / opencli (branch includes #1613's shadow-DOM publish fix so a fresh test note could be published first):

```bash
# Publish a test note (via this branch's xiaohongshu publish, which already
# has the shadow-DOM fix from #1613)
$ node ./dist/src/main.js xiaohongshu publish "明洞这家店还不错" \
    --title "明洞街景测试 可删" \
    --images /tmp/xhs_test_myeongdong.jpg
- status: ✅ 发布成功
  detail: '"明洞街景测试 可删" · 1张图片 · 发布成功'

# Wait for review to clear into "已发布"
$ node ./dist/src/main.js xiaohongshu creator-notes --limit 1 -f json
[
  {
    "rank": 1,
    "id": "6a08ba0b000000000702a893",
    "title": "明洞这家店还不错",
    "date": "2026年05月17日 02:40",
    "views": 24, "likes": 0, "collects": 0, "comments": 0,
    "url": "https://creator.xiaohongshu.com/statistics/note-detail?noteId=6a08ba0b000000000702a893"
  }
]

# Delete it
$ node ./dist/src/main.js xiaohongshu delete-note 6a08ba0b000000000702a893 -f json
[
  {
    "status": "deleted",
    "note_id": "6a08ba0b000000000702a893"
  }
]

# Verify gone
$ node ./dist/src/main.js xiaohongshu creator-notes --limit 5
error: No notes found. Are you logged into creator.xiaohongshu.com?
```

## Test plan

- [x] `npx vitest run clis/xiaohongshu/delete-note.test.js`: 7 / 7 pass (happy path, empty-id `ArgumentError`, login-redirect `AuthRequiredError`, row-not-found `EmptyResultError`, no-delete-action / no-modal / row-stays-visible `CommandExecutionError`)
- [x] `npm run build`: manifest compiles, 822 entries, no path leaks
- [x] `npm run check:typed-error-lint`: passes
- [x] `npm run check:silent-column-drop`: passes
- [x] Live verify: deleted a real published note, `creator-notes` confirms it is gone
- [ ] Reviewer: confirm on a different logged-in xhs account with a published throwaway note

## Branch base

Currently rebased on top of #1613 (`fix/xiaohongshu/publish: invoke shadow-DOM publish handler directly`) so the live verify could exercise the full publish-then-delete loop in one branch. Will rebase onto main after #1613 merges. If reviewers prefer to land delete-note first, the `#1613` commit can be dropped here without affecting the new delete-note files.

