### PR TITLE
fix(12306): accept lowercase letters in train_no regex

### DIFF
--- a/clis/12306/price.js
+++ b/clis/12306/price.js
@@ -15,7 +15,7 @@ import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwen
 import { fetchStationBundle, mintSession, resolveStation, validateDate } from './utils.js';
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
-const TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/;
+const TRAIN_NO_RE = /^[0-9A-Za-z]{8,18}$/;
 const SEAT_TYPES_RE = /^[A-Z0-9]{1,32}$/;
 
 const SEAT_LETTERS = {
@@ -163,4 +163,4 @@ cli({
     },
 });
 
-export const __test__ = { parsePriceData, pickStationNos, queryStopsForPrice, queryPrice, SEAT_LETTERS };
+export const __test__ = { parsePriceData, pickStationNos, queryStopsForPrice, queryPrice, SEAT_LETTERS, TRAIN_NO_RE };

--- a/clis/12306/train.js
+++ b/clis/12306/train.js
@@ -10,7 +10,7 @@ import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwen
 import { fetchStationBundle, mintSession, resolveStation, validateDate } from './utils.js';
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
-const TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/;
+const TRAIN_NO_RE = /^[0-9A-Za-z]{8,18}$/;
 
 async function queryStops(cookieHeader, trainNo, fromCode, toCode, date, fetchImpl = fetch) {
     const url = `https://kyfw.12306.cn/otn/czxx/queryByTrainNo?train_no=${trainNo}&from_station_telecode=${fromCode}&to_station_telecode=${toCode}&depart_date=${date}`;

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -7,8 +7,8 @@ import { __test__ as trainTest } from './train.js';
 import './orders.js';
 
 const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord, maskEmail, maskMobile, maskChineseName, unwrapEvaluateResult, requireEvaluateObject, isAuthLikePayload } = __test__;
-const { parsePriceData, queryStopsForPrice, queryPrice } = priceTest;
-const { queryStops } = trainTest;
+const { parsePriceData, queryStopsForPrice, queryPrice, TRAIN_NO_RE: PRICE_TRAIN_NO_RE } = priceTest;
+const { queryStops, TRAIN_NO_RE: TRAIN_TRAIN_NO_RE } = trainTest;
 
 describe('12306 utils - parseStationBundle', () => {
     it('parses the `@`-delimited station bundle into structured records', () => {
@@ -227,6 +227,30 @@ describe('12306 price - parsePriceData', () => {
         const zz = rows.find((r) => r.seat_code === 'ZZ');
         expect(zz?.seat_name).toBe('ZZ');
     });
+});
+
+describe('12306 train_no validation regex', () => {
+    // 12306 train_no values returned by /otn/leftTicket/query sometimes contain
+    // lowercase letters (e.g. "5l000G1970A3" for G1970 上海虹桥 -> 宝鸡南).
+    // Both `12306 price` and `12306 train` must accept the raw value emitted
+    // by `12306 trains`, otherwise the two adapters drift apart and downstream
+    // calls fail with ARGUMENT before ever hitting 12306.
+    for (const [label, re] of [['price', PRICE_TRAIN_NO_RE], ['train', TRAIN_TRAIN_NO_RE]]) {
+        describe(label, () => {
+            it('accepts an all-uppercase train_no', () => {
+                expect(re.test('24000000G10L')).toBe(true);
+            });
+            it('accepts a train_no with lowercase letters (real 12306 payload)', () => {
+                expect(re.test('5l000G1970A3')).toBe(true);
+            });
+            it('rejects public codes like G1970', () => {
+                expect(re.test('G1970')).toBe(false);
+            });
+            it('rejects values with disallowed characters', () => {
+                expect(re.test('5l000-G1970A3')).toBe(false);
+            });
+        });
+    }
 });
 
 describe('12306 public API typed boundaries', () => {


### PR DESCRIPTION
## Problem

The 12306 `leftTicket` API sometimes returns `train_no` values that contain **lowercase** letters. For example, querying 上海 → 宝鸡 on 2026-05-25 returns this for G1970:

```yaml
train_no: 5l000G1970A3   # note the lowercase "l"
code: G1970
from_station: 上海虹桥
to_station: 宝鸡南
```

`12306 trains` outputs the value verbatim, but feeding it back into the documented next step fails locally before ever hitting 12306:

```bash
$ opencli 12306 price 5l000G1970A3 --from AOH --to BBY --date 2026-05-25
ok: false
error:
  code: ARGUMENT
  message: <train-no> "5l000G1970A3" does not look like a 12306 internal train_no
  help: Use the train_no field from `12306 trains` output (e.g. 24000000G10L), not the public code (G1).
  exitCode: 2
```

Same failure on `12306 train`. Root cause: `TRAIN_NO_RE = /^[0-9A-Z]{8,18}$/` in both `price.js` and `train.js` is stricter than what 12306 actually emits. Capitalising the `l` to `L` passes the regex but then returns `EMPTY_RESULT` from 12306 — confirming the canonical id really is lowercase.

The error help text is also misleading: it tells the user to use the value from `12306 trains` output, which is exactly what they did.

## Fix

Widen the regex to `/^[0-9A-Za-z]{8,18}$/` in both adapters. Verified end-to-end after the change:

```bash
$ opencli 12306 price 5l000G1970A3 --from AOH --to BBY --date 2026-05-25
- seat_code: A9
  seat_name: 商务座
  price: '2611.0'
- seat_code: M
  seat_name: 一等座
  price: '1252.0'
- seat_code: O
  seat_name: 二等座
  price: '768.0'
  ...
```

## Tests

Added a parameterised `describe` block in `clis/12306/utils.test.js` that pins both regexes (`price` + `train`) against:

- the historical uppercase example `24000000G10L` (must accept)
- the lowercase real-world value `5l000G1970A3` (must accept — regression)
- public codes like `G1970` (must reject)
- values containing punctuation `5l000-G1970A3` (must reject)

```
Test Files  1 passed (1)
     Tests  39 passed (39)
```

`npx tsc --noEmit` clean.

## Notes

- Only the format regex changed; everything downstream (URL building, 12306 API contract) already round-trips the value as an opaque string.
- `SEAT_TYPES_RE` is intentionally left untouched — seat-type letters are a small, well-known uppercase set defined by 12306.