### PR TITLE
fix(zhihu): decode numeric entities in answer detail

### DIFF
--- a/clis/zhihu/answer-detail.js
+++ b/clis/zhihu/answer-detail.js
@@ -19,6 +19,18 @@ function stripHtml(html) {
         .replace(/&amp;/g, '&')
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
+        .replace(/&#(\d+);/g, (_, value) => {
+            const codePoint = Number(value);
+            return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF
+                ? String.fromCodePoint(codePoint)
+                : _;
+        })
+        .replace(/&#x([0-9a-f]+);/gi, (_, value) => {
+            const codePoint = Number.parseInt(value, 16);
+            return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF
+                ? String.fromCodePoint(codePoint)
+                : _;
+        })
         .replace(/\n{3,}/g, '\n\n')
         .trim();
 }

--- a/clis/zhihu/answer-detail.test.js
+++ b/clis/zhihu/answer-detail.test.js
@@ -304,6 +304,14 @@ describe('zhihu answer-detail helpers', () => {
         expect(out).toBe('hi there & you\n\nsecond');
     });
 
+    it('stripHtml decodes numeric entities', () => {
+        expect(helpers.stripHtml('&#34;中文&#34; &#x26; &#39;test&#39;')).toBe('"中文" & \'test\'');
+    });
+
+    it('stripHtml keeps invalid numeric entities unchanged', () => {
+        expect(helpers.stripHtml('bad &#9999999999; entity')).toBe('bad &#9999999999; entity');
+    });
+
     it('stripHtml maps <br> to single newline', () => {
         expect(helpers.stripHtml('a<br>b<br/>c')).toBe('a\nb\nc');
     });


### PR DESCRIPTION
## Summary
- decode decimal and hexadecimal HTML numeric entities in Zhihu answer-detail content
- keep invalid numeric entities unchanged instead of throwing
- add unit coverage for numeric entity decoding

## Why
Zhihu answer HTML can include numeric entities such as &#34; and &#x26;. The answer-detail stripper decoded a few named entities but left numeric entities visible in the returned text.

## Validation
- npx vitest run --project adapter clis/zhihu/answer-detail.test.js clis/zhihu/question.test.js
- npm run dev -- zhihu answer-detail "https://www.zhihu.com/question/2033593594901160569/answer/2034724552681453448" --max-content 500 -f json
- git diff --check