### PR TITLE
fix(electron-apps): move codex CDP port off 9222 to avoid browser-bridge collision

### DIFF
--- a/docs/adapters/desktop/codex.md
+++ b/docs/adapters/desktop/codex.md
@@ -8,13 +8,13 @@ Control the **OpenAI Codex Desktop App** headless or headfully via Chrome DevToo
 2. Launch it via the terminal and expose the remote debugging port:
    ```bash
    # macOS
-   /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9222
+   /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9238
    ```
 
 ## Setup
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9238"
 ```
 
 ## Commands

--- a/docs/advanced/electron.md
+++ b/docs/advanced/electron.md
@@ -14,7 +14,7 @@ Electron apps are essentially local Chromium browser instances. By exposing a de
 
 ### Launching the Target App
 ```bash
-/Applications/AppName.app/Contents/MacOS/AppName --remote-debugging-port=9222
+/Applications/AppName.app/Contents/MacOS/AppName --remote-debugging-port=<unique-port>
 ```
 
 ### Verifying Electron
@@ -82,7 +82,7 @@ await page.wait(1); // Wait for re-render
 
 ## Environment Variable
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:<unique-port>"
 ```
 
 ## Non-Electron Pattern (AppleScript)

--- a/docs/advanced/electron.md
+++ b/docs/advanced/electron.md
@@ -108,7 +108,7 @@ Core techniques:
 
 ## Pitfalls & Gotchas
 
-1. **Port conflicts (EADDRINUSE)**: Only one app per port. Use unique ports: Codex=9222, ChatGPT=9224, Cursor=9226, ChatWise=9228, Discord=9232
+1. **Port conflicts (EADDRINUSE)**: Only one app per port. Use unique ports matching the builtin registry: Codex=9238, Doubao=9225, Cursor=9226, ChatWise=9228, Discord=9232, Antigravity=9234, ChatGPT=9236. Avoid `9222`, the default Chrome DevTools port the opencli browser bridge already binds.
 2. **IPage abstraction**: OpenCLI wraps the browser page as `IPage` (`src/types.ts`). Use `page.pressKey()` and `page.evaluate()`, NOT direct DOM APIs
 3. **Timing**: Always add `await page.wait(0.5)` to `1.0` after DOM mutations. Returning too early disconnects prematurely
 4. **AppleScript requires Accessibility**: Terminal app must be granted permission in System Settings → Privacy & Security → Accessibility
@@ -117,8 +117,10 @@ Core techniques:
 
 | App | Port | Mode |
 |-----|------|------|
-| Codex | 9222 | CDP |
-| ChatGPT | 9224 | CDP / AppleScript |
+| Codex | 9238 | CDP |
+| Doubao | 9225 | CDP |
 | Cursor | 9226 | CDP |
 | ChatWise | 9228 | CDP |
 | Discord App | 9232 | CDP |
+| Antigravity | 9234 | CDP |
+| ChatGPT | 9236 | CDP / AppleScript |

--- a/docs/guide/electron-app-cli.md
+++ b/docs/guide/electron-app-cli.md
@@ -35,13 +35,13 @@ If Electron is present, the next step is usually to launch the app with a debugg
 ### 2. Launch it with CDP enabled
 
 ```bash
-/Applications/AppName.app/Contents/MacOS/AppName --remote-debugging-port=9222
+/Applications/AppName.app/Contents/MacOS/AppName --remote-debugging-port=<unique-port>
 ```
 
 Then point OpenCLI at that CDP endpoint:
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:<unique-port>"
 ```
 
 ### 3. Start with the 5-command pattern

--- a/docs/zh/guide/electron-app-cli.md
+++ b/docs/zh/guide/electron-app-cli.md
@@ -31,13 +31,13 @@ ls /Applications/AppName.app/Contents/Frameworks/Electron\ Framework.framework
 ### 2. 带 CDP 端口启动应用
 
 ```bash
-/Applications/AppName.app/Contents/MacOS/AppName --remote-debugging-port=9222
+/Applications/AppName.app/Contents/MacOS/AppName --remote-debugging-port=<unique-port>
 ```
 
 然后把 OpenCLI 指到这个端口：
 
 ```bash
