### PR TITLE
fix(youtube): Videos tab fallback misses lockupViewModel format

### DIFF
--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -18,6 +18,39 @@ export function extractSelectedRichGridContents(browseData) {
     return Array.isArray(fallbackContents) ? fallbackContents : [];
 }
 
+export function parseVideoItem(item) {
+    // New lockupViewModel format
+    const lvm = item.richItemRenderer?.content?.lockupViewModel;
+    if (lvm && lvm.contentType === 'LOCKUP_CONTENT_TYPE_VIDEO') {
+        const meta = lvm.metadata?.lockupMetadataViewModel;
+        const rows = meta?.metadata?.contentMetadataViewModel?.metadataRows || [];
+        const parts = (rows[0]?.metadataParts || []).map(p => p.text?.content).filter(Boolean);
+        let duration = '';
+        for (const ov of (lvm.contentImage?.thumbnailViewModel?.overlays || [])) {
+            for (const b of (ov.thumbnailBottomOverlayViewModel?.badges || [])) {
+                if (b.thumbnailBadgeViewModel?.text) duration = b.thumbnailBadgeViewModel.text;
+            }
+        }
+        return {
+            title: meta?.title?.content || '',
+            duration,
+            views: parts.join(' | '),
+            url: 'https://www.youtube.com/watch?v=' + lvm.contentId,
+        };
+    }
+    // Legacy videoRenderer format
+    const v = item.richItemRenderer?.content?.videoRenderer;
+    if (v) {
+        return {
+            title: v.title?.runs?.[0]?.text || v.title?.simpleText || '',
+            duration: v.lengthText?.simpleText || '',
+            views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
+            url: 'https://www.youtube.com/watch?v=' + v.videoId,
+        };
+    }
+    return null;
+}
+
 cli({
     site: 'youtube',
     name: 'channel',
@@ -44,6 +77,7 @@ cli({
         const context = cfg.INNERTUBE_CONTEXT;
         if (!apiKey || !context) return {error: 'YouTube config not found'};
         const extractSelectedRichGridContents = ${extractSelectedRichGridContents.toString()};
+        const parseVideoItem = ${parseVideoItem.toString()};
 
         // Resolve handle to browseId if needed
         let browseId = channelId;
@@ -156,14 +190,9 @@ cli({
               const richGrid = extractSelectedRichGridContents(videosData);
               for (const item of richGrid) {
                 if (recentVideos.length >= limit) break;
-                const v = item.richItemRenderer?.content?.videoRenderer;
-                if (v) {
-                  recentVideos.push({
-                    title: v.title?.runs?.[0]?.text || '',
-                    duration: v.lengthText?.simpleText || '',
-                    views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
-                    url: 'https://www.youtube.com/watch?v=' + v.videoId,
-                  });
+                const parsed = parseVideoItem(item);
+                if (parsed) {
+                  recentVideos.push(parsed);
                 }
               }
             }
@@ -206,4 +235,5 @@ cli({
 
 export const __test__ = {
     extractSelectedRichGridContents,
+    parseVideoItem,
 };

--- a/clis/youtube/channel.js
+++ b/clis/youtube/channel.js
@@ -19,10 +19,19 @@ export function extractSelectedRichGridContents(browseData) {
 }
 
 export function parseVideoItem(item) {
+    const content = item?.richItemRenderer?.content || item || {};
+    const normalizeId = (value) => {
+        const id = String(value || '').trim();
+        return /^[A-Za-z0-9_-]+$/.test(id) ? id : '';
+    };
     // New lockupViewModel format
-    const lvm = item.richItemRenderer?.content?.lockupViewModel;
+    const lvm = content.lockupViewModel;
     if (lvm && lvm.contentType === 'LOCKUP_CONTENT_TYPE_VIDEO') {
+        const id = normalizeId(lvm.contentId);
         const meta = lvm.metadata?.lockupMetadataViewModel;
+        const title = meta?.title?.content || '';
+        if (!id || !title)
+            return null;
         const rows = meta?.metadata?.contentMetadataViewModel?.metadataRows || [];
         const parts = (rows[0]?.metadataParts || []).map(p => p.text?.content).filter(Boolean);
         let duration = '';
@@ -32,20 +41,24 @@ export function parseVideoItem(item) {
             }
         }
         return {
-            title: meta?.title?.content || '',
+            title,
             duration,
             views: parts.join(' | '),
-            url: 'https://www.youtube.com/watch?v=' + lvm.contentId,
+            url: 'https://www.youtube.com/watch?v=' + id,
         };
     }
     // Legacy videoRenderer format
-    const v = item.richItemRenderer?.content?.videoRenderer;
+    const v = content.videoRenderer || content.gridVideoRenderer;
     if (v) {
+        const id = normalizeId(v.videoId);
+        const title = v.title?.runs?.[0]?.text || v.title?.simpleText || '';
+        if (!id || !title)
+            return null;
         return {
-            title: v.title?.runs?.[0]?.text || v.title?.simpleText || '',
-            duration: v.lengthText?.simpleText || '',
+            title,
+            duration: v.lengthText?.simpleText || v.thumbnailOverlays?.find(o => o.thumbnailOverlayTimeStatusRenderer)?.thumbnailOverlayTimeStatusRenderer?.text?.simpleText || '',
             views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
-            url: 'https://www.youtube.com/watch?v=' + v.videoId,
+            url: 'https://www.youtube.com/watch?v=' + id,
         };
     }
     return null;
@@ -132,34 +145,9 @@ cli({
           for (const section of sections) {
             for (const shelf of (section.itemSectionRenderer?.contents || [])) {
               for (const item of (shelf.shelfRenderer?.content?.horizontalListRenderer?.items || [])) {
-                // New lockupViewModel format
-                const lvm = item.lockupViewModel;
-                if (lvm && lvm.contentType === 'LOCKUP_CONTENT_TYPE_VIDEO' && recentVideos.length < limit) {
-                  const meta = lvm.metadata?.lockupMetadataViewModel;
-                  const rows = meta?.metadata?.contentMetadataViewModel?.metadataRows || [];
-                  const viewsAndTime = (rows[0]?.metadataParts || []).map(p => p.text?.content).filter(Boolean).join(' | ');
-                  let duration = '';
-                  for (const ov of (lvm.contentImage?.thumbnailViewModel?.overlays || [])) {
-                    for (const b of (ov.thumbnailBottomOverlayViewModel?.badges || [])) {
-                      if (b.thumbnailBadgeViewModel?.text) duration = b.thumbnailBadgeViewModel.text;
-                    }
-                  }
-                  recentVideos.push({
-                    title: meta?.title?.content || '',
-                    duration,
-                    views: viewsAndTime,
-                    url: 'https://www.youtube.com/watch?v=' + lvm.contentId,
-                  });
-                }
-                // Legacy gridVideoRenderer format
-                if (item.gridVideoRenderer && recentVideos.length < limit) {
-                  const v = item.gridVideoRenderer;
-                  recentVideos.push({
-                    title: v.title?.runs?.[0]?.text || v.title?.simpleText || '',
-                    duration: v.thumbnailOverlays?.[0]?.thumbnailOverlayTimeStatusRenderer?.text?.simpleText || '',
-                    views: (v.shortViewCountText?.simpleText || '') + (v.publishedTimeText?.simpleText ? ' | ' + v.publishedTimeText.simpleText : ''),
-                    url: 'https://www.youtube.com/watch?v=' + v.videoId,
-                  });
+                if (recentVideos.length < limit) {
+                  const parsed = parseVideoItem(item);
+                  if (parsed) recentVideos.push(parsed);
                 }
               }
             }

--- a/clis/youtube/channel.test.js
+++ b/clis/youtube/channel.test.js
@@ -124,6 +124,49 @@ describe('parseVideoItem', () => {
     it('returns null for non-video items', () => {
         expect(__test__.parseVideoItem({})).toBeNull();
         expect(__test__.parseVideoItem({ richItemRenderer: { content: {} } })).toBeNull();
+        expect(__test__.parseVideoItem({
+            richItemRenderer: {
+                content: {
+                    lockupViewModel: {
+                        contentType: 'LOCKUP_CONTENT_TYPE_PLAYLIST',
+                        contentId: 'playlist-id',
+                        metadata: { lockupMetadataViewModel: { title: { content: 'Playlist' } } },
+                    },
+                },
+            },
+        })).toBeNull();
+    });
+
+    it('requires stable video identity before emitting a watch URL', () => {
+        expect(__test__.parseVideoItem({
+            richItemRenderer: {
+                content: {
+                    lockupViewModel: {
+                        contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+                        metadata: { lockupMetadataViewModel: { title: { content: 'Missing id' } } },
+                    },
+                },
+            },
+        })).toBeNull();
+        expect(__test__.parseVideoItem({
+            richItemRenderer: {
+                content: {
+                    videoRenderer: {
+                        videoId: 'bad id with spaces',
+                        title: { simpleText: 'Bad id' },
+                    },
+                },
+            },
+        })).toBeNull();
+        expect(__test__.parseVideoItem({
+            richItemRenderer: {
+                content: {
+                    videoRenderer: {
+                        videoId: 'no-title-id',
+                    },
+                },
+            },
+        })).toBeNull();
     });
 
     it('handles lockupViewModel without duration overlay', () => {
@@ -147,6 +190,45 @@ describe('parseVideoItem', () => {
         const result = __test__.parseVideoItem(item);
         expect(result.duration).toBe('');
         expect(result.title).toBe('No Duration');
+    });
+
+    it('parses the Home tab direct lockupViewModel and gridVideoRenderer shapes', () => {
+        expect(__test__.parseVideoItem({
+            lockupViewModel: {
+                contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+                contentId: 'homeLockup',
+                metadata: {
+                    lockupMetadataViewModel: {
+                        title: { content: 'Home Lockup' },
+                        metadata: {
+                            contentMetadataViewModel: {
+                                metadataRows: [
+                                    { metadataParts: [{ text: { content: '7K views' } }, { text: { content: '1 day ago' } }] },
+                                ],
+                            },
+                        },
+                    },
+                },
+                contentImage: { thumbnailViewModel: { overlays: [] } },
+            },
+        })).toMatchObject({
+            title: 'Home Lockup',
+            views: '7K views | 1 day ago',
+            url: 'https://www.youtube.com/watch?v=homeLockup',
+        });
+        expect(__test__.parseVideoItem({
+            gridVideoRenderer: {
+                videoId: 'gridVideo1',
+                title: { simpleText: 'Grid Video' },
+                thumbnailOverlays: [
+                    { thumbnailOverlayTimeStatusRenderer: { text: { simpleText: '9:10' } } },
+                ],
+            },
+        })).toMatchObject({
+            title: 'Grid Video',
+            duration: '9:10',
+            url: 'https://www.youtube.com/watch?v=gridVideo1',
+        });
     });
 
     it('prefers lockupViewModel over videoRenderer', () => {

--- a/clis/youtube/channel.test.js
+++ b/clis/youtube/channel.test.js
@@ -57,3 +57,145 @@ describe('youtube channel helpers', () => {
         ]))).toEqual(videos);
     });
 });
+
+describe('parseVideoItem', () => {
+    it('parses lockupViewModel format', () => {
+        const item = {
+            richItemRenderer: {
+                content: {
+                    lockupViewModel: {
+                        contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+                        contentId: 'abc123',
+                        metadata: {
+                            lockupMetadataViewModel: {
+                                title: { content: 'Test Video' },
+                                metadata: {
+                                    contentMetadataViewModel: {
+                                        metadataRows: [
+                                            { metadataParts: [{ text: { content: '10K views' } }, { text: { content: '2 days ago' } }] },
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                        contentImage: {
+                            thumbnailViewModel: {
+                                overlays: [
+                                    { thumbnailBottomOverlayViewModel: { badges: [{ thumbnailBadgeViewModel: { text: '12:34' } }] } },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = __test__.parseVideoItem(item);
+        expect(result).toEqual({
+            title: 'Test Video',
+            duration: '12:34',
+            views: '10K views | 2 days ago',
+            url: 'https://www.youtube.com/watch?v=abc123',
+        });
+    });
+
+    it('parses legacy videoRenderer format', () => {
+        const item = {
+            richItemRenderer: {
+                content: {
+                    videoRenderer: {
+                        videoId: 'xyz789',
+                        title: { runs: [{ text: 'Legacy Video' }] },
+                        lengthText: { simpleText: '5:00' },
+                        shortViewCountText: { simpleText: '1K views' },
+                        publishedTimeText: { simpleText: '3 days ago' },
+                    },
+                },
+            },
+        };
+        const result = __test__.parseVideoItem(item);
+        expect(result).toEqual({
+            title: 'Legacy Video',
+            duration: '5:00',
+            views: '1K views | 3 days ago',
+            url: 'https://www.youtube.com/watch?v=xyz789',
+        });
+    });
+
+    it('returns null for non-video items', () => {
+        expect(__test__.parseVideoItem({})).toBeNull();
+        expect(__test__.parseVideoItem({ richItemRenderer: { content: {} } })).toBeNull();
+    });
+
+    it('handles lockupViewModel without duration overlay', () => {
+        const item = {
+            richItemRenderer: {
+                content: {
+                    lockupViewModel: {
+                        contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+                        contentId: 'nodur',
+                        metadata: {
+                            lockupMetadataViewModel: {
+                                title: { content: 'No Duration' },
+                                metadata: { contentMetadataViewModel: { metadataRows: [] } },
+                            },
+                        },
+                        contentImage: { thumbnailViewModel: { overlays: [] } },
+                    },
+                },
+            },
+        };
+        const result = __test__.parseVideoItem(item);
+        expect(result.duration).toBe('');
+        expect(result.title).toBe('No Duration');
+    });
+
+    it('prefers lockupViewModel over videoRenderer', () => {
+        const item = {
+            richItemRenderer: {
+                content: {
+                    lockupViewModel: {
+                        contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+                        contentId: 'lockup-id',
+                        metadata: {
+                            lockupMetadataViewModel: {
+                                title: { content: 'Lockup Title' },
+                                metadata: { contentMetadataViewModel: { metadataRows: [] } },
+                            },
+                        },
+                        contentImage: { thumbnailViewModel: { overlays: [] } },
+                    },
+                    videoRenderer: {
+                        videoId: 'legacy-id',
+                        title: { runs: [{ text: 'Legacy Title' }] },
+                        lengthText: { simpleText: '1:00' },
+                    },
+                },
+            },
+        };
+        const result = __test__.parseVideoItem(item);
+        expect(result.url).toContain('lockup-id');
+        expect(result.title).toBe('Lockup Title');
+    });
+
+    it('is self-contained for browser evaluate injection', () => {
+        const parseVideoItem = Function(`return ${__test__.parseVideoItem.toString()}`)();
+        const item = {
+            richItemRenderer: {
+                content: {
+                    lockupViewModel: {
+                        contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+                        contentId: 'injected',
+                        metadata: {
+                            lockupMetadataViewModel: {
+                                title: { content: 'Injected' },
+                                metadata: { contentMetadataViewModel: { metadataRows: [] } },
+                            },
+                        },
+                        contentImage: { thumbnailViewModel: { overlays: [] } },
+                    },
+                },
+            },
+        };
+        expect(parseVideoItem(item).url).toContain('injected');
+    });
+});


### PR DESCRIPTION
## Problem

After #1164 landed, `opencli youtube channel <id>` still returns empty `recent_videos` for channels whose Home tab is empty AND whose Videos tab uses the newer `lockupViewModel` InnerTube format.

**Reproducer**: `opencli youtube channel @Jett.franzen` (~207K subs, 216 videos). Returns 0 videos despite the Videos tab being fully populated.

## Root cause

The Videos-tab fallback added in #1109 only parses `item.richItemRenderer?.content?.videoRenderer` (the legacy format). Many channels now return the newer `lockupViewModel` format from the Videos tab browse endpoint, which the fallback silently skips.

Meanwhile, the Home tab extraction (lines 101-118) already handles `lockupViewModel`, creating an inconsistency between the two code paths.

Concrete shape on the reproducer channel:

```js
// Videos tab richGrid item — lockupViewModel (skipped)
{
  richItemRenderer: {
    content: {
      lockupViewModel: {
        contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
        contentId: 'G4ngHcS4aJs',
        metadata: { lockupMetadataViewModel: { title: { content: '...' }, ... } },
        contentImage: { thumbnailViewModel: { overlays: [/* duration badge */] } },
        ...
      }
    }
  }
}
```

## Fix

Extract a shared `parseVideoItem()` helper that handles both `lockupViewModel` and `videoRenderer` formats, and use it in the Videos-tab fallback loop. This reuses the same parsing logic already proven in the Home tab path.

Changes:
- `clis/youtube/channel.js`: +32 lines (new `parseVideoItem` helper, updated fallback)
- `clis/youtube/channel.test.js`: +6 test cases for the new helper

## Verification

```
$ opencli youtube channel @Jett.franzen --limit 10 -f json
# Before: returns metadata only, 0 videos
# After:  returns 10 videos with title, duration, views, url
```

`npm test --project adapter` passes (3418 / 3418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)