### PR TITLE
fix(browser): write network cache file with 0o600 owner-only permissions

### DIFF
--- a/src/browser/network-cache.test.ts
+++ b/src/browser/network-cache.test.ts
@@ -73,4 +73,25 @@ describe('network-cache', () => {
         expect(findEntry(file, 'B')?.key).toBe('B');
         expect(findEntry(file, 'missing')).toBeNull();
     });
+
+    it.skipIf(process.platform === 'win32')('writes the cache file with 0o600 owner-only permissions', () => {
+        saveNetworkCache('ws', [makeEntry('UserTweets')], baseDir);
+        const target = getCachePath('ws', baseDir);
+        const mode = fs.statSync(target).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+
+    it.skipIf(process.platform === 'win32')('tightens an existing cache file before rewriting it', () => {
+        const target = getCachePath('ws', baseDir);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, '{"version":1,"session":"ws","savedAt":"old","entries":[]}', { mode: 0o644 });
+
+        saveNetworkCache('ws', [makeEntry('UserTweets')], baseDir);
+
+        const mode = fs.statSync(target).mode & 0o777;
+        expect(mode).toBe(0o600);
+        const reloaded = loadNetworkCache('ws', { baseDir });
+        expect(reloaded.status).toBe('ok');
+        expect(reloaded.file?.entries[0].key).toBe('UserTweets');
+    });
 });

--- a/src/browser/network-cache.ts
+++ b/src/browser/network-cache.ts
@@ -63,7 +63,18 @@ export function saveNetworkCache(
         savedAt: new Date().toISOString(),
         entries,
     };
-    fs.writeFileSync(target, JSON.stringify(payload), 'utf-8');
+    // 0o600: entries can include auth tokens and PII from captured response
+    // bodies. fchmod before writing also tightens a pre-existing broad file.
+    let fd: number | undefined;
+    try {
+        fd = fs.openSync(target, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC, 0o600);
+        fs.fchmodSync(fd, 0o600);
+        fs.writeFileSync(fd, JSON.stringify(payload), 'utf8');
+    } finally {
+        if (fd !== undefined) {
+            fs.closeSync(fd);
+        }
+    }
 }
 
 export interface LoadOptions {


### PR DESCRIPTION
## Description

`saveNetworkCache` in `src/browser/network-cache.ts` writes the browser network cache via `fs.writeFileSync(target, JSON.stringify(payload), 'utf-8')` with no `mode` option. The kernel applies the process umask, so the file lands as `0644` and is readable by any local user. The file at `~/.opencli/cache/browser-network/<session>.json` stores up to a day of `entries[].body` payloads from every browser-backed adapter call, which routinely include auth tokens, session cookies, and PII. This is the same class of leak that #1742 fixed in `exportCookiesToNetscape`; apply the same `fs.openSync` + `fs.fchmodSync` pattern so new files are owner-only and pre-existing broad-permission files are tightened on rewrite.

Related issue: fixes #1765 (this is the same defense-in-depth thread continued from #1742; the larger Finding 5 in #847 about capture-by-default behavior is separate and not addressed here).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Two tests added next to existing siblings in `src/browser/network-cache.test.ts`, mirroring the #1742 layout:

- `writes the cache file with 0o600 owner-only permissions` covers the new-file case
- `tightens an existing cache file before rewriting it` pre-creates a 0o644 file and asserts the rewrite drops it to 0o600 while preserving round-trip via `loadNetworkCache`

Both skipped on Windows via `it.skipIf(process.platform === 'win32')` since POSIX mode bits do not apply there. Full suite: 511/511 pass on this branch.