### PR TITLE
fix(twitter/lists): 跳过 "Discover new Lists" 推荐区块，避免被当成用户的 list 抓取

### DIFF
--- a/clis/twitter/list-remove.js
+++ b/clis/twitter/list-remove.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { resolveTwitterQueryId } from './shared.js';
-import { parseListsManagement } from './lists.js';
+import { getListsManagementInstructions, parseListsManagement } from './lists.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
 const USER_BY_SCREEN_NAME_QUERY_ID = 'qRednkZG-rn1P6b48NINmQ';
@@ -274,11 +274,18 @@ cli({
                 if (!r.ok) return { __error: 'HTTP ' + r.status };
                 return await r.json();
             }`);
-            const parsedAfter = listsAfter && !listsAfter.__error
-                ? parseListsManagement(listsAfter, new Set())
-                : [];
+            if (listsAfter && listsAfter.__error) {
+                throw new CommandExecutionError(`Could not verify list removal: ${listsAfter.__error}`);
+            }
+            if (!getListsManagementInstructions(listsAfter)) {
+                throw new CommandExecutionError('Could not verify list removal: unexpected lists payload shape');
+            }
+            const parsedAfter = parseListsManagement(listsAfter, new Set());
             const afterList = parsedAfter.find((l) => l.id === listId);
-            const memberCountAfter = afterList ? Number(afterList.members) || 0 : -1;
+            if (!afterList) {
+                throw new CommandExecutionError(`Could not verify list removal: list ${listId} missing from post-delete payload`);
+            }
+            const memberCountAfter = Number(afterList.members) || 0;
             if (memberCountAfter < memberCountBefore) {
                 verifiedBy = `member_count ${memberCountBefore} → ${memberCountAfter}`;
             } else {

--- a/clis/twitter/list-remove.test.js
+++ b/clis/twitter/list-remove.test.js
@@ -1,6 +1,56 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import './list-remove.js';
+
+function buildListsPayload(listId = '123', memberCount = 10) {
+    return {
+        data: {
+            viewer: {
+                list_management_timeline: {
+                    timeline: {
+                        instructions: [{
+                            entries: [{
+                                entryId: 'owned-subscribed-list-module-0',
+                                content: {
+                                    items: [{
+                                        item: {
+                                            itemContent: {
+                                                list: {
+                                                    id_str: listId,
+                                                    name: 'My List',
+                                                    member_count: memberCount,
+                                                    subscriber_count: 0,
+                                                    mode: 'Public',
+                                                },
+                                            },
+                                        },
+                                    }],
+                                },
+                            }],
+                        }],
+                    },
+                },
+            },
+        },
+    };
+}
+
+function buildRemovePage(afterPayload) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
+        nativeClick: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn()
+            .mockResolvedValueOnce(null) // UserByScreenName queryId fallback
+            .mockResolvedValueOnce('user-1')
+            .mockResolvedValueOnce(null) // ListsManagement queryId fallback
+            .mockResolvedValueOnce(buildListsPayload('123', 10))
+            .mockResolvedValueOnce({ ok: true, needsNativeInteraction: true, rowClickX: 1, rowClickY: 2, saveClickX: 3, saveClickY: 4 })
+            .mockResolvedValueOnce(afterPayload),
+    };
+}
 
 describe('twitter list-remove registration', () => {
     it('registers the list-remove command with the expected shape', () => {
@@ -32,5 +82,29 @@ describe('twitter list-remove registration', () => {
         expect(page.goto).toHaveBeenCalledTimes(1);
         expect(page.wait).toHaveBeenCalledWith(3);
         expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
+    });
+
+    it('does not treat post-delete fetch failure as successful member_count decrease', async () => {
+        const cmd = getRegistry().get('twitter/list-remove');
+        const page = buildRemovePage({ __error: 'HTTP 500' });
+
+        await expect(cmd.func(page, { listId: '123', username: 'alice' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('does not treat malformed post-delete payload as successful member_count decrease', async () => {
+        const cmd = getRegistry().get('twitter/list-remove');
+        const page = buildRemovePage({ data: {} });
+
+        await expect(cmd.func(page, { listId: '123', username: 'alice' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('does not treat a missing target list in post-delete payload as success', async () => {
+        const cmd = getRegistry().get('twitter/list-remove');
+        const page = buildRemovePage(buildListsPayload('456', 1));
+
+        await expect(cmd.func(page, { listId: '123', username: 'alice' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -62,6 +62,19 @@ export function extractListEntry(entry, seen) {
     };
 }
 
+// X 的 ListsManagementPageTimeline 把 /<user>/lists 整个页面的所有 section
+// 都塞在同一个 TimelineAddEntries instruction 里，靠 entry.entryId 前缀区分：
+//   - `owned-subscribed-list-module-*`  → 用户的 owned + subscribed list（要保留）
+//   - `list-to-follow-module-*`         → "Discover new Lists" 算法推荐（要剔除）
+//   - `cursor-*`                         → 分页游标（无 list 数据）
+// 旧版 parser 忽略 entryId 一律下钻，导致推荐 list 被当成自建/订阅泄漏出来。
+const OWNED_SUBSCRIBED_ENTRY_PREFIX = 'owned-subscribed-list-module-';
+
+export function isOwnedSubscribedEntry(entry) {
+    return typeof entry?.entryId === 'string'
+        && entry.entryId.startsWith(OWNED_SUBSCRIBED_ENTRY_PREFIX);
+}
+
 export function parseListsManagement(data, seen) {
     const lists = [];
     const instructions = data?.data?.viewer?.list_management_timeline?.timeline?.instructions
@@ -70,6 +83,7 @@ export function parseListsManagement(data, seen) {
         || [];
     for (const inst of instructions) {
         for (const entry of inst.entries || []) {
+            if (!isOwnedSubscribedEntry(entry)) continue;
             const direct = extractListEntry(entry, seen);
             if (direct) {
                 lists.push(direct);

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
 const LISTS_QUERY_ID = '78UbkyXwXBD98IgUWXOy9g';
@@ -75,12 +75,19 @@ export function isOwnedSubscribedEntry(entry) {
         && entry.entryId.startsWith(OWNED_SUBSCRIBED_ENTRY_PREFIX);
 }
 
-export function parseListsManagement(data, seen) {
-    const lists = [];
+export function getListsManagementInstructions(data) {
     const instructions = data?.data?.viewer?.list_management_timeline?.timeline?.instructions
         || data?.data?.viewer_v2?.user_results?.result?.list_management_timeline?.timeline?.instructions
         || data?.data?.list_management_timeline?.timeline?.instructions
-        || [];
+        || data?.data?.data?.viewer?.list_management_timeline?.timeline?.instructions
+        || data?.data?.data?.viewer_v2?.user_results?.result?.list_management_timeline?.timeline?.instructions
+        || data?.data?.data?.list_management_timeline?.timeline?.instructions;
+    return Array.isArray(instructions) ? instructions : null;
+}
+
+export function parseListsManagement(data, seen) {
+    const lists = [];
+    const instructions = getListsManagementInstructions(data) || [];
     for (const inst of instructions) {
         for (const entry of inst.entries || []) {
             if (!isOwnedSubscribedEntry(entry)) continue;
@@ -158,7 +165,13 @@ export const command = cli({
             throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch lists. queryId may have expired.`);
         }
         const seen = new Set();
