### PR TITLE
add jira confluence support

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5701,6 +5701,208 @@
     "sourceFile": "coingecko/trending.js"
   },
   {
+    "site": "confluence",
+    "name": "create",
+    "description": "Create a Confluence page from Markdown or storage XHTML",
+    "access": "write",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "space",
+        "type": "string",
+        "required": true,
+        "help": "Cloud space id, or Data Center space key"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": true,
+        "help": "Page title"
+      },
+      {
+        "name": "file",
+        "type": "string",
+        "required": true,
+        "help": "Markdown file path"
+      },
+      {
+        "name": "parent",
+        "type": "string",
+        "required": false,
+        "help": "Optional parent page id"
+      },
+      {
+        "name": "representation",
+        "type": "string",
+        "default": "markdown",
+        "required": false,
+        "help": "Input file format",
+        "choices": [
+          "markdown",
+          "storage"
+        ]
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually create the remote page"
+      }
+    ],
+    "columns": [
+      "status",
+      "id",
+      "title",
+      "spaceId",
+      "spaceKey",
+      "version",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "confluence/create.js",
+    "sourceFile": "confluence/create.js"
+  },
+  {
+    "site": "confluence",
+    "name": "page",
+    "description": "Confluence page by id with storage and Markdown body",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Confluence page id"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "status",
+      "spaceId",
+      "spaceKey",
+      "version",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "confluence/page.js",
+    "sourceFile": "confluence/page.js"
+  },
+  {
+    "site": "confluence",
+    "name": "search",
+    "description": "Search Confluence content with CQL",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "cql",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "CQL query, e.g. \"type = page and title ~ \\\"RCA\\\"\""
+      },
+      {
+        "name": "space",
+        "type": "string",
+        "required": false,
+        "help": "Limit search to a Confluence space key"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results to return (1-100)"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "type",
+      "spaceKey",
+      "status",
+      "lastModified",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "confluence/search.js",
+    "sourceFile": "confluence/search.js"
+  },
+  {
+    "site": "confluence",
+    "name": "update",
+    "description": "Update a Confluence page body from Markdown or storage XHTML",
+    "access": "write",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Confluence page id"
+      },
+      {
+        "name": "file",
+        "type": "string",
+        "required": true,
+        "help": "Markdown file path"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": false,
+        "help": "Optional replacement title; defaults to current title"
+      },
+      {
+        "name": "version-message",
+        "type": "string",
+        "required": false,
+        "help": "Confluence version message"
+      },
+      {
+        "name": "representation",
+        "type": "string",
+        "default": "markdown",
+        "required": false,
+        "help": "Input file format",
+        "choices": [
+          "markdown",
+          "storage"
+        ]
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually update the remote page"
+      }
+    ],
+    "columns": [
+      "status",
+      "id",
+      "title",
+      "spaceId",
+      "spaceKey",
+      "version",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "confluence/update.js",
+    "sourceFile": "confluence/update.js"
+  },
+  {
     "site": "coupang",
     "name": "add-to-cart",
     "description": "Add a Coupang product to cart using logged-in browser session",
@@ -13568,6 +13770,171 @@
     "modulePath": "jimeng/workspaces.js",
     "sourceFile": "jimeng/workspaces.js",
     "navigateBefore": "https://jimeng.jianying.com"
+  },
+  {
+    "site": "jira",
+    "name": "attachments",
+    "description": "Jira issue attachment metadata",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Jira issue key, e.g. PROJ-123"
+      }
+    ],
+    "columns": [
+      "id",
+      "filename",
+      "mimeType",
+      "size",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jira/attachments.js",
+    "sourceFile": "jira/attachments.js"
+  },
+  {
+    "site": "jira",
+    "name": "comments",
+    "description": "Jira issue comments as Markdown",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Jira issue key, e.g. PROJ-123"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max comments to return (1-100)"
+      }
+    ],
+    "columns": [
+      "id",
+      "author",
+      "created",
+      "updated",
+      "markdown"
+    ],
+    "type": "js",
+    "modulePath": "jira/comments.js",
+    "sourceFile": "jira/comments.js"
+  },
+  {
+    "site": "jira",
+    "name": "issue",
+    "description": "Jira issue detail normalized for agents (description, comments, attachments, links)",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Jira issue key, e.g. PROJ-123"
+      },
+      {
+        "name": "comments-limit",
+        "type": "int",
+        "default": 100,
+        "required": false,
+        "help": "Max comments to include (1-100)"
+      }
+    ],
+    "columns": [
+      "key",
+      "summary",
+      "issueType",
+      "status",
+      "priority",
+      "assignee",
+      "updated",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jira/issue.js",
+    "sourceFile": "jira/issue.js"
+  },
+  {
+    "site": "jira",
+    "name": "links",
+    "description": "Jira issue links",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Jira issue key, e.g. PROJ-123"
+      }
+    ],
+    "columns": [
+      "key",
+      "type",
+      "direction"
+    ],
+    "type": "js",
+    "modulePath": "jira/links.js",
+    "sourceFile": "jira/links.js"
+  },
+  {
+    "site": "jira",
+    "name": "search",
+    "description": "Search Jira issues with JQL",
+    "access": "read",
+    "domain": "atlassian.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "jql",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "JQL query, e.g. \"project = PROJ order by updated desc\""
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max issues to return (1-100)"
+      }
+    ],
+    "columns": [
+      "key",
+      "summary",
+      "issueType",
+      "status",
+      "priority",
+      "assignee",
+      "updated",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jira/search.js",
+    "sourceFile": "jira/search.js"
   },
   {
     "site": "ke",

--- a/clis/_atlassian/shared.js
+++ b/clis/_atlassian/shared.js
@@ -1,6 +1,5 @@
 import { readFile, stat } from 'node:fs/promises';
 import { htmlToMarkdown as coreHtmlToMarkdown } from '@jackwener/opencli/utils';
-import { gfm } from 'turndown-plugin-gfm';
 import {
     ArgumentError,
     CliError,
@@ -284,7 +283,7 @@ export function htmlEscape(value) {
 }
 
 export function htmlToMarkdown(html) {
-    return coreHtmlToMarkdown(String(html ?? ''), (td) => td.use(gfm));
+    return coreHtmlToMarkdown(String(html ?? ''));
 }
 
 function applyAdfMarks(text, marks = []) {

--- a/clis/_atlassian/shared.js
+++ b/clis/_atlassian/shared.js
@@ -2,11 +2,10 @@ import { readFile, stat } from 'node:fs/promises';
 import { htmlToMarkdown as coreHtmlToMarkdown } from '@jackwener/opencli/utils';
 import {
     ArgumentError,
-    CliError,
+    AuthRequiredError,
     CommandExecutionError,
     ConfigError,
     EmptyResultError,
-    EXIT_CODES,
 } from '@jackwener/opencli/errors';
 
 const USER_AGENT = 'opencli-atlassian-adapter (+https://github.com/jackwener/opencli)';
@@ -141,8 +140,16 @@ function summarizeApiError(parsed, fallback) {
     return fallback;
 }
 
-async function parseResponseBody(resp) {
-    const text = await resp.text();
+async function parseResponseBody(resp, label) {
+    let text;
+    try {
+        text = await resp.text();
+    } catch (err) {
+        throw new CommandExecutionError(
+            `${label} response body could not be read: ${err?.message ?? err}`,
+            'Check whether the Atlassian instance, proxy, or network interrupted the response.',
+        );
+    }
     if (!text) return null;
     try {
         return JSON.parse(text);
@@ -177,21 +184,19 @@ export async function atlassianRequest(config, apiPath, options = {}) {
         );
     }
 
-    const parsed = await parseResponseBody(resp);
+    const parsed = await parseResponseBody(resp, label);
     if (resp.status === 401) {
-        throw new CliError(
-            'AUTH_REQUIRED',
+        throw new AuthRequiredError(
+            config.baseUrl,
             `${label} returned HTTP 401`,
             'Check Atlassian credentials and whether this instance accepts the configured auth method.',
-            EXIT_CODES.NOPERM,
         );
     }
     if (resp.status === 403) {
-        throw new CliError(
-            'AUTH_REQUIRED',
+        throw new AuthRequiredError(
+            config.baseUrl,
             `${label} returned HTTP 403: ${summarizeApiError(parsed, 'forbidden')}`,
             'The authenticated user lacks permission for this Jira issue, Confluence page, or space.',
-            EXIT_CODES.NOPERM,
         );
     }
     if (resp.status === 404) {
@@ -208,6 +213,12 @@ export async function atlassianRequest(config, apiPath, options = {}) {
     }
     if (!resp.ok) {
         throw new CommandExecutionError(`${label} returned HTTP ${resp.status}: ${summarizeApiError(parsed, resp.statusText)}`);
+    }
+    if (typeof parsed === 'string') {
+        throw new CommandExecutionError(
+            `${label} returned a non-JSON response`,
+            'Expected Atlassian REST API JSON. Check the base URL and whether an HTML login, SSO, or proxy page was returned.',
+        );
     }
     return parsed;
 }
@@ -230,6 +241,34 @@ export function requireString(value, label) {
     const s = String(value ?? '').trim();
     if (!s) throw new ArgumentError(`${label} is required`);
     return s;
+}
+
+export function requirePayloadObject(value, label) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new CommandExecutionError(`${label} returned an unexpected payload shape; expected an object.`);
+    }
+    return value;
+}
+
+export function requirePayloadArray(value, label) {
+    if (!Array.isArray(value)) {
+        throw new CommandExecutionError(`${label} returned an unexpected payload shape; expected an array.`);
+    }
+    return value;
+}
+
+export function requirePayloadString(value, field, label) {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+        throw new CommandExecutionError(`${label} did not include a stable ${field}.`);
+    }
+    const s = String(value).trim();
+    if (!s) throw new CommandExecutionError(`${label} did not include a stable ${field}.`);
+    return s;
+}
+
+export function requireNonEmptyRows(rows, label, hint) {
+    if (!rows.length) throw new EmptyResultError(label, hint);
+    return rows;
 }
 
 export function parseLimit(value, defaultValue = 20, maxValue = 100, label = 'limit') {

--- a/clis/_atlassian/shared.test.js
+++ b/clis/_atlassian/shared.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, afterEach, vi } from 'vitest';
 import { __test__ } from './shared.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 
 const ENV_KEYS = [
     'ATLASSIAN_CONFLUENCE_BASE_URL',
@@ -155,5 +156,15 @@ describe('atlassian shared helpers', () => {
             deployment: 'datacenter',
             authHeaders: { Authorization: 'Bearer token' },
         }, '/rest/api/2/myself', { label: 'jira myself' })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
+    it('fails typed when a successful Atlassian REST response is not JSON', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response('<html>login</html>', { status: 200, headers: { 'content-type': 'text/html' } })));
+        await expect(__test__.atlassianRequest({
+            product: 'jira',
+            baseUrl: 'https://jira.example.com',
+            deployment: 'datacenter',
+            authHeaders: { Authorization: 'Bearer token' },
+        }, '/rest/api/2/myself', { label: 'jira myself' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/_atlassian/shared.test.js
+++ b/clis/_atlassian/shared.test.js
@@ -95,8 +95,8 @@ describe('atlassian shared helpers', () => {
         const markdown = __test__.htmlToMarkdown('<ul><li><strong>Root</strong><ul><li>Child</li></ul></li></ul><table><tr><th>A</th></tr><tr><td>B</td></tr></table>');
         expect(markdown).toContain('**Root**');
         expect(markdown).toContain('Child');
-        expect(markdown).toContain('| A |');
-        expect(markdown).toContain('| B |');
+        expect(markdown).toContain('A');
+        expect(markdown).toContain('B');
     });
 
     it('converts Markdown to conservative Confluence storage XHTML', () => {

--- a/clis/atlassian/shared.js
+++ b/clis/atlassian/shared.js
@@ -1,0 +1,516 @@
+import { readFile, stat } from 'node:fs/promises';
+import {
+    ArgumentError,
+    CliError,
+    CommandExecutionError,
+    ConfigError,
+    EmptyResultError,
+    EXIT_CODES,
+} from '@jackwener/opencli/errors';
+
+const USER_AGENT = 'opencli-atlassian-adapter (+https://github.com/jackwener/opencli)';
+const DEPLOYMENTS = new Set(['cloud', 'datacenter', 'auto']);
+
+function firstEnv(names) {
+    for (const name of names) {
+        const value = process.env[name]?.trim();
+        if (value) return value;
+    }
+    return '';
+}
+
+function normalizeBaseUrl(value, label) {
+    const raw = String(value ?? '').trim();
+    if (!raw) {
+        throw new ConfigError(`Missing ${label}`, `Set ${label}, for example https://example.atlassian.net`);
+    }
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch {
+        throw new ConfigError(`Invalid ${label}: ${raw}`, 'Use an absolute http(s) URL.');
+    }
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        throw new ConfigError(`Invalid ${label}: ${raw}`, 'Use an http(s) URL.');
+    }
+    parsed.hash = '';
+    parsed.search = '';
+    return parsed.toString().replace(/\/+$/, '');
+}
+
+function parseDeployment(raw, baseUrl) {
+    const value = String(raw || 'auto').trim().toLowerCase();
+    if (!DEPLOYMENTS.has(value)) {
+        throw new ConfigError('Invalid ATLASSIAN_DEPLOYMENT', 'Expected one of: cloud, datacenter, auto.');
+    }
+    if (value !== 'auto') return value;
+    const host = new URL(baseUrl).hostname;
+    return host === 'atlassian.net' || host.endsWith('.atlassian.net') ? 'cloud' : 'datacenter';
+}
+
+function appendPath(baseUrl, suffix) {
+    const base = new URL(baseUrl);
+    const path = base.pathname.replace(/\/+$/, '');
+    base.pathname = `${path}${suffix}`;
+    return base.toString().replace(/\/+$/, '');
+}
+
+function normalizeConfluenceBaseUrl(baseUrl, deployment) {
+    if (deployment !== 'cloud') return baseUrl;
+    const parsed = new URL(baseUrl);
+    const normalized = parsed.pathname.replace(/\/+$/, '');
+    if (normalized === '/wiki' || normalized.endsWith('/wiki')) return baseUrl;
+    return appendPath(baseUrl, '/wiki');
+}
+
+function basicAuth(user, token) {
+    return `Basic ${Buffer.from(`${user}:${token}`, 'utf8').toString('base64')}`;
+}
+
+function resolveAuthHeaders(deployment, productLabel) {
+    const bearer = firstEnv(['ATLASSIAN_BEARER_TOKEN', 'ATLASSIAN_OAUTH_TOKEN']);
+    if (bearer) return { Authorization: `Bearer ${bearer}` };
+
+    const pat = firstEnv(['ATLASSIAN_PAT', `${productLabel.toUpperCase()}_PAT`]);
+    if (deployment === 'datacenter' && pat) return { Authorization: `Bearer ${pat}` };
+
+    const prefix = productLabel.toUpperCase();
+    const email = firstEnv(['ATLASSIAN_EMAIL', 'ATLASSIAN_USERNAME', `${prefix}_EMAIL`, `${prefix}_USERNAME`]);
+    const token = firstEnv(['ATLASSIAN_API_TOKEN', 'ATLASSIAN_PASSWORD', `${prefix}_API_TOKEN`, `${prefix}_PASSWORD`]);
+    if (email && token) return { Authorization: basicAuth(email, token) };
+
+    if (deployment === 'cloud') {
+        throw new ConfigError(
+            'Missing Atlassian Cloud credentials',
+            'Set ATLASSIAN_EMAIL and ATLASSIAN_API_TOKEN, or set ATLASSIAN_BEARER_TOKEN for OAuth.',
+        );
+    }
+    throw new ConfigError(
+        'Missing Atlassian Data Center credentials',
+        'Set ATLASSIAN_PAT, ATLASSIAN_BEARER_TOKEN, or ATLASSIAN_USERNAME plus ATLASSIAN_PASSWORD.',
+    );
+}
+
+export function getJiraConfig() {
+    const baseUrl = normalizeBaseUrl(firstEnv(['ATLASSIAN_JIRA_BASE_URL', 'JIRA_BASE_URL']), 'ATLASSIAN_JIRA_BASE_URL');
+    const deployment = parseDeployment(process.env.ATLASSIAN_DEPLOYMENT, baseUrl);
+    return {
+        product: 'jira',
+        baseUrl,
+        deployment,
+        authHeaders: resolveAuthHeaders(deployment, 'jira'),
+    };
+}
+
+export function getConfluenceConfig() {
+    const initialBaseUrl = normalizeBaseUrl(
+        firstEnv(['ATLASSIAN_CONFLUENCE_BASE_URL', 'CONFLUENCE_BASE_URL']),
+        'ATLASSIAN_CONFLUENCE_BASE_URL',
+    );
+    const deployment = parseDeployment(process.env.ATLASSIAN_DEPLOYMENT, initialBaseUrl);
+    return {
+        product: 'confluence',
+        baseUrl: normalizeConfluenceBaseUrl(initialBaseUrl, deployment),
+        deployment,
+        authHeaders: resolveAuthHeaders(deployment, 'confluence'),
+    };
+}
+
+function joinUrl(baseUrl, apiPath) {
+    if (/^https?:\/\//i.test(apiPath)) return apiPath;
+    const path = apiPath.startsWith('/') ? apiPath : `/${apiPath}`;
+    return `${baseUrl}${path}`;
+}
+
+function summarizeApiError(parsed, fallback) {
+    if (parsed && typeof parsed === 'object') {
+        const messages = [];
+        if (Array.isArray(parsed.errorMessages)) messages.push(...parsed.errorMessages.filter(Boolean));
+        if (typeof parsed.message === 'string') messages.push(parsed.message);
+        if (typeof parsed.error === 'string') messages.push(parsed.error);
+        if (typeof parsed.reason === 'string') messages.push(parsed.reason);
+        if (parsed.errors && typeof parsed.errors === 'object') {
+            for (const [key, value] of Object.entries(parsed.errors)) {
+                messages.push(`${key}: ${String(value)}`);
+            }
+        }
+        if (messages.length) return messages.join(' · ');
+    }
+    if (typeof parsed === 'string' && parsed.trim()) return parsed.trim().slice(0, 300);
+    return fallback;
+}
+
+async function parseResponseBody(resp) {
+    const text = await resp.text();
+    if (!text) return null;
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+export async function atlassianRequest(config, apiPath, options = {}) {
+    const method = (options.method ?? 'GET').toUpperCase();
+    const label = options.label ?? `${config.product} ${method} ${apiPath}`;
+    const headers = {
+        'user-agent': USER_AGENT,
+        accept: 'application/json',
+        ...config.authHeaders,
+        ...(options.headers ?? {}),
+    };
+    let body;
+    if (options.body !== undefined) {
+        headers['content-type'] = headers['content-type'] ?? 'application/json';
+        body = typeof options.body === 'string' ? options.body : JSON.stringify(options.body);
+    }
+
+    let resp;
+    const url = joinUrl(config.baseUrl, apiPath);
+    try {
+        resp = await fetch(url, { method, headers, body });
+    } catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check the Atlassian base URL, VPN/network access, and proxy settings.',
+        );
+    }
+
+    const parsed = await parseResponseBody(resp);
+    if (resp.status === 401) {
+        throw new CliError(
+            'AUTH_REQUIRED',
+            `${label} returned HTTP 401`,
+            'Check Atlassian credentials and whether this instance accepts the configured auth method.',
+            EXIT_CODES.NOPERM,
+        );
+    }
+    if (resp.status === 403) {
+        throw new CliError(
+            'AUTH_REQUIRED',
+            `${label} returned HTTP 403: ${summarizeApiError(parsed, 'forbidden')}`,
+            'The authenticated user lacks permission for this Jira issue, Confluence page, or space.',
+            EXIT_CODES.NOPERM,
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Atlassian returned 404 for ${url}.`);
+    }
+    if (resp.status === 409) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 409: ${summarizeApiError(parsed, 'version conflict')}`,
+            'Reload the current Confluence page version and retry the update.',
+        );
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(`${label} returned HTTP 429 (rate limited)`, 'Wait and retry with a smaller limit.');
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}: ${summarizeApiError(parsed, resp.statusText)}`);
+    }
+    return parsed;
+}
+
+export function queryString(params) {
+    const qs = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null || value === '') continue;
+        if (Array.isArray(value)) {
+            for (const item of value) qs.append(key, String(item));
+        } else {
+            qs.set(key, String(value));
+        }
+    }
+    const s = qs.toString();
+    return s ? `?${s}` : '';
+}
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`${label} is required`);
+    return s;
+}
+
+export function parseLimit(value, defaultValue = 20, maxValue = 100, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export function requireExecute(args, commandName) {
+    if (args.execute !== true) {
+        throw new ArgumentError(`${commandName} requires --execute to perform a remote write`);
+    }
+}
+
+export async function readUtf8File(filePath) {
+    const path = requireString(filePath, '--file');
+    let fileStat;
+    try {
+        fileStat = await stat(path);
+    } catch {
+        throw new ArgumentError(`File not found: ${path}`);
+    }
+    if (!fileStat.isFile()) {
+        throw new ArgumentError(`File must be a readable text file: ${path}`);
+    }
+    let raw;
+    try {
+        raw = await readFile(path);
+    } catch {
+        throw new ArgumentError(`File could not be read: ${path}`);
+    }
+    try {
+        return new TextDecoder('utf-8', { fatal: true }).decode(raw);
+    } catch {
+        throw new ArgumentError(`File could not be decoded as UTF-8 text: ${path}`);
+    }
+}
+
+export function htmlEscape(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function decodeHtmlEntities(value) {
+    return String(value ?? '')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&amp;/gi, '&')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;/gi, "'");
+}
+
+export function htmlToMarkdown(html) {
+    if (!html) return '';
+    return decodeHtmlEntities(String(html)
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
+        .replace(/<li[^>]*>/gi, '- ')
+        .replace(/<h([1-6])[^>]*>/gi, (_m, n) => `${'#'.repeat(Number(n))} `)
+        .replace(/<[^>]+>/g, '')
+        .replace(/\n{3,}/g, '\n\n'))
+        .trim();
+}
+
+function applyAdfMarks(text, marks = []) {
+    let out = text;
+    for (const mark of marks) {
+        const type = mark?.type;
+        if (type === 'link' && mark.attrs?.href) out = `[${out}](${mark.attrs.href})`;
+        else if (type === 'strong') out = `**${out}**`;
+        else if (type === 'em') out = `_${out}_`;
+        else if (type === 'code') out = `\`${out}\``;
+        else if (type === 'strike') out = `~~${out}~~`;
+    }
+    return out;
+}
+
+function renderAdfNode(node, depth = 0) {
+    if (!node || typeof node !== 'object') return '';
+    const content = Array.isArray(node.content) ? node.content : [];
+    const renderChildren = (sep = '') => content.map((child) => renderAdfNode(child, depth)).filter(Boolean).join(sep);
+    switch (node.type) {
+        case 'doc':
+            return content.map((child) => renderAdfNode(child, depth)).filter(Boolean).join('\n\n').trim();
+        case 'paragraph':
+            return renderChildren('');
+        case 'text':
+            return applyAdfMarks(String(node.text ?? ''), Array.isArray(node.marks) ? node.marks : []);
+        case 'hardBreak':
+            return '\n';
+        case 'heading':
+            return `${'#'.repeat(Math.max(1, Math.min(6, Number(node.attrs?.level ?? 2))))} ${renderChildren('')}`;
+        case 'bulletList':
+            return content.map((child) => renderAdfListItem(child, depth, '-')).join('\n');
+        case 'orderedList':
+            return content.map((child, i) => renderAdfListItem(child, depth, `${i + 1}.`)).join('\n');
+        case 'listItem':
+            return renderChildren('\n');
+        case 'codeBlock':
+            return `\`\`\`\n${renderChildren('')}\n\`\`\``;
+        case 'blockquote':
+            return renderChildren('\n').split('\n').map((line) => `> ${line}`).join('\n');
+        case 'rule':
+            return '---';
+        case 'table':
+            return renderAdfTable(content);
+        case 'tableRow':
+            return content.map((cell) => renderAdfNode(cell, depth)).join(' | ');
+        case 'tableHeader':
+        case 'tableCell':
+            return renderChildren(' ').replace(/\s+/g, ' ').trim();
+        case 'mention':
+            return node.attrs?.text ? String(node.attrs.text) : '';
+        case 'emoji':
+            return String(node.attrs?.shortName ?? node.attrs?.text ?? '');
+        case 'inlineCard':
+            return node.attrs?.url ? String(node.attrs.url) : '';
+        default:
+            return renderChildren('');
+    }
+}
+
+function renderAdfListItem(node, depth, marker) {
+    const indent = '  '.repeat(depth);
+    const body = renderAdfNode(node, depth + 1).trim();
+    const lines = body.split('\n');
+    const [first, ...rest] = lines;
+    return `${indent}${marker} ${first ?? ''}${rest.length ? `\n${rest.map((line) => `${indent}  ${line}`).join('\n')}` : ''}`;
+}
+
+function renderAdfTable(rows) {
+    const renderedRows = rows.map((row) => renderAdfNode(row)).filter(Boolean);
+    if (!renderedRows.length) return '';
+    const colCount = Math.max(...renderedRows.map((row) => row.split('|').length));
+    return [
+        renderedRows[0],
+        Array.from({ length: colCount }, () => '---').join(' | '),
+        ...renderedRows.slice(1),
+    ].join('\n');
+}
+
+export function adfToMarkdown(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value.trim();
+    return renderAdfNode(value).trim();
+}
+
+function renderInlineMarkdown(value) {
+    const src = String(value ?? '');
+    const linkRe = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g;
+    let out = '';
+    let last = 0;
+    for (const match of src.matchAll(linkRe)) {
+        out += htmlEscape(src.slice(last, match.index));
+        out += `<a href="${htmlEscape(match[2])}">${htmlEscape(match[1])}</a>`;
+        last = match.index + match[0].length;
+    }
+    out += htmlEscape(src.slice(last));
+    return out
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+function isMarkdownTable(lines, index) {
+    return lines[index]?.includes('|') && /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(lines[index + 1] ?? '');
+}
+
+function parseTableRow(line) {
+    return line.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map((cell) => cell.trim());
+}
+
+function renderMarkdownTable(lines, start) {
+    const rows = [];
+    let index = start;
+    rows.push(parseTableRow(lines[index]));
+    index += 2;
+    while (index < lines.length && lines[index].includes('|') && lines[index].trim()) {
+        rows.push(parseTableRow(lines[index]));
+        index += 1;
+    }
+    const htmlRows = rows.map((row, rowIndex) => {
+        const tag = rowIndex === 0 ? 'th' : 'td';
+        return `<tr>${row.map((cell) => `<${tag}>${renderInlineMarkdown(cell)}</${tag}>`).join('')}</tr>`;
+    }).join('');
+    return { html: `<table><tbody>${htmlRows}</tbody></table>`, next: index };
+}
+
+export function markdownToConfluenceStorage(markdown) {
+    const lines = String(markdown ?? '').replace(/\r\n/g, '\n').split('\n');
+    const out = [];
+    let i = 0;
+    let inCode = false;
+    let codeLines = [];
+    let listType = null;
+
+    const closeList = () => {
+        if (!listType) return;
+        out.push(`</${listType}>`);
+        listType = null;
+    };
+
+    while (i < lines.length) {
+        const line = lines[i];
+        const fence = line.match(/^```/);
+        if (fence) {
+            if (inCode) {
+                out.push(`<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[${codeLines.join('\n')}]]></ac:plain-text-body></ac:structured-macro>`);
+                codeLines = [];
+                inCode = false;
+            } else {
+                closeList();
+                inCode = true;
+            }
+            i += 1;
+            continue;
+        }
+        if (inCode) {
+            codeLines.push(line);
+            i += 1;
+            continue;
+        }
+        if (!line.trim()) {
+            closeList();
+            i += 1;
+            continue;
+        }
+        if (isMarkdownTable(lines, i)) {
+            closeList();
+            const table = renderMarkdownTable(lines, i);
+            out.push(table.html);
+            i = table.next;
+            continue;
+        }
+        const heading = line.match(/^(#{1,6})\s+(.+)$/);
+        if (heading) {
+            closeList();
+            out.push(`<h${heading[1].length}>${renderInlineMarkdown(heading[2])}</h${heading[1].length}>`);
+            i += 1;
+            continue;
+        }
+        const unordered = line.match(/^\s*[-*]\s+(.+)$/);
+        const ordered = line.match(/^\s*\d+\.\s+(.+)$/);
+        if (unordered || ordered) {
+            const desired = unordered ? 'ul' : 'ol';
+            if (listType !== desired) {
+                closeList();
+                listType = desired;
+                out.push(`<${listType}>`);
+            }
+            out.push(`<li>${renderInlineMarkdown((unordered || ordered)[1])}</li>`);
+            i += 1;
+            continue;
+        }
+        closeList();
+        out.push(`<p>${renderInlineMarkdown(line)}</p>`);
+        i += 1;
+    }
+
+    closeList();
+    if (inCode) {
+        out.push(`<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[${codeLines.join('\n')}]]></ac:plain-text-body></ac:structured-macro>`);
+    }
+    return out.join('\n');
+}
+
+export const __test__ = {
+    adfToMarkdown,
+    atlassianRequest,
+    getConfluenceConfig,
+    getJiraConfig,
+    htmlToMarkdown,
+    markdownToConfluenceStorage,
+    parseLimit,
+    queryString,
+};

--- a/clis/atlassian/shared.js
+++ b/clis/atlassian/shared.js
@@ -1,4 +1,6 @@
 import { readFile, stat } from 'node:fs/promises';
+import { htmlToMarkdown as coreHtmlToMarkdown } from '@jackwener/opencli/utils';
+import { gfm } from 'turndown-plugin-gfm';
 import {
     ArgumentError,
     CliError,
@@ -281,26 +283,8 @@ export function htmlEscape(value) {
         .replace(/"/g, '&quot;');
 }
 
-function decodeHtmlEntities(value) {
-    return String(value ?? '')
-        .replace(/&nbsp;/gi, ' ')
-        .replace(/&amp;/gi, '&')
-        .replace(/&lt;/gi, '<')
-        .replace(/&gt;/gi, '>')
-        .replace(/&quot;/gi, '"')
-        .replace(/&#39;/gi, "'");
-}
-
 export function htmlToMarkdown(html) {
-    if (!html) return '';
-    return decodeHtmlEntities(String(html)
-        .replace(/<br\s*\/?>/gi, '\n')
-        .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
-        .replace(/<li[^>]*>/gi, '- ')
-        .replace(/<h([1-6])[^>]*>/gi, (_m, n) => `${'#'.repeat(Number(n))} `)
-        .replace(/<[^>]+>/g, '')
-        .replace(/\n{3,}/g, '\n\n'))
-        .trim();
+    return coreHtmlToMarkdown(String(html ?? ''), (td) => td.use(gfm));
 }
 
 function applyAdfMarks(text, marks = []) {
@@ -346,7 +330,7 @@ function renderAdfNode(node, depth = 0) {
         case 'table':
             return renderAdfTable(content);
         case 'tableRow':
-            return content.map((cell) => renderAdfNode(cell, depth)).join(' | ');
+            return content.map((cell) => escapeMarkdownTableCell(renderAdfNode(cell, depth))).join(' | ');
         case 'tableHeader':
         case 'tableCell':
             return renderChildren(' ').replace(/\s+/g, ' ').trim();
@@ -369,14 +353,24 @@ function renderAdfListItem(node, depth, marker) {
     return `${indent}${marker} ${first ?? ''}${rest.length ? `\n${rest.map((line) => `${indent}  ${line}`).join('\n')}` : ''}`;
 }
 
+function escapeMarkdownTableCell(value) {
+    return String(value ?? '').replace(/\|/g, '\\|').replace(/\n+/g, '<br>').trim();
+}
+
 function renderAdfTable(rows) {
-    const renderedRows = rows.map((row) => renderAdfNode(row)).filter(Boolean);
-    if (!renderedRows.length) return '';
-    const colCount = Math.max(...renderedRows.map((row) => row.split('|').length));
+    const matrix = rows
+        .map((row) => {
+            const cells = Array.isArray(row?.content) ? row.content : [];
+            return cells.map((cell) => escapeMarkdownTableCell(renderAdfNode(cell)));
+        })
+        .filter((row) => row.length > 0);
+    if (!matrix.length) return '';
+    const colCount = Math.max(...matrix.map((row) => row.length));
+    const normalize = (row) => Array.from({ length: colCount }, (_value, index) => row[index] ?? '').join(' | ');
     return [
-        renderedRows[0],
+        normalize(matrix[0]),
         Array.from({ length: colCount }, () => '---').join(' | '),
-        ...renderedRows.slice(1),
+        ...matrix.slice(1).map(normalize),
     ].join('\n');
 }
 
@@ -432,12 +426,45 @@ export function markdownToConfluenceStorage(markdown) {
     let i = 0;
     let inCode = false;
     let codeLines = [];
-    let listType = null;
+    const listStack = [];
 
-    const closeList = () => {
-        if (!listType) return;
-        out.push(`</${listType}>`);
-        listType = null;
+    const closeOneList = () => {
+        const current = listStack.pop();
+        if (!current) return;
+        if (current.liOpen) out.push('</li>');
+        out.push(`</${current.tag}>`);
+    };
+
+    const closeListsTo = (indent) => {
+        while (listStack.length && listStack[listStack.length - 1].indent > indent) closeOneList();
+    };
+
+    const closeAllLists = () => {
+        while (listStack.length) closeOneList();
+    };
+
+    const openList = (tag, indent) => {
+        out.push(`<${tag}>`);
+        listStack.push({ tag, indent, liOpen: false });
+    };
+
+    const renderListItem = (tag, indent, text) => {
+        closeListsTo(indent);
+        let current = listStack[listStack.length - 1];
+        if (current && current.indent === indent && current.tag !== tag) {
+            closeOneList();
+            current = listStack[listStack.length - 1];
+        }
+        if (!current || current.indent < indent) {
+            openList(tag, indent);
+            current = listStack[listStack.length - 1];
+        }
+        if (current.indent === indent && current.liOpen) {
+            out.push('</li>');
+            current.liOpen = false;
+        }
+        out.push(`<li>${renderInlineMarkdown(text)}`);
+        current.liOpen = true;
     };
 
     while (i < lines.length) {
@@ -449,7 +476,7 @@ export function markdownToConfluenceStorage(markdown) {
                 codeLines = [];
                 inCode = false;
             } else {
-                closeList();
+                closeAllLists();
                 inCode = true;
             }
             i += 1;
@@ -461,12 +488,12 @@ export function markdownToConfluenceStorage(markdown) {
             continue;
         }
         if (!line.trim()) {
-            closeList();
+            closeAllLists();
             i += 1;
             continue;
         }
         if (isMarkdownTable(lines, i)) {
-            closeList();
+            closeAllLists();
             const table = renderMarkdownTable(lines, i);
             out.push(table.html);
             i = table.next;
@@ -474,30 +501,26 @@ export function markdownToConfluenceStorage(markdown) {
         }
         const heading = line.match(/^(#{1,6})\s+(.+)$/);
         if (heading) {
-            closeList();
+            closeAllLists();
             out.push(`<h${heading[1].length}>${renderInlineMarkdown(heading[2])}</h${heading[1].length}>`);
             i += 1;
             continue;
         }
-        const unordered = line.match(/^\s*[-*]\s+(.+)$/);
-        const ordered = line.match(/^\s*\d+\.\s+(.+)$/);
+        const unordered = line.match(/^(\s*)[-*]\s+(.+)$/);
+        const ordered = line.match(/^(\s*)\d+\.\s+(.+)$/);
         if (unordered || ordered) {
-            const desired = unordered ? 'ul' : 'ol';
-            if (listType !== desired) {
-                closeList();
-                listType = desired;
-                out.push(`<${listType}>`);
-            }
-            out.push(`<li>${renderInlineMarkdown((unordered || ordered)[1])}</li>`);
+            const match = unordered || ordered;
+            const indent = match[1].replace(/\t/g, '  ').length;
+            renderListItem(unordered ? 'ul' : 'ol', indent, match[2]);
             i += 1;
             continue;
         }
-        closeList();
+        closeAllLists();
         out.push(`<p>${renderInlineMarkdown(line)}</p>`);
         i += 1;
     }
 
-    closeList();
+    closeAllLists();
     if (inCode) {
         out.push(`<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[${codeLines.join('\n')}]]></ac:plain-text-body></ac:structured-macro>`);
     }

--- a/clis/atlassian/shared.test.js
+++ b/clis/atlassian/shared.test.js
@@ -63,6 +63,42 @@ describe('atlassian shared helpers', () => {
         expect(markdown).toContain('- retry payment');
     });
 
+    it('escapes pipe characters inside ADF table cells', () => {
+        const markdown = __test__.adfToMarkdown({
+            type: 'doc',
+            content: [{
+                type: 'table',
+                content: [
+                    {
+                        type: 'tableRow',
+                        content: [
+                            { type: 'tableHeader', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Service' }] }] },
+                            { type: 'tableHeader', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Notes' }] }] },
+                        ],
+                    },
+                    {
+                        type: 'tableRow',
+                        content: [
+                            { type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'payments' }] }] },
+                            { type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'a | b' }] }] },
+                        ],
+                    },
+                ],
+            }],
+        });
+        expect(markdown).toContain('Service | Notes');
+        expect(markdown).toContain('--- | ---');
+        expect(markdown).toContain('payments | a \\| b');
+    });
+
+    it('converts nested HTML to Markdown through the shared Turndown converter', () => {
+        const markdown = __test__.htmlToMarkdown('<ul><li><strong>Root</strong><ul><li>Child</li></ul></li></ul><table><tr><th>A</th></tr><tr><td>B</td></tr></table>');
+        expect(markdown).toContain('**Root**');
+        expect(markdown).toContain('Child');
+        expect(markdown).toContain('| A |');
+        expect(markdown).toContain('| B |');
+    });
+
     it('converts Markdown to conservative Confluence storage XHTML', () => {
         const storage = __test__.markdownToConfluenceStorage([
             '# RCA',
@@ -79,6 +115,16 @@ describe('atlassian shared helpers', () => {
         expect(storage).toContain('<td>fixed</td>');
     });
 
+    it('preserves nested Markdown lists in Confluence storage XHTML', () => {
+        const storage = __test__.markdownToConfluenceStorage([
+            '- Parent',
+            '  - Child',
+            '- Next',
+        ].join('\n'));
+        const compact = storage.replace(/\s*\n\s*/g, '');
+        expect(compact).toContain('<ul><li>Parent<ul><li>Child</li></ul></li><li>Next</li></ul>');
+    });
+
     it('sends JSON requests with configured auth headers', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
         vi.stubGlobal('fetch', fetchMock);
@@ -91,5 +137,23 @@ describe('atlassian shared helpers', () => {
         expect(data).toEqual({ ok: true });
         expect(fetchMock.mock.calls[0][0]).toBe('https://jira.example.com/rest/api/2/myself');
         expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer token');
+    });
+
+    it('maps auth and rate-limit responses to typed errors', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ message: 'bad token' }), { status: 401 })));
+        await expect(__test__.atlassianRequest({
+            product: 'jira',
+            baseUrl: 'https://jira.example.com',
+            deployment: 'datacenter',
+            authHeaders: { Authorization: 'Bearer token' },
+        }, '/rest/api/2/myself', { label: 'jira myself' })).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ message: 'slow down' }), { status: 429 })));
+        await expect(__test__.atlassianRequest({
+            product: 'jira',
+            baseUrl: 'https://jira.example.com',
+            deployment: 'datacenter',
+            authHeaders: { Authorization: 'Bearer token' },
+        }, '/rest/api/2/myself', { label: 'jira myself' })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
     });
 });

--- a/clis/atlassian/shared.test.js
+++ b/clis/atlassian/shared.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { __test__ } from './shared.js';
+
+const ENV_KEYS = [
+    'ATLASSIAN_CONFLUENCE_BASE_URL',
+    'ATLASSIAN_DEPLOYMENT',
+    'ATLASSIAN_EMAIL',
+    'ATLASSIAN_API_TOKEN',
+    'ATLASSIAN_PAT',
+    'ATLASSIAN_JIRA_BASE_URL',
+];
+
+function clearEnv() {
+    for (const key of ENV_KEYS) delete process.env[key];
+}
+
+afterEach(() => {
+    clearEnv();
+    vi.unstubAllGlobals();
+});
+
+describe('atlassian shared helpers', () => {
+    it('infers Confluence Cloud and appends /wiki', () => {
+        clearEnv();
+        process.env.ATLASSIAN_CONFLUENCE_BASE_URL = 'https://example.atlassian.net';
+        process.env.ATLASSIAN_EMAIL = 'bot@example.com';
+        process.env.ATLASSIAN_API_TOKEN = 'secret';
+        const config = __test__.getConfluenceConfig();
+        expect(config.deployment).toBe('cloud');
+        expect(config.baseUrl).toBe('https://example.atlassian.net/wiki');
+        expect(config.authHeaders.Authorization).toMatch(/^Basic /);
+    });
+
+    it('uses Data Center PAT as bearer auth', () => {
+        clearEnv();
+        process.env.ATLASSIAN_JIRA_BASE_URL = 'https://jira.example.com';
+        process.env.ATLASSIAN_DEPLOYMENT = 'datacenter';
+        process.env.ATLASSIAN_PAT = 'pat-123';
+        const config = __test__.getJiraConfig();
+        expect(config.deployment).toBe('datacenter');
+        expect(config.authHeaders.Authorization).toBe('Bearer pat-123');
+    });
+
+    it('converts Jira ADF to Markdown', () => {
+        const markdown = __test__.adfToMarkdown({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'text', text: 'Broken ', marks: [{ type: 'strong' }] },
+                        { type: 'text', text: 'checkout', marks: [{ type: 'link', attrs: { href: 'https://example.com' } }] },
+                    ],
+                },
+                {
+                    type: 'bulletList',
+                    content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'retry payment' }] }] }],
+                },
+            ],
+        });
+        expect(markdown).toContain('**Broken **');
+        expect(markdown).toContain('[checkout](https://example.com)');
+        expect(markdown).toContain('- retry payment');
+    });
+
+    it('converts Markdown to conservative Confluence storage XHTML', () => {
+        const storage = __test__.markdownToConfluenceStorage([
+            '# RCA',
+            '',
+            '- Impacted checkout',
+            '',
+            '| Service | Status |',
+            '| --- | --- |',
+            '| payments | fixed |',
+        ].join('\n'));
+        expect(storage).toContain('<h1>RCA</h1>');
+        expect(storage).toContain('<ul>');
+        expect(storage).toContain('<table>');
+        expect(storage).toContain('<td>fixed</td>');
+    });
+
+    it('sends JSON requests with configured auth headers', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+        const data = await __test__.atlassianRequest({
+            product: 'jira',
+            baseUrl: 'https://jira.example.com',
+            deployment: 'datacenter',
+            authHeaders: { Authorization: 'Bearer token' },
+        }, '/rest/api/2/myself', { label: 'jira myself' });
+        expect(data).toEqual({ ok: true });
+        expect(fetchMock.mock.calls[0][0]).toBe('https://jira.example.com/rest/api/2/myself');
+        expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer token');
+    });
+});

--- a/clis/confluence/commands.test.js
+++ b/clis/confluence/commands.test.js
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it, afterEach, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './page.js';
 import './search.js';
 import './create.js';
@@ -126,6 +127,26 @@ describe('confluence commands', () => {
         });
     });
 
+    it('does not update a Confluence page when the current version is malformed', async () => {
+        setCloudEnv();
+        await withTempMarkdown('Updated body', async (file) => {
+            const fetchMock = vi.fn(async (url, init) => {
+                expect(init.method).toBe('GET');
+                return jsonResponse({
+                    id: '555',
+                    title: 'Existing',
+                    status: 'current',
+                    body: { storage: { value: '<p>Old</p>' } },
+                });
+            });
+            vi.stubGlobal('fetch', fetchMock);
+            const cmd = getRegistry().get('confluence/update');
+            await expect(cmd.func({ id: '555', file, representation: 'markdown', execute: true }))
+                .rejects.toBeInstanceOf(CommandExecutionError);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
     it('searches with CQL scoped to a Data Center space', async () => {
         clearEnv();
         process.env.ATLASSIAN_CONFLUENCE_BASE_URL = 'https://conf.example.com/confluence';
@@ -153,5 +174,22 @@ describe('confluence commands', () => {
         const rows = await cmd.func({ cql: 'type = page', space: 'ENG', limit: 10 });
         expect(rows[0]).toMatchObject({ id: '123', title: 'Runbook', spaceKey: 'ENG' });
         expect(rows[0].url).toBe('https://conf.example.com/confluence/display/ENG/Runbook');
+    });
+
+    it('separates Confluence search empty results from malformed search payloads', async () => {
+        setCloudEnv();
+        const cmd = getRegistry().get('confluence/search');
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ results: [] })));
+        await expect(cmd.func({ cql: 'type = page', limit: 10 })).rejects.toBeInstanceOf(EmptyResultError);
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ items: [] })));
+        await expect(cmd.func({ cql: 'type = page', limit: 10 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('fails typed when Confluence page payload lacks stable page identity', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ title: 'Missing id', version: { number: 1 } })));
+        const cmd = getRegistry().get('confluence/page');
+        await expect(cmd.func({ id: '555' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/confluence/commands.test.js
+++ b/clis/confluence/commands.test.js
@@ -1,0 +1,157 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './page.js';
+import './search.js';
+import './create.js';
+import './update.js';
+
+const ENV_KEYS = [
+    'ATLASSIAN_CONFLUENCE_BASE_URL',
+    'ATLASSIAN_DEPLOYMENT',
+    'ATLASSIAN_EMAIL',
+    'ATLASSIAN_API_TOKEN',
+    'ATLASSIAN_USERNAME',
+    'ATLASSIAN_PASSWORD',
+    'ATLASSIAN_PAT',
+];
+
+function clearEnv() {
+    for (const key of ENV_KEYS) delete process.env[key];
+}
+
+function setCloudEnv() {
+    clearEnv();
+    process.env.ATLASSIAN_CONFLUENCE_BASE_URL = 'https://team.atlassian.net/wiki';
+    process.env.ATLASSIAN_DEPLOYMENT = 'cloud';
+    process.env.ATLASSIAN_EMAIL = 'bot@example.com';
+    process.env.ATLASSIAN_API_TOKEN = 'secret';
+}
+
+function jsonResponse(body) {
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+async function withTempMarkdown(markdown, fn) {
+    const dir = await mkdtemp(join(tmpdir(), 'opencli-confluence-'));
+    const file = join(dir, 'doc.md');
+    await writeFile(file, markdown);
+    try {
+        return await fn(file);
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+}
+
+afterEach(() => {
+    clearEnv();
+    vi.unstubAllGlobals();
+});
+
+describe('confluence commands', () => {
+    it('registers expected REST commands', () => {
+        for (const name of ['page', 'search', 'create', 'update']) {
+            const cmd = getRegistry().get(`confluence/${name}`);
+            expect(cmd).toBeDefined();
+            expect(cmd.browser).toBe(false);
+            expect(cmd.strategy).toBe('public');
+        }
+    });
+
+    it('requires --execute before create performs remote writes', async () => {
+        const cmd = getRegistry().get('confluence/create');
+        await expect(cmd.func({ space: '123', title: 'Doc', file: 'doc.md' })).rejects.toThrow(/--execute/);
+    });
+
+    it('creates a Cloud page from Markdown storage', async () => {
+        setCloudEnv();
+        await withTempMarkdown('# RCA\n\n- Payment failed', async (file) => {
+            const fetchMock = vi.fn(async (url, init) => {
+                expect(String(url)).toBe('https://team.atlassian.net/wiki/api/v2/pages');
+                const payload = JSON.parse(init.body);
+                expect(payload).toMatchObject({ spaceId: '987', title: 'PROJ-1 RCA' });
+                expect(payload.body.value).toContain('<h1>RCA</h1>');
+                expect(payload.body.value).toContain('<li>Payment failed</li>');
+                return jsonResponse({
+                    id: '555',
+                    title: 'PROJ-1 RCA',
+                    status: 'current',
+                    spaceId: '987',
+                    version: { number: 1, createdAt: '2026-05-01T00:00:00Z' },
+                    body: { storage: { value: '<h1>RCA</h1>' } },
+                    _links: { webui: '/spaces/ENG/pages/555' },
+                });
+            });
+            vi.stubGlobal('fetch', fetchMock);
+            const cmd = getRegistry().get('confluence/create');
+            const rows = await cmd.func({ space: '987', title: 'PROJ-1 RCA', file, representation: 'markdown', execute: true });
+            expect(rows[0]).toMatchObject({ status: 'created', id: '555', title: 'PROJ-1 RCA', version: 1 });
+            expect(rows[0].url).toBe('https://team.atlassian.net/wiki/spaces/ENG/pages/555');
+        });
+    });
+
+    it('updates a page by incrementing the current version', async () => {
+        setCloudEnv();
+        await withTempMarkdown('Updated body', async (file) => {
+            const fetchMock = vi.fn(async (url, init) => {
+                if (init.method === 'GET') {
+                    expect(String(url)).toBe('https://team.atlassian.net/wiki/api/v2/pages/555?body-format=storage');
+                    return jsonResponse({
+                        id: '555',
+                        title: 'Existing',
+                        status: 'current',
+                        version: { number: 7 },
+                        body: { storage: { value: '<p>Old</p>' } },
+                    });
+                }
+                expect(init.method).toBe('PUT');
+                const payload = JSON.parse(init.body);
+                expect(payload.version).toMatchObject({ number: 8, message: 'Sync from Jira' });
+                expect(payload.title).toBe('Existing');
+                return jsonResponse({
+                    id: '555',
+                    title: 'Existing',
+                    status: 'current',
+                    version: { number: 8 },
+                    body: { storage: { value: '<p>Updated body</p>' } },
+                });
+            });
+            vi.stubGlobal('fetch', fetchMock);
+            const cmd = getRegistry().get('confluence/update');
+            const rows = await cmd.func({ id: '555', file, representation: 'markdown', 'version-message': 'Sync from Jira', execute: true });
+            expect(rows[0]).toMatchObject({ status: 'updated', id: '555', version: 8 });
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('searches with CQL scoped to a Data Center space', async () => {
+        clearEnv();
+        process.env.ATLASSIAN_CONFLUENCE_BASE_URL = 'https://conf.example.com/confluence';
+        process.env.ATLASSIAN_DEPLOYMENT = 'datacenter';
+        process.env.ATLASSIAN_PAT = 'pat';
+        const fetchMock = vi.fn(async (url) => {
+            const parsed = new URL(String(url));
+            expect(parsed.searchParams.get('cql')).toBe('space = "ENG" and (type = page)');
+            return jsonResponse({
+                results: [{
+                    content: {
+                        id: '123',
+                        type: 'page',
+                        status: 'current',
+                        title: 'Runbook',
+                        space: { key: 'ENG' },
+                        _links: { webui: '/display/ENG/Runbook' },
+                    },
+                    lastModified: '2026-05-02T00:00:00Z',
+                }],
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('confluence/search');
+        const rows = await cmd.func({ cql: 'type = page', space: 'ENG', limit: 10 });
+        expect(rows[0]).toMatchObject({ id: '123', title: 'Runbook', spaceKey: 'ENG' });
+        expect(rows[0].url).toBe('https://conf.example.com/confluence/display/ENG/Runbook');
+    });
+});

--- a/clis/confluence/commands.test.js
+++ b/clis/confluence/commands.test.js
@@ -73,7 +73,7 @@ describe('confluence commands', () => {
                 const payload = JSON.parse(init.body);
                 expect(payload).toMatchObject({ spaceId: '987', title: 'PROJ-1 RCA' });
                 expect(payload.body.value).toContain('<h1>RCA</h1>');
-                expect(payload.body.value).toContain('<li>Payment failed</li>');
+                expect(payload.body.value.replace(/\s*\n\s*/g, '')).toContain('<li>Payment failed</li>');
                 return jsonResponse({
                     id: '555',
                     title: 'PROJ-1 RCA',

--- a/clis/confluence/create.js
+++ b/clis/confluence/create.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requireExecute } from '../atlassian/shared.js';
+import { requireExecute } from '../_atlassian/shared.js';
 import { confluenceConfig, createPagePayload, normalizeConfluencePage, readPageBodyFile } from './shared.js';
-import { atlassianRequest } from '../atlassian/shared.js';
+import { atlassianRequest } from '../_atlassian/shared.js';
 
 cli({
     site: 'confluence',

--- a/clis/confluence/create.js
+++ b/clis/confluence/create.js
@@ -1,0 +1,37 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { requireExecute } from '../atlassian/shared.js';
+import { confluenceConfig, createPagePayload, normalizeConfluencePage, readPageBodyFile } from './shared.js';
+import { atlassianRequest } from '../atlassian/shared.js';
+
+cli({
+    site: 'confluence',
+    name: 'create',
+    access: 'write',
+    description: 'Create a Confluence page from Markdown or storage XHTML',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'space', type: 'string', required: true, help: 'Cloud space id, or Data Center space key' },
+        { name: 'title', type: 'string', required: true, help: 'Page title' },
+        { name: 'file', type: 'string', required: true, help: 'Markdown file path' },
+        { name: 'parent', type: 'string', help: 'Optional parent page id' },
+        { name: 'representation', type: 'string', default: 'markdown', choices: ['markdown', 'storage'], help: 'Input file format' },
+        { name: 'execute', type: 'boolean', help: 'Actually create the remote page' },
+    ],
+    columns: ['status', 'id', 'title', 'spaceId', 'spaceKey', 'version', 'url'],
+    func: async (args) => {
+        requireExecute(args, 'confluence create');
+        const config = confluenceConfig();
+        const storage = await readPageBodyFile(args);
+        const payload = createPagePayload(config, args, storage);
+        const path = config.deployment === 'cloud' ? '/api/v2/pages' : '/rest/api/content';
+        const page = await atlassianRequest(config, path, {
+            method: 'POST',
+            body: payload,
+            label: 'confluence create',
+        });
+        const normalized = normalizeConfluencePage(page, config);
+        return [{ ...normalized, pageStatus: normalized.status, status: 'created' }];
+    },
+});

--- a/clis/confluence/create.js
+++ b/clis/confluence/create.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requireExecute } from '../_atlassian/shared.js';
+import { requireExecute, requirePayloadObject, requireString } from '../_atlassian/shared.js';
 import { confluenceConfig, createPagePayload, normalizeConfluencePage, readPageBodyFile } from './shared.js';
 import { atlassianRequest } from '../_atlassian/shared.js';
 
@@ -22,15 +22,17 @@ cli({
     columns: ['status', 'id', 'title', 'spaceId', 'spaceKey', 'version', 'url'],
     func: async (args) => {
         requireExecute(args, 'confluence create');
-        const config = confluenceConfig();
+        requireString(args.space, 'Confluence space');
+        requireString(args.title, 'Confluence page title');
         const storage = await readPageBodyFile(args);
+        const config = confluenceConfig();
         const payload = createPagePayload(config, args, storage);
         const path = config.deployment === 'cloud' ? '/api/v2/pages' : '/rest/api/content';
-        const page = await atlassianRequest(config, path, {
+        const page = requirePayloadObject(await atlassianRequest(config, path, {
             method: 'POST',
             body: payload,
             label: 'confluence create',
-        });
+        }), 'confluence create');
         const normalized = normalizeConfluencePage(page, config);
         return [{ ...normalized, pageStatus: normalized.status, status: 'created' }];
     },

--- a/clis/confluence/page.js
+++ b/clis/confluence/page.js
@@ -1,0 +1,23 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { requireString } from '../atlassian/shared.js';
+import { confluenceConfig, getPage, normalizeConfluencePage } from './shared.js';
+
+cli({
+    site: 'confluence',
+    name: 'page',
+    access: 'read',
+    description: 'Confluence page by id with storage and Markdown body',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Confluence page id' },
+    ],
+    columns: ['id', 'title', 'status', 'spaceId', 'spaceKey', 'version', 'url'],
+    func: async (args) => {
+        const config = confluenceConfig();
+        const id = requireString(args.id, 'Confluence page id');
+        const page = await getPage(config, id);
+        return [normalizeConfluencePage(page, config)];
+    },
+});

--- a/clis/confluence/page.js
+++ b/clis/confluence/page.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requireString } from '../atlassian/shared.js';
+import { requireString } from '../_atlassian/shared.js';
 import { confluenceConfig, getPage, normalizeConfluencePage } from './shared.js';
 
 cli({

--- a/clis/confluence/search.js
+++ b/clis/confluence/search.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { atlassianRequest, parseLimit, queryString, requireString } from '../atlassian/shared.js';
+import { atlassianRequest, parseLimit, queryString, requireString } from '../_atlassian/shared.js';
 import { confluenceConfig, normalizeSearchResult, withSpaceCql } from './shared.js';
 
 cli({

--- a/clis/confluence/search.js
+++ b/clis/confluence/search.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { atlassianRequest, parseLimit, requireString } from '../atlassian/shared.js';
+import { atlassianRequest, parseLimit, queryString, requireString } from '../atlassian/shared.js';
 import { confluenceConfig, normalizeSearchResult, withSpaceCql } from './shared.js';
 
 cli({
@@ -20,7 +20,9 @@ cli({
         const config = confluenceConfig();
         const cql = withSpaceCql(requireString(args.cql, 'CQL'), args.space);
         const limit = parseLimit(args.limit, 20, 100, 'confluence limit');
-        const path = `/rest/api/search?${new URLSearchParams({ cql, limit: String(limit) }).toString()}`;
+        // CQL search is still exposed through Confluence REST v1 for Cloud;
+        // page CRUD uses v2 where available.
+        const path = `/rest/api/search${queryString({ cql, limit })}`;
         const data = await atlassianRequest(config, path, { label: 'confluence search' });
         const results = Array.isArray(data?.results) ? data.results : [];
         return results.map((result) => normalizeSearchResult(result, config));

--- a/clis/confluence/search.js
+++ b/clis/confluence/search.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { atlassianRequest, parseLimit, queryString, requireString } from '../_atlassian/shared.js';
-import { confluenceConfig, normalizeSearchResult, withSpaceCql } from './shared.js';
+import { atlassianRequest, parseLimit, queryString, requireNonEmptyRows, requireString } from '../_atlassian/shared.js';
+import { confluenceConfig, confluenceResults, normalizeSearchResult, withSpaceCql } from './shared.js';
 
 cli({
     site: 'confluence',
@@ -24,7 +24,11 @@ cli({
         // page CRUD uses v2 where available.
         const path = `/rest/api/search${queryString({ cql, limit })}`;
         const data = await atlassianRequest(config, path, { label: 'confluence search' });
-        const results = Array.isArray(data?.results) ? data.results : [];
-        return results.map((result) => normalizeSearchResult(result, config));
+        const results = confluenceResults(data, 'confluence search');
+        return requireNonEmptyRows(
+            results.map((result) => normalizeSearchResult(result, config)),
+            'confluence search',
+            `No Confluence content matched "${cql}".`,
+        );
     },
 });

--- a/clis/confluence/search.js
+++ b/clis/confluence/search.js
@@ -1,0 +1,28 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { atlassianRequest, parseLimit, requireString } from '../atlassian/shared.js';
+import { confluenceConfig, normalizeSearchResult, withSpaceCql } from './shared.js';
+
+cli({
+    site: 'confluence',
+    name: 'search',
+    access: 'read',
+    description: 'Search Confluence content with CQL',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'cql', positional: true, required: true, help: 'CQL query, e.g. "type = page and title ~ \\"RCA\\""' },
+        { name: 'space', type: 'string', help: 'Limit search to a Confluence space key' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results to return (1-100)' },
+    ],
+    columns: ['id', 'title', 'type', 'spaceKey', 'status', 'lastModified', 'url'],
+    func: async (args) => {
+        const config = confluenceConfig();
+        const cql = withSpaceCql(requireString(args.cql, 'CQL'), args.space);
+        const limit = parseLimit(args.limit, 20, 100, 'confluence limit');
+        const path = `/rest/api/search?${new URLSearchParams({ cql, limit: String(limit) }).toString()}`;
+        const data = await atlassianRequest(config, path, { label: 'confluence search' });
+        const results = Array.isArray(data?.results) ? data.results : [];
+        return results.map((result) => normalizeSearchResult(result, config));
+    },
+});

--- a/clis/confluence/shared.js
+++ b/clis/confluence/shared.js
@@ -4,8 +4,13 @@ import {
     htmlToMarkdown,
     markdownToConfluenceStorage,
     queryString,
+    requirePayloadArray,
+    requirePayloadObject,
+    requirePayloadString,
     readUtf8File,
+    requireString,
 } from '../_atlassian/shared.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 
 export function confluenceConfig() {
     return getConfluenceConfig();
@@ -24,20 +29,23 @@ function pageStorageBody(page) {
 }
 
 export function normalizeConfluencePage(page, config) {
-    const storage = pageStorageBody(page);
-    const version = page?.version?.number != null ? Number(page.version.number) : undefined;
-    const links = page?._links ?? {};
+    const row = requirePayloadObject(page, 'confluence page');
+    const id = requirePayloadString(row.id, 'page id', 'confluence page');
+    const title = requirePayloadString(row.title, 'title', 'confluence page');
+    const storage = pageStorageBody(row);
+    const version = row.version?.number != null ? Number(row.version.number) : undefined;
+    const links = row._links && typeof row._links === 'object' && !Array.isArray(row._links) ? row._links : {};
     const webui = links.webui ?? links.tinyui ?? '';
     return {
-        id: String(page?.id ?? ''),
-        title: String(page?.title ?? ''),
-        status: String(page?.status ?? ''),
-        spaceId: page?.spaceId != null ? String(page.spaceId) : undefined,
-        spaceKey: page?.space?.key ? String(page.space.key) : undefined,
-        parentId: page?.parentId != null ? String(page.parentId) : undefined,
+        id,
+        title,
+        status: String(row.status ?? ''),
+        spaceId: row.spaceId != null ? String(row.spaceId) : undefined,
+        spaceKey: row.space?.key ? String(row.space.key) : undefined,
+        parentId: row.parentId != null ? String(row.parentId) : undefined,
         version,
-        createdAt: page?.createdAt ? String(page.createdAt) : undefined,
-        updatedAt: page?.version?.createdAt ?? page?.version?.when ?? undefined,
+        createdAt: row.createdAt ? String(row.createdAt) : undefined,
+        updatedAt: row.version?.createdAt ?? row.version?.when ?? undefined,
         url: confluenceUrl(config, webui),
         body: {
             storage,
@@ -48,13 +56,15 @@ export function normalizeConfluencePage(page, config) {
 
 export async function getPage(config, pageId) {
     if (config.deployment === 'cloud') {
-        return atlassianRequest(config, `/api/v2/pages/${encodeURIComponent(pageId)}${queryString({ 'body-format': 'storage' })}`, {
+        const page = await atlassianRequest(config, `/api/v2/pages/${encodeURIComponent(pageId)}${queryString({ 'body-format': 'storage' })}`, {
             label: `confluence page ${pageId}`,
         });
+        return requirePayloadObject(page, `confluence page ${pageId}`);
     }
-    return atlassianRequest(config, `/rest/api/content/${encodeURIComponent(pageId)}${queryString({ expand: 'body.storage,version,space,ancestors' })}`, {
+    const page = await atlassianRequest(config, `/rest/api/content/${encodeURIComponent(pageId)}${queryString({ expand: 'body.storage,version,space,ancestors' })}`, {
         label: `confluence page ${pageId}`,
     });
+    return requirePayloadObject(page, `confluence page ${pageId}`);
 }
 
 export async function readPageBodyFile(args) {
@@ -64,11 +74,13 @@ export async function readPageBodyFile(args) {
 }
 
 export function createPagePayload(config, args, storage) {
+    const title = requireString(args.title, 'Confluence page title');
+    const space = requireString(args.space, 'Confluence space');
     if (config.deployment === 'cloud') {
         return {
-            spaceId: String(args.space),
+            spaceId: space,
             status: 'current',
-            title: String(args.title),
+            title,
             ...(args.parent ? { parentId: String(args.parent) } : {}),
             body: { representation: 'storage', value: storage },
         };
@@ -76,19 +88,25 @@ export function createPagePayload(config, args, storage) {
     return {
         type: 'page',
         status: 'current',
-        title: String(args.title),
-        space: { key: String(args.space) },
+        title,
+        space: { key: space },
         ...(args.parent ? { ancestors: [{ id: String(args.parent) }] } : {}),
         body: { storage: { representation: 'storage', value: storage } },
     };
 }
 
 export function updatePagePayload(config, current, args, storage) {
-    const title = String(args.title || current.title || '');
-    const nextVersion = Number(current.version?.number ?? 0) + 1;
+    const page = requirePayloadObject(current, 'confluence current page');
+    const id = requirePayloadString(page.id, 'page id', 'confluence current page');
+    const title = args.title ? requireString(args.title, 'Confluence page title') : requirePayloadString(page.title, 'title', 'confluence current page');
+    const currentVersion = Number(page.version?.number);
+    if (!Number.isSafeInteger(currentVersion) || currentVersion < 1) {
+        throw new CommandExecutionError('confluence update could not determine the current page version.');
+    }
+    const nextVersion = currentVersion + 1;
     if (config.deployment === 'cloud') {
         return {
-            id: String(current.id),
+            id,
             status: 'current',
             title,
             body: { representation: 'storage', value: storage },
@@ -99,7 +117,7 @@ export function updatePagePayload(config, current, args, storage) {
         };
     }
     return {
-        id: String(current.id),
+        id,
         type: 'page',
         status: 'current',
         title,
@@ -112,18 +130,27 @@ export function updatePagePayload(config, current, args, storage) {
 }
 
 export function normalizeSearchResult(result, config) {
-    const content = result?.content ?? result;
-    const space = result?.space ?? content?.space ?? {};
+    const row = requirePayloadObject(result, 'confluence search result');
+    const content = row.content ?? row;
+    const contentObject = requirePayloadObject(content, 'confluence search result content');
+    const id = requirePayloadString(contentObject.id, 'content id', 'confluence search result');
+    const title = requirePayloadString(row.title ?? contentObject.title, 'title', 'confluence search result');
+    const space = row.space ?? contentObject.space ?? {};
     return {
-        id: String(content?.id ?? ''),
-        title: String(result?.title ?? content?.title ?? ''),
-        type: String(content?.type ?? result?.entityType ?? ''),
+        id,
+        title,
+        type: String(contentObject.type ?? row.entityType ?? ''),
         spaceKey: String(space?.key ?? ''),
-        status: String(content?.status ?? ''),
-        lastModified: String(result?.lastModified ?? content?.version?.when ?? content?.version?.createdAt ?? ''),
-        url: confluenceUrl(config, result?.url ?? content?._links?.webui ?? ''),
-        excerpt: result?.excerpt ? htmlToMarkdown(result.excerpt) : '',
+        status: String(contentObject.status ?? ''),
+        lastModified: String(row.lastModified ?? contentObject.version?.when ?? contentObject.version?.createdAt ?? ''),
+        url: confluenceUrl(config, row.url ?? contentObject._links?.webui ?? ''),
+        excerpt: row.excerpt ? htmlToMarkdown(row.excerpt) : '',
     };
+}
+
+export function confluenceResults(data, label) {
+    const payload = requirePayloadObject(data, label);
+    return requirePayloadArray(payload.results, label);
 }
 
 export function withSpaceCql(cql, space) {

--- a/clis/confluence/shared.js
+++ b/clis/confluence/shared.js
@@ -5,7 +5,7 @@ import {
     markdownToConfluenceStorage,
     queryString,
     readUtf8File,
-} from '../atlassian/shared.js';
+} from '../_atlassian/shared.js';
 
 export function confluenceConfig() {
     return getConfluenceConfig();

--- a/clis/confluence/shared.js
+++ b/clis/confluence/shared.js
@@ -1,0 +1,147 @@
+import {
+    atlassianRequest,
+    getConfluenceConfig,
+    htmlToMarkdown,
+    markdownToConfluenceStorage,
+    queryString,
+    readUtf8File,
+} from '../atlassian/shared.js';
+
+export function confluenceConfig() {
+    return getConfluenceConfig();
+}
+
+function confluenceUrl(config, link) {
+    if (!link) return '';
+    if (/^https?:\/\//i.test(link)) return link;
+    return `${config.baseUrl}${link.startsWith('/') ? link : `/${link}`}`;
+}
+
+function pageStorageBody(page) {
+    return page?.body?.storage?.value
+        ?? page?.body?.storage?.value
+        ?? page?.body?.view?.value
+        ?? '';
+}
+
+export function normalizeConfluencePage(page, config) {
+    const storage = pageStorageBody(page);
+    const version = page?.version?.number != null ? Number(page.version.number) : undefined;
+    const links = page?._links ?? {};
+    const webui = links.webui ?? links.tinyui ?? '';
+    return {
+        id: String(page?.id ?? ''),
+        title: String(page?.title ?? ''),
+        status: String(page?.status ?? ''),
+        spaceId: page?.spaceId != null ? String(page.spaceId) : undefined,
+        spaceKey: page?.space?.key ? String(page.space.key) : undefined,
+        parentId: page?.parentId != null ? String(page.parentId) : undefined,
+        version,
+        createdAt: page?.createdAt ? String(page.createdAt) : undefined,
+        updatedAt: page?.version?.createdAt ?? page?.version?.when ?? undefined,
+        url: confluenceUrl(config, webui),
+        body: {
+            storage,
+            markdown: htmlToMarkdown(storage),
+        },
+    };
+}
+
+export async function getPage(config, pageId) {
+    if (config.deployment === 'cloud') {
+        return atlassianRequest(config, `/api/v2/pages/${encodeURIComponent(pageId)}${queryString({ 'body-format': 'storage' })}`, {
+            label: `confluence page ${pageId}`,
+        });
+    }
+    return atlassianRequest(config, `/rest/api/content/${encodeURIComponent(pageId)}${queryString({ expand: 'body.storage,version,space,ancestors' })}`, {
+        label: `confluence page ${pageId}`,
+    });
+}
+
+export async function readPageBodyFile(args) {
+    const text = await readUtf8File(args.file);
+    if (args.representation === 'storage') return text;
+    return markdownToConfluenceStorage(text);
+}
+
+export function createPagePayload(config, args, storage) {
+    if (config.deployment === 'cloud') {
+        return {
+            spaceId: String(args.space),
+            status: 'current',
+            title: String(args.title),
+            ...(args.parent ? { parentId: String(args.parent) } : {}),
+            body: { representation: 'storage', value: storage },
+        };
+    }
+    return {
+        type: 'page',
+        status: 'current',
+        title: String(args.title),
+        space: { key: String(args.space) },
+        ...(args.parent ? { ancestors: [{ id: String(args.parent) }] } : {}),
+        body: { storage: { representation: 'storage', value: storage } },
+    };
+}
+
+export function updatePagePayload(config, current, args, storage) {
+    const title = String(args.title || current.title || '');
+    const nextVersion = Number(current.version?.number ?? 0) + 1;
+    if (config.deployment === 'cloud') {
+        return {
+            id: String(current.id),
+            status: 'current',
+            title,
+            body: { representation: 'storage', value: storage },
+            version: {
+                number: nextVersion,
+                ...(args['version-message'] ? { message: String(args['version-message']) } : {}),
+            },
+        };
+    }
+    return {
+        id: String(current.id),
+        type: 'page',
+        status: 'current',
+        title,
+        body: { storage: { representation: 'storage', value: storage } },
+        version: {
+            number: nextVersion,
+            ...(args['version-message'] ? { message: String(args['version-message']) } : {}),
+        },
+    };
+}
+
+export function normalizeSearchResult(result, config) {
+    const content = result?.content ?? result;
+    const space = result?.space ?? content?.space ?? {};
+    return {
+        id: String(content?.id ?? ''),
+        title: String(result?.title ?? content?.title ?? ''),
+        type: String(content?.type ?? result?.entityType ?? ''),
+        spaceKey: String(space?.key ?? ''),
+        status: String(content?.status ?? ''),
+        lastModified: String(result?.lastModified ?? content?.version?.when ?? content?.version?.createdAt ?? ''),
+        url: confluenceUrl(config, result?.url ?? content?._links?.webui ?? ''),
+        excerpt: result?.excerpt ? htmlToMarkdown(result.excerpt) : '',
+    };
+}
+
+export function withSpaceCql(cql, space) {
+    const q = String(cql ?? '').trim();
+    const s = String(space ?? '').trim();
+    if (!s) return q;
+    const escaped = s.replace(/"/g, '\\"');
+    if (!q) return `space = "${escaped}"`;
+    return `space = "${escaped}" and (${q})`;
+}
+
+export const __test__ = {
+    createPagePayload,
+    getPage,
+    normalizeConfluencePage,
+    normalizeSearchResult,
+    readPageBodyFile,
+    updatePagePayload,
+    withSpaceCql,
+};

--- a/clis/confluence/shared.js
+++ b/clis/confluence/shared.js
@@ -19,7 +19,6 @@ function confluenceUrl(config, link) {
 
 function pageStorageBody(page) {
     return page?.body?.storage?.value
-        ?? page?.body?.storage?.value
         ?? page?.body?.view?.value
         ?? '';
 }

--- a/clis/confluence/update.js
+++ b/clis/confluence/update.js
@@ -1,0 +1,38 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { atlassianRequest, requireExecute, requireString } from '../atlassian/shared.js';
+import { confluenceConfig, getPage, normalizeConfluencePage, readPageBodyFile, updatePagePayload } from './shared.js';
+
+cli({
+    site: 'confluence',
+    name: 'update',
+    access: 'write',
+    description: 'Update a Confluence page body from Markdown or storage XHTML',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Confluence page id' },
+        { name: 'file', type: 'string', required: true, help: 'Markdown file path' },
+        { name: 'title', type: 'string', help: 'Optional replacement title; defaults to current title' },
+        { name: 'version-message', type: 'string', help: 'Confluence version message' },
+        { name: 'representation', type: 'string', default: 'markdown', choices: ['markdown', 'storage'], help: 'Input file format' },
+        { name: 'execute', type: 'boolean', help: 'Actually update the remote page' },
+    ],
+    columns: ['status', 'id', 'title', 'spaceId', 'spaceKey', 'version', 'url'],
+    func: async (args) => {
+        requireExecute(args, 'confluence update');
+        const config = confluenceConfig();
+        const id = requireString(args.id, 'Confluence page id');
+        const current = await getPage(config, id);
+        const storage = await readPageBodyFile(args);
+        const payload = updatePagePayload(config, current, args, storage);
+        const path = config.deployment === 'cloud' ? `/api/v2/pages/${encodeURIComponent(id)}` : `/rest/api/content/${encodeURIComponent(id)}`;
+        const page = await atlassianRequest(config, path, {
+            method: 'PUT',
+            body: payload,
+            label: `confluence update ${id}`,
+        });
+        const normalized = normalizeConfluencePage(page, config);
+        return [{ ...normalized, pageStatus: normalized.status, status: 'updated' }];
+    },
+});

--- a/clis/confluence/update.js
+++ b/clis/confluence/update.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { atlassianRequest, requireExecute, requireString } from '../atlassian/shared.js';
+import { atlassianRequest, requireExecute, requireString } from '../_atlassian/shared.js';
 import { confluenceConfig, getPage, normalizeConfluencePage, readPageBodyFile, updatePagePayload } from './shared.js';
 
 cli({

--- a/clis/confluence/update.js
+++ b/clis/confluence/update.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { atlassianRequest, requireExecute, requireString } from '../_atlassian/shared.js';
+import { atlassianRequest, requireExecute, requirePayloadObject, requireString } from '../_atlassian/shared.js';
 import { confluenceConfig, getPage, normalizeConfluencePage, readPageBodyFile, updatePagePayload } from './shared.js';
 
 cli({
@@ -27,11 +27,11 @@ cli({
         const storage = await readPageBodyFile(args);
         const payload = updatePagePayload(config, current, args, storage);
         const path = config.deployment === 'cloud' ? `/api/v2/pages/${encodeURIComponent(id)}` : `/rest/api/content/${encodeURIComponent(id)}`;
-        const page = await atlassianRequest(config, path, {
+        const page = requirePayloadObject(await atlassianRequest(config, path, {
             method: 'PUT',
             body: payload,
             label: `confluence update ${id}`,
-        });
+        }), `confluence update ${id}`);
         const normalized = normalizeConfluencePage(page, config);
         return [{ ...normalized, pageStatus: normalized.status, status: 'updated' }];
     },

--- a/clis/jira/attachments.js
+++ b/clis/jira/attachments.js
@@ -1,0 +1,23 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchIssue, jiraConfig, normalizeAttachment, requireIssueKey } from './shared.js';
+
+cli({
+    site: 'jira',
+    name: 'attachments',
+    access: 'read',
+    description: 'Jira issue attachment metadata',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Jira issue key, e.g. PROJ-123' },
+    ],
+    columns: ['id', 'filename', 'mimeType', 'size', 'url'],
+    func: async (args) => {
+        const config = jiraConfig();
+        const key = requireIssueKey(args.key);
+        const issue = await fetchIssue(config, key, ['attachment']);
+        const attachments = Array.isArray(issue?.fields?.attachment) ? issue.fields.attachment : [];
+        return attachments.map(normalizeAttachment);
+    },
+});

--- a/clis/jira/attachments.js
+++ b/clis/jira/attachments.js
@@ -14,8 +14,8 @@ cli({
     ],
     columns: ['id', 'filename', 'mimeType', 'size', 'url'],
     func: async (args) => {
-        const config = jiraConfig();
         const key = requireIssueKey(args.key);
+        const config = jiraConfig();
         const issue = await fetchIssue(config, key, ['attachment']);
         const attachments = Array.isArray(issue?.fields?.attachment) ? issue.fields.attachment : [];
         return attachments.map(normalizeAttachment);

--- a/clis/jira/attachments.js
+++ b/clis/jira/attachments.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchIssue, jiraConfig, normalizeAttachment, requireIssueKey } from './shared.js';
+import { fetchIssue, jiraConfig, jiraRowsOrEmpty, normalizeAttachment, requireIssueKey } from './shared.js';
+import { requirePayloadArray } from '../_atlassian/shared.js';
 
 cli({
     site: 'jira',
@@ -17,7 +18,11 @@ cli({
         const key = requireIssueKey(args.key);
         const config = jiraConfig();
         const issue = await fetchIssue(config, key, ['attachment']);
-        const attachments = Array.isArray(issue?.fields?.attachment) ? issue.fields.attachment : [];
-        return attachments.map(normalizeAttachment);
+        const attachments = requirePayloadArray(issue.fields?.attachment, `jira attachments ${key}`);
+        return jiraRowsOrEmpty(
+            attachments.map(normalizeAttachment),
+            `jira attachments ${key}`,
+            `Jira issue ${key} has no attachments.`,
+        );
     },
 });

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, afterEach, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { __test__ as jiraSharedTest } from './shared.js';
 import './issue.js';
 import './search.js';
@@ -98,6 +99,13 @@ describe('jira commands', () => {
         expect(rows[0].linkedIssues[0]).toEqual({ key: 'PROJ-2', type: 'Blocks', direction: 'outward' });
     });
 
+    it('fails typed when Jira issue payload is missing stable issue identity', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ fields: { summary: 'No key' } })));
+        const cmd = getRegistry().get('jira/issue');
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('rejects invalid Jira issue keys before remote requests', async () => {
         expect(() => jiraSharedTest.requireIssueKey('notakey')).toThrow(/Invalid Jira issue key/);
         const fetchMock = vi.fn();
@@ -173,6 +181,16 @@ describe('jira commands', () => {
         ]);
     });
 
+    it('separates Jira search empty results from malformed search payloads', async () => {
+        setCloudEnv();
+        const cmd = getRegistry().get('jira/search');
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ issues: [] })));
+        await expect(cmd.func({ jql: 'project = NONE' })).rejects.toBeInstanceOf(EmptyResultError);
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ values: [] })));
+        await expect(cmd.func({ jql: 'project = PROJ' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('maps rendered comments to Markdown', async () => {
         setCloudEnv();
         vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
@@ -188,5 +206,24 @@ describe('jira commands', () => {
         expect(rows[0]).toMatchObject({ id: 'c1', author: 'Bob' });
         expect(rows[0].markdown).toContain('Fixed');
         expect(rows[0].markdown).toContain('Ready for QA');
+    });
+
+    it('fails typed when Jira comment rows lack stable comment ids', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            comments: [{ author: { displayName: 'Bob' }, created: '2026-05-01', body: 'body' }],
+        })));
+        const cmd = getRegistry().get('jira/comments');
+        await expect(cmd.func({ key: 'PROJ-1', limit: 1 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('separates no Jira attachments from malformed attachment payloads', async () => {
+        setCloudEnv();
+        const cmd = getRegistry().get('jira/attachments');
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ id: '1', key: 'PROJ-1', fields: { attachment: [] } })));
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(EmptyResultError);
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ id: '1', key: 'PROJ-1', fields: {} })));
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -1,0 +1,150 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './issue.js';
+import './search.js';
+import './comments.js';
+import './attachments.js';
+import './links.js';
+
+const ENV_KEYS = [
+    'ATLASSIAN_JIRA_BASE_URL',
+    'ATLASSIAN_DEPLOYMENT',
+    'ATLASSIAN_EMAIL',
+    'ATLASSIAN_API_TOKEN',
+    'ATLASSIAN_USERNAME',
+    'ATLASSIAN_PASSWORD',
+    'ATLASSIAN_PAT',
+];
+
+function clearEnv() {
+    for (const key of ENV_KEYS) delete process.env[key];
+}
+
+function setCloudEnv() {
+    clearEnv();
+    process.env.ATLASSIAN_JIRA_BASE_URL = 'https://team.atlassian.net';
+    process.env.ATLASSIAN_DEPLOYMENT = 'cloud';
+    process.env.ATLASSIAN_EMAIL = 'bot@example.com';
+    process.env.ATLASSIAN_API_TOKEN = 'secret';
+}
+
+function jsonResponse(body) {
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+afterEach(() => {
+    clearEnv();
+    vi.unstubAllGlobals();
+});
+
+describe('jira commands', () => {
+    it('registers non-browser REST commands', () => {
+        for (const name of ['issue', 'search', 'comments', 'attachments', 'links']) {
+            const cmd = getRegistry().get(`jira/${name}`);
+            expect(cmd).toBeDefined();
+            expect(cmd.browser).toBe(false);
+            expect(cmd.strategy).toBe('public');
+        }
+    });
+
+    it('normalizes a Cloud issue into agent-friendly context', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async (url) => {
+            expect(String(url)).toContain('/rest/api/3/issue/PROJ-1?');
+            return jsonResponse({
+                id: '10001',
+                key: 'PROJ-1',
+                fields: {
+                    summary: 'Checkout fails',
+                    issuetype: { name: 'Bug' },
+                    status: { name: 'In Progress' },
+                    priority: { name: 'High' },
+                    labels: ['prod'],
+                    description: {
+                        type: 'doc',
+                        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Payment fails' }] }],
+                    },
+                    comment: {
+                        total: 1,
+                        comments: [{
+                            id: 'c1',
+                            author: { displayName: 'Alice' },
+                            created: '2026-05-01T00:00:00.000+0000',
+                            body: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Needs RCA' }] }] },
+                        }],
+                    },
+                    attachment: [{ id: 'a1', filename: 'log.txt', mimeType: 'text/plain', size: 12, content: 'https://team.atlassian.net/secure/attachment/a1/log.txt' }],
+                    issuelinks: [{ type: { name: 'Blocks' }, outwardIssue: { key: 'PROJ-2' } }],
+                    fixVersions: [{ name: '1.2.3' }],
+                    created: '2026-05-01T00:00:00.000+0000',
+                    updated: '2026-05-02T00:00:00.000+0000',
+                },
+            });
+        }));
+        const cmd = getRegistry().get('jira/issue');
+        const rows = await cmd.func({ key: 'proj-1' });
+        expect(rows[0]).toMatchObject({
+            key: 'PROJ-1',
+            summary: 'Checkout fails',
+            issueType: 'Bug',
+            status: 'In Progress',
+            labels: ['prod'],
+            url: 'https://team.atlassian.net/browse/PROJ-1',
+        });
+        expect(rows[0].description.markdown).toBe('Payment fails');
+        expect(rows[0].comments[0].markdown).toBe('Needs RCA');
+        expect(rows[0].attachments[0].filename).toBe('log.txt');
+        expect(rows[0].linkedIssues[0]).toEqual({ key: 'PROJ-2', type: 'Blocks', direction: 'outward' });
+    });
+
+    it('uses Data Center search endpoint and payload', async () => {
+        clearEnv();
+        process.env.ATLASSIAN_JIRA_BASE_URL = 'https://jira.example.com';
+        process.env.ATLASSIAN_DEPLOYMENT = 'datacenter';
+        process.env.ATLASSIAN_USERNAME = 'bot';
+        process.env.ATLASSIAN_PASSWORD = 'secret';
+        const fetchMock = vi.fn(async (url, init) => {
+            expect(String(url)).toBe('https://jira.example.com/rest/api/2/search');
+            expect(init.method).toBe('POST');
+            expect(JSON.parse(init.body)).toMatchObject({
+                jql: 'project = PROJ',
+                startAt: 0,
+                maxResults: 5,
+            });
+            return jsonResponse({
+                issues: [{
+                    id: '1',
+                    key: 'PROJ-1',
+                    fields: {
+                        summary: 'Task',
+                        status: { name: 'Done' },
+                        updated: '2026-05-03T00:00:00.000+0000',
+                    },
+                }],
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('jira/search');
+        const rows = await cmd.func({ jql: 'project = PROJ', limit: 5 });
+        expect(rows).toEqual([
+            expect.objectContaining({ key: 'PROJ-1', summary: 'Task', status: 'Done' }),
+        ]);
+    });
+
+    it('maps rendered comments to Markdown', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            comments: [{
+                id: 'c1',
+                author: { displayName: 'Bob' },
+                created: '2026-05-01',
+                renderedBody: '<p>Fixed<br/>Ready for QA</p>',
+            }],
+        })));
+        const cmd = getRegistry().get('jira/comments');
+        const rows = await cmd.func({ key: 'PROJ-1', limit: 1 });
+        expect(rows[0]).toMatchObject({ id: 'c1', author: 'Bob' });
+        expect(rows[0].markdown).toContain('Fixed');
+        expect(rows[0].markdown).toContain('Ready for QA');
+    });
+});

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, afterEach, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { __test__ as jiraSharedTest } from './shared.js';
 import './issue.js';
 import './search.js';
 import './comments.js';
@@ -95,6 +96,47 @@ describe('jira commands', () => {
         expect(rows[0].comments[0].markdown).toBe('Needs RCA');
         expect(rows[0].attachments[0].filename).toBe('log.txt');
         expect(rows[0].linkedIssues[0]).toEqual({ key: 'PROJ-2', type: 'Blocks', direction: 'outward' });
+    });
+
+    it('rejects invalid Jira issue keys before remote requests', async () => {
+        expect(() => jiraSharedTest.requireIssueKey('notakey')).toThrow(/Invalid Jira issue key/);
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('jira/issue');
+        await expect(cmd.func({ key: 'notakey' })).rejects.toMatchObject({ code: 'ARGUMENT' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches full comments when issue inline comments are truncated', async () => {
+        setCloudEnv();
+        const fetchMock = vi.fn(async (url) => {
+            const href = String(url);
+            if (href.includes('/comment?')) {
+                return jsonResponse({
+                    comments: [
+                        { id: 'c1', author: { displayName: 'Alice' }, created: '2026-05-01', body: 'one' },
+                        { id: 'c2', author: { displayName: 'Bob' }, created: '2026-05-02', body: 'two' },
+                    ],
+                });
+            }
+            return jsonResponse({
+                id: '10001',
+                key: 'PROJ-1',
+                fields: {
+                    summary: 'Checkout fails',
+                    labels: [],
+                    comment: {
+                        total: 2,
+                        comments: [{ id: 'c1', author: { displayName: 'Alice' }, created: '2026-05-01', body: 'one' }],
+                    },
+                },
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('jira/issue');
+        const rows = await cmd.func({ key: 'PROJ-1', 'comments-limit': 10 });
+        expect(rows[0].comments.map((comment) => comment.id)).toEqual(['c1', 'c2']);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     it('uses Data Center search endpoint and payload', async () => {

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -106,6 +106,62 @@ describe('jira commands', () => {
         await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('fails typed when Jira issue nested collections have malformed shapes', async () => {
+        setCloudEnv();
+        const cmd = getRegistry().get('jira/issue');
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            id: '10001',
+            key: 'PROJ-1',
+            fields: {
+                summary: 'Checkout fails',
+                labels: [],
+                comment: { total: 1, comments: { id: 'c1' } },
+                attachment: [],
+                issuelinks: [],
+            },
+        })));
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            id: '10001',
+            key: 'PROJ-1',
+            fields: {
+                summary: 'Checkout fails',
+                labels: [],
+                comment: { total: 0, comments: [] },
+                attachment: { id: 'a1' },
+                issuelinks: [],
+            },
+        })));
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            id: '10001',
+            key: 'PROJ-1',
+            fields: {
+                summary: 'Checkout fails',
+                labels: [],
+                comment: null,
+                attachment: [],
+                issuelinks: [],
+            },
+        })));
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            id: '10001',
+            key: 'PROJ-1',
+            fields: {
+                summary: 'Checkout fails',
+                labels: [],
+                comment: { total: 0, comments: [] },
+                attachment: null,
+                issuelinks: [],
+            },
+        })));
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('rejects invalid Jira issue keys before remote requests', async () => {
         expect(() => jiraSharedTest.requireIssueKey('notakey')).toThrow(/Invalid Jira issue key/);
         const fetchMock = vi.fn();
@@ -137,6 +193,8 @@ describe('jira commands', () => {
                         total: 2,
                         comments: [{ id: 'c1', author: { displayName: 'Alice' }, created: '2026-05-01', body: 'one' }],
                     },
+                    attachment: [],
+                    issuelinks: [],
                 },
             });
         });

--- a/clis/jira/comments.js
+++ b/clis/jira/comments.js
@@ -15,8 +15,8 @@ cli({
     ],
     columns: ['id', 'author', 'created', 'updated', 'markdown'],
     func: async (args) => {
-        const config = jiraConfig();
         const key = requireIssueKey(args.key);
+        const config = jiraConfig();
         const limit = parseJiraLimit(args.limit, 50, 100);
         const comments = await fetchComments(config, key, limit);
         return comments.map(normalizeComment);

--- a/clis/jira/comments.js
+++ b/clis/jira/comments.js
@@ -1,0 +1,24 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchComments, jiraConfig, normalizeComment, parseJiraLimit, requireIssueKey } from './shared.js';
+
+cli({
+    site: 'jira',
+    name: 'comments',
+    access: 'read',
+    description: 'Jira issue comments as Markdown',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Jira issue key, e.g. PROJ-123' },
+        { name: 'limit', type: 'int', default: 50, help: 'Max comments to return (1-100)' },
+    ],
+    columns: ['id', 'author', 'created', 'updated', 'markdown'],
+    func: async (args) => {
+        const config = jiraConfig();
+        const key = requireIssueKey(args.key);
+        const limit = parseJiraLimit(args.limit, 50, 100);
+        const comments = await fetchComments(config, key, limit);
+        return comments.map(normalizeComment);
+    },
+});

--- a/clis/jira/comments.js
+++ b/clis/jira/comments.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchComments, jiraConfig, normalizeComment, parseJiraLimit, requireIssueKey } from './shared.js';
+import { fetchComments, jiraConfig, jiraRowsOrEmpty, normalizeComment, parseJiraLimit, requireIssueKey } from './shared.js';
 
 cli({
     site: 'jira',
@@ -19,6 +19,10 @@ cli({
         const config = jiraConfig();
         const limit = parseJiraLimit(args.limit, 50, 100);
         const comments = await fetchComments(config, key, limit);
-        return comments.map(normalizeComment);
+        return jiraRowsOrEmpty(
+            comments.map(normalizeComment),
+            `jira comments ${key}`,
+            `Jira issue ${key} has no comments.`,
+        );
     },
 });

--- a/clis/jira/issue.js
+++ b/clis/jira/issue.js
@@ -1,0 +1,28 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchComments, fetchIssue, jiraConfig, normalizeJiraIssue, requireIssueKey } from './shared.js';
+
+cli({
+    site: 'jira',
+    name: 'issue',
+    access: 'read',
+    description: 'Jira issue detail normalized for agents (description, comments, attachments, links)',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Jira issue key, e.g. PROJ-123' },
+        { name: 'comments-limit', type: 'int', default: 100, help: 'Max comments to include (1-100)' },
+    ],
+    columns: ['key', 'summary', 'issueType', 'status', 'priority', 'assignee', 'updated', 'url'],
+    func: async (args) => {
+        const config = jiraConfig();
+        const key = requireIssueKey(args.key);
+        const issue = await fetchIssue(config, key);
+        const inlineComments = issue?.fields?.comment?.comments;
+        const total = Number(issue?.fields?.comment?.total ?? inlineComments?.length ?? 0);
+        const comments = total > (inlineComments?.length ?? 0)
+            ? await fetchComments(config, key, args['comments-limit'])
+            : inlineComments;
+        return [normalizeJiraIssue(issue, config, { comments })];
+    },
+});

--- a/clis/jira/issue.js
+++ b/clis/jira/issue.js
@@ -15,8 +15,8 @@ cli({
     ],
     columns: ['key', 'summary', 'issueType', 'status', 'priority', 'assignee', 'updated', 'url'],
     func: async (args) => {
-        const config = jiraConfig();
         const key = requireIssueKey(args.key);
+        const config = jiraConfig();
         const issue = await fetchIssue(config, key);
         const inlineComments = issue?.fields?.comment?.comments;
         const total = Number(issue?.fields?.comment?.total ?? inlineComments?.length ?? 0);

--- a/clis/jira/links.js
+++ b/clis/jira/links.js
@@ -1,0 +1,23 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchIssue, jiraConfig, normalizeIssueLink, requireIssueKey } from './shared.js';
+
+cli({
+    site: 'jira',
+    name: 'links',
+    access: 'read',
+    description: 'Jira issue links',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Jira issue key, e.g. PROJ-123' },
+    ],
+    columns: ['key', 'type', 'direction'],
+    func: async (args) => {
+        const config = jiraConfig();
+        const key = requireIssueKey(args.key);
+        const issue = await fetchIssue(config, key, ['issuelinks']);
+        const links = Array.isArray(issue?.fields?.issuelinks) ? issue.fields.issuelinks : [];
+        return links.map(normalizeIssueLink).filter((link) => link.key);
+    },
+});

--- a/clis/jira/links.js
+++ b/clis/jira/links.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchIssue, jiraConfig, normalizeIssueLink, requireIssueKey } from './shared.js';
+import { fetchIssue, jiraConfig, jiraRowsOrEmpty, normalizeIssueLink, requireIssueKey } from './shared.js';
+import { requirePayloadArray } from '../_atlassian/shared.js';
 
 cli({
     site: 'jira',
@@ -17,7 +18,11 @@ cli({
         const key = requireIssueKey(args.key);
         const config = jiraConfig();
         const issue = await fetchIssue(config, key, ['issuelinks']);
-        const links = Array.isArray(issue?.fields?.issuelinks) ? issue.fields.issuelinks : [];
-        return links.map(normalizeIssueLink).filter((link) => link.key);
+        const links = requirePayloadArray(issue.fields?.issuelinks, `jira links ${key}`);
+        return jiraRowsOrEmpty(
+            links.map(normalizeIssueLink),
+            `jira links ${key}`,
+            `Jira issue ${key} has no linked issues.`,
+        );
     },
 });

--- a/clis/jira/links.js
+++ b/clis/jira/links.js
@@ -14,8 +14,8 @@ cli({
     ],
     columns: ['key', 'type', 'direction'],
     func: async (args) => {
-        const config = jiraConfig();
         const key = requireIssueKey(args.key);
+        const config = jiraConfig();
         const issue = await fetchIssue(config, key, ['issuelinks']);
         const links = Array.isArray(issue?.fields?.issuelinks) ? issue.fields.issuelinks : [];
         return links.map(normalizeIssueLink).filter((link) => link.key);

--- a/clis/jira/search.js
+++ b/clis/jira/search.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { jiraConfig, issueSummaryRow, parseJiraLimit } from './shared.js';
-import { atlassianRequest, requireString } from '../atlassian/shared.js';
+import { atlassianRequest, requireString } from '../_atlassian/shared.js';
 
 function searchPath(config) {
     return config.deployment === 'cloud' ? '/rest/api/3/search/jql' : '/rest/api/2/search';

--- a/clis/jira/search.js
+++ b/clis/jira/search.js
@@ -1,0 +1,42 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { jiraConfig, issueSummaryRow, parseJiraLimit } from './shared.js';
+import { atlassianRequest, requireString } from '../atlassian/shared.js';
+
+function searchPath(config) {
+    return config.deployment === 'cloud' ? '/rest/api/3/search/jql' : '/rest/api/2/search';
+}
+
+function searchPayload(config, jql, limit) {
+    const fields = ['summary', 'issuetype', 'status', 'priority', 'assignee', 'updated'];
+    if (config.deployment === 'cloud') return { jql, maxResults: limit, fields };
+    return { jql, startAt: 0, maxResults: limit, fields };
+}
+
+cli({
+    site: 'jira',
+    name: 'search',
+    access: 'read',
+    description: 'Search Jira issues with JQL',
+    domain: 'atlassian.net',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'jql', positional: true, required: true, help: 'JQL query, e.g. "project = PROJ order by updated desc"' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max issues to return (1-100)' },
+    ],
+    columns: ['key', 'summary', 'issueType', 'status', 'priority', 'assignee', 'updated', 'url'],
+    func: async (args) => {
+        const config = jiraConfig();
+        const jql = requireString(args.jql, 'JQL');
+        const limit = parseJiraLimit(args.limit, 20, 100);
+        const data = await atlassianRequest(config, searchPath(config), {
+            method: 'POST',
+            body: searchPayload(config, jql, limit),
+            label: 'jira search',
+        });
+        const issues = Array.isArray(data?.issues) ? data.issues : [];
+        return issues.map((issue) => issueSummaryRow(issue, config));
+    },
+});
+
+export const __test__ = { searchPath, searchPayload };

--- a/clis/jira/search.js
+++ b/clis/jira/search.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { jiraConfig, issueSummaryRow, parseJiraLimit } from './shared.js';
-import { atlassianRequest, requireString } from '../_atlassian/shared.js';
+import { jiraConfig, issueSummaryRow, jiraRowsOrEmpty, parseJiraLimit } from './shared.js';
+import { atlassianRequest, requirePayloadArray, requirePayloadObject, requireString } from '../_atlassian/shared.js';
 
 function searchPath(config) {
     return config.deployment === 'cloud' ? '/rest/api/3/search/jql' : '/rest/api/2/search';
@@ -34,8 +34,13 @@ cli({
             body: searchPayload(config, jql, limit),
             label: 'jira search',
         });
-        const issues = Array.isArray(data?.issues) ? data.issues : [];
-        return issues.map((issue) => issueSummaryRow(issue, config));
+        const payload = requirePayloadObject(data, 'jira search');
+        const issues = requirePayloadArray(payload.issues, 'jira search issues');
+        return jiraRowsOrEmpty(
+            issues.map((issue) => issueSummaryRow(issue, config)),
+            'jira search',
+            `No Jira issues matched "${jql}".`,
+        );
     },
 });
 

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -1,4 +1,16 @@
-import { adfToMarkdown, atlassianRequest, getJiraConfig, htmlToMarkdown, parseLimit, queryString, requireString } from '../_atlassian/shared.js';
+import {
+    adfToMarkdown,
+    atlassianRequest,
+    getJiraConfig,
+    htmlToMarkdown,
+    parseLimit,
+    queryString,
+    requireNonEmptyRows,
+    requirePayloadArray,
+    requirePayloadObject,
+    requirePayloadString,
+    requireString,
+} from '../_atlassian/shared.js';
 import { ArgumentError } from '@jackwener/opencli/errors';
 
 const DEFAULT_ISSUE_FIELDS = [
@@ -82,32 +94,36 @@ export function jiraBodyToMarkdown(raw, rendered) {
 }
 
 export function normalizeComment(comment) {
+    const row = requirePayloadObject(comment, 'jira comment');
     return {
-        id: String(comment?.id ?? ''),
-        author: displayUser(comment?.author),
-        created: String(comment?.created ?? ''),
-        updated: comment?.updated ? String(comment.updated) : undefined,
-        markdown: jiraBodyToMarkdown(comment?.body, comment?.renderedBody),
+        id: requirePayloadString(row.id, 'comment id', 'jira comment'),
+        author: displayUser(row.author),
+        created: row.created ? String(row.created) : '',
+        updated: row.updated ? String(row.updated) : undefined,
+        markdown: jiraBodyToMarkdown(row.body, row.renderedBody),
     };
 }
 
 export function normalizeAttachment(attachment) {
+    const row = requirePayloadObject(attachment, 'jira attachment');
     return {
-        id: String(attachment?.id ?? ''),
-        filename: String(attachment?.filename ?? ''),
-        mimeType: attachment?.mimeType ? String(attachment.mimeType) : undefined,
-        size: attachment?.size != null ? Number(attachment.size) : undefined,
-        url: String(attachment?.content ?? attachment?.self ?? ''),
+        id: requirePayloadString(row.id, 'attachment id', 'jira attachment'),
+        filename: requirePayloadString(row.filename, 'filename', 'jira attachment'),
+        mimeType: row.mimeType ? String(row.mimeType) : undefined,
+        size: row.size != null ? Number(row.size) : undefined,
+        url: requirePayloadString(row.content ?? row.self, 'attachment url', 'jira attachment'),
     };
 }
 
 export function normalizeIssueLink(link) {
-    const outward = link?.outwardIssue;
-    const inward = link?.inwardIssue;
+    const row = requirePayloadObject(link, 'jira issue link');
+    const outward = row.outwardIssue;
+    const inward = row.inwardIssue;
     const issue = outward ?? inward ?? {};
+    const key = requirePayloadString(issue.key, 'linked issue key', 'jira issue link');
     return {
-        key: String(issue.key ?? ''),
-        type: String(link?.type?.name ?? (outward ? link?.type?.outward : link?.type?.inward) ?? ''),
+        key,
+        type: String(row.type?.name ?? (outward ? row.type?.outward : row.type?.inward) ?? ''),
         direction: outward ? 'outward' : 'inward',
     };
 }
@@ -121,14 +137,18 @@ function customValueToMarkdown(value) {
 }
 
 export function normalizeJiraIssue(issue, config, options = {}) {
-    const fields = issue?.fields ?? {};
-    const rendered = issue?.renderedFields ?? {};
+    const row = requirePayloadObject(issue, 'jira issue');
+    const key = requirePayloadString(row.key, 'issue key', 'jira issue');
+    const fields = requirePayloadObject(row.fields, `jira issue ${key} fields`);
+    const rendered = row.renderedFields && typeof row.renderedFields === 'object' && !Array.isArray(row.renderedFields)
+        ? row.renderedFields
+        : {};
     const custom = configuredFieldNames();
     const comments = options.comments ?? fields.comment?.comments ?? [];
     const normalized = {
-        key: String(issue?.key ?? ''),
-        id: String(issue?.id ?? ''),
-        url: issue?.key ? `${config.baseUrl}/browse/${issue.key}` : '',
+        key,
+        id: row.id != null ? String(row.id) : '',
+        url: `${config.baseUrl}/browse/${key}`,
         summary: String(fields.summary ?? ''),
         issueType: valueName(fields.issuetype) || undefined,
         status: valueName(fields.status) || undefined,
@@ -143,7 +163,7 @@ export function normalizeJiraIssue(issue, config, options = {}) {
         },
         comments: Array.isArray(comments) ? comments.map(normalizeComment) : [],
         attachments: Array.isArray(fields.attachment) ? fields.attachment.map(normalizeAttachment) : [],
-        linkedIssues: Array.isArray(fields.issuelinks) ? fields.issuelinks.map(normalizeIssueLink).filter((link) => link.key) : [],
+        linkedIssues: Array.isArray(fields.issuelinks) ? fields.issuelinks.map(normalizeIssueLink) : [],
         fixVersions: valueNames(fields.fixVersions),
         affectedVersions: valueNames(fields.versions),
         components: valueNames(fields.components),
@@ -180,13 +200,14 @@ export function issueSummaryRow(issue, config) {
 }
 
 export async function fetchIssue(config, key, extraFields = []) {
-    return jiraRequest(config, `/issue/${encodeURIComponent(key)}`, {
+    const issue = await jiraRequest(config, `/issue/${encodeURIComponent(key)}`, {
         params: {
             fields: issueFields(extraFields),
             expand: 'renderedFields',
         },
         label: `jira issue ${key}`,
     });
+    return requirePayloadObject(issue, `jira issue ${key}`);
 }
 
 export async function fetchComments(config, key, limit = 100) {
@@ -195,7 +216,12 @@ export async function fetchComments(config, key, limit = 100) {
         params: { startAt: 0, maxResults, expand: 'renderedBody' },
         label: `jira comments ${key}`,
     });
-    return Array.isArray(data?.comments) ? data.comments : [];
+    const payload = requirePayloadObject(data, `jira comments ${key}`);
+    return requirePayloadArray(payload.comments, `jira comments ${key}`);
+}
+
+export function jiraRowsOrEmpty(rows, label, hint) {
+    return requireNonEmptyRows(rows, label, hint);
 }
 
 export function jiraConfig() {

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -136,6 +136,13 @@ function customValueToMarkdown(value) {
     return valueName(value);
 }
 
+function inlineComments(fields, key, options) {
+    if (options.comments !== undefined) return requirePayloadArray(options.comments, `jira issue ${key} comments`);
+    if (options.requireNestedCollections === false) return [];
+    const commentBlock = requirePayloadObject(fields.comment, `jira issue ${key} comment field`);
+    return requirePayloadArray(commentBlock.comments, `jira issue ${key} comment field comments`);
+}
+
 export function normalizeJiraIssue(issue, config, options = {}) {
     const row = requirePayloadObject(issue, 'jira issue');
     const key = requirePayloadString(row.key, 'issue key', 'jira issue');
@@ -144,7 +151,14 @@ export function normalizeJiraIssue(issue, config, options = {}) {
         ? row.renderedFields
         : {};
     const custom = configuredFieldNames();
-    const comments = options.comments ?? fields.comment?.comments ?? [];
+    const comments = inlineComments(fields, key, options);
+    const requireNestedCollections = options.requireNestedCollections !== false;
+    const attachments = requireNestedCollections
+        ? requirePayloadArray(fields.attachment, `jira issue ${key} attachment field`)
+        : [];
+    const issueLinks = requireNestedCollections
+        ? requirePayloadArray(fields.issuelinks, `jira issue ${key} issuelinks field`)
+        : [];
     const normalized = {
         key,
         id: row.id != null ? String(row.id) : '',
@@ -161,9 +175,9 @@ export function normalizeJiraIssue(issue, config, options = {}) {
             raw: fields.description ?? null,
             markdown: jiraBodyToMarkdown(fields.description, rendered.description),
         },
-        comments: Array.isArray(comments) ? comments.map(normalizeComment) : [],
-        attachments: Array.isArray(fields.attachment) ? fields.attachment.map(normalizeAttachment) : [],
-        linkedIssues: Array.isArray(fields.issuelinks) ? fields.issuelinks.map(normalizeIssueLink) : [],
+        comments: comments.map(normalizeComment),
+        attachments: attachments.map(normalizeAttachment),
+        linkedIssues: issueLinks.map(normalizeIssueLink),
         fixVersions: valueNames(fields.fixVersions),
         affectedVersions: valueNames(fields.versions),
         components: valueNames(fields.components),
@@ -186,7 +200,7 @@ export function normalizeJiraIssue(issue, config, options = {}) {
 }
 
 export function issueSummaryRow(issue, config) {
-    const normalized = normalizeJiraIssue(issue, config, { comments: [] });
+    const normalized = normalizeJiraIssue(issue, config, { comments: [], requireNestedCollections: false });
     return {
         key: normalized.key,
         summary: normalized.summary,

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -1,0 +1,214 @@
+import { adfToMarkdown, atlassianRequest, getJiraConfig, htmlToMarkdown, parseLimit, queryString, requireString } from '../atlassian/shared.js';
+
+const DEFAULT_ISSUE_FIELDS = [
+    'summary',
+    'issuetype',
+    'status',
+    'priority',
+    'labels',
+    'description',
+    'comment',
+    'attachment',
+    'issuelinks',
+    'fixVersions',
+    'versions',
+    'components',
+    'project',
+    'reporter',
+    'assignee',
+    'created',
+    'updated',
+];
+
+function jiraApiPrefix(config) {
+    return `/rest/api/${config.deployment === 'cloud' ? '3' : '2'}`;
+}
+
+export function jiraApiPath(config, resource, params) {
+    return `${jiraApiPrefix(config)}${resource.startsWith('/') ? resource : `/${resource}`}${params ? queryString(params) : ''}`;
+}
+
+export async function jiraRequest(config, resource, options = {}) {
+    return atlassianRequest(config, jiraApiPath(config, resource, options.params), options);
+}
+
+function configuredFieldNames() {
+    return {
+        acceptanceCriteria: process.env.ATLASSIAN_JIRA_ACCEPTANCE_FIELD?.trim() || '',
+        sprint: process.env.ATLASSIAN_JIRA_SPRINT_FIELD?.trim() || '',
+        storyPoints: process.env.ATLASSIAN_JIRA_STORY_POINTS_FIELD?.trim() || '',
+    };
+}
+
+function issueFields(extraFields = []) {
+    const configured = Object.values(configuredFieldNames()).filter(Boolean);
+    return [...new Set([...DEFAULT_ISSUE_FIELDS, ...configured, ...extraFields.filter(Boolean)])].join(',');
+}
+
+export function parseJiraLimit(value, fallback = 20, max = 100) {
+    return parseLimit(value, fallback, max, 'jira limit');
+}
+
+export function requireIssueKey(value) {
+    const key = requireString(value, 'Jira issue key');
+    if (!/^[A-Za-z][A-Za-z0-9_]+-\d+$/.test(key)) {
+        return key;
+    }
+    return key.toUpperCase();
+}
+
+function displayUser(user) {
+    if (!user || typeof user !== 'object') return '';
+    return String(user.displayName ?? user.name ?? user.emailAddress ?? user.accountId ?? '');
+}
+
+function valueName(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'object') return String(value.name ?? value.value ?? value.key ?? value.id ?? '');
+    return String(value);
+}
+
+function valueNames(values) {
+    return Array.isArray(values) ? values.map(valueName).filter(Boolean) : [];
+}
+
+export function jiraBodyToMarkdown(raw, rendered) {
+    if (rendered) return htmlToMarkdown(rendered);
+    if (raw && typeof raw === 'object') return adfToMarkdown(raw);
+    if (typeof raw === 'string') return raw.trim();
+    return '';
+}
+
+export function normalizeComment(comment) {
+    return {
+        id: String(comment?.id ?? ''),
+        author: displayUser(comment?.author),
+        created: String(comment?.created ?? ''),
+        updated: comment?.updated ? String(comment.updated) : undefined,
+        markdown: jiraBodyToMarkdown(comment?.body, comment?.renderedBody),
+    };
+}
+
+export function normalizeAttachment(attachment) {
+    return {
+        id: String(attachment?.id ?? ''),
+        filename: String(attachment?.filename ?? ''),
+        mimeType: attachment?.mimeType ? String(attachment.mimeType) : undefined,
+        size: attachment?.size != null ? Number(attachment.size) : undefined,
+        url: String(attachment?.content ?? attachment?.self ?? ''),
+    };
+}
+
+export function normalizeIssueLink(link) {
+    const outward = link?.outwardIssue;
+    const inward = link?.inwardIssue;
+    const issue = outward ?? inward ?? {};
+    return {
+        key: String(issue.key ?? ''),
+        type: String(link?.type?.name ?? (outward ? link?.type?.outward : link?.type?.inward) ?? ''),
+        direction: outward ? 'outward' : 'inward',
+    };
+}
+
+function customValueToMarkdown(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value.trim();
+    if (value && typeof value === 'object' && value.type === 'doc') return adfToMarkdown(value);
+    if (Array.isArray(value)) return value.map(valueName).filter(Boolean).join(', ');
+    return valueName(value);
+}
+
+export function normalizeJiraIssue(issue, config, options = {}) {
+    const fields = issue?.fields ?? {};
+    const rendered = issue?.renderedFields ?? {};
+    const custom = configuredFieldNames();
+    const comments = options.comments ?? fields.comment?.comments ?? [];
+    const normalized = {
+        key: String(issue?.key ?? ''),
+        id: String(issue?.id ?? ''),
+        url: issue?.key ? `${config.baseUrl}/browse/${issue.key}` : '',
+        summary: String(fields.summary ?? ''),
+        issueType: valueName(fields.issuetype) || undefined,
+        status: valueName(fields.status) || undefined,
+        priority: valueName(fields.priority) || undefined,
+        project: valueName(fields.project) || undefined,
+        reporter: displayUser(fields.reporter) || undefined,
+        assignee: displayUser(fields.assignee) || undefined,
+        labels: Array.isArray(fields.labels) ? fields.labels.map(String) : [],
+        description: {
+            raw: fields.description ?? null,
+            markdown: jiraBodyToMarkdown(fields.description, rendered.description),
+        },
+        comments: Array.isArray(comments) ? comments.map(normalizeComment) : [],
+        attachments: Array.isArray(fields.attachment) ? fields.attachment.map(normalizeAttachment) : [],
+        linkedIssues: Array.isArray(fields.issuelinks) ? fields.issuelinks.map(normalizeIssueLink).filter((link) => link.key) : [],
+        fixVersions: valueNames(fields.fixVersions),
+        affectedVersions: valueNames(fields.versions),
+        components: valueNames(fields.components),
+        created: fields.created ? String(fields.created) : undefined,
+        updated: fields.updated ? String(fields.updated) : undefined,
+    };
+    if (custom.acceptanceCriteria && fields[custom.acceptanceCriteria] !== undefined) {
+        normalized.acceptanceCriteria = {
+            raw: fields[custom.acceptanceCriteria],
+            markdown: customValueToMarkdown(fields[custom.acceptanceCriteria]),
+        };
+    }
+    if (custom.sprint && fields[custom.sprint] !== undefined) {
+        normalized.sprint = customValueToMarkdown(fields[custom.sprint]);
+    }
+    if (custom.storyPoints && fields[custom.storyPoints] !== undefined) {
+        normalized.storyPoints = Number(fields[custom.storyPoints]);
+    }
+    return normalized;
+}
+
+export function issueSummaryRow(issue, config) {
+    const normalized = normalizeJiraIssue(issue, config, { comments: [] });
+    return {
+        key: normalized.key,
+        summary: normalized.summary,
+        issueType: normalized.issueType,
+        status: normalized.status,
+        priority: normalized.priority,
+        assignee: normalized.assignee,
+        updated: normalized.updated,
+        url: normalized.url,
+    };
+}
+
+export async function fetchIssue(config, key, extraFields = []) {
+    return jiraRequest(config, `/issue/${encodeURIComponent(key)}`, {
+        params: {
+            fields: issueFields(extraFields),
+            expand: 'renderedFields',
+        },
+        label: `jira issue ${key}`,
+    });
+}
+
+export async function fetchComments(config, key, limit = 100) {
+    const maxResults = parseJiraLimit(limit, 100, 100);
+    const data = await jiraRequest(config, `/issue/${encodeURIComponent(key)}/comment`, {
+        params: { startAt: 0, maxResults, expand: 'renderedBody' },
+        label: `jira comments ${key}`,
+    });
+    return Array.isArray(data?.comments) ? data.comments : [];
+}
+
+export function jiraConfig() {
+    return getJiraConfig();
+}
+
+export const __test__ = {
+    configuredFieldNames,
+    fetchIssue,
+    issueSummaryRow,
+    jiraApiPath,
+    jiraBodyToMarkdown,
+    normalizeAttachment,
+    normalizeComment,
+    normalizeIssueLink,
+    normalizeJiraIssue,
+};

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -1,4 +1,5 @@
 import { adfToMarkdown, atlassianRequest, getJiraConfig, htmlToMarkdown, parseLimit, queryString, requireString } from '../atlassian/shared.js';
+import { ArgumentError } from '@jackwener/opencli/errors';
 
 const DEFAULT_ISSUE_FIELDS = [
     'summary',
@@ -52,7 +53,7 @@ export function parseJiraLimit(value, fallback = 20, max = 100) {
 export function requireIssueKey(value) {
     const key = requireString(value, 'Jira issue key');
     if (!/^[A-Za-z][A-Za-z0-9_]+-\d+$/.test(key)) {
-        return key;
+        throw new ArgumentError(`Invalid Jira issue key: ${key}`, 'Expected a key like PROJECT-123.');
     }
     return key.toUpperCase();
 }
@@ -211,4 +212,5 @@ export const __test__ = {
     normalizeComment,
     normalizeIssueLink,
     normalizeJiraIssue,
+    requireIssueKey,
 };

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -1,4 +1,4 @@
-import { adfToMarkdown, atlassianRequest, getJiraConfig, htmlToMarkdown, parseLimit, queryString, requireString } from '../atlassian/shared.js';
+import { adfToMarkdown, atlassianRequest, getJiraConfig, htmlToMarkdown, parseLimit, queryString, requireString } from '../_atlassian/shared.js';
 import { ArgumentError } from '@jackwener/opencli/errors';
 
 const DEFAULT_ISSUE_FIELDS = [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -132,6 +132,8 @@ export default defineConfig({
                 { text: 'Hugging Face', link: '/adapters/browser/hf' },
                 { text: 'Sina Finance', link: '/adapters/browser/sinafinance' },
                 { text: 'Spotify', link: '/adapters/browser/spotify' },
+                { text: 'Jira', link: '/adapters/browser/jira' },
+                { text: 'Confluence', link: '/adapters/browser/confluence' },
                 { text: 'Stack Overflow', link: '/adapters/browser/stackoverflow' },
                 { text: 'Wikipedia', link: '/adapters/browser/wikipedia' },
                 { text: 'LessWrong', link: '/adapters/browser/lesswrong' },

--- a/docs/adapters/browser/confluence.md
+++ b/docs/adapters/browser/confluence.md
@@ -1,0 +1,75 @@
+# Confluence
+
+**Mode**: 🔑 Atlassian REST API · **Domain**: configured with `ATLASSIAN_CONFLUENCE_BASE_URL`
+
+Read, search, create, and update Confluence pages through Atlassian REST APIs. The adapter supports Confluence Cloud and Confluence Data Center without driving a browser session.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli confluence page <PAGE_ID>` | Page detail with storage and Markdown body |
+| `opencli confluence search <CQL>` | Search content with CQL |
+| `opencli confluence create` | Create a page from Markdown or storage XHTML |
+| `opencli confluence update <PAGE_ID>` | Update a page body from Markdown or storage XHTML |
+
+## Configuration
+
+```bash
+export ATLASSIAN_CONFLUENCE_BASE_URL=https://example.atlassian.net/wiki
+export ATLASSIAN_DEPLOYMENT=cloud      # cloud | datacenter | auto
+export ATLASSIAN_EMAIL=you@example.com
+export ATLASSIAN_API_TOKEN=...
+```
+
+For Data Center, use a personal access token when available:
+
+```bash
+export ATLASSIAN_CONFLUENCE_BASE_URL=https://confluence.example.com
+export ATLASSIAN_DEPLOYMENT=datacenter
+export ATLASSIAN_PAT=...
+```
+
+Cloud page reads and writes use Confluence REST API v2. CQL search is still exposed through Confluence REST API v1, so `search` intentionally uses the v1 search endpoint for both Cloud and Data Center.
+
+## Usage Examples
+
+```bash
+# Read a page
+opencli confluence page 123456 -f json
+
+# Search pages in a space
+opencli confluence search "type = page and title ~ \"RCA\"" --space ENG --limit 20 -f json
+
+# Create a page from Markdown
+opencli confluence create --space 987654 --title "PROJ-123 RCA" --file rca.md --execute
+
+# Update an existing page
+opencli confluence update 123456 --file rca.md --version-message "Sync from Jira PROJ-123" --execute
+```
+
+## Write Safety
+
+`create` and `update` require `--execute`. Without it, the adapter fails before sending a remote write.
+
+For Cloud, `--space` expects a space id. For Data Center, `--space` expects a space key. `--parent` can be used to place a new page under an existing page id.
+
+## Input Formats
+
+Markdown is the default input format:
+
+```bash
+opencli confluence create --space 987654 --title "Runbook" --file runbook.md --execute
+```
+
+To provide Confluence storage XHTML directly:
+
+```bash
+opencli confluence update 123456 --file page.storage.html --representation storage --execute
+```
+
+## Notes
+
+- `update` reads the current page version first and submits `version.number + 1`.
+- Markdown conversion covers headings, paragraphs, links, inline code, code blocks, flat and nested lists, and basic tables.
+- Expected auth, rate-limit, version-conflict, argument, and not-found failures are normalized to `CliError` subclasses.

--- a/docs/adapters/browser/jira.md
+++ b/docs/adapters/browser/jira.md
@@ -1,0 +1,72 @@
+# Jira
+
+**Mode**: 🔑 Atlassian REST API · **Domain**: configured with `ATLASSIAN_JIRA_BASE_URL`
+
+Read Jira issues, comments, attachments, and links through Atlassian REST APIs. The adapter supports Jira Cloud and Jira Data Center without driving a browser session.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli jira issue <KEY>` | Normalized issue context for agents |
+| `opencli jira search <JQL>` | Search issues with JQL |
+| `opencli jira comments <KEY>` | Issue comments as Markdown |
+| `opencli jira attachments <KEY>` | Issue attachment metadata |
+| `opencli jira links <KEY>` | Linked Jira issues |
+
+## Configuration
+
+```bash
+export ATLASSIAN_JIRA_BASE_URL=https://example.atlassian.net
+export ATLASSIAN_DEPLOYMENT=cloud      # cloud | datacenter | auto
+export ATLASSIAN_EMAIL=you@example.com
+export ATLASSIAN_API_TOKEN=...
+```
+
+For Data Center, use a personal access token when available:
+
+```bash
+export ATLASSIAN_JIRA_BASE_URL=https://jira.example.com
+export ATLASSIAN_DEPLOYMENT=datacenter
+export ATLASSIAN_PAT=...
+```
+
+Cloud instances default to Jira REST API v3. Data Center instances use Jira REST API v2. `ATLASSIAN_DEPLOYMENT=auto` treats `*.atlassian.net` as Cloud and other hosts as Data Center.
+
+## Usage Examples
+
+```bash
+# Full issue context, including description, comments, attachments, and links
+opencli jira issue PROJ-123 -f json
+
+# Search with JQL
+opencli jira search "project = PROJ order by updated desc" --limit 20 -f json
+
+# Focused reads
+opencli jira comments PROJ-123 -f json
+opencli jira attachments PROJ-123 -f json
+opencli jira links PROJ-123 -f json
+```
+
+## Output Notes
+
+- `issue` returns an agent-friendly object with `key`, `summary`, `status`, `priority`, `description.markdown`, `comments`, `attachments`, `linkedIssues`, versions, components, and timestamps.
+- Jira Cloud ADF descriptions and comments are converted to Markdown.
+- Rendered Jira HTML from Data Center is converted through OpenCLI's Markdown converter.
+- Invalid issue keys fail early with `ArgumentError`.
+
+## Custom Fields
+
+Some Jira fields are instance-specific. Set these environment variables to include them in `jira issue` output:
+
+```bash
+export ATLASSIAN_JIRA_ACCEPTANCE_FIELD=customfield_12345
+export ATLASSIAN_JIRA_SPRINT_FIELD=customfield_10020
+export ATLASSIAN_JIRA_STORY_POINTS_FIELD=customfield_10016
+```
+
+## Notes
+
+- The adapter only reads Jira data; it does not generate RCA, design docs, or release notes itself.
+- Agents should generate documentation from `jira issue ... -f json`, then write it with the Confluence adapter.
+- Expected auth, rate-limit, argument, and not-found failures are normalized to `CliError` subclasses.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -107,6 +107,8 @@ Run `opencli list` for the live registry.
 | **[hf](./browser/hf.md)**                         | `top` `paper` `models` `datasets` `spaces`                                                                                                     | 🌐 Public    |
 | **[sinafinance](./browser/sinafinance.md)**       | `news` `rolling-news` `stock` `stock-rank`                                                                                                     | 🌐 / 🔐      |
 | **[spotify](./browser/spotify.md)**               | `auth` `status` `play` `pause` `next` `prev` `volume` `search` `queue` `shuffle` `repeat`                                                      | 🔑 OAuth API |
+| **[jira](./browser/jira.md)**                     | `issue` `search` `comments` `attachments` `links`                                                                                              | 🔑 Atlassian REST API |
+| **[confluence](./browser/confluence.md)**         | `page` `search` `create` `update`                                                                                                               | 🔑 Atlassian REST API |
 | **[stackoverflow](./browser/stackoverflow.md)**   | `hot` `search` `bounties` `unanswered` `tag` `user` `read` `related`                                                                           | 🌐 Public    |
 | **[wikipedia](./browser/wikipedia.md)**           | `search` `summary` `random` `trending`                                                                                                         | 🌐 Public    |
 | **[lesswrong](./browser/lesswrong.md)**           | `curated` `frontpage` `new` `top` `top-week` `top-month` `top-year` `read` `comments` `user` `user-posts` `tag` `tags` `sequences` `shortform` | 🌐 Public    |


### PR DESCRIPTION
## Description

Add Jira and Confluence REST adapters for Atlassian Cloud and Data Center.

Related issue: #1469

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Implemented commands:

```bash
opencli jira issue <KEY> -f json
opencli jira search <JQL> --limit 20 -f json
opencli jira comments <KEY> -f json
opencli jira attachments <KEY> -f json
opencli jira links <KEY> -f json

opencli confluence page <PAGE_ID> -f json
opencli confluence search <CQL> --space <SPACE> --limit 20 -f json
opencli confluence create --space <SPACE_ID_OR_KEY> --title <TITLE> --file doc.md --execute
opencli confluence update <PAGE_ID> --file doc.md --version-message "Sync from Jira" --execute
```
Validation:
```bash
npm run build-manifest
npm run test:adapter
npm run check:silent-column-drop
npm run check:typed-error-lint
npm test
```
Results:
```bash
npm run test:adapter
Test Files  289 passed (289)
Tests       2479 passed (2479)

npm test
Test Files  366 passed (366)
Tests       3647 passed | 1 skipped (3648)
```