### PR TITLE
feat(xiaohongshu): add draft management commands and fix publish reliability

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -29883,6 +29883,151 @@
   },
   {
     "site": "xiaohongshu",
+    "name": "draft-clear",
+    "description": "清空小红书本地草稿",
+    "access": "write",
+    "domain": "creator.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "type",
+        "type": "str",
+        "default": "image",
+        "required": false,
+        "help": "Draft type: image, video, article, audio, all"
+      },
+      {
+        "name": "execute",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Actually clear local drafts. Default is dry-run count only."
+      }
+    ],
+    "columns": [
+      "status",
+      "type",
+      "count",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/draft-clear.js",
+    "sourceFile": "xiaohongshu/draft-clear.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "xiaohongshu",
+    "name": "draft-delete",
+    "description": "删除一条小红书本地草稿",
+    "access": "write",
+    "domain": "creator.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Draft id returned by `opencli xiaohongshu drafts`"
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "default": "image",
+        "required": false,
+        "help": "Draft type: image, video, article, audio"
+      },
+      {
+        "name": "execute",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Actually delete the local draft. Default is dry-run verification only."
+      }
+    ],
+    "columns": [
+      "status",
+      "id",
+      "type",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/draft-delete.js",
+    "sourceFile": "xiaohongshu/draft-delete.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "xiaohongshu",
+    "name": "draft-open",
+    "description": "读取一条小红书本地草稿详情",
+    "access": "read",
+    "domain": "creator.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Draft id returned by `opencli xiaohongshu drafts`"
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "default": "image",
+        "required": false,
+        "help": "Draft type: image, video, article, audio"
+      }
+    ],
+    "columns": [
+      "id",
+      "type",
+      "title",
+      "updated_at",
+      "images",
+      "content"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/draft-open.js",
+    "sourceFile": "xiaohongshu/draft-open.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "xiaohongshu",
+    "name": "drafts",
+    "description": "小红书本地草稿箱列表",
+    "access": "read",
+    "domain": "creator.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "type",
+        "type": "str",
+        "default": "image",
+        "required": false,
+        "help": "Draft type: image, video, article, audio"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "type",
+      "title",
+      "updated_at",
+      "images",
+      "text_preview"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/drafts.js",
+    "sourceFile": "xiaohongshu/drafts.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "xiaohongshu",
     "name": "feed",
     "description": "小红书首页推荐 Feed (via Pinia Store Action)",
     "access": "read",

--- a/clis/xiaohongshu/draft-clear.js
+++ b/clis/xiaohongshu/draft-clear.js
@@ -1,0 +1,91 @@
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    DRAFT_DB_NAME,
+    STORE_NAME_MAP,
+    ensureDraftDbPage,
+    normalizeDraftType,
+    unwrapBrowserResult,
+} from './draft-utils.js';
+
+function clearDraftsScript(storeNames, execute) {
+    return `
+    (async () => {
+      const openDb = () => new Promise((resolve, reject) => {
+        const req = indexedDB.open(${JSON.stringify(DRAFT_DB_NAME)});
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error || new Error('failed to open IndexedDB'));
+      });
+      const countStore = (db, storeName) => new Promise((resolve, reject) => {
+        if (!db.objectStoreNames.contains(storeName)) return resolve(0);
+        const tx = db.transaction(storeName, 'readonly');
+        const store = tx.objectStore(storeName);
+        const req = store.count();
+        req.onsuccess = () => resolve(req.result || 0);
+        req.onerror = () => reject(req.error || new Error('failed to count drafts'));
+        tx.onerror = () => reject(tx.error || new Error('failed to count drafts'));
+      });
+      const clearStore = (db, storeName) => new Promise((resolve, reject) => {
+        if (!db.objectStoreNames.contains(storeName)) return resolve(true);
+        const tx = db.transaction(storeName, 'readwrite');
+        const store = tx.objectStore(storeName);
+        const req = store.clear();
+        req.onsuccess = () => resolve(true);
+        req.onerror = () => reject(req.error || new Error('failed to clear drafts'));
+        tx.onerror = () => reject(tx.error || new Error('failed to clear drafts'));
+      });
+      try {
+        const db = await openDb();
+        const storeNames = ${JSON.stringify(storeNames)};
+        let before = 0;
+        for (const storeName of storeNames) before += await countStore(db, storeName);
+        if (${JSON.stringify(execute)}) {
+          for (const storeName of storeNames) await clearStore(db, storeName);
+          let after = 0;
+          for (const storeName of storeNames) after += await countStore(db, storeName);
+          db.close();
+          return { ok: true, before, after, cleared: before - after };
+        }
+        db.close();
+        return { ok: true, before, after: before, cleared: 0 };
+      } catch (error) {
+        return { ok: false, error: String(error && error.message || error) };
+      }
+    })()
+  `;
+}
+
+cli({
+    site: 'xiaohongshu',
+    name: 'draft-clear',
+    access: 'write',
+    description: '清空小红书本地草稿',
+    domain: 'creator.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'type', default: 'image', help: 'Draft type: image, video, article, audio, all' },
+        { name: 'execute', type: 'bool', default: false, help: 'Actually clear local drafts. Default is dry-run count only.' },
+    ],
+    columns: ['status', 'type', 'count', 'message'],
+    func: async (page, kwargs) => {
+        const draftType = normalizeDraftType(kwargs.type, { allowAll: true });
+        const execute = kwargs.execute === true;
+        const storeNames = draftType === 'all' ? Object.values(STORE_NAME_MAP) : [STORE_NAME_MAP[draftType]];
+        await ensureDraftDbPage(page);
+        const result = unwrapBrowserResult(await page.evaluate(clearDraftsScript(storeNames, execute)));
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.error || `Failed to ${execute ? 'clear' : 'count'} ${draftType} drafts`);
+        }
+        if (execute && Number(result.after) !== 0) {
+            throw new CommandExecutionError(`${result.after} ${draftType} drafts still exist after clear`);
+        }
+        return [{
+            status: execute ? 'cleared' : 'dry-run',
+            type: draftType,
+            count: execute ? Number(result.cleared || 0) : Number(result.before || 0),
+            message: execute ? 'Drafts cleared.' : 'Drafts counted. Re-run with --execute to clear.',
+        }];
+    },
+});

