### PR TITLE
fix(adapters): migrate empty-data throws to EmptyResultError across 5 commands (#1674 follow-up)

### DIFF
--- a/clis/powerchina/search.js
+++ b/clis/powerchina/search.js
@@ -2,7 +2,7 @@
  * PowerChina search — browser DOM extraction with multi-entry URL probing.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
   cleanText,
   normalizeDate,
@@ -215,7 +215,7 @@ cli({
     );
 
     if (rows.length === 0 && extractedRows.length > 0) {
-      throw new Error('[taxonomy=empty_result] site=powerchina command=search extracted only navigation/portal rows');
+      throw new EmptyResultError('powerchina search', 'extracted only navigation/portal rows, no bid entries matched');
     }
 
     if (rows.length === 0) {
@@ -227,7 +227,7 @@ cli({
         );
       }
       if (apiFailure) {
-        throw new Error(`[taxonomy=empty_result] site=powerchina command=search api/dom yielded no result: ${apiFailure}`);
+        throw new EmptyResultError('powerchina search', `api/dom yielded no result: ${apiFailure}`);
       }
     }
 

--- a/clis/powerchina/search.test.js
+++ b/clis/powerchina/search.test.js
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './search.js';
+import './search.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('powerchina search helpers', () => {
   it('builds candidate URLs with keyword variants', () => {
@@ -63,5 +70,24 @@ describe('powerchina search helpers', () => {
     expect(mapped?.title).toContain('电梯采购公告');
     expect(mapped?.date).toBe('2026-04-07');
     expect(mapped?.url).toBe('https://bid.powerchina.cn/newcbs/recpro-newmember/BidAnnouncementSummary/getInfo/2409419657');
+  });
+
+  it('throws EmptyResultError when extraction only finds navigation rows', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    const cmd = getRegistry().get('powerchina/search');
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue([
+        {
+          title: '首页',
+          url: 'https://bid.powerchina.cn/',
+          date: '',
+          contextText: '首页',
+        },
+      ]),
+    };
+
+    await expect(cmd.func(page, { query: '电梯', limit: 1 })).rejects.toBeInstanceOf(EmptyResultError);
   });
 });

--- a/clis/xiaohongshu/creator-note-detail.js
+++ b/clis/xiaohongshu/creator-note-detail.js
@@ -9,6 +9,7 @@
  * Requires: logged into creator.xiaohongshu.com in Chrome.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 const NOTE_DETAIL_DATETIME_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
 const NOTE_DETAIL_METRICS = [
     { label: '曝光数', section: '基础数据' },
@@ -337,7 +338,7 @@ cli({
         const rows = await fetchCreatorNoteDetailRows(page, noteId);
         const hasCoreMetric = rows.some((row) => row.section !== '笔记信息' && row.value);
         if (!hasCoreMetric) {
-            throw new Error('No note detail data found. Check note_id and login status for creator.xiaohongshu.com.');
+            throw new EmptyResultError('xiaohongshu creator-note-detail', 'No note detail data found. Check note_id and login status for creator.xiaohongshu.com.');
         }
         return rows;
     },

--- a/clis/xiaohongshu/creator-note-detail.test.js
+++ b/clis/xiaohongshu/creator-note-detail.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { appendAudienceRows, appendTrendRows, parseCreatorNoteDetailDomData, parseCreatorNoteDetailText } from './creator-note-detail.js';
 import './creator-note-detail.js';
@@ -287,5 +288,15 @@ describe('xiaohongshu creator-note-detail', () => {
         await cmd.func(page, { 'note-id': 'demo-note-id' });
         expect(page.wait).toHaveBeenCalledWith(expect.objectContaining({ time: expect.any(Number) }));
         expect(page.wait.mock.calls.length).toBeGreaterThanOrEqual(4);
+    });
+    it('throws EmptyResultError when the detail page exposes no metrics', async () => {
+        const cmd = getRegistry().get('xiaohongshu/creator-note-detail');
+        const page = createPageMock(undefined);
+        page.evaluate = vi.fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce('笔记数据详情\n暂无数据')
+            .mockResolvedValue(null);
+
+        await expect(cmd.func(page, { 'note-id': 'demo-note-id' })).rejects.toBeInstanceOf(EmptyResultError);
     });
 });

