### PR TITLE
fix(browser): scope evaluateWithArgs declarations in an IIFE

### DIFF
--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -122,6 +122,43 @@ describe('BasePage.fetchJson', () => {
   });
 });
 
+describe('BasePage.evaluateWithArgs', () => {
+  class RealEvalPage extends BasePage {
+    scripts: string[] = [];
+    async goto(): Promise<void> {}
+    async evaluate<T = unknown>(_js: string): Promise<T>;
+    async evaluate<Args extends unknown[], T>(_fn: BrowserEvaluateFunction<Args, T>, ..._args: Args): Promise<Awaited<T>>;
+    async evaluate(input: string | BrowserEvaluateFunction<unknown[], unknown>): Promise<unknown> {
+      this.scripts.push(typeof input === 'string' ? input : input.toString());
+      return null;
+    }
+    async getCookies(): Promise<[]> { return []; }
+    async screenshot(): Promise<string> { return ''; }
+    async tabs(): Promise<unknown[]> { return []; }
+    async selectTab(): Promise<void> {}
+  }
+
+  it('wraps declarations and body in an IIFE so const bindings are block-scoped', async () => {
+    const page = new RealEvalPage();
+    await page.evaluateWithArgs('(() => ({ ok: true }))()', { markerAttr: 'data-x', markerValue: 'v1' });
+    expect(page.scripts).toHaveLength(1);
+    const script = page.scripts[0];
+    // Declarations must live inside an IIFE so a second call into the same
+    // Runtime.evaluate context does not throw "Identifier 'markerAttr' has
+    // already been declared".
+    expect(script.startsWith('(() => {')).toBe(true);
+    expect(script.endsWith('})()')).toBe(true);
+    expect(script).toContain('const markerAttr = "data-x";');
+    expect(script).toContain('const markerValue = "v1";');
+    expect(script).toContain('return ((() => ({ ok: true }))());');
+  });
+
+  it('rejects keys that are not valid JS identifiers', async () => {
+    const page = new RealEvalPage();
+    await expect(page.evaluateWithArgs('(() => 1)()', { 'bad-key': 1 })).rejects.toThrow(/invalid key/);
+  });
+});
+
 describe('BasePage annotatedScreenshot', () => {
   it('refreshes DOM refs, captures with a temporary visual overlay, and cleans up', async () => {
     const page = new ActionPage();

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -154,6 +154,12 @@ export abstract class BasePage implements IPage {
    * Each key in `args` becomes a `const` declaration with JSON-serialized value,
    * prepended to the JS code. Prevents injection by design.
    *
+   * The declarations and the caller-provided expression are wrapped in an IIFE
+   * so the `const` bindings are block-scoped. Without the wrapper, the bindings
+   * land in the script's top-level realm and the second call into the same
+   * Runtime.evaluate context throws `SyntaxError: Identifier '<key>' has already
+   * been declared` (the `markerAttr` regression hit by `browser upload`).
+   *
    * Usage:
    *   page.evaluateWithArgs(`(async () => { return sym; })()`, { sym: userInput })
    */
@@ -166,7 +172,7 @@ export abstract class BasePage implements IPage {
         return `const ${key} = ${JSON.stringify(value)};`;
       })
       .join('\n');
-    return this.evaluate(`${declarations}\n${js}`);
+    return this.evaluate(`(() => { ${declarations}\nreturn (${js}); })()`);
   }
 
   async fetchJson(url: string, opts: FetchJsonOptions = {}): Promise<unknown> {


### PR DESCRIPTION
## Bug

`opencli browser <session> upload <ref> <file>` throws on the **second**
invocation against the same page:

```
✖  SyntaxError: Identifier 'markerAttr' has already been declared
```

Reloading the page does not clear the error — the same execution context is reused.

### Minimal repro

```sh
opencli browser s open https://www.w3schools.com/howto/howto_html_file_upload_button.asp
opencli browser s wait selector "input[type=file]"
opencli browser s find --css "input[type=file]"   # note the ref, e.g. 1
opencli browser s upload 1 /tmp/any.png           # works (or fails with not_file_input)
opencli browser s upload 1 /tmp/any.png           # SyntaxError: 'markerAttr' has already been declared
```

## Root cause

`BasePage.uploadFiles` calls `evaluateWithArgs` with `{ markerAttr, markerValue }`.
`evaluateWithArgs` (`src/browser/base-page.ts:160-170`) emits:

```js
const markerAttr = "data-opencli-upload-target";
const markerValue = "...";
(() => { ... el.setAttribute(markerAttr, markerValue); ... })()
```

`wrapForEval` correctly classifies this as a "bare expression" and sends it as-is to
`Runtime.evaluate`. The `const` declarations land at script top level. With the bridge
reusing the same execution context, the second call hits a duplicate-binding
`SyntaxError`. Same applies to every other `evaluateWithArgs` callsite that uses fixed
keys — `upload` just happens to be the easiest to trip because it always reuses
`markerAttr` / `markerValue`.

## Fix

Wrap the declarations and the caller-supplied expression in an IIFE so the bindings
are block-scoped. `wrapForEval` already recognizes this shape as already-IIFE and
forwards it unchanged. The body is parenthesized and `return`ed so Promise return
values are preserved (CDP awaits via `awaitPromise: true`).

```diff
- return this.evaluate(`${declarations}\n${js}`);
+ return this.evaluate(`(() => { ${declarations}\nreturn (${js}); })()`);
```

## Verification

- New unit test `BasePage.evaluateWithArgs > wraps declarations and body in an IIFE …`
  asserts the emitted script is IIFE-wrapped and `return`s the inner expression.
- `npx vitest run --project unit` → **1139 passed**, 1 skipped.
- `npm run typecheck` → clean.
- End-to-end against a real page: two consecutive `browser upload` calls on the same
  session no longer throw the `markerAttr` `SyntaxError`. (Whatever underlying
  `DOM.setFileInputFiles` permission errors a page may still surface are independent
  of this fix.)

## Notes

- All current `evaluateWithArgs` callsites pass an expression (`(() => …)()` or
  `(async () => …)()`), so the `return (${js});` wrapper is safe for every caller.
- The JSDoc on `evaluateWithArgs` is updated to call out the IIFE requirement so future
  refactors don't silently regress it.