### PR TITLE
fix(extension): converge owned tab groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * **extension 1.0.16** — ship the `OpenCLI Browser` / `OpenCLI Adapter` tab-group race fix from #1693. The extension now serializes owned tab-group creation per role so concurrent adapter/browser leases reuse the same group instead of creating duplicate same-title groups.
+* **extension 1.0.17** — replace owned tab-group management with a Chrome-state-as-truth convergence model. The extension now keeps one canonical `OpenCLI Browser` / `OpenCLI Adapter` group per profile role, recovers renamed groups from stored hints or owned lease tabs, merges same-window and cross-window duplicates into the canonical group, and normalizes legacy or user-renamed container titles back to the canonical owned-container title.
 
 ## [1.8.0](https://github.com/jackwener/opencli/compare/v1.7.22...v1.8.0) (2026-05-20)
 

--- a/docs/guide/browser-bridge.md
+++ b/docs/guide/browser-bridge.md
@@ -66,6 +66,8 @@ opencli browser my-session close
 
 Use `opencli browser <session> bind` when you want to attach OpenCLI to a Chrome tab you already opened manually. Bound sessions do not have the owned-session idle close timer; they stay attached until `unbind`, tab close, window close, or daemon restart. For owned sessions, use `--window foreground` to watch OpenCLI work in a visible automation window, or `--window background` to keep that automation window out of the way.
 
