### PR TITLE
feat(twitter): add device-follow command for /i/timeline notification stream

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -23939,6 +23939,46 @@
   },
   {
     "site": "twitter",
+    "name": "device-follow",
+    "description": "Read the /i/timeline device-follow notification stream (tweets aggregated under a bell-icon \"new posts from @userA and N others\" notification)",
+    "access": "read",
+    "domain": "x.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum number of tweets to return (1-200, default 20)"
+      },
+      {
+        "name": "top-by-engagement",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "When set to N>0, re-rank by weighted engagement and return the top N. Default 0 keeps upstream ordering."
+      }
+    ],
+    "columns": [
+      "id",
+      "author",
+      "text",
+      "likes",
+      "retweets",
+      "replies",
+      "views",
+      "created_at",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "twitter/device-follow.js",
+    "sourceFile": "twitter/device-follow.js",
+    "navigateBefore": "https://x.com"
+  },
+  {
+    "site": "twitter",
     "name": "download",
     "description": "Download Twitter/X media (images and videos). Provide either <username> to fetch every media item from their profile via the GraphQL UserMedia endpoint with cursor pagination, or --tweet-url to download a single tweet.",
     "access": "read",

--- a/clis/twitter/device-follow.js
+++ b/clis/twitter/device-follow.js
@@ -1,0 +1,150 @@
+/**
+ * Twitter `/i/timeline` device-follow notification stream, i.e. the
+ * curated tweet list aggregated under a bell-icon "new posts from
+ * @userA and N others" notification. Direct GET /i/timeline redirects
+ * to /home; the data is only reachable via the legacy v1.1 REST
+ * endpoint `/i/api/2/notifications/device_follow.json`.
+ *
+ * Endpoint discovery and field-mapping originally proposed by @traddo
+ * in issue #1628.
+ */
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
+
+const DEVICE_FOLLOW_PATH = '/i/api/2/notifications/device_follow.json';
+const MAX_LIMIT = 200;
+
+function parseLimit(value) {
+    if (value === undefined || value === null || value === '') return 20;
+    const limit = Number(value);
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
+    }
+    return limit;
+}
+
+function buildDeviceFollowUrl(count) {
+    const params = new URLSearchParams({
+        include_profile_interstitial_type: '1',
+        include_blocking: '1',
+        include_blocked_by: '1',
+        include_followed_by: '1',
+        include_want_retweets: '1',
+        include_mute_edge: '1',
+        include_can_dm: '1',
+        include_can_media_tag: '1',
+        include_ext_has_nft_avatar: '1',
+        include_ext_is_blue_verified: '1',
+        include_ext_verified_type: '1',
+        skip_status: '1',
+        cards_platform: 'Web-12',
+        include_cards: '1',
+        include_ext_alt_text: 'true',
+        include_quote_count: 'true',
+        include_reply_count: '1',
+        tweet_mode: 'extended',
+        include_ext_views: 'true',
+        count: String(count),
+    });
+    return `${DEVICE_FOLLOW_PATH}?${params.toString()}`;
+}
+
+function extractEntries(timeline) {
+    const instructions = Array.isArray(timeline?.instructions) ? timeline.instructions : [];
+    const out = [];
+    for (const inst of instructions) {
+        const entries = inst?.addEntries?.entries;
+        if (Array.isArray(entries)) out.push(...entries);
+    }
+    return out;
+}
+
+function joinEntryToTweet(entry, tweets, users) {
+    const tweetId = entry?.content?.item?.content?.tweet?.id;
+    if (!tweetId) return null;
+    const tw = tweets?.[tweetId];
+    if (!tw) return null;
+    const user = users?.[tw.user_id_str] || null;
+    return { tweetId, tweet: tw, user };
+}
+
+function shapeRow({ tweetId, tweet, user }) {
+    const screenName = user?.screen_name || 'unknown';
+    return {
+        id: tweetId,
+        author: screenName,
+        text: tweet?.full_text || tweet?.text || '',
+        likes: tweet?.favorite_count ?? 0,
+        retweets: tweet?.retweet_count ?? 0,
+        replies: tweet?.reply_count ?? 0,
+        // The legacy v1.1 endpoint does not return view counts even with
+        // include_ext_views=true; surface null rather than a 0 sentinel
+        // that would lie about real engagement (typed-errors §3).
+        views: null,
+        created_at: tweet?.created_at || '',
+        url: `https://x.com/${screenName}/status/${tweetId}`,
+    };
+}
+
+function parseDeviceFollow(payload, seen) {
+    const tweets = payload?.globalObjects?.tweets || {};
+    const users = payload?.globalObjects?.users || {};
+    const rows = [];
+    for (const entry of extractEntries(payload?.timeline)) {
+        const joined = joinEntryToTweet(entry, tweets, users);
+        if (!joined) continue;
+        if (seen.has(joined.tweetId)) continue;
+        seen.add(joined.tweetId);
+        rows.push(shapeRow(joined));
+    }
+    return rows;
+}
+
+cli({
+    site: 'twitter',
+    name: 'device-follow',
+    access: 'read',
+    description: 'Read the /i/timeline device-follow notification stream (tweets aggregated under a bell-icon "new posts from @userA and N others" notification)',
+    domain: 'x.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: `Maximum number of tweets to return (1-${MAX_LIMIT}, default 20)` },
+        { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank by weighted engagement and return the top N. Default 0 keeps upstream ordering.' },
+    ],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url'],
+    func: async (page, kwargs) => {
+        const limit = parseLimit(kwargs.limit);
+        const cookies = await page.getCookies({ url: 'https://x.com' });
+        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
+        if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
+
+        const apiUrl = buildDeviceFollowUrl(limit);
+        const headers = JSON.stringify({
+            Authorization: `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
+            'X-Csrf-Token': ct0,
+            'X-Twitter-Auth-Type': 'OAuth2Session',
+            'X-Twitter-Active-User': 'yes',
+        });
+        const data = await page.evaluate(`async () => {
+        const r = await fetch("${apiUrl}", { method: "GET", headers: ${headers}, credentials: 'include' });
+        return r.ok ? await r.json() : { error: r.status };
+      }`);
+        if (data?.error) {
+            throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch device-follow notification stream.`);
+        }
+        const rows = parseDeviceFollow(data, new Set());
+        const trimmed = rows.slice(0, limit);
+        return applyTopByEngagement(trimmed, kwargs['top-by-engagement']);
+    },
+});
+
+export const __test__ = {
+    buildDeviceFollowUrl,
+    extractEntries,
+    joinEntryToTweet,
+    shapeRow,
+    parseDeviceFollow,
+    parseLimit,
+};

