### PR TITLE
feat(browser): add --via-extension flag to bypass debugger detection on anti-bot sites

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -137,17 +137,20 @@ async function evaluateViaScripting(tabId, expression) {
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`--no-debugger eval failed: ${msg}`);
+    throw new Error(`--via-extension eval failed: ${msg}`);
   }
   if (!results || results.length === 0) {
-    throw new Error("--no-debugger eval failed: executeScript returned no results");
+    throw new Error("--via-extension eval failed: executeScript returned no results");
   }
   const payload = results[0].result;
   if (!payload) {
-    throw new Error("--no-debugger eval failed: script returned undefined (return value may not be structured-cloneable)");
+    throw new Error("--via-extension eval failed: script returned undefined (return value may not be structured-cloneable)");
   }
   if (!payload.ok) {
-    throw new Error(payload.error ?? "Script evaluation failed");
+    const msg = payload.error ?? "Script evaluation failed";
+    const isCsp = /unsafe-eval|content security policy|EvalError/i.test(msg);
+    throw new Error(isCsp ? `${msg}
+(--via-extension eval runs in the page's MAIN world and is subject to its CSP; sites that block unsafe-eval will reject this. Use plain \`browser eval\` (CDP path) on such pages.)` : msg);
   }
   return payload.value;
 }
