### PR TITLE
feat(weread-official): integrate WeRead official Agent Gateway as new CLI namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* **weread-official** — integrate WeRead's official Agent Gateway as the `weread-official` CLI namespace. Pure HTTP, Bearer auth via `WEREAD_API_KEY` (no browser, no cookies). 8 commands cover the official skill bundle: `search`, `shelf`, `book` (info + chapters + progress 3-in-1), `notes` (notebook overview or per-book highlights/thoughts), `review`, `readdata` (weekly/monthly/annually/overall), `discover` (recommend or similar-book), `list-apis`. Adapter surfaces typed errors for all documented failure modes — `AuthRequiredError` on missing/rejected key (errcodes -2010/-2012), `CommandExecutionError` on HTTP/`upgrade_info`/non-zero errcode, `EmptyResultError` on empty payloads. Coexists with the existing cookie-based `weread` adapter.
+
 ### Bug Fixes
 
 * **adapters** — surface the remaining `silent-empty-fallback` adapter failures as typed errors. Douyin user video comment fetch failures, Jike SSR JSON parse failures, and WeRead search-page fetch failures now throw `CommandExecutionError`; true empty Douyin/Jike/WeRead result sets now throw `EmptyResultError`.

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -25455,6 +25455,379 @@
     "navigateBefore": "https://weread.qq.com"
   },
   {
+    "site": "weread-official",
+    "name": "book",
+    "description": "Show WeRead book metadata, chapters, and reading progress",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "bookId",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "WeRead bookId (from `weread-official search`)"
+      },
+      {
+        "name": "no-chapters",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Skip /book/chapterinfo call"
+      },
+      {
+        "name": "no-progress",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Skip /book/getprogress call"
+      }
+    ],
+    "columns": [
+      "section",
+      "idx",
+      "key",
+      "value",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/book.js",
+    "sourceFile": "weread-official/book.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "discover",
+    "description": "Personalized or similar-book recommendations from WeRead",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "bookId",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Anchor bookId for similar-book mode; omit for personalized recommendations"
+      },
+      {
+        "name": "count",
+        "type": "int",
+        "default": 12,
+        "required": false,
+        "help": "Page size (default 12)"
+      },
+      {
+        "name": "max-idx",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Pagination cursor (recommend: previous searchIdx; similar: previous idx)"
+      },
+      {
+        "name": "session-id",
+        "type": "str",
+        "required": false,
+        "help": "Carry-forward sessionId for /book/similar paging"
+      }
+    ],
+    "columns": [
+      "rank",
+      "mode",
+      "bookId",
+      "title",
+      "author",
+      "rating",
+      "readingCount",
+      "category",
+      "idx",
+      "reason",
+      "cover",
+      "intro",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/discover.js",
+    "sourceFile": "weread-official/discover.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "list-apis",
+    "description": "List every api_name supported by the WeRead agent gateway",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [],
+    "columns": [
+      "rank",
+      "apiName",
+      "description",
+      "required",
+      "optional",
+      "extras"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/list-apis.js",
+    "sourceFile": "weread-official/list-apis.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "notes",
+    "description": "List notebooks overview or merged highlights+thoughts for a book",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "bookId",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Limit to one book; omit for full notebook overview"
+      },
+      {
+        "name": "count",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Page size for the notebooks overview (1-100)"
+      },
+      {
+        "name": "last-sort",
+        "type": "int",
+        "required": false,
+        "help": "Cursor: pass previous page sort value to fetch the next page (/user/notebooks)"
+      }
+    ],
+    "columns": [
+      "kind",
+      "bookId",
+      "title",
+      "author",
+      "chapter",
+      "reviewCount",
+      "noteCount",
+      "bookmarkCount",
+      "totalNotes",
+      "progress",
+      "finished",
+      "sort",
+      "range",
+      "text",
+      "thought",
+      "star",
+      "createTime",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/notes.js",
+    "sourceFile": "weread-official/notes.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "readdata",
+    "description": "Reading statistics: time, streak, preferences, top books",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "mode",
+        "type": "str",
+        "default": "monthly",
+        "required": false,
+        "help": "Stat window: weekly / monthly / annually / overall",
+        "choices": [
+          "weekly",
+          "monthly",
+          "annually",
+          "overall"
+        ]
+      },
+      {
+        "name": "base-time",
+        "type": "int",
+        "required": false,
+        "help": "Optional Unix timestamp inside the target period; default is current period"
+      }
+    ],
+    "columns": [
+      "section",
+      "idx",
+      "key",
+      "value",
+      "detail"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/readdata.js",
+    "sourceFile": "weread-official/readdata.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "review",
+    "description": "Browse public reviews of a WeRead book",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "bookId",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "WeRead bookId (from `weread-official search`)"
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "default": "all",
+        "required": false,
+        "help": "Review filter (all/recommend/thumbs-down/newest/neutral)",
+        "choices": [
+          "all",
+          "recommend",
+          "thumbs-down",
+          "newest",
+          "neutral"
+        ]
+      },
+      {
+        "name": "count",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Page size (1-100, default 20)"
+      },
+      {
+        "name": "max-idx",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Pagination cursor — pass idx from last row of previous page"
+      },
+      {
+        "name": "synckey",
+        "type": "int",
+        "required": false,
+        "help": "Sync cursor returned by previous response"
+      }
+    ],
+    "columns": [
+      "rank",
+      "idx",
+      "reviewId",
+      "star",
+      "starLabel",
+      "author",
+      "isFinish",
+      "chapter",
+      "content",
+      "createTime",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/review.js",
+    "sourceFile": "weread-official/review.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "search",
+    "description": "Search WeRead store via the official agent gateway",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword"
+      },
+      {
+        "name": "scope",
+        "type": "str",
+        "default": "ebook",
+        "required": false,
+        "help": "Search type (all/ebook/webnovel/audio/author/fulltext/booklist/mp/article)",
+        "choices": [
+          "all",
+          "ebook",
+          "webnovel",
+          "audio",
+          "author",
+          "fulltext",
+          "booklist",
+          "mp",
+          "article"
+        ]
+      },
+      {
+        "name": "count",
+        "type": "int",
+        "required": false,
+        "help": "Page size (gateway default 15 when omitted)"
+      },
+      {
+        "name": "max-idx",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Pagination offset, use searchIdx of last item from previous page"
+      }
+    ],
+    "columns": [
+      "rank",
+      "scope",
+      "bookId",
+      "title",
+      "author",
+      "rating",
+      "readingCount",
+      "category",
+      "searchIdx",
+      "cover",
+      "intro",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/search.js",
+    "sourceFile": "weread-official/search.js"
+  },
+  {
+    "site": "weread-official",
+    "name": "shelf",
+    "description": "Sync your WeRead shelf (books + albums + article bookmark entry) via the official gateway",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [],
+    "columns": [
+      "kind",
+      "id",
+      "title",
+      "author",
+      "category",
+      "secret",
+      "isTop",
+      "finished",
+      "updateTime",
+      "cover",
+      "link"
+    ],
+    "type": "js",
+    "modulePath": "weread-official/shelf.js",
+    "sourceFile": "weread-official/shelf.js"
+  },
+  {
     "site": "wikidata",
     "name": "entity",
     "description": "Fetch a Wikidata entity by Q/P/L id (label, description, aliases, claim summary)",

--- a/clis/weread-official/book.js
+++ b/clis/weread-official/book.js
@@ -1,0 +1,135 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    callGateway,
+    emptyResult,
+    formatDate,
+    formatDuration,
+    formatRating,
+    makeDeepLink,
+    requireBookId,
+    truncate,
+} from './utils.js';
+
+/**
+ * 3-in-1 book lookup: `/book/info` always runs; `/book/chapterinfo` and
+ * `/book/getprogress` are opt-out via `--no-chapters` / `--no-progress`
+ * so users can shave 1-2 gateway calls when only a single section is needed.
+ *
+ * Output is a flat row list with a `section` column so table/json/yaml
+ * consumers can filter without ad-hoc joins:
+ *   - section=info       — single row, basic metadata
+ *   - section=chapter    — one row per chapter (level/title/wordCount)
+ *   - section=progress   — single row, progress % + cumulative read time
+ */
+cli({
+    site: 'weread-official',
+    name: 'book',
+    access: 'read',
+    description: 'Show WeRead book metadata, chapters, and reading progress',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'bookId', positional: true, required: true, help: 'WeRead bookId (from `weread-official search`)' },
+        { name: 'no-chapters', type: 'boolean', default: false, help: 'Skip /book/chapterinfo call' },
+        { name: 'no-progress', type: 'boolean', default: false, help: 'Skip /book/getprogress call' },
+    ],
+    columns: ['section', 'idx', 'key', 'value', 'link'],
+    func: async (args) => {
+        const bookId = requireBookId(args.bookId);
+
+        const tasks = [callGateway('/book/info', { bookId })];
+        const want = {
+            chapters: !args['no-chapters'],
+            progress: !args['no-progress'],
+        };
+        if (want.chapters) tasks.push(callGateway('/book/chapterinfo', { bookId }));
+        if (want.progress) tasks.push(callGateway('/book/getprogress', { bookId }));
+
+        const results = await Promise.all(tasks);
+        let cursor = 0;
+        const info = results[cursor++];
+        const chapters = want.chapters ? results[cursor++] : null;
+        const progress = want.progress ? results[cursor++] : null;
+
+        const rows = [];
+
+        // ── info section ────────────────────────────────────────────────────
+        const infoPairs = [
+            ['bookId', String(info?.bookId ?? bookId)],
+            ['title', String(info?.title ?? '')],
+            ['author', String(info?.author ?? '')],
+            ['translator', String(info?.translator ?? '')],
+            ['category', String(info?.category ?? '')],
+            ['publisher', String(info?.publisher ?? '')],
+            ['publishTime', String(info?.publishTime ?? '')],
+            ['isbn', String(info?.isbn ?? '')],
+            ['wordCount', String(info?.wordCount ?? '')],
+            ['rating', formatRating(info?.newRating)],
+            ['ratingCount', String(info?.newRatingCount ?? '')],
+            ['intro', truncate(info?.intro, 400)],
+            ['cover', String(info?.cover ?? '')],
+        ];
+        for (let i = 0; i < infoPairs.length; i += 1) {
+            const [key, value] = infoPairs[i];
+            rows.push({ section: 'info', idx: i + 1, key, value, link: '' });
+        }
+        rows.push({
+            section: 'info',
+            idx: infoPairs.length + 1,
+            key: 'link',
+            value: '',
+            link: makeDeepLink({ bookId }),
+        });
+
+        // ── chapters section ────────────────────────────────────────────────
+        if (chapters) {
+            const list = Array.isArray(chapters?.chapters) ? chapters.chapters : [];
+            list.forEach((ch, i) => {
+                const chapterUid = String(ch?.chapterUid ?? '').trim();
+                const level = Number(ch?.level ?? 1);
+                const indent = '  '.repeat(Math.max(0, level - 1));
+                const title = `${indent}${String(ch?.title ?? '')}`;
+                const wordCount = Number(ch?.wordCount ?? 0);
+                const paid = Number(ch?.paid ?? 0) === 1;
+                const price = Number(ch?.price ?? 0);
+                const meta = [`${wordCount}字`];
+                if (price > 0) meta.push(paid ? '已购买' : `${price}元`);
+                rows.push({
+                    section: 'chapter',
+                    idx: Number(ch?.chapterIdx ?? i + 1),
+                    key: chapterUid,
+                    value: `${title}  (${meta.join(' · ')})`,
+                    link: chapterUid ? makeDeepLink({ bookId, chapterUid }) : '',
+                });
+            });
+        }
+
+        // ── progress section ────────────────────────────────────────────────
+        if (progress) {
+            const p = progress?.book ?? {};
+            const pct = Number(p?.progress ?? 0);
+            const updateTime = formatDate(p?.updateTime);
+            const finishTime = pct === 100 ? formatDate(p?.finishTime) : '';
+            const cumulative = formatDuration(p?.recordReadingTime);
+            const isStart = Number(p?.isStartReading ?? 0) === 1;
+            const progressPairs = [
+                ['progress', `${pct}%`],
+                ['cumulative', cumulative],
+                ['lastReadAt', updateTime],
+                ['finishedAt', finishTime],
+                ['isStartReading', isStart ? 'true' : 'false'],
+                ['currentChapterUid', String(p?.chapterUid ?? '')],
+            ];
+            for (let i = 0; i < progressPairs.length; i += 1) {
+                const [key, value] = progressPairs[i];
+                rows.push({ section: 'progress', idx: i + 1, key, value, link: '' });
+            }
+        }
+
+        if (rows.length === 0) {
+            emptyResult('book', `No data returned for bookId=${bookId}`);
+        }
+        return rows;
+    },
+});