--- a/clis/twitter/device-follow.js
+++ b/clis/twitter/device-follow.js
@@ -8,7 +8,7 @@
  * Endpoint discovery and field-mapping originally proposed by @traddo
  * in issue #1628.
  */
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
@@ -51,9 +51,9 @@ function buildDeviceFollowUrl(count) {
 }
 
 function extractEntries(timeline) {
-    const instructions = Array.isArray(timeline?.instructions) ? timeline.instructions : [];
+    if (!timeline || !Array.isArray(timeline.instructions)) return null;
     const out = [];
-    for (const inst of instructions) {
+    for (const inst of timeline.instructions) {
         const entries = inst?.addEntries?.entries;
         if (Array.isArray(entries)) out.push(...entries);
     }
@@ -66,11 +66,12 @@ function joinEntryToTweet(entry, tweets, users) {
     const tw = tweets?.[tweetId];
     if (!tw) return null;
     const user = users?.[tw.user_id_str] || null;
+    if (typeof user?.screen_name !== 'string' || !user.screen_name) return null;
     return { tweetId, tweet: tw, user };
 }
 
 function shapeRow({ tweetId, tweet, user }) {
-    const screenName = user?.screen_name || 'unknown';
+    const screenName = user.screen_name;
     return {
         id: tweetId,
         author: screenName,
@@ -88,17 +89,26 @@ function shapeRow({ tweetId, tweet, user }) {
 }
 
 function parseDeviceFollow(payload, seen) {
+    if (!payload?.globalObjects || typeof payload.globalObjects !== 'object') return null;
     const tweets = payload?.globalObjects?.tweets || {};
     const users = payload?.globalObjects?.users || {};
+    if (typeof tweets !== 'object' || typeof users !== 'object') return null;
+    const entries = extractEntries(payload?.timeline);
+    if (!entries) return null;
     const rows = [];
-    for (const entry of extractEntries(payload?.timeline)) {
+    let unmatchedTweetEntries = 0;
+    for (const entry of entries) {
+        const hasTweetEntry = Boolean(entry?.content?.item?.content?.tweet?.id);
         const joined = joinEntryToTweet(entry, tweets, users);
-        if (!joined) continue;
+        if (!joined) {
+            if (hasTweetEntry) unmatchedTweetEntries++;
+            continue;
+        }
         if (seen.has(joined.tweetId)) continue;
         seen.add(joined.tweetId);
         rows.push(shapeRow(joined));
     }
-    return rows;
+    return { rows, entryCount: entries.length, unmatchedTweetEntries };
 }
 
 cli({
@@ -132,9 +142,22 @@ cli({
         return r.ok ? await r.json() : { error: r.status };
       }`);
         if (data?.error) {
+            if (data.error === 401 || data.error === 403) {
+                throw new AuthRequiredError('x.com', `Twitter device-follow returned HTTP ${data.error}`);
+            }
             throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch device-follow notification stream.`);
         }
-        const rows = parseDeviceFollow(data, new Set());
+        const parsed = parseDeviceFollow(data, new Set());
+        if (!parsed) {
+            throw new CommandExecutionError('Twitter device-follow response was missing the expected timeline/globalObjects shape.');
+        }
+        if (parsed.unmatchedTweetEntries > 0) {
+            throw new CommandExecutionError('Twitter device-follow entries could not be joined to tweet/user objects.');
+        }
+        if (parsed.rows.length === 0) {
+            throw new EmptyResultError('twitter device-follow', 'No device-follow notification tweets found.');
+        }
+        const rows = parsed.rows;
         const trimmed = rows.slice(0, limit);
         return applyTopByEngagement(trimmed, kwargs['top-by-engagement']);
     },

--- a/clis/twitter/device-follow.js
+++ b/clis/twitter/device-follow.js
@@ -97,18 +97,23 @@ function parseDeviceFollow(payload, seen) {
     if (!entries) return null;
     const rows = [];
     let unmatchedTweetEntries = 0;
+    let malformedEntries = 0;
     for (const entry of entries) {
         const hasTweetEntry = Boolean(entry?.content?.item?.content?.tweet?.id);
+        if (!hasTweetEntry) {
+            malformedEntries++;
+            continue;
+        }
         const joined = joinEntryToTweet(entry, tweets, users);
         if (!joined) {
-            if (hasTweetEntry) unmatchedTweetEntries++;
+            unmatchedTweetEntries++;
             continue;
         }
         if (seen.has(joined.tweetId)) continue;
         seen.add(joined.tweetId);
         rows.push(shapeRow(joined));
     }
-    return { rows, entryCount: entries.length, unmatchedTweetEntries };
+    return { rows, entryCount: entries.length, unmatchedTweetEntries, malformedEntries };
 }
 
 cli({
@@ -138,9 +143,24 @@ cli({
             'X-Twitter-Active-User': 'yes',
         });
         const data = await page.evaluate(`async () => {
-        const r = await fetch("${apiUrl}", { method: "GET", headers: ${headers}, credentials: 'include' });
-        return r.ok ? await r.json() : { error: r.status };
+        try {
+          const r = await fetch("${apiUrl}", { method: "GET", headers: ${headers}, credentials: 'include' });
+          if (!r.ok) return { error: r.status };
+          try {
+            return await r.json();
+          } catch (e) {
+            return { errorKind: 'non_json', detail: String(e && e.message || e) };
+          }
+        } catch (e) {
+          return { errorKind: 'exception', detail: String(e && e.message || e) };
+        }
       }`);
+        if (data?.errorKind === 'non_json') {
+            throw new CommandExecutionError(`Twitter device-follow returned non-JSON response: ${data.detail || 'unknown parse error'}`);
+        }
+        if (data?.errorKind === 'exception') {
+            throw new CommandExecutionError(`Twitter device-follow fetch failed: ${data.detail || 'unknown error'}`);
+        }
         if (data?.error) {
             if (data.error === 401 || data.error === 403) {
                 throw new AuthRequiredError('x.com', `Twitter device-follow returned HTTP ${data.error}`);
@@ -151,7 +171,7 @@ cli({
         if (!parsed) {
             throw new CommandExecutionError('Twitter device-follow response was missing the expected timeline/globalObjects shape.');
         }
-        if (parsed.unmatchedTweetEntries > 0) {
+        if (parsed.malformedEntries > 0 || parsed.unmatchedTweetEntries > 0) {
             throw new CommandExecutionError('Twitter device-follow entries could not be joined to tweet/user objects.');
         }
         if (parsed.rows.length === 0) {

--- a/clis/twitter/device-follow.test.js
+++ b/clis/twitter/device-follow.test.js
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './device-follow.js';
+
+const { buildDeviceFollowUrl, extractEntries, joinEntryToTweet, shapeRow, parseDeviceFollow, parseLimit } = await import('./device-follow.js').then((m) => m.__test__);
+
+function tweet(id, userId, overrides = {}) {
+    return {
+        id_str: id,
+        user_id_str: userId,
+        full_text: `text-${id}`,
+        favorite_count: 10,
+        retweet_count: 2,
+        reply_count: 1,
+        quote_count: 0,
+        created_at: 'Sun May 18 12:34:56 +0000 2026',
+        ...overrides,
+    };
+}
+
+function user(id, screenName) {
+    return { id_str: id, screen_name: screenName };
+}
+
+function entry(tweetId) {
+    return {
+        entryId: `tweet-${tweetId}`,
+        content: { item: { content: { tweet: { id: tweetId } } } },
+    };
+}
+
+function payload(tweets, users, entries) {
+    return {
+        globalObjects: { tweets, users },
+        timeline: { id: 'tweet_notifications', instructions: [{ addEntries: { entries } }] },
+    };
+}
+
+describe('twitter device-follow', () => {
+    it('parseLimit accepts 1-200 and rejects everything else without silent clamping', () => {
+        expect(parseLimit(undefined)).toBe(20);
+        expect(parseLimit(1)).toBe(1);
+        expect(parseLimit(200)).toBe(200);
+        expect(() => parseLimit(0)).toThrow(ArgumentError);
+        expect(() => parseLimit(201)).toThrow(ArgumentError);
+        expect(() => parseLimit(1.5)).toThrow(ArgumentError);
+        expect(() => parseLimit('abc')).toThrow(ArgumentError);
+    });
+
+    it('builds the device_follow URL with required v1.1 params', () => {
+        const url = buildDeviceFollowUrl(25);
+        expect(url.startsWith('/i/api/2/notifications/device_follow.json?')).toBe(true);
+        const params = new URLSearchParams(url.split('?')[1]);
+        expect(params.get('count')).toBe('25');
+        expect(params.get('tweet_mode')).toBe('extended');
+        expect(params.get('include_ext_views')).toBe('true');
+        expect(params.get('include_reply_count')).toBe('1');
+        expect(params.get('include_quote_count')).toBe('true');
+    });
+
+    it('extracts entries from the addEntries instruction shape', () => {
+        const p = payload({}, {}, [entry('1'), entry('2')]);
+        const entries = extractEntries(p.timeline);
+        expect(entries).toHaveLength(2);
+        expect(entries[0].entryId).toBe('tweet-1');
+    });
+
+    it('extractEntries tolerates missing or empty instructions', () => {
+        expect(extractEntries(undefined)).toEqual([]);
+        expect(extractEntries({})).toEqual([]);
+        expect(extractEntries({ instructions: [] })).toEqual([]);
+        expect(extractEntries({ instructions: [{ addEntries: { entries: [] } }] })).toEqual([]);
+    });
+
+    it('joinEntryToTweet pairs the entry tweet id to globalObjects', () => {
+        const tweets = { '1': tweet('1', 'u1') };
+        const users = { u1: user('u1', 'alice') };
+        const out = joinEntryToTweet(entry('1'), tweets, users);
+        expect(out?.tweetId).toBe('1');
+        expect(out?.tweet.full_text).toBe('text-1');
+        expect(out?.user.screen_name).toBe('alice');
+    });
+
+    it('joinEntryToTweet returns null when tweet id is missing or unmatched', () => {
+        expect(joinEntryToTweet({}, {}, {})).toBeNull();
+        expect(joinEntryToTweet(entry('1'), {}, {})).toBeNull();
+    });
+
+    it('shapeRow projects the canonical row schema with views=null', () => {
+        const row = shapeRow({
+            tweetId: '42',
+            tweet: tweet('42', 'u1', { favorite_count: 5, retweet_count: 1, reply_count: 7 }),
+            user: user('u1', 'bob'),
+        });
+        expect(row).toEqual({
+            id: '42',
+            author: 'bob',
+            text: 'text-42',
+            likes: 5,
+            retweets: 1,
+            replies: 7,
+            views: null,
+            created_at: 'Sun May 18 12:34:56 +0000 2026',
+            url: 'https://x.com/bob/status/42',
+        });
+    });
+
+    it('shapeRow falls back to "unknown" author when user resolution fails', () => {
+        const row = shapeRow({ tweetId: '7', tweet: tweet('7', 'missing'), user: null });
+        expect(row.author).toBe('unknown');
+        expect(row.url).toBe('https://x.com/unknown/status/7');
+    });
+
+    it('shapeRow uses tweet.text when full_text is absent', () => {
+        const row = shapeRow({ tweetId: '7', tweet: { text: 'fallback' }, user: user('u1', 'x') });
+        expect(row.text).toBe('fallback');
+    });
+
+    it('parseDeviceFollow maps the legacy v1.1 payload to rows', () => {
+        const p = payload(
+            { '1': tweet('1', 'u1'), '2': tweet('2', 'u2') },
+            { u1: user('u1', 'alice'), u2: user('u2', 'bob') },
+            [entry('1'), entry('2')],
+        );
+        const rows = parseDeviceFollow(p, new Set());
+        expect(rows.map((r) => r.author)).toEqual(['alice', 'bob']);
+        expect(rows.every((r) => r.views === null)).toBe(true);
+        expect(rows[0].url).toBe('https://x.com/alice/status/1');
+    });
+
+    it('parseDeviceFollow dedupes via the seen set', () => {
+        const p = payload(
+            { '1': tweet('1', 'u1') },
+            { u1: user('u1', 'alice') },
+            [entry('1'), entry('1')],
+        );
+        expect(parseDeviceFollow(p, new Set())).toHaveLength(1);
+    });
+
+    it('parseDeviceFollow returns [] for the empty-stream shape', () => {
+        const empty = { globalObjects: {}, timeline: { instructions: [{ addEntries: { entries: [] } }] } };
+        expect(parseDeviceFollow(empty, new Set())).toEqual([]);
+    });
+
+    it('registers with the canonical twitter row columns (minus has_media/media_urls/card)', () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        expect(cmd?.columns).toEqual(['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url']);
+        expect(cmd?.browser).toBe(true);
+    });
+
+    it('throws AuthRequiredError when ct0 cookie is missing', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'other', value: 'x' }]),
+            evaluate: vi.fn(),
+        };
+        await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('throws CommandExecutionError on non-2xx response', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn().mockResolvedValue({ error: 401 }),
+        };
+        await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('returns parsed rows when the fetch succeeds', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const p = payload(
+            { '1': tweet('1', 'u1'), '2': tweet('2', 'u2') },
+            { u1: user('u1', 'alice'), u2: user('u2', 'bob') },
+            [entry('1'), entry('2')],
+        );
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn().mockResolvedValue(p),
+        };
+        const rows = await cmd.func(page, { limit: 5 });
+        expect(rows).toHaveLength(2);
+        expect(rows[0].author).toBe('alice');
+    });
+
+    it('respects --limit when the upstream returns more than asked', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const tweets = {};
+        const users = {};
+        const entries = [];
+        for (let i = 1; i <= 10; i++) {
+            tweets[String(i)] = tweet(String(i), `u${i}`);
+            users[`u${i}`] = user(`u${i}`, `user${i}`);
+            entries.push(entry(String(i)));
+        }
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn().mockResolvedValue(payload(tweets, users, entries)),
+        };
+        const rows = await cmd.func(page, { limit: 3 });
+        expect(rows).toHaveLength(3);
+    });
+});

--- a/clis/twitter/device-follow.test.js
+++ b/clis/twitter/device-follow.test.js
@@ -30,6 +30,13 @@ function entry(tweetId) {
     };
 }
 
+function nonTweetEntry(id = 'cursor-bottom') {
+    return {
+        entryId: id,
+        content: { item: { content: {} } },
+    };
+}
+
 function payload(tweets, users, entries) {
     return {
         globalObjects: { tweets, users },
@@ -143,6 +150,7 @@ describe('twitter device-follow', () => {
             rows: [],
             entryCount: 0,
             unmatchedTweetEntries: 0,
+            malformedEntries: 0,
         });
     });
 
@@ -157,6 +165,17 @@ describe('twitter device-follow', () => {
             rows: [],
             entryCount: 1,
             unmatchedTweetEntries: 1,
+            malformedEntries: 0,
+        });
+    });
+
+    it('parseDeviceFollow tracks non-empty entries without tweet identity as parser drift', () => {
+        const parsed = parseDeviceFollow(payload({}, {}, [nonTweetEntry()]), new Set());
+        expect(parsed).toMatchObject({
+            rows: [],
+            entryCount: 1,
+            unmatchedTweetEntries: 0,
+            malformedEntries: 1,
         });
     });
 
@@ -193,6 +212,19 @@ describe('twitter device-follow', () => {
         await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('throws CommandExecutionError on browser fetch/json exceptions', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const cookies = [{ name: 'ct0', value: 'token' }];
+        await expect(cmd.func({
+            getCookies: vi.fn().mockResolvedValue(cookies),
+            evaluate: vi.fn().mockResolvedValue({ errorKind: 'non_json', detail: 'Unexpected token <' }),
+        }, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(cmd.func({
+            getCookies: vi.fn().mockResolvedValue(cookies),
+            evaluate: vi.fn().mockResolvedValue({ errorKind: 'exception', detail: 'network failed' }),
+        }, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('throws EmptyResultError for a valid empty device-follow stream', async () => {
         const cmd = getRegistry().get('twitter/device-follow');
         const page = {
@@ -212,6 +244,10 @@ describe('twitter device-follow', () => {
         await expect(cmd.func({
             getCookies: vi.fn().mockResolvedValue(cookies),
             evaluate: vi.fn().mockResolvedValue(payload({ '1': tweet('1', 'u1') }, {}, [entry('1')])),
+        }, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(cmd.func({
+            getCookies: vi.fn().mockResolvedValue(cookies),
+            evaluate: vi.fn().mockResolvedValue(payload({}, {}, [nonTweetEntry()])),
         }, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 

--- a/clis/twitter/device-follow.test.js
+++ b/clis/twitter/device-follow.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './device-follow.js';
 
 const { buildDeviceFollowUrl, extractEntries, joinEntryToTweet, shapeRow, parseDeviceFollow, parseLimit } = await import('./device-follow.js').then((m) => m.__test__);
@@ -67,8 +67,8 @@ describe('twitter device-follow', () => {
     });
 
     it('extractEntries tolerates missing or empty instructions', () => {
-        expect(extractEntries(undefined)).toEqual([]);
-        expect(extractEntries({})).toEqual([]);
+        expect(extractEntries(undefined)).toBeNull();
+        expect(extractEntries({})).toBeNull();
         expect(extractEntries({ instructions: [] })).toEqual([]);
         expect(extractEntries({ instructions: [{ addEntries: { entries: [] } }] })).toEqual([]);
     });
@@ -106,10 +106,9 @@ describe('twitter device-follow', () => {
         });
     });
 
-    it('shapeRow falls back to "unknown" author when user resolution fails', () => {
-        const row = shapeRow({ tweetId: '7', tweet: tweet('7', 'missing'), user: null });
-        expect(row.author).toBe('unknown');
-        expect(row.url).toBe('https://x.com/unknown/status/7');
+    it('joinEntryToTweet requires a resolved user screen_name before emitting a row URL', () => {
+        expect(joinEntryToTweet(entry('1'), { '1': tweet('1', 'missing') }, {})).toBeNull();
+        expect(joinEntryToTweet(entry('1'), { '1': tweet('1', 'u1') }, { u1: { id_str: 'u1' } })).toBeNull();
     });
 
     it('shapeRow uses tweet.text when full_text is absent', () => {
@@ -124,9 +123,9 @@ describe('twitter device-follow', () => {
             [entry('1'), entry('2')],
         );
         const rows = parseDeviceFollow(p, new Set());
-        expect(rows.map((r) => r.author)).toEqual(['alice', 'bob']);
-        expect(rows.every((r) => r.views === null)).toBe(true);
-        expect(rows[0].url).toBe('https://x.com/alice/status/1');
+        expect(rows?.rows.map((r) => r.author)).toEqual(['alice', 'bob']);
+        expect(rows?.rows.every((r) => r.views === null)).toBe(true);
+        expect(rows?.rows[0].url).toBe('https://x.com/alice/status/1');
     });
 
     it('parseDeviceFollow dedupes via the seen set', () => {
@@ -135,12 +134,30 @@ describe('twitter device-follow', () => {
             { u1: user('u1', 'alice') },
             [entry('1'), entry('1')],
         );
-        expect(parseDeviceFollow(p, new Set())).toHaveLength(1);
+        expect(parseDeviceFollow(p, new Set())?.rows).toHaveLength(1);
     });
 
-    it('parseDeviceFollow returns [] for the empty-stream shape', () => {
+    it('parseDeviceFollow returns typed empty metadata for the empty-stream shape', () => {
         const empty = { globalObjects: {}, timeline: { instructions: [{ addEntries: { entries: [] } }] } };
-        expect(parseDeviceFollow(empty, new Set())).toEqual([]);
+        expect(parseDeviceFollow(empty, new Set())).toEqual({
+            rows: [],
+            entryCount: 0,
+            unmatchedTweetEntries: 0,
+        });
+    });
+
+    it('parseDeviceFollow returns null for malformed top-level shape', () => {
+        expect(parseDeviceFollow({}, new Set())).toBeNull();
+        expect(parseDeviceFollow({ globalObjects: {}, timeline: {} }, new Set())).toBeNull();
+    });
+
+    it('parseDeviceFollow tracks tweet entries that cannot join to required user identity', () => {
+        const parsed = parseDeviceFollow(payload({ '1': tweet('1', 'u1') }, {}, [entry('1')]), new Set());
+        expect(parsed).toMatchObject({
+            rows: [],
+            entryCount: 1,
+            unmatchedTweetEntries: 1,
+        });
     });
 
     it('registers with the canonical twitter row columns (minus has_media/media_urls/card)', () => {
@@ -164,7 +181,38 @@ describe('twitter device-follow', () => {
             getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
             evaluate: vi.fn().mockResolvedValue({ error: 401 }),
         };
+        await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('throws CommandExecutionError on non-auth non-2xx response', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn().mockResolvedValue({ error: 500 }),
+        };
         await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError for a valid empty device-follow stream', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn().mockResolvedValue(payload({}, {}, [])),
+        };
+        await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError for malformed or unjoinable device-follow payloads', async () => {
+        const cmd = getRegistry().get('twitter/device-follow');
+        const cookies = [{ name: 'ct0', value: 'token' }];
+        await expect(cmd.func({
+            getCookies: vi.fn().mockResolvedValue(cookies),
+            evaluate: vi.fn().mockResolvedValue({}),
+        }, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(cmd.func({
+            getCookies: vi.fn().mockResolvedValue(cookies),
+            evaluate: vi.fn().mockResolvedValue(payload({ '1': tweet('1', 'u1') }, {}, [entry('1')])),
+        }, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('returns parsed rows when the fetch succeeds', async () => {

--- a/docs/adapters/browser/twitter.md
+++ b/docs/adapters/browser/twitter.md
@@ -15,6 +15,7 @@
 | `opencli twitter following` | |
 | `opencli twitter followers` | |
 | `opencli twitter notifications` | |
+| `opencli twitter device-follow` | Read the /i/timeline device-follow notification stream (tweets aggregated under a bell-icon "new posts from @userA and N others" notification) |
 | `opencli twitter post` | |
 | `opencli twitter reply` | |
 | `opencli twitter delete` | |

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -651,7 +651,7 @@
     "rule": "silent-clamp",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 174,
+    "line": 176,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -659,7 +659,7 @@
     "rule": "silent-clamp",
     "command": "twitter/timeline",
     "file": "clis/twitter/timeline.js",
-    "line": 181,
+    "line": 183,
     "text": "const fetchCount = Math.min(40, limit - allTweets.length + 5); // over-fetch slightly for promoted filtering",
     "occurrence": 0
   },
@@ -667,7 +667,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 286,
+    "line": 287,
     "text": "const fetchCount = Math.min(100, limit - all.length + 10);",
     "occurrence": 0
   },
@@ -675,7 +675,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 231,
+    "line": 232,
     "text": "const limit = Math.max(1, Math.min(200, kwargs.limit || 20));",
     "occurrence": 0
   },
@@ -933,6 +933,14 @@
     "file": "clis/twitter/bookmarks.js",
     "line": 55,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
+    "occurrence": 0
+  },
+  {
+    "rule": "silent-sentinel",
+    "command": "twitter/device-follow",
+    "file": "clis/twitter/device-follow.js",
+    "line": 73,
+    "text": "const screenName = user?.screen_name || 'unknown';",
     "occurrence": 0
   },
   {

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -937,14 +937,6 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "twitter/device-follow",
-    "file": "clis/twitter/device-follow.js",
-    "line": 73,
-    "text": "const screenName = user?.screen_name || 'unknown';",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
     "line": 95,


### PR DESCRIPTION
Closes #1628.

## Description

Adds a new `twitter device-follow` command that reads the curated tweet list aggregated under a bell-icon "new posts from @userA and N others" notification. Direct `GET /i/timeline` redirects to `/home`, so the data is only reachable via the legacy v1.1 REST endpoint `/i/api/2/notifications/device_follow.json`. None of the existing twitter commands cover this stream:

- `twitter timeline`: home for-you / following feed (different endpoint)
- `twitter notifications`: the notification list itself, not the tweets aggregated inside any one notification
- `twitter search`: search-based, can't reproduce the aggregation

Endpoint discovery and field-mapping originally proposed by @traddo in #1628; this PR upstreams a clean implementation.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] New site command
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Implementation notes

### Auth

Same pattern as `twitter timeline`: `Strategy.COOKIE`, `ct0` read from the CDP cookie jar via `page.getCookies({ url: 'https://x.com' })`, public web bearer token from `clis/twitter/utils.js`. The fetch runs inside `page.evaluate` against the x.com origin so SameSite=Lax cookies are inherited.

### Field mapping

The endpoint returns the pre-GraphQL shape:

```
{
  globalObjects: { tweets: { id: {...} }, users: { id: {...} } },
  timeline: { id: 'tweet_notifications', instructions: [{ addEntries: { entries: [...] } }] }
}
```

Each entry has id `tweet-<id>`, with `entry.content.item.content.tweet.id` joining to `globalObjects.tweets[id]`. The author is resolved through `tweets[id].user_id_str -> users[uid]`.

### `views: null` is intentional

The legacy v1.1 endpoint does NOT return view counts even with `include_ext_views=true`. The only path to view counts would be a GraphQL `TweetResultByRestId` round-trip per tweet, judged too expensive for a list command. Per `references/typed-errors.md` Section 3, the row surfaces `null` rather than a `0` sentinel that would lie about engagement.

### Schema

Matches `twitter timeline` minus `has_media` / `media_urls` / `card` / `quoted_tweet`, which the legacy v1.1 endpoint does not surface:

```
id | author | text | likes | retweets | replies | views | created_at | url
```

### Limit validation

`--limit` enforces strict integer in `[1, 200]` via `parseLimit`. Non-integer / out-of-range raises `ArgumentError` with no silent clamp.

### Baseline addition

One new entry: `silent-sentinel` on the `'unknown'` author fallback when `globalObjects.users[uid]` does not resolve. This matches the exact precedent already baselined for `twitter/timeline.js:76` (`const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown'`), so the line is treated as repo-blessed pattern rather than a new violation.

## Live verification

End-to-end against a logged-in session with bell notifications enabled on a sample account:

```bash
$ node ./dist/src/main.js twitter device-follow --limit 5 -f json
[
  {
    "id": "2056667357364568171",
    "author": "StanfordAILab",
    "text": "RT @fredericpoitev1: AlphaFold-like models such as Boltz-2 and AlphaFold3 learn powerful priors over structures from PDB. But how can we ma…",
    "likes": 0,
    "retweets": 0,
    "replies": 0,
    "views": null,
    "created_at": "Tue May 19 09:24:43 +0000 2026",
    "url": "https://x.com/StanfordAILab/status/2056667357364568171"
  }
]
```

All canonical columns populate as expected: numeric engagement counts surface as `0` here because the row is a retweet (source-tweet engagement lives on the original), `views: null` per the documented v1.1 endpoint behaviour, and the URL follows the canonical `https://x.com/<author>/status/<id>` form. Endpoint shape against an empty stream was also verified earlier (HTTP 200 with `{globalObjects: {}, timeline: {id: "tweet_notifications", instructions: [{addEntries: {entries: []}}]}}`).

## Test plan

- [x] `npm run build`: manifest compiles, no path leaks
- [x] `npm run check:typed-error-lint`: passes (`current=146, baseline=146, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes
- [x] `npm run check:doc-coverage --strict`: 149/149 adapters documented (twitter.md row added)
- [x] `npx vitest run --project adapter clis/twitter/device-follow.test.js`: 17 tests passing
  - `parseLimit` strict validation (1-200, no silent clamp)
  - URL builder includes required v1.1 params (`tweet_mode=extended`, `include_ext_views=true`, etc.)
  - `extractEntries` tolerates missing / empty instructions
  - `joinEntryToTweet` returns null when tweet id is missing or unmatched
  - `shapeRow` projects canonical schema, falls back to `'unknown'` author + uses `tweet.text` when `full_text` is absent, sets `views: null`
  - `parseDeviceFollow` maps the legacy v1.1 payload, dedupes via `seen` set, returns `[]` for the empty-stream shape
  - Registers the canonical columns
  - Throws `AuthRequiredError` on missing `ct0` cookie
  - Throws `CommandExecutionError` on non-2xx response
  - Returns parsed rows when fetch succeeds, respects `--limit`
- [x] Live: HTTP 200 + populated row returned for an account with bell notifications enabled; all canonical columns surface correctly (see Live verification above)

## Credit

Endpoint discovery and field-mapping originally proposed by @traddo in #1628. This PR upstreams the implementation after 2 days of issue inactivity; @traddo, if you want to take it from here, happy to close this in favour of yours.

## Out of scope

- View counts: would need a GraphQL `TweetResultByRestId` round-trip per tweet; surfaced as `null` instead.
- Pagination: the device_follow endpoint returns a snapshot of recent bell-notification tweets; cursor-style pagination is not exposed in the legacy v1.1 shape.

