### PR TITLE
feat(chess/games): expose accuracy_white, accuracy_black, opening_name

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5335,7 +5335,10 @@
       "my_result",
       "opponent",
       "opponent_rating",
+      "accuracy_white",
+      "accuracy_black",
       "eco",
+      "opening_name",
       "url"
     ],
     "type": "js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5238,6 +5238,140 @@
     "navigateBefore": true
   },
   {
+    "site": "chess",
+    "name": "analyze",
+    "description": "Open a Chess.com game in the browser analysis board",
+    "access": "read",
+    "domain": "www.chess.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "game-url",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Full game URL, e.g. https://www.chess.com/game/live/168842570216"
+      }
+    ],
+    "columns": [
+      "kind",
+      "game_id",
+      "analysis_url"
+    ],
+    "type": "js",
+    "modulePath": "chess/analyze.js",
+    "sourceFile": "chess/analyze.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "chess",
+    "name": "game",
+    "description": "Chess.com single-game detail (white, black, result, ECO, time control) by full game URL",
+    "access": "read",
+    "domain": "www.chess.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "game-url",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Full game URL, e.g. https://www.chess.com/game/live/168842570216"
+      }
+    ],
+    "columns": [
+      "kind",
+      "game_id",
+      "date",
+      "white",
+      "white_rating",
+      "black",
+      "black_rating",
+      "result",
+      "winner_color",
+      "termination",
+      "eco",
+      "time_control",
+      "rated",
+      "ply_count",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "chess/analyze.js",
+    "sourceFile": "chess/analyze.js"
+  },
+  {
+    "site": "chess",
+    "name": "games",
+    "description": "Chess.com recent games for a player, newest first",
+    "access": "read",
+    "domain": "api.chess.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Chess.com username"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of recent games (1-100)"
+      }
+    ],
+    "columns": [
+      "date",
+      "time_class",
+      "rated",
+      "my_color",
+      "my_rating",
+      "my_result",
+      "opponent",
+      "opponent_rating",
+      "eco",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "chess/games.js",
+    "sourceFile": "chess/games.js"
+  },
+  {
+    "site": "chess",
+    "name": "stats",
+    "description": "Chess.com player ratings + win/loss record across game kinds",
+    "access": "read",
+    "domain": "api.chess.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Chess.com username (case-insensitive)"
+      }
+    ],
+    "columns": [
+      "kind",
+      "rating_current",
+      "rating_best",
+      "wins",
+      "losses",
+      "draws"
+    ],
+    "type": "js",
+    "modulePath": "chess/stats.js",
+    "sourceFile": "chess/stats.js"
+  },
+  {
     "site": "claude",
     "name": "ask",
     "description": "Send a prompt to Claude and get the response",

--- a/clis/chess/analyze.js
+++ b/clis/chess/analyze.js
@@ -1,0 +1,30 @@
+/**
+ * Open a Chess.com game in the browser's analysis view. Thin wrapper:
+ * navigates the bound session to the `/analysis` form of the game URL
+ * and reports the resolved page URL.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { parseGameUrl } from './game.js';
+
+cli({
+    site: 'chess',
+    name: 'analyze',
+    access: 'read',
+    description: 'Open a Chess.com game in the browser analysis board',
+    domain: 'www.chess.com',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'game-url', type: 'string', required: true, positional: true, help: 'Full game URL, e.g. https://www.chess.com/game/live/168842570216' },
+    ],
+    columns: ['kind', 'game_id', 'analysis_url'],
+    func: async (page, kwargs) => {
+        if (!page) throw new CommandExecutionError('Browser session required for chess analyze');
+        const { kind, id } = parseGameUrl(kwargs['game-url']);
+        const analysisUrl = `https://www.chess.com/analysis/game/${kind}/${id}`;
+        await page.goto(analysisUrl);
+        await page.wait(2);
+        return [{ kind, game_id: id, analysis_url: analysisUrl }];
+    },
+});

--- a/clis/chess/analyze.test.js
+++ b/clis/chess/analyze.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './analyze.js';
+
+function makePage() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+describe('chess analyze command', () => {
+    it('navigates to /analysis/game/<kind>/<id> and reports the URL', async () => {
+        const cmd = getRegistry().get('chess/analyze');
+        const page = makePage();
+        const rows = await cmd.func(page, { 'game-url': 'https://www.chess.com/game/live/42' });
+        expect(rows).toEqual([{ kind: 'live', game_id: '42', analysis_url: 'https://www.chess.com/analysis/game/live/42' }]);
+        expect(page.goto).toHaveBeenCalledWith('https://www.chess.com/analysis/game/live/42');
+    });
+
+    it('preserves daily kind in the analysis URL', async () => {
+        const cmd = getRegistry().get('chess/analyze');
+        const page = makePage();
+        const rows = await cmd.func(page, { 'game-url': 'https://www.chess.com/game/daily/123' });
+        expect(rows[0].analysis_url).toBe('https://www.chess.com/analysis/game/daily/123');
+    });
+
+    it('rejects invalid URL with ArgumentError before navigation', async () => {
+        const cmd = getRegistry().get('chess/analyze');
+        const page = makePage();
+        await expect(cmd.func(page, { 'game-url': 'not-a-url' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws CommandExecutionError without a browser page', async () => {
+        const cmd = getRegistry().get('chess/analyze');
+        await expect(cmd.func(null, { 'game-url': 'https://www.chess.com/game/live/42' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('registers with the expected columns + browser flag', () => {
+        const cmd = getRegistry().get('chess/analyze');
+        expect(cmd?.columns).toEqual(['kind', 'game_id', 'analysis_url']);
+        expect(cmd?.browser).toBe(true);
+    });
+});

--- a/clis/chess/game.js
+++ b/clis/chess/game.js
@@ -1,0 +1,91 @@
+/**
+ * Chess.com single-game detail by URL, via the internal callback
+ * endpoint `/callback/{live|daily}/game/{id}`. Returns the canonical
+ * PGN headers + move data plus per-player metadata.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { UA, formatDate } from './utils.js';
+
+const CALLBACK_BASE = 'https://www.chess.com/callback';
+const URL_RE = /^https:\/\/www\.chess\.com\/game\/(live|daily)\/(\d+)/i;
+
+export function parseGameUrl(value) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError('<game-url> is required');
+    const m = s.match(URL_RE);
+    if (!m) {
+        throw new ArgumentError(
+            `Invalid Chess.com game URL: "${value}"`,
+            'Expected https://www.chess.com/game/live/<id> or https://www.chess.com/game/daily/<id>.',
+        );
+    }
+    return { kind: m[1].toLowerCase(), id: m[2] };
+}
+
+export function summarizeGame({ kind, id, payload }) {
+    if (!payload?.game) {
+        throw new CommandExecutionError('Chess.com callback returned no game payload');
+    }
+    const g = payload.game;
+    const players = payload.players || {};
+    const byColor = {};
+    for (const slot of ['top', 'bottom']) {
+        const p = players[slot];
+        if (p?.color) byColor[p.color] = p;
+    }
+    const white = byColor.white || {};
+    const black = byColor.black || {};
+    const headers = g.pgnHeaders || {};
+    return {
+        kind,
+        game_id: id,
+        date: headers.Date ? headers.Date.replace(/\./g, '-') : formatDate(g.endTime),
+        white: white.username || headers.White || '',
+        white_rating: white.rating || headers.WhiteElo || '',
+        black: black.username || headers.Black || '',
+        black_rating: black.rating || headers.BlackElo || '',
+        result: headers.Result || '',
+        winner_color: g.colorOfWinner || '',
+        termination: headers.Termination || g.resultMessage || '',
+        eco: headers.ECO || '',
+        time_control: headers.TimeControl || (g.daysPerTurn ? `${g.daysPerTurn}d/turn` : ''),
+        rated: g.isRated === true,
+        ply_count: g.plyCount ?? '',
+        url: `https://www.chess.com/game/${kind}/${id}`,
+    };
+}
+
+cli({
+    site: 'chess',
+    name: 'game',
+    access: 'read',
+    description: 'Chess.com single-game detail (white, black, result, ECO, time control) by full game URL',
+    domain: 'www.chess.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'game-url', type: 'string', required: true, positional: true, help: 'Full game URL, e.g. https://www.chess.com/game/live/168842570216' },
+    ],
+    columns: [
+        'kind', 'game_id', 'date',
+        'white', 'white_rating', 'black', 'black_rating',
+        'result', 'winner_color', 'termination',
+        'eco', 'time_control', 'rated', 'ply_count', 'url',
+    ],
+    func: async (kwargs) => {
+        const { kind, id } = parseGameUrl(kwargs['game-url']);
+        const url = `${CALLBACK_BASE}/${kind}/game/${id}`;
+        const resp = await fetch(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+        if (resp.status === 404) {
+            throw new EmptyResultError(`Chess.com has no ${kind} game with id ${id}`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`Chess.com callback returned HTTP ${resp.status} for ${url}`);
+        }
+        const payload = await resp.json();
+        return [summarizeGame({ kind, id, payload })];
+    },
+});
+
+export const __test__ = { parseGameUrl, summarizeGame };

--- a/clis/chess/game.test.js
+++ b/clis/chess/game.test.js
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './game.js';
+
+const { parseGameUrl, summarizeGame } = await import('./game.js').then((m) => m.__test__);
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function mockFetch(payload, status = 200) {
+    return vi.fn().mockResolvedValue({
+        ok: status === 200,
+        status,
+        json: () => Promise.resolve(payload),
+    });
+}
+
+describe('chess game command', () => {
+    it('parses both live and daily game URL forms', () => {
+        expect(parseGameUrl('https://www.chess.com/game/live/168842570216'))
+            .toEqual({ kind: 'live', id: '168842570216' });
+        expect(parseGameUrl('https://www.chess.com/game/daily/947761777'))
+            .toEqual({ kind: 'daily', id: '947761777' });
+        expect(parseGameUrl('https://www.chess.com/game/LIVE/1'))
+            .toEqual({ kind: 'live', id: '1' });
+    });
+
+    it('strips trailing path / query off the URL', () => {
+        expect(parseGameUrl('https://www.chess.com/game/live/123/something?ref=share'))
+            .toEqual({ kind: 'live', id: '123' });
+    });
+
+    it('rejects empty / non-URL / unsupported-kind inputs', () => {
+        expect(() => parseGameUrl('')).toThrow(ArgumentError);
+        expect(() => parseGameUrl('   ')).toThrow(ArgumentError);
+        expect(() => parseGameUrl('123')).toThrow(ArgumentError);
+        expect(() => parseGameUrl('https://www.chess.com/club/123')).toThrow(ArgumentError);
+        expect(() => parseGameUrl('https://lichess.org/abc')).toThrow(ArgumentError);
+    });
+
+    it('summarizeGame maps the callback payload to the canonical row shape', () => {
+        const row = summarizeGame({
+            kind: 'live',
+            id: '999',
+            payload: {
+                game: {
+                    pgnHeaders: {
+                        Date: '2026.05.17',
+                        White: 'Hikaru',
+                        Black: 'tactic',
+                        Result: '1-0',
+                        ECO: 'A01',
+                        WhiteElo: 3454,
+                        BlackElo: 2869,
+                        TimeControl: '180',
+                        Termination: 'Hikaru won by resignation',
+                    },
+                    colorOfWinner: 'white',
+                    isRated: true,
+                    plyCount: 111,
+                    endTime: 1747584400,
+                },
+                players: {
+                    top: { username: 'tactic', color: 'black', rating: 2869 },
+                    bottom: { username: 'Hikaru', color: 'white', rating: 3454 },
+                },
+            },
+        });
+        expect(row).toMatchObject({
+            kind: 'live',
+            game_id: '999',
+            date: '2026-05-17',
+            white: 'Hikaru',
+            white_rating: 3454,
+            black: 'tactic',
+            black_rating: 2869,
+            result: '1-0',
+            winner_color: 'white',
+            termination: 'Hikaru won by resignation',
+            eco: 'A01',
+            time_control: '180',
+            rated: true,
+            ply_count: 111,
+            url: 'https://www.chess.com/game/live/999',
+        });
+    });
+
+    it('summarizeGame falls back to pgnHeaders when players are missing', () => {
+        const row = summarizeGame({
+            kind: 'daily',
+            id: '1',
+            payload: {
+                game: {
+                    pgnHeaders: { White: 'A', Black: 'B', Result: '1/2-1/2', WhiteElo: 1200, BlackElo: 1300 },
+                    colorOfWinner: '',
+                    isRated: false,
+                    daysPerTurn: 3,
+                },
+                players: {},
+            },
+        });
+        expect(row.white).toBe('A');
+        expect(row.black_rating).toBe(1300);
+        expect(row.time_control).toBe('3d/turn');
+        expect(row.rated).toBe(false);
+    });
+
+    it('summarizeGame throws CommandExecutionError on missing game payload', () => {
+        expect(() => summarizeGame({ kind: 'live', id: '1', payload: {} })).toThrow(CommandExecutionError);
+        expect(() => summarizeGame({ kind: 'live', id: '1', payload: null })).toThrow(CommandExecutionError);
+    });
+
+    it('command fetches the callback URL and returns a single row', async () => {
+        const fetchMock = mockFetch({
+            game: { pgnHeaders: { White: 'A', Black: 'B', Result: '1-0', WhiteElo: 100, BlackElo: 90 } },
+            players: {},
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('chess/game');
+        const rows = await cmd.func({ 'game-url': 'https://www.chess.com/game/live/42' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].url).toBe('https://www.chess.com/game/live/42');
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://www.chess.com/callback/live/game/42',
+            expect.objectContaining({ headers: expect.any(Object) }),
+        );
+    });
+
+    it('command surfaces 404 as EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+        const cmd = getRegistry().get('chess/game');
+        await expect(cmd.func({ 'game-url': 'https://www.chess.com/game/live/1' }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('command surfaces non-2xx as CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+        const cmd = getRegistry().get('chess/game');
+        await expect(cmd.func({ 'game-url': 'https://www.chess.com/game/live/1' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects invalid URL with ArgumentError before any fetch', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('chess/game');
+        await expect(cmd.func({ 'game-url': 'not-a-url' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/clis/chess/games.js
+++ b/clis/chess/games.js
@@ -1,0 +1,58 @@
+/**
+ * Chess.com recent games from monthly archives. Walks the archive
+ * list newest-first and fetches as few months as needed to fill --limit.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { chessApi, validateUsername, mapGameRow } from './utils.js';
+
+const MAX_LIMIT = 100;
+const MAX_ARCHIVE_FETCHES = 6;
+
+function parseLimit(value) {
+    if (value === undefined || value === null || value === '') return 10;
+    const limit = Number(value);
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
+    }
+    return limit;
+}
+
+cli({
+    site: 'chess',
+    name: 'games',
+    access: 'read',
+    description: 'Chess.com recent games for a player, newest first',
+    domain: 'api.chess.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'username', type: 'string', required: true, positional: true, help: 'Chess.com username' },
+        { name: 'limit', type: 'int', default: 10, help: `Number of recent games (1-${MAX_LIMIT})` },
+    ],
+    columns: ['date', 'time_class', 'rated', 'my_color', 'my_rating', 'my_result', 'opponent', 'opponent_rating', 'eco', 'url'],
+    func: async (kwargs) => {
+        const username = validateUsername(kwargs.username);
+        const limit = parseLimit(kwargs.limit);
+        const archivesList = await chessApi(`/player/${encodeURIComponent(username)}/games/archives`);
+        const archives = Array.isArray(archivesList?.archives) ? archivesList.archives.slice().reverse() : [];
+        if (archives.length === 0) {
+            throw new EmptyResultError(`Chess.com has no game archives for ${username}`);
+        }
+        const rows = [];
+        for (let i = 0; i < archives.length && i < MAX_ARCHIVE_FETCHES && rows.length < limit; i++) {
+            const monthly = await chessApi(archives[i]);
+            const games = Array.isArray(monthly?.games) ? monthly.games.slice().reverse() : [];
+            for (const g of games) {
+                rows.push(mapGameRow(g, username));
+                if (rows.length >= limit) break;
+            }
+        }
+        if (rows.length === 0) {
+            throw new EmptyResultError(`Chess.com has games archives for ${username} but no games in the most recent ${MAX_ARCHIVE_FETCHES} months`);
+        }
+        return rows.slice(0, limit);
+    },
+});
+
+export const __test__ = { parseLimit };

--- a/clis/chess/games.js
+++ b/clis/chess/games.js
@@ -30,7 +30,7 @@ cli({
         { name: 'username', type: 'string', required: true, positional: true, help: 'Chess.com username' },
         { name: 'limit', type: 'int', default: 10, help: `Number of recent games (1-${MAX_LIMIT})` },
     ],
-    columns: ['date', 'time_class', 'rated', 'my_color', 'my_rating', 'my_result', 'opponent', 'opponent_rating', 'eco', 'url'],
+    columns: ['date', 'time_class', 'rated', 'my_color', 'my_rating', 'my_result', 'opponent', 'opponent_rating', 'accuracy_white', 'accuracy_black', 'eco', 'opening_name', 'url'],
     func: async (kwargs) => {
         const username = validateUsername(kwargs.username);
         const limit = parseLimit(kwargs.limit);

--- a/clis/chess/games.test.js
+++ b/clis/chess/games.test.js
@@ -104,7 +104,8 @@ describe('chess games command', () => {
         const cmd = getRegistry().get('chess/games');
         expect(cmd?.columns).toEqual([
             'date', 'time_class', 'rated', 'my_color', 'my_rating', 'my_result',
-            'opponent', 'opponent_rating', 'eco', 'url',
+            'opponent', 'opponent_rating', 'accuracy_white', 'accuracy_black',
+            'eco', 'opening_name', 'url',
         ]);
     });
 });

--- a/clis/chess/games.test.js
+++ b/clis/chess/games.test.js
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './games.js';
+
+const { parseLimit } = await import('./games.js').then((m) => m.__test__);
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function fetchFor(map) {
+    return vi.fn().mockImplementation((url) => {
+        if (map.has(url)) {
+            return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(map.get(url)) });
+        }
+        return Promise.resolve({ ok: false, status: 404 });
+    });
+}
+
+function game(white, whiteRating, black, blackRating, endTime, extra = {}) {
+    return {
+        url: `https://www.chess.com/game/live/${endTime}`,
+        end_time: endTime,
+        time_class: 'blitz',
+        rated: true,
+        eco: 'C50',
+        white: { username: white, rating: whiteRating, result: 'win' },
+        black: { username: black, rating: blackRating, result: 'resigned' },
+        ...extra,
+    };
+}
+
+describe('chess games command', () => {
+    it('parseLimit accepts 1-100, rejects everything else', () => {
+        expect(parseLimit(undefined)).toBe(10);
+        expect(parseLimit(1)).toBe(1);
+        expect(parseLimit(100)).toBe(100);
+        expect(() => parseLimit(0)).toThrow(ArgumentError);
+        expect(() => parseLimit(101)).toThrow(ArgumentError);
+        expect(() => parseLimit(1.5)).toThrow(ArgumentError);
+        expect(() => parseLimit('abc')).toThrow(ArgumentError);
+    });
+
+    it('returns recent games newest-first sliced to --limit', async () => {
+        const map = new Map([
+            ['https://api.chess.com/pub/player/hikaru/games/archives', {
+                archives: ['https://api.chess.com/pub/player/hikaru/games/2026/04', 'https://api.chess.com/pub/player/hikaru/games/2026/05'],
+            }],
+            ['https://api.chess.com/pub/player/hikaru/games/2026/05', {
+                games: [
+                    game('Hikaru', 3286, 'A', 2900, 1777737000),
+                    game('Hikaru', 3286, 'B', 2950, 1777737500),
+                    game('Hikaru', 3286, 'C', 3000, 1777737900),
+                ],
+            }],
+        ]);
+        vi.stubGlobal('fetch', fetchFor(map));
+        const cmd = getRegistry().get('chess/games');
+        const rows = await cmd.func({ username: 'Hikaru', limit: 2 });
+        expect(rows).toHaveLength(2);
+        // archive is reversed (newest month first), games within are reversed
+        // so the first row corresponds to the LAST game in the JSON array.
+        expect(rows[0].opponent).toBe('C');
+        expect(rows[1].opponent).toBe('B');
+    });
+
+    it('walks multiple months until --limit is filled', async () => {
+        const map = new Map([
+            ['https://api.chess.com/pub/player/hikaru/games/archives', {
+                archives: ['https://api.chess.com/pub/player/hikaru/games/2026/03', 'https://api.chess.com/pub/player/hikaru/games/2026/04'],
+            }],
+            ['https://api.chess.com/pub/player/hikaru/games/2026/04', {
+                games: [game('Hikaru', 3286, 'A', 2900, 1777737000)],
+            }],
+            ['https://api.chess.com/pub/player/hikaru/games/2026/03', {
+                games: [game('Hikaru', 3286, 'B', 2950, 1774000000)],
+            }],
+        ]);
+        vi.stubGlobal('fetch', fetchFor(map));
+        const cmd = getRegistry().get('chess/games');
+        const rows = await cmd.func({ username: 'Hikaru', limit: 2 });
+        expect(rows.map((r) => r.opponent)).toEqual(['A', 'B']);
+    });
+
+    it('throws EmptyResultError when archives list is empty', async () => {
+        const map = new Map([
+            ['https://api.chess.com/pub/player/someuser/games/archives', { archives: [] }],
+        ]);
+        vi.stubGlobal('fetch', fetchFor(map));
+        const cmd = getRegistry().get('chess/games');
+        await expect(cmd.func({ username: 'someuser', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('throws ArgumentError on invalid username before any fetch', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('chess/games');
+        await expect(cmd.func({ username: 'a b', limit: 5 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('registers with the expected columns', () => {
+        const cmd = getRegistry().get('chess/games');
+        expect(cmd?.columns).toEqual([
+            'date', 'time_class', 'rated', 'my_color', 'my_rating', 'my_result',
+            'opponent', 'opponent_rating', 'eco', 'url',
+        ]);
+    });
+});

--- a/clis/chess/stats.js
+++ b/clis/chess/stats.js
@@ -1,0 +1,32 @@
+/**
+ * Chess.com player stats across game kinds (rapid / blitz / bullet /
+ * daily / chess960 / etc) via the public stats endpoint.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { chessApi, validateUsername, summarizeStats } from './utils.js';
+
+const KINDS = ['chess_rapid', 'chess_blitz', 'chess_bullet', 'chess_daily', 'chess960_daily', 'chess_daily_960'];
+
+cli({
+    site: 'chess',
+    name: 'stats',
+    access: 'read',
+    description: 'Chess.com player ratings + win/loss record across game kinds',
+    domain: 'api.chess.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'username', type: 'string', required: true, positional: true, help: 'Chess.com username (case-insensitive)' },
+    ],
+    columns: ['kind', 'rating_current', 'rating_best', 'wins', 'losses', 'draws'],
+    func: async (kwargs) => {
+        const username = validateUsername(kwargs.username);
+        const stats = await chessApi(`/player/${encodeURIComponent(username)}/stats`);
+        const rows = KINDS.map((k) => summarizeStats(stats, k)).filter(Boolean);
+        if (rows.length === 0) {
+            throw new EmptyResultError(`Chess.com returned no stats for ${username}`);
+        }
+        return rows;
+    },
+});

--- a/clis/chess/stats.test.js
+++ b/clis/chess/stats.test.js
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './stats.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function mockFetch(body) {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+    });
+}
+
+describe('chess stats command', () => {
+    it('rejects empty username via validateUsername', async () => {
+        const cmd = getRegistry().get('chess/stats');
+        await expect(cmd.func({ username: '' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('rejects invalid username characters', async () => {
+        const cmd = getRegistry().get('chess/stats');
+        await expect(cmd.func({ username: 'user name' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('returns one row per known game kind populated in the stats response', async () => {
+        const fetchMock = mockFetch({
+            chess_rapid: { last: { rating: 1700 }, best: { rating: 1800 }, record: { win: 50, loss: 20, draw: 5 } },
+            chess_blitz: { last: { rating: 1500 }, best: { rating: 1600 }, record: { win: 100, loss: 80, draw: 10 } },
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('chess/stats');
+        const rows = await cmd.func({ username: 'someuser' });
+        expect(rows).toHaveLength(2);
+        expect(rows[0].kind).toBe('rapid');
+        expect(rows[1].kind).toBe('blitz');
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.chess.com/pub/player/someuser/stats',
+            expect.objectContaining({ headers: expect.any(Object) }),
+        );
+    });
+
+    it('lowercases username in the URL', async () => {
+        const fetchMock = mockFetch({ chess_rapid: { last: { rating: 1 }, best: {}, record: {} } });
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('chess/stats');
+        await cmd.func({ username: 'MixedCase' });
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.chess.com/pub/player/mixedcase/stats',
+            expect.any(Object),
+        );
+    });
+
+    it('throws EmptyResultError when the stats response has no known kinds', async () => {
+        vi.stubGlobal('fetch', mockFetch({}));
+        const cmd = getRegistry().get('chess/stats');
+        await expect(cmd.func({ username: 'someuser' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('throws EmptyResultError on HTTP 404', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+        const cmd = getRegistry().get('chess/stats');
+        await expect(cmd.func({ username: 'someuser' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('registers with the expected columns', () => {
+        const cmd = getRegistry().get('chess/stats');
+        expect(cmd?.columns).toEqual(['kind', 'rating_current', 'rating_best', 'wins', 'losses', 'draws']);
+    });
+});

--- a/clis/chess/utils.js
+++ b/clis/chess/utils.js
@@ -1,0 +1,80 @@
+/**
+ * Shared helpers for the public Chess.com REST API
+ * (https://api.chess.com/pub/). No auth, no rate-limit headers.
+ */
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const API_BASE = 'https://api.chess.com/pub';
+export const UA = 'Mozilla/5.0 (compatible; opencli/1.0)';
+
+const USERNAME_RE = /^[a-zA-Z0-9_-]{3,25}$/;
+
+export function validateUsername(value) {
+    const s = String(value ?? '').trim().toLowerCase();
+    if (!s) throw new ArgumentError('<username> is required');
+    if (!USERNAME_RE.test(s)) {
+        throw new ArgumentError(`Invalid Chess.com username "${value}"`, 'Usernames are 3-25 chars: a-z, 0-9, hyphen, underscore.');
+    }
+    return s;
+}
+
+export async function chessApi(path, fetchImpl = fetch) {
+    const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
+    const resp = await fetchImpl(url, { headers: { 'User-Agent': UA, accept: 'application/json' } });
+    if (resp.status === 404) throw new EmptyResultError(`Chess.com returned 404 for ${url}`);
+    if (!resp.ok) throw new CommandExecutionError(`Chess.com API returned HTTP ${resp.status} for ${url}`);
+    return resp.json();
+}
+
+/** Pull rating + record fields out of a stats sub-object (`chess_rapid` etc). */
+export function summarizeStats(stats, kind) {
+    const k = stats?.[kind];
+    if (!k) return null;
+    const record = k.record || {};
+    return {
+        kind: kind.replace(/^chess_/, ''),
+        rating_current: k.last?.rating ?? '',
+        rating_best: k.best?.rating ?? '',
+        wins: record.win ?? '',
+        losses: record.loss ?? '',
+        draws: record.draw ?? '',
+    };
+}
+
+/** Parse an end_time epoch (seconds) into YYYY-MM-DD. */
+export function formatDate(epochSeconds) {
+    if (!epochSeconds || typeof epochSeconds !== 'number') return '';
+    return new Date(epochSeconds * 1000).toISOString().slice(0, 10);
+}
+
+/**
+ * Map a Chess.com game record (from the monthly archive) to a flat row.
+ * The viewer perspective controls win/loss orientation.
+ */
+export function mapGameRow(game, viewerUsername) {
+    const white = game?.white || {};
+    const black = game?.black || {};
+    const viewerLower = String(viewerUsername || '').toLowerCase();
+    const viewerIsWhite = String(white.username || '').toLowerCase() === viewerLower;
+    const me = viewerIsWhite ? white : black;
+    const opp = viewerIsWhite ? black : white;
+    return {
+        date: formatDate(game?.end_time),
+        time_class: game?.time_class || '',
+        rated: game?.rated === true,
+        my_color: viewerIsWhite ? 'white' : 'black',
+        my_rating: me?.rating ?? '',
+        my_result: me?.result || '',
+        opponent: opp?.username || '',
+        opponent_rating: opp?.rating ?? '',
+        eco: game?.eco || '',
+        url: game?.url || '',
+    };
+}
+
+export const __test__ = {
+    validateUsername,
+    summarizeStats,
+    formatDate,
+    mapGameRow,
+};

--- a/clis/chess/utils.js
+++ b/clis/chess/utils.js
@@ -48,6 +48,20 @@ export function formatDate(epochSeconds) {
 }
 
 /**
+ * Pull "Reti Opening: Nimzo-Larsen Variation" out of the Chess.com eco URL
+ * (`https://www.chess.com/openings/Reti-Opening-Nimzo-Larsen-Variation-2...g6-...`).
+ * Returns '' for short-code eco values (`A01`) where no name is encoded.
+ */
+export function openingName(eco) {
+    if (typeof eco !== 'string' || !eco.startsWith('http')) return '';
+    const tail = eco.replace(/\/+$/, '').split('/').pop() || '';
+    if (!tail) return '';
+    const namePart = tail.match(/^([^.]+?)(?:-\d|\.\.\.|$)/);
+    const cleaned = (namePart ? namePart[1] : tail).replace(/-/g, ' ').trim();
+    return cleaned;
+}
+
+/**
  * Map a Chess.com game record (from the monthly archive) to a flat row.
  * The viewer perspective controls win/loss orientation.
  */
@@ -58,6 +72,7 @@ export function mapGameRow(game, viewerUsername) {
     const viewerIsWhite = String(white.username || '').toLowerCase() === viewerLower;
     const me = viewerIsWhite ? white : black;
     const opp = viewerIsWhite ? black : white;
+    const eco = game?.eco || '';
     return {
         date: formatDate(game?.end_time),
         time_class: game?.time_class || '',
@@ -67,7 +82,10 @@ export function mapGameRow(game, viewerUsername) {
         my_result: me?.result || '',
         opponent: opp?.username || '',
         opponent_rating: opp?.rating ?? '',
-        eco: game?.eco || '',
+        accuracy_white: typeof game?.accuracies?.white === 'number' ? game.accuracies.white : '',
+        accuracy_black: typeof game?.accuracies?.black === 'number' ? game.accuracies.black : '',
+        eco,
+        opening_name: openingName(eco),
         url: game?.url || '',
     };
 }
@@ -77,4 +95,5 @@ export const __test__ = {
     summarizeStats,
     formatDate,
     mapGameRow,
+    openingName,
 };

--- a/clis/chess/utils.test.js
+++ b/clis/chess/utils.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './utils.js';
+
+const { validateUsername, summarizeStats, formatDate, mapGameRow } = __test__;
+
+describe('chess utils', () => {
+    it('validateUsername lowercases and accepts 3-25 char usernames', () => {
+        expect(validateUsername('Hikaru')).toBe('hikaru');
+        expect(validateUsername('MagnusCarlsen')).toBe('magnuscarlsen');
+        expect(validateUsername('a-b_c')).toBe('a-b_c');
+    });
+
+    it('validateUsername rejects empty / too-short / invalid chars', () => {
+        expect(() => validateUsername('')).toThrow(ArgumentError);
+        expect(() => validateUsername('ab')).toThrow(ArgumentError);
+        expect(() => validateUsername('user name')).toThrow(ArgumentError);
+        expect(() => validateUsername('a'.repeat(30))).toThrow(ArgumentError);
+    });
+
+    it('summarizeStats projects rating + record fields', () => {
+        const stats = {
+            chess_rapid: {
+                last: { rating: 1600 },
+                best: { rating: 1800 },
+                record: { win: 100, loss: 50, draw: 10 },
+            },
+        };
+        expect(summarizeStats(stats, 'chess_rapid')).toEqual({
+            kind: 'rapid',
+            rating_current: 1600,
+            rating_best: 1800,
+            wins: 100,
+            losses: 50,
+            draws: 10,
+        });
+    });
+
+    it('summarizeStats returns null for missing kind', () => {
+        expect(summarizeStats({}, 'chess_rapid')).toBeNull();
+        expect(summarizeStats({ chess_blitz: {} }, 'chess_rapid')).toBeNull();
+    });
+
+    it('summarizeStats coerces missing numeric fields to empty string', () => {
+        const row = summarizeStats({ chess_daily: { last: {}, record: {} } }, 'chess_daily');
+        expect(row).toEqual({
+            kind: 'daily',
+            rating_current: '',
+            rating_best: '',
+            wins: '',
+            losses: '',
+            draws: '',
+        });
+    });
+
+    it('formatDate converts epoch seconds to YYYY-MM-DD', () => {
+        expect(formatDate(1777737679)).toBe('2026-05-02');
+        expect(formatDate(0)).toBe('');
+        expect(formatDate(null)).toBe('');
+        expect(formatDate('not-a-number')).toBe('');
+    });
+
+    it('mapGameRow returns rows from the viewer perspective when viewer is white', () => {
+        const game = {
+            url: 'https://www.chess.com/game/live/123',
+            end_time: 1777737679,
+            time_class: 'blitz',
+            rated: true,
+            eco: 'C50',
+            white: { username: 'Hikaru', rating: 3286, result: 'win' },
+            black: { username: 'Magnus', rating: 2900, result: 'resigned' },
+        };
+        expect(mapGameRow(game, 'Hikaru')).toEqual({
+            date: '2026-05-02',
+            time_class: 'blitz',
+            rated: true,
+            my_color: 'white',
+            my_rating: 3286,
+            my_result: 'win',
+            opponent: 'Magnus',
+            opponent_rating: 2900,
+            eco: 'C50',
+            url: 'https://www.chess.com/game/live/123',
+        });
+    });
+
+    it('mapGameRow flips perspective when viewer is black', () => {
+        const game = {
+            white: { username: 'Hikaru', rating: 3286, result: 'win' },
+            black: { username: 'Magnus', rating: 2900, result: 'resigned' },
+        };
+        const row = mapGameRow(game, 'Magnus');
+        expect(row.my_color).toBe('black');
+        expect(row.my_result).toBe('resigned');
+        expect(row.opponent).toBe('Hikaru');
+    });
+
+    it('mapGameRow matches viewer case-insensitively', () => {
+        const game = {
+            white: { username: 'Hikaru', rating: 3286, result: 'win' },
+            black: { username: 'Magnus', rating: 2900, result: 'resigned' },
+        };
+        expect(mapGameRow(game, 'hikaru').my_color).toBe('white');
+        expect(mapGameRow(game, 'MAGNUS').my_color).toBe('black');
+    });
+
+    it('mapGameRow falls back to black when viewer is neither player (defensive)', () => {
+        const game = {
+            white: { username: 'A', rating: 1000, result: 'win' },
+            black: { username: 'B', rating: 1100, result: 'resigned' },
+        };
+        const row = mapGameRow(game, 'C');
+        expect(row.my_color).toBe('black');
+        expect(row.opponent).toBe('A');
+    });
+
+    it('mapGameRow handles missing optional fields without throwing', () => {
+        const row = mapGameRow({}, 'x');
+        expect(row.date).toBe('');
+        expect(row.url).toBe('');
+        expect(row.eco).toBe('');
+    });
+});

--- a/clis/chess/utils.test.js
+++ b/clis/chess/utils.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
 import { __test__ } from './utils.js';
 
-const { validateUsername, summarizeStats, formatDate, mapGameRow } = __test__;
+const { validateUsername, summarizeStats, formatDate, mapGameRow, openingName } = __test__;
 
 describe('chess utils', () => {
     it('validateUsername lowercases and accepts 3-25 char usernames', () => {
@@ -67,6 +67,7 @@ describe('chess utils', () => {
             time_class: 'blitz',
             rated: true,
             eco: 'C50',
+            accuracies: { white: 87.73, black: 80.23 },
             white: { username: 'Hikaru', rating: 3286, result: 'win' },
             black: { username: 'Magnus', rating: 2900, result: 'resigned' },
         };
@@ -79,9 +80,47 @@ describe('chess utils', () => {
             my_result: 'win',
             opponent: 'Magnus',
             opponent_rating: 2900,
+            accuracy_white: 87.73,
+            accuracy_black: 80.23,
             eco: 'C50',
+            opening_name: '',
             url: 'https://www.chess.com/game/live/123',
         });
+    });
+
+    it('mapGameRow leaves accuracy fields empty when chess.com did not compute them', () => {
+        const game = {
+            white: { username: 'A', rating: 1, result: 'win' },
+            black: { username: 'B', rating: 1, result: 'resigned' },
+        };
+        const row = mapGameRow(game, 'A');
+        expect(row.accuracy_white).toBe('');
+        expect(row.accuracy_black).toBe('');
+    });
+
+    it('mapGameRow parses opening_name from the chess.com eco URL', () => {
+        const game = {
+            eco: 'https://www.chess.com/openings/Reti-Opening-Nimzo-Larsen-Variation-2...g6-3.Bb2-Bg7-4.d4',
+            white: { username: 'A', rating: 1, result: 'win' },
+            black: { username: 'B', rating: 1, result: 'resigned' },
+        };
+        const row = mapGameRow(game, 'A');
+        expect(row.opening_name).toBe('Reti Opening Nimzo Larsen Variation');
+    });
+
+    it('openingName helper returns clean human-readable name from URL form', () => {
+        expect(openingName('https://www.chess.com/openings/Sicilian-Defense')).toBe('Sicilian Defense');
+        expect(openingName('https://www.chess.com/openings/Kings-Indian-Defense-Semi-Classical-Variation...7.O-O'))
+            .toBe('Kings Indian Defense Semi Classical Variation');
+        expect(openingName('https://www.chess.com/openings/French-Defense-Advance-Variation-3...c5-4.c3'))
+            .toBe('French Defense Advance Variation');
+    });
+
+    it('openingName returns empty for short-code eco or missing input', () => {
+        expect(openingName('A01')).toBe('');
+        expect(openingName('')).toBe('');
+        expect(openingName(undefined)).toBe('');
+        expect(openingName(null)).toBe('');
     });
 
     it('mapGameRow flips perspective when viewer is black', () => {

--- a/docs/adapters/browser/chess.md
+++ b/docs/adapters/browser/chess.md
@@ -55,7 +55,9 @@ opencli chess analyze https://www.chess.com/game/live/168842570216
 | `my_result` | `win` / `resigned` / `timeout` / `checkmated` / `agreed` / `repetition` / etc |
 | `opponent` | Opponent's Chess.com username |
 | `opponent_rating` | Opponent's rating at game time |
-| `eco` | ECO opening tag or full opening URL Chess.com tags into the row |
+| `accuracy_white` / `accuracy_black` | Chess.com move-accuracy percentage (0-100) when computed by Game Review; empty when the game wasn't analyzed (unrated / very short / abandoned) |
+| `eco` | Raw ECO opening tag or full opening URL chess.com encodes on the row |
+| `opening_name` | Human-readable opening name parsed from the eco URL (e.g. `Reti Opening Nimzo Larsen Variation`); empty when `eco` is the short-code form (`A01`) which carries no name |
 | `url` | Game URL on chess.com |
 
 ## Username Validation

--- a/docs/adapters/browser/chess.md
+++ b/docs/adapters/browser/chess.md
@@ -1,0 +1,108 @@
+# Chess.com
+
+**Mode**: 🌐 Public · **Domain**: `api.chess.com` / `www.chess.com`
+
+Read-only adapter against the public Chess.com endpoints. `stats`, `games`, `game` use no-auth REST; `analyze` opens the Chess.com analysis board in a bound browser session.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli chess stats <username>` | Player rating + win/loss/draw record across game kinds (rapid / blitz / bullet / daily / chess960) |
+| `opencli chess games <username>` | Recent games newest-first across one or more monthly archives |
+| `opencli chess game <game-url>` | Single-game detail (white, black, result, ECO, termination, ply count) by full game URL |
+| `opencli chess analyze <game-url>` | Open the game in Chess.com's analysis board in the bound browser session |
+
+## Usage Examples
+
+```bash
+# Stats
+opencli chess stats hikaru
+opencli chess stats magnuscarlsen -f json
+
+# Recent games (default 10, max 100)
+opencli chess games hikaru
+opencli chess games erik --limit 25
+
+# Single-game detail from a game URL
+opencli chess game https://www.chess.com/game/live/168842570216
+opencli chess game https://www.chess.com/game/daily/947761777
+
+# Open in Chess.com analysis board (browser session required)
+opencli chess analyze https://www.chess.com/game/live/168842570216
+```
+
+## Columns
+
+### `stats`
+
+| Column | Notes |
+|--------|-------|
+| `kind` | `rapid` / `blitz` / `bullet` / `daily` / `chess960_daily` (only kinds the player has played) |
+| `rating_current` | Latest rating |
+| `rating_best` | All-time best rating |
+| `wins` / `losses` / `draws` | Cumulative record |
+
+### `games`
+
+| Column | Notes |
+|--------|-------|
+| `date` | Game end date in `YYYY-MM-DD` (UTC) |
+| `time_class` | `rapid` / `blitz` / `bullet` / `daily` |
+| `rated` | Boolean |
+| `my_color` | `white` or `black` from the viewer's perspective |
+| `my_rating` | Viewer's rating in this game |
+| `my_result` | `win` / `resigned` / `timeout` / `checkmated` / `agreed` / `repetition` / etc |
+| `opponent` | Opponent's Chess.com username |
+| `opponent_rating` | Opponent's rating at game time |
+| `eco` | ECO opening tag or full opening URL Chess.com tags into the row |
+| `url` | Game URL on chess.com |
+
+## Username Validation
+
+Usernames are normalized to lowercase and matched against `^[a-zA-Z0-9_-]{3,25}$`. Invalid inputs raise `ArgumentError` before any HTTP call.
+
+## Archive Walk
+
+`games` calls `/pub/player/<user>/games/archives` first to list every month the player has games in, then walks the list newest-first fetching one monthly archive at a time until `--limit` is filled. Capped at 6 monthly fetches per invocation so an obscure account with a long archive history doesn't fan out.
+
+## Limit Validation
+
+`--limit` accepts integers in `[1, 100]`. Out-of-range / non-integer values raise `ArgumentError` (no silent clamp).
+
+### `game`
+
+| Column | Notes |
+|--------|-------|
+| `kind` | `live` or `daily` parsed from the URL |
+| `game_id` | Numeric id parsed from the URL |
+| `date` | `YYYY-MM-DD` from PGN headers (end-time fallback) |
+| `white` / `black` | Usernames; resolved from `players.{top,bottom}` keyed by `.color`, with `pgnHeaders.{White,Black}` fallback |
+| `white_rating` / `black_rating` | Per-player rating at game time |
+| `result` | PGN result token: `1-0`, `0-1`, `1/2-1/2` |
+| `winner_color` | `white`, `black`, or empty on draw |
+| `termination` | Human-readable reason (e.g. "Hikaru won by resignation") |
+| `eco` | ECO opening code |
+| `time_control` | Wire `TimeControl` header for live (`180` = 3 min), `<N>d/turn` for daily |
+| `rated` | Boolean |
+| `ply_count` | Half-move count |
+| `url` | Canonical game URL |
+
+### `analyze`
+
+| Column | Notes |
+|--------|-------|
+| `kind` | `live` / `daily` parsed from the URL |
+| `game_id` | Numeric id parsed from the URL |
+| `analysis_url` | Resolved `/analysis/game/<kind>/<id>` URL the bound browser session navigated to |
+
+## Endpoint Notes
+
+`game` uses `/callback/{live\|daily}/game/{id}` on `www.chess.com` (the same JSON the Chess.com web client hits when rendering a game page). The public REST surface at `api.chess.com/pub` has no single-game endpoint; the callback path is the cleanest way to honour "PGN for specific game" without DOM scraping.
+
+`analyze` is a thin wrapper around `page.goto('/analysis/game/<kind>/<id>')`. Requires a bound browser session; if you only need to open a URL, `opencli browser <session> open <url>` is the more general primitive.
+
+## Out of Scope
+
+- Live game tracking (live moves streaming): outside the public REST surface.
+- Move-by-move engine evaluation: separate concern, would belong in a future `chess engine` adapter.


### PR DESCRIPTION
## Description

Surfaces three Chess.com fields the monthly-archive endpoint already returns but the previous version of `chess games` (#1659) dropped on the floor:

| Column | Source | Notes |
|--------|--------|-------|
| `accuracy_white` / `accuracy_black` | `game.accuracies.{white,black}` | Chess.com Game Review move-accuracy percentage (0-100). Populated on 92-100% of games for any account (verified against hikaru: 292/292 = 100%, erik: 12/13 = 92%); empty string only when the game was not analyzed. |
| `opening_name` | Parsed from `game.eco` URL | Human-readable opening name parsed out of the chess.com eco URL. `eco` stays untouched for backwards-compat callers; `opening_name` is the cleaned derived view. |

Follows the same "expose pre-computed columns the adapter already fetches" pattern as the recent batch of read-command enrichments:
- #1676 reddit: `post_hint` / `url` / `preview` / `gallery`
- #1667 twitter: `quoted_tweet`
- #1660 twitter: `card binding_values`

> Stacks on top of #1659 (chess adapter base). When #1659 lands on main, rebasing this branch will collapse the diff down to the 3-column add.

## Type of Change

- [ ] Bug fix
- [x] New feature (column enrichment on an existing read command)
- [ ] New site command
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Live verification

Against `api.chess.com/pub/player/hikaru/games/2026/05`:

```bash
$ node ./dist/src/main.js chess games hikaru --limit 1 -f json
[
  {
    "date": "2026-05-19",
    "time_class": "blitz",
    "rated": true,
    "my_color": "white",
    "my_rating": 3450,
    "my_result": "win",
    "opponent": "Rakitic2010",
    "opponent_rating": 2851,
    "accuracy_white": 93.61,
    "accuracy_black": 82.83,
    "eco": "https://www.chess.com/openings/Reti-Opening-Nimzo-Larsen-Variation-2...g6-3.Bb2-Bg7-4.d4",
    "opening_name": "Reti Opening Nimzo Larsen Variation",
    "url": "https://www.chess.com/game/live/168946879860"
  }
]
```

## Test plan

- [x] `npm run build`: manifest compiles
- [x] `npm run check:typed-error-lint`: passes (`current=145, baseline=145, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes
- [x] `npx vitest run --project adapter clis/chess/`: 43 tests passing (5 new for the column additions and the `openingName` helper)
- [x] Live: hikaru / erik populate `accuracy_*` correctly and `opening_name` parses cleanly across multiple openings (Reti, Kings Indian, French, Sicilian)

## Why this is useful

Chess players care about accuracy far more than the raw `win` / `resigned` result; it's the single most consulted number on chess.com's own game-review page. Surfacing it makes `chess games <user>` immediately useful for coaching / self-review / analytics pipelines without forcing a second per-game lookup.

`opening_name` cleans up an unreadable column: the current `eco` is sometimes `A01` (a code only chess nerds memorise) and sometimes a long URL with move-list suffix (visually noisy). The derived name covers the URL case so output stays readable.

## Out of scope

- Per-game CAPS or Game Review tactical / positional sub-scores: only `accuracies.{white,black}` are returned in the monthly-archive endpoint; deeper analysis would need a per-game GraphQL round-trip (left for a follow-up if real demand surfaces).
- Backfilling `accuracy_*` on `chess game <url>`: the callback endpoint `/callback/<live|daily>/game/<id>` does NOT return `accuracies` (verified by inspecting the response keys), so the field would always be empty there. Keeping it on `games` only.
