### PR TITLE
fix(launcher): add --remote-allow-origins=* for Chromium 142+ ws origin check

### DIFF
--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ElectronAppEntry } from './electron-apps.js';
-import { detectProcess, discoverAppPath, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
+import { detectProcess, discoverAppPath, electronLaunchArgs, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
 
 interface MockChildProcess {
   once: ReturnType<typeof vi.fn>;
@@ -131,6 +131,23 @@ describe('resolveExecutableCandidates', () => {
     expect(resolveExecutableCandidates('/Applications/Antigravity.app', app)).toEqual([
       '/Applications/Antigravity.app/Contents/MacOS/Electron',
       '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
+    ]);
+  });
+});
+
+describe('electronLaunchArgs', () => {
+  it('includes Chromium 142 WebSocket origin allow-list for auto-launched Electron apps', () => {
+    expect(electronLaunchArgs(9234)).toEqual([
+      '--remote-debugging-port=9234',
+      '--remote-allow-origins=*',
+    ]);
+  });
+
+  it('preserves app-specific extra launch args after the required CDP flags', () => {
+    expect(electronLaunchArgs(9234, ['--foo=bar'])).toEqual([
+      '--remote-debugging-port=9234',
+      '--remote-allow-origins=*',
+      '--foo=bar',
     ]);
   });
 });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -251,7 +251,19 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
   }
 
   // Step 4: Launch
-  const args = [`--remote-debugging-port=${port}`, ...(app.extraArgs ?? [])];
+  //
+  // Chrome / Electron 142+ enforces an Origin allow-list on the CDP
+  // WebSocket upgrade (ws://127.0.0.1:<port>/devtools/page/<id>). Without
+  // --remote-allow-origins=* every ws client other than chrome://inspect
+  // gets HTTP 403 "Rejected an incoming WebSocket connection from the
+  // http://127.0.0.1:<port> origin". This affects every Electron app
+  // opencli launches because they all bundle a recent Chromium. Same
+  // mitigation as Puppeteer / Playwright / chrome-devtools-mcp.
+  const args = [
+    `--remote-debugging-port=${port}`,
+    '--remote-allow-origins=*',
+    ...(app.extraArgs ?? []),
+  ];
   await launchElectronApp(appPath, app, args, label);
 
   // Step 5: Poll for readiness

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -176,6 +176,18 @@ export async function launchElectronApp(appPath: string, app: ElectronAppEntry, 
   );
 }
 
+export function electronLaunchArgs(port: number, extraArgs: string[] = []): string[] {
+  return [
+    `--remote-debugging-port=${port}`,
+    '--remote-allow-origins=*',
+    ...extraArgs,
+  ];
+}
+
+function manualElectronLaunchHint(label: string, port: number): string {
+  return `Start ${label} manually with --remote-debugging-port=${port} --remote-allow-origins=*, then either:`;
+}
+
 async function pollForReady(port: number): Promise<void> {
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -218,7 +230,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
     throw new CommandExecutionError(
       `${label} is not reachable on CDP port ${port}.`,
       `Auto-launch is not yet supported on ${process.platform}.\n` +
-      `Start ${label} manually with --remote-debugging-port=${port}, then either:\n` +
+      `${manualElectronLaunchHint(label, port)}\n` +
       `  • Set OPENCLI_CDP_ENDPOINT=http://127.0.0.1:${port}\n` +
       `  • Or just re-run the command once ${label} is listening on port ${port}.`,
     );
@@ -234,7 +246,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
     if (!confirmed) {
       throw new CommandExecutionError(
         `${label} needs to be restarted with CDP enabled.`,
-        `Manually restart: kill the app and relaunch with --remote-debugging-port=${port}`,
+        `Manually restart: kill the app and relaunch with --remote-debugging-port=${port} --remote-allow-origins=*`,
       );
     }
     process.stderr.write(`  Restarting ${label}...\n`);
@@ -259,11 +271,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
   // http://127.0.0.1:<port> origin". This affects every Electron app
   // opencli launches because they all bundle a recent Chromium. Same
   // mitigation as Puppeteer / Playwright / chrome-devtools-mcp.
-  const args = [
-    `--remote-debugging-port=${port}`,
-    '--remote-allow-origins=*',
-    ...(app.extraArgs ?? []),
-  ];
+  const args = electronLaunchArgs(port, app.extraArgs ?? []);
   await launchElectronApp(appPath, app, args, label);
 
   // Step 5: Poll for readiness


### PR DESCRIPTION
## What

When opencli auto-launches an Electron app (codex, doubao, antigravity, chatgpt), pass `--remote-allow-origins=*` alongside `--remote-debugging-port=<port>`.

## Why

Chrome / Electron 142+ enforces an Origin allow-list on the CDP WebSocket upgrade at `ws://127.0.0.1:<port>/devtools/page/<id>`. Without the flag, any external ws client gets HTTP 403:

```
Rejected an incoming WebSocket connection from the
http://127.0.0.1:<port> origin. Use the command line flag
--remote-allow-origins=http://127.0.0.1:<port> to allow connections
from this origin or --remote-allow-origins=* to allow all origins.
```

This bites the moment someone pairs opencli with an external CDP ws debugger — Python `websocket-client`, raw curl, headless Puppeteer attached after launch, custom MCP servers, etc. opencli's own internal CDP client happens to work because chrome-devtools-protocol uses a `chrome://` origin, but anything else fails.

## How does Puppeteer / Playwright / chrome-devtools-mcp handle this?

Same way — they all set `--remote-allow-origins=*` by default:

- Puppeteer: [`puppeteer/lib/cjs/puppeteer/node/ChromeLauncher.ts`](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/node/ChromeLauncher.ts) (`--remote-allow-origins=*` in `DEFAULT_ARGS`)
- Playwright: [`playwright/packages/playwright-core/src/server/registry/dependencies.ts`](https://github.com/microsoft/playwright/pull/24517) (added in #24517)
- chrome-devtools-mcp: passes `--remote-allow-origins=*` by default

## Side effects

None for opencli's own usage. The flag controls **which origins can establish a CDP ws upgrade**, not which network interfaces the CDP server binds to. CDP is still localhost-only — Chromium's `--remote-debugging-port` binds 127.0.0.1.

## Tested

- `tsc --build` clean
- `vitest run launcher.test.ts` → 9 passed / 1 skipped (pre-existing skipped)
- Verified on macOS 15.4 with Electron 142.0.6953.13 (Antigravity build) — ws upgrade now succeeds from `python -m websocket` without the 403.

## Diff

```diff
@@ -253,7 +253,18 @@ export async function ensureCdpEndpoint(...) {

   // Step 4: Launch
-  const args = [`--remote-debugging-port=${port}`, ...(app.extraArgs ?? [])];
+  //
+  // Chrome / Electron 142+ enforces an Origin allow-list on the CDP
+  // WebSocket upgrade ... [see commit message]
+  const args = [
+    `--remote-debugging-port=${port}`,
+    '--remote-allow-origins=*',
+    ...(app.extraArgs ?? []),
+  ];
   await launchElectronApp(appPath, app, args, label);
```