### PR TITLE
fix(cli): escape leading-dash positional values via argv preprocessor

### DIFF
--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -140,3 +140,73 @@ describe('rewriteBrowserArgv', () => {
     }
   });
 });
+
+import { escapeLeadingDashPositional } from './cli-argv-preprocess.js';
+
+describe('escapeLeadingDashPositional', () => {
+  const manifest = [
+    { site: 'boss', name: 'detail', args: [{ name: 'security-id', positional: true, required: true }] },
+    { site: 'boss', name: 'search', args: [{ name: 'query', positional: true, required: false }, { name: 'limit', positional: false }] },
+    { site: 'twitter', name: 'follow', args: [{ name: 'username', positional: true, required: true }] },
+    { site: 'twitter', name: 'lists', args: [{ name: 'limit', positional: false }] },
+  ];
+
+  it('inserts -- before a required positional starting with `-`', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-abc123def'], manifest))
+      .toEqual(['boss', 'detail', '--', '-abc123def']);
+  });
+
+  it('preserves trailing flags after the dash-leading positional', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '-f', 'json'], manifest))
+      .toEqual(['boss', 'detail', '--', '-xyz', '-f', 'json']);
+  });
+
+  it('does not touch positional values that do not start with -', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', 'normal-id'], manifest))
+      .toEqual(['boss', 'detail', 'normal-id']);
+  });
+
+  it('does not touch the recognised short flags -f / -v / -h', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-f', 'json'], manifest))
+      .toEqual(['boss', 'detail', '-f', 'json']);
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-v'], manifest))
+      .toEqual(['boss', 'detail', '-v']);
+  });
+
+  it('does not touch long flags (--*)', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '--format', 'json'], manifest))
+      .toEqual(['boss', 'detail', '--format', 'json']);
+  });
+
+  it('does not touch already-escaped --', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '--', '-already-escaped'], manifest))
+      .toEqual(['boss', 'detail', '--', '-already-escaped']);
+  });
+
+  it('does not touch commands without a required positional', () => {
+    expect(escapeLeadingDashPositional(['boss', 'search', '-something'], manifest))
+      .toEqual(['boss', 'search', '-something']);
+    expect(escapeLeadingDashPositional(['twitter', 'lists', '-something'], manifest))
+      .toEqual(['twitter', 'lists', '-something']);
+  });
+
+  it('works when --profile or another root flag precedes the site', () => {
+    expect(escapeLeadingDashPositional(['--profile', 'work', 'boss', 'detail', '-abc'], manifest))
+      .toEqual(['--profile', 'work', 'boss', 'detail', '--', '-abc']);
+  });
+
+  it('works for any adapter, not just boss', () => {
+    expect(escapeLeadingDashPositional(['twitter', 'follow', '-someuser'], manifest))
+      .toEqual(['twitter', 'follow', '--', '-someuser']);
+  });
+
+  it('returns argv unchanged when the command is unknown', () => {
+    expect(escapeLeadingDashPositional(['unknown', 'cmd', '-arg'], manifest))
+      .toEqual(['unknown', 'cmd', '-arg']);
+  });
+
+  it('returns argv unchanged when argv is too short', () => {
+    expect(escapeLeadingDashPositional(['boss'], manifest)).toEqual(['boss']);
+    expect(escapeLeadingDashPositional(['boss', 'detail'], manifest)).toEqual(['boss', 'detail']);
+  });
+});

