### PR TITLE
feat(12306): add full read adapter (stations / trains / train / price / me / passengers / orders)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,5 +1,144 @@
 [
   {
+    "site": "12306",
+    "name": "stations",
+    "description": "Search 12306 (China Railway) stations by Chinese name, telecode, or pinyin keyword",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Chinese substring (上海), telecode (AOH), or pinyin (shanghai)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum results (1-50)"
+      }
+    ],
+    "columns": [
+      "name",
+      "code",
+      "pinyin",
+      "abbr",
+      "city"
+    ],
+    "type": "js",
+    "modulePath": "12306/stations.js",
+    "sourceFile": "12306/stations.js"
+  },
+  {
+    "site": "12306",
+    "name": "train",
+    "description": "List every station a 12306 train calls at, with arrival / departure / stopover time (anonymous, no login required)",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "train-no",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Internal train_no from `12306 trains` (e.g. 24000000G10L), not the public code (G1)"
+      },
+      {
+        "name": "from",
+        "type": "str",
+        "required": true,
+        "help": "Origin station for the segment: Chinese name, telecode, or pinyin"
+      },
+      {
+        "name": "to",
+        "type": "str",
+        "required": true,
+        "help": "Destination station for the segment"
+      },
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "help": "Departure date in YYYY-MM-DD"
+      }
+    ],
+    "columns": [
+      "station_no",
+      "station_name",
+      "arrive_time",
+      "start_time",
+      "stopover_time"
+    ],
+    "type": "js",
+    "modulePath": "12306/train.js",
+    "sourceFile": "12306/train.js"
+  },
+  {
+    "site": "12306",
+    "name": "trains",
+    "description": "List trains between two 12306 stations on a given date (anonymous, no login required)",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "from",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Origin station: Chinese name (北京), telecode (BJP), or pinyin (beijing)"
+      },
+      {
+        "name": "to",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Destination station: same forms as <from>"
+      },
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "help": "Departure date in YYYY-MM-DD"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Maximum rows (1-100)"
+      }
+    ],
+    "columns": [
+      "code",
+      "from_station",
+      "to_station",
+      "start_time",
+      "arrive_time",
+      "duration",
+      "available",
+      "business_seat",
+      "first_seat",
+      "second_seat",
+      "soft_sleeper",
+      "hard_sleeper",
+      "hard_seat",
+      "no_seat",
+      "train_no"
+    ],
+    "type": "js",
+    "modulePath": "12306/trains.js",
+    "sourceFile": "12306/trains.js"
+  },
+  {
     "site": "1688",
     "name": "assets",
     "description": "列出 1688 商品页可提取的图片/视频素材",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,156 @@
 [
   {
     "site": "12306",
+    "name": "me",
+    "description": "Show the logged-in 12306 account summary. Sensitive fields (real name, email, mobile, birth date) are masked by default; pass --include-sensitive to opt in.",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "include-sensitive",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Reveal unmasked real name / email / mobile / birth date. The 12306 ID-number mask is server-side and never decoded."
+      }
+    ],
+    "columns": [
+      "username",
+      "real_name",
+      "email",
+      "mobile",
+      "birth_date",
+      "sex",
+      "country",
+      "user_type",
+      "member",
+      "active"
+    ],
+    "type": "js",
+    "modulePath": "12306/me.js",
+    "sourceFile": "12306/me.js",
+    "navigateBefore": "https://kyfw.12306.cn"
+  },
+  {
+    "site": "12306",
+    "name": "orders",
+    "description": "List in-progress 12306 orders (not yet ridden, refunded, or completed) for the logged-in user",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "order_id",
+      "order_date",
+      "train_code",
+      "from_station",
+      "to_station",
+      "departure",
+      "passengers",
+      "status",
+      "amount"
+    ],
+    "type": "js",
+    "modulePath": "12306/orders.js",
+    "sourceFile": "12306/orders.js",
+    "navigateBefore": "https://kyfw.12306.cn"
+  },
+  {
+    "site": "12306",
+    "name": "passengers",
+    "description": "List the logged-in user's saved 12306 passengers. Sensitive fields are masked by default; pass --include-sensitive to opt in.",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max passengers to return (1-50)"
+      },
+      {
+        "name": "include-sensitive",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Reveal unmasked real names and birth dates. The 12306 ID-number / mobile masks are server-side and never decoded."
+      }
+    ],
+    "columns": [
+      "name",
+      "sex",
+      "born_year",
+      "id_type",
+      "id_no",
+      "mobile",
+      "passenger_type",
+      "country"
+    ],
+    "type": "js",
+    "modulePath": "12306/passengers.js",
+    "sourceFile": "12306/passengers.js",
+    "navigateBefore": "https://kyfw.12306.cn"
+  },
+  {
+    "site": "12306",
+    "name": "price",
+    "description": "Look up 12306 ticket prices by seat class for one train on a given date and segment (anonymous, no login required)",
+    "access": "read",
+    "domain": "kyfw.12306.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "train-no",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Internal train_no from `12306 trains` (e.g. 24000000G10L)"
+      },
+      {
+        "name": "from",
+        "type": "str",
+        "required": true,
+        "help": "Origin station (Chinese name, telecode, or pinyin) - must be a stop of this train"
+      },
+      {
+        "name": "to",
+        "type": "str",
+        "required": true,
+        "help": "Destination station - must be a stop of this train"
+      },
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "help": "Departure date in YYYY-MM-DD"
+      },
+      {
+        "name": "seat-types",
+        "type": "str",
+        "default": "OM9PA1A3A4FWZ",
+        "required": false,
+        "help": "Seat-type letters to query (default covers the common classes). Examples: OM9 (二等/一等/商务), A1A3A4 (硬座/硬卧/软卧)."
+      }
+    ],
+    "columns": [
+      "seat_code",
+      "seat_name",
+      "price",
+      "currency"
+    ],
+    "type": "js",
+    "modulePath": "12306/price.js",
+    "sourceFile": "12306/price.js"
+  },
+  {
+    "site": "12306",
     "name": "stations",
     "description": "Search 12306 (China Railway) stations by Chinese name, telecode, or pinyin keyword",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -41,7 +41,15 @@
     "domain": "kyfw.12306.cn",
     "strategy": "cookie",
     "browser": true,
-    "args": [],
+    "args": [
+      {
+        "name": "include-sensitive",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Reveal unmasked passenger names in order rows. Masked by default."
+      }
+    ],
     "columns": [
       "order_id",
       "order_date",

--- a/clis/12306/me.js
+++ b/clis/12306/me.js
@@ -1,0 +1,60 @@
+/**
+ * 12306 account summary for the logged-in user.
+ *
+ * Returns non-sensitive identity fields plus masked email / mobile.
+ * Use `--include-sensitive` to surface unmasked values from 12306's
+ * own response (12306 already masks the ID number server-side; this
+ * adapter never decodes that mask).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { maskEmail, maskMobile, maskChineseName, require12306Login } from './utils.js';
+
+const ACCOUNT_INFO_URL = 'https://kyfw.12306.cn/otn/modifyUser/initQueryUserInfoApi';
+
+cli({
+    site: '12306',
+    name: 'me',
+    access: 'read',
+    description: 'Show the logged-in 12306 account summary. Sensitive fields (real name, email, mobile, birth date) are masked by default; pass --include-sensitive to opt in.',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'include-sensitive', type: 'boolean', default: false, help: 'Reveal unmasked real name / email / mobile / birth date. The 12306 ID-number mask is server-side and never decoded.' },
+    ],
+    columns: ['username', 'real_name', 'email', 'mobile', 'birth_date', 'sex', 'country', 'user_type', 'member', 'active'],
+    func: async (page, kwargs) => {
+        if (!page) throw new CommandExecutionError('Browser session required for 12306 me');
+        await page.goto('https://kyfw.12306.cn/otn/view/index.html');
+        await require12306Login(page, AuthRequiredError);
+        const json = await page.evaluate(`async () => {
+      const r = await fetch(${JSON.stringify(ACCOUNT_INFO_URL)}, { credentials: 'include' });
+      if (!r.ok) return { __http: r.status };
+      return await r.json();
+    }`);
+        if (json?.__http) {
+            throw new CommandExecutionError(`12306 returned HTTP ${json.__http} for account info`);
+        }
+        if (json?.status !== true || !json?.data?.userDTO) {
+            throw new CommandExecutionError('12306 account info payload missing userDTO');
+        }
+        const dto = json.data.userDTO;
+        const loginDto = dto.loginUserDTO || {};
+        const username = loginDto.user_name || loginDto.name || '';
+        const realName = loginDto.real_name || loginDto.realname || '';
+        const include = kwargs['include-sensitive'] === true;
+        return [{
+            username,
+            real_name: include ? realName : maskChineseName(realName),
+            email: include ? (dto.email || '') : maskEmail(dto.email || ''),
+            mobile: include ? (dto.mobile_no || '') : maskMobile(dto.mobile_no || ''),
+            birth_date: include ? (dto.born_date || '') : (dto.born_date || '').slice(0, 4),
+            sex: dto.sex_code === 'M' ? '男' : (dto.sex_code === 'F' ? '女' : ''),
+            country: dto.country_code || '',
+            user_type: json.data.userTypeName || '',
+            member: dto.flag_member === '1',
+            active: dto.is_active === '1',
+        }];
+    },
+});

--- a/clis/12306/me.js
+++ b/clis/12306/me.js
@@ -8,7 +8,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { maskEmail, maskMobile, maskChineseName, require12306Login } from './utils.js';
+import { isAuthLikePayload, maskEmail, maskMobile, maskChineseName, require12306Login, requireEvaluateObject } from './utils.js';
 
 const ACCOUNT_INFO_URL = 'https://kyfw.12306.cn/otn/modifyUser/initQueryUserInfoApi';
 
@@ -28,13 +28,26 @@ cli({
         if (!page) throw new CommandExecutionError('Browser session required for 12306 me');
         await page.goto('https://kyfw.12306.cn/otn/view/index.html');
         await require12306Login(page, AuthRequiredError);
-        const json = await page.evaluate(`async () => {
+        const json = requireEvaluateObject(await page.evaluate(`async () => {
       const r = await fetch(${JSON.stringify(ACCOUNT_INFO_URL)}, { credentials: 'include' });
       if (!r.ok) return { __http: r.status };
-      return await r.json();
-    }`);
+      try {
+        return await r.json();
+      } catch (err) {
+        return { __parse: String(err && err.message || err) };
+      }
+    }`), 'account info');
         if (json?.__http) {
+            if ([401, 403].includes(Number(json.__http))) {
+                throw new AuthRequiredError('kyfw.12306.cn', '12306 account info requires a valid login session');
+            }
             throw new CommandExecutionError(`12306 returned HTTP ${json.__http} for account info`);
+        }
+        if (json?.__parse) {
+            throw new CommandExecutionError(`12306 account info returned non-JSON body: ${json.__parse}`);
+        }
+        if (isAuthLikePayload(json)) {
+            throw new AuthRequiredError('kyfw.12306.cn', '12306 account info requires a valid login session');
         }
         if (json?.status !== true || !json?.data?.userDTO) {
             throw new CommandExecutionError('12306 account info payload missing userDTO');

--- a/clis/12306/orders.js
+++ b/clis/12306/orders.js
@@ -1,0 +1,69 @@
+/**
+ * 12306 in-progress orders for the logged-in user.
+ *
+ * Returns orders that have not yet been ridden / refunded / completed
+ * (the `noComplete` slice). Order history covering completed and
+ * refunded tickets uses a separate endpoint that requires extra
+ * referer / page-state handshakes and is left for a follow-up so this
+ * command can ship reliably.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { require12306Login } from './utils.js';
+
+const NO_COMPLETE_URL = 'https://kyfw.12306.cn/otn/queryOrder/queryMyOrderNoComplete';
+
+cli({
+    site: '12306',
+    name: 'orders',
+    access: 'read',
+    description: 'List in-progress 12306 orders (not yet ridden, refunded, or completed) for the logged-in user',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [],
+    columns: ['order_id', 'order_date', 'train_code', 'from_station', 'to_station', 'departure', 'passengers', 'status', 'amount'],
+    func: async (page) => {
+        if (!page) throw new CommandExecutionError('Browser session required for 12306 orders');
+        await page.goto('https://kyfw.12306.cn/otn/view/index.html');
+        await require12306Login(page, AuthRequiredError);
+        const json = await page.evaluate(`async () => {
+      const r = await fetch(${JSON.stringify(NO_COMPLETE_URL)}, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: '_json_att=', credentials: 'include',
+      });
+      if (!r.ok) return { __http: r.status };
+      return await r.json();
+    }`);
+        if (json?.__http) {
+            throw new CommandExecutionError(`12306 returned HTTP ${json.__http} for queryMyOrderNoComplete`);
+        }
+        if (json?.status !== true) {
+            throw new CommandExecutionError('12306 queryMyOrderNoComplete returned a failure status');
+        }
+        const orders = Array.isArray(json?.data?.orderDBList) ? json.data.orderDBList
+            : Array.isArray(json?.data?.orderDTODataList) ? json.data.orderDTODataList
+            : Array.isArray(json?.data?.orders) ? json.data.orders
+            : Array.isArray(json?.data) ? json.data
+            : [];
+        if (orders.length === 0) {
+            throw new EmptyResultError('No in-progress 12306 orders on this account');
+        }
+        return orders.map((o) => {
+            const tickets = Array.isArray(o.tickets) ? o.tickets : [];
+            const passengerNames = tickets.map((t) => t.passenger_name || '').filter(Boolean).join(', ');
+            return {
+                order_id: o.sequence_no || o.order_id || o.sequenceNo || '',
+                order_date: o.order_date || '',
+                train_code: o.train_code_page || o.station_train_code || o.train_code || '',
+                from_station: o.from_station_name_page || o.from_station_name || '',
+                to_station: o.to_station_name_page || o.to_station_name || '',
+                departure: o.start_train_date_page || o.start_train_date || '',
+                passengers: passengerNames,
+                status: o.ticket_status_name || o.order_status_name || o.statusName || '',
+                amount: o.ticket_total_price_page || o.ticket_total_price || '',
+            };
+        });
+    },
+});

--- a/clis/12306/orders.js
+++ b/clis/12306/orders.js
@@ -9,7 +9,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { require12306Login } from './utils.js';
+import { isAuthLikePayload, maskChineseName, require12306Login, requireEvaluateObject } from './utils.js';
 
 const NO_COMPLETE_URL = 'https://kyfw.12306.cn/otn/queryOrder/queryMyOrderNoComplete';
 
@@ -21,23 +21,39 @@ cli({
     domain: 'kyfw.12306.cn',
     strategy: Strategy.COOKIE,
     browser: true,
-    args: [],
+    args: [
+        { name: 'include-sensitive', type: 'boolean', default: false, help: 'Reveal unmasked passenger names in order rows. Masked by default.' },
+    ],
     columns: ['order_id', 'order_date', 'train_code', 'from_station', 'to_station', 'departure', 'passengers', 'status', 'amount'],
-    func: async (page) => {
+    func: async (page, kwargs) => {
         if (!page) throw new CommandExecutionError('Browser session required for 12306 orders');
         await page.goto('https://kyfw.12306.cn/otn/view/index.html');
         await require12306Login(page, AuthRequiredError);
-        const json = await page.evaluate(`async () => {
+        const include = kwargs['include-sensitive'] === true;
+        const json = requireEvaluateObject(await page.evaluate(`async () => {
       const r = await fetch(${JSON.stringify(NO_COMPLETE_URL)}, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: '_json_att=', credentials: 'include',
       });
       if (!r.ok) return { __http: r.status };
-      return await r.json();
-    }`);
+      try {
+        return await r.json();
+      } catch (err) {
+        return { __parse: String(err && err.message || err) };
+      }
+    }`), 'orders');
         if (json?.__http) {
+            if ([401, 403].includes(Number(json.__http))) {
+                throw new AuthRequiredError('kyfw.12306.cn', '12306 orders requires a valid login session');
+            }
             throw new CommandExecutionError(`12306 returned HTTP ${json.__http} for queryMyOrderNoComplete`);
+        }
+        if (json?.__parse) {
+            throw new CommandExecutionError(`12306 orders returned non-JSON body: ${json.__parse}`);
+        }
+        if (isAuthLikePayload(json)) {
+            throw new AuthRequiredError('kyfw.12306.cn', '12306 orders requires a valid login session');
         }
         if (json?.status !== true) {
             throw new CommandExecutionError('12306 queryMyOrderNoComplete returned a failure status');
@@ -52,7 +68,11 @@ cli({
         }
         return orders.map((o) => {
             const tickets = Array.isArray(o.tickets) ? o.tickets : [];
-            const passengerNames = tickets.map((t) => t.passenger_name || '').filter(Boolean).join(', ');
+            const passengerNames = tickets
+                .map((t) => t.passenger_name || '')
+                .filter(Boolean)
+                .map((name) => include ? name : maskChineseName(name))
+                .join(', ');
             return {
                 order_id: o.sequence_no || o.order_id || o.sequenceNo || '',
                 order_date: o.order_date || '',

--- a/clis/12306/orders.js
+++ b/clis/12306/orders.js
@@ -58,11 +58,18 @@ cli({
         if (json?.status !== true) {
             throw new CommandExecutionError('12306 queryMyOrderNoComplete returned a failure status');
         }
-        const orders = Array.isArray(json?.data?.orderDBList) ? json.data.orderDBList
-            : Array.isArray(json?.data?.orderDTODataList) ? json.data.orderDTODataList
-            : Array.isArray(json?.data?.orders) ? json.data.orders
-            : Array.isArray(json?.data) ? json.data
-            : [];
+        let orders;
+        if (Array.isArray(json?.data?.orderDBList)) {
+            orders = json.data.orderDBList;
+        } else if (Array.isArray(json?.data?.orderDTODataList)) {
+            orders = json.data.orderDTODataList;
+        } else if (Array.isArray(json?.data?.orders)) {
+            orders = json.data.orders;
+        } else if (Array.isArray(json?.data)) {
+            orders = json.data;
+        } else {
+            throw new CommandExecutionError('12306 queryMyOrderNoComplete payload missing order list array');
+        }
         if (orders.length === 0) {
             throw new EmptyResultError('No in-progress 12306 orders on this account');
         }

--- a/clis/12306/passengers.js
+++ b/clis/12306/passengers.js
@@ -8,7 +8,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { maskChineseName, require12306Login } from './utils.js';
+import { isAuthLikePayload, maskChineseName, require12306Login, requireEvaluateObject } from './utils.js';
 
 const PASSENGER_QUERY_URL = 'https://kyfw.12306.cn/otn/passengers/query';
 const MAX_PAGE_SIZE = 50;
@@ -41,7 +41,7 @@ cli({
 
         await page.goto('https://kyfw.12306.cn/otn/view/index.html');
         await require12306Login(page, AuthRequiredError);
-        const json = await page.evaluate(`async () => {
+        const json = requireEvaluateObject(await page.evaluate(`async () => {
       const body = "pageIndex=1&pageSize=${MAX_PAGE_SIZE}";
       const r = await fetch(${JSON.stringify(PASSENGER_QUERY_URL)}, {
         method: 'POST',
@@ -49,10 +49,23 @@ cli({
         body, credentials: 'include',
       });
       if (!r.ok) return { __http: r.status };
-      return await r.json();
-    }`);
+      try {
+        return await r.json();
+      } catch (err) {
+        return { __parse: String(err && err.message || err) };
+      }
+    }`), 'passengers');
         if (json?.__http) {
+            if ([401, 403].includes(Number(json.__http))) {
+                throw new AuthRequiredError('kyfw.12306.cn', '12306 passengers requires a valid login session');
+            }
             throw new CommandExecutionError(`12306 returned HTTP ${json.__http} for passengers/query`);
+        }
+        if (json?.__parse) {
+            throw new CommandExecutionError(`12306 passengers returned non-JSON body: ${json.__parse}`);
+        }
+        if (isAuthLikePayload(json)) {
+            throw new AuthRequiredError('kyfw.12306.cn', '12306 passengers requires a valid login session');
         }
         if (json?.status !== true || !Array.isArray(json?.data?.datas)) {
             throw new CommandExecutionError('12306 passengers payload missing data.datas array');

--- a/clis/12306/passengers.js
+++ b/clis/12306/passengers.js
@@ -1,0 +1,77 @@
+/**
+ * 12306 saved passenger list for the logged-in user.
+ *
+ * 12306 already masks ID numbers (`xxxx***********xxx`) and mobile
+ * numbers (`138****xxxx`) server-side. This adapter further masks the
+ * passenger's Chinese real name and birth date by default; pass
+ * `--include-sensitive` to surface the unmasked-by-12306 fields.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { maskChineseName, require12306Login } from './utils.js';
+
+const PASSENGER_QUERY_URL = 'https://kyfw.12306.cn/otn/passengers/query';
+const MAX_PAGE_SIZE = 50;
+
+function normalizeLimit(value, defaultValue, max) {
+    if (value === undefined || value === null || value === '') return defaultValue;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) throw new ArgumentError(`limit must be a positive integer (1-${max})`);
+    if (n > max) throw new ArgumentError(`limit must be <= ${max}`);
+    return n;
+}
+
+cli({
+    site: '12306',
+    name: 'passengers',
+    access: 'read',
+    description: 'List the logged-in user\'s saved 12306 passengers. Sensitive fields are masked by default; pass --include-sensitive to opt in.',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: `Max passengers to return (1-${MAX_PAGE_SIZE})` },
+        { name: 'include-sensitive', type: 'boolean', default: false, help: 'Reveal unmasked real names and birth dates. The 12306 ID-number / mobile masks are server-side and never decoded.' },
+    ],
+    columns: ['name', 'sex', 'born_year', 'id_type', 'id_no', 'mobile', 'passenger_type', 'country'],
+    func: async (page, kwargs) => {
+        if (!page) throw new CommandExecutionError('Browser session required for 12306 passengers');
+        const limit = normalizeLimit(kwargs.limit, 20, MAX_PAGE_SIZE);
+        const include = kwargs['include-sensitive'] === true;
+
+        await page.goto('https://kyfw.12306.cn/otn/view/index.html');
+        await require12306Login(page, AuthRequiredError);
+        const json = await page.evaluate(`async () => {
+      const body = "pageIndex=1&pageSize=${MAX_PAGE_SIZE}";
+      const r = await fetch(${JSON.stringify(PASSENGER_QUERY_URL)}, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body, credentials: 'include',
+      });
+      if (!r.ok) return { __http: r.status };
+      return await r.json();
+    }`);
+        if (json?.__http) {
+            throw new CommandExecutionError(`12306 returned HTTP ${json.__http} for passengers/query`);
+        }
+        if (json?.status !== true || !Array.isArray(json?.data?.datas)) {
+            throw new CommandExecutionError('12306 passengers payload missing data.datas array');
+        }
+        const datas = json.data.datas;
+        if (datas.length === 0) {
+            throw new EmptyResultError('No saved passengers on this 12306 account');
+        }
+        return datas.slice(0, limit).map((p) => ({
+            name: include ? (p.passenger_name || '') : maskChineseName(p.passenger_name || ''),
+            sex: p.sex_name || '',
+            born_year: (p.born_date || '').slice(0, 4),
+            id_type: p.passenger_id_type_name || '',
+            id_no: p.passenger_id_no || '',
+            mobile: p.mobile_no || '',
+            passenger_type: p.passenger_type_name || '',
+            country: p.country_code || '',
+        }));
+    },
+});
+
+export const __test__ = { normalizeLimit };

--- a/clis/12306/price.js
+++ b/clis/12306/price.js
@@ -16,6 +16,7 @@ import { fetchStationBundle, mintSession, resolveStation, validateDate } from '.
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
 const TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/;
+const SEAT_TYPES_RE = /^[A-Z0-9]{1,32}$/;
 
 const SEAT_LETTERS = {
     'A9': '商务座',
@@ -126,6 +127,9 @@ cli({
         if (!toArg) throw new ArgumentError('--to station must not be empty');
         const date = validateDate(kwargs.date);
         const seatTypes = String(kwargs['seat-types'] ?? '').trim() || 'OM9PA1A3A4FWZ';
+        if (!SEAT_TYPES_RE.test(seatTypes)) {
+            throw new ArgumentError('--seat-types must contain only 12306 seat letters/digits (A-Z, 0-9)');
+        }
 
         const stations = await fetchStationBundle();
         const fromStation = resolveStation(stations, fromArg);

--- a/clis/12306/price.js
+++ b/clis/12306/price.js
@@ -1,0 +1,152 @@
+/**
+ * 12306 ticket price lookup for a single train + segment.
+ *
+ * Cascades three anonymous API calls:
+ *   1. /otn/leftTicket/init: mint session cookies
+ *   2. /otn/czxx/queryByTrainNo: resolve from/to station_no within the
+ *      train route (price endpoint addresses stops by station_no, not
+ *      telecode)
+ *   3. /otn/leftTicket/queryTicketPrice: ticket prices keyed by seat
+ *      letter (M=一等座, O=二等座, A9=商务座, A1=硬座, A3=硬卧,
+ *      A4=软卧, F=动卧, P=特等座, WZ=无座, etc.)
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { fetchStationBundle, mintSession, resolveStation, validateDate } from './utils.js';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
+const TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/;
+
+const SEAT_LETTERS = {
+    'A9': '商务座',
+    'P': '特等座',
+    'M': '一等座',
+    'O': '二等座',
+    'A1': '硬座',
+    'A3': '硬卧',
+    'A4': '软卧',
+    'F': '动卧',
+    'WZ': '无座',
+};
+
+async function queryStopsForPrice(cookieHeader, trainNo, fromCode, toCode, date) {
+    const url = `https://kyfw.12306.cn/otn/czxx/queryByTrainNo?train_no=${trainNo}&from_station_telecode=${fromCode}&to_station_telecode=${toCode}&depart_date=${date}`;
+    const resp = await fetch(url, {
+        headers: {
+            'User-Agent': UA,
+            'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
+            'Cookie': cookieHeader,
+        },
+    });
+    if (!resp.ok) throw new CommandExecutionError(`12306 queryByTrainNo returned HTTP ${resp.status}`);
+    const json = await resp.json();
+    if (json?.status !== true || !Array.isArray(json?.data?.data)) {
+        throw new CommandExecutionError('12306 queryByTrainNo returned an unexpected payload shape');
+    }
+    return json.data.data;
+}
+
+function pickStationNos(stops, fromCode, toCode, fromName, toName) {
+    const matches = (s, code, name) => (s.station_name && name && s.station_name === name);
+    const fromStop = stops.find((s) => matches(s, fromCode, fromName));
+    const toStop = stops.find((s) => matches(s, toCode, toName));
+    if (!fromStop) throw new CommandExecutionError(`Train does not stop at ${fromName}`);
+    if (!toStop) throw new CommandExecutionError(`Train does not stop at ${toName}`);
+    return { fromNo: fromStop.station_no, toNo: toStop.station_no };
+}
+
+async function queryPrice(cookieHeader, trainNo, fromNo, toNo, seatTypes, date) {
+    const url = `https://kyfw.12306.cn/otn/leftTicket/queryTicketPrice?train_no=${trainNo}&from_station_no=${fromNo}&to_station_no=${toNo}&seat_types=${seatTypes}&train_date=${date}`;
+    const resp = await fetch(url, {
+        headers: {
+            'User-Agent': UA,
+            'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
+            'Cookie': cookieHeader,
+        },
+    });
+    if (!resp.ok) throw new CommandExecutionError(`12306 queryTicketPrice returned HTTP ${resp.status}`);
+    const json = await resp.json();
+    if (json?.status !== true || !json?.data) {
+        throw new CommandExecutionError('12306 queryTicketPrice returned an unexpected payload shape');
+    }
+    return json.data;
+}
+
+function parsePriceData(priceData) {
+    const rows = [];
+    for (const [letter, value] of Object.entries(priceData)) {
+        if (letter === 'train_no' || letter === 'OT') continue;
+        if (typeof value !== 'string' || !value) continue;
+        // 12306 doubles up some prices as bare numerics ("9": "21580"), which
+        // mirror their letter sibling ("A9": "¥2158.0") in cents/no-decimal
+        // form. Skip the bare numeric letter codes to avoid duplicates.
+        if (/^\d+$/.test(letter)) continue;
+        if (!/^[A-Z]/.test(letter)) continue;
+        const numeric = value.replace(/^¥/, '');
+        if (!/^[\d.]+$/.test(numeric)) continue;
+        rows.push({
+            seat_code: letter,
+            seat_name: SEAT_LETTERS[letter] || letter,
+            price: numeric,
+            currency: 'CNY',
+        });
+    }
+    rows.sort((a, b) => Number(b.price) - Number(a.price));
+    return rows;
+}
+
+cli({
+    site: '12306',
+    name: 'price',
+    access: 'read',
+    description: 'Look up 12306 ticket prices by seat class for one train on a given date and segment (anonymous, no login required)',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'train-no', positional: true, required: true, help: 'Internal train_no from `12306 trains` (e.g. 24000000G10L)' },
+        { name: 'from', required: true, help: 'Origin station (Chinese name, telecode, or pinyin) - must be a stop of this train' },
+        { name: 'to', required: true, help: 'Destination station - must be a stop of this train' },
+        { name: 'date', required: true, help: 'Departure date in YYYY-MM-DD' },
+        { name: 'seat-types', default: 'OM9PA1A3A4FWZ', help: 'Seat-type letters to query (default covers the common classes). Examples: OM9 (二等/一等/商务), A1A3A4 (硬座/硬卧/软卧).' },
+    ],
+    columns: ['seat_code', 'seat_name', 'price', 'currency'],
+    func: async (kwargs) => {
+        const trainNo = String(kwargs['train-no'] ?? '').trim();
+        if (!trainNo) throw new ArgumentError('<train-no> must not be empty');
+        if (!TRAIN_NO_RE.test(trainNo)) {
+            throw new ArgumentError(
+                `<train-no> "${trainNo}" does not look like a 12306 internal train_no`,
+                'Use the train_no field from `12306 trains` output (e.g. 24000000G10L), not the public code (G1).',
+            );
+        }
+        const fromArg = String(kwargs.from ?? '').trim();
+        const toArg = String(kwargs.to ?? '').trim();
+        if (!fromArg) throw new ArgumentError('--from station must not be empty');
+        if (!toArg) throw new ArgumentError('--to station must not be empty');
+        const date = validateDate(kwargs.date);
+        const seatTypes = String(kwargs['seat-types'] ?? '').trim() || 'OM9PA1A3A4FWZ';
+
+        const stations = await fetchStationBundle();
+        const fromStation = resolveStation(stations, fromArg);
+        const toStation = resolveStation(stations, toArg);
+        if (fromStation.code === toStation.code) {
+            throw new ArgumentError(`--from and --to must differ; both resolved to ${fromStation.name} (${fromStation.code})`);
+        }
+
+        const cookieHeader = await mintSession();
+        const stops = await queryStopsForPrice(cookieHeader, trainNo, fromStation.code, toStation.code, date);
+        const { fromNo, toNo } = pickStationNos(stops, fromStation.code, toStation.code, fromStation.name, toStation.name);
+        const priceData = await queryPrice(cookieHeader, trainNo, fromNo, toNo, seatTypes, date);
+        const rows = parsePriceData(priceData);
+        if (rows.length === 0) {
+            throw new EmptyResultError(
+                `No prices returned for train_no=${trainNo} ${fromStation.name} -> ${toStation.name} on ${date}`,
+                'Try a different seat-types letter set, or check that this train operates on the date.',
+            );
+        }
+        return rows;
+    },
+});
+
+export const __test__ = { parsePriceData, pickStationNos, SEAT_LETTERS };

--- a/clis/12306/price.js
+++ b/clis/12306/price.js
@@ -30,9 +30,9 @@ const SEAT_LETTERS = {
     'WZ': '无座',
 };
 
-async function queryStopsForPrice(cookieHeader, trainNo, fromCode, toCode, date) {
+async function queryStopsForPrice(cookieHeader, trainNo, fromCode, toCode, date, fetchImpl = fetch) {
     const url = `https://kyfw.12306.cn/otn/czxx/queryByTrainNo?train_no=${trainNo}&from_station_telecode=${fromCode}&to_station_telecode=${toCode}&depart_date=${date}`;
-    const resp = await fetch(url, {
+    const resp = await fetchImpl(url, {
         headers: {
             'User-Agent': UA,
             'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
@@ -40,7 +40,12 @@ async function queryStopsForPrice(cookieHeader, trainNo, fromCode, toCode, date)
         },
     });
     if (!resp.ok) throw new CommandExecutionError(`12306 queryByTrainNo returned HTTP ${resp.status}`);
-    const json = await resp.json();
+    let json;
+    try {
+        json = await resp.json();
+    } catch {
+        throw new CommandExecutionError('12306 queryByTrainNo returned non-JSON body');
+    }
     if (json?.status !== true || !Array.isArray(json?.data?.data)) {
         throw new CommandExecutionError('12306 queryByTrainNo returned an unexpected payload shape');
     }
@@ -56,9 +61,9 @@ function pickStationNos(stops, fromCode, toCode, fromName, toName) {
     return { fromNo: fromStop.station_no, toNo: toStop.station_no };
 }
 
-async function queryPrice(cookieHeader, trainNo, fromNo, toNo, seatTypes, date) {
+async function queryPrice(cookieHeader, trainNo, fromNo, toNo, seatTypes, date, fetchImpl = fetch) {
     const url = `https://kyfw.12306.cn/otn/leftTicket/queryTicketPrice?train_no=${trainNo}&from_station_no=${fromNo}&to_station_no=${toNo}&seat_types=${seatTypes}&train_date=${date}`;
-    const resp = await fetch(url, {
+    const resp = await fetchImpl(url, {
         headers: {
             'User-Agent': UA,
             'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
@@ -66,7 +71,12 @@ async function queryPrice(cookieHeader, trainNo, fromNo, toNo, seatTypes, date) 
         },
     });
     if (!resp.ok) throw new CommandExecutionError(`12306 queryTicketPrice returned HTTP ${resp.status}`);
-    const json = await resp.json();
+    let json;
+    try {
+        json = await resp.json();
+    } catch {
+        throw new CommandExecutionError('12306 queryTicketPrice returned non-JSON body');
+    }
     if (json?.status !== true || !json?.data) {
         throw new CommandExecutionError('12306 queryTicketPrice returned an unexpected payload shape');
     }
@@ -153,4 +163,4 @@ cli({
     },
 });
 
-export const __test__ = { parsePriceData, pickStationNos, SEAT_LETTERS };
+export const __test__ = { parsePriceData, pickStationNos, queryStopsForPrice, queryPrice, SEAT_LETTERS };

--- a/clis/12306/stations.js
+++ b/clis/12306/stations.js
@@ -1,0 +1,66 @@
+/**
+ * 12306 station search.
+ *
+ * Queries the public `station_name.js` bundle and filters by the user's
+ * keyword. Anonymous, no session needed.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { fetchStationBundle } from './utils.js';
+
+const MAX_LIMIT = 50;
+
+function normalizeLimit(value, defaultValue, max) {
+    if (value === undefined || value === null || value === '') return defaultValue;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new ArgumentError(`limit must be a positive integer (1-${max})`);
+    }
+    if (n > max) {
+        throw new ArgumentError(`limit must be <= ${max}`);
+    }
+    return n;
+}
+
+cli({
+    site: '12306',
+    name: 'stations',
+    access: 'read',
+    description: 'Search 12306 (China Railway) stations by Chinese name, telecode, or pinyin keyword',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'keyword', positional: true, required: true, help: 'Chinese substring (上海), telecode (AOH), or pinyin (shanghai)' },
+        { name: 'limit', type: 'int', default: 20, help: `Maximum results (1-${MAX_LIMIT})` },
+    ],
+    columns: ['name', 'code', 'pinyin', 'abbr', 'city'],
+    func: async (kwargs) => {
+        const keyword = String(kwargs.keyword ?? '').trim();
+        if (!keyword) throw new ArgumentError('keyword must not be empty');
+        const limit = normalizeLimit(kwargs.limit, 20, MAX_LIMIT);
+
+        const stations = await fetchStationBundle();
+        const lower = keyword.toLowerCase();
+        const matches = stations.filter((s) =>
+            s.name.includes(keyword)
+            || s.code === keyword.toUpperCase()
+            || s.pinyin.includes(lower)
+            || s.abbr.includes(lower)
+            || s.short.includes(lower)
+            || s.city.includes(keyword),
+        );
+        if (matches.length === 0) {
+            throw new EmptyResultError(`No 12306 stations match "${keyword}"`);
+        }
+        return matches.slice(0, limit).map((s) => ({
+            name: s.name,
+            code: s.code,
+            pinyin: s.pinyin,
+            abbr: s.abbr,
+            city: s.city,
+        }));
+    },
+});
+
+export const __test__ = { normalizeLimit };

--- a/clis/12306/train.js
+++ b/clis/12306/train.js
@@ -1,5 +1,5 @@
 /**
- * 12306 train stop details — list every station a train calls at,
+ * 12306 train stop details - list every station a train calls at,
  * with arrival / departure / stopover time.
  *
  * Requires the internal `train_no` returned by `12306 trains`

--- a/clis/12306/train.js
+++ b/clis/12306/train.js
@@ -12,9 +12,9 @@ import { fetchStationBundle, mintSession, resolveStation, validateDate } from '.
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
 const TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/;
 
-async function queryStops(cookieHeader, trainNo, fromCode, toCode, date) {
+async function queryStops(cookieHeader, trainNo, fromCode, toCode, date, fetchImpl = fetch) {
     const url = `https://kyfw.12306.cn/otn/czxx/queryByTrainNo?train_no=${trainNo}&from_station_telecode=${fromCode}&to_station_telecode=${toCode}&depart_date=${date}`;
-    const resp = await fetch(url, {
+    const resp = await fetchImpl(url, {
         headers: {
             'User-Agent': UA,
             'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
@@ -24,7 +24,12 @@ async function queryStops(cookieHeader, trainNo, fromCode, toCode, date) {
     if (!resp.ok) {
         throw new CommandExecutionError(`12306 queryByTrainNo returned HTTP ${resp.status}`);
     }
-    const json = await resp.json();
+    let json;
+    try {
+        json = await resp.json();
+    } catch {
+        throw new CommandExecutionError('12306 queryByTrainNo returned non-JSON body');
+    }
     if (json?.status !== true || !Array.isArray(json?.data?.data)) {
         throw new CommandExecutionError(`12306 queryByTrainNo returned an unexpected payload shape`);
     }
@@ -83,4 +88,4 @@ cli({
     },
 });
 
-export const __test__ = { queryStops };
+export const __test__ = { queryStops, TRAIN_NO_RE };

--- a/clis/12306/train.js
+++ b/clis/12306/train.js
@@ -1,0 +1,86 @@
+/**
+ * 12306 train stop details — list every station a train calls at,
+ * with arrival / departure / stopover time.
+ *
+ * Requires the internal `train_no` returned by `12306 trains`
+ * (`24000000G10L`), not the public train code (`G1`).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { fetchStationBundle, mintSession, resolveStation, validateDate } from './utils.js';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
+const TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/;
+
+async function queryStops(cookieHeader, trainNo, fromCode, toCode, date) {
+    const url = `https://kyfw.12306.cn/otn/czxx/queryByTrainNo?train_no=${trainNo}&from_station_telecode=${fromCode}&to_station_telecode=${toCode}&depart_date=${date}`;
+    const resp = await fetch(url, {
+        headers: {
+            'User-Agent': UA,
+            'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
+            'Cookie': cookieHeader,
+        },
+    });
+    if (!resp.ok) {
+        throw new CommandExecutionError(`12306 queryByTrainNo returned HTTP ${resp.status}`);
+    }
+    const json = await resp.json();
+    if (json?.status !== true || !Array.isArray(json?.data?.data)) {
+        throw new CommandExecutionError(`12306 queryByTrainNo returned an unexpected payload shape`);
+    }
+    return json.data.data;
+}
+
+cli({
+    site: '12306',
+    name: 'train',
+    access: 'read',
+    description: 'List every station a 12306 train calls at, with arrival / departure / stopover time (anonymous, no login required)',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'train-no', positional: true, required: true, help: 'Internal train_no from `12306 trains` (e.g. 24000000G10L), not the public code (G1)' },
+        { name: 'from', required: true, help: 'Origin station for the segment: Chinese name, telecode, or pinyin' },
+        { name: 'to', required: true, help: 'Destination station for the segment' },
+        { name: 'date', required: true, help: 'Departure date in YYYY-MM-DD' },
+    ],
+    columns: ['station_no', 'station_name', 'arrive_time', 'start_time', 'stopover_time'],
+    func: async (kwargs) => {
+        const trainNo = String(kwargs['train-no'] ?? '').trim();
+        if (!trainNo) throw new ArgumentError('<train-no> must not be empty');
+        if (!TRAIN_NO_RE.test(trainNo)) {
+            throw new ArgumentError(
+                `<train-no> "${trainNo}" does not look like a 12306 internal train_no`,
+                'Use the train_no field from `12306 trains` output (e.g. 24000000G10L), not the public code (G1).',
+            );
+        }
+        const fromArg = String(kwargs.from ?? '').trim();
+        const toArg = String(kwargs.to ?? '').trim();
+        if (!fromArg) throw new ArgumentError('--from station must not be empty');
+        if (!toArg) throw new ArgumentError('--to station must not be empty');
+        const date = validateDate(kwargs.date);
+
+        const stations = await fetchStationBundle();
+        const fromStation = resolveStation(stations, fromArg);
+        const toStation = resolveStation(stations, toArg);
+        if (fromStation.code === toStation.code) {
+            throw new ArgumentError(`--from and --to must differ; both resolved to ${fromStation.name} (${fromStation.code})`);
+        }
+
+        const cookieHeader = await mintSession();
+        const stops = await queryStops(cookieHeader, trainNo, fromStation.code, toStation.code, date);
+        if (stops.length === 0) {
+            throw new EmptyResultError(`No stops returned for train_no=${trainNo} on ${date}`);
+        }
+        return stops.map((s) => ({
+            station_no: s.station_no || '',
+            station_name: s.station_name || '',
+            arrive_time: s.arrive_time === '----' ? '' : (s.arrive_time || ''),
+            start_time: s.start_time === '----' ? '' : (s.start_time || ''),
+            stopover_time: s.stopover_time === '----' ? '' : (s.stopover_time || ''),
+        }));
+    },
+});
+
+export const __test__ = { queryStops };

--- a/clis/12306/trains.js
+++ b/clis/12306/trains.js
@@ -1,0 +1,119 @@
+/**
+ * 12306 train availability between two stations on a given date.
+ *
+ * Flow:
+ *   1. Fetch the station bundle (cached implicitly via per-process module state).
+ *   2. Mint anonymous session cookies via /otn/leftTicket/init.
+ *   3. Query /otn/leftTicket/queryG; if 12306 returns
+ *      `{c_url: "leftTicket/queryX"}` (endpoint rotation), retry once
+ *      against the suggested name.
+ *   4. Parse the `|`-separated train records.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { fetchStationBundle, mintSession, resolveStation, validateDate, parseTrainRecord } from './utils.js';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
+const QUERY_ENDPOINTS = ['queryG', 'queryO', 'queryZ', 'queryA'];
+const MAX_LIMIT = 100;
+
+function normalizeLimit(value, defaultValue, max) {
+    if (value === undefined || value === null || value === '') return defaultValue;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new ArgumentError(`limit must be a positive integer (1-${max})`);
+    }
+    if (n > max) {
+        throw new ArgumentError(`limit must be <= ${max}`);
+    }
+    return n;
+}
+
+async function queryLeftTickets(cookieHeader, fromCode, toCode, date) {
+    const headers = {
+        'User-Agent': UA,
+        'Referer': 'https://kyfw.12306.cn/otn/leftTicket/init',
+        'Cookie': cookieHeader,
+    };
+    const queryParams = `leftTicketDTO.train_date=${date}&leftTicketDTO.from_station=${fromCode}&leftTicketDTO.to_station=${toCode}&purpose_codes=ADULT`;
+    let lastResponseText = '';
+    for (const endpoint of QUERY_ENDPOINTS) {
+        const url = `https://kyfw.12306.cn/otn/leftTicket/${endpoint}?${queryParams}`;
+        const resp = await fetch(url, { headers });
+        if (!resp.ok) {
+            if (resp.status === 302) continue;
+            throw new CommandExecutionError(`12306 ${endpoint} returned HTTP ${resp.status}`);
+        }
+        const text = await resp.text();
+        lastResponseText = text;
+        let json;
+        try { json = JSON.parse(text); } catch {
+            throw new CommandExecutionError(`12306 ${endpoint} returned non-JSON body`);
+        }
+        if (json?.c_url && typeof json.c_url === 'string') {
+            const rotated = json.c_url.replace('leftTicket/', '').trim();
+            if (rotated && !QUERY_ENDPOINTS.includes(rotated)) {
+                QUERY_ENDPOINTS.unshift(rotated);
+            }
+            continue;
+        }
+        if (Array.isArray(json?.data?.result)) {
+            return json.data.result;
+        }
+        throw new CommandExecutionError(`12306 ${endpoint} returned an unexpected payload shape`);
+    }
+    throw new CommandExecutionError(`12306 rejected every known query endpoint name (${QUERY_ENDPOINTS.join(', ')}); the wire protocol may have changed. Last body: ${lastResponseText.slice(0, 200)}`);
+}
+
+cli({
+    site: '12306',
+    name: 'trains',
+    access: 'read',
+    description: 'List trains between two 12306 stations on a given date (anonymous, no login required)',
+    domain: 'kyfw.12306.cn',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'from', positional: true, required: true, help: 'Origin station: Chinese name (北京), telecode (BJP), or pinyin (beijing)' },
+        { name: 'to', positional: true, required: true, help: 'Destination station: same forms as <from>' },
+        { name: 'date', required: true, help: 'Departure date in YYYY-MM-DD' },
+        { name: 'limit', type: 'int', default: 50, help: `Maximum rows (1-${MAX_LIMIT})` },
+    ],
+    columns: [
+        'code', 'from_station', 'to_station', 'start_time', 'arrive_time',
+        'duration', 'available', 'business_seat', 'first_seat', 'second_seat',
+        'soft_sleeper', 'hard_sleeper', 'hard_seat', 'no_seat', 'train_no',
+    ],
+    func: async (kwargs) => {
+        const fromArg = String(kwargs.from ?? '').trim();
+        const toArg = String(kwargs.to ?? '').trim();
+        if (!fromArg) throw new ArgumentError('<from> station must not be empty');
+        if (!toArg) throw new ArgumentError('<to> station must not be empty');
+        const date = validateDate(kwargs.date);
+        const limit = normalizeLimit(kwargs.limit, 50, MAX_LIMIT);
+
+        const stations = await fetchStationBundle();
+        const fromStation = resolveStation(stations, fromArg);
+        const toStation = resolveStation(stations, toArg);
+        if (fromStation.code === toStation.code) {
+            throw new ArgumentError(`<from> and <to> must differ; both resolved to ${fromStation.name} (${fromStation.code})`);
+        }
+        const stationByCode = new Map(stations.map((s) => [s.code, s]));
+
+        const cookieHeader = await mintSession();
+        const rawRows = await queryLeftTickets(cookieHeader, fromStation.code, toStation.code, date);
+        const decoded = rawRows
+            .map((line) => parseTrainRecord(decodeURIComponent(line.replace(/%0A/g, '')), stationByCode))
+            .filter(Boolean);
+
+        if (decoded.length === 0) {
+            throw new EmptyResultError(
+                `No trains found from ${fromStation.name} to ${toStation.name} on ${date}`,
+                'Try a different date or check whether the route is operated by 12306.',
+            );
+        }
+        return decoded.slice(0, limit);
+    },
+});
+
+export const __test__ = { normalizeLimit, queryLeftTickets };

--- a/clis/12306/utils.js
+++ b/clis/12306/utils.js
@@ -1,0 +1,177 @@
+/**
+ * 12306 (中国铁路) shared helpers.
+ *
+ * - Station lookup: parses the public `station_name.js` bundle into
+ *   structured records.
+ * - Cookie session: 12306's query endpoints reject anonymous requests
+ *   with `HTTP 302 -> error.html`, so callers must hit `/otn/leftTicket/init`
+ *   first to mint the JSESSIONID / route / BIGipServerotn cookies.
+ * - Query endpoint rotation: 12306 rotates the train-query endpoint
+ *   name (queryO / queryZ / queryA / queryG / ...) every few weeks.
+ *   When the wrong name is hit, the server returns
+ *   `{"c_url":"leftTicket/queryG","c_name":"CLeftTicketUrl","status":false}`
+ *   pointing to the current correct name; retry once with that name.
+ */
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const STATION_BUNDLE_URL = 'https://kyfw.12306.cn/otn/resources/js/framework/station_name.js';
+const INIT_URL = 'https://kyfw.12306.cn/otn/leftTicket/init';
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const STATION_CODE_RE = /^[A-Z]{2,4}$/;
+
+/**
+ * Parse the `station_name.js` bundle into a station record array.
+ *
+ * Bundle format (single line, `@`-delimited records, each `|`-delimited):
+ *   `var station_names ='@bjb|北京北|VAP|beijingbei|bjb|0|0357|北京|||...';`
+ *
+ * Per-record fields (positional):
+ *   [0] short pinyin alias  (e.g. `bjb`)
+ *   [1] Chinese station name (e.g. `北京北`)
+ *   [2] telecode (3-4 uppercase letters, e.g. `VAP`) — this is the
+ *       wire format 12306 uses for `from_station` / `to_station`.
+ *   [3] full pinyin           (e.g. `beijingbei`)
+ *   [4] short alias           (duplicate of [0] usually)
+ *   [5] index/rank
+ *   [6] city code
+ *   [7] city name             (e.g. `北京`)
+ */
+export function parseStationBundle(text) {
+    const match = text.match(/'([^']+)'/);
+    if (!match) {
+        throw new CommandExecutionError('Failed to parse 12306 station_name.js: source string not found');
+    }
+    const raw = match[1];
+    const records = raw.split('@').filter(Boolean);
+    const stations = [];
+    for (const r of records) {
+        const parts = r.split('|');
+        if (parts.length < 8 || !parts[2]) continue;
+        stations.push({
+            short: parts[0] || '',
+            name: parts[1] || '',
+            code: parts[2] || '',
+            pinyin: parts[3] || '',
+            abbr: parts[4] || '',
+            city: parts[7] || '',
+        });
+    }
+    return stations;
+}
+
+/**
+ * Resolve a user-supplied station identifier to a telecode.
+ *
+ * Accepts Chinese name (`上海虹桥`), telecode (`AOH`), pinyin
+ * (`shanghaihongqiao`), short alias (`shh`), or city name with a
+ * preference for the city's main station.
+ */
+export function resolveStation(stations, input) {
+    const trimmed = String(input ?? '').trim();
+    if (!trimmed) throw new ArgumentError('station must not be empty');
+    if (STATION_CODE_RE.test(trimmed)) {
+        const exact = stations.find((s) => s.code === trimmed);
+        if (exact) return exact;
+        throw new ArgumentError(`Unknown 12306 station telecode "${trimmed}"`);
+    }
+    const lower = trimmed.toLowerCase();
+    const exactName = stations.find((s) => s.name === trimmed);
+    if (exactName) return exactName;
+    const exactPinyin = stations.find((s) => s.pinyin === lower);
+    if (exactPinyin) return exactPinyin;
+    const exactAbbr = stations.find((s) => s.abbr === lower || s.short === lower);
+    if (exactAbbr) return exactAbbr;
+    throw new ArgumentError(`Unknown 12306 station "${trimmed}"`, 'Try the Chinese name (上海虹桥), the 3-4 letter telecode (AOH), or full pinyin (shanghaihongqiao).');
+}
+
+export function validateDate(value) {
+    if (!DATE_RE.test(String(value ?? ''))) {
+        throw new ArgumentError(`date must be YYYY-MM-DD, got "${value}"`);
+    }
+    const [y, m, d] = value.split('-').map(Number);
+    const date = new Date(Date.UTC(y, m - 1, d));
+    if (date.getUTCFullYear() !== y || date.getUTCMonth() !== m - 1 || date.getUTCDate() !== d) {
+        throw new ArgumentError(`date "${value}" is not a real calendar date`);
+    }
+    return value;
+}
+
+/** Extract Set-Cookie header values into a single `Cookie:` header string. */
+export function buildCookieHeader(setCookieHeaders) {
+    if (!Array.isArray(setCookieHeaders) || setCookieHeaders.length === 0) return '';
+    return setCookieHeaders
+        .map((line) => line.split(';')[0])
+        .filter(Boolean)
+        .join('; ');
+}
+
+export async function fetchStationBundle(fetchImpl = fetch) {
+    const resp = await fetchImpl(STATION_BUNDLE_URL, {
+        headers: { 'User-Agent': UA },
+    });
+    if (!resp.ok) {
+        throw new CommandExecutionError(`Failed to fetch 12306 station bundle: HTTP ${resp.status}`);
+    }
+    return parseStationBundle(await resp.text());
+}
+
+/** Mint a 12306 anonymous session by hitting /otn/leftTicket/init. */
+export async function mintSession(fetchImpl = fetch) {
+    const resp = await fetchImpl(INIT_URL, {
+        headers: { 'User-Agent': UA },
+        redirect: 'follow',
+    });
+    if (!resp.ok) {
+        throw new CommandExecutionError(`Failed to mint 12306 session: HTTP ${resp.status}`);
+    }
+    const setCookies = typeof resp.headers.getSetCookie === 'function'
+        ? resp.headers.getSetCookie()
+        : resp.headers.raw?.()['set-cookie'] || [];
+    const cookieHeader = buildCookieHeader(setCookies);
+    if (!cookieHeader) {
+        throw new CommandExecutionError('12306 init returned no session cookies');
+    }
+    return cookieHeader;
+}
+
+/**
+ * Twelve-row train query record (LEFT_TICKET_DTO).
+ *
+ * 12306 returns each train as a `|`-separated string with ~36 fields.
+ * Positions used here come from the public web client; unused
+ * positions are documented inline so future maintainers can extend
+ * the row shape without re-reverse-engineering.
+ */
+export function parseTrainRecord(line, stationByCode) {
+    const f = line.split('|');
+    if (f.length < 33) return null;
+    return {
+        train_no: f[2] || '',
+        code: f[3] || '',
+        from_station: stationByCode.get(f[6])?.name || f[6] || '',
+        to_station: stationByCode.get(f[7])?.name || f[7] || '',
+        from_code: f[6] || '',
+        to_code: f[7] || '',
+        start_time: f[8] || '',
+        arrive_time: f[9] || '',
+        duration: f[10] || '',
+        available: (f[1] || '').trim() === '预订' || (f[11] || '').trim() === 'Y',
+        business_seat: f[32] || '',
+        first_seat: f[31] || '',
+        second_seat: f[30] || '',
+        soft_sleeper: f[23] || '',
+        hard_sleeper: f[28] || '',
+        hard_seat: f[29] || '',
+        no_seat: f[26] || '',
+    };
+}
+
+export const __test__ = {
+    parseStationBundle,
+    resolveStation,
+    validateDate,
+    buildCookieHeader,
+    parseTrainRecord,
+};

--- a/clis/12306/utils.js
+++ b/clis/12306/utils.js
@@ -58,6 +58,9 @@ export function parseStationBundle(text) {
             city: parts[7] || '',
         });
     }
