### PR TITLE
fix(download): write yt-dlp cookie file with 0o600 owner-only permissions (fixes #1741)

### DIFF
--- a/src/download/index.test.ts
+++ b/src/download/index.test.ts
@@ -145,4 +145,19 @@ describe('download helpers', { retry: process.platform === 'win32' ? 2 : 0 }, ()
     const mode = fs.statSync(cookiesPath).mode & 0o777;
     expect(mode).toBe(0o600);
   });
+
+  it.skipIf(process.platform === 'win32')('tightens an existing Netscape cookie file before rewriting it', async () => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-dl-'));
+    tempDirs.push(tempDir);
+    const cookiesPath = path.join(tempDir, 'cookies.txt');
+    fs.writeFileSync(cookiesPath, 'stale-cookie', { mode: 0o644 });
+
+    exportCookiesToNetscape([
+      { name: 'sid', value: 'secret', domain: 'example.com' },
+    ], cookiesPath);
+
+    const mode = fs.statSync(cookiesPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+    expect(fs.readFileSync(cookiesPath, 'utf8')).toContain('sid\tsecret');
+  });
 });

--- a/src/download/index.test.ts
+++ b/src/download/index.test.ts
@@ -3,7 +3,7 @@ import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { formatCookieHeader, httpDownload, resolveRedirectUrl } from './index.js';
+import { exportCookiesToNetscape, formatCookieHeader, httpDownload, resolveRedirectUrl } from './index.js';
 
 const servers: http.Server[] = [];
 const tempDirs: string[] = [];
@@ -131,5 +131,18 @@ describe('download helpers', { retry: process.platform === 'win32' ? 2 : 0 }, ()
 
     expect(result).toEqual({ success: true, size: 2 });
     expect(fs.readFileSync(destPath, 'utf8')).toBe('ok');
+  });
+
+  it.skipIf(process.platform === 'win32')('writes the Netscape cookie file with 0o600 owner-only permissions', async () => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-dl-'));
+    tempDirs.push(tempDir);
+    const cookiesPath = path.join(tempDir, 'cookies.txt');
+
+    exportCookiesToNetscape([
+      { name: 'sid', value: 'secret', domain: 'example.com' },
+    ], cookiesPath);
+
+    const mode = fs.statSync(cookiesPath).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 });

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -217,7 +217,8 @@ export function exportCookiesToNetscape(
   }
 
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, lines.join('\n'));
+  // 0o600: file holds live session cookies, must be owner-only.
+  fs.writeFileSync(filePath, lines.join('\n'), { mode: 0o600 });
 }
 
 export function formatCookieHeader(cookies: BrowserCookie[]): string {

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -217,8 +217,18 @@ export function exportCookiesToNetscape(
   }
 
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  // 0o600: file holds live session cookies, must be owner-only.
-  fs.writeFileSync(filePath, lines.join('\n'), { mode: 0o600 });
+  // 0o600: file holds live session cookies, must be owner-only. fchmod before
+  // writing also tightens a pre-existing broad file before new secrets land.
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC, 0o600);
+    fs.fchmodSync(fd, 0o600);
+    fs.writeFileSync(fd, lines.join('\n'), 'utf8');
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
+  }
 }
 
 export function formatCookieHeader(cookies: BrowserCookie[]): string {


### PR DESCRIPTION
## Description

`exportCookiesToNetscape` in `src/download/index.ts` writes the Netscape cookie file via `fs.writeFileSync(filePath, lines.join('\n'))` with no `mode` option. The kernel applies the process umask (typically 022 on macOS/Linux), so the file lands as `0644`, world-readable on multi-user systems. The file is created at `/tmp/opencli-download/media_cookies_<timestamp>.txt` and contains live session cookies for every domain whose media we just downloaded, so any other local user or sibling process could read those cookies and impersonate the session. Pass `{ mode: 0o600 }` so the file is owner-only.

Related issue: fixes #1741 (originally flagged as Finding 9 in the #847 security audit).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Before:

```
$ ls -l /tmp/opencli-download/media_cookies_*.txt
-rw-r--r--  1 me  staff  1247 May 25 17:02 .../media_cookies_1748160123456.txt
```

After:

```
$ ls -l /tmp/opencli-download/media_cookies_*.txt
-rw-------  1 me  staff  1247 May 25 17:02 .../media_cookies_1748160123456.txt
```

New test `writes the Netscape cookie file with 0o600 owner-only permissions` asserts `fs.statSync(path).mode & 0o777 === 0o600`, skipped on Windows where POSIX mode bits don't apply (same `it.skipIf(process.platform === 'win32')` pattern used in `src/launcher.test.ts`).