### PR TITLE
feat(xiaohongshu): paginate creator-notes past the 10-row /analyze/list cap

### DIFF
--- a/clis/xiaohongshu/creator-notes.js
+++ b/clis/xiaohongshu/creator-notes.js
@@ -13,6 +13,9 @@ const DATE_LINE_RE = /^发布于 (\d{4}年\d{2}月\d{2}日 \d{2}:\d{2})$/;
 const METRIC_LINE_RE = /^\d+$/;
 const VISIBILITY_LINE_RE = /可见$/;
 const NOTE_ANALYZE_API_PATH = '/api/galaxy/creator/datacenter/note/analyze/list';
+const NOTE_ANALYZE_PAGE_SIZE = 10;
+const CAPTURE_POLL_ATTEMPTS = 20;
+const CAPTURE_POLL_INTERVAL_S = 0.5;
 const NOTE_DETAIL_PAGE_URL = 'https://creator.xiaohongshu.com/statistics/note-detail';
 const NOTE_ID_HTML_RE = /&quot;noteId&quot;:&quot;([0-9a-f]{24})&quot;/g;
 function buildNoteDetailUrl(noteId) {
@@ -105,6 +108,171 @@ function mapAnalyzeItems(items) {
         url: buildNoteDetailUrl(item.id),
     }));
 }
