### PR TITLE
fix(extension): serialize tab group creation to prevent duplicates (fixes #1692)

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1092,13 +1092,13 @@ async function ensureOwnedContainerTabGroup(role, windowId, tabIds) {
   const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
   if (ids.length === 0) return;
   const container = ownedContainers[role];
-  if (container.groupPromise) {
-    await container.groupPromise;
-  }
-  container.groupPromise = ensureOwnedContainerTabGroupUnlocked(role, windowId, ids).finally(() => {
-    container.groupPromise = null;
+  const previousGroupPromise = container.groupPromise ?? Promise.resolve();
+  const nextGroupPromise = previousGroupPromise.catch(() => void 0).then(() => ensureOwnedContainerTabGroupUnlocked(role, windowId, ids));
+  const trackedGroupPromise = nextGroupPromise.finally(() => {
+    if (container.groupPromise === trackedGroupPromise) container.groupPromise = null;
   });
-  return container.groupPromise;
+  container.groupPromise = trackedGroupPromise;
+  return trackedGroupPromise;
 }
 async function ensureOwnedContainerTabGroupUnlocked(role, windowId, ids) {
   try {

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -791,8 +791,8 @@ const LEGACY_AUTOMATION_TAB_GROUP_TITLE = "OpenCLI";
 const AUTOMATION_TAB_GROUP_COLOR = "orange";
 let leaseMutationQueue = Promise.resolve();
 const ownedContainers = {
-  interactive: { windowId: null, groupId: null, promise: null },
-  automation: { windowId: null, groupId: null, promise: null }
+  interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
+  automation: { windowId: null, groupId: null, promise: null, groupPromise: null }
 };
 class CommandFailure extends Error {
   constructor(code, message, hint) {
@@ -1091,6 +1091,16 @@ async function discoverOwnedContainerFromTabGroup(role) {
 async function ensureOwnedContainerTabGroup(role, windowId, tabIds) {
   const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
   if (ids.length === 0) return;
+  const container = ownedContainers[role];
+  if (container.groupPromise) {
+    await container.groupPromise;
+  }
+  container.groupPromise = ensureOwnedContainerTabGroupUnlocked(role, windowId, ids).finally(() => {
+    container.groupPromise = null;
+  });
+  return container.groupPromise;
+}
+async function ensureOwnedContainerTabGroupUnlocked(role, windowId, ids) {
   try {
     const existingGroupId = await getOwnedContainerGroupId(role, windowId);
     if (existingGroupId !== null) {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1150,6 +1150,42 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [10] });
   });
 
+  it('serializes concurrent owned tab grouping so duplicate adapter groups are not created', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    const releaseFirstGroupCreate = deferred<void>();
+    const originalGroup = chrome.tabs.group;
+    let createGroupCalls = 0;
+    chrome.tabs.group = vi.fn(async (options: { tabIds?: number | number[]; groupId?: number; createProperties?: { windowId?: number } }) => {
+      if (options.groupId === undefined) {
+        createGroupCalls += 1;
+        if (createGroupCalls === 1) await releaseFirstGroupCreate.promise;
+      }
+      return originalGroup(options);
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('first'), { windowId: 1, owned: true, preferredTabId: 1 });
+    mod.__test__.setSession(adapterKey('second'), { windowId: 1, owned: true, preferredTabId: null });
+
+    const first = mod.__test__.handleTabs({ id: 'new-first', action: 'tabs', op: 'new', session: adapterKey('first'), url: 'https://first.example' }, adapterKey('first'));
+    const second = mod.__test__.handleTabs({ id: 'new-second', action: 'tabs', op: 'new', session: adapterKey('second'), url: 'https://second.example' }, adapterKey('second'));
+
+    await vi.waitFor(() => {
+      expect(chrome.tabs.group).toHaveBeenCalledWith({ tabIds: [10], createProperties: { windowId: 1 } });
+    });
+    releaseFirstGroupCreate.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ ok: true }),
+      expect.objectContaining({ ok: true }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(tabs.find((tab) => tab.id === 10)?.groupId).toBe(100);
+    expect(tabs.find((tab) => tab.id === 11)?.groupId).toBe(100);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [11] });
+  });
+
   it('discovers and reuses an existing OpenCLI Adapter group after service worker restart', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     groups.push({

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1186,6 +1186,58 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [11] });
   });
 
+  it('keeps queued owned tab grouping serialized after a transient group creation failure', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    const releaseFirstFailure = deferred<void>();
+    const releaseSecondGroupCreate = deferred<void>();
+    const originalGroup = chrome.tabs.group;
+    let createGroupCalls = 0;
+    chrome.tabs.group = vi.fn(async (options: { tabIds?: number | number[]; groupId?: number; createProperties?: { windowId?: number } }) => {
+      if (options.groupId === undefined) {
+        createGroupCalls += 1;
+        if (createGroupCalls === 1) {
+          await releaseFirstFailure.promise;
+          throw new Error('transient group creation failure');
+        }
+        if (createGroupCalls === 2) await releaseSecondGroupCreate.promise;
+      }
+      return originalGroup(options);
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('first'), { windowId: 1, owned: true, preferredTabId: 1 });
+    mod.__test__.setSession(adapterKey('second'), { windowId: 1, owned: true, preferredTabId: null });
+    mod.__test__.setSession(adapterKey('third'), { windowId: 1, owned: true, preferredTabId: null });
+
+    const first = mod.__test__.handleTabs({ id: 'new-first', action: 'tabs', op: 'new', session: adapterKey('first'), url: 'https://first.example' }, adapterKey('first'));
+    const second = mod.__test__.handleTabs({ id: 'new-second', action: 'tabs', op: 'new', session: adapterKey('second'), url: 'https://second.example' }, adapterKey('second'));
+    const third = mod.__test__.handleTabs({ id: 'new-third', action: 'tabs', op: 'new', session: adapterKey('third'), url: 'https://third.example' }, adapterKey('third'));
+
+    await vi.waitFor(() => {
+      expect(createGroupCalls).toBe(1);
+    });
+    releaseFirstFailure.resolve();
+    await vi.waitFor(() => {
+      expect(createGroupCalls).toBe(2);
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(createGroupCalls).toBe(2);
+    releaseSecondGroupCreate.resolve();
+
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      expect.objectContaining({ ok: true }),
+      expect.objectContaining({ ok: true }),
+      expect.objectContaining({ ok: true }),
+    ]);
+    expect(createGroupCalls).toBe(2);
+    expect(groups).toHaveLength(1);
+    expect(tabs.find((tab) => tab.id === 11)?.groupId).toBe(100);
+    expect(tabs.find((tab) => tab.id === 12)?.groupId).toBe(100);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [12] });
+  });
+
   it('discovers and reuses an existing OpenCLI Adapter group after service worker restart', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     groups.push({

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -612,12 +612,15 @@ async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: num
   if (ids.length === 0) return;
 
   const container = ownedContainers[role];
-  if (container.groupPromise) {
-    await container.groupPromise;
-  }
-  container.groupPromise = ensureOwnedContainerTabGroupUnlocked(role, windowId, ids)
-    .finally(() => { container.groupPromise = null; });
-  return container.groupPromise;
+  const previousGroupPromise = container.groupPromise ?? Promise.resolve();
+  const nextGroupPromise = previousGroupPromise
+    .catch(() => undefined)
+    .then(() => ensureOwnedContainerTabGroupUnlocked(role, windowId, ids));
+  const trackedGroupPromise = nextGroupPromise.finally(() => {
+    if (container.groupPromise === trackedGroupPromise) container.groupPromise = null;
+  });
+  container.groupPromise = trackedGroupPromise;
+  return trackedGroupPromise;
 }
 
 async function ensureOwnedContainerTabGroupUnlocked(role: OwnedWindowRole, windowId: number, ids: number[]): Promise<void> {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -242,9 +242,10 @@ const ownedContainers: Record<OwnedWindowRole, {
   windowId: number | null;
   groupId: number | null;
   promise: Promise<{ windowId: number; initialTabId?: number }> | null;
+  groupPromise: Promise<void> | null;
 }> = {
-  interactive: { windowId: null, groupId: null, promise: null },
-  automation: { windowId: null, groupId: null, promise: null },
+  interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
+  automation: { windowId: null, groupId: null, promise: null, groupPromise: null },
 };
 
 type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
@@ -610,6 +611,16 @@ async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: num
   const ids = [...new Set(tabIds.filter((id): id is number => id !== undefined))];
   if (ids.length === 0) return;
 
+  const container = ownedContainers[role];
+  if (container.groupPromise) {
+    await container.groupPromise;
+  }
+  container.groupPromise = ensureOwnedContainerTabGroupUnlocked(role, windowId, ids)
+    .finally(() => { container.groupPromise = null; });
+  return container.groupPromise;
+}
+
+async function ensureOwnedContainerTabGroupUnlocked(role: OwnedWindowRole, windowId: number, ids: number[]): Promise<void> {
   try {
     const existingGroupId = await getOwnedContainerGroupId(role, windowId);
     if (existingGroupId !== null) {


### PR DESCRIPTION
## Problem

`ensureOwnedContainerTabGroup()` lacks serialization, so concurrent callers that both observe no existing group each create a new tab group, resulting in duplicate "OpenCLI Browser" / "OpenCLI Adapter" tab groups.

## Root Cause

The function is called from 7 different call sites (window creation, tab lease, reconciliation, etc.). When two calls race:

1. Call A: `getOwnedContainerGroupId()` → returns `null`
2. Call B: `getOwnedContainerGroupId()` → also returns `null` (A hasn't created yet)
3. Both create separate groups with the same title

`ensureOwnedContainerWindow()` already solves this exact pattern with `container.promise`, but `ensureOwnedContainerTabGroup()` was missing equivalent protection.

## Fix

Add a per-role `groupPromise` field to `ownedContainers` and serialize `ensureOwnedContainerTabGroup()` calls through it. The second concurrent caller awaits the first call's promise, then finds the newly created group via the existing cache path.

This mirrors the existing `ensureOwnedContainerWindow()` / `container.promise` pattern exactly.

## Changes

- `extension/src/background.ts`: Add `groupPromise` to container type and initial values; split function into serializing wrapper + `ensureOwnedContainerTabGroupUnlocked()`

## Testing

- `npx tsc --noEmit`: clean (pre-existing jsdom errors only)
- `npm test`: 3727 passed (50 pre-existing failures in article-extract unrelated)

Fixes #1692