### PR TITLE
fix(adapters): drop silent-sentinel row fallbacks across Apple Podcasts, Reddit, and Gitee

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14766,6 +14766,42 @@
   },
   {
     "site": "linkedin",
+    "name": "people-search",
+    "description": "Search standard LinkedIn (not Sales Navigator) for people by keyword. Each invocation consumes against LinkedIn's monthly Commercial Use Limit on people search; throttle accordingly.",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "keywords",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "People search keywords, e.g. \"site reliability engineer berlin\""
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 5,
+        "required": false,
+        "help": "Maximum people to return (1-10); each query counts toward LinkedIn's monthly CUL"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "headline",
+      "location",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/people-search.js",
+    "sourceFile": "linkedin/people-search.js",
+    "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin",
     "name": "safe-send",
     "description": "Fail-closed LinkedIn message sender that verifies exact thread, recipient, and latest message before filling/sending",
     "access": "write",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14766,42 +14766,6 @@
   },
   {
     "site": "linkedin",
-    "name": "people-search",
-    "description": "Search standard LinkedIn (not Sales Navigator) for people by keyword. Each invocation consumes against LinkedIn's monthly Commercial Use Limit on people search; throttle accordingly.",
-    "access": "read",
-    "domain": "www.linkedin.com",
-    "strategy": "cookie",
-    "browser": true,
-    "args": [
-      {
-        "name": "keywords",
-        "type": "string",
-        "required": true,
-        "positional": true,
-        "help": "People search keywords, e.g. \"site reliability engineer berlin\""
-      },
-      {
-        "name": "limit",
-        "type": "int",
-        "default": 5,
-        "required": false,
-        "help": "Maximum people to return (1-10); each query counts toward LinkedIn's monthly CUL"
-      }
-    ],
-    "columns": [
-      "rank",
-      "name",
-      "headline",
-      "location",
-      "profile_url"
-    ],
-    "type": "js",
-    "modulePath": "linkedin/people-search.js",
-    "sourceFile": "linkedin/people-search.js",
-    "navigateBefore": "https://www.linkedin.com"
-  },
-  {
-    "site": "linkedin",
     "name": "safe-send",
     "description": "Fail-closed LinkedIn message sender that verifies exact thread, recipient, and latest message before filling/sending",
     "access": "write",

--- a/clis/apple-podcasts/commands.test.js
+++ b/clis/apple-podcasts/commands.test.js
@@ -41,6 +41,26 @@ describe('apple-podcasts search command', () => {
             }),
         ]);
     });
