### PR TITLE
feat(linkedin): add Sales Navigator messaging commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14432,7 +14432,14 @@
         "type": "int",
         "default": 40,
         "required": false,
-        "help": "Maximum conversations to return (1-100)"
+        "help": "Maximum conversations to return (1-500)"
+      },
+      {
+        "name": "max-scrolls",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Maximum inbox scroll attempts to lazy-load older conversations (0-80)"
       },
       {
         "name": "unread-only",
@@ -14612,6 +14619,26 @@
     "modulePath": "linkedin/search.js",
     "sourceFile": "linkedin/search.js",
     "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin",
+    "name": "sent-invitations",
+    "description": "List pending LinkedIn sent invitations for CRM reconciliation",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "rank",
+      "name",
+      "profile_url",
+      "invited_date_text"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/sent-invitations.js",
+    "sourceFile": "linkedin/sent-invitations.js",
+    "navigateBefore": true
   },
   {
     "site": "linkedin",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14534,6 +14534,44 @@
   },
   {
     "site": "linkedin",
+    "name": "salesnav-search",
+    "description": "Search LinkedIn Sales Navigator for people leads by keyword",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "keywords",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "People search keywords, e.g. \"quality manager food manufacturing\""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 25,
+        "required": false,
+        "help": "Maximum leads to return (1-500, fetched 25 per request)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "title",
+      "company",
+      "location",
+      "degree",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-search.js",
+    "sourceFile": "linkedin/salesnav-search.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
     "name": "search",
     "description": "Search LinkedIn jobs",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14643,7 +14643,7 @@
   {
     "site": "linkedin",
     "name": "thread-snapshot",
-    "description": "Load a LinkedIn messaging thread, scroll for available history, and return a full context snapshot",
+    "description": "Load a LinkedIn messaging thread, page through its full history, and return a context snapshot",
     "access": "read",
     "domain": "www.linkedin.com",
     "strategy": "ui",
@@ -14660,7 +14660,7 @@
         "type": "number",
         "default": 30,
         "required": false,
-        "help": "Maximum upward scroll attempts to load older messages"
+        "help": "Maximum older-history pages to fetch (about 20 messages each)"
       },
       {
         "name": "json",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14534,6 +14534,125 @@
   },
   {
     "site": "linkedin",
+    "name": "salesnav-inbox",
+    "description": "List LinkedIn Sales Navigator message conversations with API pagination",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 40,
+        "required": false,
+        "help": "Maximum conversations to return (1-500)"
+      },
+      {
+        "name": "max-pages",
+        "type": "number",
+        "default": 30,
+        "required": false,
+        "help": "Maximum Sales Navigator API pages to fetch"
+      },
+      {
+        "name": "unread-only",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Return only unread conversations"
+      }
+    ],
+    "columns": [
+      "rank",
+      "thread_id",
+      "thread_url",
+      "person_name",
+      "last_message_snippet",
+      "last_activity_time",
+      "unread",
+      "unread_count",
+      "total_message_count",
+      "archived",
+      "participants",
+      "next_page_starts_at"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-inbox.js",
+    "sourceFile": "linkedin/salesnav-inbox.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
+    "name": "salesnav-message",
+    "description": "Send or dry-run a LinkedIn Sales Navigator InMail to a lead using the Sales Navigator messaging API",
+    "access": "write",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "recipient",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Sales Navigator lead URL, LinkedIn /in/ URL from salesnav-search, or urn:li:fs_salesProfile:(...)"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "required": true,
+        "help": "InMail subject"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "required": true,
+        "help": "InMail body"
+      },
+      {
+        "name": "send",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Actually send the InMail. Default is dry-run validation only."
+      },
+      {
+        "name": "copy-to-crm",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Set Sales Navigator copyToCrm on the message request"
+      }
+    ],
+    "columns": [
+      "status",
+      "recipient",
+      "title",
+      "company",
+      "credits_remaining",
+      "credits_before",
+      "credits_after",
+      "sent_in_salesnav",
+      "message_chars",
+      "subject_chars",
+      "recipient_urn",
+      "authRequired",
+      "text",
+      "degree",
+      "inmail_restriction",
+      "open_link",
+      "json",
+      "href",
+      "resourceUrns"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-message.js",
+    "sourceFile": "linkedin/salesnav-message.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
     "name": "salesnav-search",
     "description": "Search LinkedIn Sales Navigator for people leads by keyword",
     "access": "read",
@@ -14563,11 +14682,63 @@
       "company",
       "location",
       "degree",
-      "profile_url"
+      "profile_url",
+      "lead_url",
+      "recipient_urn"
     ],
     "type": "js",
     "modulePath": "linkedin/salesnav-search.js",
     "sourceFile": "linkedin/salesnav-search.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
