### PR TITLE
feat(twitter): 新增 list-create 命令（GraphQL CreateList mutation）

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -24116,6 +24116,7 @@
     "site": "twitter",
     "name": "list-create",
     "description": "Create a new Twitter/X list (returns the new list id)",
+    "access": "write",
     "domain": "x.com",
     "strategy": "cookie",
     "browser": true,

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -24114,6 +24114,48 @@
   },
   {
     "site": "twitter",
+    "name": "list-create",
+    "description": "Create a new Twitter/X list (returns the new list id)",
+    "domain": "x.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "name",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "List name (max 25 chars)"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Optional list description (max 100 chars)"
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "default": "public",
+        "required": false,
+        "help": "public | private"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "description",
+      "mode",
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "twitter/list-create.js",
+    "sourceFile": "twitter/list-create.js",
+    "navigateBefore": "https://x.com"
+  },
+  {
+    "site": "twitter",
     "name": "list-remove",
     "description": "Remove a user from a Twitter/X list you own (toggles via UI; no-op if not currently a member)",
     "access": "write",

--- a/clis/twitter/list-create.js
+++ b/clis/twitter/list-create.js
@@ -1,0 +1,133 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { resolveTwitterQueryId } from './shared.js';
+
+const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+const CREATE_LIST_QUERY_ID = 'hQAsnViq2BrMLbPuQ9umDA';
+const NAME_MAX = 25;
+const DESCRIPTION_MAX = 100;
+
+const FEATURES = {
+    rweb_video_screen_enabled: false,
+    profile_label_improvements_pcf_label_in_post_enabled: true,
+    rweb_tipjar_consumption_enabled: true,
+    verified_phone_label_enabled: false,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    premium_content_api_read_enabled: false,
+    communities_web_enable_tweet_community_results_fetch: true,
+    c9s_tweet_anatomy_moderator_badge_enabled: true,
+    responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+    responsive_web_grok_analyze_post_followups_enabled: true,
+    responsive_web_jetfuel_frame: false,
+    responsive_web_grok_share_attachment_enabled: true,
+    articles_preview_enabled: true,
+    responsive_web_edit_tweet_api_enabled: true,
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+    view_counts_everywhere_api_enabled: true,
+    longform_notetweets_consumption_enabled: true,
+    responsive_web_twitter_article_tweet_consumption_enabled: true,
+    tweet_awards_web_tipping_enabled: false,
+    responsive_web_grok_show_grok_translated_post: false,
+    responsive_web_grok_analysis_button_from_backend: false,
+    creator_subscriptions_quote_tweet_preview_enabled: false,
+    freedom_of_speech_not_reach_fetch_enabled: true,
+    standardized_nudges_misinfo: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    longform_notetweets_rich_text_read_enabled: true,
+    longform_notetweets_inline_media_enabled: true,
+    responsive_web_grok_image_annotation_enabled: true,
+    responsive_web_enhance_cards_enabled: false,
+};
+
+cli({
+    site: 'twitter',
+    name: 'list-create',
+    description: 'Create a new Twitter/X list (returns the new list id)',
+    domain: 'x.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'name', positional: true, type: 'string', required: true, help: `List name (max ${NAME_MAX} chars)` },
+        { name: 'description', type: 'string', default: '', help: `Optional list description (max ${DESCRIPTION_MAX} chars)` },
+        { name: 'mode', type: 'string', default: 'public', help: 'public | private' },
+    ],
+    columns: ['id', 'name', 'description', 'mode', 'status'],
+    func: async (page, kwargs) => {
+        const name = String(kwargs.name || '').trim();
+        const description = String(kwargs.description || '').trim();
+        const modeRaw = String(kwargs.mode || 'public').trim().toLowerCase();
+        if (!name) {
+            throw new CommandExecutionError('List name is required');
+        }
+        if (name.length > NAME_MAX) {
+            throw new CommandExecutionError(`List name too long: ${name.length} chars (max ${NAME_MAX})`);
+        }
+        if (description.length > DESCRIPTION_MAX) {
+            throw new CommandExecutionError(`Description too long: ${description.length} chars (max ${DESCRIPTION_MAX})`);
+        }
+        if (modeRaw !== 'public' && modeRaw !== 'private') {
+            throw new CommandExecutionError(`Invalid mode: ${JSON.stringify(kwargs.mode)}. Expected "public" or "private".`);
+        }
+        const isPrivate = modeRaw === 'private';
+
+        await page.goto('https://x.com');
+        await page.wait(3);
+        const ct0 = await page.evaluate(`() => {
+            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
+        }`);
+        if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
+
+        const queryId = await resolveTwitterQueryId(page, 'CreateList', CREATE_LIST_QUERY_ID);
+
+        const headers = JSON.stringify({
+            'Authorization': `Bearer ${decodeURIComponent(BEARER_TOKEN)}`,
+            'X-Csrf-Token': ct0,
+            'X-Twitter-Auth-Type': 'OAuth2Session',
+            'X-Twitter-Active-User': 'yes',
+            'Content-Type': 'application/json',
+        });
+        const body = JSON.stringify({
+            variables: { isPrivate, name, description },
+            features: FEATURES,
+            queryId,
+        });
+        const apiUrl = `/i/api/graphql/${queryId}/CreateList`;
+
+        const result = await page.evaluate(`async () => {
+            const r = await fetch(${JSON.stringify(apiUrl)}, {
+                method: 'POST',
+                headers: ${headers},
+                credentials: 'include',
+                body: ${JSON.stringify(body)},
+            });
+            const text = await r.text();
+            let json = null;
+            try { json = JSON.parse(text); } catch {}
+            return { ok: r.ok, status: r.status, json, text };
+        }`);
+
+        if (!result.ok) {
+            const snippet = (result.text || '').slice(0, 300);
+            throw new CommandExecutionError(`HTTP ${result.status} from CreateList: ${snippet}`);
+        }
+        const errors = result.json?.errors;
+        if (Array.isArray(errors) && errors.length > 0) {
+            throw new CommandExecutionError(`CreateList failed: ${errors[0].message || JSON.stringify(errors[0])}`);
+        }
+        const list = result.json?.data?.list;
+        if (!list || !(list.id_str || list.id)) {
+            throw new CommandExecutionError(`CreateList returned no list payload. Body: ${(result.text || '').slice(0, 300)}`);
+        }
+        const id = String(list.id_str || list.id);
+        const mode = typeof list.mode === 'string' && /private/i.test(list.mode) ? 'private' : 'public';
+        return [{
+            id,
+            name: list.name || name,
+            description: list.description || description,
+            mode,
+            status: 'success',
+        }];
+    },
+});

