### PR TITLE
feat(linkedin): add salesnav-search command for Sales Navigator lead search

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14527,6 +14527,44 @@
   },
   {
     "site": "linkedin",
+    "name": "salesnav-search",
+    "description": "Search LinkedIn Sales Navigator for people leads by keyword",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "keywords",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "People search keywords, e.g. \"quality manager food manufacturing\""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 25,
+        "required": false,
+        "help": "Maximum leads to return (1-500, fetched 25 per request)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "title",
+      "company",
+      "location",
+      "degree",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-search.js",
+    "sourceFile": "linkedin/salesnav-search.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
     "name": "search",
     "description": "Search LinkedIn jobs",
     "access": "read",

--- a/clis/linkedin/salesnav-search.js
+++ b/clis/linkedin/salesnav-search.js
@@ -1,0 +1,153 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_HOME = 'https://www.linkedin.com/sales/';
+const LEAD_SEARCH_BASE = 'https://www.linkedin.com/sales-api/salesApiLeadSearch';
+// Versioned response decoration. LinkedIn bumps this on Sales Navigator
+// redeploys; if the response shape ever changes, refresh it from a live
+// /sales/search/people request.
+const LEAD_SEARCH_DECORATION = 'com.linkedin.sales.deco.desktop.searchv2.LeadSearchResult-14';
+const PAGE_SIZE = 25;
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function parseLimit(value) {
+  if (value === undefined || value === null || value === '') return 25;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new ArgumentError('--limit must be an integer between 1 and 500');
+  }
+  return limit;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+// Sales Navigator keeps the structural ( ) , : of the query literal and only
+// percent-encodes the keyword value.
+function leadSearchUrl(keywords, start) {
+  const query = '(spellCorrectionEnabled:true,recentSearchParam:(doLogHistory:true),keywords:'
+    + encodeURIComponent(keywords) + ')';
+  return LEAD_SEARCH_BASE
+    + '?q=searchQuery&query=' + query
+    + '&start=' + start + '&count=' + PAGE_SIZE
+    + '&decorationId=' + LEAD_SEARCH_DECORATION;
+}
+
+function fetchLeadSearchScript(url, csrf) {
+  return String.raw`(async () => {
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      'x-restli-protocol-version': '2.0.0',
+      accept: 'application/json',
+    };
+    try {
+      const res = await fetch(${JSON.stringify(url)}, { credentials: 'include', headers });
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
+      if (!res.ok) return { error: 'HTTP ' + res.status };
+      return { json: await res.json() };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+// Sales Navigator search returns no /in/ vanity URL, but the entityUrn carries
+// the obfuscated member token, and linkedin.com/in/<token> is a valid profile
+// URL that the connect command accepts.
+function profileUrlFromEntityUrn(entityUrn) {
+  const match = String(entityUrn || '').match(/fs_salesProfile:\(([^,)]+)/);
+  return match && match[1] ? 'https://www.linkedin.com/in/' + match[1] : '';
+}
+
+function parseLeads(json) {
+  const elements = (json && Array.isArray(json.elements)) ? json.elements : [];
+  const leads = [];
+  for (const el of elements) {
+    if (!el || typeof el !== 'object') continue;
+    const current = Array.isArray(el.currentPositions) ? el.currentPositions : [];
+    const past = Array.isArray(el.pastPositions) ? el.pastPositions : [];
+    const pos = current[0] || past[0] || {};
+    const name = normalizeWhitespace(el.fullName || [el.firstName, el.lastName].filter(Boolean).join(' '));
+    if (!name) continue;
+    leads.push({
+      name,
+      title: normalizeWhitespace(pos.title || ''),
+      company: normalizeWhitespace(pos.companyName || ''),
+      location: normalizeWhitespace(el.geoRegion || ''),
+      degree: normalizeWhitespace(el.degree || ''),
+      profile_url: profileUrlFromEntityUrn(el.entityUrn),
+    });
+  }
+  return leads;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-search',
+  access: 'read',
+  description: 'Search LinkedIn Sales Navigator for people leads by keyword',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'keywords', type: 'string', required: true, positional: true, help: 'People search keywords, e.g. "quality manager food manufacturing"' },
+    { name: 'limit', type: 'number', default: 25, help: 'Maximum leads to return (1-500, fetched 25 per request)' },
+  ],
+  columns: ['rank', 'name', 'title', 'company', 'location', 'degree', 'profile_url'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-search');
+    const keywords = requireStringArg(args, 'keywords', '--keywords');
+    const limit = parseLimit(args.limit);
+
+    await page.goto(SALES_HOME);
+    await page.wait(6);
+
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+    }
+    const csrf = jsession.replace(/^\"|\"$/g, '');
+
+    const leads = [];
+    const seen = new Set();
+    for (let start = 0; leads.length < limit && start < 2000; start += PAGE_SIZE) {
+      const result = unwrapEvaluateResult(await page.evaluate(fetchLeadSearchScript(leadSearchUrl(keywords, start), csrf)));
+      if (result && result.authRequired) {
+        throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator API auth failed (HTTP ' + (result.status || '') + '). Confirm the account has Sales Navigator access.');
+      }
+      if (!result || !result.json) break;
+      const pageLeads = parseLeads(result.json);
+      if (pageLeads.length === 0) break;
+      for (const lead of pageLeads) {
+        const key = lead.profile_url || lead.name.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        leads.push(lead);
+      }
+      await page.wait(1);
+    }
+
+    return leads.slice(0, limit).map((lead, index) => ({ rank: index + 1, ...lead }));
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  parseLimit,
+  leadSearchUrl,
+  profileUrlFromEntityUrn,
+  parseLeads,
+};

--- a/clis/linkedin/salesnav-search.test.js
+++ b/clis/linkedin/salesnav-search.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import './salesnav-search.js';
+
+const { parseLimit, leadSearchUrl, profileUrlFromEntityUrn, parseLeads } = await import('./salesnav-search.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-search command', () => {
+  it('builds a salesApiLeadSearch URL with encoded keywords and pagination', () => {
+    const url = leadSearchUrl('quality manager food', 50);
+    expect(url).toContain('/sales-api/salesApiLeadSearch');
+    expect(url).toContain('keywords:quality%20manager%20food');
+    expect(url).toContain('start=50');
+    expect(url).toContain('count=25');
+  });
+
+  it('derives a profile URL from the sales-profile entityUrn token', () => {
+    expect(profileUrlFromEntityUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)'))
+      .toBe('https://www.linkedin.com/in/ACwAAAJS8TABxyz');
+    expect(profileUrlFromEntityUrn('')).toBe('');
+    expect(profileUrlFromEntityUrn('not-a-urn')).toBe('');
+  });
+
+  it('validates --limit without silent clamping', () => {
+    expect(parseLimit(undefined)).toBe(25);
+    expect(parseLimit(120)).toBe(120);
+    expect(() => parseLimit(0)).toThrow();
+    expect(() => parseLimit(999)).toThrow();
+    expect(() => parseLimit('abc')).toThrow();
+  });
+
+  it('parses lead rows, falls back to past positions, skips nameless entries', () => {
+    const json = { elements: [
+      { fullName: 'Jane Q', geoRegion: 'Vancouver, BC', degree: 2,
+        entityUrn: 'urn:li:fs_salesProfile:(TOKEN1,NAME_SEARCH,abc)',
+        currentPositions: [{ title: 'QA Manager', companyName: 'Acme Foods' }] },
+      { fullName: 'No Current', geoRegion: 'Toronto',
+        entityUrn: 'urn:li:fs_salesProfile:(TOKEN2,NAME_SEARCH,def)',
+        currentPositions: [], pastPositions: [{ title: 'Past QA Lead', companyName: 'Old Co' }] },
+      { firstName: '', lastName: '', entityUrn: 'urn:li:fs_salesProfile:(TOKEN3,x,y)' },
+    ] };
+    const leads = parseLeads(json);
+    expect(leads).toHaveLength(2);
+    expect(leads[0]).toMatchObject({ name: 'Jane Q', title: 'QA Manager', company: 'Acme Foods', location: 'Vancouver, BC', profile_url: 'https://www.linkedin.com/in/TOKEN1' });
+    expect(leads[1]).toMatchObject({ name: 'No Current', title: 'Past QA Lead', company: 'Old Co' });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a new `linkedin salesnav-search` command: searches LinkedIn Sales Navigator for people (leads) by keyword and returns structured rows — `rank, name, title, company, location, degree, profile_url`.

The existing `linkedin search` command covers **jobs** only; there was no people/lead search. This fills that gap for lead-generation workflows.

## How it works

Replays the Sales Navigator `salesApiLeadSearch` API directly rather than scraping the UI:

- `GET sales-api/salesApiLeadSearch` with the keyword query and `start`/`count` pagination (25 per request).
- Headers: `csrf-token` (from the JSESSIONID cookie) + `x-restli-protocol-version`.
- Sales Navigator returns no `/in/` vanity URL, so `profile_url` is derived from the obfuscated member token in each lead's `fs_salesProfile` entityUrn — `linkedin.com/in/<token>` is a valid profile URL.
- Falls back to `pastPositions` when a lead has no current position.

Requires an account with Sales Navigator; surfaces a typed `AuthRequiredError` if the API rejects with 401/403.

## Type of Change

- [x] New feature

## Changes Made

- `clis/linkedin/salesnav-search.js` — the command (read-only, browser).
- `clis/linkedin/salesnav-search.test.js` — 4 unit tests (URL building, entityUrn parsing, limit validation, lead parsing + pastPositions fallback).
- `cli-manifest.json` — regenerated.

## Testing

- Unit tests pass; full suite green; typed-error-lint and silent-column-drop gates clean.
- Verified e2e against a live Sales Navigator session — single-page and multi-page pagination (40 results across 2 pages: distinct, contiguous, no boundary duplicates).

## Note

`decorationId` (the response-shape version, currently `LeadSearchResult-14`) is pinned. If Sales Navigator bumps it the constant needs refreshing; this is flagged in a code comment.