@@ -732,6 +735,7 @@ console.error = (...args) => {
   forwardLog("error", args);
 };
 function isDaemonSocketActive(socket = ws) {
+  if (typeof WebSocket === "undefined") return false;
   return socket?.readyState === WebSocket.OPEN || socket?.readyState === WebSocket.CONNECTING;
 }
 function connect() {
@@ -1415,6 +1419,8 @@ async function handleCommand(cmd) {
     switch (cmd.action) {
       case "exec":
         return await handleExec(cmd, leaseKey);
+      case "exec-via-scripting":
+        return await handleExecViaScripting(cmd, leaseKey);
       case "navigate":
         return await handleNavigate(cmd, leaseKey);
       case "tabs":
@@ -1645,18 +1651,22 @@ async function listAutomationWebTabs(leaseKey) {
   const tabs = await listAutomationTabs(leaseKey);
   return tabs.filter((tab) => isDebuggableUrl(tab.url));
 }
+async function handleExecViaScripting(cmd, leaseKey) {
+  if (!cmd.code) return { id: cmd.id, ok: false, error: "Missing code" };
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, leaseKey);
+  try {
+    const data = await evaluateViaScripting(tabId, cmd.code);
+    return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
 async function handleExec(cmd, leaseKey) {
   if (!cmd.code) return { id: cmd.id, ok: false, error: "Missing code" };
   const cmdTabId = await resolveCommandTabId(cmd);
   const tabId = await resolveTabId(cmdTabId, leaseKey);
   try {
-    if (cmd.noDebugger) {
-      if (cmd.frameIndex != null) {
-        return { id: cmd.id, ok: false, error: "--no-debugger does not support --frame; omit --frame or remove --no-debugger" };
-      }
-      const data2 = await evaluateViaScripting(tabId, cmd.code);
-      return pageScopedResult(cmd.id, tabId, data2);
-    }
     const aggressive = getSurfaceFromKey(leaseKey) === "browser";
     if (cmd.frameIndex != null) {
       const tree = await getFrameTree(tabId);

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -119,6 +119,38 @@ async function evaluate(tabId, expression, aggressiveRetry = false) {
   throw new Error("evaluate: max retries exhausted");
 }
 const evaluateAsync = evaluate;
+async function evaluateViaScripting(tabId, expression) {
+  let results;
+  try {
+    results = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: async (code) => {
+        try {
+          const value = await (0, eval)(code);
+          return { ok: true, value };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      args: [expression]
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`--no-debugger eval failed: ${msg}`);
+  }
+  if (!results || results.length === 0) {
+    throw new Error("--no-debugger eval failed: executeScript returned no results");
+  }
+  const payload = results[0].result;
+  if (!payload) {
+    throw new Error("--no-debugger eval failed: script returned undefined (return value may not be structured-cloneable)");
+  }
+  if (!payload.ok) {
+    throw new Error(payload.error ?? "Script evaluation failed");
+  }
+  return payload.value;
+}
 async function screenshot(tabId, options = {}) {
   await ensureAttached(tabId);
   const format = options.format ?? "png";
@@ -1618,6 +1650,13 @@ async function handleExec(cmd, leaseKey) {
   const cmdTabId = await resolveCommandTabId(cmd);
   const tabId = await resolveTabId(cmdTabId, leaseKey);
   try {
+    if (cmd.noDebugger) {
+      if (cmd.frameIndex != null) {
+        return { id: cmd.id, ok: false, error: "--no-debugger does not support --frame; omit --frame or remove --no-debugger" };
+      }
+      const data2 = await evaluateViaScripting(tabId, cmd.code);
+      return pageScopedResult(cmd.id, tabId, data2);
+    }
     const aggressive = getSurfaceFromKey(leaseKey) === "browser";
     if (cmd.frameIndex != null) {
       const tree = await getFrameTree(tabId);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,7 @@
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",
+    "scripting",
     "tabs",
     "cookies",
     "activeTab",

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -2006,7 +2006,7 @@ describe('background tab isolation', () => {
   });
 });
 
-describe('handleExec noDebugger path', () => {
+describe('handleExecViaScripting path', () => {
   // Keep WebSocket stubbed for the entire describe block so that any pending
   // connectAttempt() Promises left over from the previous describe block can
   // resolve safely (without "WebSocket is not defined") during our tests.
@@ -2031,7 +2031,7 @@ describe('handleExec noDebugger path', () => {
     vi.useRealTimers();
   });
 
-  it('calls evaluateViaScripting instead of evaluateAsync when noDebugger is true', async () => {
+  it('calls evaluateViaScripting and NOT evaluateAsync for exec-via-scripting action', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -2050,13 +2050,12 @@ describe('handleExec noDebugger path', () => {
     const mod = await import('./background');
     mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
 
-    const result = await mod.__test__.handleExec({
+    const result = await mod.__test__.handleExecViaScripting({
       id: 'scripting-exec',
-      action: 'exec',
+      action: 'exec-via-scripting',
       session: 'default',
       surface: 'browser',
       code: 'document.title',
-      noDebugger: true,
     }, browserKey('default'));
 
     expect(result.ok).toBe(true);
@@ -2065,40 +2064,7 @@ describe('handleExec noDebugger path', () => {
     expect(evaluateAsync).not.toHaveBeenCalled();
   });
 
-  it('returns an error when noDebugger is combined with frameIndex', async () => {
-    const { chrome } = createChromeMock();
-    vi.stubGlobal('chrome', chrome);
-
-    const evaluateViaScripting = vi.fn();
-    vi.doMock('./cdp', () => ({
-      registerListeners: vi.fn(),
-      registerFrameTracking: vi.fn(),
-      hasActiveNetworkCapture: vi.fn(() => false),
-      detach: vi.fn(async () => {}),
-      evaluateAsync: vi.fn(),
-      evaluateViaScripting,
-      screenshot: vi.fn(),
-    }));
-
-    const mod = await import('./background');
-    mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
-
-    const result = await mod.__test__.handleExec({
-      id: 'scripting-frame',
-      action: 'exec',
-      session: 'default',
-      surface: 'browser',
-      code: 'document.title',
-      noDebugger: true,
-      frameIndex: 0,
-    }, browserKey('default'));
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/--no-debugger.*--frame|--frame.*--no-debugger/i);
-    expect(evaluateViaScripting).not.toHaveBeenCalled();
-  });
-
-  it('still uses evaluateAsync (CDP) when noDebugger is absent', async () => {
+  it('exec action still uses evaluateAsync (CDP) and does NOT call evaluateViaScripting', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -2141,23 +2107,57 @@ describe('handleExec noDebugger path', () => {
       hasActiveNetworkCapture: vi.fn(() => false),
       detach: vi.fn(async () => {}),
       evaluateAsync: vi.fn(),
-      evaluateViaScripting: vi.fn(async () => { throw new Error('--no-debugger eval failed: Cannot access chrome:// URL'); }),
+      evaluateViaScripting: vi.fn(async () => { throw new Error('--via-extension eval failed: Cannot access chrome:// URL'); }),
       screenshot: vi.fn(),
     }));
 
     const mod = await import('./background');
     mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
 
-    const result = await mod.__test__.handleExec({
+    const result = await mod.__test__.handleExecViaScripting({
       id: 'scripting-error',
-      action: 'exec',
+      action: 'exec-via-scripting',
       session: 'default',
       surface: 'browser',
       code: 'document.title',
-      noDebugger: true,
     }, browserKey('default'));
 
     expect(result.ok).toBe(false);
-    expect(result.error).toContain('--no-debugger eval failed');
+    expect(result.error).toContain('--via-extension eval failed');
+  });
+
+  it('handleCommand returns ok:false for unrecognized actions (old extension fails loudly, no silent CDP fallback)', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const evaluateAsync = vi.fn(async () => 'cdp-result');
+    const evaluateViaScripting = vi.fn(async () => 'scripting-result');
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync,
+      evaluateViaScripting,
+      screenshot: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+
+    // An old extension that doesn't know exec-via-scripting would hit the default
+    // switch branch and return Unknown action — not silently fall through to CDP.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await mod.__test__.handleCommand({
+      id: 'unrecognized',
+      action: 'exec-unrecognized-future-action' as Parameters<typeof mod.__test__.handleCommand>[0]['action'],
+      session: 'default',
+      surface: 'browser',
+      code: 'document.title',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Unknown action/i);
+    expect(evaluateAsync).not.toHaveBeenCalled();
+    expect(evaluateViaScripting).not.toHaveBeenCalled();
   });
 });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type Listener<T extends (...args: any[]) => void> = {
   addListener: any;
@@ -215,6 +215,11 @@ function createChromeMock() {
     setLastFocusedWindowId: (windowId: number) => { lastFocusedWindowId = windowId; },
   };
 }
+
+// Keep WebSocket stubbed for the entire file so that any pending connectAttempt()
+// Promises can resolve safely between describe blocks.
+beforeAll(() => { vi.stubGlobal('WebSocket', MockWebSocket); });
+afterAll(() => { vi.unstubAllGlobals(); });
 
 describe('background tab isolation', () => {
   beforeEach(() => {
@@ -1998,5 +2003,161 @@ describe('background tab isolation', () => {
     }));
     expect(chrome.tabs.update).toHaveBeenCalledWith(2, expect.objectContaining({ url: 'https://other.example' }));
     expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleExec noDebugger path', () => {
+  // Keep WebSocket stubbed for the entire describe block so that any pending
+  // connectAttempt() Promises left over from the previous describe block can
+  // resolve safely (without "WebSocket is not defined") during our tests.
+  beforeAll(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('calls evaluateViaScripting instead of evaluateAsync when noDebugger is true', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const evaluateAsync = vi.fn(async () => 'cdp-result');
+    const evaluateViaScripting = vi.fn(async () => 'scripting-result');
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync,
+      evaluateViaScripting,
+      screenshot: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const result = await mod.__test__.handleExec({
+      id: 'scripting-exec',
+      action: 'exec',
+      session: 'default',
+      surface: 'browser',
+      code: 'document.title',
+      noDebugger: true,
+    }, browserKey('default'));
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toBe('scripting-result');
+    expect(evaluateViaScripting).toHaveBeenCalledOnce();
+    expect(evaluateAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when noDebugger is combined with frameIndex', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const evaluateViaScripting = vi.fn();
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync: vi.fn(),
+      evaluateViaScripting,
+      screenshot: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const result = await mod.__test__.handleExec({
+      id: 'scripting-frame',
+      action: 'exec',
+      session: 'default',
+      surface: 'browser',
+      code: 'document.title',
+      noDebugger: true,
+      frameIndex: 0,
+    }, browserKey('default'));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/--no-debugger.*--frame|--frame.*--no-debugger/i);
+    expect(evaluateViaScripting).not.toHaveBeenCalled();
+  });
+
+  it('still uses evaluateAsync (CDP) when noDebugger is absent', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const evaluateAsync = vi.fn(async () => 'cdp-result');
+    const evaluateViaScripting = vi.fn();
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync,
+      evaluateViaScripting,
+      screenshot: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const result = await mod.__test__.handleExec({
+      id: 'cdp-exec',
+      action: 'exec',
+      session: 'default',
+      surface: 'browser',
+      code: 'document.title',
+    }, browserKey('default'));
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toBe('cdp-result');
+    expect(evaluateAsync).toHaveBeenCalledOnce();
+    expect(evaluateViaScripting).not.toHaveBeenCalled();
+  });
+
+  it('propagates evaluateViaScripting errors as ok:false', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync: vi.fn(),
+      evaluateViaScripting: vi.fn(async () => { throw new Error('--no-debugger eval failed: Cannot access chrome:// URL'); }),
+      screenshot: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
+
+    const result = await mod.__test__.handleExec({
+      id: 'scripting-error',
+      action: 'exec',
+      session: 'default',
+      surface: 'browser',
+      code: 'document.title',
+      noDebugger: true,
+    }, browserKey('default'));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('--no-debugger eval failed');
   });
 });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1279,6 +1279,13 @@ async function handleExec(cmd: Command, leaseKey: string): Promise<Result> {
   const cmdTabId = await resolveCommandTabId(cmd);
   const tabId = await resolveTabId(cmdTabId, leaseKey);
   try {
+    if (cmd.noDebugger) {
+      if (cmd.frameIndex != null) {
+        return { id: cmd.id, ok: false, error: '--no-debugger does not support --frame; omit --frame or remove --no-debugger' };
+      }
+      const data = await executor.evaluateViaScripting(tabId, cmd.code);
+      return pageScopedResult(cmd.id, tabId, data);
+    }
     const aggressive = getSurfaceFromKey(leaseKey) === 'browser';
     if (cmd.frameIndex != null) {
       const tree = await executor.getFrameTree(tabId);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -984,6 +984,8 @@ async function handleCommand(cmd: Command): Promise<Result> {
     switch (cmd.action) {
       case 'exec':
         return await handleExec(cmd, leaseKey);
+      case 'exec-via-scripting':
+        return await handleExecViaScripting(cmd, leaseKey);
       case 'navigate':
         return await handleNavigate(cmd, leaseKey);
       case 'tabs':
@@ -1275,18 +1277,23 @@ async function listAutomationWebTabs(leaseKey: string): Promise<chrome.tabs.Tab[
   return tabs.filter((tab) => isDebuggableUrl(tab.url));
 }
 
+async function handleExecViaScripting(cmd: Command, leaseKey: string): Promise<Result> {
+  if (!cmd.code) return { id: cmd.id, ok: false, error: 'Missing code' };
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, leaseKey);
+  try {
+    const data = await executor.evaluateViaScripting(tabId, cmd.code);
+    return pageScopedResult(cmd.id, tabId, data);
+  } catch (err) {
+    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 async function handleExec(cmd: Command, leaseKey: string): Promise<Result> {
   if (!cmd.code) return { id: cmd.id, ok: false, error: 'Missing code' };
   const cmdTabId = await resolveCommandTabId(cmd);
   const tabId = await resolveTabId(cmdTabId, leaseKey);
   try {
-    if (cmd.noDebugger) {
-      if (cmd.frameIndex != null) {
-        return { id: cmd.id, ok: false, error: '--no-debugger does not support --frame; omit --frame or remove --no-debugger' };
-      }
-      const data = await executor.evaluateViaScripting(tabId, cmd.code);
-      return pageScopedResult(cmd.id, tabId, data);
-    }
     const aggressive = getSurfaceFromKey(leaseKey) === 'browser';
     if (cmd.frameIndex != null) {
       const tree = await executor.getFrameTree(tabId);
@@ -1840,6 +1847,7 @@ async function handleBind(cmd: Command, leaseKey: string): Promise<Result> {
 
 export const __test__ = {
   handleExec,
+  handleExecViaScripting,
   handleNavigate,
   isTargetUrl,
   handleTabs,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -94,6 +94,7 @@ console.error = (...args: unknown[]) => { _origError(...args); forwardLog('error
 // ─── WebSocket connection ────────────────────────────────────────────
 
 function isDaemonSocketActive(socket: WebSocket | null | undefined = ws): boolean {
+  if (typeof WebSocket === 'undefined') return false;
   return socket?.readyState === WebSocket.OPEN || socket?.readyState === WebSocket.CONNECTING;
 }
 

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -461,13 +461,13 @@ describe('evaluateViaScripting', () => {
     await expect(mod.evaluateViaScripting(1, 'document.title')).rejects.toThrow('executeScript returned no results');
   });
 
-  it('wraps executeScript errors with a --no-debugger prefix', async () => {
+  it('wraps executeScript errors with a --via-extension prefix', async () => {
     const { chrome } = createChromeMock();
     (chrome.scripting as any).executeScript = vi.fn(async () => { throw new Error('Cannot access a chrome:// URL'); });
     vi.stubGlobal('chrome', chrome);
 
     const mod = await import('./cdp');
-    await expect(mod.evaluateViaScripting(1, 'document.title')).rejects.toThrow('--no-debugger eval failed: Cannot access a chrome:// URL');
+    await expect(mod.evaluateViaScripting(1, 'document.title')).rejects.toThrow('--via-extension eval failed: Cannot access a chrome:// URL');
   });
 
   it('throws when result payload is undefined (non-cloneable return)', async () => {
@@ -476,6 +476,15 @@ describe('evaluateViaScripting', () => {
 
     const mod = await import('./cdp');
     await expect(mod.evaluateViaScripting(1, 'document.body')).rejects.toThrow('script returned undefined');
+  });
+
+  it('appends CSP hint when error mentions unsafe-eval', async () => {
+    const cspMsg = "EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self'\"";
+    const { chrome } = makeScriptingMock({ ok: false, error: cspMsg });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await expect(mod.evaluateViaScripting(1, 'eval("1")')).rejects.toThrow(/--via-extension eval runs in the page.*MAIN world.*CSP/i);
   });
 
   it('does not call chrome.debugger.attach', async () => {

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -393,3 +393,98 @@ describe('cdp download waits', () => {
     });
   });
 });
+
+describe('evaluateViaScripting', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function makeScriptingMock(result: unknown) {
+    const { chrome } = createChromeMock();
+    const scripting = {
+      executeScript: vi.fn(async () => [{ result }]),
+    };
+    return { chrome: { ...chrome, scripting }, scripting };
+  }
+
+  it('returns the value from executeScript result payload', async () => {
+    const { chrome } = makeScriptingMock({ ok: true, value: 'hello' });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    const result = await mod.evaluateViaScripting(1, 'document.title');
+
+    expect(result).toBe('hello');
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 1 }, world: 'MAIN' }),
+    );
+  });
+
+  it('returns undefined when the expression evaluates to undefined', async () => {
+    const { chrome } = makeScriptingMock({ ok: true, value: undefined });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    const result = await mod.evaluateViaScripting(1, 'void 0');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns structured values (objects, arrays)', async () => {
+    const { chrome } = makeScriptingMock({ ok: true, value: { count: 3, items: ['a', 'b', 'c'] } });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    const result = await mod.evaluateViaScripting(1, 'someExpression');
+
+    expect(result).toEqual({ count: 3, items: ['a', 'b', 'c'] });
+  });
+
+  it('throws when the script itself throws (ok: false payload)', async () => {
+    const { chrome } = makeScriptingMock({ ok: false, error: 'ReferenceError: foo is not defined' });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await expect(mod.evaluateViaScripting(1, 'foo')).rejects.toThrow('ReferenceError: foo is not defined');
+  });
+
+  it('throws when executeScript returns an empty results array', async () => {
+    const { chrome } = createChromeMock();
+    (chrome.scripting as any).executeScript = vi.fn(async () => []);
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await expect(mod.evaluateViaScripting(1, 'document.title')).rejects.toThrow('executeScript returned no results');
+  });
+
+  it('wraps executeScript errors with a --no-debugger prefix', async () => {
+    const { chrome } = createChromeMock();
+    (chrome.scripting as any).executeScript = vi.fn(async () => { throw new Error('Cannot access a chrome:// URL'); });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await expect(mod.evaluateViaScripting(1, 'document.title')).rejects.toThrow('--no-debugger eval failed: Cannot access a chrome:// URL');
+  });
+
+  it('throws when result payload is undefined (non-cloneable return)', async () => {
+    const { chrome } = makeScriptingMock(undefined);
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await expect(mod.evaluateViaScripting(1, 'document.body')).rejects.toThrow('script returned undefined');
+  });
+
+  it('does not call chrome.debugger.attach', async () => {
+    const { chrome } = makeScriptingMock({ ok: true, value: 42 });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    await mod.evaluateViaScripting(1, '42');
+
+    expect(chrome.debugger.attach).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -227,19 +227,23 @@ export async function evaluateViaScripting(tabId: number, expression: string): P
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`--no-debugger eval failed: ${msg}`);
+    throw new Error(`--via-extension eval failed: ${msg}`);
   }
 
   if (!results || results.length === 0) {
-    throw new Error('--no-debugger eval failed: executeScript returned no results');
+    throw new Error('--via-extension eval failed: executeScript returned no results');
   }
 
   const payload = results[0].result as { ok: boolean; value?: unknown; error?: string } | undefined;
   if (!payload) {
-    throw new Error('--no-debugger eval failed: script returned undefined (return value may not be structured-cloneable)');
+    throw new Error('--via-extension eval failed: script returned undefined (return value may not be structured-cloneable)');
   }
   if (!payload.ok) {
-    throw new Error(payload.error ?? 'Script evaluation failed');
+    const msg = payload.error ?? 'Script evaluation failed';
+    const isCsp = /unsafe-eval|content security policy|EvalError/i.test(msg);
+    throw new Error(isCsp
+      ? `${msg}\n(--via-extension eval runs in the page's MAIN world and is subject to its CSP; sites that block unsafe-eval will reject this. Use plain \`browser eval\` (CDP path) on such pages.)`
+      : msg);
   }
   return payload.value;
 }

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -202,6 +202,49 @@ export async function evaluate(tabId: number, expression: string, aggressiveRetr
 export const evaluateAsync = evaluate;
 
 /**
+ * Execute JS in a tab via chrome.scripting.executeScript (MAIN world).
+ * Does not attach chrome.debugger — invisible to anti-bot fingerprinting.
+ * Limitations vs CDP path: return value must be structured-cloneable (no DOM
+ * nodes, functions, or circular refs); error stacks are not preserved.
+ */
+export async function evaluateViaScripting(tabId: number, expression: string): Promise<unknown> {
+  let results: chrome.scripting.InjectionResult[];
+  try {
+    results = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: 'MAIN',
+      func: async (code: string) => {
+        try {
+          // indirect eval: runs in page global scope, not extension scope
+          // eslint-disable-next-line no-eval
+          const value = await (0, eval)(code);
+          return { ok: true, value };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      args: [expression],
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`--no-debugger eval failed: ${msg}`);
+  }
+
+  if (!results || results.length === 0) {
+    throw new Error('--no-debugger eval failed: executeScript returned no results');
+  }
+
+  const payload = results[0].result as { ok: boolean; value?: unknown; error?: string } | undefined;
+  if (!payload) {
+    throw new Error('--no-debugger eval failed: script returned undefined (return value may not be structured-cloneable)');
+  }
+  if (!payload.ok) {
+    throw new Error(payload.error ?? 'Script evaluation failed');
+  }
+  return payload.value;
+}
+
+/**
  * Capture a screenshot via CDP Page.captureScreenshot.
  * Returns base64-encoded image data.
  */

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -77,6 +77,8 @@ export interface Command {
   frameIndex?: number;
   /** Browser profile/context selected by the CLI. Used by the daemon for routing. */
   contextId?: string;
+  /** Route eval through chrome.scripting.executeScript instead of chrome.debugger (MAIN world, no attach fingerprint). Set by --via-extension CLI flag. */
+  noDebugger?: boolean;
 }
 
 export interface Result {

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -7,6 +7,7 @@
 
 export type Action =
   | 'exec'
+  | 'exec-via-scripting'
   | 'navigate'
   | 'tabs'
   | 'cookies'
@@ -77,8 +78,6 @@ export interface Command {
   frameIndex?: number;
   /** Browser profile/context selected by the CLI. Used by the daemon for routing. */
   contextId?: string;
-  /** Route eval through chrome.scripting.executeScript instead of chrome.debugger (MAIN world, no attach fingerprint). Set by --via-extension CLI flag. */
-  noDebugger?: boolean;
 }
 
 export interface Result {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -21,7 +21,7 @@ function generateId(): string {
 
 export interface DaemonCommand {
   id: string;
-  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'set-file-input' | 'insert-text' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'wait-download' | 'cdp' | 'frames';
+  action: 'exec' | 'exec-via-scripting' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'set-file-input' | 'insert-text' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'wait-download' | 'cdp' | 'frames';
   /** Target page identity (targetId). Cross-layer contract with the extension. */
   page?: string;
   code?: string;
@@ -61,8 +61,6 @@ export interface DaemonCommand {
   frameIndex?: number;
   /** Browser profile/context to route the command to. */
   contextId?: string;
-  /** Route eval through chrome.scripting.executeScript instead of chrome.debugger */
-  noDebugger?: boolean;
 }
 
 export interface DaemonResult {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -61,6 +61,8 @@ export interface DaemonCommand {
   frameIndex?: number;
   /** Browser profile/context to route the command to. */
   contextId?: string;
+  /** Route eval through chrome.scripting.executeScript instead of chrome.debugger */
+  noDebugger?: boolean;
 }
 
 export interface DaemonResult {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -335,7 +335,7 @@ export class Page extends BasePage {
 
   async evaluateNoDebugger(js: string): Promise<unknown> {
     const code = buildEvaluateExpression(js);
-    return sendCommand('exec', { code, noDebugger: true, ...this._cmdOpts() });
+    return sendCommand('exec-via-scripting', { code, ...this._cmdOpts() });
   }
 
   async cdp(method: string, params: Record<string, unknown> = {}): Promise<unknown> {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -333,6 +333,11 @@ export class Page extends BasePage {
     return sendCommand('exec', { code, frameIndex, ...this._cmdOpts() });
   }
 
+  async evaluateNoDebugger(js: string): Promise<unknown> {
+    const code = buildEvaluateExpression(js);
+    return sendCommand('exec', { code, noDebugger: true, ...this._cmdOpts() });
+  }
+
   async cdp(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
     return sendCommand('cdp', {
       cdpMethod: method,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2205,11 +2205,22 @@ Examples:
     browser.command('eval')
       .argument('<js>', 'JavaScript code')
       .option('--frame <index>', 'Cross-origin iframe index from "browser frames"')
+      .option('--via-extension', 'Run via chrome.scripting instead of CDP — bypasses debugger-detection on sites like zhipin.com; return value must be JSON-serializable, --frame is unsupported')
       .description('Execute JS in page context, return result'),
   )
     .action(browserAction(async (page, js, opts) => {
       let result: unknown;
-      if (opts.frame !== undefined) {
+      if (opts.viaExtension) {
+        if (opts.frame !== undefined) {
+          console.error('--via-extension and --frame cannot be used together. Omit --frame or remove --via-extension.');
+          process.exitCode = EXIT_CODES.USAGE_ERROR;
+          return;
+        }
+        if (!page.evaluateNoDebugger) {
+          throw new Error('This browser session does not support --via-extension evaluation');
+        }
+        result = await page.evaluateNoDebugger(js);
+      } else if (opts.frame !== undefined) {
         const frameIndex = Number.parseInt(opts.frame, 10);
         if (!Number.isInteger(frameIndex) || frameIndex < 0) {
           console.error(`Invalid frame index "${opts.frame}". Use a 0-based index from "browser frames".`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2205,7 +2205,7 @@ Examples:
     browser.command('eval')
       .argument('<js>', 'JavaScript code')
       .option('--frame <index>', 'Cross-origin iframe index from "browser frames"')
-      .option('--via-extension', 'Run via chrome.scripting instead of CDP — bypasses debugger-detection on sites like zhipin.com; return value must be JSON-serializable, --frame is unsupported')
+      .option('--via-extension', 'Run via chrome.scripting (MAIN world) instead of CDP — bypasses debugger-detection on sites like zhipin.com; return value must be JSON-serializable, --frame is unsupported, and pages with strict CSP (no unsafe-eval) will reject the eval')
       .description('Execute JS in page context, return result'),
   )
     .action(browserAction(async (page, js, opts) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,8 @@ export interface IPage {
   frames?(): Promise<Array<{ index: number; frameId: string; url: string; name: string }>>;
   /** Evaluate JavaScript inside a cross-origin iframe identified by its frame index. */
   evaluateInFrame?(js: string, frameIndex: number): Promise<unknown>;
+  /** Evaluate JavaScript via chrome.scripting instead of CDP — bypasses debugger detection. */
+  evaluateNoDebugger?(js: string): Promise<unknown>;
   /** Click at native coordinates via CDP Input.dispatchMouseEvent. */
   nativeClick?(x: number, y: number): Promise<void>;
   /** Type text via CDP Input.insertText. */

--- a/tests/e2e/browser-eval-via-extension.test.ts
+++ b/tests/e2e/browser-eval-via-extension.test.ts
@@ -1,0 +1,191 @@
+/**
+ * E2E tests for `browser eval --via-extension` flag.
+ *
+ * Uses a fake daemon to verify:
+ *  - The CLI passes noDebugger:true in the exec command when --via-extension is given
+ *  - The CLI does NOT pass noDebugger when --via-extension is absent
+ *  - --via-extension combined with --frame exits with a usage error
+ *  - Results from the daemon are printed correctly
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runCli } from './helpers.js';
+
+const PKG_VERSION: string = (() => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const pkgPath = path.resolve(here, '..', '..', 'package.json');
+  try {
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+function json(res: ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+type RecordedExec = {
+  code: string;
+  noDebugger?: boolean;
+  frameIndex?: number;
+};
+
+type FakeDaemon = {
+  port: number;
+  close: () => Promise<void>;
+  lastExec: () => RecordedExec | null;
+};
+
+async function startFakeDaemon(evalResult: unknown = 'fake-result'): Promise<FakeDaemon> {
+  let lastExec: RecordedExec | null = null;
+
+  const server = createServer(async (req, res) => {
+    const pathname = req.url?.split('?')[0] ?? '/';
+
+    if (req.method === 'GET' && pathname === '/status') {
+      const addr = server.address();
+      json(res, 200, {
+        ok: true,
+        pid: process.pid,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        extensionConnected: true,
+        extensionVersion: 'test',
+        pending: 0,
+        memoryMB: 1,
+        port: typeof addr === 'object' && addr ? addr.port : 0,
+      });
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/ping') {
+      json(res, 200, { ok: true });
+      return;
+    }
+
+    if (req.method !== 'POST' || pathname !== '/command') {
+      json(res, 404, { ok: false, error: 'Not found' });
+      return;
+    }
+
+    const body = JSON.parse(await readBody(req)) as {
+      id: string;
+      action: string;
+      code?: string;
+      noDebugger?: boolean;
+      frameIndex?: number;
+      session?: string;
+      surface?: string;
+    };
+
+    if (body.action === 'bind') {
+      json(res, 200, { id: body.id, ok: true, data: { session: body.session, url: 'https://example.com', title: 'Example' } });
+      return;
+    }
+
+    if (body.action === 'exec') {
+      lastExec = {
+        code: body.code ?? '',
+        noDebugger: body.noDebugger,
+        frameIndex: body.frameIndex,
+      };
+      json(res, 200, { id: body.id, ok: true, page: 'page-1', data: evalResult });
+      return;
+    }
+
+    json(res, 200, { id: body.id, ok: false, error: `Unhandled action: ${body.action}` });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+
+  const addr = server.address();
+  if (!addr || typeof addr !== 'object') throw new Error('Failed to bind fake daemon');
+
+  return {
+    port: addr.port,
+    close: () => new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve())),
+    lastExec: () => lastExec,
+  };
+}
+
+describe('browser eval --via-extension e2e', () => {
+  const daemons: FakeDaemon[] = [];
+
+  afterEach(async () => {
+    while (daemons.length > 0) await daemons.pop()!.close();
+  });
+
+  it('sends noDebugger:true to the daemon when --via-extension is passed', async () => {
+    const daemon = await startFakeDaemon('page-title');
+    daemons.push(daemon);
+    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+
+    const result = await runCli(['browser', 'work', 'eval', 'document.title', '--via-extension'], { env });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe('page-title');
+    expect(daemon.lastExec()?.noDebugger).toBe(true);
+    expect(daemon.lastExec()?.code).toContain('document.title');
+  });
+
+  it('does NOT send noDebugger when --via-extension is absent', async () => {
+    const daemon = await startFakeDaemon('plain-result');
+    daemons.push(daemon);
+    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+
+    const result = await runCli(['browser', 'work', 'eval', 'document.title'], { env });
+
+    expect(result.code).toBe(0);
+    expect(daemon.lastExec()?.noDebugger).toBeFalsy();
+  });
+
+  it('prints JSON for non-string results', async () => {
+    const daemon = await startFakeDaemon({ count: 5 });
+    daemons.push(daemon);
+    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+
+    const result = await runCli(['browser', 'work', 'eval', 'someExpr', '--via-extension'], { env });
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ count: 5 });
+    expect(daemon.lastExec()?.noDebugger).toBe(true);
+  });
+
+  it('exits with non-zero code when --via-extension and --frame are combined', async () => {
+    const daemon = await startFakeDaemon();
+    daemons.push(daemon);
+    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+
+    const result = await runCli(['browser', 'work', 'eval', 'document.title', '--via-extension', '--frame', '0'], { env });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/--via-extension.*--frame|--frame.*--via-extension/i);
+    expect(daemon.lastExec()).toBeNull();
+  });
+
+  it('forwards the expression unchanged to the daemon', async () => {
+    const expr = 'Array.from(document.querySelectorAll(".item")).length';
+    const daemon = await startFakeDaemon(42);
+    daemons.push(daemon);
+    const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
+
+    await runCli(['browser', 'work', 'eval', expr, '--via-extension'], { env });
+
+    expect(daemon.lastExec()?.code).toContain(expr);
+  });
+});

--- a/tests/e2e/browser-eval-via-extension.test.ts
+++ b/tests/e2e/browser-eval-via-extension.test.ts
@@ -2,8 +2,8 @@
  * E2E tests for `browser eval --via-extension` flag.
  *
  * Uses a fake daemon to verify:
- *  - The CLI passes noDebugger:true in the exec command when --via-extension is given
- *  - The CLI does NOT pass noDebugger when --via-extension is absent
+ *  - The CLI sends action 'exec-via-scripting' (not 'exec') when --via-extension is given
+ *  - The CLI sends plain 'exec' when --via-extension is absent (no silent fallback)
  *  - --via-extension combined with --frame exits with a usage error
  *  - Results from the daemon are printed correctly
  */
@@ -39,20 +39,20 @@ function json(res: ServerResponse, status: number, payload: unknown): void {
   res.end(JSON.stringify(payload));
 }
 
-type RecordedExec = {
+type RecordedCommand = {
+  action: string;
   code: string;
-  noDebugger?: boolean;
   frameIndex?: number;
 };
 
 type FakeDaemon = {
   port: number;
   close: () => Promise<void>;
-  lastExec: () => RecordedExec | null;
+  lastCommand: () => RecordedCommand | null;
 };
 
 async function startFakeDaemon(evalResult: unknown = 'fake-result'): Promise<FakeDaemon> {
-  let lastExec: RecordedExec | null = null;
+  let lastCommand: RecordedCommand | null = null;
 
   const server = createServer(async (req, res) => {
     const pathname = req.url?.split('?')[0] ?? '/';
@@ -87,7 +87,6 @@ async function startFakeDaemon(evalResult: unknown = 'fake-result'): Promise<Fak
       id: string;
       action: string;
       code?: string;
-      noDebugger?: boolean;
       frameIndex?: number;
       session?: string;
       surface?: string;
@@ -98,10 +97,10 @@ async function startFakeDaemon(evalResult: unknown = 'fake-result'): Promise<Fak
       return;
     }
 
-    if (body.action === 'exec') {
-      lastExec = {
+    if (body.action === 'exec' || body.action === 'exec-via-scripting') {
+      lastCommand = {
+        action: body.action,
         code: body.code ?? '',
-        noDebugger: body.noDebugger,
         frameIndex: body.frameIndex,
       };
       json(res, 200, { id: body.id, ok: true, page: 'page-1', data: evalResult });
@@ -119,7 +118,7 @@ async function startFakeDaemon(evalResult: unknown = 'fake-result'): Promise<Fak
   return {
     port: addr.port,
     close: () => new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve())),
-    lastExec: () => lastExec,
+    lastCommand: () => lastCommand,
   };
 }
 
@@ -130,7 +129,7 @@ describe('browser eval --via-extension e2e', () => {
     while (daemons.length > 0) await daemons.pop()!.close();
   });
 
-  it('sends noDebugger:true to the daemon when --via-extension is passed', async () => {
+  it('sends exec-via-scripting action to the daemon when --via-extension is passed', async () => {
     const daemon = await startFakeDaemon('page-title');
     daemons.push(daemon);
     const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
@@ -139,11 +138,11 @@ describe('browser eval --via-extension e2e', () => {
 
     expect(result.code).toBe(0);
     expect(result.stdout.trim()).toBe('page-title');
-    expect(daemon.lastExec()?.noDebugger).toBe(true);
-    expect(daemon.lastExec()?.code).toContain('document.title');
+    expect(daemon.lastCommand()?.action).toBe('exec-via-scripting');
+    expect(daemon.lastCommand()?.code).toContain('document.title');
   });
 
-  it('does NOT send noDebugger when --via-extension is absent', async () => {
+  it('sends plain exec action (not exec-via-scripting) when --via-extension is absent', async () => {
     const daemon = await startFakeDaemon('plain-result');
     daemons.push(daemon);
     const env = { OPENCLI_DAEMON_PORT: String(daemon.port) };
@@ -151,7 +150,7 @@ describe('browser eval --via-extension e2e', () => {
     const result = await runCli(['browser', 'work', 'eval', 'document.title'], { env });
 
     expect(result.code).toBe(0);
-    expect(daemon.lastExec()?.noDebugger).toBeFalsy();
+    expect(daemon.lastCommand()?.action).toBe('exec');
   });
 
   it('prints JSON for non-string results', async () => {
@@ -163,7 +162,7 @@ describe('browser eval --via-extension e2e', () => {
 
     expect(result.code).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({ count: 5 });
-    expect(daemon.lastExec()?.noDebugger).toBe(true);
+    expect(daemon.lastCommand()?.action).toBe('exec-via-scripting');
   });
 
   it('exits with non-zero code when --via-extension and --frame are combined', async () => {
@@ -175,7 +174,7 @@ describe('browser eval --via-extension e2e', () => {
 
     expect(result.code).not.toBe(0);
     expect(result.stderr + result.stdout).toMatch(/--via-extension.*--frame|--frame.*--via-extension/i);
-    expect(daemon.lastExec()).toBeNull();
+    expect(daemon.lastCommand()).toBeNull();
   });
 
   it('forwards the expression unchanged to the daemon', async () => {
@@ -186,6 +185,6 @@ describe('browser eval --via-extension e2e', () => {
 
     await runCli(['browser', 'work', 'eval', expr, '--via-extension'], { env });
 
-    expect(daemon.lastExec()?.code).toContain(expr);
+    expect(daemon.lastCommand()?.code).toContain(expr);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
           name: 'e2e',
           include: [
             'tests/e2e/browser-public.test.ts',
+            'tests/e2e/browser-eval-via-extension.test.ts',
             'tests/e2e/band-auth.test.ts',
             'tests/e2e/public-commands.test.ts',
             'tests/e2e/management.test.ts',


### PR DESCRIPTION
Closes #1757

## Problem

`opencli browser <profile> eval <js>` currently routes all JS execution through `chrome.debugger.attach()` (CDP). Sites like BOSS直聘 (zhipin.com) detect debugger attachment within ~100ms and immediately redirect the tab to `about:blank`, making `eval` impossible even when the user is browsing the page normally.

CDP attachment is detectable via multiple signals:
- The "Browser Bridge started debugging…" infobar causes a `visualViewport` reflow
- `debugger;` statements actually pause execution once a debugger is attached (timing-detectable)
- `Runtime.enable` has observable side effects on `console` / `Function.prototype` / microtask timing
- First-attach cold-start latency fingerprint

## Solution

Add a `--via-extension` flag that routes eval through `chrome.scripting.executeScript()` (MAIN world) instead of CDP. This is the same mechanism used by ad-blockers and password managers — page JS cannot detect it without breaking itself for all normal extension users.

```bash
# default: CDP path — full features, detectable by anti-bot sites
opencli browser work eval "document.title"

# --via-extension: scripting API path — invisible to anti-bot, limited return types
opencli browser work eval "document.title" --via-extension
```

## Changes

| File | Change |
|---|---|
| `extension/manifest.json` | Add `"scripting"` permission |
| `extension/src/protocol.ts` | Add `noDebugger?: boolean` to `Command` interface |
| `extension/src/cdp.ts` | Add `evaluateViaScripting()` — uses `chrome.scripting.executeScript` with `world: 'MAIN'` and an async indirect-eval wrapper |
| `extension/src/background.ts` | Branch in `handleExec`: `noDebugger` routes to `evaluateViaScripting`; `--via-extension` + `--frame` returns a clear error |
| `src/browser/daemon-client.ts` | Add `noDebugger?: boolean` to `DaemonCommand` |
| `src/browser/page.ts` | Add `evaluateNoDebugger()` method |
| `src/types.ts` | Declare `evaluateNoDebugger?` on `IPage` |
| `src/cli.ts` | Add `--via-extension` option to `browser eval` |

## Known Limitations (intentional for v1)

`--via-extension` is **not** a drop-in replacement for the default CDP path:

- **Return values must be structured-cloneable** — no DOM nodes, functions, or circular references
- **No remote object handles** — CDP returns `objectId` references you can re-use; scripting API returns plain values only
- **Weaker error reporting** — errors come back stringified, full stack traces are lost
- **`--frame` is unsupported** — combining `--via-extension` with `--frame` returns a clear error message; frame support can be added later via `chrome.webNavigation.getAllFrames`
- **No `console` interception** — the CDP path can observe page console output; this path cannot

## Execution World

The implementation uses `world: 'MAIN'` so that eval can access page-side JS state (Vue/React instances, `window.xxx`, etc.). This is required for the primary use case (reading `el.__vue__.jobList` on zhipin.com). `world: 'ISOLATED'` support can be added as a follow-up flag if needed.

## Manifest Permission Note

Adding `"scripting"` to `manifest.json` will prompt users to re-approve the Browser Bridge extension on next update. Worth calling out in release notes.

## E2E Test Results

Tested locally against zhipin.com:

**`--via-extension` (4 consecutive evals — page never redirected):**
```
eval 1: document.title  → "BOSS直聘-找工作BOSS直聘直接谈！招聘求职找工作！"  ✅
eval 2: location.href   → "https://www.zhipin.com/hangzhou/?seoRefer=index"  ✅
eval 3: location.href   → "https://www.zhipin.com/hangzhou/?seoRefer=index"  ✅  (page intact)
eval 4: DOM query       → undefined (correct — selector absent on homepage)  ✅
```

**CDP path (reproduced the issue):**
```
eval 1: document.title  → "BOSS直聘-..."  ✅  (before redirect)
eval 2: location.href   → "about:blank"  ❌  (redirected within ~100ms of attach)
eval 3: location.href   → "about:blank"  ❌
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)