### PR TITLE
fix(linkedin): normalize timeline text

### DIFF
--- a/clis/linkedin/shared.js
+++ b/clis/linkedin/shared.js
@@ -1,0 +1,111 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const LINKEDIN_DOMAIN = 'www.linkedin.com';
+
+export function unwrapEvaluateResult(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+  return payload;
+}
+
+export function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/[\u00a0\u202f]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function compactRepeatedText(value) {
+  const text = normalizeWhitespace(value);
+  if (!text) return '';
+  if (text.length % 2 === 0) {
+    const half = text.length / 2;
+    const left = text.slice(0, half);
+    if (left === text.slice(half)) return left;
+  }
+  const words = text.split(' ');
+  if (words.length % 2 === 0) {
+    const half = words.length / 2;
+    const left = words.slice(0, half).join(' ');
+    if (left === words.slice(half).join(' ')) return left;
+  }
+  return text;
+}
+
+export function looksLinkedInAuthWall(value) {
+  const text = normalizeWhitespace(value).toLowerCase();
+  if (!text) return false;
+  return /linkedin\.com\/(?:login|checkpoint|authwall|uas)/i.test(text)
+    || /\b(sign in|log in|join linkedin|captcha|verification required)\b/i.test(text)
+    || /(请登录|登录领英|安全验证)/.test(text);
+}
+
+export function assertSafeLinkedinUrl(value, label, fallbackPath = '/') {
+  const raw = normalizeWhitespace(value || `https://www.linkedin.com${fallbackPath}`);
+  let parsed;
+  try {
+    parsed = new URL(raw, 'https://www.linkedin.com');
+  } catch {
+    throw new ArgumentError(`${label} must be a LinkedIn URL`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password || parsed.port) {
+    throw new ArgumentError(`${label} must be an https LinkedIn URL without credentials or port`);
+  }
+  if (host !== 'linkedin.com' && host !== 'www.linkedin.com') {
+    throw new ArgumentError(`${label} must point to linkedin.com`);
+  }
+  return parsed.toString();
+}
+
+export function requireStringArg(args, key, label = key) {
+  const value = normalizeWhitespace(args?.[key]);
+  if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+export function parseLimit(value, fallback, max) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > max) {
+    throw new ArgumentError(`--limit must be an integer between 1 and ${max}`);
+  }
+  return parsed;
+}
+
+export async function requireLinkedInCookie(page, context) {
+  let cookies;
+  try {
+    cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  } catch (error) {
+    throw new CommandExecutionError(`LinkedIn cookie lookup failed: ${error?.message || error}`);
+  }
+  if (!Array.isArray(cookies)) {
+    throw new CommandExecutionError('LinkedIn cookie lookup returned malformed payload');
+  }
+  const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+  if (!jsession) {
+    throw new AuthRequiredError(LINKEDIN_DOMAIN, `${context} requires an active signed-in LinkedIn browser session.`);
+  }
+  return jsession.replace(/^"|"$/g, '');
+}
+
+export function buildAuthProbeScript() {
+  return String.raw`(() => {
+    const text = [
+      window.location.href || '',
+      document.title || '',
+      document.body ? (document.body.innerText || '').slice(0, 4000) : '',
+    ].join('\n');
+    return /linkedin\.com\/(?:login|checkpoint|authwall|uas)/i.test(text)
+      || /\b(sign in|log in|join linkedin|captcha|verification required)\b/i.test(text)
+      || /(请登录|登录领英|安全验证)/.test(text);
+  })()`;
+}
+
+export async function assertLinkedInAuthenticated(page, context) {
+  const authRequired = unwrapEvaluateResult(await page.evaluate(buildAuthProbeScript()));
+  if (authRequired) {
+    throw new AuthRequiredError(LINKEDIN_DOMAIN, `${context} requires an active signed-in LinkedIn browser session.`);
+  }
+}
+
+export function splitVisibleLines(text) {
+  return String(text || '').split(/\n+/).map(normalizeWhitespace).filter(Boolean);
+}

--- a/clis/linkedin/timeline.js
+++ b/clis/linkedin/timeline.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { compactRepeatedText } from './shared.js';
 function normalizeWhitespace(value) {
     return String(value ?? '').replace(/\s+/g, ' ').trim();
 }
