### PR TITLE
feat(linkedin): consolidate messaging and Sales Navigator commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14639,14 +14639,9 @@
       "message_chars",
       "subject_chars",
       "recipient_urn",
-      "authRequired",
-      "text",
       "degree",
       "inmail_restriction",
-      "open_link",
-      "json",
-      "href",
-      "resourceUrns"
+      "open_link"
     ],
     "type": "js",
     "modulePath": "linkedin/salesnav-message.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14411,7 +14411,16 @@
       "recipient",
       "reason",
       "profile_url",
-      "note_chars"
+      "note_chars",
+      "connectable",
+      "delivery_verified",
+      "matched_invitation_name",
+      "matched_invitation_url",
+      "actualValue",
+      "blockReason",
+      "expectedValue",
+      "observedUrl",
+      "safety"
     ],
     "type": "js",
     "modulePath": "linkedin/connect.js",
@@ -14527,6 +14536,215 @@
   },
   {
     "site": "linkedin",
+    "name": "salesnav-inbox",
+    "description": "List LinkedIn Sales Navigator message conversations with API pagination",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 40,
+        "required": false,
+        "help": "Maximum conversations to return (1-500)"
+      },
+      {
+        "name": "max-pages",
+        "type": "number",
+        "default": 30,
+        "required": false,
+        "help": "Maximum Sales Navigator API pages to fetch"
+      },
+      {
+        "name": "unread-only",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Return only unread conversations"
+      }
+    ],
+    "columns": [
+      "rank",
+      "thread_id",
+      "thread_url",
+      "person_name",
+      "last_message_snippet",
+      "last_activity_time",
+      "unread",
+      "unread_count",
+      "total_message_count",
+      "archived",
+      "participants",
+      "next_page_starts_at"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-inbox.js",
+    "sourceFile": "linkedin/salesnav-inbox.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
+    "name": "salesnav-message",
+    "description": "Send or dry-run a LinkedIn Sales Navigator InMail to a lead using the Sales Navigator messaging API",
+    "access": "write",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "recipient",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Sales Navigator lead URL, LinkedIn /in/ URL from salesnav-search, or urn:li:fs_salesProfile:(...)"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "required": true,
+        "help": "InMail subject"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "required": true,
+        "help": "InMail body"
+      },
+      {
+        "name": "send",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Actually send the InMail. Default is dry-run validation only."
+      },
+      {
+        "name": "copy-to-crm",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Set Sales Navigator copyToCrm on the message request"
+      }
+    ],
+    "columns": [
+      "status",
+      "recipient",
+      "title",
+      "company",
+      "credits_remaining",
+      "credits_before",
+      "credits_after",
+      "sent_in_salesnav",
+      "message_chars",
+      "subject_chars",
+      "recipient_urn",
+      "authRequired",
+      "text",
+      "degree",
+      "inmail_restriction",
+      "open_link",
+      "json",
+      "href",
+      "resourceUrns"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-message.js",
+    "sourceFile": "linkedin/salesnav-message.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
+    "name": "salesnav-search",
+    "description": "Search LinkedIn Sales Navigator for people leads by keyword",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "keywords",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "People search keywords, e.g. \"quality manager food manufacturing\""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 25,
+        "required": false,
+        "help": "Maximum leads to return (1-500, fetched 25 per request)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "title",
+      "company",
+      "location",
+      "degree",
+      "profile_url",
+      "lead_url",
+      "recipient_urn"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-search.js",
+    "sourceFile": "linkedin/salesnav-search.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
+    "name": "salesnav-thread",
+    "description": "Return full Sales Navigator message history for a thread id, Sales Navigator inbox URL, lead URL, recipient urn, or exact recipient name",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "thread-or-recipient",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Sales Navigator inbox URL/thread id, Sales Navigator lead URL, recipient urn, or exact participant name"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "default": 200,
+        "required": false,
+        "help": "Maximum messages to return (1-500)"
+      },
+      {
+        "name": "max-pages",
+        "type": "number",
+        "default": 30,
+        "required": false,
+        "help": "Maximum inbox pages to scan when resolving a recipient"
+      }
+    ],
+    "columns": [
+      "index",
+      "thread_id",
+      "thread_url",
+      "sender",
+      "text",
+      "timestamp",
+      "subject",
+      "message_id",
+      "sender_urn",
+      "delivered_at",
+      "type",
+      "total_message_count"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/salesnav-thread.js",
+    "sourceFile": "linkedin/salesnav-thread.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "linkedin",
     "name": "search",
     "description": "Search LinkedIn jobs",
     "access": "read",
@@ -14612,6 +14830,26 @@
     "modulePath": "linkedin/search.js",
     "sourceFile": "linkedin/search.js",
     "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin",
+    "name": "sent-invitations",
+    "description": "List pending LinkedIn sent invitations for CRM reconciliation",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "rank",
+      "name",
+      "profile_url",
+      "invited_date_text"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/sent-invitations.js",
+    "sourceFile": "linkedin/sent-invitations.js",
+    "navigateBefore": true
   },
   {
     "site": "linkedin",

--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -11,7 +11,32 @@ function normalizeName(value) {
     return normalizeWhitespace(value)
         .replace(/\s*[•·]\s*(?:1st|2nd|3rd\+?|degree connection).*$/i, '')
         .replace(/\s+LinkedIn.*$/i, '')
+        .replace(/\b(p\.?eng\.?|cpa|mba|ph\.?d\.?)\b/ig, '')
+        .replace(/[^\p{L}\p{N}\s.'-]+/gu, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
         .toLowerCase();
+}
+
+function nameTokens(value) {
+    return normalizeName(value)
+        .replace(/[.'-]+/g, ' ')
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length >= 2);
+}
+
+function matchInvitationName(candidate, expected) {
+    const candidateName = normalizeName(candidate);
+    const expectedName = normalizeName(expected);
+    if (!candidateName || !expectedName) return false;
+    if (candidateName === expectedName) return true;
+    if (candidateName.includes(expectedName) || expectedName.includes(candidateName)) return true;
+    const candidateTokens = new Set(nameTokens(candidateName));
+    const expectedTokens = nameTokens(expectedName);
+    if (expectedTokens.length < 2 || candidateTokens.size < 2) return false;
+    const matched = expectedTokens.filter((token) => candidateTokens.has(token)).length;
+    return matched >= 2 && matched / expectedTokens.length >= 0.8;
 }
 
 function isLinkedInHost(hostname) {
@@ -83,18 +108,18 @@ function assessProfileSafety(probe, expectedName, expectedProfileUrl) {
     const actual = normalizeWhitespace(probe?.name || '');
     const expectedUrl = canonicalizeLinkedInProfileUrl(expectedProfileUrl);
     const actualUrl = canonicalizeLinkedInProfileUrl(probe?.url || '');
-    if (probe?.authRequired) return { ok: false, blockReason: 'auth_required', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
-    if (!actual) return { ok: false, blockReason: 'profile_name_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (probe?.authRequired) return { ok: false, safety: 'unsafe_block', connectable: null, blockReason: 'auth_required', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (!actual) return { ok: false, safety: 'unsafe_block', connectable: null, blockReason: 'profile_name_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
     if (expected && normalizeName(actual) !== normalizeName(expected)) {
-        return { ok: false, blockReason: 'profile_name_mismatch', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+        return { ok: false, safety: 'unsafe_block', connectable: null, blockReason: 'profile_name_mismatch', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
     }
     if (expectedUrl && actualUrl && expectedUrl !== actualUrl) {
-        return { ok: false, blockReason: 'profile_url_mismatch', expectedValue: expectedUrl, actualValue: actualUrl, observedUrl: actualUrl };
+        return { ok: false, safety: 'unsafe_block', connectable: null, blockReason: 'profile_url_mismatch', expectedValue: expectedUrl, actualValue: actualUrl, observedUrl: actualUrl };
     }
-    if (probe?.alreadyConnected) return { ok: false, blockReason: 'already_connected', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
-    if (probe?.pending) return { ok: false, blockReason: 'connection_pending', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
-    if (!probe?.connectAvailable) return { ok: false, blockReason: 'connect_button_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
-    return { ok: true, blockReason: 'verified', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (probe?.alreadyConnected) return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'already_connected', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (probe?.pending) return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connection_pending', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (!probe?.connectAvailable) return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connect_button_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    return { ok: true, safety: 'connectable', connectable: true, blockReason: 'verified', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
 }
 
 function buildProfileProbeScript() {
@@ -141,6 +166,72 @@ function buildProfileProbeScript() {
 
 // Runs in-page on LinkedIn's invitation route (/preload/custom-invite/...),
 // where the "Add a note to your invitation?" dialog is already open.
+
+function buildSentInvitationsProbeScript(expectedName, expectedProfileUrl) {
+    return String.raw`(() => {
+    const expectedName = ${JSON.stringify(expectedName)};
+    const expectedUrl = ${JSON.stringify(canonicalizeLinkedInProfileUrl(expectedProfileUrl))};
+    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const normName = (s) => clean(s)
+      .replace(/\s*[•·]\s*(?:1st|2nd|3rd\+?|degree connection).*$/i, '')
+      .replace(/\s+LinkedIn.*$/i, '')
+      .replace(/\b(p\.?eng\.?|cpa|mba|ph\.?d\.?)\b/ig, '')
+      .replace(/[^\p{L}\p{N}\s.'-]+/gu, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+    const tokens = (s) => normName(s).replace(/[.'-]+/g, ' ').split(/\s+/).map((t) => t.trim()).filter((t) => t.length >= 2);
+    const nameMatchesReasonably = (candidate, expected) => {
+      const c = normName(candidate);
+      const e = normName(expected);
+      if (!c || !e) return false;
+      if (c === e || c.includes(e) || e.includes(c)) return true;
+      const candidateTokens = new Set(tokens(c));
+      const expectedTokens = tokens(e);
+      if (expectedTokens.length < 2 || candidateTokens.size < 2) return false;
+      const matched = expectedTokens.filter((token) => candidateTokens.has(token)).length;
+      return matched >= 2 && matched / expectedTokens.length >= 0.8;
+    };
+    const canon = (value) => {
+      try {
+        const url = new URL(value, 'https://www.linkedin.com');
+        if (!/^\/in\/[^/]+\/?$/i.test(url.pathname)) return '';
+        url.protocol = 'https:';
+        url.hostname = 'www.linkedin.com';
+        url.hash = '';
+        url.search = '';
+        if (!url.pathname.endsWith('/')) url.pathname += '/';
+        return url.toString();
+      } catch { return ''; }
+    };
+    const text = document.body ? (document.body.innerText || '') : '';
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
+      || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
+      || /captcha|verification required/i.test(text);
+    if (authRequired) return { authRequired: true, found: false, matchedName: '', matchedUrl: '', visibleNames: [] };
+    const structuralRows = Array.from(document.querySelectorAll('li, article, [data-view-name], .mn-invitation-card'));
+    const linkRows = Array.from(document.querySelectorAll('a[href*="/in/"]'))
+      .map((a) => a.closest('li') || a.closest('[data-view-name]') || a.closest('[class*="invitation"]') || a.closest('div'))
+      .filter(Boolean);
+    const rows = Array.from(new Set([...structuralRows, ...linkRows]));
+    const visibleNames = [];
+    for (const row of rows.slice(0, 25)) {
+      const rowText = clean(row.innerText || row.textContent || '');
+      if (!rowText) continue;
+      const link = Array.from(row.querySelectorAll('a[href*="/in/"]'))
+        .map((a) => ({ href: canon(a.href || a.getAttribute('href') || ''), text: clean(a.innerText || a.textContent || '') }))
+        .find((a) => a.href || a.text);
+      const candidateName = clean(link?.text || row.querySelector('span[aria-hidden="true"], h3, h2')?.textContent || rowText.split('\n')[0]);
+      if (candidateName) visibleNames.push(candidateName);
+      const candidateUrl = link?.href || '';
+      const nameMatches = expectedName && candidateName && nameMatchesReasonably(candidateName, expectedName);
+      const urlMatches = expectedUrl && candidateUrl && candidateUrl === expectedUrl;
+      if (urlMatches || nameMatches) return { authRequired: false, found: true, matchedName: candidateName, matchedUrl: candidateUrl, visibleNames: visibleNames.slice(0, 20) };
+    }
+    return { authRequired: false, found: false, matchedName: '', matchedUrl: '', visibleNames: visibleNames.slice(0, 20) };
+  })()`;
+}
+
 function buildInviteScript(note) {
     return String.raw`(async () => {
     const note = ${JSON.stringify(note)};
@@ -215,7 +306,7 @@ cli({
         { name: 'note', type: 'string', required: false, default: '', help: 'Optional connection note, max 300 chars' },
         { name: 'send', type: 'bool', required: false, default: false, help: 'Actually click Send. Default is dry-run verification only.' },
     ],
-    columns: ['status', 'recipient', 'reason', 'profile_url', 'note_chars'],
+    columns: ['status', 'recipient', 'reason', 'profile_url', 'note_chars', 'connectable', 'delivery_verified', 'matched_invitation_name', 'matched_invitation_url', 'actualValue', 'blockReason', 'expectedValue', 'observedUrl', 'safety'],
     func: async (page, args) => {
         if (!page) throw new CommandExecutionError('Browser session required for linkedin connect');
         const profileUrl = requireLinkedInProfileUrl(requireStringArg(args, 'profile-url', '--profile-url'), '--profile-url');
@@ -239,6 +330,9 @@ cli({
         if (safety.blockReason === 'auth_required') {
             throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn connect requires an active signed-in LinkedIn browser session.');
         }
+        if (!safety.ok && safety.safety === 'routine_non_connectable') {
+            return [{ status: 'not_connectable', recipient: safety.actualValue, reason: safety.blockReason, profile_url: safety.observedUrl, note_chars: note.length, connectable: false }];
+        }
         if (!safety.ok) {
             throw new CommandExecutionError(
                 `LinkedIn connect blocked: ${safety.blockReason}`,
@@ -246,7 +340,7 @@ cli({
             );
         }
         if (!args.send) {
-            return [{ status: 'verified_dry_run', recipient: safety.actualValue, reason: safety.blockReason, profile_url: safety.observedUrl, note_chars: note.length }];
+            return [{ status: 'connectable_dry_run', recipient: safety.actualValue, reason: safety.blockReason, profile_url: safety.observedUrl, note_chars: note.length, connectable: true }];
         }
         const inviteHref = probe?.connectHref || '';
         if (!inviteHref) {
@@ -264,15 +358,32 @@ cli({
             result = unwrapEvaluateResult(await page.evaluate(buildInviteScript(note)));
         }
         if (!result?.ok) throw new CommandExecutionError(`LinkedIn connect blocked: ${result?.reason || 'send_failed'}`);
-        await page.goto(profileUrl);
-        await page.wait(5);
-        const after = await probeProfile(page);
+        // LinkedIn can take a few seconds after the Send click to materialize the
+        // new invite in /mynetwork/invitation-manager/sent/. Wait before the
+        // first check, then retry page loads for propagation lag.
+        await page.wait(8);
+        let sentProbe = null;
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            await page.goto('https://www.linkedin.com/mynetwork/invitation-manager/sent/');
+            await page.wait(attempt === 0 ? 6 : 4);
+            sentProbe = unwrapEvaluateResult(await page.evaluate(buildSentInvitationsProbeScript(expectedName, profileUrl)));
+            if (sentProbe?.found || sentProbe?.authRequired) break;
+            if (attempt < 2) await page.wait(5);
+        }
+        if (sentProbe?.authRequired) {
+            throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn sent-invitations verification requires an active signed-in LinkedIn browser session.');
+        }
+        const verified = Boolean(sentProbe?.found);
         return [{
-            status: after?.pending ? 'sent' : (result.status || 'sent'),
+            status: verified ? 'sent_verified' : 'send_unverified',
             recipient: safety.actualValue,
-            reason: result.reason || 'connection_request_sent',
-            profile_url: canonicalizeLinkedInProfileUrl(after?.url || safety.observedUrl),
+            reason: verified ? 'sent_invitation_verified' : 'sent_invitation_not_found_after_retries',
+            profile_url: safety.observedUrl,
             note_chars: note.length,
+            connectable: true,
+            delivery_verified: verified,
+            matched_invitation_name: sentProbe?.matchedName || '',
+            matched_invitation_url: sentProbe?.matchedUrl || '',
         }];
     },
 });
@@ -280,9 +391,11 @@ cli({
 export const __test__ = {
     normalizeWhitespace,
     normalizeName,
+    matchInvitationName,
     canonicalizeLinkedInProfileUrl,
     canonicalizeLinkedInInviteUrl,
     unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,
+    buildSentInvitationsProbeScript,
 };

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -5,6 +5,7 @@ import './connect.js';
 
 const {
     normalizeName,
+    matchInvitationName,
     canonicalizeLinkedInProfileUrl,
     canonicalizeLinkedInInviteUrl,
     unwrapEvaluateResult,
@@ -24,9 +25,27 @@ function makeFakePage(probe, sendResult = { ok: true, status: 'sent', reason: 'c
     };
 }
 
+function makeSequentialFakePage(values) {
+    let index = 0;
+    return {
+        goto: vi.fn(async () => undefined),
+        wait: vi.fn(async () => undefined),
+        evaluate: vi.fn(async (script) => {
+            const text = String(script);
+            if (text.includes('custom-message') || text.includes('invite_dialog_not_found')) return { ok: true, status: 'sent', reason: 'connection_request_sent' };
+            const value = values[Math.min(index, values.length - 1)];
+            index += 1;
+            return value;
+        }),
+    };
+}
+
 describe('linkedin connect helpers', () => {
     it('normalizes names and profile URLs', () => {
         expect(normalizeName('Jane Doe • 2nd degree connection')).toBe('jane doe');
+        expect(matchInvitationName('Jane Doe, P.Eng.', ' jane   doe ')).toBe(true);
+        expect(matchInvitationName('Jane Q. Doe', 'Jane Doe')).toBe(true);
+        expect(matchInvitationName('Janet Doe', 'Jane Doe')).toBe(false);
         expect(canonicalizeLinkedInProfileUrl('https://www.linkedin.com/in/jane/?mini=true#x'))
             .toBe('https://www.linkedin.com/in/jane/');
         expect(canonicalizeLinkedInProfileUrl('https://ca.linkedin.com/in/jane/?mini=true#x'))
@@ -63,9 +82,18 @@ describe('linkedin connect helpers', () => {
             .toBe('connect_button_not_found');
     });
 
+    it('classifies routine non-connectable profiles separately from unsafe blocks', () => {
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', alreadyConnected: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/'))
+            .toMatchObject({ ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'already_connected' });
+        expect(assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', pending: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/'))
+            .toMatchObject({ ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connection_pending' });
+        expect(assessProfileSafety({ name: 'Wrong Person', url: 'https://www.linkedin.com/in/wrong/', connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/'))
+            .toMatchObject({ ok: false, safety: 'unsafe_block', connectable: null, blockReason: 'profile_name_mismatch' });
+    });
+
     it('passes only when profile url, name, and connect affordance all match', () => {
         const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/?mini=true', connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
-        expect(result).toMatchObject({ ok: true, blockReason: 'verified', actualValue: 'Jane Doe' });
+        expect(result).toMatchObject({ ok: true, blockReason: 'verified', actualValue: 'Jane Doe', connectable: true });
     });
 });
 
@@ -80,8 +108,19 @@ describe('linkedin connect command', () => {
             'expected-name': 'Jane Doe',
             note: 'quick note',
         });
-        expect(rows[0]).toMatchObject({ status: 'verified_dry_run', recipient: 'Jane Doe', reason: 'verified' });
+        expect(rows[0]).toMatchObject({ status: 'connectable_dry_run', recipient: 'Jane Doe', reason: 'verified', connectable: true });
         expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a clean not_connectable dry-run row for routine blocked states', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', alreadyConnected: true, buttonLabels: ['Message'] });
+        const rows = await command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            note: 'quick note',
+        });
+        expect(rows[0]).toMatchObject({ status: 'not_connectable', recipient: 'Jane Doe', reason: 'already_connected', connectable: false });
     });
 
     it('does not send when recipient verification fails', async () => {
@@ -119,16 +158,56 @@ describe('linkedin connect command', () => {
         })).rejects.toThrow('invalid_connect_link');
     });
 
-    it('sends only when --send is true after verification', async () => {
+    it('sends only when --send is true after verification and sent-invitations confirms delivery', async () => {
         const command = getRegistry().get('linkedin/connect');
-        const page = makeFakePage({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: '/preload/custom-invite/?vanityName=jane', buttonLabels: ['Connect'] });
+        const page = makeSequentialFakePage([
+            { name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: '/preload/custom-invite/?vanityName=jane', buttonLabels: ['Connect'] },
+            { found: true, matchedName: 'Jane Doe', matchedUrl: 'https://www.linkedin.com/in/jane/' },
+        ]);
         const rows = await command.func(page, {
             'profile-url': 'https://www.linkedin.com/in/jane/',
             'expected-name': 'Jane Doe',
             note: 'quick note',
             send: true,
         });
-        expect(rows[0]).toMatchObject({ status: 'sent', recipient: 'Jane Doe', reason: 'connection_request_sent' });
-        expect(page.evaluate).toHaveBeenCalledTimes(3);
+        expect(rows[0]).toMatchObject({ status: 'sent_verified', recipient: 'Jane Doe', reason: 'sent_invitation_verified', delivery_verified: true });
+        expect(page.goto).toHaveBeenCalledWith('https://www.linkedin.com/mynetwork/invitation-manager/sent/');
+    });
+
+    it('retries sent-invitations verification before reporting unverified', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeSequentialFakePage([
+            { name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: '/preload/custom-invite/?vanityName=jane', buttonLabels: ['Connect'] },
+            { found: false, matchedName: '', matchedUrl: '', visibleNames: ['Other Person'] },
+            { found: false, matchedName: '', matchedUrl: '', visibleNames: ['Other Person'] },
+            { found: true, matchedName: 'Jane Doe, P.Eng.', matchedUrl: '' },
+        ]);
+        const rows = await command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            note: 'quick note',
+            send: true,
+        });
+        expect(rows[0]).toMatchObject({ status: 'sent_verified', recipient: 'Jane Doe', reason: 'sent_invitation_verified', delivery_verified: true, matched_invitation_name: 'Jane Doe, P.Eng.' });
+        expect(page.goto).toHaveBeenCalledWith('https://www.linkedin.com/mynetwork/invitation-manager/sent/');
+        expect(page.evaluate).toHaveBeenCalledTimes(5);
+    });
+
+    it('does not report sent when sent-invitations verification fails after retries', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeSequentialFakePage([
+            { name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: true, connectHref: '/preload/custom-invite/?vanityName=jane', buttonLabels: ['Connect'] },
+            { found: false, matchedName: '', matchedUrl: '' },
+            { found: false, matchedName: '', matchedUrl: '' },
+            { found: false, matchedName: '', matchedUrl: '' },
+        ]);
+        const rows = await command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            note: 'quick note',
+            send: true,
+        });
+        expect(rows[0]).toMatchObject({ status: 'send_unverified', recipient: 'Jane Doe', reason: 'sent_invitation_not_found_after_retries', delivery_verified: false });
+        expect(page.evaluate).toHaveBeenCalledTimes(5);
     });
 });

--- a/clis/linkedin/salesnav-inbox.js
+++ b/clis/linkedin/salesnav-inbox.js
@@ -1,0 +1,210 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_INBOX_URL = 'https://www.linkedin.com/sales/inbox/';
+const THREADS_BASE = 'https://www.linkedin.com/sales-api/salesApiMessagingThreads';
+const PAGE_SIZE = 20;
+const DEFAULT_LIMIT = 40;
+const MAX_LIMIT = 500;
+const THREAD_DECORATION = '(id,restrictions,archived,unreadMessageCount,nextPageStartsAt,totalMessageCount,messages*(id,type,contentFlag,deliveredAt,lastEditedAt,subject,body,footerText,blockCopy,attachments,author,systemMessageContent),participants*~fs_salesProfile(entityUrn,firstName,lastName,fullName,degree,profilePictureDisplayImage,objectUrn,inmailRestriction))';
+
+export function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function parseLimit(value, defaultValue = DEFAULT_LIMIT) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
+  }
+  return limit;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+export function encodeRestliDecoration(value) {
+  // LinkedIn's Sales Navigator Rest.li endpoint returns HTTP 400 when this
+  // decoration is sent with literal parentheses. Keep parentheses percent-encoded.
+  return encodeURIComponent(value).replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+function salesnavThreadUrl(threadId) {
+  return threadId ? `https://www.linkedin.com/sales/inbox/${encodeURIComponent(threadId)}` : '';
+}
+
+function threadListUrl({ count = PAGE_SIZE, pageStartsAt = '' } = {}) {
+  let url = `${THREADS_BASE}?decoration=${encodeRestliDecoration(THREAD_DECORATION)}&count=${count}&filter=INBOX&q=filter`;
+  if (pageStartsAt) url += `&pageStartsAt=${encodeURIComponent(pageStartsAt)}`;
+  return url;
+}
+
+function getThreadParticipants(thread) {
+  const resolution = thread?.participantsResolutionResults || {};
+  const participants = Array.isArray(thread?.participants) ? thread.participants : Object.keys(resolution);
+  return participants.map((urn) => resolution[urn] || { entityUrn: urn }).filter(Boolean);
+}
+
+function isSelfParticipant(profile) {
+  const degree = String(profile?.degree ?? '').trim();
+  return degree === '0';
+}
+
+function otherParticipantName(thread) {
+  const participants = getThreadParticipants(thread);
+  const other = participants.find((p) => !isSelfParticipant(p)) || participants[0];
+  return normalizeWhitespace(other?.fullName || [other?.firstName, other?.lastName].filter(Boolean).join(' '));
+}
+
+function parseSalesnavThreads(json) {
+  if (!json || typeof json !== 'object' || !Array.isArray(json.elements)) {
+    throw new CommandExecutionError('Sales Navigator messaging threads API returned malformed payload');
+  }
+  return json.elements.map((thread) => {
+    if (!thread || typeof thread !== 'object') {
+      throw new CommandExecutionError('Sales Navigator messaging threads API returned malformed thread row');
+    }
+    const messages = Array.isArray(thread?.messages) ? thread.messages : [];
+    const lastMessage = messages[0] || {};
+    const deliveredAt = Number(lastMessage.deliveredAt || thread?.nextPageStartsAt || 0);
+    const threadId = normalizeWhitespace(thread?.id || '');
+    if (!threadId) {
+      throw new CommandExecutionError('Sales Navigator messaging thread row missing id');
+    }
+    return {
+      thread_id: threadId,
+      thread_url: salesnavThreadUrl(threadId),
+      person_name: otherParticipantName(thread),
+      last_message_snippet: normalizeWhitespace(lastMessage.body || lastMessage.subject || '').slice(0, 300),
+      last_activity_time: deliveredAt ? new Date(deliveredAt).toISOString() : '',
+      unread: Number(thread?.unreadMessageCount || 0) > 0,
+      unread_count: Number(thread?.unreadMessageCount || 0),
+      total_message_count: Number(thread?.totalMessageCount || messages.length || 0),
+      archived: Boolean(thread?.archived),
+      next_page_starts_at: normalizeWhitespace(thread?.nextPageStartsAt || ''),
+      participants: getThreadParticipants(thread).map((p) => ({
+        name: normalizeWhitespace(p.fullName || [p.firstName, p.lastName].filter(Boolean).join(' ')),
+        entity_urn: normalizeWhitespace(p.entityUrn || ''),
+        object_urn: normalizeWhitespace(p.objectUrn || ''),
+        degree: normalizeWhitespace(p.degree ?? ''),
+      })),
+    };
+  });
+}
+
+function fetchJsonScript(url, csrf) {
+  return String.raw`(async () => {
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        credentials: 'include',
+        headers: {
+          'csrf-token': ${JSON.stringify(csrf)},
+          'x-restli-protocol-version': '2.0.0',
+          accept: 'application/json',
+        },
+      });
+      const text = await res.text();
+      let json = null;
+      try { json = text ? JSON.parse(text) : null; } catch (_) { json = null; }
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status, text };
+      if (!res.ok) return { error: 'HTTP ' + res.status, status: res.status, text, json };
+      return { status: res.status, json };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+export async function getCsrf(page) {
+  const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+  if (!jsession) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+  return jsession.replace(/^\"|\"$/g, '');
+}
+
+export async function fetchSalesnavJson(page, csrf, url, label) {
+  const result = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(url, csrf)));
+  if (result?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, `${label} authentication failed (HTTP ${result.status || 'auth_required'}).`);
+  if (result?.error || !result?.json) throw new CommandExecutionError(`${label} returned an unexpected response`, `${result?.error || 'no_json'}\n${normalizeWhitespace(result?.text || '').slice(0, 500)}`);
+  return result.json;
+}
+
+export async function fetchInboxRows(page, { limit = DEFAULT_LIMIT, maxPages = 30 } = {}) {
+  const csrf = await getCsrf(page);
+  const rows = [];
+  const seen = new Set();
+  let pageStartsAt = '';
+  let pagesFetched = 0;
+  let hasMorePages = false;
+  while (rows.length < limit && pagesFetched < maxPages) {
+    const json = await fetchSalesnavJson(page, csrf, threadListUrl({ count: PAGE_SIZE, pageStartsAt }), 'Sales Navigator messaging threads API');
+    pagesFetched += 1;
+    const pageRows = parseSalesnavThreads(json);
+    if (pageRows.length === 0) break;
+    for (const row of pageRows) {
+      if (seen.has(row.thread_id)) continue;
+      seen.add(row.thread_id);
+      rows.push(row);
+      if (rows.length >= limit) break;
+    }
+    const last = pageRows[pageRows.length - 1];
+    const next = last?.next_page_starts_at;
+    hasMorePages = Boolean(next);
+    if (!next) break;
+    if (next === pageStartsAt) {
+      throw new CommandExecutionError('Sales Navigator messaging threads API returned the same cursor twice');
+    }
+    pageStartsAt = next;
+  }
+  if (rows.length < limit && hasMorePages && pagesFetched >= maxPages) {
+    throw new CommandExecutionError(`Sales Navigator messaging threads API reached the ${maxPages}-page safety cap before collecting ${limit} conversations`);
+  }
+  return rows.slice(0, limit).map((row, index) => ({ ...row, rank: index + 1 }));
+}
+
+export { THREAD_DECORATION, THREADS_BASE };
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-inbox',
+  access: 'read',
+  description: 'List LinkedIn Sales Navigator message conversations with API pagination',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'limit', type: 'number', default: DEFAULT_LIMIT, help: 'Maximum conversations to return (1-500)' },
+    { name: 'max-pages', type: 'number', default: 30, help: 'Maximum Sales Navigator API pages to fetch' },
+    { name: 'unread-only', type: 'bool', default: false, help: 'Return only unread conversations' },
+  ],
+  columns: ['rank', 'thread_id', 'thread_url', 'person_name', 'last_message_snippet', 'last_activity_time', 'unread', 'unread_count', 'total_message_count', 'archived', 'participants', 'next_page_starts_at'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-inbox');
+    const limit = parseLimit(args.limit);
+    const maxPages = parseLimit(args['max-pages'], 30);
+    await page.goto(SALES_INBOX_URL);
+    await page.wait(4);
+    let rows = await fetchInboxRows(page, { limit, maxPages });
+    if (args['unread-only']) rows = rows.filter((row) => row.unread);
+    if (rows.length === 0) {
+      if (args['unread-only']) return [];
+      throw new EmptyResultError('linkedin salesnav-inbox', 'No Sales Navigator conversations were found.');
+    }
+    return rows.slice(0, limit).map((row, index) => ({ ...row, rank: index + 1 }));
+  },
+});
+
+export const __test__ = {
+  THREAD_DECORATION,
+  normalizeWhitespace,
+  parseLimit,
+  encodeRestliDecoration,
+  salesnavThreadUrl,
+  threadListUrl,
+  parseSalesnavThreads,
+  fetchInboxRows,
+};

--- a/clis/linkedin/salesnav-inbox.test.js
+++ b/clis/linkedin/salesnav-inbox.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import './salesnav-inbox.js';
+
+const {
+  THREAD_DECORATION,
+  encodeRestliDecoration,
+  parseLimit,
+  parseSalesnavThreads,
+  salesnavThreadUrl,
+  threadListUrl,
+} = await import('./salesnav-inbox.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-inbox command', () => {
+  it('percent-encodes Rest.li decoration parentheses for Sales Navigator messaging', () => {
+    const encoded = encodeRestliDecoration('(id,messages*(body))');
+    expect(encoded).toBe('%28id%2Cmessages*%28body%29%29');
+    expect(encoded).not.toContain('(');
+    expect(encoded).not.toContain(')');
+  });
+
+  it('builds the paginated salesApiMessagingThreads inbox URL', () => {
+    const url = threadListUrl({ count: 20, pageStartsAt: '1779070755626' });
+    expect(url).toContain('/sales-api/salesApiMessagingThreads?');
+    expect(url).toContain('q=filter');
+    expect(url).toContain('filter=INBOX');
+    expect(url).toContain('count=20');
+    expect(url).toContain('pageStartsAt=1779070755626');
+    expect(url).toContain(encodeRestliDecoration(THREAD_DECORATION));
+  });
+
+  it('validates limits without silent clamping', () => {
+    expect(parseLimit(undefined)).toBe(40);
+    expect(parseLimit(12)).toBe(12);
+    expect(() => parseLimit(0)).toThrow();
+    expect(() => parseLimit(501)).toThrow();
+    expect(() => parseLimit('abc')).toThrow();
+  });
+
+  it('parses Sales Navigator thread rows with other participant and unread state', () => {
+    const rows = parseSalesnavThreads({ elements: [{
+      id: '2-thread',
+      unreadMessageCount: 1,
+      archived: false,
+      totalMessageCount: 2,
+      nextPageStartsAt: 1778206803669,
+      participants: [
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)',
+      ],
+      participantsResolutionResults: {
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)': {
+          entityUrn: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+          firstName: 'Rachael',
+          lastName: 'Stolberg',
+          fullName: 'Rachael Stolberg',
+          degree: 2,
+        },
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)': {
+          entityUrn: 'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)',
+          firstName: 'Hanzi',
+          lastName: 'Li',
+          fullName: 'Hanzi Li',
+          degree: 0,
+        },
+      },
+      messages: [{
+        id: 'msg-1',
+        author: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+        body: 'Hi hanzi, happy to chat',
+        deliveredAt: 1778206803669,
+      }],
+    }] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      thread_id: '2-thread',
+      thread_url: salesnavThreadUrl('2-thread'),
+      person_name: 'Rachael Stolberg',
+      last_message_snippet: 'Hi hanzi, happy to chat',
+      last_activity_time: '2026-05-08T02:20:03.669Z',
+      unread: true,
+      unread_count: 1,
+      total_message_count: 2,
+    });
+  });
+
+  it('does not hard-code a specific account name as the inbox owner', () => {
+    const rows = parseSalesnavThreads({ elements: [{
+      id: '2-thread',
+      participants: [
+        'urn:li:fs_salesProfile:(HANZI,NAME_SEARCH,T1)',
+        'urn:li:fs_salesProfile:(ME,NAME_SEARCH,T2)',
+      ],
+      participantsResolutionResults: {
+        'urn:li:fs_salesProfile:(HANZI,NAME_SEARCH,T1)': {
+          fullName: 'Hanzi Li',
+          degree: 2,
+        },
+        'urn:li:fs_salesProfile:(ME,NAME_SEARCH,T2)': {
+          fullName: 'Current User',
+          degree: 0,
+        },
+      },
+      messages: [],
+    }] });
+    expect(rows[0].person_name).toBe('Hanzi Li');
+  });
+
+  it('fails typed on malformed thread payloads and missing thread identity', () => {
+    expect(() => parseSalesnavThreads({})).toThrow(CommandExecutionError);
+    expect(() => parseSalesnavThreads({ elements: [{}] })).toThrow(CommandExecutionError);
+  });
+});

--- a/clis/linkedin/salesnav-message.js
+++ b/clis/linkedin/salesnav-message.js
@@ -146,13 +146,35 @@ function fetchJsonScript(url, csrf, options = {}) {
       const text = await res.text();
       let json = null;
       try { json = text ? JSON.parse(text) : null; } catch (_) { json = null; }
-      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status, text };
-      if (!res.ok) return { error: 'HTTP ' + res.status, status: res.status, text, json };
-      return { status: res.status, json, text };
+      if (res.status === 401 || res.status === 403) return ['auth', res.status, json, text];
+      if (!res.ok) return ['error', res.status, json, text, 'HTTP ' + res.status];
+      return ['ok', res.status, json, text];
     } catch (e) {
-      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+      return ['error', 0, null, '', 'fetch failed: ' + ((e && e.message) || String(e))];
     }
   })()`;
+}
+
+function requireFetchResult(result, label, { requireJson = true } = {}) {
+  if (Array.isArray(result)) {
+    const [kind, status, json, text, error] = result;
+    result = {
+      authRequired: kind === 'auth',
+      error: kind === 'error' ? error || `HTTP ${status}` : '',
+      status,
+      json,
+      text,
+    };
+  }
+  if (result?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, `${label} auth failed.`);
+  if (result?.error) throw new CommandExecutionError(`${label} failed`, result.error);
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    throw new CommandExecutionError(`${label} returned malformed response`);
+  }
+  if (requireJson && (!result.json || typeof result.json !== 'object' || Array.isArray(result.json))) {
+    throw new CommandExecutionError(`${label} returned malformed response`, 'missing_json');
+  }
+  return result;
 }
 
 function salesPageShowsSentMessage(text, recipientName) {
@@ -221,6 +243,14 @@ function profileSummary(json) {
   };
 }
 
+function requireProfileSummary(json) {
+  const summary = profileSummary(json);
+  if (!summary.recipient) {
+    throw new CommandExecutionError('Sales Navigator profile lookup returned malformed profile data', 'missing_recipient_name');
+  }
+  return summary;
+}
+
 cli({
   site: 'linkedin',
   name: 'salesnav-message',
@@ -236,7 +266,7 @@ cli({
     { name: 'send', type: 'bool', default: false, help: 'Actually send the InMail. Default is dry-run validation only.' },
     { name: 'copy-to-crm', type: 'bool', default: false, help: 'Set Sales Navigator copyToCrm on the message request' },
   ],
-  columns: ['status', 'recipient', 'title', 'company', 'credits_remaining', 'credits_before', 'credits_after', 'sent_in_salesnav', 'message_chars', 'subject_chars', 'recipient_urn', 'authRequired', 'text', 'degree', 'inmail_restriction', 'open_link', 'json', 'href', 'resourceUrns'],
+  columns: ['status', 'recipient', 'title', 'company', 'credits_remaining', 'credits_before', 'credits_after', 'sent_in_salesnav', 'message_chars', 'subject_chars', 'recipient_urn', 'degree', 'inmail_restriction', 'open_link'],
   func: async (page, args) => {
     if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-message');
     const recipientArg = requireStringArg(args, 'recipient', '--recipient');
@@ -252,17 +282,14 @@ cli({
     let summary = { recipient: '', title: '', company: '', degree: '', inmail_restriction: '', open_link: false };
     const profileUrl = profileApiUrl(recipient);
     if (profileUrl) {
-      const profileResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(profileUrl, csrf)));
-      if (profileResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator profile API auth failed.');
-      if (profileResult?.error) throw new CommandExecutionError('Sales Navigator profile lookup failed', profileResult.error);
-      summary = profileSummary(profileResult?.json);
+      const profileResult = requireFetchResult(unwrapEvaluateResult(await page.evaluate(fetchJsonScript(profileUrl, csrf))), 'LinkedIn Sales Navigator profile API');
+      summary = requireProfileSummary(profileResult.json);
     }
     if (summary.inmail_restriction && summary.inmail_restriction !== 'NO_RESTRICTION') {
       throw new CommandExecutionError('Sales Navigator InMail blocked by recipient restriction', summary.inmail_restriction);
     }
 
-    const creditsResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf)));
-    if (creditsResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator credits API auth failed.');
+    const creditsResult = requireFetchResult(unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf))), 'LinkedIn Sales Navigator credits API');
     const creditsRemaining = extractRemainingCredits(creditsResult?.json);
 
     const payload = buildCreateMessagePayload({ recipientUrn: recipient.entityUrn, subject, body, copyToCrm: args['copy-to-crm'] });
@@ -273,22 +300,26 @@ cli({
         title: summary.title,
         company: summary.company,
         credits_remaining: creditsRemaining,
+        credits_before: creditsRemaining,
+        credits_after: '',
+        sent_in_salesnav: false,
         message_chars: body.length,
         subject_chars: subject.length,
         recipient_urn: recipient.entityUrn,
+        degree: summary.degree,
+        inmail_restriction: summary.inmail_restriction,
+        open_link: summary.open_link,
       }];
     }
 
-    const sendResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(MESSAGE_ACTION_URL, csrf, {
+    const sendResult = requireFetchResult(unwrapEvaluateResult(await page.evaluate(fetchJsonScript(MESSAGE_ACTION_URL, csrf, {
       method: 'POST',
       accept: 'application/vnd.linkedin.normalized+json+2.1',
       body: payload,
-    })));
-    if (sendResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator message API auth failed.');
-    if (sendResult?.error) throw new CommandExecutionError('Sales Navigator InMail send failed', `${sendResult.error}\n${sendResult.text || ''}`);
+    }))), 'LinkedIn Sales Navigator message API', { requireJson: false });
+    void sendResult;
     await page.wait(3);
-    const creditsAfterResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf)));
-    if (creditsAfterResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator credits API auth failed after send.');
+    const creditsAfterResult = requireFetchResult(unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf))), 'LinkedIn Sales Navigator credits API after send');
     const creditsAfter = extractRemainingCredits(creditsAfterResult?.json);
     await page.goto(salesLeadUrlFromParts(recipient));
     await page.wait(6);
@@ -307,6 +338,9 @@ cli({
       message_chars: body.length,
       subject_chars: subject.length,
       recipient_urn: recipient.entityUrn,
+      degree: summary.degree,
+      inmail_restriction: summary.inmail_restriction,
+      open_link: summary.open_link,
     }];
   },
 });
@@ -321,5 +355,6 @@ export const __test__ = {
   buildCreateMessagePayload,
   extractRemainingCredits,
   profileSummary,
+  requireProfileSummary,
   salesPageShowsSentMessage,
 };

--- a/clis/linkedin/salesnav-message.js
+++ b/clis/linkedin/salesnav-message.js
@@ -1,0 +1,325 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_HOME = 'https://www.linkedin.com/sales/';
+const PROFILE_DECO = '(entityUrn,objectUrn,firstName,lastName,fullName,headline,degree,inmailRestriction,memberBadges,defaultPosition)';
+const CREDITS_URL = 'https://www.linkedin.com/sales-api/salesApiCredits?q=findCreditGrant&creditGrantType=LSS_INMAIL';
+const MESSAGE_ACTION_URL = 'https://www.linkedin.com/sales-api/salesApiMessageActions?action=createMessage';
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
+function parseSalesProfileUrn(value) {
+  const raw = normalizeWhitespace(value);
+  const match = raw.match(/^urn:li:fs_salesProfile:\(([^,()]+),([^,()]+),([^,()]+)\)$/);
+  if (!match) return null;
+  if (!isResolvedSalesProfileParts(match[1], match[2], match[3])) return null;
+  return { profileId: match[1], authType: match[2], authToken: match[3], entityUrn: raw };
+}
+
+function isResolvedSalesProfileParts(profileId, authType, authToken) {
+  return [profileId, authType, authToken].every((part) => {
+    const clean = normalizeWhitespace(part).toLowerCase();
+    return clean && clean !== 'undefined' && clean !== 'null' && clean !== 'not_available';
+  });
+}
+
+function salesLeadUrlFromParts({ profileId, authType, authToken }) {
+  return `https://www.linkedin.com/sales/lead/${encodeURIComponent(profileId)},${encodeURIComponent(authType)},${encodeURIComponent(authToken)}`;
+}
+
+function parseRecipient(value) {
+  const raw = normalizeWhitespace(value);
+  const urn = parseSalesProfileUrn(raw);
+  if (urn) return urn;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return null;
+    const salesMatch = url.pathname.match(/^\/sales\/lead\/([^,/]+),([^,/]+),([^/]+)\/?$/i);
+    if (salesMatch) {
+      const profileId = decodeURIComponent(salesMatch[1]);
+      const authType = decodeURIComponent(salesMatch[2]);
+      const authToken = decodeURIComponent(salesMatch[3]);
+      if (!isResolvedSalesProfileParts(profileId, authType, authToken)) return null;
+      return { profileId, authType, authToken, entityUrn: `urn:li:fs_salesProfile:(${profileId},${authType},${authToken})` };
+    }
+    const profileMatch = url.pathname.match(/^\/in\/([^/]+)\/?$/i);
+    if (profileMatch) {
+      return { profileId: decodeURIComponent(profileMatch[1]), authType: '', authToken: '', entityUrn: '' };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function encodeRestliDecoration(value) {
+  return encodeURIComponent(value).replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+function profileApiUrl(recipient) {
+  if (!recipient?.profileId || !recipient?.authType || !recipient?.authToken) return '';
+  const key = `(profileId:${recipient.profileId},authType:${recipient.authType},authToken:${recipient.authToken})`;
+  return `https://www.linkedin.com/sales-api/salesApiProfiles/${key}?decoration=${encodeRestliDecoration(PROFILE_DECO)}`;
+}
+
+function randomTrackingId() {
+  const bytes = new Uint8Array(8);
+  if (globalThis.crypto?.getRandomValues) globalThis.crypto.getRandomValues(bytes);
+  else for (let i = 0; i < bytes.length; i += 1) bytes[i] = Math.floor(Math.random() * 256);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function buildCreateMessagePayload({ recipientUrn, subject, body, trackingId = randomTrackingId(), copyToCrm = false }) {
+  const cleanRecipient = normalizeWhitespace(recipientUrn);
+  if (!parseSalesProfileUrn(cleanRecipient)) throw new ArgumentError('--recipient must resolve to a Sales Navigator lead urn');
+  const cleanSubject = normalizeWhitespace(subject);
+  const cleanBody = String(body ?? '').trim();
+  if (!cleanSubject) throw new ArgumentError('--subject is required');
+  if (!cleanBody) throw new ArgumentError('--body is required');
+  if (cleanSubject.length > 200) throw new ArgumentError('--subject must be 200 characters or fewer');
+  if (cleanBody.length > 1900) throw new ArgumentError('--body must be 1900 characters or fewer');
+  return {
+    createMessageRequest: {
+      recipients: [cleanRecipient],
+      subject: cleanSubject,
+      body: cleanBody,
+      copyToCrm: Boolean(copyToCrm),
+      trackingId,
+    },
+  };
+}
+
+function extractRemainingCredits(json) {
+  const elements = Array.isArray(json?.elements) ? json.elements : [];
+  const inmailGrant = elements.find((el) => el?.type === 'LSS_INMAIL' && Number.isInteger(el.value));
+  if (inmailGrant) return inmailGrant.value;
+  const candidates = [];
+  const visit = (value) => {
+    if (value === null || value === undefined) return;
+    if (typeof value === 'number' && Number.isFinite(value)) candidates.push(value);
+    if (Array.isArray(value)) value.forEach(visit);
+    else if (typeof value === 'object') {
+      for (const [key, child] of Object.entries(value)) {
+        if (/remaining|available|balance|value/i.test(key) && typeof child === 'number') candidates.unshift(child);
+        else if (!/^count$|^start$|^id$/i.test(key)) visit(child);
+      }
+    }
+  };
+  visit(json);
+  return candidates.find((n) => Number.isInteger(n) && n >= 0) ?? null;
+}
+
+function fetchJsonScript(url, csrf, options = {}) {
+  return String.raw`(async () => {
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      'x-restli-protocol-version': '2.0.0',
+      accept: ${JSON.stringify(options.accept || 'application/json')},
+      ...((${JSON.stringify(Boolean(options.body))}) ? { 'content-type': 'application/json' } : {}),
+    };
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        credentials: 'include',
+        method: ${JSON.stringify(options.method || 'GET')},
+        headers,
+        body: ${options.body ? JSON.stringify(JSON.stringify(options.body)) : 'undefined'},
+      });
+      const text = await res.text();
+      let json = null;
+      try { json = text ? JSON.parse(text) : null; } catch (_) { json = null; }
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status, text };
+      if (!res.ok) return { error: 'HTTP ' + res.status, status: res.status, text, json };
+      return { status: res.status, json, text };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+function salesPageShowsSentMessage(text, recipientName) {
+  const normalizedText = normalizeWhitespace(text);
+  const firstName = normalizeWhitespace(recipientName).split(' ')[0];
+  return normalizedText.includes('You sent a Sales Navigator message')
+    && (!firstName || normalizedText.includes(firstName));
+}
+
+async function getCsrf(page) {
+  const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+  if (!jsession) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+  return jsession.replace(/^\"|\"$/g, '');
+}
+
+async function resolveRecipient(page, parsed, csrf) {
+  if (!parsed) throw new ArgumentError('--recipient must be a Sales Navigator lead URL, Sales Navigator profile URL, LinkedIn /in/ URL, or urn:li:fs_salesProfile:(...)');
+  if (parsed.entityUrn && parsed.authType && parsed.authToken) return parsed;
+
+  await page.goto(`https://www.linkedin.com/sales/lead/${encodeURIComponent(parsed.profileId)}`);
+  await page.wait(6);
+  const probe = unwrapEvaluateResult(await page.evaluate(String.raw`(() => {
+    const href = location.href;
+    const text = document.body ? document.body.innerText : '';
+    const resourceUrns = Array.from(performance.getEntriesByType('resource'))
+      .map((entry) => entry.name)
+      .filter((name) => name.includes('/sales-api/salesApiProfiles/'))
+      .slice(-20);
+    return { href, text: text.slice(0, 1000), resourceUrns };
+  })()`));
+    const urlMatch = String(probe?.href || '').match(/\/sales\/lead\/([^,/]+),([^,/]+),([^/?#]+)/i);
+  if (urlMatch && isResolvedSalesProfileParts(urlMatch[1], urlMatch[2], urlMatch[3])) {
+    return {
+      profileId: decodeURIComponent(urlMatch[1]),
+      authType: decodeURIComponent(urlMatch[2]),
+      authToken: decodeURIComponent(urlMatch[3]),
+      entityUrn: `urn:li:fs_salesProfile:(${decodeURIComponent(urlMatch[1])},${decodeURIComponent(urlMatch[2])},${decodeURIComponent(urlMatch[3])})`,
+    };
+  }
+  for (const resource of probe?.resourceUrns || []) {
+    const resourceMatch = String(resource).match(/profileId:([^,)]+),authType:([^,)]+),authToken:([^,)]+)\)/);
+    if (resourceMatch && resourceMatch[1] === parsed.profileId) {
+      return {
+        profileId: resourceMatch[1],
+        authType: resourceMatch[2],
+        authToken: resourceMatch[3],
+        entityUrn: `urn:li:fs_salesProfile:(${resourceMatch[1]},${resourceMatch[2]},${resourceMatch[3]})`,
+      };
+    }
+  }
+  void csrf;
+  throw new CommandExecutionError('Could not resolve Sales Navigator auth token for recipient', `Observed URL: ${probe?.href || 'url_not_available'}\nBody: ${normalizeWhitespace(probe?.text || '').slice(0, 500)}`);
+}
+
+function profileSummary(json) {
+  const data = json?.data || json || {};
+  const pos = data.defaultPosition || (Array.isArray(data.positions) ? data.positions.find((p) => p.current) || data.positions[0] : {}) || {};
+  return {
+    recipient: normalizeWhitespace(data.fullName || [data.firstName, data.lastName].filter(Boolean).join(' ')),
+    title: normalizeWhitespace(pos.title || data.headline || ''),
+    company: normalizeWhitespace(pos.companyName || pos.company?.name || ''),
+    degree: normalizeWhitespace(data.degree || ''),
+    inmail_restriction: normalizeWhitespace(data.inmailRestriction || ''),
+    open_link: Boolean(data.memberBadges?.openLink),
+  };
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-message',
+  access: 'write',
+  description: 'Send or dry-run a LinkedIn Sales Navigator InMail to a lead using the Sales Navigator messaging API',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'recipient', type: 'string', required: true, positional: true, help: 'Sales Navigator lead URL, LinkedIn /in/ URL from salesnav-search, or urn:li:fs_salesProfile:(...)' },
+    { name: 'subject', type: 'string', required: true, help: 'InMail subject' },
+    { name: 'body', type: 'string', required: true, help: 'InMail body' },
+    { name: 'send', type: 'bool', default: false, help: 'Actually send the InMail. Default is dry-run validation only.' },
+    { name: 'copy-to-crm', type: 'bool', default: false, help: 'Set Sales Navigator copyToCrm on the message request' },
+  ],
+  columns: ['status', 'recipient', 'title', 'company', 'credits_remaining', 'credits_before', 'credits_after', 'sent_in_salesnav', 'message_chars', 'subject_chars', 'recipient_urn', 'authRequired', 'text', 'degree', 'inmail_restriction', 'open_link', 'json', 'href', 'resourceUrns'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-message');
+    const recipientArg = requireStringArg(args, 'recipient', '--recipient');
+    const subject = requireStringArg(args, 'subject', '--subject');
+    const body = String(args.body ?? '').trim();
+    if (!body) throw new ArgumentError('--body is required');
+
+    await page.goto(SALES_HOME);
+    await page.wait(4);
+    const csrf = await getCsrf(page);
+    const recipient = await resolveRecipient(page, parseRecipient(recipientArg), csrf);
+
+    let summary = { recipient: '', title: '', company: '', degree: '', inmail_restriction: '', open_link: false };
+    const profileUrl = profileApiUrl(recipient);
+    if (profileUrl) {
+      const profileResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(profileUrl, csrf)));
+      if (profileResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator profile API auth failed.');
+      if (profileResult?.error) throw new CommandExecutionError('Sales Navigator profile lookup failed', profileResult.error);
+      summary = profileSummary(profileResult?.json);
+    }
+    if (summary.inmail_restriction && summary.inmail_restriction !== 'NO_RESTRICTION') {
+      throw new CommandExecutionError('Sales Navigator InMail blocked by recipient restriction', summary.inmail_restriction);
+    }
+
+    const creditsResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf)));
+    if (creditsResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator credits API auth failed.');
+    const creditsRemaining = extractRemainingCredits(creditsResult?.json);
+
+    const payload = buildCreateMessagePayload({ recipientUrn: recipient.entityUrn, subject, body, copyToCrm: args['copy-to-crm'] });
+    if (!args.send) {
+      return [{
+        status: 'validated_dry_run',
+        recipient: summary.recipient,
+        title: summary.title,
+        company: summary.company,
+        credits_remaining: creditsRemaining,
+        message_chars: body.length,
+        subject_chars: subject.length,
+        recipient_urn: recipient.entityUrn,
+      }];
+    }
+
+    const sendResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(MESSAGE_ACTION_URL, csrf, {
+      method: 'POST',
+      accept: 'application/vnd.linkedin.normalized+json+2.1',
+      body: payload,
+    })));
+    if (sendResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator message API auth failed.');
+    if (sendResult?.error) throw new CommandExecutionError('Sales Navigator InMail send failed', `${sendResult.error}\n${sendResult.text || ''}`);
+    await page.wait(3);
+    const creditsAfterResult = unwrapEvaluateResult(await page.evaluate(fetchJsonScript(CREDITS_URL, csrf)));
+    if (creditsAfterResult?.authRequired) throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator credits API auth failed after send.');
+    const creditsAfter = extractRemainingCredits(creditsAfterResult?.json);
+    await page.goto(salesLeadUrlFromParts(recipient));
+    await page.wait(6);
+    const salesPageText = unwrapEvaluateResult(await page.evaluate('document.body ? document.body.innerText : ""'));
+    const sentInSalesNav = salesPageShowsSentMessage(salesPageText, summary.recipient);
+    if (!sentInSalesNav) throw new CommandExecutionError('Sales Navigator post-send verification failed', 'Sent activity was not found on the Sales Navigator lead page.');
+    return [{
+      status: 'sent',
+      recipient: summary.recipient,
+      title: summary.title,
+      company: summary.company,
+      credits_remaining: creditsAfter,
+      credits_before: creditsRemaining,
+      credits_after: creditsAfter,
+      sent_in_salesnav: sentInSalesNav,
+      message_chars: body.length,
+      subject_chars: subject.length,
+      recipient_urn: recipient.entityUrn,
+    }];
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  parseSalesProfileUrn,
+  isResolvedSalesProfileParts,
+  parseRecipient,
+  salesLeadUrlFromParts,
+  profileApiUrl,
+  buildCreateMessagePayload,
+  extractRemainingCredits,
+  profileSummary,
+  salesPageShowsSentMessage,
+};

--- a/clis/linkedin/salesnav-message.test.js
+++ b/clis/linkedin/salesnav-message.test.js
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import './salesnav-message.js';
 
 const {
@@ -9,8 +11,21 @@ const {
   buildCreateMessagePayload,
   extractRemainingCredits,
   profileSummary,
+  requireProfileSummary,
   salesPageShowsSentMessage,
 } = await import('./salesnav-message.js').then((m) => m.__test__);
+
+function createPageMock(evaluateResults = []) {
+  const evaluate = vi.fn();
+  for (const result of evaluateResults) evaluate.mockResolvedValueOnce(result);
+  evaluate.mockResolvedValue(undefined);
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate,
+    getCookies: vi.fn().mockResolvedValue([{ name: 'JSESSIONID', value: '"csrf"', domain: '.linkedin.com' }]),
+  };
+}
 
 describe('linkedin salesnav-message command', () => {
   it('parses Sales Navigator profile urns and lead URLs', () => {
@@ -97,5 +112,61 @@ describe('linkedin salesnav-message command', () => {
       degree: '3',
       open_link: false,
     });
+  });
+
+  it('fails typed when decorated profile data has no recipient identity', () => {
+    expect(() => requireProfileSummary({ data: { defaultPosition: { title: 'FSQA' } } }))
+      .toThrow(CommandExecutionError);
+  });
+
+  it('keeps manifest columns aligned with dry-run rows and fails typed on malformed profile API', async () => {
+    const cmd = getRegistry().get('linkedin/salesnav-message');
+    expect(cmd?.columns).toEqual([
+      'status',
+      'recipient',
+      'title',
+      'company',
+      'credits_remaining',
+      'credits_before',
+      'credits_after',
+      'sent_in_salesnav',
+      'message_chars',
+      'subject_chars',
+      'recipient_urn',
+      'degree',
+      'inmail_restriction',
+      'open_link',
+    ]);
+
+    const goodPage = createPageMock([
+      { status: 200, json: { data: { fullName: 'Jane Doe', defaultPosition: { title: 'QA', companyName: 'Acme' }, degree: 2, inmailRestriction: 'NO_RESTRICTION', memberBadges: { openLink: true } } } },
+      { status: 200, json: { elements: [{ type: 'LSS_INMAIL', value: 12 }] } },
+    ]);
+    const rows = await cmd.func(goodPage, {
+      recipient: 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)',
+      subject: 'Hello',
+      body: 'Quick question',
+    });
+    expect(Object.keys(rows[0]).sort()).toEqual([...cmd.columns].sort());
+    expect(rows[0]).toMatchObject({
+      status: 'validated_dry_run',
+      recipient: 'Jane Doe',
+      credits_remaining: 12,
+      credits_before: 12,
+      credits_after: '',
+      sent_in_salesnav: false,
+      degree: '2',
+      inmail_restriction: 'NO_RESTRICTION',
+      open_link: true,
+    });
+
+    const malformedPage = createPageMock([
+      { status: 200, json: { data: { defaultPosition: { title: 'QA' } } } },
+    ]);
+    await expect(cmd.func(malformedPage, {
+      recipient: 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)',
+      subject: 'Hello',
+      body: 'Quick question',
+    })).rejects.toThrow(CommandExecutionError);
   });
 });

