### PR TITLE
fix(bilibili): subtitle 支持 bangumi/PGC bvid（番剧/纪录片/电影/综艺）

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2732,6 +2732,7 @@
     "name": "subtitle",
     "description": "获取 Bilibili 视频的字幕",
     "access": "read",
+    "domain": "www.bilibili.com",
     "strategy": "cookie",
     "browser": true,
     "args": [
@@ -2758,7 +2759,7 @@
     "type": "js",
     "modulePath": "bilibili/subtitle.js",
     "sourceFile": "bilibili/subtitle.js",
-    "navigateBefore": true
+    "navigateBefore": "https://www.bilibili.com"
   },
   {
     "site": "bilibili",

--- a/clis/bilibili/subtitle.js
+++ b/clis/bilibili/subtitle.js
@@ -21,7 +21,13 @@ cli({
         //    以前的实现走 page.goto(/video/<bvid>) + window.__INITIAL_STATE__.videoData.cid，
         //    bangumi 绑定的 bvid（番剧/纪录片/电影/综艺）页面 state 不在 videoData 而在 epList，
         //    导致 SELECTOR 错。view API 接受任何 bvid（UGC + PGC 都通），且不依赖 DOM 结构。
-        const view = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
+        let view;
+        try {
+            view = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`获取视频信息失败: ${err?.message || err}`);
+        }
         if (view?.code !== 0) {
             throw new CommandExecutionError(`获取视频信息失败: ${view?.message ?? 'unknown'} (${view?.code})`);
         }
@@ -30,15 +36,24 @@ cli({
             throw new CommandExecutionError(`无法从 view API 拿到 cid (bvid=${bvid})`);
         }
         // 2. 用带 Wbi 签名的 player/v2 拿字幕列表（之前 evaluate 里 fetch 因为没签名会 403）
-        const payload = await apiGet(page, '/x/player/wbi/v2', {
-            params: { bvid, cid },
-            signed: true,
-        });
+        let payload;
+        try {
+            payload = await apiGet(page, '/x/player/wbi/v2', {
+                params: { bvid, cid },
+                signed: true,
+            });
+        }
+        catch (err) {
+            throw new CommandExecutionError(`获取视频播放信息失败: ${err?.message || err}`);
+        }
         if (payload.code !== 0) {
             throw new CommandExecutionError(`获取视频播放信息失败: ${payload.message} (${payload.code})`);
         }
         const needLoginSubtitle = payload.data?.need_login_subtitle === true;
-        const subtitles = payload.data?.subtitle?.subtitles || [];
+        const subtitles = payload.data?.subtitle?.subtitles;
+        if (!Array.isArray(subtitles)) {
+            throw new CommandExecutionError('获取到的字幕列表对象不符合数组格式');
+        }
         if (subtitles.length === 0) {
             if (needLoginSubtitle) {
                 throw new AuthRequiredError('bilibili.com', 'Bilibili subtitles are hidden behind login for this video. Please log in to bilibili.com in Chrome and retry.');
@@ -49,11 +64,17 @@ cli({
         const target = kwargs.lang
             ? subtitles.find((s) => s.lan === kwargs.lang) || subtitles[0]
             : subtitles[0];
-        const targetSubUrl = target.subtitle_url;
-        if (!targetSubUrl || targetSubUrl === '') {
+        if (!target || typeof target !== 'object' || !Object.hasOwn(target, 'subtitle_url')) {
+            throw new CommandExecutionError('字幕条目缺少 subtitle_url 字段');
+        }
+        const targetSubUrl = typeof target.subtitle_url === 'string' ? target.subtitle_url.trim() : '';
+        if (!targetSubUrl) {
             throw new AuthRequiredError('bilibili.com', '[风控拦截/未登录] 获取到的 subtitle_url 为空！请确保 CLI 已成功登录且风控未封锁此账号。');
         }
         const finalUrl = targetSubUrl.startsWith('//') ? 'https:' + targetSubUrl : targetSubUrl;
+        if (!/^https?:\/\//i.test(finalUrl)) {
+            throw new CommandExecutionError(`字幕 URL 非法: ${finalUrl}`);
+        }
         // 4. 解析并拉取 CDN 的 JSON 文件
         const fetchJs = `
       (async () => {
@@ -76,20 +97,39 @@ cli({
          }
       })()
     `;
-        const items = await page.evaluate(fetchJs);
+        let items;
+        try {
+            items = await page.evaluate(fetchJs);
+        }
+        catch (err) {
+            throw new CommandExecutionError(`字幕获取失败: ${err?.message || err}`);
+        }
         if (items?.error) {
             throw new CommandExecutionError(`字幕获取失败: ${items.error}${items.text ? ' — ' + items.text : ''}`);
         }
-        const finalItems = items?.data || [];
+        if (!items || typeof items !== 'object' || items.success !== true) {
+            throw new CommandExecutionError('字幕获取结果对象不符合预期格式');
+        }
+        const finalItems = items.data;
         if (!Array.isArray(finalItems)) {
             throw new CommandExecutionError('解析到的字幕列表对象不符合数组格式');
         }
+        if (finalItems.length === 0) {
+            throw new EmptyResultError('bilibili subtitle', '字幕文件中没有字幕片段。');
+        }
         // 5. 数据映射
-        return finalItems.map((item, idx) => ({
-            index: idx + 1,
-            from: Number(item.from || 0).toFixed(2) + 's',
-            to: Number(item.to || 0).toFixed(2) + 's',
-            content: item.content
-        }));
+        return finalItems.map((item, idx) => {
+            const from = Number(item?.from);
+            const to = Number(item?.to);
+            if (!item || typeof item !== 'object' || !Number.isFinite(from) || !Number.isFinite(to)) {
+                throw new CommandExecutionError('字幕片段缺少有效 from/to 时间戳');
+            }
+            return {
+                index: idx + 1,
+                from: from.toFixed(2) + 's',
+                to: to.toFixed(2) + 's',
+                content: String(item.content ?? '')
+            };
+        });
     },
 });

--- a/clis/bilibili/subtitle.js
+++ b/clis/bilibili/subtitle.js
@@ -46,6 +46,9 @@ cli({
         catch (err) {
             throw new CommandExecutionError(`获取视频播放信息失败: ${err?.message || err}`);
         }
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+            throw new CommandExecutionError('获取到的视频播放信息对象不符合预期格式');
+        }
         if (payload.code !== 0) {
             throw new CommandExecutionError(`获取视频播放信息失败: ${payload.message} (${payload.code})`);
         }

--- a/clis/bilibili/subtitle.js
+++ b/clis/bilibili/subtitle.js
@@ -1,11 +1,12 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError, EmptyResultError, selectorError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { apiGet, resolveBvid } from './utils.js';
 cli({
     site: 'bilibili',
     name: 'subtitle',
     access: 'read',
     description: '获取 Bilibili 视频的字幕',
+    domain: 'www.bilibili.com',
     strategy: Strategy.COOKIE,
     args: [
         { name: 'bvid', required: true, positional: true, help: 'Bilibili 视频 BV ID（如 BV1xx411c7mD），或视频 URL / b23.tv 短链' },
@@ -16,21 +17,22 @@ cli({
         if (!page)
             throw new CommandExecutionError('Browser session required for bilibili subtitle');
         const bvid = await resolveBvid(kwargs.bvid);
-        // 1. 先前往视频详情页 (建立有鉴权的 Session，且这里不需要加载完整个视频)
-        await page.goto(`https://www.bilibili.com/video/${bvid}/`);
-        // 2. 利用 __INITIAL_STATE__ 获取基础信息，拿 CID
-        const cid = await page.evaluate(`(async () => {
-      const state = window.__INITIAL_STATE__ || {};
-      return state?.videoData?.cid;
-    })()`);
-        if (!cid) {
-            throw selectorError('videoData.cid', '无法在页面中提取到当前视频的 CID，请检查页面是否正常加载。');
+        // 1. 通过 view API 拿 cid。
+        //    以前的实现走 page.goto(/video/<bvid>) + window.__INITIAL_STATE__.videoData.cid，
+        //    bangumi 绑定的 bvid（番剧/纪录片/电影/综艺）页面 state 不在 videoData 而在 epList，
+        //    导致 SELECTOR 错。view API 接受任何 bvid（UGC + PGC 都通），且不依赖 DOM 结构。
+        const view = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
+        if (view?.code !== 0) {
+            throw new CommandExecutionError(`获取视频信息失败: ${view?.message ?? 'unknown'} (${view?.code})`);
         }
-        // 3. 在 Node 端使用 apiGet 获取带 Wbi 签名的字幕列表
-        // 之前纯靠 evaluate 里的 fetch 会失败，因为 B 站 /wbi/ 开头的接口强校验 w_rid，未签名直接被风控返回 403 HTML
+        const cid = view?.data?.cid;
+        if (!cid) {
+            throw new CommandExecutionError(`无法从 view API 拿到 cid (bvid=${bvid})`);
+        }
+        // 2. 用带 Wbi 签名的 player/v2 拿字幕列表（之前 evaluate 里 fetch 因为没签名会 403）
         const payload = await apiGet(page, '/x/player/wbi/v2', {
             params: { bvid, cid },
-            signed: true, // 开启 wbi_sign 自动签名
+            signed: true,
         });
         if (payload.code !== 0) {
             throw new CommandExecutionError(`获取视频播放信息失败: ${payload.message} (${payload.code})`);
@@ -43,7 +45,7 @@ cli({
             }
             throw new EmptyResultError('bilibili subtitle', '此视频没有发现外挂或智能字幕。');
         }
-        // 4. 选择目标字幕语言
+        // 3. 选择目标字幕语言
         const target = kwargs.lang
             ? subtitles.find((s) => s.lan === kwargs.lang) || subtitles[0]
             : subtitles[0];
@@ -52,17 +54,17 @@ cli({
             throw new AuthRequiredError('bilibili.com', '[风控拦截/未登录] 获取到的 subtitle_url 为空！请确保 CLI 已成功登录且风控未封锁此账号。');
         }
         const finalUrl = targetSubUrl.startsWith('//') ? 'https:' + targetSubUrl : targetSubUrl;
-        // 5. 解析并拉取 CDN 的 JSON 文件
+        // 4. 解析并拉取 CDN 的 JSON 文件
         const fetchJs = `
       (async () => {
          const url = ${JSON.stringify(finalUrl)};
          const res = await fetch(url);
          const text = await res.text();
-         
+
          if (text.startsWith('<!DOCTYPE') || text.startsWith('<html')) {
             return { error: 'HTML', text: text.substring(0, 100), url };
          }
-         
+
          try {
              const subJson = JSON.parse(text);
              // B站真实返回格式是 { font_size: 0.4, font_color: "#FFFFFF", background_alpha: 0.5, background_color: "#9C27B0", Stroke: "none", type: "json" , body: [{from: 0, to: 0, content: ""}] }
@@ -82,7 +84,7 @@ cli({
         if (!Array.isArray(finalItems)) {
             throw new CommandExecutionError('解析到的字幕列表对象不符合数组格式');
         }
-        // 6. 数据映射
+        // 5. 数据映射
         return finalItems.map((item, idx) => ({
             index: idx + 1,
             from: Number(item.from || 0).toFixed(2) + 's',

--- a/clis/bilibili/subtitle.test.js
+++ b/clis/bilibili/subtitle.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 const { mockApiGet } = vi.hoisted(() => ({
     mockApiGet: vi.fn(),
 }));
@@ -20,30 +20,86 @@ describe('bilibili subtitle', () => {
         page.goto.mockClear();
         page.evaluate.mockReset();
     });
+
+    // 帮助函数：第一发 apiGet（view）固定返 cid=123456 的 OK 响应
+    const mockViewOk = (cid = 123456) =>
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { bvid: 'BV1GbXPBeEZm', cid } });
+
     it('throws AuthRequiredError when bilibili hides subtitles behind login', async () => {
-        page.evaluate.mockResolvedValueOnce(123456);
+        mockViewOk();
         mockApiGet.mockResolvedValueOnce({
             code: 0,
             data: {
                 need_login_subtitle: true,
-                subtitle: {
-                    subtitles: [],
-                },
+                subtitle: { subtitles: [] },
             },
         });
-        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toSatisfy((err) => err instanceof AuthRequiredError && /login|登录/i.test(err.message));
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toSatisfy(
+            (err) => err instanceof AuthRequiredError && /login|登录/i.test(err.message),
+        );
     });
+
     it('throws EmptyResultError when a video truly has no subtitles', async () => {
-        page.evaluate.mockResolvedValueOnce(123456);
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [] },
+            },
+        });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError when view API returns non-zero code', async () => {
+        // 番剧/地区限制等场景下 view API 也会返非零；之前路径走 SELECTOR 错，现在统一走 view 错
+        mockApiGet.mockResolvedValueOnce({ code: -404, message: '啥都木有' });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws CommandExecutionError when view API succeeds but lacks cid', async () => {
+        mockApiGet.mockResolvedValueOnce({ code: 0, data: { bvid: 'BV1GbXPBeEZm' /* no cid */ } });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(/cid/);
+    });
+
+    it('works for bangumi-bound bvid (PGC content) — same code path, view API returns cid + redirect_url', async () => {
+        // 回归保护：以前 page.goto(/video/<bvid>) 对 bangumi 走重定向，
+        // window.__INITIAL_STATE__.videoData 不存在 → SELECTOR 错。view API 不依赖页面结构，bangumi 同样能拿 cid。
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                bvid: 'BV1Py4y1D781',
+                cid: 267270412,
+                redirect_url: 'https://www.bilibili.com/bangumi/play/ep371508',
+                title: '【纪录片】灭绝的真相',
+            },
+        });
         mockApiGet.mockResolvedValueOnce({
             code: 0,
             data: {
                 need_login_subtitle: false,
                 subtitle: {
-                    subtitles: [],
+                    subtitles: [{ lan: 'zh-CN', subtitle_url: '//example.com/sub.json' }],
                 },
             },
         });
-        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(EmptyResultError);
+        page.evaluate.mockResolvedValueOnce({
+            success: true,
+            data: [
+                { from: 0, to: 1.5, content: 'hello' },
+                { from: 1.5, to: 3.2, content: 'world' },
+            ],
+        });
+        const out = await command.func(page, { bvid: 'BV1Py4y1D781' });
+        expect(out).toEqual([
+            { index: 1, from: '0.00s', to: '1.50s', content: 'hello' },
+            { index: 2, from: '1.50s', to: '3.20s', content: 'world' },
+        ]);
+        // 关键：不再依赖 page.goto，所有 cid 解析走 apiGet
+        expect(page.goto).not.toHaveBeenCalled();
+        // 第一发 apiGet 一定是 view 端点
+        const firstCall = mockApiGet.mock.calls[0];
+        expect(firstCall[1]).toBe('/x/web-interface/view');
+        expect(firstCall[2]?.params?.bvid).toBe('BV1Py4y1D781');
     });
 });

--- a/clis/bilibili/subtitle.test.js
+++ b/clis/bilibili/subtitle.test.js
@@ -57,9 +57,89 @@ describe('bilibili subtitle', () => {
         await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
     });
 
+    it('wraps view API fetch/json exceptions as CommandExecutionError', async () => {
+        mockApiGet.mockRejectedValueOnce(new SyntaxError('Unexpected token <'));
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+    });
+
     it('throws CommandExecutionError when view API succeeds but lacks cid', async () => {
         mockApiGet.mockResolvedValueOnce({ code: 0, data: { bvid: 'BV1GbXPBeEZm' /* no cid */ } });
         await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(/cid/);
+    });
+
+    it('throws CommandExecutionError when player subtitle payload is malformed', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: { lan: 'zh-CN' } },
+            },
+        });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws AuthRequiredError only for explicit empty subtitle_url entries', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [{ lan: 'zh-CN', subtitle_url: '' }] },
+            },
+        });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(AuthRequiredError);
+    });
+
+    it('throws CommandExecutionError when subtitle entry lacks subtitle_url field', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [{ lan: 'zh-CN' }] },
+            },
+        });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('wraps subtitle file fetch exceptions as CommandExecutionError', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [{ lan: 'zh-CN', subtitle_url: '//example.com/sub.json' }] },
+            },
+        });
+        page.evaluate.mockRejectedValueOnce(new Error('Failed to fetch'));
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when subtitle file has no cue rows', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [{ lan: 'zh-CN', subtitle_url: '//example.com/sub.json' }] },
+            },
+        });
+        page.evaluate.mockResolvedValueOnce({ success: true, data: [] });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError when subtitle cue rows have malformed time ranges', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [{ lan: 'zh-CN', subtitle_url: '//example.com/sub.json' }] },
+            },
+        });
+        page.evaluate.mockResolvedValueOnce({ success: true, data: [{ from: 'bad', to: 1.5, content: 'hello' }] });
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
     });
 
     it('works for bangumi-bound bvid (PGC content) — same code path, view API returns cid + redirect_url', async () => {

--- a/clis/bilibili/subtitle.test.js
+++ b/clis/bilibili/subtitle.test.js
@@ -79,6 +79,17 @@ describe('bilibili subtitle', () => {
         await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
     });
 
+    it('throws CommandExecutionError when player API returns a non-object payload', async () => {
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce(null);
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+
+        mockApiGet.mockReset();
+        mockViewOk();
+        mockApiGet.mockResolvedValueOnce([]);
+        await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
+    });
+
     it('throws AuthRequiredError only for explicit empty subtitle_url entries', async () => {
         mockViewOk();
         mockApiGet.mockResolvedValueOnce({


### PR DESCRIPTION
## 现象

`opencli bilibili subtitle <bvid>` 对绑定到 bangumi 的 bvid 报 SELECTOR 错：

```
Could not find element: videoData.cid
```

复现：

- BV1Py4y1D781 (ep371508《灭绝的真相》)
- 任何番剧 / 纪录片 / 电影 / 综艺类的 bvid（PGC 内容）

普通 UGC bvid 工作正常。

## 根因

旧实现 `page.goto('/video/<bvid>')` 之后从 `window.__INITIAL_STATE__.videoData.cid` 读 cid。
但 bangumi (番剧/纪录片/电影/综艺) 页面会**重定向**到 `/bangumi/play/ep<id>`，
state 结构变成 `epList[]`，**根本不挂在 `videoData` 下面**。selector 因此永远找不到。

## 修复

换成 `apiGet(page, '/x/web-interface/view', { params: { bvid } })` 拿 cid：

- `view` 端点对 UGC 和 PGC bvid 都返 `cid + redirect_url`
- 与 DOM 结构**完全无关**——即使 bilibili 改了页面或重定向规则也不影响
- 跟 `clis/bilibili/comments.js` 已有的 `view → aid` 路径**完全同款**，没有引入新的访问模式

顺手补 `domain: 'www.bilibili.com'` 让 strategy 显式落到 bilibili origin —— `apiGet` 内部 `credentials: 'include'` 依赖 origin 上下文。

## 测试

- `npx vitest run clis/bilibili` —— 7 文件 / 39 测试全过（含新增"bangumi-bound bvid 走同一代码路径"回归 case）
- `npx tsc --noEmit` 干净
- `npm run build` 干净
- 端到端：
  - BV1Py4y1D781 (ep371508《灭绝的真相》) 不再 SELECTOR 错，字幕正常返回
  - BV1UbyZB9ERb (TED 合集，UGC) 字幕完整返回，与原行为**一致**

## 兼容性

完全向后兼容——`view` 端点对 UGC 和 PGC 都工作，UGC 路径行为不变。新增的 `domain` 字段是 strategy declarations 标配，build-manifest 也已经接受。