### PR TITLE
fix(weibo/publish): replace brittle CSS-module hash with placeholder selector

### DIFF
--- a/clis/weibo/publish.js
+++ b/clis/weibo/publish.js
@@ -30,8 +30,15 @@ const SUBMIT_POLL_MS = 500;
 const SUBMIT_TIMEOUT_MS = 20_000;
 const SUPPORTED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
 
-// Weibo PC UI selectors
-const TEXTAREA_SELECTOR = 'textarea._input_13iqr_8';
+// Weibo PC UI selectors. The CSS-module hash drifts on every frontend
+// rebuild (#1602), so match on the stable placeholder text and keep the
+// legacy hash as a last-resort fallback. Callers pick the LAST visible
+// match because the compose modal renders on top of the home-feed strip.
+const TEXTAREA_SELECTORS = [
+    'textarea[placeholder*="有什么新鲜事"]',
+    'textarea[placeholder*="新鲜事"]',
+    'textarea._input_13iqr_8',
+];
 const FILE_INPUT_SELECTOR = 'input[type="file"][class*="_file_"]';
 
 function validateText(text) {
@@ -125,12 +132,19 @@ cli({
         let editorFound = false;
         for (let i = 0; i < Math.ceil(COMPOSE_TIMEOUT_MS / COMPOSE_POLL_MS); i++) {
             const result = await page.evaluate(`
-                () => {
-                    const ta = document.querySelector('textarea._input_13iqr_8');
-                    if (!ta) return { found: false };
-                    const visible = ta.offsetParent !== null;
-                    return { found: true, visible, rectTop: visible ? ta.getBoundingClientRect().top : -1 };
-                }
+                (selectors => {
+                    // Pick the LAST visible match across all selectors so
+                    // the modal (rendered on top of the home-feed strip)
+                    // wins over earlier matches. See TEXTAREA_SELECTORS.
+                    let last = null;
+                    for (const sel of selectors) {
+                        for (const t of document.querySelectorAll(sel)) {
+                            if (t.offsetParent !== null) last = t;
+                        }
+                    }
+                    if (!last) return { found: false };
+                    return { found: true, visible: true, rectTop: last.getBoundingClientRect().top };
+                })(${JSON.stringify(TEXTAREA_SELECTORS)})
             `);
             if (result?.found && result.visible && result.rectTop >= 0) {
                 editorFound = true;
@@ -187,9 +201,14 @@ cli({
         // IMPORTANT: Using nativeSetter preserves the textarea's reactive/internal state.
         // Direct ta.value= assignment bypasses Weibo's Vue reactivity and causes "undefined" content.
         const insertResult = await page.evaluateWithArgs(`
-            (() => {
-                const ta = document.querySelector('textarea._input_13iqr_8');
-                if (!ta || ta.offsetParent === null) return { ok: false, message: 'textarea not visible' };
+            ((selectors) => {
+                let ta = null;
+                for (const sel of selectors) {
+                    for (const t of document.querySelectorAll(sel)) {
+                        if (t.offsetParent !== null) ta = t;
+                    }
+                }
+                if (!ta) return { ok: false, message: 'textarea not visible' };
                 ta.focus();
                 const nativeSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
                 if (nativeSetter) {
@@ -200,7 +219,7 @@ cli({
                 ta.dispatchEvent(new Event('input', { bubbles: true }));
                 ta.dispatchEvent(new Event('change', { bubbles: true }));
                 return { ok: true, valueLength: ta.value.length };
-            })()
+            })(${JSON.stringify(TEXTAREA_SELECTORS)})
         `, { textContent: text });
 
         if (!insertResult?.ok) {
@@ -233,10 +252,14 @@ cli({
         }
 
         // Step 8: Wait for success/failure result
+        // Use page.evaluate (not evaluateWithArgs): the IIFE doesn't reference
+        // any outer args, and evaluateWithArgs would re-declare its const
+        // bindings each loop iteration in the same page context, throwing
+        // "Identifier already declared" after the first iteration.
         let finalResult = null;
         for (let i = 0; i < Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS); i++) {
             await page.wait({ time: SUBMIT_POLL_MS / 1000 });
-            finalResult = await page.evaluateWithArgs(`
+            finalResult = await page.evaluate(`
                 (() => {
                     const successMarkers = ['发布成功', '已发布', '发送成功'];
                     const errorMarkers = ['发布失败', '发送失败', '内容违规', '请稍后再试', '频繁'];
@@ -257,7 +280,7 @@ cli({
                     }
                     return null;
                 })()
-            `, { maxIterations: Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS), currentIndex: i });
+            `);
             if (finalResult !== null) break;
         }
 

--- a/clis/weibo/publish.test.js
+++ b/clis/weibo/publish.test.js
@@ -72,6 +72,9 @@ describe('weibo publish command', () => {
 
     expect(result).toEqual([{ status: 'success', message: '发送成功', text: 'hello' }]);
     expect(page.goto).toHaveBeenCalledWith('https://weibo.com', { waitUntil: 'load', settleMs: 2000 });
+    expect(page.evaluate.mock.calls[2][0]).toContain('有什么新鲜事');
+    expect(page.evaluate.mock.calls[2][0]).toContain('textarea._input_13iqr_8');
+    expect(page.evaluateWithArgs.mock.calls[0][0]).toContain('有什么新鲜事');
   });
 
   it('uploads up to nine images before publishing', async () => {
@@ -83,11 +86,11 @@ describe('weibo publish command', () => {
         { found: true, visible: true, rectTop: 100 },
         true,
         { ok: true, label: '发送' },
+        { ok: true, message: '发送成功' },
       ],
       evaluateWithArgsResults: [
         { ok: true, count: 2 },
         { ok: true, valueLength: 11 },
-        { ok: true, message: '发送成功' },
       ],
     });
 

--- a/clis/weibo/publish.test.js
+++ b/clis/weibo/publish.test.js
@@ -61,10 +61,10 @@ describe('weibo publish command', () => {
         { ok: true },
         { found: true, visible: true, rectTop: 100 },
         { ok: true, label: '发送' },
+        { ok: true, message: '发送成功' },
       ],
       evaluateWithArgsResults: [
         { ok: true, valueLength: 5 },
-        { ok: true, message: '发送成功' },
       ],
     });
 
@@ -149,10 +149,10 @@ describe('weibo publish command', () => {
         { ok: true },
         { found: true, visible: true, rectTop: 100 },
         { ok: true, label: '发送' },
+        { ok: false, message: '内容违规' },
       ],
       evaluateWithArgsResults: [
         { ok: true, valueLength: 5 },
-        { ok: false, message: '内容违规' },
       ],
     });
 
@@ -161,22 +161,28 @@ describe('weibo publish command', () => {
 
   it('does not treat editor close as positive publish proof', async () => {
     const command = getCommand();
+    // Step 8 polls up to SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS iterations
+    // (= 20000 / 500 = 40 in upstream). Derive the window programmatically
+    // so the test stays aligned with the implementation if the timeout
+    // changes, and override the makePage default { ok: true } fallback that
+    // would otherwise satisfy the success-marker break.
+    const SUBMIT_POLL_ITERATIONS = Math.ceil(20_000 / 500);
     const page = makePage({
       evaluateResults: [
         '123456',
         { ok: true },
         { found: true, visible: true, rectTop: 100 },
         { ok: true, label: '发送' },
+        ...Array(SUBMIT_POLL_ITERATIONS).fill(null),
       ],
       evaluateWithArgsResults: [
         { ok: true, valueLength: 5 },
-        null,
       ],
     });
 
     await expect(command.func(page, { text: 'hello' })).rejects.toBeInstanceOf(CommandExecutionError);
 
-    const submitScript = page.evaluateWithArgs.mock.calls.at(-1)[0];
+    const submitScript = page.evaluate.mock.calls.at(-1)[0];
     expect(submitScript).not.toContain('Editor closed after publish');
     expect(submitScript).toContain('发布成功');
   });


### PR DESCRIPTION
## Description

`clis/weibo/publish.js` matched the compose textarea via `textarea._input_13iqr_8`, where `_input_13iqr_8` is the Vite CSS-module hash Weibo rebuilds on every frontend deploy. The hash has drifted (current build emits `_input_1f5hn_8`), so step 4 of the publish flow throws `Weibo compose editor did not appear` before anything else can run. Reported in #1602.

Replace the single hashed selector with a placeholder-text-based chain that survives CSS-module rebuilds. Closes #1602.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

New selector chain at the top of `publish.js`:

```js
const TEXTAREA_SELECTORS = [
    'textarea[placeholder*="有什么新鲜事"]',  // weibo's actual prompt text
    'textarea[placeholder*="新鲜事"]',         // shorter placeholder fallback
    'textarea._input_13iqr_8',                 // legacy CSS-module hash
];
```

Both the editor-visibility poll (Step 4) and the native-setter text insertion (Step 6) walk this chain. Two visible textareas can match on the home feed: the always-rendered "home strip" prompt and the post-click modal compose. The implementation picks the LAST visible candidate, because the modal opens on top and is appended to DOM later (so the last-visible match is the modal, never the home strip).

### Secondary fix in the same scope

Step 8 success polling used `page.evaluateWithArgs` even though the IIFE there does not reference any outer args. `evaluateWithArgs` injects its `const`-bound parameter names into the page context, and re-running the same call on each iteration of the success-poll loop threw `Identifier 'maxIterations' has already been declared` after the first iteration. This was masked previously because Step 4 always failed first; with the selector fixed, the latent Step 8 bug surfaces immediately. Switched Step 8 to plain `page.evaluate` to avoid the per-iteration re-declaration.

## Screenshots / Output

Before (on `upstream/main`, with the hashed selector):

```bash
$ node ./dist/src/main.js weibo publish "明洞那家店真不错"
error:
  code: COMMAND_EXEC
  message: Weibo compose editor did not appear
  exitCode: 1
```

After (this branch):

```bash
$ node ./dist/src/main.js weibo publish "明洞那家店真不错"
- status: success
  message: 发布成功
  text: 明洞那家店真不错

# Verify the post actually landed with the right text:
$ # in-page fetch /ajax/statuses/mymblog?uid=<self>&page=1
{
  "idstr": "5299403716821218",
  "mblogid": "QFHWzsCvE",
  "text": "明洞那家店真不错 ​​​",
  "created_at": "Sun May 17 03:29:26 +0800 2026"
}
```

The test post was deleted right after verification via the same `/ajax/statuses/destroy` path that PR #1620 exposes as `weibo delete`.

## Test plan

- [x] `npx vitest run clis/weibo/publish.test.js`: 8 / 8 pass (mocks updated to reflect the `evaluate` vs `evaluateWithArgs` split for Step 8 and the longer success-poll window)
- [x] `npm run build`: manifest compiles, 821 entries, no path leaks
- [x] `npm run check:typed-error-lint`: passes
- [x] `npm run check:silent-column-drop`: passes
- [x] Live verify: text-only publish landed with the typed text intact, post visible on the account feed, then cleaned up
- [ ] Reviewer to confirm with images: image upload + text path on a different account (text-only path verified here; image path uses the same TEXTAREA_SELECTORS chain so should follow)