--- a/clis/linkedin/salesnav-message.test.js
+++ b/clis/linkedin/salesnav-message.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import './salesnav-message.js';
+
+const {
+  parseSalesProfileUrn,
+  parseRecipient,
+  salesLeadUrlFromParts,
+  profileApiUrl,
+  buildCreateMessagePayload,
+  extractRemainingCredits,
+  profileSummary,
+  salesPageShowsSentMessage,
+} = await import('./salesnav-message.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-message command', () => {
+  it('parses Sales Navigator profile urns and lead URLs', () => {
+    const urn = 'urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)';
+    expect(parseSalesProfileUrn(urn)).toMatchObject({
+      profileId: 'ACwAAAJS8TABxyz',
+      authType: 'NAME_SEARCH',
+      authToken: 'Enlo',
+      entityUrn: urn,
+    });
+    expect(parseSalesProfileUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,undefined,undefined)')).toBeNull();
+
+    const parsed = parseRecipient('https://www.linkedin.com/sales/lead/ACwAAAJS8TABxyz,NAME_SEARCH,Enlo');
+    expect(parsed).toMatchObject({ profileId: 'ACwAAAJS8TABxyz', authType: 'NAME_SEARCH', authToken: 'Enlo' });
+    expect(parsed.entityUrn).toBe(urn);
+    expect(salesLeadUrlFromParts(parsed)).toBe('https://www.linkedin.com/sales/lead/ACwAAAJS8TABxyz,NAME_SEARCH,Enlo');
+  });
+
+  it('accepts LinkedIn /in tokens as unresolved recipients', () => {
+    expect(parseRecipient('https://www.linkedin.com/in/ACwAAAJS8TABxyz/')).toMatchObject({
+      profileId: 'ACwAAAJS8TABxyz',
+      authType: '',
+      authToken: '',
+      entityUrn: '',
+    });
+  });
+
+  it('builds profile API URLs with the Sales Navigator auth key', () => {
+    const url = profileApiUrl({ profileId: 'P1', authType: 'NAME_SEARCH', authToken: 'T1' });
+    expect(url).toContain('/sales-api/salesApiProfiles/(profileId:P1,authType:NAME_SEARCH,authToken:T1)');
+    expect(url).toContain('decoration=');
+  });
+
+  it('constructs the createMessage action payload used by Sales Navigator', () => {
+    const payload = buildCreateMessagePayload({
+      recipientUrn: 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)',
+      subject: 'Quick QA doc question',
+      body: 'Hi Jane, can I ask a quick question?',
+      trackingId: '0123456789abcdef',
+      copyToCrm: false,
+    });
+    expect(payload).toEqual({
+      createMessageRequest: {
+        recipients: ['urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)'],
+        subject: 'Quick QA doc question',
+        body: 'Hi Jane, can I ask a quick question?',
+        copyToCrm: false,
+        trackingId: '0123456789abcdef',
+      },
+    });
+  });
+
+  it('validates payload fields before any send attempt', () => {
+    expect(() => buildCreateMessagePayload({ recipientUrn: '', subject: 's', body: 'b' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,A,T)', subject: '', body: 'b' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,A,T)', subject: 's', body: '' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,A,T)', subject: 'x'.repeat(201), body: 'b' })).toThrow();
+    expect(() => buildCreateMessagePayload({ recipientUrn: 'urn:li:fs_salesProfile:(P,undefined,undefined)', subject: 's', body: 'b' })).toThrow();
+  });
+
+  it('detects the Sales Navigator sent activity on a verified lead page', () => {
+    expect(salesPageShowsSentMessage('5/18/2026 You sent a Sales Navigator message to Jane', 'Jane Q')).toBe(true);
+    expect(salesPageShowsSentMessage('No recent activity', 'Jane Q')).toBe(false);
+  });
+
+  it('extracts a plausible remaining InMail credit count', () => {
+    expect(extractRemainingCredits({ elements: [{ type: 'LSS_INMAIL', value: 149, id: 1 }], paging: { count: 10 } })).toBe(149);
+    expect(extractRemainingCredits({ data: { remaining: 149, used: 1 } })).toBe(149);
+    expect(extractRemainingCredits({ elements: [{ availableCount: 12 }] })).toBe(12);
+    expect(extractRemainingCredits({})).toBe(null);
+  });
+
+  it('summarizes decorated Sales Navigator profile data', () => {
+    expect(profileSummary({ data: {
+      fullName: 'Rayki Goh',
+      headline: 'Food Safety',
+      degree: 3,
+      defaultPosition: { title: 'FSQA Manager', companyName: 'Acme Foods' },
+      memberBadges: { openLink: false },
+    } })).toMatchObject({
+      recipient: 'Rayki Goh',
+      title: 'FSQA Manager',
+      company: 'Acme Foods',
+      degree: '3',
+      open_link: false,
+    });
+  });
+});

