### PR TITLE
fix(twitter): read profile name/created_at from result.core (fixes #1745)

### DIFF
--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -90,20 +90,23 @@ cli({
         if (!result) return {error: 'User @' + screenName + ' not found'};
 
         const legacy = result.legacy || {};
+        // X moved name/screen_name/created_at into result.core and location into
+        // result.location.location; fall back to legacy for older response shapes.
+        const core = result.core || {};
         const expandedUrl = legacy.entities?.url?.urls?.[0]?.expanded_url || '';
 
         return [{
-          screen_name: legacy.screen_name || screenName,
-          name: legacy.name || '',
+          screen_name: core.screen_name || legacy.screen_name || screenName,
+          name: core.name || legacy.name || '',
           bio: legacy.description || '',
-          location: legacy.location || '',
+          location: result.location?.location || legacy.location || '',
           url: expandedUrl,
           followers: legacy.followers_count || 0,
           following: legacy.friends_count || 0,
           tweets: legacy.statuses_count || 0,
           likes: legacy.favourites_count || 0,
           verified: result.is_blue_verified || legacy.verified || false,
-          created_at: legacy.created_at || '',
+          created_at: core.created_at || legacy.created_at || '',
         }];
       }
     `);

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -1,8 +1,48 @@
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { normalizeTwitterScreenName, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
+
+function isPlainObject(value) {
+    return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringField(value) {
+    return typeof value === 'string' ? value : '';
+}
+
+export function mapTwitterProfileResult(result, screenName) {
+    if (!isPlainObject(result)) {
+        throw new CommandExecutionError(`Twitter profile response for @${screenName} is malformed`);
+    }
+    const hasLegacy = isPlainObject(result.legacy);
+    const hasCore = isPlainObject(result.core);
+    if (!hasLegacy && !hasCore) {
+        throw new CommandExecutionError(`Twitter profile response for @${screenName} is missing profile fields`);
+    }
+    const legacy = hasLegacy ? result.legacy : {};
+    const core = hasCore ? result.core : {};
+    if (!stringField(core.screen_name) && !stringField(legacy.screen_name) && !stringField(core.name) && !stringField(legacy.name) && !stringField(core.created_at) && !stringField(legacy.created_at)) {
+        throw new CommandExecutionError(`Twitter profile response for @${screenName} is missing profile identity fields`);
+    }
+    const location = isPlainObject(result.location) ? result.location : {};
+    const expandedUrl = legacy.entities?.url?.urls?.[0]?.expanded_url || '';
+    return [{
+        screen_name: stringField(core.screen_name) || stringField(legacy.screen_name) || screenName,
+        name: stringField(core.name) || stringField(legacy.name),
+        bio: stringField(legacy.description),
+        location: stringField(location.location) || stringField(legacy.location),
+        url: stringField(expandedUrl),
+        followers: legacy.followers_count || 0,
+        following: legacy.friends_count || 0,
+        tweets: legacy.statuses_count || 0,
+        likes: legacy.favourites_count || 0,
+        verified: Boolean(result.is_blue_verified || legacy.verified),
+        created_at: stringField(core.created_at) || stringField(legacy.created_at),
+    }];
+}
+
 cli({
     site: 'twitter',
     name: 'profile',
@@ -46,7 +86,7 @@ cli({
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
-        const result = await page.evaluate(`
+        const rawResult = unwrapBrowserResult(await page.evaluate(`
       async () => {
         const screenName = "${username}";
         const ct0 = ${JSON.stringify(ct0)};
@@ -82,37 +122,47 @@ cli({
           + encodeURIComponent(variables)
           + '&features=' + encodeURIComponent(features);
 
-        const resp = await fetch(url, {headers, credentials: 'include'});
-        if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'User may not exist or queryId expired'};
-        const d = await resp.json();
+        let resp;
+        try {
+          resp = await fetch(url, {headers, credentials: 'include'});
+        } catch (error) {
+          return {ok: false, error: 'Twitter profile request failed: ' + String(error && error.message || error)};
+        }
+        if (!resp.ok) {
+          return {
+            ok: false,
+            auth: resp.status === 401 || resp.status === 403,
+            error: 'HTTP ' + resp.status,
+            hint: 'User may not exist, auth may be required, or queryId expired'
+          };
+        }
+        let d;
+        try {
+          d = await resp.json();
+        } catch (error) {
+          return {ok: false, error: 'Twitter profile response was not JSON: ' + String(error && error.message || error)};
+        }
 
         const result = d.data?.user?.result;
-        if (!result) return {error: 'User @' + screenName + ' not found'};
-
-        const legacy = result.legacy || {};
-        // X moved name/screen_name/created_at into result.core and location into
-        // result.location.location; fall back to legacy for older response shapes.
-        const core = result.core || {};
-        const expandedUrl = legacy.entities?.url?.urls?.[0]?.expanded_url || '';
-
-        return [{
-          screen_name: core.screen_name || legacy.screen_name || screenName,
-          name: core.name || legacy.name || '',
-          bio: legacy.description || '',
-          location: result.location?.location || legacy.location || '',
-          url: expandedUrl,
-          followers: legacy.followers_count || 0,
-          following: legacy.friends_count || 0,
-          tweets: legacy.statuses_count || 0,
-          likes: legacy.favourites_count || 0,
-          verified: result.is_blue_verified || legacy.verified || false,
-          created_at: core.created_at || legacy.created_at || '',
-        }];
+        if (!result) return {ok: false, notFound: true, error: 'User @' + screenName + ' not found'};
+        return {ok: true, result};
       }
-    `);
-        if (result?.error) {
-            throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
+    `));
+        if (!isPlainObject(rawResult)) {
+            throw new CommandExecutionError('Twitter profile response payload is malformed');
         }
-        return result || [];
+        if (!rawResult.ok) {
+            const message = rawResult.error + (rawResult.hint ? ` (${rawResult.hint})` : '');
+            if (rawResult.auth) {
+                throw new AuthRequiredError('x.com', message);
+            }
+            if (rawResult.notFound) {
+                throw new EmptyResultError('twitter profile', message);
+            }
+            throw new CommandExecutionError(message);
+        }
+        return mapTwitterProfileResult(rawResult.result, username);
     }
 });
+
+export const __test__ = { mapTwitterProfileResult };

--- a/clis/twitter/profile.test.js
+++ b/clis/twitter/profile.test.js
@@ -1,9 +1,73 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
-import './profile.js';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { __test__ } from './profile.js';
 
 describe('twitter profile command', () => {
+    it('maps current result.core profile fields while preserving legacy fallback fields', () => {
+        const rows = __test__.mapTwitterProfileResult({
+            core: {
+                screen_name: 'AstroHanRay',
+                name: 'AstroHan',
+                created_at: 'Sun Mar 20 00:00:00 +0000 2011',
+            },
+            legacy: {
+                screen_name: null,
+                name: null,
+                description: 'bio text',
+                location: 'legacy location',
+                followers_count: 117,
+                friends_count: 12,
+                statuses_count: 30,
+                favourites_count: 4,
+                verified: false,
+                entities: { url: { urls: [{ expanded_url: 'https://example.com' }] } },
+            },
+            location: { location: 'core location' },
+            is_blue_verified: true,
+        }, 'fallback');
+
+        expect(rows).toEqual([{
+            screen_name: 'AstroHanRay',
+            name: 'AstroHan',
+            bio: 'bio text',
+            location: 'core location',
+            url: 'https://example.com',
+            followers: 117,
+            following: 12,
+            tweets: 30,
+            likes: 4,
+            verified: true,
+            created_at: 'Sun Mar 20 00:00:00 +0000 2011',
+        }]);
+    });
+
+    it('falls back to legacy profile fields for older UserByScreenName responses', () => {
+        const rows = __test__.mapTwitterProfileResult({
+            legacy: {
+                screen_name: 'legacy_user',
+                name: 'Legacy Name',
+                created_at: 'Wed Jan 01 00:00:00 +0000 2020',
+                location: 'legacy location',
+            },
+        }, 'fallback');
+
+        expect(rows[0]).toMatchObject({
+            screen_name: 'legacy_user',
+            name: 'Legacy Name',
+            created_at: 'Wed Jan 01 00:00:00 +0000 2020',
+            location: 'legacy location',
+        });
+    });
+
+    it('throws typed when the profile result is structurally malformed', () => {
+        expect(() => __test__.mapTwitterProfileResult(null, 'jack')).toThrow(CommandExecutionError);
+        expect(() => __test__.mapTwitterProfileResult([], 'jack')).toThrow(CommandExecutionError);
+        expect(() => __test__.mapTwitterProfileResult({}, 'jack')).toThrow(CommandExecutionError);
+        expect(() => __test__.mapTwitterProfileResult({ __typename: 'UserUnavailable' }, 'jack')).toThrow(CommandExecutionError);
+        expect(() => __test__.mapTwitterProfileResult({ legacy: {}, core: {} }, 'jack')).toThrow(CommandExecutionError);
+    });
+
     it('rejects invalid explicit usernames before navigation', async () => {
         const command = getRegistry().get('twitter/profile');
         const page = {
@@ -35,5 +99,52 @@ describe('twitter profile command', () => {
         expect(page.goto).toHaveBeenCalledWith('https://x.com/home');
         expect(page.goto).toHaveBeenCalledTimes(1);
         expect(page.getCookies).not.toHaveBeenCalled();
+    });
+
+    it('unwraps Browser Bridge envelopes around UserByScreenName payloads', async () => {
+        const command = getRegistry().get('twitter/profile');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf' }]),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce({
+                    session: 'site:twitter',
+                    data: {
+                        ok: true,
+                        result: {
+                            core: { screen_name: 'core_user', name: 'Core User', created_at: 'now' },
+                            legacy: { description: 'bio' },
+                        },
+                    },
+                }),
+        };
+
+        await expect(command.func(page, { username: 'core_user' })).resolves.toEqual([
+            expect.objectContaining({
+                screen_name: 'core_user',
+                name: 'Core User',
+                bio: 'bio',
+                created_at: 'now',
+            }),
+        ]);
+    });
+
+    it('maps GraphQL auth and not-found envelopes to typed failures', async () => {
+        const command = getRegistry().get('twitter/profile');
+        const createPage = (payload) => ({
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf' }]),
+            evaluate: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(payload),
+        });
+
+        await expect(command.func(createPage({ ok: false, auth: true, error: 'HTTP 401' }), { username: 'jack' }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(command.func(createPage({ ok: false, notFound: true, error: 'User @missing not found' }), { username: 'missing' }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+        await expect(command.func(createPage({ session: 'site:twitter', data: [] }), { username: 'jack' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
 });


### PR DESCRIPTION
## Description

`opencli twitter profile <user>` returns an empty `name` and `created_at` for accounts that clearly have both. Other fields (`bio`, `followers`, `verified`, …) are correct.

**Root cause:** X moved fields in the `UserByScreenName` GraphQL response — `name`, `screen_name`, `created_at` out of `result.legacy` into `result.core`, and `location` into `result.location.location`. The adapter still read them from `legacy`, where they are now `null`. `screen_name` stayed correct only because of the existing fallback to the input handle, and `location` was masked when empty, so `name` and `created_at` were the visible breakage.

**Fix:** read the new locations first, fall back to `legacy` for older response shapes. No other fields are touched.

Related issue: #1745

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before (against an account that has both fields):

```shell
$ opencli twitter profile <handle> -f yaml
name: ''          # expected the display name
created_at: ''    # expected the join date
bio: '...'        # correct
followers: 117    # correct
```

Field positions verified against a live `UserByScreenName` response:

```
result.core.name        = "AstroHan"
result.core.screen_name = "AstroHanRay"
result.core.created_at  = "Sun Mar 20 ... 2011"
result.legacy.name      = null
result.location         = { location: "" }
```

After the patch, `name` and `created_at` populate from `core`; all other fields are unchanged.

**On tests:** field extraction runs inside the browser `page.evaluate` string, which the existing unit tests mock — so they cannot execute the core/legacy mapping. `npx tsc --noEmit` and `npx vitest run clis/twitter/profile.test.js` pass; field positions were verified against the live response above.
