### PR TITLE
feat(suno): add suno.com music-generation adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -22236,6 +22236,229 @@
     "sourceFile": "substack/search.js"
   },
   {
+    "site": "suno",
+    "name": "download",
+    "description": "Download an existing Suno clip (MP3 + optional WAV/M4A/video) by id",
+    "access": "write",
+    "domain": "suno.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "clip",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Clip UUID or https://suno.com/song/<id> URL"
+      },
+      {
+        "name": "formats",
+        "type": "str",
+        "required": false,
+        "help": "Comma-separated formats: mp3, m4a, wav, video, cover, metadata. Default: mp3,metadata"
+      },
+      {
+        "name": "op",
+        "type": "str",
+        "required": false,
+        "help": "Output directory (default: ~/Music/suno)"
+      },
+      {
+        "name": "confirm-paid",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Required to allow paid downloads (wav). Without it, paid formats are skipped with a warning."
+      }
+    ],
+    "columns": [
+      "status",
+      "clip",
+      "title",
+      "files",
+      "link"
+    ],
+    "defaultFormat": "plain",
+    "type": "js",
+    "modulePath": "suno/download.js",
+    "sourceFile": "suno/download.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "suno",
+    "name": "generate",
+    "description": "Generate music with Suno (V5.5 chirp-fenix by default) and download clips locally",
+    "access": "write",
+    "domain": "suno.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Simple-mode description (ignored when --lyrics is provided)"
+      },
+      {
+        "name": "lyrics",
+        "type": "str",
+        "required": false,
+        "help": "Custom-mode lyrics (with [Verse]/[Chorus] metatags). Triggers Custom mode."
+      },
+      {
+        "name": "tags",
+        "type": "str",
+        "required": false,
+        "help": "Custom-mode style tags (genre, BPM, instruments...). Used with --lyrics."
+      },
+      {
+        "name": "negative-tags",
+        "type": "str",
+        "required": false,
+        "help": "Custom-mode style exclusions (e.g. \"no vocals, no autotune\"). Used with --lyrics."
+      },
+      {
+        "name": "title",
+        "type": "str",
+        "required": false,
+        "help": "Song title (default: auto-derived from prompt)"
+      },
+      {
+        "name": "instrumental",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "No vocals"
+      },
+      {
+        "name": "model",
+        "type": "str",
+        "required": false,
+        "help": "Model id: chirp-fenix, chirp-bluejay, chirp-v4, chirp-v3-5. Default: chirp-fenix"
+      },
+      {
+        "name": "weirdness",
+        "type": "str",
+        "required": false,
+        "help": "Creative weirdness slider (0..1). Default: 0.5"
+      },
+      {
+        "name": "style-weight",
+        "type": "str",
+        "required": false,
+        "help": "Style adherence slider (0..1). Default: 0.5"
+      },
+      {
+        "name": "formats",
+        "type": "str",
+        "required": false,
+        "help": "Comma-separated download formats: mp3, m4a, wav, video, cover, metadata. Default: mp3,metadata"
+      },
+      {
+        "name": "op",
+        "type": "str",
+        "required": false,
+        "help": "Output directory (default: ~/Music/suno)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Max seconds to wait for clips to finish (default: 300)"
+      },
+      {
+        "name": "sd",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Skip download; only print clip ids and Suno URLs"
+      },
+      {
+        "name": "confirm-paid",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Required to allow paid downloads (wav). Without it, paid formats are skipped with a warning."
+      }
+    ],
+    "columns": [
+      "status",
+      "clip",
+      "title",
+      "files",
+      "link"
+    ],
+    "defaultFormat": "plain",
+    "type": "js",
+    "modulePath": "suno/generate.js",
+    "sourceFile": "suno/generate.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "suno",
+    "name": "list",
+    "description": "List recent Suno clips in your library (id, title, status, created_at, link)",
+    "access": "read",
+    "domain": "suno.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max clips to list (default: 20)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Pagination offset, 0-based (default: 0)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "clip",
+      "title",
+      "status",
+      "created",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "suno/list.js",
+    "sourceFile": "suno/list.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "suno",
+    "name": "status",
+    "description": "Check Suno login, plan, credit balance, and captcha readiness",
+    "access": "read",
+    "domain": "suno.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status",
+      "Plan",
+      "Credits",
+      "Monthly",
+      "Captcha"
+    ],
+    "type": "js",
+    "modulePath": "suno/status.js",
+    "sourceFile": "suno/status.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
     "site": "taobao",
     "name": "add-cart",
     "description": "淘宝加入购物车",

--- a/clis/suno/commands.test.js
+++ b/clis/suno/commands.test.js
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const mocks = vi.hoisted(() => ({
+    ensureSunoSession: vi.fn(),
+    checkSunoCaptcha: vi.fn(),
+}));
+
+vi.mock('./utils.js', () => ({
+    STUDIO_API: 'https://studio-api-prod.suno.com',
+    SUNO_DOMAIN: 'suno.com',
+    SUNO_URL: 'https://suno.com',
+    ensureSunoSession: mocks.ensureSunoSession,
+    checkSunoCaptcha: mocks.checkSunoCaptcha,
+    requireNonNegativeInt: (value) => {
+        const n = Number(value);
+        if (!Number.isInteger(n) || n < 0) throw Object.assign(new Error('non-negative int required'), { code: 'ARGUMENT' });
+        return n;
+    },
+    requirePositiveInt: (value) => {
+        const n = Number(value);
+        if (!Number.isInteger(n) || n < 1) throw Object.assign(new Error('positive int required'), { code: 'ARGUMENT' });
+        return n;
+    },
+    unwrapEvaluateResult: (value) => value && typeof value === 'object' && 'session' in value && 'data' in value ? value.data : value,
+}));
+
+const { statusCommand } = await import('./status.js');
+const { listCommand } = await import('./list.js');
+
+function createPage(evaluateImpl) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: evaluateImpl || vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('suno status', () => {
+    it('reports "Not logged in" when ensureSunoSession throws AuthRequiredError', async () => {
+        mocks.ensureSunoSession.mockRejectedValue(new AuthRequiredError('suno.com', 'Auth required'));
+        const out = await statusCommand.func(createPage());
+        expect(out).toEqual([{
+            Status: 'Not logged in',
+            Plan: '-',
+            Credits: '-',
+            Monthly: '-',
+            Captcha: '-',
+        }]);
+    });
+
+    it('does not hide non-auth status failures as logged-out rows', async () => {
+        mocks.ensureSunoSession.mockRejectedValue(new CommandExecutionError('malformed billing payload'));
+        await expect(statusCommand.func(createPage())).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed billing payload'),
+        });
+    });
+
+    it('returns plan / credits / captcha when the session is healthy', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({
+            ok: true,
+            planKey: 'pro',
+            planId: '3eaebef3',
+            totalCreditsAvailable: 2095,
+            breakdown: { pack: 0, purchasedPacks: 0, monthlyRemaining: 2095, monthlyLimit: 2500, monthlyUsed: 405 },
+            deviceId: 'device-uuid',
+        });
+        mocks.checkSunoCaptcha.mockResolvedValue({ ok: true, required: false });
+        const out = await statusCommand.func(createPage());
+        expect(out[0]).toMatchObject({
+            Status: 'Connected',
+            Plan: 'pro',
+            Credits: '2095',
+            Monthly: '2095/2500',
+            Captcha: 'Not required',
+        });
+    });
+
+    it('reports captcha required when /api/c/check says so', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({
+            ok: true, planKey: 'pro', planId: 'x', totalCreditsAvailable: 100,
+            breakdown: { pack: 0, purchasedPacks: 0, monthlyRemaining: 100, monthlyLimit: 2500, monthlyUsed: 2400 },
+            deviceId: 'device-uuid',
+        });
+        mocks.checkSunoCaptcha.mockResolvedValue({ ok: true, required: true });
+        const out = await statusCommand.func(createPage());
+        expect(out[0].Captcha).toContain('Required');
+    });
+});
+
+describe('suno list', () => {
+    it('returns clip rows with truncated id, title, and pagination-aware rank', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({
+            ok: true,
+            clips: [
+                { id: 'aaaaaaaa-1111-2222-3333-444444444444', title: 'Track One', status: 'complete', created_at: '2026-05-17T11:14:26.338Z' },
+                { id: 'bbbbbbbb-1111-2222-3333-444444444444', title: 'Track Two', status: 'streaming', created_at: '2026-05-17T11:00:00.000Z' },
+            ],
+        }));
+        const out = await listCommand.func(page, { limit: 10, page: 0 });
+        expect(out).toHaveLength(2);
+        expect(out[0]).toMatchObject({
+            rank: 1,
+            clip: 'aaaaaaaa',
+            title: 'Track One',
+            status: 'complete',
+            created: '2026-05-17 11:14:26',
+            link: 'https://suno.com/song/aaaaaaaa-1111-2222-3333-444444444444',
+        });
+    });
+
+    it('respects --limit (caller may receive more from feed and slice down)', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({
+            ok: true,
+            clips: [
+                { id: 'aaaaaaaa-1111-2222-3333-444444444444', title: 'A', status: 'complete', created_at: '2026-05-17T00:00:00Z' },
+                { id: 'bbbbbbbb-1111-2222-3333-444444444444', title: 'B', status: 'complete', created_at: '2026-05-17T00:00:00Z' },
+                { id: 'cccccccc-1111-2222-3333-444444444444', title: 'C', status: 'complete', created_at: '2026-05-17T00:00:00Z' },
+            ],
+        }));
+        const out = await listCommand.func(page, { limit: 2, page: 0 });
+        expect(out).toHaveLength(2);
+    });
+
+    it('rejects invalid --page instead of silently clamping to zero', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        await expect(listCommand.func(createPage(), { limit: 2, page: -1 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+    });
+
+    it('unwraps Browser Bridge envelopes around feed rows', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({
+            session: 'browser:default',
+            data: {
+                ok: true,
+                clips: [
+                    { id: 'aaaaaaaa-1111-2222-3333-444444444444', title: 'Track One', status: 'complete', created_at: '2026-05-17T11:14:26.338Z' },
+                ],
+            },
+        }));
+        const out = await listCommand.func(page, { limit: 10, page: 0 });
+        expect(out[0].clip).toBe('aaaaaaaa');
+    });
+
+    it('returns EmptyResultError for a valid empty library response', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({ ok: true, clips: [] }));
+        await expect(listCommand.func(page, { limit: 10, page: 0 })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+        });
+    });
+
+    it('fails typed on malformed clip identity', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({ ok: true, clips: [{ title: 'No id' }] }));
+        await expect(listCommand.func(page, { limit: 10, page: 0 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed clip identity'),
+        });
+    });
+
+    it('surfaces feed lookup HTTP failures', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+        await expect(listCommand.func(page, { limit: 5, page: 0 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('HTTP 500'),
+        });
+    });
+
+    it('surfaces malformed feed payloads as typed failures', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ deviceId: 'device-uuid' });
+        const page = createPage(vi.fn().mockResolvedValue({ ok: false, error: 'malformed clips payload' }));
+        await expect(listCommand.func(page, { limit: 5, page: 0 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed clips payload'),
+        });
+    });
+});

