### PR TITLE
fix(extension): skip user windows in tab-group discovery

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1045,6 +1045,11 @@ async function focusOwnedWindowIfRequested(windowId, mode) {
 async function toOwnedContainerDiscoveryCandidate(group) {
   try {
     const chromeWindow = await chrome.windows.get(group.windowId);
+    const windowTabs = await chrome.tabs.query({ windowId: group.windowId });
+    const hasUserTabsOutsideGroup = windowTabs.some(
+      (tab) => tab.groupId !== group.id && !!tab.url && isSafeNavigationUrl(tab.url)
+    );
+    if (hasUserTabsOutsideGroup) return null;
     const reusableTabId = await findReusableOwnedContainerTab(group.windowId);
     return {
       windowId: group.windowId,

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1290,6 +1290,35 @@ describe('background tab isolation', () => {
     expect(chrome.tabGroups.update).not.toHaveBeenCalled();
   });
 
+  it('skips a residual OpenCLI Adapter group when its window holds user http tabs outside the group', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push({
+      id: 77,
+      windowId: 7,
+      url: 'https://example.com/users-real-tab',
+      title: 'users real tab',
+      active: true,
+      status: 'complete',
+      groupId: -1,
+    });
+    groups.push({
+      id: 99,
+      windowId: 7,
+      title: 'OpenCLI Adapter',
+      color: 'orange',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(chrome.windows.create).toHaveBeenCalledTimes(1);
+    expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).not.toBe(7);
+    expect(tabs.find((tab) => tab.id === 77)?.url).toBe('https://example.com/users-real-tab');
+    expect(tabs.find((tab) => tab.id === tabId)?.windowId).not.toBe(7);
+  });
+
   it('prefers a focused OpenCLI Adapter group when multiple matching groups exist', async () => {
     const { chrome, tabs, groups, setLastFocusedWindowId } = createChromeMock();
     setLastFocusedWindowId(8);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -557,6 +557,13 @@ async function focusOwnedWindowIfRequested(windowId: number, mode: WindowMode): 
 async function toOwnedContainerDiscoveryCandidate(group: chrome.tabGroups.TabGroup): Promise<OwnedContainerDiscoveryCandidate | null> {
   try {
     const chromeWindow = await chrome.windows.get(group.windowId);
+    // Skip windows holding user http(s) tabs outside our group: a tab group
+    // moved into the user's main window (via drag or merge) is residue.
+    const windowTabs = await chrome.tabs.query({ windowId: group.windowId });
+    const hasUserTabsOutsideGroup = windowTabs.some((tab) =>
+      tab.groupId !== group.id && !!tab.url && isSafeNavigationUrl(tab.url),
+    );
+    if (hasUserTabsOutsideGroup) return null;
     const reusableTabId = await findReusableOwnedContainerTab(group.windowId);
     return {
       windowId: group.windowId,


### PR DESCRIPTION
## Description

`discoverOwnedContainerFromTabGroup` queries Chrome for any tab group titled "OpenCLI Adapter" across all windows and adopts the first match as the automation container. When Chrome moves our tab group into the user's main window (via tab drag or "Merge all windows"), the residual group survives there after the original automation window closes. The next service-worker discovery cycle then adopts the user's window, and `findReusableOwnedContainerTab` happily returns the user's real http(s) tab as a reusable automation target. `resolveTab` proceeds to overwrite that tab.

Adapter tabs created by the extension are always added to our group via `ensureOwnedContainerTabGroup`, so any http(s) tab in the candidate window that is outside our group must be a user tab. Use that as the residue signal in `toOwnedContainerDiscoveryCandidate`: when present, return null so `selectOwnedContainerDiscoveryCandidate` does not adopt the window and a fresh automation window is created instead.

Related issue: fixes #1760.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Unit test `skips a residual OpenCLI Adapter group when its window holds user http tabs outside the group` covers the regression: a window with a user `https://` tab outside the matched group and an "OpenCLI Adapter" group inside it now triggers a fresh automation window via `chrome.windows.create` and the user's tab url is preserved.

Live test on Chrome for Testing 149 with the patched extension loaded: a probe driven from the service-worker debug WS prepared the residue state (user window with one `https://example.com/users-real-tab` tab outside the group and one `about:blank` tab inside an "OpenCLI Adapter" group) and the patched discovery returned `adopted: null` while the pre-patch logic would have selected the user's window. Full extension suite: 75/75 pass.