### PR TITLE
fix(plugin): pass --ignore-scripts to npm install for cloned plugin repos

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -613,6 +613,21 @@ describe('installDependencies', () => {
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it('passes --ignore-scripts to npm install', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-plugin-ok-'));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'plugin-ok' }));
+
+    _installDependencies(tmpDir);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npm',
+      ['install', '--omit=dev', '--ignore-scripts'],
+      expect.objectContaining({ cwd: tmpDir }),
+    );
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });
 
 describe('postInstallMonorepoLifecycle', () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -564,7 +564,9 @@ function installDependencies(dir: string): void {
   if (!fs.existsSync(pkgJsonPath)) return;
 
   try {
-    execFileSync('npm', ['install', '--omit=dev'], {
+    // --ignore-scripts: dir was just cloned from a third-party Git URL, so
+    // running its npm lifecycle hooks would execute arbitrary code as the user.
+    execFileSync('npm', ['install', '--omit=dev', '--ignore-scripts'], {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Description

`installDependencies` in `src/plugin.ts` runs `execFileSync('npm', ['install', '--omit=dev'], ...)` against a directory just cloned from a third-party Git URL via `opencli adapter install`. Without `--ignore-scripts`, npm executes preinstall / install / postinstall hooks declared in the plugin's `package.json` (and in every transitive dep), so a malicious plugin or a compromised dep can run arbitrary code with the user's privileges at install time. Adapter code is loaded later by the plugin discovery path; the install-time script execution is an extra vector that adapter plugins do not need.

This is Finding 2 in the #847 security audit. @Astro-Han ranked it the top-priority unfixed item in his triage: *"`plugin install` is a real issue, and one we should treat seriously … Using `--ignore-scripts` plus a clear warning would be a good first step."* This PR is the `--ignore-scripts` half; a follow-up could add a one-time advisory if useful.

Plugins that depend on install scripts to compile native modules will silently skip those hooks. If a real case appears, an opt-in such as a manifest field or env var can be added in a follow-up; opencli adapter plugins observed in the wild depend on small pure-JS packages and do not exercise lifecycle scripts.

Related issue: fixes #1753.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Existing test `throws when npm install fails` still passes (mock-based regression check at the install error path). New test `passes --ignore-scripts to npm install` asserts the flag reaches the `execFileSync` call via the existing `mockExecFileSync` infrastructure. Full `src/plugin*.test.ts` suite: 105/105 pass on this branch.