### PR TITLE
[codex] Fix YouTube Browser Bridge envelope handling

### DIFF
--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -3,6 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapBrowserResult } from './utils.js';
 
 export function extractSelectedRichGridContents(browseData) {
     const tabs = browseData?.contents?.twoColumnBrowseResultsRenderer?.tabs || [];
@@ -35,7 +36,7 @@ cli({
         const limit = Math.min(kwargs.limit || 10, 30);
         await page.goto('https://www.youtube.com');
         await page.wait(2);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const channelId = ${JSON.stringify(channelId)};
         const limit = ${limit};
@@ -182,6 +183,7 @@ cli({
         };
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!data || typeof data !== 'object')
             throw new CommandExecutionError('Failed to fetch channel data');
         if (data.error)

--- a/clis/youtube/comments.js
+++ b/clis/youtube/comments.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { parseVideoId } from './utils.js';
+import { parseVideoId, unwrapBrowserResult } from './utils.js';
 cli({
     site: 'youtube',
     name: 'comments',
@@ -21,7 +21,7 @@ cli({
         const limit = Math.min(kwargs.limit || 20, 100);
         await page.goto(`https://www.youtube.com/watch?v=${videoId}`);
         await page.wait(3);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const videoId = ${JSON.stringify(videoId)};
         const limit = ${limit};
@@ -85,6 +85,7 @@ cli({
         });
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!Array.isArray(data)) {
             const errMsg = data && typeof data === 'object' ? String(data.error || '') : '';
             if (errMsg)

--- a/clis/youtube/feed.js
+++ b/clis/youtube/feed.js
@@ -4,6 +4,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapBrowserResult } from './utils.js';
 
 cli({
     site: 'youtube',
@@ -20,7 +21,7 @@ cli({
         const limit = Math.min(kwargs.limit || 20, 100);
         await page.goto('https://www.youtube.com');
         await page.wait(3);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const d = window.ytInitialData;
         if (!d) return { error: 'YouTube data not found — are you logged in?' };
@@ -109,6 +110,7 @@ cli({
         return videos;
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!Array.isArray(data)) {
             const errMsg = data && typeof data === 'object' ? String(data.error || '') : '';
             throw new CommandExecutionError(errMsg || 'Failed to fetch YouTube feed');

--- a/clis/youtube/history.js
+++ b/clis/youtube/history.js
@@ -3,6 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapBrowserResult } from './utils.js';
 
 cli({
     site: 'youtube',
@@ -20,7 +21,7 @@ cli({
         await page.goto('https://www.youtube.com/feed/history');
         await page.wait(3);
         await page.autoScroll({ times: Math.min(Math.max(Math.ceil(limit / 20), 1), 8), delayMs: 1200 });
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const limit = ${limit};
 
@@ -107,6 +108,7 @@ cli({
         return videos.length ? videos : { error: 'No watch history items found on youtube.com/feed/history' };
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!Array.isArray(data)) {
             const errMsg = data && typeof data === 'object' ? String(data.error || '') : '';
             throw new CommandExecutionError(errMsg || 'Failed to fetch watch history — make sure you are logged into YouTube');

--- a/clis/youtube/like.js
+++ b/clis/youtube/like.js
@@ -2,7 +2,7 @@
  * YouTube like — like a video via InnerTube like API (requires SAPISIDHASH auth).
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { parseVideoId, prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN } from './utils.js';
+import { parseVideoId, prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -23,7 +23,7 @@ cli({
         const sapisid = await readYoutubeSapisid(page);
         if (!sapisid)
             throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
-        const result = await page.evaluate(`
+        const rawResult = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
 
@@ -56,6 +56,7 @@ cli({
         return { ok: true };
       })()
     `);
+        const result = unwrapBrowserResult(rawResult);
         if (result?.error === 'auth') {
             throw new AuthRequiredError('www.youtube.com');
         }

--- a/clis/youtube/playlist.js
+++ b/clis/youtube/playlist.js
@@ -2,7 +2,7 @@
  * YouTube playlist — get playlist info and video list via InnerTube browse API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { prepareYoutubeApiPage, FETCH_BROWSE_FN, extractPlaylistVideos } from './utils.js';
+import { prepareYoutubeApiPage, FETCH_BROWSE_FN, extractPlaylistVideos, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 /**
@@ -36,7 +36,7 @@ cli({
         const playlistId = parsePlaylistId(String(kwargs.id));
         const limit = Math.min(kwargs.limit || 50, 200);
         await prepareYoutubeApiPage(page);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const cfg = window.ytcfg?.data_ || {};
         const apiKey = cfg.INNERTUBE_API_KEY;
@@ -82,6 +82,7 @@ cli({
         return { title, channelName, stats, videos: videos.slice(0, limit) };
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!data || typeof data !== 'object') {
             throw new CommandExecutionError('Failed to fetch playlist data');
         }

--- a/clis/youtube/search.js
+++ b/clis/youtube/search.js
@@ -2,6 +2,7 @@
  * YouTube search — innertube API via browser session.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { unwrapBrowserResult } from './utils.js';
 cli({
     site: 'youtube',
     name: 'search',
@@ -54,7 +55,7 @@ cli({
             url += `&sp=${sp}`;
         await page.goto(url);
         await page.wait(3);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const data = window.ytInitialData;
         if (!data) return {error: 'YouTube data not found'};
@@ -93,6 +94,7 @@ cli({
         return videos;
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!Array.isArray(data))
             return [];
         return data;

--- a/clis/youtube/search.test.js
+++ b/clis/youtube/search.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+
+describe('youtube search', () => {
+    it('uses Browser Bridge envelope-wrapped search results', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                session: 'browser:default',
+                data: [{
+                    rank: 1,
+                    title: 'First Time in China',
+                    channel: 'Travel Channel',
+                    views: '1M views',
+                    duration: '20:00',
+                    published: '1 day ago',
+                    url: 'https://www.youtube.com/watch?v=abc123def45',
+                }],
+            }),
+        };
+        const command = getRegistry().get('youtube/search');
+
+        const rows = await command.func(page, { query: 'first time in China', limit: 3, type: 'video' });
+
+        expect(rows).toEqual([expect.objectContaining({
+            title: 'First Time in China',
+            url: 'https://www.youtube.com/watch?v=abc123def45',
+        })]);
+    });
+});

--- a/clis/youtube/subscribe.js
+++ b/clis/youtube/subscribe.js
@@ -2,7 +2,7 @@
  * YouTube subscribe — subscribe to a channel via InnerTube subscription API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN } from './utils.js';
+import { prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -23,7 +23,7 @@ cli({
         const sapisid = await readYoutubeSapisid(page);
         if (!sapisid)
             throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
-        const result = await page.evaluate(`
+        const rawResult = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
 
@@ -65,6 +65,7 @@ cli({
         return { ok: true, channelId };
       })()
     `);
+        const result = unwrapBrowserResult(rawResult);
         if (result?.error === 'auth') {
             throw new AuthRequiredError('www.youtube.com');
         }

--- a/clis/youtube/subscriptions.js
+++ b/clis/youtube/subscriptions.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { extractSubscriptionChannel } from './utils.js';
+import { extractSubscriptionChannel, unwrapBrowserResult } from './utils.js';
 
 cli({
     site: 'youtube',
@@ -20,7 +20,7 @@ cli({
         const limit = Math.min(kwargs.limit || 50, 1000);
         await page.goto('https://www.youtube.com/feed/channels');
         await page.wait(3);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const d = window.ytInitialData;
         if (!d) return { error: 'YouTube data not found — are you logged in?' };
@@ -46,6 +46,7 @@ cli({
         return channels;
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!Array.isArray(data)) {
             const errMsg = data && typeof data === 'object' ? String(data.error || '') : '';
             throw new CommandExecutionError(errMsg || 'Failed to fetch subscriptions — make sure you are logged into YouTube');

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -10,16 +10,9 @@
  *   --mode raw: every caption segment as-is with precise timestamps
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage } from './utils.js';
+import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage, unwrapBrowserResult } from './utils.js';
 import { groupTranscriptSegments, formatGroupedTranscript, } from './transcript-group.js';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-
-function unwrapBrowserResult(value) {
-    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
-        return value.data;
-    }
-    return value;
-}
 
 function normalizeSegmentsPayload(value, source, { allowNull = false } = {}) {
     const payload = unwrapBrowserResult(value);

--- a/clis/youtube/unlike.js
+++ b/clis/youtube/unlike.js
@@ -2,7 +2,7 @@
  * YouTube unlike — remove like from a video via InnerTube like API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { parseVideoId, prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN } from './utils.js';
+import { parseVideoId, prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -23,7 +23,7 @@ cli({
         const sapisid = await readYoutubeSapisid(page);
         if (!sapisid)
             throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
-        const result = await page.evaluate(`
+        const rawResult = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
 
@@ -56,6 +56,7 @@ cli({
         return { ok: true };
       })()
     `);
+        const result = unwrapBrowserResult(rawResult);
         if (result?.error === 'auth') {
             throw new AuthRequiredError('www.youtube.com');
         }

--- a/clis/youtube/unsubscribe.js
+++ b/clis/youtube/unsubscribe.js
@@ -2,7 +2,7 @@
  * YouTube unsubscribe — unsubscribe from a channel via InnerTube subscription API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN } from './utils.js';
+import { prepareYoutubeApiPage, readYoutubeSapisid, SAPISID_HASH_FN, RESOLVE_CHANNEL_HANDLE_FN, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError, AuthRequiredError } from '@jackwener/opencli/errors';
 
 cli({
@@ -23,7 +23,7 @@ cli({
         const sapisid = await readYoutubeSapisid(page);
         if (!sapisid)
             throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
-        const result = await page.evaluate(`
+        const rawResult = await page.evaluate(`
       (async () => {
         ${SAPISID_HASH_FN}
 
@@ -65,6 +65,7 @@ cli({
         return { ok: true, channelId };
       })()
     `);
+        const result = unwrapBrowserResult(rawResult);
         if (result?.error === 'auth') {
             throw new AuthRequiredError('www.youtube.com');
         }

--- a/clis/youtube/utils.js
+++ b/clis/youtube/utils.js
@@ -2,6 +2,19 @@
  * Extract a YouTube video ID from a URL or bare video ID string.
  * Supports: watch?v=, youtu.be/, /shorts/, /embed/, /live/, /v/
  */
+export function unwrapBrowserResult(value) {
+    if (
+        value
+        && typeof value === 'object'
+        && !Array.isArray(value)
+        && 'session' in value
+        && 'data' in value
+    ) {
+        return value.data;
+    }
+    return value;
+}
+
 export function parseVideoId(input) {
     if (!input.startsWith('http'))
         return input;

--- a/clis/youtube/utils.test.js
+++ b/clis/youtube/utils.test.js
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { extractJsonAssignmentFromHtml, extractSubscriptionChannel, prepareYoutubeApiPage, readYoutubeSapisid } from './utils.js';
+import { extractJsonAssignmentFromHtml, extractSubscriptionChannel, prepareYoutubeApiPage, readYoutubeSapisid, unwrapBrowserResult } from './utils.js';
 describe('youtube utils', () => {
+    it('unwraps Browser Bridge envelope payloads', () => {
+        expect(unwrapBrowserResult({
+            session: 'browser:default',
+            data: [{ title: 'First Time in China' }],
+        })).toEqual([{ title: 'First Time in China' }]);
+        expect(unwrapBrowserResult({ data: { legitimate: true } })).toEqual({ data: { legitimate: true } });
+    });
+
     it('extractJsonAssignmentFromHtml parses bootstrap objects with nested braces in strings', () => {
         const html = `
       <script>

--- a/clis/youtube/video.js
+++ b/clis/youtube/video.js
@@ -2,7 +2,7 @@
  * YouTube video metadata — fetch watch HTML and parse bootstrap data without opening the watch UI.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage } from './utils.js';
+import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 cli({
     site: 'youtube',
@@ -18,7 +18,7 @@ cli({
     func: async (page, kwargs) => {
         const videoId = parseVideoId(kwargs.url);
         await prepareYoutubeApiPage(page);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const extractJsonAssignmentFromHtml = ${extractJsonAssignmentFromHtml.toString()};
 
@@ -104,6 +104,7 @@ cli({
         };
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!data || typeof data !== 'object')
             throw new CommandExecutionError('Failed to extract video metadata from page');
         if (data.error)

--- a/clis/youtube/watch-later.js
+++ b/clis/youtube/watch-later.js
@@ -3,7 +3,7 @@
  * Navigates to /playlist?list=WL and reads ytInitialData directly.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { FETCH_BROWSE_FN, extractPlaylistVideos } from './utils.js';
+import { FETCH_BROWSE_FN, extractPlaylistVideos, unwrapBrowserResult } from './utils.js';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 cli({
@@ -21,7 +21,7 @@ cli({
         const limit = Math.min(kwargs.limit || 50, 200);
         await page.goto('https://www.youtube.com/playlist?list=WL');
         await page.wait(3);
-        const data = await page.evaluate(`
+        const rawData = await page.evaluate(`
       (async () => {
         const d = window.ytInitialData;
         if (!d) return { error: 'YouTube data not found — are you logged in?' };
@@ -61,6 +61,7 @@ cli({
         return { title, stats, videos: videos.slice(0, limit) };
       })()
     `);
+        const data = unwrapBrowserResult(rawData);
         if (!data || typeof data !== 'object') {
             throw new CommandExecutionError('Failed to fetch Watch Later — make sure you are logged into YouTube');
         }


### PR DESCRIPTION
## Problem

`opencli youtube search` can return an empty JSON array even when the loaded YouTube results page contains video rows.

Example command that reproduced the issue locally:

```bash
opencli youtube search "first time in China vlog" --limit 3 --type video -f json --window background
```

Before this patch the command exited successfully but printed:

```json
[]
```

## Root cause

The YouTube DOM extractor itself was not empty: the page had `window.ytInitialData` and `videoRenderer` entries. The failure happened at the Browser Bridge boundary.

Some Browser Bridge / daemon combinations return `page.evaluate(...)` payloads wrapped as:

```json
{
  "session": "browser:default",
  "data": [ /* actual evaluate return value */ ]
}
```

Several YouTube adapters validated the raw `page.evaluate()` result directly, for example with `Array.isArray(data)` or object checks. With the wrapper present, a valid array looked like a plain object, so commands such as `youtube search` silently fell through to `[]` or treated the response as malformed.

`youtube transcript` already had its own local unwrapping helper, which is why this was an uneven YouTube-only compatibility gap rather than a totally new pattern.

## Fix

- Add a shared `unwrapBrowserResult()` helper in `clis/youtube/utils.js`.
- Apply it at the `page.evaluate()` boundary across YouTube adapters that consume Browser Bridge results:
  - `search`, `comments`, `feed`, `history`, `subscriptions`
  - `playlist`, `watch-later`, `video`, `channel`
  - `like`, `unlike`, `subscribe`, `unsubscribe`
- Refactor `transcript` to use the shared YouTube helper instead of keeping a duplicate local function.
- Add regression coverage for envelope-wrapped `youtube search` results and helper behavior.

## Why scoped to YouTube adapters

This PR does not change the Browser Bridge protocol or globally unwrap `Page.evaluate()` results. Many existing adapters already unwrap at their own adapter boundary, and global unwrapping would be a wider compatibility change with more blast radius. The immediate user-visible regression was in YouTube commands, so this keeps the fix narrow and consistent with nearby adapter patterns.

## Verification

```bash
npx vitest run --project adapter clis/youtube/search.test.js clis/youtube/utils.test.js
npx vitest run --project adapter clis/youtube
npm run typecheck
npm run build
node dist/src/main.js youtube search "first time in China vlog" --limit 3 --type video -f json --window background
```

The final live smoke test returned 3 YouTube video rows instead of `[]`.

I also scanned `clis/youtube/*.js` for non-test `page.evaluate` callers and confirmed they now go through `unwrapBrowserResult` where applicable.
