### PR TITLE
feat(reddit): 新增 subscribed 命令 + 在 listing 命令上暴露 id / created_utc / selftext

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20065,11 +20065,15 @@
     ],
     "columns": [
       "rank",
+      "id",
       "title",
       "subreddit",
       "score",
       "comments",
-      "url"
+      "author",
+      "url",
+      "created_utc",
+      "selftext"
     ],
     "type": "js",
     "modulePath": "reddit/popular.js",
@@ -20294,12 +20298,15 @@
       }
     ],
     "columns": [
+      "id",
       "title",
       "subreddit",
       "author",
       "score",
       "comments",
-      "url"
+      "url",
+      "created_utc",
+      "selftext"
     ],
     "type": "js",
     "modulePath": "reddit/search.js",
@@ -20345,11 +20352,15 @@
       }
     ],
     "columns": [
+      "id",
       "title",
+      "subreddit",
       "author",
       "upvotes",
       "comments",
-      "url"
+      "url",
+      "created_utc",
+      "selftext"
     ],
     "type": "js",
     "modulePath": "reddit/subreddit.js",
@@ -20413,6 +20424,35 @@
     "type": "js",
     "modulePath": "reddit/subscribe.js",
     "sourceFile": "reddit/subscribe.js",
+    "navigateBefore": "https://reddit.com"
+  },
+  {
+    "site": "reddit",
+    "name": "subscribed",
+    "description": "List subreddits you are subscribed to",
+    "access": "read",
+    "domain": "reddit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 100,
+        "required": false,
+        "help": "Max subreddits to return (auto-paginates; hard cap 1000)"
+      }
+    ],
+    "columns": [
+      "subreddit",
+      "title",
+      "subscribers",
+      "description",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "reddit/subscribed.js",
+    "sourceFile": "reddit/subscribed.js",
     "navigateBefore": "https://reddit.com"
   },
   {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20440,10 +20440,11 @@
         "type": "int",
         "default": 100,
         "required": false,
-        "help": "Max subreddits to return (auto-paginates; hard cap 1000)"
+        "help": "Max subreddits to return (1-1000, auto-paginates)"
       }
     ],
     "columns": [
+      "id",
       "subreddit",
       "title",
       "subscribers",

--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -10,7 +10,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'url'],
+    columns: ['rank', 'id', 'title', 'subreddit', 'score', 'comments', 'author', 'url', 'created_utc', 'selftext'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
@@ -20,22 +20,29 @@ cli({
   });
   const d = await res.json();
   return (d?.data?.children || []).map(c => ({
+    id: c.data.id,
     title: c.data.title,
     subreddit: c.data.subreddit_name_prefixed,
     score: c.data.score,
     comments: c.data.num_comments,
     author: c.data.author,
     url: 'https://www.reddit.com' + c.data.permalink,
+    created_utc: c.data.created_utc,
+    selftext: c.data.selftext || '',
   }));
 })()
 ` },
         { map: {
                 rank: '${{ index + 1 }}',
+                id: '${{ item.id }}',
                 title: '${{ item.title }}',
                 subreddit: '${{ item.subreddit }}',
                 score: '${{ item.score }}',
                 comments: '${{ item.comments }}',
+                author: '${{ item.author }}',
                 url: '${{ item.url }}',
+                created_utc: '${{ item.created_utc }}',
+                selftext: '${{ item.selftext }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -29,7 +29,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['title', 'subreddit', 'author', 'score', 'comments', 'url'],
+    columns: ['id', 'title', 'subreddit', 'author', 'score', 'comments', 'url', 'created_utc', 'selftext'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
@@ -44,22 +44,28 @@ cli({
   const res = await fetch(basePath + '?' + params, { credentials: 'include' });
   const d = await res.json();
   return (d?.data?.children || []).map(c => ({
+    id: c.data.id,
     title: c.data.title,
     subreddit: c.data.subreddit_name_prefixed,
     author: c.data.author,
     score: c.data.score,
     comments: c.data.num_comments,
     url: 'https://www.reddit.com' + c.data.permalink,
+    created_utc: c.data.created_utc,
+    selftext: c.data.selftext || '',
   }));
 })()
 ` },
         { map: {
+                id: '${{ item.id }}',
                 title: '${{ item.title }}',
                 subreddit: '${{ item.subreddit }}',
                 author: '${{ item.author }}',
                 score: '${{ item.score }}',
                 comments: '${{ item.comments }}',
                 url: '${{ item.url }}',
+                created_utc: '${{ item.created_utc }}',
+                selftext: '${{ item.selftext }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -23,7 +23,7 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['title', 'author', 'upvotes', 'comments', 'url'],
+    columns: ['id', 'title', 'subreddit', 'author', 'upvotes', 'comments', 'url', 'created_utc', 'selftext'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
@@ -42,11 +42,15 @@ cli({
 })()
 ` },
         { map: {
+                id: '${{ item.data.id }}',
                 title: '${{ item.data.title }}',
+                subreddit: '${{ item.data.subreddit_name_prefixed }}',
                 author: '${{ item.data.author }}',
                 upvotes: '${{ item.data.score }}',
                 comments: '${{ item.data.num_comments }}',
                 url: 'https://www.reddit.com${{ item.data.permalink }}',
+                created_utc: '${{ item.data.created_utc }}',
+                selftext: '${{ item.data.selftext }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/subscribed.js
+++ b/clis/reddit/subscribed.js
@@ -27,9 +27,10 @@ function mapSubredditRow(entry, index) {
     if (!data || typeof data !== 'object') {
         throw new CommandExecutionError(`Reddit subscriptions row ${index + 1} was missing data.`);
     }
-    const id = typeof data.name === 'string' && data.name
-        ? data.name
-        : (typeof data.id === 'string' && data.id ? `t5_${data.id}` : '');
+    const fullname = typeof data.name === 'string' ? data.name : '';
+    const id = fullname.startsWith('t5_')
+        ? fullname
+        : (entry?.kind === 't5' && typeof data.id === 'string' && data.id ? `t5_${data.id}` : '');
     const displayName = typeof data.display_name === 'string' && data.display_name
         ? data.display_name
         : '';

--- a/clis/reddit/subscribed.js
+++ b/clis/reddit/subscribed.js
@@ -1,0 +1,66 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+cli({
+    site: 'reddit',
+    name: 'subscribed',
+    description: 'List subreddits you are subscribed to',
+    access: 'read',
+    domain: 'reddit.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'limit', type: 'int', default: 100, help: 'Max subreddits to return (auto-paginates; hard cap 1000)' },
+    ],
+    columns: ['subreddit', 'title', 'subscribers', 'description', 'url'],
+    func: async (page, kwargs) => {
+        if (!page)
+            throw new CommandExecutionError('Browser session required');
+        await page.goto('https://www.reddit.com');
+        const result = await page.evaluate(`(async () => {
+      try {
+        const meRes = await fetch('/api/me.json?raw_json=1', { credentials: 'include' });
+        const me = await meRes.json();
+        const username = me?.name || me?.data?.name;
+        if (!username) return { error: 'Not logged in — cannot list subscriptions' };
+
+        const target = ${kwargs.limit};
+        const HARD_CAP = 1000;
+        const PAGE_SIZE = 100;
+        const want = Math.min(target, HARD_CAP);
+        const out = [];
+        let after = null;
+        while (out.length < want) {
+          const remaining = want - out.length;
+          const pageLimit = Math.min(PAGE_SIZE, remaining);
+          const url = '/subreddits/mine/subscriptions.json?limit=' + pageLimit
+            + '&raw_json=1'
+            + (after ? '&after=' + encodeURIComponent(after) : '');
+          const res = await fetch(url, { credentials: 'include' });
+          if (!res.ok) return { error: 'HTTP ' + res.status + ' from ' + url };
+          const d = await res.json();
+          const children = d?.data?.children || [];
+          for (const c of children) {
+            out.push({
+              subreddit: c.data.display_name_prefixed || ('r/' + (c.data.display_name || '?')),
+              title: c.data.title || '',
+              subscribers: c.data.subscribers || 0,
+              description: (c.data.public_description || '').slice(0, 200),
+              url: 'https://www.reddit.com' + (c.data.url || ''),
+            });
+          }
+          after = d?.data?.after || null;
+          if (!after || children.length === 0) break;
+        }
+        return out;
+      } catch (e) {
+        return { error: e.toString() };
+      }
+    })()`);
+        if (result?.error) {
+            if (String(result.error).includes('Not logged in'))
+                throw new AuthRequiredError('reddit.com', result.error);
+            throw new CommandExecutionError(result.error);
+        }
+        return (result || []).slice(0, kwargs.limit);
+    }
+});

--- a/clis/reddit/subscribed.js
+++ b/clis/reddit/subscribed.js
@@ -1,5 +1,55 @@
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
+
+export const REDDIT_SUBSCRIBED_MAX_LIMIT = 1000;
+
+export function parseRedditSubscribedLimit(raw) {
+    if (raw === undefined || raw === null || raw === '') return 100;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1 || n > REDDIT_SUBSCRIBED_MAX_LIMIT) {
+        throw new ArgumentError(
+            `limit must be an integer in [1, ${REDDIT_SUBSCRIBED_MAX_LIMIT}].`,
+            `Got: ${raw}`,
+        );
+    }
+    return n;
+}
+
+export function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
+
+function mapSubredditRow(entry, index) {
+    const data = entry?.data;
+    if (!data || typeof data !== 'object') {
+        throw new CommandExecutionError(`Reddit subscriptions row ${index + 1} was missing data.`);
+    }
+    const id = typeof data.name === 'string' && data.name
+        ? data.name
+        : (typeof data.id === 'string' && data.id ? `t5_${data.id}` : '');
+    const displayName = typeof data.display_name === 'string' && data.display_name
+        ? data.display_name
+        : '';
+    const subreddit = typeof data.display_name_prefixed === 'string' && data.display_name_prefixed
+        ? data.display_name_prefixed
+        : (displayName ? `r/${displayName}` : '');
+    const path = typeof data.url === 'string' && data.url.startsWith('/r/') ? data.url : '';
+    if (!id || !displayName || !subreddit || !path) {
+        throw new CommandExecutionError(`Reddit subscriptions row ${index + 1} was missing subreddit identity.`);
+    }
+    return {
+        id,
+        subreddit,
+        title: typeof data.title === 'string' ? data.title : '',
+        subscribers: typeof data.subscribers === 'number' ? data.subscribers : null,
+        description: typeof data.public_description === 'string' ? data.public_description.slice(0, 200) : '',
+        url: 'https://www.reddit.com' + path,
+    };
+}
+
 cli({
     site: 'reddit',
     name: 'subscribed',
@@ -9,58 +59,93 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 100, help: 'Max subreddits to return (auto-paginates; hard cap 1000)' },
+        { name: 'limit', type: 'int', default: 100, help: `Max subreddits to return (1-${REDDIT_SUBSCRIBED_MAX_LIMIT}, auto-paginates)` },
     ],
-    columns: ['subreddit', 'title', 'subscribers', 'description', 'url'],
+    columns: ['id', 'subreddit', 'title', 'subscribers', 'description', 'url'],
     func: async (page, kwargs) => {
+        const limit = parseRedditSubscribedLimit(kwargs.limit);
         if (!page)
             throw new CommandExecutionError('Browser session required');
         await page.goto('https://www.reddit.com');
-        const result = await page.evaluate(`(async () => {
+        const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
       try {
         const meRes = await fetch('/api/me.json?raw_json=1', { credentials: 'include' });
+        if (meRes.status === 401 || meRes.status === 403) {
+          return { kind: 'auth', detail: 'Reddit /api/me.json returned HTTP ' + meRes.status };
+        }
+        if (!meRes.ok) {
+          return { kind: 'http', httpStatus: meRes.status, where: '/api/me.json' };
+        }
         const me = await meRes.json();
-        const username = me?.name || me?.data?.name;
-        if (!username) return { error: 'Not logged in — cannot list subscriptions' };
+        const username = me?.data?.name || me?.name;
+        if (!username) return { kind: 'auth', detail: 'Not logged in to reddit.com (no identity in /api/me.json)' };
 
-        const target = ${kwargs.limit};
-        const HARD_CAP = 1000;
+        const target = ${JSON.stringify(limit)};
         const PAGE_SIZE = 100;
-        const want = Math.min(target, HARD_CAP);
         const out = [];
         let after = null;
-        while (out.length < want) {
-          const remaining = want - out.length;
+        const seenCursors = new Set();
+        for (let pageIndex = 0; pageIndex < 20 && out.length < target; pageIndex++) {
+          const remaining = target - out.length;
           const pageLimit = Math.min(PAGE_SIZE, remaining);
           const url = '/subreddits/mine/subscriptions.json?limit=' + pageLimit
             + '&raw_json=1'
             + (after ? '&after=' + encodeURIComponent(after) : '');
           const res = await fetch(url, { credentials: 'include' });
-          if (!res.ok) return { error: 'HTTP ' + res.status + ' from ' + url };
-          const d = await res.json();
-          const children = d?.data?.children || [];
-          for (const c of children) {
-            out.push({
-              subreddit: c.data.display_name_prefixed || ('r/' + (c.data.display_name || '?')),
-              title: c.data.title || '',
-              subscribers: c.data.subscribers || 0,
-              description: (c.data.public_description || '').slice(0, 200),
-              url: 'https://www.reddit.com' + (c.data.url || ''),
-            });
+          if (res.status === 401 || res.status === 403) {
+            return { kind: 'auth', detail: 'Reddit subscriptions endpoint returned HTTP ' + res.status };
           }
-          after = d?.data?.after || null;
-          if (!after || children.length === 0) break;
+          if (!res.ok) return { kind: 'http', httpStatus: res.status, where: url };
+          const d = await res.json();
+          const children = d?.data?.children;
+          if (!Array.isArray(children)) {
+            return { kind: 'malformed', detail: 'Reddit subscriptions payload was missing data.children.' };
+          }
+          for (const child of children) {
+            if (out.length >= target) break;
+            out.push(child);
+          }
+          const next = d?.data?.after ?? null;
+          if (next !== null && typeof next !== 'string') {
+            return { kind: 'malformed', detail: 'Reddit subscriptions payload had a malformed after cursor.' };
+          }
+          if (out.length >= target || !next) break;
+          if (children.length === 0) {
+            return { kind: 'malformed', detail: 'Reddit subscriptions page was empty but returned an after cursor.' };
+          }
+          if (seenCursors.has(next)) {
+            return { kind: 'malformed', detail: 'Reddit subscriptions repeated pagination cursor ' + next + '.' };
+          }
+          seenCursors.add(next);
+          after = next;
         }
-        return out;
+        if (out.length < target && after) {
+          return { kind: 'malformed', detail: 'Reddit subscriptions pagination exceeded the safety cap before satisfying the requested limit.' };
+        }
+        return { kind: 'ok', entries: out };
       } catch (e) {
-        return { error: e.toString() };
+        return { kind: 'exception', detail: String(e && e.message || e) };
       }
-    })()`);
-        if (result?.error) {
-            if (String(result.error).includes('Not logged in'))
-                throw new AuthRequiredError('reddit.com', result.error);
-            throw new CommandExecutionError(result.error);
+    })()`));
+        if (result?.kind === 'auth') {
+            throw new AuthRequiredError('reddit.com', result.detail);
         }
-        return (result || []).slice(0, kwargs.limit);
+        if (result?.kind === 'http') {
+            throw new CommandExecutionError(`HTTP ${result.httpStatus} from ${result.where}`);
+        }
+        if (result?.kind === 'malformed') {
+            throw new CommandExecutionError(result.detail);
+        }
+        if (result?.kind === 'exception') {
+            throw new CommandExecutionError(`subscribed failed: ${result.detail}`);
+        }
+        if (result?.kind !== 'ok' || !Array.isArray(result.entries)) {
+            throw new CommandExecutionError(`Unexpected result from reddit subscribed: ${JSON.stringify(result)}`);
+        }
+        const rows = result.entries.slice(0, limit).map((entry, index) => mapSubredditRow(entry, index));
+        if (rows.length === 0) {
+            throw new EmptyResultError('Reddit returned no subscribed subreddits for the logged-in account.');
+        }
+        return rows;
     }
 });

