### PR TITLE
feat(reddit/subscribed): 接入 LoginWallError 嗅探（#1650 的第一个 caller）

### DIFF
--- a/clis/reddit/subscribed.js
+++ b/clis/reddit/subscribed.js
@@ -1,5 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { BROWSER_JSON_SNIFF_FN, throwIfLoginWall } from '@jackwener/opencli/utils';
 
 export const REDDIT_SUBSCRIBED_MAX_LIMIT = 1000;
 
@@ -69,15 +70,21 @@ cli({
             throw new CommandExecutionError('Browser session required');
         await page.goto('https://www.reddit.com');
         const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+      ${BROWSER_JSON_SNIFF_FN}
       try {
-        const meRes = await fetch('/api/me.json?raw_json=1', { credentials: 'include' });
-        if (meRes.status === 401 || meRes.status === 403) {
-          return { kind: 'auth', detail: 'Reddit /api/me.json returned HTTP ' + meRes.status };
+        // fetchJsonOrLoginWall sniffs HTML responses (login wall / WAF / rate-limit
+        // page) and returns a structured { __loginWall, status, url, ... } sentinel
+        // instead of letting JSON.parse blow up with "Unexpected token '<'".
+        const me = await fetchJsonOrLoginWall('/api/me.json?raw_json=1', { credentials: 'include' });
+        if (me && me.__loginWall) {
+          return { kind: 'login-wall', sentinel: me, where: '/api/me.json' };
         }
-        if (!meRes.ok) {
-          return { kind: 'http', httpStatus: meRes.status, where: '/api/me.json' };
+        if (me && me.error === 401 || me && me.error === 403) {
+          return { kind: 'auth', detail: 'Reddit /api/me.json returned HTTP ' + me.error };
         }
-        const me = await meRes.json();
+        if (me && me.error) {
+          return { kind: 'http', httpStatus: me.error, where: '/api/me.json' };
+        }
         const username = me?.data?.name || me?.name;
         if (!username) return { kind: 'auth', detail: 'Not logged in to reddit.com (no identity in /api/me.json)' };
 
@@ -92,12 +99,14 @@ cli({
           const url = '/subreddits/mine/subscriptions.json?limit=' + pageLimit
             + '&raw_json=1'
             + (after ? '&after=' + encodeURIComponent(after) : '');
-          const res = await fetch(url, { credentials: 'include' });
-          if (res.status === 401 || res.status === 403) {
-            return { kind: 'auth', detail: 'Reddit subscriptions endpoint returned HTTP ' + res.status };
+          const d = await fetchJsonOrLoginWall(url, { credentials: 'include' });
+          if (d && d.__loginWall) {
+            return { kind: 'login-wall', sentinel: d, where: url };
           }
-          if (!res.ok) return { kind: 'http', httpStatus: res.status, where: url };
-          const d = await res.json();
+          if (d && (d.error === 401 || d.error === 403)) {
+            return { kind: 'auth', detail: 'Reddit subscriptions endpoint returned HTTP ' + d.error };
+          }
+          if (d && d.error) return { kind: 'http', httpStatus: d.error, where: url };
           const children = d?.data?.children;
           if (!Array.isArray(children)) {
             return { kind: 'malformed', detail: 'Reddit subscriptions payload was missing data.children.' };
@@ -128,6 +137,10 @@ cli({
         return { kind: 'exception', detail: String(e && e.message || e) };
       }
     })()`));
+        if (result?.kind === 'login-wall') {
+            // Convert the browser-side sentinel into a typed LoginWallError on the Node side.
+            throwIfLoginWall(result.sentinel, { url: result.where });
+        }
         if (result?.kind === 'auth') {
             throw new AuthRequiredError('reddit.com', result.detail);
         }

--- a/clis/reddit/subscribed.test.js
+++ b/clis/reddit/subscribed.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError, LoginWallError } from '@jackwener/opencli/errors';
 import { parseRedditSubscribedLimit, unwrapEvaluateResult } from './subscribed.js';
 import './subscribed.js';
 
@@ -105,6 +105,26 @@ describe('reddit subscribed adapter', () => {
             .rejects.toBeInstanceOf(CommandExecutionError);
         await expect(command.func(makePage({ ok: true }), { limit: 100 }))
             .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('converts a browser-side login-wall sentinel into a typed LoginWallError', async () => {
+        const sentinel = {
+            __loginWall: true,
+            status: 200,
+            url: 'https://www.reddit.com/api/me.json?raw_json=1',
+            contentType: 'text/html; charset=utf-8',
+            bodyPreview: '<!DOCTYPE html><html><head><title>reddit.com: over 18?</title>',
+        };
+        const page = makePage({ kind: 'login-wall', sentinel, where: '/api/me.json' });
+        try {
+            await command.func(page, { limit: 100 });
+            throw new Error('expected LoginWallError, got success');
+        } catch (err) {
+            expect(err).toBeInstanceOf(LoginWallError);
+            expect(err.status).toBe(200);
+            expect(err.url).toBe('/api/me.json');
+            expect(err.bodyPreview).toContain('reddit.com: over 18');
+        }
     });
 
     it('throws EmptyResultError for a valid empty subscriptions list', async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -161,6 +161,40 @@ export class PluginError extends CliError {
   }
 }
 
+/**
+ * Thrown when a JSON endpoint returns HTML instead of JSON — typically a login
+ * wall, rate-limit page, or WAF challenge. Surfaced as a structured error so
+ * callers can show "re-login or wait out the rate limit" guidance instead of
+ * the cryptic `SyntaxError: Unexpected token '<', "<!DOCTYPE "...` that a naive
+ * JSON.parse on an HTML body produces.
+ *
+ * `bodyPreview` is the first 100 chars of the response body (after trimming
+ * leading whitespace) — useful for logs / debugging without dumping the full
+ * page.
+ */
+export class LoginWallError extends CliError {
+  readonly status: number;
+  readonly url: string;
+  readonly bodyPreview: string;
+  constructor(
+    message: string,
+    status: number,
+    url: string,
+    bodyPreview: string,
+    hint?: string,
+  ) {
+    super(
+      'LOGIN_WALL',
+      message,
+      hint ?? 'The server returned an HTML page instead of JSON — likely a login wall, rate limit, or WAF challenge. Try re-logging in via your browser, or wait a few minutes before retrying.',
+      EXIT_CODES.NOPERM,
+    );
+    this.status = status;
+    this.url = url;
+    this.bodyPreview = bodyPreview;
+  }
+}
+
 // ── Error Envelope ──────────────────────────────────────────────────────────
 
 /** Structured error output — unified contract for all consumers (AI agents, scripts, humans). */

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseJsonOrThrowLoginWall,
+  throwIfLoginWall,
+  BROWSER_JSON_SNIFF_FN,
+  type LoginWallSignal,
+} from './utils.js';
+import { LoginWallError } from './errors.js';
+
+function makeResponse(body: string, opts: { status?: number; contentType?: string; url?: string } = {}): Response {
+  return new Response(body, {
+    status: opts.status ?? 200,
+    headers: { 'content-type': opts.contentType ?? 'application/json' },
+  });
+}
+
+describe('parseJsonOrThrowLoginWall', () => {
+  it('returns parsed JSON on a normal application/json response', async () => {
+    const res = makeResponse(JSON.stringify({ hello: 'world', n: 42 }));
+    const parsed = await parseJsonOrThrowLoginWall(res);
+    expect(parsed).toEqual({ hello: 'world', n: 42 });
+  });
+
+  it('throws LoginWallError when content-type is text/html', async () => {
+    const res = makeResponse('<html><body>Please log in</body></html>', {
+      status: 401,
+      contentType: 'text/html; charset=utf-8',
+    });
+    await expect(parseJsonOrThrowLoginWall(res, { url: 'https://example.com/api' })).rejects.toMatchObject({
+      name: 'LoginWallError',
+      code: 'LOGIN_WALL',
+      status: 401,
+      url: 'https://example.com/api',
+    });
+  });
+
+  it('throws LoginWallError when body starts with <!DOCTYPE even if content-type is missing', async () => {
+    // application/json content-type but body is actually HTML — WAFs sometimes do this
+    const res = new Response('<!DOCTYPE html><html><head></head><body>blocked</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    try {
+      await parseJsonOrThrowLoginWall(res, { url: 'https://x.com/api/list' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoginWallError);
+      const e = err as LoginWallError;
+      expect(e.status).toBe(200);
+      expect(e.url).toBe('https://x.com/api/list');
+      expect(e.bodyPreview.startsWith('<!DOCTYPE')).toBe(true);
+      expect(e.exitCode).toBe(77); // NOPERM
+    }
+  });
+
+  it('throws LoginWallError when body starts with <html (no DOCTYPE)', async () => {
+    const res = new Response('<html lang="en"><body>nope</body></html>', {
+      status: 429,
+      headers: { 'content-type': 'application/json' },
+    });
+    await expect(parseJsonOrThrowLoginWall(res)).rejects.toBeInstanceOf(LoginWallError);
+  });
+
+  it('throws LoginWallError when body has leading whitespace before <!DOCTYPE', async () => {
+    const res = new Response('   \n\n<!DOCTYPE html><html></html>', {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    await expect(parseJsonOrThrowLoginWall(res)).rejects.toBeInstanceOf(LoginWallError);
+  });
+
+  it('throws a regular Error (NOT LoginWallError) on real malformed JSON', async () => {
+    const res = makeResponse('{not really json,');
+    try {
+      await parseJsonOrThrowLoginWall(res);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).not.toBeInstanceOf(LoginWallError);
+      const msg = (err as Error).message;
+      expect(msg).toContain('JSON parse failed');
+      expect(msg).toContain('body[0..50]=');
+      // body preview must be present so debugging doesn't require a repro
+      expect(msg).toContain('not really json');
+    }
+  });
+
+  it('preserves first 100 chars of body in bodyPreview', async () => {
+    const longHtml = '<!DOCTYPE html><html><head><title>' + 'x'.repeat(500) + '</title></head></html>';
+    const res = new Response(longHtml, { status: 403, headers: { 'content-type': 'text/html' } });
+    try {
+      await parseJsonOrThrowLoginWall(res);
+      throw new Error('expected throw');
+    } catch (err) {
+      const e = err as LoginWallError;
+      expect(e.bodyPreview.length).toBe(100);
+      expect(e.bodyPreview.startsWith('<!DOCTYPE')).toBe(true);
+    }
+  });
+});
+
+describe('throwIfLoginWall', () => {
+  it('returns the value unchanged when it is not a login-wall sentinel', () => {
+    const data = { data: { foo: 'bar' } };
+    expect(throwIfLoginWall(data)).toBe(data);
+    expect(throwIfLoginWall('hello')).toBe('hello');
+    expect(throwIfLoginWall(null)).toBe(null);
+    expect(throwIfLoginWall(undefined)).toBe(undefined);
+    expect(throwIfLoginWall(42)).toBe(42);
+    expect(throwIfLoginWall([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('returns objects that happen to have unrelated __loginWall-ish keys unchanged', () => {
+    // Must NOT trigger on partial matches — sentinel needs __loginWall === true AND numeric status
+    expect(throwIfLoginWall({ __loginWall: false })).toEqual({ __loginWall: false });
+    expect(throwIfLoginWall({ __loginWall: true })).toEqual({ __loginWall: true }); // missing status → not a real sentinel
+  });
+
+  it('throws LoginWallError when value is the browser-side sentinel', () => {
+    const signal: LoginWallSignal = {
+      __loginWall: true,
+      status: 403,
+      url: 'https://x.com/i/api/graphql/...',
+      contentType: 'text/html',
+      bodyPreview: '<!DOCTYPE html><html><head><title>Login</title>',
+    };
+    try {
+      throwIfLoginWall(signal);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoginWallError);
+      const e = err as LoginWallError;
+      expect(e.status).toBe(403);
+      expect(e.url).toBe('https://x.com/i/api/graphql/...');
+      expect(e.bodyPreview).toContain('<!DOCTYPE');
+      expect(e.code).toBe('LOGIN_WALL');
+    }
+  });
+
+  it('opts.url overrides the URL embedded in the sentinel', () => {
+    const signal: LoginWallSignal = {
+      __loginWall: true,
+      status: 401,
+      url: '',
+      contentType: 'text/html',
+      bodyPreview: '<html>',
+    };
+    try {
+      throwIfLoginWall(signal, { url: 'https://override.example.com/api' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as LoginWallError).url).toBe('https://override.example.com/api');
+    }
+  });
+});
+
+describe('BROWSER_JSON_SNIFF_FN', () => {
+  it('is a non-empty string that defines fetchJsonOrLoginWall', () => {
+    expect(typeof BROWSER_JSON_SNIFF_FN).toBe('string');
+    expect(BROWSER_JSON_SNIFF_FN).toContain('fetchJsonOrLoginWall');
+    expect(BROWSER_JSON_SNIFF_FN).toContain('__loginWall');
+  });
+
+  it('can be evaluated as JS without syntax errors', () => {
+    // We can't run the actual fetch path here (no Response polyfill loop), but
+    // we CAN confirm the fragment parses cleanly when embedded inside an async IIFE.
+    expect(() => new Function(`(async () => { ${BROWSER_JSON_SNIFF_FN} })`)).not.toThrow();
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import TurndownService from 'turndown';
+import { LoginWallError } from './errors.js';
 
 /** Type guard: checks if a value is a non-null, non-array object. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -67,3 +68,151 @@ export function htmlToMarkdown(value: string, configure?: (td: TurndownService) 
     .replace(/[ \t]+$/gm, '')
     .trim();
 }
+
+// \u2500\u2500 HTML-as-JSON response sniffer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+//
+// Adapters that hit JSON endpoints (twitter list-tweets / thread, reddit
+// search / subreddit, etc.) historically did blind `JSON.parse(await r.text())`
+// or `await r.json()`. When the server returns a login wall, rate-limit page,
+// or WAF challenge instead of JSON, the body starts with `<!DOCTYPE html>` or
+// `<html ...>` and the parser blows up with a cryptic
+// `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+// that callers can't distinguish from "real" malformed JSON.
+//
+// `parseJsonOrThrowLoginWall` is the Node-side version (consumes a Fetch
+// `Response`). Adapters that fetch from inside `page.evaluate` should use the
+// `LOGIN_WALL_SENTINEL` + `throwIfLoginWall` pair: the browser-side fetch
+// sniffs the response and either returns the parsed JSON wrapped in
+// `{ ok: true, data }`, or `{ ok: false, loginWall: { ... } }`; the Node side
+// inspects the result and throws a structured `LoginWallError`.
+
+/** Sentinel shape that browser-side `fetch` wrappers return when they detect an
+ * HTML response in place of JSON. Kept as a plain object so it survives the
+ * `page.evaluate` JSON round-trip. */
+export interface LoginWallSignal {
+  __loginWall: true;
+  status: number;
+  url: string;
+  contentType: string;
+  bodyPreview: string;
+}
+
+function isLoginWallSignal(v: unknown): v is LoginWallSignal {
+  return (
+    typeof v === 'object'
+    && v !== null
+    && (v as Record<string, unknown>).__loginWall === true
+    && typeof (v as Record<string, unknown>).status === 'number'
+  );
+}
+
+/** Throw a `LoginWallError` if `value` is the sentinel returned by the
+ * browser-side sniffer; otherwise return `value` unchanged. Adapters that
+ * fetch from inside `page.evaluate` call this on the result before consuming
+ * it, so the Node-side gets a typed error instead of a JSON-parse stack
+ * trace. */
+export function throwIfLoginWall<T>(value: T, opts: { url?: string } = {}): T {
+  if (isLoginWallSignal(value)) {
+    throw new LoginWallError(
+      `Server returned HTML instead of JSON (status=${value.status}). `
+      + `Likely a login wall, rate limit, or WAF challenge.`,
+      value.status,
+      opts.url || value.url || '',
+      value.bodyPreview,
+    );
+  }
+  return value;
+}
+
+/** Parse a `Response` body as JSON, throwing `LoginWallError` if the server
+ * returned an HTML page (login wall / rate limit / WAF interception) instead
+ * of the expected JSON. Catches the common case of `<!DOCTYPE` or `<html`
+ * leading the body \u2014 naive `JSON.parse` on these gives a cryptic
+ * `SyntaxError` that callers can't distinguish from "real" malformed JSON.
+ *
+ * On real (non-HTML) JSON-parse failures, throws a regular `Error` with a
+ * body preview attached so debugging doesn't require a packet capture. */
+export async function parseJsonOrThrowLoginWall(
+  response: Response,
+  opts: { url?: string } = {},
+): Promise<unknown> {
+  const contentType = response.headers.get('content-type') || '';
+  const text = await response.text();
+  const trimmed = text.trimStart();
+
+  const looksLikeHtml =
+    contentType.toLowerCase().includes('text/html')
+    || trimmed.startsWith('<!DOCTYPE')
+    || trimmed.startsWith('<!doctype')
+    || trimmed.startsWith('<html')
+    || trimmed.startsWith('<HTML');
+
+  if (looksLikeHtml) {
+    throw new LoginWallError(
+      `Server returned HTML instead of JSON (status=${response.status}). `
+      + `Likely a login wall, rate limit, or WAF challenge.`,
+      response.status,
+      opts.url || response.url || '',
+      trimmed.slice(0, 100),
+    );
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    // Real malformed JSON \u2014 surface body preview alongside the parser message
+    // so we don't have to repro to know what came back.
+    throw new Error(
+      `JSON parse failed (status=${response.status}, body[0..50]=${JSON.stringify(trimmed.slice(0, 50))}): `
+      + (err instanceof Error ? err.message : String(err)),
+    );
+  }
+}
+
+/** Browser-side JS source fragment (as a string) that performs a `fetch` and
+ * either returns the parsed JSON body or a `LoginWallSignal` sentinel when
+ * the response is HTML. Intended to be embedded inside an adapter's
+ * `page.evaluate` block.
+ *
+ * Usage from inside a `page.evaluate` IIFE:
+ *
+ *     ${BROWSER_JSON_SNIFF_FN}
+ *     const res = await fetchJsonOrLoginWall('/some/path.json', { credentials: 'include' });
+ *     // res is the parsed JSON object, OR { __loginWall: true, status, url, contentType, bodyPreview }
+ *     return res;
+ *
+ * The Node side then calls `throwIfLoginWall(res, { url })` on the result. */
+export const BROWSER_JSON_SNIFF_FN = `
+async function fetchJsonOrLoginWall(input, init) {
+  const r = await fetch(input, init);
+  const contentType = r.headers.get('content-type') || '';
+  const text = await r.text();
+  const trimmed = text.replace(/^\\s+/, '');
+  const looksLikeHtml =
+    contentType.toLowerCase().includes('text/html')
+    || trimmed.startsWith('<!DOCTYPE')
+    || trimmed.startsWith('<!doctype')
+    || trimmed.startsWith('<html')
+    || trimmed.startsWith('<HTML');
+  if (looksLikeHtml) {
+    return {
+      __loginWall: true,
+      status: r.status,
+      url: r.url || (typeof input === 'string' ? input : ''),
+      contentType,
+      bodyPreview: trimmed.slice(0, 100),
+    };
+  }
+  if (!r.ok) {
+    return { error: r.status };
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      'JSON parse failed (status=' + r.status + ', body[0..50]=' + JSON.stringify(trimmed.slice(0, 50)) + '): '
+      + (err && err.message ? err.message : String(err))
+    );
+  }
+}
+`;


### PR DESCRIPTION
## 概要

**Companion PR to #1650**——给那个 infra-only PR 提供第一个真实 caller，演示 \`BROWSER_JSON_SNIFF_FN\` + \`throwIfLoginWall\` + \`LoginWallError\` 三块 export 端到端怎么用。

\`reddit subscribed\`（#1651 合入的命令）从 browser session 调 Reddit JSON API：

- \`/api/me.json\` —— 拿登录身份
- \`/subreddits/mine/subscriptions.json\` —— 拉订阅列表

两处 \`await res.json()\` 在 Reddit 返回登录墙 / WAF / over-18 拦截页（HTML body + 经常带 200 OK）时会抛 \`SyntaxError: Unexpected token '<'\`，被外层 try/catch 兜底成 \`kind: 'exception'\` → Node 侧报成 \`CommandExecutionError: subscribed failed: SyntaxError ...\`，root cause 完全隐藏。

## 改动

| 端 | 改动 |
|---|---|
| browser 侧 | 把两处 \`fetch + .json()\` 换成 \`fetchJsonOrLoginWall(url, init)\`（来自 \`BROWSER_JSON_SNIFF_FN\`），它内部 sniff Content-Type / body 前缀，返回 \`{ __loginWall, status, url, contentType, bodyPreview }\` 哨兵 |
| 跨边界 | 两处 fetch 站点检测到哨兵后返回 \`{ kind: 'login-wall', sentinel, where }\` 透传给 Node |
| Node 侧 | 新增 \`if (result?.kind === 'login-wall') throwIfLoginWall(result.sentinel, { url: result.where })\` —— 把哨兵转成结构化 \`LoginWallError\`，带 \`status\`/\`url\`/\`bodyPreview\` 字段、退出码 \`EXIT_CODES.NOPERM\`、hint 提示重登录或等限流 |

## Type of Change

- [x] 🐛 Bug fix（HTML 响应原本抛裸 SyntaxError）
- [x] ♻️ Refactor（接入 #1650 的共享 helper）

## 验证

- \`clis/reddit/subscribed.test.js\` 新增 1 个测试 \`'converts a browser-side login-wall sentinel into a typed LoginWallError'\`：mock evaluate 返回哨兵，断言抛 \`LoginWallError\` 且 \`status\` / \`url\` / \`bodyPreview\` 字段都对
- \`npx vitest run clis/reddit/subscribed.test.js --project adapter\` —— 13/13 通过（12 原有 + 1 新）
- \`npx tsc --noEmit\` 干净
- \`npm run build\` 干净
- \`node scripts/check-silent-column-drop.mjs\` —— \`current=97, baseline=97, new=0\`

## 依赖

依赖 #1650 先 merge（本 PR 引用的 \`BROWSER_JSON_SNIFF_FN\` / \`throwIfLoginWall\` / \`LoginWallError\` 都在那 PR 里）。

GitHub 当前显示 2 个 commit 是因为 #1650 还没合；一旦 #1650 合入 main，diff 会自动收窄到只剩本 PR 的 1 个 commit / 2 个文件。