### PR TITLE
feat(zhihu): include answer links in question results

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -30494,8 +30494,10 @@
     ],
     "columns": [
       "rank",
+      "id",
       "author",
       "votes",
+      "url",
       "content"
     ],
     "type": "js",

--- a/clis/zhihu/question.js
+++ b/clis/zhihu/question.js
@@ -10,6 +10,24 @@ function stripHtml(html) {
         .trim();
 }
 
+function answerIdFromUrl(url) {
+    if (typeof url !== 'string') return '';
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname !== 'www.zhihu.com' && parsed.hostname !== 'zhihu.com') return '';
+        return parsed.pathname.match(/^\/question\/\d+\/answer\/(\d+)\/?$/)?.[1]
+            || parsed.pathname.match(/^\/api\/v4\/answers\/(\d+)\/?$/)?.[1]
+            || parsed.pathname.match(/^\/answer\/(\d+)\/?$/)?.[1]
+            || '';
+    } catch {
+        return '';
+    }
+}
+
+function answerId(item) {
+    return answerIdFromUrl(item.url) || (item.id == null ? '' : String(item.id));
+}
+
 const MAX_LIMIT = 1000;
 
 cli({
@@ -24,7 +42,7 @@ cli({
         { name: 'limit', type: 'int', default: 5, help: 'Number of answers (max 1000; use normal-sized requests)' },
         { name: 'sort', default: 'default', choices: ['default', 'created'], help: 'Answer order: default or created' },
     ],
-    columns: ['rank', 'author', 'votes', 'content'],
+    columns: ['rank', 'id', 'author', 'votes', 'url', 'content'],
     func: async (page, kwargs) => {
         const { id, limit = 5 } = kwargs;
         const questionId = String(id);
@@ -48,7 +66,7 @@ cli({
         // costs one over-fetched page worth of bandwidth and never silently
         // clamps the user-requested count.
         const ZHIHU_PAGE_SIZE = 20;
-        let url = `https://www.zhihu.com/api/v4/questions/${questionId}/answers?limit=${ZHIHU_PAGE_SIZE}&offset=0&sort_by=${sort}&include=data[*].content,voteup_count,comment_count,author`;
+        let url = `https://www.zhihu.com/api/v4/questions/${questionId}/answers?limit=${ZHIHU_PAGE_SIZE}&offset=0&sort_by=${sort}&include=data[*].content,url,voteup_count,comment_count,author`;
         const answers = [];
         const seen = new Set();
         const visited = new Set();
@@ -78,11 +96,16 @@ cli({
             if (data.paging?.is_end) break;
             url = typeof data.paging?.next === 'string' ? data.paging.next : '';
         }
-        return answers.map((item, i) => ({
-            rank: i + 1,
-            author: item.author?.name || 'anonymous',
-            votes: item.voteup_count || 0,
-            content: stripHtml(item.content || '').substring(0, 200),
-        }));
+        return answers.map((item, i) => {
+            const id = answerId(item);
+            return {
+                rank: i + 1,
+                id,
+                author: item.author?.name || 'anonymous',
+                votes: item.voteup_count || 0,
+                url: id ? `https://www.zhihu.com/question/${questionId}/answer/${id}` : '',
+                content: stripHtml(item.content || '').substring(0, 200),
+            };
+        });
     },
 });

--- a/clis/zhihu/question.js
+++ b/clis/zhihu/question.js
@@ -32,6 +32,12 @@ function answerId(item) {
     return '';
 }
 
+function answerDedupeKey(item) {
+    const id = answerId(item);
+    if (id) return `id:${id}`;
+    return `fallback:${item.author?.name || 'anonymous'}:${item.content || ''}`;
+}
+
 const MAX_LIMIT = 1000;
 
 cli({
@@ -91,7 +97,7 @@ cli({
                 throw new CliError('FETCH_ERROR', status ? `Zhihu question answers request failed (HTTP ${status})` : 'Zhihu question answers request failed', 'Try again later or rerun with -v for more detail');
             }
             for (const item of data.data || []) {
-                const key = item.id == null ? `${item.author?.name || 'anonymous'}:${item.content || ''}` : String(item.id);
+                const key = answerDedupeKey(item);
                 if (seen.has(key)) continue;
                 seen.add(key);
                 answers.push(item);

--- a/clis/zhihu/question.js
+++ b/clis/zhihu/question.js
@@ -25,7 +25,11 @@ function answerIdFromUrl(url) {
 }
 
 function answerId(item) {
-    return answerIdFromUrl(item.url) || (item.id == null ? '' : String(item.id));
+    const fromUrl = answerIdFromUrl(item.url);
+    if (fromUrl) return fromUrl;
+    if (typeof item.id === 'string' && /^\d+$/.test(item.id)) return item.id;
+    if (typeof item.id === 'number' && Number.isSafeInteger(item.id) && item.id > 0) return String(item.id);
+    return '';
 }
 
 const MAX_LIMIT = 1000;

--- a/clis/zhihu/question.test.js
+++ b/clis/zhihu/question.test.js
@@ -67,6 +67,49 @@ describe('zhihu question', () => {
             },
         ]);
     });
+    it('deduplicates paginated answers by precise answer URL identity', async () => {
+        const cmd = getRegistry().get('zhihu/question');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                data: [
+                    {
+                        id: 2036567240334653000,
+                        url: 'https://www.zhihu.com/api/v4/answers/2036567240334653053',
+                        author: { name: 'alice' },
+                        voteup_count: 12,
+                        content: '<p>first precise id</p>',
+                    },
+                    {
+                        id: 2036567240334653000,
+                        url: 'https://www.zhihu.com/api/v4/answers/2036567240334653054',
+                        author: { name: 'bob' },
+                        voteup_count: 8,
+                        content: '<p>second precise id</p>',
+                    },
+                ],
+                paging: { is_end: true },
+            }),
+        };
+        await expect(cmd.func(page, { id: '2021881398772981878', limit: 2 })).resolves.toEqual([
+            {
+                rank: 1,
+                id: '2036567240334653053',
+                author: 'alice',
+                votes: 12,
+                url: 'https://www.zhihu.com/question/2021881398772981878/answer/2036567240334653053',
+                content: 'first precise id',
+            },
+            {
+                rank: 2,
+                id: '2036567240334653054',
+                author: 'bob',
+                votes: 8,
+                url: 'https://www.zhihu.com/question/2021881398772981878/answer/2036567240334653054',
+                content: 'second precise id',
+            },
+        ]);
+    });
     it('follows paging.next until the requested limit is reached', async () => {
         const cmd = getRegistry().get('zhihu/question');
         const goto = vi.fn().mockResolvedValue(undefined);

--- a/clis/zhihu/question.test.js
+++ b/clis/zhihu/question.test.js
@@ -12,10 +12,12 @@ describe('zhihu question', () => {
             // user-requested `--limit 3` is enforced by the dedup loop's
             // `answers.length >= answerLimit` break, not by the fetch URL.
             expect(js).toContain('questions/2021881398772981878/answers?limit=20');
+            expect(js).toContain('content,url,voteup_count');
             expect(js).toContain("credentials: 'include'");
             return {
                 data: [
                     {
+                        id: '2036567240334653053',
                         author: { name: 'alice' },
                         voteup_count: 12,
                         content: 'Hello Zhihu',
@@ -27,13 +29,43 @@ describe('zhihu question', () => {
         await expect(cmd.func(page, { id: '2021881398772981878', limit: 3 })).resolves.toEqual([
             {
                 rank: 1,
+                id: '2036567240334653053',
                 author: 'alice',
                 votes: 12,
+                url: 'https://www.zhihu.com/question/2021881398772981878/answer/2036567240334653053',
                 content: 'Hello Zhihu',
             },
         ]);
         expect(goto).toHaveBeenCalledWith('https://www.zhihu.com/question/2021881398772981878');
         expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+    it('prefers the answer URL when extracting large answer IDs', async () => {
+        const cmd = getRegistry().get('zhihu/question');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                data: [
+                    {
+                        id: 2036567240334653000,
+                        url: 'https://www.zhihu.com/api/v4/answers/2036567240334653053',
+                        author: { name: 'alice' },
+                        voteup_count: 12,
+                        content: '<p>precise id</p>',
+                    },
+                ],
+                paging: { is_end: true },
+            }),
+        };
+        await expect(cmd.func(page, { id: '2021881398772981878', limit: 1 })).resolves.toEqual([
+            {
+                rank: 1,
+                id: '2036567240334653053',
+                author: 'alice',
+                votes: 12,
+                url: 'https://www.zhihu.com/question/2021881398772981878/answer/2036567240334653053',
+                content: 'precise id',
+            },
+        ]);
     });
     it('follows paging.next until the requested limit is reached', async () => {
         const cmd = getRegistry().get('zhihu/question');
@@ -58,9 +90,9 @@ describe('zhihu question', () => {
             });
         const page = { goto, evaluate };
         await expect(cmd.func(page, { id: '2021881398772981878', limit: 3 })).resolves.toEqual([
-            { rank: 1, author: 'alice', votes: 12, content: 'first' },
-            { rank: 2, author: 'bob', votes: 8, content: 'second' },
-            { rank: 3, author: 'carol', votes: 5, content: 'third' },
+            { rank: 1, id: 'a1', author: 'alice', votes: 12, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a1', content: 'first' },
+            { rank: 2, id: 'a2', author: 'bob', votes: 8, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a2', content: 'second' },
+            { rank: 3, id: 'a3', author: 'carol', votes: 5, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a3', content: 'third' },
         ]);
         expect(evaluate).toHaveBeenCalledTimes(2);
         expect(evaluate.mock.calls[1][0]).toContain('offset=80');
@@ -84,7 +116,7 @@ describe('zhihu question', () => {
         });
         const page = { goto, evaluate };
         await expect(cmd.func(page, { id: '2021881398772981878', limit: 1, sort: 'created' })).resolves.toEqual([
-            { rank: 1, author: 'newest', votes: 1, content: 'created order' },
+            { rank: 1, id: 'a1', author: 'newest', votes: 1, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a1', content: 'created order' },
         ]);
         expect(goto).toHaveBeenCalledWith('https://www.zhihu.com/question/2021881398772981878/answers/updated');
     });

--- a/clis/zhihu/question.test.js
+++ b/clis/zhihu/question.test.js
@@ -73,8 +73,8 @@ describe('zhihu question', () => {
         const evaluate = vi.fn()
             .mockResolvedValueOnce({
                 data: [
-                    { id: 'a1', author: { name: 'alice' }, voteup_count: 12, content: '<p>first</p>' },
-                    { id: 'a2', author: { name: 'bob' }, voteup_count: 8, content: '<p>second</p>' },
+                    { id: '101', author: { name: 'alice' }, voteup_count: 12, content: '<p>first</p>' },
+                    { id: '102', author: { name: 'bob' }, voteup_count: 8, content: '<p>second</p>' },
                 ],
                 paging: {
                     is_end: false,
@@ -83,16 +83,16 @@ describe('zhihu question', () => {
             })
             .mockResolvedValueOnce({
                 data: [
-                    { id: 'a2', author: { name: 'bob duplicate' }, voteup_count: 8, content: '<p>duplicate</p>' },
-                    { id: 'a3', author: { name: 'carol' }, voteup_count: 5, content: '<p>third</p>' },
+                    { id: '102', author: { name: 'bob duplicate' }, voteup_count: 8, content: '<p>duplicate</p>' },
+                    { id: '103', author: { name: 'carol' }, voteup_count: 5, content: '<p>third</p>' },
                 ],
                 paging: { is_end: true },
             });
         const page = { goto, evaluate };
         await expect(cmd.func(page, { id: '2021881398772981878', limit: 3 })).resolves.toEqual([
-            { rank: 1, id: 'a1', author: 'alice', votes: 12, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a1', content: 'first' },
-            { rank: 2, id: 'a2', author: 'bob', votes: 8, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a2', content: 'second' },
-            { rank: 3, id: 'a3', author: 'carol', votes: 5, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a3', content: 'third' },
+            { rank: 1, id: '101', author: 'alice', votes: 12, url: 'https://www.zhihu.com/question/2021881398772981878/answer/101', content: 'first' },
+            { rank: 2, id: '102', author: 'bob', votes: 8, url: 'https://www.zhihu.com/question/2021881398772981878/answer/102', content: 'second' },
+            { rank: 3, id: '103', author: 'carol', votes: 5, url: 'https://www.zhihu.com/question/2021881398772981878/answer/103', content: 'third' },
         ]);
         expect(evaluate).toHaveBeenCalledTimes(2);
         expect(evaluate.mock.calls[1][0]).toContain('offset=80');
@@ -105,7 +105,7 @@ describe('zhihu question', () => {
             return {
                 data: [
                     {
-                        id: 'a1',
+                        id: '101',
                         author: { name: 'newest' },
                         voteup_count: 1,
                         content: '<p>created order</p>',
@@ -116,9 +116,36 @@ describe('zhihu question', () => {
         });
         const page = { goto, evaluate };
         await expect(cmd.func(page, { id: '2021881398772981878', limit: 1, sort: 'created' })).resolves.toEqual([
-            { rank: 1, id: 'a1', author: 'newest', votes: 1, url: 'https://www.zhihu.com/question/2021881398772981878/answer/a1', content: 'created order' },
+            { rank: 1, id: '101', author: 'newest', votes: 1, url: 'https://www.zhihu.com/question/2021881398772981878/answer/101', content: 'created order' },
         ]);
         expect(goto).toHaveBeenCalledWith('https://www.zhihu.com/question/2021881398772981878/answers/updated');
+    });
+    it('does not emit a fake answer URL for malformed answer IDs', async () => {
+        const cmd = getRegistry().get('zhihu/question');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                data: [
+                    {
+                        id: 'not-an-id',
+                        author: { name: 'alice' },
+                        voteup_count: 12,
+                        content: '<p>malformed id</p>',
+                    },
+                ],
+                paging: { is_end: true },
+            }),
+        };
+        await expect(cmd.func(page, { id: '2021881398772981878', limit: 1 })).resolves.toEqual([
+            {
+                rank: 1,
+                id: '',
+                author: 'alice',
+                votes: 12,
+                url: '',
+                content: 'malformed id',
+            },
+        ]);
     });
     it('maps auth-like answer failures to AuthRequiredError', async () => {
         const cmd = getRegistry().get('zhihu/question');


### PR DESCRIPTION
## Summary
- include answer id and canonical answer URL in zhihu question rows
- request answer URL metadata from Zhihu and prefer it when extracting large answer ids
- add coverage for preserving large answer id precision

## Why
Question answer lists currently expose only author, votes, and an excerpt, so users cannot directly pipe a selected row into zhihu answer-detail. Returning id/url makes the list command naturally connect to the full answer reader.

## Validation
- npx vitest run --project adapter clis/zhihu/question.test.js clis/zhihu/answer-detail.test.js
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- npm run dev -- zhihu question 2022852734622114542 --limit 2 -f json
- npm run dev -- zhihu answer-detail "https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053" --max-content 120 -f json
- git diff --check HEAD~1..HEAD