### PR TITLE
test(download): retry media-download Windows tests to absorb runner cold-start variance

### DIFF
--- a/src/download/media-download.test.ts
+++ b/src/download/media-download.test.ts
@@ -31,7 +31,11 @@ async function startServer(handler: http.RequestListener): Promise<string> {
   return `http://127.0.0.1:${address.port}`;
 }
 
-describe('media downloads', () => {
+// Mirrors src/download/index.test.ts: Windows runners occasionally exceed the
+// default 5s timeout on the first network test (cold-start cost of the
+// http.createServer + downloadMedia pipeline on a loaded GitHub Actions VM,
+// observed on CI run 26217100578).
+describe('media downloads', { retry: process.platform === 'win32' ? 2 : 0 }, () => {
   it('keeps custom filenames inside the output directory', async () => {
     const baseUrl = await startServer((_req, res) => {
       res.statusCode = 200;

--- a/src/download/media-download.test.ts
+++ b/src/download/media-download.test.ts
@@ -31,10 +31,8 @@ async function startServer(handler: http.RequestListener): Promise<string> {
   return `http://127.0.0.1:${address.port}`;
 }
 
-// Mirrors src/download/index.test.ts: Windows runners occasionally exceed the
-// default 5s timeout on the first network test (cold-start cost of the
-// http.createServer + downloadMedia pipeline on a loaded GitHub Actions VM,
-// observed on CI run 26217100578).
+// Windows runners occasionally exceed the default 5s timeout on the first
+// http.createServer + downloadMedia roundtrip (cold-start cost on a loaded VM).
 describe('media downloads', { retry: process.platform === 'win32' ? 2 : 0 }, () => {
   it('keeps custom filenames inside the output directory', async () => {
     const baseUrl = await startServer((_req, res) => {


### PR DESCRIPTION
## Description

CI run [26217100578](https://github.com/jackwener/OpenCLI/actions/runs/26217100578) (Windows shard 2/2 on commit `d4640b24`) failed with `src/download/media-download.test.ts > 'keeps custom filenames inside the output directory'` timing out at the default 5000ms.

The other two tests in the same `describe` block completed in ~417ms and ~156ms on the same run, so the failure is cold-start cost of the first `http.createServer` + `downloadMedia` roundtrip on a loaded GitHub Actions Windows runner, not a logic regression. The 14 previous main commits in the last 5 days passed this exact shard.

Adopt the same `{ retry: process.platform === 'win32' ? 2 : 0 }` describe option that `src/download/index.test.ts:36` already uses for the same class of Windows-only network/IO flake (the sibling's comment cites Windows Defender locking .tmp files; the underlying cause class is shared).

Related issue: (none)

## Type of Change

- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

CI failure summary (Windows shard 2/2, run 26217100578):
```
src/download/media-download.test.ts > media downloads
  keeps custom filenames inside the output directory  FAILED  21908ms (timed out at 5000ms)
  strips nested and absolute path components from custom filenames  passed  417ms
  falls back to generated names for empty dot-directory filenames  passed  156ms

 Test Files  1 failed | 38 passed (39)
      Tests  1 failed | 419 passed | 3 skipped (423)
```

Local re-run after the fix (3 tests pass under the new retry option):
```
$ npx vitest run src/download/media-download.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  200ms
```