### PR TITLE
Revert "fix(doctor): poll briefly for extension reconnect" (#1718)

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -177,59 +177,16 @@ describe('doctor report rendering', () => {
     ]));
   });
 
-  it('reports flapping when live check succeeds but the extension stays disconnected through the reconnect poll', async () => {
-    // Resolve every call (initial + poll iterations) to `no-extension` so the
-    // poll exhausts its budget and the final state still reports disconnected.
-    mockGetDaemonHealth.mockResolvedValue({ state: 'no-extension', status: { extensionConnected: false } });
+  it('reports flapping when live check succeeds but final status shows extension disconnected', async () => {
+    mockGetDaemonHealth.mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } });
 
-    const report = await runBrowserDoctor({ extensionPoll: { timeoutMs: 30, intervalMs: 5 } });
+    const report = await runBrowserDoctor();
 
     expect(report.daemonRunning).toBe(true);
     expect(report.extensionConnected).toBe(false);
     expect(report.extensionFlaky).toBe(true);
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('Extension connection is unstable'),
-    ]));
-  });
-
-  it('reports the extension as connected when it reconnects during the post-check poll', async () => {
-    // First read sees the daemon up but no extension yet (status snapshot
-    // races the keepalive alarm). On the next poll iteration the extension
-    // reconnects and the report should reflect the steady state, not the snapshot.
-    mockGetDaemonHealth
-      .mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } })
-      .mockResolvedValue({
-        state: 'ready',
-        status: { extensionConnected: true, extensionVersion: '1.0.15' },
-      });
-
-    const report = await runBrowserDoctor({ extensionPoll: { timeoutMs: 200, intervalMs: 5 } });
-
-    expect(report.daemonRunning).toBe(true);
-    expect(report.extensionConnected).toBe(true);
-    expect(report.extensionVersion).toBe('1.0.15');
-    expect(report.extensionFlaky).toBeFalsy();
-    expect(report.issues).not.toEqual(expect.arrayContaining([
-      expect.stringContaining('not connected'),
-    ]));
-  });
-
-  it('re-runs connectivity when the extension reconnects after the initial live check failed', async () => {
-    mockConnect.mockRejectedValueOnce(new Error('Browser Bridge extension not connected'));
-    mockGetDaemonHealth
-      .mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } })
-      .mockResolvedValue({
-        state: 'ready',
-        status: { extensionConnected: true, extensionVersion: '1.0.15' },
-      });
-
-    const report = await runBrowserDoctor({ extensionPoll: { timeoutMs: 200, intervalMs: 5 } });
-
-    expect(mockConnect).toHaveBeenCalledTimes(2);
-    expect(report.extensionConnected).toBe(true);
-    expect(report.connectivity?.ok).toBe(true);
-    expect(report.issues).not.toEqual(expect.arrayContaining([
-      expect.stringContaining('Browser connectivity test failed'),
     ]));
   });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -10,17 +10,12 @@ import { getDaemonHealth } from './browser/daemon-client.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
-import type { BrowserProfileStatus, DaemonHealth } from './browser/daemon-client.js';
+import type { BrowserProfileStatus } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
-// After connectivity finishes, the daemon may have only just come up while
-// the extension's last keepalive probe (every ~24 s) predates it. Poll briefly
-// so a transient `no-extension` state can resolve before we report it.
-const DOCTOR_EXTENSION_POLL_TIMEOUT_SECONDS = 30;
-const DOCTOR_EXTENSION_POLL_INTERVAL_MS = 1000;
 const DOCTOR_SESSION = '__doctor__';
 
 /** Parse a semver string into [major, minor, patch]. Returns null on invalid input. */
@@ -54,8 +49,6 @@ function satisfiesRange(version: string, range: string): boolean {
 export type DoctorOptions = {
   yes?: boolean;
   cliVersion?: string;
-  /** Override the post-connectivity extension reconnect poll (mainly for tests). */
-  extensionPoll?: { timeoutMs?: number; intervalMs?: number };
 };
 
 export type ConnectivityResult = {
@@ -106,49 +99,13 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   }
 }
 