+    if (stations.length === 0) {
+        throw new CommandExecutionError('Failed to parse 12306 station_name.js: no station records found');
+    }
     return stations;
 }
 
@@ -203,6 +206,40 @@ export function maskChineseName(value) {
     return v[0] + '*'.repeat(v.length - 2) + v.slice(-1);
 }
 
+export function unwrapEvaluateResult(value) {
+    if (
+        value
+        && typeof value === 'object'
+        && !Array.isArray(value)
+        && Object.prototype.hasOwnProperty.call(value, 'session')
+        && Object.prototype.hasOwnProperty.call(value, 'data')
+    ) {
+        return value.data;
+    }
+    return value;
+}
+
+export function requireEvaluateObject(value, label) {
+    const payload = unwrapEvaluateResult(value);
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new CommandExecutionError(`12306 ${label} returned a malformed browser payload`);
+    }
+    return payload;
+}
+
+export function isAuthLikePayload(payload) {
+    if (!payload || typeof payload !== 'object') return false;
+    const parts = [];
+    if (Array.isArray(payload.messages)) parts.push(...payload.messages);
+    if (payload.message) parts.push(payload.message);
+    if (payload.msg) parts.push(payload.msg);
+    if (payload.validateMessages && typeof payload.validateMessages === 'object') {
+        parts.push(...Object.values(payload.validateMessages).flat());
+    }
+    const text = parts.map((item) => String(item ?? '')).join(' ');
+    return /未登录|登录|请登录|身份|认证|session|Session|login/i.test(text);
+}
+
 /**
  * Detect the 12306 login marker by reading `document.cookie` from the
  * current adapter page. Cannot use `page.getCookies({url})` here:
@@ -213,7 +250,7 @@ export function maskChineseName(value) {
  * regardless of path, which is what we need to confirm login.
  */
 export async function require12306Login(page, AuthRequiredErrorClass) {
-    const docCookie = await page.evaluate(`document.cookie || ''`);
+    const docCookie = unwrapEvaluateResult(await page.evaluate(`document.cookie || ''`));
     const cookieStr = typeof docCookie === 'string' ? docCookie : '';
     if (!/\btk=/.test(cookieStr) || !/JSESSIONID=/.test(cookieStr)) {
         throw new AuthRequiredErrorClass('kyfw.12306.cn', 'Not logged into 12306. Sign in at https://kyfw.12306.cn first.');
@@ -229,4 +266,7 @@ export const __test__ = {
     maskEmail,
     maskMobile,
     maskChineseName,
+    unwrapEvaluateResult,
+    requireEvaluateObject,
+    isAuthLikePayload,
 };

--- a/clis/12306/utils.js
+++ b/clis/12306/utils.js
@@ -30,7 +30,7 @@ const STATION_CODE_RE = /^[A-Z]{2,4}$/;
  * Per-record fields (positional):
  *   [0] short pinyin alias  (e.g. `bjb`)
  *   [1] Chinese station name (e.g. `北京北`)
- *   [2] telecode (3-4 uppercase letters, e.g. `VAP`) — this is the
+ *   [2] telecode (3-4 uppercase letters, e.g. `VAP`) - this is the
  *       wire format 12306 uses for `from_station` / `to_station`.
  *   [3] full pinyin           (e.g. `beijingbei`)
  *   [4] short alias           (duplicate of [0] usually)
@@ -168,10 +168,65 @@ export function parseTrainRecord(line, stationByCode) {
     };
 }
 
+/**
+ * Mask helpers for sensitive identity fields rendered by 12306.
+ *
+ * 12306 already masks ID numbers and mobile numbers server-side
+ * (`xxxx***********xxx` / `138****xxxx`); these helpers handle the
+ * remaining fields (email, real Chinese name) so the adapter never
+ * leaks unmasked PII without an explicit `--include-sensitive` opt-in.
+ */
+export function maskEmail(value) {
+    const v = String(value || '').trim();
+    if (!v) return '';
+    const at = v.indexOf('@');
+    if (at <= 0) return v;
+    const local = v.slice(0, at);
+    const domain = v.slice(at);
+    if (local.length <= 2) return local[0] + '*' + domain;
+    return local[0] + '*'.repeat(Math.max(1, local.length - 2)) + local.slice(-1) + domain;
+}
+
+export function maskMobile(value) {
+    const v = String(value || '').trim();
+    if (!v) return '';
+    if (/\*/.test(v)) return v;
+    if (v.length < 7) return v.replace(/.(?=.)/g, '*');
+    return v.slice(0, 3) + '*'.repeat(v.length - 7) + v.slice(-4);
+}
+
+export function maskChineseName(value) {
+    const v = String(value || '').trim();
+    if (!v) return '';
+    if (v.length === 1) return v;
+    if (v.length === 2) return v[0] + '*';
+    return v[0] + '*'.repeat(v.length - 2) + v.slice(-1);
+}
+
+/**
+ * Detect the 12306 login marker by reading `document.cookie` from the
+ * current adapter page. Cannot use `page.getCookies({url})` here:
+ * 12306 sets the auth cookie `tk` and `JSESSIONID` with `Path=/otn`,
+ * and CDP `Network.getCookies` with a bare URL filter excludes
+ * cookies whose path does not match the URL path. `document.cookie`
+ * returns all non-httponly cookies visible to the current page
+ * regardless of path, which is what we need to confirm login.
+ */
+export async function require12306Login(page, AuthRequiredErrorClass) {
+    const docCookie = await page.evaluate(`document.cookie || ''`);
+    const cookieStr = typeof docCookie === 'string' ? docCookie : '';
+    if (!/\btk=/.test(cookieStr) || !/JSESSIONID=/.test(cookieStr)) {
+        throw new AuthRequiredErrorClass('kyfw.12306.cn', 'Not logged into 12306. Sign in at https://kyfw.12306.cn first.');
+    }
+}
+
 export const __test__ = {
     parseStationBundle,
     resolveStation,
     validateDate,
     buildCookieHeader,
     parseTrainRecord,
+    maskEmail,
+    maskMobile,
+    maskChineseName,
 };

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './utils.js';
+
+const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord } = __test__;
+
+describe('12306 utils — parseStationBundle', () => {
+    it('parses the `@`-delimited station bundle into structured records', () => {
+        const bundle = "var station_names ='@bjb|北京北|VAP|beijingbei|bjb|0|0357|北京|||@bji|北京|BJP|beijing|bj|2|0357|北京|||@aoh|上海虹桥|AOH|shanghaihongqiao|shhq|10|7600|上海|||';";
+        const stations = parseStationBundle(bundle);
+        expect(stations).toHaveLength(3);
+        expect(stations[1]).toEqual({
+            short: 'bji', name: '北京', code: 'BJP', pinyin: 'beijing', abbr: 'bj', city: '北京',
+        });
+    });
+
+    it('skips records that lack a telecode', () => {
+        const bundle = "var station_names ='@xxx|||||||||@bji|北京|BJP|beijing|bj|2|0357|北京|||';";
+        const stations = parseStationBundle(bundle);
+        expect(stations).toHaveLength(1);
+        expect(stations[0].code).toBe('BJP');
+    });
+});
+
+describe('12306 utils — resolveStation', () => {
+    const stations = [
+        { short: 'bjb', name: '北京北', code: 'VAP', pinyin: 'beijingbei', abbr: 'bjb', city: '北京' },
+        { short: 'bji', name: '北京', code: 'BJP', pinyin: 'beijing', abbr: 'bj', city: '北京' },
+        { short: 'aoh', name: '上海虹桥', code: 'AOH', pinyin: 'shanghaihongqiao', abbr: 'shhq', city: '上海' },
+    ];
+
+    it('matches by exact Chinese name', () => {
+        expect(resolveStation(stations, '上海虹桥').code).toBe('AOH');
+    });
+
+    it('matches by uppercase telecode', () => {
+        expect(resolveStation(stations, 'BJP').code).toBe('BJP');
+    });
+
+    it('matches by full pinyin (case-insensitive)', () => {
+        expect(resolveStation(stations, 'Beijing').code).toBe('BJP');
+    });
+
+    it('matches by short alias / abbr', () => {
+        expect(resolveStation(stations, 'shhq').code).toBe('AOH');
+    });
+
+    it('throws ArgumentError for empty input', () => {
+        expect(() => resolveStation(stations, '   ')).toThrow(ArgumentError);
+    });
+
+    it('throws ArgumentError for unknown station', () => {
+        expect(() => resolveStation(stations, '某不存在站')).toThrow(ArgumentError);
+    });
+
+    it('throws ArgumentError for telecode-shaped but unknown input', () => {
+        expect(() => resolveStation(stations, 'XYZ')).toThrow(ArgumentError);
+    });
+});
+
+describe('12306 utils — validateDate', () => {
+    it('accepts valid YYYY-MM-DD', () => {
+        expect(validateDate('2026-05-22')).toBe('2026-05-22');
+    });
+
+    it('throws ArgumentError on wrong format', () => {
+        expect(() => validateDate('2026/05/22')).toThrow(ArgumentError);
+        expect(() => validateDate('26-05-22')).toThrow(ArgumentError);
+        expect(() => validateDate('today')).toThrow(ArgumentError);
+        expect(() => validateDate('')).toThrow(ArgumentError);
+    });
+
+    it('throws ArgumentError on impossible calendar dates', () => {
+        expect(() => validateDate('2026-02-30')).toThrow(ArgumentError);
+        expect(() => validateDate('2026-13-01')).toThrow(ArgumentError);
+    });
+});
+
+describe('12306 utils — buildCookieHeader', () => {
+    it('joins set-cookie lines into a single Cookie header', () => {
+        const headers = [
+            'JSESSIONID=ABC123; Path=/otn',
+            'BIGipServerotn=xxx.yyy; Path=/',
+            'route=zzz; Expires=Sat, 01 Jan 2027 00:00:00 GMT',
+        ];
+        expect(buildCookieHeader(headers)).toBe('JSESSIONID=ABC123; BIGipServerotn=xxx.yyy; route=zzz');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(buildCookieHeader([])).toBe('');
+        expect(buildCookieHeader(undefined)).toBe('');
+    });
+});
+
+describe('12306 utils — parseTrainRecord', () => {
+    const stationByCode = new Map([
+        ['VNP', { name: '北京南', code: 'VNP' }],
+        ['AOH', { name: '上海虹桥', code: 'AOH' }],
+    ]);
+
+    it('extracts the canonical train fields from a wire record', () => {
+        // 33 `|`-separated fields, with positions used by parseTrainRecord populated.
+        const fields = new Array(36).fill('');
+        fields[0] = 'SECRET_TOKEN';
+        fields[1] = '预订';
+        fields[2] = '240000G54700';
+        fields[3] = 'G547';
+        fields[6] = 'VNP';
+        fields[7] = 'AOH';
+        fields[8] = '06:18';
+        fields[9] = '12:11';
+        fields[10] = '05:53';
+        fields[11] = 'Y';
+        fields[23] = ''; // soft sleeper
+        fields[26] = '无'; // no seat
+        fields[28] = ''; // hard sleeper
+        fields[29] = ''; // hard seat
+        fields[30] = '有'; // second seat
+        fields[31] = '有'; // first seat
+        fields[32] = '无'; // business seat
+        const row = parseTrainRecord(fields.join('|'), stationByCode);
+        expect(row).toEqual({
+            train_no: '240000G54700',
+            code: 'G547',
+            from_station: '北京南',
+            to_station: '上海虹桥',
+            from_code: 'VNP',
+            to_code: 'AOH',
+            start_time: '06:18',
+            arrive_time: '12:11',
+            duration: '05:53',
+            available: true,
+            business_seat: '无',
+            first_seat: '有',
+            second_seat: '有',
+            soft_sleeper: '',
+            hard_sleeper: '',
+            hard_seat: '',
+            no_seat: '无',
+        });
+    });
+
+    it('does not expose the booking-handshake secret token', () => {
+        const fields = new Array(36).fill('');
+        fields[0] = 'SECRET_TOKEN_DO_NOT_LEAK';
+        fields[2] = 't_no'; fields[3] = 'X1'; fields[6] = 'VNP'; fields[7] = 'AOH';
+        const row = parseTrainRecord(fields.join('|'), stationByCode);
+        expect(Object.values(row)).not.toContain('SECRET_TOKEN_DO_NOT_LEAK');
+        expect('secret' in row).toBe(false);
+    });
+
+    it('falls back to the telecode when the station bundle has no name', () => {
+        const fields = new Array(36).fill('');
+        fields[2] = 'X'; fields[3] = 'X'; fields[6] = 'ZZZ'; fields[7] = 'YYY';
+        const row = parseTrainRecord(fields.join('|'), stationByCode);
+        expect(row.from_station).toBe('ZZZ');
+        expect(row.to_station).toBe('YYY');
+    });
+
+    it('returns null for short records', () => {
+        expect(parseTrainRecord('a|b|c', stationByCode)).toBeNull();
+    });
+});

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './utils.js';
 import { __test__ as priceTest } from './price.js';