+The `OpenCLI Browser` and `OpenCLI Adapter` tab groups are extension-managed automation containers; avoid putting your own long-lived tabs in them or renaming them.
+
 ## How It Works
 
 ```

--- a/docs/zh/guide/browser-bridge.md
+++ b/docs/zh/guide/browser-bridge.md
@@ -64,6 +64,8 @@ opencli browser my-session close
 
 如果要把 OpenCLI 绑定到你已经手动打开的 Chrome tab，请使用 `opencli browser <session> bind`。绑定 session 没有 owned session 的 idle close 计时器，会一直保持到 `unbind`、tab 关闭、窗口关闭或 daemon 重启。对于 OpenCLI 自己创建的 owned session，使用 `--window foreground` 可以在可见自动化窗口里观察 OpenCLI 操作；使用 `--window background` 可以让这个自动化窗口留在后台。
 
+`OpenCLI Browser` 和 `OpenCLI Adapter` tab group 是扩展管理的自动化容器；请不要把自己的长期 tab 放进去，也不要重命名。
+
 ## Daemon 生命周期
 
 Daemon 在首次运行浏览器命令时自动启动，之后保持常驻运行。

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1013,26 +1013,6 @@ function resetWindowIdleTimer(leaseKey) {
     await releaseLease(leaseKey, "idle timeout");
   }, timeout);
 }
-async function getOwnedContainerGroupId(role, windowId) {
-  const container = ownedContainers[role];
-  if (container.groupId !== null) {
-    try {
-      const group = await chrome.tabGroups.get(container.groupId);
-      if (group.windowId === windowId) return container.groupId;
-    } catch {
-    }
-    container.groupId = null;
-  }
-  for (const title of getOwnedContainerGroupTitles(role)) {
-    const groups = await chrome.tabGroups.query({ windowId, title });
-    const existing = groups[0];
-    if (existing) {
-      container.groupId = existing.id;
-      return existing.id;
-    }
-  }
-  return null;
-}
 function getOwnedContainerGroupTitles(role) {
   return role === "automation" ? [CONTAINER_TAB_GROUP_TITLE.automation, LEGACY_AUTOMATION_TAB_GROUP_TITLE] : [CONTAINER_TAB_GROUP_TITLE.interactive];
 }
@@ -1042,13 +1022,14 @@ async function focusOwnedWindowIfRequested(windowId, mode) {
   if (typeof updateWindow === "function") await updateWindow(windowId, { focused: true }).catch(() => {
   });
 }
-async function toOwnedContainerDiscoveryCandidate(group) {
+async function toOwnedContainerGroupCandidate(group) {
   try {
     const chromeWindow = await chrome.windows.get(group.windowId);
     const reusableTabId = await findReusableOwnedContainerTab(group.windowId);
     return {
+      id: group.id,
       windowId: group.windowId,
-      groupId: group.id,
+      title: group.title,
       focused: !!chromeWindow.focused,
       hasReusableTab: reusableTabId !== void 0
     };
@@ -1056,71 +1037,149 @@ async function toOwnedContainerDiscoveryCandidate(group) {
     return null;
   }
 }
-function selectOwnedContainerDiscoveryCandidate(candidates) {
+function selectOwnedContainerGroupCandidate(candidates) {
   if (candidates.length === 0) return null;
   return [...candidates].sort((a, b) => {
     if (a.focused !== b.focused) return a.focused ? -1 : 1;
     if (a.hasReusableTab !== b.hasReusableTab) return a.hasReusableTab ? -1 : 1;
-    return a.groupId - b.groupId;
+    if (a.windowId !== b.windowId) return a.windowId - b.windowId;
+    return a.id - b.id;
   })[0];
 }
-async function discoverOwnedContainerFromTabGroup(role) {
+async function collectOwnedGroupCandidates(role) {
   const container = ownedContainers[role];
+  const groupsById = /* @__PURE__ */ new Map();
   if (container.groupId !== null) {
     try {
       const group = await chrome.tabGroups.get(container.groupId);
-      await chrome.windows.get(group.windowId);
-      container.windowId = group.windowId;
-      return { windowId: group.windowId, groupId: group.id };
+      groupsById.set(group.id, group);
     } catch {
-      container.windowId = null;
       container.groupId = null;
     }
   }
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
-    const candidates = (await Promise.all(groups.map(toOwnedContainerDiscoveryCandidate))).filter((candidate) => candidate !== null);
-    const selected = selectOwnedContainerDiscoveryCandidate(candidates);
-    if (!selected) continue;
-    container.windowId = selected.windowId;
-    container.groupId = selected.groupId;
-    return { windowId: selected.windowId, groupId: selected.groupId };
+    for (const group of groups) groupsById.set(group.id, group);
   }
-  return null;
+  for (const [leaseKey, session] of automationSessions.entries()) {
+    if (!session.owned || getOwnedWindowRole(leaseKey) !== role || session.preferredTabId === null) continue;
+    try {
+      const tab = await chrome.tabs.get(session.preferredTabId);
+      const groupId = tab.groupId;
+      if (typeof groupId !== "number" || groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) continue;
+      const group = await chrome.tabGroups.get(groupId);
+      groupsById.set(group.id, group);
+    } catch {
+    }
+  }
+  const candidates = await Promise.all([...groupsById.values()].map(toOwnedContainerGroupCandidate));
+  return candidates.filter((candidate) => candidate !== null);
 }
-async function ensureOwnedContainerTabGroup(role, windowId, tabIds) {
+function updateOwnedSessionWindowForTabs(role, tabIds, windowId) {
+  const moved = new Set(tabIds);
+  for (const [leaseKey, session] of automationSessions.entries()) {
+    if (!session.owned || getOwnedWindowRole(leaseKey) !== role) continue;
+    if (session.preferredTabId !== null && moved.has(session.preferredTabId)) {
+      session.windowId = windowId;
+    }
+  }
+}
+async function ensureTabsInWindow(tabIds, windowId) {
+  const movedIds = [];
+  for (const tabId of tabIds) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (tab.windowId !== windowId) {
+        await chrome.tabs.move(tabId, { windowId, index: -1 });
+        movedIds.push(tabId);
+      }
+    } catch {
+    }
+  }
+  return movedIds;
+}
+async function ensureCanonicalGroupTitle(role, group) {
+  const canonicalTitle = CONTAINER_TAB_GROUP_TITLE[role];
+  if (group.title === canonicalTitle) return group;
+  const updated = await chrome.tabGroups.update(group.id, {
+    title: canonicalTitle,
+    color: AUTOMATION_TAB_GROUP_COLOR
+  });
+  return { id: updated.id, windowId: updated.windowId, title: updated.title };
+}
+async function convergeOwnedGroupDuplicates(role, canonical, candidates) {
+  for (const duplicate of candidates) {
+    if (duplicate.id === canonical.id) continue;
+    const tabs = await chrome.tabs.query({ groupId: duplicate.id });
+    const tabIds = tabs.map((tab) => tab.id).filter((id) => id !== void 0);
+    if (tabIds.length === 0) continue;
+    await ensureTabsInWindow(tabIds, canonical.windowId);
+    await chrome.tabs.group({ groupId: canonical.id, tabIds });
+    updateOwnedSessionWindowForTabs(role, tabIds, canonical.windowId);
+  }
+  return canonical;
+}
+async function attachTabsToOwnedGroup(role, group, ids) {
+  if (ids.length === 0) return group;
+  await ensureTabsInWindow(ids, group.windowId);
+  const tabs = await Promise.all(ids.map((id) => chrome.tabs.get(id).catch(() => null)));
+  const missing = tabs.filter((tab) => tab !== null && tab.id !== void 0 && tab.groupId !== group.id).map((tab) => tab.id);
+  if (missing.length > 0) await chrome.tabs.group({ groupId: group.id, tabIds: missing });
+  updateOwnedSessionWindowForTabs(role, ids, group.windowId);
+  return group;
+}
+async function createOwnedGroupWithRollback(role, windowId, ids) {
+  if (ids.length === 0) throw new Error(`Cannot create ${role} tab group without tabs`);
+  await ensureTabsInWindow(ids, windowId);
+  const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
+  try {
+    const group = await chrome.tabGroups.update(groupId, {
+      color: AUTOMATION_TAB_GROUP_COLOR,
+      title: CONTAINER_TAB_GROUP_TITLE[role],
+      collapsed: false
+    });
+    updateOwnedSessionWindowForTabs(role, ids, group.windowId);
+    return { id: group.id, windowId: group.windowId, title: group.title };
+  } catch (err) {
+    await chrome.tabs.ungroup(ids).catch(() => {
+    });
+    throw err;
+  }
+}
+async function ensureOwnedContainerGroup(role, fallbackWindowId, tabIds) {
   const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
-  if (ids.length === 0) return;
   const container = ownedContainers[role];
-  const previousGroupPromise = container.groupPromise ?? Promise.resolve();
-  const nextGroupPromise = previousGroupPromise.catch(() => void 0).then(() => ensureOwnedContainerTabGroupUnlocked(role, windowId, ids));
+  const previousGroupPromise = container.groupPromise ?? Promise.resolve(null);
+  const nextGroupPromise = previousGroupPromise.catch(() => null).then(() => ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids));
   const trackedGroupPromise = nextGroupPromise.finally(() => {
     if (container.groupPromise === trackedGroupPromise) container.groupPromise = null;
   });
   container.groupPromise = trackedGroupPromise;
   return trackedGroupPromise;
 }
-async function ensureOwnedContainerTabGroupUnlocked(role, windowId, ids) {
+async function ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids) {
   try {
-    const existingGroupId = await getOwnedContainerGroupId(role, windowId);
-    if (existingGroupId !== null) {
-      const tabs = await chrome.tabs.query({ windowId });
-      const alreadyGrouped = new Set(
-        tabs.filter((tab) => tab.id !== void 0 && ids.includes(tab.id) && tab.groupId === existingGroupId).map((tab) => tab.id)
-      );
-      const missing = ids.filter((id) => !alreadyGrouped.has(id));
-      if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
-      return;
+    const candidates = await collectOwnedGroupCandidates(role);
+    const selected = selectOwnedContainerGroupCandidate(candidates);
+    let canonical = selected ? { id: selected.id, windowId: selected.windowId, title: selected.title } : null;
+    if (canonical) {
+      canonical = await convergeOwnedGroupDuplicates(role, canonical, candidates);
+      canonical = await ensureCanonicalGroupTitle(role, canonical);
+      canonical = await attachTabsToOwnedGroup(role, canonical, ids);
+    } else if (fallbackWindowId !== null && ids.length > 0) {
+      canonical = await createOwnedGroupWithRollback(role, fallbackWindowId, ids);
     }
-    const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-    ownedContainers[role].groupId = groupId;
-    await chrome.tabGroups.update(groupId, {
-      color: AUTOMATION_TAB_GROUP_COLOR,
-      title: CONTAINER_TAB_GROUP_TITLE[role],
-      collapsed: false
-    });
+    if (canonical) {
+      ownedContainers[role].windowId = canonical.windowId;
+      ownedContainers[role].groupId = canonical.id;
+    } else {
+      ownedContainers[role].groupId = null;
+      if (fallbackWindowId === null) ownedContainers[role].windowId = null;
+    }
+    return canonical;
   } catch (err) {
-    console.warn(`[opencli] Failed to mark ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
+    console.warn(`[opencli] Failed to ensure ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
+    throw err;
   }
 }
 async function ensureOwnedContainerWindow(role, initialUrl, mode = "background") {
@@ -1136,9 +1195,24 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
   if (container.windowId !== null) {
     try {
       await chrome.windows.get(container.windowId);
+      const group2 = await ensureOwnedContainerGroup(role, container.windowId, []);
+      if (group2) {
+        await focusOwnedWindowIfRequested(group2.windowId, mode);
+        const initialTabId3 = await findReusableOwnedContainerTab(group2.windowId);
+        return {
+          windowId: group2.windowId,
+          initialTabId: initialTabId3
+        };
+      }
       await focusOwnedWindowIfRequested(container.windowId, mode);
       const initialTabId2 = await findReusableOwnedContainerTab(container.windowId);
-      await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId2]);
+      const createdGroup = await ensureOwnedContainerGroup(role, container.windowId, [initialTabId2]);
+      if (createdGroup) {
+        return {
+          windowId: createdGroup.windowId,
+          initialTabId: initialTabId2
+        };
+      }
       return {
         windowId: container.windowId,
         initialTabId: initialTabId2
@@ -1148,14 +1222,13 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
       container.groupId = null;
     }
   }
-  const discovered = await discoverOwnedContainerFromTabGroup(role);
-  if (discovered) {
-    await focusOwnedWindowIfRequested(discovered.windowId, mode);
-    const initialTabId2 = await findReusableOwnedContainerTab(discovered.windowId);
-    await ensureOwnedContainerTabGroup(role, discovered.windowId, [initialTabId2]);
+  const existingGroup = await ensureOwnedContainerGroup(role, null, []);
+  if (existingGroup) {
+    await focusOwnedWindowIfRequested(existingGroup.windowId, mode);
+    const initialTabId2 = await findReusableOwnedContainerTab(existingGroup.windowId);
     await persistRuntimeState();
     return {
-      windowId: discovered.windowId,
+      windowId: existingGroup.windowId,
       initialTabId: initialTabId2
     };
   }
@@ -1189,9 +1262,9 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
       }
     });
   }
-  await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId]);
+  const group = await ensureOwnedContainerGroup(role, container.windowId, [initialTabId]);
   await persistRuntimeState();
-  return { windowId: container.windowId, initialTabId };
+  return { windowId: group?.windowId ?? container.windowId, initialTabId };
 }
 async function findReusableOwnedContainerTab(windowId) {
   try {
@@ -1229,18 +1302,21 @@ async function createOwnedTabLeaseUnlocked(leaseKey, initialUrl) {
   } else {
     tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
   }
-  if (!tab.id) throw new Error("Failed to create tab lease in automation container");
-  await ensureOwnedContainerTabGroup(role, windowId, [tab.id]);
+  const tabId = tab.id;
+  if (!tabId) throw new Error("Failed to create tab lease in automation container");
+  const group = await ensureOwnedContainerGroup(role, windowId, [tabId]);
+  const sessionWindowId = group?.windowId ?? tab.windowId;
+  if (tab.windowId !== sessionWindowId) tab = await chrome.tabs.get(tabId);
   setLeaseSession(leaseKey, {
     session: getSessionFromKey(leaseKey),
     surface: getSurfaceFromKey(leaseKey),
     kind: "owned",
-    windowId,
+    windowId: sessionWindowId,
     owned: true,
-    preferredTabId: tab.id
+    preferredTabId: tabId
   });
   resetWindowIdleTimer(leaseKey);
-  return { tabId: tab.id, tab };
+  return { tabId, tab };
 }
 async function getAutomationWindow(leaseKey, initialUrl) {
   const existing = automationSessions.get(leaseKey);
@@ -1581,7 +1657,8 @@ async function resolveTab(tabId, leaseKey, initialUrl) {
   }
   const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
   if (!newTab.id) throw new Error("Failed to create tab in automation container");
-  return { tabId: newTab.id, tab: newTab };
+  await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [newTab.id]);
+  return { tabId: newTab.id, tab: await chrome.tabs.get(newTab.id) };
 }
 async function pageScopedResult(id, tabId, data) {
   const page = await resolveTargetId(tabId);
@@ -1746,19 +1823,22 @@ async function handleTabs(cmd, leaseKey) {
         return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
       }
       const windowId = await getAutomationWindow(leaseKey);
-      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
-      if (!tab.id) return { id: cmd.id, ok: false, error: "Failed to create tab" };
-      await ensureOwnedContainerTabGroup(getOwnedWindowRole(leaseKey), windowId, [tab.id]);
+      let tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      const tabId = tab.id;
+      if (!tabId) return { id: cmd.id, ok: false, error: "Failed to create tab" };
+      const group = await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [tabId]);
+      const sessionWindowId = group?.windowId ?? tab.windowId;
+      if (tab.windowId !== sessionWindowId) tab = await chrome.tabs.get(tabId);
       setLeaseSession(leaseKey, {
         session: getSessionFromKey(leaseKey),
         surface: getSurfaceFromKey(leaseKey),
         kind: "owned",
-        windowId: tab.windowId,
+        windowId: sessionWindowId,
         owned: true,
-        preferredTabId: tab.id
+        preferredTabId: tabId
       });
       resetWindowIdleTimer(leaseKey);
-      return pageScopedResult(cmd.id, tab.id, { url: tab.url });
+      return pageScopedResult(cmd.id, tabId, { url: tab.url });
     }
     case "close": {
       if (cmd.index !== void 0) {
@@ -1992,7 +2072,8 @@ async function releaseLease(leaseKey, reason = "released") {
       } else {
         try {
           const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
-          await ensureOwnedContainerTabGroup(getOwnedWindowRole(leaseKey), session.windowId, [tab.id ?? tabId]);
+          const group = await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), session.windowId, [tab.id ?? tabId]);
+          if (group) session.windowId = group.windowId;
           console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (session=${session.session}, surface=${session.surface}, ${reason})`);
         } catch {
           await chrome.tabs.remove(tabId).catch(() => {
@@ -2055,7 +2136,11 @@ async function reconcileTargetLeaseRegistry() {
       if (session.owned) {
         const role = getOwnedWindowRole(leaseKey);
         if (ownedContainers[role].windowId === null) ownedContainers[role].windowId = tab.windowId;
-        await ensureOwnedContainerTabGroup(role, tab.windowId, [tabId]);
+        const group = await ensureOwnedContainerGroup(role, tab.windowId, [tabId]);
+        if (group) {
+          const current = automationSessions.get(leaseKey);
+          if (current) current.windowId = group.windowId;
+        }
       }
       const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
       if (timeout > 0) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -74,11 +74,19 @@ function createChromeMock() {
   const groups: MockTabGroup[] = [];
   let lastFocusedWindowId = 2;
 
-  const query = vi.fn(async (queryInfo: { windowId?: number; active?: boolean; lastFocusedWindow?: boolean } = {}) => {
+  const removeEmptyGroups = () => {
+    for (let i = groups.length - 1; i >= 0; i -= 1) {
+      const group = groups[i];
+      if (!tabs.some((tab) => tab.groupId === group.id)) groups.splice(i, 1);
+    }
+  };
+
+  const query = vi.fn(async (queryInfo: { windowId?: number; active?: boolean; lastFocusedWindow?: boolean; groupId?: number } = {}) => {
     return tabs.filter((tab) => {
       if (queryInfo.windowId !== undefined && tab.windowId !== queryInfo.windowId) return false;
       if (queryInfo.lastFocusedWindow && tab.windowId !== lastFocusedWindowId) return false;
       if (queryInfo.active !== undefined && !!tab.active !== queryInfo.active) return false;
+      if (queryInfo.groupId !== undefined && tab.groupId !== queryInfo.groupId) return false;
       return true;
     });
   });
@@ -118,6 +126,8 @@ function createChromeMock() {
         const tab = tabs.find((entry) => entry.id === tabId);
         if (!tab) throw new Error(`Unknown tab ${tabId}`);
         tab.windowId = moveProps.windowId;
+        tab.groupId = -1;
+        removeEmptyGroups();
         return tab;
       }),
       group: vi.fn(async (options: { tabIds?: number | number[]; groupId?: number; createProperties?: { windowId?: number } }) => {
@@ -135,8 +145,19 @@ function createChromeMock() {
           const tab = tabs.find((entry) => entry.id === tabId);
           if (!tab) throw new Error(`Unknown tab ${tabId}`);
           tab.groupId = groupId;
+          const group = groups.find((entry) => entry.id === groupId);
+          if (group) tab.windowId = group.windowId;
         }
+        removeEmptyGroups();
         return groupId;
+      }),
+      ungroup: vi.fn(async (tabIds: number | number[]) => {
+        const ids = Array.isArray(tabIds) ? tabIds : [tabIds];
+        for (const tabId of ids) {
+          const tab = tabs.find((entry) => entry.id === tabId);
+          if (tab) tab.groupId = -1;
+        }
+        removeEmptyGroups();
       }),
       onUpdated: { addListener: vi.fn(), removeListener: vi.fn() } as Listener<(id: number, info: chrome.tabs.TabChangeInfo) => void>,
       onRemoved: { addListener: vi.fn() } as Listener<(tabId: number) => void>,
@@ -1150,6 +1171,73 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 100, tabIds: [10] });
   });
 
+  it('converges duplicate OpenCLI Adapter groups in the same window', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push(
+      { id: 77, windowId: 7, url: 'about:blank', title: 'blank', active: true, status: 'complete', groupId: 201 },
+      { id: 78, windowId: 7, url: 'about:blank', title: 'blank', active: false, status: 'complete', groupId: 202 },
+    );
+    groups.push(
+      { id: 201, windowId: 7, title: 'OpenCLI Adapter', color: 'orange', collapsed: false },
+      { id: 202, windowId: 7, title: 'OpenCLI Adapter', color: 'orange', collapsed: false },
+    );
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabId).toBe(77);
+    expect(groups).toEqual([
+      expect.objectContaining({ id: 201, windowId: 7, title: 'OpenCLI Adapter' }),
+    ]);
+    expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(201);
+    expect(tabs.find((tab) => tab.id === 78)?.groupId).toBe(201);
+    expect(chrome.tabs.move).not.toHaveBeenCalledWith(78, expect.anything());
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 201, tabIds: [78] });
+  });
+
+  it('converges duplicate OpenCLI Adapter groups across windows by moving tabs to the canonical window', async () => {
+    const { chrome, tabs, groups, setLastFocusedWindowId } = createChromeMock();
+    setLastFocusedWindowId(2);
+    tabs.push(
+      { id: 77, windowId: 7, url: 'about:blank', title: 'blank', active: true, status: 'complete', groupId: 201 },
+      { id: 78, windowId: 8, url: 'about:blank', title: 'blank', active: false, status: 'complete', groupId: 202 },
+    );
+    groups.push(
+      { id: 201, windowId: 7, title: 'OpenCLI Adapter', color: 'orange', collapsed: false },
+      { id: 202, windowId: 8, title: 'OpenCLI Adapter', color: 'orange', collapsed: false },
+    );
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabId).toBe(77);
+    expect(groups).toEqual([
+      expect.objectContaining({ id: 201, windowId: 7, title: 'OpenCLI Adapter' }),
+    ]);
+    expect(tabs.find((tab) => tab.id === 78)).toEqual(expect.objectContaining({ windowId: 7, groupId: 201 }));
+    expect(chrome.tabs.move).toHaveBeenCalledWith(78, { windowId: 7, index: -1 });
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 201, tabIds: [78] });
+    expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).toBe(7);
+  });
+
+  it('rolls back a newly created group when setting the canonical title fails', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    chrome.tabGroups.update = vi.fn(async () => {
+      throw new Error('title update failed');
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    await expect(mod.__test__.resolveTabId(undefined, adapterKey('twitter'))).rejects.toThrow('title update failed');
+
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ tabIds: [1], createProperties: { windowId: 1 } });
+    expect(chrome.tabs.ungroup).toHaveBeenCalledWith([1]);
+    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(-1);
+    expect(groups).toHaveLength(0);
+  });
+
   it('serializes concurrent owned tab grouping so duplicate adapter groups are not created', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     const releaseFirstGroupCreate = deferred<void>();
@@ -1210,7 +1298,8 @@ describe('background tab isolation', () => {
     mod.__test__.setSession(adapterKey('second'), { windowId: 1, owned: true, preferredTabId: null });
     mod.__test__.setSession(adapterKey('third'), { windowId: 1, owned: true, preferredTabId: null });
 
-    const first = mod.__test__.handleTabs({ id: 'new-first', action: 'tabs', op: 'new', session: adapterKey('first'), url: 'https://first.example' }, adapterKey('first'));
+    const first = mod.__test__.handleTabs({ id: 'new-first', action: 'tabs', op: 'new', session: adapterKey('first'), url: 'https://first.example' }, adapterKey('first'))
+      .then((result) => ({ status: 'fulfilled' as const, result }), (error) => ({ status: 'rejected' as const, error }));
     const second = mod.__test__.handleTabs({ id: 'new-second', action: 'tabs', op: 'new', session: adapterKey('second'), url: 'https://second.example' }, adapterKey('second'));
     const third = mod.__test__.handleTabs({ id: 'new-third', action: 'tabs', op: 'new', session: adapterKey('third'), url: 'https://third.example' }, adapterKey('third'));
 
@@ -1226,8 +1315,11 @@ describe('background tab isolation', () => {
     expect(createGroupCalls).toBe(2);
     releaseSecondGroupCreate.resolve();
 
-    await expect(Promise.all([first, second, third])).resolves.toEqual([
-      expect.objectContaining({ ok: true }),
+    await expect(first).resolves.toEqual(expect.objectContaining({
+      status: 'rejected',
+      error: expect.objectContaining({ message: 'transient group creation failure' }),
+    }));
+    await expect(Promise.all([second, third])).resolves.toEqual([
       expect.objectContaining({ ok: true }),
       expect.objectContaining({ ok: true }),
     ]);
@@ -1288,6 +1380,46 @@ describe('background tab isolation', () => {
     expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(99);
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [77] });
     expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+  });
+
+  it('prefers a discovered OpenCLI Adapter group over a stale stored window hint', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push({
+      id: 77,
+      windowId: 7,
+      url: 'about:blank',
+      title: 'blank',
+      active: true,
+      status: 'complete',
+      groupId: -1,
+    });
+    groups.push({
+      id: 99,
+      windowId: 7,
+      title: 'OpenCLI Adapter',
+      color: 'orange',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v2: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: { interactive: { windowId: null }, automation: { windowId: 1 } },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabId).toBe(77);
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).toBe(7);
+    expect(tabs.find((tab) => tab.id === 1)?.windowId).toBe(1);
+    expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(99);
+    expect(chrome.tabs.move).not.toHaveBeenCalledWith(1, expect.anything());
   });
 
   it('prefers a focused OpenCLI Adapter group when multiple matching groups exist', async () => {
@@ -1402,7 +1534,7 @@ describe('background tab isolation', () => {
     });
     tabs.push({
       id: 78,
-      windowId: 8,
+      windowId: 7,
       url: 'about:blank',
       title: 'blank',
       active: true,
@@ -1419,7 +1551,7 @@ describe('background tab isolation', () => {
       },
       {
         id: 98,
-        windowId: 8,
+        windowId: 7,
         title: 'OpenCLI Adapter',
         color: 'orange',
         collapsed: true,
@@ -1430,11 +1562,11 @@ describe('background tab isolation', () => {
     const mod = await import('./background');
     const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
 
-    expect(tabId).toBe(78);
+    expect(tabId).toBe(77);
     expect(chrome.windows.create).not.toHaveBeenCalled();
-    expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).toBe(8);
-    expect(tabs.find((tab) => tab.id === 78)?.groupId).toBe(98);
-    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 98, tabIds: [78] });
+    expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).toBe(7);
+    expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(98);
+    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 98, tabIds: [77] });
   });
 
   it('discovers and reuses a legacy OpenCLI automation group before creating a duplicate', async () => {
@@ -1465,7 +1597,10 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).toBe(8);
     expect(tabs.find((tab) => tab.id === 78)?.groupId).toBe(98);
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 98, tabIds: [78] });
-    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+    expect(chrome.tabGroups.update).toHaveBeenCalledWith(98, {
+      title: 'OpenCLI Adapter',
+      color: 'orange',
+    });
   });
 
   it('reuses a persisted automation group id after service worker restart even if the user renamed it', async () => {
@@ -1506,13 +1641,47 @@ describe('background tab isolation', () => {
     expect(groups).toEqual([
       expect.objectContaining({
         id: 99,
-        title: 'My Automation',
-        color: 'cyan',
+        title: 'OpenCLI Adapter',
+        color: 'orange',
         collapsed: true,
       }),
     ]);
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [1] });
-    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+    expect(chrome.tabGroups.update).toHaveBeenCalledWith(99, {
+      title: 'OpenCLI Adapter',
+      color: 'orange',
+    });
+  });
+
+  it('recovers an owned session tab group even when title and stored group hints are missing', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs[0].groupId = 99;
+    groups.push({
+      id: 99,
+      windowId: 1,
+      title: 'Renamed Container',
+      color: 'cyan',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 1, owned: true, preferredTabId: 1 });
+    await mod.__test__.ensureOwnedContainerGroup('automation', 1, [1]);
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        id: 99,
+        title: 'OpenCLI Adapter',
+        color: 'orange',
+      }),
+    ]);
+    expect(tabs[0].groupId).toBe(99);
+    expect(chrome.tabs.group).not.toHaveBeenCalledWith({ tabIds: [1], createProperties: { windowId: 1 } });
+    expect(chrome.tabGroups.update).toHaveBeenCalledWith(99, {
+      title: 'OpenCLI Adapter',
+      color: 'orange',
+    });
   });
 
   it('falls back to title discovery when a persisted automation group id is stale', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -242,7 +242,7 @@ const ownedContainers: Record<OwnedWindowRole, {
   windowId: number | null;
   groupId: number | null;
   promise: Promise<{ windowId: number; initialTabId?: number }> | null;
-  groupPromise: Promise<void> | null;
+  groupPromise: Promise<OwnedContainerGroup | null> | null;
 }> = {
   interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
   automation: { windowId: null, groupId: null, promise: null, groupPromise: null },
@@ -512,38 +512,19 @@ function resetWindowIdleTimer(leaseKey: string): void {
   }, timeout);
 }
 
