### PR TITLE
feat(twitter): 在 read 命令上暴露 card binding_values（链接预览卡片）

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -24189,7 +24189,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "card"
     ],
     "type": "js",
     "modulePath": "twitter/list-tweets.js",
@@ -24586,7 +24587,8 @@
       "views",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "card"
     ],
     "type": "js",
     "modulePath": "twitter/search.js",
@@ -24632,7 +24634,8 @@
       "retweets",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "card"
     ],
     "type": "js",
     "modulePath": "twitter/thread.js",
@@ -24685,7 +24688,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "card"
     ],
     "type": "js",
     "modulePath": "twitter/timeline.js",

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { extractMedia } from './shared.js';
+import { extractMedia, extractCard } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 const LIST_TWEETS_QUERY_ID = 'RlZzktZY_9wJynoepm8ZsA';
@@ -73,6 +73,7 @@ export function extractTimelineTweet(result, seen) {
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
         ...extractMedia(legacy),
+        card: extractCard(tw),
     };
 }
 
@@ -120,7 +121,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'card'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -32,6 +32,7 @@ describe('twitter list-tweets parser', () => {
             url: 'https://x.com/bob/status/99',
             has_media: false,
             media_urls: [],
+            card: null,
         });
     });
 

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -1,6 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { extractMedia, normalizeTwitterGraphqlPayload, resolveTwitterOperationMetadata } from './shared.js';
+import { extractMedia, extractCard, normalizeTwitterGraphqlPayload, resolveTwitterOperationMetadata } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 // ── Public-search operator surface ─────────────────────────────────────
@@ -221,6 +221,7 @@ function tweetToRow(result, seen) {
         views: tweet.views?.count || '0',
         url: `https://x.com/i/status/${tweet.rest_id}`,
         ...extractMedia(tweet.legacy),
+        card: extractCard(tweet),
     };
 }
 
