### PR TITLE
fix(douyin/hashtag): validate per-action required args before the API call

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9201,7 +9201,7 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "search=关键词搜索 suggest=AI推荐 hot=热点词",
+        "help": "search=关键词搜索 (--keyword 必填), suggest=AI推荐 (--cover 必填), hot=热点词 (--keyword 可选)",
         "choices": [
           "search",
           "suggest",
@@ -9213,14 +9213,14 @@
         "type": "str",
         "default": "",
         "required": false,
-        "help": "搜索关键词（search/hot 使用）"
+        "help": "搜索关键词. search 必填; hot 可选; suggest 不使用 (传 --cover)"
       },
       {
         "name": "cover",
         "type": "str",
         "default": "",
         "required": false,
-        "help": "封面 URI（suggest 使用）"
+        "help": "封面 URI (cover_uri). suggest 必填; 其它 action 不使用"
       },
       {
         "name": "limit",

--- a/clis/douyin/hashtag.js
+++ b/clis/douyin/hashtag.js
@@ -1,6 +1,23 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { browserFetch } from './_shared/browser-fetch.js';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireListField(res, field, action) {
+    if (!isPlainObject(res)) {
+        throw new CommandExecutionError(`douyin hashtag ${action}: API returned malformed payload`);
+    }
+    const list = res[field];
+    if (list === undefined || list === null) return [];
+    if (!Array.isArray(list)) {
+        throw new CommandExecutionError(`douyin hashtag ${action}: API returned malformed "${field}"`);
+    }
+    return list;
+}
+
 cli({
     site: 'douyin',
     name: 'hashtag',
@@ -24,11 +41,20 @@ cli({
             }
             const url = `https://creator.douyin.com/aweme/v1/challenge/search/?keyword=${encodeURIComponent(keyword)}&count=${kwargs.limit}&aid=1128`;
             const res = await browserFetch(page, 'GET', url);
-            return (res.challenge_list ?? []).map(c => ({
-                name: c.challenge_info.cha_name,
-                id: c.challenge_info.cid,
-                view_count: c.challenge_info.view_count,
-            }));
+            const list = requireListField(res, 'challenge_list', 'search');
+            const rows = list.flatMap(c => {
+                const info = c?.challenge_info;
+                if (!isPlainObject(info)) return [];
+                return [{
+                    name: info.cha_name,
+                    id: info.cid,
+                    view_count: info.view_count,
+                }];
+            });
+            if (list.length > 0 && rows.length === 0) {
+                throw new CommandExecutionError('douyin hashtag search: API returned challenges but none had stable challenge_info shape');
+            }
+            return rows;
         }
         if (action === 'suggest') {
             const cover = String(kwargs.cover ?? '').trim();
@@ -37,23 +63,37 @@ cli({
             }
             const url = `https://creator.douyin.com/web/api/media/hashtag/rec/?cover_uri=${encodeURIComponent(cover)}&aid=1128`;
             const res = await browserFetch(page, 'GET', url);
-            return (res.hashtag_list ?? []).map(h => ({ name: h.name, id: h.id, view_count: h.view_count }));
+            const list = requireListField(res, 'hashtag_list', 'suggest');
+            return list.map(h => ({ name: h?.name ?? '', id: h?.id ?? '', view_count: h?.view_count ?? 0 }));
         }
         if (action === 'hot') {
             const kw = String(kwargs.keyword ?? '').trim();
             const url = `https://creator.douyin.com/aweme/v1/hotspot/recommend/?${kw ? `keyword=${encodeURIComponent(kw)}&` : ''}aid=1128`;
             const res = await browserFetch(page, 'GET', url);
-            const items = res.hotspot_list
-                ?? res.all_sentences?.map(h => ({
-                    sentence: h.word ?? '',
-                    hot_value: h.hot_value,
-                    sentence_id: h.sentence_id ?? '',
-                }))
-                ?? [];
+            if (!isPlainObject(res)) {
+                throw new CommandExecutionError('douyin hashtag hot: API returned malformed payload');
+            }
+            const hotspotList = res.hotspot_list;
+            const allSentences = res.all_sentences;
+            if (hotspotList !== undefined && hotspotList !== null && !Array.isArray(hotspotList)) {
+                throw new CommandExecutionError('douyin hashtag hot: API returned malformed "hotspot_list"');
+            }
+            if (allSentences !== undefined && allSentences !== null && !Array.isArray(allSentences)) {
+                throw new CommandExecutionError('douyin hashtag hot: API returned malformed "all_sentences"');
+            }
+            const items = Array.isArray(hotspotList)
+                ? hotspotList
+                : Array.isArray(allSentences)
+                    ? allSentences.map(h => ({
+                        sentence: h?.word ?? '',
+                        hot_value: h?.hot_value,
+                        sentence_id: h?.sentence_id ?? '',
+                    }))
+                    : [];
             return items.slice(0, kwargs.limit).map(h => ({
-                name: h.sentence,
-                id: 'sentence_id' in h ? h.sentence_id : '',
-                view_count: h.hot_value,
+                name: h?.sentence ?? '',
+                id: h && 'sentence_id' in h ? h.sentence_id : '',
+                view_count: h?.hot_value ?? 0,
             }));
         }
         throw new ArgumentError(`未知的 action: ${action}`);

--- a/clis/douyin/hashtag.js
+++ b/clis/douyin/hashtag.js
@@ -18,6 +18,23 @@ function requireListField(res, field, action) {
     return list;
 }
 
+function validateHashtagArgs(kwargs) {
+    const action = kwargs.action;
+    if (action === 'search') {
+        const keyword = String(kwargs.keyword ?? '').trim();
+        if (!keyword) {
+            throw new ArgumentError('douyin hashtag search 需要 --keyword <关键词>', '示例: opencli douyin hashtag search --keyword 美食');
+        }
+        return;
+    }
+    if (action === 'suggest') {
+        const cover = String(kwargs.cover ?? '').trim();
+        if (!cover) {
+            throw new ArgumentError('douyin hashtag suggest 需要 --cover <cover_uri>', 'suggest 基于已上传的视频封面做 AI 推荐, 不是关键词搜索. 关键词搜索请用 `douyin hashtag search --keyword <词>`.');
+        }
+    }
+}
+
 cli({
     site: 'douyin',
     name: 'hashtag',
@@ -32,13 +49,12 @@ cli({
         { name: 'limit', type: 'int', default: 10 },
     ],
     columns: ['name', 'id', 'view_count'],
+    validateArgs: validateHashtagArgs,
     func: async (page, kwargs) => {
+        validateHashtagArgs(kwargs);
         const action = kwargs.action;
         if (action === 'search') {
             const keyword = String(kwargs.keyword ?? '').trim();
-            if (!keyword) {
-                throw new ArgumentError('douyin hashtag search 需要 --keyword <关键词>', '示例: opencli douyin hashtag search --keyword 美食');
-            }
             const url = `https://creator.douyin.com/aweme/v1/challenge/search/?keyword=${encodeURIComponent(keyword)}&count=${kwargs.limit}&aid=1128`;
             const res = await browserFetch(page, 'GET', url);
             const list = requireListField(res, 'challenge_list', 'search');
@@ -58,9 +74,6 @@ cli({
         }
         if (action === 'suggest') {
             const cover = String(kwargs.cover ?? '').trim();
-            if (!cover) {
-                throw new ArgumentError('douyin hashtag suggest 需要 --cover <cover_uri>', 'suggest 基于已上传的视频封面做 AI 推荐, 不是关键词搜索. 关键词搜索请用 `douyin hashtag search --keyword <词>`.');
-            }
             const url = `https://creator.douyin.com/web/api/media/hashtag/rec/?cover_uri=${encodeURIComponent(cover)}&aid=1128`;
             const res = await browserFetch(page, 'GET', url);
             const list = requireListField(res, 'hashtag_list', 'suggest');

--- a/clis/douyin/hashtag.js
+++ b/clis/douyin/hashtag.js
@@ -9,16 +9,20 @@ cli({
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'action', required: true, positional: true, choices: ['search', 'suggest', 'hot'], help: 'search=关键词搜索 suggest=AI推荐 hot=热点词' },
-        { name: 'keyword', default: '', help: '搜索关键词（search/hot 使用）' },
-        { name: 'cover', default: '', help: '封面 URI（suggest 使用）' },
+        { name: 'action', required: true, positional: true, choices: ['search', 'suggest', 'hot'], help: 'search=关键词搜索 (--keyword 必填), suggest=AI推荐 (--cover 必填), hot=热点词 (--keyword 可选)' },
+        { name: 'keyword', default: '', help: '搜索关键词. search 必填; hot 可选; suggest 不使用 (传 --cover)' },
+        { name: 'cover', default: '', help: '封面 URI (cover_uri). suggest 必填; 其它 action 不使用' },
         { name: 'limit', type: 'int', default: 10 },
     ],
     columns: ['name', 'id', 'view_count'],
     func: async (page, kwargs) => {
         const action = kwargs.action;
         if (action === 'search') {
-            const url = `https://creator.douyin.com/aweme/v1/challenge/search/?keyword=${encodeURIComponent(kwargs.keyword)}&count=${kwargs.limit}&aid=1128`;
+            const keyword = String(kwargs.keyword ?? '').trim();
+            if (!keyword) {
+                throw new ArgumentError('douyin hashtag search 需要 --keyword <关键词>', '示例: opencli douyin hashtag search --keyword 美食');
+            }
+            const url = `https://creator.douyin.com/aweme/v1/challenge/search/?keyword=${encodeURIComponent(keyword)}&count=${kwargs.limit}&aid=1128`;
             const res = await browserFetch(page, 'GET', url);
             return (res.challenge_list ?? []).map(c => ({
                 name: c.challenge_info.cha_name,
@@ -27,12 +31,16 @@ cli({
             }));
         }
         if (action === 'suggest') {
-            const url = `https://creator.douyin.com/web/api/media/hashtag/rec/?cover_uri=${encodeURIComponent(kwargs.cover)}&aid=1128`;
+            const cover = String(kwargs.cover ?? '').trim();
+            if (!cover) {
+                throw new ArgumentError('douyin hashtag suggest 需要 --cover <cover_uri>', 'suggest 基于已上传的视频封面做 AI 推荐, 不是关键词搜索. 关键词搜索请用 `douyin hashtag search --keyword <词>`.');
+            }
+            const url = `https://creator.douyin.com/web/api/media/hashtag/rec/?cover_uri=${encodeURIComponent(cover)}&aid=1128`;
             const res = await browserFetch(page, 'GET', url);
             return (res.hashtag_list ?? []).map(h => ({ name: h.name, id: h.id, view_count: h.view_count }));
         }
         if (action === 'hot') {
-            const kw = kwargs.keyword;
+            const kw = String(kwargs.keyword ?? '').trim();
             const url = `https://creator.douyin.com/aweme/v1/hotspot/recommend/?${kw ? `keyword=${encodeURIComponent(kw)}&` : ''}aid=1128`;
             const res = await browserFetch(page, 'GET', url);
             const items = res.hotspot_list

--- a/clis/douyin/hashtag.test.js
+++ b/clis/douyin/hashtag.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 const { browserFetchMock } = vi.hoisted(() => ({
     browserFetchMock: vi.fn(),
 }));
@@ -87,6 +87,48 @@ describe('douyin hashtag', () => {
         const url = browserFetchMock.mock.calls[0][2];
         expect(url).toContain('hashtag/rec');
         expect(url).toContain('cover_uri=' + encodeURIComponent('tos-cn-i-cover/abc'));
+    });
+
+    it('search throws CommandExecutionError when API returns a non-object payload', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce(null);
+        await expect(cmd.func({}, { action: 'search', keyword: '美食', cover: '', limit: 10 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('search throws CommandExecutionError when challenge_list has wrong shape', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({ challenge_list: 'not-an-array' });
+        await expect(cmd.func({}, { action: 'search', keyword: '美食', cover: '', limit: 10 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('search throws CommandExecutionError when challenges return but none parse', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({
+            challenge_list: [{ challenge_info: null }, { other_field: 1 }],
+        });
+        await expect(cmd.func({}, { action: 'search', keyword: '美食', cover: '', limit: 10 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('suggest throws CommandExecutionError when hashtag_list has wrong shape', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({ hashtag_list: 'oops' });
+        await expect(cmd.func({}, { action: 'suggest', keyword: '', cover: 'tos-cn-i-cover/x', limit: 10 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('hot throws CommandExecutionError when hotspot_list has wrong shape', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({ hotspot_list: { malformed: true } });
+        await expect(cmd.func({}, { action: 'hot', keyword: '', cover: '', limit: 5 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('parses the current hotspot recommendation shape', async () => {

--- a/clis/douyin/hashtag.test.js
+++ b/clis/douyin/hashtag.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
 const { browserFetchMock } = vi.hoisted(() => ({
     browserFetchMock: vi.fn(),
 }));
@@ -31,6 +32,63 @@ describe('douyin hashtag', () => {
         const cmd = [...registry.values()].find(c => c.site === 'douyin' && c.name === 'hashtag');
         expect(cmd?.strategy).toBe('cookie');
     });
+    it('search throws ArgumentError when --keyword is missing or blank (#1689)', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        await expect(cmd.func({}, { action: 'search', keyword: '', cover: '', limit: 10 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func({}, { action: 'search', keyword: '   ', cover: '', limit: 10 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(browserFetchMock).not.toHaveBeenCalled();
+    });
+
+    it('suggest throws ArgumentError when --cover is missing (#1689 root cause)', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        await expect(cmd.func({}, { action: 'suggest', keyword: '速效救心丸', cover: '', limit: 10 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--cover') });
+        await expect(cmd.func({}, { action: 'suggest', keyword: '', cover: '   ', limit: 10 }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(browserFetchMock).not.toHaveBeenCalled();
+    });
+
+    it('hot accepts empty --keyword (it is optional for hot)', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({ hotspot_list: [{ sentence: '热点1', hot_value: 100, sentence_id: 'h1' }] });
+        const rows = await cmd.func({}, { action: 'hot', keyword: '', cover: '', limit: 5 });
+        expect(rows[0]).toEqual({ name: '热点1', id: 'h1', view_count: 100 });
+        const url = browserFetchMock.mock.calls[0][2];
+        expect(url).not.toContain('keyword=');
+    });
+
+    it('search threads --keyword + count into the challenge/search URL', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({
+            challenge_list: [{ challenge_info: { cha_name: '美食', cid: '123', view_count: 5000 } }],
+        });
+        const rows = await cmd.func({}, { action: 'search', keyword: '美食', cover: '', limit: 10 });
+        expect(rows).toEqual([{ name: '美食', id: '123', view_count: 5000 }]);
+        const url = browserFetchMock.mock.calls[0][2];
+        expect(url).toContain('challenge/search');
+        expect(url).toContain('keyword=' + encodeURIComponent('美食'));
+        expect(url).toContain('count=10');
+    });
+
+    it('suggest threads --cover into the hashtag/rec URL on success', async () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        browserFetchMock.mockResolvedValueOnce({
+            hashtag_list: [{ name: '推荐话题', id: 'h99', view_count: 1234 }],
+        });
+        const rows = await cmd.func({}, { action: 'suggest', keyword: '', cover: 'tos-cn-i-cover/abc', limit: 10 });
+        expect(rows).toEqual([{ name: '推荐话题', id: 'h99', view_count: 1234 }]);
+        const url = browserFetchMock.mock.calls[0][2];
+        expect(url).toContain('hashtag/rec');
+        expect(url).toContain('cover_uri=' + encodeURIComponent('tos-cn-i-cover/abc'));
+    });
+
     it('parses the current hotspot recommendation shape', async () => {
         const registry = getRegistry();
         const command = [...registry.values()].find((cmd) => cmd.site === 'douyin' && cmd.name === 'hashtag');

--- a/clis/douyin/hashtag.test.js
+++ b/clis/douyin/hashtag.test.js
@@ -32,6 +32,19 @@ describe('douyin hashtag', () => {
         const cmd = [...registry.values()].find(c => c.site === 'douyin' && c.name === 'hashtag');
         expect(cmd?.strategy).toBe('cookie');
     });
+    it('registers action-specific validation so missing args fail before browser pre-navigation', () => {
+        const registry = getRegistry();
+        const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');
+        expect(cmd?.validateArgs).toBeTypeOf('function');
+        expect(() => cmd.validateArgs({ action: 'search', keyword: '', cover: '', limit: 10 }))
+            .toThrow(ArgumentError);
+        expect(() => cmd.validateArgs({ action: 'suggest', keyword: '速效救心丸', cover: '', limit: 10 }))
+            .toThrow(ArgumentError);
+        expect(() => cmd.validateArgs({ action: 'hot', keyword: '', cover: '', limit: 10 }))
+            .not.toThrow();
+        expect(browserFetchMock).not.toHaveBeenCalled();
+    });
+
     it('search throws ArgumentError when --keyword is missing or blank (#1689)', async () => {
         const registry = getRegistry();
         const cmd = [...registry.values()].find((c) => c.site === 'douyin' && c.name === 'hashtag');

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -102,6 +102,19 @@ describe('cli() registration', () => {
     expect(getRegistry().get('test-registry/plain-default')?.defaultFormat).toBe('plain');
   });
 
+  it('preserves validateArgs on the registered command', () => {
+    const validateArgs = () => undefined;
+    const cmd = cli({
+      site: 'test-registry',
+      name: 'validated', access: 'read',
+      description: 'validates args before execution',
+      validateArgs,
+    });
+
+    expect(cmd.validateArgs).toBe(validateArgs);
+    expect(getRegistry().get('test-registry/validated')?.validateArgs).toBe(validateArgs);
+  });
+
   it('rejects commands without explicit access metadata', () => {
     expect(() => cli({
       site: 'test-registry',

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -135,6 +135,7 @@ export function cli(opts: CliOptions): CliCommand {
     func: opts.func,
     pipeline: opts.pipeline,
     footerExtra: opts.footerExtra,
+    validateArgs: opts.validateArgs,
     navigateBefore: opts.navigateBefore,
     siteSession: opts.siteSession,
     defaultFormat: opts.defaultFormat,


### PR DESCRIPTION
Closes #1689.

## Description

Reporter @alexcc4 ran:

```bash
opencli douyin hashtag suggest --keyword 速效救心丸
```

which the previous code happily forwarded to:

```
GET creator.douyin.com/web/api/media/hashtag/rec/?cover_uri=&aid=1128
```

with an empty `cover_uri`, because the `suggest` action reads `kwargs.cover` (not `kwargs.keyword`) and there was no upfront validation. The Douyin server rejected the empty `cover_uri` with API error `5` (`参数不合法`), which surfaces to the user as an opaque server-side error rather than the obvious adapter-side mismatch.

## Fix

Validate each action's required args up front and throw `ArgumentError` with a concrete hint pointing the user at the right action / flag combination:

- `search` requires `--keyword` (hint includes an example command)
- `suggest` requires `--cover` (explains it operates on an uploaded video cover, not a keyword; redirects keyword-search users to `hashtag search --keyword <词>`)
- `hot` still accepts an empty `--keyword` (it is optional for `hot`)

Also tightened the per-arg `help` strings so the per-action requirements are obvious from `--help` output without reading source.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New site command
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Live verification

Reporter's exact failing command now surfaces a clean, actionable error before any network call:

```bash
$ node ./dist/src/main.js douyin hashtag suggest --keyword 速效救心丸
ok: false
error:
  code: ARGUMENT
  message: douyin hashtag suggest 需要 --cover <cover_uri>
  help: suggest 基于已上传的视频封面做 AI 推荐, 不是关键词搜索.
        关键词搜索请用 `douyin hashtag search --keyword <词>`.
  exitCode: 2
```

Zero network calls on the invalid invocation (verified that the helpful hint, not the upstream `参数不合法`, is what the user sees).

## Test plan

- [x] `npm run build`: manifest compiles
- [x] `npm run check:typed-error-lint`: passes (`current=145, baseline=145, new=0, resolved=0`)
- [x] `npm run check:silent-column-drop`: passes
- [x] `npx vitest run --project adapter clis/douyin/hashtag.test.js`: 9 tests passing (5 new for the validation branches + URL shape assertions for search / suggest / hot)
- [x] Live: reporter's failing command surfaces the new ArgumentError with a redirect hint to the correct action

## Out of scope

- The reporter's underlying intent (keyword-based hashtag search for "速效救心丸") is what `douyin hashtag search` covers; this PR is only about removing the confusing per-action arg mismatch. The `search` action still needs a logged-in creator.douyin.com session, which is the standard COOKIE-strategy expectation.