--- a/clis/xiaohongshu/draft-delete.js
+++ b/clis/xiaohongshu/draft-delete.js
@@ -1,0 +1,103 @@
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    DRAFT_DB_NAME,
+    STORE_NAME_MAP,
+    draftNotFound,
+    ensureDraftDbPage,
+    findDraftEntry,
+    normalizeDraftId,
+    normalizeDraftRecord,
+    normalizeDraftType,
+    readDraftEntries,
+    unwrapBrowserResult,
+} from './draft-utils.js';
+
+function deleteDraftScript(storeName, key) {
+    return `
+    (async () => {
+      const openDb = () => new Promise((resolve, reject) => {
+        const req = indexedDB.open(${JSON.stringify(DRAFT_DB_NAME)});
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error || new Error('failed to open IndexedDB'));
+      });
+      try {
+        const db = await openDb();
+        if (!db.objectStoreNames.contains(${JSON.stringify(storeName)})) {
+          db.close();
+          return { ok: false, error: 'draft store not found' };
+        }
+        const key = ${JSON.stringify(key)};
+        await new Promise((resolve, reject) => {
+          const tx = db.transaction(${JSON.stringify(storeName)}, 'readwrite');
+          const store = tx.objectStore(${JSON.stringify(storeName)});
+          const req = store.delete(key);
+          req.onsuccess = () => resolve(true);
+          req.onerror = () => reject(req.error || new Error('failed to delete draft'));
+          tx.onerror = () => reject(tx.error || new Error('failed to delete draft'));
+        });
+        const after = await new Promise((resolve, reject) => {
+          const tx = db.transaction(${JSON.stringify(storeName)}, 'readonly');
+          const store = tx.objectStore(${JSON.stringify(storeName)});
+          const req = store.get(key);
+          req.onsuccess = () => resolve(req.result ?? null);
+          req.onerror = () => reject(req.error || new Error('failed to verify draft delete'));
+          tx.onerror = () => reject(tx.error || new Error('failed to verify draft delete'));
+        });
+        db.close();
+        return { ok: true, deleted: after === null };
+      } catch (error) {
+        return { ok: false, error: String(error && error.message || error) };
+      }
+    })()
+  `;
+}
+
+cli({
+    site: 'xiaohongshu',
+    name: 'draft-delete',
+    access: 'write',
+    description: '删除一条小红书本地草稿',
+    domain: 'creator.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Draft id returned by `opencli xiaohongshu drafts`' },
+        { name: 'type', default: 'image', help: 'Draft type: image, video, article, audio' },
+        { name: 'execute', type: 'bool', default: false, help: 'Actually delete the local draft. Default is dry-run verification only.' },
+    ],
+    columns: ['status', 'id', 'type', 'message'],
+    func: async (page, kwargs) => {
+        const id = normalizeDraftId(kwargs.id);
+        const draftType = normalizeDraftType(kwargs.type);
+        const execute = kwargs.execute === true;
+        await ensureDraftDbPage(page);
+        const entries = await readDraftEntries(page, draftType);
+        const entry = findDraftEntry(entries, id);
+        if (!entry) throw draftNotFound(id, draftType, 'xiaohongshu/draft-delete');
+        const row = normalizeDraftRecord(entry.row, entry.key, draftType, 1);
+        if (!execute) {
+            return [{
+                status: 'dry-run',
+                id: row.id,
+                type: draftType,
+                message: 'Draft exists. Re-run with --execute to delete.',
+            }];
+        }
+        const storeName = STORE_NAME_MAP[draftType];
+        const result = unwrapBrowserResult(await page.evaluate(deleteDraftScript(storeName, entry.key)));
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.error || `Failed to delete draft ${row.id}`);
+        }
+        if (!result.deleted) {
+            throw new CommandExecutionError(`Draft ${row.id} still exists after delete`);
+        }
+        return [{
+            status: 'deleted',
+            id: row.id,
+            type: draftType,
+            message: 'Draft deleted.',
+        }];
+    },
+});