--- a/clis/weread-official/commands.test.js
+++ b/clis/weread-official/commands.test.js
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+
+import './search.js';
+import './shelf.js';
+import './book.js';
+import './notes.js';
+import './review.js';
+import './readdata.js';
+import './discover.js';
+import './list-apis.js';
+
+function jsonResponse(body, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        json: vi.fn().mockResolvedValue(body),
+        text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+    };
+}
+
+function stubGateway(...payloads) {
+    const mock = vi.fn();
+    for (const payload of payloads) {
+        mock.mockResolvedValueOnce(jsonResponse(payload));
+    }
+    vi.stubGlobal('fetch', mock);
+    return mock;
+}
+
+beforeEach(() => {
+    vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+});
+
+describe('weread-official command registration', () => {
+    it('registers eight read-only public commands without browser dependency', () => {
+        const registry = getRegistry();
+        const expected = ['search', 'shelf', 'book', 'notes', 'review', 'readdata', 'discover', 'list-apis'];
+        for (const name of expected) {
+            const command = registry.get(`weread-official/${name}`);
+            expect(command, `weread-official/${name}`).toBeDefined();
+            expect(command.access).toBe('read');
+            expect(command.strategy).toBe('public');
+            expect(command.browser).toBe(false);
+            expect(command.domain).toBe('weread.qq.com');
+        }
+    });
+});
+
+describe('weread-official search', () => {
+    const search = () => getRegistry().get('weread-official/search').func;
+
+    it('maps scope alias, flattens params, surfaces rating + searchIdx', async () => {
+        const mock = stubGateway({
+            errcode: 0,
+            results: [{
+                title: '电子书', scope: 10, scopeCount: 2, books: [
+                    {
+                        searchIdx: 1, readingCount: 1000, newRating: 950,
+                        bookInfo: { bookId: 'b1', title: '三体', author: '刘慈欣', category: '科幻', cover: 'cover1', intro: '...' },
+                    },
+                    {
+                        searchIdx: 2, readingCount: 200, newRating: 0,
+                        bookInfo: { bookId: 'b2', title: '三体II', author: '刘慈欣' },
+                    },
+                ],
+            }],
+        });
+        const rows = await search()({ keyword: '三体', scope: 'ebook' });
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({ rank: 1, scope: '电子书', bookId: 'b1', title: '三体', searchIdx: 1, readingCount: 1000 });
+        expect(rows[0].rating).toMatch(/神作/);
+        expect(rows[0].link).toBe('weread://reading?bId=b1');
+        expect(rows[1].rating).toBe('暂无');
+        // verify the request body
+        const [, init] = mock.mock.calls[0];
+        const body = JSON.parse(init.body);
+        expect(body.scope).toBe(10);
+        expect(body.keyword).toBe('三体');
+        expect(body.skill_version).toBeDefined();
+    });
+
+    it('rejects empty keyword and unknown scope before fetch', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const fn = search();
+        await expect(fn({ keyword: ' ' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(fn({ keyword: '三体', scope: 'movie' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws EmptyResultError when the gateway returns no groups', async () => {
+        stubGateway({ errcode: 0, results: [] });
+        await expect(search()({ keyword: '三体' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('weread-official shelf', () => {
+    const shelf = () => getRegistry().get('weread-official/shelf').func;
+
+    it('returns books + albums + mp entry in a single flat list', async () => {
+        stubGateway({
+            errcode: 0,
+            books: [
+                { bookId: 'b1', title: '三体', author: '刘慈欣', category: '科幻', isTop: 1, secret: 0, finishReading: 1, readUpdateTime: 1748563200, cover: 'c1' },
+            ],
+            albums: [
+                {
+                    albumInfo: { albumId: 'a1', name: '红楼梦广播剧', authorName: '播主', finish: 1, cover: 'cover-a', updateTime: 1700000000 },
+                    albumInfoExtra: { secret: 1, isTop: 0, lectureReadUpdateTime: 1748000000 },
+                },
+            ],
+            mp: { entry: 'present' },
+        });
+        const rows = await shelf()({});
+        expect(rows).toHaveLength(3);
+        expect(rows[0]).toMatchObject({ kind: 'book', id: 'b1', isTop: true, finished: true, secret: false });
+        expect(rows[0].link).toBe('weread://reading?bId=b1');
+        expect(rows[1]).toMatchObject({ kind: 'album', id: 'a1', title: '红楼梦广播剧', author: '播主', secret: true, finished: true });
+        expect(rows[2]).toMatchObject({ kind: 'mp', title: '文章收藏', secret: true });
+    });
+
+    it('omits mp row when mp is empty / absent', async () => {
+        stubGateway({ errcode: 0, books: [{ bookId: 'b1', title: 't' }], albums: [], mp: {} });
+        const rows = await shelf()({});
+        expect(rows.map((r) => r.kind)).toEqual(['book']);
+    });
+
+    it('throws EmptyResultError on a fully empty shelf', async () => {
+        stubGateway({ errcode: 0, books: [], albums: [] });
+        await expect(shelf()({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('weread-official book', () => {
+    const book = () => getRegistry().get('weread-official/book').func;
+
+    it('runs all three calls by default and groups output into sections', async () => {
+        const fetchMock = stubGateway(
+            { errcode: 0, bookId: 'b1', title: '三体', author: '刘慈欣', newRating: 920, intro: 'intro', cover: 'cov' },
+            { errcode: 0, chapters: [{ chapterUid: 107, chapterIdx: 1, title: 'Ch1', wordCount: 1234, level: 1, paid: 1, price: 0 }] },
+            { errcode: 0, book: { chapterUid: 107, progress: 45, recordReadingTime: 3660, updateTime: 1748563200, isStartReading: 1 } },
+        );
+        const rows = await book()({ bookId: 'b1' });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(rows.find((r) => r.section === 'info' && r.key === 'title').value).toBe('三体');
+        expect(rows.find((r) => r.section === 'info' && r.key === 'rating').value).toMatch(/神作/);
+        const chapterRow = rows.find((r) => r.section === 'chapter');
+        expect(chapterRow).toMatchObject({ key: '107' });
+        expect(chapterRow.link).toBe('weread://reading?bId=b1&chapterUid=107');
+        const progressRow = rows.find((r) => r.section === 'progress' && r.key === 'progress');
+        expect(progressRow.value).toBe('45%');
+        const cumulative = rows.find((r) => r.section === 'progress' && r.key === 'cumulative');
+        expect(cumulative.value).toBe('1小时1分钟');
+    });
+
+    it('skips /book/chapterinfo when --no-chapters and /book/getprogress when --no-progress', async () => {
+        const fetchMock = stubGateway(
+            { errcode: 0, bookId: 'b1', title: '三体' },
+        );
+        await book()({ bookId: 'b1', 'no-chapters': true, 'no-progress': true });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects empty bookId before fetch', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(book()({ bookId: '' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('weread-official notes', () => {
+    const notes = () => getRegistry().get('weread-official/notes').func;
+
+    it('returns a notebooks overview with totalNotes = review + note + bookmark counts', async () => {
+        stubGateway({
+            errcode: 0,
+            totalBookCount: 1,
+            books: [{
+                bookId: 'b1',
+                book: { title: '三体', author: '刘慈欣' },
+                reviewCount: 3, noteCount: 12, bookmarkCount: 4,
+                readingProgress: 45, markedStatus: 0, sort: 1778312777,
+            }],
+            hasMore: 0,
+        });
+        const rows = await notes()({});
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ kind: 'notebook', bookId: 'b1', totalNotes: 19, reviewCount: 3, noteCount: 12, bookmarkCount: 4 });
+    });
+
+    it('merges /book/bookmarklist + /review/list/mine when bookId is provided', async () => {
+        stubGateway(
+            {
+                errcode: 0,
+                chapters: [{ chapterUid: 107, title: '第一章' }],
+                updated: [{ bookmarkId: 'bm1', chapterUid: 107, markText: 'highlighted text', range: '900-2004', createTime: 1748563200 }],
+            },
+            {
+                errcode: 0,
+                reviews: [{ review: { reviewId: 'rv1', content: 'great chapter', chapterUid: 107, star: 100, isFinish: 0, createTime: 1748563200, chapterName: '第一章' } }],
+            },
+        );
+        const rows = await notes()({ bookId: 'b1' });
+        const highlight = rows.find((r) => r.kind === 'highlight');
+        const thought = rows.find((r) => r.kind === 'thought');
+        expect(highlight).toBeDefined();
+        expect(thought).toBeDefined();
+        expect(highlight.chapter).toBe('第一章');
+        expect(highlight.range).toBe('900-2004');
+        expect(highlight.link).toBe('weread://bestbookmark?bookId=b1&chapterUid=107&rangeStart=900&rangeEnd=2004');
+        expect(thought.thought).toBe('great chapter');
+    });
+
+    it('throws EmptyResultError when both bookmarks and reviews are empty for a book', async () => {
+        stubGateway(
+            { errcode: 0, chapters: [], updated: [] },
+            { errcode: 0, reviews: [] },
+        );
+        await expect(notes()({ bookId: 'b1' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('weread-official review', () => {
+    const review = () => getRegistry().get('weread-official/review').func;
+
+    it('maps the type alias to reviewListType and shapes nested reviews', async () => {
+        const mock = stubGateway({
+            errcode: 0,
+            reviewsCnt: 1,
+            reviews: [{
+                idx: 7,
+                review: {
+                    reviewId: 'rv1',
+                    review: {
+                        reviewId: 'rv1',
+                        content: 'amazing',
+                        star: 100,
+                        isFinish: 1,
+                        chapterName: '终章',
+                        createTime: 1748563200,
+                        author: { name: 'Alice' },
+                    },
+                },
+            }],
+        });
+        const rows = await review()({ bookId: 'b1', type: 'recommend' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ reviewId: 'rv1', author: 'Alice', isFinish: true, chapter: '终章' });
+        expect(rows[0].starLabel).toBe('⭐⭐⭐⭐⭐');
+        const body = JSON.parse(mock.mock.calls[0][1].body);
+        expect(body.reviewListType).toBe(1);
+    });
+
+    it('rejects invalid type alias', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(review()({ bookId: 'b1', type: 'bogus' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('weread-official readdata', () => {
+    const readdata = () => getRegistry().get('weread-official/readdata').func;
+
+    it('produces summary + longest + readStat + preferCategory rows', async () => {
+        stubGateway({
+            errcode: 0,
+            baseTime: 1748563200,
+            readDays: 22,
+            totalReadTime: 7320,
+            dayAverageReadTime: 1200,
+            compare: 0.2,
+            readLongest: [{ book: { title: '三体', author: '刘慈欣' }, readTime: 3600, tags: ['笔记最多'] }],
+            readStat: [{ stat: '读过', counts: '12本' }, { stat: '笔记', counts: '120条' }],
+            preferCategory: [{ categoryTitle: '科幻', readingTime: 7200, readingCount: 3 }],
+            preferAuthor: [{ name: '刘慈欣', readTime: '5小时30分钟', count: 4 }],
+        });
+        const rows = await readdata()({ mode: 'weekly' });
+        const summaryTotal = rows.find((r) => r.section === 'summary' && r.key === 'totalReadTime');
+        expect(summaryTotal.value).toBe('2小时2分钟');
+        expect(summaryTotal.detail).toBe('7320s');
+        const compare = rows.find((r) => r.section === 'summary' && r.key === 'compareToPrev');
+        expect(compare.value).toBe('20.0%');
+        expect(rows.some((r) => r.section === 'longest' && r.key === '三体')).toBe(true);
+        expect(rows.some((r) => r.section === 'readStat' && r.key === '读过')).toBe(true);
+        expect(rows.some((r) => r.section === 'preferCategory' && r.key === '科幻')).toBe(true);
+        expect(rows.some((r) => r.section === 'preferAuthor' && r.key === '刘慈欣')).toBe(true);
+    });
+
+    it('rejects unknown mode before fetch', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(readdata()({ mode: 'fortnight' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('weread-official discover', () => {
+    const discover = () => getRegistry().get('weread-official/discover').func;
+
+    it('calls /book/recommend when no bookId provided', async () => {
+        const mock = stubGateway({
+            errcode: 0,
+            books: [{ bookId: 'b1', title: '三体', author: '刘慈欣', newRating: 920, searchIdx: 1, reason: '科幻经典' }],
+        });
+        const rows = await discover()({});
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ mode: 'recommend', bookId: 'b1', reason: '科幻经典' });
+        const body = JSON.parse(mock.mock.calls[0][1].body);
+        expect(body.api_name).toBe('/book/recommend');
+    });
+
+    it('calls /book/similar when bookId given and unwraps booksimilar.books', async () => {
+        const mock = stubGateway({
+            errcode: 0,
+            booksimilar: {
+                sessionId: 'sess1',
+                books: [{ idx: 1, book: { bookInfo: { bookId: 'b2', title: '三体II', author: '刘慈欣' } } }],
+            },
+        });
+        const rows = await discover()({ bookId: 'b1' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ mode: 'similar', bookId: 'b2', title: '三体II' });
+        const body = JSON.parse(mock.mock.calls[0][1].body);
+        expect(body.api_name).toBe('/book/similar');
+        expect(body.bookId).toBe('b1');
+    });
+});
+
+describe('weread-official list-apis', () => {
+    const listApis = () => getRegistry().get('weread-official/list-apis').func;
+
+    it('normalises gateway inventory shapes and appends a client SKILL_VERSION row', async () => {
+        stubGateway({
+            errcode: 0,
+            apis: [
+                { api_name: '/store/search', description: 'search store', required: ['keyword'], optional: ['scope', 'maxIdx'] },
+                { name: '/shelf/sync', summary: 'shelf', params: { required: [], optional: [] } },
+            ],
+        });
+        const rows = await listApis()({});
+        expect(rows.find((r) => r.apiName === '/store/search')).toMatchObject({ required: 'keyword', optional: 'scope, maxIdx' });
+        const client = rows[rows.length - 1];
+        expect(client.apiName).toBe('(client)');
+        expect(client.extras).toMatch(/^SKILL_VERSION=/);
+    });
+
+    it('throws EmptyResultError when the gateway returns no inventory shape', async () => {
+        stubGateway({ errcode: 0, apis: [] });
+        await expect(listApis()({})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('weread-official auth wiring', () => {
+    it('every command refuses to run without WEREAD_API_KEY', async () => {
+        vi.unstubAllEnvs();
+        vi.stubEnv('WEREAD_API_KEY', '');
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        // pick a representative subset; each command's first call is callGateway which checks env first
+        const cases = [
+            ['search', { keyword: '三体' }],
+            ['shelf', {}],
+            ['book', { bookId: 'b1' }],
+            ['readdata', { mode: 'weekly' }],
+            ['list-apis', {}],
+        ];
+        for (const [name, args] of cases) {
+            await expect(getRegistry().get(`weread-official/${name}`).func(args)).rejects.toBeInstanceOf(AuthRequiredError);
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/clis/weread-official/discover.js
+++ b/clis/weread-official/discover.js
@@ -1,0 +1,107 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    callGateway,
+    emptyResult,
+    formatRating,
+    makeDeepLink,
+    requireBookId,
+    requirePositiveInt,
+    truncate,
+} from './utils.js';
+
+/**
+ * Two endpoints share a single command surface:
+ *   - no bookId → `/book/recommend` (personalized "for you" feed)
+ *   - bookId    → `/book/similar`   (similar-books for a given book)
+ *
+ * Pagination differs: `/recommend` uses `searchIdx`; `/similar` uses `idx` plus
+ * an opaque `sessionId` cursor. The CLI surfaces both verbatim so multi-page
+ * fetches can use the SKILL contract without translation.
+ */
+cli({
+    site: 'weread-official',
+    name: 'discover',
+    access: 'read',
+    description: 'Personalized or similar-book recommendations from WeRead',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'bookId', positional: true, help: 'Anchor bookId for similar-book mode; omit for personalized recommendations' },
+        { name: 'count', type: 'int', default: 12, help: 'Page size (default 12)' },
+        { name: 'max-idx', type: 'int', default: 0, help: 'Pagination cursor (recommend: previous searchIdx; similar: previous idx)' },
+        { name: 'session-id', help: 'Carry-forward sessionId for /book/similar paging' },
+    ],
+    columns: ['rank', 'mode', 'bookId', 'title', 'author', 'rating', 'readingCount', 'category', 'idx', 'reason', 'cover', 'intro', 'link'],
+    func: async (args) => {
+        const count = requirePositiveInt(args.count, 'count', { defaultValue: 12, max: 50 });
+        const maxIdx = Number(args['max-idx'] ?? 0);
+        const rawBookId = args.bookId !== undefined && args.bookId !== null && String(args.bookId).trim() !== ''
+            ? requireBookId(args.bookId)
+            : null;
+
+        if (!rawBookId) {
+            return runRecommend({ count, maxIdx });
+        }
+        return runSimilar({ bookId: rawBookId, count, maxIdx, sessionId: args['session-id'] });
+    },
+});
+
+async function runRecommend({ count, maxIdx }) {
+    const payload = await callGateway('/book/recommend', { count, maxIdx });
+    const books = Array.isArray(payload?.books) ? payload.books : [];
+    if (books.length === 0) {
+        emptyResult('discover', 'No personalized recommendations available.');
+    }
+    return books.map((entry, i) => {
+        const bookId = String(entry?.bookId ?? '').trim();
+        return {
+            rank: i + 1,
+            mode: 'recommend',
+            bookId,
+            title: String(entry?.title ?? ''),
+            author: String(entry?.author ?? ''),
+            rating: formatRating(entry?.newRating),
+            readingCount: Number(entry?.readingCount ?? 0),
+            category: String(entry?.category ?? ''),
+            idx: Number(entry?.searchIdx ?? 0),
+            reason: String(entry?.reason ?? ''),
+            cover: String(entry?.cover ?? ''),
+            intro: truncate(entry?.intro, 200),
+            link: bookId ? makeDeepLink({ bookId }) : '',
+        };
+    });
+}
+
+async function runSimilar({ bookId, count, maxIdx, sessionId }) {
+    const params = { bookId, count, maxIdx };
+    const sid = String(sessionId ?? '').trim();
+    if (sid) params.sessionId = sid;
+
+    const payload = await callGateway('/book/similar', params);
+    const inner = payload?.booksimilar ?? payload;
+    const books = Array.isArray(inner?.books) ? inner.books : [];
+    if (books.length === 0) {
+        emptyResult('discover', `No similar books for bookId=${bookId}.`);
+    }
+    return books.map((wrapper, i) => {
+        // /book/similar nests bookInfo under entry.book.bookInfo
+        const info = wrapper?.book?.bookInfo ?? wrapper?.bookInfo ?? {};
+        const id = String(info?.bookId ?? '').trim();
+        return {
+            rank: i + 1,
+            mode: 'similar',
+            bookId: id,
+            title: String(info?.title ?? ''),
+            author: String(info?.author ?? ''),
+            rating: formatRating(info?.newRating),
+            readingCount: Number(info?.readingCount ?? 0),
+            category: String(info?.category ?? ''),
+            idx: Number(wrapper?.idx ?? 0),
+            reason: '', // /book/similar does not surface a recommendation reason
+            cover: String(info?.cover ?? ''),
+            intro: truncate(info?.intro, 200),
+            link: id ? makeDeepLink({ bookId: id }) : '',
+        };
+    });
+}

--- a/clis/weread-official/list-apis.js
+++ b/clis/weread-official/list-apis.js
@@ -1,0 +1,95 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { callGateway, emptyResult, SKILL_VERSION } from './utils.js';
+
+/**
+ * `/_list` is the gateway's meta-endpoint. The response shape is not strongly
+ * specified in SKILL.md beyond "returns all available api_name + their param
+ * definitions", so we surface every visible field with light normalization
+ * (api_name + description/help + required/optional params, falling back to a
+ * raw-JSON column when the gateway changes shape).
+ *
+ * `clientSkillVersion` row is appended so debug output makes the local
+ * SKILL_VERSION explicit — useful when triaging upgrade_info mismatches.
+ */
+cli({
+    site: 'weread-official',
+    name: 'list-apis',
+    access: 'read',
+    description: 'List every api_name supported by the WeRead agent gateway',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [],
+    columns: ['rank', 'apiName', 'description', 'required', 'optional', 'extras'],
+    func: async () => {
+        const payload = await callGateway('/_list', {});
+        const apis = extractApiList(payload);
+        if (apis.length === 0) {
+            emptyResult('list-apis', 'Gateway returned no api inventory.');
+        }
+        const rows = apis.map((entry, i) => {
+            const required = formatParamList(entry?.required ?? entry?.requiredParams ?? entry?.params?.required);
+            const optional = formatParamList(entry?.optional ?? entry?.optionalParams ?? entry?.params?.optional);
+            const description = String(entry?.description ?? entry?.help ?? entry?.summary ?? '');
+            const extras = summarizeExtras(entry, ['api_name', 'apiName', 'name', 'description', 'help', 'summary', 'required', 'optional', 'requiredParams', 'optionalParams', 'params']);
+            return {
+                rank: i + 1,
+                apiName: String(entry?.api_name ?? entry?.apiName ?? entry?.name ?? ''),
+                description,
+                required,
+                optional,
+                extras,
+            };
+        });
+        rows.push({
+            rank: rows.length + 1,
+            apiName: '(client)',
+            description: 'Local skill version reported with every gateway request',
+            required: '',
+            optional: '',
+            extras: `SKILL_VERSION=${SKILL_VERSION}`,
+        });
+        return rows;
+    },
+});
+
+function extractApiList(payload) {
+    if (!payload || typeof payload !== 'object') return [];
+    const candidates = [payload?.apis, payload?.list, payload?.data, payload?.items, payload?.endpoints];
+    for (const candidate of candidates) {
+        if (Array.isArray(candidate) && candidate.length > 0) return candidate;
+    }
+    if (Array.isArray(payload)) return payload;
+    return [];
+}
+
+function formatParamList(value) {
+    if (!value) return '';
+    if (Array.isArray(value)) {
+        return value
+            .map((entry) => (typeof entry === 'string' ? entry : entry?.name ?? entry?.param ?? ''))
+            .filter(Boolean)
+            .join(', ');
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).filter(Boolean).join(', ');
+    }
+    return String(value);
+}
+
+function summarizeExtras(entry, knownKeys) {
+    if (!entry || typeof entry !== 'object') return '';
+    const known = new Set(knownKeys);
+    const rest = {};
+    for (const [key, value] of Object.entries(entry)) {
+        if (known.has(key)) continue;
+        rest[key] = value;
+    }
+    if (Object.keys(rest).length === 0) return '';
+    try {
+        return JSON.stringify(rest);
+    }
+    catch {
+        return '';
+    }
+}

--- a/clis/weread-official/notes.js
+++ b/clis/weread-official/notes.js
@@ -1,0 +1,171 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    callGateway,
+    emptyResult,
+    formatDate,
+    makeDeepLink,
+    parseRange,
+    requireBookId,
+    requirePositiveInt,
+    truncate,
+} from './utils.js';
+
+/**
+ * Two modes share a single command (matches the ninehills reference shape):
+ *
+ *   - No bookId → `/user/notebooks` overview. One row per book that has notes.
+ *                 Total-note column follows SKILL.md statistical contract:
+ *                 `total = reviewCount + noteCount + bookmarkCount`. The
+ *                 individual fields stay separate so downstream consumers do
+ *                 not have to re-derive them.
+ *
+ *   - With bookId → merge `/book/bookmarklist` (highlights) +
+ *                    `/review/list/mine` (thoughts/reviews) into one feed.
+ *                    Bookmarks (type=0) are filtered server-side already.
+ *
+ * Pagination of `/user/notebooks` is cursor-based via `lastSort`; this command
+ * surfaces `--last-sort` rather than offset/limit to keep the SKILL.md contract
+ * visible at the CLI surface.
+ */
+cli({
+    site: 'weread-official',
+    name: 'notes',
+    access: 'read',
+    description: 'List notebooks overview or merged highlights+thoughts for a book',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'bookId', positional: true, help: 'Limit to one book; omit for full notebook overview' },
+        { name: 'count', type: 'int', default: 20, help: 'Page size for the notebooks overview (1-100)' },
+        { name: 'last-sort', type: 'int', help: 'Cursor: pass previous page sort value to fetch the next page (/user/notebooks)' },
+    ],
+    columns: ['kind', 'bookId', 'title', 'author', 'chapter', 'reviewCount', 'noteCount', 'bookmarkCount', 'totalNotes', 'progress', 'finished', 'sort', 'range', 'text', 'thought', 'star', 'createTime', 'link'],
+    func: async (args) => {
+        const rawBookId = args.bookId !== undefined && args.bookId !== null && String(args.bookId).trim() !== ''
+            ? requireBookId(args.bookId)
+            : null;
+
+        if (!rawBookId) {
+            return listNotebooks(args);
+        }
+        return listBookNotes(rawBookId);
+    },
+});
+
+async function listNotebooks(args) {
+    const count = requirePositiveInt(args.count, 'count', { defaultValue: 20, max: 100 });
+    const params = { count };
+    if (args['last-sort'] !== undefined && args['last-sort'] !== null && args['last-sort'] !== '') {
+        params.lastSort = requirePositiveInt(args['last-sort'], 'last-sort');
+    }
+    const payload = await callGateway('/user/notebooks', params);
+    const books = Array.isArray(payload?.books) ? payload.books : [];
+    if (books.length === 0) {
+        emptyResult('notes', 'No notebooks found.');
+    }
+    return books.map((entry) => {
+        const book = entry?.book ?? {};
+        const bookId = String(entry?.bookId ?? book?.bookId ?? '').trim();
+        const reviewCount = Number(entry?.reviewCount ?? 0);
+        const noteCount = Number(entry?.noteCount ?? 0);
+        const bookmarkCount = Number(entry?.bookmarkCount ?? 0);
+        return {
+            kind: 'notebook',
+            bookId,
+            title: String(book?.title ?? ''),
+            author: String(book?.author ?? ''),
+            chapter: '',
+            reviewCount,
+            noteCount,
+            bookmarkCount,
+            totalNotes: reviewCount + noteCount + bookmarkCount,
+            progress: String(entry?.readingProgress ?? ''),
+            finished: Number(entry?.markedStatus ?? 0) === 1,
+            sort: Number(entry?.sort ?? 0),
+            range: '',
+            text: '',
+            thought: '',
+            star: '',
+            createTime: '',
+            link: bookId ? makeDeepLink({ bookId }) : '',
+        };
+    });
+}
+
+async function listBookNotes(bookId) {
+    const [bookmarksResp, reviewsResp] = await Promise.all([
+        callGateway('/book/bookmarklist', { bookId }),
+        callGateway('/review/list/mine', { bookid: bookId }),
+    ]);
+
+    const chapterIndex = new Map();
+    const chapterList = Array.isArray(bookmarksResp?.chapters) ? bookmarksResp.chapters : [];
+    for (const ch of chapterList) {
+        const uid = String(ch?.chapterUid ?? '').trim();
+        if (!uid) continue;
+        chapterIndex.set(uid, String(ch?.title ?? ''));
+    }
+
+    const rows = [];
+
+    const bookmarks = Array.isArray(bookmarksResp?.updated) ? bookmarksResp.updated : [];
+    for (const bm of bookmarks) {
+        const chapterUid = String(bm?.chapterUid ?? '').trim();
+        const { rangeStart, rangeEnd } = parseRange(bm?.range);
+        rows.push({
+            kind: 'highlight',
+            bookId,
+            title: '',
+            author: '',
+            chapter: chapterIndex.get(chapterUid) ?? '',
+            reviewCount: 0,
+            noteCount: 0,
+            bookmarkCount: 0,
+            totalNotes: 0,
+            progress: '',
+            finished: false,
+            sort: 0,
+            range: String(bm?.range ?? ''),
+            text: truncate(bm?.markText, 400),
+            thought: '',
+            star: '',
+            createTime: formatDate(bm?.createTime),
+            link: rangeStart && rangeEnd && chapterUid
+                ? makeDeepLink({ bookId, chapterUid, rangeStart, rangeEnd })
+                : (chapterUid ? makeDeepLink({ bookId, chapterUid }) : makeDeepLink({ bookId })),
+        });
+    }
+
+    const reviews = Array.isArray(reviewsResp?.reviews) ? reviewsResp.reviews : [];
+    for (const wrapper of reviews) {
+        const rv = wrapper?.review ?? {};
+        const chapterUid = String(rv?.chapterUid ?? '').trim();
+        const star = Number(rv?.star ?? -1);
+        rows.push({
+            kind: 'thought',
+            bookId,
+            title: '',
+            author: '',
+            chapter: String(rv?.chapterName ?? '') || (chapterIndex.get(chapterUid) ?? ''),
+            reviewCount: 0,
+            noteCount: 0,
+            bookmarkCount: 0,
+            totalNotes: 0,
+            progress: '',
+            finished: Number(rv?.isFinish ?? 0) === 1,
+            sort: 0,
+            range: String(rv?.range ?? ''),
+            text: '',
+            thought: truncate(rv?.content, 400),
+            star: star >= 0 ? String(star) : '',
+            createTime: formatDate(rv?.createTime),
+            link: chapterUid ? makeDeepLink({ bookId, chapterUid }) : makeDeepLink({ bookId }),
+        });
+    }
+
+    if (rows.length === 0) {
+        emptyResult('notes', `No highlights or thoughts saved for bookId=${bookId}.`);
+    }
+    return rows;
+}

--- a/clis/weread-official/readdata.js
+++ b/clis/weread-official/readdata.js
@@ -1,0 +1,158 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    callGateway,
+    emptyResult,
+    formatDate,
+    formatDuration,
+    requireChoice,
+    requirePositiveInt,
+} from './utils.js';
+
+/**
+ * `/readdata/detail` — reading statistics summary.
+ * Per SKILL.md every duration field is in SECONDS — `totalReadTime`,
+ * `dayAverageReadTime`, `readLongest[].readTime`, `preferTime`, etc.
+ * `preferAuthor[].readTime` is the one exception (already formatted by server
+ * as "X小时Y分钟"); we surface it verbatim.
+ *
+ * Output uses a `section` column so callers can filter:
+ *   - summary       — single overview row
+ *   - longest       — books / albums sorted by read time
+ *   - readStat      — counts (读过 / 读完 / 阅读 / 笔记)
+ *   - preferCategory / preferAuthor / preferPublisher
+ *   - preferTime    — 24h time distribution (starts at 6am per SKILL.md)
+ */
+const MODE_CHOICES = ['weekly', 'monthly', 'annually', 'overall'];
+
+cli({
+    site: 'weread-official',
+    name: 'readdata',
+    access: 'read',
+    description: 'Reading statistics: time, streak, preferences, top books',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'mode', default: 'monthly', choices: MODE_CHOICES, help: 'Stat window: weekly / monthly / annually / overall' },
+        { name: 'base-time', type: 'int', help: 'Optional Unix timestamp inside the target period; default is current period' },
+    ],
+    columns: ['section', 'idx', 'key', 'value', 'detail'],
+    func: async (args) => {
+        const mode = requireChoice(args.mode, MODE_CHOICES, 'mode', 'monthly');
+        const params = { mode };
+        if (args['base-time'] !== undefined && args['base-time'] !== null && args['base-time'] !== '') {
+            params.baseTime = requirePositiveInt(args['base-time'], 'base-time');
+        }
+        const payload = await callGateway('/readdata/detail', params);
+
+        const rows = [];
+        const totalReadTime = Number(payload?.totalReadTime ?? 0);
+        const dayAverage = Number(payload?.dayAverageReadTime ?? 0);
+        const readDays = Number(payload?.readDays ?? 0);
+        const compareRaw = payload?.compare;
+        const compare = Number.isFinite(Number(compareRaw)) ? Number(compareRaw) : null;
+
+        const summary = [
+            ['mode', mode, ''],
+            ['baseTime', formatDate(payload?.baseTime), String(payload?.baseTime ?? '')],
+            ['readDays', String(readDays), ''],
+            ['totalReadTime', formatDuration(totalReadTime), `${totalReadTime}s`],
+            ['dayAverageReadTime', formatDuration(dayAverage), `${dayAverage}s`],
+            ['compareToPrev', compare === null ? '' : `${(compare * 100).toFixed(1)}%`, ''],
+            ['readRate', payload?.readRate !== undefined ? `${Number(payload.readRate).toFixed(1)}%` : '', ''],
+            ['preferTimeWord', String(payload?.preferTimeWord ?? ''), ''],
+            ['preferCategoryWord', String(payload?.preferCategoryWord ?? ''), ''],
+        ];
+        for (let i = 0; i < summary.length; i += 1) {
+            const [key, value, detail] = summary[i];
+            rows.push({ section: 'summary', idx: i + 1, key, value, detail });
+        }
+
+        const longest = Array.isArray(payload?.readLongest) ? payload.readLongest : [];
+        longest.forEach((entry, i) => {
+            const book = entry?.book ?? {};
+            const albumInfo = entry?.albumInfo ?? null;
+            const title = albumInfo ? String(albumInfo?.name ?? '') : String(book?.title ?? '');
+            const author = albumInfo ? String(albumInfo?.authorName ?? '') : String(book?.author ?? '');
+            const tags = Array.isArray(entry?.tags) ? entry.tags.join(',') : '';
+            const readTime = Number(entry?.readTime ?? 0);
+            rows.push({
+                section: 'longest',
+                idx: i + 1,
+                key: title,
+                value: formatDuration(readTime),
+                detail: `${author}${tags ? `  [${tags}]` : ''}`,
+            });
+        });
+
+        const readStat = Array.isArray(payload?.readStat) ? payload.readStat : [];
+        readStat.forEach((entry, i) => {
+            rows.push({
+                section: 'readStat',
+                idx: i + 1,
+                key: String(entry?.stat ?? ''),
+                value: String(entry?.counts ?? ''),
+                detail: '',
+            });
+        });
+
+        const preferCategory = Array.isArray(payload?.preferCategory) ? payload.preferCategory : [];
+        preferCategory.forEach((entry, i) => {
+            const seconds = Number(entry?.readingTime ?? 0);
+            rows.push({
+                section: 'preferCategory',
+                idx: i + 1,
+                key: String(entry?.categoryTitle ?? ''),
+                value: formatDuration(seconds),
+                detail: `${Number(entry?.readingCount ?? 0)}本`,
+            });
+        });
+
+        const preferAuthor = Array.isArray(payload?.preferAuthor) ? payload.preferAuthor : [];
+        preferAuthor.forEach((entry, i) => {
+            rows.push({
+                section: 'preferAuthor',
+                idx: i + 1,
+                key: String(entry?.name ?? ''),
+                // preferAuthor[].readTime is server-formatted ("5小时30分钟"), not seconds.
+                value: String(entry?.readTime ?? ''),
+                detail: `${Number(entry?.count ?? 0)}本`,
+            });
+        });
+
+        const preferPublisher = Array.isArray(payload?.preferPublisher) ? payload.preferPublisher : [];
+        preferPublisher.forEach((entry, i) => {
+            rows.push({
+                section: 'preferPublisher',
+                idx: i + 1,
+                key: String(entry?.name ?? ''),
+                value: `${Number(entry?.count ?? 0)}本`,
+                detail: '',
+            });
+        });
+
+        const preferTime = Array.isArray(payload?.preferTime) ? payload.preferTime : [];
+        if (preferTime.length === 24) {
+            // SKILL.md: order starts at 06:00 and wraps to 05:00. Translate to a flat
+            // (hour-of-day → duration) view so consumers do not need to know the offset.
+            for (let i = 0; i < 24; i += 1) {
+                const hour = (6 + i) % 24;
+                const seconds = Number(preferTime[i] ?? 0);
+                rows.push({
+                    section: 'preferTime',
+                    idx: i + 1,
+                    key: `${String(hour).padStart(2, '0')}:00`,
+                    value: formatDuration(seconds),
+                    detail: `${seconds}s`,
+                });
+            }
+        }
+
+        if (rows.length === 0) {
+            emptyResult('readdata', `No reading data for mode=${mode}.`);
+        }
+        return rows;
+    },
+});
+
+export { MODE_CHOICES };

--- a/clis/weread-official/review.js
+++ b/clis/weread-official/review.js
@@ -1,0 +1,93 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    callGateway,
+    emptyResult,
+    formatDate,
+    formatStar,
+    makeDeepLink,
+    requireBookId,
+    requirePositiveInt,
+    truncate,
+} from './utils.js';
+
+/**
+ * `/review/list` (public book reviews). Per SKILL.md the `reviewListType`
+ * enum is:
+ *   0=all  1=recommend  2=不行(thumbs-down)  3=newest  4=一般(neutral)
+ *
+ * Pagination is `idx`-based (use `idx` from last row of previous page as the
+ * next `maxIdx`), with an optional `synckey` carried forward. Surface these
+ * to the user instead of synthesizing an offset scheme so the SKILL contract
+ * stays visible.
+ */
+const TYPE_ALIASES = Object.freeze({
+    all: 0,
+    recommend: 1,
+    'thumbs-down': 2,
+    newest: 3,
+    neutral: 4,
+});
+
+cli({
+    site: 'weread-official',
+    name: 'review',
+    access: 'read',
+    description: 'Browse public reviews of a WeRead book',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'bookId', positional: true, required: true, help: 'WeRead bookId (from `weread-official search`)' },
+        { name: 'type', default: 'all', choices: Object.keys(TYPE_ALIASES), help: 'Review filter (all/recommend/thumbs-down/newest/neutral)' },
+        { name: 'count', type: 'int', default: 20, help: 'Page size (1-100, default 20)' },
+        { name: 'max-idx', type: 'int', default: 0, help: 'Pagination cursor — pass idx from last row of previous page' },
+        { name: 'synckey', type: 'int', help: 'Sync cursor returned by previous response' },
+    ],
+    columns: ['rank', 'idx', 'reviewId', 'star', 'starLabel', 'author', 'isFinish', 'chapter', 'content', 'createTime', 'link'],
+    func: async (args) => {
+        const bookId = requireBookId(args.bookId);
+        const typeKey = String(args.type ?? 'all').trim();
+        if (!Object.prototype.hasOwnProperty.call(TYPE_ALIASES, typeKey)) {
+            throw new ArgumentError(
+                `weread-official: type must be one of: ${Object.keys(TYPE_ALIASES).join(', ')}`,
+            );
+        }
+        const reviewListType = TYPE_ALIASES[typeKey];
+        const count = requirePositiveInt(args.count, 'count', { defaultValue: 20, max: 100 });
+        const params = { bookId, reviewListType, count, maxIdx: Number(args['max-idx'] ?? 0) };
+        if (args.synckey !== undefined && args.synckey !== null && args.synckey !== '') {
+            params.synckey = requirePositiveInt(args.synckey, 'synckey');
+        }
+
+        const payload = await callGateway('/review/list', params);
+        const reviews = Array.isArray(payload?.reviews) ? payload.reviews : [];
+        if (reviews.length === 0) {
+            emptyResult('review', `No public reviews for bookId=${bookId} (type=${typeKey}).`);
+        }
+
+        return reviews.map((wrapper, i) => {
+            const reviewOuter = wrapper?.review ?? {};
+            // `/review/list` nests the actual review under reviewOuter.review
+            const rv = reviewOuter?.review ?? {};
+            const author = rv?.author ?? {};
+            const chapter = String(rv?.chapterName ?? '').trim();
+            const reviewId = String(reviewOuter?.reviewId ?? rv?.reviewId ?? '').trim();
+            return {
+                rank: i + 1,
+                idx: Number(wrapper?.idx ?? 0),
+                reviewId,
+                star: Number(rv?.star ?? 0),
+                starLabel: formatStar(rv?.star),
+                author: String(author?.name ?? ''),
+                isFinish: Number(rv?.isFinish ?? 0) === 1,
+                chapter,
+                content: truncate(rv?.content, 300),
+                createTime: formatDate(rv?.createTime),
+                link: makeDeepLink({ bookId }),
+            };
+        });
+    },
+});
+
+export { TYPE_ALIASES };

--- a/clis/weread-official/search.js
+++ b/clis/weread-official/search.js
@@ -1,0 +1,106 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    callGateway,
+    emptyResult,
+    formatRating,
+    makeDeepLink,
+    requirePositiveInt,
+    requireText,
+    truncate,
+} from './utils.js';
+
+/**
+ * Search scope mapping — mirrors the official SKILL.md "scope 对应关系" table.
+ * Keys are user-facing aliases; values are the int the gateway expects.
+ */
+export const SEARCH_SCOPES = Object.freeze({
+    all: 0,
+    ebook: 10,
+    webnovel: 16,
+    audio: 14,
+    author: 6,
+    fulltext: 12,
+    booklist: 13,
+    mp: 2,
+    article: 4,
+});
+
+const SCOPE_LABEL = Object.freeze({
+    0: '全部',
+    10: '电子书',
+    16: '网文小说',
+    14: '微信听书',
+    6: '作者',
+    12: '全文',
+    13: '书单',
+    2: '公众号',
+    4: '文章',
+});
+
+cli({
+    site: 'weread-official',
+    name: 'search',
+    access: 'read',
+    description: 'Search WeRead store via the official agent gateway',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'keyword', positional: true, required: true, help: 'Search keyword' },
+        { name: 'scope', default: 'ebook', choices: Object.keys(SEARCH_SCOPES), help: 'Search type (all/ebook/webnovel/audio/author/fulltext/booklist/mp/article)' },
+        { name: 'count', type: 'int', help: 'Page size (gateway default 15 when omitted)' },
+        { name: 'max-idx', type: 'int', default: 0, help: 'Pagination offset, use searchIdx of last item from previous page' },
+    ],
+    columns: ['rank', 'scope', 'bookId', 'title', 'author', 'rating', 'readingCount', 'category', 'searchIdx', 'cover', 'intro', 'link'],
+    func: async (args) => {
+        const keyword = requireText(args.keyword, 'keyword');
+        const scopeKey = String(args.scope ?? 'ebook').trim();
+        if (!Object.prototype.hasOwnProperty.call(SEARCH_SCOPES, scopeKey)) {
+            throw new ArgumentError(
+                `weread-official: scope must be one of: ${Object.keys(SEARCH_SCOPES).join(', ')}`,
+            );
+        }
+        const scope = SEARCH_SCOPES[scopeKey];
+        const params = { keyword, scope, maxIdx: args['max-idx'] ?? 0 };
+        if (args.count !== undefined && args.count !== null && args.count !== '') {
+            params.count = requirePositiveInt(args.count, 'count', { max: 100 });
+        }
+
+        const payload = await callGateway('/store/search', params);
+        const groups = Array.isArray(payload?.results) ? payload.results : [];
+        if (groups.length === 0) {
+            emptyResult('search', `No results for "${keyword}" (scope=${scopeKey}).`);
+        }
+
+        const rows = [];
+        let rank = 0;
+        for (const group of groups) {
+            const groupScope = SCOPE_LABEL[Number(group?.scope)] ?? '';
+            const books = Array.isArray(group?.books) ? group.books : [];
+            for (const entry of books) {
+                rank += 1;
+                const info = entry?.bookInfo ?? {};
+                const bookId = String(info.bookId ?? '').trim();
+                rows.push({
+                    rank,
+                    scope: groupScope,
+                    bookId,
+                    title: String(info.title ?? ''),
+                    author: String(info.author ?? ''),
+                    rating: formatRating(entry?.newRating),
+                    readingCount: Number(entry?.readingCount ?? 0),
+                    category: String(info.category ?? ''),
+                    searchIdx: Number(entry?.searchIdx ?? 0),
+                    cover: String(info.cover ?? ''),
+                    intro: truncate(info.intro, 120),
+                    link: bookId ? makeDeepLink({ bookId }) : '',
+                });
+            }
+        }
+        if (rows.length === 0) {
+            emptyResult('search', `No books found in results for "${keyword}" (scope=${scopeKey}).`);
+        }
+        return rows;
+    },
+});

--- a/clis/weread-official/shelf.js
+++ b/clis/weread-official/shelf.js
@@ -1,0 +1,97 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { callGateway, emptyResult, formatDate, makeDeepLink } from './utils.js';
+
+/**
+ * `/shelf/sync` returns three independent entry kinds:
+ *   - `books[]`   — ebooks / imported / mp-style book entries
+ *   - `albums[]`  — audiobooks / podcasts (官方 SKILL.md 强调专辑 = 有声书)
+ *   - `mp`        — opaque "文章收藏" (article bookmarks) entry; non-empty
+ *                   = 1 shelf entry but its content is NOT exposed here.
+ *
+ * Per official skill: shelf count = books.length + albums.length +
+ *                     (mp non-empty ? 1 : 0). This adapter surfaces all three
+ *                     row kinds in a `kind` column so callers can filter.
+ */
+cli({
+    site: 'weread-official',
+    name: 'shelf',
+    access: 'read',
+    description: 'Sync your WeRead shelf (books + albums + article bookmark entry) via the official gateway',
+    domain: 'weread.qq.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [],
+    columns: ['kind', 'id', 'title', 'author', 'category', 'secret', 'isTop', 'finished', 'updateTime', 'cover', 'link'],
+    func: async () => {
+        const payload = await callGateway('/shelf/sync', {});
+        const books = Array.isArray(payload?.books) ? payload.books : [];
+        const albums = Array.isArray(payload?.albums) ? payload.albums : [];
+        // `mp` is an object (or array) marking the "文章收藏" entry. Non-empty = 1 shelf entry.
+        const mp = payload?.mp;
+        const hasMp = Boolean(
+            mp && typeof mp === 'object'
+                && (Array.isArray(mp) ? mp.length > 0 : Object.keys(mp).length > 0),
+        );
+
+        const rows = [];
+
+        for (const b of books) {
+            const bookId = String(b?.bookId ?? '').trim();
+            rows.push({
+                kind: 'book',
+                id: bookId,
+                title: String(b?.title ?? ''),
+                author: String(b?.author ?? ''),
+                category: String(b?.category ?? ''),
+                secret: Number(b?.secret ?? 0) === 1,
+                isTop: Number(b?.isTop ?? 0) === 1,
+                finished: Number(b?.finishReading ?? 0) === 1,
+                updateTime: formatDate(b?.readUpdateTime ?? b?.updateTime),
+                cover: String(b?.cover ?? ''),
+                link: bookId ? makeDeepLink({ bookId }) : '',
+            });
+        }
+
+        for (const a of albums) {
+            const info = a?.albumInfo ?? {};
+            const extra = a?.albumInfoExtra ?? {};
+            const albumId = String(info?.albumId ?? '').trim();
+            rows.push({
+                kind: 'album',
+                id: albumId,
+                title: String(info?.name ?? ''),
+                author: String(info?.authorName ?? ''),
+                category: '',
+                secret: Number(extra?.secret ?? 0) === 1,
+                isTop: Number(extra?.isTop ?? 0) === 1,
+                finished: Number(info?.finish ?? 0) === 1,
+                updateTime: formatDate(extra?.lectureReadUpdateTime ?? info?.updateTime),
+                cover: String(info?.cover ?? ''),
+                link: '',
+            });
+        }
+
+        if (hasMp) {
+            // The mp entry is an opaque directory; only the count is meaningful here.
+            // Per SKILL.md it's always private, so secret=true matches the official rule.
+            rows.push({
+                kind: 'mp',
+                id: '',
+                title: '文章收藏',
+                author: '',
+                category: '',
+                secret: true,
+                isTop: false,
+                finished: false,
+                updateTime: '',
+                cover: '',
+                link: '',
+            });
+        }
+
+        if (rows.length === 0) {
+            emptyResult('shelf', 'Your WeRead shelf is empty.');
+        }
+        return rows;
+    },
+});

--- a/clis/weread-official/utils.js
+++ b/clis/weread-official/utils.js
@@ -1,0 +1,293 @@
+/**
+ * WeRead Official Agent Gateway helpers.
+ *
+ * Auth model: Bearer API key (WEREAD_API_KEY env var, format `wrk-*`).
+ * Transport:  pure HTTP, no browser required. Body shape must keep every
+ *             business parameter flat alongside `api_name` and `skill_version`
+ *             (wrapping them in `params`/`data`/`body` silently breaks the
+ *             gateway — see SKILL.md "请求 few-shot").
+ *
+ * This module is intentionally side-effect free outside `callGateway` so each
+ * command file can import only the helpers it needs.
+ */
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+
+export const WEREAD_GATEWAY_URL = 'https://i.weread.qq.com/api/agent/gateway';
+export const WEREAD_DOMAIN = 'weread.qq.com';
+
+/**
+ * Skill version reported with every gateway request. Bump when official
+ * `weread-skills.zip` ships a new SKILL.md `version:` line.
+ */
+export const SKILL_VERSION = '1.0.3';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** errcodes that mean "Bearer key invalid / token expired" — map to AuthRequiredError. */
+const AUTH_ERRCODES = new Set([-2010, -2012]);
+
+/** Resolve API key from env. Throws AuthRequiredError on missing / blank value. */
+export function getApiKey() {
+    const key = String(process.env.WEREAD_API_KEY ?? '').trim();
+    if (!key) {
+        throw new AuthRequiredError(
+            WEREAD_DOMAIN,
+            'WEREAD_API_KEY is not set. Export it with `export WEREAD_API_KEY=<wrk-...>`.',
+        );
+    }
+    return key;
+}
+
+/**
+ * Build the gateway request body. Business params are flattened next to
+ * `api_name` and `skill_version` — never wrapped in a `params` / `data` /
+ * `body` object (the gateway silently drops them and returns page 1).
+ */
+export function buildGatewayBody(apiName, params = {}) {
+    if (!apiName || typeof apiName !== 'string') {
+        throw new ArgumentError('weread-official: api_name is required');
+    }
+    const body = { api_name: apiName, skill_version: SKILL_VERSION };
+    for (const [key, value] of Object.entries(params ?? {})) {
+        if (value === undefined || value === null || value === '') continue;
+        body[key] = value;
+    }
+    return body;
+}
+
+/**
+ * POST to the agent gateway. Returns the parsed JSON payload on success.
+ * Maps every documented failure mode to a typed CliError:
+ *   - missing env key            → AuthRequiredError
+ *   - HTTP non-2xx               → CommandExecutionError
+ *   - network timeout            → TimeoutError
+ *   - response includes upgrade_info → CommandExecutionError (with version hint)
+ *   - errcode in AUTH_ERRCODES   → AuthRequiredError (Bearer key likely revoked)
+ *   - errcode != 0               → CommandExecutionError
+ */
+export async function callGateway(apiName, params = {}, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    const key = getApiKey();
+    const body = buildGatewayBody(apiName, params);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    let response;
+    try {
+        response = await fetch(WEREAD_GATEWAY_URL, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${key}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+        });
+    }
+    catch (error) {
+        if (error?.name === 'AbortError') {
+            throw new TimeoutError(`weread-official ${apiName}`, Math.round(timeoutMs / 1000));
+        }
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(`weread-official ${apiName} request failed`, detail);
+    }
+    finally {
+        clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+        throw new CommandExecutionError(
+            `weread-official ${apiName} HTTP ${response.status}`,
+            'Check WeRead gateway availability and that WEREAD_API_KEY is still valid.',
+        );
+    }
+
+    let payload;
+    try {
+        payload = await response.json();
+    }
+    catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new CommandExecutionError(`weread-official ${apiName} returned invalid JSON`, detail);
+    }
+
+    if (payload && typeof payload === 'object' && payload.upgrade_info) {
+        const info = payload.upgrade_info;
+        const required = info?.required_version ?? info?.version ?? 'unknown';
+        const message = info?.message ?? 'WeRead skill version is outdated';
+        throw new CommandExecutionError(
+            `WeRead skill 需升级: ${message}. Required skill_version=${required}, current=${SKILL_VERSION}`,
+            'Pull the latest weread-skills.zip and bump SKILL_VERSION in clis/weread-official/utils.js.',
+        );
+    }
+
+    const errcode = Number(payload?.errcode ?? 0);
+    if (errcode !== 0) {
+        const errmsg = String(payload?.errmsg ?? 'unknown error');
+        if (AUTH_ERRCODES.has(errcode)) {
+            throw new AuthRequiredError(
+                WEREAD_DOMAIN,
+                `WEREAD_API_KEY rejected (errcode=${errcode}, ${errmsg}). Regenerate the key and re-export it.`,
+            );
+        }
+        throw new CommandExecutionError(
+            `weread-official ${apiName} returned errcode=${errcode}`,
+            errmsg,
+        );
+    }
+
+    return payload;
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────────────
+
+/** Unix timestamp (sec) → YYYY-MM-DD using UTC for stable test snapshots. */
+export function formatDate(ts) {
+    const seconds = Number(ts);
+    if (!Number.isFinite(seconds) || seconds <= 0) return '';
+    const date = new Date(seconds * 1000);
+    if (Number.isNaN(date.getTime())) return '';
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(date.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+}
+
+/** Seconds → "X小时Y分钟" (or "Y分钟" if no hours, "0分钟" if < 1 minute). */
+export function formatDuration(secs) {
+    if (secs === null || secs === undefined || secs === '') return '';
+    const total = Number(secs);
+    if (!Number.isFinite(total) || total < 0) return '';
+    const seconds = Math.floor(total);
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    if (hours > 0) return `${hours}小时${minutes}分钟`;
+    return `${minutes}分钟`;
+}
+
+/**
+ * WeRead `star` field uses multiples of 20 (20=1⭐, 40=2⭐, …, 100=5⭐).
+ * `-1` and `0` both mean "no rating".
+ */
+export function formatStar(star) {
+    const value = Number(star);
+    if (!Number.isFinite(value) || value <= 0) return '无评分';
+    const count = Math.min(5, Math.floor(value / 20));
+    if (count <= 0) return '无评分';
+    return '⭐'.repeat(count);
+}
+
+/**
+ * WeRead book rating uses a 0-1000 scale (1000 = 100%). Returns a short label
+ * with the canonical tier names from the official skill output examples.
+ */
+export function formatRating(rating) {
+    const value = Number(rating);
+    if (!Number.isFinite(value) || value <= 0) return '暂无';
+    const percent = value / 10;
+    if (percent >= 90) return `神作 ${Math.round(percent)}%`;
+    if (percent >= 80) return `力荐 ${Math.round(percent)}%`;
+    if (percent >= 70) return `好评 ${Math.round(percent)}%`;
+    return `${percent.toFixed(1)}分`;
+}
+
+/** Truncate text to `maxLen` chars with an ellipsis suffix. Returns '' for nullish. */
+export function truncate(text, maxLen = 200) {
+    const value = String(text ?? '');
+    if (!value) return '';
+    if (value.length <= maxLen) return value;
+    return `${value.slice(0, maxLen)}…`;
+}
+
+// ── Deep links ──────────────────────────────────────────────────────────────
+
+/**
+ * Build a `weread://` deep link.
+ *  - bookId only                                 → open at last reading position
+ *  - bookId + chapterUid                         → open chapter
+ *  - bookId + chapterUid + rangeStart + rangeEnd → open bestbookmark position
+ */
+export function makeDeepLink({ bookId, chapterUid = '', rangeStart = '', rangeEnd = '', userVid = '' } = {}) {
+    const bid = String(bookId ?? '').trim();
+    if (!bid) return '';
+    const chapter = String(chapterUid ?? '').trim();
+    const start = String(rangeStart ?? '').trim();
+    const end = String(rangeEnd ?? '').trim();
+    if (chapter && start && end) {
+        const params = new URLSearchParams({ bookId: bid, chapterUid: chapter, rangeStart: start, rangeEnd: end });
+        const vid = String(userVid ?? '').trim();
+        if (vid) params.set('userVid', vid);
+        return `weread://bestbookmark?${params.toString()}`;
+    }
+    if (chapter) return `weread://reading?bId=${bid}&chapterUid=${chapter}`;
+    return `weread://reading?bId=${bid}`;
+}
+
+/**
+ * Split a WeRead `range` field ("900-2004") into `{rangeStart, rangeEnd}`.
+ * Returns empty strings when the input is missing/malformed.
+ */
+export function parseRange(range) {
+    const text = String(range ?? '').trim();
+    const match = text.match(/^(\d+)-(\d+)$/);
+    if (!match) return { rangeStart: '', rangeEnd: '' };
+    return { rangeStart: match[1], rangeEnd: match[2] };
+}
+
+// ── Argument validation ─────────────────────────────────────────────────────
+
+export function requireText(value, label) {
+    const text = String(value ?? '').trim();
+    if (!text) throw new ArgumentError(`weread-official: ${label} cannot be empty`);
+    return text;
+}
+
+export function requireBookId(value, label = 'bookId') {
+    const text = requireText(value, label);
+    if (!/^[A-Za-z0-9_-]+$/.test(text)) {
+        throw new ArgumentError(`weread-official: ${label} contains invalid characters`, 'Pass a bookId from `weread-official search`.');
+    }
+    return text;
+}
+
+export function requirePositiveInt(value, label, { defaultValue, max } = {}) {
+    if (value === undefined || value === null || value === '') {
+        if (defaultValue === undefined) {
+            throw new ArgumentError(`weread-official: ${label} is required`);
+        }
+        return defaultValue;
+    }
+    const text = String(value).trim();
+    if (!/^\d+$/.test(text)) {
+        throw new ArgumentError(`weread-official: ${label} must be a positive integer`);
+    }
+    const n = Number(text);
+    if (!Number.isSafeInteger(n) || n < 1) {
+        throw new ArgumentError(`weread-official: ${label} must be a positive integer`);
+    }
+    if (max !== undefined && n > max) {
+        throw new ArgumentError(`weread-official: ${label} must be <= ${max}`);
+    }
+    return n;
+}
+
+export function requireChoice(value, choices, label, defaultValue) {
+    const text = String(value ?? defaultValue ?? '').trim();
+    if (!choices.includes(text)) {
+        throw new ArgumentError(`weread-official: ${label} must be one of: ${choices.join(', ')}`);
+    }
+    return text;
+}
+
+// ── Empty-result helper ────────────────────────────────────────────────────
+
+/** Throw EmptyResultError with a stable command label. */
+export function emptyResult(command, hint) {
+    throw new EmptyResultError(`weread-official ${command}`, hint);
+}

--- a/clis/weread-official/utils.test.js
+++ b/clis/weread-official/utils.test.js
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import {
+    SKILL_VERSION,
+    WEREAD_GATEWAY_URL,
+    buildGatewayBody,
+    callGateway,
+    emptyResult,
+    formatDate,
+    formatDuration,
+    formatRating,
+    formatStar,
+    getApiKey,
+    makeDeepLink,
+    parseRange,
+    requireBookId,
+    requireChoice,
+    requirePositiveInt,
+    requireText,
+    truncate,
+} from './utils.js';
+
+function jsonResponse(body, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        json: vi.fn().mockResolvedValue(body),
+        text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+    };
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+});
+
+describe('weread-official utils — formatting', () => {
+    it('formats Unix timestamps as YYYY-MM-DD (UTC) and falls back to empty', () => {
+        expect(formatDate(1748563200)).toBe('2025-05-30');
+        expect(formatDate(0)).toBe('');
+        expect(formatDate(null)).toBe('');
+        expect(formatDate('not-a-number')).toBe('');
+    });
+
+    it('formats duration seconds into "X小时Y分钟" / "Y分钟"', () => {
+        expect(formatDuration(3600)).toBe('1小时0分钟');
+        expect(formatDuration(3660)).toBe('1小时1分钟');
+        expect(formatDuration(59)).toBe('0分钟');
+        expect(formatDuration(0)).toBe('0分钟');
+        expect(formatDuration(-1)).toBe('');
+        expect(formatDuration(null)).toBe('');
+    });
+
+    it('translates star multiples-of-20 into ⭐ glyphs (caps at 5)', () => {
+        expect(formatStar(20)).toBe('⭐');
+        expect(formatStar(80)).toBe('⭐⭐⭐⭐');
+        expect(formatStar(100)).toBe('⭐⭐⭐⭐⭐');
+        expect(formatStar(120)).toBe('⭐⭐⭐⭐⭐');
+        expect(formatStar(0)).toBe('无评分');
+        expect(formatStar(-1)).toBe('无评分');
+    });
+
+    it('labels ratings by the official 0-1000 tiers', () => {
+        expect(formatRating(950)).toMatch(/^神作 95%$/);
+        expect(formatRating(820)).toMatch(/^力荐 82%$/);
+        expect(formatRating(710)).toMatch(/^好评 71%$/);
+        expect(formatRating(550)).toBe('55.0分');
+        expect(formatRating(0)).toBe('暂无');
+        expect(formatRating(null)).toBe('暂无');
+    });
+
+    it('truncates text with an ellipsis suffix and tolerates nullish input', () => {
+        expect(truncate('hello', 100)).toBe('hello');
+        expect(truncate('1234567890', 5)).toBe('12345…');
+        expect(truncate(null, 5)).toBe('');
+        expect(truncate(undefined, 5)).toBe('');
+    });
+});
+
+describe('weread-official utils — deep links', () => {
+    it('builds book-level, chapter-level, and bestbookmark URLs', () => {
+        expect(makeDeepLink({ bookId: '3300045871' })).toBe('weread://reading?bId=3300045871');
+        expect(makeDeepLink({ bookId: '3300045871', chapterUid: '107' })).toBe('weread://reading?bId=3300045871&chapterUid=107');
+        expect(makeDeepLink({ bookId: '3300045871', chapterUid: '107', rangeStart: '900', rangeEnd: '2004' }))
+            .toBe('weread://bestbookmark?bookId=3300045871&chapterUid=107&rangeStart=900&rangeEnd=2004');
+        expect(makeDeepLink({ bookId: '3300045871', chapterUid: '107', rangeStart: '900', rangeEnd: '2004', userVid: '583802764' }))
+            .toBe('weread://bestbookmark?bookId=3300045871&chapterUid=107&rangeStart=900&rangeEnd=2004&userVid=583802764');
+        expect(makeDeepLink({})).toBe('');
+        expect(makeDeepLink({ bookId: '' })).toBe('');
+    });
+
+    it('parses ranges like "900-2004" and returns empty on malformed input', () => {
+        expect(parseRange('900-2004')).toEqual({ rangeStart: '900', rangeEnd: '2004' });
+        expect(parseRange('garbage')).toEqual({ rangeStart: '', rangeEnd: '' });
+        expect(parseRange('')).toEqual({ rangeStart: '', rangeEnd: '' });
+        expect(parseRange(null)).toEqual({ rangeStart: '', rangeEnd: '' });
+    });
+});
+
+describe('weread-official utils — argument validation', () => {
+    it('rejects empty text and blank bookIds', () => {
+        expect(requireText('hello', 'q')).toBe('hello');
+        expect(() => requireText('', 'q')).toThrow(ArgumentError);
+        expect(() => requireText('   ', 'q')).toThrow(ArgumentError);
+        expect(requireBookId('book_123-AbC')).toBe('book_123-AbC');
+        expect(() => requireBookId('')).toThrow(ArgumentError);
+        expect(() => requireBookId('book id with space')).toThrow(ArgumentError);
+    });
+
+    it('enforces positive integers with optional default and max', () => {
+        expect(requirePositiveInt(undefined, 'n', { defaultValue: 10 })).toBe(10);
+        expect(requirePositiveInt('15', 'n')).toBe(15);
+        expect(() => requirePositiveInt('0', 'n')).toThrow(ArgumentError);
+        expect(() => requirePositiveInt('-3', 'n')).toThrow(ArgumentError);
+        expect(() => requirePositiveInt('abc', 'n')).toThrow(ArgumentError);
+        expect(() => requirePositiveInt('200', 'n', { max: 100 })).toThrow(/<= 100/);
+    });
+
+    it('requireChoice rejects values outside the allowlist', () => {
+        expect(requireChoice('weekly', ['weekly', 'monthly'], 'mode', 'monthly')).toBe('weekly');
+        expect(requireChoice(undefined, ['weekly', 'monthly'], 'mode', 'monthly')).toBe('monthly');
+        expect(() => requireChoice('quarterly', ['weekly', 'monthly'], 'mode', 'monthly')).toThrow(ArgumentError);
+    });
+});
+
+describe('weread-official utils — request building', () => {
+    it('flattens business params alongside api_name + skill_version', () => {
+        const body = buildGatewayBody('/store/search', { keyword: '三体', scope: 10, maxIdx: 0 });
+        expect(body.api_name).toBe('/store/search');
+        expect(body.skill_version).toBe(SKILL_VERSION);
+        expect(body.keyword).toBe('三体');
+        expect(body.scope).toBe(10);
+        // Empty values should be dropped so the gateway does not see empty strings.
+        const body2 = buildGatewayBody('/_list', { foo: '', bar: null, baz: undefined, keep: 'yes' });
+        expect(body2).not.toHaveProperty('foo');
+        expect(body2).not.toHaveProperty('bar');
+        expect(body2).not.toHaveProperty('baz');
+        expect(body2.keep).toBe('yes');
+    });
+
+    it('rejects empty api_name', () => {
+        expect(() => buildGatewayBody('', {})).toThrow(ArgumentError);
+        expect(() => buildGatewayBody(null, {})).toThrow(ArgumentError);
+    });
+});
+
+describe('weread-official utils — auth and callGateway', () => {
+    it('throws AuthRequiredError when WEREAD_API_KEY env var is missing', () => {
+        vi.stubEnv('WEREAD_API_KEY', '');
+        expect(() => getApiKey()).toThrow(AuthRequiredError);
+    });
+
+    it('reads and trims WEREAD_API_KEY from env', () => {
+        vi.stubEnv('WEREAD_API_KEY', '  wrk-abc  ');
+        expect(getApiKey()).toBe('wrk-abc');
+    });
+
+    it('posts with Bearer auth and JSON body to the gateway URL', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ errcode: 0, ok: 1 }));
+        vi.stubGlobal('fetch', fetchMock);
+        const result = await callGateway('/store/search', { keyword: '三体', scope: 10 });
+        expect(result).toEqual({ errcode: 0, ok: 1 });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe(WEREAD_GATEWAY_URL);
+        expect(init.method).toBe('POST');
+        expect(init.headers.Authorization).toBe('Bearer wrk-test');
+        expect(init.headers['Content-Type']).toBe('application/json');
+        const parsed = JSON.parse(init.body);
+        expect(parsed.api_name).toBe('/store/search');
+        expect(parsed.skill_version).toBe(SKILL_VERSION);
+        expect(parsed.keyword).toBe('三体');
+    });
+
+    it('maps upgrade_info responses into CommandExecutionError naming both versions', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            upgrade_info: { message: '请升级 skill', required_version: '99.9.9' },
+            errcode: 0,
+        })));
+        await expect(callGateway('/_list', {})).rejects.toThrow(/Required skill_version=99\.9\.9/);
+        await expect(callGateway('/_list', {})).rejects.toThrow(/current=/);
+    });
+
+    it('maps Bearer-key reject errcodes into AuthRequiredError', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ errcode: -2010, errmsg: 'token expired' })));
+        await expect(callGateway('/shelf/sync', {})).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('maps non-zero non-auth errcodes into CommandExecutionError', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ errcode: 7, errmsg: 'oops' })));
+        await expect(callGateway('/shelf/sync', {})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps HTTP non-2xx into CommandExecutionError', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({}, false, 500)));
+        await expect(callGateway('/shelf/sync', {})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps abort signals into TimeoutError', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' })));
+        await expect(callGateway('/shelf/sync', {})).rejects.toBeInstanceOf(TimeoutError);
+    });
+
+    it('maps generic fetch errors into CommandExecutionError', async () => {
+        vi.stubEnv('WEREAD_API_KEY', 'wrk-test');
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('socket hang up')));
+        await expect(callGateway('/shelf/sync', {})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('refuses to call the gateway without an API key', async () => {
+        vi.stubEnv('WEREAD_API_KEY', '');
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(callGateway('/shelf/sync', {})).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('weread-official utils — empty-result helper', () => {
+    it('throws EmptyResultError with the canonical command label', () => {
+        try {
+            emptyResult('search', 'No hits');
+            expect.unreachable('emptyResult should have thrown');
+        }
+        catch (error) {
+            expect(error).toBeInstanceOf(EmptyResultError);
+            expect(error.message).toContain('weread-official search');
+        }
+    });
+});

--- a/docs/adapters/browser/weread-official.md
+++ b/docs/adapters/browser/weread-official.md
@@ -1,0 +1,138 @@
+# WeRead (Official Agent Gateway)
+
+**Mode**: 🌐 Public · **Domain**: `weread.qq.com`
+
+Pure HTTP adapter against WeRead's **official Agent Gateway** (`https://i.weread.qq.com/api/agent/gateway`). Coexists with the cookie-driven [`weread`](./weread.md) adapter — pick whichever auth model the operator has.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli weread-official search <keyword>` | Search the WeRead store via `/store/search` (9 scope codes) |
+| `opencli weread-official shelf` | Sync your shelf — books, albums, and the `文章收藏` (article) entry |
+| `opencli weread-official book <bookId>` | Book metadata + chapter list + reading progress (3-in-1) |
+| `opencli weread-official notes [bookId]` | Notebook overview, or merged highlights + thoughts for a specific book |
+| `opencli weread-official review <bookId>` | Browse public reviews of a book |
+| `opencli weread-official readdata` | Reading statistics: time, streak, preferences, top books |
+| `opencli weread-official discover [bookId]` | Personalized recommendations (no bookId) or similar books (with bookId) |
+| `opencli weread-official list-apis` | List every `api_name` supported by the gateway (meta endpoint) |
+
+## Usage Examples
+
+```bash
+# Search
+opencli weread-official search "三体"
+opencli weread-official search "刘慈欣" --scope author --count 20
+opencli weread-official search "AI" --scope ebook --max-idx 20   # next page
+
+# Shelf — books + albums + article-bookmark entry
+opencli weread-official shelf
+
+# Book detail (info + chapters + progress)
+opencli weread-official book 3300045871
+opencli weread-official book 3300045871 --no-chapters   # skip chapter list
+opencli weread-official book 3300045871 --no-progress   # skip reading progress
+
+# Notebook overview (all books you've annotated)
+opencli weread-official notes
+opencli weread-official notes --last-sort 1748563200    # next page cursor
+
+# Merged highlights + thoughts for a specific book
+opencli weread-official notes 3300045871
+
+# Public reviews of a book
+opencli weread-official review 3300045871
+opencli weread-official review 3300045871 --type recommend --count 20
+opencli weread-official review 3300045871 --type newest
+
+# Reading statistics
+opencli weread-official readdata --mode weekly
+opencli weread-official readdata --mode monthly
+opencli weread-official readdata --mode annually
+opencli weread-official readdata --mode overall
+opencli weread-official readdata --mode weekly --base-time 1748563200
+
+# Discover — personalized recommendations
+opencli weread-official discover --count 20
+
+# Discover — books similar to a given one
+opencli weread-official discover 3300045871 --count 20
+
+# Meta — list every gateway endpoint
+opencli weread-official list-apis
+
+# JSON output (useful for piping into other tools)
+opencli weread-official book 3300045871 -f json
+```
+
+### Search Scopes
+
+| `--scope` | Code | Meaning |
+|-----------|------|---------|
+| `all` (default) | 0 | All categories |
+| `ebook` | 10 | E-books only |
+| `webnovel` | 16 | Web novels |
+| `audio` | 14 | Audiobooks |
+| `author` | 6 | Author profiles |
+| `fulltext` | 12 | Full-text search inside books |
+| `booklist` | 13 | Curated book lists |
+| `mp` | 2 | WeChat Official Account subscriptions |
+| `article` | 4 | Individual articles |
+
+### Review Types
+
+| `--type` | Code | Meaning |
+|----------|------|---------|
+| `all` (default) | 0 | All reviews |
+| `recommend` | 1 | Recommended reviews |
+| `thumbs-down` | 2 | Negative reviews |
+| `newest` | 3 | Most recent reviews |
+| `neutral` | 4 | Neutral reviews |
+
+### Reading Stat Modes
+
+`weekly`, `monthly`, `annually`, `overall`. Optional `--base-time <unix-seconds>` shifts the period anchor.
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `search` | `rank, scope, bookId, title, author, rating, readingCount, category, searchIdx, cover, intro, link` |
+| `shelf` | `rank, kind, bookId, title, author, rating, finishReadingTime, readingTime, progress, secret, link` |
+| `book` | `section, bookId, title, value, ...` (rows tagged `info` / `chapter` / `progress`) |
+| `notes` | `kind, bookId, title, count|chapter, content|markText, ...` (`notebook` / `highlight` / `thought`) |
+| `review` | `rank, reviewId, bookId, userName, star, content, likedCount, commentCount, time, link` |
+| `readdata` | `section, label, value` (sections: `summary`, `longest`, `readStat`, `preferCategory`, `preferAuthor`, `preferPublisher`, `preferTime`) |
+| `discover` | `rank, mode, bookId, title, author, rating, readingCount, category, idx, reason, cover, intro, link` |
+| `list-apis` | `rank, apiName, description, required, optional, extras` (last row: `(client) SKILL_VERSION=...`) |
+
+## Notes
+
+- **Bearer auth only.** All commands require `WEREAD_API_KEY` (format `wrk-*`) exported in the environment. The adapter refuses to call the gateway when the key is missing.
+- **No browser, no cookies.** Pure HTTP — works in containers / CI / headless servers without a Chrome dependency.
+- **`mp` entry on the shelf** represents the user's WeChat Official Account / article bookmark feed. Shelf count formula: `books.length + albums.length + (mp非空 ? 1 : 0)`.
+- **Rating tiers**: 神作 ≥90%, 力荐 ≥80%, 好评 ≥70%, otherwise `X.X分` (raw 0-1000 scale rendered as a percentage).
+- **Star field** uses multiples of 20: `20=⭐, 40=⭐⭐, ..., 100=⭐⭐⭐⭐⭐`. `-1` and `0` both mean "no rating".
+- **`readdata` preferTime** is a 24-hour rotation starting at 06:00, mirroring the official SKILL output.
+- **Deep links** in the `link` column use the `weread://` URI scheme — clickable on devices with the WeRead app installed.
+- **Errors are typed**:
+  - Missing key / blank env var → `AuthRequiredError` (refuses to call the gateway).
+  - errcode `-2010` / `-2012` → `AuthRequiredError` (token rejected by gateway).
+  - `upgrade_info` in response → `CommandExecutionError` naming both required and current `skill_version`.
+  - HTTP non-2xx, invalid JSON, timeout, or any non-zero errcode → `CommandExecutionError` / `TimeoutError`.
+  - Empty result sets → `EmptyResultError` (never silent `[]`, never sentinel rows).
+
+## Prerequisites
+
+- No browser required — pure HTTP gateway calls.
+- Export an API key obtained from the official WeRead agent-skill program:
+
+  ```bash
+  export WEREAD_API_KEY=wrk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  ```
+
+- Skill version is pinned to `1.0.3` and reported with every request. When the gateway returns `upgrade_info`, pull the latest `weread-skills.zip` and bump `SKILL_VERSION` in `clis/weread-official/utils.js`.
+
+## Related
+
+- [`weread`](./weread.md) — Cookie + browser adapter for the reverse-engineered private endpoints. Use this when you don't have an official API key.


### PR DESCRIPTION
## Summary

Integrates WeRead's official Agent Gateway as a new CLI namespace (`clis/weread-official/`), separate from the existing cookie-driven `clis/weread/`. Pure HTTP, Bearer auth via `WEREAD_API_KEY` (format `wrk-*`). No browser, no cookies.

Source: `https://cdn.weread.qq.com/skills/weread-skills.zip` (official skill bundle).

## Commands (8)

| Command | Endpoint(s) | Notes |
|---|---|---|
| `search <keyword>` | `/store/search` | 9 scope codes (all/ebook/webnovel/audio/author/fulltext/booklist/mp/article) |
| `shelf` | `/shelf/sync` | Books + albums + `文章收藏` entry flattened |
| `book <bookId>` | `/book/info` + `/book/chapterinfo` + `/book/getprogress` | 3-in-1 with `--no-chapters` / `--no-progress` opt-outs |
| `notes [bookId]` | `/user/notebooks` OR `/book/bookmarklist` + `/review/list/mine` | Dual mode: overview vs per-book merged highlights+thoughts |
| `review <bookId>` | `/review/list` | Type aliases `all/recommend/thumbs-down/newest/neutral` |
| `readdata` | `/readdata/detail` | Modes `weekly/monthly/annually/overall` + optional `--base-time` |
| `discover [bookId]` | `/book/recommend` OR `/book/similar` | sessionId carry-forward for similar paging |
| `list-apis` | `/_list` | Meta endpoint; appends client `SKILL_VERSION` row |

## Why a separate namespace

`clis/weread/` already exists as a cookie + browser adapter (reverse-engineered private endpoints). The official gateway uses a different transport (Bearer API key, JSON body, no cookies) and different endpoints. Folding them together would conflate two auth models and confuse users. Both can coexist — pick whichever auth the operator has.

## Typed error coverage

`callGateway` maps every documented failure to a typed error — no silent `return []`, no sentinel rows, no silent clamp:

- Missing/blank `WEREAD_API_KEY` → `AuthRequiredError` (refuses to even call the gateway)
- errcode `-2010` / `-2012` → `AuthRequiredError` (Bearer key rejected)
- `upgrade_info` present in response → `CommandExecutionError` naming required + current `SKILL_VERSION`
- HTTP non-2xx → `CommandExecutionError`
- `AbortError` (timeout) → `TimeoutError`
- Other non-zero errcode → `CommandExecutionError`
- Empty payloads → `EmptyResultError`

## Body shape (critical)

Business params flatten directly next to `api_name` + `skill_version`. Wrapping in `params` / `data` / `body` silently returns page 1 with empty filters — `buildGatewayBody` documents and enforces this.

## Tests

- `utils.test.js` (23) — formatters, deep links, validators, `callGateway` full error matrix, auth.
- `commands.test.js` (22) — per-command registration, happy path with mocked gateway, arg validation, `EmptyResultError` paths, cross-command `AuthRequiredError` enforcement when env unset.
- `npm run build` — manifest 829 entries (+8 from baseline 821).
- `tsc --noEmit` clean.
- Smoke: `node dist/src/main.js weread-official search "三体"` returns AUTH_REQUIRED envelope (no key), `weread-official --help` lists all 8 commands.

## Test plan

- [ ] Provision a live `WEREAD_API_KEY` and smoke each command end-to-end
- [ ] Capture verify fixtures under `~/.opencli/sites/weread-official/verify/<cmd>.json`
- [ ] Confirm `upgrade_info` handling against a deliberately stale `SKILL_VERSION`

## Site memory

`~/.opencli/sites/weread-official/{notes.md, endpoints.json}` (this PR) — endpoint inventory, field decoding (star, newRating, readingTime), deep-link schemas, and known traps documented for future authors.

## Deferred (Phase 2)

- `npm run check:weread-official-skill-version` script to diff local `SKILL_VERSION` against latest published skill bundle (would need a stable URL or scrape rule — `weread-skills.zip` doesn't expose a version header).
- Nice-to-have endpoints: standalone `bestbookmarks` / `underlines` / `review-single` (not required by SKILL contract but the gateway exposes them).
- Verify fixtures (need provisioned `WEREAD_API_KEY` to capture real responses).