--- a/clis/linkedin/salesnav-search.js
+++ b/clis/linkedin/salesnav-search.js
@@ -1,0 +1,186 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_HOME = 'https://www.linkedin.com/sales/';
+const LEAD_SEARCH_BASE = 'https://www.linkedin.com/sales-api/salesApiLeadSearch';
+// Versioned response decoration. LinkedIn bumps this on Sales Navigator
+// redeploys; if the response shape ever changes, refresh it from a live
+// /sales/search/people request.
+const LEAD_SEARCH_DECORATION = 'com.linkedin.sales.deco.desktop.searchv2.LeadSearchResult-14';
+const PAGE_SIZE = 25;
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function parseLimit(value) {
+  if (value === undefined || value === null || value === '') return 25;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new ArgumentError('--limit must be an integer between 1 and 500');
+  }
+  return limit;
+}
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+// Sales Navigator keeps the structural ( ) , : of the query literal and only
+// percent-encodes the keyword value.
+function leadSearchUrl(keywords, start) {
+  const query = '(spellCorrectionEnabled:true,recentSearchParam:(doLogHistory:true),keywords:'
+    + encodeURIComponent(keywords) + ')';
+  return LEAD_SEARCH_BASE
+    + '?q=searchQuery&query=' + query
+    + '&start=' + start + '&count=' + PAGE_SIZE
+    + '&decorationId=' + LEAD_SEARCH_DECORATION;
+}
+
+function fetchLeadSearchScript(url, csrf) {
+  return String.raw`(async () => {
+    const headers = {
+      'csrf-token': ${JSON.stringify(csrf)},
+      'x-restli-protocol-version': '2.0.0',
+      accept: 'application/json',
+    };
+    try {
+      const res = await fetch(${JSON.stringify(url)}, { credentials: 'include', headers });
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
+      if (!res.ok) return { error: 'HTTP ' + res.status };
+      return { json: await res.json() };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+// Sales Navigator search returns no /in/ vanity URL, but the entityUrn carries
+// the obfuscated member token, and linkedin.com/in/<token> is a valid profile
+// URL that the connect command accepts.
+function profileUrlFromEntityUrn(entityUrn) {
+  const match = String(entityUrn || '').match(/fs_salesProfile:\(([^,)]+)/);
+  return match && match[1] ? 'https://www.linkedin.com/in/' + match[1] : '';
+}
+
+function leadUrlFromEntityUrn(entityUrn) {
+  const match = String(entityUrn || '').match(/^urn:li:fs_salesProfile:\(([^,()]+),([^,()]+),([^,()]+)\)$/);
+  if (!match) return '';
+  return `https://www.linkedin.com/sales/lead/${encodeURIComponent(match[1])},${encodeURIComponent(match[2])},${encodeURIComponent(match[3])}`;
+}
+
+function parseLeads(json) {
+  if (!json || typeof json !== 'object' || !Array.isArray(json.elements)) {
+    throw new CommandExecutionError('Sales Navigator lead search API returned malformed payload');
+  }
+  const leads = [];
+  for (const el of json.elements) {
+    if (!el || typeof el !== 'object') {
+      throw new CommandExecutionError('Sales Navigator lead search API returned malformed lead row');
+    }
+    const current = Array.isArray(el.currentPositions) ? el.currentPositions : [];
+    const past = Array.isArray(el.pastPositions) ? el.pastPositions : [];
+    const pos = current[0] || past[0] || {};
+    const name = normalizeWhitespace(el.fullName || [el.firstName, el.lastName].filter(Boolean).join(' '));
+    if (!name) {
+      throw new CommandExecutionError('Sales Navigator lead row missing name');
+    }
+    const entityUrn = normalizeWhitespace(el.entityUrn || '');
+    if (!profileUrlFromEntityUrn(entityUrn)) {
+      throw new CommandExecutionError('Sales Navigator lead row missing profile identity');
+    }
+    leads.push({
+      name,
+      title: normalizeWhitespace(pos.title || ''),
+      company: normalizeWhitespace(pos.companyName || ''),
+      location: normalizeWhitespace(el.geoRegion || ''),
+      degree: normalizeWhitespace(el.degree || ''),
+      profile_url: profileUrlFromEntityUrn(entityUrn),
+      lead_url: leadUrlFromEntityUrn(entityUrn),
+      recipient_urn: entityUrn,
+    });
+  }
+  return leads;
+}
+
+function requireLeadSearchResult(result) {
+  if (result?.authRequired) {
+    throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn Sales Navigator API auth failed (HTTP ' + (result.status || '') + '). Confirm the account has Sales Navigator access.');
+  }
+  if (result?.error) {
+    throw new CommandExecutionError('Sales Navigator lead search API returned an unexpected response', result.error);
+  }
+  if (!result || !result.json) {
+    throw new CommandExecutionError('Sales Navigator lead search API returned an unexpected response', 'no_json');
+  }
+  return result.json;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-search',
+  access: 'read',
+  description: 'Search LinkedIn Sales Navigator for people leads by keyword',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'keywords', type: 'string', required: true, positional: true, help: 'People search keywords, e.g. "quality manager food manufacturing"' },
+    { name: 'limit', type: 'number', default: 25, help: 'Maximum leads to return (1-500, fetched 25 per request)' },
+  ],
+  columns: ['rank', 'name', 'title', 'company', 'location', 'degree', 'profile_url', 'lead_url', 'recipient_urn'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-search');
+    const keywords = requireStringArg(args, 'keywords', '--keywords');
+    const limit = parseLimit(args.limit);
+
+    await page.goto(SALES_HOME);
+    await page.wait(6);
+
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.');
+    }
+    const csrf = jsession.replace(/^\"|\"$/g, '');
+
+    const leads = [];
+    const seen = new Set();
+    for (let start = 0; leads.length < limit && start < 2000; start += PAGE_SIZE) {
+      const result = unwrapEvaluateResult(await page.evaluate(fetchLeadSearchScript(leadSearchUrl(keywords, start), csrf)));
+      const json = requireLeadSearchResult(result);
+      const pageLeads = parseLeads(json);
+      if (pageLeads.length === 0) break;
+      for (const lead of pageLeads) {
+        const key = lead.profile_url || lead.name.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        leads.push(lead);
+      }
+      await page.wait(1);
+    }
+
+    if (leads.length === 0) {
+      throw new EmptyResultError('linkedin salesnav-search', 'No Sales Navigator leads were found.');
+    }
+    return leads.slice(0, limit).map((lead, index) => ({ rank: index + 1, ...lead }));
+  },
+});
+
+export const __test__ = {
+  normalizeWhitespace,
+  parseLimit,
+  leadSearchUrl,
+  profileUrlFromEntityUrn,
+  leadUrlFromEntityUrn,
+  parseLeads,
+  requireLeadSearchResult,
+};

