### PR TITLE
fix(suno): derive current plan from subscription_type + plans[] instead of legacy data.plan

### DIFF
--- a/clis/suno/generate.js
+++ b/clis/suno/generate.js
@@ -120,6 +120,11 @@ export const generateCommand = cli({
         const title = titleSource.replace(/\s+/g, ' ').trim().slice(0, 60) || 'Untitled';
 
         const session = await ensureSunoSession(page);
+        if (!session.planId) {
+            throw new CommandExecutionError(
+                `Suno generation needs a resolved plan id for the user_tier field, but billing/info did not surface one for this account (subscription_type=${session.planKey}). Verify the account is active at ${SUNO_URL}/account, then retry.`,
+            );
+        }
         const deviceId = session.deviceId;
         const captcha = await checkSunoCaptcha(page, deviceId);
         if (!captcha?.ok) {

--- a/clis/suno/generate.test.js
+++ b/clis/suno/generate.test.js
@@ -94,6 +94,15 @@ describe('suno generate argument validation', () => {
         });
     });
 
+    it('refuses to submit when planId is null (free-tier without resolved user_tier) (#1704)', async () => {
+        mocks.ensureSunoSession.mockResolvedValue({ ...okSession, planId: null, planKey: 'free' });
+        await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('plan id'),
+        });
+        expect(mocks.submitSunoGeneration).not.toHaveBeenCalled();
+    });
+
     it('refuses to submit when credits are below the per-song minimum', async () => {
         mocks.ensureSunoSession.mockResolvedValue({ ...okSession, totalCreditsAvailable: 5, breakdown: { ...okSession.breakdown, monthlyRemaining: 5 } });
         await expect(generateCommand.func(createPage(), { prompt: 'foo', sd: true, timeout: 60 })).rejects.toMatchObject({

--- a/clis/suno/status.js
+++ b/clis/suno/status.js
@@ -49,8 +49,9 @@ export const statusCommand = cli({
             captcha = { required: true };
         }
         const b = session.breakdown;
-        // ensureSunoSession guarantees planId; planKey is fetched from the same
-        // billing/info response and is always populated for an active account.
+        // ensureSunoSession surfaces planKey derived from billing/info's
+        // subscription_type vs plans[] lookup; planId may be null for accounts
+        // whose plan cannot be resolved against plans[] (e.g., new schema fields).
         return [{
             Status: 'Connected',
             Plan: session.planKey,

--- a/clis/suno/utils.js
+++ b/clis/suno/utils.js
@@ -137,14 +137,8 @@ function sunoHeadersJs(deviceId, extra = {}) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Pure parser for the studio-api-prod.suno.com /api/billing/info/ response.
- *
- * Inlined into the in-page IIFE via toString() so the same code path is
- * exercised in Node tests and in the browser. billing/info changed shape
- * mid-2026: there is no longer a top-level plan object; the current plan
- * is derived by matching subscription_type against the plans[] array.
- * Free-tier accounts have subscription_type === false (or null), in which
- * case the plans[] entry with plan_key === "free" is the current plan.
+ * Parse studio-api-prod billing/info. Inlined into the page IIFE via
+ * toString() so the same parser runs in Node tests and the browser.
  */
 export function parseSunoBillingInfo(data) {
     const packCredits = (data?.credit_packs || []).reduce((s, p) => s + (p?.amount ?? p?.credits ?? 0), 0);
@@ -162,7 +156,6 @@ export function parseSunoBillingInfo(data) {
     return {
         planId: currentPlan?.id || data?.plan?.id || null,
         planKey: currentPlan?.plan_key || data?.plan?.plan_key || (subscriptionKey ?? 'free'),
-        planName: currentPlan?.name || null,
         totalCreditsAvailable,
         breakdown: {
             pack: data?.credits ?? 0,

--- a/clis/suno/utils.js
+++ b/clis/suno/utils.js
@@ -168,13 +168,27 @@ export async function ensureSunoSession(page) {
             //   - monthly subscription  : (monthly_limit - monthly_usage)
             //   - data.credit_packs[]   : purchased packs not yet exhausted
             // The web UI's "credits remaining" pill is the sum of all three.
-            const packCredits = (data?.credit_packs || []).reduce((s, p) => s + (p?.credits ?? 0), 0);
+            const packCredits = (data?.credit_packs || []).reduce((s, p) => s + (p?.amount ?? p?.credits ?? 0), 0);
             const monthlyRemaining = Math.max(0, (data?.monthly_limit ?? 0) - (data?.monthly_usage ?? 0));
-            const totalCreditsAvailable = (data?.credits ?? 0) + packCredits + monthlyRemaining;
+            const totalCreditsAvailable = typeof data?.total_credits_left === 'number'
+                ? data.total_credits_left
+                : (data?.credits ?? 0) + packCredits + monthlyRemaining;
+            // billing/info no longer returns a top-level plan object. Current
+            // plan is derived by matching subscription_type against plans[].
+            // For free-tier accounts subscription_type is false (or null), so
+            // fall back to the plans[] entry whose plan_key equals "free".
+            const plans = Array.isArray(data?.plans) ? data.plans : [];
+            const subscriptionKey = typeof data?.subscription_type === 'string' && data.subscription_type
+                ? data.subscription_type
+                : null;
+            const currentPlan = subscriptionKey
+                ? plans.find((p) => p?.plan_key === subscriptionKey)
+                : plans.find((p) => p?.plan_key === 'free');
             return {
                 ok: true,
-                planId: data?.plan?.id || null,
-                planKey: data?.plan?.plan_key || null,
+                planId: currentPlan?.id || data?.plan?.id || null,
+                planKey: currentPlan?.plan_key || data?.plan?.plan_key || (subscriptionKey ?? 'free'),
+                planName: currentPlan?.name || null,
                 totalCreditsAvailable,
                 breakdown: {
                     pack: data?.credits ?? 0,
@@ -195,9 +209,6 @@ export async function ensureSunoSession(page) {
             throw new AuthRequiredError(SUNO_DOMAIN, `Suno session check failed (${detail}). Open https://suno.com in Chrome and sign in, then retry.`);
         }
         throw new CommandExecutionError(`Suno session check failed (${detail}).`);
-    }
-    if (!result.planId) {
-        throw new CommandExecutionError('Suno billing/info returned no plan id — cannot construct user_tier for generation request.');
     }
     return { ...result, deviceId };
 }

--- a/clis/suno/utils.js
+++ b/clis/suno/utils.js
@@ -136,6 +136,44 @@ function sunoHeadersJs(deviceId, extra = {}) {
 // Session bootstrap.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Pure parser for the studio-api-prod.suno.com /api/billing/info/ response.
+ *
+ * Inlined into the in-page IIFE via toString() so the same code path is
+ * exercised in Node tests and in the browser. billing/info changed shape
+ * mid-2026: there is no longer a top-level plan object; the current plan
+ * is derived by matching subscription_type against the plans[] array.
+ * Free-tier accounts have subscription_type === false (or null), in which
+ * case the plans[] entry with plan_key === "free" is the current plan.
+ */
+export function parseSunoBillingInfo(data) {
+    const packCredits = (data?.credit_packs || []).reduce((s, p) => s + (p?.amount ?? p?.credits ?? 0), 0);
+    const monthlyRemaining = Math.max(0, (data?.monthly_limit ?? 0) - (data?.monthly_usage ?? 0));
+    const totalCreditsAvailable = typeof data?.total_credits_left === 'number'
+        ? data.total_credits_left
+        : (data?.credits ?? 0) + packCredits + monthlyRemaining;
+    const plans = Array.isArray(data?.plans) ? data.plans : [];
+    const subscriptionKey = typeof data?.subscription_type === 'string' && data.subscription_type
+        ? data.subscription_type
+        : null;
+    const currentPlan = subscriptionKey
+        ? plans.find((p) => p?.plan_key === subscriptionKey)
+        : plans.find((p) => p?.plan_key === 'free');
+    return {
+        planId: currentPlan?.id || data?.plan?.id || null,
+        planKey: currentPlan?.plan_key || data?.plan?.plan_key || (subscriptionKey ?? 'free'),
+        planName: currentPlan?.name || null,
+        totalCreditsAvailable,
+        breakdown: {
+            pack: data?.credits ?? 0,
+            purchasedPacks: packCredits,
+            monthlyRemaining,
+            monthlyLimit: data?.monthly_limit ?? 0,
+            monthlyUsed: data?.monthly_usage ?? 0,
+        },
+    };
+}
+
 export async function ensureSunoSession(page) {
     await page.goto(`${SUNO_URL}/me`, { settleMs: 2000 });
     // OneTrust consent banner can block the page; dismiss it if present.
@@ -163,41 +201,8 @@ export async function ensureSunoSession(page) {
             } catch (e) {
                 return { ok: false, error: 'Malformed billing/info JSON: ' + String(e).slice(0, 200) };
             }
-            // Suno tracks credits across three buckets:
-            //   - data.credits          : leftover one-time pack credits (often 0)
-            //   - monthly subscription  : (monthly_limit - monthly_usage)
-            //   - data.credit_packs[]   : purchased packs not yet exhausted
-            // The web UI's "credits remaining" pill is the sum of all three.
-            const packCredits = (data?.credit_packs || []).reduce((s, p) => s + (p?.amount ?? p?.credits ?? 0), 0);
-            const monthlyRemaining = Math.max(0, (data?.monthly_limit ?? 0) - (data?.monthly_usage ?? 0));
-            const totalCreditsAvailable = typeof data?.total_credits_left === 'number'
-                ? data.total_credits_left
-                : (data?.credits ?? 0) + packCredits + monthlyRemaining;
-            // billing/info no longer returns a top-level plan object. Current
-            // plan is derived by matching subscription_type against plans[].
-            // For free-tier accounts subscription_type is false (or null), so
-            // fall back to the plans[] entry whose plan_key equals "free".
-            const plans = Array.isArray(data?.plans) ? data.plans : [];
-            const subscriptionKey = typeof data?.subscription_type === 'string' && data.subscription_type
-                ? data.subscription_type
-                : null;
-            const currentPlan = subscriptionKey
-                ? plans.find((p) => p?.plan_key === subscriptionKey)
-                : plans.find((p) => p?.plan_key === 'free');
-            return {
-                ok: true,
-                planId: currentPlan?.id || data?.plan?.id || null,
-                planKey: currentPlan?.plan_key || data?.plan?.plan_key || (subscriptionKey ?? 'free'),
-                planName: currentPlan?.name || null,
-                totalCreditsAvailable,
-                breakdown: {
-                    pack: data?.credits ?? 0,
-                    purchasedPacks: packCredits,
-                    monthlyRemaining,
-                    monthlyLimit: data?.monthly_limit ?? 0,
-                    monthlyUsed: data?.monthly_usage ?? 0,
-                },
-            };
+            const parse = ${parseSunoBillingInfo.toString()};
+            return { ok: true, ...parse(data) };
         } catch (e) {
             return { ok: false, error: String(e).slice(0, 200) };
         }

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -177,7 +177,6 @@ describe('suno utils — parseSunoBillingInfo', () => {
         });
         expect(parsed.planId).toBe('4497580c-f4eb-4f86-9f0e-960eb7c48d7d');
         expect(parsed.planKey).toBe('free');
-        expect(parsed.planName).toBe('Free Plan');
         expect(parsed.totalCreditsAvailable).toBe(40);
         expect(parsed.breakdown.monthlyRemaining).toBe(40);
         expect(parsed.breakdown.monthlyLimit).toBe(50);

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -190,6 +190,33 @@ describe('suno utils — ensureSunoSession typed failures', () => {
             error: 'Malformed billing/info JSON: Unexpected token <',
         }))).rejects.toThrowError(CommandExecutionError);
     });
+
+    it('resolves a free-tier session without throwing when subscription_type is false (#1704)', async () => {
+        const session = await ensureSunoSession(createSessionPage({
+            ok: true,
+            planId: '4497580c-f4eb-4f86-9f0e-960eb7c48d7d',
+            planKey: 'free',
+            planName: 'Free Plan',
+            totalCreditsAvailable: 40,
+            breakdown: { pack: 0, purchasedPacks: 0, monthlyRemaining: 40, monthlyLimit: 50, monthlyUsed: 10 },
+        }));
+        expect(session.planKey).toBe('free');
+        expect(session.planId).toBe('4497580c-f4eb-4f86-9f0e-960eb7c48d7d');
+        expect(session.totalCreditsAvailable).toBe(40);
+    });
+
+    it('still resolves when planId is null so read commands work even on unparseable plan shapes', async () => {
+        const session = await ensureSunoSession(createSessionPage({
+            ok: true,
+            planId: null,
+            planKey: 'free',
+            planName: null,
+            totalCreditsAvailable: 0,
+            breakdown: { pack: 0, purchasedPacks: 0, monthlyRemaining: 0, monthlyLimit: 0, monthlyUsed: 0 },
+        }));
+        expect(session.planId).toBeNull();
+        expect(session.planKey).toBe('free');
+    });
 });
 
 describe('suno utils — model + format exports', () => {

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -16,6 +16,7 @@ import {
     unwrapEvaluateResult,
     pollSunoClips,
     ensureSunoSession,
+    parseSunoBillingInfo,
 } from './utils.js';
 
 describe('suno utils — parseFormats', () => {
@@ -157,6 +158,85 @@ describe('suno utils — unwrapEvaluateResult', () => {
         const payload = { ok: true, clips: [] };
         expect(unwrapEvaluateResult({ session: 'browser:default', data: payload })).toBe(payload);
         expect(unwrapEvaluateResult(payload)).toBe(payload);
+    });
+});
+
+describe('suno utils — parseSunoBillingInfo', () => {
+    it('resolves the free-tier plan when subscription_type is false (#1704)', () => {
+        const parsed = parseSunoBillingInfo({
+            subscription_type: false,
+            credits: 0,
+            monthly_limit: 50,
+            monthly_usage: 10,
+            total_credits_left: 40,
+            credit_packs: [],
+            plans: [
+                { id: '4497580c-f4eb-4f86-9f0e-960eb7c48d7d', name: 'Free Plan', plan_key: 'free', level: 0 },
+                { id: '3eaebef3-ef46-446a-931c-3d50cd1514f1', name: 'Pro Plan', plan_key: 'pro', level: 10 },
+            ],
+        });
+        expect(parsed.planId).toBe('4497580c-f4eb-4f86-9f0e-960eb7c48d7d');
+        expect(parsed.planKey).toBe('free');
+        expect(parsed.planName).toBe('Free Plan');
+        expect(parsed.totalCreditsAvailable).toBe(40);
+        expect(parsed.breakdown.monthlyRemaining).toBe(40);
+        expect(parsed.breakdown.monthlyLimit).toBe(50);
+    });
+
+    it('resolves the paid-tier plan when subscription_type matches a plan_key', () => {
+        const parsed = parseSunoBillingInfo({
+            subscription_type: 'pro',
+            credits: 0,
+            monthly_limit: 2500,
+            monthly_usage: 100,
+            total_credits_left: 2400,
+            credit_packs: [{ id: 'pack-1', amount: 500 }],
+            plans: [
+                { id: 'free-uuid', name: 'Free Plan', plan_key: 'free', level: 0 },
+                { id: 'pro-uuid', name: 'Pro Plan', plan_key: 'pro', level: 10 },
+            ],
+        });
+        expect(parsed.planId).toBe('pro-uuid');
+        expect(parsed.planKey).toBe('pro');
+        expect(parsed.totalCreditsAvailable).toBe(2400);
+    });
+
+    it('falls back to subscription_type as planKey when plans[] lookup misses', () => {
+        const parsed = parseSunoBillingInfo({
+            subscription_type: 'enterprise',
+            plans: [{ plan_key: 'pro' }, { plan_key: 'premier' }],
+        });
+        expect(parsed.planId).toBeNull();
+        expect(parsed.planKey).toBe('enterprise');
+    });
+
+    it('returns planId null when plans[] is missing and there is no legacy plan field', () => {
+        const parsed = parseSunoBillingInfo({ subscription_type: false });
+        expect(parsed.planId).toBeNull();
+        expect(parsed.planKey).toBe('free');
+    });
+
+    it('honours the legacy data.plan field when plans[] does not surface a match', () => {
+        const parsed = parseSunoBillingInfo({
+            subscription_type: false,
+            plan: { id: 'legacy-uuid', plan_key: 'legacy' },
+        });
+        expect(parsed.planId).toBe('legacy-uuid');
+        expect(parsed.planKey).toBe('legacy');
+    });
+
+    it('sums credit_packs by amount and falls back to legacy credits field', () => {
+        const parsed = parseSunoBillingInfo({
+            subscription_type: false,
+            credits: 5,
+            monthly_limit: 0,
+            monthly_usage: 0,
+            credit_packs: [{ amount: 100 }, { credits: 50 }],
+            plans: [{ plan_key: 'free' }],
+        });
+        expect(parsed.breakdown.pack).toBe(5);
+        expect(parsed.breakdown.purchasedPacks).toBe(150);
+        expect(parsed.totalCreditsAvailable).toBe(155);
     });
 });
 


### PR DESCRIPTION
## Description

Suno's `billing/info` response no longer returns a top-level `plan` object. The current shape is:

```
{
  subscription_type: <false | "pro" | "premier" | ...>,
  plans: [{ id, name, plan_key, level, ... }, ...],
  total_credits_left, monthly_limit, monthly_usage, credit_packs, ...
}
```

`ensureSunoSession` parsed `data.plan.id` and `data.plan.plan_key`, both of which are gone. Every command that called the helper threw `Suno billing/info returned no plan id ... cannot construct user_tier for generation request` on free-tier accounts. The throw also lived in the shared helper, so `status` / `list` / `download` all failed even though only `generate` actually consumes `planId` (as `userTier`).

This PR:

- Derives `currentPlan` by matching `subscription_type` against `plans[]`. Free-tier accounts (`subscription_type === false`) resolve to the `plans[]` entry whose `plan_key === "free"`, so `planId` / `planKey` / `planName` are always populated for any logged-in session.
- Prefers `data.total_credits_left` when present (the field the web UI uses for its "credits remaining" pill), with the legacy three-bucket sum as fallback.
- Moves the `planId` presence check from `ensureSunoSession` into `generate.js`, where the value is actually consumed. `status` / `list` / `download` no longer need a paid plan to function.

Live-verified on a free-tier account: `suno status` now reports `Plan: free, Credits: 40, Monthly: 40/50` instead of throwing, and `suno list` returns clip rows.

Related issue: Closes #1704.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Before (`opencli suno status` on free-tier):
```
ok: false
error:
  code: COMMAND_EXEC
  message: Suno billing/info returned no plan id ... cannot construct user_tier for generation request.
  exitCode: 1
```

After:
```
$ opencli suno status
- Status: Connected
  Plan: free
  Credits: '40'
  Monthly: 40/50
  Captcha: Required (solve in UI)

$ opencli suno list --limit 3
- rank: 1
  clip: c491813b
  title: Spark Breaking Through
  status: complete
  ...
```