@@ -23,9 +24,9 @@ function buildPostId(post) {
     const url = normalizeWhitespace(post.url);
     if (url)
         return url;
-    const author = normalizeWhitespace(post.author);
+    const author = compactRepeatedText(post.author);
     const text = normalizeWhitespace(post.text);
-    const postedAt = normalizeWhitespace(post.posted_at);
+    const postedAt = normalizeTimestamp(post.posted_at);
     return `${author}::${postedAt}::${text.slice(0, 120)}`;
 }
 function mergeTimelinePosts(existing, batch) {
@@ -34,11 +35,11 @@ function mergeTimelinePosts(existing, batch) {
     for (const rawPost of batch) {
         const post = {
             id: buildPostId(rawPost),
-            author: normalizeWhitespace(rawPost.author),
+            author: compactRepeatedText(rawPost.author),
             author_url: normalizeWhitespace(rawPost.author_url),
-            headline: normalizeWhitespace(rawPost.headline),
+            headline: compactRepeatedText(rawPost.headline),
             text: normalizeWhitespace(rawPost.text),
-            posted_at: normalizeWhitespace(rawPost.posted_at),
+            posted_at: normalizeTimestamp(rawPost.posted_at),
             reactions: Number(rawPost.reactions) || 0,
             comments: Number(rawPost.comments) || 0,
             url: normalizeWhitespace(rawPost.url),
@@ -51,6 +52,11 @@ function mergeTimelinePosts(existing, batch) {
         merged.push(post);
     }
     return merged;
+}
+function normalizeTimestamp(value) {
+    const text = normalizeWhitespace(value).replace(/[•·.]$/g, '').trim();
+    const match = text.match(/\b(\d+\s*(?:s|m|h|d|w|mo|yr|min))\b/i);
+    return match ? match[1].replace(/\s+/g, '') : text;
 }
 async function extractVisiblePosts(page) {
     return page.evaluate(`(function () {
@@ -376,7 +382,7 @@ async function extractVisiblePosts(page) {
           || /see more|more/i.test(normalize(el.getAttribute('aria-label')));
       })
       .slice(0, 8);
-    var cards = Array.from(document.querySelectorAll('article, .feed-shared-update-v2, .occludable-update, [role="listitem"]'));
+    var cards = Array.from(document.querySelectorAll('article, [role="article"], .feed-shared-update-v2, .occludable-update, [role="listitem"]'));
     var seen = new Set();
     var posts = [];
     var i;
@@ -397,7 +403,7 @@ async function extractVisiblePosts(page) {
 
     for (i = 0; i < cards.length; i += 1) {
       card = cards[i];
-      root = card.closest('article, .feed-shared-update-v2, .occludable-update, [role="listitem"]') || card;
+      root = card.closest('article, [role="article"], .feed-shared-update-v2, .occludable-update, [role="listitem"]') || card;
       if (!root || seen.has(root)) continue;
       seen.add(root);
 
@@ -501,4 +507,5 @@ export const __test__ = {
     parseMetric,
     buildPostId,
     mergeTimelinePosts,
+    normalizeTimestamp,
 };


### PR DESCRIPTION
## What and why

The existing LinkedIn timeline adapter can return noisy post text because LinkedIn activity cards repeat author/headline/timestamp fragments inside the same visible card. That makes the command harder for agents to consume when they only need clean post text and stable counters.

This PR tightens the extraction while preserving the existing command surface.

## What this PR does

Updates the existing `Strategy.COOKIE` LinkedIn browser adapter:

```bash
opencli linkedin timeline -f json
```

**Implementation details:**
- Adds shared LinkedIn helpers for text normalization and repeated-text compaction
- Cleans duplicated author/headline fragments from extracted timeline rows
- Keeps the existing timeline command shape and columns intact
- Preserves read-only behavior and authenticated browser-session requirements

## Live verification

Verified against a logged-in LinkedIn profile session. Timeline rows returned cleaner visible activity text while preserving reaction/comment/repost counters.

## Checklist

- [x] `npm run build`
- [x] `npx vitest run --project adapter clis/linkedin/timeline.test.js`
- [x] `npm run typecheck`
- [x] `node scripts/check-typed-error-lint.mjs`
- [x] `node scripts/check-silent-column-drop.mjs`
