### PR TITLE
docs(readme): add Trendshift trending-repo badge to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<a href="https://trendshift.io/repositories/23541" target="_blank"><img src="https://trendshift.io/api/badge/repositories/23541" alt="jackwener%2FOpenCLI | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
 # OpenCLI
 
 > **Convert any website into a CLI & run Browser Use on your logged-in Chrome.**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,3 +1,5 @@
+<a href="https://trendshift.io/repositories/23541" target="_blank"><img src="https://trendshift.io/api/badge/repositories/23541" alt="jackwener%2FOpenCLI | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
 # OpenCLI
 
 > **把任意网站变成 CLI & 在你的登录态浏览器上跑 Browser Use。**


### PR DESCRIPTION
## Summary

Per WAWQAQ DM. OpenCLI is featured on Trendshift (https://trendshift.io/repositories/23541) — surfacing the badge at the top of the README gives social proof to new visitors and links back to the Trendshift listing.

## Placement

Above the `# OpenCLI` heading so it renders as a banner before the title (the convention Trendshift's own snippet uses). 250×55 inline SVG; both EN and ZH READMEs updated.

## Test plan

- [x] Manual diff
- [ ] Visual render on GitHub after merge