--- a/clis/xiaohongshu/creator-notes-summary.js
+++ b/clis/xiaohongshu/creator-notes-summary.js
@@ -5,6 +5,7 @@
  * returns one summary row per note, suitable for quick review or downstream JSON use.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { fetchCreatorNotes } from './creator-notes.js';
 import { fetchCreatorNoteDetailRows } from './creator-note-detail.js';
 function findDetailValue(rows, metric) {
@@ -61,7 +62,7 @@ cli({
         const limit = kwargs.limit || 3;
         const notes = await fetchCreatorNotes(page, limit);
         if (!notes.length) {
-            throw new Error('No notes found. Are you logged into creator.xiaohongshu.com?');
+            throw new EmptyResultError('xiaohongshu creator-notes-summary', 'No notes found. Ensure you are logged into creator.xiaohongshu.com and the account has published notes.');
         }
         const results = [];
         for (const [index, note] of notes.entries()) {

--- a/clis/xiaohongshu/creator-notes-summary.test.js
+++ b/clis/xiaohongshu/creator-notes-summary.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { summarizeCreatorNote } from './creator-notes-summary.js';
 import { getRegistry } from '@jackwener/opencli/registry';
 import * as creatorNotesModule from './creator-notes.js';
@@ -83,5 +84,11 @@ describe('xiaohongshu creator-notes-summary', () => {
         await cmd.func(page, { limit: 2 });
         expect(page.wait).toHaveBeenCalledWith(expect.objectContaining({ time: expect.any(Number) }));
         expect(page.wait.mock.calls).toHaveLength(1);
+    });
+    it('throws EmptyResultError when there are no notes to summarize', async () => {
+        const cmd = getRegistry().get('xiaohongshu/creator-notes-summary');
+        vi.spyOn(creatorNotesModule, 'fetchCreatorNotes').mockResolvedValue([]);
+
+        await expect(cmd.func({ wait: vi.fn() }, { limit: 2 })).rejects.toBeInstanceOf(EmptyResultError);
     });
 });

--- a/clis/xiaohongshu/creator-notes.js
+++ b/clis/xiaohongshu/creator-notes.js
@@ -8,6 +8,7 @@
  * Requires: logged into creator.xiaohongshu.com in Chrome.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 const DATE_LINE_RE = /^发布于 (\d{4}年\d{2}月\d{2}日 \d{2}:\d{2})$/;
 const METRIC_LINE_RE = /^\d+$/;
 const VISIBILITY_LINE_RE = /可见$/;
@@ -210,7 +211,7 @@ cli({
         const limit = kwargs.limit || 20;
         const notes = await fetchCreatorNotes(page, limit);
         if (!Array.isArray(notes) || notes.length === 0) {
-            throw new Error('No notes found. Are you logged into creator.xiaohongshu.com?');
+            throw new EmptyResultError('xiaohongshu creator-notes', 'No notes found. Ensure you are logged into creator.xiaohongshu.com and the account has published notes.');
         }
         return notes
             .slice(0, limit)

--- a/clis/xiaohongshu/creator-notes.test.js
+++ b/clis/xiaohongshu/creator-notes.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { parseCreatorNoteIdsFromHtml, parseCreatorNotesText } from './creator-notes.js';
 import './creator-notes.js';
@@ -188,5 +189,16 @@ describe('xiaohongshu creator-notes', () => {
             'aaaaaaaaaaaaaaaaaaaaaaaa',
             'dddddddddddddddddddddddd',
         ]);
+    });
+    it('throws EmptyResultError when the creator account has no notes', async () => {
+        const cmd = getRegistry().get('xiaohongshu/creator-notes');
+        const page = createPageMock(undefined);
+        page.evaluate = vi.fn()
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce({ text: '', html: '' });
+
+        await expect(cmd.func(page, { limit: 1 })).rejects.toBeInstanceOf(EmptyResultError);
     });
 });