-/**
- * If the initial status read shows the daemon up but the extension not yet
- * connected, give the extension's keepalive alarm time to fire one more probe.
- * Returns the latest health observed; transitions out of `no-extension` resolve
- * immediately, otherwise polls until the timeout elapses.
- */
-async function pollForExtensionReady(
-  initial: DaemonHealth,
-  opts?: { timeoutMs?: number; intervalMs?: number },
-): Promise<DaemonHealth> {
-  if (initial.state !== 'no-extension') return initial;
-  const timeoutMs = opts?.timeoutMs ?? DOCTOR_EXTENSION_POLL_TIMEOUT_SECONDS * 1000;
-  const intervalMs = opts?.intervalMs ?? DOCTOR_EXTENSION_POLL_INTERVAL_MS;
-  if (timeoutMs <= 0) return initial;
-  const deadline = Date.now() + timeoutMs;
-  let latest: DaemonHealth = initial;
-  while (Date.now() < deadline) {
-    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
-    latest = await getDaemonHealth();
-    if (latest.state !== 'no-extension') return latest;
-  }
-  return latest;
-}
-
 export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<DoctorReport> {
   // Live connectivity check is the core of doctor — it doubles as auto-start
   // (bridge.connect spawns daemon) and validates end-to-end browser bridge health.
-  let connectivity = await checkConnectivity();
+  const connectivity = await checkConnectivity();
 
   // Single status read *after* connectivity side-effects settle.
-  // If the daemon was just auto-spawned by `bridge.connect`, the extension's
-  // last keepalive probe predates the daemon and the status snapshot will
-  // briefly say `no-extension` even though a clean reconnect is moments away.
-  // Poll long enough for one more keepalive cycle (~24 s) so the report
-  // reflects the steady state, not the snapshot at t = 0.
-  const initialHealth = await getDaemonHealth();
-  const health = await pollForExtensionReady(initialHealth, opts.extensionPoll);
-  if (!connectivity.ok && initialHealth.state === 'no-extension' && health.state === 'ready') {
-    // The original live probe can time out before the extension's next
-    // keepalive. Once the poll observes a ready extension, re-run the probe so
-    // doctor reports the settled connectivity state instead of the stale race.
-    connectivity = await checkConnectivity();
-  }
+  const health = await getDaemonHealth();
   const daemonRunning = health.state !== 'stopped';
   const extensionConnected = health.state === 'ready';
   const daemonFlaky = connectivity.ok && !daemonRunning;


### PR DESCRIPTION
## Summary

Reverts PR #1718 per WAWQAQ direction.

The poll-based fix paper over the symptom — adding a 30s wait in `doctor` so the extension's keepalive (~24s) had time to fire. WAWQAQ's first-principles call: this trades UX latency for correctness without addressing the underlying cause, which is the extension's keepalive cadence after exhausting eager backoff.

The proper direction is to fix the **extension's reconnect mechanism** so the daemon-up signal reaches the extension within seconds (not minutes), at which point `doctor` doesn't need any post-connectivity poll at all.

## What this revert does

- Reverts `d1076c0d` (the original squash merge of #1718)
- Restores `src/doctor.ts` and `src/doctor.test.ts` to their pre-#1718 state
- `runBrowserDoctor()` returns to a single snapshot-based status read after the live connectivity probe
- The pre-existing "extension flaky" detection still flags the inconsistency, so users will see the warning (just without the 30s wait)

## Follow-up

A separate issue / PR should implement the deeper fix: tighten the extension's reconnect loop so the post-eager-backoff keepalive cadence isn't a hard 24s. Two candidate approaches were discussed:
- (preferred) Add a short HTTP probe in keepalive mode that resets state to eager once daemon is reachable
- Daemon-side push notification to known extension contexts on startup