-async function getOwnedContainerGroupId(role: OwnedWindowRole, windowId: number): Promise<number | null> {
-  const container = ownedContainers[role];
-  if (container.groupId !== null) {
-    try {
-      const group = await chrome.tabGroups.get(container.groupId);
-      if (group.windowId === windowId) return container.groupId;
-    } catch {
-      // Group IDs are browser-session state and can disappear when the last tab closes.
-    }
-    container.groupId = null;
-  }
-
-  for (const title of getOwnedContainerGroupTitles(role)) {
-    const groups = await chrome.tabGroups.query({ windowId, title });
-    const existing = groups[0];
-    if (existing) {
-      container.groupId = existing.id;
-      return existing.id;
-    }
-  }
-  return null;
-}
-
 function getOwnedContainerGroupTitles(role: OwnedWindowRole): string[] {
   return role === 'automation'
     ? [CONTAINER_TAB_GROUP_TITLE.automation, LEGACY_AUTOMATION_TAB_GROUP_TITLE]
     : [CONTAINER_TAB_GROUP_TITLE.interactive];
 }
 
-type OwnedContainerDiscoveryCandidate = {
+type OwnedContainerGroup = {
+  id: number;
   windowId: number;
-  groupId: number;
+  title?: string;
+};
+
+type OwnedContainerGroupCandidate = OwnedContainerGroup & {
   focused: boolean;
   hasReusableTab: boolean;
 };
@@ -554,13 +535,14 @@ async function focusOwnedWindowIfRequested(windowId: number, mode: WindowMode): 
   if (typeof updateWindow === 'function') await updateWindow(windowId, { focused: true }).catch(() => {});
 }
 