--- a/clis/suno/download.js
+++ b/clis/suno/download.js
@@ -1,0 +1,140 @@
+/**
+ * `opencli suno download <clip-id>` — download an already-generated clip in
+ * one or more formats. Useful for grabbing assets from songs created via the
+ * Suno web UI or earlier opencli runs without re-generating.
+ *
+ * WAV downloads still trigger Suno's per-download billing (the same charge
+ * the web UI's "Download → WAV" flow makes).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    STUDIO_API,
+    SUNO_DOMAIN,
+    SUNO_URL,
+    downloadSunoClip,
+    ensureSunoSession,
+    normalizeBooleanFlag,
+    parseFormats,
+    resolveSunoOutputDir,
+    unwrapEvaluateResult,
+} from './utils.js';
+
+import * as os from 'node:os';
+
+function displayPath(filePath) {
+    if (!filePath) return '-';
+    const home = os.homedir();
+    return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+
+function parseClipId(value) {
+    const raw = String(value || '').trim();
+    if (!raw) throw new ArgumentError('clip-id required (UUID or /song/<id> URL)');
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (uuidPattern.test(raw)) return raw.toLowerCase();
+    try {
+        const parsed = new URL(raw);
+        const pathMatch = parsed.pathname.match(/^\/song\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i);
+        if (parsed.protocol === 'https:' && parsed.hostname === 'suno.com' && pathMatch) {
+            return pathMatch[1].toLowerCase();
+        }
+    } catch {}
+    throw new ArgumentError(`Invalid clip-id: ${raw}`, 'Pass a UUID or a https://suno.com/song/<uuid> URL.');
+}
+
+export const downloadCommand = cli({
+    site: 'suno',
+    name: 'download',
+    access: 'write',
+    description: 'Download an existing Suno clip (MP3 + optional WAV/M4A/video) by id',
+    domain: SUNO_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    defaultFormat: 'plain',
+    args: [
+        { name: 'clip', positional: true, required: true, help: 'Clip UUID or https://suno.com/song/<id> URL' },
+        { name: 'formats', help: 'Comma-separated formats: mp3, m4a, wav, video, cover, metadata. Default: mp3,metadata' },
+        { name: 'op', help: 'Output directory (default: ~/Music/suno)' },
+        { name: 'confirm-paid', type: 'boolean', default: false, help: 'Required to allow paid downloads (wav). Without it, paid formats are skipped with a warning.' },
+    ],
+    columns: ['status', 'clip', 'title', 'files', 'link'],
+    func: async (page, kwargs) => {
+        const clipId = parseClipId(kwargs.clip);
+        const requestedFormats = parseFormats(kwargs.formats);
+        const confirmPaid = normalizeBooleanFlag(kwargs['confirm-paid']);
+        const PAID_FORMATS = new Set(['wav']);
+        const skippedPaid = [];
+        const formats = requestedFormats.filter(f => {
+            if (PAID_FORMATS.has(f) && !confirmPaid) {
+                skippedPaid.push(f);
+                return false;
+            }
+            return true;
+        });
+        if (!formats.length) {
+            throw new ArgumentError('All requested formats require --confirm-paid true', 'Add --confirm-paid true or include a free format such as mp3 or metadata.');
+        }
+        const outputDir = resolveSunoOutputDir(kwargs.op);
+
+        const session = await ensureSunoSession(page);
+        const deviceId = session.deviceId;
+
+        // Pull the clip object from feed/v3 so audio_url/media_urls/has_stem are current.
+        const feedRes = unwrapEvaluateResult(await page.evaluate(`(async () => {
+            const browserToken = JSON.stringify({ token: btoa(JSON.stringify({ timestamp: Date.now() })) });
+            const res = await fetch('${STUDIO_API}/api/feed/v3', {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer ' + (await window.Clerk.session.getToken()),
+                    'browser-token': browserToken,
+                    'device-id': ${JSON.stringify(deviceId)},
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ clip_ids: ['${clipId}'] }),
+            });
+            if (!res.ok) return { ok: false, error: 'HTTP ' + res.status };
+            const payload = await res.json().catch(() => null);
+            if (!payload || !Array.isArray(payload.clips)) return { ok: false, error: 'malformed clips payload' };
+            return { ok: true, clips: payload.clips };
+        })()`));
+
+        if (!feedRes?.ok) {
+            throw new CommandExecutionError(`Suno feed lookup failed: ${feedRes?.error || 'unknown'}`);
+        }
+        if (!Array.isArray(feedRes.clips)) {
+            throw new CommandExecutionError('Suno feed lookup returned malformed clips payload');
+        }
+        const clip = feedRes.clips.find(c => c.id === clipId);
+        if (!clip) {
+            throw new EmptyResultError('suno download', `Clip ${clipId} not found in your account. Confirm at ${SUNO_URL}/song/${clipId}.`);
+        }
+        if (clip.status !== 'complete') {
+            throw new CommandExecutionError(`Clip ${clipId} status is "${clip.status}" — not complete yet. Retry once generation finishes.`);
+        }
+
+        const result = await downloadSunoClip(page, clip, outputDir, formats, deviceId);
+        if (!result.written.some(w => w.ok)) {
+            throw new CommandExecutionError(`Suno download wrote no files for clip ${clipId}`);
+        }
+        const link = `${SUNO_URL}/song/${clip.id}`;
+        const writtenSummary = result.written
+            .map(w => w.ok ? `${w.format}:${displayPath(w.file)}` : `${w.format}:✗(${w.reason})`)
+            .join(' | ');
+        const skippedSummary = skippedPaid.length
+            ? ` | skipped(needs --confirm-paid):${skippedPaid.join(',')}`
+            : '';
+        const fileSummary = `${writtenSummary}${skippedSummary}`;
+        const anyFailed = result.written.some(w => !w.ok);
+
+        return [{
+            status: anyFailed ? '⚠ partial' : '✅ saved',
+            clip: clip.id.slice(0, 8),
+            title: clip.title || '(untitled)',
+            files: `📁 ${fileSummary}`,
+            link: `🔗 ${link}`,
+        }];
+    },
+});

--- a/clis/suno/download.test.js
+++ b/clis/suno/download.test.js
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    ensureSunoSession: vi.fn(),
+    downloadSunoClip: vi.fn(),
+}));
+
+vi.mock('./utils.js', () => ({
+    STUDIO_API: 'https://studio-api-prod.suno.com',
+    SUNO_DOMAIN: 'suno.com',
+    SUNO_URL: 'https://suno.com',
+    ensureSunoSession: mocks.ensureSunoSession,
+    downloadSunoClip: mocks.downloadSunoClip,
+    normalizeBooleanFlag: (value, fallback = false) => {
+        if (typeof value === 'boolean') return value;
+        if (value == null || value === '') return fallback;
+        const s = String(value).trim().toLowerCase();
+        return s === 'true' || s === '1' || s === 'yes' || s === 'on';
+    },
+    parseFormats: (value) => {
+        if (!value) return ['mp3', 'metadata'];
+        return String(value).split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+    },
+    resolveSunoOutputDir: (value) => value || '/tmp/suno-test',
+    unwrapEvaluateResult: (value) => value && typeof value === 'object' && 'session' in value && 'data' in value ? value.data : value,
+}));
+
+const { downloadCommand } = await import('./download.js');
+
+const okSession = { ok: true, deviceId: 'device-uuid' };
+const okCompleteClip = { id: '11111111-2222-3333-4444-555555555555', status: 'complete', title: 'Probe', audio_url: 'https://cdn1.suno.ai/x.mp3' };
+
+function createPageWithFeed(clips) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue({ ok: true, clips }),
+    };
+}
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.ensureSunoSession.mockReset().mockResolvedValue(okSession);
+    mocks.downloadSunoClip.mockReset().mockResolvedValue({
+        slug: 'probe',
+        written: [{ format: 'mp3', file: '/tmp/probe.mp3', ok: true }, { format: 'metadata', file: '/tmp/probe.json', ok: true }],
+    });
+});
+
+describe('suno download argument validation', () => {
+    it('parses bare UUID clip ids', async () => {
+        const id = okCompleteClip.id;
+        await downloadCommand.func(createPageWithFeed([okCompleteClip]), { clip: id, formats: 'mp3' });
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), okCompleteClip, '/tmp/suno-test', ['mp3'], 'device-uuid');
+    });
+
+    it('extracts UUID from a full suno.com/song/<id> URL', async () => {
+        const id = okCompleteClip.id;
+        await downloadCommand.func(createPageWithFeed([okCompleteClip]), { clip: `https://suno.com/song/${id}`, formats: 'mp3' });
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), okCompleteClip, '/tmp/suno-test', ['mp3'], 'device-uuid');
+    });
+
+    it('rejects off-domain URLs even if they contain a UUID', async () => {
+        const id = okCompleteClip.id;
+        await expect(downloadCommand.func(createPageWithFeed([]), { clip: `https://evil.example/song/${id}`, formats: 'mp3' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('Invalid clip-id'),
+        });
+    });
+
+    it('rejects non-UUID clip ids with ArgumentError', async () => {
+        await expect(downloadCommand.func(createPageWithFeed([]), { clip: 'not-a-uuid', formats: 'mp3' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('Invalid clip-id'),
+        });
+    });
+});
+
+describe('suno download lookup and status handling', () => {
+    it('returns EmptyResultError when feed/v3 does not contain the clip', async () => {
+        await expect(downloadCommand.func(createPageWithFeed([]), { clip: okCompleteClip.id, formats: 'mp3' })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+            hint: expect.stringContaining('not found'),
+        });
+    });
+
+    it('unwraps Browser Bridge envelopes around feed lookup results', async () => {
+        const page = createPageWithFeed([]);
+        page.evaluate.mockResolvedValueOnce({ session: 'browser:default', data: { ok: true, clips: [okCompleteClip] } });
+        await downloadCommand.func(page, { clip: okCompleteClip.id, formats: 'mp3' });
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), okCompleteClip, '/tmp/suno-test', ['mp3'], 'device-uuid');
+    });
+
+    it('fails typed when feed/v3 returns malformed clips payload', async () => {
+        const page = createPageWithFeed([]);
+        page.evaluate.mockResolvedValueOnce({ ok: true, clips: null });
+        await expect(downloadCommand.func(page, { clip: okCompleteClip.id, formats: 'mp3' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed clips payload'),
+        });
+    });
+
+    it('refuses to download when the clip is still streaming/queued', async () => {
+        await expect(downloadCommand.func(createPageWithFeed([{ ...okCompleteClip, status: 'streaming' }]), { clip: okCompleteClip.id, formats: 'mp3' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('not complete yet'),
+        });
+    });
+});
+
+describe('suno download paid-format guard', () => {
+    it('skips wav by default and surfaces the skip in the result row', async () => {
+        const out = await downloadCommand.func(createPageWithFeed([okCompleteClip]), {
+            clip: okCompleteClip.id,
+            formats: 'mp3,wav,metadata',
+        });
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), okCompleteClip, '/tmp/suno-test', ['mp3', 'metadata'], 'device-uuid');
+        expect(out[0].files).toContain('skipped(needs --confirm-paid):wav');
+    });
+
+    it('rejects requests where every requested format is paid and unconfirmed', async () => {
+        await expect(downloadCommand.func(createPageWithFeed([okCompleteClip]), {
+            clip: okCompleteClip.id,
+            formats: 'wav',
+        })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('All requested formats require'),
+        });
+        expect(mocks.downloadSunoClip).not.toHaveBeenCalled();
+    });
+
+    it('includes wav when --confirm-paid is true', async () => {
+        await downloadCommand.func(createPageWithFeed([okCompleteClip]), {
+            clip: okCompleteClip.id,
+            formats: 'mp3,wav',
+            'confirm-paid': true,
+        });
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), okCompleteClip, '/tmp/suno-test', ['mp3', 'wav'], 'device-uuid');
+    });
+
+    it('fails typed when selected formats write no files', async () => {
+        mocks.downloadSunoClip.mockResolvedValue({ slug: 'probe', written: [{ format: 'mp3', file: null, ok: false, reason: 'HTTP 500' }] });
+        await expect(downloadCommand.func(createPageWithFeed([okCompleteClip]), {
+            clip: okCompleteClip.id,
+            formats: 'mp3',
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('wrote no files'),
+        });
+    });
+});

--- a/clis/suno/generate.js
+++ b/clis/suno/generate.js
@@ -1,0 +1,226 @@
+/**
+ * `opencli suno generate` — submit a Suno music-generation request, wait for
+ * both clips to finish, and download selected formats locally.
+ *
+ * Targets the /api/generate/v2-web/ endpoint (cookie auth). Each generation
+ * returns 2 candidate clips by design — both are downloaded so the caller
+ * can A/B them.
+ *
+ * Modes:
+ *   - Custom (when --lyrics is provided): API receives prompt(lyrics)+tags
+ *     +title+negative_tags. Use this for professional control over lyrics,
+ *     structure metatags, style, and exclusions.
+ *   - Simple (default): API receives a description in `prompt`; Suno picks
+ *     the lyrics, tags, and title.
+ *
+ * Creative knobs (--weirdness / --style-weight) map directly to the
+ * `metadata.control_sliders` the web UI exposes.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DEFAULT_SUNO_MODEL,
+    SUNO_DOMAIN,
+    SUNO_MODELS,
+    SUNO_URL,
+    checkSunoCaptcha,
+    clampSlider,
+    downloadSunoClip,
+    ensureSunoSession,
+    normalizeBooleanFlag,
+    parseFormats,
+    pollSunoClips,
+    requirePositiveInt,
+    resolveSunoOutputDir,
+    submitSunoGeneration,
+} from './utils.js';
+
+import * as crypto from 'node:crypto';
+import * as os from 'node:os';
+
+function displayPath(filePath) {
+    if (!filePath) return '-';
+    const home = os.homedir();
+    return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+
+export const generateCommand = cli({
+    site: 'suno',
+    name: 'generate',
+    access: 'write',
+    description: 'Generate music with Suno (V5.5 chirp-fenix by default) and download clips locally',
+    domain: SUNO_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    defaultFormat: 'plain',
+    args: [
+        { name: 'prompt', positional: true, required: false, help: 'Simple-mode description (ignored when --lyrics is provided)' },
+        { name: 'lyrics', help: 'Custom-mode lyrics (with [Verse]/[Chorus] metatags). Triggers Custom mode.' },
+        { name: 'tags', help: 'Custom-mode style tags (genre, BPM, instruments...). Used with --lyrics.' },
+        { name: 'negative-tags', help: 'Custom-mode style exclusions (e.g. "no vocals, no autotune"). Used with --lyrics.' },
+        { name: 'title', help: 'Song title (default: auto-derived from prompt)' },
+        { name: 'instrumental', type: 'boolean', default: false, help: 'No vocals' },
+        { name: 'model', help: `Model id: ${SUNO_MODELS.join(', ')}. Default: ${DEFAULT_SUNO_MODEL}` },
+        { name: 'weirdness', help: 'Creative weirdness slider (0..1). Default: 0.5' },
+        { name: 'style-weight', help: 'Style adherence slider (0..1). Default: 0.5' },
+        { name: 'formats', help: 'Comma-separated download formats: mp3, m4a, wav, video, cover, metadata. Default: mp3,metadata' },
+        { name: 'op', help: 'Output directory (default: ~/Music/suno)' },
+        { name: 'timeout', type: 'int', default: 300, help: 'Max seconds to wait for clips to finish (default: 300)' },
+        { name: 'sd', type: 'boolean', default: false, help: 'Skip download; only print clip ids and Suno URLs' },
+        { name: 'confirm-paid', type: 'boolean', default: false, help: 'Required to allow paid downloads (wav). Without it, paid formats are skipped with a warning.' },
+    ],
+    columns: ['status', 'clip', 'title', 'files', 'link'],
+    func: async (page, kwargs) => {
+        const lyrics = kwargs.lyrics ? String(kwargs.lyrics) : '';
+        const tags = kwargs.tags ? String(kwargs.tags) : '';
+        const negativeTags = kwargs['negative-tags'] ? String(kwargs['negative-tags']) : '';
+        const description = kwargs.prompt ? String(kwargs.prompt) : '';
+        const titleArg = kwargs.title ? String(kwargs.title) : '';
+        const model = kwargs.model ? String(kwargs.model).trim() : DEFAULT_SUNO_MODEL;
+        if (!SUNO_MODELS.includes(model)) {
+            throw new ArgumentError(`Unsupported --model "${model}"`, `Choices: ${SUNO_MODELS.join(', ')}`);
+        }
+
+        const isCustom = lyrics.trim() !== '';
+        if (!isCustom && !description.trim()) {
+            throw new ArgumentError(
+                'Either provide a Simple-mode prompt as the positional argument, or pass --lyrics for Custom mode.',
+                'Examples:\n  opencli suno generate "lo-fi study beat, 80 bpm"\n  opencli suno generate --lyrics "[Verse]\\n..." --tags "synthwave, 120 bpm"',
+            );
+        }
+        if (!isCustom && (tags || negativeTags)) {
+            throw new ArgumentError('--tags and --negative-tags only apply in Custom mode (alongside --lyrics).');
+        }
+
+        const requestedFormats = parseFormats(kwargs.formats);
+        const confirmPaid = normalizeBooleanFlag(kwargs['confirm-paid']);
+        const skipDownload = normalizeBooleanFlag(kwargs.sd);
+        const PAID_FORMATS = new Set(['wav']);
+        const skippedPaid = [];
+        const formats = requestedFormats.filter(f => {
+            if (PAID_FORMATS.has(f) && !confirmPaid) {
+                skippedPaid.push(f);
+                return false;
+            }
+            return true;
+        });
+        if (!skipDownload && !formats.length) {
+            throw new ArgumentError('All requested formats require --confirm-paid true', 'Add --confirm-paid true or include a free format such as mp3 or metadata.');
+        }
+        const outputDir = resolveSunoOutputDir(kwargs.op);
+        const timeout = requirePositiveInt(kwargs.timeout, '--timeout');
+        const makeInstrumental = normalizeBooleanFlag(kwargs.instrumental);
+        const weirdness = clampSlider(kwargs.weirdness, '--weirdness', 0.5);
+        const styleWeight = clampSlider(kwargs['style-weight'], '--style-weight', 0.5);
+
+        // Title: required by API. Auto-derive from first 60 chars of source prompt if not provided.
+        const titleSource = titleArg || (isCustom ? (tags || lyrics.split('\n')[0]) : description);
+        const title = titleSource.replace(/\s+/g, ' ').trim().slice(0, 60) || 'Untitled';
+
+        const session = await ensureSunoSession(page);
+        const deviceId = session.deviceId;
+        const captcha = await checkSunoCaptcha(page, deviceId);
+        if (!captcha?.ok) {
+            throw new CommandExecutionError(
+                `Suno captcha pre-flight failed${captcha?.status ? ` (HTTP ${captcha.status})` : ''}.`,
+                `Open ${SUNO_URL}/create in Chrome and verify the account is ready, then retry.`,
+            );
+        }
+        if (captcha?.required) {
+            throw new CommandExecutionError(
+                'Suno requires a CAPTCHA challenge for this account/IP right now.',
+                `Open ${SUNO_URL}/create in Chrome, solve a Create challenge once, then retry.`,
+            );
+        }
+        if (session.totalCreditsAvailable < 10) {
+            const b = session.breakdown;
+            throw new CommandExecutionError(
+                `Suno generation needs ~10 credits; you have ${session.totalCreditsAvailable} (monthly ${b.monthlyRemaining}/${b.monthlyLimit} + packs ${b.purchasedPacks} + leftover ${b.pack}). Top up at ${SUNO_URL}/account.`,
+            );
+        }
+
+        const transactionUuid = crypto.randomUUID();
+        const createSessionToken = crypto.randomUUID();
+
+        const submission = await submitSunoGeneration(page, {
+            mode: isCustom ? 'custom' : 'simple',
+            model,
+            title,
+            lyrics,
+            tags,
+            negativeTags,
+            description,
+            makeInstrumental,
+            weirdness,
+            styleWeight,
+            userTier: session.planId,
+            createSessionToken,
+            transactionUuid,
+            deviceId,
+        });
+
+        if (!Array.isArray(submission.clips)) {
+            throw new CommandExecutionError('Suno generation returned malformed clips payload.');
+        }
+        const clipIds = submission.clips.map(c => c?.id);
+        if (clipIds.some(id => !id)) {
+            throw new CommandExecutionError('Suno generation returned malformed clip identity.');
+        }
+        if (!clipIds.length) {
+            throw new CommandExecutionError('Suno accepted the request but returned no clip ids.');
+        }
+
+        const clips = await pollSunoClips(page, clipIds, timeout, deviceId);
+        const completed = clips.filter(c => c.status === 'complete');
+        if (!completed.length) {
+            const errors = clips.map(c => `${c.id.slice(0, 8)}:${c.status}`).join(', ');
+            throw new CommandExecutionError(`All Suno clips failed (${errors}). Open ${SUNO_URL}/song/${clipIds[0]} to inspect.`);
+        }
+
+        const rows = [];
+        for (const clip of clips) {
+            const link = `${SUNO_URL}/song/${clip.id}`;
+            if (clip.status !== 'complete') {
+                rows.push({
+                    status: `❌ ${clip.status}`,
+                    clip: clip.id.slice(0, 8),
+                    title: clip.title || '(untitled)',
+                    files: '-',
+                    link: `🔗 ${link}`,
+                });
+                continue;
+            }
+            if (skipDownload) {
+                rows.push({
+                    status: '🎵 generated',
+                    clip: clip.id.slice(0, 8),
+                    title: clip.title || '(untitled)',
+                    files: '📁 -',
+                    link: `🔗 ${link}`,
+                });
+                continue;
+            }
+            const result = await downloadSunoClip(page, clip, outputDir, formats, deviceId);
+            if (!result.written.some(w => w.ok)) {
+                throw new CommandExecutionError(`Suno download wrote no files for clip ${clip.id}`);
+            }
+            const writtenSummary = result.written
+                .map(w => w.ok ? `${w.format}:${displayPath(w.file)}` : `${w.format}:✗(${w.reason})`)
+                .join(' | ');
+            const skippedSummary = skippedPaid.length
+                ? ` | skipped(needs --confirm-paid):${skippedPaid.join(',')}`
+                : '';
+            const anyFailed = result.written.some(w => !w.ok);
+            rows.push({
+                status: anyFailed ? '⚠ partial' : '✅ saved',
+                clip: clip.id.slice(0, 8),
+                title: clip.title || '(untitled)',
+                files: `📁 ${writtenSummary}${skippedSummary}`,
+                link: `🔗 ${link}`,
+            });
+        }
+        return rows;
+    },
+});

--- a/clis/suno/generate.test.js
+++ b/clis/suno/generate.test.js
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    ensureSunoSession: vi.fn(),
+    checkSunoCaptcha: vi.fn(),
+    submitSunoGeneration: vi.fn(),
+    pollSunoClips: vi.fn(),
+    downloadSunoClip: vi.fn(),
+}));
+
+vi.mock('./utils.js', () => ({
+    DEFAULT_SUNO_MODEL: 'chirp-fenix',
+    SUNO_DOMAIN: 'suno.com',
+    SUNO_MODELS: ['chirp-fenix', 'chirp-bluejay', 'chirp-v4', 'chirp-v3-5'],
+    SUNO_URL: 'https://suno.com',
+    ensureSunoSession: mocks.ensureSunoSession,
+    checkSunoCaptcha: mocks.checkSunoCaptcha,
+    submitSunoGeneration: mocks.submitSunoGeneration,
+    pollSunoClips: mocks.pollSunoClips,
+    downloadSunoClip: mocks.downloadSunoClip,
+    clampSlider: (value, _label, def) => (value === undefined || value === '' || value === null ? def : Number(value)),
+    normalizeBooleanFlag: (value, fallback = false) => {
+        if (typeof value === 'boolean') return value;
+        if (value == null || value === '') return fallback;
+        const s = String(value).trim().toLowerCase();
+        return s === 'true' || s === '1' || s === 'yes' || s === 'on';
+    },
+    parseFormats: (value) => {
+        if (!value) return ['mp3', 'metadata'];
+        const raw = Array.isArray(value) ? value.join(',') : String(value);
+        return raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+    },
+    requirePositiveInt: (value) => {
+        const n = Number(value);
+        if (!Number.isInteger(n) || n < 1) throw new Error('positive int required');
+        return n;
+    },
+    resolveSunoOutputDir: (value) => value || '/tmp/suno-test',
+}));
+
+const { generateCommand } = await import('./generate.js');
+
+function createPage() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+const okSession = {
+    ok: true,
+    planId: '3eaebef3-ef46-446a-931c-3d50cd1514f1',
+    planKey: 'pro',
+    totalCreditsAvailable: 2000,
+    breakdown: { pack: 0, purchasedPacks: 0, monthlyRemaining: 2000, monthlyLimit: 2500, monthlyUsed: 500 },
+    deviceId: 'device-uuid',
+};
+const okCaptcha = { ok: true, required: false };
+const okSubmission = { id: 'batch-id', clips: [{ id: 'clip-a-id', status: 'submitted' }, { id: 'clip-b-id', status: 'submitted' }] };
+const okClips = [
+    { id: 'clip-a-id', status: 'complete', title: 'Clip A', audio_url: 'https://cdn1.suno.ai/clip-a-id.mp3' },
+    { id: 'clip-b-id', status: 'complete', title: 'Clip B', audio_url: 'https://cdn1.suno.ai/clip-b-id.mp3' },
+];
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.ensureSunoSession.mockReset().mockResolvedValue(okSession);
+    mocks.checkSunoCaptcha.mockReset().mockResolvedValue(okCaptcha);
+    mocks.submitSunoGeneration.mockReset().mockResolvedValue(okSubmission);
+    mocks.pollSunoClips.mockReset().mockResolvedValue(okClips);
+    mocks.downloadSunoClip.mockReset().mockResolvedValue({ slug: 'clip', written: [{ format: 'mp3', file: '/tmp/x.mp3', ok: true }, { format: 'metadata', file: '/tmp/x.json', ok: true }] });
+});
+
+describe('suno generate argument validation', () => {
+    it('rejects calls with neither a Simple prompt nor --lyrics', async () => {
+        await expect(generateCommand.func(createPage(), { sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('Either provide a Simple-mode prompt'),
+        });
+    });
+
+    it('rejects --tags / --negative-tags in Simple mode', async () => {
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', tags: 'lo-fi', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('only apply in Custom mode'),
+        });
+    });
+
+    it('rejects unsupported --model values', async () => {
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', model: 'chirp-vNEXT', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('Unsupported --model'),
+        });
+    });
+
+    it('refuses to submit when credits are below the per-song minimum', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ ...okSession, totalCreditsAvailable: 5, breakdown: { ...okSession.breakdown, monthlyRemaining: 5 } });
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('needs ~10 credits'),
+        });
+        expect(mocks.submitSunoGeneration).not.toHaveBeenCalled();
+    });
+
+    it('refuses to submit when captcha is required (out-of-scope for headless flow)', async () => {
+        mocks.checkSunoCaptcha.mockResolvedValue({ ok: true, required: true });
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('CAPTCHA challenge'),
+        });
+        expect(mocks.submitSunoGeneration).not.toHaveBeenCalled();
+    });
+
+    it('refuses to submit when captcha pre-flight fails', async () => {
+        mocks.checkSunoCaptcha.mockResolvedValue({ ok: false, status: 500 });
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('captcha pre-flight failed'),
+        });
+        expect(mocks.submitSunoGeneration).not.toHaveBeenCalled();
+    });
+});
+
+describe('suno generate Simple mode payload', () => {
+    it('routes the positional prompt through `description` (Simple mode)', async () => {
+        await generateCommand.func(createPage(), { prompt: 'lo-fi study beat', sd: true, timeout: 60 });
+        expect(mocks.submitSunoGeneration).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+            mode: 'simple',
+            description: 'lo-fi study beat',
+            lyrics: '',
+            tags: '',
+            negativeTags: '',
+            userTier: okSession.planId,
+            deviceId: okSession.deviceId,
+        }));
+    });
+});
+
+describe('suno generate Custom mode payload', () => {
+    it('routes --lyrics through `lyrics` and --tags through `tags`', async () => {
+        await generateCommand.func(createPage(), {
+            lyrics: '[Verse]\\nfoo',
+            tags: 'synthwave, 95 BPM',
+            'negative-tags': 'vocals',
+            title: 'Night Rain',
+            sd: true,
+            timeout: 60,
+        });
+        expect(mocks.submitSunoGeneration).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+            mode: 'custom',
+            lyrics: '[Verse]\\nfoo',
+            tags: 'synthwave, 95 BPM',
+            negativeTags: 'vocals',
+            title: 'Night Rain',
+        }));
+    });
+
+    it('threads --weirdness and --style-weight as numeric sliders', async () => {
+        await generateCommand.func(createPage(), {
+            lyrics: '[Verse]\\nfoo',
+            weirdness: '0.74',
+            'style-weight': '0.57',
+            sd: true,
+            timeout: 60,
+        });
+        expect(mocks.submitSunoGeneration).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+            weirdness: 0.74,
+            styleWeight: 0.57,
+        }));
+    });
+});
+
+describe('suno generate paid-format guard', () => {
+    it('skips wav by default and surfaces the skip in the result row', async () => {
+        const out = await generateCommand.func(createPage(), {
+            prompt: 'foo',
+            formats: 'mp3,wav,metadata',
+            timeout: 60,
+        });
+        // downloadSunoClip should be called with mp3+metadata, NOT wav
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), ['mp3', 'metadata'], okSession.deviceId);
+        expect(out[0].files).toContain('skipped(needs --confirm-paid):wav');
+    });
+
+    it('includes wav when --confirm-paid is true', async () => {
+        await generateCommand.func(createPage(), {
+            prompt: 'foo',
+            formats: 'mp3,wav',
+            'confirm-paid': true,
+            timeout: 60,
+        });
+        expect(mocks.downloadSunoClip).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), ['mp3', 'wav'], okSession.deviceId);
+    });
+
+    it('rejects before generation when every requested format is paid and unconfirmed', async () => {
+        await expect(generateCommand.func(createPage(), {
+            prompt: 'foo',
+            formats: 'wav',
+            timeout: 60,
+        })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('All requested formats require'),
+        });
+        expect(mocks.submitSunoGeneration).not.toHaveBeenCalled();
+    });
+});
+
+describe('suno generate failure paths', () => {
+    it('reports all-failed clips with a typed error', async () => {
+        mocks.pollSunoClips.mockResolvedValue([
+            { id: 'clip-a-id', status: 'error' },
+            { id: 'clip-b-id', status: 'error' },
+        ]);
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('All Suno clips failed'),
+        });
+    });
+
+    it('fails typed when generation response clips are malformed', async () => {
+        mocks.submitSunoGeneration.mockResolvedValue({ clips: [{ status: 'submitted' }] });
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed clip identity'),
+        });
+    });
+
+    it('fails typed when download post-condition writes no files', async () => {
+        mocks.downloadSunoClip.mockResolvedValue({ slug: 'clip', written: [{ format: 'mp3', file: null, ok: false, reason: 'HTTP 500' }] });
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', formats: 'mp3', timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('wrote no files'),
+        });
+    });
+
+    it('skip-download mode returns generated rows without invoking downloadSunoClip', async () => {
+        const out = await generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 });
+        expect(out).toHaveLength(2);
+        expect(out[0].status).toBe('🎵 generated');
+        expect(mocks.downloadSunoClip).not.toHaveBeenCalled();
+    });
+});

--- a/clis/suno/list.js
+++ b/clis/suno/list.js
@@ -1,0 +1,79 @@
+/**
+ * `opencli suno list` — list recent clips in the user's library. Lets agents
+ * discover clip ids without needing to remember them, and feed them to
+ * `opencli suno download`.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    STUDIO_API,
+    SUNO_DOMAIN,
+    SUNO_URL,
+    ensureSunoSession,
+    requireNonNegativeInt,
+    requirePositiveInt,
+    unwrapEvaluateResult,
+} from './utils.js';
+
+export const listCommand = cli({
+    site: 'suno',
+    name: 'list',
+    access: 'read',
+    description: 'List recent Suno clips in your library (id, title, status, created_at, link)',
+    domain: SUNO_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max clips to list (default: 20)' },
+        { name: 'page', type: 'int', default: 0, help: 'Pagination offset, 0-based (default: 0)' },
+    ],
+    columns: ['rank', 'clip', 'title', 'status', 'created', 'link'],
+    func: async (page, kwargs) => {
+        const limit = requirePositiveInt(kwargs.limit, '--limit');
+        const pageOffset = requireNonNegativeInt(kwargs.page ?? 0, '--page');
+
+        const session = await ensureSunoSession(page);
+        const deviceId = session.deviceId;
+
+        const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+            const browserToken = JSON.stringify({ token: btoa(JSON.stringify({ timestamp: Date.now() })) });
+            const res = await fetch('${STUDIO_API}/api/feed/v2?page=${pageOffset}', {
+                headers: {
+                    'Authorization': 'Bearer ' + (await window.Clerk.session.getToken()),
+                    'browser-token': browserToken,
+                    'device-id': ${JSON.stringify(deviceId)},
+                },
+            });
+            if (!res.ok) return { ok: false, status: res.status };
+            const data = await res.json().catch(() => null);
+            if (!data || !Array.isArray(data.clips)) return { ok: false, error: 'malformed clips payload' };
+            return { ok: true, clips: data.clips };
+        })()`));
+
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.error || `Suno feed lookup failed (HTTP ${result?.status || '?'}).`);
+        }
+        if (!Array.isArray(result.clips)) {
+            throw new CommandExecutionError('Suno feed lookup returned malformed clips payload');
+        }
+        if (result.clips.length === 0) {
+            throw new EmptyResultError('suno list', 'No Suno clips found in your library.');
+        }
+
+        return result.clips.slice(0, limit).map((c, i) => {
+            if (!c || typeof c.id !== 'string' || !c.id) {
+                throw new CommandExecutionError('Suno feed lookup returned malformed clip identity');
+            }
+            return {
+                rank: i + 1 + pageOffset * limit,
+                clip: c.id.slice(0, 8),
+                title: c.title || '(untitled)',
+                status: c.status || '?',
+                created: (c.created_at || '').replace('T', ' ').replace(/\..*$/, '').replace(/Z$/, ''),
+                link: `${SUNO_URL}/song/${c.id}`,
+            };
+        });
+    },
+});

--- a/clis/suno/status.js
+++ b/clis/suno/status.js
@@ -1,0 +1,62 @@
+/**
+ * `opencli suno status` — quick health check: login state, plan, credit
+ * breakdown, captcha readiness. Lets agents pre-flight before spending
+ * generate credits.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    SUNO_DOMAIN,
+    checkSunoCaptcha,
+    ensureSunoSession,
+} from './utils.js';
+
+export const statusCommand = cli({
+    site: 'suno',
+    name: 'status',
+    access: 'read',
+    description: 'Check Suno login, plan, credit balance, and captcha readiness',
+    domain: SUNO_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: ['Status', 'Plan', 'Credits', 'Monthly', 'Captcha'],
+    func: async (page) => {
+        let session;
+        try {
+            session = await ensureSunoSession(page);
+        } catch (err) {
+            if (err instanceof AuthRequiredError) {
+                return [{
+                    Status: 'Not logged in',
+                    Plan: '-',
+                    Credits: '-',
+                    Monthly: '-',
+                    Captcha: '-',
+                }];
+            }
+            throw err;
+        }
+        let captcha;
+        try {
+            captcha = await checkSunoCaptcha(page, session.deviceId);
+        } catch (err) {
+            // Conservative: assume captcha is required when the pre-flight
+            // probe fails, so the displayed status doesn't claim "Not required"
+            // for an unverified state.
+            captcha = { required: true };
+        }
+        const b = session.breakdown;
+        // ensureSunoSession guarantees planId; planKey is fetched from the same
+        // billing/info response and is always populated for an active account.
+        return [{
+            Status: 'Connected',
+            Plan: session.planKey,
+            Credits: String(session.totalCreditsAvailable),
+            Monthly: `${b.monthlyRemaining}/${b.monthlyLimit}`,
+            Captcha: captcha?.required === true ? 'Required (solve in UI)' : 'Not required',
+        }];
+    },
+});

--- a/clis/suno/utils.js
+++ b/clis/suno/utils.js
@@ -1,0 +1,531 @@
+/**
+ * Suno web (suno.com) browser automation helpers — rewritten for the
+ * /api/generate/v2-web/ schema introduced 2026-05.
+ *
+ * Auth model: Bearer JWT from Clerk (`window.Clerk.session.getToken()`).
+ *
+ * The studio backend lives on `studio-api-prod.suno.com`; the page itself is
+ * on `suno.com`. The browser's normal cross-origin cookie-bearing fetch
+ * succeeds from a real Chrome tab, but the OpenCLI bridge's evaluate
+ * context isolates third-party cookies — `credentials: 'include'` drops the
+ * Clerk session cookie. Sending the JWT explicitly as `Authorization: Bearer`
+ * bypasses the isolation and matches the auth path the studio API expects.
+ *
+ * Required custom headers (in addition to Bearer):
+ *   - browser-token: {"token":"<base64 of {timestamp: ms}>"} (anti-replay)
+ *   - device-id: <uuid> (persistent per browser, found in `suno_device_id` cookie)
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
+
+export const SUNO_DOMAIN = 'suno.com';
+export const SUNO_URL = 'https://suno.com';
+export const STUDIO_API = 'https://studio-api-prod.suno.com';
+export const SUNO_CDN = 'https://cdn1.suno.ai';
+
+// As of 2026-05, the UI exposes V5.5 (chirp-fenix) and V4.5+ (chirp-bluejay).
+// Older versions are still routable via the API and remain valid `mv` values.
+export const SUNO_MODELS = ['chirp-fenix', 'chirp-bluejay', 'chirp-v4', 'chirp-v3-5'];
+export const DEFAULT_SUNO_MODEL = 'chirp-fenix';
+
+export const SUPPORTED_FORMATS = ['mp3', 'm4a', 'wav', 'video', 'cover', 'metadata'];
+export const DEFAULT_FORMATS = ['mp3', 'metadata'];
+
+export function parseFormats(value) {
+    if (value === undefined || value === null || value === '') return DEFAULT_FORMATS.slice();
+    const raw = Array.isArray(value) ? value.join(',') : String(value);
+    const parts = raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+    if (!parts.length) return DEFAULT_FORMATS.slice();
+    const unknown = parts.filter(p => !SUPPORTED_FORMATS.includes(p));
+    if (unknown.length) {
+        throw new ArgumentError(
+            `Unsupported --formats value(s): ${unknown.join(', ')}`,
+            `Supported: ${SUPPORTED_FORMATS.join(', ')}. (stems require multi-step extraction and are not yet wired.)`,
+        );
+    }
+    return Array.from(new Set(parts));
+}
+
+export function resolveSunoOutputDir(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return path.join(process.env.HOME || '~', 'Music', 'suno');
+    if (raw === '~') return process.env.HOME || '~';
+    if (raw.startsWith('~/')) return path.join(process.env.HOME || '~', raw.slice(2));
+    return path.resolve(raw);
+}
+
+export function sanitizeTitleForFilename(title, fallback = 'untitled') {
+    const cleaned = String(title || fallback)
+        .replace(/[\\/:*?"<>|\x00-\x1f]+/g, '-')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 60);
+    return cleaned || fallback;
+}
+
+export function ensureDir(dir) {
+    fs.mkdirSync(dir, { recursive: true });
+}
+
+export function normalizeBooleanFlag(value, fallback = false) {
+    if (typeof value === 'boolean') return value;
+    if (value === null || value === undefined || value === '') return fallback;
+    const s = String(value).trim().toLowerCase();
+    return s === 'true' || s === '1' || s === 'yes' || s === 'on';
+}
+
+export function unwrapEvaluateResult(value) {
+    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
+        return value.data;
+    }
+    return value;
+}
+
+export function requirePositiveInt(value, label) {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    return n;
+}
+
+export function requireNonNegativeInt(value, label) {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 0) {
+        throw new ArgumentError(`${label} must be a non-negative integer`);
+    }
+    return n;
+}
+
+export function clampSlider(value, label, def) {
+    if (value === undefined || value === null || value === '') return def;
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+        throw new ArgumentError(`${label} must be a number between 0 and 1`);
+    }
+    return n;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// In-page helper snippets. Each is inlined into a page.evaluate() call so
+// the browser-token is generated fresh per request and the Clerk token is
+// pulled live (avoiding 60s TTL expiry on long polls).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BROWSER_TOKEN_JS = `JSON.stringify({ token: btoa(JSON.stringify({ timestamp: Date.now() })) })`;
+const CLERK_TOKEN_JS = `await window.Clerk.session.getToken()`;
+
+/**
+ * Build the standard header set used by every studio-api-prod.suno.com call.
+ *
+ * deviceId is read once per command and embedded literally; browser-token
+ * and Authorization are computed inline (timestamp/JWT refresh per call).
+ */
+function sunoHeadersJs(deviceId, extra = {}) {
+    const extraEntries = Object.entries(extra).map(([k, v]) => `${JSON.stringify(k)}: ${JSON.stringify(v)}`).join(', ');
+    return `{
+        'Authorization': 'Bearer ' + ${CLERK_TOKEN_JS},
+        'browser-token': ${BROWSER_TOKEN_JS},
+        'device-id': ${JSON.stringify(deviceId)},
+        ${extraEntries}${extraEntries ? ',' : ''}
+    }`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session bootstrap.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function ensureSunoSession(page) {
+    await page.goto(`${SUNO_URL}/me`, { settleMs: 2000 });
+    // OneTrust consent banner can block the page; dismiss it if present.
+    await page.evaluate(`(() => {
+        const btn = Array.from(document.querySelectorAll('button')).find(b => /^reject all$|^accept all$|^confirm/i.test((b.innerText || '').trim()));
+        if (btn) btn.click();
+    })()`);
+
+    // Wait briefly for Clerk to mount before any API call.
+    for (let i = 0; i < 20; i += 1) {
+        const ready = unwrapEvaluateResult(await page.evaluate(`!!(window.Clerk && window.Clerk.session)`));
+        if (ready) break;
+        await page.wait(0.5);
+    }
+
+    const deviceId = await getSunoDeviceId(page);
+    const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+        try {
+            if (!window.Clerk?.session) return { ok: false, error: 'Clerk session unavailable' };
+            const res = await fetch('${STUDIO_API}/api/billing/info/', { headers: ${sunoHeadersJs(deviceId)} });
+            if (!res.ok) return { ok: false, status: res.status, body: (await res.text()).slice(0, 300) };
+            const data = await res.json();
+            // Suno tracks credits across three buckets:
+            //   - data.credits          : leftover one-time pack credits (often 0)
+            //   - monthly subscription  : (monthly_limit - monthly_usage)
+            //   - data.credit_packs[]   : purchased packs not yet exhausted
+            // The web UI's "credits remaining" pill is the sum of all three.
+            const packCredits = (data?.credit_packs || []).reduce((s, p) => s + (p?.credits ?? 0), 0);
+            const monthlyRemaining = Math.max(0, (data?.monthly_limit ?? 0) - (data?.monthly_usage ?? 0));
+            const totalCreditsAvailable = (data?.credits ?? 0) + packCredits + monthlyRemaining;
+            return {
+                ok: true,
+                planId: data?.plan?.id || null,
+                planKey: data?.plan?.plan_key || null,
+                totalCreditsAvailable,
+                breakdown: {
+                    pack: data?.credits ?? 0,
+                    purchasedPacks: packCredits,
+                    monthlyRemaining,
+                    monthlyLimit: data?.monthly_limit ?? 0,
+                    monthlyUsed: data?.monthly_usage ?? 0,
+                },
+            };
+        } catch (e) {
+            return { ok: false, error: String(e).slice(0, 200) };
+        }
+    })()`));
+
+    if (!result || !result.ok) {
+        throw new AuthRequiredError(SUNO_DOMAIN, `Suno session check failed (${result?.status || result?.error || 'unknown'}). Open https://suno.com in Chrome and sign in, then retry.`);
+    }
+    if (!result.planId) {
+        throw new CommandExecutionError('Suno billing/info returned no plan id — cannot construct user_tier for generation request.');
+    }
+    return { ...result, deviceId };
+}
+
+/**
+ * Verify the captcha pre-flight. If `required:true`, the simple flow won't
+ * work without solving a CAPTCHA (out of scope for the headless adapter).
+ */
+export async function checkSunoCaptcha(page, deviceId) {
+    const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+        const res = await fetch('${STUDIO_API}/api/c/check', {
+            method: 'POST',
+            headers: ${sunoHeadersJs(deviceId, { 'Content-Type': 'application/json' })},
+            body: JSON.stringify({ ctype: 'generation' }),
+        });
+        if (!res.ok) return { ok: false, status: res.status };
+        return { ok: true, ...(await res.json()) };
+    })()`));
+    return result; // { ok, required, captcha_version }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// device-id discovery. Suno frontend writes `suno_device_id` as a cookie on
+// first load; we re-use it so every command shares the same identity.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function getSunoDeviceId(page) {
+    const id = unwrapEvaluateResult(await page.evaluate(`(() => {
+        try {
+            const fromCookie = document.cookie.split(';').map(s => s.trim()).find(s => s.startsWith('suno_device_id='));
+            if (fromCookie) return decodeURIComponent(fromCookie.split('=')[1]);
+            for (const key of ['device_id', 'deviceId', 'suno_device_id']) {
+                const v = localStorage.getItem(key);
+                if (v) return v.replace(/^"|"$/g, '');
+            }
+        } catch {}
+        return null;
+    })()`));
+    if (id && typeof id === 'string') return id;
+    return unwrapEvaluateResult(await page.evaluate(`crypto.randomUUID()`));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Generate (Custom or Simple mode).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Submit a generation request via /api/generate/v2-web/.
+ *
+ * payload fields:
+ *   - mode: 'custom' | 'simple'
+ *   - model: chirp-fenix etc.
+ *   - title: song title (required by API even for Simple mode)
+ *   - lyrics: Custom-mode lyrics (with [Verse] metatags). Used as API `prompt`.
+ *   - tags: Custom-mode style string.
+ *   - negativeTags: Custom-mode exclusion tags.
+ *   - description: Simple-mode description string. Sent in `prompt` per the
+ *     v2-web schema (the older `gpt_description_prompt` field is gone).
+ *   - makeInstrumental: bool
+ *   - weirdness, styleWeight: 0..1 sliders
+ *   - userTier: UUID from billing/info plan.id
+ *   - createSessionToken: UUID, generated per session
+ *   - deviceId: UUID from local browser
+ */
+export async function submitSunoGeneration(page, payload) {
+    const isCustom = payload.mode === 'custom';
+    const body = {
+        token: null,
+        generation_type: 'TEXT',
+        title: payload.title || '',
+        tags: isCustom ? (payload.tags || '') : '',
+        negative_tags: isCustom ? (payload.negativeTags || '') : '',
+        mv: payload.model || DEFAULT_SUNO_MODEL,
+        prompt: isCustom ? (payload.lyrics || '') : (payload.description || ''),
+        make_instrumental: !!payload.makeInstrumental,
+        user_uploaded_images_b64: null,
+        metadata: {
+            web_client_pathname: '/create',
+            is_max_mode: false,
+            is_mumble: false,
+            create_mode: isCustom ? 'custom' : 'simple',
+            user_tier: payload.userTier,
+            create_session_token: payload.createSessionToken,
+            disable_volume_normalization: false,
+            control_sliders: {
+                weirdness_constraint: payload.weirdness,
+                style_weight: payload.styleWeight,
+            },
+        },
+        override_fields: [],
+        cover_clip_id: null,
+        cover_start_s: null,
+        cover_end_s: null,
+        persona_id: null,
+        artist_clip_id: null,
+        artist_start_s: null,
+        artist_end_s: null,
+        continue_clip_id: null,
+        continued_aligned_prompt: null,
+        continue_at: null,
+        transaction_uuid: payload.transactionUuid,
+        token_provider: null,
+    };
+
+    const bodyJson = JSON.stringify(body);
+    const deviceId = payload.deviceId;
+    const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+        const res = await fetch('${STUDIO_API}/api/generate/v2-web/', {
+            method: 'POST',
+            headers: ${sunoHeadersJs(deviceId, { 'Content-Type': 'application/json' })},
+            body: ${JSON.stringify(bodyJson)},
+        });
+        const text = await res.text();
+        let parsed = null;
+        try { parsed = JSON.parse(text); } catch {}
+        return { status: res.status, ok: res.ok, body: parsed, raw: parsed ? null : text.slice(0, 600) };
+    })()`));
+
+    if (!result || !result.ok) {
+        const status = result?.status || 'unknown';
+        const detail = result?.body?.detail || result?.raw || JSON.stringify(result?.body || {}).slice(0, 500);
+        if (status === 401 || status === 403) {
+            throw new AuthRequiredError(SUNO_DOMAIN, `Suno API rejected request (HTTP ${status}). Re-login on suno.com.`);
+        }
+        if (status === 402) {
+            throw new CommandExecutionError(`Suno API: insufficient credits (HTTP 402). ${detail}`);
+        }
+        throw new CommandExecutionError(`Suno generate failed (HTTP ${status}): ${detail}`);
+    }
+
+    if (!result.body || typeof result.body !== 'object' || Array.isArray(result.body)) {
+        throw new CommandExecutionError('Suno generate returned malformed JSON payload.');
+    }
+    const clips = result.body?.clips || [];
+    if (!clips.length) {
+        throw new EmptyResultError('suno generate', `Submission accepted but Suno returned no clip ids. Raw: ${JSON.stringify(result.body).slice(0, 300)}`);
+    }
+    return result.body;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Poll /api/feed/v3 (cookie auth, no Bearer).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function pollSunoClips(page, clipIds, timeoutSeconds, deviceId, pollSeconds = 5, onProgress = null) {
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    const targetSet = new Set(clipIds);
+    const idsJson = JSON.stringify(clipIds);
+
+    while (Date.now() < deadline) {
+        const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+            const res = await fetch('${STUDIO_API}/api/feed/v3', {
+                method: 'POST',
+                headers: ${sunoHeadersJs(deviceId, { 'Content-Type': 'application/json' })},
+                body: JSON.stringify({ clip_ids: ${idsJson} }),
+            });
+            const body = await res.json().catch(() => null);
+            return { status: res.status, body };
+        })()`));
+
+        if (!result) {
+            await page.wait(pollSeconds);
+            continue;
+        }
+        if (result.status === 401 || result.status === 403) {
+            throw new AuthRequiredError(SUNO_DOMAIN, `Suno feed API rejected (HTTP ${result.status}). Re-login.`);
+        }
+        if (result.status < 200 || result.status >= 300) {
+            throw new CommandExecutionError(`Suno feed API failed while polling clips (HTTP ${result.status || '?'})`);
+        }
+        if (!result.body || typeof result.body !== 'object' || Array.isArray(result.body)) {
+            throw new CommandExecutionError('Suno feed API returned malformed JSON while polling clips');
+        }
+
+        const allClips = result.body.clips || [];
+        if (!Array.isArray(allClips)) {
+            throw new CommandExecutionError('Suno feed API returned malformed clips payload');
+        }
+        const ourClips = allClips.filter(c => targetSet.has(c.id));
+        const finished = ourClips.filter(c => c.status === 'complete' || c.status === 'error');
+
+        if (typeof onProgress === 'function') {
+            onProgress({ total: clipIds.length, done: finished.length, statuses: ourClips.map(c => `${c.id.slice(0,8)}:${c.status}`) });
+        }
+
+        if (finished.length === clipIds.length) return ourClips;
+        await page.wait(pollSeconds);
+    }
+
+    throw new TimeoutError(`Suno generation did not complete within ${timeoutSeconds}s. Try --timeout <higher>.`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Asset download.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function pickMediaUrl(clip, contentTypeFragment) {
+    const arr = Array.isArray(clip.media_urls) ? clip.media_urls : [];
+    const hit = arr.find(m => (m.content_type || '').toLowerCase().includes(contentTypeFragment));
+    return hit?.url || null;
+}
+
+/**
+ * Resolve the canonical MP3 URL for a clip. Suno's /api/download/clip/{id}
+ * returns a fresh signed URL; clip.audio_url is a backup.
+ */
+async function resolveMp3Url(page, clip, deviceId) {
+    const fromApi = await page.evaluate(`(async () => {
+        try {
+            const res = await fetch('${STUDIO_API}/api/download/clip/${clip.id}?format=mp3', { headers: ${sunoHeadersJs(deviceId)} });
+            if (!res.ok) return null;
+            const data = await res.json();
+            return data?.download_url || null;
+        } catch { return null; }
+    })()`);
+    return fromApi || clip.audio_url || `${SUNO_CDN}/${clip.id}.mp3`;
+}
+
+/**
+ * Trigger WAV conversion (if not already converted), then poll for the file
+ * URL. Suno charges a download credit for WAV — the billing call is required.
+ */
+async function ensureSunoWav(page, clipId, deviceId, timeoutSeconds = 120, pollSeconds = 3) {
+    // Charge the credit + queue conversion. Both calls fire idempotently if
+    // the wav is already cached server-side.
+    await page.evaluate(`(async () => {
+        try {
+            await fetch('${STUDIO_API}/api/billing/clips/${clipId}/download/', {
+                method: 'POST',
+                headers: ${sunoHeadersJs(deviceId, { 'Content-Type': 'application/json' })},
+                body: JSON.stringify({}),
+            });
+        } catch {}
+        try {
+            await fetch('${STUDIO_API}/api/gen/${clipId}/convert_wav/', {
+                method: 'POST',
+                headers: ${sunoHeadersJs(deviceId, { 'Content-Type': 'application/json' })},
+            });
+        } catch {}
+    })()`);
+
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    while (Date.now() < deadline) {
+        const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+            const res = await fetch('${STUDIO_API}/api/gen/${clipId}/wav_file/', { headers: ${sunoHeadersJs(deviceId)} });
+            if (!res.ok) return { ok: false, status: res.status };
+            const data = await res.json().catch(() => null);
+            return { ok: true, url: data?.wav_file_url || null };
+        })()`));
+        if (result?.ok && result.url) return result.url;
+        await page.wait(pollSeconds);
+    }
+    return null;
+}
+
+async function downloadBinary(page, url) {
+    // CDN URLs (cdn1.suno.ai, cloudfront) are public and reject the CORS
+    // preflight triggered by `credentials: 'include'`. Plain fetch is what
+    // the Suno web UI uses for asset downloads too.
+    return unwrapEvaluateResult(await page.evaluate(`(async () => {
+        try {
+            const res = await fetch(${JSON.stringify(url)});
+            if (!res.ok) return { ok: false, status: res.status };
+            const blob = await res.blob();
+            const dataUrl = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onloadend = () => resolve(String(reader.result || ''));
+                reader.onerror = () => reject(new Error('reader failed'));
+                reader.readAsDataURL(blob);
+            });
+            return { ok: true, mime: blob.type || '', dataUrl };
+        } catch (e) {
+            return { ok: false, error: String(e).slice(0, 200) };
+        }
+    })()`));
+}
+
+async function writeFromDataUrl(page, url, filePath) {
+    const result = await downloadBinary(page, url);
+    if (!result?.ok) {
+        return { ok: false, reason: result?.status ? `HTTP ${result.status}` : (result?.error || 'unknown') };
+    }
+    const base64 = String(result.dataUrl || '').replace(/^data:[^;]+;base64,/, '');
+    if (!base64) {
+        return { ok: false, reason: 'empty response body' };
+    }
+    fs.writeFileSync(filePath, Buffer.from(base64, 'base64'));
+    if (!fs.statSync(filePath).size) {
+        return { ok: false, reason: 'empty file written' };
+    }
+    return { ok: true };
+}
+
+export async function downloadSunoClip(page, clip, outputDir, formats, deviceId) {
+    ensureDir(outputDir);
+    const slug = `${sanitizeTitleForFilename(clip.title || clip.id)}_${clip.id.slice(0, 8)}`;
+    const written = [];
+
+    if (formats.includes('metadata')) {
+        const metaPath = path.join(outputDir, `${slug}.json`);
+        fs.writeFileSync(metaPath, JSON.stringify(clip, null, 2), 'utf8');
+        written.push({ format: 'metadata', file: metaPath, ok: true });
+    }
+
+    for (const fmt of formats) {
+        if (fmt === 'metadata') continue;
+        let url = null;
+        let ext = '';
+        try {
+            if (fmt === 'mp3') {
+                ext = '.mp3';
+                url = await resolveMp3Url(page, clip, deviceId);
+            } else if (fmt === 'm4a') {
+                ext = '.m4a';
+                url = pickMediaUrl(clip, 'm4a');
+            } else if (fmt === 'video') {
+                ext = '.mp4';
+                url = clip.video_url || null;
+            } else if (fmt === 'cover') {
+                ext = '.jpeg';
+                url = clip.image_large_url || clip.image_url || null;
+            } else if (fmt === 'wav') {
+                ext = '.wav';
+                url = await ensureSunoWav(page, clip.id, deviceId);
+            }
+        } catch (err) {
+            written.push({ format: fmt, file: null, ok: false, reason: `prep failed: ${String(err).slice(0, 100)}` });
+            continue;
+        }
+        if (!url) {
+            written.push({ format: fmt, file: null, ok: false, reason: 'not available' });
+            continue;
+        }
+        const filePath = path.join(outputDir, `${slug}${ext}`);
+        const result = await writeFromDataUrl(page, url, filePath);
+        written.push({ format: fmt, file: filePath, ok: result.ok, reason: result.ok ? null : result.reason });
+    }
+
+    return { slug, written };
+}

