### PR TITLE
fix(pixiv): migrate user/detail to pixivFetch helper for typed errors

### DIFF
--- a/clis/pixiv/detail.js
+++ b/clis/pixiv/detail.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { pixivFetch } from './utils.js';
 cli({
     site: 'pixiv',
@@ -27,7 +27,7 @@ cli({
     func: async (page, kwargs) => {
         const id = String(kwargs.id ?? '');
         if (!/^\d+$/.test(id)) {
-            throw new CommandExecutionError(`Invalid illustration ID: ${id}`);
+            throw new ArgumentError(`Invalid illustration ID: ${id}`, 'Example: opencli pixiv detail 123456');
         }
         const b = await pixivFetch(page, `/ajax/illust/${id}`, {
             notFoundMsg: `Illustration not found: ${id}`,

--- a/clis/pixiv/detail.js
+++ b/clis/pixiv/detail.js
@@ -1,6 +1,21 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { pixivFetch } from './utils.js';
+
+function requireIllustBody(body, id) {
+    if (!body || Array.isArray(body) || typeof body !== 'object') {
+        throw new CommandExecutionError(`Pixiv illustration ${id} returned malformed detail payload`);
+    }
+    const illustId = String(body.illustId ?? '').trim();
+    const title = String(body.illustTitle ?? '').trim();
+    const userName = String(body.userName ?? '').trim();
+    const userId = String(body.userId ?? '').trim();
+    if (!/^\d+$/.test(illustId) || illustId !== id || !title || !userName || !/^\d+$/.test(userId)) {
+        throw new CommandExecutionError(`Pixiv illustration ${id} returned malformed detail payload`);
+    }
+    return { ...body, illustId, illustTitle: title, userName, userId };
+}
+
 cli({
     site: 'pixiv',
     name: 'detail',
@@ -29,12 +44,10 @@ cli({
         if (!/^\d+$/.test(id)) {
             throw new ArgumentError(`Invalid illustration ID: ${id}`, 'Example: opencli pixiv detail 123456');
         }
-        const b = await pixivFetch(page, `/ajax/illust/${id}`, {
+        const body = await pixivFetch(page, `/ajax/illust/${id}`, {
             notFoundMsg: `Illustration not found: ${id}`,
         });
-        if (!b) {
-            throw new CommandExecutionError(`Illustration not found: ${id}`);
-        }
+        const b = requireIllustBody(body, id);
         return [{
             illust_id: b.illustId,
             title: b.illustTitle,

--- a/clis/pixiv/detail.js
+++ b/clis/pixiv/detail.js
@@ -1,4 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { pixivFetch } from './utils.js';
 cli({
     site: 'pixiv',
     name: 'detail',
@@ -6,7 +8,6 @@ cli({
     description: 'View illustration details (tags, stats, URLs)',
     domain: 'www.pixiv.net',
     strategy: Strategy.COOKIE,
-    browser: true,
     args: [
         { name: 'id', required: true, positional: true, help: 'Illustration ID' },
     ],
@@ -23,37 +24,30 @@ cli({
         'created',
         'url',
     ],
-    pipeline: [
-        { navigate: 'https://www.pixiv.net' },
-        { evaluate: `(async () => {
-  const id = \${{ args.id | json }};
-  const res = await fetch(
-    'https://www.pixiv.net/ajax/illust/' + id,
-    { credentials: 'include' }
-  );
-  if (!res.ok) {
-    if (res.status === 401 || res.status === 403) throw new Error('Authentication required — please log in to Pixiv in Chrome');
-    if (res.status === 404) throw new Error('Illustration not found: ' + id);
-    throw new Error('Pixiv request failed (HTTP ' + res.status + ')');
-  }
-  const data = await res.json();
-  const b = data?.body;
-  if (!b) throw new Error('Illustration not found');
-  return [{
-    illust_id: b.illustId,
-    title: b.illustTitle,
-    author: b.userName,
-    user_id: b.userId,
-    type: b.illustType === 0 ? 'illust' : b.illustType === 1 ? 'manga' : b.illustType === 2 ? 'ugoira' : String(b.illustType),
-    pages: b.pageCount,
-    bookmarks: b.bookmarkCount,
-    likes: b.likeCount,
-    views: b.viewCount,
-    tags: (b.tags?.tags || []).map(t => t.tag).join(', '),
-    created: b.createDate?.split('T')[0] || '',
-    url: 'https://www.pixiv.net/artworks/' + b.illustId
-  }];
-})()
-` },
-    ],
+    func: async (page, kwargs) => {
+        const id = String(kwargs.id ?? '');
+        if (!/^\d+$/.test(id)) {
+            throw new CommandExecutionError(`Invalid illustration ID: ${id}`);
+        }
+        const b = await pixivFetch(page, `/ajax/illust/${id}`, {
+            notFoundMsg: `Illustration not found: ${id}`,
+        });
+        if (!b) {
+            throw new CommandExecutionError(`Illustration not found: ${id}`);
+        }
+        return [{
+            illust_id: b.illustId,
+            title: b.illustTitle,
+            author: b.userName,
+            user_id: b.userId,
+            type: b.illustType === 0 ? 'illust' : b.illustType === 1 ? 'manga' : b.illustType === 2 ? 'ugoira' : String(b.illustType),
+            pages: b.pageCount,
+            bookmarks: b.bookmarkCount,
+            likes: b.likeCount,
+            views: b.viewCount,
+            tags: (b.tags?.tags || []).map(t => t.tag).join(', '),
+            created: b.createDate?.split('T')[0] || '',
+            url: `https://www.pixiv.net/artworks/${b.illustId}`,
+        }];
+    },
 });

--- a/clis/pixiv/detail.test.js
+++ b/clis/pixiv/detail.test.js
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { createPageMock } from '../test-utils.js';
+import './detail.js';
+let cmd;
+beforeAll(() => {
+    cmd = getRegistry().get('pixiv/detail');
+    expect(cmd?.func).toBeTypeOf('function');
+});
+describe('pixiv detail', () => {
+    it('throws CommandExecutionError on invalid illustration ID', async () => {
+        const page = createPageMock([]);
+        await expect(cmd.func(page, { id: 'xyz' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('throws AuthRequiredError on 401', async () => {
+        const page = createPageMock([{ __httpError: 401 }]);
+        await expect(cmd.func(page, { id: '12345' })).rejects.toThrow(AuthRequiredError);
+    });
+    it('throws CommandExecutionError on 404', async () => {
+        const page = createPageMock([{ __httpError: 404 }]);
+        await expect(cmd.func(page, { id: '12345' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('throws CommandExecutionError on non-auth HTTP failure', async () => {
+        const page = createPageMock([{ __httpError: 500 }]);
+        await expect(cmd.func(page, { id: '12345' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('returns detail row with mapped fields', async () => {
+        const page = createPageMock([
+            {
+                body: {
+                    illustId: '12345',
+                    illustTitle: 'Test Illust',
+                    userName: 'Test Artist',
+                    userId: '99',
+                    illustType: 1,
+                    pageCount: 4,
+                    bookmarkCount: 200,
+                    likeCount: 100,
+                    viewCount: 5000,
+                    tags: { tags: [{ tag: 'original' }, { tag: 'fantasy' }] },
+                    createDate: '2025-01-15T12:00:00+09:00',
+                },
+            },
+        ]);
+        const result = await cmd.func(page, { id: '12345' });
+        expect(result).toEqual([{
+            illust_id: '12345',
+            title: 'Test Illust',
+            author: 'Test Artist',
+            user_id: '99',
+            type: 'manga',
+            pages: 4,
+            bookmarks: 200,
+            likes: 100,
+            views: 5000,
+            tags: 'original, fantasy',
+            created: '2025-01-15',
+            url: 'https://www.pixiv.net/artworks/12345',
+        }]);
+    });
+});

--- a/clis/pixiv/detail.test.js
+++ b/clis/pixiv/detail.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { createPageMock } from '../test-utils.js';
 import './detail.js';
 let cmd;
@@ -9,9 +9,10 @@ beforeAll(() => {
     expect(cmd?.func).toBeTypeOf('function');
 });
 describe('pixiv detail', () => {
-    it('throws CommandExecutionError on invalid illustration ID', async () => {
+    it('throws ArgumentError on invalid illustration ID before navigation', async () => {
         const page = createPageMock([]);
-        await expect(cmd.func(page, { id: 'xyz' })).rejects.toThrow(CommandExecutionError);
+        await expect(cmd.func(page, { id: 'xyz' })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
     it('throws AuthRequiredError on 401', async () => {
         const page = createPageMock([{ __httpError: 401 }]);
@@ -24,6 +25,13 @@ describe('pixiv detail', () => {
     it('throws CommandExecutionError on non-auth HTTP failure', async () => {
         const page = createPageMock([{ __httpError: 500 }]);
         await expect(cmd.func(page, { id: '12345' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('surfaces HTTP error body messages from pixivFetch', async () => {
+        const page = createPageMock([{ __httpError: 429, message: 'Too many requests' }]);
+        await expect(cmd.func(page, { id: '12345' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Too many requests'),
+        });
     });
     it('returns detail row with mapped fields', async () => {
         const page = createPageMock([

--- a/clis/pixiv/detail.test.js
+++ b/clis/pixiv/detail.test.js
@@ -33,6 +33,29 @@ describe('pixiv detail', () => {
             message: expect.stringContaining('Too many requests'),
         });
     });
+    it('fails typed when the detail body lacks stable illustration identity fields', async () => {
+        const page = createPageMock([{ body: { illustId: '12345', illustTitle: 'Title' } }]);
+        await expect(cmd.func(page, { id: '12345' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed detail payload'),
+        });
+    });
+    it('fails typed when the detail body id does not match the requested illustration', async () => {
+        const page = createPageMock([
+            {
+                body: {
+                    illustId: '99999',
+                    illustTitle: 'Wrong',
+                    userName: 'Artist',
+                    userId: '99',
+                },
+            },
+        ]);
+        await expect(cmd.func(page, { id: '12345' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed detail payload'),
+        });
+    });
     it('returns detail row with mapped fields', async () => {
         const page = createPageMock([
             {

--- a/clis/pixiv/user.js
+++ b/clis/pixiv/user.js
@@ -1,4 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { pixivFetch } from './utils.js';
 cli({
     site: 'pixiv',
     name: 'user',
@@ -6,7 +8,6 @@ cli({
     description: 'View Pixiv artist profile',
     domain: 'www.pixiv.net',
     strategy: Strategy.COOKIE,
-    browser: true,
     args: [
         { name: 'uid', required: true, positional: true, help: 'Pixiv user ID' },
     ],
@@ -21,34 +22,28 @@ cli({
         'comment',
         'url',
     ],
-    pipeline: [
-        { navigate: 'https://www.pixiv.net' },
-        { evaluate: `(async () => {
-  const uid = \${{ args.uid | json }};
-  const res = await fetch(
-    'https://www.pixiv.net/ajax/user/' + uid + '?full=1',
-    { credentials: 'include' }
-  );
-  if (!res.ok) {
-    if (res.status === 401 || res.status === 403) throw new Error('Authentication required — please log in to Pixiv in Chrome');
-    if (res.status === 404) throw new Error('User not found: ' + uid);
-    throw new Error('Pixiv request failed (HTTP ' + res.status + ')');
-  }
-  const data = await res.json();
-  const b = data?.body;
-  if (!b) throw new Error('User not found');
-  return [{
-    user_id: uid,
-    name: b.name,
-    premium: b.premium ? 'Yes' : 'No',
-    following: b.following,
-    illusts: typeof b.illusts === 'object' ? Object.keys(b.illusts).length : (b.illusts || 0),
-    manga: typeof b.manga === 'object' ? Object.keys(b.manga).length : (b.manga || 0),
-    novels: typeof b.novels === 'object' ? Object.keys(b.novels).length : (b.novels || 0),
-    comment: (b.comment || '').slice(0, 80),
-    url: 'https://www.pixiv.net/users/' + uid
-  }];
-})()
-` },
-    ],
+    func: async (page, kwargs) => {
+        const uid = String(kwargs.uid ?? '');
+        if (!/^\d+$/.test(uid)) {
+            throw new CommandExecutionError(`Invalid user ID: ${uid}`);
+        }
+        const b = await pixivFetch(page, `/ajax/user/${uid}`, {
+            params: { full: 1 },
+            notFoundMsg: `User not found: ${uid}`,
+        });
+        if (!b) {
+            throw new CommandExecutionError(`User not found: ${uid}`);
+        }
+        return [{
+            user_id: uid,
+            name: b.name,
+            premium: b.premium ? 'Yes' : 'No',
+            following: b.following,
+            illusts: typeof b.illusts === 'object' ? Object.keys(b.illusts).length : (b.illusts || 0),
+            manga: typeof b.manga === 'object' ? Object.keys(b.manga).length : (b.manga || 0),
+            novels: typeof b.novels === 'object' ? Object.keys(b.novels).length : (b.novels || 0),
+            comment: (b.comment || '').slice(0, 80),
+            url: `https://www.pixiv.net/users/${uid}`,
+        }];
+    },
 });

--- a/clis/pixiv/user.js
+++ b/clis/pixiv/user.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { pixivFetch } from './utils.js';
 cli({
     site: 'pixiv',
@@ -25,7 +25,7 @@ cli({
     func: async (page, kwargs) => {
         const uid = String(kwargs.uid ?? '');
         if (!/^\d+$/.test(uid)) {
-            throw new CommandExecutionError(`Invalid user ID: ${uid}`);
+            throw new ArgumentError(`Invalid user ID: ${uid}`, 'Example: opencli pixiv user 123456');
         }
         const b = await pixivFetch(page, `/ajax/user/${uid}`, {
             params: { full: 1 },

--- a/clis/pixiv/user.js
+++ b/clis/pixiv/user.js
@@ -1,6 +1,18 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { pixivFetch } from './utils.js';
+
+function requireUserBody(body, uid) {
+    if (!body || Array.isArray(body) || typeof body !== 'object') {
+        throw new CommandExecutionError(`Pixiv user ${uid} returned malformed profile payload`);
+    }
+    const name = String(body.name ?? '').trim();
+    if (!name) {
+        throw new CommandExecutionError(`Pixiv user ${uid} returned malformed profile payload`);
+    }
+    return { ...body, name };
+}
+
 cli({
     site: 'pixiv',
     name: 'user',
@@ -27,13 +39,11 @@ cli({
         if (!/^\d+$/.test(uid)) {
             throw new ArgumentError(`Invalid user ID: ${uid}`, 'Example: opencli pixiv user 123456');
         }
-        const b = await pixivFetch(page, `/ajax/user/${uid}`, {
+        const body = await pixivFetch(page, `/ajax/user/${uid}`, {
             params: { full: 1 },
             notFoundMsg: `User not found: ${uid}`,
         });
-        if (!b) {
-            throw new CommandExecutionError(`User not found: ${uid}`);
-        }
+        const b = requireUserBody(body, uid);
         return [{
             user_id: uid,
             name: b.name,

--- a/clis/pixiv/user.test.js
+++ b/clis/pixiv/user.test.js
@@ -63,6 +63,13 @@ describe('pixiv user', () => {
             message: expect.stringContaining('malformed API payload'),
         });
     });
+    it('fails typed when the user body lacks stable profile identity fields', async () => {
+        const page = createPageMock([{ body: { premium: false, following: 0 } }]);
+        await expect(cmd.func(page, { uid: '11' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed profile payload'),
+        });
+    });
     it('returns profile row with computed counts for object-shaped illust fields', async () => {
         const page = createPageMock([
             {

--- a/clis/pixiv/user.test.js
+++ b/clis/pixiv/user.test.js
@@ -1,0 +1,55 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { createPageMock } from '../test-utils.js';
+import './user.js';
+let cmd;
+beforeAll(() => {
+    cmd = getRegistry().get('pixiv/user');
+    expect(cmd?.func).toBeTypeOf('function');
+});
+describe('pixiv user', () => {
+    it('throws CommandExecutionError on invalid user ID', async () => {
+        const page = createPageMock([]);
+        await expect(cmd.func(page, { uid: 'abc' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('throws AuthRequiredError on 401', async () => {
+        const page = createPageMock([{ __httpError: 401 }]);
+        await expect(cmd.func(page, { uid: '11' })).rejects.toThrow(AuthRequiredError);
+    });
+    it('throws CommandExecutionError on 404', async () => {
+        const page = createPageMock([{ __httpError: 404 }]);
+        await expect(cmd.func(page, { uid: '11' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('throws CommandExecutionError on non-auth HTTP failure', async () => {
+        const page = createPageMock([{ __httpError: 500 }]);
+        await expect(cmd.func(page, { uid: '11' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('returns profile row with computed counts for object-shaped illust fields', async () => {
+        const page = createPageMock([
+            {
+                body: {
+                    name: 'Test Artist',
+                    premium: true,
+                    following: 42,
+                    illusts: { '111': null, '222': null, '333': null },
+                    manga: {},
+                    novels: { '999': null },
+                    comment: 'Hello world',
+                },
+            },
+        ]);
+        const result = await cmd.func(page, { uid: '11' });
+        expect(result).toEqual([{
+            user_id: '11',
+            name: 'Test Artist',
+            premium: 'Yes',
+            following: 42,
+            illusts: 3,
+            manga: 0,
+            novels: 1,
+            comment: 'Hello world',
+            url: 'https://www.pixiv.net/users/11',
+        }]);
+    });
+});

--- a/clis/pixiv/user.test.js
+++ b/clis/pixiv/user.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { createPageMock } from '../test-utils.js';
 import './user.js';
 let cmd;
@@ -9,9 +9,10 @@ beforeAll(() => {
     expect(cmd?.func).toBeTypeOf('function');
 });
 describe('pixiv user', () => {
-    it('throws CommandExecutionError on invalid user ID', async () => {
+    it('throws ArgumentError on invalid user ID before navigation', async () => {
         const page = createPageMock([]);
-        await expect(cmd.func(page, { uid: 'abc' })).rejects.toThrow(CommandExecutionError);
+        await expect(cmd.func(page, { uid: 'abc' })).rejects.toThrow(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
     });
     it('throws AuthRequiredError on 401', async () => {
         const page = createPageMock([{ __httpError: 401 }]);
@@ -24,6 +25,43 @@ describe('pixiv user', () => {
     it('throws CommandExecutionError on non-auth HTTP failure', async () => {
         const page = createPageMock([{ __httpError: 500 }]);
         await expect(cmd.func(page, { uid: '11' })).rejects.toThrow(CommandExecutionError);
+    });
+    it('unwraps Browser Bridge envelopes around Pixiv API payloads', async () => {
+        const page = createPageMock([
+            {
+                session: 'site:pixiv',
+                data: {
+                    body: {
+                        name: 'Envelope Artist',
+                        premium: false,
+                        following: 0,
+                        illusts: {},
+                        manga: {},
+                        novels: {},
+                    },
+                },
+            },
+        ]);
+        const result = await cmd.func(page, { uid: '12' });
+        expect(result[0]).toMatchObject({
+            user_id: '12',
+            name: 'Envelope Artist',
+            premium: 'No',
+        });
+    });
+    it('surfaces Pixiv API error bodies instead of treating them as not found', async () => {
+        const page = createPageMock([{ error: true, message: 'rate limited' }]);
+        await expect(cmd.func(page, { uid: '11' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: 'rate limited',
+        });
+    });
+    it('fails typed on malformed Pixiv API payloads', async () => {
+        const page = createPageMock([{ ok: true }]);
+        await expect(cmd.func(page, { uid: '11' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed API payload'),
+        });
     });
     it('returns profile row with computed counts for object-shaped illust fields', async () => {
         const page = createPageMock([

--- a/clis/pixiv/utils.js
+++ b/clis/pixiv/utils.js
@@ -7,6 +7,25 @@
  */
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 const PIXIV_DOMAIN = 'www.pixiv.net';
+
+function unwrapEvaluateResult(payload) {
+    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
+
+function extractPixivErrorMessage(payload) {
+    if (!payload || typeof payload !== 'object') return '';
+    const candidates = [
+        payload.message,
+        payload.errorMessage,
+        payload.error?.message,
+        payload.error,
+    ];
+    const found = candidates.find((value) => typeof value === 'string' && value.trim());
+    return found ? found.trim() : '';
+}
 /**
  * Navigate to Pixiv (to attach cookies) then fetch a Pixiv Ajax API endpoint.
  *
@@ -21,27 +40,57 @@ const PIXIV_DOMAIN = 'www.pixiv.net';
  * @throws CommandExecutionError on 404 or other HTTP errors
  */
 export async function pixivFetch(page, path, opts = {}) {
-    await page.goto(`https://${PIXIV_DOMAIN}`);
+    try {
+        await page.goto(`https://${PIXIV_DOMAIN}`);
+    } catch (error) {
+        throw new CommandExecutionError(`Pixiv navigation failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
     const qs = opts.params
         ? '?' + Object.entries(opts.params).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&')
         : '';
     const url = `https://${PIXIV_DOMAIN}${path}${qs}`;
-    const data = await page.evaluate(`
+    let data;
+    try {
+        data = unwrapEvaluateResult(await page.evaluate(`
     (async () => {
       const res = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
-      if (!res.ok) return { __httpError: res.status };
-      return await res.json();
+      const text = await res.text();
+      let json = null;
+      if (text) {
+        try { json = JSON.parse(text); } catch {}
+      }
+      if (!res.ok) {
+        return {
+          __httpError: res.status,
+          message: json?.message || json?.errorMessage || json?.error?.message || (typeof json?.error === 'string' ? json.error : '') || text.slice(0, 200),
+        };
+      }
+      if (!json) return { __malformed: true, message: 'invalid JSON' };
+      return json;
     })()
-  `);
+  `));
+    } catch (error) {
+        throw new CommandExecutionError(`Pixiv request failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
     if (data?.__httpError) {
         const status = data.__httpError;
         if (status === 401 || status === 403) {
             throw new AuthRequiredError(PIXIV_DOMAIN, 'Authentication required — please log in to Pixiv in Chrome');
         }
+        const message = extractPixivErrorMessage(data);
         if (status === 404) {
-            throw new CommandExecutionError(opts.notFoundMsg || `Pixiv resource not found (HTTP 404)`);
+            throw new CommandExecutionError(message || opts.notFoundMsg || `Pixiv resource not found (HTTP 404)`);
         }
-        throw new CommandExecutionError(`Pixiv request failed (HTTP ${status})`);
+        throw new CommandExecutionError(message ? `Pixiv request failed (HTTP ${status}): ${message}` : `Pixiv request failed (HTTP ${status})`);
+    }
+    if (!data || Array.isArray(data) || typeof data !== 'object' || data.__malformed) {
+        throw new CommandExecutionError('Pixiv request returned malformed JSON payload');
+    }
+    if (data.error === true) {
+        throw new CommandExecutionError(extractPixivErrorMessage(data) || 'Pixiv API returned an error');
+    }
+    if (!('body' in data)) {
+        throw new CommandExecutionError('Pixiv request returned malformed API payload');
     }
     return data?.body;
 }


### PR DESCRIPTION
## Description

`clis/pixiv/user.js` and `clis/pixiv/detail.js` hand-rolled their own inline `fetch` in the pipeline `evaluate` block and threw raw `Error` on 401/403/404/5xx, surfacing `code: UNKNOWN` to agents instead of the typed `AUTH_REQUIRED` / `COMMAND_EXEC` that `pixivFetch` in `clis/pixiv/utils.js` provides and that the sibling commands `illusts.js` / `download.js` / `search.js` already use.

Migrate to `func`-style adapters that go through `pixivFetch`. Also add up-front numeric-ID validation matching the sibling pattern in `illusts.js`, so malformed IDs fail before hitting the network.

`ranking.js` is intentionally left for follow-up: it hits `/ranking.php?format=json` whose response shape is `data.contents`, not the `data.body` that `pixivFetch` returns, so the helper needs a small extension before the migration can land cleanly there.

Related issue: fixes #1767. Continues the typed-error / silent-sentinel sweep direction from #1611, #1631, #1634.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Live before / after on this branch:

`opencli pixiv user 999999999999 --format yaml` (any nonexistent ID):

```
# before (main)
ok: false
error:
  code: UNKNOWN
  message: |-
    Error: User not found: 999999999999
        at <anonymous>:9:35

# after (this branch)
ok: false
error:
  code: COMMAND_EXEC
  message: 'User not found: 999999999999'
```

`opencli pixiv detail 12345 --format yaml` (404) same swap from `UNKNOWN` to `COMMAND_EXEC`. Happy paths `opencli pixiv user 11` and `opencli pixiv detail 99999999` continue to return populated rows on this branch.

New `clis/pixiv/user.test.js` and `clis/pixiv/detail.test.js` mirror the `illusts.test.js` shape and cover `invalid id → CommandExecutionError`, `401 → AuthRequiredError`, `404 → CommandExecutionError`, `500 → CommandExecutionError`, and the happy-path row mapping. Full pixiv suite: 28/28 pass.