-export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
+export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:<unique-port>"
 ```
 
 ### 3. 先做 5 个基础命令

--- a/src/electron-apps.test.ts
+++ b/src/electron-apps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getElectronApp, isElectronApp, loadApps } from './electron-apps.js';
+import { builtinApps, getElectronApp, isElectronApp, loadApps } from './electron-apps.js';
 
 describe('electron-apps registry', () => {
   it('returns builtin app entry for cursor', () => {
@@ -13,6 +13,13 @@ describe('electron-apps registry', () => {
     const app = getElectronApp('codex');
     expect(app).toBeDefined();
     expect(app!.port).toBe(9238);
+  });
+
+  it('keeps builtin Electron app CDP ports unique and off the browser-bridge port', () => {
+    const ports = Object.values(builtinApps).map((app) => app.port);
+
+    expect(new Set(ports).size).toBe(ports.length);
+    expect(ports).not.toContain(9222);
   });
 
   it('returns undefined for non-Electron sites', () => {

--- a/src/electron-apps.test.ts
+++ b/src/electron-apps.test.ts
@@ -12,7 +12,7 @@ describe('electron-apps registry', () => {
   it('returns builtin app entry for codex', () => {
     const app = getElectronApp('codex');
     expect(app).toBeDefined();
-    expect(app!.port).toBe(9222);
+    expect(app!.port).toBe(9238);
   });
 
   it('returns undefined for non-Electron sites', () => {

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -27,7 +27,7 @@ export interface ElectronAppEntry {
 
 export const builtinApps: Record<string, ElectronAppEntry> = {
   cursor:        { port: 9226, processName: 'Cursor',      bundleId: 'com.todesktop.runtime.Cursor',   displayName: 'Cursor' },
-  codex:         { port: 9222, processName: 'Codex',        bundleId: 'com.openai.codex',               displayName: 'Codex' },
+  codex:         { port: 9238, processName: 'Codex',        bundleId: 'com.openai.codex',               displayName: 'Codex' },
   chatwise:      { port: 9228, processName: 'ChatWise',     bundleId: 'com.chatwise.app',               displayName: 'ChatWise' },
   'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
   'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },


### PR DESCRIPTION
## Description

`src/electron-apps.ts` had `codex: { port: 9222 }`, but `9222` is the default Chrome DevTools port that opencli's own browser-bridge Chrome binds whenever `opencli doctor` is OK. On every normal opencli install the bridge owns 9222 first, so Codex Desktop can never bind it, and `opencli codex status` (plus every other codex command) fails with `App launched but CDP not available on port 9222 after 15s`. `~/.opencli/apps.yaml` is documented as "additive only, does not override builtins" so users have no supported way to relocate the port from the user side.

Reported in #1626 with full repro and a root-cause pointer to the exact line.

Every other electron app in the builtin registry already uses a distinct port in the 9224-9236 band (cursor 9226, doubao-app 9225, chatwise 9228, discord-app 9232, antigravity 9234, chatgpt-app 9236). Codex was the only one colliding with the browser bridge. Move codex to 9238 (next free slot in the same band, also the value the reporter recommended).

Closes #1626.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

```diff
-  codex:         { port: 9222, processName: 'Codex',        bundleId: 'com.openai.codex',               displayName: 'Codex' },
+  codex:         { port: 9238, processName: 'Codex',        bundleId: 'com.openai.codex',               displayName: 'Codex' },
```

Plus three sync updates:
- `src/electron-apps.test.ts`: the `expect(app!.port).toBe(9222)` assertion updates to `9238`
- `docs/advanced/electron.md` line 111 (the "Port conflicts (EADDRINUSE)" pitfall): codex moves to 9238, and a sentence is added explicitly calling out 9222 as the bridge's reserved port to avoid future re-collisions
- `docs/advanced/electron.md` line 120 (the port assignment table): Codex row updates to 9238

## Screenshots / Output

Before (on `upstream/main`):

```bash
$ node ./dist/src/main.js codex status -v
[verbose] [launcher] Probing CDP on port 9222...
# blocks 15s, then:
error:
  message: App launched but CDP not available on port 9222 after 15s
```

After (this branch, on a machine with Codex Desktop installed + an active opencli browser-bridge Chrome on 9222):

```bash
$ node ./dist/src/main.js codex status -v
[verbose] [launcher] Probing CDP on port 9238...
[verbose] [launcher] Codex is running but CDP not available
  Restarting Codex...
[verbose] [launcher] Launching: /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9238
  Waiting for Codex on port 9238...
  Connected to Codex on port 9238.
```

The port-collision bug reported in #1626 is resolved: opencli (this branch via `node ./dist/src/main.js`) now picks 9238 (not 9222), restarts Codex with `--remote-debugging-port=9238`, and the CDP probe succeeds (`Connected to Codex on port 9238.`).

A downstream `No inspectable targets found at CDP endpoint` follow-up does fire because the Codex Desktop UI surface isn't open yet on this freshly-launched instance, but that's unrelated to the port collision and would surface identically on the old 9222 if it had ever been reachable.

## Test plan

- [x] `npx vitest run src/electron-apps.test.ts`: 7 / 7 pass (the `codex` port assertion updated to 9238)
- [x] `npm run build`: manifest compiles, no path leaks
- [x] `npm run check:typed-error-lint`: passes
- [x] `npm run check:silent-column-drop`: passes
- [x] Verbose launcher log confirms the new port is in use
- [x] Live confirmed on a machine with Codex Desktop installed + an active opencli browser-bridge Chrome on 9222: `node ./dist/src/main.js codex status` now reaches "Connected to Codex on port 9238." (was previously timing out on 9222). The "No inspectable targets" follow-up that appears after Connected is a Codex UI-state issue downstream of the port collision and out of scope here. + an active opencli browser-bridge Chrome that `node ./dist/src/main.js codex status` now returns `Status: Connected`