+    "name": "salesnav-thread",
+    "description": "Return full Sales Navigator message history for a thread id, Sales Navigator inbox URL, lead URL, recipient urn, or exact recipient name",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "thread-or-recipient",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Sales Navigator inbox URL/thread id, Sales Navigator lead URL, recipient urn, or exact participant name"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 200,
+        "required": false,
+        "help": "Maximum messages to return (1-500)"
+      },
+      {
+        "name": "max-pages",
+        "type": "number",
+        "default": 30,
+        "required": false,
+        "help": "Maximum inbox pages to scan when resolving a recipient"
+      }
+    ],
+    "columns": [
+      "index",
+      "thread_id",
+      "thread_url",
+      "sender",
+      "text",
+      "timestamp",
+      "subject",
+      "message_id",
+      "sender_urn",
+      "delivered_at",
+      "type",
+      "total_message_count"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-thread.js",
+    "sourceFile": "linkedin/salesnav-thread.js",
     "navigateBefore": true
   },
   {

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -35,26 +35,41 @@ function parseMaxScrolls(value) {
   return scrolls;
 }
 
-function installInboxFetchCaptureScript() {
-  return String.raw`(() => {
-    window.__opencli_inbox_pages = Array.isArray(window.__opencli_inbox_pages) ? window.__opencli_inbox_pages : [];
-    if (window.__opencli_inbox_fetch_patched) return { patched: false, count: window.__opencli_inbox_pages.length };
-    const originalFetch = window.fetch;
-    window.__opencli_inbox_fetch_patched = true;
-    window.fetch = async function(...args) {
-      const response = await originalFetch.apply(this, args);
-      try {
-        const request = args[0];
-        const url = typeof request === 'string' ? request : (request && request.url) || '';
-        if (/messengerConversations/i.test(String(url || response.url || ''))) {
-          response.clone().text().then((text) => {
-            if (text) window.__opencli_inbox_pages.push(text);
-          }).catch(() => {});
-        }
-      } catch {}
-      return response;
+// LinkedIn lazy-loads conversations as the list is scrolled, firing a fresh
+// messengerConversations request per page. We cannot capture those by patching
+// window.fetch: page.evaluate runs in an isolated world (its window.fetch is
+// not the one LinkedIn calls), and LinkedIn's CSP blocks injecting a main-world
+// script. Instead we scroll to make the page fire the requests, read the
+// request URLs back from the Performance API (visible to the isolated world),
+// and re-issue each one ourselves — the same requests the page already made.
+function collectMessagingUrlsScript() {
+  return String.raw`(() => Array.from(new Set(
+    performance.getEntriesByType('resource')
+      .map((entry) => entry.name)
+      .filter((url) => /messengerConversations/i.test(url) && /mailboxUrn/i.test(url)),
+  )))()`;
+}
+
+function fetchMessagingPagesScript(urls, csrf) {
+  return String.raw`(async () => {
+    const urls = ${JSON.stringify(urls)};
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      accept: 'application/vnd.linkedin.normalized+json+2.1',
+      'x-restli-protocol-version': '2.0.0',
     };
-    return { patched: true, count: window.__opencli_inbox_pages.length };
+    const out = [];
+    for (const url of urls) {
+      try {
+        const res = await fetch(url, { credentials: 'include', headers });
+        if (res.status === 401 || res.status === 403) { out.push({ url, authRequired: true }); continue; }
+        if (!res.ok) { out.push({ url, error: 'HTTP ' + res.status }); continue; }
+        out.push({ url, json: await res.json() });
+      } catch (e) {
+        out.push({ url, error: 'fetch failed: ' + ((e && e.message) || String(e)) });
+      }
+    }
+    return out;
   })()`;
 }
 
@@ -84,10 +99,6 @@ function scrollInboxConversationListScript() {
     window.scrollTo(0, document.body?.scrollHeight || 0);
     return { scrolled: scrollers.size, items: items.length };
   })()`;
-}
-
-function getCapturedInboxPagesScript() {
-  return String.raw`(() => Array.isArray(window.__opencli_inbox_pages) ? window.__opencli_inbox_pages.slice() : [])()`;
 }
 
 function mergeConversations(pageJsons, mailboxUrn) {
@@ -254,7 +265,9 @@ cli({
 
     await page.goto(MESSAGING_URL);
     await page.wait(10);
-    await page.evaluate(installInboxFetchCaptureScript());
+    // Enlarge the resource-timing buffer so the messengerConversations request
+    // URLs fired during scrolling are not evicted before we collect them.
+    await page.evaluate('performance.setResourceTimingBufferSize(3000)');
 
     // Locate the messaging API request the page fired on load; retry once if the
     // SPA was slow to issue it.
@@ -296,18 +309,29 @@ cli({
       );
     }
 
-    let conversations = parseConversations(fetched.json, located.mailboxUrn || '');
+    const pageJsons = [fetched.json];
+    let conversations = mergeConversations(pageJsons, located.mailboxUrn || '');
+    const fetchedUrls = new Set([targetUrl]);
+    let stablePasses = 0;
     for (let i = 0; i < maxScrolls && conversations.length < limit; i += 1) {
+      // Scroll so LinkedIn lazy-loads the next page, then read the request URLs
+      // it fired from the Performance API and re-issue any we have not fetched.
       await page.evaluate(scrollInboxConversationListScript());
       await page.wait(1.5);
-      const capturedBodies = unwrapEvaluateResult(await page.evaluate(getCapturedInboxPagesScript()));
-      const pageJsons = [fetched.json];
-      for (const body of Array.isArray(capturedBodies) ? capturedBodies : []) {
-        try {
-          pageJsons.push(JSON.parse(body));
-        } catch {
-          // Ignore non-JSON or partial bodies; LinkedIn occasionally emits tracking responses.
-        }
+      const seenUrls = unwrapEvaluateResult(await page.evaluate(collectMessagingUrlsScript()));
+      const newUrls = (Array.isArray(seenUrls) ? seenUrls : []).filter((u) => !fetchedUrls.has(u));
+      if (newUrls.length === 0) {
+        stablePasses += 1;
+        if (stablePasses >= 3) break; // list fully loaded; nothing new is appearing
+        continue;
+      }
+      stablePasses = 0;
+      for (const u of newUrls) fetchedUrls.add(u);
+      const fetchedPages = unwrapEvaluateResult(
+        await page.evaluate(fetchMessagingPagesScript(newUrls, csrf)),
+      );
+      for (const entry of Array.isArray(fetchedPages) ? fetchedPages : []) {
+        if (entry && entry.json) pageJsons.push(entry.json);
       }
       conversations = mergeConversations(pageJsons, located.mailboxUrn || '');
     }

--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -4,7 +4,7 @@ import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultErr
 const LINKEDIN_DOMAIN = 'linkedin.com';
 const MESSAGING_URL = 'https://www.linkedin.com/messaging/';
 const MIN_LIMIT = 1;
-const MAX_LIMIT = 100;
+const MAX_LIMIT = 500;
 const DEFAULT_LIMIT = 40;
 
 // ── Why this command reads an API response instead of scraping the DOM ──
@@ -24,6 +24,89 @@ function unwrapEvaluateResult(payload) {
 
 function threadUrl(threadId) {
   return threadId ? `https://www.linkedin.com/messaging/thread/${threadId}/` : '';
+}
+
+function parseMaxScrolls(value) {
+  if (value === undefined || value === null || value === '') return 30;
+  const scrolls = Number(value);
+  if (!Number.isInteger(scrolls) || scrolls < 0 || scrolls > 80) {
+    throw new ArgumentError('--max-scrolls must be an integer between 0 and 80');
+  }
+  return scrolls;
+}
+
+function installInboxFetchCaptureScript() {
+  return String.raw`(() => {
+    window.__opencli_inbox_pages = Array.isArray(window.__opencli_inbox_pages) ? window.__opencli_inbox_pages : [];
+    if (window.__opencli_inbox_fetch_patched) return { patched: false, count: window.__opencli_inbox_pages.length };
+    const originalFetch = window.fetch;
+    window.__opencli_inbox_fetch_patched = true;
+    window.fetch = async function(...args) {
+      const response = await originalFetch.apply(this, args);
+      try {
+        const request = args[0];
+        const url = typeof request === 'string' ? request : (request && request.url) || '';
+        if (/messengerConversations/i.test(String(url || response.url || ''))) {
+          response.clone().text().then((text) => {
+            if (text) window.__opencli_inbox_pages.push(text);
+          }).catch(() => {});
+        }
+      } catch {}
+      return response;
+    };
+    return { patched: true, count: window.__opencli_inbox_pages.length };
+  })()`;
+}
+
+function scrollInboxConversationListScript() {
+  return String.raw`(() => {
+    const items = Array.from(document.querySelectorAll('.msg-conversation-listitem'));
+    const scrollers = new Set();
+    for (const item of items) {
+      let el = item.parentElement;
+      while (el && el !== document.body && el !== document.documentElement) {
+        if (el.scrollHeight > el.clientHeight) scrollers.add(el);
+        el = el.parentElement;
+      }
+    }
+    for (const el of Array.from(document.querySelectorAll('*'))) {
+      if (el.scrollHeight > el.clientHeight && el.querySelector && el.querySelector('.msg-conversation-listitem')) {
+        scrollers.add(el);
+      }
+    }
+    const fallback = document.scrollingElement || document.documentElement;
+    scrollers.add(fallback);
+    for (const el of scrollers) {
+      el.scrollTop = el.scrollHeight;
+      el.dispatchEvent(new Event('scroll', { bubbles: true }));
+      el.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 1200 }));
+    }
+    window.scrollTo(0, document.body?.scrollHeight || 0);
+    return { scrolled: scrollers.size, items: items.length };
+  })()`;
+}
+
+function getCapturedInboxPagesScript() {
+  return String.raw`(() => Array.isArray(window.__opencli_inbox_pages) ? window.__opencli_inbox_pages.slice() : [])()`;
+}
+
+function mergeConversations(pageJsons, mailboxUrn) {
+  const byThread = new Map();
+  for (const normalized of pageJsons) {
+    let rows = [];
+    try {
+      rows = parseConversations(normalized, mailboxUrn);
+    } catch {
+      continue;
+    }
+    for (const row of rows) {
+      const previous = byThread.get(row.thread_id);
+      if (!previous || Date.parse(row.timestamp || '') > Date.parse(previous.timestamp || '')) {
+        byThread.set(row.thread_id, row);
+      }
+    }
+  }
+  return Array.from(byThread.values()).sort((a, b) => Date.parse(b.timestamp || '') - Date.parse(a.timestamp || ''));
 }
 
 // Runs in-page: locate the messengerConversations request the page already fired.
@@ -142,7 +225,8 @@ cli({
   strategy: Strategy.COOKIE,
   browser: true,
   args: [
-    { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: 'Maximum conversations to return (1-100)' },
+    { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: 'Maximum conversations to return (1-500)' },
+    { name: 'max-scrolls', type: 'int', default: 30, help: 'Maximum inbox scroll attempts to lazy-load older conversations (0-80)' },
     { name: 'unread-only', type: 'bool', default: false, help: 'Return only conversations with unread messages' },
   ],
   columns: [
@@ -165,10 +249,12 @@ cli({
         throw new ArgumentError(`--limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}`);
       }
     }
+    const maxScrolls = parseMaxScrolls(kwargs['max-scrolls']);
     const unreadOnly = Boolean(kwargs['unread-only']);
 
     await page.goto(MESSAGING_URL);
     await page.wait(10);
+    await page.evaluate(installInboxFetchCaptureScript());
 
     // Locate the messaging API request the page fired on load; retry once if the
     // SPA was slow to issue it.
@@ -193,8 +279,11 @@ cli({
     }
     const csrf = jsession.replace(/^"|"$/g, '');
 
-    // Widen the page size to the requested limit where the query supports it.
-    const targetUrl = located.url.replace(/count:\d+/, 'count:' + limit);
+    // Widen the page size to the requested limit where the query supports it, and keep
+    // this direct fetch as page 1 in case the fetch patch missed the initial SPA load.
+    const targetUrl = located.url
+      .replace(/count%3A\d+/i, 'count%3A' + limit)
+      .replace(/count:\d+/i, 'count:' + limit);
     const fetched = unwrapEvaluateResult(
       await page.evaluate(`(${fetchMessagingApi.toString()})(${JSON.stringify(targetUrl)}, ${JSON.stringify(csrf)})`),
     );
@@ -208,6 +297,20 @@ cli({
     }
 
     let conversations = parseConversations(fetched.json, located.mailboxUrn || '');
+    for (let i = 0; i < maxScrolls && conversations.length < limit; i += 1) {
+      await page.evaluate(scrollInboxConversationListScript());
+      await page.wait(1.5);
+      const capturedBodies = unwrapEvaluateResult(await page.evaluate(getCapturedInboxPagesScript()));
+      const pageJsons = [fetched.json];
+      for (const body of Array.isArray(capturedBodies) ? capturedBodies : []) {
+        try {
+          pageJsons.push(JSON.parse(body));
+        } catch {
+          // Ignore non-JSON or partial bodies; LinkedIn occasionally emits tracking responses.
+        }
+      }
+      conversations = mergeConversations(pageJsons, located.mailboxUrn || '');
+    }
     if (unreadOnly) conversations = conversations.filter((c) => c.unread);
     if (conversations.length === 0) {
       if (unreadOnly) return [];
@@ -230,5 +333,7 @@ cli({
 
 export const __test__ = {
   parseConversations,
+  parseMaxScrolls,
+  mergeConversations,
   threadUrl,
 };

--- a/clis/linkedin/inbox.test.js
+++ b/clis/linkedin/inbox.test.js
@@ -3,7 +3,7 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import './inbox.js';
 
-const { parseConversations, threadUrl } = await import('./inbox.js').then((m) => m.__test__);
+const { mergeConversations, parseConversations, parseMaxScrolls, threadUrl } = await import('./inbox.js').then((m) => m.__test__);
 
 const SELF = 'urn:li:fsd_profile:SELF';
 
@@ -99,6 +99,37 @@ describe('linkedin inbox adapter', () => {
         'timestamp',
       ]),
     );
+  });
+
+
+
+  it('validates max-scrolls and raises the inbox limit ceiling to 500', () => {
+    expect(command.args.find((arg) => arg.name === 'limit').help).toContain('1-500');
+    expect(command.args.find((arg) => arg.name === 'max-scrolls')).toBeDefined();
+    expect(parseMaxScrolls(undefined)).toBe(30);
+    expect(parseMaxScrolls(80)).toBe(80);
+    expect(() => parseMaxScrolls(81)).toThrow('--max-scrolls must be an integer between 0 and 80');
+  });
+
+  it('merges paginated conversation pages by thread id and keeps most recent order', () => {
+    const first = fixture();
+    const second = fixture();
+    second.included = second.included.filter((entity) => entity.backendUrn !== 'urn:li:messagingThread:2-aaa==');
+    second.included.push({
+      $type: 'com.linkedin.messenger.Conversation',
+      entityUrn: 'urn:li:msg_conversation:C4',
+      backendUrn: 'urn:li:messagingThread:2-ddd==',
+      unreadCount: 0,
+      read: true,
+      categories: ['INBOX', 'PRIMARY_INBOX'],
+      lastActivityAt: 4000,
+      '*conversationParticipants': ['urn:li:msg_messagingParticipant:P1', 'urn:li:msg_messagingParticipant:SELF'],
+      messages: { '*elements': [] },
+      title: 'Newest page row',
+    });
+
+    const rows = mergeConversations([first, second], SELF);
+    expect(rows.map((row) => row.thread_id)).toEqual(['2-ddd==', '2-bbb==', '2-aaa==', '2-ccc==']);
   });
 
   it('builds a thread URL from a thread id', () => {

--- a/clis/linkedin/salesnav-inbox.js
+++ b/clis/linkedin/salesnav-inbox.js
@@ -1,0 +1,194 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_INBOX_URL = 'https://www.linkedin.com/sales/inbox/';
+const THREADS_BASE = 'https://www.linkedin.com/sales-api/salesApiMessagingThreads';
+const PAGE_SIZE = 20;
+const DEFAULT_LIMIT = 40;
+const MAX_LIMIT = 500;
+const THREAD_DECORATION = '(id,restrictions,archived,unreadMessageCount,nextPageStartsAt,totalMessageCount,messages*(id,type,contentFlag,deliveredAt,lastEditedAt,subject,body,footerText,blockCopy,attachments,author,systemMessageContent),participants*~fs_salesProfile(entityUrn,firstName,lastName,fullName,degree,profilePictureDisplayImage,objectUrn,inmailRestriction))';
+
+export function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function parseLimit(value, defaultValue = DEFAULT_LIMIT) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
+  }
+  return limit;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+export function encodeRestliDecoration(value) {
+  // LinkedIn's Sales Navigator Rest.li endpoint returns HTTP 400 when this
+  // decoration is sent with literal parentheses. Keep parentheses percent-encoded.
+  return encodeURIComponent(value).replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+function salesnavThreadUrl(threadId) {
+  return threadId ? `https://www.linkedin.com/sales/inbox/${encodeURIComponent(threadId)}` : '';
+}
+
+function threadListUrl({ count = PAGE_SIZE, pageStartsAt = '' } = {}) {
+  let url = `${THREADS_BASE}?decoration=${encodeRestliDecoration(THREAD_DECORATION)}&count=${count}&filter=INBOX&q=filter`;
+  if (pageStartsAt) url += `&pageStartsAt=${encodeURIComponent(pageStartsAt)}`;
+  return url;
+}
+
+function getThreadParticipants(thread) {
+  const resolution = thread?.participantsResolutionResults || {};
+  const participants = Array.isArray(thread?.participants) ? thread.participants : Object.keys(resolution);
+  return participants.map((urn) => resolution[urn] || { entityUrn: urn }).filter(Boolean);
+}
+
+function isSelfParticipant(profile) {
+  const degree = String(profile?.degree ?? '').trim();
+  return degree === '0' || normalizeWhitespace(profile?.fullName).toLowerCase() === 'hanzi li';
+}
+
+function otherParticipantName(thread) {
+  const participants = getThreadParticipants(thread);
+  const other = participants.find((p) => !isSelfParticipant(p)) || participants[0];
+  return normalizeWhitespace(other?.fullName || [other?.firstName, other?.lastName].filter(Boolean).join(' '));
+}
+
+function parseSalesnavThreads(json) {
+  const elements = Array.isArray(json?.elements) ? json.elements : [];
+  return elements.map((thread) => {
+    const messages = Array.isArray(thread?.messages) ? thread.messages : [];
+    const lastMessage = messages[0] || {};
+    const deliveredAt = Number(lastMessage.deliveredAt || thread?.nextPageStartsAt || 0);
+    const threadId = normalizeWhitespace(thread?.id || '');
+    return {
+      thread_id: threadId,
+      thread_url: salesnavThreadUrl(threadId),
+      person_name: otherParticipantName(thread),
+      last_message_snippet: normalizeWhitespace(lastMessage.body || lastMessage.subject || '').slice(0, 300),
+      last_activity_time: deliveredAt ? new Date(deliveredAt).toISOString() : '',
+      unread: Number(thread?.unreadMessageCount || 0) > 0,
+      unread_count: Number(thread?.unreadMessageCount || 0),
+      total_message_count: Number(thread?.totalMessageCount || messages.length || 0),
+      archived: Boolean(thread?.archived),
+      next_page_starts_at: normalizeWhitespace(thread?.nextPageStartsAt || ''),
+      participants: getThreadParticipants(thread).map((p) => ({
+        name: normalizeWhitespace(p.fullName || [p.firstName, p.lastName].filter(Boolean).join(' ')),
+        entity_urn: normalizeWhitespace(p.entityUrn || ''),
+        object_urn: normalizeWhitespace(p.objectUrn || ''),
+        degree: normalizeWhitespace(p.degree ?? ''),
+      })),
+    };
+  }).filter((row) => row.thread_id);
+}
+
+function fetchJsonScript(url, csrf) {
+  return String.raw`(async () => {
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        credentials: 'include',
+        headers: {
+          'csrf-token': ${JSON.stringify(csrf)},
+          'x-restli-protocol-version': '2.0.0',
+          accept: 'application/json',
+        },
+      });
+      const text = await res.text();
+      let json = null;
+      try { json = text ? JSON.parse(text) : null; } catch (_) { json = null; }
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status, text };
+      if (!res.ok) return { error: 'HTTP ' + res.status, status: res.status, text, json };
+      return { status: res.status, json };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+export async function getCsrf(page) {
+  const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+  if (!jsession) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+  return jsession.replace(/^\"|\"$/g, '');
+}
+
+export async function fetchSalesnavJson(page, csrf, url, label) {
+  const result = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(url, csrf)));
+  if (result?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, `${label} authentication failed (HTTP ${result.status || 'auth_required'}).`);
+  if (result?.error || !result?.json) throw new CommandExecutionError(`${label} returned an unexpected response`, `${result?.error || 'no_json'}\n${normalizeWhitespace(result?.text || '').slice(0, 500)}`);
+  return result.json;
+}
+
+export async function fetchInboxRows(page, { limit = DEFAULT_LIMIT, maxPages = 30 } = {}) {
+  const csrf = await getCsrf(page);
+  const rows = [];
+  const seen = new Set();
+  let pageStartsAt = '';
+  let pagesFetched = 0;
+  while (rows.length < limit && pagesFetched < maxPages) {
+    const json = await fetchSalesnavJson(page, csrf, threadListUrl({ count: PAGE_SIZE, pageStartsAt }), 'Sales Navigator messaging threads API');
+    pagesFetched += 1;
+    const pageRows = parseSalesnavThreads(json);
+    if (pageRows.length === 0) break;
+    for (const row of pageRows) {
+      if (seen.has(row.thread_id)) continue;
+      seen.add(row.thread_id);
+      rows.push(row);
+      if (rows.length >= limit) break;
+    }
+    const last = pageRows[pageRows.length - 1];
+    const next = last?.next_page_starts_at;
+    if (!next || next === pageStartsAt) break;
+    pageStartsAt = next;
+  }
+  return rows.slice(0, limit).map((row, index) => ({ ...row, rank: index + 1 }));
+}
+
+export { THREAD_DECORATION, THREADS_BASE };
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-inbox',
+  access: 'read',
+  description: 'List LinkedIn Sales Navigator message conversations with API pagination',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'limit', type: 'number', default: DEFAULT_LIMIT, help: 'Maximum conversations to return (1-500)' },
+    { name: 'max-pages', type: 'number', default: 30, help: 'Maximum Sales Navigator API pages to fetch' },
+    { name: 'unread-only', type: 'bool', default: false, help: 'Return only unread conversations' },
+  ],
+  columns: ['rank', 'thread_id', 'thread_url', 'person_name', 'last_message_snippet', 'last_activity_time', 'unread', 'unread_count', 'total_message_count', 'archived', 'participants', 'next_page_starts_at'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-inbox');
+    const limit = parseLimit(args.limit);
+    const maxPages = parseLimit(args['max-pages'], 30);
+    await page.goto(SALES_INBOX_URL);
+    await page.wait(4);
+    let rows = await fetchInboxRows(page, { limit, maxPages });
+    if (args['unread-only']) rows = rows.filter((row) => row.unread);
+    if (rows.length === 0) {
+      if (args['unread-only']) return [];
+      throw new EmptyResultError('linkedin salesnav-inbox', 'No Sales Navigator conversations were found.');
+    }
+    return rows.slice(0, limit).map((row, index) => ({ ...row, rank: index + 1 }));
+  },
+});
+
+export const __test__ = {
+  THREAD_DECORATION,
+  normalizeWhitespace,
+  parseLimit,
+  encodeRestliDecoration,
+  salesnavThreadUrl,
+  threadListUrl,
+  parseSalesnavThreads,
+  fetchInboxRows,
+};

--- a/clis/linkedin/salesnav-inbox.test.js
+++ b/clis/linkedin/salesnav-inbox.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import './salesnav-inbox.js';
+
+const {
+  THREAD_DECORATION,
+  encodeRestliDecoration,
+  parseLimit,
+  parseSalesnavThreads,
+  salesnavThreadUrl,
+  threadListUrl,
+} = await import('./salesnav-inbox.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-inbox command', () => {
+  it('percent-encodes Rest.li decoration parentheses for Sales Navigator messaging', () => {
+    const encoded = encodeRestliDecoration('(id,messages*(body))');
+    expect(encoded).toBe('%28id%2Cmessages*%28body%29%29');
+    expect(encoded).not.toContain('(');
+    expect(encoded).not.toContain(')');
+  });
+
+  it('builds the paginated salesApiMessagingThreads inbox URL', () => {
+    const url = threadListUrl({ count: 20, pageStartsAt: '1779070755626' });
+    expect(url).toContain('/sales-api/salesApiMessagingThreads?');
+    expect(url).toContain('q=filter');
+    expect(url).toContain('filter=INBOX');
+    expect(url).toContain('count=20');
+    expect(url).toContain('pageStartsAt=1779070755626');
+    expect(url).toContain(encodeRestliDecoration(THREAD_DECORATION));
+  });
+
+  it('validates limits without silent clamping', () => {
+    expect(parseLimit(undefined)).toBe(40);
+    expect(parseLimit(12)).toBe(12);
+    expect(() => parseLimit(0)).toThrow();
+    expect(() => parseLimit(501)).toThrow();
+    expect(() => parseLimit('abc')).toThrow();
+  });
+
+  it('parses Sales Navigator thread rows with other participant and unread state', () => {
+    const rows = parseSalesnavThreads({ elements: [{
+      id: '2-thread',
+      unreadMessageCount: 1,
+      archived: false,
+      totalMessageCount: 2,
+      nextPageStartsAt: 1778206803669,
+      participants: [
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)',
+      ],
+      participantsResolutionResults: {
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)': {
+          entityUrn: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+          firstName: 'Rachael',
+          lastName: 'Stolberg',
+          fullName: 'Rachael Stolberg',
+          degree: 2,
+        },
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)': {
+          entityUrn: 'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)',
+          firstName: 'Hanzi',
+          lastName: 'Li',
+          fullName: 'Hanzi Li',
+          degree: 0,
+        },
+      },
+      messages: [{
+        id: 'msg-1',
+        author: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+        body: 'Hi hanzi, happy to chat',
+        deliveredAt: 1778206803669,
+      }],
+    }] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      thread_id: '2-thread',
+      thread_url: salesnavThreadUrl('2-thread'),
+      person_name: 'Rachael Stolberg',
+      last_message_snippet: 'Hi hanzi, happy to chat',
+      last_activity_time: '2026-05-08T02:20:03.669Z',
+      unread: true,
+      unread_count: 1,
+      total_message_count: 2,
+    });
+  });
+});

--- a/clis/linkedin/salesnav-message.js
+++ b/clis/linkedin/salesnav-message.js
@@ -1,0 +1,325 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_HOME = 'https://www.linkedin.com/sales/';
+const PROFILE_DECO = '(entityUrn,objectUrn,firstName,lastName,fullName,headline,degree,inmailRestriction,memberBadges,defaultPosition)';
+const CREDITS_URL = 'https://www.linkedin.com/sales-api/salesApiCredits?q=findCreditGrant&creditGrantType=LSS_INMAIL';
+const MESSAGE_ACTION_URL = 'https://www.linkedin.com/sales-api/salesApiMessageActions?action=createMessage';
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
+function parseSalesProfileUrn(value) {
+  const raw = normalizeWhitespace(value);
+  const match = raw.match(/^urn:li:fs_salesProfile:\(([^,()]+),([^,()]+),([^,()]+)\)$/);
+  if (!match) return null;
+  if (!isResolvedSalesProfileParts(match[1], match[2], match[3])) return null;
+  return { profileId: match[1], authType: match[2], authToken: match[3], entityUrn: raw };
+}
+
+function isResolvedSalesProfileParts(profileId, authType, authToken) {
+  return [profileId, authType, authToken].every((part) => {
+    const clean = normalizeWhitespace(part).toLowerCase();
+    return clean && clean !== 'undefined' && clean !== 'null' && clean !== 'not_available';
+  });
+}
+
+function salesLeadUrlFromParts({ profileId, authType, authToken }) {
+  return `https://www.linkedin.com/sales/lead/${encodeURIComponent(profileId)},${encodeURIComponent(authType)},${encodeURIComponent(authToken)}`;
+}
+
+function parseRecipient(value) {
+  const raw = normalizeWhitespace(value);
+  const urn = parseSalesProfileUrn(raw);
+  if (urn) return urn;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return null;
+    const salesMatch = url.pathname.match(/^\/sales\/lead\/([^,/]+),([^,/]+),([^/]+)\/?$/i);
+    if (salesMatch) {
+      const profileId = decodeURIComponent(salesMatch[1]);
+      const authType = decodeURIComponent(salesMatch[2]);
+      const authToken = decodeURIComponent(salesMatch[3]);
+      if (!isResolvedSalesProfileParts(profileId, authType, authToken)) return null;
+      return { profileId, authType, authToken, entityUrn: `urn:li:fs_salesProfile:(${profileId},${authType},${authToken})` };
+    }
+    const profileMatch = url.pathname.match(/^\/in\/([^/]+)\/?$/i);
+    if (profileMatch) {
+      return { profileId: decodeURIComponent(profileMatch[1]), authType: '', authToken: '', entityUrn: '' };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function encodeRestliDecoration(value) {
+  return encodeURIComponent(value).replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+function profileApiUrl(recipient) {
+  if (!recipient?.profileId || !recipient?.authType || !recipient?.authToken) return '';
+  const key = `(profileId:${recipient.profileId},authType:${recipient.authType},authToken:${recipient.authToken})`;
+  return `https://www.linkedin.com/sales-api/salesApiProfiles/${key}?decoration=${encodeRestliDecoration(PROFILE_DECO)}`;
+}
+
+function randomTrackingId() {
+  const bytes = new Uint8Array(8);
+  if (globalThis.crypto?.getRandomValues) globalThis.crypto.getRandomValues(bytes);
+  else for (let i = 0; i < bytes.length; i += 1) bytes[i] = Math.floor(Math.random() * 256);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function buildCreateMessagePayload({ recipientUrn, subject, body, trackingId = randomTrackingId(), copyToCrm = false }) {
+  const cleanRecipient = normalizeWhitespace(recipientUrn);
+  if (!parseSalesProfileUrn(cleanRecipient)) throw new ArgumentError('--recipient must resolve to a Sales Navigator lead urn');
+  const cleanSubject = normalizeWhitespace(subject);
+  const cleanBody = String(body ?? '').trim();
+  if (!cleanSubject) throw new ArgumentError('--subject is required');
+  if (!cleanBody) throw new ArgumentError('--body is required');
+  if (cleanSubject.length > 200) throw new ArgumentError('--subject must be 200 characters or fewer');
+  if (cleanBody.length > 1900) throw new ArgumentError('--body must be 1900 characters or fewer');
+  return {
+    createMessageRequest: {
+      recipients: [cleanRecipient],
+      subject: cleanSubject,
+      body: cleanBody,
+      copyToCrm: Boolean(copyToCrm),
+      trackingId,
+    },
+  };
+}
+
+function extractRemainingCredits(json) {
+  const elements = Array.isArray(json?.elements) ? json.elements : [];
+  const inmailGrant = elements.find((el) => el?.type === 'LSS_INMAIL' && Number.isInteger(el.value));
+  if (inmailGrant) return inmailGrant.value;
+  const candidates = [];
+  const visit = (value) => {
+    if (value === null || value === undefined) return;
+    if (typeof value === 'number' && Number.isFinite(value)) candidates.push(value);
+    if (Array.isArray(value)) value.forEach(visit);
+    else if (typeof value === 'object') {
+      for (const [key, child] of Object.entries(value)) {
+        if (/remaining|available|balance|value/i.test(key) && typeof child === 'number') candidates.unshift(child);
+        else if (!/^count$|^start$|^id$/i.test(key)) visit(child);
+      }
+    }
+  };
+  visit(json);
+  return candidates.find((n) => Number.isInteger(n) && n >= 0) ?? null;
+}
+
+function fetchJsonScript(url, csrf, options = {}) {
+  return String.raw`(async () => {
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      'x-restli-protocol-version': '2.0.0',
+      accept: ${JSON.stringify(options.accept || 'application/json')},
+      ...((${JSON.stringify(Boolean(options.body))}) ? { 'content-type': 'application/json' } : {}),
+    };
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        credentials: 'include',
+        method: ${JSON.stringify(options.method || 'GET')},
+        headers,
+        body: ${options.body ? JSON.stringify(JSON.stringify(options.body)) : 'undefined'},
+      });
+      const text = await res.text();
+      let json = null;
+      try { json = text ? JSON.parse(text) : null; } catch (_) { json = null; }
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status, text };
+      if (!res.ok) return { error: 'HTTP ' + res.status, status: res.status, text, json };
+      return { status: res.status, json, text };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+function salesPageShowsSentMessage(text, recipientName) {
+  const normalizedText = normalizeWhitespace(text);
+  const firstName = normalizeWhitespace(recipientName).split(' ')[0];
+  return normalizedText.includes('You sent a Sales Navigator message')
+    && (!firstName || normalizedText.includes(firstName));
+}
+
+async function getCsrf(page) {
+  const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+  if (!jsession) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+  return jsession.replace(/^\"|\"$/g, '');
+}
+
+async function resolveRecipient(page, parsed, csrf) {
+  if (!parsed) throw new ArgumentError('--recipient must be a Sales Navigator lead URL, Sales Navigator profile URL, LinkedIn /in/ URL, or urn:li:fs_salesProfile:(...)');
+  if (parsed.entityUrn && parsed.authType && parsed.authToken) return parsed;
+
+  await page.goto(`https://www.linkedin.com/sales/lead/${encodeURIComponent(parsed.profileId)}`);
+  await page.wait(6);
+  const probe = unwrapEvaluateResult(await page.evaluate(String.raw`(() => {
+    const href = location.href;
+    const text = document.body ? document.body.innerText : '';
+    const resourceUrns = Array.from(performance.getEntriesByType('resource'))
+      .map((entry) => entry.name)
+      .filter((name) => name.includes('/sales-api/salesApiProfiles/'))
+      .slice(-20);
+    return { href, text: text.slice(0, 1000), resourceUrns };
+  })()`));
+    const urlMatch = String(probe?.href || '').match(/\/sales\/lead\/([^,/]+),([^,/]+),([^/?#]+)/i);
+  if (urlMatch && isResolvedSalesProfileParts(urlMatch[1], urlMatch[2], urlMatch[3])) {
+    return {
+      profileId: decodeURIComponent(urlMatch[1]),
+      authType: decodeURIComponent(urlMatch[2]),
+      authToken: decodeURIComponent(urlMatch[3]),
+      entityUrn: `urn:li:fs_salesProfile:(${decodeURIComponent(urlMatch[1])},${decodeURIComponent(urlMatch[2])},${decodeURIComponent(urlMatch[3])})`,
+    };
+  }
+  for (const resource of probe?.resourceUrns || []) {
+    const resourceMatch = String(resource).match(/profileId:([^,)]+),authType:([^,)]+),authToken:([^,)]+)\)/);
+    if (resourceMatch && resourceMatch[1] === parsed.profileId) {
+      return {
+        profileId: resourceMatch[1],
+        authType: resourceMatch[2],
+        authToken: resourceMatch[3],
+        entityUrn: `urn:li:fs_salesProfile:(${resourceMatch[1]},${resourceMatch[2]},${resourceMatch[3]})`,
+      };
+    }
+  }
+  void csrf;
+  throw new CommandExecutionError('Could not resolve Sales Navigator auth token for recipient', `Observed URL: ${probe?.href || 'url_not_available'}\nBody: ${normalizeWhitespace(probe?.text || '').slice(0, 500)}`);
+}
+
+function profileSummary(json) {
+  const data = json?.data || json || {};
+  const pos = data.defaultPosition || (Array.isArray(data.positions) ? data.positions.find((p) => p.current) || data.positions[0] : {}) || {};
+  return {
+    recipient: normalizeWhitespace(data.fullName || [data.firstName, data.lastName].filter(Boolean).join(' ')),
+    title: normalizeWhitespace(pos.title || data.headline || ''),
+    company: normalizeWhitespace(pos.companyName || pos.company?.name || ''),
+    degree: normalizeWhitespace(data.degree || ''),
+    inmail_restriction: normalizeWhitespace(data.inmailRestriction || ''),
+    open_link: Boolean(data.memberBadges?.openLink),
+  };
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-message',
+  access: 'write',
+  description: 'Send or dry-run a LinkedIn Sales Navigator InMail to a lead using the Sales Navigator messaging API',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'recipient', type: 'string', required: true, positional: true, help: 'Sales Navigator lead URL, LinkedIn /in/ URL from salesnav-search, or urn:li:fs_salesProfile:(...)' },
+    { name: 'subject', type: 'string', required: true, help: 'InMail subject' },
+    { name: 'body', type: 'string', required: true, help: 'InMail body' },
+    { name: 'send', type: 'bool', default: false, help: 'Actually send the InMail. Default is dry-run validation only.' },
+    { name: 'copy-to-crm', type: 'bool', default: false, help: 'Set Sales Navigator copyToCrm on the message request' },
+  ],
+  columns: ['status', 'recipient', 'title', 'company', 'credits_remaining', 'credits_before', 'credits_after', 'sent_in_salesnav', 'message_chars', 'subject_chars', 'recipient_urn', 'authRequired', 'text', 'degree', 'inmail_restriction', 'open_link', 'json', 'href', 'resourceUrns'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-message');
+    const recipientArg = requireStringArg(args, 'recipient', '--recipient');
+    const subject = requireStringArg(args, 'subject', '--subject');
+    const body = String(args.body ?? '').trim();
+    if (!body) throw new ArgumentError('--body is required');
+
+    await page.goto(SALES_HOME);
+    await page.wait(4);
+    const csrf = await getCsrf(page);
+    const recipient = await resolveRecipient(page, parseRecipient(recipientArg), csrf);
+
+    let summary = { recipient: '', title: '', company: '', degree: '', inmail_restriction: '', open_link: false };
+    const profileUrl = profileApiUrl(recipient);
+    if (profileUrl) {
+      const profileResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(profileUrl, csrf)));
+      if (profileResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator profile API auth failed.');
+      if (profileResult?.error) throw new CommandExecutionError('Sales Navigator profile lookup failed', profileResult.error);
+      summary = profileSummary(profileResult?.json);
+    }
+    if (summary.inmail_restriction && summary.inmail_restriction !== 'NO_RESTRICTION') {
+      throw new CommandExecutionError('Sales Navigator InMail blocked by recipient restriction', summary.inmail_restriction);
+    }
+
+    const creditsResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf)));
+    if (creditsResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator credits API auth failed.');
+    const creditsRemaining = extractRemainingCredits(creditsResult?.json);
+
+    const payload = buildCreateMessagePayload({ recipientUrn: recipient.entityUrn, subject, body, copyToCrm: args['copy-to-crm'] });
+    if (!args.send) {
+      return [{
+        status: 'validated_dry_run',
+        recipient: summary.recipient,
+        title: summary.title,
+        company: summary.company,
+        credits_remaining: creditsRemaining,
+        message_chars: body.length,
+        subject_chars: subject.length,
+        recipient_urn: recipient.entityUrn,
+      }];
+    }
+
+    const sendResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(MESSAGE_ACTION_URL, csrf, {
+      method: 'POST',
+      accept: 'application/vnd.linkedin.normalized+json+2.1',
+      body: payload,
+    })));
+    if (sendResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator message API auth failed.');
+    if (sendResult?.error) throw new CommandExecutionError('Sales Navigator InMail send failed', `${sendResult.error}\n${sendResult.text || ''}`);
+    await page.wait(3);
+    const creditsAfterResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf)));
+    if (creditsAfterResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator credits API auth failed after send.');
+    const creditsAfter = extractRemainingCredits(creditsAfterResult?.json);
+    await page.goto(salesLeadUrlFromParts(recipient));
+    await page.wait(6);
+    const salesPageText = unwrapEvaluateResult(await page.evaluate('document.body ? document.body.innerText : ""'));
+    const sentInSalesNav = salesPageShowsSentMessage(salesPageText, summary.recipient);
+    if (!sentInSalesNav) throw new CommandExecutionError('Sales Navigator post-send verification failed', 'Sent activity was not found on the Sales Navigator lead page.');
+    return [{
+      status: 'sent',
+      recipient: summary.recipient,
+      title: summary.title,
+      company: summary.company,
+      credits_remaining: creditsAfter,
+      credits_before: creditsRemaining,
+      credits_after: creditsAfter,
+      sent_in_salesnav: sentInSalesNav,
+      message_chars: body.length,
+      subject_chars: subject.length,
+      recipient_urn: recipient.entityUrn,
+    }];
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  parseSalesProfileUrn,
+  isResolvedSalesProfileParts,
+  parseRecipient,
+  salesLeadUrlFromParts,
+  profileApiUrl,
+  buildCreateMessagePayload,
+  extractRemainingCredits,
+  profileSummary,
+  salesPageShowsSentMessage,
+};

--- a/clis/linkedin/salesnav-message.test.js
+++ b/clis/linkedin/salesnav-message.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import './salesnav-message.js';
+
+const {
+  parseSalesProfileUrn,
+  parseRecipient,
+  salesLeadUrlFromParts,
+  profileApiUrl,
+  buildCreateMessagePayload,
+  extractRemainingCredits,
+  profileSummary,
+  salesPageShowsSentMessage,
+} = await import('./salesnav-message.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-message command', () => {
+  it('parses Sales Navigator profile urns and lead URLs', () => {
+    const urn = 'urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)';
+    expect(parseSalesProfileUrn(urn)).toMatchObject({
+      profileId: 'ACwAAAJS8TABxyz',
+      authType: 'NAME_SEARCH',
+      authToken: 'Enlo',
+      entityUrn: urn,
+    });
+    expect(parseSalesProfileUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,undefined,undefined)')).toBeNull();
+
+    const parsed = parseRecipient('https://www.linkedin.com/sales/lead/ACwAAAJS8TABxyz,NAME_SEARCH,Enlo');
+    expect(parsed).toMatchObject({ profileId: 'ACwAAAJS8TABxyz', authType: 'NAME_SEARCH', authToken: 'Enlo' });
+    expect(parsed.entityUrn).toBe(urn);
+    expect(salesLeadUrlFromParts(parsed)).toBe('https://www.linkedin.com/sales/lead/ACwAAAJS8TABxyz,NAME_SEARCH,Enlo');
+  });
+
+  it('accepts LinkedIn /in tokens as unresolved recipients', () => {
+    expect(parseRecipient('https://www.linkedin.com/in/ACwAAAJS8TABxyz/')).toMatchObject({
+      profileId: 'ACwAAAJS8TABxyz',
+      authType: '',
+      authToken: '',
+      entityUrn: '',
+    });
+  });
+
+  it('builds profile API URLs with the Sales Navigator auth key', () => {
+    const url = profileApiUrl({ profileId: 'P1', authType: 'NAME_SEARCH', authToken: 'T1' });
+    expect(url).toContain('/sales-api/salesApiProfiles/(profileId:P1,authType:NAME_SEARCH,authToken:T1)');
+    expect(url).toContain('decoration=');
+  });
+
+  it('constructs the createMessage action payload used by Sales Navigator', () => {
+    const payload = buildCreateMessagePayload({
+      recipientUrn: 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)',
+      subject: 'Quick QA doc question',
+      body: 'Hi Jane, can I ask a quick question?',
+      trackingId: '0123456789abcdef',
+      copyToCrm: false,
+    });
+    expect(payload).toEqual({
+      createMessageRequest: {
+        recipients: ['urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)'],
+        subject: 'Quick QA doc question',
+        body: 'Hi Jane, can I ask a quick question?',
+        copyToCrm: false,
+        trackingId: '0123456789abcdef',
+      },
+    });
+  });
+
+  it('validates payload fields before any send attempt', () => {
+    expect(() => buildCreateMessagePayload({ recipientUrn: '', subject: 's', body: 'b' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,A,T)', subject: '', body: 'b' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,A,T)', subject: 's', body: '' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,A,T)', subject: 'x'.repeat(201), body: 'b' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,undefined,undefined)', subject: 's', body: 'b' })).toThrow();
+  });
+
+  it('detects the Sales Navigator sent activity on a verified lead page', () => {
+    expect(salesPageShowsSentMessage('5/18/2026 You sent a Sales Navigator message to Jane', 'Jane Q')).toBe(true);
+    expect(salesPageShowsSentMessage('No recent activity', 'Jane Q')).toBe(false);
+  });
+
+  it('extracts a plausible remaining InMail credit count', () => {
+    expect(extractRemainingCredits({ elements: [{ type: 'LSS_INMAIL', value: 149, id: 1 }], paging: { count: 10 } })).toBe(149);
+    expect(extractRemainingCredits({ data: { remaining: 149, used: 1 } })).toBe(149);
+    expect(extractRemainingCredits({ elements: [{ availableCount: 12 }] })).toBe(12);
+    expect(extractRemainingCredits({})).toBe(null);
+  });
+
+  it('summarizes decorated Sales Navigator profile data', () => {
+    expect(profileSummary({ data: {
+      fullName: 'Rayki Goh',
+      headline: 'Food Safety',
+      degree: 3,
+      defaultPosition: { title: 'FSQA Manager', companyName: 'Acme Foods' },
+      memberBadges: { openLink: false },
+    } })).toMatchObject({
+      recipient: 'Rayki Goh',
+      title: 'FSQA Manager',
+      company: 'Acme Foods',
+      degree: '3',
+      open_link: false,
+    });
+  });
+});

--- a/clis/linkedin/salesnav-search.js
+++ b/clis/linkedin/salesnav-search.js
@@ -71,6 +71,12 @@ function profileUrlFromEntityUrn(entityUrn) {
   return match && match[1] ? 'https://www.linkedin.com/in/' + match[1] : '';
 }
 
+function leadUrlFromEntityUrn(entityUrn) {
+  const match = String(entityUrn || '').match(/^urn:li:fs_salesProfile:\(([^,()]+),([^,()]+),([^,()]+)\)$/);
+  if (!match) return '';
+  return `https://www.linkedin.com/sales/lead/${encodeURIComponent(match[1])},${encodeURIComponent(match[2])},${encodeURIComponent(match[3])}`;
+}
+
 function parseLeads(json) {
   const elements = (json && Array.isArray(json.elements)) ? json.elements : [];
   const leads = [];
@@ -88,6 +94,8 @@ function parseLeads(json) {
       location: normalizeWhitespace(el.geoRegion || ''),
       degree: normalizeWhitespace(el.degree || ''),
       profile_url: profileUrlFromEntityUrn(el.entityUrn),
+      lead_url: leadUrlFromEntityUrn(el.entityUrn),
+      recipient_urn: normalizeWhitespace(el.entityUrn || ''),
     });
   }
   return leads;
@@ -105,7 +113,7 @@ cli({
     { name: 'keywords', type: 'string', required: true, positional: true, help: 'People search keywords, e.g. "quality manager food manufacturing"' },
     { name: 'limit', type: 'number', default: 25, help: 'Maximum leads to return (1-500, fetched 25 per request)' },
   ],
-  columns: ['rank', 'name', 'title', 'company', 'location', 'degree', 'profile_url'],
+  columns: ['rank', 'name', 'title', 'company', 'location', 'degree', 'profile_url', 'lead_url', 'recipient_urn'],
   func: async (page, args) => {
     if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-search');
     const keywords = requireStringArg(args, 'keywords', '--keywords');
@@ -149,5 +157,6 @@ export const __test__ = {
   parseLimit,
   leadSearchUrl,
   profileUrlFromEntityUrn,
+  leadUrlFromEntityUrn,
   parseLeads,
 };

--- a/clis/linkedin/salesnav-search.js
+++ b/clis/linkedin/salesnav-search.js
@@ -1,0 +1,153 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_HOME = 'https://www.linkedin.com/sales/';
+const LEAD_SEARCH_BASE = 'https://www.linkedin.com/sales-api/salesApiLeadSearch';
+// Versioned response decoration. LinkedIn bumps this on Sales Navigator
+// redeploys; if the response shape ever changes, refresh it from a live
+// /sales/search/people request.
+const LEAD_SEARCH_DECORATION = 'com.linkedin.sales.deco.desktop.searchv2.LeadSearchResult-14';
+const PAGE_SIZE = 25;
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function parseLimit(value) {
+  if (value === undefined || value === null || value === '') return 25;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new ArgumentError('--limit must be an integer between 1 and 500');
+  }
+  return limit;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+// Sales Navigator keeps the structural ( ) , : of the query literal and only
+// percent-encodes the keyword value.
+function leadSearchUrl(keywords, start) {
+  const query = '(spellCorrectionEnabled:true,recentSearchParam:(doLogHistory:true),keywords:'
+    + encodeURIComponent(keywords) + ')';
+  return LEAD_SEARCH_BASE
+    + '?q=searchQuery&query=' + query
+    + '&start=' + start + '&count=' + PAGE_SIZE
+    + '&decorationId=' + LEAD_SEARCH_DECORATION;
+}
+
+function fetchLeadSearchScript(url, csrf) {
+  return String.raw`(async () => {
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      'x-restli-protocol-version': '2.0.0',
+      accept: 'application/json',
+    };
+    try {
+      const res = await fetch(${JSON.stringify(url)}, { credentials: 'include', headers });
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
+      if (!res.ok) return { error: 'HTTP ' + res.status };
+      return { json: await res.json() };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+// Sales Navigator search returns no /in/ vanity URL, but the entityUrn carries
+// the obfuscated member token, and linkedin.com/in/<token> is a valid profile
+// URL that the connect command accepts.
+function profileUrlFromEntityUrn(entityUrn) {
+  const match = String(entityUrn || '').match(/fs_salesProfile:\(([^,)]+)/);
+  return match && match[1] ? 'https://www.linkedin.com/in/' + match[1] : '';
+}
+
+function parseLeads(json) {
+  const elements = (json && Array.isArray(json.elements)) ? json.elements : [];
+  const leads = [];
+  for (const el of elements) {
+    if (!el || typeof el !== 'object') continue;
+    const current = Array.isArray(el.currentPositions) ? el.currentPositions : [];
+    const past = Array.isArray(el.pastPositions) ? el.pastPositions : [];
+    const pos = current[0] || past[0] || {};
+    const name = normalizeWhitespace(el.fullName || [el.firstName, el.lastName].filter(Boolean).join(' '));
+    if (!name) continue;
+    leads.push({
+      name,
+      title: normalizeWhitespace(pos.title || ''),
+      company: normalizeWhitespace(pos.companyName || ''),
+      location: normalizeWhitespace(el.geoRegion || ''),
+      degree: normalizeWhitespace(el.degree || ''),
+      profile_url: profileUrlFromEntityUrn(el.entityUrn),
+    });
+  }
+  return leads;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-search',
+  access: 'read',
+  description: 'Search LinkedIn Sales Navigator for people leads by keyword',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'keywords', type: 'string', required: true, positional: true, help: 'People search keywords, e.g. "quality manager food manufacturing"' },
+    { name: 'limit', type: 'number', default: 25, help: 'Maximum leads to return (1-500, fetched 25 per request)' },
+  ],
+  columns: ['rank', 'name', 'title', 'company', 'location', 'degree', 'profile_url'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-search');
+    const keywords = requireStringArg(args, 'keywords', '--keywords');
+    const limit = parseLimit(args.limit);
+
+    await page.goto(SALES_HOME);
+    await page.wait(6);
+
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+    }
+    const csrf = jsession.replace(/^\"|\"$/g, '');
+
+    const leads = [];
+    const seen = new Set();
+    for (let start = 0; leads.length < limit && start < 2000; start += PAGE_SIZE) {
+      const result = unwrapEvaluateResult(await page.evaluate(fetchLeadSearchScript(leadSearchUrl(keywords, start), csrf)));
+      if (result && result.authRequired) {
+        throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator API auth failed (HTTP ' + (result.status || '') + '). Confirm the account has Sales Navigator access.');
+      }
+      if (!result || !result.json) break;
+      const pageLeads = parseLeads(result.json);
+      if (pageLeads.length === 0) break;
+      for (const lead of pageLeads) {
+        const key = lead.profile_url || lead.name.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        leads.push(lead);
+      }
+      await page.wait(1);
+    }
+
+    return leads.slice(0, limit).map((lead, index) => ({ rank: index + 1, ...lead }));
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  parseLimit,
+  leadSearchUrl,
+  profileUrlFromEntityUrn,
+  parseLeads,
+};

--- a/clis/linkedin/salesnav-search.test.js
+++ b/clis/linkedin/salesnav-search.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import './salesnav-search.js';
+
+const { parseLimit, leadSearchUrl, profileUrlFromEntityUrn, parseLeads } = await import('./salesnav-search.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-search command', () => {
+  it('builds a salesApiLeadSearch URL with encoded keywords and pagination', () => {
+    const url = leadSearchUrl('quality manager food', 50);
+    expect(url).toContain('/sales-api/salesApiLeadSearch');
+    expect(url).toContain('keywords:quality%20manager%20food');
+    expect(url).toContain('start=50');
+    expect(url).toContain('count=25');
+  });
+
+  it('derives a profile URL from the sales-profile entityUrn token', () => {
+    expect(profileUrlFromEntityUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)'))
+      .toBe('https://www.linkedin.com/in/ACwAAAJS8TABxyz');
+    expect(profileUrlFromEntityUrn('')).toBe('');
+    expect(profileUrlFromEntityUrn('not-a-urn')).toBe('');
+  });
+
+  it('validates --limit without silent clamping', () => {
+    expect(parseLimit(undefined)).toBe(25);
+    expect(parseLimit(120)).toBe(120);
+    expect(() => parseLimit(0)).toThrow();
+    expect(() => parseLimit(999)).toThrow();
+    expect(() => parseLimit('abc')).toThrow();
+  });
+
+  it('parses lead rows, falls back to past positions, skips nameless entries', () => {
+    const json = { elements: [
+      { fullName: 'Jane Q', geoRegion: 'Vancouver, BC', degree: 2,
+        entityUrn: 'urn:li:fs_salesProfile:(TOKEN1,NAME_SEARCH,abc)',
+        currentPositions: [{ title: 'QA Manager', companyName: 'Acme Foods' }] },
+      { fullName: 'No Current', geoRegion: 'Toronto',
+        entityUrn: 'urn:li:fs_salesProfile:(TOKEN2,NAME_SEARCH,def)',
+        currentPositions: [], pastPositions: [{ title: 'Past QA Lead', companyName: 'Old Co' }] },
+      { firstName: '', lastName: '', entityUrn: 'urn:li:fs_salesProfile:(TOKEN3,x,y)' },
+    ] };
+    const leads = parseLeads(json);
+    expect(leads).toHaveLength(2);
+    expect(leads[0]).toMatchObject({ name: 'Jane Q', title: 'QA Manager', company: 'Acme Foods', location: 'Vancouver, BC', profile_url: 'https://www.linkedin.com/in/TOKEN1' });
+    expect(leads[1]).toMatchObject({ name: 'No Current', title: 'Past QA Lead', company: 'Old Co' });
+  });
+});

--- a/clis/linkedin/salesnav-search.test.js
+++ b/clis/linkedin/salesnav-search.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import './salesnav-search.js';
 
-const { parseLimit, leadSearchUrl, profileUrlFromEntityUrn, parseLeads } = await import('./salesnav-search.js').then((m) => m.__test__);
+const { parseLimit, leadSearchUrl, profileUrlFromEntityUrn, leadUrlFromEntityUrn, parseLeads } = await import('./salesnav-search.js').then((m) => m.__test__);
 
 describe('linkedin salesnav-search command', () => {
   it('builds a salesApiLeadSearch URL with encoded keywords and pagination', () => {
@@ -17,6 +17,12 @@ describe('linkedin salesnav-search command', () => {
       .toBe('https://www.linkedin.com/in/ACwAAAJS8TABxyz');
     expect(profileUrlFromEntityUrn('')).toBe('');
     expect(profileUrlFromEntityUrn('not-a-urn')).toBe('');
+  });
+
+  it('derives a Sales Navigator lead URL from the full sales-profile entityUrn', () => {
+    expect(leadUrlFromEntityUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)'))
+      .toBe('https://www.linkedin.com/sales/lead/ACwAAAJS8TABxyz,NAME_SEARCH,Enlo');
+    expect(leadUrlFromEntityUrn('not-a-urn')).toBe('');
   });
 
   it('validates --limit without silent clamping', () => {
@@ -39,7 +45,15 @@ describe('linkedin salesnav-search command', () => {
     ] };
     const leads = parseLeads(json);
     expect(leads).toHaveLength(2);
-    expect(leads[0]).toMatchObject({ name: 'Jane Q', title: 'QA Manager', company: 'Acme Foods', location: 'Vancouver, BC', profile_url: 'https://www.linkedin.com/in/TOKEN1' });
+    expect(leads[0]).toMatchObject({
+      name: 'Jane Q',
+      title: 'QA Manager',
+      company: 'Acme Foods',
+      location: 'Vancouver, BC',
+      profile_url: 'https://www.linkedin.com/in/TOKEN1',
+      lead_url: 'https://www.linkedin.com/sales/lead/TOKEN1,NAME_SEARCH,abc',
+      recipient_urn: 'urn:li:fs_salesProfile:(TOKEN1,NAME_SEARCH,abc)',
+    });
     expect(leads[1]).toMatchObject({ name: 'No Current', title: 'Past QA Lead', company: 'Old Co' });
   });
 });

--- a/clis/linkedin/salesnav-thread.js
+++ b/clis/linkedin/salesnav-thread.js
@@ -1,0 +1,183 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+  THREAD_DECORATION,
+  THREADS_BASE,
+  encodeRestliDecoration,
+  fetchInboxRows,
+  fetchSalesnavJson,
+  getCsrf,
+  normalizeWhitespace,
+  parseLimit,
+} from './salesnav-inbox.js';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_INBOX_URL = 'https://www.linkedin.com/sales/inbox/';
+const DEFAULT_MESSAGE_LIMIT = 200;
+const THREAD_PAGE_SIZE = 20;
+
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
+function parseSalesProfileUrn(value) {
+  const raw = normalizeWhitespace(value);
+  const match = raw.match(/^urn:li:fs_salesProfile:\(([^,()]+),([^,()]+),([^,()]+)\)$/);
+  return match ? raw : '';
+}
+
+function parseThreadInput(value) {
+  const raw = normalizeWhitespace(value);
+  if (!raw) return ['empty', ''];
+  if (/^2-[A-Za-z0-9+/=_-]+$/.test(raw)) return ['thread_id', raw];
+  if (/^urn:li:fs_salesProfile:\(/.test(raw)) return ['recipient_urn', parseSalesProfileUrn(raw) || raw];
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return ['name', raw.toLowerCase()];
+    const inboxMatch = url.pathname.match(/^\/sales\/inbox\/([^/]+)\/?$/i);
+    if (inboxMatch) return ['thread_id', decodeURIComponent(inboxMatch[1])];
+    const leadMatch = url.pathname.match(/^\/sales\/lead\/([^,/]+),([^,/]+),([^/]+)\/?$/i);
+    if (leadMatch) {
+      const urn = `urn:li:fs_salesProfile:(${decodeURIComponent(leadMatch[1])},${decodeURIComponent(leadMatch[2])},${decodeURIComponent(leadMatch[3])})`;
+      return ['recipient_urn', urn];
+    }
+  } catch {
+    // Fall through to name matching.
+  }
+  return ['name', raw.toLowerCase()];
+}
+
+function salesnavThreadUrl(threadId) {
+  return threadId ? `https://www.linkedin.com/sales/inbox/${encodeURIComponent(threadId)}` : '';
+}
+
+function threadApiUrl(threadId, messageCount) {
+  return `${THREADS_BASE}/${encodeURIComponent(threadId)}?decoration=${encodeRestliDecoration(THREAD_DECORATION)}&count=1&messageCount=${messageCount}`;
+}
+
+function participantName(profile) {
+  return normalizeWhitespace(profile?.fullName || [profile?.firstName, profile?.lastName].filter(Boolean).join(' '));
+}
+
+function participantIndex(thread) {
+  const resolution = thread?.participantsResolutionResults || {};
+  const participants = Array.isArray(thread?.participants) ? thread.participants : Object.keys(resolution);
+  const byUrn = new Map();
+  for (const urn of participants) {
+    const profile = resolution[urn] || { entityUrn: urn };
+    byUrn.set(urn, profile);
+  }
+  return byUrn;
+}
+
+function parseSalesnavThreadMessages(thread) {
+  const byUrn = participantIndex(thread);
+  const messages = Array.isArray(thread?.messages) ? thread.messages : [];
+  const rows = messages.map((message) => {
+    const deliveredAt = Number(message?.deliveredAt || 0);
+    const senderProfile = byUrn.get(message?.author);
+    return {
+      message_id: normalizeWhitespace(message?.id || ''),
+      thread_id: normalizeWhitespace(thread?.id || ''),
+      sender: participantName(senderProfile) || normalizeWhitespace(message?.author || ''),
+      sender_urn: normalizeWhitespace(message?.author || ''),
+      text: normalizeWhitespace(message?.body || message?.systemMessageContent || ''),
+      subject: normalizeWhitespace(message?.subject || ''),
+      timestamp: deliveredAt ? new Date(deliveredAt).toISOString() : '',
+      delivered_at: deliveredAt || '',
+      type: normalizeWhitespace(message?.type || ''),
+    };
+  }).filter((row) => row.text || row.subject || row.message_id);
+  rows.sort((a, b) => Number(a.delivered_at || 0) - Number(b.delivered_at || 0));
+  return rows.map((row, index) => ({ index, ...row }));
+}
+
+function threadMatchesInput(row, parsed) {
+  if (!row || !parsed) return false;
+  const [kind, criterion] = parsed;
+  if (kind === 'thread_id') return row.thread_id === criterion;
+  if (kind === 'recipient_urn') {
+    return (row.participants || []).some((p) => normalizeWhitespace(p.entity_urn) === criterion);
+  }
+  if (kind === 'name') {
+    const needle = normalizeWhitespace(criterion).toLowerCase();
+    if (!needle) return false;
+    if (normalizeWhitespace(row.person_name).toLowerCase() === needle) return true;
+    return (row.participants || []).some((p) => normalizeWhitespace(p.name).toLowerCase() === needle);
+  }
+  return false;
+}
+
+async function resolveThreadId(page, input, { maxPages = 30 } = {}) {
+  const parsed = parseThreadInput(input);
+  if (parsed[0] === 'empty') throw new ArgumentError('thread or recipient is required');
+  if (parsed[0] === 'thread_id') return parsed[1];
+  const inboxRows = await fetchInboxRows(page, { limit: 500, maxPages });
+  const match = inboxRows.find((row) => threadMatchesInput(row, parsed));
+  if (!match) {
+    throw new EmptyResultError('linkedin salesnav-thread', `No Sales Navigator thread matched ${input}`);
+  }
+  return match.thread_id;
+}
+
+async function fetchThreadWithPagination(page, csrf, threadId, limit = DEFAULT_MESSAGE_LIMIT) {
+  let requested = THREAD_PAGE_SIZE;
+  if (limit < requested) requested = limit;
+  let thread = null;
+  for (let attempts = 0; attempts < 30; attempts += 1) {
+    thread = await fetchSalesnavJson(page, csrf, threadApiUrl(threadId, requested), 'Sales Navigator messaging thread API');
+    const total = Number(thread?.totalMessageCount || 0);
+    const have = Array.isArray(thread?.messages) ? thread.messages.length : 0;
+    if (have >= limit || (total && have >= total) || requested >= limit) break;
+    let nextRequested = requested + THREAD_PAGE_SIZE;
+    if (total && total > nextRequested) nextRequested = total;
+    if (nextRequested > limit) nextRequested = limit;
+    requested = nextRequested;
+  }
+  return thread;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-thread',
+  access: 'read',
+  description: 'Return full Sales Navigator message history for a thread id, Sales Navigator inbox URL, lead URL, recipient urn, or exact recipient name',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'thread-or-recipient', type: 'string', required: true, positional: true, help: 'Sales Navigator inbox URL/thread id, Sales Navigator lead URL, recipient urn, or exact participant name' },
+    { name: 'limit', type: 'number', default: DEFAULT_MESSAGE_LIMIT, help: 'Maximum messages to return (1-500)' },
+    { name: 'max-pages', type: 'number', default: 30, help: 'Maximum inbox pages to scan when resolving a recipient' },
+  ],
+  columns: ['index', 'thread_id', 'thread_url', 'sender', 'text', 'timestamp', 'subject', 'message_id', 'sender_urn', 'delivered_at', 'type', 'total_message_count'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-thread');
+    const input = normalizeWhitespace(args['thread-or-recipient']);
+    if (!input) throw new ArgumentError('thread-or-recipient is required');
+    const limit = parseLimit(args.limit, DEFAULT_MESSAGE_LIMIT);
+    const maxPages = parseLimit(args['max-pages'], 30);
+    await page.goto(SALES_INBOX_URL);
+    await page.wait(4);
+    const threadId = await resolveThreadId(page, input, { maxPages });
+    const csrf = await getCsrf(page);
+    const thread = await fetchThreadWithPagination(page, csrf, threadId, limit);
+    const messages = parseSalesnavThreadMessages(thread).slice(0, limit);
+    if (messages.length === 0) throw new EmptyResultError('linkedin salesnav-thread', `No messages found for ${threadId}`);
+    return messages.map((message) => ({
+      ...message,
+      thread_url: salesnavThreadUrl(threadId),
+      total_message_count: Number(thread?.totalMessageCount || messages.length),
+    }));
+  },
+});
+
+export const __test__ = {
+  parseThreadInput,
+  threadApiUrl,
+  participantIndex,
+  parseSalesnavThreadMessages,
+  threadMatchesInput,
+  salesnavThreadUrl,
+};

--- a/clis/linkedin/salesnav-thread.test.js
+++ b/clis/linkedin/salesnav-thread.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import './salesnav-thread.js';
+
+const {
+  parseThreadInput,
+  threadApiUrl,
+  parseSalesnavThreadMessages,
+  threadMatchesInput,
+  salesnavThreadUrl,
+} = await import('./salesnav-thread.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-thread command', () => {
+  it('accepts Sales Navigator inbox URLs, raw thread ids, lead URLs, urns, and names', () => {
+    expect(parseThreadInput('https://www.linkedin.com/sales/inbox/2-abc%3D%3D')).toEqual(['thread_id', '2-abc==']);
+    expect(parseThreadInput('2-abc==')).toEqual(['thread_id', '2-abc==']);
+    expect(parseThreadInput('https://www.linkedin.com/sales/lead/P1,NAME_SEARCH,T1')).toEqual(['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)']);
+    expect(parseThreadInput('urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)')).toEqual(['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)']);
+    expect(parseThreadInput('Rachael Stolberg')).toEqual(['name', 'rachael stolberg']);
+  });
+
+  it('builds the decorated thread API URL with encoded parentheses and message pagination size', () => {
+    const url = threadApiUrl('2-thread==', 40);
+    expect(url).toContain('/sales-api/salesApiMessagingThreads/2-thread%3D%3D?');
+    expect(url).toContain('messageCount=40');
+    expect(url).toContain('count=1');
+    expect(url).toContain('decoration=%28');
+    expect(url).not.toContain('decoration=(');
+  });
+
+  it('parses thread messages in chronological order with sender names and timestamps', () => {
+    const rows = parseSalesnavThreadMessages({
+      id: '2-thread',
+      participants: [
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)',
+      ],
+      participantsResolutionResults: {
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)': { fullName: 'Rachael Stolberg', entityUrn: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)' },
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)': { fullName: 'Hanzi Li', entityUrn: 'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)' },
+      },
+      messages: [
+        { id: 'm2', author: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)', body: 'Happy to chat', deliveredAt: 1778206803669, type: 'MEMBER_TO_MEMBER' },
+        { id: 'm1', author: 'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)', subject: 'Quick question', body: 'Hi Rachael', deliveredAt: 1777188013523, type: 'INMAIL' },
+      ],
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      index: 0,
+      message_id: 'm1',
+      thread_id: '2-thread',
+      sender: 'Hanzi Li',
+      subject: 'Quick question',
+      text: 'Hi Rachael',
+      timestamp: '2026-04-26T07:20:13.523Z',
+    });
+    expect(rows[1]).toMatchObject({ index: 1, message_id: 'm2', sender: 'Rachael Stolberg', text: 'Happy to chat' });
+  });
+
+  it('matches recipient identifiers against inbox rows', () => {
+    const row = {
+      thread_id: '2-thread',
+      person_name: 'Rachael Stolberg',
+      participants: [{ name: 'Rachael Stolberg', entity_urn: 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)' }],
+    };
+    expect(threadMatchesInput(row, ['thread_id', '2-thread'])).toBe(true);
+    expect(threadMatchesInput(row, ['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)'])).toBe(true);
+    expect(threadMatchesInput(row, ['name', 'rachael stolberg'])).toBe(true);
+    expect(salesnavThreadUrl('2-thread')).toBe('https://www.linkedin.com/sales/inbox/2-thread');
+  });
+});

