### PR TITLE
fix(antigravity): correct dynamic import path for serve.js (off-by-one parent)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3289,7 +3289,7 @@ cli({
     .option('--timeout <seconds>', 'Maximum time to wait for a reply (default: 120s)')
     .action(async (opts) => {
       // @ts-expect-error JS adapter — no type declarations
-      const { startServe } = await import('../clis/antigravity/serve.js');
+      const { startServe } = await import('../../clis/antigravity/serve.js');
       await startServe({
         port: parseInt(opts.port, 10),
         timeout: opts.timeout ? parsePositiveIntOption(opts.timeout, '--timeout', 120) : undefined,


### PR DESCRIPTION
Closes #1785.

## What

One-character fix in [`src/cli.ts:3292`](https://github.com/jackwener/opencli/blob/main/src/cli.ts#L3292):

```diff
-      const { startServe } = await import('../clis/antigravity/serve.js');
+      const { startServe } = await import('../../clis/antigravity/serve.js');
```

## Why

`cli.js` lives at `dist/src/cli.js`. The relative path `'../clis/...'` resolves to `dist/clis/...` — a directory that **does not exist** in the built artifact. The bundled JS source for adapter modules sits at `<package_root>/clis/...` (one level higher than `dist/`), so the dynamic import needs an extra `..`.

Without this fix, `opencli antigravity serve` throws `ERR_MODULE_NOT_FOUND` immediately, completely breaking the Anthropic-compatible API proxy feature (which is the cleanest path for synchronous push-and-wait IPC between external orchestrators and Antigravity).

## Verification (local)

| step | result |
|---|---|
| `npm install` | ✅ 232 packages, no errors |
| `npm run typecheck` | ✅ clean |
| `npm run build` | ✅ `dist/src/cli.js` now has correct `'../../clis/antigravity/serve.js'` |
| `node dist/src/main.js antigravity serve --port 8083 --timeout 600` | ✅ `[serve] CDP connection will be established on first request.` |
| `curl -X OPTIONS http://localhost:8083/v1/messages` | ✅ `HTTP 204` |

## Audit

Confirmed no similar bugs in the rest of `src/cli.ts`:

```bash
$ grep -nE "import\(['\"]\\.\\.[/\\\\]clis[/\\\\]" src/cli.ts
src/cli.ts:3292:      const { startServe } = await import('../clis/antigravity/serve.js');
# After fix: 0 matches with old wrong path; only the corrected one remains.
```

Single-occurrence offender — this PR is comprehensive.

## Context

Discovered while building a synchronous Claude-Code → multi-IDE bridge layer ([Issue #1786](https://github.com/jackwener/opencli/issues/1786) for the related Trae SOLO + Qoder adapter request). The `antigravity serve` Anthropic-API proxy is the single most valuable opencli feature for orchestrating multi-agent code review pipelines — losing it forces fallback to fragile DOM-polling and is a much larger productivity hit than the 1-line LoC suggests.