--- a/clis/reddit/subscribed.test.js
+++ b/clis/reddit/subscribed.test.js
@@ -117,6 +117,21 @@ describe('reddit subscribed adapter', () => {
             .rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('does not synthesize subreddit identity from a non-t5 listing item', async () => {
+        await expect(command.func(makePage({
+            kind: 'ok',
+            entries: [{
+                kind: 't3',
+                data: {
+                    id: 'abc',
+                    display_name: 'notasub',
+                    display_name_prefixed: 'r/notasub',
+                    url: '/r/notasub/',
+                },
+            }],
+        }), { limit: 100 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('respects --limit by slicing the final result', async () => {
         const page = makePage({ kind: 'ok', entries: Array.from({ length: 5 }, (_, i) => subredditThing(String(i))) });
         const result = await command.func(page, { limit: 3 });

--- a/clis/reddit/subscribed.test.js
+++ b/clis/reddit/subscribed.test.js
@@ -1,49 +1,133 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { parseRedditSubscribedLimit, unwrapEvaluateResult } from './subscribed.js';
 import './subscribed.js';
+
+function subredditThing(id, overrides = {}) {
+    const displayName = `sub${id}`;
+    return {
+        kind: 't5',
+        data: {
+            id,
+            name: `t5_${id}`,
+            display_name: displayName,
+            display_name_prefixed: `r/${displayName}`,
+            title: `Sub ${id}`,
+            subscribers: 1000,
+            public_description: `Description ${id}`,
+            url: `/r/${displayName}/`,
+            ...overrides,
+        },
+    };
+}
+
+function makePage(result) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(result),
+    };
+}
+
 describe('reddit subscribed adapter', () => {
     const command = getRegistry().get('reddit/subscribed');
+
+    it('registers with id-bearing output columns', () => {
+        expect(command).toBeDefined();
+        expect(command.columns).toEqual(['id', 'subreddit', 'title', 'subscribers', 'description', 'url']);
+    });
+
+    it('parseRedditSubscribedLimit rejects out-of-range values without silent clamp', () => {
+        expect(parseRedditSubscribedLimit(undefined)).toBe(100);
+        expect(parseRedditSubscribedLimit(null)).toBe(100);
+        expect(parseRedditSubscribedLimit('')).toBe(100);
+        expect(parseRedditSubscribedLimit(1)).toBe(1);
+        expect(parseRedditSubscribedLimit(1000)).toBe(1000);
+        for (const bad of [0, -1, 1001, 1.5, NaN, 'abc']) {
+            expect(() => parseRedditSubscribedLimit(bad)).toThrow(ArgumentError);
+        }
+    });
+
+    it('rejects bad limit before navigation', async () => {
+        const page = makePage({ kind: 'ok', entries: [] });
+        await expect(command.func(page, { limit: 1001 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('unwraps Browser Bridge envelopes', () => {
+        const inner = { kind: 'ok', entries: [] };
+        expect(unwrapEvaluateResult({ session: 'browser:default', data: inner })).toBe(inner);
+        expect(unwrapEvaluateResult(inner)).toBe(inner);
+    });
+
     it('returns subscribed subreddits from the browser-evaluated payload', async () => {
-        const fixture = [
-            { subreddit: 'r/programming', title: 'Programming', subscribers: 6000000, description: 'All things code', url: 'https://www.reddit.com/r/programming/' },
-            { subreddit: 'r/MachineLearning', title: 'Machine Learning', subscribers: 3000000, description: 'ML research', url: 'https://www.reddit.com/r/MachineLearning/' },
-        ];
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue(fixture),
-        };
+        const page = makePage({
+            kind: 'ok',
+            entries: [
+                subredditThing('abc', {
+                    display_name: 'programming',
+                    display_name_prefixed: 'r/programming',
+                    title: 'Programming',
+                    subscribers: 6000000,
+                    public_description: 'All things code',
+                    url: '/r/programming/',
+                }),
+                subredditThing('def', {
+                    display_name: 'MachineLearning',
+                    display_name_prefixed: 'r/MachineLearning',
+                    title: 'Machine Learning',
+                    subscribers: 3000000,
+                    public_description: 'ML research',
+                    url: '/r/MachineLearning/',
+                }),
+            ],
+        });
         const result = await command.func(page, { limit: 100 });
         expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
-        expect(result).toEqual(fixture);
+        expect(result).toEqual([
+            { id: 't5_abc', subreddit: 'r/programming', title: 'Programming', subscribers: 6000000, description: 'All things code', url: 'https://www.reddit.com/r/programming/' },
+            { id: 't5_def', subreddit: 'r/MachineLearning', title: 'Machine Learning', subscribers: 3000000, description: 'ML research', url: 'https://www.reddit.com/r/MachineLearning/' },
+        ]);
     });
+
     it('throws AuthRequiredError when not logged in', async () => {
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ error: 'Not logged in — cannot list subscriptions' }),
-        };
-        await expect(command.func(page, { limit: 100 })).rejects.toThrow('Not logged in');
+        await expect(command.func(makePage({ kind: 'auth', detail: 'login required' }), { limit: 100 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
     });
-    it('surfaces HTTP errors clearly', async () => {
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ error: 'HTTP 429 from /subreddits/mine/subscriptions.json?limit=100' }),
-        };
-        await expect(command.func(page, { limit: 100 })).rejects.toThrow('HTTP 429');
+
+    it('surfaces HTTP, malformed, exception, and unexpected envelopes as CommandExecutionError', async () => {
+        await expect(command.func(makePage({ kind: 'http', httpStatus: 429, where: '/subreddits/mine/subscriptions.json?limit=100' }), { limit: 100 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ kind: 'malformed', detail: 'missing data.children' }), { limit: 100 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ kind: 'exception', detail: 'network' }), { limit: 100 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(makePage({ ok: true }), { limit: 100 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
+
+    it('throws EmptyResultError for a valid empty subscriptions list', async () => {
+        await expect(command.func(makePage({ kind: 'ok', entries: [] }), { limit: 100 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError when rows lack subreddit identity', async () => {
+        await expect(command.func(makePage({ kind: 'ok', entries: [subredditThing('abc', { name: '', id: '', display_name: '', display_name_prefixed: '', url: '' })] }), { limit: 100 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('respects --limit by slicing the final result', async () => {
-        const fixture = Array.from({ length: 5 }, (_, i) => ({
-            subreddit: 'r/sub' + i,
-            title: 'Sub ' + i,
-            subscribers: 1000,
-            description: '',
-            url: 'https://www.reddit.com/r/sub' + i + '/',
-        }));
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue(fixture),
-        };
+        const page = makePage({ kind: 'ok', entries: Array.from({ length: 5 }, (_, i) => subredditThing(String(i))) });
         const result = await command.func(page, { limit: 3 });
         expect(result).toHaveLength(3);
         expect(result[0].subreddit).toBe('r/sub0');
+    });
+
+    it('embeds the validated limit literally in the browser script', async () => {
+        const page = makePage({ kind: 'ok', entries: [subredditThing('x')] });
+        await command.func(page, { limit: 7 });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('const target = 7');
     });
 });

--- a/clis/reddit/subscribed.test.js
+++ b/clis/reddit/subscribed.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './subscribed.js';
+describe('reddit subscribed adapter', () => {
+    const command = getRegistry().get('reddit/subscribed');
+    it('returns subscribed subreddits from the browser-evaluated payload', async () => {
+        const fixture = [
+            { subreddit: 'r/programming', title: 'Programming', subscribers: 6000000, description: 'All things code', url: 'https://www.reddit.com/r/programming/' },
+            { subreddit: 'r/MachineLearning', title: 'Machine Learning', subscribers: 3000000, description: 'ML research', url: 'https://www.reddit.com/r/MachineLearning/' },
+        ];
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(fixture),
+        };
+        const result = await command.func(page, { limit: 100 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
+        expect(result).toEqual(fixture);
+    });
+    it('throws AuthRequiredError when not logged in', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ error: 'Not logged in — cannot list subscriptions' }),
+        };
+        await expect(command.func(page, { limit: 100 })).rejects.toThrow('Not logged in');
+    });
+    it('surfaces HTTP errors clearly', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ error: 'HTTP 429 from /subreddits/mine/subscriptions.json?limit=100' }),
+        };
+        await expect(command.func(page, { limit: 100 })).rejects.toThrow('HTTP 429');
+    });
+    it('respects --limit by slicing the final result', async () => {
+        const fixture = Array.from({ length: 5 }, (_, i) => ({
+            subreddit: 'r/sub' + i,
+            title: 'Sub ' + i,
+            subscribers: 1000,
+            description: '',
+            url: 'https://www.reddit.com/r/sub' + i + '/',
+        }));
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(fixture),
+        };
+        const result = await command.func(page, { limit: 3 });
+        expect(result).toHaveLength(3);
+        expect(result[0].subreddit).toBe('r/sub0');
+    });
+});

--- a/docs/adapters/browser/reddit.md
+++ b/docs/adapters/browser/reddit.md
@@ -23,6 +23,7 @@
 | `opencli reddit comment` | Comment on a post |
 | `opencli reddit reply` | Reply to a comment |
 | `opencli reddit subscribe` | Join / leave a subreddit |
+| `opencli reddit subscribed` | List subreddits you are subscribed to |
 | `opencli reddit saved` | List your saved items |
 | `opencli reddit upvoted` | List your upvoted posts |
 
@@ -43,6 +44,9 @@ opencli reddit home --limit 10
 
 # Who am I logged in as?
 opencli reddit whoami
+
+# Subscribed subreddits (requires login)
+opencli reddit subscribed --limit 50
 
 # Read a post thread
 opencli reddit read 1abc123 --depth 2
@@ -65,8 +69,8 @@ opencli reddit hot -v
 
 ## Auth-required commands
 
-`whoami`, `home`, `saved`, `upvoted`, `subscribe`, `upvote`, `save`, `comment`,
-and `reply` all require a logged-in `reddit.com` cookie session. When the
+`whoami`, `home`, `subscribed`, `saved`, `upvoted`, `subscribe`, `upvote`,
+`save`, `comment`, and `reply` all require a logged-in `reddit.com` cookie session. When the
 session is missing or expired they raise `AuthRequiredError` (exit code 5)
 instead of silently returning empty rows.
 

--- a/scripts/silent-column-drop-baseline.json
+++ b/scripts/silent-column-drop-baseline.json
@@ -583,13 +583,6 @@
     ]
   },
   {
-    "command": "reddit/popular",
-    "file": "clis/reddit/popular.js",
-    "missing": [
-      "author"
-    ]
-  },
-  {
     "command": "tieba/search",
     "file": "clis/tieba/search.js",
     "missing": [


### PR DESCRIPTION
## 概要

两类相关改动，合在一起便于 review：

### 1. 新命令 `reddit subscribed`

列出当前登录用户**订阅**的 subreddit 列表（不是 popular / hot，而是 my-subreddits）。

- 走 `/subreddits/mine/subscribers.json` API，COOKIE 策略
- 自动分页，硬上限 1000（默认 limit=100）
- columns：`subreddit / title / subscribers / description / url`
- access: `'read'`（build-manifest 校验通过）

### 2. 现有 listing 命令新增 3 列（**纯 additive**）

`popular` / `search` / `subreddit` 三个命令的输出，原本只给 `title / author / score / comments / url`。为了让下游消费者（按 ID 去重、按时间过滤、阅读 selftext）不用再去抓 `read` 命令补一次，本 PR 加：

- `id` — Reddit post id（去重 key）
- `created_utc` — 发布时间戳
- `selftext` — self-post 正文

字段语义、列顺序、既有字段值均**不变**；新字段加在末尾，下游用 `--format columns` 或读 JSON 都不受影响。

## Type of Change

- [x] ✨ New feature（subscribed 命令）
- [x] ♻️ Additive enhancement（既有 listing 命令）

## 验证

- `clis/reddit/subscribed.test.js` 新增 4 个单测
- `npx vitest run clis/reddit/ --project adapter` 全绿
- `npx tsc --noEmit` 干净
- `npm run build` 干净