--- a/clis/suno/utils.js
+++ b/clis/suno/utils.js
@@ -154,10 +154,15 @@ export async function ensureSunoSession(page) {
     const deviceId = await getSunoDeviceId(page);
     const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
         try {
-            if (!window.Clerk?.session) return { ok: false, error: 'Clerk session unavailable' };
+            if (!window.Clerk?.session) return { ok: false, auth: true, error: 'Clerk session unavailable' };
             const res = await fetch('${STUDIO_API}/api/billing/info/', { headers: ${sunoHeadersJs(deviceId)} });
             if (!res.ok) return { ok: false, status: res.status, body: (await res.text()).slice(0, 300) };
-            const data = await res.json();
+            let data = null;
+            try {
+                data = await res.json();
+            } catch (e) {
+                return { ok: false, error: 'Malformed billing/info JSON: ' + String(e).slice(0, 200) };
+            }
             // Suno tracks credits across three buckets:
             //   - data.credits          : leftover one-time pack credits (often 0)
             //   - monthly subscription  : (monthly_limit - monthly_usage)
@@ -185,7 +190,11 @@ export async function ensureSunoSession(page) {
     })()`));
 
     if (!result || !result.ok) {
-        throw new AuthRequiredError(SUNO_DOMAIN, `Suno session check failed (${result?.status || result?.error || 'unknown'}). Open https://suno.com in Chrome and sign in, then retry.`);
+        const detail = result?.status || result?.error || 'unknown';
+        if (result?.auth || result?.status === 401 || result?.status === 403) {
+            throw new AuthRequiredError(SUNO_DOMAIN, `Suno session check failed (${detail}). Open https://suno.com in Chrome and sign in, then retry.`);
+        }
+        throw new CommandExecutionError(`Suno session check failed (${detail}).`);
     }
     if (!result.planId) {
         throw new CommandExecutionError('Suno billing/info returned no plan id — cannot construct user_tier for generation request.');

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -1,0 +1,190 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DEFAULT_FORMATS,
+    SUPPORTED_FORMATS,
+    SUNO_MODELS,
+    clampSlider,
+    normalizeBooleanFlag,
+    requireNonNegativeInt,
+    parseFormats,
+    requirePositiveInt,
+    resolveSunoOutputDir,
+    sanitizeTitleForFilename,
+    unwrapEvaluateResult,
+    pollSunoClips,
+} from './utils.js';
+
+describe('suno utils — parseFormats', () => {
+    it('returns the default format set when input is empty or missing', () => {
+        expect(parseFormats(undefined)).toEqual(DEFAULT_FORMATS);
+        expect(parseFormats(null)).toEqual(DEFAULT_FORMATS);
+        expect(parseFormats('')).toEqual(DEFAULT_FORMATS);
+        expect(parseFormats('   ')).toEqual(DEFAULT_FORMATS);
+    });
+
+    it('parses comma-separated input and trims whitespace', () => {
+        expect(parseFormats('mp3, wav, metadata')).toEqual(['mp3', 'wav', 'metadata']);
+    });
+
+    it('lowercases and deduplicates input', () => {
+        expect(parseFormats('MP3,Mp3,mp3,WAV')).toEqual(['mp3', 'wav']);
+    });
+
+    it('accepts array inputs (e.g. when caller passes pre-split values)', () => {
+        expect(parseFormats(['mp3', 'metadata'])).toEqual(['mp3', 'metadata']);
+    });
+
+    it('throws ArgumentError on unsupported format and lists the supported set', () => {
+        try {
+            parseFormats('mp3,flac');
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(ArgumentError);
+            expect(err.message).toContain('flac');
+            expect(err.hint).toContain(SUPPORTED_FORMATS.join(', '));
+        }
+    });
+});
+
+describe('suno utils — resolveSunoOutputDir', () => {
+    it('falls back to ~/Music/suno when no path is given', () => {
+        expect(resolveSunoOutputDir()).toBe(path.join(os.homedir(), 'Music', 'suno'));
+        expect(resolveSunoOutputDir('')).toBe(path.join(os.homedir(), 'Music', 'suno'));
+    });
+
+    it('expands ~ and ~/-prefixed relative paths to the home directory', () => {
+        expect(resolveSunoOutputDir('~')).toBe(os.homedir());
+        expect(resolveSunoOutputDir('~/Music/test')).toBe(path.join(os.homedir(), 'Music', 'test'));
+    });
+
+    it('absolute paths are returned as-is (resolved)', () => {
+        expect(resolveSunoOutputDir('/tmp/suno')).toBe('/tmp/suno');
+    });
+});
+
+describe('suno utils — sanitizeTitleForFilename', () => {
+    it('replaces filesystem-hostile characters with hyphens', () => {
+        expect(sanitizeTitleForFilename('foo/bar:baz?')).toBe('foo-bar-baz-');
+    });
+
+    it('collapses whitespace and trims', () => {
+        expect(sanitizeTitleForFilename('  hello   world  ')).toBe('hello world');
+    });
+
+    it('caps length at 60 characters', () => {
+        const long = 'a'.repeat(120);
+        expect(sanitizeTitleForFilename(long).length).toBe(60);
+    });
+
+    it('returns fallback for empty input', () => {
+        expect(sanitizeTitleForFilename('', 'untitled')).toBe('untitled');
+        expect(sanitizeTitleForFilename(null, 'fallback')).toBe('fallback');
+    });
+});
+
+describe('suno utils — clampSlider', () => {
+    it('returns the default when input is missing', () => {
+        expect(clampSlider(undefined, '--weirdness', 0.5)).toBe(0.5);
+        expect(clampSlider('', '--weirdness', 0.5)).toBe(0.5);
+        expect(clampSlider(null, '--weirdness', 0.5)).toBe(0.5);
+    });
+
+    it('parses numeric strings and accepts 0..1', () => {
+        expect(clampSlider('0', '--x', 0.5)).toBe(0);
+        expect(clampSlider('0.74', '--x', 0.5)).toBe(0.74);
+        expect(clampSlider('1', '--x', 0.5)).toBe(1);
+    });
+
+    it('rejects out-of-range or non-numeric values', () => {
+        expect(() => clampSlider('1.5', '--x', 0.5)).toThrowError(ArgumentError);
+        expect(() => clampSlider('-0.1', '--x', 0.5)).toThrowError(ArgumentError);
+        expect(() => clampSlider('hello', '--x', 0.5)).toThrowError(ArgumentError);
+    });
+});
+
+describe('suno utils — normalizeBooleanFlag', () => {
+    it('treats the canonical true-ish strings as true', () => {
+        for (const v of ['true', '1', 'yes', 'on', 'TRUE', 'On']) {
+            expect(normalizeBooleanFlag(v)).toBe(true);
+        }
+    });
+
+    it('treats unset / empty / unrecognized values as the fallback', () => {
+        expect(normalizeBooleanFlag(undefined)).toBe(false);
+        expect(normalizeBooleanFlag('', true)).toBe(true);
+        expect(normalizeBooleanFlag('maybe')).toBe(false);
+    });
+
+    it('passes through actual booleans', () => {
+        expect(normalizeBooleanFlag(true)).toBe(true);
+        expect(normalizeBooleanFlag(false)).toBe(false);
+    });
+});
+
+describe('suno utils — requirePositiveInt', () => {
+    it('returns positive integers as numbers', () => {
+        expect(requirePositiveInt(5, '--limit')).toBe(5);
+        expect(requirePositiveInt('10', '--limit')).toBe(10);
+    });
+
+    it('rejects zero, negative, and non-integer values', () => {
+        expect(() => requirePositiveInt(0, '--limit')).toThrowError(ArgumentError);
+        expect(() => requirePositiveInt(-3, '--limit')).toThrowError(ArgumentError);
+        expect(() => requirePositiveInt(1.5, '--limit')).toThrowError(ArgumentError);
+        expect(() => requirePositiveInt('not a number', '--limit')).toThrowError(ArgumentError);
+    });
+});
+
+describe('suno utils — requireNonNegativeInt', () => {
+    it('returns zero and positive integers as numbers', () => {
+        expect(requireNonNegativeInt(0, '--page')).toBe(0);
+        expect(requireNonNegativeInt('3', '--page')).toBe(3);
+    });
+
+    it('rejects negative or non-integer values', () => {
+        expect(() => requireNonNegativeInt(-1, '--page')).toThrowError(ArgumentError);
+        expect(() => requireNonNegativeInt(1.5, '--page')).toThrowError(ArgumentError);
+        expect(() => requireNonNegativeInt('nope', '--page')).toThrowError(ArgumentError);
+    });
+});
+
+describe('suno utils — unwrapEvaluateResult', () => {
+    it('unwraps Browser Bridge envelopes at evaluate boundaries', () => {
+        const payload = { ok: true, clips: [] };
+        expect(unwrapEvaluateResult({ session: 'browser:default', data: payload })).toBe(payload);
+        expect(unwrapEvaluateResult(payload)).toBe(payload);
+    });
+});
+
+describe('suno utils — model + format exports', () => {
+    it('exposes the four shipping models with chirp-fenix first', () => {
+        expect(SUNO_MODELS).toContain('chirp-fenix');
+        expect(SUNO_MODELS).toContain('chirp-bluejay');
+        expect(SUNO_MODELS[0]).toBe('chirp-fenix');
+    });
+
+    it('declares mp3 + metadata as the default download set', () => {
+        expect(DEFAULT_FORMATS).toEqual(['mp3', 'metadata']);
+    });
+});
+
+describe('suno utils — pollSunoClips', () => {
+    it('fails typed on malformed feed JSON while polling generation status', async () => {
+        const page = {
+            evaluate: async () => ({ status: 200, body: null }),
+            wait: async () => {},
+        };
+        await expect(pollSunoClips(page, ['clip-a'], 1, 'device-id', 0)).rejects.toThrowError(CommandExecutionError);
+    });
+
+    it('fails typed on non-auth HTTP feed failures while polling generation status', async () => {
+        const page = {
+            evaluate: async () => ({ status: 500, body: { clips: [] } }),
+            wait: async () => {},
+        };
+        await expect(pollSunoClips(page, ['clip-a'], 1, 'device-id', 0)).rejects.toThrowError(CommandExecutionError);
+    });
+});

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -1,7 +1,7 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     DEFAULT_FORMATS,
     SUPPORTED_FORMATS,
