### PR TITLE
chore(extension): bump to 1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **extension 1.0.16** — ship the `OpenCLI Browser` / `OpenCLI Adapter` tab-group race fix from #1693. The extension now serializes owned tab-group creation per role so concurrent adapter/browser leases reuse the same group instead of creating duplicate same-title groups.
+
 ## [1.8.0](https://github.com/jackwener/opencli/compare/v1.7.22...v1.8.0) (2026-05-20)
 
 Substantial release: a new official-API adapter (`weread-official`), wider LinkedIn / Twitter / Reddit / Zhihu coverage, the 12306 / Suno / Xianyu inbox additions, security and reliability fixes for the Browser Bridge and media downloads, plus a 20% README shrink. Node 20 compatibility is restored after an automated `undici` bump regression.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.14",
+      "version": "1.0.16",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"


### PR DESCRIPTION
## Summary
- bump Browser Bridge extension package and manifest to 1.0.16
- sync the extension lockfile version (it was stale at 1.0.14)
- add a changelog note that 1.0.16 ships the #1693 duplicate tab-group race fix

## Why
#1693 fixed duplicate OpenCLI Browser / Adapter tab groups on main, but it landed after v1.8.0 and did not bump the extension version. Users on the released extension still run pre-#1693 code, so the duplicate group issue can continue until a new extension package is cut.

## Verification
- npm --prefix extension run typecheck
- npm --prefix extension run build
- npx vitest run --project extension extension/src/background.test.ts -t "group"
- git diff --check
