### PR TITLE
docs(readme): tighten skill attribution (T1) + remove redundant Highlights (T2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenCLI
 
-> **Convert any website into a CLI & Drive your logged-in browser from AI agents.**
+> **Convert any website into a CLI & run Browser Use on your logged-in Chrome.**
 > Turn websites, browser sessions, Electron apps, and local tools into deterministic interfaces for humans and AI agents.
-> Or drive your logged-in browser to do anything — navigate, fill forms, click, extract, automate.
+> Or run Browser Use against any page — navigate, fill forms, click, extract, automate.
 
 [![中文文档](https://img.shields.io/badge/docs-%E4%B8%AD%E6%96%87-0F766E?style=flat-square)](./README.zh-CN.md)
 [![npm](https://img.shields.io/npm/v/@jackwener/opencli?style=flat-square)](https://www.npmjs.com/package/@jackwener/opencli)
@@ -16,16 +16,6 @@ OpenCLI gives you one surface for three different kinds of automation:
 - **Write new adapters** end-to-end with `opencli browser` + the `opencli-adapter-author` skill, which guides from first recon through field decoding, code, and `opencli browser verify`.
 
 It also works as a **CLI hub** for local tools such as `gh`, `docker`, `longbridge`, `tg`, `discord`, `wx`, `ntn` (Notion), and other binaries you register yourself, plus **desktop app adapters** for Electron apps like Cursor, Codex, Antigravity, and ChatGPT.
-
-## Highlights
-
-- **Live Browser Automation** — Drive your logged-in Chrome from AI agents: navigate, fill forms, click, extract. Credentials stay in the browser.
-- **Desktop App Control** — Drive Electron apps (Cursor, Codex, ChatGPT) directly via CDP.
-- **Multi-profile Browser Bridge** — Route commands to specific Chrome profiles via `--profile` or `OPENCLI_PROFILE`.
-- **100+ adapters + CLI Hub** — Built-in site commands (bilibili / xiaohongshu / twitter / hackernews / ...) plus external CLI passthrough (`gh`, `docker`, `ntn`, `longbridge`).
-- **Zero LLM cost at runtime** — Deterministic output, no tokens consumed.
-
----
 
 ## Quick Start
 
@@ -122,15 +112,15 @@ npx skills add jackwener/opencli --skill smart-search
 
 | Skill | When to use | Example prompt to your AI agent |
 |-------|------------|-------------------------------|
-| **opencli-adapter-author** | Operate a site in real time, or write a reusable adapter for a new site | "Help me check my Xiaohongshu notifications" / "Write an adapter for douyin trending" / "Make a command that grabs the top posts from this page" |
+| **opencli-adapter-author** | Write a reusable adapter for a new site or add a command to an existing site | "Write an adapter for douyin trending" / "Make a command that grabs the top posts from this page" |
 | **opencli-autofix** | Repair a broken adapter when a built-in command fails | "`opencli zhihu hot` is returning empty — fix it" |
-| **opencli-browser** | Browser automation reference for AI agents | "Help me fill out this form" / "Use browser commands to scrape this page" |
+| **opencli-browser** | Drive a real Chrome page ad-hoc — navigate, fill forms, click, extract | "Help me check my Xiaohongshu notifications" / "Help me fill out this form" / "Use browser commands to scrape this page" |
 | **opencli-usage** | Quick reference for all OpenCLI commands and sites | "What commands does OpenCLI have for Twitter?" |
 | **smart-search** | Search across existing OpenCLI capabilities | "Find me a Bilibili trending adapter" |
 
 ### How it works
 
-Once `opencli-adapter-author` is installed, your AI agent can:
+Once `opencli-browser` is installed, your AI agent can:
 
 1. **Navigate** to any URL using your logged-in browser
 2. **Read** page content via structured DOM snapshots (not screenshots)
@@ -141,9 +131,9 @@ Once `opencli-adapter-author` is installed, your AI agent can:
 The agent handles all the `opencli browser` commands internally — you just describe what you want done in natural language.
 
 **Skill references:**
-- [`skills/opencli-adapter-author/SKILL.md`](./skills/opencli-adapter-author/SKILL.md) — browser operation + adapter authoring, end-to-end
+- [`skills/opencli-browser/SKILL.md`](./skills/opencli-browser/SKILL.md) — drive Chrome ad-hoc (navigate, fill forms, click, extract)
+- [`skills/opencli-adapter-author/SKILL.md`](./skills/opencli-adapter-author/SKILL.md) — write a new adapter end-to-end
 - [`skills/opencli-autofix/SKILL.md`](./skills/opencli-autofix/SKILL.md) — repair broken adapters
-- [`skills/opencli-browser/SKILL.md`](./skills/opencli-browser/SKILL.md) — browser automation reference
 - [`skills/opencli-usage/SKILL.md`](./skills/opencli-usage/SKILL.md) — command and site reference
 - [`skills/smart-search/SKILL.md`](./skills/smart-search/SKILL.md) — capability search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,8 @@
 # OpenCLI
 
-> **把任意网站变成 CLI & 让 AI Agent 操控你的登录态浏览器。**
+> **把任意网站变成 CLI & 在你的登录态浏览器上跑 Browser Use。**
 > 把网站、浏览器会话、Electron 应用和本地工具，统一变成适合人类与 AI Agent 使用的确定性接口。
-> 或者直接操控你的登录态浏览器做任何事 —— 导航、填表单、点击、抓取、自动化。
+> 或者在任意页面上跑 Browser Use —— 导航、填表单、点击、抓取、自动化。
 
 [![English](https://img.shields.io/badge/docs-English-1D4ED8?style=flat-square)](./README.md)
 [![npm](https://img.shields.io/npm/v/@jackwener/opencli?style=flat-square)](https://www.npmjs.com/package/@jackwener/opencli)
@@ -16,14 +16,6 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 - **把新网站写成 CLI**：用 `opencli browser` 原语 + `opencli-adapter-author` skill，从站点侦察、API 发现、字段解码到 `opencli browser verify` 一条龙。
 
 除了网站能力，OpenCLI 还是一个 **CLI 枢纽**：你可以把 `gh`、`docker`、`longbridge`、`tg`、`discord`、`wx`、`ntn`（Notion）等本地工具统一注册到 `opencli` 下，也可以通过桌面端适配器控制 Cursor、Codex、Antigravity、ChatGPT 等 Electron 应用。
-
-## 亮点
-
-- **登录态浏览器自动化** — 让 AI Agent 驱动你的已登录 Chrome：导航、填表单、点击、提取。凭证永远不离开浏览器。
-- **桌面应用控制** — 通过 CDP 直接驱动 Electron 应用（Cursor、Codex、ChatGPT）。
-- **多 Profile 浏览器桥接** — 通过 `--profile` 或 `OPENCLI_PROFILE` 把命令路由到指定 Chrome profile。
-- **100+ 适配器 + CLI 枢纽** — 内置站点命令（B站 / 小红书 / Twitter / HackerNews / ...）加外部 CLI 透传（`gh`、`docker`、`ntn`、`longbridge`）。
-- **零 LLM 运行成本** — 确定性输出，运行时不消耗 token。
 
 ## 快速开始
 
@@ -107,15 +99,15 @@ npx skills add jackwener/opencli --skill smart-search
 
 | Skill | 适用场景 | 你对 AI Agent 说的话 |
 |-------|---------|-------------------|
-| **opencli-adapter-author** | 实时操作任意网站，或为新站点写可复用适配器 | "帮我看看小红书的通知" / "帮我做一个抖音热门的适配器" / "帮我做一个抓取这个页面热帖的命令" |
+| **opencli-adapter-author** | 为新站点写可复用适配器，或给已有站点添加命令 | "帮我做一个抖音热门的适配器" / "帮我做一个抓取这个页面热帖的命令" |
 | **opencli-autofix** | 内置命令失败时修复已有适配器 | "`opencli zhihu hot` 返回空了，修一下" |
-| **opencli-browser** | 浏览器自动化参考文档 | "帮我填一下这个表单" / "用浏览器命令抓取这个页面" |
+| **opencli-browser** | 实时驱动 Chrome 页面——导航、填表单、点击、抓取 | "帮我看看小红书的通知" / "帮我填一下这个表单" / "用浏览器命令抓取这个页面" |
 | **opencli-usage** | 所有命令和站点的快速参考 | "OpenCLI 有哪些 Twitter 相关的命令？" |
 | **smart-search** | 在现有 OpenCLI 能力里搜索 | "帮我找个 B 站热门相关的适配器" |
 
 ### 工作原理
 
-安装 `opencli-adapter-author` skill 后，你的 AI Agent 可以：
+安装 `opencli-browser` skill 后，你的 AI Agent 可以：
 
 1. **导航**到任意 URL，使用你的已登录浏览器
 2. **读取**页面内容——通过结构化 DOM 快照（不是截图）
@@ -126,9 +118,9 @@ npx skills add jackwener/opencli --skill smart-search
 Agent 在内部自动处理所有 `opencli browser` 命令——你只需用自然语言描述想做的事。
 
 **Skill 参考文档：**
-- [`skills/opencli-adapter-author/SKILL.md`](./skills/opencli-adapter-author/SKILL.md) — 浏览器操作 + 适配器编写，全流程
+- [`skills/opencli-browser/SKILL.md`](./skills/opencli-browser/SKILL.md) — 实时驱动 Chrome（导航、填表单、点击、抓取）
+- [`skills/opencli-adapter-author/SKILL.md`](./skills/opencli-adapter-author/SKILL.md) — 给新站点写适配器，全流程
 - [`skills/opencli-autofix/SKILL.md`](./skills/opencli-autofix/SKILL.md) — 修复已有适配器
-- [`skills/opencli-browser/SKILL.md`](./skills/opencli-browser/SKILL.md) — 浏览器自动化参考
 - [`skills/opencli-usage/SKILL.md`](./skills/opencli-usage/SKILL.md) — 命令和站点参考
 - [`skills/smart-search/SKILL.md`](./skills/smart-search/SKILL.md) — 能力搜索
 


### PR DESCRIPTION
## Summary

Per WAWQAQ T1 + T2 review:

### T1 — Finish cleaning up the skill attribution PR #1654 started

`opencli-browser` is the ad-hoc browser-driving skill; `opencli-adapter-author` is the adapter-writing skill. The two SKILL.md frontmatters explicitly point at each other for the opposite use case. PR #1654 fixed the intro bullet + Core Concepts section, but four other spots still mixed them:

1. **Skill table row for `opencli-adapter-author`** (line 125): "When to use" no longer claims "Operate a site in real time"; the browser-op example ("Help me check my Xiaohongshu notifications") moved to the `opencli-browser` row where it belongs.
2. **`opencli-browser` row "When to use"** is now concrete: "Drive a real Chrome page ad-hoc — navigate, fill forms, click, extract".
3. **"How it works" section** (line 133): browser primitives (navigate / read / interact / extract / wait) now point to `opencli-browser` instead of `opencli-adapter-author`.
4. **Skill references list** (line 144): `opencli-browser` surfaces first with a concrete description; `opencli-adapter-author` description drops the "browser operation" overlap.

### T2 — Drop the redundant Highlights section

Pre–Quick-Start had **four parallel summary blocks**:

1. 3-line tagline (lines 3-5)
2. "OpenCLI gives you one surface for three different kinds of automation" 3-bullet intro (lines 14-16)
3. "It also works as a CLI hub..." single-line scope expansion (line 18)
4. Highlights 5-bullet (lines 22-26)

All four said the same thing in slightly different framing. Highlights was the most-recent and most-redundant of the four; the remaining three carry the value props cleanly: tagline → three usage modes → CLI-hub + desktop scope.

EN + ZH READMEs synced.

## Test plan

- [x] Manual diff inspection on both READMEs
- [ ] Visual render on GitHub after merge