--- a/clis/xiaohongshu/creator-stats.js
+++ b/clis/xiaohongshu/creator-stats.js
@@ -8,6 +8,7 @@
  * Requires: logged into creator.xiaohongshu.com in Chrome.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 cli({
     site: 'xiaohongshu',
     name: 'creator-stats',
@@ -52,7 +53,7 @@ cli({
         }
         const stats = data.data[period];
         if (!stats) {
-            throw new Error(`No data for period "${period}". Available: ${Object.keys(data.data).join(', ')}`);
+            throw new EmptyResultError('xiaohongshu creator-stats', `No data for period "${period}". Available: ${Object.keys(data.data).join(', ')}`);
         }
         // Format daily trend as sparkline-like summary
         const formatTrend = (list) => {

--- a/clis/xiaohongshu/creator-stats.test.js
+++ b/clis/xiaohongshu/creator-stats.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './creator-stats.js';
+
+describe('xiaohongshu creator-stats', () => {
+    it('throws EmptyResultError when the requested stats period has no data', async () => {
+        const cmd = getRegistry().get('xiaohongshu/creator-stats');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                data: {
+                    seven: null,
+                    thirty: {
+                        view_count: 1,
+                        view_list: [{ count: 1 }],
+                    },
+                },
+            }),
+        };
+
+        await expect(cmd.func(page, { period: 'seven' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});


### PR DESCRIPTION
Continues the structured-error migration owner started in #1674 (`fix(xhs,youtube): 把合法空数据语义切到 EmptyResultError`). Same motivation, applied to the next batch of adapters where `throw new Error('No <data>')` semantically means "the platform legitimately has no data for this target" rather than "fetch infrastructure broke".

This is cluster-4 in the silent-sentinel / empty-result migration thread (cluster-1 #1611, cluster-2 #1631, cluster-3 #1634 all merged).

## Description

5 commands, 6 throw sites migrated to `EmptyResultError`:

| File | Site count | Old message |
|------|-----------|-------------|
| `powerchina/search.js` | 2 | `[taxonomy=empty_result] ... extracted only navigation/portal rows` / `... api/dom yielded no result` |
| `xiaohongshu/creator-notes.js` | 1 | `No notes found. Are you logged into creator.xiaohongshu.com?` |
| `xiaohongshu/creator-notes-summary.js` | 1 | Same as above |
| `xiaohongshu/creator-stats.js` | 1 | `No data for period "X". Available: a, b, c` |
| `xiaohongshu/creator-note-detail.js` | 1 | `No note detail data found. Check note_id and login status...` |

The "is logged in" / "available periods" hints are preserved inside the `EmptyResultError` message so users can self-diagnose; only the error TYPE changes from plain `Error` to structured `EmptyResultError`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New site command
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Behaviour change

- Exit code on legitimate empty data: was `1` (generic), now `66` (EMPTY_RESULT).
- `stderr` now includes `code: EMPTY_RESULT`, matching `bilibili/subtitle`, `xhs/user`, `youtube/transcript` precedent.
- Pipeline callers can now distinguish "this powerchina query genuinely matched zero bids" from "powerchina DOM extraction broke and we should retry / page out". Same downstream win as #1674.

## Out of scope

The wide scan also surfaced these `throw new Error('No ...')` sites that are intentionally NOT included:

- `tiktok/{user,notifications,explore}.js`: the throws live INSIDE a `page.evaluate(\`...\`)` template literal and execute in browser context. The Node-side caller already regex-routes them via `throwTikTokPageContextError({ emptyPattern: /No videos found/, emptyTarget: 'tiktok user', ... })` into a proper `EmptyResultError`. Existing design is correct, no migration needed.
- `eastmoney/_secid.js` (`empty symbol`), `antigravity/serve.js` (`Empty user message`), `instagram/collection-create.js` / `collection-delete.js` (`Collection ... cannot be empty`): all input-validation throws, semantically `ArgumentError` territory, not `EmptyResultError`.

## Test plan

- [x] `npm run build`: manifest compiles
- [x] `npm run check:typed-error-lint`: passes (`current=145, baseline=145, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes
- [x] `npx vitest run --project adapter clis/powerchina/ clis/xiaohongshu/`: 143 tests passing in the affected adapters
- [x] Manual smoke: `node ./dist/src/main.js xiaohongshu creator-stats --period invalid` surfaces the EmptyResultError with the same content, just typed