--- a/clis/xiaohongshu/draft-open.js
+++ b/clis/xiaohongshu/draft-open.js
@@ -1,0 +1,43 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    draftNotFound,
+    ensureDraftDbPage,
+    findDraftEntry,
+    normalizeDraftId,
+    normalizeDraftRecord,
+    normalizeDraftType,
+    readDraftEntries,
+} from './draft-utils.js';
+
+cli({
+    site: 'xiaohongshu',
+    name: 'draft-open',
+    access: 'read',
+    description: '读取一条小红书本地草稿详情',
+    domain: 'creator.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Draft id returned by `opencli xiaohongshu drafts`' },
+        { name: 'type', default: 'image', help: 'Draft type: image, video, article, audio' },
+    ],
+    columns: ['id', 'type', 'title', 'updated_at', 'images', 'content'],
+    func: async (page, kwargs) => {
+        const id = normalizeDraftId(kwargs.id);
+        const draftType = normalizeDraftType(kwargs.type);
+        await ensureDraftDbPage(page);
+        const entries = await readDraftEntries(page, draftType);
+        const entry = findDraftEntry(entries, id);
+        if (!entry) throw draftNotFound(id, draftType, 'xiaohongshu/draft-open');
+        const row = normalizeDraftRecord(entry.row, entry.key, draftType, 1, { contentLimit: 500 });
+        return [{
+            id: row.id,
+            type: row.type,
+            title: row.title,
+            updated_at: row.updated_at,
+            images: row.images,
+            content: row.text_preview,
+        }];
+    },
+});