--- a/clis/linkedin/salesnav-search.test.js
+++ b/clis/linkedin/salesnav-search.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import './salesnav-search.js';
+
+const {
+  parseLimit,
+  leadSearchUrl,
+  profileUrlFromEntityUrn,
+  leadUrlFromEntityUrn,
+  parseLeads,
+  requireLeadSearchResult,
+} = await import('./salesnav-search.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-search command', () => {
+  it('builds a salesApiLeadSearch URL with encoded keywords and pagination', () => {
+    const url = leadSearchUrl('quality manager food', 50);
+    expect(url).toContain('/sales-api/salesApiLeadSearch');
+    expect(url).toContain('keywords:quality%20manager%20food');
+    expect(url).toContain('start=50');
+    expect(url).toContain('count=25');
+  });
+
+  it('derives a profile URL from the sales-profile entityUrn token', () => {
+    expect(profileUrlFromEntityUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)'))
+      .toBe('https://www.linkedin.com/in/ACwAAAJS8TABxyz');
+    expect(profileUrlFromEntityUrn('')).toBe('');
+    expect(profileUrlFromEntityUrn('not-a-urn')).toBe('');
+  });
+
+  it('derives a Sales Navigator lead URL from the full sales-profile entityUrn', () => {
+    expect(leadUrlFromEntityUrn('urn:li:fs_salesProfile:(ACwAAAJS8TABxyz,NAME_SEARCH,Enlo)'))
+      .toBe('https://www.linkedin.com/sales/lead/ACwAAAJS8TABxyz,NAME_SEARCH,Enlo');
+    expect(leadUrlFromEntityUrn('not-a-urn')).toBe('');
+  });
+
+  it('validates --limit without silent clamping', () => {
+    expect(parseLimit(undefined)).toBe(25);
+    expect(parseLimit(120)).toBe(120);
+    expect(() => parseLimit(0)).toThrow();
+    expect(() => parseLimit(999)).toThrow();
+    expect(() => parseLimit('abc')).toThrow();
+  });
+
+  it('parses lead rows and falls back to past positions', () => {
+    const json = { elements: [
+      { fullName: 'Jane Q', geoRegion: 'Vancouver, BC', degree: 2,
+        entityUrn: 'urn:li:fs_salesProfile:(TOKEN1,NAME_SEARCH,abc)',
+        currentPositions: [{ title: 'QA Manager', companyName: 'Acme Foods' }] },
+      { fullName: 'No Current', geoRegion: 'Toronto',
+        entityUrn: 'urn:li:fs_salesProfile:(TOKEN2,NAME_SEARCH,def)',
+        currentPositions: [], pastPositions: [{ title: 'Past QA Lead', companyName: 'Old Co' }] },
+    ] };
+    const leads = parseLeads(json);
+    expect(leads).toHaveLength(2);
+    expect(leads[0]).toMatchObject({
+      name: 'Jane Q',
+      title: 'QA Manager',
+      company: 'Acme Foods',
+      location: 'Vancouver, BC',
+      profile_url: 'https://www.linkedin.com/in/TOKEN1',
+      lead_url: 'https://www.linkedin.com/sales/lead/TOKEN1,NAME_SEARCH,abc',
+      recipient_urn: 'urn:li:fs_salesProfile:(TOKEN1,NAME_SEARCH,abc)',
+    });
+    expect(leads[1]).toMatchObject({ name: 'No Current', title: 'Past QA Lead', company: 'Old Co' });
+  });
+
+  it('fails typed on malformed lead payloads instead of silently dropping rows', () => {
+    expect(() => parseLeads({})).toThrow(CommandExecutionError);
+    expect(() => parseLeads({ elements: [{ firstName: '', lastName: '', entityUrn: 'urn:li:fs_salesProfile:(TOKEN3,x,y)' }] }))
+      .toThrow(CommandExecutionError);
+    expect(() => parseLeads({ elements: [{ fullName: 'No Identity' }] }))
+      .toThrow(CommandExecutionError);
+    expect(() => requireLeadSearchResult({ error: 'HTTP 500' })).toThrow(CommandExecutionError);
+    expect(() => requireLeadSearchResult({})).toThrow(CommandExecutionError);
+  });
+});

