### PR TITLE
build: tsc 重建后恢复 dist/src/main.js 的 +x 权限

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dev": "tsx src/main.ts",
     "dev:bun": "bun src/main.ts",
     "build": "npm run clean-dist && npm run copy-yaml && npm run build-manifest",
-    "prebuild-manifest": "tsc --build",
+    "prebuild-manifest": "tsc --build && node -e \"require('fs').chmodSync('dist/src/main.js', 0o755)\"",
     "build-manifest": "tsx src/build-manifest.ts",
     "clean-dist": "node scripts/clean-dist.cjs",
     "copy-yaml": "node scripts/copy-yaml.cjs",


### PR DESCRIPTION
## 问题

`npm run build` 链路是 `clean-dist → copy-yaml → build-manifest`，其中 `prebuild-manifest` 跑 `tsc --build`。`clean-dist` 删掉 `dist/` 之后，tsc 重新 emit 时不保留 bin entry 的可执行位。

`prepublishOnly` 也跑 `build`，所以 npm publish 出去的包里 `dist/src/main.js` 不带 +x；用户 `npm i -g @jackwener/opencli` 后第一次跑 `opencli` 直接 EACCES，要手动 `chmod` 才能用。

## 修复

在 `prebuild-manifest` 后面 chain 一个 `fs.chmodSync('dist/src/main.js', 0o755)`：

```diff
- "prebuild-manifest": "tsc --build",
+ "prebuild-manifest": "tsc --build && node -e \"require('fs').chmodSync('dist/src/main.js', 0o755)\"",
```

用 `node -e ... chmodSync` 而不是裸 `chmod +x`：Windows 上 npm 在 Git Bash 里跑，`chmod` 是 no-op，但 `fs.chmodSync` 在 Windows 上同样是 silent no-op，不需要再加一层平台分支。

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 CI / build / tooling

## 验证

- `npm run build` 完成后 `ls -l dist/src/main.js` → `-rwxr-xr-x`
- `npx tsc --noEmit` 干净
- build 链未引入新警告