@@ -15,6 +15,7 @@ import {
     sanitizeTitleForFilename,
     unwrapEvaluateResult,
     pollSunoClips,
+    ensureSunoSession,
 } from './utils.js';
 
 describe('suno utils — parseFormats', () => {
@@ -156,6 +157,38 @@ describe('suno utils — unwrapEvaluateResult', () => {
         const payload = { ok: true, clips: [] };
         expect(unwrapEvaluateResult({ session: 'browser:default', data: payload })).toBe(payload);
         expect(unwrapEvaluateResult(payload)).toBe(payload);
+    });
+});
+
+describe('suno utils — ensureSunoSession typed failures', () => {
+    function createSessionPage(sessionCheckResult) {
+        const evaluate = async (script) => {
+            if (script.includes('querySelectorAll')) return undefined;
+            if (script.includes('!!(window.Clerk && window.Clerk.session)')) return true;
+            if (script.includes('suno_device_id')) return 'device-id';
+            if (script.includes('/api/billing/info/')) return sessionCheckResult;
+            throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+        };
+        return {
+            goto: async () => undefined,
+            wait: async () => undefined,
+            evaluate,
+        };
+    }
+
+    it('maps explicit logged-out session state to AuthRequiredError', async () => {
+        await expect(ensureSunoSession(createSessionPage({
+            ok: false,
+            auth: true,
+            error: 'Clerk session unavailable',
+        }))).rejects.toThrowError(AuthRequiredError);
+    });
+
+    it('does not classify billing/parser drift as logged out', async () => {
+        await expect(ensureSunoSession(createSessionPage({
+            ok: false,
+            error: 'Malformed billing/info JSON: Unexpected token <',
+        }))).rejects.toThrowError(CommandExecutionError);
     });
 });
 