--- a/clis/linkedin/salesnav-thread.js
+++ b/clis/linkedin/salesnav-thread.js
@@ -47,10 +47,14 @@ function parseThreadInput(value) {
     const leadMatch = url.pathname.match(/^\/sales\/lead\/([^,/]+),([^,/]+),([^/]+)\/?$/i);
     if (leadMatch) {
       const urn = `urn:li:fs_salesProfile:(${decodeURIComponent(leadMatch[1])},${decodeURIComponent(leadMatch[2])},${decodeURIComponent(leadMatch[3])})`;
+      if (!parseSalesProfileUrn(urn)) {
+        throw new ArgumentError('Sales Navigator lead URL must contain resolved profileId, authType, and authToken');
+      }
       return ['recipient_urn', urn];
     }
-  } catch {
-    // Fall through to name matching.
+  } catch (err) {
+    if (err instanceof ArgumentError) throw err;
+    // Fall through to name matching for non-URL text.
   }
   return ['name', raw.toLowerCase()];
 }

--- a/clis/linkedin/salesnav-thread.js
+++ b/clis/linkedin/salesnav-thread.js
@@ -1,0 +1,208 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+  THREAD_DECORATION,
+  THREADS_BASE,
+  encodeRestliDecoration,
+  fetchInboxRows,
+  fetchSalesnavJson,
+  getCsrf,
+  normalizeWhitespace,
+  parseLimit,
+} from './salesnav-inbox.js';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SALES_INBOX_URL = 'https://www.linkedin.com/sales/inbox/';
+const DEFAULT_MESSAGE_LIMIT = 200;
+const THREAD_PAGE_SIZE = 20;
+
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
+function parseSalesProfileUrn(value) {
+  const raw = normalizeWhitespace(value);
+  const match = raw.match(/^urn:li:fs_salesProfile:\(([^,()]+),([^,()]+),([^,()]+)\)$/);
+  if (!match) return '';
+  const parts = [match[1], match[2], match[3]].map((part) => normalizeWhitespace(part).toLowerCase());
+  if (parts.some((part) => !part || part === 'undefined' || part === 'null' || part === 'not_available')) return '';
+  return raw;
+}
+
+function parseThreadInput(value) {
+  const raw = normalizeWhitespace(value);
+  if (!raw) return ['empty', ''];
+  if (/^2-[A-Za-z0-9+/=_-]+$/.test(raw)) return ['thread_id', raw];
+  if (/^urn:li:fs_salesProfile:\(/.test(raw)) {
+    const urn = parseSalesProfileUrn(raw);
+    if (!urn) throw new ArgumentError('Sales Navigator recipient urn must be urn:li:fs_salesProfile:(profileId,authType,authToken)');
+    return ['recipient_urn', urn];
+  }
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return ['name', raw.toLowerCase()];
+    const inboxMatch = url.pathname.match(/^\/sales\/inbox\/([^/]+)\/?$/i);
+    if (inboxMatch) return ['thread_id', decodeURIComponent(inboxMatch[1])];
+    const leadMatch = url.pathname.match(/^\/sales\/lead\/([^,/]+),([^,/]+),([^/]+)\/?$/i);
+    if (leadMatch) {
+      const urn = `urn:li:fs_salesProfile:(${decodeURIComponent(leadMatch[1])},${decodeURIComponent(leadMatch[2])},${decodeURIComponent(leadMatch[3])})`;
+      return ['recipient_urn', urn];
+    }
+  } catch {
+    // Fall through to name matching.
+  }
+  return ['name', raw.toLowerCase()];
+}
+
+function salesnavThreadUrl(threadId) {
+  return threadId ? `https://www.linkedin.com/sales/inbox/${encodeURIComponent(threadId)}` : '';
+}
+
+function threadApiUrl(threadId, messageCount) {
+  return `${THREADS_BASE}/${encodeURIComponent(threadId)}?decoration=${encodeRestliDecoration(THREAD_DECORATION)}&count=1&messageCount=${messageCount}`;
+}
+
+function participantName(profile) {
+  return normalizeWhitespace(profile?.fullName || [profile?.firstName, profile?.lastName].filter(Boolean).join(' '));
+}
+
+function participantIndex(thread) {
+  const resolution = thread?.participantsResolutionResults || {};
+  const participants = Array.isArray(thread?.participants) ? thread.participants : Object.keys(resolution);
+  const byUrn = new Map();
+  for (const urn of participants) {
+    const profile = resolution[urn] || { entityUrn: urn };
+    byUrn.set(urn, profile);
+  }
+  return byUrn;
+}
+
+function parseSalesnavThreadMessages(thread) {
+  if (!thread || typeof thread !== 'object') {
+    throw new CommandExecutionError('Sales Navigator messaging thread API returned malformed payload');
+  }
+  const threadId = normalizeWhitespace(thread?.id || '');
+  if (!threadId) {
+    throw new CommandExecutionError('Sales Navigator messaging thread API returned a thread without id');
+  }
+  if (!Array.isArray(thread?.messages)) {
+    throw new CommandExecutionError('Sales Navigator messaging thread API returned malformed messages');
+  }
+  const byUrn = participantIndex(thread);
+  const messages = thread.messages;
+  const rows = messages.map((message) => {
+    if (!message || typeof message !== 'object') {
+      throw new CommandExecutionError('Sales Navigator messaging thread API returned malformed message row');
+    }
+    const deliveredAt = Number(message?.deliveredAt || 0);
+    const senderProfile = byUrn.get(message?.author);
+    return {
+      message_id: normalizeWhitespace(message?.id || ''),
+      thread_id: threadId,
+      sender: participantName(senderProfile) || normalizeWhitespace(message?.author || ''),
+      sender_urn: normalizeWhitespace(message?.author || ''),
+      text: normalizeWhitespace(message?.body || message?.systemMessageContent || ''),
+      subject: normalizeWhitespace(message?.subject || ''),
+      timestamp: deliveredAt ? new Date(deliveredAt).toISOString() : '',
+      delivered_at: deliveredAt || '',
+      type: normalizeWhitespace(message?.type || ''),
+    };
+  }).filter((row) => row.text || row.subject || row.message_id);
+  rows.sort((a, b) => Number(a.delivered_at || 0) - Number(b.delivered_at || 0));
+  return rows.map((row, index) => ({ index, ...row }));
+}
+
+function threadMatchesInput(row, parsed) {
+  if (!row || !parsed) return false;
+  const [kind, criterion] = parsed;
+  if (kind === 'thread_id') return row.thread_id === criterion;
+  if (kind === 'recipient_urn') {
+    return (row.participants || []).some((p) => normalizeWhitespace(p.entity_urn) === criterion);
+  }
+  if (kind === 'name') {
+    const needle = normalizeWhitespace(criterion).toLowerCase();
+    if (!needle) return false;
+    if (normalizeWhitespace(row.person_name).toLowerCase() === needle) return true;
+    return (row.participants || []).some((p) => normalizeWhitespace(p.name).toLowerCase() === needle);
+  }
+  return false;
+}
+
+async function resolveThreadId(page, input, { maxPages = 30 } = {}) {
+  const parsed = parseThreadInput(input);
+  if (parsed[0] === 'empty') throw new ArgumentError('thread or recipient is required');
+  if (parsed[0] === 'thread_id') return parsed[1];
+  const inboxRows = await fetchInboxRows(page, { limit: 500, maxPages });
+  const match = inboxRows.find((row) => threadMatchesInput(row, parsed));
+  if (!match) {
+    throw new EmptyResultError('linkedin salesnav-thread', `No Sales Navigator thread matched ${input}`);
+  }
+  return match.thread_id;
+}
+
+async function fetchThreadWithPagination(page, csrf, threadId, limit = DEFAULT_MESSAGE_LIMIT) {
+  let requested = THREAD_PAGE_SIZE;
+  if (limit < requested) requested = limit;
+  let thread = null;
+  for (let attempts = 0; attempts < 30; attempts += 1) {
+    thread = await fetchSalesnavJson(page, csrf, threadApiUrl(threadId, requested), 'Sales Navigator messaging thread API');
+    const total = Number(thread?.totalMessageCount || 0);
+    const have = Array.isArray(thread?.messages) ? thread.messages.length : 0;
+    if (have >= limit || (total && have >= total) || requested >= limit) break;
+    let nextRequested = requested + THREAD_PAGE_SIZE;
+    if (total && total > nextRequested) nextRequested = total;
+    if (nextRequested > limit) nextRequested = limit;
+    requested = nextRequested;
+  }
+  const total = Number(thread?.totalMessageCount || 0);
+  const have = Array.isArray(thread?.messages) ? thread.messages.length : 0;
+  if (total && have < total && have < limit) {
+    throw new CommandExecutionError(`Sales Navigator messaging thread API returned partial history (${have}/${total})`);
+  }
+  return thread;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'salesnav-thread',
+  access: 'read',
+  description: 'Return full Sales Navigator message history for a thread id, Sales Navigator inbox URL, lead URL, recipient urn, or exact recipient name',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [
+    { name: 'thread-or-recipient', type: 'string', required: true, positional: true, help: 'Sales Navigator inbox URL/thread id, Sales Navigator lead URL, recipient urn, or exact participant name' },
+    { name: 'limit', type: 'number', default: DEFAULT_MESSAGE_LIMIT, help: 'Maximum messages to return (1-500)' },
+    { name: 'max-pages', type: 'number', default: 30, help: 'Maximum inbox pages to scan when resolving a recipient' },
+  ],
+  columns: ['index', 'thread_id', 'thread_url', 'sender', 'text', 'timestamp', 'subject', 'message_id', 'sender_urn', 'delivered_at', 'type', 'total_message_count'],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin salesnav-thread');
+    const input = normalizeWhitespace(args['thread-or-recipient']);
+    if (!input) throw new ArgumentError('thread-or-recipient is required');
+    const limit = parseLimit(args.limit, DEFAULT_MESSAGE_LIMIT);
+    const maxPages = parseLimit(args['max-pages'], 30);
+    await page.goto(SALES_INBOX_URL);
+    await page.wait(4);
+    const threadId = await resolveThreadId(page, input, { maxPages });
+    const csrf = await getCsrf(page);
+    const thread = await fetchThreadWithPagination(page, csrf, threadId, limit);
+    const messages = parseSalesnavThreadMessages(thread).slice(0, limit);
+    if (messages.length === 0) throw new EmptyResultError('linkedin salesnav-thread', `No messages found for ${threadId}`);
+    return messages.map((message) => ({
+      ...message,
+      thread_url: salesnavThreadUrl(threadId),
+      total_message_count: Number(thread?.totalMessageCount || messages.length),
+    }));
+  },
+});
+
+export const __test__ = {
+  parseThreadInput,
+  threadApiUrl,
+  participantIndex,
+  parseSalesnavThreadMessages,
+  threadMatchesInput,
+  salesnavThreadUrl,
+};

