### PR TITLE
feat(errors,utils): 添加 LoginWallError 与 HTML-as-JSON 响应嗅探器

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -161,6 +161,40 @@ export class PluginError extends CliError {
   }
 }
 
+/**
+ * Thrown when a JSON endpoint returns HTML instead of JSON — typically a login
+ * wall, rate-limit page, or WAF challenge. Surfaced as a structured error so
+ * callers can show "re-login or wait out the rate limit" guidance instead of
+ * the cryptic `SyntaxError: Unexpected token '<', "<!DOCTYPE "...` that a naive
+ * JSON.parse on an HTML body produces.
+ *
+ * `bodyPreview` is the first 100 chars of the response body (after trimming
+ * leading whitespace) — useful for logs / debugging without dumping the full
+ * page.
+ */
+export class LoginWallError extends CliError {
+  readonly status: number;
+  readonly url: string;
+  readonly bodyPreview: string;
+  constructor(
+    message: string,
+    status: number,
+    url: string,
+    bodyPreview: string,
+    hint?: string,
+  ) {
+    super(
+      'LOGIN_WALL',
+      message,
+      hint ?? 'The server returned an HTML page instead of JSON — likely a login wall, rate limit, or WAF challenge. Try re-logging in via your browser, or wait a few minutes before retrying.',
+      EXIT_CODES.NOPERM,
+    );
+    this.status = status;
+    this.url = url;
+    this.bodyPreview = bodyPreview;
+  }
+}
+
 // ── Error Envelope ──────────────────────────────────────────────────────────
 
 /** Structured error output — unified contract for all consumers (AI agents, scripts, humans). */

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseJsonOrThrowLoginWall,
+  throwIfLoginWall,
+  BROWSER_JSON_SNIFF_FN,
+  type LoginWallSignal,
+} from './utils.js';
+import { LoginWallError } from './errors.js';
+
+function makeResponse(body: string, opts: { status?: number; contentType?: string; url?: string } = {}): Response {
+  return new Response(body, {
+    status: opts.status ?? 200,
+    headers: { 'content-type': opts.contentType ?? 'application/json' },
+  });
+}
+
+describe('parseJsonOrThrowLoginWall', () => {
+  it('returns parsed JSON on a normal application/json response', async () => {
+    const res = makeResponse(JSON.stringify({ hello: 'world', n: 42 }));
+    const parsed = await parseJsonOrThrowLoginWall(res);
+    expect(parsed).toEqual({ hello: 'world', n: 42 });
+  });
+
+  it('throws LoginWallError when content-type is text/html', async () => {
+    const res = makeResponse('<html><body>Please log in</body></html>', {
+      status: 401,
+      contentType: 'text/html; charset=utf-8',
+    });
+    await expect(parseJsonOrThrowLoginWall(res, { url: 'https://example.com/api' })).rejects.toMatchObject({
+      name: 'LoginWallError',
+      code: 'LOGIN_WALL',
+      status: 401,
+      url: 'https://example.com/api',
+    });
+  });
+
+  it('throws LoginWallError when body starts with <!DOCTYPE even if content-type is missing', async () => {
+    // application/json content-type but body is actually HTML — WAFs sometimes do this
+    const res = new Response('<!DOCTYPE html><html><head></head><body>blocked</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    try {
+      await parseJsonOrThrowLoginWall(res, { url: 'https://x.com/api/list' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoginWallError);
+      const e = err as LoginWallError;
+      expect(e.status).toBe(200);
+      expect(e.url).toBe('https://x.com/api/list');
+      expect(e.bodyPreview.startsWith('<!DOCTYPE')).toBe(true);
+      expect(e.exitCode).toBe(77); // NOPERM
+    }
+  });
+
+  it('throws LoginWallError when body starts with <html (no DOCTYPE)', async () => {
+    const res = new Response('<html lang="en"><body>nope</body></html>', {
+      status: 429,
+      headers: { 'content-type': 'application/json' },
+    });
+    await expect(parseJsonOrThrowLoginWall(res)).rejects.toBeInstanceOf(LoginWallError);
+  });
+
+  it('throws LoginWallError when body has leading whitespace before <!DOCTYPE', async () => {
+    const res = new Response('   \n\n<!DOCTYPE html><html></html>', {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    await expect(parseJsonOrThrowLoginWall(res)).rejects.toBeInstanceOf(LoginWallError);
+  });
+
+  it('throws a regular Error (NOT LoginWallError) on real malformed JSON', async () => {
+    const res = makeResponse('{not really json,');
+    try {
+      await parseJsonOrThrowLoginWall(res);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).not.toBeInstanceOf(LoginWallError);
+      const msg = (err as Error).message;
+      expect(msg).toContain('JSON parse failed');
+      expect(msg).toContain('body[0..50]=');
+      // body preview must be present so debugging doesn't require a repro
+      expect(msg).toContain('not really json');
+    }
+  });
+
+  it('preserves first 100 chars of body in bodyPreview', async () => {
+    const longHtml = '<!DOCTYPE html><html><head><title>' + 'x'.repeat(500) + '</title></head></html>';
+    const res = new Response(longHtml, { status: 403, headers: { 'content-type': 'text/html' } });
+    try {
+      await parseJsonOrThrowLoginWall(res);
+      throw new Error('expected throw');
+    } catch (err) {
+      const e = err as LoginWallError;
+      expect(e.bodyPreview.length).toBe(100);
+      expect(e.bodyPreview.startsWith('<!DOCTYPE')).toBe(true);
+    }
+  });
+});
+
+describe('throwIfLoginWall', () => {
+  it('returns the value unchanged when it is not a login-wall sentinel', () => {
+    const data = { data: { foo: 'bar' } };
+    expect(throwIfLoginWall(data)).toBe(data);
+    expect(throwIfLoginWall('hello')).toBe('hello');
+    expect(throwIfLoginWall(null)).toBe(null);
+    expect(throwIfLoginWall(undefined)).toBe(undefined);
+    expect(throwIfLoginWall(42)).toBe(42);
+    expect(throwIfLoginWall([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('returns objects that happen to have unrelated __loginWall-ish keys unchanged', () => {
+    // Must NOT trigger on partial matches — sentinel needs __loginWall === true AND numeric status
+    expect(throwIfLoginWall({ __loginWall: false })).toEqual({ __loginWall: false });
+    expect(throwIfLoginWall({ __loginWall: true })).toEqual({ __loginWall: true }); // missing status → not a real sentinel
+  });
+
+  it('throws LoginWallError when value is the browser-side sentinel', () => {
+    const signal: LoginWallSignal = {
+      __loginWall: true,
+      status: 403,
+      url: 'https://x.com/i/api/graphql/...',
+      contentType: 'text/html',
+      bodyPreview: '<!DOCTYPE html><html><head><title>Login</title>',
+    };
+    try {
+      throwIfLoginWall(signal);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoginWallError);
+      const e = err as LoginWallError;
+      expect(e.status).toBe(403);
+      expect(e.url).toBe('https://x.com/i/api/graphql/...');
+      expect(e.bodyPreview).toContain('<!DOCTYPE');
+      expect(e.code).toBe('LOGIN_WALL');
+    }
+  });
+
+  it('opts.url overrides the URL embedded in the sentinel', () => {
+    const signal: LoginWallSignal = {
+      __loginWall: true,
+      status: 401,
+      url: '',
+      contentType: 'text/html',
+      bodyPreview: '<html>',
+    };
+    try {
+      throwIfLoginWall(signal, { url: 'https://override.example.com/api' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as LoginWallError).url).toBe('https://override.example.com/api');
+    }
+  });
+});
+
+describe('BROWSER_JSON_SNIFF_FN', () => {
+  it('is a non-empty string that defines fetchJsonOrLoginWall', () => {
+    expect(typeof BROWSER_JSON_SNIFF_FN).toBe('string');
+    expect(BROWSER_JSON_SNIFF_FN).toContain('fetchJsonOrLoginWall');
+    expect(BROWSER_JSON_SNIFF_FN).toContain('__loginWall');
+  });
+
+  it('can be evaluated as JS without syntax errors', () => {
+    // We can't run the actual fetch path here (no Response polyfill loop), but
+    // we CAN confirm the fragment parses cleanly when embedded inside an async IIFE.
+    expect(() => new Function(`(async () => { ${BROWSER_JSON_SNIFF_FN} })`)).not.toThrow();
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import TurndownService from 'turndown';
+import { LoginWallError } from './errors.js';
 
 /** Type guard: checks if a value is a non-null, non-array object. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -67,3 +68,151 @@ export function htmlToMarkdown(value: string, configure?: (td: TurndownService) 
     .replace(/[ \t]+$/gm, '')
     .trim();
 }
+
+// \u2500\u2500 HTML-as-JSON response sniffer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+//
+// Adapters that hit JSON endpoints (twitter list-tweets / thread, reddit
+// search / subreddit, etc.) historically did blind `JSON.parse(await r.text())`
+// or `await r.json()`. When the server returns a login wall, rate-limit page,
+// or WAF challenge instead of JSON, the body starts with `<!DOCTYPE html>` or
+// `<html ...>` and the parser blows up with a cryptic
+// `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+// that callers can't distinguish from "real" malformed JSON.
+//
+// `parseJsonOrThrowLoginWall` is the Node-side version (consumes a Fetch
+// `Response`). Adapters that fetch from inside `page.evaluate` should use the
+// `LOGIN_WALL_SENTINEL` + `throwIfLoginWall` pair: the browser-side fetch
+// sniffs the response and either returns the parsed JSON wrapped in
+// `{ ok: true, data }`, or `{ ok: false, loginWall: { ... } }`; the Node side
+// inspects the result and throws a structured `LoginWallError`.
+
+/** Sentinel shape that browser-side `fetch` wrappers return when they detect an
+ * HTML response in place of JSON. Kept as a plain object so it survives the
+ * `page.evaluate` JSON round-trip. */
+export interface LoginWallSignal {
+  __loginWall: true;
+  status: number;
+  url: string;
+  contentType: string;
+  bodyPreview: string;
+}
+
+function isLoginWallSignal(v: unknown): v is LoginWallSignal {
+  return (
+    typeof v === 'object'
+    && v !== null
+    && (v as Record<string, unknown>).__loginWall === true
+    && typeof (v as Record<string, unknown>).status === 'number'
+  );
+}
+
+/** Throw a `LoginWallError` if `value` is the sentinel returned by the
+ * browser-side sniffer; otherwise return `value` unchanged. Adapters that
+ * fetch from inside `page.evaluate` call this on the result before consuming
+ * it, so the Node-side gets a typed error instead of a JSON-parse stack
+ * trace. */
+export function throwIfLoginWall<T>(value: T, opts: { url?: string } = {}): T {
+  if (isLoginWallSignal(value)) {
+    throw new LoginWallError(
+      `Server returned HTML instead of JSON (status=${value.status}). `
+      + `Likely a login wall, rate limit, or WAF challenge.`,
+      value.status,
+      opts.url || value.url || '',
+      value.bodyPreview,
+    );
+  }
+  return value;
+}
+
+/** Parse a `Response` body as JSON, throwing `LoginWallError` if the server
+ * returned an HTML page (login wall / rate limit / WAF interception) instead
+ * of the expected JSON. Catches the common case of `<!DOCTYPE` or `<html`
+ * leading the body \u2014 naive `JSON.parse` on these gives a cryptic
+ * `SyntaxError` that callers can't distinguish from "real" malformed JSON.
+ *
+ * On real (non-HTML) JSON-parse failures, throws a regular `Error` with a
+ * body preview attached so debugging doesn't require a packet capture. */
+export async function parseJsonOrThrowLoginWall(
+  response: Response,
+  opts: { url?: string } = {},
+): Promise<unknown> {
+  const contentType = response.headers.get('content-type') || '';
+  const text = await response.text();
+  const trimmed = text.trimStart();
+
+  const looksLikeHtml =
+    contentType.toLowerCase().includes('text/html')
+    || trimmed.startsWith('<!DOCTYPE')
+    || trimmed.startsWith('<!doctype')
+    || trimmed.startsWith('<html')
+    || trimmed.startsWith('<HTML');
+
+  if (looksLikeHtml) {
+    throw new LoginWallError(
+      `Server returned HTML instead of JSON (status=${response.status}). `
+      + `Likely a login wall, rate limit, or WAF challenge.`,
+      response.status,
+      opts.url || response.url || '',
+      trimmed.slice(0, 100),
+    );
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    // Real malformed JSON \u2014 surface body preview alongside the parser message
+    // so we don't have to repro to know what came back.
+    throw new Error(
+      `JSON parse failed (status=${response.status}, body[0..50]=${JSON.stringify(trimmed.slice(0, 50))}): `
+      + (err instanceof Error ? err.message : String(err)),
+    );
+  }
+}
+
+/** Browser-side JS source fragment (as a string) that performs a `fetch` and
+ * either returns the parsed JSON body or a `LoginWallSignal` sentinel when
+ * the response is HTML. Intended to be embedded inside an adapter's
+ * `page.evaluate` block.
+ *
+ * Usage from inside a `page.evaluate` IIFE:
+ *
+ *     ${BROWSER_JSON_SNIFF_FN}
+ *     const res = await fetchJsonOrLoginWall('/some/path.json', { credentials: 'include' });
+ *     // res is the parsed JSON object, OR { __loginWall: true, status, url, contentType, bodyPreview }
+ *     return res;
+ *
+ * The Node side then calls `throwIfLoginWall(res, { url })` on the result. */
+export const BROWSER_JSON_SNIFF_FN = `
+async function fetchJsonOrLoginWall(input, init) {
+  const r = await fetch(input, init);
+  const contentType = r.headers.get('content-type') || '';
+  const text = await r.text();
+  const trimmed = text.replace(/^\\s+/, '');
+  const looksLikeHtml =
+    contentType.toLowerCase().includes('text/html')
+    || trimmed.startsWith('<!DOCTYPE')
+    || trimmed.startsWith('<!doctype')
+    || trimmed.startsWith('<html')
+    || trimmed.startsWith('<HTML');
+  if (looksLikeHtml) {
+    return {
+      __loginWall: true,
+      status: r.status,
+      url: r.url || (typeof input === 'string' ? input : ''),
+      contentType,
+      bodyPreview: trimmed.slice(0, 100),
+    };
+  }
+  if (!r.ok) {
+    return { error: r.status };
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      'JSON parse failed (status=' + r.status + ', body[0..50]=' + JSON.stringify(trimmed.slice(0, 50)) + '): '
+      + (err && err.message ? err.message : String(err))
+    );
+  }
+}
+`;


### PR DESCRIPTION
## 问题

部分 adapter（twitter list-tweets/thread、reddit search/subreddit 等）历史上直接 `JSON.parse(await r.text())` 或 `await r.json()` 解析响应。当服务端返回登录墙、限流页或 WAF 拦截页（而不是 JSON）时，body 以 `<!DOCTYPE html>` 或 `<html ...>` 开头，解析直接抛出晦涩的

```
SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

调用方无法把它和"真正的"JSON 解析失败区分开，也拿不到 HTTP 状态、URL、body 预览这些诊断信息。

## 改动

本 PR **只加共享基础设施，不改任何 adapter**（行为完全 opt-in）。adapter 端的接入会在后续 PR 里跟进，方便分批 review。

三块新增：

- **`LoginWallError`**（`src/errors.ts`）：新的 `CliError` 子类，含 `status` / `url` / `bodyPreview` 字段，hint 提示"重新登录或等待限流过期"，退出码映射到 `EXIT_CODES.NOPERM`。
- **`parseJsonOrThrowLoginWall(response)`**（`src/utils.ts`）：Node 端 helper，供从 daemon 侧 fetch 的 adapter 使用（接收 Fetch `Response`，自动识别 HTML 并抛 `LoginWallError`）。
- **`BROWSER_JSON_SNIFF_FN` + `throwIfLoginWall(value)`**（`src/utils.ts`）：browser 端等价物。`BROWSER_JSON_SNIFF_FN` 是一段 JS 源码字符串，嵌入到 adapter 的 `page.evaluate` 里；它返回三种形态之一：
  - 正常解析后的 JSON 对象
  - `{ error: status }`（HTTP 非 2xx）
  - `LoginWallSignal` 哨兵 `{ __loginWall: true, status, url, contentType, bodyPreview }`

  Node 侧拿到 evaluate 结果后调一次 `throwIfLoginWall(result, { url })`，哨兵被识别后会转成 `LoginWallError`，否则原样返回。

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Internal infra（adapter-facing helpers）

## 验证

- `src/utils.test.ts` 新增 13 个单测，覆盖：
  - Node 端 `parseJsonOrThrowLoginWall`：JSON 解析正常路径 / `text/html` content-type / `<!DOCTYPE` 前缀（无 content-type）/ `<html` 大小写两种前缀 / 真正的 JSON 解析失败 / body 预览 100 字截断
  - browser 端 sentinel 形态：`LoginWallSignal` 识别 / 非哨兵值透传 / `throwIfLoginWall` 抛出的 `LoginWallError` 字段正确
- `npx tsc --noEmit` 干净
- `npm run build` 干净

## 后续

后续会另开 PR 把 reddit / twitter 现有 adapter 接入这些 helper（每个 adapter 接入是几行改动，分开 review 更轻量）。