### PR TITLE
fix(browser): goto 重试时回收陈旧 page identity + 把 -32000 "Cannot find default execution context" 归类为可重试

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * **adapters** — surface the remaining `silent-empty-fallback` adapter failures as typed errors. Douyin user video comment fetch failures, Jike SSR JSON parse failures, and WeRead search-page fetch failures now throw `CommandExecutionError`; true empty Douyin/Jike/WeRead result sets now throw `EmptyResultError`.
+* **browser** — recover `Page.goto()` from stale page identities by clearing the cached targetId and retrying navigation once through the session lease; classify CDP `-32000 Cannot find default execution context` as retryable target navigation.
 
 ### Internal
 

--- a/src/browser/errors.test.ts
+++ b/src/browser/errors.test.ts
@@ -37,6 +37,15 @@ describe('classifyBrowserError', () => {
     expect(advice.delayMs).toBe(200);
   });
 
+  it('classifies CDP -32000 execution-context errors with 200ms delay', () => {
+    const advice = classifyBrowserError(
+      new Error('{"code":-32000,"message":"Cannot find default execution context"}'),
+    );
+    expect(advice.kind).toBe('target-navigation');
+    expect(advice.retryable).toBe(true);
+    expect(advice.delayMs).toBe(200);
+  });
+
   it('returns non-retryable for unrelated errors', () => {
     for (const msg of ['Permission denied', 'malformed exec payload', 'SyntaxError']) {
       const advice = classifyBrowserError(new Error(msg));

--- a/src/browser/errors.ts
+++ b/src/browser/errors.ts
@@ -81,8 +81,10 @@ export function classifyBrowserError(err: unknown): RetryAdvice {
     return { kind: 'target-navigation', retryable: true, delayMs: 200 };
   }
 
-  // CDP protocol error with target context (e.g., -32000 "target closed")
-  if (msg.includes('-32000') && msg.toLowerCase().includes('target')) {
+  // CDP protocol error with target/context invalidation (e.g., -32000 "target closed" or
+  // -32000 "Cannot find default execution context" — both indicate the inspected target
+  // went away and a fresh attach should recover).
+  if (msg.includes('-32000') && /target|context/i.test(msg)) {
     return { kind: 'target-navigation', retryable: true, delayMs: 200 };
   }
 

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -297,6 +297,59 @@ describe('Page active target tracking', () => {
     }));
   });
 
+  // Regression: chrome-backed adapter calls in the same process were re-sending a
+  // cached targetId after the tab had been closed externally, so the extension threw
+  // "Page not found: <id> — stale page identity" on every follow-up pre-navigation.
+  // goto() now drops the stale identity and retries once without it so the extension's
+  // session lease can resolve through to a live tab.
+  it('drops a stale page identity and retries navigate once', async () => {
+    sendCommandFullMock
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/first' }, page: 'page-1' })
+      .mockRejectedValueOnce(new Error('Page not found: deadbeef — stale page identity'))
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/second' }, page: 'page-2' });
+
+    const page = new Page('site:youtube', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await page.goto('https://example.com/first', { waitUntil: 'none' });
+    expect(page.getActivePage()).toBe('page-1');
+
+    await page.goto('https://example.com/second', { waitUntil: 'none' });
+    expect(page.getActivePage()).toBe('page-2');
+
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(3);
+    // First retry attempt carried the stale page; the recovery call must drop it.
+    const retryCall = sendCommandFullMock.mock.calls[2];
+    expect(retryCall[0]).toBe('navigate');
+    expect(retryCall[1]).not.toHaveProperty('page');
+  });
+
+  it('does not retry stale page errors when no identity was cached', async () => {
+    // _page is undefined on a fresh Page — there's nothing to drop, so propagate the
+    // error instead of silently retrying with the same params.
+    sendCommandFullMock
+      .mockRejectedValueOnce(new Error('Page not found: deadbeef — stale page identity'));
+
+    const page = new Page('site:youtube', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await expect(page.goto('https://example.com', { waitUntil: 'none' }))
+      .rejects.toThrow('stale page identity');
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates non-stale navigate errors unchanged', async () => {
+    sendCommandFullMock
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/first' }, page: 'page-1' })
+      .mockRejectedValueOnce(new Error('Extension disconnected'));
+
+    const page = new Page('site:youtube', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await page.goto('https://example.com/first', { waitUntil: 'none' });
+    await expect(page.goto('https://example.com/second', { waitUntil: 'none' }))
+      .rejects.toThrow('Extension disconnected');
+    // No retry for unrelated errors — exactly two navigate calls total.
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(2);
+  });
+
   it('creates a new tab without changing the current active page binding', async () => {
     sendCommandFullMock
       .mockResolvedValueOnce({ data: { url: 'https://first.example' }, page: 'page-1' })

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -297,9 +297,9 @@ describe('Page active target tracking', () => {
     }));
   });
 
-  // Regression: chrome-backed adapter calls in the same process were re-sending a
-  // cached targetId after the tab had been closed externally, so the extension threw
-  // "Page not found: <id> — stale page identity" on every follow-up pre-navigation.
+  // Regression: a Page instance can keep re-sending a cached targetId after the tab
+  // has been closed externally, so the extension throws
+  // "Page not found: <id> — stale page identity" on follow-up navigation.
   // goto() now drops the stale identity and retries once without it so the extension's
   // session lease can resolve through to a live tab.
   it('drops a stale page identity and retries navigate once', async () => {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -26,6 +26,16 @@ function isUnsupportedNetworkCaptureError(err: unknown): boolean {
     || (normalized.includes('network capture') && normalized.includes('not supported'));
 }
 
+// The extension throws "Page not found: <id> — stale page identity" when our cached
+// `_page` targetId no longer maps to a live tab — e.g. the user closed the automation
+// window, or a long-running script left the cache pointing at an evicted target.
+// Detect that signature so goto() can drop the stale id and let resolveTab fall back
+// to the session lease (or create a fresh tab).
+function isStalePageIdentityError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes('stale page identity') || message.includes('Page not found:');
+}
+
 /**
  * Page — implements IPage by talking to the daemon via HTTP.
  */
@@ -75,10 +85,25 @@ export class Page extends BasePage {
   }
 
   async goto(url: string, options?: { waitUntil?: 'load' | 'none'; settleMs?: number }): Promise<void> {
-    const result = await sendCommandFull('navigate', {
-      url,
-      ...this._cmdOpts(),
-    });
+    let result: { data: unknown; page?: string };
+    try {
+      result = await sendCommandFull('navigate', {
+        url,
+        ...this._cmdOpts(),
+      });
+    } catch (err) {
+      // If our cached targetId went stale (tab closed externally, identity evicted),
+      // drop the dead id and retry without it — the extension will resolve through the
+      // session lease or open a fresh automation tab. Without this, every subsequent
+      // adapter call in the same process keeps re-sending the same dead targetId and
+      // cascades into "Page not found:" failures across concurrent calls.
+      if (!isStalePageIdentityError(err) || this._page === undefined) throw err;
+      this._page = undefined;
+      result = await sendCommandFull('navigate', {
+        url,
+        ...this._cmdOpts(),
+      });
+    }
     // Remember the page identity (targetId) for subsequent calls
     if (result.page) {
       this._page = result.page;

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -33,7 +33,7 @@ function isUnsupportedNetworkCaptureError(err: unknown): boolean {
 // to the session lease (or create a fresh tab).
 function isStalePageIdentityError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return message.includes('stale page identity') || message.includes('Page not found:');
+  return message.includes('stale page identity');
 }
 
 /**
@@ -94,9 +94,9 @@ export class Page extends BasePage {
     } catch (err) {
       // If our cached targetId went stale (tab closed externally, identity evicted),
       // drop the dead id and retry without it — the extension will resolve through the
-      // session lease or open a fresh automation tab. Without this, every subsequent
-      // adapter call in the same process keeps re-sending the same dead targetId and
-      // cascades into "Page not found:" failures across concurrent calls.
+      // session lease or open a fresh automation tab. Without this, subsequent
+      // navigations in the same Page instance keep re-sending the same dead targetId
+      // and cascade into "Page not found:" failures.
       if (!isStalePageIdentityError(err) || this._page === undefined) throw err;
       this._page = undefined;
       result = await sendCommandFull('navigate', {


### PR DESCRIPTION
## 概要

两个互相独立的 browser 容错小修复，都带回归测试。

### 1. `Page.goto()` 在 page identity 失效时自动 retry

当 chrome-backed `Page` 实例缓存的 `_page` targetId 已经失效（tab 被外部关掉、identity 被驱逐），extension 抛 `Page not found: <id> — stale page identity`。之前没有任何检测/恢复机制，failure 会在同一个 Page 实例生命周期内级联：后续导航继续往 daemon 发同一个死 targetId。

实际观察到：一个死 page handle 在同一进程里被复用 4+ 次（twitter thread / twitter search / reddit search）。更准确地说，风险边界是同一个 Page 实例的后续导航；普通 `executeCommand()` 路径每次 CLI command 会新建 Page，不把 `_page` cache 跨独立命令复用。

`Page.goto()` 现在专门 catch `stale page identity`，drop `_page`，retry 一次（不带 stale id）。Retry 会经由 extension 的 session lease 解析路径（resolveTab → preferredTabId / new owned tab），那条路本来就已经正确处理 tab 驱逐。Happy path 完全不变。

`src/browser/page.test.ts` 加 3 个回归测试：
- **recovery**: stale id 被 drop，retry 用新 identity 成功
- **no-cache safety**: fresh page 无 `_page` 时错误原样上抛（无 id 可 drop，retry 会死循环）
- **error scoping**: 无关 extension 错误（如 disconnected）立即上抛——不做隐式 retry

### 2. `-32000 Cannot find default execution context` 改为可重试

`classifyBrowserError` 之前只在消息含 "target" 时匹配 CDP -32000（比如 "target closed"），漏掉了 "Cannot find default execution context"。这同样是表示被检 target / execution context 已经走了的 CDP 协议错误。

把次级匹配从 `/target/i` 拓宽到 `/target|context/i`，让现有的 target-navigation retry 路径（200ms 延迟 + re-attach）能恢复，而不是把错误当作 non-retryable 上抛。

## Type of Change

- [x] 🐛 Bug fix

## 验证

- `npx vitest run src/browser/page.test.ts src/browser/errors.test.ts --project unit` — 32/32 通过
- `npx tsc --noEmit` 干净
- `git diff --check` 干净

## 设计边界

这个 PR 只在 `goto(url)` 上做 stale page recovery，因为 `goto` 有显式目标 URL，旧 targetId 失效后重路由到 session lease 再导航是安全的。`evaluate/click/type/screenshot` 等 page-scoped 操作不做 silent reroute，避免在错误页面执行副作用。

## 历史

之前 #1482 提过 page identity recovery 但我自己 close 了（当时未充分测试）。这次 reroll 到当前 main + 把同主题的 -32000 分类修复一起带上，3 个回归测试做 lock-in。