--- a/clis/linkedin/salesnav-thread.test.js
+++ b/clis/linkedin/salesnav-thread.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './salesnav-thread.js';
+
+const {
+  parseThreadInput,
+  threadApiUrl,
+  parseSalesnavThreadMessages,
+  threadMatchesInput,
+  salesnavThreadUrl,
+} = await import('./salesnav-thread.js').then((m) => m.__test__);
+
+describe('linkedin salesnav-thread command', () => {
+  it('accepts Sales Navigator inbox URLs, raw thread ids, lead URLs, urns, and names', () => {
+    expect(parseThreadInput('https://www.linkedin.com/sales/inbox/2-abc%3D%3D')).toEqual(['thread_id', '2-abc==']);
+    expect(parseThreadInput('2-abc==')).toEqual(['thread_id', '2-abc==']);
+    expect(parseThreadInput('https://www.linkedin.com/sales/lead/P1,NAME_SEARCH,T1')).toEqual(['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)']);
+    expect(parseThreadInput('urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)')).toEqual(['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)']);
+    expect(parseThreadInput('Rachael Stolberg')).toEqual(['name', 'rachael stolberg']);
+    expect(() => parseThreadInput('urn:li:fs_salesProfile:(P1,undefined,T1)')).toThrow(ArgumentError);
+  });
+
+  it('builds the decorated thread API URL with encoded parentheses and message pagination size', () => {
+    const url = threadApiUrl('2-thread==', 40);
+    expect(url).toContain('/sales-api/salesApiMessagingThreads/2-thread%3D%3D?');
+    expect(url).toContain('messageCount=40');
+    expect(url).toContain('count=1');
+    expect(url).toContain('decoration=%28');
+    expect(url).not.toContain('decoration=(');
+  });
+
+  it('parses thread messages in chronological order with sender names and timestamps', () => {
+    const rows = parseSalesnavThreadMessages({
+      id: '2-thread',
+      participants: [
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)',
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)',
+      ],
+      participantsResolutionResults: {
+        'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)': { fullName: 'Rachael Stolberg', entityUrn: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)' },
+        'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)': { fullName: 'Hanzi Li', entityUrn: 'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)' },
+      },
+      messages: [
+        { id: 'm2', author: 'urn:li:fs_salesProfile:(OTHER,NAME_SEARCH,T1)', body: 'Happy to chat', deliveredAt: 1778206803669, type: 'MEMBER_TO_MEMBER' },
+        { id: 'm1', author: 'urn:li:fs_salesProfile:(SELF,NAME_SEARCH,T2)', subject: 'Quick question', body: 'Hi Rachael', deliveredAt: 1777188013523, type: 'INMAIL' },
+      ],
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      index: 0,
+      message_id: 'm1',
+      thread_id: '2-thread',
+      sender: 'Hanzi Li',
+      subject: 'Quick question',
+      text: 'Hi Rachael',
+      timestamp: '2026-04-26T07:20:13.523Z',
+    });
+    expect(rows[1]).toMatchObject({ index: 1, message_id: 'm2', sender: 'Rachael Stolberg', text: 'Happy to chat' });
+  });
+
+  it('fails typed on malformed thread message payloads', () => {
+    expect(() => parseSalesnavThreadMessages({ messages: [] })).toThrow(CommandExecutionError);
+    expect(() => parseSalesnavThreadMessages({ id: '2-thread' })).toThrow(CommandExecutionError);
+    expect(() => parseSalesnavThreadMessages({ id: '2-thread', messages: [null] })).toThrow(CommandExecutionError);
+  });
+
+  it('matches recipient identifiers against inbox rows', () => {
+    const row = {
+      thread_id: '2-thread',
+      person_name: 'Rachael Stolberg',
+      participants: [{ name: 'Rachael Stolberg', entity_urn: 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)' }],
+    };
+    expect(threadMatchesInput(row, ['thread_id', '2-thread'])).toBe(true);
+    expect(threadMatchesInput(row, ['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)'])).toBe(true);
+    expect(threadMatchesInput(row, ['name', 'rachael stolberg'])).toBe(true);
+    expect(salesnavThreadUrl('2-thread')).toBe('https://www.linkedin.com/sales/inbox/2-thread');
+  });
+});

