### PR TITLE
fix(xhs,youtube): 把合法空数据语义切到 EmptyResultError

### DIFF
--- a/clis/xiaohongshu/user-helpers.test.js
+++ b/clis/xiaohongshu/user-helpers.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { assertReadableUserSnapshot } from './user.js';
 import { buildXhsNoteUrl, extractXhsUserNotes, flattenXhsNoteGroups, normalizeXhsUserId, } from './user-helpers.js';
 describe('normalizeXhsUserId', () => {
     it('extracts the profile id from a full Xiaohongshu URL', () => {
@@ -115,5 +117,26 @@ describe('extractXhsUserNotes', () => {
             ],
         }, 'fallback-user', 'www.rednote.com');
         expect(rows[0]?.url).toBe('https://www.rednote.com/user/profile/user-red/note-red?xsec_token=tok&xsec_source=pc_user');
+    });
+});
+
+describe('assertReadableUserSnapshot', () => {
+    it('accepts an explicit empty notes array from a readable user store', () => {
+        expect(() => assertReadableUserSnapshot({
+            storePresent: true,
+            notesPresent: true,
+            pageDataPresent: false,
+            noteGroups: [],
+            pageData: {},
+        })).not.toThrow();
+    });
+    it('fails typed when the user store is missing instead of treating parser drift as empty', () => {
+        expect(() => assertReadableUserSnapshot({
+            storePresent: false,
+            notesPresent: false,
+            pageDataPresent: false,
+            noteGroups: [],
+            pageData: {},
+        })).toThrow(CommandExecutionError);
     });
 });

--- a/clis/xiaohongshu/user-helpers.test.js
+++ b/clis/xiaohongshu/user-helpers.test.js
@@ -139,4 +139,22 @@ describe('assertReadableUserSnapshot', () => {
             pageData: {},
         })).toThrow(CommandExecutionError);
     });
+    it('fails typed when profile metadata exists but the notes array is missing', () => {
+        expect(() => assertReadableUserSnapshot({
+            storePresent: true,
+            notesPresent: false,
+            pageDataPresent: true,
+            noteGroups: [],
+            pageData: { user: { nickname: 'Alice' } },
+        })).toThrow(CommandExecutionError);
+    });
+    it('fails typed when notesPresent metadata and cloned noteGroups disagree', () => {
+        expect(() => assertReadableUserSnapshot({
+            storePresent: true,
+            notesPresent: true,
+            pageDataPresent: false,
+            noteGroups: null,
+            pageData: {},
+        })).toThrow(CommandExecutionError);
+    });
 });