-async function toOwnedContainerDiscoveryCandidate(group: chrome.tabGroups.TabGroup): Promise<OwnedContainerDiscoveryCandidate | null> {
+async function toOwnedContainerGroupCandidate(group: chrome.tabGroups.TabGroup): Promise<OwnedContainerGroupCandidate | null> {
   try {
     const chromeWindow = await chrome.windows.get(group.windowId);
     const reusableTabId = await findReusableOwnedContainerTab(group.windowId);
     return {
+      id: group.id,
       windowId: group.windowId,
-      groupId: group.id,
+      title: group.title,
       focused: !!chromeWindow.focused,
       hasReusableTab: reusableTabId !== undefined,
     };
@@ -570,52 +552,154 @@ async function toOwnedContainerDiscoveryCandidate(group: chrome.tabGroups.TabGro
   }
 }
 
-function selectOwnedContainerDiscoveryCandidate(candidates: OwnedContainerDiscoveryCandidate[]): OwnedContainerDiscoveryCandidate | null {
+function selectOwnedContainerGroupCandidate(candidates: OwnedContainerGroupCandidate[]): OwnedContainerGroupCandidate | null {
   if (candidates.length === 0) return null;
   return [...candidates].sort((a, b) => {
     if (a.focused !== b.focused) return a.focused ? -1 : 1;
     if (a.hasReusableTab !== b.hasReusableTab) return a.hasReusableTab ? -1 : 1;
-    return a.groupId - b.groupId;
+    if (a.windowId !== b.windowId) return a.windowId - b.windowId;
+    return a.id - b.id;
   })[0];
 }
 
-async function discoverOwnedContainerFromTabGroup(role: OwnedWindowRole): Promise<{ windowId: number; groupId: number } | null> {
+async function collectOwnedGroupCandidates(role: OwnedWindowRole): Promise<OwnedContainerGroupCandidate[]> {
   const container = ownedContainers[role];
+  const groupsById = new Map<number, chrome.tabGroups.TabGroup>();
+
   if (container.groupId !== null) {
     try {
       const group = await chrome.tabGroups.get(container.groupId);
-      await chrome.windows.get(group.windowId);
-      container.windowId = group.windowId;
-      return { windowId: group.windowId, groupId: group.id };
+      groupsById.set(group.id, group);
     } catch {
-      container.windowId = null;
       container.groupId = null;
     }
   }
 
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
-    const candidates = (await Promise.all(groups.map(toOwnedContainerDiscoveryCandidate)))
-      .filter((candidate): candidate is OwnedContainerDiscoveryCandidate => candidate !== null);
-    const selected = selectOwnedContainerDiscoveryCandidate(candidates);
-    if (!selected) continue;
-    container.windowId = selected.windowId;
-    container.groupId = selected.groupId;
-    return { windowId: selected.windowId, groupId: selected.groupId };
+    for (const group of groups) groupsById.set(group.id, group);
   }
 
-  return null;
+  for (const [leaseKey, session] of automationSessions.entries()) {
+    if (!session.owned || getOwnedWindowRole(leaseKey) !== role || session.preferredTabId === null) continue;
+    try {
+      const tab = await chrome.tabs.get(session.preferredTabId);
+      const groupId = tab.groupId;
+      if (typeof groupId !== 'number' || groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) continue;
+      const group = await chrome.tabGroups.get(groupId);
+      groupsById.set(group.id, group);
+    } catch {
+      // Lease tabs and browser-session groups can disappear independently.
+    }
+  }
+
+  const candidates = await Promise.all([...groupsById.values()].map(toOwnedContainerGroupCandidate));
+  return candidates.filter((candidate): candidate is OwnedContainerGroupCandidate => candidate !== null);
 }
 
-async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: number, tabIds: Array<number | undefined>): Promise<void> {
+function updateOwnedSessionWindowForTabs(role: OwnedWindowRole, tabIds: number[], windowId: number): void {
+  const moved = new Set(tabIds);
+  for (const [leaseKey, session] of automationSessions.entries()) {
+    if (!session.owned || getOwnedWindowRole(leaseKey) !== role) continue;
+    if (session.preferredTabId !== null && moved.has(session.preferredTabId)) {
+      session.windowId = windowId;
+    }
+  }
+}
+
+async function ensureTabsInWindow(tabIds: number[], windowId: number): Promise<number[]> {
+  const movedIds: number[] = [];
+  for (const tabId of tabIds) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (tab.windowId !== windowId) {
+        await chrome.tabs.move(tabId, { windowId, index: -1 });
+        movedIds.push(tabId);
+      }
+    } catch {
+      // The caller may be cleaning stale session state. Missing tabs are ignored here.
+    }
+  }
+  return movedIds;
+}
+
+async function ensureCanonicalGroupTitle(role: OwnedWindowRole, group: OwnedContainerGroup): Promise<OwnedContainerGroup> {
+  const canonicalTitle = CONTAINER_TAB_GROUP_TITLE[role];
+  if (group.title === canonicalTitle) return group;
+  const updated = await chrome.tabGroups.update(group.id, {
+    title: canonicalTitle,
+    color: AUTOMATION_TAB_GROUP_COLOR,
+  });
+  return { id: updated.id, windowId: updated.windowId, title: updated.title };
+}
+
+async function convergeOwnedGroupDuplicates(
+  role: OwnedWindowRole,
+  canonical: OwnedContainerGroup,
+  candidates: OwnedContainerGroup[],
+): Promise<OwnedContainerGroup> {
+  for (const duplicate of candidates) {
+    if (duplicate.id === canonical.id) continue;
+    const tabs = await chrome.tabs.query({ groupId: duplicate.id });
+    const tabIds = tabs.map((tab) => tab.id).filter((id): id is number => id !== undefined);
+    if (tabIds.length === 0) continue;
+    await ensureTabsInWindow(tabIds, canonical.windowId);
+    await chrome.tabs.group({ groupId: canonical.id, tabIds });
+    updateOwnedSessionWindowForTabs(role, tabIds, canonical.windowId);
+  }
+  return canonical;
+}
+
+async function attachTabsToOwnedGroup(
+  role: OwnedWindowRole,
+  group: OwnedContainerGroup,
+  ids: number[],
+): Promise<OwnedContainerGroup> {
+  if (ids.length === 0) return group;
+  await ensureTabsInWindow(ids, group.windowId);
+  const tabs = await Promise.all(ids.map((id) => chrome.tabs.get(id).catch(() => null)));
+  const missing = tabs
+    .filter((tab): tab is chrome.tabs.Tab => tab !== null && tab.id !== undefined && tab.groupId !== group.id)
+    .map((tab) => tab.id!);
+  if (missing.length > 0) await chrome.tabs.group({ groupId: group.id, tabIds: missing });
+  updateOwnedSessionWindowForTabs(role, ids, group.windowId);
+  return group;
+}
+
+async function createOwnedGroupWithRollback(
+  role: OwnedWindowRole,
+  windowId: number,
+  ids: number[],
+): Promise<OwnedContainerGroup> {
+  if (ids.length === 0) throw new Error(`Cannot create ${role} tab group without tabs`);
+  await ensureTabsInWindow(ids, windowId);
+  const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
+  try {
+    const group = await chrome.tabGroups.update(groupId, {
+      color: AUTOMATION_TAB_GROUP_COLOR,
+      title: CONTAINER_TAB_GROUP_TITLE[role],
+      collapsed: false,
+    });
+    updateOwnedSessionWindowForTabs(role, ids, group.windowId);
+    return { id: group.id, windowId: group.windowId, title: group.title };
+  } catch (err) {
+    await chrome.tabs.ungroup(ids).catch(() => {});
+    throw err;
+  }
+}
+
+async function ensureOwnedContainerGroup(
+  role: OwnedWindowRole,
+  fallbackWindowId: number | null,
+  tabIds: Array<number | undefined>,
+): Promise<OwnedContainerGroup | null> {
   const ids = [...new Set(tabIds.filter((id): id is number => id !== undefined))];
-  if (ids.length === 0) return;
 
   const container = ownedContainers[role];
-  const previousGroupPromise = container.groupPromise ?? Promise.resolve();
+  const previousGroupPromise = container.groupPromise ?? Promise.resolve(null);
   const nextGroupPromise = previousGroupPromise
-    .catch(() => undefined)
-    .then(() => ensureOwnedContainerTabGroupUnlocked(role, windowId, ids));
+    .catch(() => null)
+    .then(() => ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids));
   const trackedGroupPromise = nextGroupPromise.finally(() => {
     if (container.groupPromise === trackedGroupPromise) container.groupPromise = null;
   });
@@ -623,30 +707,37 @@ async function ensureOwnedContainerTabGroup(role: OwnedWindowRole, windowId: num
   return trackedGroupPromise;
 }
 
-async function ensureOwnedContainerTabGroupUnlocked(role: OwnedWindowRole, windowId: number, ids: number[]): Promise<void> {
+async function ensureOwnedContainerGroupUnlocked(
+  role: OwnedWindowRole,
+  fallbackWindowId: number | null,
+  ids: number[],
+): Promise<OwnedContainerGroup | null> {
   try {
-    const existingGroupId = await getOwnedContainerGroupId(role, windowId);
-    if (existingGroupId !== null) {
-      const tabs = await chrome.tabs.query({ windowId });
-      const alreadyGrouped = new Set(
-        tabs
-          .filter((tab) => tab.id !== undefined && ids.includes(tab.id) && tab.groupId === existingGroupId)
-          .map((tab) => tab.id!),
-      );
-      const missing = ids.filter((id) => !alreadyGrouped.has(id));
-      if (missing.length > 0) await chrome.tabs.group({ groupId: existingGroupId, tabIds: missing });
-      return;
+    const candidates = await collectOwnedGroupCandidates(role);
+    const selected = selectOwnedContainerGroupCandidate(candidates);
+    let canonical: OwnedContainerGroup | null = selected
+      ? { id: selected.id, windowId: selected.windowId, title: selected.title }
+      : null;
+
+    if (canonical) {
+      canonical = await convergeOwnedGroupDuplicates(role, canonical, candidates);
+      canonical = await ensureCanonicalGroupTitle(role, canonical);
+      canonical = await attachTabsToOwnedGroup(role, canonical, ids);
+    } else if (fallbackWindowId !== null && ids.length > 0) {
+      canonical = await createOwnedGroupWithRollback(role, fallbackWindowId, ids);
     }
 
-    const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-    ownedContainers[role].groupId = groupId;
-    await chrome.tabGroups.update(groupId, {
-      color: AUTOMATION_TAB_GROUP_COLOR,
-      title: CONTAINER_TAB_GROUP_TITLE[role],
-      collapsed: false,
-    });
+    if (canonical) {
+      ownedContainers[role].windowId = canonical.windowId;
+      ownedContainers[role].groupId = canonical.id;
+    } else {
+      ownedContainers[role].groupId = null;
+      if (fallbackWindowId === null) ownedContainers[role].windowId = null;
+    }
+    return canonical;
   } catch (err) {
-    console.warn(`[opencli] Failed to mark ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
+    console.warn(`[opencli] Failed to ensure ${role} tab group: ${err instanceof Error ? err.message : String(err)}`);
+    throw err;
   }
 }
 
@@ -682,9 +773,24 @@ async function ensureOwnedContainerWindowUnlocked(
   if (container.windowId !== null) {
     try {
       await chrome.windows.get(container.windowId);
+      const group = await ensureOwnedContainerGroup(role, container.windowId, []);
+      if (group) {
+        await focusOwnedWindowIfRequested(group.windowId, mode);
+        const initialTabId = await findReusableOwnedContainerTab(group.windowId);
+        return {
+          windowId: group.windowId,
+          initialTabId,
+        };
+      }
       await focusOwnedWindowIfRequested(container.windowId, mode);
       const initialTabId = await findReusableOwnedContainerTab(container.windowId);
-      await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId]);
+      const createdGroup = await ensureOwnedContainerGroup(role, container.windowId, [initialTabId]);
+      if (createdGroup) {
+        return {
+          windowId: createdGroup.windowId,
+          initialTabId,
+        };
+      }
       return {
         windowId: container.windowId,
         initialTabId,
@@ -695,14 +801,13 @@ async function ensureOwnedContainerWindowUnlocked(
     }
   }
 
-  const discovered = await discoverOwnedContainerFromTabGroup(role);
-  if (discovered) {
-    await focusOwnedWindowIfRequested(discovered.windowId, mode);
-    const initialTabId = await findReusableOwnedContainerTab(discovered.windowId);
-    await ensureOwnedContainerTabGroup(role, discovered.windowId, [initialTabId]);
+  const existingGroup = await ensureOwnedContainerGroup(role, null, []);
+  if (existingGroup) {
+    await focusOwnedWindowIfRequested(existingGroup.windowId, mode);
+    const initialTabId = await findReusableOwnedContainerTab(existingGroup.windowId);
     await persistRuntimeState();
     return {
-      windowId: discovered.windowId,
+      windowId: existingGroup.windowId,
       initialTabId,
     };
   }
@@ -743,9 +848,9 @@ async function ensureOwnedContainerWindowUnlocked(
       }
     });
   }
-  await ensureOwnedContainerTabGroup(role, container.windowId, [initialTabId]);
+  const group = await ensureOwnedContainerGroup(role, container.windowId, [initialTabId]);
   await persistRuntimeState();
-  return { windowId: container.windowId, initialTabId };
+  return { windowId: group?.windowId ?? container.windowId, initialTabId };
 }
 
 async function findReusableOwnedContainerTab(windowId: number): Promise<number | undefined> {
@@ -790,19 +895,22 @@ async function createOwnedTabLeaseUnlocked(leaseKey: string, initialUrl?: string
   } else {
     tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
   }
-  if (!tab.id) throw new Error('Failed to create tab lease in automation container');
-  await ensureOwnedContainerTabGroup(role, windowId, [tab.id]);
+  const tabId = tab.id;
+  if (!tabId) throw new Error('Failed to create tab lease in automation container');
+  const group = await ensureOwnedContainerGroup(role, windowId, [tabId]);
+  const sessionWindowId = group?.windowId ?? tab.windowId;
+  if (tab.windowId !== sessionWindowId) tab = await chrome.tabs.get(tabId);
 
   setLeaseSession(leaseKey, {
     session: getSessionFromKey(leaseKey),
     surface: getSurfaceFromKey(leaseKey),
     kind: 'owned',
-    windowId,
+    windowId: sessionWindowId,
     owned: true,
-    preferredTabId: tab.id,
+    preferredTabId: tabId,
   });
   resetWindowIdleTimer(leaseKey);
-  return { tabId: tab.id, tab };
+  return { tabId, tab };
 }
 
 /** Get or create the dedicated automation container window.
@@ -1235,7 +1343,8 @@ async function resolveTab(tabId: number | undefined, leaseKey: string, initialUr
   // Fallback: create a new tab
   const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
   if (!newTab.id) throw new Error('Failed to create tab in automation container');
-  return { tabId: newTab.id, tab: newTab };
+  await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [newTab.id]);
+  return { tabId: newTab.id, tab: await chrome.tabs.get(newTab.id) };
 }
 
 /** Build a page-scoped success result with targetId resolved from tabId */
@@ -1437,19 +1546,22 @@ async function handleTabs(cmd: Command, leaseKey: string): Promise<Result> {
         return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
       }
       const windowId = await getAutomationWindow(leaseKey);
-      const tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
-      if (!tab.id) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
-      await ensureOwnedContainerTabGroup(getOwnedWindowRole(leaseKey), windowId, [tab.id]);
+      let tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      const tabId = tab.id;
+      if (!tabId) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
+      const group = await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [tabId]);
+      const sessionWindowId = group?.windowId ?? tab.windowId;
+      if (tab.windowId !== sessionWindowId) tab = await chrome.tabs.get(tabId);
       setLeaseSession(leaseKey, {
         session: getSessionFromKey(leaseKey),
         surface: getSurfaceFromKey(leaseKey),
         kind: 'owned',
-        windowId: tab.windowId,
+        windowId: sessionWindowId,
         owned: true,
-        preferredTabId: tab.id,
+        preferredTabId: tabId,
       });
       resetWindowIdleTimer(leaseKey);
-      return pageScopedResult(cmd.id, tab.id, { url: tab.url });
+      return pageScopedResult(cmd.id, tabId, { url: tab.url });
     }
     case 'close': {
       if (cmd.index !== undefined) {
@@ -1704,7 +1816,8 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
       } else {
         try {
           const tab = await chrome.tabs.update(tabId, { url: BLANK_PAGE, active: true });
-          await ensureOwnedContainerTabGroup(getOwnedWindowRole(leaseKey), session.windowId, [tab.id ?? tabId]);
+          const group = await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), session.windowId, [tab.id ?? tabId]);
+          if (group) session.windowId = group.windowId;
           console.log(`[opencli] Released owned tab lease ${tabId} as reusable placeholder (session=${session.session}, surface=${session.surface}, ${reason})`);
         } catch {
           await chrome.tabs.remove(tabId).catch(() => {});
@@ -1770,7 +1883,11 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
       if (session.owned) {
         const role = getOwnedWindowRole(leaseKey);
         if (ownedContainers[role].windowId === null) ownedContainers[role].windowId = tab.windowId;
-        await ensureOwnedContainerTabGroup(role, tab.windowId, [tabId]);
+        const group = await ensureOwnedContainerGroup(role, tab.windowId, [tabId]);
+        if (group) {
+          const current = automationSessions.get(leaseKey);
+          if (current) current.windowId = group.windowId;
+        }
       }
       const remaining = stored.idleDeadlineAt > 0 ? stored.idleDeadlineAt - Date.now() : timeout;
       if (timeout > 0) {
@@ -1845,6 +1962,7 @@ export const __test__ = {
   getLeaseKey,
   sessionTimeoutOverrides,
   reconcileTargetLeaseRegistry,
+  ensureOwnedContainerGroup,
   getSession: (leaseKey: string = 'default') => automationSessions.get(leaseKey) ?? null,
   getAutomationWindowId: (leaseKey: string = 'default') => automationSessions.get(leaseKey)?.windowId ?? null,
   setAutomationWindowId: (leaseKey: string, windowId: number | null) => {


### PR DESCRIPTION
## Summary

Replaces owned tab-group management with a Chrome-state-as-truth convergence model:

- keeps one canonical OpenCLI Browser / OpenCLI Adapter group per Chrome profile role
- treats stored group/window ids as recovery hints, not authority
- recovers candidates from canonical/legacy title scans, stored hints, and owned lease tab group ids
- merges same-window and cross-window duplicate groups by moving tabs into the canonical window/group
- normalizes legacy/user-renamed OpenCLI owned groups back to canonical titles
- rolls back newly created groups when title setup fails
- bumps the extension to 1.0.17 and documents that OpenCLI tab groups are extension-managed automation containers

## Verification

- npm --prefix extension run typecheck
- npm --prefix extension run build
- npx vitest run --project extension extension/src/background.test.ts
- npm run docs:build
- git diff --check

## Notes

I also ran a real Chrome for Testing spike with a temporary MV3 extension: closing the last tab in a tab group deletes that group, and moving a duplicate group's last tab into the canonical group deletes the duplicate group. So convergence does not need an empty-group deletion hack.