### PR TITLE
fix(twitter): handle CDP Not-allowed error, fix files property redefinition, add reply button wait

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { isRecoverableFileInputError } from './utils.js';
 
 const MAX_IMAGES = 4;
 const UPLOAD_POLL_MS = 500;
@@ -142,6 +143,55 @@ async function waitForImageUpload(page, expectedCount) {
     })()`);
 }
 
+async function attachImagesViaDataTransfer(page, absPaths) {
+    const files = absPaths.map((absPath) => {
+        const ext = path.extname(absPath).toLowerCase();
+        const mime = ext === '.png'
+            ? 'image/png'
+            : ext === '.gif'
+                ? 'image/gif'
+                : ext === '.webp'
+                    ? 'image/webp'
+                    : 'image/jpeg';
+        return {
+            name: path.basename(absPath),
+            mime,
+            base64: fs.readFileSync(absPath).toString('base64'),
+        };
+    });
+    const upload = await page.evaluate(`(() => {
+        const input = document.querySelector(${JSON.stringify(FILE_INPUT_SELECTOR)});
+        if (!input) return { ok: false, error: 'No file input found' };
+        const dt = new DataTransfer();
+        for (const file of ${JSON.stringify(files)}) {
+            const bin = atob(file.base64);
+            const bytes = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+            dt.items.add(new File([bytes], file.name, { type: file.mime }));
+        }
+        let assigned = false;
+        try {
+            Object.defineProperty(input, 'files', { value: dt.files, writable: false, configurable: true });
+            assigned = input.files && input.files.length >= ${JSON.stringify(absPaths.length)};
+        } catch(e) {
+            try {
+                const nativeInputFileSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files');
+                if (nativeInputFileSetter && nativeInputFileSetter.set) {
+                    nativeInputFileSetter.set.call(input, dt.files);
+                    assigned = input.files && input.files.length >= ${JSON.stringify(absPaths.length)};
+                }
+            } catch(e2) { /* ignore */ }
+        }
+        if (!assigned) return { ok: false, error: 'Could not assign files to input' };
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        return { ok: true };
+    })()`);
+    if (!upload?.ok) {
+        throw new CommandExecutionError(`Image upload failed (base64 fallback): ${upload?.error ?? 'unknown error'}`);
+    }
+}
+
 async function submitTweet(page, text) {
     const clickResult = await page.evaluate(`(async () => {
         try {
@@ -224,41 +274,18 @@ cli({
         // Attach media before inserting text. Uploading media after Draft.js has
         // text can re-render/reset the editor, causing image-only posts.
         if (absPaths.length > 0) {
-            if (!page.setFileInput) {
-                throw new CommandExecutionError('Browser extension does not support file upload. Please update the extension.');
-            }
             await page.wait({ selector: FILE_INPUT_SELECTOR, timeout: 20 });
-            try {
-                await page.setFileInput(absPaths, FILE_INPUT_SELECTOR);
-            } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed')) {
-                    throw err;
+            if (page.setFileInput) {
+                try {
+                    await page.setFileInput(absPaths, FILE_INPUT_SELECTOR);
+                } catch (err) {
+                    if (!isRecoverableFileInputError(err)) {
+                        throw err;
+                    }
+                    await attachImagesViaDataTransfer(page, absPaths);
                 }
-                // CDP setFileInput rejected — fall back to base64 DataTransfer shim
-                const fs2 = await import('node:fs');
-                const path2 = await import('node:path');
-                for (const absPath of absPaths) {
-                    const ext = path2.default.extname(absPath).toLowerCase();
-                    const mime = ext === '.png' ? 'image/png' : ext === '.gif' ? 'image/gif' : ext === '.webp' ? 'image/webp' : 'image/jpeg';
-                    const b64 = fs2.default.readFileSync(absPath).toString('base64');
-                    const fname = path2.default.basename(absPath);
-                    const up = await page.evaluate(`(() => {
-                        const input = document.querySelector(${JSON.stringify(FILE_INPUT_SELECTOR)});
-                        if (!input) return { ok: false, error: 'No file input found' };
-                        const bin = atob(${JSON.stringify(b64)});
-                        const bytes = new Uint8Array(bin.length);
-                        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-                        const dt = new DataTransfer();
-                        dt.items.add(new File([bytes], ${JSON.stringify(fname)}, { type: ${JSON.stringify(mime)} }));
-                        try { Object.defineProperty(input, 'files', { value: dt.files, writable: false, configurable: true }); } catch(e) { try { const s = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files'); if (s && s.set) s.set.call(input, dt.files); } catch(e2) {} }
-                        input.dispatchEvent(new Event('change', { bubbles: true }));
-                        input.dispatchEvent(new Event('input', { bubbles: true }));
-                        return { ok: true };
-                    })()`);
-                    if (!up?.ok) throw new Error('Image upload failed (base64 fallback): ' + (up?.error ?? 'unknown'));
-                    await page.wait(1);
-                }
+            } else {
+                await attachImagesViaDataTransfer(page, absPaths);
             }
             const uploadState = await waitForImageUpload(page, absPaths.length);
             if (!uploadState?.ok) {

--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -228,7 +228,38 @@ cli({
                 throw new CommandExecutionError('Browser extension does not support file upload. Please update the extension.');
             }
             await page.wait({ selector: FILE_INPUT_SELECTOR, timeout: 20 });
-            await page.setFileInput(absPaths, FILE_INPUT_SELECTOR);
+            try {
+                await page.setFileInput(absPaths, FILE_INPUT_SELECTOR);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed')) {
+                    throw err;
+                }
+                // CDP setFileInput rejected — fall back to base64 DataTransfer shim
+                const fs2 = await import('node:fs');
+                const path2 = await import('node:path');
+                for (const absPath of absPaths) {
+                    const ext = path2.default.extname(absPath).toLowerCase();
+                    const mime = ext === '.png' ? 'image/png' : ext === '.gif' ? 'image/gif' : ext === '.webp' ? 'image/webp' : 'image/jpeg';
+                    const b64 = fs2.default.readFileSync(absPath).toString('base64');
+                    const fname = path2.default.basename(absPath);
+                    const up = await page.evaluate(`(() => {
+                        const input = document.querySelector(${JSON.stringify(FILE_INPUT_SELECTOR)});
+                        if (!input) return { ok: false, error: 'No file input found' };
+                        const bin = atob(${JSON.stringify(b64)});
+                        const bytes = new Uint8Array(bin.length);
+                        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+                        const dt = new DataTransfer();
+                        dt.items.add(new File([bytes], ${JSON.stringify(fname)}, { type: ${JSON.stringify(mime)} }));
+                        try { Object.defineProperty(input, 'files', { value: dt.files, writable: false, configurable: true }); } catch(e) { try { const s = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files'); if (s && s.set) s.set.call(input, dt.files); } catch(e2) {} }
+                        input.dispatchEvent(new Event('change', { bubbles: true }));
+                        input.dispatchEvent(new Event('input', { bubbles: true }));
+                        return { ok: true };
+                    })()`);
+                    if (!up?.ok) throw new Error('Image upload failed (base64 fallback): ' + (up?.error ?? 'unknown'));
+                    await page.wait(1);
+                }
+            }
             const uploadState = await waitForImageUpload(page, absPaths.length);
             if (!uploadState?.ok) {
                 return [{ status: 'failed', message: uploadState?.message ?? `Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).`, text }];

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -11,6 +11,7 @@ vi.mock('node:fs', async (importOriginal) => {
                 return undefined;
             return { isFile: () => true };
         }),
+        readFileSync: vi.fn(() => Buffer.from([0x89, 0x50, 0x4e, 0x47])),
     };
 });
 
@@ -123,10 +124,41 @@ describe('twitter post command', () => {
         await expect(command.func(page, { text: 'hi', images: 'photo.bmp' })).rejects.toThrow('Unsupported image format');
     });
 
-    it('throws when page.setFileInput is not available', async () => {
+    it('falls back to DataTransfer upload when page.setFileInput is not available', async () => {
         const command = getCommand();
-        const page = makePage([], { setFileInput: undefined });
-        await expect(command.func(page, { text: 'hi', images: 'a.png' })).rejects.toThrow('Browser extension does not support file upload');
+        const page = makePage([
+            { ok: true }, // DataTransfer fallback
+            { ok: true, previewCount: 1 }, // upload polling
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ], { setFileInput: undefined });
+
+        const result = await command.func(page, { text: 'hi', images: 'a.png' });
+
+        expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'hi' }]);
+        expect(page.evaluate.mock.calls[0][0]).toContain('new DataTransfer()');
+        expect(page.evaluate.mock.calls[0][0]).toContain('Could not assign files to input');
+    });
+
+    it('falls back to DataTransfer upload when CDP rejects file input as not allowed', async () => {
+        const command = getCommand();
+        const setFileInput = vi.fn().mockRejectedValue(new Error('NotAllowedError: Not allowed'));
+        const page = makePage([
+            { ok: true }, // DataTransfer fallback
+            { ok: true, previewCount: 1 }, // upload polling
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ], { setFileInput });
+
+        const result = await command.func(page, { text: 'with fallback', images: 'a.png' });
+
+        expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'with fallback' }]);
+        expect(setFileInput).toHaveBeenCalledWith(['/abs/a.png'], 'input[type="file"][data-testid="fileInput"]');
+        expect(page.evaluate.mock.calls[0][0]).toContain('new DataTransfer()');
     });
 
     it('uploads images before inserting text so media re-renders cannot erase the tweet text', async () => {

--- a/clis/twitter/quote.js
+++ b/clis/twitter/quote.js
@@ -62,10 +62,15 @@ async function submitQuote(page, text, tweetId) {
                 return { ok: false, message: 'Quote target did not render in the composer. The source tweet may be deleted or restricted.' };
             }
 
-            const buttons = Array.from(
-                document.querySelectorAll('[data-testid="tweetButton"], [data-testid="tweetButtonInline"]')
-            );
-            const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
+            let btn = null;
+            for (let i = 0; i < 30; i++) {
+                const buttons = Array.from(
+                    document.querySelectorAll('[data-testid="tweetButton"], [data-testid="tweetButtonInline"]')
+                );
+                btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
+                if (btn) break;
+                await new Promise(r => setTimeout(r, 500));
+            }
             if (!btn) {
                 return { ok: false, message: 'Tweet button is disabled or not found.' };
             }

--- a/clis/twitter/reply.js
+++ b/clis/twitter/reply.js
@@ -222,6 +222,17 @@ cli({
             if (localImagePath) {
                 await page.wait({ selector: COMPOSER_FILE_INPUT_SELECTOR, timeout: 20 });
                 await attachComposerImage(page, localImagePath);
+                // Wait for X to finish uploading the image to its servers
+                // (button stays disabled while upload is in progress)
+                await page.evaluate(`(async () => {
+                    const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+                    for (let i = 0; i < 60; i++) {
+                        await new Promise(r => setTimeout(r, 1000));
+                        const btns = Array.from(document.querySelectorAll('[data-testid="tweetButton"],[data-testid="tweetButtonInline"]'));
+                        const ready = btns.find(el => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
+                        if (ready) return;
+                    }
+                })()`);
             }
             const result = await submitReply(page, kwargs.text);
             return [{

--- a/clis/twitter/reply.js
+++ b/clis/twitter/reply.js
@@ -90,19 +90,22 @@ async function insertReplyText(page, text) {
 }
 
 async function clickReplyButton(page) {
-    return page.evaluate(`(() => {
+    const iterations = Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS);
+    return page.evaluate(`(async () => {
       try {
           const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
-          const buttons = Array.from(
-              document.querySelectorAll('[data-testid="tweetButton"], [data-testid="tweetButtonInline"]')
-          );
-          const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
-          if (!btn) {
-              return { ok: false, message: 'Reply button is disabled or not found.' };
+          for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
+              const buttons = Array.from(
+                  document.querySelectorAll('[data-testid="tweetButton"], [data-testid="tweetButtonInline"]')
+              );
+              const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
+              if (btn) {
+                  btn.click();
+                  return { ok: true };
+              }
+              await new Promise(r => setTimeout(r, ${JSON.stringify(SUBMIT_POLL_MS)}));
           }
-
-          btn.click();
-          return { ok: true };
+          return { ok: false, message: 'Reply button is disabled or not found.' };
       } catch (e) {
           return { ok: false, message: e.toString() };
       }
@@ -222,17 +225,6 @@ cli({
             if (localImagePath) {
                 await page.wait({ selector: COMPOSER_FILE_INPUT_SELECTOR, timeout: 20 });
                 await attachComposerImage(page, localImagePath);
-                // Wait for X to finish uploading the image to its servers
-                // (button stays disabled while upload is in progress)
-                await page.evaluate(`(async () => {
-                    const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
-                    for (let i = 0; i < 60; i++) {
-                        await new Promise(r => setTimeout(r, 1000));
-                        const btns = Array.from(document.querySelectorAll('[data-testid="tweetButton"],[data-testid="tweetButtonInline"]'));
-                        const ready = btns.find(el => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
-                        if (ready) return;
-                    }
-                })()`);
             }
             const result = await submitReply(page, kwargs.text);
             return [{

--- a/clis/twitter/reply.test.js
+++ b/clis/twitter/reply.test.js
@@ -193,4 +193,22 @@ describe('twitter image helpers (utils.js)', () => {
         expect(utilsTest.resolveImageExtension('https://example.com/no-ext', 'image/webp')).toBe('.webp');
         expect(utilsTest.resolveImageExtension('https://example.com/a.jpeg?x=1', null)).toBe('.jpeg');
     });
+
+    it('classifies CDP NotAllowed file-input failures as recoverable', () => {
+        expect(utilsTest.isRecoverableFileInputError(new Error('NotAllowedError: Not allowed'))).toBe(true);
+        expect(utilsTest.isRecoverableFileInputError(new Error('ProtocolError: not-allowed'))).toBe(true);
+        expect(utilsTest.isRecoverableFileInputError(new Error('Permission denied'))).toBe(false);
+    });
+
+    it('fails closed when a composer image preview never appears', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-twitter-helper-'));
+        const imagePath = path.join(tempDir, 'missing-preview.png');
+        fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+        const page = createPageMock([{ ok: false, message: 'Image upload timed out (30s).' }], {
+            setFileInput: vi.fn().mockResolvedValue(undefined),
+        });
+
+        await expect(utilsTest.attachComposerImage(page, imagePath)).rejects.toThrow('Image upload timed out');
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
 });

--- a/clis/twitter/reply.test.js
+++ b/clis/twitter/reply.test.js
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
@@ -210,5 +211,27 @@ describe('twitter image helpers (utils.js)', () => {
 
         await expect(utilsTest.attachComposerImage(page, imagePath)).rejects.toThrow('Image upload timed out');
         fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('does not treat an empty attachments container as uploaded media', async () => {
+        const runMediaReadyProbe = async (html) => {
+            const dom = new JSDOM(`<!doctype html><body>${html}</body>`, {
+                url: 'https://x.com/compose/post',
+                runScripts: 'outside-only',
+            });
+            dom.window.setTimeout = (callback) => {
+                callback();
+                return 0;
+            };
+            const page = {
+                evaluate: vi.fn(async (script) => dom.window.eval(script)),
+            };
+            return utilsTest.waitForComposerMediaReady(page, 1);
+        };
+
+        await expect(runMediaReadyProbe('<div data-testid="attachments"></div>'))
+            .resolves.toMatchObject({ ok: false });
+        await expect(runMediaReadyProbe('<div data-testid="attachments"><img src="blob:https://x.com/1"></div>'))
+            .resolves.toMatchObject({ ok: true, previewCount: 1 });
     });
 });

--- a/clis/twitter/utils.js
+++ b/clis/twitter/utils.js
@@ -19,6 +19,8 @@ export const SUPPORTED_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gi
 
 /** 20 MB hard cap. Twitter allows ~5MB images / 15MB GIFs; 20MB is a safety net. */
 export const MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024;
+const MEDIA_UPLOAD_POLL_MS = 500;
+const MEDIA_UPLOAD_TIMEOUT_MS = 30_000;
 
 const CONTENT_TYPE_TO_EXTENSION = {
     'image/jpeg': '.jpg',
@@ -133,7 +135,7 @@ export async function attachComposerImage(page, absImagePath, fileInputSelector 
             uploaded = true;
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed')) {
+            if (!isRecoverableFileInputError(msg)) {
                 throw new Error(`Image upload failed: ${msg}`);
             }
             // setFileInput not supported by extension — fall through to base64 fallback.
@@ -167,17 +169,21 @@ export async function attachComposerImage(page, absImagePath, fileInputSelector 
         const blob = new Blob([bytes], { type: ${JSON.stringify(mimeType)} });
         dt.items.add(new File([blob], ${JSON.stringify(path.basename(absImagePath))}, { type: ${JSON.stringify(mimeType)} }));
 
+        let assigned = false;
         try {
           Object.defineProperty(input, 'files', { value: dt.files, writable: false, configurable: true });
+          assigned = input.files && input.files.length > 0;
         } catch(e) {
           // files property not redefinable — use nativeInputValueSetter trick
           try {
             const nativeInputFileSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files');
             if (nativeInputFileSetter && nativeInputFileSetter.set) {
               nativeInputFileSetter.set.call(input, dt.files);
+              assigned = input.files && input.files.length > 0;
             }
           } catch(e2) { /* ignore */ }
         }
+        if (!assigned) return { ok: false, error: 'Could not assign files to input' };
         input.dispatchEvent(new Event('change', { bubbles: true }));
         input.dispatchEvent(new Event('input', { bubbles: true }));
         return { ok: true };
@@ -187,27 +193,42 @@ export async function attachComposerImage(page, absImagePath, fileInputSelector 
             throw new Error(`Image upload failed: ${upload?.error ?? 'unknown error'}`);
         }
     }
-    await page.wait(2);
-    const uploadState = await page.evaluate(`
-    (() => {
-      const previewCount = document.querySelectorAll(
-        '[data-testid="attachments"] img, [data-testid="attachments"] video, [data-testid="tweetPhoto"]'
-      ).length;
-      const hasMedia = previewCount > 0
-        || !!document.querySelector('[data-testid="attachments"]')
-        || !!Array.from(document.querySelectorAll('button,[role="button"]')).find((el) =>
+    const uploadState = await waitForComposerMediaReady(page, 1);
+    if (!uploadState?.ok) {
+        throw new Error(uploadState?.message ?? 'Image upload failed: preview did not appear.');
+    }
+}
+
+export function isRecoverableFileInputError(error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return /unknown action|not supported|not[-\s]?allowed|notallowederror/i.test(msg);
+}
+
+export async function waitForComposerMediaReady(page, expectedCount = 1) {
+    const iterations = Math.ceil(MEDIA_UPLOAD_TIMEOUT_MS / MEDIA_UPLOAD_POLL_MS);
+    return page.evaluate(`
+    (async () => {
+      const expected = ${JSON.stringify(expectedCount)};
+      for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
+        await new Promise(r => setTimeout(r, ${JSON.stringify(MEDIA_UPLOAD_POLL_MS)}));
+        const previewCount = document.querySelectorAll(
+          '[data-testid="attachments"] img, [data-testid="attachments"] video, [data-testid="tweetPhoto"]'
+        ).length;
+        const blobCount = document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length;
+        const removeButtonCount = Array.from(document.querySelectorAll('button,[role="button"]')).filter((el) =>
           /remove media|remove image|remove|编辑/i.test((el.getAttribute('aria-label') || '') + ' ' + (el.textContent || ''))
-        )
-        || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0
-        || !!document.querySelector('[data-testid="media-upload-preview"]')
-        || !!document.querySelector('[data-testid="card.layoutLarge.media"]');
-      return { ok: hasMedia, previewCount };
+        ).length;
+        const hasMedia = previewCount >= expected
+          || !!document.querySelector('[data-testid="attachments"]')
+          || removeButtonCount >= expected
+          || blobCount >= expected
+          || !!document.querySelector('[data-testid="media-upload-preview"]')
+          || !!document.querySelector('[data-testid="card.layoutLarge.media"]');
+        if (hasMedia) return { ok: true, previewCount: Math.max(previewCount, blobCount, removeButtonCount) };
+      }
+      return { ok: false, message: 'Image upload timed out (${MEDIA_UPLOAD_TIMEOUT_MS / 1000}s).' };
     })()
   `);
-    if (!uploadState?.ok) {
-        // Image may still be processing — log warning but do not throw
-        console.warn('[warn] Image preview not detected, proceeding anyway.');
-    }
 }
 
 // ── Engagement scoring (P3) ────────────────────────────────────────────
@@ -294,6 +315,8 @@ export const __test__ = {
     resolveImageExtension,
     downloadRemoteImage,
     attachComposerImage,
+    isRecoverableFileInputError,
+    waitForComposerMediaReady,
     computeEngagementScore,
     applyTopByEngagement,
     ENGAGEMENT_WEIGHTS,

--- a/clis/twitter/utils.js
+++ b/clis/twitter/utils.js
@@ -212,19 +212,19 @@ export async function waitForComposerMediaReady(page, expectedCount = 1) {
       for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
         await new Promise(r => setTimeout(r, ${JSON.stringify(MEDIA_UPLOAD_POLL_MS)}));
         const previewCount = document.querySelectorAll(
-          '[data-testid="attachments"] img, [data-testid="attachments"] video, [data-testid="tweetPhoto"]'
+          '[data-testid="attachments"] img, [data-testid="attachments"] video, [data-testid="attachments"] [role="group"], [data-testid="tweetPhoto"]'
         ).length;
         const blobCount = document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length;
         const removeButtonCount = Array.from(document.querySelectorAll('button,[role="button"]')).filter((el) =>
           /remove media|remove image|remove|编辑/i.test((el.getAttribute('aria-label') || '') + ' ' + (el.textContent || ''))
         ).length;
-        const hasMedia = previewCount >= expected
-          || !!document.querySelector('[data-testid="attachments"]')
-          || removeButtonCount >= expected
-          || blobCount >= expected
-          || !!document.querySelector('[data-testid="media-upload-preview"]')
-          || !!document.querySelector('[data-testid="card.layoutLarge.media"]');
-        if (hasMedia) return { ok: true, previewCount: Math.max(previewCount, blobCount, removeButtonCount) };
+        const explicitPreviewCount = Math.max(
+          previewCount,
+          blobCount,
+          removeButtonCount,
+          document.querySelectorAll('[data-testid="media-upload-preview"], [data-testid="card.layoutLarge.media"]').length
+        );
+        if (explicitPreviewCount >= expected) return { ok: true, previewCount: explicitPreviewCount };
       }
       return { ok: false, message: 'Image upload timed out (${MEDIA_UPLOAD_TIMEOUT_MS / 1000}s).' };
     })()

--- a/clis/twitter/utils.js
+++ b/clis/twitter/utils.js
@@ -133,7 +133,7 @@ export async function attachComposerImage(page, absImagePath, fileInputSelector 
             uploaded = true;
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            if (!msg.includes('Unknown action') && !msg.includes('not supported')) {
+            if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed')) {
                 throw new Error(`Image upload failed: ${msg}`);
             }
             // setFileInput not supported by extension — fall through to base64 fallback.
@@ -167,7 +167,17 @@ export async function attachComposerImage(page, absImagePath, fileInputSelector 
         const blob = new Blob([bytes], { type: ${JSON.stringify(mimeType)} });
         dt.items.add(new File([blob], ${JSON.stringify(path.basename(absImagePath))}, { type: ${JSON.stringify(mimeType)} }));
 
-        Object.defineProperty(input, 'files', { value: dt.files, writable: false });
+        try {
+          Object.defineProperty(input, 'files', { value: dt.files, writable: false, configurable: true });
+        } catch(e) {
+          // files property not redefinable — use nativeInputValueSetter trick
+          try {
+            const nativeInputFileSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files');
+            if (nativeInputFileSetter && nativeInputFileSetter.set) {
+              nativeInputFileSetter.set.call(input, dt.files);
+            }
+          } catch(e2) { /* ignore */ }
+        }
         input.dispatchEvent(new Event('change', { bubbles: true }));
         input.dispatchEvent(new Event('input', { bubbles: true }));
         return { ok: true };
@@ -186,13 +196,17 @@ export async function attachComposerImage(page, absImagePath, fileInputSelector 
       const hasMedia = previewCount > 0
         || !!document.querySelector('[data-testid="attachments"]')
         || !!Array.from(document.querySelectorAll('button,[role="button"]')).find((el) =>
-          /remove media|remove image|remove/i.test((el.getAttribute('aria-label') || '') + ' ' + (el.textContent || ''))
-        );
+          /remove media|remove image|remove|编辑/i.test((el.getAttribute('aria-label') || '') + ' ' + (el.textContent || ''))
+        )
+        || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0
+        || !!document.querySelector('[data-testid="media-upload-preview"]')
+        || !!document.querySelector('[data-testid="card.layoutLarge.media"]');
       return { ok: hasMedia, previewCount };
     })()
   `);
     if (!uploadState?.ok) {
-        throw new Error('Image upload failed: preview did not appear.');
+        // Image may still be processing — log warning but do not throw
+        console.warn('[warn] Image preview not detected, proceeding anyway.');
     }
 }
 


### PR DESCRIPTION
## Problem

Three bugs that prevent `twitter post --images` and `twitter reply --image` from working on macOS with certain Chrome versions.

### Bug 1 — `utils.js`: CDP `Not allowed` not handled

`setFileInput` returns `{"code":-32000,"message":"Not allowed"}` on macOS/Chrome. The fallback condition only catches `Unknown action` and `not supported`, so it throws instead of falling back to the base64 DataTransfer shim.

### Bug 2 — `utils.js`: `Cannot redefine property: files`

The base64 fallback calls `Object.defineProperty(input, "files", { writable: false })`. In the X reply composer, `files` is non-configurable, so this throws `TypeError: Cannot redefine property: files`.

### Bug 3 — `reply.js`: reply button still disabled when `submitReply` fires

After `attachComposerImage`, `submitReply` is called immediately. X keeps the reply button disabled while uploading to its servers, so the click fires on a disabled button and the reply is never submitted.

### Bug 4 — `post.js`: `setFileInput` called without try/catch

`post.js` calls `page.setFileInput` directly without error handling, unlike `utils.js` which has a try/catch. The `Not allowed` error propagates uncaught.

## Fix

**`utils.js`** (3 changes):
- Add `Not allowed` to the CDP fallback condition
- Use `configurable: true` in `Object.defineProperty` + native `HTMLInputElement.prototype.files` setter fallback
- Downgrade `uploadState` failure from `throw` to `console.warn`; add `blob:` URL and additional testid selectors to preview detection

**`post.js`** (1 change):
- Wrap `page.setFileInput` in try/catch with the same `Not allowed` fallback

**`reply.js`** (1 change):
- After `attachComposerImage`, poll until the reply button is enabled before calling `submitReply`

## Testing

Tested on: macOS 15, Chrome 136, opencli 1.8.0

All 5 changes are minimal and backward-compatible. The `Not allowed` fallback path is only triggered when CDP rejects the native file input; on systems where CDP works normally, behavior is unchanged.