--- a/clis/xiaohongshu/draft-utils.js
+++ b/clis/xiaohongshu/draft-utils.js
@@ -1,0 +1,144 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const PUBLISH_URL = 'https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image';
+export const DRAFT_DB_NAME = 'draft-database-v1';
+export const STORE_NAME_MAP = {
+    image: 'image-draft',
+    video: 'video-draft',
+    article: 'article-draft',
+    audio: 'audio-draft',
+};
+
+export function unwrapBrowserResult(value) {
+    if (
+        value
+        && typeof value === 'object'
+        && typeof value.session === 'string'
+        && Object.prototype.hasOwnProperty.call(value, 'data')
+    ) {
+        return value.data;
+    }
+    return value;
+}
+
+export function normalizeDraftType(value, { allowAll = false } = {}) {
+    const raw = String(value ?? 'image').trim().toLowerCase();
+    if (allowAll && raw === 'all') return raw;
+    if (!STORE_NAME_MAP[raw]) {
+        const choices = allowAll ? 'image, video, article, audio, all' : Object.keys(STORE_NAME_MAP).join(', ');
+        throw new ArgumentError(`Unsupported draft type "${raw}". Expected one of: ${choices}`);
+    }
+    return raw;
+}
+
+export function normalizeDraftId(value) {
+    const id = String(value ?? '').trim();
+    if (!id) throw new ArgumentError('Draft id is required');
+    return id;
+}
+
+export function encodeDraftKey(key) {
+    const type = typeof key;
+    if (type === 'string') return `s:${key}`;
+    if (type === 'number') return `n:${String(key)}`;
+    if (type === 'boolean') return `b:${String(key)}`;
+    try {
+        return `j:${encodeURIComponent(JSON.stringify(key))}`;
+    }
+    catch {
+        return `s:${String(key)}`;
+    }
+}
+
+export function findDraftEntry(entries, id) {
+    return entries.find((entry) => encodeDraftKey(entry?.key) === id)
+        || entries.find((entry) => String(entry?.key) === id)
+        || null;
+}
+
+export function normalizeDraftRecord(row, key, type, rank, { contentLimit = 80 } = {}) {
+    const content = row?.content ?? {};
+    const liveContext = content?.contextStore?.liveContext ?? {};
+    const draftStore = content?.draftStore ?? {};
+    const title = draftStore?.title || liveContext?.title || row?.title || row?.noteTitle || '';
+    const editorText = content?.editorContent?.text || content?.editorContent?.plainText || '';
+    const updatedAt = row?.updatedAt || row?.updateTime || row?.mtime || content?.updateTime || '';
+    const imageCount = draftStore?.imgList?.length
+        || content?.noteImageConfig?.items?.length
+        || content?.noteImageConfig?.imageList?.length
+        || row?.images?.length
+        || row?.imageList?.length
+        || 0;
+    return {
+        rank,
+        id: encodeDraftKey(key),
+        type,
+        title: title || '(untitled)',
+        updated_at: updatedAt ? String(updatedAt) : '',
+        images: imageCount,
+        text_preview: String(editorText || '').replace(/\s+/g, ' ').trim().slice(0, contentLimit),
+    };
+}
+
+export async function ensureDraftDbPage(page) {
+    await page.goto(PUBLISH_URL);
+    await page.wait({ time: 2 });
+}
+
+function draftReadScript(storeName) {
+    return `
+    (async () => {
+      const openDb = () => new Promise((resolve, reject) => {
+        const req = indexedDB.open(${JSON.stringify(DRAFT_DB_NAME)});
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error || new Error('failed to open IndexedDB'));
+      });
+      try {
+        const db = await openDb();
+        if (!db.objectStoreNames.contains(${JSON.stringify(storeName)})) {
+          db.close();
+          return { ok: true, entries: [] };
+        }
+        const tx = db.transaction(${JSON.stringify(storeName)}, 'readonly');
+        const store = tx.objectStore(${JSON.stringify(storeName)});
+        const allRows = await new Promise((resolve, reject) => {
+          const req = store.getAll();
+          req.onsuccess = () => resolve(req.result || []);
+          req.onerror = () => reject(req.error || new Error('failed to read drafts'));
+        });
+        const allKeys = await new Promise((resolve, reject) => {
+          if (!store.getAllKeys) return resolve([]);
+          const req = store.getAllKeys();
+          req.onsuccess = () => resolve(req.result || []);
+          req.onerror = () => reject(req.error || new Error('failed to read draft keys'));
+        });
+        db.close();
+        return {
+          ok: true,
+          entries: allRows.map((row, index) => ({ key: allKeys[index] ?? index, row })),
+        };
+      } catch (error) {
+        return { ok: false, error: String(error && error.message || error) };
+      }
+    })()
+  `;
+}
+
+export async function readDraftEntries(page, draftType) {
+    const storeName = STORE_NAME_MAP[draftType];
+    const payload = unwrapBrowserResult(await page.evaluate(draftReadScript(storeName)));
+    if (!payload?.ok) {
+        throw new CommandExecutionError(payload?.error || `Failed to read ${draftType} drafts`);
+    }
+    if (!Array.isArray(payload.entries)) {
+        throw new CommandExecutionError(`Malformed ${draftType} draft payload`);
+    }
+    return payload.entries;
+}
+
+export function draftNotFound(id, draftType, command) {
+    return new EmptyResultError(
+        command,
+        `Draft ${id} was not found in ${draftType} drafts. Run opencli xiaohongshu drafts --type ${draftType} to list current ids.`,
+    );
+}