--- a/clis/xiaohongshu/user.js
+++ b/clis/xiaohongshu/user.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { extractXhsUserNotes, normalizeXhsUserId } from './user-helpers.js';
 /**
  * Host-agnostic IIFE that snapshots the user profile's Pinia store. Exported
@@ -56,7 +57,10 @@ export const command = cli({
             previousCount = nextResults.length;
         }
         if (results.length === 0) {
-            throw new Error('No public notes found for this Xiaohongshu user.');
+            // 与 bilibili subtitle 同模式：作者无公开内容是合法 empty 数据条件
+            // （销号 / 私密号 / 全删笔记），不是 fetch 失败。下游应识别 code
+            // EMPTY_RESULT 跳过 rate-limit 启发式、不计入 softFail 阈值。
+            throw new EmptyResultError('xiaohongshu user', '该用户没有公开笔记（可能销号 / 私密 / 全部删除）。');
         }
         return results.slice(0, limit);
     },

--- a/clis/xiaohongshu/user.js
+++ b/clis/xiaohongshu/user.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { extractXhsUserNotes, normalizeXhsUserId } from './user-helpers.js';
 /**
  * Host-agnostic IIFE that snapshots the user profile's Pinia store. Exported
@@ -15,15 +15,29 @@ export const USER_SNAPSHOT_JS = `
         }
       };
 
-      const userStore = window.__INITIAL_STATE__?.user || {};
+      const userStore = window.__INITIAL_STATE__?.user;
+      const hasUserStore = Boolean(userStore && typeof userStore === 'object');
+      const rawNotes = hasUserStore ? (userStore.notes?._value || userStore.notes) : undefined;
+      const rawPageData = hasUserStore ? (userStore.userPageData?._value || userStore.userPageData) : undefined;
       return {
-        noteGroups: safeClone(userStore.notes?._value || userStore.notes || []),
-        pageData: safeClone(userStore.userPageData?._value || userStore.userPageData || {}),
+        noteGroups: safeClone(rawNotes || []),
+        pageData: safeClone(rawPageData || {}),
+        storePresent: hasUserStore,
+        notesPresent: Array.isArray(rawNotes),
+        pageDataPresent: Boolean(rawPageData && typeof rawPageData === 'object' && Object.keys(rawPageData).length > 0),
       };
     })()
   `;
 async function readUserSnapshot(page) {
     return await page.evaluate(USER_SNAPSHOT_JS);
+}
+export function assertReadableUserSnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+        throw new CommandExecutionError('Malformed Xiaohongshu user snapshot');
+    }
+    if (snapshot.storePresent === false || (!snapshot.notesPresent && !snapshot.pageDataPresent)) {
+        throw new CommandExecutionError('Malformed Xiaohongshu user snapshot: user store was not found');
+    }
 }
 export const command = cli({
     site: 'xiaohongshu',
@@ -44,12 +58,14 @@ export const command = cli({
         const limit = Math.max(1, Number(kwargs.limit ?? 15));
         await page.goto(`https://www.xiaohongshu.com/user/profile/${userId}`);
         let snapshot = await readUserSnapshot(page);
+        assertReadableUserSnapshot(snapshot);
         let results = extractXhsUserNotes(snapshot ?? {}, userId);
         let previousCount = results.length;
         for (let i = 0; results.length < limit && i < 4; i += 1) {
             await page.autoScroll({ times: 1, delayMs: 1500 });
             await page.wait(1);
             snapshot = await readUserSnapshot(page);
+            assertReadableUserSnapshot(snapshot);
             const nextResults = extractXhsUserNotes(snapshot ?? {}, userId);
             if (nextResults.length <= previousCount)
                 break;

--- a/clis/xiaohongshu/user.js
+++ b/clis/xiaohongshu/user.js
@@ -35,8 +35,11 @@ export function assertReadableUserSnapshot(snapshot) {
     if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
         throw new CommandExecutionError('Malformed Xiaohongshu user snapshot');
     }
-    if (snapshot.storePresent === false || (!snapshot.notesPresent && !snapshot.pageDataPresent)) {
+    if (snapshot.storePresent !== true) {
         throw new CommandExecutionError('Malformed Xiaohongshu user snapshot: user store was not found');
+    }
+    if (snapshot.notesPresent !== true || !Array.isArray(snapshot.noteGroups)) {
+        throw new CommandExecutionError('Malformed Xiaohongshu user snapshot: notes array was not found');
     }
 }
 export const command = cli({

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -443,7 +443,14 @@ cli({
             throw new CommandExecutionError(`Failed to get caption info: ${typeof captionData === 'string' ? captionData : 'malformed response'}`);
         }
         if (captionData?.error) {
-            throw new CommandExecutionError(`${captionData.error}${captionData.available ? ' (available: ' + captionData.available.join(', ') + ')' : ''}`);
+            const msg = `${captionData.error}${captionData.available ? ' (available: ' + captionData.available.join(', ') + ')' : ''}`;
+            // "No captions available" 是合法 empty 数据条件（作者没开字幕 + YT 没自动生成），
+            // 与 bilibili subtitle 的 EmptyResultError 同模式。下游应按 code EMPTY_RESULT 跳过
+            // 重试和 softFail 计数。其它 error（HTTP / parse / 短暂空响应）仍按 fetch 失败抛。
+            if (/no captions available/i.test(captionData.error)) {
+                throw new EmptyResultError('youtube transcript', '该视频没有字幕（作者未开启 + 无自动字幕）。');
+            }
+            throw new CommandExecutionError(msg);
         }
         if (!segments && typeof captionData?.captionUrl !== 'string') {
             throw new CommandExecutionError('Malformed caption info payload');

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -447,7 +447,7 @@ cli({
             // "No captions available" 是合法 empty 数据条件（作者没开字幕 + YT 没自动生成），
             // 与 bilibili subtitle 的 EmptyResultError 同模式。下游应按 code EMPTY_RESULT 跳过
             // 重试和 softFail 计数。其它 error（HTTP / parse / 短暂空响应）仍按 fetch 失败抛。
-            if (/no captions available/i.test(captionData.error)) {
+            if (captionData.error === 'No captions available for this video') {
                 throw new EmptyResultError('youtube transcript', '该视频没有字幕（作者未开启 + 无自动字幕）。');
             }
             throw new CommandExecutionError(msg);

--- a/clis/youtube/transcript.test.js
+++ b/clis/youtube/transcript.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './transcript.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -251,6 +252,26 @@ describe('youtube transcript caption fetch', () => {
             code: 'COMMAND_EXEC',
             message: expect.stringContaining('Malformed caption info payload'),
         });
+    });
+
+    it('maps explicit no-captions watch metadata to EmptyResultError', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+        page.evaluate.mockReset();
+        page.evaluate
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ error: 'No captions available for this video' });
+
+        await expect(command.func(page, { url: 'abc', mode: 'raw' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('keeps malformed watch metadata as CommandExecutionError', async () => {
+        const page = createPageMock('https://www.youtube.com/api/timedtext?v=abc&lang=en');
+        page.evaluate.mockReset();
+        page.evaluate
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ error: 'ytInitialPlayerResponse not found in watch HTML' });
+
+        await expect(command.func(page, { url: 'abc', mode: 'raw' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('fails typed on malformed captured timedtext json3', async () => {


### PR DESCRIPTION
## 背景

把 `xiaohongshu/user` 和 `youtube/transcript` 跟 `bilibili/subtitle` 已有的 structured-error 模式对齐，让下游能区分**"用户/视频没内容"**和**"fetch 真的挂了"**。这两种情况以前都被当成 generic error，调用方拿不到正确信号。

## 改动 (#1)：xiaohongshu user

**场景**：目标用户零公开笔记（销号 / 私密号 / 全删）。

```
xhs user some_user_id
  → No public notes found for this Xiaohongshu user.
```

- **旧**：`throw new Error(...)` —— 下游收到的是 plain JS Error，跟"cookie 死 / 网络挂 / WAF 拦截"无法区分
- **新**：`throw new EmptyResultError('xiaohongshu user', '该用户没有公开笔记（可能销号 / 私密 / 全部删除）。')` —— exit code 66，stderr 带 `code: EMPTY_RESULT`，跟 `bilibili subtitle` empty 同 shape

## 改动 (#2)：youtube transcript

**场景**：视频确实没字幕（作者没开 CC、YouTube 也没自动生成）——watch 页明确返回 `No captions available for this video`。

- **旧**：跟"HTTP 错误 / 解析错误 / empty response"一样抛 `CommandExecutionError` —— 调用方对每个失败做 retry，本来真没字幕的视频被反复重试浪费配额
- **新**：仅这个特定 case 抛 `EmptyResultError`；**其他**字幕错误（HTTP / parse / 空响应）继续走 `CommandExecutionError` 触发重试

## 为什么 downstream 需要这个

调用方（自动化采集流水线、批量字幕导出工具）通常对 "data.length === 0 && exitCode !== 0" 做 **soft-rate-limit 启发式**：N 次连续 soft fail 后写 24h 平台跳过 flag。

当 seed 列表里有变质条目（XHS 账号销号 / YouTube 视频删除字幕）：
- "empty" 响应在统计里堆积
- 跳过 flag 触发——但 cookies 和平台本身都健康
- **整个平台被误判挂掉，业务连带降级**

`EmptyResultError` 让调用方能区分"这个用户/视频没内容（跳过即可）"和"API 真挂了（应该 retry / 告警）"。

跟 `bilibili subtitle` 的处理对齐，bilibili 已经在用这套模式很久了。

## 测试

- `npx vitest run clis/xiaohongshu clis/youtube` —— 16 文件 / 166 测试全过
- `npx tsc --noEmit` 干净

## 兼容性

**有 behavior change**：
- exit code：以前是 `1`（generic Error）/ `1`（CommandExecutionError），现在 empty case 是 `66`（`EmptyResultError` 标准 code）
- stderr：以前是错误消息，现在 carry `code: EMPTY_RESULT`

调用方如果之前 hard-code 检查 exit code === 1 / 错误消息，需要适配。但这就是这个 PR 的**目标**——让"empty"成为独立 signal。

跟 `bilibili subtitle` 已有行为对齐，没引入新模式。