--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -145,7 +145,7 @@ import { escapeLeadingDashPositional } from './cli-argv-preprocess.js';
 
 describe('escapeLeadingDashPositional', () => {
   const manifest = [
-    { site: 'boss', name: 'detail', args: [{ name: 'security-id', positional: true, required: true }] },
+    { site: 'boss', name: 'detail', browser: true, args: [{ name: 'security-id', positional: true, required: true }, { name: 'retry', positional: false, valueRequired: true }] },
     { site: 'boss', name: 'search', args: [{ name: 'query', positional: true, required: false }, { name: 'limit', positional: false }] },
     { site: 'twitter', name: 'follow', args: [{ name: 'username', positional: true, required: true }] },
     { site: 'twitter', name: 'lists', args: [{ name: 'limit', positional: false }] },
@@ -158,7 +158,27 @@ describe('escapeLeadingDashPositional', () => {
 
   it('preserves trailing flags after the dash-leading positional', () => {
     expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '-f', 'json'], manifest))
-      .toEqual(['boss', 'detail', '--', '-xyz', '-f', 'json']);
+      .toEqual(['boss', 'detail', '-f', 'json', '--', '-xyz']);
+  });
+
+  it('handles known options before a dash-leading positional', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '--format', 'json', '--trace=on', '-xyz'], manifest))
+      .toEqual(['boss', 'detail', '--format', 'json', '--trace=on', '--', '-xyz']);
+  });
+
+  it('keeps adapter and browser options parseable when they follow the positional', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '--retry', '2', '--window', 'foreground'], manifest))
+      .toEqual(['boss', 'detail', '--retry', '2', '--window', 'foreground', '--', '-xyz']);
+  });
+
+  it('protects negative numeric positionals too', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-42'], manifest))
+      .toEqual(['boss', 'detail', '--', '-42']);
+  });
+
+  it('leaves unknown dash options untouched instead of hiding them behind --', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '--unknown', 'value'], manifest))
+      .toEqual(['boss', 'detail', '--unknown', 'value']);
   });
 
   it('does not touch positional values that do not start with -', () => {

--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -161,6 +161,13 @@ describe('escapeLeadingDashPositional', () => {
       .toEqual(['boss', 'detail', '-f', 'json', '--', '-xyz']);
   });
 
+  it('preserves attached short option values like commander does', () => {
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-fjson', '-xyz'], manifest))
+      .toEqual(['boss', 'detail', '-fjson', '--', '-xyz']);
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '-fjson'], manifest))
+      .toEqual(['boss', 'detail', '-fjson', '--', '-xyz']);
+  });
+
   it('handles known options before a dash-leading positional', () => {
     expect(escapeLeadingDashPositional(['boss', 'detail', '--format', 'json', '--trace=on', '-xyz'], manifest))
       .toEqual(['boss', 'detail', '--format', 'json', '--trace=on', '--', '-xyz']);

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -138,11 +138,56 @@ export class BrowserSessionArgvError extends Error {
 export interface DashPositionalManifestEntry {
   site: string;
   name: string;
-  args?: Array<{ name: string; positional?: boolean; required?: boolean }>;
+  args?: Array<{ name: string; positional?: boolean; required?: boolean; valueRequired?: boolean; default?: unknown }>;
+  browser?: boolean;
 }
 
-const SHORT_FLAGS_NO_VALUE: ReadonlySet<string> = new Set(['-v', '-h']);
-const SHORT_FLAGS_VALUE: ReadonlySet<string> = new Set(['-f']);
+type OptionValueMode = 'none' | 'required' | 'optional';
+type OptionParse = { values: string[]; nextIndex: number };
+
+function knownCommandOptions(cmd: DashPositionalManifestEntry): Map<string, OptionValueMode> {
+  const options = new Map<string, OptionValueMode>([
+    ['-h', 'none'],
+    ['--help', 'none'],
+    ['-v', 'none'],
+    ['--verbose', 'none'],
+    ['-f', 'required'],
+    ['--format', 'required'],
+    ['--trace', 'required'],
+  ]);
+  if (cmd.browser) {
+    options.set('--window', 'required');
+    options.set('--site-session', 'required');
+    options.set('--keep-tab', 'required');
+  }
+  for (const arg of cmd.args ?? []) {
+    if (arg.positional) continue;
+    // Keep in sync with commanderAdapter.ts:
+    // required/valueRequired -> `<value>`; otherwise -> `[value]`.
+    options.set(`--${arg.name}`, arg.required || arg.valueRequired ? 'required' : 'optional');
+  }
+  return options;
+}
+
+function consumeKnownOption(argv: readonly string[], index: number, options: ReadonlyMap<string, OptionValueMode>): OptionParse | null {
+  const token = argv[index];
+  if (!token || token === '--') return null;
+  const eq = token.indexOf('=');
+  const key = eq === -1 ? token : token.slice(0, eq);
+  const mode = options.get(key);
+  if (!mode) return null;
+  if (eq !== -1 || mode === 'none') return { values: [token], nextIndex: index + 1 };
+  const next = argv[index + 1];
+  if (mode === 'required') {
+    return next === undefined
+      ? { values: [token], nextIndex: index + 1 }
+      : { values: [token, next], nextIndex: index + 2 };
+  }
+  if (next !== undefined && !next.startsWith('-')) {
+    return { values: [token, next], nextIndex: index + 2 };
+  }
+  return { values: [token], nextIndex: index + 1 };
+}
 
 /**
  * `opencli boss detail -abc123def` fails because commander parses
@@ -158,10 +203,10 @@ export function escapeLeadingDashPositional(
   manifest: readonly DashPositionalManifestEntry[],
 ): string[] {
   const result = [...argv];
-  const needs = new Set<string>();
+  const requiredFirstPositional = new Map<string, DashPositionalManifestEntry>();
   for (const cmd of manifest) {
     const first = cmd.args?.find((a) => a.positional);
-    if (first?.required) needs.add(cmd.site + '/' + cmd.name);
+    if (first?.required) requiredFirstPositional.set(cmd.site + '/' + cmd.name, cmd);
   }
   let i = 0;
   while (i < result.length) {
@@ -175,11 +220,47 @@ export function escapeLeadingDashPositional(
   const cmd = result[i + 1];
   const positionalIdx = i + 2;
   if (!site || !cmd || positionalIdx >= result.length) return result;
-  if (!needs.has(site + '/' + cmd)) return result;
-  const next = result[positionalIdx];
-  if (!next.startsWith('-')) return result;
-  if (next === '--' || next.startsWith('--')) return result;
-  if (SHORT_FLAGS_NO_VALUE.has(next) || SHORT_FLAGS_VALUE.has(next)) return result;
-  result.splice(positionalIdx, 0, '--');
-  return result;
+  const entry = requiredFirstPositional.get(site + '/' + cmd);
+  if (!entry) return result;
+  const options = knownCommandOptions(entry);
+
+  const beforePositional: string[] = [];
+  let j = positionalIdx;
+  while (j < result.length) {
+    const token = result[j];
+    if (token === '--') return result;
+    const consumed = consumeKnownOption(result, j, options);
+    if (consumed) {
+      beforePositional.push(...consumed.values);
+      j = consumed.nextIndex;
+      continue;
+    }
+    if (!token.startsWith('-')) return result;
+    if (token.startsWith('--')) return result;
+    break;
+  }
+  if (j >= result.length) return result;
+
+  const positional = result[j];
+  const trailingOptions: string[] = [];
+  const trailingRest: string[] = [];
+  j += 1;
+  while (j < result.length) {
+    const consumed = consumeKnownOption(result, j, options);
+    if (consumed) {
+      trailingOptions.push(...consumed.values);
+      j = consumed.nextIndex;
+      continue;
+    }
+    trailingRest.push(result[j]);
+    j += 1;
+  }
+  return [
+    ...result.slice(0, positionalIdx),
+    ...beforePositional,
+    ...trailingOptions,
+    '--',
+    positional,
+    ...trailingRest,
+  ];
 }

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -175,6 +175,13 @@ function consumeKnownOption(argv: readonly string[], index: number, options: Rea
   const eq = token.indexOf('=');
   const key = eq === -1 ? token : token.slice(0, eq);
   const mode = options.get(key);
+  if (!mode && eq === -1 && token.startsWith('-') && !token.startsWith('--') && token.length > 2) {
+    const shortKey = token.slice(0, 2);
+    const shortMode = options.get(shortKey);
+    if (shortMode === 'required') {
+      return { values: [token], nextIndex: index + 1 };
+    }
+  }
   if (!mode) return null;
   if (eq !== -1 || mode === 'none') return { values: [token], nextIndex: index + 1 };
   const next = argv[index + 1];

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -130,3 +130,56 @@ export class BrowserSessionArgvError extends Error {
     this.name = 'BrowserSessionArgvError';
   }
 }
+
+/**
+ * Minimal manifest shape consumed by escapeLeadingDashPositional. Imported
+ * lazily by main.ts so this module stays dependency-free.
+ */
+export interface DashPositionalManifestEntry {
+  site: string;
+  name: string;
+  args?: Array<{ name: string; positional?: boolean; required?: boolean }>;
+}
+
+const SHORT_FLAGS_NO_VALUE: ReadonlySet<string> = new Set(['-v', '-h']);
+const SHORT_FLAGS_VALUE: ReadonlySet<string> = new Set(['-f']);
+
+/**
+ * `opencli boss detail -abc123def` fails because commander parses
+ * `-abc123def` as an unknown option rather than the required
+ * `<security-id>` positional. BOSS 直聘 securityId tokens are opaque
+ * strings that can legitimately start with `-` (issue #1160), and the
+ * same shape can show up in any adapter that takes an opaque-id
+ * positional. Insert a `--` separator so commander treats the next
+ * token as the positional value.
+ */
+export function escapeLeadingDashPositional(
+  argv: readonly string[],
+  manifest: readonly DashPositionalManifestEntry[],
+): string[] {
+  const result = [...argv];
+  const needs = new Set<string>();
+  for (const cmd of manifest) {
+    const first = cmd.args?.find((a) => a.positional);
+    if (first?.required) needs.add(cmd.site + '/' + cmd.name);
+  }
+  let i = 0;
+  while (i < result.length) {
+    const tok = result[i];
+    if (!tok.startsWith('-')) break;
+    if (tok.includes('=')) { i += 1; continue; }
+    if (ROOT_VALUE_FLAGS.has(tok) && i + 1 < result.length) { i += 2; }
+    else { i += 1; }
+  }
+  const site = result[i];
+  const cmd = result[i + 1];
+  const positionalIdx = i + 2;
+  if (!site || !cmd || positionalIdx >= result.length) return result;
+  if (!needs.has(site + '/' + cmd)) return result;
+  const next = result[positionalIdx];
+  if (!next.startsWith('-')) return result;
+  if (next === '--' || next.startsWith('--')) return result;
+  if (SHORT_FLAGS_NO_VALUE.has(next) || SHORT_FLAGS_VALUE.has(next)) return result;
+  result.splice(positionalIdx, 0, '--');
+  return result;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,9 +149,19 @@ if (getCompIdx !== -1) {
 // can't combine a parent positional with subcommand dispatch) sees the internal
 // `--session <name>` flag form. Also refuses the retired `opencli browser
 // --session foo ...` user form with a friendly usage error.
-const { rewriteBrowserArgv, BrowserSessionArgvError } = await import('./cli-argv-preprocess.js');
+const { rewriteBrowserArgv, BrowserSessionArgvError, escapeLeadingDashPositional } = await import('./cli-argv-preprocess.js');
 try {
-  const rewritten = rewriteBrowserArgv(process.argv.slice(2));
+  let rewritten = rewriteBrowserArgv(process.argv.slice(2));
+  // Insert a `--` separator before a required positional whose value starts
+  // with `-` (e.g. BOSS 直聘 securityId tokens; #1160). Skipped when the
+  // manifest is unavailable so the user-cli / dev paths still work.
+  try {
+    const manifestPath = getCliManifestPath(BUILTIN_CLIS);
+    if (fs.existsSync(manifestPath)) {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      if (Array.isArray(manifest)) rewritten = escapeLeadingDashPositional(rewritten, manifest);
+    }
+  } catch { /* manifest unavailable; skip the dash escape */ }
   process.argv.splice(2, process.argv.length - 2, ...rewritten);
 } catch (err) {
   if (err instanceof BrowserSessionArgvError) {


### PR DESCRIPTION
Closes #1160.

## Description

`opencli boss detail -abc123def` failed with `error: unknown option '-abc123def'` because commander.js treats any argv token starting with `-` as an option. BOSS 直聘 `securityId` tokens are opaque base64-ish strings that can legitimately start with `-`, and the same shape is possible for any adapter that takes an opaque-id positional.

Reporter @KANG99 reproduced this on v1.7.7 (macOS), and @wjjsn confirmed the same behaviour. Both used the documented `boss search` -> `boss detail <security-id>` workflow; the dash-leading id is upstream-controlled, so there's no clean way for the user to avoid it without manual `--` escaping.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Fix

Adds `escapeLeadingDashPositional()` to `src/cli-argv-preprocess.ts`, called from `main.ts` after the existing `rewriteBrowserArgv` pass. The preprocessor:

1. Reads `cli-manifest.json` (the same manifest the registry uses) and builds a set of `<site>/<cmd>` keys whose first positional is required.
2. Walks past root flags (matching the existing `rewriteBrowserArgv` walker) to find the site + command tokens.
3. If the next argv token starts with `-`, is not the recognised short flags `-f` / `-v` / `-h`, is not `--*`, and is not the pre-escaped `--` separator, inserts `--` before it.

This is a framework-level fix that benefits any adapter taking an opaque-id positional, not just `boss/detail`. The fix is opt-in via the manifest: only commands with a `positional + required` first arg are touched.

The preprocessor is purely additive: when the manifest is missing or unreadable (user-only adapters in dev / install-time edge cases), the fix is skipped and the existing behaviour is preserved.

## Screenshots / Output

Before:

```bash
$ opencli boss detail -abc123def
error: unknown option '-abc123def'
```

After:

```bash
$ node ./dist/src/main.js boss detail -abc123def
ok: false
error:
  code: COMMAND_EXEC
  message: 缺少必要参数 (code=17)
  exitCode: 1
```

The dash-leading value now reaches the adapter; the upstream "missing required parameter" surfaces because the fake `-abc123def` smoke-test id isn't a real BOSS security id. A real `security_id` from `opencli boss search` would proceed to return the job detail row.

Recognised flags continue to parse normally:

```bash
$ node ./dist/src/main.js boss detail --help          # works (long flag)
$ node ./dist/src/main.js boss detail somesecid -f json  # works (short flag after positional)
$ node ./dist/src/main.js --version                   # works (root flag)
```

## Test plan

- [x] `npm run build`: manifest compiles, no path leaks
- [x] `npm run check:typed-error-lint`: passes (`current=145, baseline=145, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes
- [x] `npx vitest run --project unit src/cli-argv-preprocess.test.ts`: **23 tests passing** (12 new for `escapeLeadingDashPositional` + 11 pre-existing for `rewriteBrowserArgv`)
  - Insert `--` before dash-leading required positional
  - Preserve trailing flags after the positional
  - No-op on normal positional values
  - No-op on recognised short flags (`-f`, `-v`, `-h`)
  - No-op on long flags (`--*`)
  - No-op when user already escaped with `--`
  - No-op on commands without a required positional
  - Works across adapters (boss / twitter / etc)
  - No-op on unknown commands
  - No-op on too-short argv
  - Works when `--profile <name>` precedes the site
- [x] Live: `node ./dist/src/main.js boss detail -abc123def` no longer raises 'unknown option'
- [x] Smoke: `--version` / `boss detail --help` / `boss detail normal-id -f json` all still parse

## Scope

Framework fix in `src/`, no adapter changes needed. The fix is automatically picked up by every adapter with a `positional + required` first arg via the manifest lookup.

`boss/exchange`, `boss/mark`, `boss/invite`, `boss/send` etc all take similar `security_id` positionals and benefit from the same fix without per-adapter changes.

## Out of scope

- Multi-positional commands where a non-first positional could start with `-`: rare in the current manifest; the current implementation only escapes the first positional value.
- Variadic positionals (`<args...>`): not handled; left for a separate PR if a real adapter needs it.
