### PR TITLE
fix(youtube/transcript): 把 timedtext URL 匹配限定到当前 videoId，修跨视频字幕串台

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* **youtube/transcript** — scope timedtext URL matching to the current `videoId` across the in-page resource-buffer scan (`findTimedtextUrl`), the in-page fetch/XHR hook (`isJson3TimedtextUrl`), and the Node-side CDP capture (`extractSegmentsFromNetworkCapture`). Previously, SPA-style watch→watch navigation kept stale timedtext URLs from prior videos in `performance.getEntriesByType('resource')`, letting the polling loop fetch a same-language predecessor's captions and return them as the current video's transcript. Most likely to hit callers that reuse a single daemon tab to fetch many transcripts back-to-back (e.g. ml-scout).
 * **adapters** — surface the remaining `silent-empty-fallback` adapter failures as typed errors. Douyin user video comment fetch failures, Jike SSR JSON parse failures, and WeRead search-page fetch failures now throw `CommandExecutionError`; true empty Douyin/Jike/WeRead result sets now throw `EmptyResultError`.
 * **browser** — recover `Page.goto()` from stale page identities by clearing the cached targetId and retrying navigation once through the session lease; classify CDP `-32000 Cannot find default execution context` as retryable target navigation.
 * **download** — keep custom media filenames inside the requested output directory by stripping path components and sanitizing generated fallback names.

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -61,18 +61,25 @@ function parseJson3Segments(text) {
     return rows;
 }
 