@@ -271,7 +272,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Maximum number of tweets to return (default 15). Result count after server-side filtering.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the results by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'card'],
     func: async (page, kwargs) => {
         const finalQuery = buildSearchQuery(kwargs.query, kwargs);
         if (!finalQuery) {

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -75,6 +75,7 @@ describe('twitter search command', () => {
                 url: 'https://x.com/i/status/1',
                 has_media: false,
                 media_urls: [],
+                card: null,
             },
         ]);
         expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -293,7 +293,7 @@ export function extractMedia(legacy) {
  * Extract the link-preview card from a tweet's GraphQL response.
  *
  * Reads `tweet.card.legacy.{name, binding_values}` plus the expanded URL from
- * `tweet.legacy.entities.urls[0].expanded_url` (which is already t.co-resolved).
+ * the `tweet.legacy.entities.urls` entry matching the card's t.co URL.
  * `binding_values` is an array of `{ key, value: { type, string_value, image_value: { url } } }`.
  *
  * Returns `null` when:
@@ -326,9 +326,15 @@ export function extractCard(tweet) {
     const domainBinding = str('domain');
     const cardUrlBinding = str('card_url');
     const image_url = img('thumbnail_image_large') || img('photo_image_full_size_large') || img('summary_photo_image_large');
-    const expandedUrl = tweet?.legacy?.entities?.urls?.[0]?.expanded_url;
-    const url = (typeof expandedUrl === 'string' && expandedUrl.length > 0)
-        ? expandedUrl
+    const urlEntities = Array.isArray(tweet?.legacy?.entities?.urls)
+        ? tweet.legacy.entities.urls
+        : [];
+    const matchingEntity = cardUrlBinding
+        ? urlEntities.find((entity) => entity?.url === cardUrlBinding || entity?.expanded_url === cardUrlBinding)
+        : undefined;
+    const matchedExpandedUrl = matchingEntity?.expanded_url;
+    const url = (typeof matchedExpandedUrl === 'string' && matchedExpandedUrl.length > 0)
+        ? matchedExpandedUrl
         : cardUrlBinding;
     let domain = domainBinding;
     if (!domain && url) {

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -288,6 +288,63 @@ export function extractMedia(legacy) {
     }
     return { has_media: urls.length > 0, media_urls: urls };
 }
+
+/**
+ * Extract the link-preview card from a tweet's GraphQL response.
+ *
+ * Reads `tweet.card.legacy.{name, binding_values}` plus the expanded URL from
+ * `tweet.legacy.entities.urls[0].expanded_url` (which is already t.co-resolved).
+ * `binding_values` is an array of `{ key, value: { type, string_value, image_value: { url } } }`.
+ *
+ * Returns `null` when:
+ *   - the tweet has no card, OR
+ *   - the card is structurally empty (no landing URL AND no title/description),
+ *     which would be useless to downstream renderers.
+ *
+ * Otherwise returns a partial card object — missing fields are simply omitted
+ * (no `undefined` values in the output) so JSON consumers see a clean shape.
+ */
+export function extractCard(tweet) {
+    const cardLegacy = tweet?.card?.legacy;
+    if (!cardLegacy) return null;
+    const bindings = Array.isArray(cardLegacy.binding_values) ? cardLegacy.binding_values : [];
+    const byKey = new Map();
+    for (const b of bindings) {
+        if (b && typeof b.key === 'string') byKey.set(b.key, b.value);
+    }
+    const str = (key) => {
+        const v = byKey.get(key);
+        return typeof v?.string_value === 'string' && v.string_value.length > 0 ? v.string_value : undefined;
+    };
+    const img = (key) => {
+        const v = byKey.get(key);
+        const u = v?.image_value?.url;
+        return typeof u === 'string' && u.length > 0 ? u : undefined;
+    };
+    const title = str('title');
+    const description = str('description');
+    const domainBinding = str('domain');
+    const cardUrlBinding = str('card_url');
+    const image_url = img('thumbnail_image_large') || img('photo_image_full_size_large') || img('summary_photo_image_large');
+    const expandedUrl = tweet?.legacy?.entities?.urls?.[0]?.expanded_url;
+    const url = (typeof expandedUrl === 'string' && expandedUrl.length > 0)
+        ? expandedUrl
+        : cardUrlBinding;
+    let domain = domainBinding;
+    if (!domain && url) {
+        try { domain = new URL(url).hostname; }
+        catch { /* malformed url — domain stays undefined */ }
+    }
+    if (!url && !title && !description) return null;
+    const out = { name: cardLegacy.name };
+    if (title) out.title = title;
+    if (description) out.description = description;
+    if (image_url) out.image_url = image_url;
+    if (url) out.url = url;
+    if (domain) out.domain = domain;
+    return out;
+}
+
 export const __test__ = {
     sanitizeQueryId,
     sanitizeTwitterOperationMetadata,
@@ -295,6 +352,7 @@ export const __test__ = {
     normalizeTwitterGraphqlPayload,
     normalizeTwitterScreenName,
     extractMedia,
+    extractCard,
     parseTweetUrl,
     buildTwitterArticleScopeSource,
 };

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -3,7 +3,23 @@ import { JSDOM } from 'jsdom';
 import { __test__ } from './shared.js';
 import { ArgumentError } from '@jackwener/opencli/errors';
 
-const { extractMedia, parseTweetUrl, buildTwitterArticleScopeSource, unwrapBrowserResult, normalizeTwitterGraphqlPayload, normalizeTwitterScreenName, sanitizeTwitterOperationMetadata } = __test__;
+const { extractMedia, extractCard, parseTweetUrl, buildTwitterArticleScopeSource, unwrapBrowserResult, normalizeTwitterGraphqlPayload, normalizeTwitterScreenName, sanitizeTwitterOperationMetadata } = __test__;
+
+function makeCardTweet({ name, bindings, expandedUrl }) {
+    const tweet = {
+        card: { legacy: { name, binding_values: bindings } },
+    };
+    if (expandedUrl !== undefined) {
+        tweet.legacy = { entities: { urls: [{ expanded_url: expandedUrl }] } };
+    }
+    return tweet;
+}
+function strBinding(key, string_value) {
+    return { key, value: { type: 'STRING', string_value } };
+}
+function imgBinding(key, url) {
+    return { key, value: { type: 'IMAGE', image_value: { url } } };
+}
 
 describe('twitter browser result helpers', () => {
     it('unwraps Browser Bridge exec envelopes', () => {
@@ -325,6 +341,139 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/c.jpg'],
+        });
+    });
+});
+
+describe('twitter extractCard', () => {
+    it('returns null when tweet has no card', () => {
+        expect(extractCard({})).toBeNull();
+        expect(extractCard(undefined)).toBeNull();
+        expect(extractCard({ legacy: { full_text: 'hi' } })).toBeNull();
+    });
+
+    it('extracts full summary_large_image card with all bindings present', () => {
+        const tweet = makeCardTweet({
+            name: 'summary_large_image',
+            bindings: [
+                strBinding('title', 'jackwener/OpenCLI'),
+                strBinding('description', 'Make Any Website & Tool Your CLI'),
+                strBinding('domain', 'github.com'),
+                strBinding('card_url', 'https://t.co/abc'),
+                imgBinding('thumbnail_image_large', 'https://pbs.twimg.com/card_img/thumb_large.jpg'),
+                imgBinding('photo_image_full_size_large', 'https://pbs.twimg.com/card_img/photo_large.jpg'),
+                imgBinding('summary_photo_image_large', 'https://pbs.twimg.com/card_img/summary_large.jpg'),
+            ],
+            expandedUrl: 'https://github.com/jackwener/OpenCLI',
+        });
+        expect(extractCard(tweet)).toEqual({
+            name: 'summary_large_image',
+            title: 'jackwener/OpenCLI',
+            description: 'Make Any Website & Tool Your CLI',
+            image_url: 'https://pbs.twimg.com/card_img/thumb_large.jpg',
+            url: 'https://github.com/jackwener/OpenCLI',
+            domain: 'github.com',
+        });
+    });
+
+    it('picks summary_photo_image_large when higher-priority image keys are missing', () => {
+        const tweet = makeCardTweet({
+            name: 'summary',
+            bindings: [
+                strBinding('title', 'Some article'),
+                strBinding('description', 'Body text'),
+                strBinding('domain', 'example.com'),
+                imgBinding('summary_photo_image_large', 'https://pbs.twimg.com/card_img/fallback.jpg'),
+            ],
+            expandedUrl: 'https://example.com/article',
+        });
+        const card = extractCard(tweet);
+        expect(card.image_url).toBe('https://pbs.twimg.com/card_img/fallback.jpg');
+        expect(card.name).toBe('summary');
+    });
+
+    it('derives domain from expanded_url when domain binding is missing', () => {
+        const tweet = makeCardTweet({
+            name: 'promo_image_convo',
+            bindings: [
+                strBinding('title', 'YouTube video'),
+                imgBinding('photo_image_full_size_large', 'https://pbs.twimg.com/card_img/yt.jpg'),
+            ],
+            expandedUrl: 'https://www.youtube.com/watch?v=abc',
+        });
+        const card = extractCard(tweet);
+        expect(card.url).toBe('https://www.youtube.com/watch?v=abc');
+        expect(card.domain).toBe('www.youtube.com');
+        expect(card.image_url).toBe('https://pbs.twimg.com/card_img/yt.jpg');
+    });
+
+    it('falls back to card_url binding when there is no expanded_url', () => {
+        const tweet = makeCardTweet({
+            name: 'summary_large_image',
+            bindings: [
+                strBinding('title', 'arXiv paper'),
+                strBinding('card_url', 'https://arxiv.org/abs/2305.12345'),
+            ],
+            expandedUrl: undefined,
+        });
+        const card = extractCard(tweet);
+        expect(card.url).toBe('https://arxiv.org/abs/2305.12345');
+        expect(card.domain).toBe('arxiv.org');
+    });
+
+    it('omits missing fields rather than emitting undefined values', () => {
+        const tweet = makeCardTweet({
+            name: 'summary',
+            bindings: [
+                strBinding('title', 'Just a title'),
+                strBinding('description', 'Just a description'),
+            ],
+            expandedUrl: 'https://example.com/x',
+        });
+        const card = extractCard(tweet);
+        expect('image_url' in card).toBe(false);
+        expect(card).toEqual({
+            name: 'summary',
+            title: 'Just a title',
+            description: 'Just a description',
+            url: 'https://example.com/x',
+            domain: 'example.com',
+        });
+    });
+
+    it('returns null for a structurally empty card (no url, no title, no description)', () => {
+        const tweet = makeCardTweet({
+            name: 'summary',
+            bindings: [
+                imgBinding('thumbnail_image_large', 'https://pbs.twimg.com/card_img/x.jpg'),
+            ],
+            expandedUrl: undefined,
+        });
+        expect(extractCard(tweet)).toBeNull();
+    });
+
+    it('does not throw on a malformed expanded_url; domain is simply omitted', () => {
+        const tweet = makeCardTweet({
+            name: 'summary',
+            bindings: [strBinding('title', 'broken url card')],
+            expandedUrl: 'not a url',
+        });
+        const card = extractCard(tweet);
+        expect(card.url).toBe('not a url');
+        expect('domain' in card).toBe(false);
+    });
+
+    it('tolerates missing binding_values array', () => {
+        const tweet = {
+            card: { legacy: { name: 'summary' } },
+            legacy: { entities: { urls: [{ expanded_url: 'https://example.com/' }] } },
+        };
+        const card = extractCard(tweet);
+        // No title/description means the URL alone keeps the card alive
+        expect(card).toEqual({
+            name: 'summary',
+            url: 'https://example.com/',
+            domain: 'example.com',
         });
     });
 });

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -5,10 +5,14 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 
 const { extractMedia, extractCard, parseTweetUrl, buildTwitterArticleScopeSource, unwrapBrowserResult, normalizeTwitterGraphqlPayload, normalizeTwitterScreenName, sanitizeTwitterOperationMetadata } = __test__;
 
-function makeCardTweet({ name, bindings, expandedUrl }) {
+function makeCardTweet({ name, bindings, expandedUrl, urls }) {
     const tweet = {
         card: { legacy: { name, binding_values: bindings } },
     };
+    if (urls !== undefined) {
+        tweet.legacy = { entities: { urls } };
+        return tweet;
+    }
     if (expandedUrl !== undefined) {
         tweet.legacy = { entities: { urls: [{ expanded_url: expandedUrl }] } };
     }
@@ -364,7 +368,7 @@ describe('twitter extractCard', () => {
                 imgBinding('photo_image_full_size_large', 'https://pbs.twimg.com/card_img/photo_large.jpg'),
                 imgBinding('summary_photo_image_large', 'https://pbs.twimg.com/card_img/summary_large.jpg'),
             ],
-            expandedUrl: 'https://github.com/jackwener/OpenCLI',
+            urls: [{ url: 'https://t.co/abc', expanded_url: 'https://github.com/jackwener/OpenCLI' }],
         });
         expect(extractCard(tweet)).toEqual({
             name: 'summary_large_image',
@@ -397,9 +401,10 @@ describe('twitter extractCard', () => {
             name: 'promo_image_convo',
             bindings: [
                 strBinding('title', 'YouTube video'),
+                strBinding('card_url', 'https://t.co/youtube'),
                 imgBinding('photo_image_full_size_large', 'https://pbs.twimg.com/card_img/yt.jpg'),
             ],
-            expandedUrl: 'https://www.youtube.com/watch?v=abc',
+            urls: [{ url: 'https://t.co/youtube', expanded_url: 'https://www.youtube.com/watch?v=abc' }],
         });
         const card = extractCard(tweet);
         expect(card.url).toBe('https://www.youtube.com/watch?v=abc');
@@ -421,14 +426,48 @@ describe('twitter extractCard', () => {
         expect(card.domain).toBe('arxiv.org');
     });
 
+    it('matches card_url to the correct URL entity instead of assuming the first tweet URL', () => {
+        const tweet = makeCardTweet({
+            name: 'summary_large_image',
+            bindings: [
+                strBinding('title', 'OpenCLI release'),
+                strBinding('card_url', 'https://t.co/card123'),
+            ],
+            urls: [
+                { url: 'https://t.co/unrelated', expanded_url: 'https://example.com/unrelated' },
+                { url: 'https://t.co/card123', expanded_url: 'https://github.com/jackwener/OpenCLI/releases' },
+            ],
+        });
+        const card = extractCard(tweet);
+        expect(card.url).toBe('https://github.com/jackwener/OpenCLI/releases');
+        expect(card.domain).toBe('github.com');
+    });
+
+    it('falls back to card_url itself when no matching URL entity is present', () => {
+        const tweet = makeCardTweet({
+            name: 'summary_large_image',
+            bindings: [
+                strBinding('title', 'Unmatched card'),
+                strBinding('card_url', 'https://t.co/card123'),
+            ],
+            urls: [
+                { url: 'https://t.co/unrelated', expanded_url: 'https://example.com/unrelated' },
+            ],
+        });
+        const card = extractCard(tweet);
+        expect(card.url).toBe('https://t.co/card123');
+        expect(card.domain).toBe('t.co');
+    });
+
     it('omits missing fields rather than emitting undefined values', () => {
         const tweet = makeCardTweet({
             name: 'summary',
             bindings: [
                 strBinding('title', 'Just a title'),
                 strBinding('description', 'Just a description'),
+                strBinding('card_url', 'https://t.co/example'),
             ],
-            expandedUrl: 'https://example.com/x',
+            urls: [{ url: 'https://t.co/example', expanded_url: 'https://example.com/x' }],
         });
         const card = extractCard(tweet);
         expect('image_url' in card).toBe(false);
@@ -455,8 +494,11 @@ describe('twitter extractCard', () => {
     it('does not throw on a malformed expanded_url; domain is simply omitted', () => {
         const tweet = makeCardTweet({
             name: 'summary',
-            bindings: [strBinding('title', 'broken url card')],
-            expandedUrl: 'not a url',
+            bindings: [
+                strBinding('title', 'broken url card'),
+                strBinding('card_url', 'https://t.co/broken'),
+            ],
+            urls: [{ url: 'https://t.co/broken', expanded_url: 'not a url' }],
         });
         const card = extractCard(tweet);
         expect(card.url).toBe('not a url');
@@ -469,11 +511,6 @@ describe('twitter extractCard', () => {
             legacy: { entities: { urls: [{ expanded_url: 'https://example.com/' }] } },
         };
         const card = extractCard(tweet);
-        // No title/description means the URL alone keeps the card alive
-        expect(card).toEqual({
-            name: 'summary',
-            url: 'https://example.com/',
-            domain: 'example.com',
-        });
+        expect(card).toBeNull();
     });
 });

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { extractMedia } from './shared.js';
+import { extractMedia, extractCard } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const TWEET_DETAIL_QUERY_ID = 'nBS-WpgA6ZG0CyNHD517JQ';
@@ -56,6 +56,7 @@ function extractTweet(r, seen) {
         created_at: l.created_at,
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
         ...extractMedia(l),
+        card: extractCard(tw),
     };
 }
 function parseTweetDetail(data, seen) {
@@ -105,7 +106,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the thread by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the conversation\'s structural ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -1,6 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { resolveTwitterQueryId, extractMedia } from './shared.js';
+import { resolveTwitterQueryId, extractMedia, extractCard } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const HOME_TIMELINE_QUERY_ID = 'c-CzHF1LboFilMpsx4ZCrQ';
@@ -87,6 +87,7 @@ function extractTweet(result, seen) {
         created_at: l.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
         ...extractMedia(l),
+        card: extractCard(tw),
     };
 }
 function parseHomeTimeline(data, seen) {
@@ -152,7 +153,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'card'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';


### PR DESCRIPTION
## 背景

当一条 tweet 包含外链时，X 会渲染一张「链接预览卡片」——title / description / 缩略图 / domain。这些数据在 GraphQL 响应里位于 `tweet.card.legacy.binding_values`，是一个 `{ key, value: { type, string_value, image_value: { url } } }` 数组。

目前 `search` / `list-tweets` / `thread` / `timeline` 这 4 个 read 命令都没有暴露这块数据，下游消费者（比如要在终端 / 网页里渲染原生链接卡片预览）必须二次抓取或自己解析 entities，体验很糟糕。

## 改动

**纯 GraphQL-response 提取器，没有任何查询策略、interceptor、网络层改动。**

1. `clis/twitter/shared.js` — 新增 `extractCard(tweet)` 辅助函数（与现有 `extractMedia` 同款风格）：
   - 读 `tweet.card.legacy.{name, binding_values}` 拼出 `{ name, title, description, image_url, url, domain }`
   - `url` 优先从 `tweet.legacy.entities.urls[0].expanded_url` 取（t.co 已解析过的真实落地 URL）；fallback 到 binding 里的 `card_url`
   - `domain` 优先取 binding `domain`，否则从 `url` 解析 hostname
   - `image_url` 按优先级取 `thumbnail_image_large` → `photo_image_full_size_large` → `summary_photo_image_large`
2. 4 个 read 命令各加一行 `card: extractCard(tw)`，columns 数组追加 `'card'`
3. `cli-manifest.json` 同步重生成

## 设计取舍

**`extractCard` 返回 `null` 的两种情况**，避免下游渲染出空卡：
- tweet 没有 card 字段
- card 结构上为空（既无 landing URL 也无 title/description）—— 渲染出来也没意义

**输出对象省略 undefined 字段**——`{ title?, description?, image_url?, url?, domain? }`，让 JSON 消费者看到的 shape 干净，不用每个字段都判空。

## 测试

- `clis/twitter/shared.test.js` 新增覆盖：
  - tweet 无 card → `null`
  - card 完全空 → `null`
  - 完整 STRING binding（title/description/domain）
  - IMAGE binding 按优先级回退
  - `expanded_url` 优先于 binding `card_url`
  - hostname 解析失败时 `domain` 保持 undefined
  - 完整字段都缺时整体返回 `null`
- `clis/twitter/list-tweets.test.js` / `clis/twitter/search.test.js` 验证 row 里包含 `card` 字段
- `npx vitest run clis/twitter` —— 29 文件 / 295 测试全过
- `npx tsc --noEmit` 干净
- `npm run build` 干净，manifest 自动追加 4 个命令的 `card` 列

## 兼容性

完全向后兼容：
- 没有 card 的 tweet（绝大多数）现在 `card: null`——纯增量字段，旧调用方完全不感知
- `--format table` 已经支持 nullable 列，不需要任何 CLI 层改动