--- a/clis/linkedin/sent-invitations.js
+++ b/clis/linkedin/sent-invitations.js
@@ -11,43 +11,46 @@ function unwrapEvaluateResult(payload) {
 
 function buildSentInvitationsScript() {
   return String.raw`(() => {
-    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const clean = (s) => String(s || '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
     const text = document.body ? (document.body.innerText || '') : '';
     const href = location.href;
     const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
       || /linkedin\.com\/(login|checkpoint|authwall|uas)/i.test(href);
     const warning = /captcha|verification required|unusual activity|account restricted|temporarily restricted|security check|checkpoint/i.test(text);
+    const cleanName = (value) => {
+      const first = String(value || '').split(/\n+/).map(clean).filter(Boolean)[0] || '';
+      return clean(first
+        .replace(/^(view\s+)?profile\s+of\s+/i, '')
+        .replace(/\s*(?:View profile|LinkedIn|Pending|Sent|Withdraw).*$/i, ''));
+    };
     const cards = Array.from(document.querySelectorAll('li, div, section, article')).filter((el) => {
       if (!el || el.offsetParent === null) return false;
       const t = clean(el.innerText || el.textContent || '');
-      return t && /withdraw|pending|sent/i.test(t) && t.length < 1200;
+      return t && /withdraw/i.test(t) && t.length < 1200;
     });
-    const rows = [];
-    const seen = new Set();
+    const byName = new Map();
     for (const card of cards) {
-      const raw = clean(card.innerText || card.textContent || '');
-      if (!raw) continue;
-      const link = Array.from(card.querySelectorAll('a[href*="/in/"]')).find((a) => clean(a.innerText || a.textContent || a.getAttribute('aria-label')));
-      const linkText = clean(link?.innerText || link?.textContent || link?.getAttribute('aria-label') || '');
+      const raw = card.innerText || card.textContent || '';
+      if (!/withdraw/i.test(raw)) continue;
       const lines = raw.split(/\n+/).map(clean).filter(Boolean);
-      const cleanName = (value) => {
-        const line = clean(value).split(/\n+/).map(clean).filter(Boolean)[0] || '';
-        return clean(line
-          .replace(/^(view\s+)?profile\s+of\s+/i, '')
-          .replace(/\s*(?:View profile|LinkedIn|Pending|Sent|Withdraw).*$/i, ''));
-      };
-      let name = cleanName(linkText)
-        || cleanName(lines.find((line) => !/^(pending|sent|withdraw|message|view profile|invitation|invited|ago|manage)/i.test(line)) || '');
+      const link = card.querySelector('a[href*="/in/"]');
+      const linkName = cleanName(link ? (link.innerText || link.textContent || link.getAttribute('aria-label') || '') : '');
+      const name = linkName
+        || cleanName(lines.find((line) => !/^(pending|sent|withdraw|message|view profile|invitation|invited|ago|manage|received)\b/i.test(line)) || '');
+      if (!name) continue;
       const hrefAttr = link ? (link.getAttribute('href') || '') : '';
       const profile_url = hrefAttr ? new URL(hrefAttr, location.origin).toString().replace(/[?#].*$/, '') : '';
-      const dateLine = lines.find((line) => /sent|invited|ago|\b\d{4}\b|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/i.test(line)) || '';
-      const invited_date_text = clean((dateLine.match(/(?:sent|invited)\s+(?:\d+\s+\w+\s+ago|yesterday|today|on\s+[^\n]+|[A-Z][a-z]{2,9}\s+\d{1,2},?\s+\d{4}|\d{4})/i) || [''])[0] || dateLine);
-      const key = (profile_url || name).toLowerCase();
-      if (name && !seen.has(key)) {
-        seen.add(key);
-        rows.push({ name, profile_url, invited_date_text });
+      const invited_date_text = clean((raw.match(/(?:Sent|Invited)\s+(?:\d+\s+\w+\s+ago|yesterday|today)/i) || [''])[0]);
+      const key = name.toLowerCase();
+      const existing = byName.get(key);
+      if (!existing) {
+        byName.set(key, { name, profile_url, invited_date_text });
+      } else {
+        if (!existing.profile_url && profile_url) existing.profile_url = profile_url;
+        if (!existing.invited_date_text && invited_date_text) existing.invited_date_text = invited_date_text;
       }
     }
+    const rows = Array.from(byName.values());
     return { url: href, title: document.title || '', authRequired, warning, count: rows.length, rows, bodyText: text.slice(0, 1000) };
   })()`;
 }
@@ -65,7 +68,7 @@ cli({
   func: async (page) => {
     if (!page) throw new CommandExecutionError('Browser session required for linkedin sent-invitations');
     await page.goto(SENT_URL);
-    await page.wait(8);
+    await page.wait(12);
     let result = unwrapEvaluateResult(await page.evaluate(buildSentInvitationsScript()));
     if (result?.authRequired) {
       throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn sent invitations requires an active signed-in browser session.');

--- a/clis/linkedin/sent-invitations.js
+++ b/clis/linkedin/sent-invitations.js
@@ -1,0 +1,89 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SENT_URL = 'https://www.linkedin.com/mynetwork/invitation-manager/sent/';
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function buildSentInvitationsScript() {
+  return String.raw`(() => {
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const text = document.body ? (document.body.innerText || '') : '';
+    const href = location.href;
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
+      || /linkedin\.com\/(login|checkpoint|authwall|uas)/i.test(href);
+    const warning = /captcha|verification required|unusual activity|account restricted|temporarily restricted|security check|checkpoint/i.test(text);
+    const cards = Array.from(document.querySelectorAll('li, div, section, article')).filter((el) => {
+      if (!el || el.offsetParent === null) return false;
+      const t = clean(el.innerText || el.textContent || '');
+      return t && /withdraw|pending|sent/i.test(t) && t.length < 1200;
+    });
+    const rows = [];
+    const seen = new Set();
+    for (const card of cards) {
+      const raw = clean(card.innerText || card.textContent || '');
+      if (!raw) continue;
+      const link = Array.from(card.querySelectorAll('a[href*="/in/"]')).find((a) => clean(a.innerText || a.textContent || a.getAttribute('aria-label')));
+      const linkText = clean(link?.innerText || link?.textContent || link?.getAttribute('aria-label') || '');
+      const lines = raw.split(/\n+/).map(clean).filter(Boolean);
+      const cleanName = (value) => {
+        const line = clean(value).split(/\n+/).map(clean).filter(Boolean)[0] || '';
+        return clean(line
+          .replace(/^(view\s+)?profile\s+of\s+/i, '')
+          .replace(/\s*(?:View profile|LinkedIn|Pending|Sent|Withdraw).*$/i, ''));
+      };
+      let name = cleanName(linkText)
+        || cleanName(lines.find((line) => !/^(pending|sent|withdraw|message|view profile|invitation|invited|ago|manage)/i.test(line)) || '');
+      const hrefAttr = link ? (link.getAttribute('href') || '') : '';
+      const profile_url = hrefAttr ? new URL(hrefAttr, location.origin).toString().replace(/[?#].*$/, '') : '';
+      const dateLine = lines.find((line) => /sent|invited|ago|\b\d{4}\b|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/i.test(line)) || '';
+      const invited_date_text = clean((dateLine.match(/(?:sent|invited)\s+(?:\d+\s+\w+\s+ago|yesterday|today|on\s+[^\n]+|[A-Z][a-z]{2,9}\s+\d{1,2},?\s+\d{4}|\d{4})/i) || [''])[0] || dateLine);
+      const key = (profile_url || name).toLowerCase();
+      if (name && !seen.has(key)) {
+        seen.add(key);
+        rows.push({ name, profile_url, invited_date_text });
+      }
+    }
+    return { url: href, title: document.title || '', authRequired, warning, count: rows.length, rows, bodyText: text.slice(0, 1000) };
+  })()`;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'sent-invitations',
+  access: 'read',
+  description: 'List pending LinkedIn sent invitations for CRM reconciliation',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [],
+  columns: ['rank', 'name', 'profile_url', 'invited_date_text'],
+  func: async (page) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin sent-invitations');
+    await page.goto(SENT_URL);
+    await page.wait(8);
+    let result = unwrapEvaluateResult(await page.evaluate(buildSentInvitationsScript()));
+    if (result?.authRequired) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn sent invitations requires an active signed-in browser session.');
+    }
+    if (result?.warning) {
+      throw new CommandExecutionError('LinkedIn warning/restriction state visible on sent invitations page.');
+    }
+    const rows = Array.isArray(result?.rows) ? result.rows : [];
+    return rows.map((row, index) => ({
+      rank: index + 1,
+      name: row.name || '',
+      profile_url: row.profile_url || '',
+      invited_date_text: row.invited_date_text || '',
+    }));
+  },
+});
+
+export const __test__ = {
+  buildSentInvitationsScript,
+  unwrapEvaluateResult,
+};

--- a/clis/linkedin/sent-invitations.test.js
+++ b/clis/linkedin/sent-invitations.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './sent-invitations.js';
+
+const { buildSentInvitationsScript } = await import('./sent-invitations.js').then((m) => m.__test__);
+
+describe('linkedin sent-invitations command', () => {
+  it('registers with structured columns that do not include raw blobs', () => {
+    const command = getRegistry().get('linkedin/sent-invitations');
+    expect(command).toBeDefined();
+    expect(command.access).toBe('read');
+    expect(command.columns).toEqual(['rank', 'name', 'profile_url', 'invited_date_text']);
+  });
+
+  it('extracts clean names and dedupes invitation cards by profile url', () => {
+    const dom = new JSDOM(`<!doctype html><body>
+      <ul>
+        <li>
+          <a href="/in/olga-magere/?miniProfileUrn=x"><span>Olga Magere</span></a>
+          <span>Pending</span><button>Withdraw</button><span>Sent 2 weeks ago</span>
+        </li>
+        <li>
+          <a href="/in/olga-magere/?trk=dup"><span>Olga Magere</span></a>
+          <span>Pending</span><button>Withdraw</button><span>Sent 2 weeks ago</span>
+        </li>
+        <li>
+          <div>Sam Founder\nSent yesterday\nWithdraw</div>
+        </li>
+      </ul>
+    </body>`, { url: 'https://www.linkedin.com/mynetwork/invitation-manager/sent/' });
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    const previousLocation = globalThis.location;
+    try {
+      globalThis.window = dom.window;
+      globalThis.document = dom.window.document;
+      globalThis.location = dom.window.location;
+      globalThis.getComputedStyle = dom.window.getComputedStyle;
+      Object.defineProperty(dom.window.HTMLElement.prototype, 'offsetParent', { get() { return dom.window.document.body; }, configurable: true });
+      const run = Function(`return ${buildSentInvitationsScript()}`);
+      const result = run();
+      expect(result.rows).toEqual([
+        {
+          name: 'Olga Magere',
+          profile_url: 'https://www.linkedin.com/in/olga-magere/',
+          invited_date_text: 'Sent 2 weeks ago',
+        },
+        {
+          name: 'Sam Founder',
+          profile_url: '',
+          invited_date_text: 'Sent yesterday',
+        },
+      ]);
+      expect(result.rows[0]).not.toHaveProperty('raw');
+    } finally {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+      globalThis.location = previousLocation;
+    }
+  });
+});

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -62,26 +62,34 @@ function parseMaxScrolls(value) {
   return scrolls;
 }
 
-function installThreadFetchCaptureScript() {
-  return String.raw`(() => {
-    window.__opencli_thread_pages = Array.isArray(window.__opencli_thread_pages) ? window.__opencli_thread_pages : [];
-    if (window.__opencli_thread_fetch_patched) return { patched: false, count: window.__opencli_thread_pages.length };
-    const originalFetch = window.fetch;
-    window.__opencli_thread_fetch_patched = true;
-    window.fetch = async function(...args) {
-      const response = await originalFetch.apply(this, args);
-      try {
-        const request = args[0];
-        const url = typeof request === 'string' ? request : (request && request.url) || '';
-        if (/messengerMessages/i.test(String(url || response.url || ''))) {
-          response.clone().text().then((text) => {
-            if (text) window.__opencli_thread_pages.push(text);
-          }).catch(() => {});
-        }
-      } catch {}
-      return response;
+function collectThreadMessageUrlsScript() {
+  return String.raw`(() => Array.from(new Set(
+    performance.getEntriesByType('resource')
+      .map((entry) => entry.name)
+      .filter((url) => /messengerMessages/i.test(url)),
+  )))()`;
+}
+
+function fetchThreadPagesScript(urls, csrf) {
+  return String.raw`(async () => {
+    const urls = ${JSON.stringify(urls)};
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      accept: 'application/vnd.linkedin.normalized+json+2.1',
+      'x-restli-protocol-version': '2.0.0',
     };
-    return { patched: true, count: window.__opencli_thread_pages.length };
+    const out = [];
+    for (const url of urls) {
+      try {
+        const res = await fetch(url, { credentials: 'include', headers });
+        if (res.status === 401 || res.status === 403) { out.push({ url, authRequired: true, error: 'HTTP ' + res.status }); continue; }
+        if (!res.ok) { out.push({ url, error: 'HTTP ' + res.status }); continue; }
+        out.push({ url, json: await res.json() });
+      } catch (e) {
+        out.push({ url, error: 'fetch failed: ' + ((e && e.message) || String(e)) });
+      }
+    }
+    return out;
   })()`;
 }
 
@@ -106,10 +114,6 @@ function scrollThreadMessagePaneScript() {
   })()`;
 }
 
-function getCapturedThreadPagesScript() {
-  return String.raw`(() => Array.isArray(window.__opencli_thread_pages) ? window.__opencli_thread_pages.slice() : [])()`;
-}
-
 function parseThreadMessages(normalized) {
   if (!normalized || typeof normalized !== 'object' || Array.isArray(normalized) || !Array.isArray(normalized.included)) return [];
   const clean = normalizeWhitespace;
@@ -126,7 +130,7 @@ function parseThreadMessages(normalized) {
     return clean(participant.name?.text || participant.name || '');
   };
   const resolveSpeaker = (message) => {
-    const candidates = [message['*sender'], message['*from'], message.sender, message.from, message.actor, message.creator, message.backendAuthorUrn];
+    const candidates = [message['*sender'], message['*senderParticipant'], message['*from'], message.sender, message.senderParticipant, message.from, message.actor, message.creator, message.backendAuthorUrn];
     for (const candidate of candidates) {
       const urn = typeof candidate === 'string' ? candidate : candidate?.entityUrn;
       if (!urn) continue;
@@ -171,7 +175,11 @@ function mergeThreadMessages(apiMessages, domMessages) {
   for (const message of apiMessages || []) add(message);
   for (const message of domMessages || []) add(message);
   if (merged.some((message) => Number(message.createdAt || 0))) {
-    merged.sort((a, b) => Number(a.createdAt || 0) - Number(b.createdAt || 0));
+    merged.sort((a, b) => {
+      const aTime = Number(a.createdAt || 0) || Number.MAX_SAFE_INTEGER;
+      const bTime = Number(b.createdAt || 0) || Number.MAX_SAFE_INTEGER;
+      return aTime - bTime;
+    });
   }
   return merged.map((message, index) => ({ ...message, index }));
 }
@@ -308,12 +316,40 @@ cli({
     await page.wait(4);
     await page.goto(threadUrl);
     await page.wait(10);
-    await page.evaluate(installThreadFetchCaptureScript());
-    for (let i = 0; i < maxScrolls; i += 1) {
-      await page.evaluate(scrollThreadMessagePaneScript());
-      await page.wait(1);
+    await page.evaluate('performance.setResourceTimingBufferSize(3000)');
+
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
     }
-    const capturedBodies = unwrapEvaluateResult(await page.evaluate(getCapturedThreadPagesScript()));
+    const csrf = jsession.replace(/^\"|\"$/g, '');
+
+    const fetchedUrls = new Set();
+    const apiPageJsons = [];
+    let stablePasses = 0;
+    for (let i = 0; i <= maxScrolls; i += 1) {
+      if (i > 0) {
+        await page.evaluate(scrollThreadMessagePaneScript());
+        await page.wait(1);
+      }
+      const seenUrls = unwrapEvaluateResult(await page.evaluate(collectThreadMessageUrlsScript()));
+      const newUrls = (Array.isArray(seenUrls) ? seenUrls : []).filter((u) => !fetchedUrls.has(u));
+      if (newUrls.length === 0) {
+        stablePasses += 1;
+        if (i > 0 && stablePasses >= 3) break;
+        continue;
+      }
+      stablePasses = 0;
+      for (const url of newUrls) fetchedUrls.add(url);
+      const fetchedPages = unwrapEvaluateResult(await page.evaluate(fetchThreadPagesScript(newUrls, csrf)));
+      for (const entry of Array.isArray(fetchedPages) ? fetchedPages : []) {
+        if (entry && entry.authRequired) {
+          throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn messengerMessages API authentication failed: ' + (entry.error || 'auth required'));
+        }
+        if (entry && entry.json) apiPageJsons.push(entry.json);
+      }
+    }
 
     const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(0)));
     if (snapshot?.authRequired) {
@@ -329,11 +365,11 @@ cli({
     }
 
     const apiMessages = [];
-    for (const body of Array.isArray(capturedBodies) ? capturedBodies : []) {
+    for (const pageJson of apiPageJsons) {
       try {
-        apiMessages.push(...parseThreadMessages(JSON.parse(body)));
+        apiMessages.push(...parseThreadMessages(pageJson));
       } catch {
-        // Ignore non-JSON or malformed captured bodies.
+        // Ignore malformed captured pages.
       }
     }
     const mergedMessages = mergeThreadMessages(apiMessages, snapshot.messages);
@@ -346,7 +382,7 @@ cli({
       headerNames: snapshot.headerNames,
       latestMessageText: normalizeWhitespace(mergedMessages[mergedMessages.length - 1]?.text || snapshot?.latestMessageText || ''),
       messages: mergedMessages,
-      capturedApiPageCount: Array.isArray(capturedBodies) ? capturedBodies.length : 0,
+      capturedApiPageCount: apiPageJsons.length,
     };
 
     return [{
@@ -366,6 +402,8 @@ export const __test__ = {
   parseMaxScrolls,
   unwrapEvaluateResult,
   buildThreadSnapshotScript,
+  collectThreadMessageUrlsScript,
+  fetchThreadPagesScript,
   parseThreadMessages,
   mergeThreadMessages,
 };

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -62,6 +62,120 @@ function parseMaxScrolls(value) {
   return scrolls;
 }
 
+function installThreadFetchCaptureScript() {
+  return String.raw`(() => {
+    window.__opencli_thread_pages = Array.isArray(window.__opencli_thread_pages) ? window.__opencli_thread_pages : [];
+    if (window.__opencli_thread_fetch_patched) return { patched: false, count: window.__opencli_thread_pages.length };
+    const originalFetch = window.fetch;
+    window.__opencli_thread_fetch_patched = true;
+    window.fetch = async function(...args) {
+      const response = await originalFetch.apply(this, args);
+      try {
+        const request = args[0];
+        const url = typeof request === 'string' ? request : (request && request.url) || '';
+        if (/messengerMessages/i.test(String(url || response.url || ''))) {
+          response.clone().text().then((text) => {
+            if (text) window.__opencli_thread_pages.push(text);
+          }).catch(() => {});
+        }
+      } catch {}
+      return response;
+    };
+    return { patched: true, count: window.__opencli_thread_pages.length };
+  })()`;
+}
+
+function scrollThreadMessagePaneScript() {
+  return String.raw`(() => {
+    const candidates = [
+      '.msg-s-message-list-scrollable',
+      '.msg-s-message-list',
+      '.msg-thread',
+      'main [role="main"]',
+      'main'
+    ];
+    let scroller = null;
+    for (const selector of candidates) {
+      const el = document.querySelector(selector);
+      if (el && (el.scrollHeight > el.clientHeight || selector === 'main')) { scroller = el; break; }
+    }
+    scroller = scroller || document.scrollingElement || document.documentElement;
+    scroller.scrollTop = 0;
+    window.scrollTo(0, 0);
+    return { scrollTop: scroller.scrollTop, scrollHeight: scroller.scrollHeight || 0, clientHeight: scroller.clientHeight || 0 };
+  })()`;
+}
+
+function getCapturedThreadPagesScript() {
+  return String.raw`(() => Array.isArray(window.__opencli_thread_pages) ? window.__opencli_thread_pages.slice() : [])()`;
+}
+
+function parseThreadMessages(normalized) {
+  if (!normalized || typeof normalized !== 'object' || Array.isArray(normalized) || !Array.isArray(normalized.included)) return [];
+  const clean = normalizeWhitespace;
+  const byUrn = new Map();
+  for (const entity of normalized.included) {
+    if (entity && entity.entityUrn) byUrn.set(entity.entityUrn, entity);
+  }
+  const participantName = (participant) => {
+    if (!participant) return '';
+    const pt = participant.participantType || {};
+    if (pt.member) return clean([pt.member.firstName?.text, pt.member.lastName?.text].filter(Boolean).join(' '));
+    if (pt.organization?.name) return clean(pt.organization.name.text);
+    if (pt.agent?.name) return clean(pt.agent.name.text);
+    return clean(participant.name?.text || participant.name || '');
+  };
+  const resolveSpeaker = (message) => {
+    const candidates = [message['*sender'], message['*from'], message.sender, message.from, message.actor, message.creator, message.backendAuthorUrn];
+    for (const candidate of candidates) {
+      const urn = typeof candidate === 'string' ? candidate : candidate?.entityUrn;
+      if (!urn) continue;
+      const entity = byUrn.get(urn);
+      const name = participantName(entity);
+      if (name) return name;
+    }
+    return '';
+  };
+  const createdMs = (message) => Number(message.createdAt || message.deliveredAt || message.timestamp || message.sentAt || 0);
+  const rows = [];
+  for (const message of normalized.included) {
+    if (!message || !/\.Message$/i.test(String(message.$type || ''))) continue;
+    const text = clean(message.body?.text || message.attributedBody?.text || message.text || '');
+    if (!text) continue;
+    rows.push({
+      index: rows.length,
+      urn: message.entityUrn || '',
+      timestamp: createdMs(message) ? new Date(createdMs(message)).toISOString() : '',
+      createdAt: createdMs(message),
+      speaker: cleanPersonName(resolveSpeaker(message)),
+      text,
+    });
+  }
+  if (rows.some((row) => row.createdAt)) rows.sort((a, b) => a.createdAt - b.createdAt);
+  return rows.map((row, index) => ({ ...row, index }));
+}
+
+function mergeThreadMessages(apiMessages, domMessages) {
+  const seen = new Set();
+  const merged = [];
+  const add = (message) => {
+    const text = normalizeWhitespace(message?.text || '');
+    if (!text) return;
+    const speakerTextKey = `${normalizeWhitespace(message?.speaker || '')}\n${text}`;
+    const key = normalizeWhitespace(message?.urn || '') || `${speakerTextKey}\n${normalizeWhitespace(message?.timestamp || '')}`;
+    if (seen.has(key) || seen.has(speakerTextKey)) return;
+    seen.add(key);
+    seen.add(speakerTextKey);
+    merged.push({ ...message, text });
+  };
+  for (const message of apiMessages || []) add(message);
+  for (const message of domMessages || []) add(message);
+  if (merged.some((message) => Number(message.createdAt || 0))) {
+    merged.sort((a, b) => Number(a.createdAt || 0) - Number(b.createdAt || 0));
+  }
+  return merged.map((message, index) => ({ ...message, index }));
+}
+
 function buildThreadSnapshotScript(maxScrolls) {
   const scrolls = maxScrolls;
   return String.raw`(async () => {
@@ -194,8 +308,14 @@ cli({
     await page.wait(4);
     await page.goto(threadUrl);
     await page.wait(10);
+    await page.evaluate(installThreadFetchCaptureScript());
+    for (let i = 0; i < maxScrolls; i += 1) {
+      await page.evaluate(scrollThreadMessagePaneScript());
+      await page.wait(1);
+    }
+    const capturedBodies = unwrapEvaluateResult(await page.evaluate(getCapturedThreadPagesScript()));
 
-    const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(maxScrolls)));
+    const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(0)));
     if (snapshot?.authRequired) {
       throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn thread-snapshot requires an active signed-in LinkedIn browser session.');
     }
@@ -208,14 +328,25 @@ cli({
       throw new CommandExecutionError('LinkedIn thread-snapshot blocked: thread_url_mismatch', `Expected ${threadUrl}; actual ${actualUrl}`);
     }
 
+    const apiMessages = [];
+    for (const body of Array.isArray(capturedBodies) ? capturedBodies : []) {
+      try {
+        apiMessages.push(...parseThreadMessages(JSON.parse(body)));
+      } catch {
+        // Ignore non-JSON or malformed captured bodies.
+      }
+    }
+    const mergedMessages = mergeThreadMessages(apiMessages, snapshot.messages);
+
     const recipient = cleanPersonName(snapshot.headerNames[0] || '');
-    const messageCount = snapshot.messages.length;
+    const messageCount = mergedMessages.length;
     const normalized = {
       ...snapshot,
       url: actualUrl || threadUrl,
       headerNames: snapshot.headerNames,
-      latestMessageText: normalizeWhitespace(snapshot?.latestMessageText || ''),
-      messages: snapshot.messages,
+      latestMessageText: normalizeWhitespace(mergedMessages[mergedMessages.length - 1]?.text || snapshot?.latestMessageText || ''),
+      messages: mergedMessages,
+      capturedApiPageCount: Array.isArray(capturedBodies) ? capturedBodies.length : 0,
     };
 
     return [{
@@ -235,4 +366,6 @@ export const __test__ = {
   parseMaxScrolls,
   unwrapEvaluateResult,
   buildThreadSnapshotScript,
+  parseThreadMessages,
+  mergeThreadMessages,
 };

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -62,6 +62,35 @@ function parseMaxScrolls(value) {
   return scrolls;
 }
 
+// LinkedIn loads only the most recent ~20 messages of a thread on open. Older
+// history is fetched by replaying the messengerMessages GraphQL query with a
+// deliveredAt anchor: the oldest message seen so far, walked backward until a
+// page returns nothing.
+const MESSAGING_GRAPHQL_BASE = 'https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql';
+const OLDER_THREAD_QUERY_ID = 'messengerMessages.d8ea76885a52fd5dc5c317078ab7c977';
+
+function oldestDeliveredAt(messages) {
+  let oldest = 0;
+  for (const message of messages || []) {
+    const at = Number(message && message.createdAt);
+    if (at > 0 && (oldest === 0 || at < oldest)) oldest = at;
+  }
+  return oldest;
+}
+
+function buildOlderThreadPageUrl(recentUrl, deliveredAt) {
+  // The recent messengerMessages request carries variables=(conversationUrn:<urn>)
+  // with the conversationUrn already RestLi-encoded. Reuse that encoded value
+  // verbatim and splice in a deliveredAt anchor; LinkedIn keeps the structural
+  // ( ) , : literal, so only plain integers are appended.
+  const match = String(recentUrl || '').match(/variables=\(conversationUrn:([^&]+)\)/);
+  if (!match || !match[1]) return '';
+  if (!Number.isInteger(deliveredAt) || deliveredAt <= 0) return '';
+  return MESSAGING_GRAPHQL_BASE + '?queryId=' + OLDER_THREAD_QUERY_ID
+    + '&variables=(deliveredAt:' + deliveredAt + ',conversationUrn:' + match[1]
+    + ',countBefore:20,countAfter:0)';
+}
+
 function collectThreadMessageUrlsScript() {
   return String.raw`(() => Array.from(new Set(
     performance.getEntriesByType('resource')
@@ -90,27 +119,6 @@ function fetchThreadPagesScript(urls, csrf) {
       }
     }
     return out;
-  })()`;
-}
-
-function scrollThreadMessagePaneScript() {
-  return String.raw`(() => {
-    const candidates = [
-      '.msg-s-message-list-scrollable',
-      '.msg-s-message-list',
-      '.msg-thread',
-      'main [role="main"]',
-      'main'
-    ];
-    let scroller = null;
-    for (const selector of candidates) {
-      const el = document.querySelector(selector);
-      if (el && (el.scrollHeight > el.clientHeight || selector === 'main')) { scroller = el; break; }
-    }
-    scroller = scroller || document.scrollingElement || document.documentElement;
-    scroller.scrollTop = 0;
-    window.scrollTo(0, 0);
-    return { scrollTop: scroller.scrollTop, scrollHeight: scroller.scrollHeight || 0, clientHeight: scroller.clientHeight || 0 };
   })()`;
 }
 
@@ -297,13 +305,13 @@ cli({
   site: 'linkedin',
   name: 'thread-snapshot',
   access: 'read',
-  description: 'Load a LinkedIn messaging thread, scroll for available history, and return a full context snapshot',
+  description: 'Load a LinkedIn messaging thread, page through its full history, and return a context snapshot',
   domain: LINKEDIN_DOMAIN,
   strategy: Strategy.UI,
   browser: true,
   args: [
     { name: 'thread-url', required: true, help: 'Exact LinkedIn messaging thread URL to open and snapshot' },
-    { name: 'max-scrolls', type: 'number', default: 30, help: 'Maximum upward scroll attempts to load older messages' },
+    { name: 'max-scrolls', type: 'number', default: 30, help: 'Maximum older-history pages to fetch (about 20 messages each)' },
     { name: 'json', type: 'bool', default: false, help: 'Return only JSON snapshot string in the snapshot_json field' },
   ],
   columns: ['thread_url', 'recipient', 'message_count', 'latest_text', 'snapshot_json'],
@@ -325,29 +333,37 @@ cli({
     }
     const csrf = jsession.replace(/^\"|\"$/g, '');
 
-    const fetchedUrls = new Set();
+    // Capture the recent messengerMessages request the page fired on load, then
+    // page backward through older history with the deliveredAt-anchored query.
+    const recentUrls = unwrapEvaluateResult(await page.evaluate(collectThreadMessageUrlsScript()));
+    const recentUrl = (Array.isArray(recentUrls) ? recentUrls : [])
+      .find((url) => /variables=\(conversationUrn:/.test(url) && !/deliveredAt/.test(url));
+
     const apiPageJsons = [];
-    let stablePasses = 0;
-    for (let i = 0; i <= maxScrolls; i += 1) {
-      if (i > 0) {
-        await page.evaluate(scrollThreadMessagePaneScript());
-        await page.wait(1);
+    const fetchThreadPage = async (pageUrl) => {
+      const fetched = unwrapEvaluateResult(await page.evaluate(fetchThreadPagesScript([pageUrl], csrf)));
+      const entry = (Array.isArray(fetched) ? fetched : [])[0];
+      if (entry && entry.authRequired) {
+        throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn messengerMessages API authentication failed: ' + (entry.error || 'auth required'));
       }
-      const seenUrls = unwrapEvaluateResult(await page.evaluate(collectThreadMessageUrlsScript()));
-      const newUrls = (Array.isArray(seenUrls) ? seenUrls : []).filter((u) => !fetchedUrls.has(u));
-      if (newUrls.length === 0) {
-        stablePasses += 1;
-        if (i > 0 && stablePasses >= 3) break;
-        continue;
-      }
-      stablePasses = 0;
-      for (const url of newUrls) fetchedUrls.add(url);
-      const fetchedPages = unwrapEvaluateResult(await page.evaluate(fetchThreadPagesScript(newUrls, csrf)));
-      for (const entry of Array.isArray(fetchedPages) ? fetchedPages : []) {
-        if (entry && entry.authRequired) {
-          throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn messengerMessages API authentication failed: ' + (entry.error || 'auth required'));
+      return entry && entry.json ? entry.json : null;
+    };
+
+    if (recentUrl) {
+      const recentJson = await fetchThreadPage(recentUrl);
+      if (recentJson) {
+        apiPageJsons.push(recentJson);
+        let anchor = oldestDeliveredAt(parseThreadMessages(recentJson));
+        for (let i = 0; i < maxScrolls && anchor > 0; i += 1) {
+          const olderUrl = buildOlderThreadPageUrl(recentUrl, anchor);
+          if (!olderUrl) break;
+          const olderJson = await fetchThreadPage(olderUrl);
+          if (!olderJson) break;
+          const next = oldestDeliveredAt(parseThreadMessages(olderJson));
+          if (next <= 0 || next >= anchor) break;
+          apiPageJsons.push(olderJson);
+          anchor = next;
         }
-        if (entry && entry.json) apiPageJsons.push(entry.json);
       }
     }
 
@@ -404,6 +420,8 @@ export const __test__ = {
   buildThreadSnapshotScript,
   collectThreadMessageUrlsScript,
   fetchThreadPagesScript,
+  buildOlderThreadPageUrl,
+  oldestDeliveredAt,
   parseThreadMessages,
   mergeThreadMessages,
 };

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -78,17 +78,62 @@ function oldestDeliveredAt(messages) {
   return oldest;
 }
 
-function buildOlderThreadPageUrl(recentUrl, deliveredAt) {
-  // The recent messengerMessages request carries variables=(conversationUrn:<urn>)
-  // with the conversationUrn already RestLi-encoded. Reuse that encoded value
-  // verbatim and splice in a deliveredAt anchor; LinkedIn keeps the structural
-  // ( ) , : literal, so only plain integers are appended.
+function buildOlderThreadPageUrl(recentUrl, deliveredAt, discoveredUrl) {
+  if (!Number.isInteger(deliveredAt) || deliveredAt <= 0) return '';
+  // Preferred: an older-history request LinkedIn itself fired after the scroll.
+  // It carries LinkedIn's current persisted-query id, so re-anchoring its
+  // deliveredAt survives LinkedIn rotating that id on a redeploy.
+  if (discoveredUrl && /messengerMessages/.test(discoveredUrl) && /deliveredAt/.test(discoveredUrl)) {
+    return discoveredUrl.replace(/deliveredAt(%3[Aa]|:)\d+/, 'deliveredAt$1' + deliveredAt);
+  }
+  // Fallback: construct from a known query id and the recent request's already
+  // RestLi-encoded conversationUrn (LinkedIn keeps the structural ( ) , : literal).
   const match = String(recentUrl || '').match(/variables=\(conversationUrn:([^&]+)\)/);
   if (!match || !match[1]) return '';
-  if (!Number.isInteger(deliveredAt) || deliveredAt <= 0) return '';
   return MESSAGING_GRAPHQL_BASE + '?queryId=' + OLDER_THREAD_QUERY_ID
     + '&variables=(deliveredAt:' + deliveredAt + ',conversationUrn:' + match[1]
     + ',countBefore:20,countAfter:0)';
+}
+
+function threadPaneCenterScript() {
+  return String.raw`(() => {
+    const panes = Array.from(document.querySelectorAll('*')).filter((el) => {
+      let s;
+      try { s = getComputedStyle(el); } catch (e) { return false; }
+      return (s.overflowY === 'auto' || s.overflowY === 'scroll')
+        && el.scrollHeight > el.clientHeight + 20
+        && typeof el.querySelector === 'function'
+        && el.querySelector('.msg-s-event-listitem');
+    });
+    const pane = panes.sort((a, b) => b.scrollHeight - a.scrollHeight)[0];
+    if (!pane) return null;
+    const rect = pane.getBoundingClientRect();
+    return { x: Math.round(rect.x + rect.width / 2), y: Math.round(rect.y + rect.height / 2) };
+  })()`;
+}
+
+// LinkedIn lazy-loads older messages (firing its older-history query) only when
+// the thread pane has a real height and gets a genuine scroll. The automation
+// viewport can be tiny, so widen it via CDP and wheel the pane up a few times;
+// the older-history request this triggers is read back from the Performance API
+// to discover LinkedIn's current persisted-query id.
+async function provokeOlderHistoryQuery(page) {
+  if (typeof page.cdp !== 'function') return;
+  try {
+    await page.cdp('Emulation.setDeviceMetricsOverride', { width: 1280, height: 2000, deviceScaleFactor: 1, mobile: false });
+  } catch {
+    return;
+  }
+  const pane = unwrapEvaluateResult(await page.evaluate(threadPaneCenterScript()));
+  if (!pane || typeof pane.x !== 'number') return;
+  for (let i = 0; i < 6; i += 1) {
+    try {
+      await page.cdp('Input.dispatchMouseEvent', { type: 'mouseWheel', x: pane.x, y: pane.y, deltaX: 0, deltaY: -600 });
+    } catch {
+      return;
+    }
+    await page.wait(1);
+  }
 }
 
 function collectThreadMessageUrlsScript() {
@@ -333,13 +378,19 @@ cli({
     }
     const csrf = jsession.replace(/^\"|\"$/g, '');
 
-    // Capture the recent messengerMessages request the page fired on load, then
-    // page backward through older history with the deliveredAt-anchored query.
-    const recentUrls = unwrapEvaluateResult(await page.evaluate(collectThreadMessageUrlsScript()));
-    const recentUrl = (Array.isArray(recentUrls) ? recentUrls : [])
+    // Provoke LinkedIn's older-history request so its current persisted-query id
+    // can be discovered, then capture every messengerMessages request the page
+    // has made and page backward through history with the deliveredAt anchor.
+    await provokeOlderHistoryQuery(page);
+    const seenUrls = unwrapEvaluateResult(await page.evaluate(collectThreadMessageUrlsScript()));
+    const messageUrls = Array.isArray(seenUrls) ? seenUrls : [];
+    const recentUrl = messageUrls
       .find((url) => /variables=\(conversationUrn:/.test(url) && !/deliveredAt/.test(url));
+    const discoveredOlderUrl = messageUrls
+      .find((url) => /messengerMessages/.test(url) && /deliveredAt/.test(url));
 
     const apiPageJsons = [];
+    let historyComplete = true;
     const fetchThreadPage = async (pageUrl) => {
       const fetched = unwrapEvaluateResult(await page.evaluate(fetchThreadPagesScript([pageUrl], csrf)));
       const entry = (Array.isArray(fetched) ? fetched : [])[0];
@@ -355,10 +406,10 @@ cli({
         apiPageJsons.push(recentJson);
         let anchor = oldestDeliveredAt(parseThreadMessages(recentJson));
         for (let i = 0; i < maxScrolls && anchor > 0; i += 1) {
-          const olderUrl = buildOlderThreadPageUrl(recentUrl, anchor);
+          const olderUrl = buildOlderThreadPageUrl(recentUrl, anchor, discoveredOlderUrl);
           if (!olderUrl) break;
           const olderJson = await fetchThreadPage(olderUrl);
-          if (!olderJson) break;
+          if (!olderJson) { historyComplete = false; break; }
           const next = oldestDeliveredAt(parseThreadMessages(olderJson));
           if (next <= 0 || next >= anchor) break;
           apiPageJsons.push(olderJson);
@@ -399,6 +450,7 @@ cli({
       latestMessageText: normalizeWhitespace(mergedMessages[mergedMessages.length - 1]?.text || snapshot?.latestMessageText || ''),
       messages: mergedMessages,
       capturedApiPageCount: apiPageJsons.length,
+      historyComplete,
     };
 
     return [{

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -7,6 +7,12 @@ function normalizeWhitespace(value) {
   return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+function cleanPersonName(value) {
+  return normalizeWhitespace(value)
+    .replace(/\s+(?:status is (?:online|reachable|away|offline)\b|active(?:\s+now|\s+\S+)?\b|view profile\b).*$/i, '')
+    .trim();
+}
+
 function unwrapEvaluateResult(payload) {
   if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
   return payload;
@@ -63,6 +69,7 @@ function buildThreadSnapshotScript(maxScrolls) {
     void marker;
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
     const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const cleanPersonName = (s) => clean(s).replace(/\s+(?:status is (?:online|reachable|away|offline)\b|active(?:\s+now|\s+\S+)?\b|view profile\b).*$/i, '').trim();
     const text = document.body ? (document.body.innerText || '') : '';
     const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
       || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
@@ -108,7 +115,7 @@ function buildThreadSnapshotScript(maxScrolls) {
     ];
     for (const selector of headerSelectors) {
       for (const el of Array.from(document.querySelectorAll(selector)).slice(0, 8)) {
-        const value = clean(el.innerText || el.textContent || el.getAttribute('aria-label'));
+        const value = cleanPersonName(el.innerText || el.textContent || el.getAttribute('aria-label'));
         if (value && value.length <= 120 && !/^(message|messaging|send|profile|view profile)$/i.test(value)) {
           headerCandidates.push(value);
         }
@@ -117,14 +124,30 @@ function buildThreadSnapshotScript(maxScrolls) {
 
     const seen = new Set();
     const messages = [];
-    const nodes = Array.from(document.querySelectorAll('.msg-s-message-list__event, .msg-s-event-listitem, [data-event-urn], .msg-s-message-list-content'));
+    let currentSpeaker = '';
+    const nodes = Array.from(document.querySelectorAll('.msg-s-event-listitem'));
     for (const [nodeIndex, el] of nodes.entries()) {
-      const raw = clean(el.innerText || el.textContent);
-      if (!raw || seen.has(raw)) continue;
-      seen.add(raw);
-      const lines = raw.split(/\n+/).map(clean).filter(Boolean);
-      const speaker = lines.length > 1 && lines[0].length <= 120 ? lines[0] : '';
-      messages.push({ index: messages.length, nodeIndex, speaker, text: raw });
+      const speakerEl = el.querySelector('.msg-s-message-group__name');
+      const speaker = cleanPersonName(speakerEl?.innerText || speakerEl?.textContent || '');
+      if (speaker) currentSpeaker = speaker;
+      const bodyEl = el.querySelector('.msg-s-event-listitem__body');
+      const body = clean(bodyEl?.innerText || bodyEl?.textContent || '');
+      if (!body) continue;
+      const key = currentSpeaker + '\n' + body;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      messages.push({ index: messages.length, nodeIndex, speaker: currentSpeaker, text: body });
+    }
+    if (messages.length === 0) {
+      const fallbackNodes = Array.from(document.querySelectorAll('.msg-s-message-list__event, [data-event-urn]'));
+      for (const [nodeIndex, el] of fallbackNodes.entries()) {
+        const raw = clean(el.innerText || el.textContent);
+        if (!raw) continue;
+        const key = '\n' + raw;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        messages.push({ index: messages.length, nodeIndex, speaker: '', text: raw });
+      }
     }
 
     const refreshedText = document.body ? (document.body.innerText || '') : '';
@@ -185,7 +208,7 @@ cli({
       throw new CommandExecutionError('LinkedIn thread-snapshot blocked: thread_url_mismatch', `Expected ${threadUrl}; actual ${actualUrl}`);
     }
 
-    const recipient = normalizeWhitespace(snapshot.headerNames[0] || '');
+    const recipient = cleanPersonName(snapshot.headerNames[0] || '');
     const messageCount = snapshot.messages.length;
     const normalized = {
       ...snapshot,
@@ -207,6 +230,7 @@ cli({
 
 export const __test__ = {
   normalizeWhitespace,
+  cleanPersonName,
   canonicalizeLinkedInThreadUrl,
   parseMaxScrolls,
   unwrapEvaluateResult,

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -253,7 +253,7 @@ function buildThreadSnapshotScript(maxScrolls) {
       const speaker = cleanPersonName(speakerEl?.innerText || speakerEl?.textContent || '');
       if (speaker) currentSpeaker = speaker;
       const bodyEl = el.querySelector('.msg-s-event-listitem__body');
-      const body = clean(bodyEl?.innerText || bodyEl?.textContent || '');
+      const body = clean(bodyEl?.innerText || bodyEl?.textContent || '').replace(/\s*\(edited\)$/i, '');
       if (!body) continue;
       const key = currentSpeaker + '\n' + body;
       if (seen.has(key)) continue;

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -4,13 +4,21 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
 
-const { buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, mergeThreadMessages, parseMaxScrolls, parseThreadMessages } = await import('./thread-snapshot.js').then((m) => m.__test__);
+const { buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, collectThreadMessageUrlsScript, fetchThreadPagesScript, mergeThreadMessages, parseMaxScrolls, parseThreadMessages } = await import('./thread-snapshot.js').then((m) => m.__test__);
 
-function makeFakePage(snapshot) {
+function makeFakePage(snapshot, { urls = [], pages = [] } = {}) {
   return {
     goto: vi.fn(async () => undefined),
     wait: vi.fn(async () => undefined),
-    evaluate: vi.fn(async () => snapshot),
+    getCookies: vi.fn(async () => [{ name: 'JSESSIONID', value: 'ajax:123' }]),
+    evaluate: vi.fn(async (script) => {
+      const source = String(script || '');
+      if (source.includes('setResourceTimingBufferSize')) return undefined;
+      if (source.includes('messengerMessages') && source.includes('getEntriesByType')) return urls;
+      if (source.includes('fetch(url')) return pages.map((json, index) => ({ url: urls[index] || `https://www.linkedin.com/voyager/api/messaging/messengerMessages.${index}`, json }));
+      if (source.includes('__OPENCLI_LINKEDIN_THREAD_SNAPSHOT__')) return snapshot;
+      return undefined;
+    }),
   };
 }
 
@@ -68,6 +76,15 @@ describe('linkedin thread-snapshot command', () => {
 
 
 
+
+  it('builds Performance API collection and in-page refetch scripts for messengerMessages pages', () => {
+    expect(collectThreadMessageUrlsScript()).toContain("performance.getEntriesByType('resource')");
+    expect(collectThreadMessageUrlsScript()).toContain('messengerMessages');
+    const fetchScript = fetchThreadPagesScript(['https://www.linkedin.com/voyager/api/messaging/messengerMessages?q=x'], 'ajax:123');
+    expect(fetchScript).toContain('\'csrf-token\': "ajax:123"');
+    expect(fetchScript).toContain("accept: 'application/vnd.linkedin.normalized+json+2.1'");
+  });
+
   it('parses and merges captured messengerMessages pages oldest first', () => {
     const normalized = {
       included: [
@@ -120,6 +137,14 @@ describe('linkedin thread-snapshot command', () => {
         { index: 0, speaker: 'Neha Rudraraju', text: 'damn i just saw ur msg sry sry' },
         { index: 1, speaker: 'Me', text: 'safe-send test from hermes. pls ignore :)' },
       ],
+    }, {
+      urls: ['https://www.linkedin.com/voyager/api/messaging/messengerMessages?q=thread'],
+      pages: [{
+        included: [
+          { $type: 'com.linkedin.messenger.MessagingParticipant', entityUrn: 'urn:li:msg_messagingParticipant:P1', participantType: { member: { firstName: { text: 'Neha' }, lastName: { text: 'Rudraraju' } } } },
+          { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M0', deliveredAt: 500, '*senderParticipant': 'urn:li:msg_messagingParticipant:P1', body: { text: 'real conversation opener' } },
+        ],
+      }],
     });
 
     const rows = await command.func(page, {
@@ -133,10 +158,11 @@ describe('linkedin thread-snapshot command', () => {
     expect(rows[0]).toMatchObject({
       thread_url: 'https://www.linkedin.com/messaging/thread/abc/',
       recipient: 'Neha Rudraraju',
-      message_count: 2,
+      message_count: 3,
       latest_text: 'safe-send test from hermes. pls ignore :)',
     });
-    expect(rows[0].snapshot_json).toContain('damn i just saw ur msg sry sry');
+    expect(rows[0].snapshot_json).toContain('real conversation opener');
+    expect(JSON.parse(rows[0].snapshot_json).capturedApiPageCount).toBe(1);
   });
 
   it('rejects invalid thread URL before navigation', async () => {

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -137,6 +137,9 @@ describe('linkedin thread-snapshot command', () => {
     expect(older).toContain('deliveredAt:1776742893955');
     expect(older).toContain('conversationUrn:urn%3Ali%3Amsg_conversation%3A%28ABC%29');
     expect(older).toContain('countBefore:20,countAfter:0');
+    const discovered = 'https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.NEWID&variables=(deliveredAt:111,conversationUrn:urn%3Ax,countBefore:20,countAfter:0)';
+    expect(buildOlderThreadPageUrl(recentUrl, 555, discovered)).toContain('queryId=messengerMessages.NEWID');
+    expect(buildOlderThreadPageUrl(recentUrl, 555, discovered)).toContain('deliveredAt:555');
     expect(buildOlderThreadPageUrl('https://example.com/no-conversation-urn', 123)).toBe('');
     expect(buildOlderThreadPageUrl(recentUrl, 0)).toBe('');
     expect(oldestDeliveredAt([{ createdAt: 500 }, { createdAt: 300 }, { createdAt: 0 }])).toBe(300);
@@ -161,7 +164,7 @@ describe('linkedin thread-snapshot command', () => {
       urls: [recentUrl],
       pageFor: (url) => {
         if (/deliveredAt:500,/.test(url)) return olderPage;
-        if (/deliveredAt:300,/.test(url)) return null;
+        if (/deliveredAt:300,/.test(url)) return { included: [] };
         if (url === recentUrl) return recentPage;
         return null;
       },
@@ -183,6 +186,7 @@ describe('linkedin thread-snapshot command', () => {
     });
     expect(rows[0].snapshot_json).toContain('real conversation opener');
     expect(JSON.parse(rows[0].snapshot_json).capturedApiPageCount).toBe(2);
+    expect(JSON.parse(rows[0].snapshot_json).historyComplete).toBe(true);
   });
 
   it('rejects invalid thread URL before navigation', async () => {

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
 
-const { canonicalizeLinkedInThreadUrl, parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
+const { buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
 
 function makeFakePage(snapshot) {
   return {
@@ -14,6 +15,57 @@ function makeFakePage(snapshot) {
 }
 
 describe('linkedin thread-snapshot command', () => {
+  it('strips LinkedIn presence and profile cruft from person names', () => {
+    expect(cleanPersonName('Eugene Huo Status is online Active now')).toBe('Eugene Huo');
+    expect(cleanPersonName('Eugene Huo active 2h')).toBe('Eugene Huo');
+    expect(cleanPersonName('Eugene Huo View profile')).toBe('Eugene Huo');
+    expect(cleanPersonName('  Eugene\u00a0Huo  ')).toBe('Eugene Huo');
+  });
+
+  it('extracts non-overlapping event-listitem message bodies with carried speakers', async () => {
+    const dom = new JSDOM(`<!doctype html><body>
+      <main>
+        <h1>Eugene Huo Status is online Active now</h1>
+        <div class="msg-s-message-list">
+          <div class="msg-s-event-listitem" data-event-urn="1">
+            <div class="msg-s-message-group__name">Hanzi Li</div>
+            <div class="msg-s-event-listitem__body">hey eugene</div>
+          </div>
+          <div class="msg-s-event-listitem" data-event-urn="2">
+            <div class="msg-s-event-listitem__body">following up with a clean body</div>
+          </div>
+          <div class="msg-s-event-listitem" data-event-urn="3">
+            <div class="msg-s-message-group__name">Eugene Huo</div>
+            <div class="msg-s-event-listitem__body">sounds good</div>
+          </div>
+          <div class="msg-s-message-list__event"><div class="msg-s-event-listitem__body">duplicate selector should not be read</div></div>
+        </div>
+      </main>
+    </body>`, { url: 'https://www.linkedin.com/messaging/thread/abc/' });
+    Object.defineProperty(dom.window.document, 'title', { value: 'Messaging | LinkedIn' });
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    const previousLocation = globalThis.location;
+    try {
+      globalThis.window = dom.window;
+      globalThis.document = dom.window.document;
+      globalThis.location = dom.window.location;
+      const runSnapshotScript = Function(`return ${buildThreadSnapshotScript(0)}`);
+      const snapshot = await runSnapshotScript();
+      expect(snapshot.headerNames[0]).toBe('Eugene Huo');
+      expect(snapshot.latestMessageText).toBe('sounds good');
+      expect(snapshot.messages).toEqual([
+        { index: 0, nodeIndex: 0, speaker: 'Hanzi Li', text: 'hey eugene' },
+        { index: 1, nodeIndex: 1, speaker: 'Hanzi Li', text: 'following up with a clean body' },
+        { index: 2, nodeIndex: 2, speaker: 'Eugene Huo', text: 'sounds good' },
+      ]);
+    } finally {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+      globalThis.location = previousLocation;
+    }
+  });
+
   it('accepts only exact LinkedIn messaging thread URLs', () => {
     expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/2-abc==/?mini=true#x'))
       .toBe('https://www.linkedin.com/messaging/thread/2-abc==/');

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -4,7 +4,7 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
 
-const { buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
+const { buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, mergeThreadMessages, parseMaxScrolls, parseThreadMessages } = await import('./thread-snapshot.js').then((m) => m.__test__);
 
 function makeFakePage(snapshot) {
   return {
@@ -64,6 +64,27 @@ describe('linkedin thread-snapshot command', () => {
       globalThis.document = previousDocument;
       globalThis.location = previousLocation;
     }
+  });
+
+
+
+  it('parses and merges captured messengerMessages pages oldest first', () => {
+    const normalized = {
+      included: [
+        {
+          $type: 'com.linkedin.messenger.MessagingParticipant',
+          entityUrn: 'urn:li:msg_messagingParticipant:P1',
+          participantType: { member: { firstName: { text: 'Neha' }, lastName: { text: 'Rudraraju' } } },
+        },
+        { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M2', createdAt: 2000, '*sender': 'urn:li:msg_messagingParticipant:P1', body: { text: 'second message' } },
+        { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M1', createdAt: 1000, '*sender': 'urn:li:msg_messagingParticipant:P1', body: { text: 'first message' } },
+      ],
+    };
+    const apiMessages = parseThreadMessages(normalized);
+    expect(apiMessages.map((message) => message.text)).toEqual(['first message', 'second message']);
+    expect(apiMessages[0].speaker).toBe('Neha Rudraraju');
+    const merged = mergeThreadMessages(apiMessages, [{ index: 0, speaker: 'Neha Rudraraju', text: 'second message' }]);
+    expect(merged.map((message) => message.text)).toEqual(['first message', 'second message']);
   });
 
   it('accepts only exact LinkedIn messaging thread URLs', () => {

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -4,9 +4,9 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
 
-const { buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, collectThreadMessageUrlsScript, fetchThreadPagesScript, mergeThreadMessages, parseMaxScrolls, parseThreadMessages } = await import('./thread-snapshot.js').then((m) => m.__test__);
+const { buildOlderThreadPageUrl, buildThreadSnapshotScript, canonicalizeLinkedInThreadUrl, cleanPersonName, collectThreadMessageUrlsScript, fetchThreadPagesScript, mergeThreadMessages, oldestDeliveredAt, parseMaxScrolls, parseThreadMessages } = await import('./thread-snapshot.js').then((m) => m.__test__);
 
-function makeFakePage(snapshot, { urls = [], pages = [] } = {}) {
+function makeFakePage(snapshot, { urls = [], pageFor = () => null } = {}) {
   return {
     goto: vi.fn(async () => undefined),
     wait: vi.fn(async () => undefined),
@@ -15,7 +15,11 @@ function makeFakePage(snapshot, { urls = [], pages = [] } = {}) {
       const source = String(script || '');
       if (source.includes('setResourceTimingBufferSize')) return undefined;
       if (source.includes('messengerMessages') && source.includes('getEntriesByType')) return urls;
-      if (source.includes('fetch(url')) return pages.map((json, index) => ({ url: urls[index] || `https://www.linkedin.com/voyager/api/messaging/messengerMessages.${index}`, json }));
+      if (source.includes('fetch(url')) {
+        const match = source.match(/const urls = (\[[\s\S]*?\]);/);
+        const requested = match ? JSON.parse(match[1]) : [];
+        return requested.map((url) => ({ url, json: pageFor(url) })).filter((entry) => entry.json);
+      }
       if (source.includes('__OPENCLI_LINKEDIN_THREAD_SNAPSHOT__')) return snapshot;
       return undefined;
     }),
@@ -127,8 +131,24 @@ describe('linkedin thread-snapshot command', () => {
     expect(command.columns).toEqual(expect.arrayContaining(['thread_url', 'recipient', 'message_count', 'latest_text']));
   });
 
-  it('opens messaging first, then exact thread, and returns extracted messages', async () => {
+  it('builds deliveredAt-anchored older-page URLs and finds the oldest timestamp', () => {
+    const recentUrl = 'https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.5846eeb7&variables=(conversationUrn:urn%3Ali%3Amsg_conversation%3A%28ABC%29)';
+    const older = buildOlderThreadPageUrl(recentUrl, 1776742893955);
+    expect(older).toContain('deliveredAt:1776742893955');
+    expect(older).toContain('conversationUrn:urn%3Ali%3Amsg_conversation%3A%28ABC%29');
+    expect(older).toContain('countBefore:20,countAfter:0');
+    expect(buildOlderThreadPageUrl('https://example.com/no-conversation-urn', 123)).toBe('');
+    expect(buildOlderThreadPageUrl(recentUrl, 0)).toBe('');
+    expect(oldestDeliveredAt([{ createdAt: 500 }, { createdAt: 300 }, { createdAt: 0 }])).toBe(300);
+    expect(oldestDeliveredAt([])).toBe(0);
+  });
+
+  it('opens messaging first, then pages through full thread history', async () => {
     const command = getRegistry().get('linkedin/thread-snapshot');
+    const recentUrl = 'https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.5846eeb7&variables=(conversationUrn:urn%3Ali%3Amsg_conversation%3A%28ABC%29)';
+    const participant = { $type: 'com.linkedin.messenger.MessagingParticipant', entityUrn: 'urn:li:msg_messagingParticipant:P1', participantType: { member: { firstName: { text: 'Neha' }, lastName: { text: 'Rudraraju' } } } };
+    const recentPage = { included: [participant, { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M1', deliveredAt: 500, '*senderParticipant': 'urn:li:msg_messagingParticipant:P1', body: { text: 'recent reply' } }] };
+    const olderPage = { included: [participant, { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M0', deliveredAt: 300, '*senderParticipant': 'urn:li:msg_messagingParticipant:P1', body: { text: 'real conversation opener' } }] };
     const page = makeFakePage({
       url: 'https://www.linkedin.com/messaging/thread/abc/',
       headerNames: ['Neha Rudraraju'],
@@ -138,13 +158,13 @@ describe('linkedin thread-snapshot command', () => {
         { index: 1, speaker: 'Me', text: 'safe-send test from hermes. pls ignore :)' },
       ],
     }, {
-      urls: ['https://www.linkedin.com/voyager/api/messaging/messengerMessages?q=thread'],
-      pages: [{
-        included: [
-          { $type: 'com.linkedin.messenger.MessagingParticipant', entityUrn: 'urn:li:msg_messagingParticipant:P1', participantType: { member: { firstName: { text: 'Neha' }, lastName: { text: 'Rudraraju' } } } },
-          { $type: 'com.linkedin.messenger.Message', entityUrn: 'urn:li:msg_message:M0', deliveredAt: 500, '*senderParticipant': 'urn:li:msg_messagingParticipant:P1', body: { text: 'real conversation opener' } },
-        ],
-      }],
+      urls: [recentUrl],
+      pageFor: (url) => {
+        if (/deliveredAt:500,/.test(url)) return olderPage;
+        if (/deliveredAt:300,/.test(url)) return null;
+        if (url === recentUrl) return recentPage;
+        return null;
+      },
     });
 
     const rows = await command.func(page, {
@@ -158,11 +178,11 @@ describe('linkedin thread-snapshot command', () => {
     expect(rows[0]).toMatchObject({
       thread_url: 'https://www.linkedin.com/messaging/thread/abc/',
       recipient: 'Neha Rudraraju',
-      message_count: 3,
+      message_count: 4,
       latest_text: 'safe-send test from hermes. pls ignore :)',
     });
     expect(rows[0].snapshot_json).toContain('real conversation opener');
-    expect(JSON.parse(rows[0].snapshot_json).capturedApiPageCount).toBe(1);
+    expect(JSON.parse(rows[0].snapshot_json).capturedApiPageCount).toBe(2);
   });
 
   it('rejects invalid thread URL before navigation', async () => {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -148,6 +148,18 @@ export class Page extends BasePage {
     try {
       return await sendCommand('exec', { code, ...this._cmdOpts() });
     } catch (err) {
+      // A "stale page identity" means the cached page handle is dead — the tab
+      // was re-identified (e.g. a SPA client-side navigation re-keyed it). The
+      // tab and its JS state still exist; only our handle is stale. Drop it so
+      // _cmdOpts() omits `page` and the bridge re-resolves the active tab, then
+      // retry. Without this, long-running scroll/evaluate commands die mid-run.
+      const message = err instanceof Error ? err.message : String(err);
+      if (/stale page identity|Page not found/i.test(message)) {
+        this._page = undefined;
+        this._lastUrl = null;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return sendCommand('exec', { code, ...this._cmdOpts() });
+      }
       const advice = classifyBrowserError(err);
       if (advice.kind !== 'target-navigation') throw err;
       await new Promise((resolve) => setTimeout(resolve, advice.delayMs));


### PR DESCRIPTION
## Summary

Follow-up fixes and Sales Navigator messaging additions for the LinkedIn commands.

- Add `linkedin salesnav-search` for Sales Navigator lead search.
- Add `linkedin salesnav-message` for Sales Navigator InMail API validation and explicit-send delivery.
- Add read-only `linkedin salesnav-inbox`, backed by `salesApiMessagingThreads`, with API pagination across the Sales Navigator inbox.
- Add read-only `linkedin salesnav-thread`, backed by `salesApiMessagingThreads/<thread>`, for full message history by thread id, Sales Navigator inbox URL, lead URL, recipient urn, or exact recipient name.
- Preserve the Sales Navigator Rest.li decoration gotcha: decoration parentheses are percent-encoded as `%28` and `%29` to avoid HTTP 400.
- Keep the earlier LinkedIn messaging fixes in this branch: regular inbox pagination, thread-snapshot full-history pagination, sent-invitations cleanup, and stale page identity recovery.

## Test plan

Local gates pass:

- `npm run test:adapter -- clis/linkedin/salesnav-inbox.test.js clis/linkedin/salesnav-thread.test.js clis/linkedin/salesnav-search.test.js clis/linkedin/salesnav-message.test.js`
- `npm run build`
- `npm run check:silent-column-drop`
- `npm run check:typed-error-lint`
- `npm run typecheck`

Live Sales Navigator smoke tests passed against a logged-in session:

- `node dist/src/main.js linkedin salesnav-inbox --limit 3 -f json`
- `node dist/src/main.js linkedin salesnav-thread 'Rachael Stolberg' --limit 10 -f json`

🤖 Generated with Hermes / Claude Code orchestration