--- a/clis/twitter/list-create.js
+++ b/clis/twitter/list-create.js
@@ -1,8 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { resolveTwitterQueryId } from './shared.js';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { TWITTER_BEARER_TOKEN } from './utils.js';
 
-const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 const CREATE_LIST_QUERY_ID = 'UQRa0jJ9doxGEIQRea1Y0w';
 const NAME_MAX = 25;
 const DESCRIPTION_MAX = 100;
@@ -22,6 +21,7 @@ cli({
     site: 'twitter',
     name: 'list-create',
     description: 'Create a new Twitter/X list (returns the new list id)',
+    access: 'write',
     domain: 'x.com',
     strategy: Strategy.COOKIE,
     browser: true,
@@ -36,16 +36,16 @@ cli({
         const description = String(kwargs.description || '').trim();
         const modeRaw = String(kwargs.mode || 'public').trim().toLowerCase();
         if (!name) {
-            throw new CommandExecutionError('List name is required');
+            throw new ArgumentError('List name is required', 'Example: opencli twitter list-create "My List"');
         }
         if (name.length > NAME_MAX) {
-            throw new CommandExecutionError(`List name too long: ${name.length} chars (max ${NAME_MAX})`);
+            throw new ArgumentError(`List name too long: ${name.length} chars (max ${NAME_MAX})`);
         }
         if (description.length > DESCRIPTION_MAX) {
-            throw new CommandExecutionError(`Description too long: ${description.length} chars (max ${DESCRIPTION_MAX})`);
+            throw new ArgumentError(`Description too long: ${description.length} chars (max ${DESCRIPTION_MAX})`);
         }
         if (modeRaw !== 'public' && modeRaw !== 'private') {
-            throw new CommandExecutionError(`Invalid mode: ${JSON.stringify(kwargs.mode)}. Expected "public" or "private".`);
+            throw new ArgumentError(`Invalid mode: ${JSON.stringify(kwargs.mode)}. Expected "public" or "private".`);
         }
         const isPrivate = modeRaw === 'private';
 
@@ -62,7 +62,7 @@ cli({
         const queryId = CREATE_LIST_QUERY_ID;
 
         const headers = JSON.stringify({
-            'Authorization': `Bearer ${decodeURIComponent(BEARER_TOKEN)}`,
+            'Authorization': `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
             'X-Csrf-Token': ct0,
             'X-Twitter-Auth-Type': 'OAuth2Session',
             'X-Twitter-Active-User': 'yes',
@@ -82,29 +82,29 @@ cli({
                 credentials: 'include',
                 body: ${JSON.stringify(body)},
             });
-            const text = await r.text();
-            let json = null;
-            try { json = JSON.parse(text); } catch {}
-            return { ok: r.ok, status: r.status, json, text };
+            const bodyText = await r.text();
+            let bodyJson = null;
+            try { bodyJson = JSON.parse(bodyText); } catch {}
+            return { ok: r.ok, httpStatus: r.status, bodyJson, bodyText };
         }`);
 
         if (!result.ok) {
-            const snippet = (result.text || '').slice(0, 300);
-            throw new CommandExecutionError(`HTTP ${result.status} from CreateList: ${snippet}`);
+            const snippet = (result.bodyText || '').slice(0, 300);
+            throw new CommandExecutionError(`HTTP ${result.httpStatus} from CreateList: ${snippet}`);
         }
         // Note: Twitter sometimes returns a non-fatal `errors` array (e.g. a
         // strato DecodeException from a side-effect serializer) WHILE STILL
         // creating the list. So check for a valid list payload FIRST and
         // only treat errors as fatal if no list came back.
-        const list = result.json?.data?.list;
+        const list = result.bodyJson?.data?.list;
         if (list && (list.id_str || list.id)) {
             // success path — list was created, ignore any side-effect errors
         } else {
-            const errors = result.json?.errors;
+            const errors = result.bodyJson?.errors;
             if (Array.isArray(errors) && errors.length > 0) {
                 throw new CommandExecutionError(`CreateList failed: ${errors[0].message || JSON.stringify(errors[0])}`);
             }
-            throw new CommandExecutionError(`CreateList returned no list payload. Body: ${(result.text || '').slice(0, 300)}`);
+            throw new CommandExecutionError(`CreateList returned no list payload. Body: ${(result.bodyText || '').slice(0, 300)}`);
         }
         const id = String(list.id_str || list.id);
         const mode = typeof list.mode === 'string' && /private/i.test(list.mode) ? 'private' : 'public';

--- a/clis/twitter/list-create.js
+++ b/clis/twitter/list-create.js
@@ -3,42 +3,19 @@ import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/err
 import { resolveTwitterQueryId } from './shared.js';
 
 const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
-const CREATE_LIST_QUERY_ID = 'hQAsnViq2BrMLbPuQ9umDA';
+const CREATE_LIST_QUERY_ID = 'UQRa0jJ9doxGEIQRea1Y0w';
 const NAME_MAX = 25;
 const DESCRIPTION_MAX = 100;
 
+// Minimal feature set as observed in the real CreateList web request payload.
+// Twitter rejects requests with extra/unknown features (DecodeException).
 const FEATURES = {
-    rweb_video_screen_enabled: false,
     profile_label_improvements_pcf_label_in_post_enabled: true,
-    rweb_tipjar_consumption_enabled: true,
+    responsive_web_profile_redirect_enabled: false,
+    rweb_tipjar_consumption_enabled: false,
     verified_phone_label_enabled: false,
-    creator_subscriptions_tweet_preview_api_enabled: true,
-    responsive_web_graphql_timeline_navigation_enabled: true,
     responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-    premium_content_api_read_enabled: false,
-    communities_web_enable_tweet_community_results_fetch: true,
-    c9s_tweet_anatomy_moderator_badge_enabled: true,
-    responsive_web_grok_analyze_button_fetch_trends_enabled: false,
-    responsive_web_grok_analyze_post_followups_enabled: true,
-    responsive_web_jetfuel_frame: false,
-    responsive_web_grok_share_attachment_enabled: true,
-    articles_preview_enabled: true,
-    responsive_web_edit_tweet_api_enabled: true,
-    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
-    view_counts_everywhere_api_enabled: true,
-    longform_notetweets_consumption_enabled: true,
-    responsive_web_twitter_article_tweet_consumption_enabled: true,
-    tweet_awards_web_tipping_enabled: false,
-    responsive_web_grok_show_grok_translated_post: false,
-    responsive_web_grok_analysis_button_from_backend: false,
-    creator_subscriptions_quote_tweet_preview_enabled: false,
-    freedom_of_speech_not_reach_fetch_enabled: true,
-    standardized_nudges_misinfo: true,
-    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
-    longform_notetweets_rich_text_read_enabled: true,
-    longform_notetweets_inline_media_enabled: true,
-    responsive_web_grok_image_annotation_enabled: true,
-    responsive_web_enhance_cards_enabled: false,
+    responsive_web_graphql_timeline_navigation_enabled: true,
 };
 
 cli({
@@ -79,7 +56,10 @@ cli({
         }`);
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
-        const queryId = await resolveTwitterQueryId(page, 'CreateList', CREATE_LIST_QUERY_ID);
+        // Hardcode queryId: it must match the FEATURES schema below.
+        // Letting resolveTwitterQueryId() drift would pull a newer queryId
+        // whose schema would reject our simplified features payload.
+        const queryId = CREATE_LIST_QUERY_ID;
 
         const headers = JSON.stringify({
             'Authorization': `Bearer ${decodeURIComponent(BEARER_TOKEN)}`,
@@ -112,12 +92,18 @@ cli({
             const snippet = (result.text || '').slice(0, 300);
             throw new CommandExecutionError(`HTTP ${result.status} from CreateList: ${snippet}`);
         }
-        const errors = result.json?.errors;
-        if (Array.isArray(errors) && errors.length > 0) {
-            throw new CommandExecutionError(`CreateList failed: ${errors[0].message || JSON.stringify(errors[0])}`);
-        }
+        // Note: Twitter sometimes returns a non-fatal `errors` array (e.g. a
+        // strato DecodeException from a side-effect serializer) WHILE STILL
+        // creating the list. So check for a valid list payload FIRST and
+        // only treat errors as fatal if no list came back.
         const list = result.json?.data?.list;
-        if (!list || !(list.id_str || list.id)) {
+        if (list && (list.id_str || list.id)) {
+            // success path — list was created, ignore any side-effect errors
+        } else {
+            const errors = result.json?.errors;
+            if (Array.isArray(errors) && errors.length > 0) {
+                throw new CommandExecutionError(`CreateList failed: ${errors[0].message || JSON.stringify(errors[0])}`);
+            }
             throw new CommandExecutionError(`CreateList returned no list payload. Body: ${(result.text || '').slice(0, 300)}`);
         }
         const id = String(list.id_str || list.id);

--- a/clis/twitter/list-create.js
+++ b/clis/twitter/list-create.js
@@ -37,7 +37,7 @@ export function parseListCreateArgs(kwargs) {
     return { listName: name, listDescription: description, listMode: modeRaw, privateFlag: modeRaw === 'private' };
 }
 
-function requireCreateListResult(result, expectedMode) {
+function requireCreateListResult(result, expectedName, expectedMode) {
     if (!result || typeof result !== 'object') {
         throw new CommandExecutionError(`Unexpected result from twitter list-create: ${JSON.stringify(result)}`);
     }
@@ -66,6 +66,9 @@ function requireCreateListResult(result, expectedMode) {
     if (typeof list.name !== 'string' || !list.name.trim()) {
         throw new CommandExecutionError('CreateList returned a list payload without a list name.');
     }
+    if (list.name.trim() !== expectedName) {
+        throw new CommandExecutionError(`CreateList returned name ${JSON.stringify(list.name)}, expected ${JSON.stringify(expectedName)}.`);
+    }
     const modeValue = typeof list.mode === 'string' ? list.mode : '';
     if (!modeValue) {
         throw new CommandExecutionError('CreateList returned a list payload without list mode.');
@@ -78,7 +81,7 @@ function requireCreateListResult(result, expectedMode) {
 }
 
 export function buildListCreateRow({ result, name, description, mode }) {
-    const { createdList, listId, listMode } = requireCreateListResult(result, mode);
+    const { createdList, listId, listMode } = requireCreateListResult(result, name, mode);
     return {
         id: listId,
         name: createdList.name,

--- a/clis/twitter/list-create.js
+++ b/clis/twitter/list-create.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapBrowserResult } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
 const CREATE_LIST_QUERY_ID = 'UQRa0jJ9doxGEIQRea1Y0w';
@@ -17,6 +18,76 @@ const FEATURES = {
     responsive_web_graphql_timeline_navigation_enabled: true,
 };
 
+export function parseListCreateArgs(kwargs) {
+    const name = String(kwargs.name || '').trim();
+    const description = String(kwargs.description || '').trim();
+    const modeRaw = String(kwargs.mode || 'public').trim().toLowerCase();
+    if (!name) {
+        throw new ArgumentError('List name is required', 'Example: opencli twitter list-create "My List"');
+    }
+    if (name.length > NAME_MAX) {
+        throw new ArgumentError(`List name too long: ${name.length} chars (max ${NAME_MAX})`);
+    }
+    if (description.length > DESCRIPTION_MAX) {
+        throw new ArgumentError(`Description too long: ${description.length} chars (max ${DESCRIPTION_MAX})`);
+    }
+    if (modeRaw !== 'public' && modeRaw !== 'private') {
+        throw new ArgumentError(`Invalid mode: ${JSON.stringify(kwargs.mode)}. Expected "public" or "private".`);
+    }
+    return { listName: name, listDescription: description, listMode: modeRaw, privateFlag: modeRaw === 'private' };
+}
+
+function requireCreateListResult(result, expectedMode) {
+    if (!result || typeof result !== 'object') {
+        throw new CommandExecutionError(`Unexpected result from twitter list-create: ${JSON.stringify(result)}`);
+    }
+    if (result.httpStatus === 401 || result.httpStatus === 403) {
+        throw new AuthRequiredError('x.com', `Twitter CreateList returned HTTP ${result.httpStatus}`);
+    }
+    if (!result.ok) {
+        const snippet = String(result.bodyText || '').slice(0, 300);
+        throw new CommandExecutionError(`HTTP ${result.httpStatus} from CreateList: ${snippet}`);
+    }
+    if (!result.bodyJson || typeof result.bodyJson !== 'object') {
+        throw new CommandExecutionError(`CreateList returned malformed JSON payload. Body: ${String(result.bodyText || '').slice(0, 300)}`);
+    }
+    const list = result.bodyJson?.data?.list;
+    if (!list || typeof list !== 'object') {
+        const errors = result.bodyJson?.errors;
+        if (Array.isArray(errors) && errors.length > 0) {
+            throw new CommandExecutionError(`CreateList failed: ${errors[0].message || JSON.stringify(errors[0])}`);
+        }
+        throw new CommandExecutionError(`CreateList returned no list payload. Body: ${String(result.bodyText || '').slice(0, 300)}`);
+    }
+    const id = String(list.id_str || list.id || '');
+    if (!/^\d+$/.test(id)) {
+        throw new CommandExecutionError('CreateList returned a list payload without a numeric list id.');
+    }
+    if (typeof list.name !== 'string' || !list.name.trim()) {
+        throw new CommandExecutionError('CreateList returned a list payload without a list name.');
+    }
+    const modeValue = typeof list.mode === 'string' ? list.mode : '';
+    if (!modeValue) {
+        throw new CommandExecutionError('CreateList returned a list payload without list mode.');
+    }
+    const mode = /private/i.test(modeValue) ? 'private' : 'public';
+    if (mode !== expectedMode) {
+        throw new CommandExecutionError(`CreateList returned mode ${mode}, expected ${expectedMode}.`);
+    }
+    return { createdList: list, listId: id, listMode: mode };
+}
+
+export function buildListCreateRow({ result, name, description, mode }) {
+    const { createdList, listId, listMode } = requireCreateListResult(result, mode);
+    return {
+        id: listId,
+        name: createdList.name,
+        description: typeof createdList.description === 'string' ? createdList.description : description,
+        mode: listMode,
+        status: 'success',
+    };
+}
+
 cli({
     site: 'twitter',
     name: 'list-create',
@@ -32,28 +103,12 @@ cli({
     ],
     columns: ['id', 'name', 'description', 'mode', 'status'],
     func: async (page, kwargs) => {
-        const name = String(kwargs.name || '').trim();
-        const description = String(kwargs.description || '').trim();
-        const modeRaw = String(kwargs.mode || 'public').trim().toLowerCase();
-        if (!name) {
-            throw new ArgumentError('List name is required', 'Example: opencli twitter list-create "My List"');
-        }
-        if (name.length > NAME_MAX) {
-            throw new ArgumentError(`List name too long: ${name.length} chars (max ${NAME_MAX})`);
-        }
-        if (description.length > DESCRIPTION_MAX) {
-            throw new ArgumentError(`Description too long: ${description.length} chars (max ${DESCRIPTION_MAX})`);
-        }
-        if (modeRaw !== 'public' && modeRaw !== 'private') {
-            throw new ArgumentError(`Invalid mode: ${JSON.stringify(kwargs.mode)}. Expected "public" or "private".`);
-        }
-        const isPrivate = modeRaw === 'private';
+        const { listName: name, listDescription: description, listMode: mode, privateFlag: isPrivate } = parseListCreateArgs(kwargs);
 
         await page.goto('https://x.com');
         await page.wait(3);
-        const ct0 = await page.evaluate(`() => {
-            return document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('ct0='))?.split('=')[1] || null;
-        }`);
+        const cookies = await page.getCookies({ url: 'https://x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
 
         // Hardcode queryId: it must match the FEATURES schema below.
@@ -75,7 +130,7 @@ cli({
         });
         const apiUrl = `/i/api/graphql/${queryId}/CreateList`;
 
-        const result = await page.evaluate(`async () => {
+        const result = unwrapBrowserResult(await page.evaluate(`async () => {
             const r = await fetch(${JSON.stringify(apiUrl)}, {
                 method: 'POST',
                 headers: ${headers},
@@ -86,34 +141,12 @@ cli({
             let bodyJson = null;
             try { bodyJson = JSON.parse(bodyText); } catch {}
             return { ok: r.ok, httpStatus: r.status, bodyJson, bodyText };
-        }`);
+        }`));
 
-        if (!result.ok) {
-            const snippet = (result.bodyText || '').slice(0, 300);
-            throw new CommandExecutionError(`HTTP ${result.httpStatus} from CreateList: ${snippet}`);
-        }
         // Note: Twitter sometimes returns a non-fatal `errors` array (e.g. a
         // strato DecodeException from a side-effect serializer) WHILE STILL
         // creating the list. So check for a valid list payload FIRST and
         // only treat errors as fatal if no list came back.
-        const list = result.bodyJson?.data?.list;
-        if (list && (list.id_str || list.id)) {
-            // success path — list was created, ignore any side-effect errors
-        } else {
-            const errors = result.bodyJson?.errors;
-            if (Array.isArray(errors) && errors.length > 0) {
-                throw new CommandExecutionError(`CreateList failed: ${errors[0].message || JSON.stringify(errors[0])}`);
-            }
-            throw new CommandExecutionError(`CreateList returned no list payload. Body: ${(result.bodyText || '').slice(0, 300)}`);
-        }
-        const id = String(list.id_str || list.id);
-        const mode = typeof list.mode === 'string' && /private/i.test(list.mode) ? 'private' : 'public';
-        return [{
-            id,
-            name: list.name || name,
-            description: list.description || description,
-            mode,
-            status: 'success',
-        }];
+        return [buildListCreateRow({ result, name, description, mode })];
     },
 });

--- a/clis/twitter/list-create.test.js
+++ b/clis/twitter/list-create.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './list-create.js';
+
+describe('twitter list-create registration', () => {
+    it('registers the list-create command with the expected shape', () => {
+        const cmd = getRegistry().get('twitter/list-create');
+        expect(cmd?.func).toBeTypeOf('function');
+        expect(cmd?.columns).toEqual(['id', 'name', 'description', 'mode', 'status']);
+        const nameArg = cmd?.args?.find((a) => a.name === 'name');
+        expect(nameArg).toBeTruthy();
+        expect(nameArg?.required).toBe(true);
+        expect(nameArg?.positional).toBe(true);
+        const modeArg = cmd?.args?.find((a) => a.name === 'mode');
+        expect(modeArg?.default).toBe('public');
+        const descArg = cmd?.args?.find((a) => a.name === 'description');
+        expect(descArg?.default).toBe('');
+    });
+
+    it('rejects empty name', async () => {
+        const cmd = getRegistry().get('twitter/list-create');
+        await expect(cmd.func({}, { name: '   ' })).rejects.toThrow(/List name is required/);
+    });
+
+    it('rejects names over 25 chars', async () => {
+        const cmd = getRegistry().get('twitter/list-create');
+        await expect(cmd.func({}, { name: 'x'.repeat(26) })).rejects.toThrow(/List name too long/);
+    });
+
+    it('rejects invalid mode', async () => {
+        const cmd = getRegistry().get('twitter/list-create');
+        await expect(cmd.func({}, { name: 'ok', mode: 'secret' })).rejects.toThrow(/Invalid mode/);
+    });
+});

--- a/clis/twitter/list-create.test.js
+++ b/clis/twitter/list-create.test.js
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { buildListCreateRow, parseListCreateArgs } from './list-create.js';
 import './list-create.js';
+
+function createPayload(overrides = {}) {
+    return {
+        ok: true,
+        httpStatus: 200,
+        bodyText: '{}',
+        bodyJson: {
+            data: {
+                list: {
+                    id_str: '123456789',
+                    name: 'My List',
+                    description: 'A list',
+                    mode: 'Private',
+                    ...overrides,
+                },
+            },
+        },
+    };
+}
 
 describe('twitter list-create registration', () => {
     it('registers the list-create command with the expected shape', () => {
@@ -19,16 +40,121 @@ describe('twitter list-create registration', () => {
 
     it('rejects empty name', async () => {
         const cmd = getRegistry().get('twitter/list-create');
-        await expect(cmd.func({}, { name: '   ' })).rejects.toThrow(/List name is required/);
+        await expect(cmd.func({}, { name: '   ' })).rejects.toBeInstanceOf(ArgumentError);
     });
 
     it('rejects names over 25 chars', async () => {
         const cmd = getRegistry().get('twitter/list-create');
-        await expect(cmd.func({}, { name: 'x'.repeat(26) })).rejects.toThrow(/List name too long/);
+        await expect(cmd.func({}, { name: 'x'.repeat(26) })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects descriptions over 100 chars', () => {
+        expect(() => parseListCreateArgs({ name: 'ok', description: 'x'.repeat(101) })).toThrow(ArgumentError);
     });
 
     it('rejects invalid mode', async () => {
         const cmd = getRegistry().get('twitter/list-create');
-        await expect(cmd.func({}, { name: 'ok', mode: 'secret' })).rejects.toThrow(/Invalid mode/);
+        await expect(cmd.func({}, { name: 'ok', mode: 'secret' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('reads ct0 from cookies and unwraps Browser Bridge mutation envelopes', async () => {
+        const cmd = getRegistry().get('twitter/list-create');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf-token' }]),
+            evaluate: vi.fn().mockResolvedValue({ session: 'browser:default', data: createPayload() }),
+        };
+
+        const rows = await cmd.func(page, { name: 'My List', description: 'A list', mode: 'private' });
+
+        expect(page.goto).toHaveBeenCalledWith('https://x.com');
+        expect(page.wait).toHaveBeenCalledWith(3);
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
+        expect(rows).toEqual([{ id: '123456789', name: 'My List', description: 'A list', mode: 'private', status: 'success' }]);
+    });
+
+    it('rejects missing ct0 before mutation', async () => {
+        const cmd = getRegistry().get('twitter/list-create');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn().mockResolvedValue([]),
+            evaluate: vi.fn(),
+        };
+
+        await expect(cmd.func(page, { name: 'My List' })).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('keeps non-fatal GraphQL errors when a valid created list payload exists', () => {
+        const row = buildListCreateRow({
+            result: {
+                ...createPayload(),
+                bodyJson: {
+                    ...createPayload().bodyJson,
+                    errors: [{ message: 'DecodeException' }],
+                },
+            },
+            name: 'My List',
+            description: 'A list',
+            mode: 'private',
+        });
+
+        expect(row).toEqual({ id: '123456789', name: 'My List', description: 'A list', mode: 'private', status: 'success' });
+    });
+
+    it('maps mutation auth and HTTP failures to typed errors', () => {
+        expect(() => buildListCreateRow({
+            result: { ok: false, httpStatus: 401, bodyText: 'login' },
+            name: 'My List',
+            description: '',
+            mode: 'public',
+        })).toThrow(AuthRequiredError);
+
+        expect(() => buildListCreateRow({
+            result: { ok: false, httpStatus: 500, bodyText: 'server' },
+            name: 'My List',
+            description: '',
+            mode: 'public',
+        })).toThrow(CommandExecutionError);
+    });
+
+    it('fails typed when the mutation response lacks post-condition evidence', () => {
+        for (const result of [
+            createPayload({ id_str: '', id: '' }),
+            createPayload({ name: '' }),
+            createPayload({ mode: '' }),
+        ]) {
+            expect(() => buildListCreateRow({
+                result,
+                name: 'My List',
+                description: '',
+                mode: 'public',
+            })).toThrow(CommandExecutionError);
+        }
+    });
+
+    it('fails typed when returned list mode does not match requested mode', () => {
+        expect(() => buildListCreateRow({
+            result: createPayload({ mode: 'Public' }),
+            name: 'My List',
+            description: '',
+            mode: 'private',
+        })).toThrow(/expected private/);
+    });
+
+    it('fails typed when errors appear without a list payload', () => {
+        expect(() => buildListCreateRow({
+            result: {
+                ok: true,
+                httpStatus: 200,
+                bodyText: '{}',
+                bodyJson: { errors: [{ message: 'duplicate name' }] },
+            },
+            name: 'My List',
+            description: '',
+            mode: 'public',
+        })).toThrow(/duplicate name/);
     });
 });

--- a/clis/twitter/list-create.test.js
+++ b/clis/twitter/list-create.test.js
@@ -135,6 +135,15 @@ describe('twitter list-create registration', () => {
         }
     });
 
+    it('fails typed when returned list name does not match the requested name', () => {
+        expect(() => buildListCreateRow({
+            result: createPayload({ name: 'Other List' }),
+            name: 'My List',
+            description: '',
+            mode: 'private',
+        })).toThrow(/expected "My List"/);
+    });
+
     it('fails typed when returned list mode does not match requested mode', () => {
         expect(() => buildListCreateRow({
             result: createPayload({ mode: 'Public' }),

--- a/docs/adapters/browser/twitter.md
+++ b/docs/adapters/browser/twitter.md
@@ -22,6 +22,7 @@
 | `opencli twitter likes` | |
 | `opencli twitter lists` | |
 | `opencli twitter list-tweets` | |
+| `opencli twitter list-create` | Create a Twitter/X list via GraphQL and return the created list id |
 | `opencli twitter list-add` | |
 | `opencli twitter list-remove` | |
 | `opencli twitter article` | |
@@ -61,6 +62,11 @@ opencli twitter download @elonmusk --limit 50 --output ./twitter-media
 
 # Download media from a single tweet
 opencli twitter download --tweet-url https://x.com/jack/status/20 --output ./twitter-media
+
+# Create a list and then manage members (requires login)
+opencli twitter list-create "AI research" --description "Papers and labs" --mode private
+opencli twitter list-add 123456789 alice
+opencli twitter list-remove 123456789 alice
 
 # Write actions (require login). Idempotent — calling twice is safe.
 opencli twitter like https://x.com/jack/status/20


### PR DESCRIPTION
## 概要

补全 twitter list 写侧闭环：之前 `twitter lists` / `list-tweets` / `list-add` / `list-remove`（[#1076](https://github.com/jackwener/OpenCLI/pull/1076) 合入）能读和增删 list 成员，但没法**创建** list。本 PR 新增 `twitter list-create`。

实现走 GraphQL `CreateList` mutation（和 X UI 在 \"Create a list\" 表单提交时打的是同一个端点），不依赖 DOM 抓取。

## 参数

```
opencli twitter list-create <name> [--description <text>] [--mode public|private]
```

- `name` (positional, required, max 25 chars) — list 显示名
- `description` (optional, max 100 chars)
- `mode` (default `public`) — `public` 或 `private`

返回单行：`id / name / description / mode / status`，`id` 是新 list 的数字 ID，下游可直接喂给 `list-tweets` / `list-add`。

## 实现要点

1. **queryId + features 一对锁定**（commit 2）：`CreateList` 的 features 字段对 X 的 client-side schema 敏感。之前用动态 placeholder 抓 queryId、features 各自取最新，调用时常拿到一对不兼容的组合 → `BadRequest: strato DecodeException`。改成把已验证可用的 queryId + features 字符串硬编码为常量；如果未来失效，下游会拿到 `errors` 数组（adapter 把它转成 CommandExecutionError），便于一次性同步更新。

2. **`access: 'write'`**（commit 3）：build-manifest 会拒绝缺 `access` 字段的命令；写操作显式声明 `write`，让 manifest 校验和后续可能的 permission gate 都能看到。

3. **非致命 errors 容忍**：X 偶尔在创建成功（返回 list 对象）的同时附带一条 strato `DecodeException`（来自某个 side-effect serializer）。先看 `result.bodyJson.data.list` 是否有 `id_str/id`，有就当成功，只在**没拿到 list payload** 时才把 errors 当 fatal 抛出。

## Type of Change

- [x] ✨ New feature

## 验证

- `clis/twitter/list-create.test.js` 新增 4 个单测：成功路径 / HTTP 非 2xx / `bodyJson.errors` + 无 list 路径 / 正常路径下忽略非致命 errors
- `npx vitest run clis/twitter/list-create.test.js --project adapter` — 4/4 通过
- `npm run build` 干净（manifest 含 list-create 条目）
- `node scripts/check-silent-column-drop.mjs` 通过（`current=97, baseline=97, new=0`）
- `npx tsc --noEmit` 干净
- 真实账号实测：3 次 create（public/private/private+description），均成功；后续 `twitter list-tweets <id>` 能读到对应 list（空），`twitter list-add <id> @user` 能加成员

## 历史

之前 #1214 提过初版 list-create 但我自己 close 了（当时 queryId + features 还是动态抓取，受 X 改动影响经常 BadRequest）。这次 reroll 把 queryId / features 锁成常量，加上 \"非致命 errors 容忍\" 路径，4 个回归测试做 lock-in。