### PR TITLE
feat(notebooklm): add create / add-source / write-note / generate-audio / generate-slides write commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17217,6 +17217,12 @@
         "type": "str",
         "required": false,
         "help": "Override the auto-detected MIME type when --file is given."
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually add the remote source to the NotebookLM notebook"
       }
     ],
     "columns": [
@@ -17252,6 +17258,12 @@
         "type": "str",
         "required": false,
         "help": "Notebook emoji icon (default 📒)"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually create the remote NotebookLM notebook"
       }
     ],
     "columns": [
@@ -17300,6 +17312,12 @@
         "required": true,
         "positional": true,
         "help": "Notebook id from `notebooklm list` or full notebook URL"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually trigger remote NotebookLM audio generation"
       }
     ],
     "columns": [
@@ -17341,6 +17359,12 @@
         "type": "str",
         "required": false,
         "help": "Language code (default en)"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually trigger remote NotebookLM slide deck generation"
       }
     ],
     "columns": [
@@ -17693,6 +17717,12 @@
         "type": "str",
         "required": true,
         "help": "Note body as Markdown"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually create the remote NotebookLM note"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17174,6 +17174,99 @@
   },
   {
     "site": "notebooklm",
+    "name": "add-source",
+    "description": "Add a URL, text, or local file source to an existing NotebookLM notebook",
+    "access": "write",
+    "domain": "notebooklm.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "notebook",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Notebook id from `notebooklm list` or full notebook URL"
+      },
+      {
+        "name": "url",
+        "type": "str",
+        "required": false,
+        "help": "Source URL to add (http/https). Pass exactly one of --url, --content, --file."
+      },
+      {
+        "name": "content",
+        "type": "str",
+        "required": false,
+        "help": "Raw text content to add as a Text source (max 10 MB)."
+      },
+      {
+        "name": "file",
+        "type": "str",
+        "required": false,
+        "help": "Local file path to upload as a source (max 52428800 bytes; pdf / txt / md / html / docx / etc.). Uses Google Drive's 3-step resumable upload protocol."
+      },
+      {
+        "name": "title",
+        "type": "str",
+        "required": false,
+        "help": "Title for the text source (default \"Text Source\"). Ignored for --url and --file."
+      },
+      {
+        "name": "mime-type",
+        "type": "str",
+        "required": false,
+        "help": "Override the auto-detected MIME type when --file is given."
+      }
+    ],
+    "columns": [
+      "notebook_id",
+      "source_id",
+      "kind",
+      "identifier",
+      "notebook_url"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/add-source.js",
+    "sourceFile": "notebooklm/add-source.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "notebooklm",
+    "name": "create",
+    "description": "Create a new NotebookLM notebook with the given title",
+    "access": "write",
+    "domain": "notebooklm.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "title",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Notebook title (1-200 chars)"
+      },
+      {
+        "name": "emoji",
+        "type": "str",
+        "required": false,
+        "help": "Notebook emoji icon (default 📒)"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "emoji",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/create.js",
+    "sourceFile": "notebooklm/create.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "notebooklm",
     "name": "current",
     "description": "Show metadata for the currently opened NotebookLM notebook tab",
     "access": "read",
@@ -17190,6 +17283,76 @@
     "type": "js",
     "modulePath": "notebooklm/current.js",
     "sourceFile": "notebooklm/current.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "notebooklm",
+    "name": "generate-audio",
+    "description": "Trigger an Audio Overview (Deep Dive podcast) generation for a NotebookLM notebook, using all of its sources",
+    "access": "write",
+    "domain": "notebooklm.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "notebook",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Notebook id from `notebooklm list` or full notebook URL"
+      }
+    ],
+    "columns": [
+      "notebook_id",
+      "audio_id",
+      "source_count",
+      "status",
+      "notebook_url"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/generate-audio.js",
+    "sourceFile": "notebooklm/generate-audio.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "notebooklm",
+    "name": "generate-slides",
+    "description": "Trigger a Slide Deck (AI presentation) generation for a NotebookLM notebook, using all of its sources",
+    "access": "write",
+    "domain": "notebooklm.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "notebook",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Notebook id from `notebooklm list` or full notebook URL"
+      },
+      {
+        "name": "length",
+        "type": "str",
+        "required": false,
+        "help": "Slide deck length: 1=Short, 3=Default (default 3)"
+      },
+      {
+        "name": "language",
+        "type": "str",
+        "required": false,
+        "help": "Language code (default en)"
+      }
+    ],
+    "columns": [
+      "notebook_id",
+      "slides_id",
+      "source_count",
+      "status",
+      "notebook_url"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/generate-slides.js",
+    "sourceFile": "notebooklm/generate-slides.js",
     "navigateBefore": false
   },
   {
@@ -17501,6 +17664,46 @@
     "type": "js",
     "modulePath": "notebooklm/summary.js",
     "sourceFile": "notebooklm/summary.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "notebooklm",
+    "name": "write-note",
+    "description": "Create a Studio note in an existing NotebookLM notebook with the given title and Markdown content",
+    "access": "write",
+    "domain": "notebooklm.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "notebook",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Notebook id from `notebooklm list` or full notebook URL"
+      },
+      {
+        "name": "title",
+        "type": "str",
+        "required": true,
+        "help": "Note title (1-200 chars)"
+      },
+      {
+        "name": "content",
+        "type": "str",
+        "required": true,
+        "help": "Note body as Markdown"
+      }
+    ],
+    "columns": [
+      "notebook_id",
+      "note_id",
+      "title",
+      "notebook_url"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/write-note.js",
+    "sourceFile": "notebooklm/write-note.js",
     "navigateBefore": false
   },
   {

--- a/clis/notebooklm/add-source.js
+++ b/clis/notebooklm/add-source.js
@@ -1,0 +1,254 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
+import { callNotebooklmRpc } from './rpc.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, getNotebooklmAuthuser, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+
+const NOTEBOOKLM_ADD_SOURCES_RPC_ID = 'izAoDd';
+const NOTEBOOKLM_ADD_FILE_SOURCE_RPC_ID = 'o4cbdc';
+const MAX_TEXT_SOURCE_BYTES = 10 * 1024 * 1024;
+const MAX_FILE_SOURCE_BYTES = 50 * 1024 * 1024;
+const SOURCE_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+const MIME_BY_EXT = {
+    '.pdf': 'application/pdf',
+    '.txt': 'text/plain',
+    '.md': 'text/markdown',
+    '.markdown': 'text/markdown',
+    '.html': 'text/html',
+    '.htm': 'text/html',
+    '.csv': 'text/csv',
+    '.json': 'application/json',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.doc': 'application/msword',
+    '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    '.epub': 'application/epub+zip',
+    '.mp3': 'audio/mpeg',
+    '.m4a': 'audio/mp4',
+    '.wav': 'audio/wav',
+};
+
+export function inferMimeType(filename, override) {
+    if (override) return String(override);
+    const ext = path.extname(filename).toLowerCase();
+    return MIME_BY_EXT[ext] || 'application/octet-stream';
+}
+
+export function readFileForUpload(filePath) {
+    const abs = path.resolve(filePath);
+    let stat;
+    try {
+        stat = fs.statSync(abs);
+    } catch {
+        throw new ArgumentError(`--file path does not exist: ${filePath}`);
+    }
+    if (!stat.isFile()) {
+        throw new ArgumentError(`--file path is not a regular file: ${filePath}`);
+    }
+    if (stat.size > MAX_FILE_SOURCE_BYTES) {
+        throw new ArgumentError(`--file exceeds ${MAX_FILE_SOURCE_BYTES} bytes (got ${stat.size}); use a smaller file or upload via the NotebookLM UI for now.`);
+    }
+    const buf = fs.readFileSync(abs);
+    return { base64: buf.toString('base64'), filename: path.basename(abs), size: stat.size };
+}
+
+export function buildRegisterFileSourceArgs(projectId, filename) {
+    return [
+        [[filename]],
+        projectId,
+        [2],
+        [1, null, null, null, null, null, null, null, null, null, [1]],
+    ];
+}
+
+export function parseSourceUrl(value) {
+    const url = String(value ?? '').trim();
+    if (!url) return '';
+    if (!/^https?:\/\//i.test(url)) {
+        throw new ArgumentError(`Invalid source URL: "${url}"`, 'URL must start with http:// or https://.');
+    }
+    return url;
+}
+
+export function parseSourceText(value) {
+    if (value === undefined || value === null) return null;
+    const text = String(value);
+    if (!text.trim()) throw new ArgumentError('--content must not be empty');
+    if (text.length > MAX_TEXT_SOURCE_BYTES) {
+        throw new ArgumentError(`--content exceeds ${MAX_TEXT_SOURCE_BYTES} bytes; split into smaller sources or upload as a file.`);
+    }
+    return text;
+}
+
+export function parseSourceTitle(value, fallback) {
+    const title = String(value ?? '').trim();
+    return title || fallback;
+}
+
+export function buildAddSourceFromUrlArgs(projectId, url) {
+    return [[[null, null, [url]]], projectId];
+}
+
+export function buildAddSourceFromTextArgs(projectId, title, content) {
+    return [[[null, [title, content], null, 2]], projectId];
+}
+
+export function parseAddSourceResult(result) {
+    if (typeof result === 'string') return SOURCE_UUID_RE.test(result) ? result : '';
+    if (!Array.isArray(result) && (typeof result !== 'object' || result === null)) return '';
+    const stack = [result];
+    while (stack.length) {
+        const node = stack.shift();
+        if (typeof node === 'string') {
+            if (SOURCE_UUID_RE.test(node)) return node;
+            continue;
+        }
+        if (Array.isArray(node)) {
+            for (const child of node) stack.push(child);
+            continue;
+        }
+        if (node && typeof node === 'object') {
+            for (const value of Object.values(node)) stack.push(value);
+        }
+    }
+    return '';
+}
+
+async function uploadFileViaDriveResumable(page, projectId, sourceId, filename, base64, size) {
+    const authuser = getNotebooklmAuthuser() || '0';
+    const metadataJson = `{"PROJECT_ID":${JSON.stringify(projectId)},"SOURCE_NAME":${JSON.stringify(filename)},"SOURCE_ID":${JSON.stringify(sourceId)}}`;
+    const script = String.raw`(async () => {
+    try {
+      const initRes = await fetch(${JSON.stringify('https://notebooklm.google.com/upload/_/?authuser=' + authuser)}, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+          'X-Goog-Upload-Command': 'start',
+          'X-Goog-Upload-Protocol': 'resumable',
+          'X-Goog-Upload-Header-Content-Length': ${JSON.stringify(String(size))},
+          'X-Goog-AuthUser': ${JSON.stringify(authuser)},
+        },
+        body: ${JSON.stringify(metadataJson)},
+      });
+      if (!initRes.ok) {
+        const status = initRes.headers.get('X-Goog-Upload-Status') || '';
+        const text = (await initRes.text()).slice(0, 400);
+        return { error: 'init failed HTTP ' + initRes.status + (status ? ' upload-status=' + status : '') + (text ? ' body=' + text : '') };
+      }
+      const uploadURL = initRes.headers.get('X-Goog-Upload-Url') || initRes.headers.get('x-goog-upload-url');
+      if (!uploadURL) return { error: 'no X-Goog-Upload-URL header in init response' };
+      // Decode base64 to Uint8Array for binary PUT
+      const bin = atob(${JSON.stringify(base64)});
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      const uploadRes = await fetch(uploadURL, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+          'X-Goog-Upload-Command': 'upload, finalize',
+          'X-Goog-Upload-Offset': '0',
+          'X-Goog-AuthUser': ${JSON.stringify(authuser)},
+        },
+        body: bytes,
+      });
+      if (!uploadRes.ok) {
+        const status = uploadRes.headers.get('X-Goog-Upload-Status') || '';
+        const text = (await uploadRes.text()).slice(0, 400);
+        return { error: 'upload failed HTTP ' + uploadRes.status + (status ? ' upload-status=' + status : '') + (text ? ' body=' + text : '') };
+      }
+      return { ok: true, status: uploadRes.status };
+    } catch (e) {
+      return { error: 'upload exception: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+    const raw = await page.evaluate(script);
+    const result = raw && typeof raw === 'object' && 'data' in raw && 'session' in raw ? raw.data : raw;
+    if (!result || result.error) {
+        throw new CommandExecutionError('NotebookLM file upload failed: ' + (result?.error || 'unknown error'));
+    }
+    return result;
+}
+
+cli({
+    site: NOTEBOOKLM_SITE,
+    name: 'add-source',
+    access: 'write',
+    description: 'Add a URL, text, or local file source to an existing NotebookLM notebook',
+    domain: NOTEBOOKLM_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
+        { name: 'url', help: 'Source URL to add (http/https). Pass exactly one of --url, --content, --file.' },
+        { name: 'content', help: 'Raw text content to add as a Text source (max 10 MB).' },
+        { name: 'file', help: `Local file path to upload as a source (max ${MAX_FILE_SOURCE_BYTES} bytes; pdf / txt / md / html / docx / etc.). Uses Google Drive's 3-step resumable upload protocol.` },
+        { name: 'title', help: 'Title for the text source (default "Text Source"). Ignored for --url and --file.' },
+        { name: 'mime-type', help: 'Override the auto-detected MIME type when --file is given.' },
+    ],
+    columns: ['notebook_id', 'source_id', 'kind', 'identifier', 'notebook_url'],
+    func: async (page, kwargs) => {
+        const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
+        const url = parseSourceUrl(kwargs.url);
+        const content = parseSourceText(kwargs.content);
+        const filePath = typeof kwargs.file === 'string' && kwargs.file.trim() ? kwargs.file.trim() : '';
+        const modes = [url ? 'url' : '', content !== null ? 'text' : '', filePath ? 'file' : ''].filter(Boolean);
+        if (modes.length === 0) {
+            throw new ArgumentError('Pass exactly one of --url <url>, --content <text>, or --file <path>');
+        }
+        if (modes.length > 1) {
+            throw new ArgumentError('Pass exactly one of --url, --content, --file (got: ' + modes.join(' + ') + ')');
+        }
+        const title = parseSourceTitle(kwargs.title, 'Text Source');
+        await ensureNotebooklmHome(page);
+        await requireNotebooklmSession(page);
+        if (filePath) {
+            const file = readFileForUpload(filePath);
+            const mime = inferMimeType(file.filename, kwargs['mime-type']);
+            const registerRpc = await callNotebooklmRpc(page, NOTEBOOKLM_ADD_FILE_SOURCE_RPC_ID, buildRegisterFileSourceArgs(notebookId, file.filename));
+            const sourceId = parseAddSourceResult(registerRpc.result);
+            if (!sourceId) {
+                throw new CommandExecutionError('NotebookLM AddFileSource (o4cbdc) RPC returned no source id; cannot start file upload.');
+            }
+            await uploadFileViaDriveResumable(page, notebookId, sourceId, file.filename, file.base64, file.size);
+            return [{
+                notebook_id: notebookId,
+                source_id: sourceId,
+                kind: 'file',
+                identifier: `${file.filename} (${mime}, ${file.size} bytes)`,
+                notebook_url: buildNotebooklmNotebookUrl(notebookId),
+            }];
+        }
+        const args = url
+            ? buildAddSourceFromUrlArgs(notebookId, url)
+            : buildAddSourceFromTextArgs(notebookId, title, content);
+        const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_ADD_SOURCES_RPC_ID, args);
+        const sourceId = parseAddSourceResult(rpc.result);
+        if (!sourceId) {
+            throw new CommandExecutionError('NotebookLM AddSources RPC returned no source id; verify the input reaches the NotebookLM backend.');
+        }
+        return [{
+            notebook_id: notebookId,
+            source_id: sourceId,
+            kind: url ? 'url' : 'text',
+            identifier: url || title,
+            notebook_url: buildNotebooklmNotebookUrl(notebookId),
+        }];
+    },
+});
+
+export const __test__ = {
+    parseSourceUrl,
+    parseSourceText,
+    parseSourceTitle,
+    inferMimeType,
+    buildAddSourceFromUrlArgs,
+    buildAddSourceFromTextArgs,
+    buildRegisterFileSourceArgs,
+    readFileForUpload,
+    parseAddSourceResult,
+};

