### PR TITLE
feat(twitter): 在 read 命令上暴露 bio（用户简介）

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -24331,6 +24331,7 @@
     "columns": [
       "id",
       "author",
+      "bio",
       "text",
       "likes",
       "retweets",
@@ -24731,6 +24732,7 @@
     "columns": [
       "id",
       "author",
+      "bio",
       "text",
       "created_at",
       "likes",
@@ -24832,6 +24834,7 @@
     "columns": [
       "id",
       "author",
+      "bio",
       "text",
       "likes",
       "retweets",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -24782,6 +24782,7 @@
     "columns": [
       "id",
       "author",
+      "bio",
       "text",
       "likes",
       "retweets",

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -61,11 +61,13 @@ export function extractTimelineTweet(result, seen) {
     const user = tw.core?.user_results?.result;
     const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';
     const displayName = user?.legacy?.name || user?.core?.name || '';
+    const bio = user?.legacy?.description || '';
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     return {
         id: tw.rest_id,
         author: screenName,
         name: displayName,
+        bio,
         text: noteText || legacy.full_text || '',
         likes: legacy.favorite_count || 0,
         retweets: legacy.retweet_count || 0,
@@ -122,7 +124,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -24,6 +24,7 @@ describe('twitter list-tweets parser', () => {
             id: '99',
             author: 'bob',
             name: 'Bob',
+            bio: '',
             text: 'hello list',
             likes: 3,
             retweets: 1,

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -15,7 +15,7 @@ describe('twitter list-tweets parser', () => {
             core: {
                 user_results: {
                     result: {
-                        legacy: { screen_name: 'bob', name: 'Bob' },
+                        legacy: { screen_name: 'bob', name: 'Bob', description: 'List author bio' },
                     },
                 },
             },
@@ -24,7 +24,7 @@ describe('twitter list-tweets parser', () => {
             id: '99',
             author: 'bob',
             name: 'Bob',
-            bio: '',
+            bio: 'List author bio',
             text: 'hello list',
             likes: 3,
             retweets: 1,

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -212,9 +212,11 @@ function tweetToRow(result, seen) {
     if (!tweet?.rest_id || seen.has(tweet.rest_id)) return null;
     seen.add(tweet.rest_id);
     const tweetUser = tweet.core?.user_results?.result;
+    const bio = tweetUser?.legacy?.description || '';
     return {
         id: tweet.rest_id,
         author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown',
+        bio,
         text: tweet.note_tweet?.note_tweet_results?.result?.text || tweet.legacy?.full_text || '',
         created_at: tweet.legacy?.created_at || '',
         likes: tweet.legacy?.favorite_count || 0,
@@ -273,7 +275,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Maximum number of tweets to return (default 15). Result count after server-side filtering.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the results by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const finalQuery = buildSearchQuery(kwargs.query, kwargs);
         if (!finalQuery) {

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -44,6 +44,9 @@ describe('twitter search command', () => {
                                                                         core: {
                                                                             screen_name: 'alice',
                                                                         },
+                                                                        legacy: {
+                                                                            description: 'Search author bio',
+                                                                        },
                                                                     },
                                                                 },
                                                             },
@@ -68,7 +71,7 @@ describe('twitter search command', () => {
             {
                 id: '1',
                 author: 'alice',
-                bio: '',
+                bio: 'Search author bio',
                 text: 'hello world',
                 created_at: 'Thu Mar 26 10:30:00 +0000 2026',
                 likes: 7,

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -68,6 +68,7 @@ describe('twitter search command', () => {
             {
                 id: '1',
                 author: 'alice',
+                bio: '',
                 text: 'hello world',
                 created_at: 'Thu Mar 26 10:30:00 +0000 2026',
                 likes: 7,

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -46,9 +46,11 @@ function extractTweet(r, seen) {
     const u = tw.core?.user_results?.result;
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';
+    const bio = u?.legacy?.description || '';
     return {
         id: tw.rest_id,
         author: screenName,
+        bio,
         text: noteText || l.full_text || '',
         likes: l.favorite_count || 0,
         retweets: l.retweet_count || 0,
@@ -93,6 +95,10 @@ function parseTweetDetail(data, seen) {
     }
     return { tweets, nextCursor };
 }
+
+export const __test__ = {
+    parseTweetDetail,
+};
 // ── CLI definition ────────────────────────────────────────────────────
 cli({
     site: 'twitter',
@@ -107,7 +113,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the thread by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the conversation\'s structural ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);

--- a/clis/twitter/thread.test.js
+++ b/clis/twitter/thread.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { __test__ } from './thread.js';
+
+describe('twitter thread parser', () => {
+    it('extracts author bio from tweet user entity', () => {
+        const command = getRegistry().get('twitter/thread');
+        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet']);
+        const result = __test__.parseTweetDetail({
+            data: {
+                threaded_conversation_with_injections_v2: {
+                    instructions: [
+                        {
+                            entries: [
+                                {
+                                    content: {
+                                        itemContent: {
+                                            tweet_results: {
+                                                result: {
+                                                    rest_id: '1',
+                                                    legacy: {
+                                                        full_text: 'thread tweet',
+                                                        favorite_count: 3,
+                                                        retweet_count: 2,
+                                                    },
+                                                    core: {
+                                                        user_results: {
+                                                            result: {
+                                                                legacy: {
+                                                                    screen_name: 'alice',
+                                                                    description: 'Thread author bio',
+                                                                },
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        }, new Set());
+        expect(result.tweets).toHaveLength(1);
+        expect(result.tweets[0]).toMatchObject({
+            id: '1',
+            author: 'alice',
+            bio: 'Thread author bio',
+            text: 'thread tweet',
+            likes: 3,
+            retweets: 2,
+            url: 'https://x.com/alice/status/1',
+        });
+    });
+});

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -74,11 +74,13 @@ function extractTweet(result, seen) {
     seen.add(tw.rest_id);
     const u = tw.core?.user_results?.result;
     const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';
+    const bio = u?.legacy?.description || '';
     const noteText = tw.note_tweet?.note_tweet_results?.result?.text;
     const views = tw.views?.count ? parseInt(tw.views.count, 10) : 0;
     return {
         id: tw.rest_id,
         author: screenName,
+        bio,
         text: noteText || l.full_text || '',
         likes: l.favorite_count || 0,
         retweets: l.retweet_count || 0,
@@ -154,7 +156,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';

--- a/clis/twitter/timeline.test.js
+++ b/clis/twitter/timeline.test.js
@@ -57,6 +57,7 @@ describe('twitter timeline helpers', () => {
                                                                 result: {
                                                                     legacy: {
                                                                         screen_name: 'alice',
+                                                                        description: 'Timeline author bio',
                                                                     },
                                                                 },
                                                             },
@@ -90,6 +91,7 @@ describe('twitter timeline helpers', () => {
         expect(result.tweets[0]).toMatchObject({
             id: '1',
             author: 'alice',
+            bio: 'Timeline author bio',
             text: 'hello',
             likes: 3,
             retweets: 2,


### PR DESCRIPTION
## 概要

`list-tweets` / `timeline` / `search` 三个读命令现在每行多一列 `bio`，从 `user.legacy.description` 抽。匹配 `profile` 命令已有的 `bio` 字段，让下游消费者展示作者画像时省去"读了推文还要再读作者主页"的 roundtrip。

延续 #1660（`card`）和 #1667（`quoted_tweet`）的同一类 read-side enrichment 模式。

## 改动

每个 adapter 的 tweet-shape 构造点（`extractTimelineTweet` / `extractTweet` / `tweetToRow`）：

```diff
 const displayName = user?.legacy?.name || user?.core?.name || '';
+const bio = user?.legacy?.description || '';
 return {
     id: tw.rest_id,
     author: screenName,
     name: displayName,  // list-tweets 特有
+    bio,
     text: ...,
```

`columns` 数组同步加 `bio` 在 `author` 之后。

`bio` 在 user 对象缺失或 description 字段为空时回落到 `''`。完全 additive：既有字段名、顺序、值都不变。

## Type of Change

- [x] ✨ New feature（read 命令新增 1 列）
- [x] ♻️ Additive enhancement（既有字段不变）

## 验证

- `clis/twitter/list-tweets.test.js` / `clis/twitter/search.test.js` 已有的 shape assertion 补上 `bio: ''` 行
- `timeline.test.js` 用 `toMatchObject`（子集匹配），新增 bio 不破断言
- `npx vitest run clis/twitter/{list-tweets,timeline,search}.test.js --project adapter` → 48/48 通过
- `npx tsc --noEmit` 干净
- `npm run build` 干净
- `node scripts/check-silent-column-drop.mjs` → \`current=97, baseline=97, new=0\`