--- a/clis/linkedin/salesnav-thread.test.js
+++ b/clis/linkedin/salesnav-thread.test.js
@@ -18,6 +18,7 @@ describe('linkedin salesnav-thread command', () => {
     expect(parseThreadInput('urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)')).toEqual(['recipient_urn', 'urn:li:fs_salesProfile:(P1,NAME_SEARCH,T1)']);
     expect(parseThreadInput('Rachael Stolberg')).toEqual(['name', 'rachael stolberg']);
     expect(() => parseThreadInput('urn:li:fs_salesProfile:(P1,undefined,T1)')).toThrow(ArgumentError);
+    expect(() => parseThreadInput('https://www.linkedin.com/sales/lead/P1,undefined,T1')).toThrow(ArgumentError);
   });
 
   it('builds the decorated thread API URL with encoded parentheses and message pagination size', () => {

--- a/clis/linkedin/sent-invitations.js
+++ b/clis/linkedin/sent-invitations.js
@@ -1,0 +1,92 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const LINKEDIN_DOMAIN = 'www.linkedin.com';
+const SENT_URL = 'https://www.linkedin.com/mynetwork/invitation-manager/sent/';
+
+function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+function buildSentInvitationsScript() {
+  return String.raw`(() => {
+    const clean = (s) => String(s || '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
+    const text = document.body ? (document.body.innerText || '') : '';
+    const href = location.href;
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
+      || /linkedin\.com\/(login|checkpoint|authwall|uas)/i.test(href);
+    const warning = /captcha|verification required|unusual activity|account restricted|temporarily restricted|security check|checkpoint/i.test(text);
+    const cleanName = (value) => {
+      const first = String(value || '').split(/\n+/).map(clean).filter(Boolean)[0] || '';
+      return clean(first
+        .replace(/^(view\s+)?profile\s+of\s+/i, '')
+        .replace(/\s*(?:View profile|LinkedIn|Pending|Sent|Withdraw).*$/i, ''));
+    };
+    const cards = Array.from(document.querySelectorAll('li, div, section, article')).filter((el) => {
+      if (!el || el.offsetParent === null) return false;
+      const t = clean(el.innerText || el.textContent || '');
+      return t && /withdraw/i.test(t) && t.length < 1200;
+    });
+    const byName = new Map();
+    for (const card of cards) {
+      const raw = card.innerText || card.textContent || '';
+      if (!/withdraw/i.test(raw)) continue;
+      const lines = raw.split(/\n+/).map(clean).filter(Boolean);
+      const link = card.querySelector('a[href*="/in/"]');
+      const linkName = cleanName(link ? (link.innerText || link.textContent || link.getAttribute('aria-label') || '') : '');
+      const name = linkName
+        || cleanName(lines.find((line) => !/^(pending|sent|withdraw|message|view profile|invitation|invited|ago|manage|received)\b/i.test(line)) || '');
+      if (!name) continue;
+      const hrefAttr = link ? (link.getAttribute('href') || '') : '';
+      const profile_url = hrefAttr ? new URL(hrefAttr, location.origin).toString().replace(/[?#].*$/, '') : '';
+      const invited_date_text = clean((raw.match(/(?:Sent|Invited)\s+(?:\d+\s+\w+\s+ago|yesterday|today)/i) || [''])[0]);
+      const key = name.toLowerCase();
+      const existing = byName.get(key);
+      if (!existing) {
+        byName.set(key, { name, profile_url, invited_date_text });
+      } else {
+        if (!existing.profile_url && profile_url) existing.profile_url = profile_url;
+        if (!existing.invited_date_text && invited_date_text) existing.invited_date_text = invited_date_text;
+      }
+    }
+    const rows = Array.from(byName.values());
+    return { url: href, title: document.title || '', authRequired, warning, count: rows.length, rows, bodyText: text.slice(0, 1000) };
+  })()`;
+}
+
+cli({
+  site: 'linkedin',
+  name: 'sent-invitations',
+  access: 'read',
+  description: 'List pending LinkedIn sent invitations for CRM reconciliation',
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  args: [],
+  columns: ['rank', 'name', 'profile_url', 'invited_date_text'],
+  func: async (page) => {
+    if (!page) throw new CommandExecutionError('Browser session required for linkedin sent-invitations');
+    await page.goto(SENT_URL);
+    await page.wait(12);
+    let result = unwrapEvaluateResult(await page.evaluate(buildSentInvitationsScript()));
+    if (result?.authRequired) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn sent invitations requires an active signed-in browser session.');
+    }
+    if (result?.warning) {
+      throw new CommandExecutionError('LinkedIn warning/restriction state visible on sent invitations page.');
+    }
+    const rows = Array.isArray(result?.rows) ? result.rows : [];
+    return rows.map((row, index) => ({
+      rank: index + 1,
+      name: row.name || '',
+      profile_url: row.profile_url || '',
+      invited_date_text: row.invited_date_text || '',
+    }));
+  },
+});
+
+export const __test__ = {
+  buildSentInvitationsScript,
+  unwrapEvaluateResult,
+};

--- a/clis/linkedin/sent-invitations.test.js
+++ b/clis/linkedin/sent-invitations.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './sent-invitations.js';
+
+const { buildSentInvitationsScript } = await import('./sent-invitations.js').then((m) => m.__test__);
+
+describe('linkedin sent-invitations command', () => {
+  it('registers with structured columns that do not include raw blobs', () => {
+    const command = getRegistry().get('linkedin/sent-invitations');
+    expect(command).toBeDefined();
+    expect(command.access).toBe('read');
+    expect(command.columns).toEqual(['rank', 'name', 'profile_url', 'invited_date_text']);
+  });
+
+  it('extracts clean names and dedupes invitation cards by profile url', () => {
+    const dom = new JSDOM(`<!doctype html><body>
+      <ul>
+        <li>
+          <a href="/in/olga-magere/?miniProfileUrn=x"><span>Olga Magere</span></a>
+          <span>Pending</span><button>Withdraw</button><span>Sent 2 weeks ago</span>
+        </li>
+        <li>
+          <a href="/in/olga-magere/?trk=dup"><span>Olga Magere</span></a>
+          <span>Pending</span><button>Withdraw</button><span>Sent 2 weeks ago</span>
+        </li>
+        <li>
+          <div>Sam Founder\nSent yesterday\nWithdraw</div>
+        </li>
+      </ul>
+    </body>`, { url: 'https://www.linkedin.com/mynetwork/invitation-manager/sent/' });
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    const previousLocation = globalThis.location;
+    try {
+      globalThis.window = dom.window;
+      globalThis.document = dom.window.document;
+      globalThis.location = dom.window.location;
+      globalThis.getComputedStyle = dom.window.getComputedStyle;
+      Object.defineProperty(dom.window.HTMLElement.prototype, 'offsetParent', { get() { return dom.window.document.body; }, configurable: true });
+      const run = Function(`return ${buildSentInvitationsScript()}`);
+      const result = run();
+      expect(result.rows).toEqual([
+        {
+          name: 'Olga Magere',
+          profile_url: 'https://www.linkedin.com/in/olga-magere/',
+          invited_date_text: 'Sent 2 weeks ago',
+        },
+        {
+          name: 'Sam Founder',
+          profile_url: '',
+          invited_date_text: 'Sent yesterday',
+        },
+      ]);
+      expect(result.rows[0]).not.toHaveProperty('raw');
+    } finally {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+      globalThis.location = previousLocation;
+    }
+  });
+});

--- a/docs/adapters/browser/linkedin.md
+++ b/docs/adapters/browser/linkedin.md
@@ -9,7 +9,12 @@
 | `opencli linkedin connect` | Send a fail-closed connection request after verifying the exact profile |
 | `opencli linkedin inbox` | List LinkedIn messaging inbox conversations and unread status |
 | `opencli linkedin safe-send` | Verify exact recipient/thread context before optionally sending a message |
+| `opencli linkedin salesnav-inbox` | List Sales Navigator message conversations with API pagination |
+| `opencli linkedin salesnav-message` | Validate or send a Sales Navigator InMail to an exact lead |
+| `opencli linkedin salesnav-search` | Search Sales Navigator people leads by keyword |
+| `opencli linkedin salesnav-thread` | Return Sales Navigator message history for a thread or lead |
 | `opencli linkedin search` | Search LinkedIn jobs (Voyager API), with optional `--details` enrichment |
+| `opencli linkedin sent-invitations` | List pending sent LinkedIn invitations |
 | `opencli linkedin thread-snapshot` | Load a LinkedIn messaging thread and return available context |
 | `opencli linkedin timeline` | Read posts from your LinkedIn home feed |
 
@@ -37,6 +42,17 @@ opencli linkedin connect https://www.linkedin.com/in/example/ --expected-name "J
 # Snapshot a thread, then safe-send only if exact recipient/thread context still matches
 opencli linkedin thread-snapshot --thread-url https://www.linkedin.com/messaging/thread/abc/ -f json
 opencli linkedin safe-send --thread-url https://www.linkedin.com/messaging/thread/abc/ --expected-name "Jane Doe" --message "thanks" --send
+
+# Search Sales Navigator leads and inspect Sales Navigator messages
+opencli linkedin salesnav-search "quality manager food manufacturing" --limit 10 -f json
+opencli linkedin salesnav-inbox --limit 20 -f json
+opencli linkedin salesnav-thread "https://www.linkedin.com/sales/inbox/2-thread" -f json
+
+# Dry-run a Sales Navigator InMail; add --send only after validating the row
+opencli linkedin salesnav-message "urn:li:fs_salesProfile:(PROFILE,NAME_SEARCH,TOKEN)" --subject "Quick question" --body "Hello"
+
+# Reconcile pending sent invitations
+opencli linkedin sent-invitations -f json
 
 # JSON output
 opencli linkedin search -f json
@@ -68,6 +84,16 @@ Previously the adapter returned `description: '', apply_url: ''` for both the mi
 `connect` and `safe-send` are write commands but dry-run by default. They only click LinkedIn write actions when `--send` is explicitly passed. `connect` requires an exact `https://www.linkedin.com/in/<profile>/` URL and verifies the landed profile plus visible name before sending. `safe-send` requires an exact `https://www.linkedin.com/messaging/thread/<id>/` URL and verifies the landed thread, visible recipient name, composer presence, and optional latest-message guard before filling or sending.
 
 `thread-snapshot` opens an exact messaging thread URL, validates `--max-scrolls` before navigation, scrolls for available history, and returns a JSON snapshot suitable for caller-side recipient safety checks.
+
+### Sales Navigator commands
+
+`salesnav-search` uses the Sales Navigator lead search API and returns `rank`, `name`, `title`, `company`, `location`, `degree`, `profile_url`, `lead_url`, and `recipient_urn`. Missing lead identity or malformed API payloads fail typed instead of emitting unaddressable rows.
+
+`salesnav-inbox` and `salesnav-thread` use Sales Navigator messaging APIs rather than virtualized DOM rows. They require a signed-in LinkedIn session with Sales Navigator access; auth/API failures and malformed thread payloads fail typed, while a valid empty inbox/thread is reported as an empty result.
+
+`salesnav-message` is a write command but dry-run by default. It resolves the recipient to a Sales Navigator lead identity, checks profile/credit state, and only sends when `--send` is explicitly passed. Post-send verification checks the Sales Navigator lead page for sent activity.
+
+`sent-invitations` reads the pending invitations page for CRM reconciliation and returns `rank`, `name`, `profile_url`, and `invited_date_text`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Consolidates the LinkedIn messaging command set into one canonical branch.
- Adds/restores: connect, inbox, safe-send, search, sent-invitations, thread-snapshot, timeline, salesnav-search, salesnav-message, salesnav-inbox, and salesnav-thread.
- Improves linkedin/connect sent-invitation verification with retrying and more tolerant name matching.
- Restores standalone linkedin/sent-invitations with adapter tests and manifest entry.

Supersedes #1632, #1640, and #1641.

## Test plan
- npm run build
- npm run typecheck
- npm run test:adapter
- npm run check:silent-column-drop
- npm run check:typed-error-lint
- npm test