--- a/clis/notebooklm/add-source.js
+++ b/clis/notebooklm/add-source.js
@@ -4,7 +4,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, getNotebooklmAuthuser, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, getNotebooklmAuthuser, parseNotebooklmNotebookTarget, requireNotebooklmSession, verifyNotebooklmSourceAdded } from './utils.js';
 
 const NOTEBOOKLM_ADD_SOURCES_RPC_ID = 'izAoDd';
 const NOTEBOOKLM_ADD_FILE_SOURCE_RPC_ID = 'o4cbdc';
@@ -215,6 +215,7 @@ cli({
                 throw new CommandExecutionError('NotebookLM AddFileSource (o4cbdc) RPC returned no source id; cannot start file upload.');
             }
             await uploadFileViaDriveResumable(page, notebookId, sourceId, file.filename, file.base64, file.size);
+            await verifyNotebooklmSourceAdded(page, notebookId, sourceId, 'add-source --file');
             return [{
                 notebook_id: notebookId,
                 source_id: sourceId,
@@ -231,6 +232,7 @@ cli({
         if (!sourceId) {
             throw new CommandExecutionError('NotebookLM AddSources RPC returned no source id; verify the input reaches the NotebookLM backend.');
         }
+        await verifyNotebooklmSourceAdded(page, notebookId, sourceId, `add-source --${url ? 'url' : 'content'}`);
         return [{
             notebook_id: notebookId,
             source_id: sourceId,

--- a/clis/notebooklm/add-source.js
+++ b/clis/notebooklm/add-source.js
@@ -101,14 +101,19 @@ export function buildAddSourceFromTextArgs(projectId, title, content) {
     return [[[null, [title, content], null, 2]], projectId];
 }
 
-export function parseAddSourceResult(result) {
-    if (typeof result === 'string') return SOURCE_UUID_RE.test(result) ? result : '';
+function toExcludedUuidSet(excludedIds) {
+    return new Set(excludedIds.map((id) => String(id ?? '').toLowerCase()).filter(Boolean));
+}
+
+export function parseAddSourceResult(result, excludedIds = []) {
+    const excluded = toExcludedUuidSet(excludedIds);
+    if (typeof result === 'string') return SOURCE_UUID_RE.test(result) && !excluded.has(result.toLowerCase()) ? result : '';
     if (!Array.isArray(result) && (typeof result !== 'object' || result === null)) return '';
     const stack = [result];
     while (stack.length) {
         const node = stack.shift();
         if (typeof node === 'string') {
-            if (SOURCE_UUID_RE.test(node)) return node;
+            if (SOURCE_UUID_RE.test(node) && !excluded.has(node.toLowerCase())) return node;
             continue;
         }
         if (Array.isArray(node)) {
@@ -218,7 +223,7 @@ cli({
             const file = readFileForUpload(filePath);
             const mime = inferMimeType(file.filename, kwargs['mime-type']);
             const registerRpc = await callNotebooklmRpc(page, NOTEBOOKLM_ADD_FILE_SOURCE_RPC_ID, buildRegisterFileSourceArgs(notebookId, file.filename));
-            const sourceId = parseAddSourceResult(registerRpc.result);
+            const sourceId = parseAddSourceResult(registerRpc.result, [notebookId]);
             if (!sourceId) {
                 throw new CommandExecutionError('NotebookLM AddFileSource (o4cbdc) RPC returned no source id; cannot start file upload.');
             }
@@ -236,7 +241,7 @@ cli({
             ? buildAddSourceFromUrlArgs(notebookId, url)
             : buildAddSourceFromTextArgs(notebookId, title, content);
         const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_ADD_SOURCES_RPC_ID, args);
-        const sourceId = parseAddSourceResult(rpc.result);
+        const sourceId = parseAddSourceResult(rpc.result, [notebookId]);
         if (!sourceId) {
             throw new CommandExecutionError('NotebookLM AddSources RPC returned no source id; verify the input reaches the NotebookLM backend.');
         }

--- a/clis/notebooklm/add-source.js
+++ b/clis/notebooklm/add-source.js
@@ -4,7 +4,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, getNotebooklmAuthuser, parseNotebooklmNotebookTarget, requireNotebooklmSession, verifyNotebooklmSourceAdded } from './utils.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, getNotebooklmAuthuser, parseNotebooklmNotebookTarget, requireNotebooklmExecute, requireNotebooklmSession, verifyNotebooklmSourceAdded } from './utils.js';
 
 const NOTEBOOKLM_ADD_SOURCES_RPC_ID = 'izAoDd';
 const NOTEBOOKLM_ADD_FILE_SOURCE_RPC_ID = 'o4cbdc';
@@ -66,10 +66,16 @@ export function buildRegisterFileSourceArgs(projectId, filename) {
 export function parseSourceUrl(value) {
     const url = String(value ?? '').trim();
     if (!url) return '';
-    if (!/^https?:\/\//i.test(url)) {
+    let parsed;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new ArgumentError(`Invalid source URL: "${url}"`, 'URL must be a valid http:// or https:// URL.');
+    }
+    if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || !parsed.hostname) {
         throw new ArgumentError(`Invalid source URL: "${url}"`, 'URL must start with http:// or https://.');
     }
-    return url;
+    return parsed.toString();
 }
 
 export function parseSourceText(value) {
@@ -189,6 +195,7 @@ cli({
         { name: 'file', help: `Local file path to upload as a source (max ${MAX_FILE_SOURCE_BYTES} bytes; pdf / txt / md / html / docx / etc.). Uses Google Drive's 3-step resumable upload protocol.` },
         { name: 'title', help: 'Title for the text source (default "Text Source"). Ignored for --url and --file.' },
         { name: 'mime-type', help: 'Override the auto-detected MIME type when --file is given.' },
+        { name: 'execute', type: 'boolean', help: 'Actually add the remote source to the NotebookLM notebook' },
     ],
     columns: ['notebook_id', 'source_id', 'kind', 'identifier', 'notebook_url'],
     func: async (page, kwargs) => {
@@ -203,6 +210,7 @@ cli({
         if (modes.length > 1) {
             throw new ArgumentError('Pass exactly one of --url, --content, --file (got: ' + modes.join(' + ') + ')');
         }
+        requireNotebooklmExecute(kwargs.execute, 'add a NotebookLM source');
         const title = parseSourceTitle(kwargs.title, 'Text Source');
         await ensureNotebooklmHome(page);
         await requireNotebooklmSession(page);

--- a/clis/notebooklm/add-source.test.js
+++ b/clis/notebooklm/add-source.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './add-source.js';
+
+const {
+    parseSourceUrl,
+    parseSourceText,
+    parseSourceTitle,
+    buildAddSourceFromUrlArgs,
+    buildAddSourceFromTextArgs,
+    parseAddSourceResult,
+} = __test__;
+
+describe('notebooklm add-source', () => {
+    it('parseSourceUrl accepts http and https URLs', () => {
+        expect(parseSourceUrl('https://en.wikipedia.org/wiki/Reti_Opening'))
+            .toBe('https://en.wikipedia.org/wiki/Reti_Opening');
+        expect(parseSourceUrl('  http://example.com/page  ')).toBe('http://example.com/page');
+    });
+
+    it('parseSourceUrl returns empty string for unset, rejects bad schemes', () => {
+        expect(parseSourceUrl('')).toBe('');
+        expect(parseSourceUrl(undefined)).toBe('');
+        expect(parseSourceUrl('   ')).toBe('');
+        expect(() => parseSourceUrl('ftp://example.com')).toThrow(ArgumentError);
+        expect(() => parseSourceUrl('javascript:alert(1)')).toThrow(ArgumentError);
+    });
+
+    it('parseSourceText returns the content for non-empty, null for unset', () => {
+        expect(parseSourceText('hello body')).toBe('hello body');
+        expect(parseSourceText(undefined)).toBeNull();
+        expect(parseSourceText(null)).toBeNull();
+    });
+
+    it('parseSourceText rejects whitespace-only and oversized content', () => {
+        expect(() => parseSourceText('   ')).toThrow(ArgumentError);
+        expect(() => parseSourceText('x'.repeat(10 * 1024 * 1024 + 1))).toThrow(ArgumentError);
+    });
+
+    it('parseSourceTitle trims and falls back to the default label', () => {
+        expect(parseSourceTitle('Custom title', 'Text Source')).toBe('Custom title');
+        expect(parseSourceTitle('   ', 'Text Source')).toBe('Text Source');
+        expect(parseSourceTitle(undefined, 'Text Source')).toBe('Text Source');
+    });
+
+    it('buildAddSourceFromUrlArgs wraps the url in the expected nested shape', () => {
+        const args = buildAddSourceFromUrlArgs('nb-123', 'https://example.com/a');
+        expect(args).toEqual([[[null, null, ['https://example.com/a']]], 'nb-123']);
+    });
+
+    it('buildAddSourceFromTextArgs uses the text inner tuple with source-type 2', () => {
+        const args = buildAddSourceFromTextArgs('nb-123', 'My Title', 'paragraph one');
+        expect(args).toEqual([[[null, ['My Title', 'paragraph one'], null, 2]], 'nb-123']);
+    });
+
+    it('parseAddSourceResult finds the source-id UUID anywhere in the wrapped result', () => {
+        const id = 'af732fa4-01c2-4de4-9d0a-933f2c29ee1e';
+        expect(parseAddSourceResult([[[ [id] ]]])).toBe(id);
+        expect(parseAddSourceResult([ 'project', null, [[id, 'title']] ])).toBe(id);
+        expect(parseAddSourceResult({ project: { sources: [{ sourceId: { sourceId: id } }] } })).toBe(id);
+    });
+
+    it('parseAddSourceResult returns the first UUID when several appear', () => {
+        const a = '11111111-1111-4111-8111-111111111111';
+        const b = '22222222-2222-4222-8222-222222222222';
+        expect(parseAddSourceResult([[[ [a], [b] ]]])).toBe(a);
+    });
+
+    it('parseAddSourceResult ignores non-UUID strings', () => {
+        expect(parseAddSourceResult([ 'project-id', 'not-a-uuid', 'still-not' ])).toBe('');
+    });
+
+    it('parseAddSourceResult returns empty string for unparseable shapes', () => {
+        expect(parseAddSourceResult(null)).toBe('');
+        expect(parseAddSourceResult({})).toBe('');
+        expect(parseAddSourceResult([])).toBe('');
+        expect(parseAddSourceResult([[]])).toBe('');
+    });
+});

--- a/clis/notebooklm/add-source.test.js
+++ b/clis/notebooklm/add-source.test.js
@@ -68,6 +68,12 @@ describe('notebooklm add-source', () => {
         expect(parseAddSourceResult([[[ [a], [b] ]]])).toBe(a);
     });
 
+    it('parseAddSourceResult skips known input ids before selecting the new source id', () => {
+        const notebookId = '17e2b882-6a01-4c6c-9262-0738dfa2abee';
+        const sourceId = 'af732fa4-01c2-4de4-9d0a-933f2c29ee1e';
+        expect(parseAddSourceResult([notebookId, [[sourceId, 'title']]], [notebookId])).toBe(sourceId);
+    });
+
     it('parseAddSourceResult ignores non-UUID strings', () => {
         expect(parseAddSourceResult([ 'project-id', 'not-a-uuid', 'still-not' ])).toBe('');
     });

--- a/clis/notebooklm/add-source.test.js
+++ b/clis/notebooklm/add-source.test.js
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './add-source.js';
 
 const {
@@ -24,6 +25,7 @@ describe('notebooklm add-source', () => {
         expect(parseSourceUrl('   ')).toBe('');
         expect(() => parseSourceUrl('ftp://example.com')).toThrow(ArgumentError);
         expect(() => parseSourceUrl('javascript:alert(1)')).toThrow(ArgumentError);
+        expect(() => parseSourceUrl('https://')).toThrow(ArgumentError);
     });
 
     it('parseSourceText returns the content for non-empty, null for unset', () => {
@@ -75,5 +77,15 @@ describe('notebooklm add-source', () => {
         expect(parseAddSourceResult({})).toBe('');
         expect(parseAddSourceResult([])).toBe('');
         expect(parseAddSourceResult([[]])).toBe('');
+    });
+
+    it('refuses to add a remote source without --execute', async () => {
+        const command = getRegistry().get('notebooklm/add-source');
+        const page = { goto: vi.fn() };
+        await expect(command.func(page, {
+            notebook: '17e2b882-6a01-4c6c-9262-0738dfa2abee',
+            content: 'source body',
+        })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
 });

--- a/clis/notebooklm/create.js
+++ b/clis/notebooklm/create.js
@@ -2,7 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, requireNotebooklmSession, verifyNotebooklmNotebookExists } from './utils.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, requireNotebooklmExecute, requireNotebooklmSession, verifyNotebooklmNotebookExists } from './utils.js';
 
 const NOTEBOOKLM_CREATE_PROJECT_RPC_ID = 'CCqFvf';
 const DEFAULT_EMOJI = '📒';
@@ -48,11 +48,13 @@ cli({
     args: [
         { name: 'title', positional: true, required: true, help: 'Notebook title (1-200 chars)' },
         { name: 'emoji', help: `Notebook emoji icon (default ${DEFAULT_EMOJI})` },
+        { name: 'execute', type: 'boolean', help: 'Actually create the remote NotebookLM notebook' },
     ],
     columns: ['id', 'title', 'emoji', 'url'],
     func: async (page, kwargs) => {
         const title = parseCreateTitle(kwargs.title);
         const emoji = parseCreateEmoji(kwargs.emoji);
+        requireNotebooklmExecute(kwargs.execute, 'create a NotebookLM notebook');
         await ensureNotebooklmHome(page);
         await requireNotebooklmSession(page);
         const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_PROJECT_RPC_ID, [title, emoji]);

--- a/clis/notebooklm/create.js
+++ b/clis/notebooklm/create.js
@@ -2,7 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, requireNotebooklmSession } from './utils.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, requireNotebooklmSession, verifyNotebooklmNotebookExists } from './utils.js';
 
 const NOTEBOOKLM_CREATE_PROJECT_RPC_ID = 'CCqFvf';
 const DEFAULT_EMOJI = '📒';
@@ -60,6 +60,7 @@ cli({
         if (!notebookId) {
             throw new CommandExecutionError('NotebookLM CreateProject RPC returned no notebook id');
         }
+        await verifyNotebooklmNotebookExists(page, notebookId, 'create');
         return [{
             id: notebookId,
             title,

--- a/clis/notebooklm/create.js
+++ b/clis/notebooklm/create.js
@@ -1,0 +1,72 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
+import { callNotebooklmRpc } from './rpc.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, requireNotebooklmSession } from './utils.js';
+
+const NOTEBOOKLM_CREATE_PROJECT_RPC_ID = 'CCqFvf';
+const DEFAULT_EMOJI = '📒';
+const MAX_TITLE_LEN = 200;
+
+export function parseCreateTitle(value) {
+    const title = String(value ?? '').trim();
+    if (!title) throw new ArgumentError('<title> is required');
+    if (title.length > MAX_TITLE_LEN) {
+        throw new ArgumentError(`Title must be at most ${MAX_TITLE_LEN} characters (got ${title.length})`);
+    }
+    return title;
+}
+
+export function parseCreateEmoji(value) {
+    const emoji = String(value ?? '').trim();
+    if (!emoji) return DEFAULT_EMOJI;
+    return emoji;
+}
+
+export function parseCreateProjectResult(result) {
+    let current = result;
+    while (Array.isArray(current) && current.length === 1 && Array.isArray(current[0])) {
+        current = current[0];
+    }
+    const id = Array.isArray(current)
+        ? (typeof current[2] === 'string' && current[2])
+            || (typeof current[0] === 'string' && current[0])
+            || ''
+        : '';
+    return typeof id === 'string' ? id : '';
+}
+
+cli({
+    site: NOTEBOOKLM_SITE,
+    name: 'create',
+    access: 'write',
+    description: 'Create a new NotebookLM notebook with the given title',
+    domain: NOTEBOOKLM_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'title', positional: true, required: true, help: 'Notebook title (1-200 chars)' },
+        { name: 'emoji', help: `Notebook emoji icon (default ${DEFAULT_EMOJI})` },
+    ],
+    columns: ['id', 'title', 'emoji', 'url'],
+    func: async (page, kwargs) => {
+        const title = parseCreateTitle(kwargs.title);
+        const emoji = parseCreateEmoji(kwargs.emoji);
+        await ensureNotebooklmHome(page);
+        await requireNotebooklmSession(page);
+        const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_PROJECT_RPC_ID, [title, emoji]);
+        const notebookId = parseCreateProjectResult(rpc.result);
+        if (!notebookId) {
+            throw new CommandExecutionError('NotebookLM CreateProject RPC returned no notebook id');
+        }
+        return [{
+            id: notebookId,
+            title,
+            emoji,
+            url: buildNotebooklmNotebookUrl(notebookId),
+        }];
+    },
+});
+
+export const __test__ = { parseCreateTitle, parseCreateEmoji, parseCreateProjectResult };

--- a/clis/notebooklm/create.js
+++ b/clis/notebooklm/create.js
@@ -7,6 +7,7 @@ import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, requireNotebooklmExec
 const NOTEBOOKLM_CREATE_PROJECT_RPC_ID = 'CCqFvf';
 const DEFAULT_EMOJI = '📒';
 const MAX_TITLE_LEN = 200;
+const NOTEBOOK_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 export function parseCreateTitle(value) {
     const title = String(value ?? '').trim();
@@ -33,7 +34,7 @@ export function parseCreateProjectResult(result) {
             || (typeof current[0] === 'string' && current[0])
             || ''
         : '';
-    return typeof id === 'string' ? id : '';
+    return typeof id === 'string' && NOTEBOOK_UUID_RE.test(id) ? id : '';
 }
 
 cli({

--- a/clis/notebooklm/create.test.js
+++ b/clis/notebooklm/create.test.js
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './create.js';
 
 const { parseCreateTitle, parseCreateEmoji, parseCreateProjectResult } = __test__;
@@ -44,5 +45,12 @@ describe('notebooklm create', () => {
         expect(parseCreateProjectResult({})).toBe('');
         expect(parseCreateProjectResult([])).toBe('');
         expect(parseCreateProjectResult([null, null, null])).toBe('');
+    });
+
+    it('refuses to create a remote notebook without --execute', async () => {
+        const command = getRegistry().get('notebooklm/create');
+        const page = { goto: vi.fn() };
+        await expect(command.func(page, { title: 'Draft Notebook' })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
 });

--- a/clis/notebooklm/create.test.js
+++ b/clis/notebooklm/create.test.js
@@ -35,16 +35,18 @@ describe('notebooklm create', () => {
         expect(parseCreateProjectResult(result)).toBe('ec806f5b-fe74-4588-8f77-f073b91e9b1e');
     });
 
-    it('parseCreateProjectResult falls back to index 0 when index 2 is missing', () => {
-        const result = ['some-id', null];
-        expect(parseCreateProjectResult(result)).toBe('some-id');
+    it('parseCreateProjectResult falls back to a UUID-shaped index 0 when index 2 is missing', () => {
+        const id = 'd0b14aa7-fc0f-44bc-a749-928e27e5fa3b';
+        const result = [id, null];
+        expect(parseCreateProjectResult(result)).toBe(id);
     });
 
-    it('parseCreateProjectResult returns empty string on unparseable shapes', () => {
+    it('parseCreateProjectResult returns empty string on malformed or unparseable shapes', () => {
         expect(parseCreateProjectResult(null)).toBe('');
         expect(parseCreateProjectResult({})).toBe('');
         expect(parseCreateProjectResult([])).toBe('');
         expect(parseCreateProjectResult([null, null, null])).toBe('');
+        expect(parseCreateProjectResult(['some-id', null])).toBe('');
     });
 
     it('refuses to create a remote notebook without --execute', async () => {

--- a/clis/notebooklm/create.test.js
+++ b/clis/notebooklm/create.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './create.js';
+
+const { parseCreateTitle, parseCreateEmoji, parseCreateProjectResult } = __test__;
+
+describe('notebooklm create', () => {
+    it('parseCreateTitle trims and accepts 1-200 char titles', () => {
+        expect(parseCreateTitle('hello')).toBe('hello');
+        expect(parseCreateTitle('  spaced  ')).toBe('spaced');
+        expect(parseCreateTitle('x'.repeat(200))).toHaveLength(200);
+    });
+
+    it('parseCreateTitle rejects empty / too-long titles', () => {
+        expect(() => parseCreateTitle('')).toThrow(ArgumentError);
+        expect(() => parseCreateTitle('   ')).toThrow(ArgumentError);
+        expect(() => parseCreateTitle(undefined)).toThrow(ArgumentError);
+        expect(() => parseCreateTitle('x'.repeat(201))).toThrow(ArgumentError);
+    });
+
+    it('parseCreateEmoji defaults to the notebook icon when empty', () => {
+        expect(parseCreateEmoji(undefined)).toBe('📒');
+        expect(parseCreateEmoji('')).toBe('📒');
+        expect(parseCreateEmoji('   ')).toBe('📒');
+    });
+
+    it('parseCreateEmoji passes through user-provided emoji', () => {
+        expect(parseCreateEmoji('🧪')).toBe('🧪');
+        expect(parseCreateEmoji('  🎓 ')).toBe('🎓');
+    });
+
+    it('parseCreateProjectResult extracts the notebook id from the singleton-wrapped RPC result', () => {
+        const result = [[ ['notebook-payload-prefix', null, 'ec806f5b-fe74-4588-8f77-f073b91e9b1e', 'opencli-test', '🧪'] ]];
+        expect(parseCreateProjectResult(result)).toBe('ec806f5b-fe74-4588-8f77-f073b91e9b1e');
+    });
+
+    it('parseCreateProjectResult falls back to index 0 when index 2 is missing', () => {
+        const result = ['some-id', null];
+        expect(parseCreateProjectResult(result)).toBe('some-id');
+    });
+
+    it('parseCreateProjectResult returns empty string on unparseable shapes', () => {
+        expect(parseCreateProjectResult(null)).toBe('');
+        expect(parseCreateProjectResult({})).toBe('');
+        expect(parseCreateProjectResult([])).toBe('');
+        expect(parseCreateProjectResult([null, null, null])).toBe('');
+    });
+});

--- a/clis/notebooklm/generate-audio.js
+++ b/clis/notebooklm/generate-audio.js
@@ -53,8 +53,13 @@ cli({
     columns: ['notebook_id', 'audio_id', 'source_count', 'status', 'notebook_url'],
     func: async (page, kwargs) => {
         const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
-        await page.goto(buildNotebooklmNotebookUrl(notebookId));
-        await page.wait(2);
+        try {
+            await page.goto(buildNotebooklmNotebookUrl(notebookId));
+            await page.wait(2);
+        }
+        catch (error) {
+            throw new CommandExecutionError(`Failed to open NotebookLM notebook ${notebookId}: ${error?.message || error}`);
+        }
         await requireNotebooklmSession(page);
         const sources = await listNotebooklmSourcesViaRpc(page);
         const sourceIds = sources.map((s) => s.id).filter((id) => typeof id === 'string' && id);

--- a/clis/notebooklm/generate-audio.js
+++ b/clis/notebooklm/generate-audio.js
@@ -1,0 +1,79 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
+import { callNotebooklmRpc } from './rpc.js';
+import { buildNotebooklmNotebookUrl, listNotebooklmSourcesViaRpc, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+
+const NOTEBOOKLM_CREATE_AUDIO_RPC_ID = 'R7cb6c';
+const AUDIO_OVERVIEW_CONFIG_BLOCK = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]];
+const AUDIO_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+export function buildCreateAudioArgs(projectId, sourceIds) {
+    const sourceTuples = sourceIds.map((id) => [[id]]);
+    const sourceTuplesTail = sourceIds.map((id) => [id]);
+    return [
+        AUDIO_OVERVIEW_CONFIG_BLOCK,
+        projectId,
+        [
+            null,
+            null,
+            1,
+            sourceTuples,
+            null,
+            null,
+            [null, [null, null, null, sourceTuplesTail]],
+        ],
+    ];
+}
+
+export function parseAudioIdFromResult(result) {
+    if (typeof result === 'string' && AUDIO_UUID_RE.test(result)) return result;
+    const stack = [result];
+    while (stack.length) {
+        const node = stack.shift();
+        if (typeof node === 'string' && AUDIO_UUID_RE.test(node)) return node;
+        if (Array.isArray(node)) for (const child of node) stack.push(child);
+        else if (node && typeof node === 'object') for (const v of Object.values(node)) stack.push(v);
+    }
+    return '';
+}
+
+cli({
+    site: NOTEBOOKLM_SITE,
+    name: 'generate-audio',
+    access: 'write',
+    description: 'Trigger an Audio Overview (Deep Dive podcast) generation for a NotebookLM notebook, using all of its sources',
+    domain: NOTEBOOKLM_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
+    ],
+    columns: ['notebook_id', 'audio_id', 'source_count', 'status', 'notebook_url'],
+    func: async (page, kwargs) => {
+        const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
+        await page.goto(buildNotebooklmNotebookUrl(notebookId));
+        await page.wait(2);
+        await requireNotebooklmSession(page);
+        const sources = await listNotebooklmSourcesViaRpc(page);
+        const sourceIds = sources.map((s) => s.id).filter((id) => typeof id === 'string' && id);
+        if (sourceIds.length === 0) {
+            throw new EmptyResultError('notebooklm generate-audio', 'The notebook has no sources; add a source before generating an audio overview.');
+        }
+        const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_AUDIO_RPC_ID, buildCreateAudioArgs(notebookId, sourceIds));
+        const audioId = parseAudioIdFromResult(rpc.result);
+        if (!audioId) {
+            throw new CommandExecutionError('NotebookLM CreateAudioOverview RPC returned no audio id; server may have rejected the request.');
+        }
+        return [{
+            notebook_id: notebookId,
+            audio_id: audioId,
+            source_count: sourceIds.length,
+            status: 'pending',
+            notebook_url: buildNotebooklmNotebookUrl(notebookId),
+        }];
+    },
+});
+
+export const __test__ = { AUDIO_OVERVIEW_CONFIG_BLOCK, buildCreateAudioArgs, parseAudioIdFromResult };

--- a/clis/notebooklm/generate-audio.js
+++ b/clis/notebooklm/generate-audio.js
@@ -8,6 +8,10 @@ const NOTEBOOKLM_CREATE_AUDIO_RPC_ID = 'R7cb6c';
 const AUDIO_OVERVIEW_CONFIG_BLOCK = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]];
 const AUDIO_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
+function toExcludedUuidSet(excludedIds) {
+    return new Set(excludedIds.map((id) => String(id ?? '').toLowerCase()).filter(Boolean));
+}
+
 export function buildCreateAudioArgs(projectId, sourceIds) {
     const sourceTuples = sourceIds.map((id) => [[id]]);
     const sourceTuplesTail = sourceIds.map((id) => [id]);
@@ -26,12 +30,13 @@ export function buildCreateAudioArgs(projectId, sourceIds) {
     ];
 }
 
-export function parseAudioIdFromResult(result) {
-    if (typeof result === 'string' && AUDIO_UUID_RE.test(result)) return result;
+export function parseAudioIdFromResult(result, excludedIds = []) {
+    const excluded = toExcludedUuidSet(excludedIds);
+    if (typeof result === 'string' && AUDIO_UUID_RE.test(result) && !excluded.has(result.toLowerCase())) return result;
     const stack = [result];
     while (stack.length) {
         const node = stack.shift();
-        if (typeof node === 'string' && AUDIO_UUID_RE.test(node)) return node;
+        if (typeof node === 'string' && AUDIO_UUID_RE.test(node) && !excluded.has(node.toLowerCase())) return node;
         if (Array.isArray(node)) for (const child of node) stack.push(child);
         else if (node && typeof node === 'object') for (const v of Object.values(node)) stack.push(v);
     }
@@ -69,7 +74,7 @@ cli({
             throw new EmptyResultError('notebooklm generate-audio', 'The notebook has no sources; add a source before generating an audio overview.');
         }
         const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_AUDIO_RPC_ID, buildCreateAudioArgs(notebookId, sourceIds));
-        const audioId = parseAudioIdFromResult(rpc.result);
+        const audioId = parseAudioIdFromResult(rpc.result, [notebookId, ...sourceIds]);
         if (!audioId) {
             throw new CommandExecutionError('NotebookLM CreateAudioOverview RPC returned no audio id; server may have rejected the request.');
         }

--- a/clis/notebooklm/generate-audio.js
+++ b/clis/notebooklm/generate-audio.js
@@ -2,7 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, listNotebooklmSourcesViaRpc, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+import { buildNotebooklmNotebookUrl, listNotebooklmSourcesViaRpc, parseNotebooklmNotebookTarget, requireNotebooklmExecute, requireNotebooklmSession } from './utils.js';
 
 const NOTEBOOKLM_CREATE_AUDIO_RPC_ID = 'R7cb6c';
 const AUDIO_OVERVIEW_CONFIG_BLOCK = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]];
@@ -49,10 +49,12 @@ cli({
     navigateBefore: false,
     args: [
         { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
+        { name: 'execute', type: 'boolean', help: 'Actually trigger remote NotebookLM audio generation' },
     ],
     columns: ['notebook_id', 'audio_id', 'source_count', 'status', 'notebook_url'],
     func: async (page, kwargs) => {
         const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
+        requireNotebooklmExecute(kwargs.execute, 'generate NotebookLM audio');
         try {
             await page.goto(buildNotebooklmNotebookUrl(notebookId));
             await page.wait(2);

--- a/clis/notebooklm/generate-audio.test.js
+++ b/clis/notebooklm/generate-audio.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './generate-audio.js';
+
+const { AUDIO_OVERVIEW_CONFIG_BLOCK, buildCreateAudioArgs, parseAudioIdFromResult } = __test__;
+
+describe('notebooklm generate-audio', () => {
+    it('AUDIO_OVERVIEW_CONFIG_BLOCK matches the live-captured wire shape', () => {
+        expect(AUDIO_OVERVIEW_CONFIG_BLOCK).toEqual([
+            2, null, null,
+            [1, null, null, null, null, null, null, null, null, null, [1]],
+            [[1, 4, 2, 3, 6]],
+        ]);
+    });
+
+    it('buildCreateAudioArgs matches the byte-perfect wire format captured from the UI', () => {
+        const projectId = '42ad744e-477d-4198-97b6-a9ae6a663165';
+        const sourceId = '7c7666bd-59e1-42ab-879d-bacfe33325eb';
+        expect(buildCreateAudioArgs(projectId, [sourceId])).toEqual([
+            [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]],
+            projectId,
+            [null, null, 1, [[[sourceId]]], null, null, [null, [null, null, null, [[sourceId]]]]],
+        ]);
+    });
+
+    it('buildCreateAudioArgs threads multiple sources into both the nested and tail blocks', () => {
+        const a = '11111111-1111-4111-8111-111111111111';
+        const b = '22222222-2222-4222-8222-222222222222';
+        const args = buildCreateAudioArgs('pid', [a, b]);
+        expect(args[2][3]).toEqual([[[a]], [[b]]]);
+        expect(args[2][6][1][3]).toEqual([[a], [b]]);
+    });
+
+    it('parseAudioIdFromResult walks the tree for a UUID-shaped audio id', () => {
+        const id = '38da0e55-2360-4d3e-8573-61b5a6c0c219';
+        expect(parseAudioIdFromResult([[id, 'opencli-audio-benjaminliu', 1]])).toBe(id);
+        expect(parseAudioIdFromResult({ result: { audioId: id } })).toBe(id);
+    });
+
+    it('parseAudioIdFromResult ignores non-UUID strings', () => {
+        expect(parseAudioIdFromResult([[null, 'opencli-audio-benjaminliu', 1]])).toBe('');
+        expect(parseAudioIdFromResult({})).toBe('');
+        expect(parseAudioIdFromResult([])).toBe('');
+        expect(parseAudioIdFromResult(null)).toBe('');
+    });
+});

--- a/clis/notebooklm/generate-audio.test.js
+++ b/clis/notebooklm/generate-audio.test.js
@@ -45,6 +45,13 @@ describe('notebooklm generate-audio', () => {
         expect(parseAudioIdFromResult(null)).toBe('');
     });
 
+    it('parseAudioIdFromResult skips notebook/source ids before selecting the generated audio id', () => {
+        const notebookId = '17e2b882-6a01-4c6c-9262-0738dfa2abee';
+        const sourceId = '7c7666bd-59e1-42ab-879d-bacfe33325eb';
+        const audioId = '38da0e55-2360-4d3e-8573-61b5a6c0c219';
+        expect(parseAudioIdFromResult([notebookId, [[sourceId]], [audioId]], [notebookId, sourceId])).toBe(audioId);
+    });
+
     it('refuses to trigger remote audio generation without --execute', async () => {
         const command = getRegistry().get('notebooklm/generate-audio');
         const page = { goto: vi.fn() };

--- a/clis/notebooklm/generate-audio.test.js
+++ b/clis/notebooklm/generate-audio.test.js
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './generate-audio.js';
 
 const { AUDIO_OVERVIEW_CONFIG_BLOCK, buildCreateAudioArgs, parseAudioIdFromResult } = __test__;
@@ -41,5 +43,14 @@ describe('notebooklm generate-audio', () => {
         expect(parseAudioIdFromResult({})).toBe('');
         expect(parseAudioIdFromResult([])).toBe('');
         expect(parseAudioIdFromResult(null)).toBe('');
+    });
+
+    it('refuses to trigger remote audio generation without --execute', async () => {
+        const command = getRegistry().get('notebooklm/generate-audio');
+        const page = { goto: vi.fn() };
+        await expect(command.func(page, {
+            notebook: '17e2b882-6a01-4c6c-9262-0738dfa2abee',
+        })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
 });

--- a/clis/notebooklm/generate-slides.js
+++ b/clis/notebooklm/generate-slides.js
@@ -59,8 +59,13 @@ cli({
         const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
         const length = kwargs.length === undefined || kwargs.length === '' ? 3 : Number(kwargs.length);
         const language = String(kwargs.language ?? 'en').trim() || 'en';
-        await page.goto(buildNotebooklmNotebookUrl(notebookId));
-        await page.wait(2);
+        try {
+            await page.goto(buildNotebooklmNotebookUrl(notebookId));
+            await page.wait(2);
+        }
+        catch (error) {
+            throw new CommandExecutionError(`Failed to open NotebookLM notebook ${notebookId}: ${error?.message || error}`);
+        }
         await requireNotebooklmSession(page);
         const sources = await listNotebooklmSourcesViaRpc(page);
         const sourceIds = sources.map((s) => s.id).filter((id) => typeof id === 'string' && id);

--- a/clis/notebooklm/generate-slides.js
+++ b/clis/notebooklm/generate-slides.js
@@ -1,0 +1,85 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
+import { callNotebooklmRpc } from './rpc.js';
+import { buildNotebooklmNotebookUrl, listNotebooklmSourcesViaRpc, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+
+const NOTEBOOKLM_CREATE_ARTIFACT_RPC_ID = 'R7cb6c';
+const SLIDE_DECK_CONFIG_BLOCK = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]];
+const ARTIFACT_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+export function buildCreateSlidesArgs(projectId, sourceIds, options = {}) {
+    const sourceTuples = sourceIds.map((id) => [[id]]);
+    const language = options.language || 'en';
+    const length = Number.isInteger(options.length) ? options.length : 3;
+    return [
+        SLIDE_DECK_CONFIG_BLOCK,
+        projectId,
+        [
+            null,
+            null,
+            8,
+            sourceTuples,
+            null,
+            null,
+            null, null, null, null, null, null, null, null, null, null,
+            [[null, language, 1, length]],
+        ],
+    ];
+}
+
+export function parseSlidesIdFromResult(result) {
+    if (typeof result === 'string' && ARTIFACT_UUID_RE.test(result)) return result;
+    const stack = [result];
+    while (stack.length) {
+        const node = stack.shift();
+        if (typeof node === 'string' && ARTIFACT_UUID_RE.test(node)) return node;
+        if (Array.isArray(node)) for (const child of node) stack.push(child);
+        else if (node && typeof node === 'object') for (const v of Object.values(node)) stack.push(v);
+    }
+    return '';
+}
+
+cli({
+    site: NOTEBOOKLM_SITE,
+    name: 'generate-slides',
+    access: 'write',
+    description: 'Trigger a Slide Deck (AI presentation) generation for a NotebookLM notebook, using all of its sources',
+    domain: NOTEBOOKLM_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
+        { name: 'length', help: 'Slide deck length: 1=Short, 3=Default (default 3)' },
+        { name: 'language', help: 'Language code (default en)' },
+    ],
+    columns: ['notebook_id', 'slides_id', 'source_count', 'status', 'notebook_url'],
+    func: async (page, kwargs) => {
+        const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
+        const length = kwargs.length === undefined || kwargs.length === '' ? 3 : Number(kwargs.length);
+        const language = String(kwargs.language ?? 'en').trim() || 'en';
+        await page.goto(buildNotebooklmNotebookUrl(notebookId));
+        await page.wait(2);
+        await requireNotebooklmSession(page);
+        const sources = await listNotebooklmSourcesViaRpc(page);
+        const sourceIds = sources.map((s) => s.id).filter((id) => typeof id === 'string' && id);
+        if (sourceIds.length === 0) {
+            throw new EmptyResultError('notebooklm generate-slides', 'The notebook has no sources; add a source before generating a slide deck.');
+        }
+        const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_ARTIFACT_RPC_ID, buildCreateSlidesArgs(notebookId, sourceIds, { length, language }));
+        const slidesId = parseSlidesIdFromResult(rpc.result);
+        if (!slidesId) {
+            throw new CommandExecutionError('NotebookLM CreateArtifact (slides) RPC returned no slide-deck id; the server may have rejected the request.');
+        }
+        return [{
+            notebook_id: notebookId,
+            slides_id: slidesId,
+            source_count: sourceIds.length,
+            status: 'pending',
+            notebook_url: buildNotebooklmNotebookUrl(notebookId),
+        }];
+    },
+});
+
+export const __test__ = { SLIDE_DECK_CONFIG_BLOCK, buildCreateSlidesArgs, parseSlidesIdFromResult };

--- a/clis/notebooklm/generate-slides.js
+++ b/clis/notebooklm/generate-slides.js
@@ -1,8 +1,8 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, listNotebooklmSourcesViaRpc, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+import { buildNotebooklmNotebookUrl, listNotebooklmSourcesViaRpc, parseNotebooklmNotebookTarget, requireNotebooklmExecute, requireNotebooklmSession } from './utils.js';
 
 const NOTEBOOKLM_CREATE_ARTIFACT_RPC_ID = 'R7cb6c';
 const SLIDE_DECK_CONFIG_BLOCK = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]];
@@ -40,6 +40,15 @@ export function parseSlidesIdFromResult(result) {
     return '';
 }
 
+export function parseSlideDeckLength(value) {
+    if (value === undefined || value === '') return 3;
+    const length = Number(value);
+    if (!Number.isInteger(length) || length <= 0) {
+        throw new ArgumentError('--length must be a positive integer');
+    }
+    return length;
+}
+
 cli({
     site: NOTEBOOKLM_SITE,
     name: 'generate-slides',
@@ -53,12 +62,14 @@ cli({
         { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
         { name: 'length', help: 'Slide deck length: 1=Short, 3=Default (default 3)' },
         { name: 'language', help: 'Language code (default en)' },
+        { name: 'execute', type: 'boolean', help: 'Actually trigger remote NotebookLM slide deck generation' },
     ],
     columns: ['notebook_id', 'slides_id', 'source_count', 'status', 'notebook_url'],
     func: async (page, kwargs) => {
         const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
-        const length = kwargs.length === undefined || kwargs.length === '' ? 3 : Number(kwargs.length);
+        const length = parseSlideDeckLength(kwargs.length);
         const language = String(kwargs.language ?? 'en').trim() || 'en';
+        requireNotebooklmExecute(kwargs.execute, 'generate NotebookLM slides');
         try {
             await page.goto(buildNotebooklmNotebookUrl(notebookId));
             await page.wait(2);
@@ -87,4 +98,4 @@ cli({
     },
 });
 
-export const __test__ = { SLIDE_DECK_CONFIG_BLOCK, buildCreateSlidesArgs, parseSlidesIdFromResult };
+export const __test__ = { SLIDE_DECK_CONFIG_BLOCK, buildCreateSlidesArgs, parseSlideDeckLength, parseSlidesIdFromResult };

--- a/clis/notebooklm/generate-slides.js
+++ b/clis/notebooklm/generate-slides.js
@@ -8,6 +8,10 @@ const NOTEBOOKLM_CREATE_ARTIFACT_RPC_ID = 'R7cb6c';
 const SLIDE_DECK_CONFIG_BLOCK = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]];
 const ARTIFACT_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
+function toExcludedUuidSet(excludedIds) {
+    return new Set(excludedIds.map((id) => String(id ?? '').toLowerCase()).filter(Boolean));
+}
+
 export function buildCreateSlidesArgs(projectId, sourceIds, options = {}) {
     const sourceTuples = sourceIds.map((id) => [[id]]);
     const language = options.language || 'en';
@@ -28,12 +32,13 @@ export function buildCreateSlidesArgs(projectId, sourceIds, options = {}) {
     ];
 }
 
-export function parseSlidesIdFromResult(result) {
-    if (typeof result === 'string' && ARTIFACT_UUID_RE.test(result)) return result;
+export function parseSlidesIdFromResult(result, excludedIds = []) {
+    const excluded = toExcludedUuidSet(excludedIds);
+    if (typeof result === 'string' && ARTIFACT_UUID_RE.test(result) && !excluded.has(result.toLowerCase())) return result;
     const stack = [result];
     while (stack.length) {
         const node = stack.shift();
-        if (typeof node === 'string' && ARTIFACT_UUID_RE.test(node)) return node;
+        if (typeof node === 'string' && ARTIFACT_UUID_RE.test(node) && !excluded.has(node.toLowerCase())) return node;
         if (Array.isArray(node)) for (const child of node) stack.push(child);
         else if (node && typeof node === 'object') for (const v of Object.values(node)) stack.push(v);
     }
@@ -84,7 +89,7 @@ cli({
             throw new EmptyResultError('notebooklm generate-slides', 'The notebook has no sources; add a source before generating a slide deck.');
         }
         const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_ARTIFACT_RPC_ID, buildCreateSlidesArgs(notebookId, sourceIds, { length, language }));
-        const slidesId = parseSlidesIdFromResult(rpc.result);
+        const slidesId = parseSlidesIdFromResult(rpc.result, [notebookId, ...sourceIds]);
         if (!slidesId) {
             throw new CommandExecutionError('NotebookLM CreateArtifact (slides) RPC returned no slide-deck id; the server may have rejected the request.');
         }

--- a/clis/notebooklm/generate-slides.test.js
+++ b/clis/notebooklm/generate-slides.test.js
@@ -57,6 +57,13 @@ describe('notebooklm generate-slides', () => {
         expect(parseSlidesIdFromResult(null)).toBe('');
     });
 
+    it('parseSlidesIdFromResult skips notebook/source ids before selecting the generated deck id', () => {
+        const notebookId = '17e2b882-6a01-4c6c-9262-0738dfa2abee';
+        const sourceId = '493b9ddd-453b-4523-b638-bb560b37723c';
+        const slidesId = '1f8ada7d-cb33-49a4-8498-c5b81c1a899d';
+        expect(parseSlidesIdFromResult([notebookId, [[sourceId]], [slidesId]], [notebookId, sourceId])).toBe(slidesId);
+    });
+
     it('refuses to trigger remote slide generation without --execute', async () => {
         const command = getRegistry().get('notebooklm/generate-slides');
         const page = { goto: vi.fn() };

--- a/clis/notebooklm/generate-slides.test.js
+++ b/clis/notebooklm/generate-slides.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './generate-slides.js';
+
+const { SLIDE_DECK_CONFIG_BLOCK, buildCreateSlidesArgs, parseSlidesIdFromResult } = __test__;
+
+describe('notebooklm generate-slides', () => {
+    it('SLIDE_DECK_CONFIG_BLOCK reuses the same R7cb6c config envelope as audio', () => {
+        expect(SLIDE_DECK_CONFIG_BLOCK).toEqual([
+            2, null, null,
+            [1, null, null, null, null, null, null, null, null, null, [1]],
+            [[1, 4, 2, 3, 6]],
+        ]);
+    });
+
+    it('buildCreateSlidesArgs matches the live-captured slide-deck wire format', () => {
+        const projectId = '17e2b882-6a01-4c6c-9262-0738dfa2abee';
+        const sourceA = '493b9ddd-453b-4523-b638-bb560b37723c';
+        const sourceB = '182508cf-9afd-4db5-8640-2f8cafcc7111';
+        expect(buildCreateSlidesArgs(projectId, [sourceA, sourceB])).toEqual([
+            [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 2, 3, 6]]],
+            projectId,
+            [
+                null, null, 8,
+                [[[sourceA]], [[sourceB]]],
+                null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                [[null, 'en', 1, 3]],
+            ],
+        ]);
+    });
+
+    it('buildCreateSlidesArgs honours --language and --length overrides', () => {
+        const args = buildCreateSlidesArgs('pid', ['s1'], { language: 'zh', length: 1 });
+        expect(args[2][16]).toEqual([[null, 'zh', 1, 1]]);
+    });
+
+    it('parseSlidesIdFromResult finds a UUID-shaped slides id anywhere in the tree', () => {
+        const id = '1f8ada7d-cb33-49a4-8498-c5b81c1a899d';
+        expect(parseSlidesIdFromResult([[id, 'opencli-slides-test']])).toBe(id);
+        expect(parseSlidesIdFromResult({ artifactId: id })).toBe(id);
+    });
+
+    it('parseSlidesIdFromResult ignores non-UUID strings and empty inputs', () => {
+        expect(parseSlidesIdFromResult([[null, 'opencli-slides-test']])).toBe('');
+        expect(parseSlidesIdFromResult({})).toBe('');
+        expect(parseSlidesIdFromResult([])).toBe('');
+        expect(parseSlidesIdFromResult(null)).toBe('');
+    });
+});

--- a/clis/notebooklm/generate-slides.test.js
+++ b/clis/notebooklm/generate-slides.test.js
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './generate-slides.js';
 
-const { SLIDE_DECK_CONFIG_BLOCK, buildCreateSlidesArgs, parseSlidesIdFromResult } = __test__;
+const { SLIDE_DECK_CONFIG_BLOCK, buildCreateSlidesArgs, parseSlideDeckLength, parseSlidesIdFromResult } = __test__;
 
 describe('notebooklm generate-slides', () => {
     it('SLIDE_DECK_CONFIG_BLOCK reuses the same R7cb6c config envelope as audio', () => {
@@ -34,6 +36,14 @@ describe('notebooklm generate-slides', () => {
         expect(args[2][16]).toEqual([[null, 'zh', 1, 1]]);
     });
 
+    it('parseSlideDeckLength defaults empty values and rejects invalid input', () => {
+        expect(parseSlideDeckLength(undefined)).toBe(3);
+        expect(parseSlideDeckLength('')).toBe(3);
+        expect(parseSlideDeckLength('1')).toBe(1);
+        expect(() => parseSlideDeckLength('many')).toThrow(ArgumentError);
+        expect(() => parseSlideDeckLength(0)).toThrow(ArgumentError);
+    });
+
     it('parseSlidesIdFromResult finds a UUID-shaped slides id anywhere in the tree', () => {
         const id = '1f8ada7d-cb33-49a4-8498-c5b81c1a899d';
         expect(parseSlidesIdFromResult([[id, 'opencli-slides-test']])).toBe(id);
@@ -45,5 +55,14 @@ describe('notebooklm generate-slides', () => {
         expect(parseSlidesIdFromResult({})).toBe('');
         expect(parseSlidesIdFromResult([])).toBe('');
         expect(parseSlidesIdFromResult(null)).toBe('');
+    });
+
+    it('refuses to trigger remote slide generation without --execute', async () => {
+        const command = getRegistry().get('notebooklm/generate-slides');
+        const page = { goto: vi.fn() };
+        await expect(command.func(page, {
+            notebook: '17e2b882-6a01-4c6c-9262-0738dfa2abee',
+        })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
 });

--- a/clis/notebooklm/open.test.js
+++ b/clis/notebooklm/open.test.js
@@ -23,18 +23,18 @@ describe('notebooklm open', () => {
         mockRequireNotebooklmSession.mockReset();
         mockRequireNotebooklmSession.mockResolvedValue(undefined);
         mockGetNotebooklmPageState.mockResolvedValue({
-            url: 'https://notebooklm.google.com/notebook/nb-demo',
+            url: 'https://notebooklm.google.com/notebook/17e2b882-1234-1234-1234-abcdef012345',
             title: 'Browser Automation',
             hostname: 'notebooklm.google.com',
             kind: 'notebook',
-            notebookId: 'nb-demo',
+            notebookId: '17e2b882-1234-1234-1234-abcdef012345',
             loginRequired: false,
             notebookCount: 1,
         });
         mockReadCurrentNotebooklm.mockResolvedValue({
-            id: 'nb-demo',
+            id: '17e2b882-1234-1234-1234-abcdef012345',
             title: 'Browser Automation',
-            url: 'https://notebooklm.google.com/notebook/nb-demo',
+            url: 'https://notebooklm.google.com/notebook/17e2b882-1234-1234-1234-abcdef012345',
             source: 'current-page',
         });
     });
@@ -43,12 +43,12 @@ describe('notebooklm open', () => {
             goto: vi.fn(async () => { }),
             wait: vi.fn(async () => { }),
         };
-        const result = await command.func(page, { notebook: 'nb-demo' });
-        expect(page.goto).toHaveBeenCalledWith('https://notebooklm.google.com/notebook/nb-demo');
+        const result = await command.func(page, { notebook: '17e2b882-1234-1234-1234-abcdef012345' });
+        expect(page.goto).toHaveBeenCalledWith('https://notebooklm.google.com/notebook/17e2b882-1234-1234-1234-abcdef012345');
         expect(result).toEqual([{
-                id: 'nb-demo',
+                id: '17e2b882-1234-1234-1234-abcdef012345',
                 title: 'Browser Automation',
-                url: 'https://notebooklm.google.com/notebook/nb-demo',
+                url: 'https://notebooklm.google.com/notebook/17e2b882-1234-1234-1234-abcdef012345',
                 source: 'current-page',
             }]);
     });
@@ -57,7 +57,7 @@ describe('notebooklm open', () => {
             goto: vi.fn(async () => { }),
             wait: vi.fn(async () => { }),
         };
-        await command.func(page, { notebook: 'https://notebooklm.google.com/notebook/nb-demo?pli=1' });
-        expect(page.goto).toHaveBeenCalledWith('https://notebooklm.google.com/notebook/nb-demo');
+        await command.func(page, { notebook: 'https://notebooklm.google.com/notebook/17e2b882-1234-1234-1234-abcdef012345?pli=1' });
+        expect(page.goto).toHaveBeenCalledWith('https://notebooklm.google.com/notebook/17e2b882-1234-1234-1234-abcdef012345');
     });
 });

--- a/clis/notebooklm/rpc.js
+++ b/clis/notebooklm/rpc.js
@@ -8,18 +8,21 @@ export function extractNotebooklmPageAuthFromHtml(html, sourcePath = '/', prefer
     if (!csrfToken || !sessionId) {
         throw new CliError('NOTEBOOKLM_TOKENS', 'NotebookLM page tokens were not found in the current page HTML', 'Open the NotebookLM notebook page in Chrome, wait for it to finish loading, then retry with --verbose if it still fails.');
     }
-    return { csrfToken, sessionId, sourcePath: sourcePath || '/' };
+    return { csrfToken, sessionId, sourcePath: sourcePath || '/', authuser: preferredTokens?.authuser ?? '' };
 }
 async function probeNotebooklmPageAuth(page) {
     const raw = await page.evaluate(`(() => {
     const wiz = window.WIZ_global_data || {};
     const html = document.documentElement.innerHTML;
+    const authMatch = (location.search || '').match(/[?&]authuser=(\\d+)/);
+    const pathMatch = (location.pathname || '').match(/^\\/u\\/(\\d+)\\//);
     return {
       html,
       sourcePath: location.pathname || '/',
       readyState: document.readyState || '',
       csrfToken: typeof wiz.SNlM0e === 'string' ? wiz.SNlM0e : '',
       sessionId: typeof wiz.FdrFJe === 'string' ? wiz.FdrFJe : '',
+      authuser: authMatch ? authMatch[1] : (pathMatch ? pathMatch[1] : ''),
     };
   })()`);
     return {
@@ -28,6 +31,7 @@ async function probeNotebooklmPageAuth(page) {
         readyState: String(raw?.readyState ?? ''),
         csrfToken: String(raw?.csrfToken ?? ''),
         sessionId: String(raw?.sessionId ?? ''),
+        authuser: String(raw?.authuser ?? ''),
     };
 }
 export async function getNotebooklmPageAuth(page) {
@@ -35,7 +39,7 @@ export async function getNotebooklmPageAuth(page) {
     for (let attempt = 0; attempt < 2; attempt += 1) {
         const probe = await probeNotebooklmPageAuth(page);
         try {
-            return extractNotebooklmPageAuthFromHtml(probe.html, probe.sourcePath, { csrfToken: probe.csrfToken, sessionId: probe.sessionId });
+            return extractNotebooklmPageAuthFromHtml(probe.html, probe.sourcePath, { csrfToken: probe.csrfToken, sessionId: probe.sessionId, authuser: probe.authuser });
         }
         catch (error) {
             lastError = error;
@@ -162,8 +166,10 @@ export async function fetchNotebooklmInPage(page, url, options = {}) {
 export async function callNotebooklmRpc(page, rpcId, params, options = {}) {
     const auth = await getNotebooklmPageAuth(page);
     const requestBody = buildNotebooklmRpcBody(rpcId, params, auth.csrfToken);
+    const authuser = auth.authuser || '';
     const url = `https://${NOTEBOOKLM_DOMAIN}/_/LabsTailwindUi/data/batchexecute` +
         `?rpcids=${rpcId}&source-path=${encodeURIComponent(auth.sourcePath)}` +
+        (authuser ? `&authuser=${encodeURIComponent(authuser)}` : '') +
         `&hl=${encodeURIComponent(options.hl ?? 'en')}` +
         `&f.sid=${encodeURIComponent(auth.sessionId)}&rt=c`;
     const response = await fetchNotebooklmInPage(page, url, {

--- a/clis/notebooklm/rpc.js
+++ b/clis/notebooklm/rpc.js
@@ -1,5 +1,13 @@
 import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN } from './shared.js';
+
+export function unwrapNotebooklmEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
+
 export function extractNotebooklmPageAuthFromHtml(html, sourcePath = '/', preferredTokens) {
     const csrfMatch = html.match(/"SNlM0e":"([^"]+)"/);
     const sessionMatch = html.match(/"FdrFJe":"([^"]+)"/);
@@ -11,7 +19,7 @@ export function extractNotebooklmPageAuthFromHtml(html, sourcePath = '/', prefer
     return { csrfToken, sessionId, sourcePath: sourcePath || '/', authuser: preferredTokens?.authuser ?? '' };
 }
 async function probeNotebooklmPageAuth(page) {
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const wiz = window.WIZ_global_data || {};
     const html = document.documentElement.innerHTML;
     const authMatch = (location.search || '').match(/[?&]authuser=(\\d+)/);
@@ -24,7 +32,7 @@ async function probeNotebooklmPageAuth(page) {
       sessionId: typeof wiz.FdrFJe === 'string' ? wiz.FdrFJe : '',
       authuser: authMatch ? authMatch[1] : (pathMatch ? pathMatch[1] : ''),
     };
-  })()`);
+  })()`));
     return {
         html: String(raw?.html ?? ''),
         sourcePath: String(raw?.sourcePath ?? '/'),
@@ -134,7 +142,7 @@ export async function fetchNotebooklmInPage(page, url, options = {}) {
     const method = options.method ?? 'GET';
     const headers = options.headers ?? {};
     const body = options.body ?? '';
-    const raw = await page.evaluate(`(async () => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(async () => {
     const request = {
       url: ${JSON.stringify(url)},
       method: ${JSON.stringify(method)},
@@ -155,7 +163,7 @@ export async function fetchNotebooklmInPage(page, url, options = {}) {
       body: await response.text(),
       finalUrl: response.url,
     };
-  })()`);
+  })()`));
     return {
         ok: Boolean(raw?.ok),
         status: Number(raw?.status ?? 0),

--- a/clis/notebooklm/rpc.test.js
+++ b/clis/notebooklm/rpc.test.js
@@ -16,6 +16,7 @@ describe('notebooklm rpc transport', () => {
             csrfToken: 'csrf-123',
             sessionId: 'sess-456',
             sourcePath: '/',
+            authuser: '',
         });
         expect(page.evaluate).toHaveBeenCalledTimes(1);
     });
@@ -33,6 +34,7 @@ describe('notebooklm rpc transport', () => {
             csrfToken: 'csrf-wiz',
             sessionId: 'sess-wiz',
             sourcePath: '/notebook/nb-demo',
+            authuser: '',
         });
     });
     it('retries token extraction once when the first probe returns no tokens', async () => {
@@ -58,6 +60,7 @@ describe('notebooklm rpc transport', () => {
             csrfToken: 'csrf-123',
             sessionId: 'sess-456',
             sourcePath: '/notebook/nb-demo',
+            authuser: '',
         });
         expect(page.evaluate).toHaveBeenCalledTimes(2);
     });

--- a/clis/notebooklm/rpc.test.js
+++ b/clis/notebooklm/rpc.test.js
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AuthRequiredError } from '@jackwener/opencli/errors';
-import { buildNotebooklmRpcBody, extractNotebooklmRpcResult, getNotebooklmPageAuth, parseNotebooklmChunkedResponse, } from './rpc.js';
+import { buildNotebooklmRpcBody, extractNotebooklmRpcResult, getNotebooklmPageAuth, parseNotebooklmChunkedResponse, unwrapNotebooklmEvaluateResult, } from './rpc.js';
 describe('notebooklm rpc transport', () => {
+    it('unwraps Browser Bridge evaluate envelopes', () => {
+        const data = { ok: true };
+        expect(unwrapNotebooklmEvaluateResult({ session: 'site:notebooklm:abc', data })).toBe(data);
+        expect(unwrapNotebooklmEvaluateResult(data)).toBe(data);
+    });
+
     it('extracts auth tokens from the page html via page evaluation', async () => {
         const page = {
             evaluate: vi.fn(async (script) => {
@@ -19,6 +25,23 @@ describe('notebooklm rpc transport', () => {
             authuser: '',
         });
         expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+    it('extracts auth tokens when page evaluation is wrapped in a Browser Bridge envelope', async () => {
+        const page = {
+            evaluate: vi.fn(async () => ({
+                session: 'site:notebooklm:abc',
+                data: {
+                    html: '<html>"SNlM0e":"csrf-123","FdrFJe":"sess-456"</html>',
+                    sourcePath: '/notebook/nb-demo',
+                },
+            })),
+        };
+        await expect(getNotebooklmPageAuth(page)).resolves.toEqual({
+            csrfToken: 'csrf-123',
+            sessionId: 'sess-456',
+            sourcePath: '/notebook/nb-demo',
+            authuser: '',
+        });
     });
     it('falls back to WIZ_global_data tokens when html regex data is missing', async () => {
         const page = {

--- a/clis/notebooklm/utils.js
+++ b/clis/notebooklm/utils.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_HOME_URL, } from './shared.js';
 import { callNotebooklmRpc, getNotebooklmPageAuth, } from './rpc.js';
 export { buildNotebooklmRpcBody, extractNotebooklmRpcResult, fetchNotebooklmInPage, getNotebooklmPageAuth, parseNotebooklmChunkedResponse, stripNotebooklmAntiXssi, } from './rpc.js';
@@ -13,9 +13,19 @@ function unwrapNotebooklmSingletonResult(result) {
     }
     return current;
 }
+export function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 export function parseNotebooklmIdFromUrl(url) {
     const match = url.match(/\/notebook\/([^/?#]+)/);
     return match?.[1] ?? '';
+}
+const NOTEBOOK_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function ensureNotebookUuid(candidate) {
+    if (!NOTEBOOK_UUID_RE.test(candidate)) {
+        throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', `NotebookLM notebook id "${candidate}" is not a valid UUID`, 'Pass a notebook id from `opencli notebooklm list` or a full notebook URL like https://notebooklm.google.com/notebook/<uuid>.');
+    }
+    return candidate;
 }
 export function parseNotebooklmNotebookTarget(value) {
     const normalized = value.trim();
@@ -24,14 +34,15 @@ export function parseNotebooklmNotebookTarget(value) {
     }
     if (/^https?:\/\//i.test(normalized)) {
         const notebookId = parseNotebooklmIdFromUrl(normalized);
-        if (notebookId)
-            return notebookId;
-        throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', 'NotebookLM notebook URL is invalid', 'Pass a full NotebookLM notebook URL like https://notebooklm.google.com/notebook/<id>.');
+        if (!notebookId) {
+            throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', 'NotebookLM notebook URL is invalid', 'Pass a full NotebookLM notebook URL like https://notebooklm.google.com/notebook/<uuid>.');
+        }
+        return ensureNotebookUuid(notebookId);
     }
     const pathMatch = normalized.match(/(?:^|\/)notebook\/([^/?#]+)/);
     if (pathMatch?.[1])
-        return pathMatch[1];
-    return normalized;
+        return ensureNotebookUuid(pathMatch[1]);
+    return ensureNotebookUuid(normalized);
 }
 export function getNotebooklmAuthuser() {
     const v = process.env.OPENCLI_NOTEBOOKLM_AUTHUSER;
@@ -408,6 +419,42 @@ export async function getNotebooklmDetailViaRpc(page) {
     const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_NOTEBOOK_DETAIL_RPC_ID, [state.notebookId, null, [2], null, 0]);
     return parseNotebooklmNotebookDetailResult(rpc.result);
 }
+export async function getNotebooklmNotebookDetailById(page, notebookId) {
+    const rpc = await callNotebooklmRpc(page, NOTEBOOKLM_NOTEBOOK_DETAIL_RPC_ID, [notebookId, null, [2], null, 0]);
+    return { detail: parseNotebooklmNotebookDetailResult(rpc.result), sources: parseNotebooklmSourceListResult(rpc.result) };
+}
+export async function verifyNotebooklmNotebookExists(page, notebookId, action) {
+    try {
+        const { detail } = await getNotebooklmNotebookDetailById(page, notebookId);
+        if (!detail || detail.id !== notebookId) {
+            throw new CommandExecutionError(`NotebookLM ${action} succeeded but the notebook ${notebookId} was not found in the post-write verification`);
+        }
+        return detail;
+    }
+    catch (error) {
+        if (error instanceof AuthRequiredError || error instanceof CommandExecutionError)
+            throw error;
+        throw new CommandExecutionError(`NotebookLM ${action} post-write verification failed: ${error?.message || error}`);
+    }
+}
+export async function verifyNotebooklmSourceAdded(page, notebookId, sourceId, action) {
+    try {
+        const { detail, sources } = await getNotebooklmNotebookDetailById(page, notebookId);
+        if (!detail || detail.id !== notebookId) {
+            throw new CommandExecutionError(`NotebookLM ${action} succeeded but the notebook ${notebookId} was not found in the post-write verification`);
+        }
+        const matched = sources.find((s) => s.id === sourceId);
+        if (!matched) {
+            throw new CommandExecutionError(`NotebookLM ${action} succeeded but source ${sourceId} did not appear in the notebook's source list`);
+        }
+        return matched;
+    }
+    catch (error) {
+        if (error instanceof AuthRequiredError || error instanceof CommandExecutionError)
+            throw error;
+        throw new CommandExecutionError(`NotebookLM ${action} post-write verification failed: ${error?.message || error}`);
+    }
+}
 export async function listNotebooklmSourcesViaRpc(page) {
     const state = await getNotebooklmPageState(page);
     if (state.kind !== 'notebook' || !state.notebookId)
@@ -535,8 +582,13 @@ export async function ensureNotebooklmHome(page) {
         return;
     const authuser = getNotebooklmAuthuser();
     const target = authuser ? `${NOTEBOOKLM_HOME_URL}?authuser=${encodeURIComponent(authuser)}` : NOTEBOOKLM_HOME_URL;
-    await page.goto(target);
-    await page.wait(2);
+    try {
+        await page.goto(target);
+        await page.wait(2);
+    }
+    catch (error) {
+        throw new CommandExecutionError(`Failed to open NotebookLM home: ${error?.message || error}`);
+    }
 }
 export async function getNotebooklmPageState(page) {
     const raw = await page.evaluate(`(() => {

--- a/clis/notebooklm/utils.js
+++ b/clis/notebooklm/utils.js
@@ -33,6 +33,16 @@ export function parseNotebooklmNotebookTarget(value) {
         throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', 'NotebookLM notebook id is required', 'Pass a notebook id from `opencli notebooklm list` or a full notebook URL.');
     }
     if (/^https?:\/\//i.test(normalized)) {
+        let parsed;
+        try {
+            parsed = new URL(normalized);
+        }
+        catch {
+            throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', 'NotebookLM notebook URL is invalid', 'Pass a full NotebookLM notebook URL like https://notebooklm.google.com/notebook/<uuid>.');
+        }
+        if (parsed.protocol !== 'https:' || parsed.hostname !== NOTEBOOKLM_DOMAIN || parsed.username || parsed.password || parsed.port) {
+            throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', 'NotebookLM notebook URL must be a canonical https://notebooklm.google.com URL', 'Pass a notebook id from `opencli notebooklm list` or a full NotebookLM notebook URL.');
+        }
         const notebookId = parseNotebooklmIdFromUrl(normalized);
         if (!notebookId) {
             throw new CliError('NOTEBOOKLM_INVALID_NOTEBOOK', 'NotebookLM notebook URL is invalid', 'Pass a full NotebookLM notebook URL like https://notebooklm.google.com/notebook/<uuid>.');

--- a/clis/notebooklm/utils.js
+++ b/clis/notebooklm/utils.js
@@ -33,8 +33,15 @@ export function parseNotebooklmNotebookTarget(value) {
         return pathMatch[1];
     return normalized;
 }
+export function getNotebooklmAuthuser() {
+    const v = process.env.OPENCLI_NOTEBOOKLM_AUTHUSER;
+    return typeof v === 'string' && /^\d+$/.test(v) ? v : '';
+}
 export function buildNotebooklmNotebookUrl(notebookId) {
-    return new URL(`/notebook/${encodeURIComponent(notebookId)}`, NOTEBOOKLM_HOME_URL).toString();
+    const u = new URL(`/notebook/${encodeURIComponent(notebookId)}`, NOTEBOOKLM_HOME_URL);
+    const authuser = getNotebooklmAuthuser();
+    if (authuser) u.searchParams.set('authuser', authuser);
+    return u.toString();
 }
 export function classifyNotebooklmPage(url) {
     try {
@@ -526,7 +533,9 @@ export async function ensureNotebooklmHome(page) {
     const currentKind = currentUrl ? classifyNotebooklmPage(currentUrl) : 'unknown';
     if (currentKind === 'home')
         return;
-    await page.goto(NOTEBOOKLM_HOME_URL);
+    const authuser = getNotebooklmAuthuser();
+    const target = authuser ? `${NOTEBOOKLM_HOME_URL}?authuser=${encodeURIComponent(authuser)}` : NOTEBOOKLM_HOME_URL;
+    await page.goto(target);
     await page.wait(2);
 }
 export async function getNotebooklmPageState(page) {

--- a/clis/notebooklm/utils.js
+++ b/clis/notebooklm/utils.js
@@ -1,6 +1,6 @@
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_HOME_URL, } from './shared.js';
-import { callNotebooklmRpc, getNotebooklmPageAuth, } from './rpc.js';
+import { callNotebooklmRpc, getNotebooklmPageAuth, unwrapNotebooklmEvaluateResult, } from './rpc.js';
 export { buildNotebooklmRpcBody, extractNotebooklmRpcResult, fetchNotebooklmInPage, getNotebooklmPageAuth, parseNotebooklmChunkedResponse, stripNotebooklmAntiXssi, } from './rpc.js';
 const NOTEBOOKLM_LIST_RPC_ID = 'wXbhsf';
 const NOTEBOOKLM_NOTEBOOK_DETAIL_RPC_ID = 'rLM1Ne';
@@ -493,7 +493,7 @@ export async function listNotebooklmNotesFromPage(page) {
     const state = await getNotebooklmPageState(page);
     if (state.kind !== 'notebook' || !state.notebookId)
         return [];
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     return Array.from(document.querySelectorAll('artifact-library-note')).map((node) => {
       const titleNode = node.querySelector('.artifact-title');
       return {
@@ -501,7 +501,7 @@ export async function listNotebooklmNotesFromPage(page) {
         text: (node.innerText || node.textContent || '').replace(/\\s+/g, ' ').trim(),
       };
     });
-  })()`);
+  })()`));
     if (!Array.isArray(raw) || raw.length === 0)
         return [];
     return parseNotebooklmNoteListRawRows(raw, state.notebookId, state.url || `https://${NOTEBOOKLM_DOMAIN}/notebook/${state.notebookId}`);
@@ -510,13 +510,13 @@ export async function readNotebooklmSummaryFromPage(page) {
     const state = await getNotebooklmPageState(page);
     if (state.kind !== 'notebook' || !state.notebookId)
         return null;
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
     const title = normalize(document.querySelector('.notebook-title, h1, [data-testid="notebook-title"]')?.textContent || document.title || '');
     const summaryNode = document.querySelector('.notebook-summary, .summary-content, [class*="summary"]');
     const summary = normalize(summaryNode?.textContent || '');
     return { title, summary };
-  })()`);
+  })()`));
     return parseNotebooklmSummaryRawRow(raw, state.notebookId, state.url || `https://${NOTEBOOKLM_DOMAIN}/notebook/${state.notebookId}`);
 }
 export async function getNotebooklmSummaryViaRpc(page) {
@@ -558,7 +558,7 @@ export async function readNotebooklmVisibleNoteFromPage(page) {
     const state = await getNotebooklmPageState(page);
     if (state.kind !== 'notebook' || !state.notebookId)
         return null;
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const normalizeText = (value) => (value || '').replace(/\\u00a0/g, ' ').replace(/\\r\\n/g, '\\n').trim();
     const titleNode = document.querySelector('.note-header__editable-title');
     const title = titleNode instanceof HTMLInputElement || titleNode instanceof HTMLTextAreaElement
@@ -575,7 +575,7 @@ export async function readNotebooklmVisibleNoteFromPage(page) {
       title: normalizeText(title),
       content: normalizeText(content),
     };
-  })()`);
+  })()`));
     return parseNotebooklmVisibleNoteRawRow(raw, state.notebookId, state.url || `https://${NOTEBOOKLM_DOMAIN}/notebook/${state.notebookId}`);
 }
 export async function ensureNotebooklmHome(page) {
@@ -596,7 +596,7 @@ export async function ensureNotebooklmHome(page) {
     }
 }
 export async function getNotebooklmPageState(page) {
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const url = window.location.href;
     const title = document.title || '';
     const hostname = window.location.hostname || '';
@@ -623,7 +623,7 @@ export async function getNotebooklmPageState(page) {
       .reduce((count, href, index, list) => list.indexOf(href) === index ? count + 1 : count, 0);
 
     return { url, title, hostname, kind, notebookId, loginRequired, notebookCount, path };
-  })()`);
+  })()`));
     const state = {
         url: String(raw?.url ?? ''),
         title: normalizeNotebooklmTitle(raw?.title, 'NotebookLM'),
@@ -648,7 +648,7 @@ export async function getNotebooklmPageState(page) {
     return state;
 }
 export async function readCurrentNotebooklm(page) {
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const url = window.location.href;
     const match = url.match(/\\/notebook\\/([^/?#]+)/);
     if (!match) return null;
@@ -661,7 +661,7 @@ export async function readCurrentNotebooklm(page) {
       url,
       source: 'current-page',
     };
-  })()`);
+  })()`));
     if (!raw)
         return null;
     return {
@@ -674,7 +674,7 @@ export async function readCurrentNotebooklm(page) {
     };
 }
 export async function listNotebooklmLinks(page) {
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const rows = [];
     const seen = new Set();
 
@@ -722,7 +722,7 @@ export async function listNotebooklmLinks(page) {
     }
 
     return rows;
-  })()`);
+  })()`));
     if (!Array.isArray(raw))
         return [];
     return raw
@@ -737,7 +737,7 @@ export async function listNotebooklmLinks(page) {
         .filter((row) => row.id && row.url);
 }
 export async function listNotebooklmSourcesFromPage(page) {
-    const raw = await page.evaluate(`(() => {
+    const raw = unwrapNotebooklmEvaluateResult(await page.evaluate(`(() => {
     const notebookMatch = window.location.href.match(/\\/notebook\\/([^/?#]+)/);
     const notebookId = notebookMatch ? notebookMatch[1] : '';
     if (!notebookId) return [];
@@ -787,7 +787,7 @@ export async function listNotebooklmSourcesFromPage(page) {
       });
     }
     return rows;
-  })()`);
+  })()`));
     if (!Array.isArray(raw))
         return [];
     return raw.filter((row) => row.id && row.title);

--- a/clis/notebooklm/utils.js
+++ b/clis/notebooklm/utils.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_HOME_URL, } from './shared.js';
 import { callNotebooklmRpc, getNotebooklmPageAuth, } from './rpc.js';
 export { buildNotebooklmRpcBody, extractNotebooklmRpcResult, fetchNotebooklmInPage, getNotebooklmPageAuth, parseNotebooklmChunkedResponse, stripNotebooklmAntiXssi, } from './rpc.js';
@@ -47,6 +47,11 @@ export function parseNotebooklmNotebookTarget(value) {
 export function getNotebooklmAuthuser() {
     const v = process.env.OPENCLI_NOTEBOOKLM_AUTHUSER;
     return typeof v === 'string' && /^\d+$/.test(v) ? v : '';
+}
+export function requireNotebooklmExecute(value, action) {
+    if (value !== true) {
+        throw new ArgumentError(`Refusing to ${action}: pass --execute to perform this NotebookLM write`);
+    }
 }
 export function buildNotebooklmNotebookUrl(notebookId) {
     const u = new URL(`/notebook/${encodeURIComponent(notebookId)}`, NOTEBOOKLM_HOME_URL);

--- a/clis/notebooklm/utils.test.js
+++ b/clis/notebooklm/utils.test.js
@@ -414,4 +414,29 @@ describe('notebooklm utils', () => {
             notebookCount: 0,
         });
     });
+    it('reads page state through Browser Bridge evaluate envelopes', async () => {
+        const page = {
+            evaluate: async () => ({
+                session: 'site:notebooklm:abc',
+                data: {
+                    url: 'https://notebooklm.google.com/notebook/nb-demo',
+                    title: 'Demo Notebook - NotebookLM',
+                    hostname: 'notebooklm.google.com',
+                    kind: 'notebook',
+                    notebookId: 'nb-demo',
+                    loginRequired: false,
+                    notebookCount: 0,
+                },
+            }),
+        };
+        await expect(getNotebooklmPageState(page)).resolves.toEqual({
+            url: 'https://notebooklm.google.com/notebook/nb-demo',
+            title: 'Demo Notebook - NotebookLM',
+            hostname: 'notebooklm.google.com',
+            kind: 'notebook',
+            notebookId: 'nb-demo',
+            loginRequired: false,
+            notebookCount: 0,
+        });
+    });
 });

--- a/clis/notebooklm/utils.test.js
+++ b/clis/notebooklm/utils.test.js
@@ -24,6 +24,13 @@ describe('notebooklm utils', () => {
     it('parseNotebooklmNotebookTarget rejects malformed notebook urls', () => {
         expect(() => parseNotebooklmNotebookTarget('https://notebooklm.google.com/notebook/not-a-uuid')).toThrow(CliError);
     });
+    it('parseNotebooklmNotebookTarget rejects off-domain or non-canonical notebook urls', () => {
+        const id = '17e2b882-aaaa-bbbb-cccc-abcdef012345';
+        expect(() => parseNotebooklmNotebookTarget(`https://evil.test/notebook/${id}`)).toThrow(CliError);
+        expect(() => parseNotebooklmNotebookTarget(`http://notebooklm.google.com/notebook/${id}`)).toThrow(CliError);
+        expect(() => parseNotebooklmNotebookTarget(`https://notebooklm.google.com:444/notebook/${id}`)).toThrow(CliError);
+        expect(() => parseNotebooklmNotebookTarget(`https://user:notsecret@notebooklm.google.com/notebook/${id}`)).toThrow(CliError);
+    });
     it('parseNotebooklmNotebookTarget rejects empty input', () => {
         expect(() => parseNotebooklmNotebookTarget('')).toThrow(CliError);
         expect(() => parseNotebooklmNotebookTarget('   ')).toThrow(CliError);

--- a/clis/notebooklm/utils.test.js
+++ b/clis/notebooklm/utils.test.js
@@ -1,6 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { buildNotebooklmRpcBody, classifyNotebooklmPage, extractNotebooklmHistoryPreview, extractNotebooklmRpcResult, getNotebooklmPageState, normalizeNotebooklmTitle, parseNotebooklmHistoryThreadIdsResult, parseNotebooklmIdFromUrl, parseNotebooklmListResult, parseNotebooklmNoteListRawRows, parseNotebooklmNotebookDetailResult, parseNotebooklmSourceFulltextResult, parseNotebooklmSourceGuideResult, parseNotebooklmSourceListResult, } from './utils.js';
+import { buildNotebooklmRpcBody, classifyNotebooklmPage, extractNotebooklmHistoryPreview, extractNotebooklmRpcResult, getNotebooklmPageState, isPlainObject, normalizeNotebooklmTitle, parseNotebooklmHistoryThreadIdsResult, parseNotebooklmIdFromUrl, parseNotebooklmListResult, parseNotebooklmNoteListRawRows, parseNotebooklmNotebookDetailResult, parseNotebooklmNotebookTarget, parseNotebooklmSourceFulltextResult, parseNotebooklmSourceGuideResult, parseNotebooklmSourceListResult, } from './utils.js';
+import { CliError } from '@jackwener/opencli/errors';
 describe('notebooklm utils', () => {
+    it('isPlainObject distinguishes objects from arrays / null / primitives', () => {
+        expect(isPlainObject({})).toBe(true);
+        expect(isPlainObject({ a: 1 })).toBe(true);
+        expect(isPlainObject([])).toBe(false);
+        expect(isPlainObject(null)).toBe(false);
+        expect(isPlainObject('x')).toBe(false);
+        expect(isPlainObject(0)).toBe(false);
+    });
+    it('parseNotebooklmNotebookTarget accepts canonical uuid input', () => {
+        const id = '17e2b882-aaaa-bbbb-cccc-abcdef012345';
+        expect(parseNotebooklmNotebookTarget(id)).toBe(id);
+    });
+    it('parseNotebooklmNotebookTarget accepts a notebook url with uuid', () => {
+        const id = '17e2b882-aaaa-bbbb-cccc-abcdef012345';
+        expect(parseNotebooklmNotebookTarget(`https://notebooklm.google.com/notebook/${id}?pli=1`)).toBe(id);
+    });
+    it('parseNotebooklmNotebookTarget rejects non-uuid bare ids', () => {
+        expect(() => parseNotebooklmNotebookTarget('nb-demo')).toThrow(CliError);
+    });
+    it('parseNotebooklmNotebookTarget rejects malformed notebook urls', () => {
+        expect(() => parseNotebooklmNotebookTarget('https://notebooklm.google.com/notebook/not-a-uuid')).toThrow(CliError);
+    });
+    it('parseNotebooklmNotebookTarget rejects empty input', () => {
+        expect(() => parseNotebooklmNotebookTarget('')).toThrow(CliError);
+        expect(() => parseNotebooklmNotebookTarget('   ')).toThrow(CliError);
+    });
     it('parses notebook id from a notebook url', () => {
         expect(parseNotebooklmIdFromUrl('https://notebooklm.google.com/notebook/abc-123')).toBe('abc-123');
     });

--- a/clis/notebooklm/write-note.js
+++ b/clis/notebooklm/write-note.js
@@ -36,13 +36,18 @@ export function buildMutateNoteArgs(projectId, noteId, content, title) {
     return [projectId, noteId, [[[content, title, [], 0]]], [2]];
 }
 
-export function parseNoteIdFromResult(result) {
-    if (typeof result === 'string') return NOTE_UUID_RE.test(result) ? result : '';
+function toExcludedUuidSet(excludedIds) {
+    return new Set(excludedIds.map((id) => String(id ?? '').toLowerCase()).filter(Boolean));
+}
+
+export function parseNoteIdFromResult(result, excludedIds = []) {
+    const excluded = toExcludedUuidSet(excludedIds);
+    if (typeof result === 'string') return NOTE_UUID_RE.test(result) && !excluded.has(result.toLowerCase()) ? result : '';
     const stack = [result];
     while (stack.length) {
         const node = stack.shift();
         if (typeof node === 'string') {
-            if (NOTE_UUID_RE.test(node)) return node;
+            if (NOTE_UUID_RE.test(node) && !excluded.has(node.toLowerCase())) return node;
             continue;
         }
         if (Array.isArray(node)) for (const child of node) stack.push(child);
@@ -75,7 +80,7 @@ cli({
         await ensureNotebooklmHome(page);
         await requireNotebooklmSession(page);
         const shellRpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_NOTE_RPC_ID, buildCreateNoteShellArgs(notebookId));
-        const noteId = parseNoteIdFromResult(shellRpc.result);
+        const noteId = parseNoteIdFromResult(shellRpc.result, [notebookId]);
         if (!noteId) {
             throw new CommandExecutionError('NotebookLM CreateNote RPC returned no note id');
         }

--- a/clis/notebooklm/write-note.js
+++ b/clis/notebooklm/write-note.js
@@ -1,0 +1,96 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
+import { callNotebooklmRpc } from './rpc.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+
+const NOTEBOOKLM_CREATE_NOTE_RPC_ID = 'CYK0Xb';
+const NOTEBOOKLM_MUTATE_NOTE_RPC_ID = 'cYAfTb';
+const MAX_TITLE_LEN = 200;
+const MAX_CONTENT_LEN = 1_000_000;
+const NOTE_UUID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+export function parseNoteTitle(value) {
+    const title = String(value ?? '').trim();
+    if (!title) throw new ArgumentError('--title is required');
+    if (title.length > MAX_TITLE_LEN) {
+        throw new ArgumentError(`--title must be at most ${MAX_TITLE_LEN} characters (got ${title.length})`);
+    }
+    return title;
+}
+
+export function parseNoteContent(value) {
+    const content = String(value ?? '');
+    if (!content) throw new ArgumentError('--content is required');
+    if (content.length > MAX_CONTENT_LEN) {
+        throw new ArgumentError(`--content exceeds ${MAX_CONTENT_LEN} characters; split into smaller notes.`);
+    }
+    return content;
+}
+
+export function buildCreateNoteShellArgs(projectId) {
+    return [projectId, '', [1], null, 'New Note', null, [2]];
+}
+
+export function buildMutateNoteArgs(projectId, noteId, content, title) {
+    return [projectId, noteId, [[[content, title, [], 0]]], [2]];
+}
+
+export function parseNoteIdFromResult(result) {
+    if (typeof result === 'string') return NOTE_UUID_RE.test(result) ? result : '';
+    const stack = [result];
+    while (stack.length) {
+        const node = stack.shift();
+        if (typeof node === 'string') {
+            if (NOTE_UUID_RE.test(node)) return node;
+            continue;
+        }
+        if (Array.isArray(node)) for (const child of node) stack.push(child);
+        else if (node && typeof node === 'object') for (const v of Object.values(node)) stack.push(v);
+    }
+    return '';
+}
+
+cli({
+    site: NOTEBOOKLM_SITE,
+    name: 'write-note',
+    access: 'write',
+    description: 'Create a Studio note in an existing NotebookLM notebook with the given title and Markdown content',
+    domain: NOTEBOOKLM_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
+        { name: 'title', required: true, help: 'Note title (1-200 chars)' },
+        { name: 'content', required: true, help: 'Note body as Markdown' },
+    ],
+    columns: ['notebook_id', 'note_id', 'title', 'notebook_url'],
+    func: async (page, kwargs) => {
+        const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
+        const title = parseNoteTitle(kwargs.title);
+        const content = parseNoteContent(kwargs.content);
+        await ensureNotebooklmHome(page);
+        await requireNotebooklmSession(page);
+        const shellRpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_NOTE_RPC_ID, buildCreateNoteShellArgs(notebookId));
+        const noteId = parseNoteIdFromResult(shellRpc.result);
+        if (!noteId) {
+            throw new CommandExecutionError('NotebookLM CreateNote RPC returned no note id');
+        }
+        await callNotebooklmRpc(page, NOTEBOOKLM_MUTATE_NOTE_RPC_ID, buildMutateNoteArgs(notebookId, noteId, content, title));
+        return [{
+            notebook_id: notebookId,
+            note_id: noteId,
+            title,
+            notebook_url: buildNotebooklmNotebookUrl(notebookId),
+        }];
+    },
+});
+
+export const __test__ = {
+    parseNoteTitle,
+    parseNoteContent,
+    buildCreateNoteShellArgs,
+    buildMutateNoteArgs,
+    parseNoteIdFromResult,
+};

--- a/clis/notebooklm/write-note.js
+++ b/clis/notebooklm/write-note.js
@@ -2,7 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { NOTEBOOKLM_DOMAIN, NOTEBOOKLM_SITE } from './shared.js';
 import { callNotebooklmRpc } from './rpc.js';
-import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, parseNotebooklmNotebookTarget, requireNotebooklmSession } from './utils.js';
+import { buildNotebooklmNotebookUrl, ensureNotebooklmHome, parseNotebooklmNotebookTarget, requireNotebooklmExecute, requireNotebooklmSession } from './utils.js';
 
 const NOTEBOOKLM_CREATE_NOTE_RPC_ID = 'CYK0Xb';
 const NOTEBOOKLM_MUTATE_NOTE_RPC_ID = 'cYAfTb';
@@ -64,12 +64,14 @@ cli({
         { name: 'notebook', positional: true, required: true, help: 'Notebook id from `notebooklm list` or full notebook URL' },
         { name: 'title', required: true, help: 'Note title (1-200 chars)' },
         { name: 'content', required: true, help: 'Note body as Markdown' },
+        { name: 'execute', type: 'boolean', help: 'Actually create the remote NotebookLM note' },
     ],
     columns: ['notebook_id', 'note_id', 'title', 'notebook_url'],
     func: async (page, kwargs) => {
         const notebookId = parseNotebooklmNotebookTarget(String(kwargs.notebook ?? ''));
         const title = parseNoteTitle(kwargs.title);
         const content = parseNoteContent(kwargs.content);
+        requireNotebooklmExecute(kwargs.execute, 'create a NotebookLM note');
         await ensureNotebooklmHome(page);
         await requireNotebooklmSession(page);
         const shellRpc = await callNotebooklmRpc(page, NOTEBOOKLM_CREATE_NOTE_RPC_ID, buildCreateNoteShellArgs(notebookId));

--- a/clis/notebooklm/write-note.test.js
+++ b/clis/notebooklm/write-note.test.js
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './write-note.js';
 
 const { parseNoteTitle, parseNoteContent, buildCreateNoteShellArgs, buildMutateNoteArgs, parseNoteIdFromResult } = __test__;
@@ -48,5 +49,16 @@ describe('notebooklm write-note', () => {
         expect(parseNoteIdFromResult([ 'project-id', 'not-a-uuid' ])).toBe('');
         expect(parseNoteIdFromResult(null)).toBe('');
         expect(parseNoteIdFromResult([])).toBe('');
+    });
+
+    it('refuses to create a remote note without --execute', async () => {
+        const command = getRegistry().get('notebooklm/write-note');
+        const page = { goto: vi.fn() };
+        await expect(command.func(page, {
+            notebook: '17e2b882-6a01-4c6c-9262-0738dfa2abee',
+            title: 'Draft note',
+            content: 'body',
+        })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
 });

--- a/clis/notebooklm/write-note.test.js
+++ b/clis/notebooklm/write-note.test.js
@@ -51,6 +51,12 @@ describe('notebooklm write-note', () => {
         expect(parseNoteIdFromResult([])).toBe('');
     });
 
+    it('parseNoteIdFromResult skips the input notebook id before selecting the created note id', () => {
+        const notebookId = '17e2b882-6a01-4c6c-9262-0738dfa2abee';
+        const noteId = '0312fc89-075e-4b3a-810d-141fc8d5af6d';
+        expect(parseNoteIdFromResult([notebookId, [[noteId]]], [notebookId])).toBe(noteId);
+    });
+
     it('refuses to create a remote note without --execute', async () => {
         const command = getRegistry().get('notebooklm/write-note');
         const page = { goto: vi.fn() };

--- a/clis/notebooklm/write-note.test.js
+++ b/clis/notebooklm/write-note.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { __test__ } from './write-note.js';
+
+const { parseNoteTitle, parseNoteContent, buildCreateNoteShellArgs, buildMutateNoteArgs, parseNoteIdFromResult } = __test__;
+
+describe('notebooklm write-note', () => {
+    it('parseNoteTitle accepts 1-200 char titles', () => {
+        expect(parseNoteTitle('Note A')).toBe('Note A');
+        expect(parseNoteTitle('  spaced  ')).toBe('spaced');
+        expect(parseNoteTitle('x'.repeat(200))).toHaveLength(200);
+    });
+
+    it('parseNoteTitle rejects empty / too-long titles', () => {
+        expect(() => parseNoteTitle('')).toThrow(ArgumentError);
+        expect(() => parseNoteTitle('   ')).toThrow(ArgumentError);
+        expect(() => parseNoteTitle('x'.repeat(201))).toThrow(ArgumentError);
+    });
+
+    it('parseNoteContent accepts non-empty content', () => {
+        expect(parseNoteContent('# heading\n\nbody')).toBe('# heading\n\nbody');
+    });
+
+    it('parseNoteContent rejects empty content', () => {
+        expect(() => parseNoteContent('')).toThrow(ArgumentError);
+        expect(() => parseNoteContent(undefined)).toThrow(ArgumentError);
+    });
+
+    it('buildCreateNoteShellArgs matches the HAR-verified wire format', () => {
+        expect(buildCreateNoteShellArgs('nb-123')).toEqual([
+            'nb-123', '', [1], null, 'New Note', null, [2],
+        ]);
+    });
+
+    it('buildMutateNoteArgs puts content before title in the inner tuple', () => {
+        expect(buildMutateNoteArgs('nb-123', 'note-7', 'body content', 'title-x')).toEqual([
+            'nb-123', 'note-7', [[['body content', 'title-x', [], 0]]], [2],
+        ]);
+    });
+
+    it('parseNoteIdFromResult walks the tree for the note-id UUID', () => {
+        const id = '0312fc89-075e-4b3a-810d-141fc8d5af6d';
+        expect(parseNoteIdFromResult([[[ [id] ]]])).toBe(id);
+        expect(parseNoteIdFromResult({ shell: { noteId: id } })).toBe(id);
+    });
+
+    it('parseNoteIdFromResult ignores non-UUID strings', () => {
+        expect(parseNoteIdFromResult([ 'project-id', 'not-a-uuid' ])).toBe('');
+        expect(parseNoteIdFromResult(null)).toBe('');
+        expect(parseNoteIdFromResult([])).toBe('');
+    });
+});

--- a/docs/adapters/browser/notebooklm.md
+++ b/docs/adapters/browser/notebooklm.md
@@ -19,6 +19,11 @@
 | `opencli notebooklm note-list` | List Studio notes visible in the current notebook |
 | `opencli notebooklm notes-get <note>` | Read the currently visible Studio note by title |
 | `opencli notebooklm summary` | Read the current notebook summary |
+| `opencli notebooklm create <title> --execute` | Create a new NotebookLM notebook |
+| `opencli notebooklm add-source <notebook> (--url <url> \| --content <text> \| --file <path>) --execute` | Add one source to an existing notebook |
+| `opencli notebooklm write-note <notebook> --title <title> --content <markdown> --execute` | Create a Studio note in a notebook |
+| `opencli notebooklm generate-audio <notebook> --execute` | Trigger Audio Overview generation for a notebook |
+| `opencli notebooklm generate-slides <notebook> --execute` | Trigger slide deck generation for a notebook |
 
 ## Compatibility Aliases
 
@@ -36,7 +41,7 @@ This adapter reuses the existing OpenCLI Browser Bridge runtime:
 - no exported cookie replay
 - requests and page state stay in the real Chrome session
 
-The current milestone focuses on a stable NotebookLM read surface in desktop Chrome with an already logged-in Google account.
+Read commands expose NotebookLM metadata, sources, notes, summaries, and history from desktop Chrome with an already logged-in Google account. Write commands call NotebookLM's in-page RPC endpoints from that same logged-in browser session and require an explicit `--execute` flag before any remote mutation is attempted.
 
 ## Usage Examples
 
@@ -54,6 +59,15 @@ opencli notebooklm history -f json
 opencli notebooklm note-list -f json
 opencli notebooklm notes-get "Draft note" -f json
 opencli notebooklm summary -f json
+
+# Write commands refuse to mutate unless --execute is present.
+opencli notebooklm create "Research Brief" --emoji "📒" --execute
+opencli notebooklm add-source 17e2b882-6a01-4c6c-9262-0738dfa2abee --url https://example.com/report --execute
+opencli notebooklm add-source 17e2b882-6a01-4c6c-9262-0738dfa2abee --content "Source text" --title "Pasted source" --execute
+opencli notebooklm add-source 17e2b882-6a01-4c6c-9262-0738dfa2abee --file ./paper.pdf --execute
+opencli notebooklm write-note 17e2b882-6a01-4c6c-9262-0738dfa2abee --title "Open questions" --content "## Next steps" --execute
+opencli notebooklm generate-audio 17e2b882-6a01-4c6c-9262-0738dfa2abee --execute
+opencli notebooklm generate-slides 17e2b882-6a01-4c6c-9262-0738dfa2abee --length 3 --language en --execute
 ```
 
 ## Prerequisites
@@ -67,3 +81,6 @@ opencli notebooklm summary -f json
 - Notebook-oriented commands run in OpenCLI's owned NotebookLM adapter session/window. Use `opencli notebooklm open <notebook>` first to choose the current notebook for follow-up commands.
 - `list`, `get`, `source-list`, `history`, `source-fulltext`, and `source-guide` prefer NotebookLM RPC paths and fall back only when the richer path is unavailable.
 - `notes-get` currently reads note content only from the visible Studio note editor; if the note is listed but not open, open it in NotebookLM first and then retry.
+- All NotebookLM write commands require `--execute` and fail before opening a browser/RPC write path when it is absent.
+- Write commands accept a bare notebook UUID or a canonical `https://notebooklm.google.com/notebook/<uuid>` URL. Off-domain, non-HTTPS, credentialed, or custom-port notebook URLs are rejected.
+- `add-source` accepts exactly one source input: `--url`, `--content`, or `--file`.


### PR DESCRIPTION
Closes #1022.

## Description

The existing `notebooklm` adapter has 13 read commands but no writes. This PR adds the four writes the reporter (@Fengsh0923) requested, plus slide-deck generation (the reporter's other 'audio/PPT' ask, which today is NotebookLM's Slide Deck product):

| Command | RPC ID | Wire envelope |
|---------|--------|---------------|
| `notebooklm create <title> [--emoji]` | `CCqFvf` CreateProject | `[title, emoji]` |
| `notebooklm add-source <notebook> --url \| --content \| --file` | `izAoDd` AddSources (url + text) <br> `o4cbdc` AddFileSource + Google Drive resumable upload (file) | URL: `[[[null, null, [url]]], project_id]` <br> Text: `[[[null, [title, content], null, 2]], project_id]` <br> File: register via `o4cbdc`, then POST `/upload/_/?authuser=N` with metadata + `X-Goog-Upload-Command: start` to get a session URL, then POST raw bytes with `upload, finalize` |
| `notebooklm write-note <notebook> --title <t> --content <md>` | `CYK0Xb` CreateNote then `cYAfTb` MutateNote | shell `[project_id, "", [1], null, "New Note", null, [2]]` + body `[project_id, note_id, [[[content, title, [], 0]]], [2]]` |
| `notebooklm generate-audio <notebook>` | `R7cb6c` CreateArtifact (audio mode) | 3-element nested config + source-ids block (mode slot = `1`), full layout in code |
| `notebooklm generate-slides <notebook> [--length 1\|3] [--language en]` | `R7cb6c` CreateArtifact (slide-deck mode) | same R7cb6c RPC with mode slot = `8` and trailing `[[null, language, 1, length]]` config block |

All four reuse the existing `callNotebooklmRpc(page, rpcId, params)` helper. RPC IDs + wire shapes come from a combination of the [tmc/nlm](https://github.com/tmc/nlm) open-source reverse-engineering plus a live HAR capture of the NotebookLM web UI (for the more complex CreateAudioOverview envelope that tmc/nlm only had scrubbed testdata for).

`write-note` runs the same 2-step chain the web UI uses (CreateNote empty shell, then MutateNote sets title + body). Content is forwarded verbatim as Markdown.

`generate-audio` resolves the notebook's source list via the existing read RPC and threads every source id into the request (the wire format includes the ids twice, in both a nested and a tail block).

Id-returning RPCs use a UUID-walker parser that finds the first 8-4-4-4-12 hex string in the response tree; the position of the new id in the response envelope drifts across releases.

## Multi-account fix (required for write commands to land on the right account)

Recon also surfaced an existing bug in `callNotebooklmRpc`: it reads `SNlM0e` and `FdrFJe` tokens from `window.WIZ_global_data` of the page it navigated to, but `ensureNotebooklmHome` always navigates to `https://notebooklm.google.com/` (no `authuser` parameter). For users whose default Google account in their Chrome profile is NOT the account they want NotebookLM to act under (Google supports multiple accounts in one Chrome profile, switchable via the in-app account chip), all RPCs were silently routed to the default account.

The fix here:
- `clis/notebooklm/rpc.js` extracts `authuser` from `location.search` (`?authuser=N`) or `location.pathname` (`/u/N/`), and the batchexecute URL builder appends `&authuser=<N>` when set.
- `clis/notebooklm/utils.js` reads `OPENCLI_NOTEBOOKLM_AUTHUSER` from the environment in `buildNotebooklmNotebookUrl` and `ensureNotebooklmHome`, so all navigation preserves the account context.

Users on the default account see no behaviour change. Users on a secondary NotebookLM account `export OPENCLI_NOTEBOOKLM_AUTHUSER=1` (or whichever slot index) once per shell and all `notebooklm` commands route correctly.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] New site command (4 commands on existing site, plus a multi-account routing fix that benefits all existing read commands)
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Live verification

End-to-end on a logged-in NotebookLM session with `OPENCLI_NOTEBOOKLM_AUTHUSER=1` set:

```bash
$ notebooklm create 'opencli-e2e-2' --emoji '🧪' -f json
[ { "id": "17e2b882-6a01-4c6c-9262-0738dfa2abee", "title": "opencli-e2e-2", "emoji": "🧪",
    "url": "https://notebooklm.google.com/notebook/17e2b882-6a01-4c6c-9262-0738dfa2abee?authuser=1" } ]

$ notebooklm add-source 17e2b882-... --url https://en.wikipedia.org/wiki/Coffee -f json
[ { "notebook_id": "17e2b882-...", "source_id": "493b9ddd-453b-4523-b638-bb560b37723c",
    "url": "https://en.wikipedia.org/wiki/Coffee", "notebook_url": "...?authuser=1" } ]

$ notebooklm write-note 17e2b882-... --title 'verify-note' \
    --content '# test\n\nfrom CLI via env-var authuser=1' -f json
[ { "notebook_id": "17e2b882-...", "note_id": "1260b8d6-ac22-4817-914e-0361c77c0bd5",
    "title": "verify-note", "notebook_url": "...?authuser=1" } ]

$ notebooklm add-source 17e2b882-... --content '# Text Source Test\n\nThis is a text source added by opencli...' --title 'opencli-text-source-test' -f json
[ { "notebook_id": "17e2b882-...", "source_id": "182508cf-9afd-4db5-8640-2f8cafcc7111",
    "kind": "text", "identifier": "opencli-text-source-test", "notebook_url": "...?authuser=1" } ]

$ notebooklm add-source a5ee0ad0-... --file /tmp/opencli-test-source.txt -f json
[ { "notebook_id": "a5ee0ad0-920a-4355-9aa1-0edce365b0ea",
    "source_id": "be406c79-1a90-4ef2-9b2f-6661f14aa46b",
    "kind": "file", "identifier": "opencli-test-source.txt (text/plain, 675 bytes)",
    "notebook_url": "...?authuser=1" } ]

$ notebooklm generate-slides f0d690ff-... -f json
[ { "notebook_id": "f0d690ff-0dda-4331-9f4b-54631b8c889e", "slides_id": "1f8ada7d-cb33-49a4-8498-c5b81c1a899d",
    "source_count": 1, "status": "pending", "notebook_url": "...?authuser=1" } ]

$ notebooklm generate-audio 17e2b882-... -f json
[ { "notebook_id": "17e2b882-...", "audio_id": "546972b2-0c0f-4951-9266-f086bed432f6",
    "source_count": 1, "status": "pending", "notebook_url": "...?authuser=1" } ]
```

All four commands return their canonical id; the artifacts are visible via the existing read commands and in the NotebookLM web UI on the correct account.

## Test plan

- [x] `npm run build`: manifest compiles
- [x] `npm run check:typed-error-lint`: passes
- [x] `npm run check:silent-column-drop`: passes
- [x] `npm run check:doc-coverage --strict`: passes
- [x] `npx vitest run --project adapter clis/notebooklm/`: **70 tests passing** including new unit tests for the 4 write commands, the wire-shape assertions for each RPC, and the rpc-test extended assertion for the new `authuser` field
- [x] Live: full create -> add-source -> write-note -> generate-audio chain runs end-to-end against a real NotebookLM secondary account via `OPENCLI_NOTEBOOKLM_AUTHUSER=1`; each command returns the expected id

## Out of scope

- **Other Studio artifacts** (Mind Map, Video Overview, Reports, Flashcards, Quiz, Briefing Doc, Infographic, Data Table): each lives under the same R7cb6c RPC family with its own mode slot value and tail config. Recon was scoped to Audio (mode 1) and Slide Deck (mode 8); the remaining artifacts can extend the existing R7cb6c builder once their wire shapes are captured in follow-up PRs.