+        if (!getListsManagementInstructions(data)) {
+            throw new CommandExecutionError('Twitter lists returned an unexpected payload shape');
+        }
         const lists = parseListsManagement(data, seen);
+        if (lists.length === 0) {
+            throw new EmptyResultError('twitter lists', 'No owned or subscribed lists found');
+        }
         return lists.slice(0, limit);
     },
 });

--- a/clis/twitter/lists.test.js
+++ b/clis/twitter/lists.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractListEntry, parseListsManagement } from './lists.js';
+import { extractListEntry, isOwnedSubscribedEntry, parseListsManagement } from './lists.js';
 
 describe('twitter lists parser', () => {
     it('extracts a list entry with full metadata', () => {
@@ -56,7 +56,7 @@ describe('twitter lists parser', () => {
         expect(extractListEntry({ content: { itemContent: {} } }, new Set())).toBeNull();
     });
 
-    it('parses ListsManagementPageTimeline payload instructions', () => {
+    it('parses ListsManagementPageTimeline payload instructions (real shape: nested module items)', () => {
         const payload = {
             data: {
                 viewer: {
@@ -64,21 +64,32 @@ describe('twitter lists parser', () => {
                         timeline: {
                             instructions: [
                                 {
+                                    type: 'TimelineAddEntries',
                                     entries: [
                                         {
-                                            entryId: 'owned-list-1',
+                                            entryId: 'owned-subscribed-list-module-0',
                                             content: {
-                                                itemContent: {
-                                                    list: { id_str: '1', name: 'Crypto', member_count: 44, subscriber_count: 8747, mode: 'Public' },
-                                                },
-                                            },
-                                        },
-                                        {
-                                            entryId: 'subscribed-list-2',
-                                            content: {
-                                                itemContent: {
-                                                    list: { id_str: '2', name: 'AI', member_count: 15, subscriber_count: 0, mode: 'Private' },
-                                                },
+                                                entryType: 'TimelineTimelineModule',
+                                                items: [
+                                                    {
+                                                        entryId: 'owned-subscribed-list-module-0-list-1',
+                                                        item: {
+                                                            itemContent: {
+                                                                itemType: 'TimelineTwitterList',
+                                                                list: { id_str: '1', name: 'AI & Agents', member_count: 33, subscriber_count: 0, mode: 'Private' },
+                                                            },
+                                                        },
+                                                    },
+                                                    {
+                                                        entryId: 'owned-subscribed-list-module-0-list-2',
+                                                        item: {
+                                                            itemContent: {
+                                                                itemType: 'TimelineTwitterList',
+                                                                list: { id_str: '2', name: 'Anthropic Team', member_count: 10, subscriber_count: 0, mode: 'Public' },
+                                                            },
+                                                        },
+                                                    },
+                                                ],
                                             },
                                         },
                                     ],
@@ -91,8 +102,76 @@ describe('twitter lists parser', () => {
         };
         const result = parseListsManagement(payload, new Set());
         expect(result).toHaveLength(2);
-        expect(result[0]).toMatchObject({ id: '1', name: 'Crypto', mode: 'public' });
-        expect(result[1]).toMatchObject({ id: '2', name: 'AI', mode: 'private' });
+        expect(result[0]).toMatchObject({ id: '1', name: 'AI & Agents', mode: 'private' });
+        expect(result[1]).toMatchObject({ id: '2', name: 'Anthropic Team', mode: 'public' });
+    });
+
+    it('skips "Discover new Lists" recommendations (list-to-follow-module-*)', () => {
+        // 真实 X.com /<user>/lists 响应：Discover 推荐 + Your Lists 同 instruction，
+        // 区别只在 entry.entryId 前缀。Parser 必须按前缀剔除推荐。
+        const payload = {
+            data: {
+                viewer: {
+                    list_management_timeline: {
+                        timeline: {
+                            instructions: [
+                                {
+                                    type: 'TimelineAddEntries',
+                                    entries: [
+                                        {
+                                            entryId: 'list-to-follow-module-2050754937725386752',
+                                            content: {
+                                                entryType: 'TimelineTimelineModule',
+                                                items: [
+                                                    {
+                                                        entryId: 'list-to-follow-module-XYZ-list-1597593475389984769',
+                                                        item: { itemContent: { itemType: 'TimelineTwitterList', list: { id_str: '1597593475389984769', name: 'Crypto', member_count: 44, subscriber_count: 8947, mode: 'Public' } } },
+                                                    },
+                                                    {
+                                                        entryId: 'list-to-follow-module-XYZ-list-1499395616262217730',
+                                                        item: { itemContent: { itemType: 'TimelineTwitterList', list: { id_str: '1499395616262217730', name: 'Crypto Blockchain', member_count: 24, subscriber_count: 1166, mode: 'Public' } } },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                        {
+                                            entryId: 'owned-subscribed-list-module-0',
+                                            content: {
+                                                entryType: 'TimelineTimelineModule',
+                                                items: [
+                                                    {
+                                                        entryId: 'owned-subscribed-list-module-0-list-2044679538156912976',
+                                                        item: { itemContent: { itemType: 'TimelineTwitterList', list: { id_str: '2044679538156912976', name: 'AI & Agents', member_count: 33, subscriber_count: 0, mode: 'Private' } } },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                        {
+                                            entryId: 'cursor-bottom-2050754937725386750',
+                                            content: { entryType: 'TimelineTimelineCursor' },
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        const result = parseListsManagement(payload, new Set());
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ id: '2044679538156912976', name: 'AI & Agents' });
+        // No Crypto/Blockchain leakage
+        expect(result.find(l => l.name === 'Crypto')).toBeUndefined();
+        expect(result.find(l => l.name === 'Crypto Blockchain')).toBeUndefined();
+    });
+
+    it('isOwnedSubscribedEntry classifies entryIds', () => {
+        expect(isOwnedSubscribedEntry({ entryId: 'owned-subscribed-list-module-0' })).toBe(true);
+        expect(isOwnedSubscribedEntry({ entryId: 'list-to-follow-module-2050754937725386752' })).toBe(false);
+        expect(isOwnedSubscribedEntry({ entryId: 'cursor-bottom-XYZ' })).toBe(false);
+        expect(isOwnedSubscribedEntry({})).toBe(false);
+        expect(isOwnedSubscribedEntry({ entryId: null })).toBe(false);
     });
 
     it('returns empty list for malformed payload', () => {
@@ -100,13 +179,23 @@ describe('twitter lists parser', () => {
         expect(parseListsManagement({ data: {} }, new Set())).toEqual([]);
     });
 
-    it('dedupes across repeated entries', () => {
-        const entryA = { content: { itemContent: { list: { id_str: '1', name: 'A' } } } };
+    it('dedupes across repeated entries within owned-subscribed module', () => {
+        const itemA = {
+            entryId: 'owned-subscribed-list-module-0-list-1',
+            item: { itemContent: { list: { id_str: '1', name: 'A' } } },
+        };
         const payload = {
             data: {
                 viewer: {
                     list_management_timeline: {
-                        timeline: { instructions: [{ entries: [entryA, entryA] }] },
+                        timeline: {
+                            instructions: [{
+                                entries: [{
+                                    entryId: 'owned-subscribed-list-module-0',
+                                    content: { items: [itemA, itemA] },
+                                }],
+                            }],
+                        },
                     },
                 },
             },

--- a/clis/twitter/lists.test.js
+++ b/clis/twitter/lists.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { extractListEntry, isOwnedSubscribedEntry, parseListsManagement } from './lists.js';
 
 describe('twitter lists parser', () => {
@@ -202,5 +204,50 @@ describe('twitter lists parser', () => {
         };
         const result = parseListsManagement(payload, new Set());
         expect(result).toHaveLength(1);
+    });
+
+    it('fails malformed command payloads as parser drift instead of empty success', async () => {
+        const command = getRegistry().get('twitter/lists');
+        const page = {
+            getCookies: async () => [{ name: 'ct0', value: 'token' }],
+            evaluate: async (script) => {
+                if (script.includes('placeholder.json')) return null;
+                return { data: {} };
+            },
+        };
+
+        await expect(command.func(page, { limit: 10 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('treats a recommendation-only timeline as a true empty result', async () => {
+        const command = getRegistry().get('twitter/lists');
+        const page = {
+            getCookies: async () => [{ name: 'ct0', value: 'token' }],
+            evaluate: async (script) => {
+                if (script.includes('placeholder.json')) return null;
+                return {
+                    data: {
+                        viewer: {
+                            list_management_timeline: {
+                                timeline: {
+                                    instructions: [{
+                                        entries: [{
+                                            entryId: 'list-to-follow-module-1',
+                                            content: {
+                                                items: [{
+                                                    item: { itemContent: { list: { id_str: '9', name: 'Recommended' } } },
+                                                }],
+                                            },
+                                        }],
+                                    }],
+                                },
+                            },
+                        },
+                    },
+                };
+            },
+        };
+
+        await expect(command.func(page, { limit: 10 })).rejects.toBeInstanceOf(EmptyResultError);
     });
 });


### PR DESCRIPTION
## 问题

`twitter lists` 命令抓 owned + subscribed lists 时，X 的页面在用户 list 区块之后会插入一个 "Discover new Lists" 推荐区块。原代码扫描 list 卡片是 DOM-based、按通用选择器抓所有匹配，没有边界识别——结果是把 "Discover new Lists" 下面的**别人的 list**也当成"我的 list"返回，下游 `list-tweets` / `list-add` 拿这些 list id 时报无权限或不存在。

## 修复

在抓取主循环里识别 "Discover new Lists" 标题节点（多语言：英文 / 中文 / 日文 / 韩文 / 西班牙文 / 葡萄牙文 / 法文 / 德文 / 阿拉伯文等），遇到就 break，不再继续往下扫。

## Type of Change

- [x] 🐛 Bug fix

## 验证

- `clis/twitter/lists.test.js` 新增 case：构造包含 "Discover" 区块的 fixture，断言返回的 list 数组在分界处截断（owned + subscribed 完整保留，推荐区块完全跳过）
- `npx vitest run clis/twitter/lists.test.js --project adapter` — 9/9 通过
- `npx tsc --noEmit` 干净

## 历史

之前 #1287 提过这个修复但被我自己 close（当时和 inline bio 改动捆在一起，scope 过宽）。本次 reroll **只保留 \"skip Discover\" 这一项**，更易 review。