+    it('emits empty-string for missing trackCount and primaryGenreName instead of a sentinel', async () => {
+        const cmd = getRegistry().get('apple-podcasts/search');
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({
+                results: [
+                    {
+                        collectionId: 99,
+                        collectionName: 'No-Meta Show',
+                        artistName: 'Anon Host',
+                        collectionViewUrl: 'https://example.com/p/99',
+                    },
+                ],
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const result = await cmd.func({ query: 'no-meta', limit: 1 });
+        expect(result[0].episodes).toBe('');
+        expect(result[0].genre).toBe('');
+    });
 });
 describe('apple-podcasts top command', () => {
     beforeEach(() => {

--- a/clis/apple-podcasts/search.js
+++ b/clis/apple-podcasts/search.js
@@ -23,8 +23,8 @@ cli({
             id: p.collectionId,
             title: p.collectionName,
             author: p.artistName,
-            episodes: p.trackCount ?? '-',
-            genre: p.primaryGenreName ?? '-',
+            episodes: p.trackCount ?? '',
+            genre: p.primaryGenreName ?? '',
             url: p.collectionViewUrl || '',
         }));
     },

--- a/clis/gitee/search.js
+++ b/clis/gitee/search.js
@@ -123,8 +123,8 @@ cli({
             rows.push({
                 rank: rows.length + 1,
                 name,
-                language: normalizeText(getFirstText(fields.langs)) || '-',
-                description: normalizeText(getFirstText(fields.description)) || '-',
+                language: normalizeText(getFirstText(fields.langs)) || '',
+                description: normalizeText(getFirstText(fields.description)) || '',
                 stars: normalizeStars(fields['count.star']),
                 url: repoUrl,
             });

--- a/clis/gitee/search.test.js
+++ b/clis/gitee/search.test.js
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+
+function mockGiteeResponse(hits) {
+    return {
+        ok: true,
+        json: () => Promise.resolve({ hits: { hits } }),
+    };
+}
+
+function makePage() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+describe('gitee search', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('emits empty-string for missing language / description instead of a sentinel', async () => {
+        const cmd = getRegistry().get('gitee/search');
+        expect(cmd?.func).toBeTypeOf('function');
+        const fetchMock = vi.fn().mockResolvedValue(mockGiteeResponse([
+            {
+                fields: {
+                    title: 'someuser/no-meta-repo',
+                    url: 'https://gitee.com/someuser/no-meta-repo',
+                },
+            },
+        ]));
+        vi.stubGlobal('fetch', fetchMock);
+        const rows = await cmd.func(makePage(), { keyword: 'test', limit: 10 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].name).toBe('someuser/no-meta-repo');
+        expect(rows[0].language).toBe('');
+        expect(rows[0].description).toBe('');
+    });
+
+    it('passes through populated language / description verbatim', async () => {
+        const cmd = getRegistry().get('gitee/search');
+        const fetchMock = vi.fn().mockResolvedValue(mockGiteeResponse([
+            {
+                fields: {
+                    title: 'org/repo-a',
+                    url: 'https://gitee.com/org/repo-a',
+                    langs: 'TypeScript',
+                    description: 'A test repo',
+                    'count.star': '42',
+                },
+            },
+        ]));
+        vi.stubGlobal('fetch', fetchMock);
+        const rows = await cmd.func(makePage(), { keyword: 'test', limit: 10 });
+        expect(rows[0].language).toBe('TypeScript');
+        expect(rows[0].description).toBe('A test repo');
+        expect(rows[0].stars).toBe('42');
+    });
+});

--- a/clis/reddit/saved.js
+++ b/clis/reddit/saved.js
@@ -30,7 +30,7 @@ cli({
         });
         const d = await res.json();
         return (d?.data?.children || []).map(c => ({
-          title: c.data.title || c.data.body?.slice(0, 100) || '-',
+          title: c.data.title || c.data.body?.slice(0, 100) || '',
           subreddit: c.data.subreddit_name_prefixed || 'r/' + (c.data.subreddit || '?'),
           score: c.data.score || 0,
           comments: c.data.num_comments || 0,

--- a/clis/reddit/upvoted.js
+++ b/clis/reddit/upvoted.js
@@ -30,7 +30,7 @@ cli({
         });
         const d = await res.json();
         return (d?.data?.children || []).map(c => ({
-          title: c.data.title || '-',
+          title: c.data.title || '',
           subreddit: c.data.subreddit_name_prefixed || 'r/' + (c.data.subreddit || '?'),
           score: c.data.score || 0,
           comments: c.data.num_comments || 0,

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -819,7 +819,7 @@
     "rule": "silent-clamp",
     "command": "zhihu/collection",
     "file": "clis/zhihu/collection.js",
-    "line": 141,
+    "line": 154,
     "text": "const currentFetchLimit = Math.min(pageLimit, requestedLimit - collected.length);",
     "occurrence": 0
   },
@@ -827,7 +827,7 @@
     "rule": "silent-clamp",
     "command": "zhihu/collection",
     "file": "clis/zhihu/collection.js",
-    "line": 130,
+    "line": 143,
     "text": "const pageLimit = Math.min(requestedLimit, 20); // 知乎 API 限制每页最大 20",
     "occurrence": 0
   },
@@ -857,22 +857,6 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "apple-podcasts/search",
-    "file": "clis/apple-podcasts/search.js",
-    "line": 26,
-    "text": "episodes: p.trackCount ?? '-',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "apple-podcasts/search",
-    "file": "clis/apple-podcasts/search.js",
-    "line": 27,
-    "text": "genre: p.primaryGenreName ?? '-',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "bilibili/download",
     "file": "clis/bilibili/download.js",
     "line": 47,
@@ -885,22 +869,6 @@
     "file": "clis/boss/stats.js",
     "line": 39,
     "text": "const jobName = f.jobName || 'unknown';",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "gitee/search",
-    "file": "clis/gitee/search.js",
-    "line": 127,
-    "text": "description: normalizeText(getFirstText(fields.description)) || '-',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "gitee/search",
-    "file": "clis/gitee/search.js",
-    "line": 126,
-    "text": "language: normalizeText(getFirstText(fields.langs)) || '-',",
     "occurrence": 0
   },
   {
@@ -933,22 +901,6 @@
     "file": "clis/jimeng/history.js",
     "line": 30,
     "text": "prompt: params.prompt || item.common_attr?.title || 'N/A',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "reddit/saved",
-    "file": "clis/reddit/saved.js",
-    "line": 33,
-    "text": "title: c.data.title || c.data.body?.slice(0, 100) || '-',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "reddit/upvoted",
-    "file": "clis/reddit/upvoted.js",
-    "line": 33,
-    "text": "title: c.data.title || '-',",
     "occurrence": 0
   },
   {


### PR DESCRIPTION
## Description

Continues the audit-baseline cleanup from #1611 (lesswrong) and #1631 (wikipedia / 36kr / xiaoyuzhou / zhihu), aligned with the direction set by 71646158 (silent-empty-fallback resolutions across Douyin / Jike / WeRead) and ee54eb8e (ignore sentinels in thrown errors).

Replaces silent-sentinel row fallbacks with the empty-string signal so agents can tell apart "field has the literal value Unknown" from "upstream returned no value".

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

| Adapter | Field | Pattern |
|---------|-------|---------|
| `apple-podcasts/search` | episodes, genre | `?? '-'` to `?? ''` |
| `reddit/saved` | title | `\|\| '-'` to `\|\| ''` |
| `reddit/upvoted` | title | `\|\| '-'` to `\|\| ''` |
| `gitee/search` | language, description | `\|\| '-'` to `\|\| ''` |

All four files audited for downstream sentinel checks (`grep -nE "=== ?['\"](Unknown|unknown|-)['\"]"`); none reference the swapped values in control flow. This is the audit step that caught the v2ex/me.js regression in #1631 before merge.

### Intentionally skipped

- `gitee/trending.js:272`: downstream `project.description !== '-'` check drives the mergedDescription fallback. Same control-flow sentinel pattern as v2ex/me.js. Stays on baseline.
- `web/read.js` (4 entries): `'-'` lives inside `lines.push(...)` rendered diagnostic text, not row fields. Empty would render with doubled spaces.
- `yollomi/{edit,video}.js` (6 entries): `file: '-'`, `size: '-'`, `credits: '-'` are user-facing status rows. Empty would collapse columns visually.
- `zsxq/dynamics.js:31`: `title: '[${d.action || 'unknown'}]'` is a template-literal-rendered title prefix. Empty would render `[]`.

## Screenshots / Output

Smoke test on two of the touched commands (read-only, public):

```bash
$ opencli apple-podcasts search "lex fridman" --limit 2 -f json
[
  {
    "id": 1434243584,
    "title": "Lex Fridman Podcast",
    "author": "Lex Fridman",
    "episodes": 497,
    "genre": "Technology",
    "url": "https://podcasts.apple.com/us/podcast/lex-fridman-podcast/id1434243584?uo=4"
  },
  {
    "id": 1567129969,
    "title": "Lex Fridman Podcast | 5 minute podcast summaries",
    "author": "5 minute podcast summaries",
    "episodes": 18,
    "genre": "Technology",
    "url": "https://podcasts.apple.com/us/podcast/lex-fridman-podcast-5-minute-podcast-summaries/id1567129969?uo=4"
  }
]

$ opencli gitee search "vue" --limit 2 -f json
[
  {
    "rank": 1,
    "name": "XE/vxe-table",
    "language": "TypeScript",
    "description": "vxe table 支持 vue2, vue3 的表格解决方案",
    "stars": "5160",
    "url": "https://gitee.com/x-extends/vxe-table"
  },
  {
    "rank": 2,
    "name": "有来开源/vue3-element-admin",
    "language": "Vue",
    "description": "🔥Vue3 + Vite 8+ TypeScript + Element-Plus 构建的后台管理前端模板，配套官方 Java 和 Node 后端源码，vue-element-admin 的 Vue3 版本。",
    "stars": "5843",
    "url": "https://gitee.com/youlaiorg/vue3-element-admin"
  }
]
```

These outputs come from the v1.7.22 published code path; populated rows are byte-identical between the published code and this PR. The empty-signal path only fires when the upstream API returns a null or missing field (`trackCount`, `primaryGenreName`, `c.data.title`, `c.data.body`, `fields.langs`, `fields.description`), which doesn't surface in the public-API samples above.

## Test plan

- [x] `npm run build`: manifest compiles, no path leaks (`git diff cli-manifest.json` empty)
- [x] `npm run check:typed-error-lint`: passes (`current=167, baseline=167, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes
- [x] Smoke test: `opencli apple-podcasts search` and `opencli gitee search` still return populated rows (populated-row path is byte-identical to this PR; not a direct exercise of the changed fallback).
- [x] Downstream sentinel audit: `grep -nE "=== ?['\"](-|unknown|Unknown)['\"]"` across the 4 touched files returns zero hits, so the swapped value is never consumed as a control-flow marker.
- [ ] `reddit/{saved,upvoted}` smoke test omitted (requires logged-in reddit session on this machine); the diff is the same `|| '-'` to `|| ''` shape as the audited apple-podcasts / gitee files and downstream-sentinel grep is clean.
