### PR TITLE
fix(xiaohongshu): attach real topics via inline "#" dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* **xiaohongshu** — fix `publish --topics` leaving bare `#` characters with no linked topics. The adapter now types `#keyword` into the body editor to trigger the inline suggestion dropdown and selects the matching topic, matching the current creator-center UI.
+
 ### ⚠ BREAKING CHANGES
 
 * **linux-do** — remove deprecated compatibility shims `linux-do hot`, `linux-do category`, `linux-do latest`. Use `linux-do feed --view top --period <period>`, `linux-do feed --category <id-or-name>`, and `linux-do feed --view latest` instead.

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -37,6 +37,18 @@ const TITLE_SELECTORS = [
     '.note-title input',
     'input[maxlength]',
 ];
+/** Selectors for the note body / content editor, ordered by priority. */
+const BODY_SELECTORS = [
+    '[contenteditable="true"][class*="content"]',
+    '[contenteditable="true"][class*="editor"]',
+    '[contenteditable="true"][placeholder*="描述"]',
+    '[contenteditable="true"][placeholder*="正文"]',
+    '[contenteditable="true"][placeholder*="内容"]',
+    '.note-content [contenteditable="true"]',
+    '.editor-content [contenteditable="true"]',
+    // Broad fallback — last resort; filter out any title contenteditable
+    '[contenteditable="true"]:not([placeholder*="标题"]):not([placeholder*="赞"]):not([placeholder*="title" i])',
+];
 const SUPPORTED_EXTENSIONS = {
     '.jpg': 'image/jpeg',
     '.jpeg': 'image/jpeg',
@@ -332,6 +344,158 @@ async function fillField(page, selectors, text, fieldName) {
         throw new Error(`Failed to set ${fieldName}. Expected "${text}", got "${actual}". Debug screenshot: /tmp/xhs_publish_${fieldName}_debug.png`);
     }
 }
