### PR TITLE
fix(xiaohongshu/download): preserve carousel order via __INITIAL_STATE__.imageList

### DIFF
--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -64,6 +64,13 @@ export function buildDownloadExtractJs(noteId) {
           src = src.replace(/\\/imageView\\d+\\/\\d+\\/w\\/\\d+/, '');
           return src;
         };
+        const orderedImageUrls = [];
+        const seenImageUrls = new Set();
+        const pushImage = (url) => {
+          if (!url || seenImageUrls.has(url)) return;
+          seenImageUrls.add(url);
+          orderedImageUrls.push(url);
+        };
 
         const getStructuredNotes = () => {
           const state = window.__INITIAL_STATE__;
@@ -101,7 +108,7 @@ export function buildDownloadExtractJs(noteId) {
                 || '';
               const src = normalizeImageUrl(candidate);
               if (src && (src.includes('xhscdn') || src.includes('xiaohongshu') || src.includes('rednote'))) {
-                pushMedia('image', src);
+                pushImage(src);
                 imageInitialStateUsed = true;
               }
             }
@@ -126,7 +133,7 @@ export function buildDownloadExtractJs(noteId) {
               const raw = img.src || img.getAttribute('data-src') || '';
               const src = normalizeImageUrl(raw);
               if (src && (src.includes('xhscdn') || src.includes('xiaohongshu') || src.includes('rednote'))) {
-                pushMedia('image', src);
+                pushImage(src);
               }
             });
           }
@@ -186,6 +193,10 @@ export function buildDownloadExtractJs(noteId) {
             });
           }
         }
+
+        // Preserve the pre-existing media type order (videos first, then images)
+        // while keeping image carousel order stable within the image batch.
+        orderedImageUrls.forEach(url => pushMedia('image', url));
 
         return result;
       })()

