### PR TITLE
fix(extension): cleanup empty owned tab groups

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1113,6 +1113,26 @@ async function ensureOwnedContainerTabGroup(role, windowId, tabIds) {
     console.warn(`[opencli] Failed to mark ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
+async function ungroupOwnedTabIfLastInGroup(role, windowId, tabId) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    const groupId = tab.groupId;
+    if (groupId === void 0 || groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) return;
+    const group = await chrome.tabGroups.get(groupId);
+    if (group.windowId !== windowId) return;
+    if (!getOwnedContainerGroupTitles(role).includes(group.title ?? "")) return;
+    const tabs = await chrome.tabs.query({ windowId });
+    const groupedTabs = tabs.filter((entry) => entry.groupId === groupId);
+    if (groupedTabs.length > 1) return;
+    await chrome.tabs.ungroup(tabId);
+    if (ownedContainers[role].groupId === groupId) ownedContainers[role].groupId = null;
+  } catch {
+  }
+}
+async function removeOwnedContainerTab(role, windowId, tabId) {
+  await ungroupOwnedTabIfLastInGroup(role, windowId, tabId);
+  await chrome.tabs.remove(tabId);
+}
 async function ensureOwnedContainerWindow(role, initialUrl, mode = "background") {
   const container = ownedContainers[role];
   if (container.promise) return container.promise;
@@ -1761,7 +1781,7 @@ async function handleTabs(cmd, leaseKey) {
           await releaseLease(leaseKey, "tab close");
         } else {
           await safeDetach(target.id);
-          await chrome.tabs.remove(target.id);
+          await removeOwnedContainerTab(getOwnedWindowRole(leaseKey), target.windowId, target.id);
         }
         return { id: cmd.id, ok: true, data: { closed: closedPage2 } };
       }
@@ -1772,8 +1792,9 @@ async function handleTabs(cmd, leaseKey) {
       if (currentSession?.preferredTabId === tabId) {
         await releaseLease(leaseKey, "tab close");
       } else {
+        const tab = await chrome.tabs.get(tabId);
         await safeDetach(tabId);
-        await chrome.tabs.remove(tabId);
+        await removeOwnedContainerTab(getOwnedWindowRole(leaseKey), tab.windowId, tabId);
       }
       return { id: cmd.id, ok: true, data: { closed: closedPage } };
     }
@@ -1970,22 +1991,23 @@ async function releaseLease(leaseKey, reason = "released") {
   if (session.owned) {
     const tabId = session.preferredTabId;
     if (tabId !== null) {
+      const role = getOwnedWindowRole(leaseKey);
       const hasOtherOwnedLease = [...automationSessions.entries()].some(
         ([otherLease, otherSession]) => otherLease !== leaseKey && otherSession.owned && otherSession.windowId === session.windowId && otherSession.preferredTabId !== null
       );
       await safeDetach(tabId);
       evictTab(tabId);
       if (hasOtherOwnedLease) {
-        await chrome.tabs.remove(tabId).catch(() => {
+        await removeOwnedContainerTab(role, session.windowId, tabId).catch(() => {
         });
         console.log(`[opencli] Released owned tab lease ${tabId} (session=${session.session}, surface=${session.surface}, ${reason})`);
       } else {
         try {
           const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
-          await ensureOwnedContainerTabGroup(getOwnedWindowRole(leaseKey), session.windowId, [tab.id ?? tabId]);
+          await ensureOwnedContainerTabGroup(role, session.windowId, [tab.id ?? tabId]);
           console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (session=${session.session}, surface=${session.surface}, ${reason})`);
         } catch {
-          await chrome.tabs.remove(tabId).catch(() => {
+          await removeOwnedContainerTab(role, session.windowId, tabId).catch(() => {
           });
           console.log(`[opencli] Released owned tab lease ${tabId} (session=${session.session}, surface=${session.surface}, ${reason})`);
         }

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -108,7 +108,10 @@ function createChromeMock() {
       query,
       create,
       update,
-      remove: vi.fn(async (_tabId: number) => {}),
+      remove: vi.fn(async (tabId: number) => {
+        const index = tabs.findIndex((entry) => entry.id === tabId);
+        if (index >= 0) tabs.splice(index, 1);
+      }),
       get: vi.fn(async (tabId: number) => {
         const tab = tabs.find((entry) => entry.id === tabId);
         if (!tab) throw new Error(`Unknown tab ${tabId}`);
@@ -137,6 +140,22 @@ function createChromeMock() {
           tab.groupId = groupId;
         }
         return groupId;
+      }),
+      ungroup: vi.fn(async (tabIds: number | number[]) => {
+        const ids = Array.isArray(tabIds) ? tabIds : [tabIds];
+        const changedGroupIds = new Set<number>();
+        for (const tabId of ids) {
+          const tab = tabs.find((entry) => entry.id === tabId);
+          if (!tab) throw new Error(`Unknown tab ${tabId}`);
+          if (tab.groupId !== undefined && tab.groupId !== -1) changedGroupIds.add(tab.groupId);
+          tab.groupId = -1;
+        }
+        for (const groupId of changedGroupIds) {
+          if (!tabs.some((entry) => entry.groupId === groupId)) {
+            const index = groups.findIndex((entry) => entry.id === groupId);
+            if (index >= 0) groups.splice(index, 1);
+          }
+        }
       }),
       onUpdated: { addListener: vi.fn(), removeListener: vi.fn() } as Listener<(id: number, info: chrome.tabs.TabChangeInfo) => void>,
       onRemoved: { addListener: vi.fn() } as Listener<(tabId: number) => void>,
@@ -869,6 +888,7 @@ describe('background tab isolation', () => {
     const closeSecond = await mod.__test__.handleCommand({ id: 'close-second', action: 'close-window', session: 'second', surface: 'adapter' });
     expect(closeSecond).toEqual(expect.objectContaining({ ok: true }));
     expect(chrome.tabs.remove).toHaveBeenCalledWith(10);
+    expect(chrome.tabs.ungroup).not.toHaveBeenCalled();
     expect(chrome.tabs.update).not.toHaveBeenCalledWith(10, { url: 'about:blank', active: true });
     expect(chrome.windows.remove).not.toHaveBeenCalled();
     expect(mod.__test__.getSession(adapterKey('first'))).not.toBeNull();
@@ -877,6 +897,32 @@ describe('background tab isolation', () => {
     await mod.__test__.handleCommand({ id: 'close-first', action: 'close-window', session: 'first', surface: 'adapter' });
     expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank' });
     expect(chrome.windows.remove).not.toHaveBeenCalled();
+  });
+
+  it('ungroups the final owned tab before removing it so Chrome does not leave an empty tab group', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(100);
+    expect(groups).toHaveLength(1);
+
+    chrome.tabs.update.mockRejectedValueOnce(new Error('tab cannot become placeholder'));
+
+    const result = await mod.__test__.handleCommand({
+      id: 'close-twitter',
+      action: 'close-window',
+      session: 'twitter',
+      surface: 'adapter',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true }));
+    expect(chrome.tabs.ungroup).toHaveBeenCalledWith(1);
+    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
+    expect(tabs.some((tab) => tab.id === 1)).toBe(false);
+    expect(groups).toHaveLength(0);
   });
 
   it('releases the current owned tab lease when tabs close targets it', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -636,6 +636,33 @@ async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: num
   }
 }
 
+async function ungroupOwnedTabIfLastInGroup(role: OwnedWindowRole, windowId: number, tabId: number): Promise<void> {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    const groupId = tab.groupId;
+    if (groupId === undefined || groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) return;
+
+    const group = await chrome.tabGroups.get(groupId);
+    if (group.windowId !== windowId) return;
+    if (!getOwnedContainerGroupTitles(role).includes(group.title ?? '')) return;
+
+    const tabs = await chrome.tabs.query({ windowId });
+    const groupedTabs = tabs.filter((entry) => entry.groupId === groupId);
+    if (groupedTabs.length > 1) return;
+
+    await chrome.tabs.ungroup(tabId);
+    if (ownedContainers[role].groupId === groupId) ownedContainers[role].groupId = null;
+  } catch {
+    // Best-effort cleanup only. Tab close/release must not fail because Chrome
+    // discarded transient group state first.
+  }
+}
+
+async function removeOwnedContainerTab(role: OwnedWindowRole, windowId: number, tabId: number): Promise<void> {
+  await ungroupOwnedTabIfLastInGroup(role, windowId, tabId);
+  await chrome.tabs.remove(tabId);
+}
+
 /**
  * Ensure the owned window for the requested role exists.
  *
@@ -1448,7 +1475,7 @@ async function handleTabs(cmd: Command, leaseKey: string): Promise<Result> {
           await releaseLease(leaseKey, 'tab close');
         } else {
           await safeDetach(target.id);
-          await chrome.tabs.remove(target.id);
+          await removeOwnedContainerTab(getOwnedWindowRole(leaseKey), target.windowId, target.id);
         }
         return { id: cmd.id, ok: true, data: { closed: closedPage } };
       }
@@ -1459,8 +1486,9 @@ async function handleTabs(cmd: Command, leaseKey: string): Promise<Result> {
       if (currentSession?.preferredTabId === tabId) {
         await releaseLease(leaseKey, 'tab close');
       } else {
+        const tab = await chrome.tabs.get(tabId);
         await safeDetach(tabId);
-        await chrome.tabs.remove(tabId);
+        await removeOwnedContainerTab(getOwnedWindowRole(leaseKey), tab.windowId, tabId);
       }
       return { id: cmd.id, ok: true, data: { closed: closedPage } };
     }
@@ -1676,6 +1704,7 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
   if (session.owned) {
     const tabId = session.preferredTabId;
     if (tabId !== null) {
+      const role = getOwnedWindowRole(leaseKey);
       const hasOtherOwnedLease = [...automationSessions.entries()].some(([otherLease, otherSession]) =>
         otherLease !== leaseKey &&
         otherSession.owned &&
@@ -1685,15 +1714,15 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
       await safeDetach(tabId);
       identity.evictTab(tabId);
       if (hasOtherOwnedLease) {
-        await chrome.tabs.remove(tabId).catch(() => {});
+        await removeOwnedContainerTab(role, session.windowId, tabId).catch(() => {});
         console.log(`[opencli] Released owned tab lease ${tabId} (session=${session.session}, surface=${session.surface}, ${reason})`);
       } else {
         try {
           const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
-          await ensureOwnedContainerTabGroup(getOwnedWindowRole(leaseKey), session.windowId, [tab.id ?? tabId]);
+          await ensureOwnedContainerTabGroup(role, session.windowId, [tab.id ?? tabId]);
           console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (session=${session.session}, surface=${session.surface}, ${reason})`);
         } catch {
-          await chrome.tabs.remove(tabId).catch(() => {});
+          await removeOwnedContainerTab(role, session.windowId, tabId).catch(() => {});
           console.log(`[opencli] Released owned tab lease ${tabId} (session=${session.session}, surface=${session.surface}, ${reason})`);
         }
       }


### PR DESCRIPTION

  ## Description

  Fixes #1627.

  When an owned OpenCLI tab is removed, Chrome can leave behind an empty named tab group such as `OpenCLI
  Adapter` / `OpenCLI Browser`. This is visible after ephemeral adapter sessions clean up their temporary tabs.

  This PR adds a small owned-tab removal helper that checks whether the tab being removed is the last tab in an
  OpenCLI-managed tab group. If so, it calls `chrome.tabs.ungroup(tabId)` before `chrome.tabs.remove(tabId)`,
  preventing Chrome from leaving an empty group behind.

  The default grouping behavior is unchanged. OpenCLI still groups owned browser/adapter tabs as before; this only
  cleans up the final tab before removal.

  Related issue: #1627

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 🌐 New site adapter
  - [ ] 📝 Documentation
  - [ ] ♻️ Refactor
  - [ ] 🔧 CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR
  - [x] I updated tests or docs if needed
  - [x] I included output or screenshots when useful

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter)
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
  - [ ] Used positional args for the command's primary subject unless a named flag is clearly better
  - [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

  ## Screenshots / Output

  ```bash
  npx vitest run extension/src/background.test.ts
  # Test Files  1 passed (1)
  # Tests  61 passed (61)

  npx vitest run --project extension
  # Test Files  2 passed (2)
  # Tests  73 passed (73)

  cd extension && npm run typecheck
  # passed

  npm run typecheck
  # passed

  cd extension && npm run build
  # passed

  git diff --check
  # passed


