### PR TITLE
feat(douban): include download file paths

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8316,7 +8316,8 @@
       "index",
       "title",
       "status",
-      "size"
+      "size",
+      "path"
     ],
     "type": "js",
     "modulePath": "douban/download.js",

--- a/clis/douban/download.js
+++ b/clis/douban/download.js
@@ -24,7 +24,7 @@ cli({
         { name: 'photo-id', help: '只下载指定 photo_id 的图片' },
         { name: 'output', default: './douban-downloads', help: '输出目录' },
     ],
-    columns: ['index', 'title', 'status', 'size'],
+    columns: ['index', 'title', 'status', 'size', 'path'],
     func: async (page, kwargs) => {
         const subjectId = normalizeDoubanSubjectId(String(kwargs.id || ''));
         const output = String(kwargs.output || './douban-downloads');
@@ -61,6 +61,7 @@ cli({
                 detail_url: photo.detailUrl,
                 status: result.success ? 'success' : 'failed',
                 size: result.success ? formatBytes(result.size) : (result.error || 'unknown error'),
+                path: path.resolve(destPath),
             });
         }
         return results;

--- a/clis/douban/download.test.js
+++ b/clis/douban/download.test.js
@@ -103,6 +103,7 @@ describe('douban download', () => {
                 detail_url: 'https://movie.douban.com/photos/photo/2913450214/',
                 status: 'success',
                 size: '1200 B',
+                path: path.resolve('/tmp/douban-test/30382501/30382501_001_2913450214_Main_poster.webp'),
             },
             {
                 index: 2,
@@ -112,6 +113,7 @@ describe('douban download', () => {
                 detail_url: 'https://movie.douban.com/photos/photo/2913450215/',
                 status: 'success',
                 size: '980 B',
+                path: path.resolve('/tmp/douban-test/30382501/30382501_002_2913450215_Character_poster.jpg'),
             },
         ]);
     });
@@ -160,6 +162,7 @@ describe('douban download', () => {
                 detail_url: 'https://movie.douban.com/photos/photo/2913450215/',
                 status: 'success',
                 size: '980 B',
+                path: path.resolve('/tmp/douban-test/30382501/30382501_002_2913450215_Character_poster.jpg'),
             },
         ]);
     });


### PR DESCRIPTION
## Summary

- include the local file path in each `douban download` result row
- add the new `path` column to the generated manifest
- update download command coverage to assert returned paths

## Why

`douban download` writes image files locally but only returned status and size metadata. Returning the resolved path makes the command easier to script and lets users pipe downloaded files into follow-up tools without reconstructing filenames.

## Validation

- `npx vitest run --project adapter clis/douban/download.test.js`
- `npm run build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `git diff --check`
- `node dist/src/main.js douban download 26266893 --limit 1 --output .tmp/douban-download-path-check -f json`