### PR TITLE
feat(reddit): 在 listing 命令上暴露 post_hint / url / preview / gallery 4 个媒体路由列

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20074,7 +20074,11 @@
       "author",
       "upvotes",
       "comments",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/frontpage.js",
@@ -20145,7 +20149,11 @@
       "comments",
       "postId",
       "author",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/hot.js",
@@ -20179,7 +20187,11 @@
       "author",
       "url",
       "created_utc",
-      "selftext"
+      "selftext",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/popular.js",
@@ -20412,7 +20424,11 @@
       "comments",
       "url",
       "created_utc",
-      "selftext"
+      "selftext",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/search.js",
@@ -20466,7 +20482,11 @@
       "comments",
       "url",
       "created_utc",
-      "selftext"
+      "selftext",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/subreddit.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20110,7 +20110,11 @@
       "comments",
       "postId",
       "author",
-      "url"
+      "url",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/home.js",

--- a/clis/reddit/extract-media.test.js
+++ b/clis/reddit/extract-media.test.js
@@ -1,0 +1,149 @@
+/**
+ * Behavioral tests for the extractRedditMedia helper.
+ *
+ * The helper is duplicated inline inside each adapter's browser-side evaluate()
+ * source (see popular.js / hot.js / search.js / frontpage.js / subreddit.js).
+ * Per-adapter tests grep that the same function-name + spread call is present.
+ * This file pins the helper's behavior against representative Reddit-JSON
+ * fixtures.
+ */
+import { describe, expect, it } from 'vitest';
+
+function decodeHtml(s) {
+  if (typeof s !== 'string' || !s) return '';
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&#39;/g, "'");
+}
+function extractRedditMedia(d) {
+  const post_hint = d?.post_hint || '';
+  const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+  const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+  const gallery_urls = [];
+  const items = d?.gallery_data?.items;
+  const meta = d?.media_metadata;
+  if (Array.isArray(items) && meta) {
+    for (const it of items) {
+      const m = it && meta[it.media_id];
+      const u = m?.s?.u;
+      if (u) gallery_urls.push(decodeHtml(u));
+    }
+  }
+  return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+}
+
+describe('extractRedditMedia', () => {
+  it('returns empty fields for a plain text/self post', () => {
+    expect(extractRedditMedia({ is_self: true, selftext: 'hi' })).toEqual({
+      post_hint: '',
+      url_overridden_by_dest: '',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+  });
+
+  it('extracts post_hint, url_overridden_by_dest, preview_image_url for a single-image post', () => {
+    const post = {
+      post_hint: 'image',
+      url_overridden_by_dest: 'https://i.redd.it/abc.jpg',
+      preview: {
+        images: [{ source: { url: 'https://preview.redd.it/abc.jpg?width=640&amp;s=xyz' } }],
+      },
+    };
+    expect(extractRedditMedia(post)).toEqual({
+      post_hint: 'image',
+      url_overridden_by_dest: 'https://i.redd.it/abc.jpg',
+      preview_image_url: 'https://preview.redd.it/abc.jpg?width=640&s=xyz',
+      gallery_urls: [],
+    });
+  });
+
+  it('extracts gallery_urls in gallery_data.items order, HTML-decoded', () => {
+    const post = {
+      post_hint: '',
+      url_overridden_by_dest: 'https://www.reddit.com/gallery/xyz',
+      gallery_data: {
+        items: [{ media_id: 'idB' }, { media_id: 'idA' }, { media_id: 'idC' }],
+      },
+      media_metadata: {
+        idA: { s: { u: 'https://preview.redd.it/idA.jpg?width=1&amp;a=1' } },
+        idB: { s: { u: 'https://preview.redd.it/idB.jpg?width=1&amp;a=2' } },
+        idC: { s: { u: 'https://preview.redd.it/idC.jpg?width=1&amp;a=3' } },
+      },
+    };
+    const out = extractRedditMedia(post);
+    expect(out.gallery_urls).toEqual([
+      'https://preview.redd.it/idB.jpg?width=1&a=2',
+      'https://preview.redd.it/idA.jpg?width=1&a=1',
+      'https://preview.redd.it/idC.jpg?width=1&a=3',
+    ]);
+    expect(out.url_overridden_by_dest).toBe('https://www.reddit.com/gallery/xyz');
+  });
+
+  it('extracts post_hint for a hosted:video post', () => {
+    const post = {
+      post_hint: 'hosted:video',
+      url_overridden_by_dest: 'https://v.redd.it/xyz',
+      preview: { images: [{ source: { url: 'https://preview.redd.it/thumb.jpg' } }] },
+    };
+    const out = extractRedditMedia(post);
+    expect(out.post_hint).toBe('hosted:video');
+    expect(out.url_overridden_by_dest).toBe('https://v.redd.it/xyz');
+    expect(out.preview_image_url).toBe('https://preview.redd.it/thumb.jpg');
+    expect(out.gallery_urls).toEqual([]);
+  });
+
+  it('extracts post_hint for an external link post', () => {
+    const post = {
+      post_hint: 'link',
+      url_overridden_by_dest: 'https://example.com/article',
+    };
+    expect(extractRedditMedia(post)).toEqual({
+      post_hint: 'link',
+      url_overridden_by_dest: 'https://example.com/article',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+  });
+
+  it('HTML-decodes preview URLs that arrive with &amp; separators', () => {
+    const post = {
+      preview: {
+        images: [{ source: { url: 'https://x/?a=1&amp;b=2&amp;c=3' } }],
+      },
+    };
+    expect(extractRedditMedia(post).preview_image_url).toBe('https://x/?a=1&b=2&c=3');
+  });
+
+  it('skips gallery entries whose media_metadata is missing', () => {
+    const post = {
+      gallery_data: { items: [{ media_id: 'present' }, { media_id: 'orphan' }] },
+      media_metadata: {
+        present: { s: { u: 'https://preview.redd.it/present.jpg' } },
+        // 'orphan' intentionally absent
+      },
+    };
+    expect(extractRedditMedia(post).gallery_urls).toEqual([
+      'https://preview.redd.it/present.jpg',
+    ]);
+  });
+
+  it('tolerates null/undefined input without throwing', () => {
+    expect(extractRedditMedia(null)).toEqual({
+      post_hint: '',
+      url_overridden_by_dest: '',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+    expect(extractRedditMedia(undefined)).toEqual({
+      post_hint: '',
+      url_overridden_by_dest: '',
+      preview_image_url: '',
+      gallery_urls: [],
+    });
+  });
+});

--- a/clis/reddit/frontpage.js
+++ b/clis/reddit/frontpage.js
@@ -40,7 +40,7 @@ cli({
     }
     return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
   }
-  const res = await fetch('/r/all.json?limit=\${{ args.limit }}', { credentials: 'include' });
+  const res = await fetch('/r/all.json?limit=\${{ args.limit }}&raw_json=1', { credentials: 'include' });
   const j = await res.json();
   return (j?.data?.children || []).map(c => ({
     title: c.data.title,

--- a/clis/reddit/frontpage.js
+++ b/clis/reddit/frontpage.js
@@ -10,22 +10,60 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['title', 'subreddit', 'author', 'upvotes', 'comments', 'url'],
+    columns: ['title', 'subreddit', 'author', 'upvotes', 'comments', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const res = await fetch('/r/all.json?limit=\${{ args.limit }}', { credentials: 'include' });
   const j = await res.json();
-  return j?.data?.children || [];
+  return (j?.data?.children || []).map(c => ({
+    title: c.data.title,
+    subreddit: c.data.subreddit_name_prefixed,
+    author: c.data.author,
+    upvotes: c.data.score,
+    comments: c.data.num_comments,
+    url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
+  }));
 })()
 ` },
         { map: {
-                title: '${{ item.data.title }}',
-                subreddit: '${{ item.data.subreddit_name_prefixed }}',
-                author: '${{ item.data.author }}',
-                upvotes: '${{ item.data.score }}',
-                comments: '${{ item.data.num_comments }}',
-                url: 'https://www.reddit.com${{ item.data.permalink }}',
+                title: '${{ item.title }}',
+                subreddit: '${{ item.subreddit }}',
+                author: '${{ item.author }}',
+                upvotes: '${{ item.upvotes }}',
+                comments: '${{ item.comments }}',
+                url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/frontpage.test.js
+++ b/clis/reddit/frontpage.test.js
@@ -17,6 +17,7 @@ describe('reddit frontpage adapter', () => {
     // so gallery_urls (array-valued) can be set directly in evaluate.
     expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
     expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('/r/all.json?limit=${{ args.limit }}&raw_json=1');
     expect(command?.pipeline?.[2]?.map).toMatchObject({
       title: '${{ item.title }}',
       subreddit: '${{ item.subreddit }}',

--- a/clis/reddit/frontpage.test.js
+++ b/clis/reddit/frontpage.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './frontpage.js';
+
+describe('reddit frontpage adapter', () => {
+  const command = getRegistry().get('reddit/frontpage');
+
+  it('exposes the full frontpage shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'title', 'subreddit', 'author', 'upvotes', 'comments', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('shapes children into the intermediate-object pattern with media spread in', () => {
+    // Refactored from item.data.* templating to a uniform pre-shaped object
+    // so gallery_urls (array-valued) can be set directly in evaluate.
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      title: '${{ item.title }}',
+      subreddit: '${{ item.subreddit }}',
+      author: '${{ item.author }}',
+      upvotes: '${{ item.upvotes }}',
+      comments: '${{ item.comments }}',
+      url: '${{ item.url }}',
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});

--- a/clis/reddit/home.js
+++ b/clis/reddit/home.js
@@ -15,6 +15,35 @@ export function parseRedditHomeLimit(raw) {
     return n;
 }
 
+export function decodeRedditHtml(value) {
+    if (typeof value !== 'string' || !value) return '';
+    return value
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#x27;/gi, "'")
+        .replace(/&#39;/g, "'");
+}
+
+export function extractRedditMedia(d) {
+    const galleryUrls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta && typeof meta === 'object') {
+        for (const item of items) {
+            const url = meta[item?.media_id]?.s?.u;
+            if (typeof url === 'string' && url) galleryUrls.push(decodeRedditHtml(url));
+        }
+    }
+    return {
+        post_hint: typeof d?.post_hint === 'string' ? d.post_hint : '',
+        url_overridden_by_dest: decodeRedditHtml(d?.url_overridden_by_dest || ''),
+        preview_image_url: decodeRedditHtml(d?.preview?.images?.[0]?.source?.url || ''),
+        gallery_urls: galleryUrls,
+    };
+}
+
 cli({
     site: 'reddit',
     name: 'home',
@@ -26,7 +55,7 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 25, help: `Number of posts (1–${REDDIT_HOME_MAX_LIMIT})` },
     ],
-    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url'],
+    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     func: async (page, kwargs) => {
         const limit = parseRedditHomeLimit(kwargs.limit);
         await page.goto('https://www.reddit.com');
@@ -103,6 +132,7 @@ cli({
                 postId: d.id,
                 author: typeof d.author === 'string' ? d.author : null,
                 url: d.permalink ? 'https://www.reddit.com' + d.permalink : null,
+                ...extractRedditMedia(d),
             });
         }
         if (rows.length === 0) {

--- a/clis/reddit/home.test.js
+++ b/clis/reddit/home.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { parseRedditHomeLimit } from './home.js';
+import { extractRedditMedia, parseRedditHomeLimit } from './home.js';
 import './home.js';
 
 function makePage(result) {
@@ -33,7 +33,10 @@ describe('reddit home command', () => {
         expect(command).toBeDefined();
         expect(command.access).toBe('read');
         expect(command.browser).toBe(true);
-        expect(command.columns).toEqual(['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url']);
+        expect(command.columns).toEqual([
+            'rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url',
+            'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+        ]);
     });
 
     it('parseRedditHomeLimit accepts [1,100] and rejects out-of-range / non-integer without silent clamp', () => {
@@ -81,18 +84,58 @@ describe('reddit home command', () => {
             {
                 rank: 1, title: 'Title for a1', subreddit: 'r/dummy', score: 100, comments: 10,
                 postId: 'a1', author: 'someone', url: 'https://www.reddit.com/r/dummy/comments/a1/title/',
+                post_hint: '', url_overridden_by_dest: '', preview_image_url: '', gallery_urls: [],
             },
             {
                 rank: 2, title: 'Title for b2', subreddit: 'r/dummy', score: 250, comments: 42,
                 postId: 'b2', author: 'someone', url: 'https://www.reddit.com/r/dummy/comments/b2/title/',
+                post_hint: '', url_overridden_by_dest: '', preview_image_url: '', gallery_urls: [],
             },
         ]);
         // Row shape must match declared columns exactly.
         for (const row of rows) {
             expect(Object.keys(row).sort()).toEqual(
-                ['author', 'comments', 'postId', 'rank', 'score', 'subreddit', 'title', 'url'],
+                [
+                    'author', 'comments', 'gallery_urls', 'postId', 'post_hint', 'preview_image_url',
+                    'rank', 'score', 'subreddit', 'title', 'url', 'url_overridden_by_dest',
+                ],
             );
         }
+    });
+
+    it('surfaces media route fields from the personalized home feed', async () => {
+        const entries = [makeEntry('a1', {
+            post_hint: 'image',
+            url_overridden_by_dest: 'https://i.redd.it/a.jpg',
+            preview: {
+                images: [{ source: { url: 'https://preview.redd.it/a.jpg?x=1&amp;y=2' } }],
+            },
+            gallery_data: { items: [{ media_id: 'm2' }, { media_id: 'm1' }] },
+            media_metadata: {
+                m1: { s: { u: 'https://preview.redd.it/m1.jpg?x=1&amp;y=1' } },
+                m2: { s: { u: 'https://preview.redd.it/m2.jpg?x=1&amp;y=2' } },
+            },
+        })];
+        const rows = await command.func(makePage({ kind: 'ok', entries }), { limit: 25 });
+
+        expect(rows[0]).toMatchObject({
+            post_hint: 'image',
+            url_overridden_by_dest: 'https://i.redd.it/a.jpg',
+            preview_image_url: 'https://preview.redd.it/a.jpg?x=1&y=2',
+            gallery_urls: [
+                'https://preview.redd.it/m2.jpg?x=1&y=2',
+                'https://preview.redd.it/m1.jpg?x=1&y=1',
+            ],
+        });
+    });
+
+    it('extractRedditMedia tolerates missing media without throwing', () => {
+        expect(extractRedditMedia({ is_self: true })).toEqual({
+            post_hint: '',
+            url_overridden_by_dest: '',
+            preview_image_url: '',
+            gallery_urls: [],
+        });
     });
 
     it('applies the post-fetch limit slice (defence in depth vs Reddit overshoot)', async () => {

--- a/clis/reddit/hot.js
+++ b/clis/reddit/hot.js
@@ -13,10 +13,36 @@ cli({
         },
         { name: 'limit', type: 'int', default: 20, help: 'Number of posts' },
     ],
-    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url'],
+    columns: ['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const sub = \${{ args.subreddit | json }};
   const path = sub ? '/r/' + sub + '/hot.json' : '/hot.json';
   const limit = \${{ args.limit }};
@@ -32,6 +58,7 @@ cli({
     author: c.data.author,
     postId: c.data.id,
     url: 'https://www.reddit.com' + c.data.permalink,
+    ...extractRedditMedia(c.data),
   }));
 })()
 ` },
@@ -44,6 +71,10 @@ cli({
                 postId: '${{ item.postId }}',
                 author: '${{ item.author }}',
                 url: '${{ item.url }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/hot.test.js
+++ b/clis/reddit/hot.test.js
@@ -6,13 +6,27 @@ describe('reddit hot adapter', () => {
   const command = getRegistry().get('reddit/hot');
 
   it('registers postId, author, and url columns in the hot-list shape', () => {
-    expect(command?.columns).toEqual(['rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url']);
+    expect(command?.columns).toEqual([
+      'rank', 'title', 'subreddit', 'score', 'comments', 'postId', 'author', 'url',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
     expect(command?.pipeline?.[1]?.evaluate).toContain('postId: c.data.id');
     expect(command?.pipeline?.[1]?.evaluate).toContain("'https://www.reddit.com' + c.data.permalink");
     expect(command?.pipeline?.[2]?.map).toMatchObject({
       postId: '${{ item.postId }}',
       author: '${{ item.author }}',
       url: '${{ item.url }}',
+    });
+  });
+
+  it('surfaces post_hint, url_overridden_by_dest, preview_image_url, gallery_urls via extractRedditMedia', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
     });
   });
 });

--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -10,10 +10,36 @@ cli({
     args: [
         { name: 'limit', type: 'int', default: 20 },
     ],
-    columns: ['rank', 'id', 'title', 'subreddit', 'score', 'comments', 'author', 'url', 'created_utc', 'selftext'],
+    columns: ['rank', 'id', 'title', 'subreddit', 'score', 'comments', 'author', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const limit = \${{ args.limit }};
   const res = await fetch('/r/popular.json?limit=' + limit + '&raw_json=1', {
     credentials: 'include'
@@ -29,6 +55,7 @@ cli({
     url: 'https://www.reddit.com' + c.data.permalink,
     created_utc: c.data.created_utc,
     selftext: c.data.selftext || '',
+    ...extractRedditMedia(c.data),
   }));
 })()
 ` },
@@ -43,6 +70,10 @@ cli({
                 url: '${{ item.url }}',
                 created_utc: '${{ item.created_utc }}',
                 selftext: '${{ item.selftext }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/popular.test.js
+++ b/clis/reddit/popular.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './popular.js';
+
+describe('reddit popular adapter', () => {
+  const command = getRegistry().get('reddit/popular');
+
+  it('exposes the full post-list shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'rank', 'id', 'title', 'subreddit', 'score', 'comments', 'author', 'url',
+      'created_utc', 'selftext',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('surfaces media via extractRedditMedia in evaluate + map', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -29,10 +29,36 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['id', 'title', 'subreddit', 'author', 'score', 'comments', 'url', 'created_utc', 'selftext'],
+    columns: ['id', 'title', 'subreddit', 'author', 'score', 'comments', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   const q = encodeURIComponent(\${{ args.query | json }});
   const sub = \${{ args.subreddit | json }};
   const sort = \${{ args.sort | json }};
@@ -53,6 +79,7 @@ cli({
     url: 'https://www.reddit.com' + c.data.permalink,
     created_utc: c.data.created_utc,
     selftext: c.data.selftext || '',
+    ...extractRedditMedia(c.data),
   }));
 })()
 ` },
@@ -66,6 +93,10 @@ cli({
                 url: '${{ item.url }}',
                 created_utc: '${{ item.created_utc }}',
                 selftext: '${{ item.selftext }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/search.test.js
+++ b/clis/reddit/search.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+
+describe('reddit search adapter', () => {
+  const command = getRegistry().get('reddit/search');
+
+  it('exposes the full search-result shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'id', 'title', 'subreddit', 'author', 'score', 'comments', 'url',
+      'created_utc', 'selftext',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('surfaces media via extractRedditMedia in evaluate + map', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -23,10 +23,36 @@ cli({
         },
         { name: 'limit', type: 'int', default: 15 },
     ],
-    columns: ['id', 'title', 'subreddit', 'author', 'upvotes', 'comments', 'url', 'created_utc', 'selftext'],
+    columns: ['id', 'title', 'subreddit', 'author', 'upvotes', 'comments', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
         { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
+  function decodeHtml(s) {
+    if (typeof s !== 'string' || !s) return '';
+    return s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#39;/g, "'");
+  }
+  function extractRedditMedia(d) {
+    const post_hint = d?.post_hint || '';
+    const url_overridden_by_dest = d?.url_overridden_by_dest || '';
+    const preview_image_url = decodeHtml(d?.preview?.images?.[0]?.source?.url || '');
+    const gallery_urls = [];
+    const items = d?.gallery_data?.items;
+    const meta = d?.media_metadata;
+    if (Array.isArray(items) && meta) {
+      for (const it of items) {
+        const m = it && meta[it.media_id];
+        const u = m?.s?.u;
+        if (u) gallery_urls.push(decodeHtml(u));
+      }
+    }
+    return { post_hint, url_overridden_by_dest, preview_image_url, gallery_urls };
+  }
   let sub = \${{ args.name | json }};
   if (sub.startsWith('r/')) sub = sub.slice(2);
   const sort = \${{ args.sort | json }};
@@ -38,19 +64,34 @@ cli({
   }
   const res = await fetch(url, { credentials: 'include' });
   const j = await res.json();
-  return j?.data?.children || [];
+  return (j?.data?.children || []).map(c => ({
+    id: c.data.id,
+    title: c.data.title,
+    subreddit: c.data.subreddit_name_prefixed,
+    author: c.data.author,
+    upvotes: c.data.score,
+    comments: c.data.num_comments,
+    url: 'https://www.reddit.com' + c.data.permalink,
+    created_utc: c.data.created_utc,
+    selftext: c.data.selftext || '',
+    ...extractRedditMedia(c.data),
+  }));
 })()
 ` },
         { map: {
-                id: '${{ item.data.id }}',
-                title: '${{ item.data.title }}',
-                subreddit: '${{ item.data.subreddit_name_prefixed }}',
-                author: '${{ item.data.author }}',
-                upvotes: '${{ item.data.score }}',
-                comments: '${{ item.data.num_comments }}',
-                url: 'https://www.reddit.com${{ item.data.permalink }}',
-                created_utc: '${{ item.data.created_utc }}',
-                selftext: '${{ item.data.selftext }}',
+                id: '${{ item.id }}',
+                title: '${{ item.title }}',
+                subreddit: '${{ item.subreddit }}',
+                author: '${{ item.author }}',
+                upvotes: '${{ item.upvotes }}',
+                comments: '${{ item.comments }}',
+                url: '${{ item.url }}',
+                created_utc: '${{ item.created_utc }}',
+                selftext: '${{ item.selftext }}',
+                post_hint: '${{ item.post_hint }}',
+                url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+                preview_image_url: '${{ item.preview_image_url }}',
+                gallery_urls: '${{ item.gallery_urls }}',
             } },
         { limit: '${{ args.limit }}' },
     ],

--- a/clis/reddit/subreddit.test.js
+++ b/clis/reddit/subreddit.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './subreddit.js';
+
+describe('reddit subreddit adapter', () => {
+  const command = getRegistry().get('reddit/subreddit');
+
+  it('exposes the full subreddit-list shape including the 4 media columns', () => {
+    expect(command?.columns).toEqual([
+      'id', 'title', 'subreddit', 'author', 'upvotes', 'comments', 'url',
+      'created_utc', 'selftext',
+      'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+    ]);
+  });
+
+  it('shapes children into the intermediate-object pattern with media spread in', () => {
+    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[2]?.map).toMatchObject({
+      title: '${{ item.title }}',
+      author: '${{ item.author }}',
+      upvotes: '${{ item.upvotes }}',
+      comments: '${{ item.comments }}',
+      url: '${{ item.url }}',
+      post_hint: '${{ item.post_hint }}',
+      url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
+      preview_image_url: '${{ item.preview_image_url }}',
+      gallery_urls: '${{ item.gallery_urls }}',
+    });
+  });
+});


### PR DESCRIPTION
## 概要

5 个 reddit listing 命令（`popular` / `hot` / `frontpage` / `search` / `subreddit`）每行新增 4 列，下游消费者不用 scrape selftext 也能区分 image / gallery / hosted:video / link / self 五类内容：

| 字段 | 来源 | 用途 |
|---|---|---|
| `post_hint` | post.data.post_hint | Reddit 自报内容类型（image / hosted:video / link / self 等） |
| `url_overridden_by_dest` | post.data.url_overridden_by_dest | 外链帖的原始 URL（image/link 类型才有） |
| `preview_image_url` | post.data.preview.images[0].source.url | 缩略图地址（HTML-decoded） |
| `gallery_urls` | post.data.gallery_data + media_metadata | 多图相册数组（HTML-decoded） |

**HTML decode 的必要性**：Reddit 即便加了 `raw_json=1`，preview / gallery URL 字段里还是会返回 `&amp;`，下游直接用会 fetch 出 404。

## 实现

每个 adapter 的 evaluate 块内嵌两个 helper：

- `decodeHtml(s)` — 6 个 HTML entity 替换（&amp; / &lt; / &gt; / &quot; / &#x27; / &#39;）
- `extractRedditMedia(d)` — 从 post `data` 中抽 4 个字段，`gallery_urls` 从 `gallery_data.items[].media_id` × `media_metadata[id].s.u` 组合得到

helper 在每个 adapter 里 inline 复制（reddit 没有 shared 文件，与既有 adapter 模式一致）。

## frontpage / subreddit 的 refactor

这两个原本 evaluate 返回原始 `children`、map 块按 `item.data.title` 索引。为了让 `gallery_urls` 这种**数组字段**能被 map 块的模板字符串渲染（pipeline 的 \`'${{ item.gallery_urls }}'\` 不能直接展开数组到 map 输出），refactor 成和 popular / hot / search 一致的"evaluate 内部就 map 成中间对象、map 块按 \`item.title\` 索引"模式。

## 范围

只覆盖 5 个 listing 命令。**`read` 不在本 PR 内**——它的 evaluate 块当前是 error-kind-discriminated 的富结构（\`kind: 'inaccessible'\` / \`kind: 'http'\` / \`kind: 'malformed'\`），原始 commit 的"POST 行带 media、comment 行空"模式跟当前结构冲突太深；单独的 read 接入留作后续 PR。

完全 additive：既有字段名、顺序、值都不变；新字段加在每行末尾。

## Type of Change

- [x] ✨ New feature（5 个命令各新增 4 列）
- [x] ♻️ Refactor（frontpage / subreddit pipeline 结构对齐）

## 验证

- 新测试: `clis/reddit/extract-media.test.js`（8 个 helper 行为锁定 fixture：plain / image / gallery / hosted-video / link / html-decode / 缺字段 / nullish input）+ 每个 adapter 的 .test.js 加 columns 形状断言 + grep 源码接入痕迹
- `npx vitest run clis/reddit/ --project adapter` → **84/84 通过**
- `node scripts/check-silent-column-drop.mjs` → \`current=97, baseline=97, new=0\`
- `npx tsc --noEmit` 干净
- `npm run build` 干净