+// Capture the dashboard's signed /api/galaxy/* responses on window.__xhsCapture
+// since a direct fetch() from page.evaluate bypasses the x-s signing and gets 406.
+async function installXhsFetchCaptureHook(page) {
+    await page.evaluate(`(() => {
+    window.__xhsCapture = {};
+    if (window.__xhsCaptureInstalled) return;
+    window.__xhsCaptureInstalled = true;
+    const origFetch = window.fetch;
+    window.fetch = async function(...args) {
+      const resp = await origFetch.apply(this, args);
+      try {
+        const url = typeof args[0] === 'string' ? args[0] : (args[0] && args[0].url) || '';
+        if (url.includes('/api/galaxy/')) {
+          resp.clone().text().then((body) => {
+            try { window.__xhsCapture[url] = { status: resp.status, ok: resp.ok, body }; } catch (_) {}
+          }).catch(() => {});
+        }
+      } catch (_) {}
+      return resp;
+    };
+    const OrigXHR = window.XMLHttpRequest;
+    function HookedXHR() {
+      const xhr = new OrigXHR();
+      const origOpen = xhr.open;
+      let capturedUrl = '';
+      xhr.open = function(method, url, ...rest) {
+        capturedUrl = url;
+        return origOpen.call(this, method, url, ...rest);
+      };
+      xhr.addEventListener('load', () => {
+        try {
+          if (capturedUrl.includes('/api/galaxy/')) {
+            window.__xhsCapture[capturedUrl] = { status: xhr.status, ok: xhr.status >= 200 && xhr.status < 300, body: xhr.responseText };
+          }
+        } catch (_) {}
+      });
+      return xhr;
+    }
+    HookedXHR.prototype = OrigXHR.prototype;
+    for (const key of ['UNSENT', 'OPENED', 'HEADERS_RECEIVED', 'LOADING', 'DONE']) {
+      if (key in OrigXHR) HookedXHR[key] = OrigXHR[key];
+    }
+    window.XMLHttpRequest = HookedXHR;
+  })()`);
+}
+function harvestAnalyzeListCaptures(captureMap) {
+    const items = [];
+    const seen = new Set();
+    let total = 0;
+    for (const [url, capture] of Object.entries(captureMap)) {
+        if (!url.includes('/note/analyze/list')) continue;
+        if (!capture?.ok) continue;
+        try {
+            const json = JSON.parse(capture.body);
+            const data = json?.data ?? {};
+            if (typeof data.total === 'number' && data.total > total) total = data.total;
+            for (const note of data.note_infos ?? []) {
+                if (!note?.id || seen.has(note.id)) continue;
+                seen.add(note.id);
+                items.push(note);
+            }
+        }
+        catch { }
+    }
+    return { items, total };
+}
+async function pollCaptureMap(page) {
+    let captureMap = {};
+    for (let i = 0; i < CAPTURE_POLL_ATTEMPTS; i++) {
+        await page.wait(CAPTURE_POLL_INTERVAL_S);
+        const raw = await page.evaluate('JSON.stringify(window.__xhsCapture || {})');
+        captureMap = typeof raw === 'string' ? JSON.parse(raw) : {};
+        if (Object.keys(captureMap).some((url) => url.includes('/note/analyze/list'))) break;
+    }
+    return captureMap;
+}
+// Fresh-published notes return title: "" from /note/analyze/list (the field
+// only populates once xhs's backend has indexed the content). Scrape the
+// /new/note-manager card DOM as a secondary source so freshly-published
+// notes still get a title even before backend indexing catches up.
+async function fetchNoteManagerTitleMap(page, neededCount) {
+    const map = new Map();
+    try {
+        await page.goto('https://creator.xiaohongshu.com/new/note-manager');
+        await page.wait(2);
+        // The note-manager renders 10 cards per scroll batch and lazy-loads more
+        // on PageDown. Scroll enough batches to cover all caller-requested ids.
+        const scrollBatches = Math.max(1, Math.ceil(neededCount / NOTE_ANALYZE_PAGE_SIZE) + 1);
+        for (let i = 0; i < scrollBatches; i++) {
+            const cards = await page.evaluate(`() => {
+        const noteIdRe = /"noteId":"([0-9a-f]{24})"/;
+        return Array.from(document.querySelectorAll('div.note[data-impression], div.note')).map((card) => {
+          const impression = card.getAttribute('data-impression') || '';
+          const id = impression.match(noteIdRe)?.[1] || '';
+          const title = (card.querySelector('.title, .raw')?.innerText || '').trim();
+          return { id, title };
+        }).filter((entry) => entry.id && entry.title);
+      }`);
+            for (const card of Array.isArray(cards) ? cards : []) {
+                if (!map.has(card.id)) map.set(card.id, card.title);
+            }
+            if (map.size >= neededCount) break;
+            await page.pressKey('PageDown');
+            await page.wait(1);
+        }
+        return map;
+    }
+    catch {
+        return map;
+    }
+}
+async function fetchCreatorNotesByCapture(page, limit) {
+    // Land on dashboard root before installing the hook so the data-analysis
+    // SPA navigation fires page_num=1's signed request UNDER the hook.
+    await page.goto('https://creator.xiaohongshu.com/statistics');
+    await installXhsFetchCaptureHook(page);
+    await page.evaluate(`(() => {
+    history.pushState({}, '', '/statistics/data-analysis?source=official');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  })()`);
+    let captureMap = await pollCaptureMap(page);
+    let { items, total } = harvestAnalyzeListCaptures(captureMap);
+    if (items.length === 0) return [];
+    const totalPages = total > 0 ? Math.ceil(total / NOTE_ANALYZE_PAGE_SIZE) : 1;
+    const neededPages = Math.min(totalPages, Math.ceil(limit / NOTE_ANALYZE_PAGE_SIZE));
+    for (let pageNum = 2; pageNum <= neededPages && items.length < limit; pageNum++) {
+        const clicked = await page.evaluate(`(() => {
+      const target = String(${pageNum});
+      // .d-pagination-page renders the page number doubled (a visible span +
+      // an accessibility span), so textContent for page 2 reads "22". Match
+      // both the raw digit and the doubled form to tolerate either render.
+      const btns = Array.from(document.querySelectorAll('.d-pagination-page'));
+      const match = btns.find((btn) => {
+        const text = (btn.textContent || '').trim();
+        return text === target || text === target + target;
+      });
+      if (match) { match.click(); return true; }
+      return false;
+    })()`);
+        if (!clicked) break;
+        const before = items.length;
+        for (let attempt = 0; attempt < CAPTURE_POLL_ATTEMPTS; attempt++) {
+            await page.wait(CAPTURE_POLL_INTERVAL_S);
+            const raw = await page.evaluate('JSON.stringify(window.__xhsCapture || {})');
+            captureMap = typeof raw === 'string' ? JSON.parse(raw) : {};
+            const harvested = harvestAnalyzeListCaptures(captureMap);
+            if (harvested.items.length > before) {
+                items = harvested.items;
+                total = Math.max(total, harvested.total);
+                break;
+            }
+        }
+    }
+    const notes = mapAnalyzeItems(items).slice(0, limit);
+    const missingTitles = notes.filter((note) => !note.title).length;
+    if (missingTitles > 0) {
+        const titleMap = await fetchNoteManagerTitleMap(page, notes.length);
+        for (const note of notes) {
+            if (!note.title && note.id && titleMap.has(note.id)) {
+                note.title = titleMap.get(note.id);
+            }
+        }
+    }
+    return notes;
+}
 async function fetchCreatorNotesByApi(page, limit) {
     const pageSize = Math.min(Math.max(limit, 10), 20);
     const maxPages = Math.max(1, Math.ceil(limit / pageSize));
@@ -148,7 +316,10 @@ async function fetchCreatorNotesByApi(page, limit) {
     return notes.slice(0, limit);
 }
 export async function fetchCreatorNotes(page, limit) {
-    let notes = await fetchCreatorNotesByApi(page, limit);
+    let notes = await fetchCreatorNotesByCapture(page, limit).catch(() => []);
+    if (notes.length === 0) {
+        notes = await fetchCreatorNotesByApi(page, limit);
+    }
     if (notes.length === 0) {
         await page.goto('https://creator.xiaohongshu.com/new/note-manager');
         const maxPageDowns = Math.max(0, Math.ceil(limit / 10) + 1);

--- a/clis/xiaohongshu/creator-notes.js
+++ b/clis/xiaohongshu/creator-notes.js
@@ -8,7 +8,7 @@
  * Requires: logged into creator.xiaohongshu.com in Chrome.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 const DATE_LINE_RE = /^发布于 (\d{4}年\d{2}月\d{2}日 \d{2}:\d{2})$/;
 const METRIC_LINE_RE = /^\d+$/;
 const VISIBILITY_LINE_RE = /可见$/;
@@ -324,7 +324,9 @@ async function fetchCreatorNotesByCapture(page, limit) {
         }
         if (!advanced) break;
     }
-    if (!isAnalyzeCaptureComplete(items, total, limit)) return [];
+    if (!isAnalyzeCaptureComplete(items, total, limit)) {
+        throw new CommandExecutionError(`xiaohongshu creator-notes: captured ${items.length} of ${Math.min(total, limit)} expected analyze rows; refusing partial results`);
+    }
     const notes = mapAnalyzeItems(items).slice(0, limit);
     const missingTitles = notes.filter((note) => !note.title).length;
     if (missingTitles > 0) {
@@ -380,7 +382,13 @@ async function fetchCreatorNotesByApi(page, limit) {
     return notes.slice(0, limit);
 }
 export async function fetchCreatorNotes(page, limit) {
-    let notes = await fetchCreatorNotesByCapture(page, limit).catch(() => []);
+    let notes = [];
+    try {
+        notes = await fetchCreatorNotesByCapture(page, limit);
+    }
+    catch (error) {
+        if (error instanceof CommandExecutionError) throw error;
+    }
     if (notes.length === 0) {
         notes = await fetchCreatorNotesByApi(page, limit);
     }

--- a/clis/xiaohongshu/creator-notes.js
+++ b/clis/xiaohongshu/creator-notes.js
@@ -184,34 +184,54 @@ async function pollCaptureMap(page) {
     }
     return captureMap;
 }
-// Fresh-published notes return title: "" from /note/analyze/list (the field
-// only populates once xhs's backend has indexed the content). Scrape the
-// /new/note-manager card DOM as a secondary source so freshly-published
-// notes still get a title even before backend indexing catches up.
+// Fresh-published notes return title: "" from /note/analyze/list. Scrape the
+// /new/note-manager card DOM (under its "全部笔记" tab, which surfaces every
+// state including 审核中) so the rows the API leaves empty still get the
+// derived title that the note-manager UI shows.
 async function fetchNoteManagerTitleMap(page, neededCount) {
     const map = new Map();
+    const scrapeCards = async () => {
+        const cards = await page.evaluate(`() => {
+      const noteIdRe = /"noteId":"([0-9a-f]{24})"/;
+      return Array.from(document.querySelectorAll('div.note[data-impression], div.note')).map((card) => {
+        const impression = card.getAttribute('data-impression') || '';
+        const id = impression.match(noteIdRe)?.[1] || '';
+        const title = (card.querySelector('.title, .raw')?.innerText || '').trim();
+        return { id, title };
+      }).filter((entry) => entry.id && entry.title);
+    }`);
+        for (const card of Array.isArray(cards) ? cards : []) {
+            if (!map.has(card.id)) map.set(card.id, card.title);
+        }
+    };
+    // Scroll the first scrollable ancestor of a note card to the bottom so
+    // the list lazy-loads the rest of its rows. Page-level scrollTo does not
+    // work because the cards live inside an inner overflow-auto container.
+    const scrollInnerListToBottom = async () => {
+        return page.evaluate(`(() => {
+      const firstCard = document.querySelector('div.note[data-impression]');
+      let el = firstCard && firstCard.parentElement;
+      while (el) {
+        const s = window.getComputedStyle(el);
+        if ((s.overflowY === 'auto' || s.overflowY === 'scroll') && el.scrollHeight > el.clientHeight + 10) {
+          el.scrollTop = el.scrollHeight;
+          return true;
+        }
+        el = el.parentElement;
+      }
+      return false;
+    })()`);
+    };
     try {
         await page.goto('https://creator.xiaohongshu.com/new/note-manager');
-        await page.wait(2);
-        // The note-manager renders 10 cards per scroll batch and lazy-loads more
-        // on PageDown. Scroll enough batches to cover all caller-requested ids.
-        const scrollBatches = Math.max(1, Math.ceil(neededCount / NOTE_ANALYZE_PAGE_SIZE) + 1);
-        for (let i = 0; i < scrollBatches; i++) {
-            const cards = await page.evaluate(`() => {
-        const noteIdRe = /"noteId":"([0-9a-f]{24})"/;
-        return Array.from(document.querySelectorAll('div.note[data-impression], div.note')).map((card) => {
-          const impression = card.getAttribute('data-impression') || '';
-          const id = impression.match(noteIdRe)?.[1] || '';
-          const title = (card.querySelector('.title, .raw')?.innerText || '').trim();
-          return { id, title };
-        }).filter((entry) => entry.id && entry.title);
-      }`);
-            for (const card of Array.isArray(cards) ? cards : []) {
-                if (!map.has(card.id)) map.set(card.id, card.title);
-            }
-            if (map.size >= neededCount) break;
-            await page.pressKey('PageDown');
+        // Poll for the initial hydration batch and then scroll the inner list
+        // container to surface the rest of the rows. The all-notes tab is the
+        // default state so no tab click is needed here.
+        for (let i = 0; i < 12; i++) {
             await page.wait(1);
+            await scrapeCards();
+            if (map.size >= neededCount) return map;
+            await scrollInnerListToBottom();
         }
         return map;
     }

--- a/clis/xiaohongshu/creator-notes.js
+++ b/clis/xiaohongshu/creator-notes.js
@@ -108,6 +108,12 @@ function mapAnalyzeItems(items) {
         url: buildNoteDetailUrl(item.id),
     }));
 }
+function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
 // Capture the dashboard's signed /api/galaxy/* responses on window.__xhsCapture
 // since a direct fetch() from page.evaluate bypasses the x-s signing and gets 406.
 async function installXhsFetchCaptureHook(page) {
@@ -153,12 +159,41 @@ async function installXhsFetchCaptureHook(page) {
     window.XMLHttpRequest = HookedXHR;
   })()`);
 }
+function parseCaptureMapPayload(raw) {
+    const payload = unwrapEvaluateResult(raw);
+    if (typeof payload === 'string') {
+        try {
+            return JSON.parse(payload);
+        }
+        catch {
+            return {};
+        }
+    }
+    if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+        return payload;
+    }
+    return {};
+}
+function getAnalyzeListPageNumber(url) {
+    try {
+        const parsed = new URL(url, 'https://creator.xiaohongshu.com');
+        const pageNum = Number.parseInt(parsed.searchParams.get('page_num') || '', 10);
+        if (Number.isFinite(pageNum) && pageNum > 0)
+            return pageNum;
+    }
+    catch { }
+    const match = String(url || '').match(/[?&]page_num=(\d+)/);
+    const pageNum = Number.parseInt(match?.[1] || '', 10);
+    return Number.isFinite(pageNum) && pageNum > 0 ? pageNum : Number.MAX_SAFE_INTEGER;
+}
 function harvestAnalyzeListCaptures(captureMap) {
     const items = [];
     const seen = new Set();
     let total = 0;
-    for (const [url, capture] of Object.entries(captureMap)) {
-        if (!url.includes('/note/analyze/list')) continue;
+    const entries = Object.entries(captureMap)
+        .filter(([url]) => url.includes('/note/analyze/list'))
+        .sort(([a], [b]) => getAnalyzeListPageNumber(a) - getAnalyzeListPageNumber(b));
+    for (const [url, capture] of entries) {
         if (!capture?.ok) continue;
         try {
             const json = JSON.parse(capture.body);
@@ -174,12 +209,17 @@ function harvestAnalyzeListCaptures(captureMap) {
     }
     return { items, total };
 }
+function isAnalyzeCaptureComplete(items, total, limit) {
+    if (total <= 0)
+        return true;
+    return items.length >= Math.min(total, limit);
+}
 async function pollCaptureMap(page) {
     let captureMap = {};
     for (let i = 0; i < CAPTURE_POLL_ATTEMPTS; i++) {
         await page.wait(CAPTURE_POLL_INTERVAL_S);
         const raw = await page.evaluate('JSON.stringify(window.__xhsCapture || {})');
-        captureMap = typeof raw === 'string' ? JSON.parse(raw) : {};
+        captureMap = parseCaptureMapPayload(raw);
         if (Object.keys(captureMap).some((url) => url.includes('/note/analyze/list'))) break;
     }
     return captureMap;
@@ -191,7 +231,7 @@ async function pollCaptureMap(page) {
 async function fetchNoteManagerTitleMap(page, neededCount) {
     const map = new Map();
     const scrapeCards = async () => {
-        const cards = await page.evaluate(`() => {
+        const cards = unwrapEvaluateResult(await page.evaluate(`() => {
       const noteIdRe = /"noteId":"([0-9a-f]{24})"/;
       return Array.from(document.querySelectorAll('div.note[data-impression], div.note')).map((card) => {
         const impression = card.getAttribute('data-impression') || '';
@@ -199,7 +239,7 @@ async function fetchNoteManagerTitleMap(page, neededCount) {
         const title = (card.querySelector('.title, .raw')?.innerText || '').trim();
         return { id, title };
       }).filter((entry) => entry.id && entry.title);
-    }`);
+    }`));
         for (const card of Array.isArray(cards) ? cards : []) {
             if (!map.has(card.id)) map.set(card.id, card.title);
         }
@@ -208,7 +248,7 @@ async function fetchNoteManagerTitleMap(page, neededCount) {
     // the list lazy-loads the rest of its rows. Page-level scrollTo does not
     // work because the cards live inside an inner overflow-auto container.
     const scrollInnerListToBottom = async () => {
-        return page.evaluate(`(() => {
+        return unwrapEvaluateResult(await page.evaluate(`(() => {
       const firstCard = document.querySelector('div.note[data-impression]');
       let el = firstCard && firstCard.parentElement;
       while (el) {
@@ -220,7 +260,7 @@ async function fetchNoteManagerTitleMap(page, neededCount) {
         el = el.parentElement;
       }
       return false;
-    })()`);
+    })()`));
     };
     try {
         await page.goto('https://creator.xiaohongshu.com/new/note-manager');
@@ -254,7 +294,7 @@ async function fetchCreatorNotesByCapture(page, limit) {
     const totalPages = total > 0 ? Math.ceil(total / NOTE_ANALYZE_PAGE_SIZE) : 1;
     const neededPages = Math.min(totalPages, Math.ceil(limit / NOTE_ANALYZE_PAGE_SIZE));
     for (let pageNum = 2; pageNum <= neededPages && items.length < limit; pageNum++) {
-        const clicked = await page.evaluate(`(() => {
+        const clicked = unwrapEvaluateResult(await page.evaluate(`(() => {
       const target = String(${pageNum});
       // .d-pagination-page renders the page number doubled (a visible span +
       // an accessibility span), so textContent for page 2 reads "22". Match
@@ -266,21 +306,25 @@ async function fetchCreatorNotesByCapture(page, limit) {
       });
       if (match) { match.click(); return true; }
       return false;
-    })()`);
+    })()`));
         if (!clicked) break;
         const before = items.length;
+        let advanced = false;
         for (let attempt = 0; attempt < CAPTURE_POLL_ATTEMPTS; attempt++) {
             await page.wait(CAPTURE_POLL_INTERVAL_S);
             const raw = await page.evaluate('JSON.stringify(window.__xhsCapture || {})');
-            captureMap = typeof raw === 'string' ? JSON.parse(raw) : {};
+            captureMap = parseCaptureMapPayload(raw);
             const harvested = harvestAnalyzeListCaptures(captureMap);
             if (harvested.items.length > before) {
                 items = harvested.items;
                 total = Math.max(total, harvested.total);
+                advanced = true;
                 break;
             }
         }
+        if (!advanced) break;
     }
+    if (!isAnalyzeCaptureComplete(items, total, limit)) return [];
     const notes = mapAnalyzeItems(items).slice(0, limit);
     const missingTitles = notes.filter((note) => !note.title).length;
     if (missingTitles > 0) {
@@ -419,3 +463,9 @@ cli({
         }));
     },
 });
+export const __test__ = {
+    harvestAnalyzeListCaptures,
+    isAnalyzeCaptureComplete,
+    parseCaptureMapPayload,
+    unwrapEvaluateResult,
+};

--- a/clis/xiaohongshu/creator-notes.test.js
+++ b/clis/xiaohongshu/creator-notes.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__, parseCreatorNoteIdsFromHtml, parseCreatorNotesText } from './creator-notes.js';
 import './creator-notes.js';
@@ -241,6 +241,31 @@ describe('xiaohongshu creator-notes', () => {
         };
         expect(__test__.parseCaptureMapPayload({ session: 'site:xiaohongshu', data: JSON.stringify(captureMap) })).toEqual(captureMap);
         expect(__test__.parseCaptureMapPayload({ session: 'site:xiaohongshu', data: captureMap })).toEqual(captureMap);
+    });
+    it('does not fall back to partial DOM rows when captured total proves pagination is incomplete', async () => {
+        const cmd = getRegistry().get('xiaohongshu/creator-notes');
+        const captureMap = {
+            '/api/galaxy/creator/datacenter/note/analyze/list?type=0&page_size=10&page_num=1': {
+                ok: true,
+                body: JSON.stringify({
+                    data: {
+                        total: 25,
+                        note_infos: Array.from({ length: 10 }, (_, index) => ({
+                            id: String(index).padStart(24, '0'),
+                            title: `note ${index}`,
+                        })),
+                    },
+                }),
+            },
+        };
+        const page = createPageMock(undefined);
+        page.evaluate = vi.fn()
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(JSON.stringify(captureMap))
+            .mockResolvedValueOnce(false);
+
+        await expect(cmd.func(page, { limit: 20 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
     it('throws EmptyResultError when the creator account has no notes', async () => {
         const cmd = getRegistry().get('xiaohongshu/creator-notes');

--- a/clis/xiaohongshu/creator-notes.test.js
+++ b/clis/xiaohongshu/creator-notes.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { parseCreatorNoteIdsFromHtml, parseCreatorNotesText } from './creator-notes.js';
+import { __test__, parseCreatorNoteIdsFromHtml, parseCreatorNotesText } from './creator-notes.js';
 import './creator-notes.js';
 function createPageMock(evaluateResult, interceptedRequests = []) {
     const evaluate = Array.isArray(evaluateResult)
@@ -189,6 +189,58 @@ describe('xiaohongshu creator-notes', () => {
             'aaaaaaaaaaaaaaaaaaaaaaaa',
             'dddddddddddddddddddddddd',
         ]);
+    });
+    it('harvests captured analyze pages in page order and dedupes note ids', () => {
+        const captureMap = {
+            '/api/galaxy/creator/datacenter/note/analyze/list?type=0&page_size=10&page_num=2': {
+                ok: true,
+                body: JSON.stringify({
+                    data: {
+                        total: 3,
+                        note_infos: [
+                            { id: 'bbbbbbbbbbbbbbbbbbbbbbbb', title: 'page 2' },
+                            { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', title: 'duplicate from page 2' },
+                        ],
+                    },
+                }),
+            },
+            '/api/galaxy/creator/datacenter/note/analyze/list?type=0&page_size=10&page_num=1': {
+                ok: true,
+                body: JSON.stringify({
+                    data: {
+                        total: 3,
+                        note_infos: [
+                            { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', title: 'page 1' },
+                        ],
+                    },
+                }),
+            },
+        };
+        expect(__test__.harvestAnalyzeListCaptures(captureMap)).toEqual({
+            total: 3,
+            items: [
+                { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', title: 'page 1' },
+                { id: 'bbbbbbbbbbbbbbbbbbbbbbbb', title: 'page 2' },
+            ],
+        });
+    });
+    it('treats incomplete captured pagination as fallback-needed instead of partial success', () => {
+        const firstPageItems = Array.from({ length: 10 }, (_, index) => ({
+            id: String(index).padStart(24, '0'),
+        }));
+        expect(__test__.isAnalyzeCaptureComplete(firstPageItems, 25, 20)).toBe(false);
+        expect(__test__.isAnalyzeCaptureComplete(firstPageItems, 25, 10)).toBe(true);
+        expect(__test__.isAnalyzeCaptureComplete(firstPageItems, 0, 20)).toBe(true);
+    });
+    it('unwraps browser bridge capture-map envelopes', () => {
+        const captureMap = {
+            '/api/galaxy/creator/datacenter/note/analyze/list?page_num=1': {
+                ok: true,
+                body: '{"data":{"total":0,"note_infos":[]}}',
+            },
+        };
+        expect(__test__.parseCaptureMapPayload({ session: 'site:xiaohongshu', data: JSON.stringify(captureMap) })).toEqual(captureMap);
+        expect(__test__.parseCaptureMapPayload({ session: 'site:xiaohongshu', data: captureMap })).toEqual(captureMap);
     });
     it('throws EmptyResultError when the creator account has no notes', async () => {
         const cmd = getRegistry().get('xiaohongshu/creator-notes');


### PR DESCRIPTION
## Description

The `/api/galaxy/creator/datacenter/note/analyze/list` endpoint serves 10 note rows per page, and the previous `fetchCreatorNotesByApi` only ever requested page 1 because the in-page direct `fetch()` bypassed xhs's signing interceptor and got HTTP 406 on subsequent pages. As a result `opencli xiaohongshu creator-notes --limit 25` silently capped at 10 even for accounts with hundreds of notes.

Install the same `window.__xhsCapture` fetch + XHR hook used by `creator-note-detail` (#1732), SPA-navigate to `/statistics/data-analysis` so the dashboard fires its own signed `page_num=1` request under the hook, then click `.d-pagination-page` buttons for pages 2..N to make the dashboard's React router fire successive signed requests. Dedupe by `note.id` and return up to `--limit`.

The pagination buttons render the page number duplicated in `textContent` (`"22"` for page 2 because of an inner accessibility span + visible span), so the click selector tolerates both the raw digit and the doubled form. `CAPTURE_POLL_ATTEMPTS` / `CAPTURE_POLL_INTERVAL_S` match the constant naming used by sibling `delete-note.js`.

Fresh-published notes return `title: ""` from `/note/analyze/list` (xhs's own data-analysis UI labels them `无标题笔记`). To preserve the title coverage that the existing DOM-fallback path delivered, the helper enriches missing titles from the `/new/note-manager` card DOM — that view derives a title from the note's first line of content, which is what users actually see in their note-manager UI. Selectors are structural (scrollable-ancestor walk, indexed reads) rather than Chinese-text matches.

Related issue: Closes #1729. Reporter diagnosis: @ppop123 traced the signing-bypass + pagination click pattern and verified on 86-148-note accounts.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before (capped at 10 even on accounts with more notes):
```
$ opencli xiaohongshu creator-notes --limit 15
(returns 10 rows, no rank 11+)
```

After (live-verified on benjamin-eecs's account, 11 published notes, data-permission active):
```
$ opencli xiaohongshu creator-notes --limit 15
- rank: 1   id: 6a11ae4d...   title: 'OpenCLI #1729 verify test 11 ...'
- rank: 2   id: 6a11a752...   title: 'OpenCLI #1729 verify test 10 ...'
- rank: 3   id: 6a11a68f...   title: 'OpenCLI #1729 verify test 9 ...'
...
- rank: 10  id: 6a11a077...   title: 'OpenCLI #1729 verify test 1 ...'
- rank: 11  id: 6a1195a8...   title: 'OpenCLI #1728 fix verification ...'
```

All 11 rows returned with titles populated. Rank 11 is the oldest note (past the first hydration batch of note-manager) and required the inner-list scroll-load to surface its title; the simpler implementation that didn't scroll returned its title empty.