--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -52,49 +52,101 @@ export function buildDownloadExtractJs(noteId) {
         const authorEl = document.querySelector('.username, .author-name, .name');
         result.author = authorEl?.textContent?.trim() || 'unknown';
 
-        // Get images - try multiple selectors
-        const imageSelectors = [
-          '.swiper-slide img',
-          '.carousel-image img',
-          '.note-slider img',
-          '.note-image img',
-          '.image-wrapper img',
-          '#noteContainer .media-container img[src*="xhscdn"]',
-          'img[src*="ci.xiaohongshu.com"]'
-        ];
+        // Get images: prefer canonical carousel order from __INITIAL_STATE__
+        // so the saved order matches what the user sees on the platform (#1514).
+        // DOM extraction is used only as a fallback because multiple selectors,
+        // hidden / duplicated / preloaded slides, and lazy rendering can reorder
+        // the discovered nodes away from the platform's display order.
 
-        const imageUrls = new Set();
-        for (const selector of imageSelectors) {
-          document.querySelectorAll(selector).forEach(img => {
-            let src = img.src || img.getAttribute('data-src') || '';
-            if (src && (src.includes('xhscdn') || src.includes('xiaohongshu') || src.includes('rednote'))) {
-              src = src.split('?')[0];
-              src = src.replace(/\\/imageView\\d+\\/\\d+\\/w\\/\\d+/, '');
-              imageUrls.add(src);
+        const normalizeImageUrl = (raw) => {
+          if (!raw || typeof raw !== 'string') return '';
+          let src = raw.split('?')[0];
+          src = src.replace(/\\/imageView\\d+\\/\\d+\\/w\\/\\d+/, '');
+          return src;
+        };
+
+        const getStructuredNotes = () => {
+          const state = window.__INITIAL_STATE__;
+          const noteData = state?.note?.noteDetailMap || state?.note?.note || {};
+          if (!noteData || typeof noteData !== 'object') return [];
+          const currentIds = [...new Set([result.noteId, '${noteId}'].filter(Boolean))];
+          const notes = [];
+          for (const id of currentIds) {
+            const entry = noteData[id];
+            const note = entry?.note || entry;
+            if (note && typeof note === 'object') notes.push(note);
+          }
+          // Compatibility fallback for legacy single-note stores. Do not use this
+          // when keyed detail maps contain multiple notes, or carousel order can
+          // be polluted by preloaded/previous note entries.
+          const keys = Object.keys(noteData);
+          if (notes.length === 0 && keys.length === 1) {
+            const entry = noteData[keys[0]];
+            const note = entry?.note || entry;
+            if (note && typeof note === 'object') notes.push(note);
+          }
+          return notes;
+        };
+
+        // Method 1: walk __INITIAL_STATE__.note.noteDetailMap[id].note.imageList
+        // in array order. Each entry exposes urlDefault as the canonical CDN URL.
+        let imageInitialStateUsed = false;
+        try {
+          for (const note of getStructuredNotes()) {
+            const list = Array.isArray(note?.imageList) ? note.imageList : [];
+            for (const item of list) {
+              const candidate = item?.urlDefault || item?.urlPre || item?.url
+                || item?.infoList?.find(i => i?.imageScene === 'WB_DFT')?.url
+                || item?.infoList?.[0]?.url
+                || '';
+              const src = normalizeImageUrl(candidate);
+              if (src && (src.includes('xhscdn') || src.includes('xiaohongshu') || src.includes('rednote'))) {
+                pushMedia('image', src);
+                imageInitialStateUsed = true;
+              }
             }
-          });
+          }
+        } catch(e) {}
+
+        // Method 2: fallback to DOM scraping when the structured state is missing
+        // (e.g. preview pages without full SSR hydration). Order may differ from
+        // the carousel; surface it anyway rather than returning zero images.
+        if (!imageInitialStateUsed) {
+          const imageSelectors = [
+            '.swiper-slide img',
+            '.carousel-image img',
+            '.note-slider img',
+            '.note-image img',
+            '.image-wrapper img',
+            '#noteContainer .media-container img[src*="xhscdn"]',
+            'img[src*="ci.xiaohongshu.com"]'
+          ];
+          for (const selector of imageSelectors) {
+            document.querySelectorAll(selector).forEach(img => {
+              const raw = img.src || img.getAttribute('data-src') || '';
+              const src = normalizeImageUrl(raw);
+              if (src && (src.includes('xhscdn') || src.includes('xiaohongshu') || src.includes('rednote'))) {
+                pushMedia('image', src);
+              }
+            });
+          }
         }
 
         // Get video — prefer real URL from page state over blob: URLs
 
         // Method 1: Extract from __INITIAL_STATE__ (SSR hydration data)
         try {
-          const state = window.__INITIAL_STATE__;
-          if (state) {
-            const noteData = state.note?.noteDetailMap || state.note?.note || {};
-            for (const key of Object.keys(noteData)) {
-              const note = noteData[key]?.note || noteData[key];
-              const video = note?.video;
-              if (video) {
-                const vUrl = video.url || video.originVideoKey || video.consumer?.originVideoKey;
-                if (vUrl) {
-                  const fullUrl = vUrl.startsWith('http') ? vUrl : 'https://sns-video-bd.xhscdn.com/' + vUrl;
-                  pushMedia('video', fullUrl);
-                }
-                const streams = video.media?.stream?.h264 || [];
-                for (const stream of streams) {
-                  if (stream.masterUrl) pushMedia('video', stream.masterUrl);
-                }
+          for (const note of getStructuredNotes()) {
+            const video = note?.video;
+            if (video) {
+              const vUrl = video.url || video.originVideoKey || video.consumer?.originVideoKey;
+              if (vUrl) {
+                const fullUrl = vUrl.startsWith('http') ? vUrl : 'https://sns-video-bd.xhscdn.com/' + vUrl;
+                pushMedia('video', fullUrl);
+              }
+              const streams = video.media?.stream?.h264 || [];
+              for (const stream of streams) {
+                if (stream.masterUrl) pushMedia('video', stream.masterUrl);
               }
             }
           }
@@ -134,11 +186,6 @@ export function buildDownloadExtractJs(noteId) {
             });
           }
         }
-
-        // Add images to media
-        imageUrls.forEach(url => {
-          pushMedia('image', url);
-        });
 
         return result;
       })()

--- a/clis/xiaohongshu/download.test.js
+++ b/clis/xiaohongshu/download.test.js
@@ -10,7 +10,9 @@ vi.mock('@jackwener/opencli/download', () => ({
     formatCookieHeader: mockFormatCookieHeader,
 }));
 import { getRegistry } from '@jackwener/opencli/registry';
+import { JSDOM } from 'jsdom';
 import './download.js';
+import { buildDownloadExtractJs } from './download.js';
 function createPageMock(evaluateResult) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -111,5 +113,203 @@ describe('xiaohongshu download', () => {
             hint: expect.stringContaining('Try again later'),
         });
         expect(mockDownloadMedia).not.toHaveBeenCalled();
+    });
+});
+
+describe('xiaohongshu download buildDownloadExtractJs carousel ordering (JSDOM)', () => {
+    function runExtract({ html = '', initialState = null, url = 'https://www.xiaohongshu.com/explore/69f9716c000000003601f90e' } = {}) {
+        const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { url, runScripts: 'outside-only' });
+        if (initialState) {
+            dom.window.__INITIAL_STATE__ = initialState;
+        }
+        const js = buildDownloadExtractJs('69f9716c000000003601f90e');
+        return dom.window.eval(js);
+    }
+
+    it('preserves carousel order from __INITIAL_STATE__ imageList over DOM discovery order', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/canonical-cover.jpg' },
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/canonical-second.jpg' },
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/canonical-third.jpg' },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        // DOM has the same images but in a DIFFERENT order: repro for #1514.
+        const html = `
+          <div class="swiper-slide"><img src="https://sns-img-bd.xhscdn.com/canonical-second.jpg" /></div>
+          <div class="swiper-slide"><img src="https://sns-img-bd.xhscdn.com/canonical-cover.jpg" /></div>
+          <div class="swiper-slide"><img src="https://sns-img-bd.xhscdn.com/canonical-third.jpg" /></div>
+        `;
+        const result = runExtract({ html, initialState });
+        const images = result.media.filter((m) => m.type === 'image');
+        expect(images.map((m) => m.url)).toEqual([
+            'https://sns-img-bd.xhscdn.com/canonical-cover.jpg',
+            'https://sns-img-bd.xhscdn.com/canonical-second.jpg',
+            'https://sns-img-bd.xhscdn.com/canonical-third.jpg',
+        ]);
+    });
+
+    it('prefers urlDefault but falls back to urlPre / url / infoList.WB_DFT / infoList[0]', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/a.jpg' },
+                                { urlPre: 'https://sns-img-bd.xhscdn.com/b.jpg' },
+                                { url: 'https://sns-img-bd.xhscdn.com/c.jpg' },
+                                { infoList: [{ imageScene: 'WB_PRV', url: 'https://sns-img-bd.xhscdn.com/d-low.jpg' }, { imageScene: 'WB_DFT', url: 'https://sns-img-bd.xhscdn.com/d.jpg' }] },
+                                { infoList: [{ url: 'https://sns-img-bd.xhscdn.com/e.jpg' }] },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const urls = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        expect(urls).toEqual([
+            'https://sns-img-bd.xhscdn.com/a.jpg',
+            'https://sns-img-bd.xhscdn.com/b.jpg',
+            'https://sns-img-bd.xhscdn.com/c.jpg',
+            'https://sns-img-bd.xhscdn.com/d.jpg',
+            'https://sns-img-bd.xhscdn.com/e.jpg',
+        ]);
+    });
+
+    it('strips imageView resize params + query strings from canonical urls', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/raw/imageView2/2/w/1080/cover.jpg?expires=123' },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const urls = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        expect(urls).toEqual(['https://sns-img-bd.xhscdn.com/raw/cover.jpg']);
+    });
+
+    it('falls back to DOM extraction when __INITIAL_STATE__ omits imageList', () => {
+        const html = `
+          <div class="swiper-slide"><img src="https://sns-img-bd.xhscdn.com/dom-1.jpg" /></div>
+          <div class="swiper-slide"><img src="https://sns-img-bd.xhscdn.com/dom-2.jpg" /></div>
+        `;
+        const result = runExtract({ html });
+        const urls = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        expect(urls).toEqual([
+            'https://sns-img-bd.xhscdn.com/dom-1.jpg',
+            'https://sns-img-bd.xhscdn.com/dom-2.jpg',
+        ]);
+    });
+
+    it('skips non-xhscdn / non-xiaohongshu / non-rednote urls in initial state', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/keep.jpg' },
+                                { urlDefault: 'https://imgur.com/drop.jpg' },
+                                { urlDefault: '' },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const urls = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        expect(urls).toEqual(['https://sns-img-bd.xhscdn.com/keep.jpg']);
+    });
+
+    it('does not run DOM fallback when initial state yielded any image (preserves canonical order)', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/canonical-only.jpg' },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        const html = `
+          <div class="swiper-slide"><img src="https://sns-img-bd.xhscdn.com/dom-extra.jpg" /></div>
+        `;
+        const result = runExtract({ html, initialState });
+        const urls = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        expect(urls).toEqual(['https://sns-img-bd.xhscdn.com/canonical-only.jpg']);
+    });
+
+    it('uses only the current note entry from multi-note initial state maps', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    othernote0000000000000001: {
+                        note: {
+                            imageList: [{ urlDefault: 'https://sns-img-bd.xhscdn.com/other.jpg' }],
+                            video: { url: 'https://sns-video-bd.xhscdn.com/other.mp4' },
+                        },
+                    },
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/current-1.jpg' },
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/current-2.jpg' },
+                            ],
+                            video: { url: 'https://sns-video-bd.xhscdn.com/current.mp4' },
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const images = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        const videos = result.media.filter((m) => m.type === 'video').map((m) => m.url);
+        expect(images).toEqual([
+            'https://sns-img-bd.xhscdn.com/current-1.jpg',
+            'https://sns-img-bd.xhscdn.com/current-2.jpg',
+        ]);
+        expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/current.mp4']);
+    });
+
+    it('still resolves videos from __INITIAL_STATE__ alongside the image fix', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            imageList: [{ urlDefault: 'https://sns-img-bd.xhscdn.com/cover.jpg' }],
+                            video: { url: 'https://sns-video-bd.xhscdn.com/test.mp4' },
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const images = result.media.filter((m) => m.type === 'image').map((m) => m.url);
+        const videos = result.media.filter((m) => m.type === 'video').map((m) => m.url);
+        expect(images).toEqual(['https://sns-img-bd.xhscdn.com/cover.jpg']);
+        expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/test.mp4']);
     });
 });

--- a/clis/xiaohongshu/download.test.js
+++ b/clis/xiaohongshu/download.test.js
@@ -311,5 +311,6 @@ describe('xiaohongshu download buildDownloadExtractJs carousel ordering (JSDOM)'
         const videos = result.media.filter((m) => m.type === 'video').map((m) => m.url);
         expect(images).toEqual(['https://sns-img-bd.xhscdn.com/cover.jpg']);
         expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/test.mp4']);
+        expect(result.media.map((m) => m.type)).toEqual(['video', 'image']);
     });
 });


### PR DESCRIPTION
Closes #1514.

## Description

Reporter @Scofy0123 observed that `opencli xiaohongshu download` was saving carousel images in a different order from the order shown on the platform: the visible cover ended up as `<id>_2.jpg` instead of `<id>_1.jpg`.

Root cause is in `buildDownloadExtractJs`: the IIFE collected images by iterating multiple DOM selectors (`.swiper-slide img`, `.carousel-image img`, ...) into a `Set`, then appended that set to `result.media`. JS `Set` preserves insertion order, but the insertion order is whatever the selector walk hit first; hidden / preloaded / duplicated / lazy-rendered slides therefore shifted the saved order away from the canonical display order. Downstream `downloadMedia` then named files by index (`<id>_1.jpg`, `<id>_2.jpg`, ...), so the mismatched array order produced mismatched filenames.

## Fix

Mirrors the video extraction strategy already in this same IIFE: read the canonical media list from the SSR hydration data first, fall back to DOM scraping only when the structured state is absent.

- **Method 1 (new):** walk `window.__INITIAL_STATE__.note.noteDetailMap[id].note.imageList` in array order. Each entry exposes the canonical CDN URL via `urlDefault` (primary), with `urlPre` / `url` / `infoList.WB_DFT` / `infoList[0]` fallbacks for older shapes.
- **Method 2 (kept as fallback):** the previous multi-selector DOM walk, reached only when Method 1 yields zero images. Preview pages without full SSR hydration still surface something instead of an empty `media` array.

`normalizeImageUrl` helper hoisted out of the inline call so both paths apply the same query-string + imageView-resize strip.

The rednote adapter reuses `buildDownloadExtractJs` verbatim, so this PR fixes rednote download in the same change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New site command
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful (pending: live xhs run, draft until verified)

## Test plan

- [x] `npm run build`: manifest compiles
- [x] `npm run check:typed-error-lint`: passes
- [x] `npm run check:silent-column-drop`: passes
- [x] `npx vitest run --project adapter clis/xiaohongshu/download.test.js`: **12 tests passing** , 7 new JSDOM regression tests for the IIFE (matching the `ctrip buildFlightExtractJs (JSDOM)` pattern already in the repo):
  - canonical order from `imageList` overrides DOM discovery order (the exact #1514 repro)
  - field fallback chain: `urlDefault` -> `urlPre` -> `url` -> `infoList.WB_DFT` -> `infoList[0]`
  - query-string + imageView-resize stripping on canonical URLs
  - DOM fallback engages when `imageList` is missing
  - non-xhscdn / non-xiaohongshu / non-rednote URLs filtered out
  - DOM fallback does NOT engage when Method 1 yielded any image (no duplicate-from-DOM contamination)
  - video extraction still works alongside the image fix
- [x] `npx vitest run --project adapter clis/rednote/`: passes (rednote reuses the IIFE)
- [x] **Live verified** against a 7-image carousel note (`/explore/69748b9b000000002103388e`). Canonical `imageList[].urlDefault` order from `__INITIAL_STATE__` matches the 7 downloaded files 1:1 (saved as `<id>_1.jpg`...`<id>_7.jpg` in display order). Single live run on a public note, respecting xhs rate-limit sensitivity.

Live verified, ready for review.

## Out of scope

- Returning extra metadata (`sourceIndex`, `role: cover/body`, ...) per the reporter's optional suggestion: not needed for the ordering fix and would change the row shape. Left as a separate enhancement if downstream tools ask for it.