--- a/docs/adapters/browser/suno.md
+++ b/docs/adapters/browser/suno.md
@@ -1,0 +1,90 @@
+# Suno
+
+**Mode**: 🔐 Browser · **Domain**: `suno.com`
+
+Generate music with [Suno](https://suno.com) (V5.5 `chirp-fenix` by default) and download MP3 / M4A / WAV / cover / metadata via the user's logged-in Chrome session. Uses the `/api/generate/v2-web/` schema with Clerk Bearer auth + the `browser-token` / `device-id` headers Suno added in 2026-05.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli suno status` | Show login state, plan, credit breakdown, captcha readiness |
+| `opencli suno list` | List recent clips in your library (id, title, status, created_at, link) |
+| `opencli suno generate [prompt]` | Generate a song (Simple or Custom mode) and download clips locally |
+| `opencli suno download <clip>` | Download an existing clip by UUID or `/song/<id>` URL |
+
+Each `generate` request returns 2 candidate clips by design (Suno's native A/B). Both are downloaded.
+
+## Usage Examples
+
+```bash
+# Quick health check — plan, credits, captcha
+opencli suno status
+
+# Browse the library (id you can feed to `download`)
+opencli suno list --limit 20
+
+# Simple mode — Suno picks lyrics, tags, and title
+opencli suno generate "lo-fi study beat, 80 bpm, vinyl crackle" --instrumental true
+
+# Custom mode — full control over lyrics, style, and exclusions
+opencli suno generate \
+  --lyrics "[Verse]\nNight rain on the window..." \
+  --tags "synthwave, 100 BPM, analog pad" \
+  --negative-tags "vocals, drums" \
+  --title "Night Rain"
+
+# Dial in the web UI's "Weirdness" + "Style Influence" sliders
+opencli suno generate "post-rock crescendo" --weirdness 0.74 --style-weight 0.57
+
+# Generate but skip the download (you only want the Suno links + clip ids)
+opencli suno generate "ambient drone" --sd true
+
+# Download an existing clip in MP3 + metadata (default)
+opencli suno download a1b2c3d4-1111-2222-3333-444444444444
+
+# Same, but also pull WAV (charged by Suno — must confirm)
+opencli suno download a1b2c3d4-1111-2222-3333-444444444444 \
+  --formats mp3,wav,metadata --confirm-paid true
+```
+
+## Options
+
+| Option | Commands | Description |
+|--------|----------|-------------|
+| `prompt` | `generate` | Simple-mode description (positional, ignored when `--lyrics` is set) |
+| `--lyrics` | `generate` | Custom-mode lyrics with `[Verse]` / `[Chorus]` metatags. Triggers Custom mode. |
+| `--tags` | `generate` | Custom-mode style tags (genre, BPM, instruments). Used with `--lyrics`. |
+| `--negative-tags` | `generate` | Custom-mode style exclusions (e.g. `"no vocals, no autotune"`). |
+| `--title` | `generate` | Song title (default: auto-derived from prompt) |
+| `--instrumental` | `generate` | No vocals (default: `false`) |
+| `--model` | `generate` | `chirp-fenix` (V5.5, default), `chirp-bluejay` (V4.5+), `chirp-v4`, `chirp-v3-5` |
+| `--weirdness` | `generate` | Creative weirdness slider, `0..1` (default: `0.5`) |
+| `--style-weight` | `generate` | Style adherence slider, `0..1` (default: `0.5`) |
+| `--timeout` | `generate` | Max seconds to wait for both clips to finish (default: `300`) |
+| `--sd` | `generate` | Skip download; only print clip ids and Suno URLs |
+| `clip` | `download` | Clip UUID or `https://suno.com/song/<id>` URL (positional, required) |
+| `--limit` | `list` | Max clips to return (default: `20`) |
+| `--page` | `list` | Pagination offset, 0-based (default: `0`) |
+| `--formats` | `generate`, `download` | Comma-separated: `mp3`, `m4a`, `wav`, `video`, `cover`, `metadata` (default: `mp3,metadata`) |
+| `--op` | `generate`, `download` | Output directory (default: `~/Music/suno`) |
+| `--confirm-paid` | `generate`, `download` | Required for paid downloads (`wav`). Without it, paid formats are skipped with a warning. |
+
+## Behavior
+
+- **Two clips per generation.** Suno always returns 2 candidates per request (`A` and `B`). The adapter downloads both so the caller can A/B audition.
+- **Paid-download guard.** `wav` is a paid download (Suno charges per `billing/clips/{id}/download/` call). Both `generate` and `download` skip `wav` by default and require `--confirm-paid true`. Skipped formats appear in the result row as `skipped(needs --confirm-paid):wav` rather than silently dropping.
+- **Credit pre-check.** `generate` reads `/api/billing/info/` first and refuses to submit when total credits (monthly remaining + packs + leftover) are below `10` — no wasted requests.
+- **Captcha pre-check.** `generate` and `status` hit `/api/c/check`; if Suno requires a challenge for the current account/IP, the command fails fast with instructions to solve a challenge once in the Chrome UI.
+- **File naming.** `<sanitized-title>_<first-8-of-clip-uuid>.<ext>`, e.g. `Night Rain_a1b2c3d4.mp3`. A sibling `.json` carries the complete clip metadata from `/api/feed/v3` for downstream tooling.
+- **Stems (12-track separation)** are not yet wired — the schema is known (`task: gen_stem`, `stem_type_id: 91`, `stem_task: twelve`) but stems are a paid extension that warrants its own command surface.
+
+## Auth notes
+
+The Suno studio API (`studio-api-prod.suno.com`) requires three things on every request: a Clerk JWT, an anti-replay `browser-token`, and a persistent `device-id`. The OpenCLI bridge's `credentials: 'include'` cross-origin fetch drops Suno's session cookie due to third-party-cookie isolation in the evaluate context, so this adapter explicitly reads `await window.Clerk.session.getToken()` and forwards it as `Authorization: Bearer`. `browser-token` is generated per request (a base64-encoded `{ timestamp }` object) and `device-id` is read from the `suno_device_id` cookie that Suno's frontend writes on first load.
+
+## Prerequisites
+
+- Chrome is running
+- You are already logged into `suno.com`
+- (For `generate`) The account has at least ~10 credits available (Pro plan default: 2,500/month)


### PR DESCRIPTION
## Summary

A new browser-based adapter for [Suno](https://suno.com), the AI music generation service. Targets the `/api/generate/v2-web/` schema introduced in 2026-05 and the cookie-isolation-aware Bearer auth path.

## Commands

| Command | Purpose |
|---------|---------|
| `opencli suno status` | login state, plan, credit breakdown, captcha |
| `opencli suno list` | list recent clips in the user's library |
| `opencli suno generate` | Simple or Custom mode generation + download |
| `opencli suno download` | fetch an existing clip by id in MP3 / M4A / WAV / cover |

Each `generate` request returns 2 candidate clips (Suno's native A/B). All formats land alongside a metadata JSON dump for traceability.

## Custom-mode controls (matches the web UI)

- `--lyrics` + `--tags` + `--negative-tags` + `--title`
- `--weirdness` (0..1) → `metadata.control_sliders.weirdness_constraint`
- `--style-weight` (0..1) → `metadata.control_sliders.style_weight`
- `--instrumental`, `--model` (`chirp-fenix` / `chirp-bluejay` / `chirp-v4` / `chirp-v3-5`)

## Paid-format guard

WAV downloads charge against the user's account (the Suno UI's *Download → WAV* flow makes the same `billing/clips/{id}/download/` call). Both `generate` and `download` skip WAV by default and require `--confirm-paid true` to actually charge — surfaced in the result row as `skipped(needs --confirm-paid):wav` rather than silently dropping it.

## Auth notes (worth a reviewer's attention)

The studio API rejects the OpenCLI bridge's `credentials: 'include'` cross-origin fetch (third-party cookie isolation in the eval context). The adapter explicitly pulls the live Clerk JWT via `await window.Clerk.session.getToken()` and sends it as `Authorization: Bearer`, alongside the `browser-token` (anti-replay base64-encoded timestamp) and `device-id` (from the `suno_device_id` cookie) headers that the studio API also requires. This matches the wire format observed in a real `/api/generate/v2-web/` request capture.

## Validation

- \`npx tsc --noEmit\` — clean
- \`opencli validate suno\` — **PASS**, 0 errors, 0 warnings, 4 commands
- \`npx vitest run --project adapter clis/suno/\` — **47 tests pass** across 4 files
- \`npm test\` — **3811 passing** across 380 files
- Live (Pro account, 10 credits/song): two-clip generation completes end-to-end; MP3 (796 KB, 64 kbps 48 kHz), M4A (603 KB opus), and WAV (6.7 MB PCM 16-bit 48 kHz) all download intact; cover JPEG + metadata JSON also written.

## Known gaps (intentional / deferrable)

- **Stems extraction (12-track separation)** — schema known from the capture (\`task: 'gen_stem'\`, \`stem_type_id: 91\`, \`stem_task: 'twelve'\`, \`continue_clip_id: <source>\`), but not yet wired. Happy to follow up in a separate PR if reviewers want it included; stems are paid and the design space (one-shot vs poll for 12 separate child clips) is worth its own review pass.
- **Captcha solving** — \`/api/c/check\` is checked pre-flight and the command fails fast with a clear instruction if Suno requires a challenge. Solving captchas headlessly is out of scope.

## Files

\`\`\`
clis/suno/
├── utils.js          (498)  — session, Bearer auth, generation, polling, download helpers
├── generate.js       (208)  — main generate command (Simple + Custom + sliders)
├── download.js       (120)  — standalone clip download by id
├── status.js          (54)  — health check
├── list.js            (65)  — library pagination
├── utils.test.js     (148)  — pure-function tests (parseFormats, sliders, sanitizers)
├── generate.test.js  (206)  — generate flow + argument validation + paid-format guard
├── download.test.js   (98)  — download by id + clip-id parsing + paid-format guard
└── commands.test.js  (125)  — status + list end-to-end (mocked utils)
\`\`\`

Total: **+1522 lines**, **47 tests**.