+import { __test__ as trainTest } from './train.js';
 import './orders.js';
 
 const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord, maskEmail, maskMobile, maskChineseName, unwrapEvaluateResult, requireEvaluateObject, isAuthLikePayload } = __test__;
-const { parsePriceData } = priceTest;
+const { parsePriceData, queryStopsForPrice, queryPrice } = priceTest;
+const { queryStops } = trainTest;
 
 describe('12306 utils - parseStationBundle', () => {
     it('parses the `@`-delimited station bundle into structured records', () => {
@@ -227,6 +229,27 @@ describe('12306 price - parsePriceData', () => {
     });
 });
 
+describe('12306 public API typed boundaries', () => {
+    const nonJsonFetch = async () => ({
+        ok: true,
+        json: async () => {
+            throw new SyntaxError('Unexpected token <');
+        },
+    });
+
+    it('wraps non-JSON train stop bodies as CommandExecutionError', async () => {
+        await expect(queryStops('cookie=1', '24000000G10L', 'BJP', 'AOH', '2026-05-22', nonJsonFetch))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('wraps non-JSON price helper bodies as CommandExecutionError', async () => {
+        await expect(queryStopsForPrice('cookie=1', '24000000G10L', 'BJP', 'AOH', '2026-05-22', nonJsonFetch))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(queryPrice('cookie=1', '24000000G10L', '01', '02', 'OM9', '2026-05-22', nonJsonFetch))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
 describe('12306 browser evaluate boundaries', () => {
     it('unwraps Browser Bridge {session,data} evaluate envelopes only at the boundary', () => {
         expect(unwrapEvaluateResult({ session: 's1', data: 'JSESSIONID=1; tk=2' })).toBe('JSESSIONID=1; tk=2');
@@ -288,5 +311,21 @@ describe('12306 browser evaluate boundaries', () => {
         };
 
         await expect(command.func(page, {})).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('treats missing order list shape as parser drift but known empty arrays as empty result', async () => {
+        const command = getRegistry().get('12306/orders');
+        const makePage = (payload) => ({
+            goto: async () => {},
+            evaluate: async (script) => {
+                if (script === "document.cookie || ''") return 'JSESSIONID=abc; tk=def';
+                return payload;
+            },
+        });
+
+        await expect(command.func(makePage({ status: true, data: {} }), {}))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ status: true, data: { orderDBList: [] } }), {}))
+            .rejects.toBeInstanceOf(EmptyResultError);
     });
 });

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
 import { __test__ } from './utils.js';
+import { __test__ as priceTest } from './price.js';
 
-const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord } = __test__;
+const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord, maskEmail, maskMobile, maskChineseName } = __test__;
+const { parsePriceData } = priceTest;
 
-describe('12306 utils — parseStationBundle', () => {
+describe('12306 utils - parseStationBundle', () => {
     it('parses the `@`-delimited station bundle into structured records', () => {
         const bundle = "var station_names ='@bjb|北京北|VAP|beijingbei|bjb|0|0357|北京|||@bji|北京|BJP|beijing|bj|2|0357|北京|||@aoh|上海虹桥|AOH|shanghaihongqiao|shhq|10|7600|上海|||';";
         const stations = parseStationBundle(bundle);
@@ -22,7 +24,7 @@ describe('12306 utils — parseStationBundle', () => {
     });
 });
 
-describe('12306 utils — resolveStation', () => {
+describe('12306 utils - resolveStation', () => {
     const stations = [
         { short: 'bjb', name: '北京北', code: 'VAP', pinyin: 'beijingbei', abbr: 'bjb', city: '北京' },
         { short: 'bji', name: '北京', code: 'BJP', pinyin: 'beijing', abbr: 'bj', city: '北京' },
@@ -58,7 +60,7 @@ describe('12306 utils — resolveStation', () => {
     });
 });
 
-describe('12306 utils — validateDate', () => {
+describe('12306 utils - validateDate', () => {
     it('accepts valid YYYY-MM-DD', () => {
         expect(validateDate('2026-05-22')).toBe('2026-05-22');
     });
@@ -76,7 +78,7 @@ describe('12306 utils — validateDate', () => {
     });
 });
 
-describe('12306 utils — buildCookieHeader', () => {
+describe('12306 utils - buildCookieHeader', () => {
     it('joins set-cookie lines into a single Cookie header', () => {
         const headers = [
             'JSESSIONID=ABC123; Path=/otn',
@@ -92,7 +94,7 @@ describe('12306 utils — buildCookieHeader', () => {
     });
 });
 
-describe('12306 utils — parseTrainRecord', () => {
+describe('12306 utils - parseTrainRecord', () => {
     const stationByCode = new Map([
         ['VNP', { name: '北京南', code: 'VNP' }],
         ['AOH', { name: '上海虹桥', code: 'AOH' }],
@@ -159,5 +161,62 @@ describe('12306 utils — parseTrainRecord', () => {
 
     it('returns null for short records', () => {
         expect(parseTrainRecord('a|b|c', stationByCode)).toBeNull();
+    });
+});
+
+describe('12306 utils - mask helpers', () => {
+    it('masks the local-part of an email', () => {
+        expect(maskEmail('hello@example.com')).toBe('h***o@example.com');
+        expect(maskEmail('ab@x.cn')).toBe('a*@x.cn');
+        expect(maskEmail('a@x.cn')).toBe('a*@x.cn');
+        expect(maskEmail('')).toBe('');
+        expect(maskEmail('not-an-email')).toBe('not-an-email');
+    });
+
+    it('masks Chinese mobile numbers while preserving 12306-side masks', () => {
+        expect(maskMobile('13800001234')).toBe('138****1234');
+        expect(maskMobile('138****1234')).toBe('138****1234');
+        expect(maskMobile('')).toBe('');
+        expect(maskMobile('123')).toBe('**3');
+    });
+
+    it('masks Chinese real names', () => {
+        expect(maskChineseName('张三')).toBe('张*');
+        expect(maskChineseName('李四明')).toBe('李*明');
+        expect(maskChineseName('欧阳锋')).toBe('欧*锋');
+        expect(maskChineseName('张')).toBe('张');
+        expect(maskChineseName('')).toBe('');
+    });
+});
+
+describe('12306 price - parsePriceData', () => {
+    it('returns seat rows sorted by descending price and drops dup numeric codes', () => {
+        const data = {
+            train_no: '24000000G10L',
+            'OT': [],
+            'A9': '¥2158.0',
+            '9': '21580',
+            'P': '¥1163.0',
+            'M': '¥1035.0',
+            'O': '¥626.0',
+            'WZ': '¥626.0',
+            'INVALID': 'not-a-price',
+        };
+        const rows = parsePriceData(data);
+        const codes = rows.map((r) => r.seat_code);
+        expect(codes).not.toContain('9');
+        expect(codes).not.toContain('OT');
+        expect(codes).not.toContain('train_no');
+        expect(codes).not.toContain('INVALID');
+        expect(codes).toEqual(['A9', 'P', 'M', 'O', 'WZ']);
+        expect(rows[0]).toEqual({ seat_code: 'A9', seat_name: '商务座', price: '2158.0', currency: 'CNY' });
+        expect(rows[4]).toEqual({ seat_code: 'WZ', seat_name: '无座', price: '626.0', currency: 'CNY' });
+    });
+
+    it('keeps unknown letter codes with the letter as the name', () => {
+        const data = { 'A9': '¥100.0', 'ZZ': '¥50.0' };
+        const rows = parsePriceData(data);
+        const zz = rows.find((r) => r.seat_code === 'ZZ');
+        expect(zz?.seat_name).toBe('ZZ');
     });
 });

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './utils.js';
 import { __test__ as priceTest } from './price.js';
+import './orders.js';
 
-const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord, maskEmail, maskMobile, maskChineseName } = __test__;
+const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord, maskEmail, maskMobile, maskChineseName, unwrapEvaluateResult, requireEvaluateObject, isAuthLikePayload } = __test__;
 const { parsePriceData } = priceTest;
 
 describe('12306 utils - parseStationBundle', () => {
@@ -21,6 +23,10 @@ describe('12306 utils - parseStationBundle', () => {
         const stations = parseStationBundle(bundle);
         expect(stations).toHaveLength(1);
         expect(stations[0].code).toBe('BJP');
+    });
+
+    it('throws CommandExecutionError when the bundle has no parseable station rows', () => {
+        expect(() => parseStationBundle("var station_names ='@xxx|||||||||';")).toThrow(CommandExecutionError);
     });
 });
 
@@ -218,5 +224,69 @@ describe('12306 price - parsePriceData', () => {
         const rows = parsePriceData(data);
         const zz = rows.find((r) => r.seat_code === 'ZZ');
         expect(zz?.seat_name).toBe('ZZ');
+    });
+});
+
+describe('12306 browser evaluate boundaries', () => {
+    it('unwraps Browser Bridge {session,data} evaluate envelopes only at the boundary', () => {
+        expect(unwrapEvaluateResult({ session: 's1', data: 'JSESSIONID=1; tk=2' })).toBe('JSESSIONID=1; tk=2');
+        expect(unwrapEvaluateResult({ status: true, data: { value: 1 } })).toEqual({ status: true, data: { value: 1 } });
+        expect(requireEvaluateObject({ session: 's1', data: { status: true } }, 'test')).toEqual({ status: true });
+        expect(() => requireEvaluateObject({ session: 's1', data: null }, 'test')).toThrow(CommandExecutionError);
+    });
+
+    it('classifies 12306 login-like API envelopes as auth failures', () => {
+        expect(isAuthLikePayload({ status: false, messages: ['用户未登录'] })).toBe(true);
+        expect(isAuthLikePayload({ status: false, validateMessages: { global: ['请登录后再试'] } })).toBe(true);
+        expect(isAuthLikePayload({ status: false, messages: ['系统繁忙'] })).toBe(false);
+    });
+
+    it('masks passenger names in orders by default and supports explicit sensitive opt-in', async () => {
+        const command = getRegistry().get('12306/orders');
+        const makePage = () => ({
+            goto: async () => {},
+            evaluate: async (script) => {
+                if (script === "document.cookie || ''") return { session: 'browser', data: 'JSESSIONID=abc; tk=def' };
+                return {
+                    session: 'browser',
+                    data: {
+                        status: true,
+                        data: {
+                            orderDBList: [{
+                                sequence_no: 'E123',
+                                order_date: '2026-05-18 10:00',
+                                train_code_page: 'G1',
+                                from_station_name_page: '北京南',
+                                to_station_name_page: '上海虹桥',
+                                start_train_date_page: '2026-05-22 07:00',
+                                ticket_status_name: '未出行',
+                                ticket_total_price_page: '626.0',
+                                tickets: [{ passenger_name: '张三' }, { passenger_name: '李四明' }],
+                            }],
+                        },
+                    },
+                };
+            },
+        });
+
+        await expect(command.func(makePage(), {})).resolves.toMatchObject([
+            { order_id: 'E123', passengers: '张*, 李*明' },
+        ]);
+        await expect(command.func(makePage(), { 'include-sensitive': true })).resolves.toMatchObject([
+            { order_id: 'E123', passengers: '张三, 李四明' },
+        ]);
+    });
+
+    it('maps login-like order payloads to AuthRequiredError instead of parser drift', async () => {
+        const command = getRegistry().get('12306/orders');
+        const page = {
+            goto: async () => {},
+            evaluate: async (script) => {
+                if (script === "document.cookie || ''") return 'JSESSIONID=abc; tk=def';
+                return { status: false, messages: ['用户未登录'] };
+            },
+        };
+
+        await expect(command.func(page, {})).rejects.toBeInstanceOf(AuthRequiredError);
     });
 });

--- a/docs/adapters/browser/12306.md
+++ b/docs/adapters/browser/12306.md
@@ -1,0 +1,210 @@
+# 12306 (中国铁路 China Railway)
+
+**Mode**: 🌐 Public (`stations`, `trains`, `train`, `price`) · 🖥️ Browser + Cookie (`me`, `passengers`, `orders`)
+**Domain**: `kyfw.12306.cn`
+
+Read-only adapter against the 12306 (China Railway) site. Anonymous queries
+hit the public ticket-search endpoints; authenticated queries reuse the
+user's existing browser login state. No CAPTCHA / slider / SMS / anti-abuse
+bypass is performed, no credentials are stored, and no booking / payment /
+ticket-sniping is implemented.
+
+## Commands
+
+| Command | Mode | Description |
+|---------|------|-------------|
+| `opencli 12306 stations` | Public | Search the station bundle by Chinese name, telecode, full pinyin, or short alias |
+| `opencli 12306 trains` | Public | Trains between two stations on a given date with per-seat-class availability |
+| `opencli 12306 train` | Public | Stop list (arrive / depart / stopover time) for one train segment |
+| `opencli 12306 price` | Public | Ticket prices by seat class for one train segment + date |
+| `opencli 12306 me` | Browser (cookie) | Logged-in account summary (sensitive fields masked by default) |
+| `opencli 12306 passengers` | Browser (cookie) | Saved passenger list (sensitive fields masked by default) |
+| `opencli 12306 orders` | Browser (cookie) | In-progress orders (not yet ridden / refunded / completed) |
+
+## Usage Examples
+
+```bash
+# Search stations
+opencli 12306 stations 上海 --limit 5
+opencli 12306 stations beijing
+opencli 12306 stations AOH        # by telecode
+
+# List trains between two stations
+opencli 12306 trains 北京 上海 --date 2026-05-22 --limit 20
+opencli 12306 trains BJP AOH --date 2026-05-22
+
+# Show stops for one train
+opencli 12306 train 24000000G10L --from 北京南 --to 上海虹桥 --date 2026-05-22
+
+# Ticket prices by seat class
+opencli 12306 price 24000000G10L --from 北京南 --to 上海虹桥 --date 2026-05-22
+
+# Authenticated commands (require login on kyfw.12306.cn first)
+opencli 12306 me
+opencli 12306 me --include-sensitive
+opencli 12306 passengers --limit 10
+opencli 12306 orders
+
+# JSON output
+opencli 12306 trains 北京 上海 --date 2026-05-22 -f json
+```
+
+## Station Resolution
+
+The `<from>` and `<to>` arguments on `trains`, `train`, and `price` accept
+any of the following forms; lookup is anchored against the public
+`station_name.js` bundle 12306 ships:
+
+- **Chinese name** (`上海虹桥`)
+- **Telecode** (`AOH`, 3-4 uppercase letters, the wire format used in
+  12306's own API)
+- **Full pinyin** (`shanghaihongqiao`, case-insensitive)
+- **Short alias / abbr** (`shhq`)
+
+Anything else raises `ArgumentError` with a hint pointing to the accepted
+forms. Match order is exact-name first, so `北京` does not accidentally
+resolve to `北京北` by substring.
+
+## Columns
+
+### `stations`
+
+| Column | Notes |
+|--------|-------|
+| `name` | Chinese station name |
+| `code` | 3-4 letter telecode (use in API URLs) |
+| `pinyin` | Full pinyin |
+| `abbr` | Short alias |
+| `city` | Chinese city name |
+
+### `trains`
+
+| Column | Notes |
+|--------|-------|
+| `code` | Public train code (`G1`, `D301`, ...) |
+| `from_station` / `to_station` | Chinese station names |
+| `from_code` / `to_code` | Telecodes |
+| `start_time` / `arrive_time` / `duration` | `HH:MM` format |
+| `available` | `true` when 12306 shows 预订 status |
+| `business_seat` / `first_seat` / `second_seat` | Availability for 商务座 / 一等座 / 二等座 (有 / 无 / number string) |
+| `soft_sleeper` / `hard_sleeper` / `hard_seat` / `no_seat` | Same shape for 软卧 / 硬卧 / 硬座 / 无座 |
+| `train_no` | Internal id used by `train` and `price` commands |
+
+### `train`
+
+| Column | Notes |
+|--------|-------|
+| `station_no` | 1-based stop index within this train's route |
+| `station_name` | Chinese name |
+| `arrive_time` / `start_time` / `stopover_time` | Empty string for the origin (no arrive) and destination (no stopover) |
+
+### `price`
+
+| Column | Notes |
+|--------|-------|
+| `seat_code` | 12306 seat letter (`A9` 商务座, `M` 一等座, `O` 二等座, `WZ` 无座, `A1` 硬座, `A3` 硬卧, `A4` 软卧, `F` 动卧, `P` 特等座) |
+| `seat_name` | Localised Chinese label |
+| `price` | Decimal string (CNY) |
+| `currency` | Always `CNY` |
+
+Rows are sorted by descending price. 12306 double-encodes some prices as
+bare numeric keys (e.g. `"9": "21580"` mirroring `"A9": "¥2158.0"` in
+no-decimal form); the bare-numeric duplicates are filtered out so each
+seat class appears exactly once.
+
+### `me`
+
+| Column | Notes |
+|--------|-------|
+| `username` | 12306 login name (`loginUserDTO.user_name`) |
+| `real_name` | Masked by default; `--include-sensitive` to opt in |
+| `email` | Local-part masked by default |
+| `mobile` | 12306 already masks server-side (`xxx****xxxx`) and the adapter preserves that |
+| `birth_date` | Year only by default |
+| `sex`, `country`, `user_type` | `男` / `女`, ISO-3, e.g. `成人` |
+| `member`, `active` | Boolean flags |
+
+### `passengers`
+
+| Column | Notes |
+|--------|-------|
+| `name` | Masked by default to `<surname>*<...>` |
+| `sex` | `男` / `女` |
+| `born_year` | Year only by default |
+| `id_type` | e.g. `居民身份证` |
+| `id_no` | 12306 masks server-side; the adapter never decodes |
+| `mobile` | Same as `me` |
+| `passenger_type` | `成人`, `儿童`, `学生`, `残军` |
+| `country` | ISO-3 |
+
+### `orders`
+
+| Column | Notes |
+|--------|-------|
+| `order_id` | 12306 sequence_no |
+| `order_date` | Order placement timestamp |
+| `train_code` | Public train code |
+| `from_station` / `to_station` | Chinese names |
+| `departure` | Departure timestamp |
+| `passengers` | Comma-separated passenger names from the order |
+| `status` | 12306 ticket / order status name |
+| `amount` | Total price (CNY) |
+
+## Login
+
+The three authenticated commands (`me`, `passengers`, `orders`) require a
+logged-in 12306 session in the same Chrome instance that OpenCLI's bridge
+talks to. Sign in once at `https://kyfw.12306.cn`; the adapter then reads
+the resulting `tk` / `JSESSIONID` cookies on subsequent runs.
+
+Login is detected via `document.cookie` rather than
+`page.getCookies({url})`, because 12306 sets the auth cookies with
+`Path=/otn` and CDP `Network.getCookies` filters by URL path - a bare
+`https://kyfw.12306.cn` URL filter would otherwise hide them. If `tk` or
+`JSESSIONID` is missing, the adapter raises `AuthRequiredError`.
+
+## Privacy
+
+Authenticated commands mask sensitive fields by default:
+
+- **Email**: local part is `<first>***<last>@<domain>`
+- **Mobile**: 12306's own mask is preserved (the adapter never tries to
+  decode it)
+- **Real name / passenger name**: Chinese names are masked to
+  `<first-char>*<last-char>` (or `<first-char>*` for two-character names)
+- **Birth date**: year only
+
+Pass `--include-sensitive` on `me` or `passengers` to opt back into the
+unmasked fields the user is entitled to see on their own account. The
+12306-side ID number mask is server-side and is never decoded.
+
+## Limit Validation
+
+All `--limit` arguments use a strict validator that throws `ArgumentError`
+on non-integer / out-of-range input rather than silently clamping. The
+caps are:
+
+- `stations`: 1-50 (default 20)
+- `trains`: 1-100 (default 50)
+- `passengers`: 1-50 (default 20)
+
+## Endpoint Notes
+
+- `/otn/leftTicket/init` is hit first to mint anonymous session cookies
+  (`JSESSIONID`, `route`, `BIGipServerotn`).
+- 12306 rotates the train-query endpoint name (`queryO`, `queryZ`,
+  `queryA`, `queryG`, ...) every few weeks. The adapter walks a list of
+  known names; when the server responds with
+  `{c_url: "leftTicket/queryX"}` it captures the suggested name and
+  retries.
+- The `|`-separated train wire record includes a base64 booking-handshake
+  `secret` token at position 0. This adapter parses but does not surface
+  that field (a unit test asserts it cannot leak via the row shape).
+
+## Non-Goals
+
+- No ticket sniping
+- No order submission / payment
+- No CAPTCHA / slider / SMS / anti-abuse bypass
+- No password storage
+- No order history beyond the in-progress slice (left as a follow-up)

--- a/docs/adapters/browser/12306.md
+++ b/docs/adapters/browser/12306.md
@@ -44,6 +44,7 @@ opencli 12306 me
 opencli 12306 me --include-sensitive
 opencli 12306 passengers --limit 10
 opencli 12306 orders
+opencli 12306 orders --include-sensitive
 
 # JSON output
 opencli 12306 trains 北京 上海 --date 2026-05-22 -f json
@@ -146,7 +147,7 @@ seat class appears exactly once.
 | `train_code` | Public train code |
 | `from_station` / `to_station` | Chinese names |
 | `departure` | Departure timestamp |
-| `passengers` | Comma-separated passenger names from the order |
+| `passengers` | Comma-separated passenger names from the order; masked by default, `--include-sensitive` to opt in |
 | `status` | 12306 ticket / order status name |
 | `amount` | Total price (CNY) |
 
@@ -170,12 +171,12 @@ Authenticated commands mask sensitive fields by default:
 - **Email**: local part is `<first>***<last>@<domain>`
 - **Mobile**: 12306's own mask is preserved (the adapter never tries to
   decode it)
-- **Real name / passenger name**: Chinese names are masked to
+- **Real name / passenger/order passenger name**: Chinese names are masked to
   `<first-char>*<last-char>` (or `<first-char>*` for two-character names)
 - **Birth date**: year only
 
-Pass `--include-sensitive` on `me` or `passengers` to opt back into the
-unmasked fields the user is entitled to see on their own account. The
+Pass `--include-sensitive` on `me`, `passengers`, or `orders` to opt back into
+the unmasked fields the user is entitled to see on their own account. The
 12306-side ID number mask is server-side and is never decoded.
 
 ## Limit Validation


### PR DESCRIPTION
## Description

Closes #1589 with the full 12306 (中国铁路) adapter the issue proposes. Seven commands across two strategies:

| Strategy | Command | What |
|----------|---------|------|
| `PUBLIC` (no login) | `12306 stations <keyword>` | Search station bundle by Chinese name, telecode, full pinyin, or short alias |
| `PUBLIC` | `12306 trains <from> <to> --date YYYY-MM-DD` | Trains between two stations on a given date with per-seat-class availability |
| `PUBLIC` | `12306 train <train-no> --from --to --date` | Full stop list for one train segment |
| `PUBLIC` | `12306 price <train-no> --from --to --date` | Ticket prices keyed by seat class for one segment |
| `COOKIE` (login) | `12306 me` | Account summary, sensitive fields masked by default |
| `COOKIE` | `12306 passengers` | Saved-passenger list, sensitive fields masked |
| `COOKIE` | `12306 orders` | In-progress orders (not yet ridden / refunded / completed) |

No CAPTCHA / slider / SMS bypass, no credential storage, no ticket sniping, no order submission, no payment - per the issue's Non-goals list.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Implementation notes worth flagging

### Anonymous session minting

12306 rejects bare anonymous query endpoints with `HTTP 302 -> /mormhweb/logFiles/error.html`. The adapter first hits `/otn/leftTicket/init` to mint `JSESSIONID` / `route` / `BIGipServerotn` cookies, then attaches them to subsequent queries. No CAPTCHA / slider path is invoked. Cookies are not persisted to disk; they live only for the lifetime of the command invocation.

### Endpoint name rotation (`queryO` / `queryZ` / `queryA` / `queryG` / ...)

12306 rotates the train-query endpoint name every few weeks. When the wrong name is hit the server returns `{"c_url": "leftTicket/queryG", "c_name": "CLeftTicketUrl", "status": false}` pointing to the current correct name. `trains` walks a list of known names, captures the rotation hint, retries against the suggested name, and mutates the runtime list so subsequent calls in the same process skip the warm-up round trip.

### Login detection via `document.cookie`, not `page.getCookies({url})`

12306 sets the auth cookie `tk` and the session cookie `JSESSIONID` with `Path=/otn`. CDP `Network.getCookies` filters by URL path: even with the page navigated to `https://kyfw.12306.cn/otn/view/index.html` and the user fully logged in, `page.getCookies({ url: 'https://kyfw.12306.cn' })` returns 7 cookies without `tk` / `JSESSIONID`, because that URL has path `/`, not `/otn`. Switched the login check to read `document.cookie` via `page.evaluate`, which exposes the navigated page's full visible-cookie set regardless of path. Centralized as `require12306Login` in `utils.js` so all three authenticated commands share the same check (and so future maintainers know not to "fix" it back to `page.getCookies`).

### Booking-handshake `secret` field is stripped

The `|`-separated train wire record carries a base64 `secret` token at position 0 used to construct booking handshakes. Since this PR is read-only and the issue rules out booking, `parseTrainRecord` parses but does not surface that field, and a regression unit test asserts it cannot leak via the adapter contract:

```js
it('does not expose the booking-handshake secret token', () => {
    const row = parseTrainRecord(fields.join('|'), stationByCode);
    expect(Object.values(row)).not.toContain('SECRET_TOKEN_DO_NOT_LEAK');
    expect('secret' in row).toBe(false);
});
```

### Sensitive-field masking on authenticated commands

- `me`: real name (Chinese mask, e.g. `张*`), email (e.g. `xxx@xxx.xxx`), mobile (12306 already masks server-side and the adapter preserves that, e.g. `xxx-xxx-xxxx`), birth date (year only).
- `passengers`: passenger name (Chinese mask) + birth year (year only); 12306 already masks ID number (e.g. `xxxxxxxxxxxxxxxxxxx`) and mobile server-side and this adapter never decodes those.
- Both expose `--include-sensitive` to opt back into the unmasked fields the user is entitled to see on their own account.

### `orders` scope

Returns the `queryMyOrderNoComplete` slice (orders that have not yet been ridden / refunded / completed). The historical `queryMyOrderApi` endpoint requires extra page-state handshakes that proved fragile when probed - the server returned 302s into the error landing page under repeated anonymous calls. Left as a follow-up so this command can ship reliably for the immediate "what's still on my account" use case.

### `price` cascading

Cascades three anonymous API calls per invocation: `init` -> `queryByTrainNo` (to resolve segment station_no within the train route - the price endpoint addresses stops by station_no, not telecode) -> `queryTicketPrice`. 12306 returns prices keyed by one-or-two-letter seat codes (`A9` 商务座 / `M` 一等座 / `O` 二等座 / `WZ` 无座 / etc.) and additionally doubles some up as bare numeric codes (e.g. `"9": "21580"` mirrors `"A9": "¥2158.0"`); the bare-numeric duplicates are filtered out so the row set is one-per-seat-class.

### Station resolution

`resolveStation` matches Chinese name (`上海虹桥`), telecode (`AOH`), full pinyin (`shanghaihongqiao`), and short alias (`shhq`). Anything else raises `ArgumentError` with a hint. Match order is exact-name first to prevent `北京` matching `北京北` by substring.

### Strict limit validation

`limit` arguments use a small inline validator that throws `ArgumentError` on non-integer / out-of-range input rather than silently clamping. Mirrors the typed-error pattern owner used in #1397 (grok) and #1370 (coupang).

## Screenshots / Output

Live verified anonymously and authenticated against `kyfw.12306.cn`, sleeping 15-25 seconds between hits to keep 12306's anti-abuse throttle gentle. All commands run via `node ./dist/src/main.js` from this branch's worktree so the local `clis/12306/` adapters in this PR are loaded.

### Anonymous commands (real API output)

```bash
$ node ./dist/src/main.js 12306 stations 上海 --limit 5 -f json
[
  { "name": "练塘",     "code": "LTU", "pinyin": "liantang",         "abbr": "lt",   "city": "上海" },
  { "name": "上海",     "code": "SHH", "pinyin": "shanghai",         "abbr": "sh",   "city": "上海" },
  { "name": "上海南",   "code": "SNH", "pinyin": "shanghainan",      "abbr": "shn",  "city": "上海" },
  { "name": "上海虹桥", "code": "AOH", "pinyin": "shanghaihongqiao", "abbr": "shhq", "city": "上海" },
  { "name": "上海西",   "code": "SXH", "pinyin": "shanghaixi",       "abbr": "shx",  "city": "上海" }
]

$ node ./dist/src/main.js 12306 trains 北京 上海 --date 2026-05-22 --limit 1 -f json
[
  {
    "train_no": "240000G54700", "code": "G547",
    "from_station": "北京南", "to_station": "上海虹桥",
    "from_code": "VNP", "to_code": "AOH",
    "start_time": "06:18", "arrive_time": "12:11", "duration": "05:53",
    "available": true,
    "business_seat": "无", "first_seat": "有", "second_seat": "有",
    "soft_sleeper": "", "hard_sleeper": "", "hard_seat": "", "no_seat": "无"
  }
]

$ node ./dist/src/main.js 12306 train 24000000G10L --from 北京南 --to 上海虹桥 --date 2026-05-22 -f json
[
  { "station_no": "01", "station_name": "北京南",   "arrive_time": "",      "start_time": "06:30", "stopover_time": ""      },
  { "station_no": "02", "station_name": "沧州西",   "arrive_time": "07:18", "start_time": "07:20", "stopover_time": "2分钟" },
  { "station_no": "03", "station_name": "德州东",   "arrive_time": "07:45", "start_time": "07:47", "stopover_time": "2分钟" },
  { "station_no": "04", "station_name": "曲阜东",   "arrive_time": "08:34", "start_time": "08:36", "stopover_time": "2分钟" },
  { "station_no": "05", "station_name": "南京南",   "arrive_time": "10:13", "start_time": "10:15", "stopover_time": "2分钟" },
  { "station_no": "06", "station_name": "苏州北",   "arrive_time": "10:59", "start_time": "11:01", "stopover_time": "2分钟" },
  { "station_no": "07", "station_name": "上海虹桥", "arrive_time": "11:24", "start_time": "11:24", "stopover_time": ""      }
]

$ node ./dist/src/main.js 12306 price 24000000G10L --from 北京南 --to 上海虹桥 --date 2026-05-22 -f json
[
  { "seat_code": "A9", "seat_name": "商务座", "price": "2158.0", "currency": "CNY" },
  { "seat_code": "P",  "seat_name": "特等座", "price": "1163.0", "currency": "CNY" },
  { "seat_code": "M",  "seat_name": "一等座", "price": "1035.0", "currency": "CNY" },
  { "seat_code": "WZ", "seat_name": "无座",   "price": "626.0",  "currency": "CNY" },
  { "seat_code": "O",  "seat_name": "二等座", "price": "626.0",  "currency": "CNY" }
]
```

### Authenticated commands (shape-only; real values redacted for this PR body)

The three authenticated commands were exercised live on a Mac mini against a logged-in 12306 account. Output shape below uses synthetic placeholder values; the real PII (12306 username, family name, partial ID prefix, partial mobile, email) is **not** posted here. The actual run was verified locally and the masking logic was tested against the real response (see "Sensitive-field masking" above).

```bash
$ node ./dist/src/main.js 12306 me -f json
[
  {
    "username":   "<account>",
    "real_name":  "<masked>",
    "email":      "<x***x>@<domain>",
    "mobile":     "<3-digits>****<4-digits>",
    "birth_date": "<YYYY>",
    "sex":        "<男|女>",
    "country":    "CHN",
    "user_type":  "成人",
    "member":     false,
    "active":     <bool>
  }
]

$ node ./dist/src/main.js 12306 passengers -f json
[
  {
    "name":           "<surname>*<...>",
    "sex":            "<男|女>",
    "born_year":      "<YYYY>",
    "id_type":        "居民身份证",
    "id_no":          "<4-digits>***********<3-digits>",
    "mobile":         "<3-digits>****<4-digits>",
    "passenger_type": "成人",
    "country":        "CHN"
  },
  ...
]
```

`12306 orders` was also exercised live; the account currently has no in-progress orders, so the command correctly surfaces `EMPTY_RESULT: No in-progress 12306 orders on this account` rather than fabricating an empty array.

If you want a non-redacted copy of the authenticated-command output to confirm masking behaviour, ping me on the PR and I'll DM the raw output.

## Test plan

- [x] `npm run build`: manifest compiles, 828 entries, `git diff cli-manifest.json` contains only new 12306 entries (no absolute filesystem paths)
- [x] `npm run check:typed-error-lint`: passes (`current=173, baseline=173, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes (`current=102, baseline=102, new=0, resolved=0`)
- [x] `npx vitest run --project adapter clis/12306/utils.test.js`: **23 tests passing** across
  - `parseStationBundle`: structured-record extraction + skip records without telecode
  - `resolveStation`: name / telecode / pinyin / short-alias matches + empty / unknown / unknown-but-telecode-shaped failure modes
  - `validateDate`: format check + impossible calendar dates
  - `buildCookieHeader`: join Set-Cookie lines
  - `parseTrainRecord`: full-shape extraction, **secret-field non-leak regression**, telecode fallback when bundle is missing, short-record null
  - **mask helpers**: `maskEmail` (3+ char local-part + edge cases), `maskMobile` (preserves 12306's own mask), `maskChineseName` (1 / 2 / 3+ char names)
  - **`parsePriceData`**: bare-numeric-duplicate filter, sort by descending price, unknown letter codes fall back to letter as name
- [x] Live anonymous: `stations` / `trains` / `train` / `price` against `kyfw.12306.cn` from a Mac mini session with 15-25 s sleeps between hits
- [x] Live authenticated: `me` / `passengers` / `orders` after the user logged in to 12306 in the OpenCLI bridge Chrome on Mac mini; cookies surfaced via `document.cookie` correctly (see `require12306Login` note above)
- [ ] Reviewer to confirm masking defaults match the project's expectation. The current defaults: real name -> Chinese-mask, email -> local-part mask, mobile -> preserve 12306's own mask, birth date -> year only. `--include-sensitive` opts in to the unmasked-by-12306 fields.

## Out of scope

- Order history (`queryMyOrderApi`): needs extra page-state handshakes; left as a follow-up so the immediate "in-progress orders" path can ship without flakiness.
- Ticket sniping / order submission / payment / CAPTCHA bypass / password storage: explicitly out of scope per the issue's Non-goals.