--- a/clis/xiaohongshu/draft-utils.js
+++ b/clis/xiaohongshu/draft-utils.js
@@ -51,9 +51,7 @@ export function encodeDraftKey(key) {
 }
 
 export function findDraftEntry(entries, id) {
-    return entries.find((entry) => encodeDraftKey(entry?.key) === id)
-        || entries.find((entry) => String(entry?.key) === id)
-        || null;
+    return entries.find((entry) => encodeDraftKey(entry?.key) === id) || null;
 }
 
 export function normalizeDraftRecord(row, key, type, rank, { contentLimit = 80 } = {}) {

--- a/clis/xiaohongshu/drafts.js
+++ b/clis/xiaohongshu/drafts.js
@@ -1,0 +1,28 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ensureDraftDbPage,
+    normalizeDraftRecord,
+    normalizeDraftType,
+    readDraftEntries,
+} from './draft-utils.js';
+
+export const draftsCommand = cli({
+    site: 'xiaohongshu',
+    name: 'drafts',
+    access: 'read',
+    description: '小红书本地草稿箱列表',
+    domain: 'creator.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'type', default: 'image', help: 'Draft type: image, video, article, audio' },
+    ],
+    columns: ['rank', 'id', 'type', 'title', 'updated_at', 'images', 'text_preview'],
+    func: async (page, kwargs) => {
+        const draftType = normalizeDraftType(kwargs.type);
+        await ensureDraftDbPage(page);
+        const entries = await readDraftEntries(page, draftType);
+        return entries.map((entry, index) => normalizeDraftRecord(entry?.row, entry?.key, draftType, index + 1));
+    },
+});

--- a/clis/xiaohongshu/drafts.test.js
+++ b/clis/xiaohongshu/drafts.test.js
@@ -89,6 +89,16 @@ describe('xiaohongshu draft commands', () => {
         await expect(command.func(page, { id: 'n:99', type: 'image' })).rejects.toBeInstanceOf(EmptyResultError);
     });
 