-function extractSegmentsFromNetworkCapture(entries, lang) {
+function extractSegmentsFromNetworkCapture(entries, lang, videoId) {
     const payload = unwrapBrowserResult(entries);
     if (!Array.isArray(payload) || payload.length === 0)
         return { segments: [] };
     const wanted = String(lang || '').toLowerCase();
     const wantedBase = wanted.split('-')[0];
+    // Scope to the current video — daemon-shared tabs can retain captured
+    // timedtext entries from prior YouTube SPA navigations that match
+    // the same lang, which would otherwise leak the previous video's
+    // captions into this one's transcript.
+    const videoIdMarker = videoId ? 'v=' + encodeURIComponent(videoId) : '';
     const timedtext = payload
         .filter((entry) => {
         const url = String(entry?.url || '');
         if (!url.includes('/api/timedtext'))
             return false;
         if (!url.includes('fmt=json3') || !url.includes('pot='))
+            return false;
+        if (videoIdMarker && !url.includes(videoIdMarker))
             return false;
         if (!wanted)
             return true;
@@ -137,6 +144,12 @@ cli({
         const playerResult = await page.evaluate(`
       (async () => {
         const langPref = ${JSON.stringify(lang)};
+        // Scope all timedtext URL matching to the current video. YouTube is an
+        // SPA, so watch→watch navigations preserve performance.getEntriesByType
+        // entries from prior videos. Without this check a stale same-language
+        // URL can be picked up by the polling loop before the current video's
+        // fetch hook fires, leaking the predecessor's captions.
+        const videoIdMarker = 'v=' + encodeURIComponent(${JSON.stringify(videoId)});
         const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
         function textFromJson3Event(event) {
@@ -212,7 +225,10 @@ cli({
         function findTimedtextUrl(track) {
           const urls = performance.getEntriesByType('resource')
             .map(entry => entry.name)
-            .filter(url => url.includes('/api/timedtext') && url.includes('fmt=json3') && url.includes('pot='));
+            .filter(url => url.includes('/api/timedtext')
+                        && url.includes('fmt=json3')
+                        && url.includes('pot=')
+                        && url.includes(videoIdMarker));
           if (!urls.length) return '';
           if (track?.languageCode) {
             const wanted = String(track.languageCode || '').toLowerCase();
@@ -236,6 +252,7 @@ cli({
           if (!url || !url.includes('/api/timedtext')) return false;
           if (!url.includes('fmt=json3')) return false;
           if (!url.includes('pot=')) return false;
+          if (!url.includes(videoIdMarker)) return false;
           if (!track?.languageCode) return true;
           try {
             const u = new URL(url, location.origin);
@@ -342,7 +359,7 @@ cli({
         let segments = normalizeSegmentsPayload(playerResult, 'player caption extraction', { allowNull: true });
         if (!segments && canCapture) {
             try {
-                const captured = extractSegmentsFromNetworkCapture(await page.readNetworkCapture(), lang);
+                const captured = extractSegmentsFromNetworkCapture(await page.readNetworkCapture(), lang, videoId);
                 if (captured.error) {
                     throw new CommandExecutionError(captured.error);
                 }

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -61,17 +61,24 @@ function parseJson3Segments(text) {
     return rows;
 }
 
+function timedtextUrlMatchesVideo(url, videoId) {
+    if (!videoId)
+        return true;
+    try {
+        const parsed = new URL(url);
+        return parsed.searchParams.get('v') === videoId;
+    }
+    catch {
+        return false;
+    }
+}
+
 function extractSegmentsFromNetworkCapture(entries, lang, videoId) {
     const payload = unwrapBrowserResult(entries);
     if (!Array.isArray(payload) || payload.length === 0)
         return { segments: [] };
     const wanted = String(lang || '').toLowerCase();
     const wantedBase = wanted.split('-')[0];
-    // Scope to the current video — daemon-shared tabs can retain captured
-    // timedtext entries from prior YouTube SPA navigations that match
-    // the same lang, which would otherwise leak the previous video's
-    // captions into this one's transcript.
-    const videoIdMarker = videoId ? 'v=' + encodeURIComponent(videoId) : '';
     const timedtext = payload
         .filter((entry) => {
         const url = String(entry?.url || '');
@@ -79,7 +86,11 @@ function extractSegmentsFromNetworkCapture(entries, lang, videoId) {
             return false;
         if (!url.includes('fmt=json3') || !url.includes('pot='))
             return false;
-        if (videoIdMarker && !url.includes(videoIdMarker))
+        // Scope to the current video — daemon-shared tabs can retain captured
+        // timedtext entries from prior YouTube SPA navigations that match
+        // the same lang. Use exact query-param equality rather than substring
+        // matching so v=<prefix> cannot match v=<prefix><suffix>.
+        if (!timedtextUrlMatchesVideo(url, videoId))
             return false;
         if (!wanted)
             return true;
@@ -149,7 +160,7 @@ cli({
         // entries from prior videos. Without this check a stale same-language
         // URL can be picked up by the polling loop before the current video's
         // fetch hook fires, leaking the predecessor's captions.
-        const videoIdMarker = 'v=' + encodeURIComponent(${JSON.stringify(videoId)});
+        const targetVideoId = ${JSON.stringify(videoId)};
         const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
         function textFromJson3Event(event) {
@@ -180,6 +191,15 @@ cli({
             });
           }
           return { rows };
+        }
+
+        function timedtextUrlMatchesVideo(url) {
+          try {
+            const parsed = new URL(url, location.origin);
+            return parsed.searchParams.get('v') === targetVideoId;
+          } catch {
+            return false;
+          }
         }
 
         function captionTrackToPlayerTrack(track) {
@@ -228,7 +248,7 @@ cli({
             .filter(url => url.includes('/api/timedtext')
                         && url.includes('fmt=json3')
                         && url.includes('pot=')
-                        && url.includes(videoIdMarker));
+                        && timedtextUrlMatchesVideo(url));
           if (!urls.length) return '';
           if (track?.languageCode) {
             const wanted = String(track.languageCode || '').toLowerCase();
@@ -252,7 +272,7 @@ cli({
           if (!url || !url.includes('/api/timedtext')) return false;
           if (!url.includes('fmt=json3')) return false;
           if (!url.includes('pot=')) return false;
-          if (!url.includes(videoIdMarker)) return false;
+          if (!timedtextUrlMatchesVideo(url)) return false;
           if (!track?.languageCode) return true;
           try {
             const u = new URL(url, location.origin);

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -65,10 +65,9 @@ describe('youtube transcript source contract', () => {
         // Both findTimedtextUrl (resource buffer) and isJson3TimedtextUrl (fetch/XHR
         // hook) must require the URL contain v=<currentVideoId>, otherwise a
         // previously-viewed same-language video's captions can be returned.
-        expect(transcriptSource).toContain(
-            "const videoIdMarker = 'v=' + encodeURIComponent(",
-        );
-        expect(transcriptSource).toContain('url.includes(videoIdMarker)');
+        expect(transcriptSource).toContain('const targetVideoId = ');
+        expect(transcriptSource).toContain("parsed.searchParams.get('v') === targetVideoId");
+        expect(transcriptSource).toContain('timedtextUrlMatchesVideo(url)');
     });
 });
 
@@ -146,6 +145,15 @@ describe('youtube transcript caption fetch', () => {
                         responsePreview: JSON.stringify({
                             events: [
                                 { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: 'WRONG video captions' }] },
+                            ],
+                        }),
+                    },
+                    {
+                        // Prefix collision: substring matching for "v=abc" would accept this.
+                        url: 'https://www.youtube.com/api/timedtext?v=abcd&lang=en&fmt=json3&pot=token',
+                        responsePreview: JSON.stringify({
+                            events: [
+                                { tStartMs: 1000, dDurationMs: 1000, segs: [{ utf8: 'WRONG prefix captions' }] },
                             ],
                         }),
                     },

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -58,6 +58,18 @@ describe('youtube transcript source contract', () => {
         expect(transcriptSource).toContain('globalThis.fetch = originalFetch');
         expect(transcriptSource).toContain('globalThis.XMLHttpRequest = OriginalXHR');
     });
+
+    it('scopes timedtext URL matching to the current videoId in both in-page paths', () => {
+        // YouTube is an SPA — daemon-shared tabs preserve prior videos'
+        // performance.getEntriesByType('resource') across watch→watch navigations.
+        // Both findTimedtextUrl (resource buffer) and isJson3TimedtextUrl (fetch/XHR
+        // hook) must require the URL contain v=<currentVideoId>, otherwise a
+        // previously-viewed same-language video's captions can be returned.
+        expect(transcriptSource).toContain(
+            "const videoIdMarker = 'v=' + encodeURIComponent(",
+        );
+        expect(transcriptSource).toContain('url.includes(videoIdMarker)');
+    });
 });
 
 describe('youtube transcript caption fetch', () => {
@@ -113,6 +125,47 @@ describe('youtube transcript caption fetch', () => {
         expect(page.startNetworkCapture).toHaveBeenCalledWith('/api/timedtext');
         expect(page.evaluate).toHaveBeenCalledTimes(1);
         expect(rows).toEqual([{ index: 1, start: '1.00s', end: '2.50s', text: 'hello capture' }]);
+    });
+
+    it('ignores captured timedtext entries from a prior video and uses only the current videoId', async () => {
+        // Regression: opencli daemon reuses one Chrome tab across sequential
+        // youtube transcript calls. YouTube's SPA navigation between watch URLs
+        // leaves prior videos' timedtext entries in performance.getEntriesByType
+        // and (rarely) in the CDP capture buffer. Without filtering by videoId,
+        // the same-language predecessor's captions can leak into the current row.
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            startNetworkCapture: vi.fn().mockResolvedValue(undefined),
+            readNetworkCapture: vi.fn().mockResolvedValue({
+                session: 'browser:default',
+                data: [
+                    {
+                        // Stale entry from a prior watch on the shared tab — must be ignored.
+                        url: 'https://www.youtube.com/api/timedtext?v=prev&lang=en&fmt=json3&pot=token',
+                        responsePreview: JSON.stringify({
+                            events: [
+                                { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: 'WRONG video captions' }] },
+                            ],
+                        }),
+                    },
+                    {
+                        // Current video's captions.
+                        url: 'https://www.youtube.com/api/timedtext?v=abc&lang=en&fmt=json3&pot=token',
+                        responsePreview: JSON.stringify({
+                            events: [
+                                { tStartMs: 2000, dDurationMs: 1000, segs: [{ utf8: 'right captions' }] },
+                            ],
+                        }),
+                    },
+                ],
+            }),
+            evaluate: vi.fn().mockResolvedValueOnce(null),
+        };
+
+        const rows = await command.func(page, { url: 'abc', mode: 'raw', lang: 'en' });
+
+        expect(rows).toEqual([{ index: 1, start: '2.00s', end: '3.00s', text: 'right captions' }]);
     });
 
     it('does not override an existing caption format', async () => {


### PR DESCRIPTION
## 现象

`opencli youtube transcript <url>` 在「共享 daemon tab + 连续抓多条 youtube 字幕」的
场景下，偶发把**上一条视频的字幕**写成下一条的输出。

实地命中：用 opencli 给一段 Fox News 视频 `XPZLEgu239Y`
（*Ukraine launches LARGEST drone attack on Russia in months*）抓字幕，结果拿到
之前抓过的另一条英文视频里的 Whisper Flow 产品宣传文案。url 传入正确、
`parseVideoId` 解析正确——是 transcript 抓回来的内容本身就错了。

## 根因

`clis/youtube/transcript.js` 内三条抓 timedtext 的通道**全部只按 `lang` 过滤、
不按 `videoId` 过滤**：

1. `findTimedtextUrl`（line 212）— 扫 `performance.getEntriesByType('resource')`
2. `isJson3TimedtextUrl`（line 235）— in-page fetch/XHR hook
3. `extractSegmentsFromNetworkCapture`（line 64）— Node 侧 CDP 抓包 fallback

YouTube watch 页是 SPA，`page.goto(watchUrl, { waitUntil: 'none' })` 在 watch→watch
之间走的是 history.pushState 路径，document **不重建**，
`performance.getEntriesByType('resource')` **不会自动清空**。源码 line 322-323 注释
里也写明了作者是**主动**不调 `performance.clearResourceTimings()` 的（为了不漏掉
早到的 timedtext URL）。

YouTube timedtext URL 形如：
```
.../api/timedtext?v=<VIDEO_ID>&lang=en&fmt=json3&pot=<token>
```

`v=` 这一段才是定位视频的关键，但过滤代码完全忽略。

→ Polling 第一个 500ms tick 时，如果当前视频的 fetch hook 还没填上
`capturedJson3Text`、但 resource buffer 里有上一条**同语言**视频的 timedtext URL
（pot 令牌通常 ~6h 内有效），代码就会直接 `fetch(oldUrl, { credentials:'include' })`
拿回旧视频的字幕并返回。

特别容易命中的 caller：**复用单个 daemon tab 连续抓 N 条字幕**的下游
（ml-scout 之类）。单独从命令行打一条 transcript 的用户感知不到。

## 修复

三条过滤都加 `v=<currentVideoId>` 检查，最小侵入。在 IIFE 顶部引入共享变量：

```js
// IIFE 顶部
const videoIdMarker = 'v=' + encodeURIComponent(${JSON.stringify(videoId)});

// findTimedtextUrl
.filter(url => url.includes('/api/timedtext')
            && url.includes('fmt=json3')
            && url.includes('pot=')
            && url.includes(videoIdMarker));   // ← 新增

// isJson3TimedtextUrl
if (!url.includes(videoIdMarker)) return false;   // ← 新增

// extractSegmentsFromNetworkCapture(entries, lang, videoId)  ← 新增 videoId 参数
if (videoIdMarker && !url.includes(videoIdMarker)) return false;   // ← 新增
```

## 故意不做的事

- **不改** `waitUntil: 'none'`——改成 `domcontentloaded` 会拖慢所有 youtube 命令
  2–5 秒，不在本 PR 范围
- **不调** `performance.clearResourceTimings()`——源码注释明确说明保留早到 URL
  是有意为之；既然按 videoId 过滤已经能挡住跨视频串台，清 buffer 是过度修复

## 测试

- ✅ `npx vitest run clis/youtube/transcript.test.js` —— 全部 15 项通过（含 2 项新增）
- **新增 source-contract 测试**：断言两个 in-page 站点都使用共享的 `videoIdMarker`
- **新增 behavioral regression 测试**：CDP capture buffer 同时返回
  `v=prev&lang=en` + `v=abc&lang=en` 两条 entry，验证只取 `v=abc` 那条的字幕

## 兼容性

完全向后兼容：`extractSegmentsFromNetworkCapture` 的新参数 `videoId` 是可选的，
没传时退化为原行为；in-page 的 `videoIdMarker` 总是从当前命令参数解析得来，无外部接口变化。

## 上下游记录

本修复已在 [huanghe/OpenCLI#15](https://github.com/huanghe/OpenCLI/pull/15) fork
上合并并由 ml-scout 在线试用，问题不再复现（同一条 `XPZLEgu239Y` 重抓后字幕内容
与视频标题/评论区话题完全吻合，从 852 字符的错误片段升到 1691 字符的实际报道）。