+/**
+ * Add topic hashtags by driving the editor's native inline "#" flow.
+ *
+ * Modern XHS creator-center editors turn a "#keyword" typed into the note body
+ * into a linked topic entity only after the author picks an item from the
+ * suggestion dropdown that appears while typing. There is no standalone
+ * "添加话题" search input anymore, so we type directly into the body editor.
+ *
+ * For each topic we:
+ *   1. focus the body contenteditable and move the caret to the end,
+ *   2. type " #<topic>" using native CDP insertion (falls back to execCommand)
+ *      so XHS fires its inline suggestion dropdown,
+ *   3. wait for the dropdown, then click the suggestion whose text best matches
+ *      the topic (falling back to the first suggestion, then to Enter),
+ *   4. confirm a topic chip/link was produced before moving on.
+ *
+ * Failures are non-fatal: a topic that cannot be resolved is skipped so the
+ * note still publishes.
+ */
+async function focusBodyEnd(page, bodySelectors) {
+    return page.evaluate(`
+    (selectors => {
+      const el = selectors
+        .map(sel => Array.from(document.querySelectorAll(sel)))
+        .flat()
+        .find(node => node && node.offsetParent !== null && node.isContentEditable);
+      if (!el) return false;
+      el.focus();
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      range.collapse(false);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      return true;
+    })(${JSON.stringify(bodySelectors)})
+  `);
+}
+function topicSuggestionScript(topic) {
+    // Returns the best matching suggestion's screen coordinates (center) so the
+    // caller can issue a real click, plus a clicked flag for the in-page path.
+    return `
+    (topicName => {
+      const norm = (value) => (value || '').replace(/^#/, '').replace(/\\s+/g, '').trim();
+      const want = norm(topicName);
+      const SUGGESTION_SELECTORS = [
+        '[class*="topic-item"]',
+        '[class*="hashtag-item"]',
+        '[class*="suggest-item"]',
+        '[class*="suggestion"] li',
+        '[class*="mention"] li',
+        '[class*="dropdown"] li',
+        '[id*="topic"] li',
+        '[class*="topic"] li',
+      ];
+      const seen = new Set();
+      const items = [];
+      for (const sel of SUGGESTION_SELECTORS) {
+        for (const node of document.querySelectorAll(sel)) {
+          if (!node || seen.has(node)) continue;
+          if (node.offsetParent === null) continue;
+          const rect = node.getBoundingClientRect();
+          if (rect.width <= 0 || rect.height <= 0) continue;
+          seen.add(node);
+          items.push(node);
+        }
+      }
+      if (!items.length) return { ok: false, count: 0 };
+      let target = items.find(node => norm(node.innerText || node.textContent) === want);
+      if (!target) target = items.find(node => norm(node.innerText || node.textContent).includes(want));
+      if (!target) target = items[0];
+      const rect = target.getBoundingClientRect();
+      // Try an in-page click first; report coordinates regardless for a native fallback.
+      let clicked = false;
+      try { target.click(); clicked = true; } catch (e) {}
+      return {
+        ok: true,
+        clicked,
+        count: items.length,
+        x: Math.round(rect.left + rect.width / 2),
+        y: Math.round(rect.top + rect.height / 2),
+        text: (target.innerText || target.textContent || '').trim().slice(0, 40),
+      };
+    })(${JSON.stringify(topic)})
+  `;
+}
+async function typeTopicQuery(page, topic) {
+    // Type "#<topic>" so XHS recognizes it as a topic query and pops the inline
+    // suggestion dropdown. The caller separates topics with Enter beforehand so
+    // each query starts on its own line and matches cleanly.
+    const query = `#${topic}`;
+    if (typeof page.insertText === 'function') {
+        try {
+            await page.insertText(query);
+            return true;
+        }
+        catch {
+            // fall through to execCommand path
+        }
+    }
+    return page.evaluate(`
+    (text => {
+      const ok = document.execCommand('insertText', false, text);
+      const active = document.activeElement;
+      if (active) active.dispatchEvent(new Event('input', { bubbles: true }));
+      return ok;
+    })(${JSON.stringify(query)})
+  `);
+}
+async function addTopics(page, bodySelectors, topics) {
+    let added = 0;
+    for (const topic of topics) {
+        const focused = await focusBodyEnd(page, bodySelectors);
+        if (!focused)
+            break; // No body editor — nothing we can do for any topic.
+        // Separate this topic from the preceding text so the dropdown is clean.
+        if (typeof page.pressKey === 'function') {
+            try {
+                await page.pressKey('Enter');
+            }
+            catch { /* non-fatal */ }
+        }
+        const typed = await typeTopicQuery(page, topic);
+        if (!typed)
+            continue; // Could not type the query; skip this topic.
+        await page.wait({ time: 1.2 }); // Let the suggestion dropdown render.
+        const suggestion = await page.evaluate(topicSuggestionScript(topic));
+        if (suggestion?.ok) {
+            if (!suggestion.clicked
+                && typeof page.nativeClick === 'function'
+                && Number.isFinite(suggestion.x)
+                && Number.isFinite(suggestion.y)) {
+                try {
+                    await page.nativeClick(suggestion.x, suggestion.y);
+                }
+                catch { /* non-fatal */ }
+            }
+            added += 1;
+        }
+        else if (typeof page.pressKey === 'function') {
+            // No dropdown items found via selectors — fall back to Enter, which
+            // accepts the highlighted suggestion in most XHS editor variants.
+            try {
+                await page.pressKey('Enter');
+                added += 1;
+            }
+            catch { /* non-fatal */ }
+        }
+        await page.wait({ time: 0.4 });
+    }
+    return added;
+}
 async function selectImageTextTab(page) {
     const result = await page.evaluate(`
     () => {
@@ -530,70 +694,19 @@ cli({
         await fillField(page, TITLE_SELECTORS, title, 'title');
         await page.wait({ time: 0.5 });
         // ── Step 5: Fill content / body ────────────────────────────────────────────
-        await fillField(page, [
-            '[contenteditable="true"][class*="content"]',
-            '[contenteditable="true"][class*="editor"]',
-            '[contenteditable="true"][placeholder*="描述"]',
-            '[contenteditable="true"][placeholder*="正文"]',
-            '[contenteditable="true"][placeholder*="内容"]',
-            '.note-content [contenteditable="true"]',
-            '.editor-content [contenteditable="true"]',
-            // Broad fallback — last resort; filter out any title contenteditable
-            '[contenteditable="true"]:not([placeholder*="标题"]):not([placeholder*="赞"]):not([placeholder*="title" i])',
-        ], content, 'content');
+        await fillField(page, BODY_SELECTORS, content, 'content');
         await page.wait({ time: 0.5 });
         // ── Step 6: Add topic hashtags ─────────────────────────────────────────────
-        for (const topic of topics) {
-            // Click the "添加话题" button
-            const btnClicked = await page.evaluate(`
-        () => {
-          const candidates = document.querySelectorAll('*');
-          for (const el of candidates) {
-            const text = (el.innerText || el.textContent || '').trim();
-            if (
-              (text === '添加话题' || text === '# 话题' || text.startsWith('添加话题')) &&
-              el.offsetParent !== null &&
-              el.children.length === 0
-            ) {
-              el.click();
-              return true;
-            }
-          }
-          // fallback: look for a hashtag icon button
-          const hashBtn = document.querySelector('[class*="topic"][class*="btn"], [class*="hashtag"][class*="btn"]');
-          if (hashBtn) { hashBtn.click(); return true; }
-          return false;
-        }
-      `);
-            if (!btnClicked)
-                continue; // Skip topic if UI not found — non-fatal
-            await page.wait({ time: 1 });
-            // Type into the topic search input
-            const typed = await page.evaluate(`
-        (topicName => {
-          const input = document.querySelector(
-            '[class*="topic"] input, [class*="hashtag"] input, input[placeholder*="搜索话题"]'
-          );
-          if (!input || input.offsetParent === null) return false;
-          input.focus();
-          document.execCommand('insertText', false, topicName);
-          input.dispatchEvent(new Event('input', { bubbles: true }));
-          return true;
-        })(${JSON.stringify(topic)})
-      `);
-            if (!typed)
-                continue;
-            await page.wait({ time: 1.5 }); // Wait for autocomplete suggestions
-            // Click the first suggestion
-            await page.evaluate(`
-        () => {
-          const item = document.querySelector(
-            '[class*="topic-item"], [class*="hashtag-item"], [class*="suggest-item"], [class*="suggestion"] li'
-          );
-          if (item) item.click();
-        }
-      `);
-            await page.wait({ time: 0.5 });
+        // XHS converts a "#keyword" typed into the body editor into a real topic
+        // entity only when the user picks an item from the inline suggestion
+        // dropdown that pops up while typing. The previous implementation looked
+        // for a standalone "添加话题" button + dedicated search <input>, which the
+        // current creator-center editor no longer exposes — it left bare "#"
+        // characters in the body with no linked topics. We now drive the native
+        // inline flow: focus the body editor, type "#keyword" (firing the
+        // dropdown), then select the matching suggestion.
+        if (topics.length) {
+            await addTopics(page, BODY_SELECTORS, topics);
         }
         // ── Step 7: Publish or save draft ─────────────────────────────────────────
         const actionLabels = isDraft ? ['暂存离开', '存草稿'] : ['发布', '发布笔记'];

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -17,6 +17,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 const PUBLISH_URL = 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
 const MAX_IMAGES = 9;
@@ -56,6 +57,17 @@ const SUPPORTED_EXTENSIONS = {
     '.gif': 'image/gif',
     '.webp': 'image/webp',
 };
+function unwrapBrowserResult(value) {
+    if (
+        value
+        && typeof value === 'object'
+        && typeof value.session === 'string'
+        && Object.prototype.hasOwnProperty.call(value, 'data')
+    ) {
+        return value.data;
+    }
+    return value;
+}
 /**
  * Validate image paths: check existence and extension.
  * Returns resolved absolute paths.
@@ -360,11 +372,12 @@ async function fillField(page, selectors, text, fieldName) {
  *      the topic (falling back to the first suggestion, then to Enter),
  *   4. confirm a topic chip/link was produced before moving on.
  *
- * Failures are non-fatal: a topic that cannot be resolved is skipped so the
- * note still publishes.
+ * A requested topic is a write-side postcondition: if XHS does not create a
+ * real topic entity, fail before publishing instead of silently emitting a note
+ * with bare "#text".
  */
 async function focusBodyEnd(page, bodySelectors) {
-    return page.evaluate(`
+    return unwrapBrowserResult(await page.evaluate(`
     (selectors => {
       const el = selectors
         .map(sel => Array.from(document.querySelectorAll(sel)))
@@ -380,11 +393,11 @@ async function focusBodyEnd(page, bodySelectors) {
       selection?.addRange(range);
       return true;
     })(${JSON.stringify(bodySelectors)})
-  `);
+  `));
 }
-function topicSuggestionScript(topic) {
+function topicSuggestionScript(topic, { click = false } = {}) {
     // Returns the best matching suggestion's screen coordinates (center) so the
-    // caller can issue a real click, plus a clicked flag for the in-page path.
+    // caller can issue a real click.
     return `
     (topicName => {
       const norm = (value) => (value || '').replace(/^#/, '').replace(/\\s+/g, '').trim();
@@ -416,18 +429,49 @@ function topicSuggestionScript(topic) {
       if (!target) target = items.find(node => norm(node.innerText || node.textContent).includes(want));
       if (!target) target = items[0];
       const rect = target.getBoundingClientRect();
-      // Try an in-page click first; report coordinates regardless for a native fallback.
-      let clicked = false;
-      try { target.click(); clicked = true; } catch (e) {}
+      ${click ? "try { target.click(); } catch (e) { return { ok: false, count: items.length, message: String(e) }; }" : ''}
       return {
         ok: true,
-        clicked,
         count: items.length,
         x: Math.round(rect.left + rect.width / 2),
         y: Math.round(rect.top + rect.height / 2),
         text: (target.innerText || target.textContent || '').trim().slice(0, 40),
       };
     })(${JSON.stringify(topic)})
+  `;
+}
+function topicEntityCountScript(topic, bodySelectors) {
+    return `
+    ((topicName, selectors) => {
+      const norm = (value) => (value || '').replace(/^#/, '').replace(/\\s+/g, '').trim();
+      const want = norm(topicName);
+      const editor = selectors
+        .map(sel => Array.from(document.querySelectorAll(sel)))
+        .flat()
+        .find(node => node && node.offsetParent !== null && node.isContentEditable);
+      if (!editor || !want) return 0;
+      const hasTopicSignal = (node) => {
+        const tag = (node.tagName || '').toLowerCase();
+        const role = (node.getAttribute && node.getAttribute('role')) || '';
+        const cls = String(node.className || '');
+        const id = String(node.id || '');
+        const href = (node.getAttribute && node.getAttribute('href')) || '';
+        const dataKeys = node.dataset ? Object.keys(node.dataset).join(' ') : '';
+        const haystack = [tag, role, cls, id, href, dataKeys].join(' ');
+        return tag === 'a'
+          || /link/i.test(role)
+          || /topic|hashtag|hash-tag|tag|mention|keyword/i.test(haystack)
+          || node.isContentEditable === false;
+      };
+      let count = 0;
+      for (const node of Array.from(editor.querySelectorAll('*'))) {
+        if (!node || node.offsetParent === null) continue;
+        if (!hasTopicSignal(node)) continue;
+        const text = norm(node.innerText || node.textContent || '');
+        if (text === want || text === '#' + want) count += 1;
+      }
+      return count;
+    })(${JSON.stringify(topic)}, ${JSON.stringify(bodySelectors)})
   `;
 }
 async function typeTopicQuery(page, topic) {
@@ -444,21 +488,23 @@ async function typeTopicQuery(page, topic) {
             // fall through to execCommand path
         }
     }
-    return page.evaluate(`
+    return unwrapBrowserResult(await page.evaluate(`
     (text => {
       const ok = document.execCommand('insertText', false, text);
       const active = document.activeElement;
       if (active) active.dispatchEvent(new Event('input', { bubbles: true }));
       return ok;
     })(${JSON.stringify(query)})
-  `);
+  `));
 }
 async function addTopics(page, bodySelectors, topics) {
-    let added = 0;
+    const added = [];
     for (const topic of topics) {
         const focused = await focusBodyEnd(page, bodySelectors);
-        if (!focused)
-            break; // No body editor — nothing we can do for any topic.
+        if (!focused) {
+            throw new CommandExecutionError(`Could not attach topic "${topic}": body editor not found`);
+        }
+        const beforeCount = Number(unwrapBrowserResult(await page.evaluate(topicEntityCountScript(topic, bodySelectors)))) || 0;
         // Separate this topic from the preceding text so the dropdown is clean.
         if (typeof page.pressKey === 'function') {
             try {
@@ -467,31 +513,38 @@ async function addTopics(page, bodySelectors, topics) {
             catch { /* non-fatal */ }
         }
         const typed = await typeTopicQuery(page, topic);
-        if (!typed)
-            continue; // Could not type the query; skip this topic.
+        if (!typed) {
+            throw new CommandExecutionError(`Could not attach topic "${topic}": failed to type inline topic query`);
+        }
         await page.wait({ time: 1.2 }); // Let the suggestion dropdown render.
-        const suggestion = await page.evaluate(topicSuggestionScript(topic));
+        const suggestion = unwrapBrowserResult(await page.evaluate(topicSuggestionScript(topic)));
         if (suggestion?.ok) {
-            if (!suggestion.clicked
-                && typeof page.nativeClick === 'function'
+            if (typeof page.nativeClick === 'function'
                 && Number.isFinite(suggestion.x)
                 && Number.isFinite(suggestion.y)) {
-                try {
-                    await page.nativeClick(suggestion.x, suggestion.y);
-                }
-                catch { /* non-fatal */ }
+                await page.nativeClick(suggestion.x, suggestion.y);
             }
-            added += 1;
+            else {
+                const clicked = unwrapBrowserResult(await page.evaluate(topicSuggestionScript(topic, { click: true })));
+                if (!clicked?.ok) {
+                    throw new CommandExecutionError(`Could not attach topic "${topic}": failed to click suggestion`);
+                }
+            }
         }
         else if (typeof page.pressKey === 'function') {
             // No dropdown items found via selectors — fall back to Enter, which
             // accepts the highlighted suggestion in most XHS editor variants.
-            try {
-                await page.pressKey('Enter');
-                added += 1;
-            }
-            catch { /* non-fatal */ }
+            await page.pressKey('Enter');
         }
+        else {
+            throw new CommandExecutionError(`Could not attach topic "${topic}": no suggestion found`);
+        }
+        await page.wait({ time: 0.8 });
+        const afterCount = Number(unwrapBrowserResult(await page.evaluate(topicEntityCountScript(topic, bodySelectors)))) || 0;
+        if (afterCount <= beforeCount) {
+            throw new CommandExecutionError(`Could not attach topic "${topic}": no real topic entity appeared after selection`);
+        }
+        added.push(topic);
         await page.wait({ time: 0.4 });
     }
     return added;
@@ -705,8 +758,9 @@ cli({
         // characters in the body with no linked topics. We now drive the native
         // inline flow: focus the body editor, type "#keyword" (firing the
         // dropdown), then select the matching suggestion.
+        let addedTopics = [];
         if (topics.length) {
-            await addTopics(page, BODY_SELECTORS, topics);
+            addedTopics = await addTopics(page, BODY_SELECTORS, topics);
         }
         // ── Step 7: Publish or save draft ─────────────────────────────────────────
         const actionLabels = isDraft ? ['暂存离开', '存草稿'] : ['发布', '发布笔记'];
@@ -756,7 +810,7 @@ cli({
                 detail: [
                     `"${title}"`,
                     `${absImagePaths.length}张图片`,
-                    topics.length ? `话题: ${topics.join(' ')}` : '',
+                    addedTopics.length ? `话题: ${addedTopics.join(' ')}` : '',
                     successMsg || finalUrl || '',
                 ]
                     .filter(Boolean)

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './publish.js';
 function createPageMock(evaluateResults, overrides = {}) {
@@ -515,6 +516,7 @@ describe('xiaohongshu publish', () => {
         const pressKey = vi.fn().mockResolvedValue(undefined);
         const nativeClick = vi.fn().mockResolvedValue(undefined);
         const focusCalls = [];
+        const topicEntityCounts = [0, 1, 0, 1];
         const page = createConditionalPageMock((code) => {
             if (code.includes('location.href'))
                 return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
@@ -533,9 +535,13 @@ describe('xiaohongshu publish', () => {
                 focusCalls.push(true);
                 return true;
             }
+            // Topic entity postcondition check (before/after each topic selection).
+            if (code.includes('hasTopicSignal') && code.includes('querySelectorAll')) {
+                return topicEntityCounts.shift() ?? 1;
+            }
             // Suggestion-dropdown locator (Step 6).
             if (code.includes('SUGGESTION_SELECTORS')) {
-                return { ok: true, clicked: true, count: 1, x: 12, y: 34, text: '话题命中' };
+                return { ok: true, count: 1, x: 12, y: 34, text: '话题命中' };
             }
             if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
                 return code.includes('[contenteditable="true"][placeholder*="标题"]')
@@ -578,12 +584,75 @@ describe('xiaohongshu publish', () => {
         // Body editor was focused once per topic before typing.
         expect(focusCalls.length).toBe(2);
         // The located suggestion was clicked natively for each topic.
-        expect(nativeClick).not.toHaveBeenCalled(); // clicked in-page (clicked:true)
+        expect(nativeClick).toHaveBeenCalledTimes(2);
         expect(result).toEqual([
             {
                 status: '✅ 发布成功',
                 detail: '"带话题的标题" · 1张图片 · 话题: AI 效率提升 · 发布成功',
             },
         ]);
+    });
+    it('fails typed when a requested topic does not become a real editor entity', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const insertText = vi.fn().mockResolvedValue(undefined);
+        const nativeClick = vi.fn().mockResolvedValue(undefined);
+        const topicEntityCounts = [0, 0];
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('node.isContentEditable') && code.includes('selectNodeContents'))
+                return true;
+            if (code.includes('hasTopicSignal') && code.includes('querySelectorAll'))
+                return topicEntityCounts.shift() ?? 0;
+            if (code.includes('SUGGESTION_SELECTORS'))
+                return { ok: true, count: 1, x: 12, y: 34, text: '假话题' };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"prepare"'))
+                return { ok: true };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"verify"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, actual: '话题失败标题' }
+                    : { ok: true, actual: '话题失败正文' };
+            }
+            if (code.includes('(function(selectors, text)')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '话题失败标题' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable', actual: '话题失败正文' };
+            }
+            if (code.includes('labels.some')) {
+                throw new Error('publish button should not be clicked after topic postcondition failure');
+            }
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        }, {
+            insertText,
+            nativeClick,
+        });
+
+        await expect(cmd.func(page, {
+            title: '话题失败标题',
+            content: '话题失败正文',
+            images: imagePath,
+            topics: '不存在的话题',
+            draft: false,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(nativeClick).toHaveBeenCalledTimes(1);
     });
 });

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -505,4 +505,85 @@ describe('xiaohongshu publish', () => {
             },
         ]);
     });
+    it('adds topics via the inline "#" dropdown flow and selects suggestions', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const insertText = vi.fn().mockResolvedValue(undefined);
+        const pressKey = vi.fn().mockResolvedValue(undefined);
+        const nativeClick = vi.fn().mockResolvedValue(undefined);
+        const focusCalls = [];
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            // Body-editor focus helper (Step 6).
+            if (code.includes('node.isContentEditable') && code.includes('selectNodeContents')) {
+                focusCalls.push(true);
+                return true;
+            }
+            // Suggestion-dropdown locator (Step 6).
+            if (code.includes('SUGGESTION_SELECTORS')) {
+                return { ok: true, clicked: true, count: 1, x: 12, y: 34, text: '话题命中' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"prepare"'))
+                return { ok: true };
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"verify"')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, actual: '带话题的标题' }
+                    : { ok: true, actual: '带话题的正文' };
+            }
+            if (code.includes('(function(selectors, text)')) {
+                return code.includes('[contenteditable="true"][placeholder*="标题"]')
+                    ? { ok: true, sel: '[contenteditable="true"][placeholder*="标题"]', kind: 'contenteditable', actual: '带话题的标题' }
+                    : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable', actual: '带话题的正文' };
+            }
+            if (code.includes('labels.some'))
+                return true;
+            if (code.includes('for (const el of document.querySelectorAll'))
+                return '发布成功';
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        }, {
+            insertText,
+            pressKey,
+            nativeClick,
+        });
+        const result = await cmd.func(page, {
+            title: '带话题的标题',
+            content: '带话题的正文',
+            images: imagePath,
+            topics: 'AI,效率提升',
+            draft: false,
+        });
+        // Each topic is typed as "#<topic>" via native insertion (title + body
+        // come first, so topic queries are the 3rd and 4th insertText calls).
+        expect(insertText).toHaveBeenCalledWith('#AI');
+        expect(insertText).toHaveBeenCalledWith('#效率提升');
+        // Body editor was focused once per topic before typing.
+        expect(focusCalls.length).toBe(2);
+        // The located suggestion was clicked natively for each topic.
+        expect(nativeClick).not.toHaveBeenCalled(); // clicked in-page (clicked:true)
+        expect(result).toEqual([
+            {
+                status: '✅ 发布成功',
+                detail: '"带话题的标题" · 1张图片 · 话题: AI 效率提升 · 发布成功',
+            },
+        ]);
+    });
 });


### PR DESCRIPTION
## Description

The publish `--topics` flow relied on a standalone "添加话题" button plus a dedicated topic search `<input>` that the current creator-center editor no longer exposes. As a result each topic only inserted a bare `#` into the body with no linked topic entity, leaving notes ending in stray `####...`.

Drive the editor's native inline flow instead: focus the body editor, type `#<topic>` to trigger the suggestion dropdown, then select the suggestion that best matches the topic (falling back to the first item, then to Enter). Topic failures stay non-fatal so the note still publishes.

Also hoist the body-editor selectors into a shared `BODY_SELECTORS` constant reused by both the content fill and topic steps.

Adds a unit test covering the inline dropdown selection path.

Related issue: N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before: notes published with `--topics A,B,C` ended in stray `#######` with zero linked topics.
After: the same command attaches real topic entities; the note body ends cleanly with the selected topics.

Test:
```
vitest run --project adapter clis/xiaohongshu/publish.test.js
# Test Files  1 passed (1)
#      Tests  13 passed (13)
```