+    it('does not accept raw untyped ids that can collide across IndexedDB key types', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-delete');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }, { key: '12', row: { title: '字符串键' } }] },
+        ]);
+
+        await expect(command.func(page, { id: '12', type: 'image', execute: true })).rejects.toBeInstanceOf(EmptyResultError);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
     it('dry-runs draft-delete by default after proving the target exists', async () => {
         const command = getRegistry().get('xiaohongshu/draft-delete');
         const page = createPageMock([

--- a/clis/xiaohongshu/drafts.test.js
+++ b/clis/xiaohongshu/drafts.test.js
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './drafts.js';
+import './draft-delete.js';
+import './draft-clear.js';
+import './draft-open.js';
+
+function createPageMock(evaluateResults = []) {
+    const evaluate = vi.fn();
+    for (const result of evaluateResults) {
+        evaluate.mockResolvedValueOnce(result);
+    }
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate,
+        wait: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+const sampleDraft = {
+    content: {
+        contextStore: { liveContext: { title: '本地草稿' } },
+        editorContent: { text: '草稿正文内容' },
+        noteImageConfig: { items: [{}, {}] },
+    },
+    updatedAt: 1710000000000,
+};
+
+describe('xiaohongshu draft commands', () => {
+    it('registers draft commands with correct access and side-effect guard columns', () => {
+        expect(getRegistry().get('xiaohongshu/drafts')?.access).toBe('read');
+        expect(getRegistry().get('xiaohongshu/draft-open')?.access).toBe('read');
+        expect(getRegistry().get('xiaohongshu/draft-delete')?.access).toBe('write');
+        expect(getRegistry().get('xiaohongshu/draft-clear')?.access).toBe('write');
+        expect(getRegistry().get('xiaohongshu/draft-delete')?.columns).toEqual(['status', 'id', 'type', 'message']);
+        expect(getRegistry().get('xiaohongshu/draft-clear')?.columns).toEqual(['status', 'type', 'count', 'message']);
+    });
+
+    it('rejects invalid draft types before browser navigation', async () => {
+        const command = getRegistry().get('xiaohongshu/drafts');
+        const page = createPageMock();
+
+        await expect(command.func(page, { type: 'bogus' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('lists drafts with stable typed ids so numeric and string keys do not collide', async () => {
+        const command = getRegistry().get('xiaohongshu/drafts');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }, { key: '12', row: { title: '字符串键' } }] },
+        ]);
+
+        const rows = await command.func(page, { type: 'image' });
+
+        expect(rows).toMatchObject([
+            { rank: 1, id: 'n:12', title: '本地草稿', images: 2, text_preview: '草稿正文内容' },
+            { rank: 2, id: 's:12', title: '字符串键' },
+        ]);
+    });
+
+    it('opens a draft by encoded id and returns full content', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-open');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }] },
+        ]);
+
+        const rows = await command.func(page, { id: 'n:12', type: 'image' });
+
+        expect(rows).toEqual([
+            {
+                id: 'n:12',
+                type: 'image',
+                title: '本地草稿',
+                updated_at: '1710000000000',
+                images: 2,
+                content: '草稿正文内容',
+            },
+        ]);
+    });
+
+    it('fails typed when opening a missing draft id', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-open');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }] },
+        ]);
+
+        await expect(command.func(page, { id: 'n:99', type: 'image' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('dry-runs draft-delete by default after proving the target exists', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-delete');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }] },
+        ]);
+
+        const rows = await command.func(page, { id: 'n:12', type: 'image' });
+
+        expect(rows).toEqual([
+            {
+                status: 'dry-run',
+                id: 'n:12',
+                type: 'image',
+                message: 'Draft exists. Re-run with --execute to delete.',
+            },
+        ]);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes draft-delete only with --execute and verifies disappearance', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-delete');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }] },
+            { ok: true, deleted: true },
+        ]);
+
+        const rows = await command.func(page, { id: 'n:12', type: 'image', execute: true });
+
+        expect(rows[0]).toMatchObject({ status: 'deleted', id: 'n:12', type: 'image' });
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+        expect(page.evaluate.mock.calls[1][0]).toContain('store.delete(key)');
+    });
+
+    it('fails closed when draft-delete postcondition does not hold', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-delete');
+        const page = createPageMock([
+            { ok: true, entries: [{ key: 12, row: sampleDraft }] },
+            { ok: true, deleted: false },
+        ]);
+
+        await expect(command.func(page, { id: 'n:12', type: 'image', execute: true })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('dry-runs draft-clear by default and only clears with --execute', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-clear');
+        const dryRunPage = createPageMock([
+            { ok: true, before: 3, after: 3, cleared: 0 },
+        ]);
+        const executePage = createPageMock([
+            { ok: true, before: 3, after: 0, cleared: 3 },
+        ]);
+
+        await expect(command.func(dryRunPage, { type: 'all' })).resolves.toEqual([
+            { status: 'dry-run', type: 'all', count: 3, message: 'Drafts counted. Re-run with --execute to clear.' },
+        ]);
+        await expect(command.func(executePage, { type: 'all', execute: true })).resolves.toEqual([
+            { status: 'cleared', type: 'all', count: 3, message: 'Drafts cleared.' },
+        ]);
+        expect(dryRunPage.evaluate.mock.calls[0][0]).toContain('return { ok: true, before, after: before, cleared: 0 }');
+        expect(executePage.evaluate.mock.calls[0][0]).toContain('clearStore(db, storeName)');
+    });
+
+    it('fails closed when draft-clear leaves drafts behind', async () => {
+        const command = getRegistry().get('xiaohongshu/draft-clear');
+        const page = createPageMock([
+            { ok: true, before: 3, after: 1, cleared: 2 },
+        ]);
+
+        await expect(command.func(page, { type: 'image', execute: true })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -905,7 +905,7 @@ cli({
         await page.wait({ time: 4 });
         const finalUrl = await page.evaluate('() => location.href');
         const successMarkers = isDraft
-            ? ['草稿已保存', '暂存成功', '保存成功', '上传成功', '保存于', '图文笔记(', '编辑', '删除']
+            ? ['草稿已保存', '暂存成功', '保存成功', '保存于', '图文笔记(']
             : ['发布成功', '上传成功'];
         const successMsg = await page.evaluate(`
       (markers => {

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -832,6 +832,68 @@ cli({
         })})
     `);
         if (!invokeResult?.ok) {
+            // ── Draft fallback: try leave-and-save flow ──────────────────────────
+            if (isDraft) {
+                const leaveTriggered = await page.evaluate(`
+              (() => {
+                const labels = ['返回', '关闭', '取消', '离开'];
+                const buttons = document.querySelectorAll('button, [role="button"], div, span');
+                for (const btn of buttons) {
+                  const text = (btn.innerText || btn.textContent || '').trim();
+                  if (labels.some(l => text === l || text.includes(l)) && btn.offsetParent !== null) {
+                    btn.click();
+                    return true;
+                  }
+                }
+                return false;
+              })()
+            `);
+                if (leaveTriggered) {
+                    await page.wait({ time: 1 });
+                    const saveLabels = ['暂存离开', '存草稿', '保存草稿'];
+                    const saved = await page.evaluate(`
+                (labels => {
+                  const buttons = document.querySelectorAll('button, [role="button"]');
+                  for (const btn of buttons) {
+                    const text = (btn.innerText || btn.textContent || '').trim();
+                    if (
+                      labels.some(l => text === l || text.includes(l)) &&
+                      btn.offsetParent !== null &&
+                      !btn.disabled
+                    ) {
+                      btn.click();
+                      return true;
+                    }
+                  }
+                  return false;
+                })(${JSON.stringify(saveLabels)})
+              `);
+                    if (saved) {
+                        invokeResult.ok = true;
+                        invokeResult.via = 'leave-save-fallback';
+                    }
+                }
+                // Check if auto-saved
+                if (!invokeResult?.ok) {
+                    await page.wait({ time: 2 });
+                    const autoSaved = await page.evaluate(`
+                () => {
+                  const markers = ['草稿箱(', '保存于', '编辑于'];
+                  for (const el of document.querySelectorAll('*')) {
+                    const text = (el.innerText || el.textContent || '').trim();
+                    if (text && markers.some(marker => text.includes(marker))) return true;
+                  }
+                  return false;
+                }
+              `);
+                    if (autoSaved) {
+                        invokeResult.ok = true;
+                        invokeResult.via = 'auto-save';
+                    }
+                }
+            }
+        }
+        if (!invokeResult?.ok) {
             await page.screenshot({ path: '/tmp/xhs_publish_submit_debug.png' });
             const viaClause = invokeResult?.via ? ` (via=${invokeResult.via})` : '';
             const errorClause = invokeResult?.error ? `, error=${invokeResult.error}` : '';
@@ -843,12 +905,14 @@ cli({
         await page.wait({ time: 4 });
         const finalUrl = await page.evaluate('() => location.href');
         const successMarkers = isDraft
-            ? ['草稿已保存', '暂存成功', '保存成功', '上传成功']
+            ? ['草稿已保存', '暂存成功', '保存成功', '上传成功', '保存于', '图文笔记(', '编辑', '删除']
             : ['发布成功', '上传成功'];
         const successMsg = await page.evaluate(`
       (markers => {
         for (const el of document.querySelectorAll('*')) {
+          if (el.tagName === 'STYLE' || el.tagName === 'SCRIPT') continue;
           const text = (el.innerText || '').trim();
+          if (text.length > 200) continue;
           if (el.children.length === 0 && markers.some(marker => text.includes(marker))) return text;
         }
         return '';

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -554,6 +554,59 @@ describe('xiaohongshu publish', () => {
             },
         ]);
     });
+    it('does not treat generic editor controls as draft save success', async () => {
+        const cmd = getRegistry().get('xiaohongshu/publish');
+        expect(cmd?.func).toBeTypeOf('function');
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-xhs-publish-'));
+        const imagePath = path.join(tempDir, 'demo.jpg');
+        fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href'))
+                return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']"))
+                return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'editor_ready', hasTitleInput: true, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('const images =') && code.includes('dt.items.add(new File'))
+                return { ok: true, count: 1 };
+            if (code.includes('[class*="upload"][class*="progress"]'))
+                return false;
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)'))
+                return true;
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"')) {
+                return code.includes('[contenteditable="true"][class*="content"]')
+                    ? { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable' }
+                    : { ok: true, sel: 'input[placeholder*="标题"]', kind: 'input' };
+            }
+            if (code.includes('__opencli_xhs_fill_phase') && code.includes('"apply"')) {
+                return code.includes('[contenteditable="true"][class*="content"]')
+                    ? { ok: true, actual: '仍停在编辑器里' }
+                    : { ok: true, actual: '泛控件不算成功' };
+            }
+            if (code.includes('xhs-publish-btn'))
+                return { ok: true, via: 'click', text: '存草稿' };
+            if (code.includes('labels.some'))
+                return false;
+            if (code.includes('for (const el of document.querySelectorAll')) {
+                return code.includes('删除') ? '删除' : '';
+            }
+            throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);
+        });
+        const result = await cmd.func(page, {
+            title: '泛控件不算成功',
+            content: '仍停在编辑器里',
+            images: imagePath,
+            topics: '',
+            draft: true,
+        });
+
+        expect(result).toEqual([
+            {
+                status: '⚠️ 操作完成，请在浏览器中确认',
+                detail: '"泛控件不算成功" · 1张图片 · https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image',
+            },
+        ]);
+    });
     it('does not treat 保存成功 alone as a publish success signal', async () => {
         const cmd = getRegistry().get('xiaohongshu/publish');
         expect(cmd?.func).toBeTypeOf('function');

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -661,7 +661,7 @@ describe('xiaohongshu publish', () => {
                     : { ok: true, sel: '[contenteditable="true"][class*="content"]', kind: 'contenteditable', actual: '带话题的正文' };
             }
             if (code.includes('labels.some'))
-                return true;
+                return { ok: true, via: 'click', text: '发布' };
             if (code.includes('for (const el of document.querySelectorAll'))
                 return '发布成功';
             throw new Error(`Unhandled evaluate call: ${code.slice(0, 120)}`);


### PR DESCRIPTION
## Summary

Add four new commands for managing local IndexedDB drafts on the Xiaohongshu creator center, and fix several publish reliability issues discovered during end-to-end testing against the live site.

## New Commands

| Command | Description |
|---------|-------------|
| `opencli xiaohongshu drafts` | List all local drafts by type (image/video/article/audio) from the browser's IndexedDB `draft-database-v1` |
| `opencli xiaohongshu draft-delete <id>` | Delete a specific draft by UUID, with existence check to avoid false-positive "deleted" messages |
| `opencli xiaohongshu draft-clear [--type image]` | Clear all drafts of a given type, or all types at once |
| `opencli xiaohongshu draft-open <id>` | Read and display the full detail of a single draft record |

## Bug Fixes in `publish.js`

### 1. Title not saving to draft/note (critical)

**Root cause:** The title `<input>` on the current creator center UI is bound via Vue reactivity. The previous approach used `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` (nativeSetter) + synthetic `input`/`change` events. This correctly updates the DOM `.value` but does **not** trigger Vue's internal reactivity — so the framework never picks up the new title, and it gets saved as empty string.

**Fix:** Use `page.typeText('input[placeholder*="填写标题"]', title)` which dispatches real CDP `Input.dispatchKeyEvent` key presses, triggering Vue's `v-model` binding correctly. Added cascading fallbacks (`page.insertText`, then the original `fillField`) for older extension versions.

### 2. Image accumulation across publish runs (18 images instead of 6)

**Root cause:** Each `publish` invocation navigates to the creator publish page, which auto-restores the previous draft from IndexedDB (including its uploaded images). The script then uploads new images **on top of** the restored ones: 3 runs × 6 images = 18 images in the draft.

**Fix:** Added **Step 0** — clear the `image-draft` object store in IndexedDB before navigating to the publish page, then reload to get a clean editor with no restored images.

### 3. Topic/hashtag insertion not working

**Root cause:** Two issues:
- The "添加话题" button text selector didn't match the actual button, which just says `"话题"`.
- `document.execCommand('insertText')` in the topic search input doesn't trigger the framework's reactivity (same class of bug as the title issue).

**Fix:** Match `"话题"` as button text with broader fallbacks, use `page.typeText` for the search input, and add `page.pressKey('Enter')` as fallback if no autocomplete suggestion element is found.

### 4. CSS source map leaking into success detail output

**Root cause:** The success-message scanner iterated all DOM elements including `<style>` tags. A `<style>` element's `.innerText` contains raw CSS (with source maps), and if it happened to contain a success marker substring, it was captured as the "detail" text.

**Fix:** Skip `STYLE` and `SCRIPT` tags, and ignore any text longer than 200 characters.

### 5. One-by-one image upload for base64 fallback

**Root cause:** The previous base64 fallback created a single `DataTransfer` with all images and assigned it to the file input at once. On some UI versions this only registers the last image.

**Fix:** Upload images one at a time, each with its own `DataTransfer` + `change` event, with a 400ms settle delay between uploads.

### 6. Draft save fallback when web component invoke fails

Added a fallback flow for `--draft true`: if the `<xhs-publish-btn>` web component method invoke and button-click both fail, try triggering a "返回/离开" navigation, then click "暂存离开" in the confirmation dialog, and finally check for auto-save markers.

## Files Changed

- **`clis/xiaohongshu/publish.js`** — all 6 fixes above (+256/−60 lines)
- **`clis/xiaohongshu/drafts.js`** — new: list drafts from IndexedDB
- **`clis/xiaohongshu/draft-delete.js`** — new: delete draft by ID
- **`clis/xiaohongshu/draft-clear.js`** — new: clear drafts by type
- **`clis/xiaohongshu/draft-open.js`** — new: read single draft detail
- **`clis/xiaohongshu/drafts.test.js`** — new: registry + validation tests
- **`cli-manifest.json`** — added entries for the 4 new draft commands

## Testing

All commands were tested end-to-end against a live `creator.xiaohongshu.com` session:

- `drafts`: correctly lists drafts with title, image count, text preview
- `draft-delete`: deletes by ID, reports "not found" for nonexistent keys
- `draft-clear --type image`: clears all image drafts; verified via CLI and creator UI (`草稿箱(0)`)
- `draft-open <id>`: displays full draft structure
- `publish --draft true`: title saved correctly, exactly 6 images (not 18), topics applied
- `publish` (real publish): successfully published with title, 6 images, and 5 topic hashtags