### PR TITLE
fix(extension): reconnect via chrome.idle on OS resume / screen unlock

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1626,6 +1626,11 @@ chrome.runtime.onStartup.addListener(() => {
   initialize();
 });
 initialize();
+if (chrome.idle?.onStateChanged?.addListener) {
+  chrome.idle.onStateChanged.addListener((newState) => {
+    if (newState === "active") void connect();
+  });
+}
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   await workerReady;
   if (alarm.name === "keepalive") void connect();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,6 +9,7 @@
     "cookies",
     "activeTab",
     "alarms",
+    "idle",
     "storage",
     "tabGroups",
     "downloads"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -209,6 +209,9 @@ function createChromeMock() {
       clear: vi.fn(),
       onAlarm: { addListener: vi.fn() } as Listener<(alarm: { name: string }) => void>,
     },
+    idle: {
+      onStateChanged: { addListener: vi.fn() } as Listener<(newState: string) => void>,
+    },
     storage: {
       local: {
         get: vi.fn(async (key: string) => ({ [key]: storageState[key] })),
@@ -836,6 +839,27 @@ describe('background tab isolation', () => {
     await import('./background');
 
     expect(chrome.alarms.create).toHaveBeenCalledWith('keepalive', { periodInMinutes: 0.5 });
+  });
+
+  it('reconnects when chrome.idle reports the user active again', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+
+    await import('./background');
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    // Dead socket with no pending backoff timer: only the idle listener can
+    // start the next attempt.
+    MockWebSocket.instances[0].readyState = MockWebSocket.CLOSED;
+
+    const onStateChanged = chrome.idle.onStateChanged.addListener.mock.calls[0][0];
+    onStateChanged('active');
+
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
   });
 
   it('reconnect delay backs off exponentially with a 15s cap and resets on success', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1237,6 +1237,18 @@ chrome.runtime.onStartup.addListener(() => {
 // initialize() is idempotent, so lifecycle events remain harmless.
 initialize();
 
+// Reconnect when the user becomes active after OS resume or screen unlock.
+// The 20s WS ping and backoff timers die with a suspended worker, and the 30s
+// keepalive alarm can miss ticks across deep sleep (#1735 recurred on v1.0.22
+// with both shipped), so idle 'active' is the only wake at the moment of resume.
+// Guarded: a restarted worker can run updated code under a pre-"idle" manifest
+// grant until the unpacked extension reloads.
+if (chrome.idle?.onStateChanged?.addListener) {
+  chrome.idle.onStateChanged.addListener((newState) => {
+    if (newState === 'active') void connect();
+  });
+}
+
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   // Idle-lease alarms and keepalive can both fire in a freshly woken worker;
   // gate on recovery so releaseLease never persists an empty snapshot.


### PR DESCRIPTION
## Description

The Browser Bridge extension can stay disconnected after the OS resumes from sleep or unlocks. The 20s application-level WS ping and the exponential backoff both run on timers that die when Chrome suspends the MV3 service worker, leaving the 30s `keepalive` alarm as the only wake path, and #1735 recurred on 2026-08-01 with both #2070 mechanisms shipped: the reporter's worker stayed down until opening the extension details page woke it, after which it reconnected in about 0.2s.

Add a `chrome.idle.onStateChanged` listener that calls `connect()` on the transition to `active`: the documented signal Chrome delivers on unlock and OS resume, waking the suspended worker immediately instead of waiting on the next alarm tick. The listener sits behind a capability guard, since a restarted worker can run updated code under a pre-`idle` permission grant until the unpacked extension reloads.

Related issue: #1735, closed 2026-07-03 as believed fixed by #2070; a recurrence with both mechanisms shipped was reported there on 2026-08-01.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Rebased onto current main. Extension suite 97 / 97 with a test that fires the captured idle listener against a closed socket and asserts a reconnect attempt; it fails with the listener registration removed. Typecheck, both lint gates and doc coverage pass. `extension/dist/background.js` carries exactly the idle block and matches a fresh vite build byte for byte; `cli-manifest.json` untouched.

The original live verification (a real OS idle transition reconnecting the WebSocket, June, Chrome for Testing 149) predates this rebase and has not been rerun on the current build.
