### PR TITLE
fix(weread): use same-origin web API instead of i.weread.qq.com private API

### DIFF
--- a/clis/weread/book.js
+++ b/clis/weread/book.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
-import { fetchPrivateApi, fetchWebApi, resolveShelfReader, WEREAD_UA, WEREAD_WEB_ORIGIN, } from './utils.js';
+import { fetchWebApiWithCookies, fetchWebApi, resolveShelfReader, WEREAD_UA, WEREAD_WEB_ORIGIN, } from './utils.js';
 function decodeHtmlText(value) {
     return value
         .replace(/<[^>]+>/g, '')
@@ -191,7 +191,7 @@ cli({
     func: async (page, args) => {
         const bookId = String(args['book-id'] || '').trim();
         try {
-            const data = await fetchPrivateApi(page, '/book/info', { bookId });
+            const data = await fetchWebApiWithCookies(page, '/book/info', { bookId });
             // newRating is 0-1000 scale per community docs; needs runtime verification
             const rating = data.newRating ? `${(data.newRating / 10).toFixed(1)}%` : '-';
             return [{

--- a/clis/weread/highlights.js
+++ b/clis/weread/highlights.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchPrivateApi, formatDate } from './utils.js';
+import { fetchWebApiWithCookies, formatDate } from './utils.js';
 cli({
     site: 'weread',
     name: 'highlights',
@@ -13,7 +13,7 @@ cli({
     ],
     columns: ['chapter', 'text', 'createTime'],
     func: async (page, args) => {
-        const data = await fetchPrivateApi(page, '/book/bookmarklist', { bookId: args['book-id'] });
+        const data = await fetchWebApiWithCookies(page, '/book/bookmarklist', { bookId: args['book-id'] });
         const items = data?.updated ?? [];
         return items.slice(0, Number(args.limit)).map((item) => ({
             chapter: item.chapterName ?? '',

--- a/clis/weread/notebooks.js
+++ b/clis/weread/notebooks.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchWebApiWithCookies } from './utils.js';
+import { fetchPrivateApi } from './utils.js';
 cli({
     site: 'weread',
     name: 'notebooks',
@@ -9,7 +9,7 @@ cli({
     strategy: Strategy.COOKIE,
     columns: ['title', 'author', 'noteCount', 'bookId'],
     func: async (page, _args) => {
-        const data = await fetchWebApiWithCookies(page, '/user/notebooks');
+        const data = await fetchPrivateApi(page, '/user/notebooks');
         const books = data?.books ?? [];
         return books.map((item) => ({
             title: item.book?.title ?? '',

--- a/clis/weread/notebooks.js
+++ b/clis/weread/notebooks.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchPrivateApi } from './utils.js';
+import { fetchWebApiWithCookies } from './utils.js';
 cli({
     site: 'weread',
     name: 'notebooks',
@@ -9,7 +9,7 @@ cli({
     strategy: Strategy.COOKIE,
     columns: ['title', 'author', 'noteCount', 'bookId'],
     func: async (page, _args) => {
-        const data = await fetchPrivateApi(page, '/user/notebooks');
+        const data = await fetchWebApiWithCookies(page, '/user/notebooks');
         const books = data?.books ?? [];
         return books.map((item) => ({
             title: item.book?.title ?? '',

--- a/clis/weread/notes.js
+++ b/clis/weread/notes.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchPrivateApi, formatDate } from './utils.js';
+import { fetchWebApiWithCookies, formatDate } from './utils.js';
 cli({
     site: 'weread',
     name: 'notes',
@@ -13,7 +13,7 @@ cli({
     ],
     columns: ['chapter', 'text', 'review', 'createTime'],
     func: async (page, args) => {
-        const data = await fetchPrivateApi(page, '/review/list', {
+        const data = await fetchWebApiWithCookies(page, '/review/list', {
             bookId: args['book-id'],
             listType: '11',
             mine: '1',

--- a/clis/weread/shelf.js
+++ b/clis/weread/shelf.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
 import { log } from '@jackwener/opencli/logger';
-import { buildWebShelfEntries, fetchPrivateApi, loadWebShelfSnapshot, } from './utils.js';
+import { buildWebShelfEntries, fetchWebApiWithCookies, loadWebShelfSnapshot, } from './utils.js';
 function normalizeShelfLimit(limit) {
     if (!Number.isFinite(limit))
         return 0;
@@ -46,7 +46,7 @@ cli({
         if (limit <= 0)
             return [];
         try {
-            const data = await fetchPrivateApi(page, '/shelf/sync', { synckey: '0', lectureSynckey: '0' });
+            const data = await fetchWebApiWithCookies(page, '/shelf/sync', { synckey: '0', lectureSynckey: '0' });
             return normalizePrivateApiRows(data, limit);
         }
         catch (error) {

--- a/clis/weread/utils.js
+++ b/clis/weread/utils.js
@@ -98,6 +98,60 @@ function buildShelfSnapshotPollScript(storageKeys, requireTrustedIndexes) {
   `;
 }
 /**
+ * Fetch a WeRead web endpoint with cookies extracted from the browser.
+ * Uses the same-origin web API (weread.qq.com/web/*) which correctly receives
+ * auth cookies, unlike the cross-subdomain i.weread.qq.com private API.
+ */
+export async function fetchWebApiWithCookies(page, path, params) {
+    const url = new URL(`${WEB_API}${path}`);
+    if (params) {
+        for (const [k, v] of Object.entries(params))
+            url.searchParams.set(k, v);
+    }
+    const urlStr = url.toString();
+    const [apiCookies, domainCookies] = await Promise.all([
+        page.getCookies({ url: urlStr }),
+        page.getCookies({ domain: WEREAD_DOMAIN }),
+    ]);
+    const merged = new Map();
+    for (const c of domainCookies)
+        merged.set(c.name, c);
+    for (const c of apiCookies)
+        merged.set(c.name, c);
+    const cookieHeader = buildCookieHeader(Array.from(merged.values()));
+    let resp;
+    try {
+        resp = await fetch(urlStr, {
+            headers: {
+                'User-Agent': WEREAD_UA,
+                'Origin': 'https://weread.qq.com',
+                'Referer': 'https://weread.qq.com/',
+                ...(cookieHeader ? { 'Cookie': cookieHeader } : {}),
+            },
+        });
+    }
+    catch (error) {
+        throw new CliError('FETCH_ERROR', `Failed to fetch ${path}: ${error instanceof Error ? error.message : String(error)}`, 'WeRead API may be temporarily unavailable');
+    }
+    let data;
+    try {
+        data = await resp.json();
+    }
+    catch {
+        throw new CliError('PARSE_ERROR', `Invalid JSON response for ${path}`, 'WeRead may have returned an HTML error page');
+    }
+    if (isAuthErrorResponse(resp, data)) {
+        throw new CliError('AUTH_REQUIRED', 'Not logged in to WeRead', 'Please log in to weread.qq.com in Chrome first');
+    }
+    if (!resp.ok) {
+        throw new CliError('FETCH_ERROR', `HTTP ${resp.status} for ${path}`, 'WeRead API may be temporarily unavailable');
+    }
+    if (data?.errcode != null && data.errcode !== 0) {
+        throw new CliError('API_ERROR', data.errmsg ?? `WeRead API error ${data.errcode}`);
+    }
+    return data;
+}
+/**
  * Fetch a public WeRead web endpoint (Node.js direct fetch).
  * Used by search and ranking commands (browser: false).
  */


### PR DESCRIPTION
## Summary

- Add `fetchWebApiWithCookies()` to `utils.js` — same-origin GET with cookies to `weread.qq.com/web/*`
- Migrate `book`, `highlights`, `notes`, `shelf` from `fetchPrivateApi` (hits `i.weread.qq.com`) to `fetchWebApiWithCookies`
- Root cause: `wr_skey` is a host-only cookie on `weread.qq.com`, never sent to subdomain `i.weread.qq.com`

## Problem

All commands using `fetchPrivateApi` fail with `AUTH_REQUIRED` even when the user is logged in:

```
$ opencli weread book 855812
error: AUTH_REQUIRED — Not logged in to WeRead
```

Verified the browser itself cannot authenticate to `i.weread.qq.com`:
```js
// Same-origin — works
fetch('https://weread.qq.com/web/book/info?bookId=855812', {credentials:'include'})
// → {title: "人类简史", ...}

// Cross-subdomain — fails
fetch('https://i.weread.qq.com/book/info?bookId=855812', {credentials:'include'})
// → {errcode: -2012}
```

## Why `ai-outline` was unaffected

`ai-outline.js` already uses its own `postWebApiWithCookies()` hitting `weread.qq.com/web/book/chapterInfos` (same-origin), which correctly receives cookies.

## Not fixed: `notebooks`

`/user/notebooks` only exists on `i.weread.qq.com` — there is no `/web/user/notebooks` equivalent (returns 404). This command cannot be fixed with the same-origin approach and remains affected.

## Local verification

All migrated commands tested successfully after patching:
- ✅ `opencli weread book 855812` — returns full metadata
- ✅ `opencli weread shelf` — returns shelf without fallback warning  
- ✅ `opencli weread highlights 855812` — returns highlights
- ✅ `opencli weread notes 855812` — returns notes

Fixes #1709