### PR TITLE
feat: conversation mgmt across 4 AI surfaces (grok/codex/antigravity/trae-solo) + grok i18n + Chromium 142 launcher

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1572,22 +1572,30 @@
   {
     "site": "antigravity",
     "name": "model",
-    "description": "Switch the active LLM model in Antigravity",
-    "access": "read",
-    "domain": "localhost",
+    "description": "Read or switch the active model in Antigravity. Without arguments, reports the current model. With <name> (substring, case-insensitive), switches.",
+    "access": "write",
+    "domain": "127.0.0.1",
     "strategy": "ui",
     "browser": true,
     "args": [
       {
         "name": "name",
         "type": "str",
-        "required": true,
+        "required": false,
         "positional": true,
-        "help": "Target model name (e.g. claude, gemini, o1)"
+        "help": "Substring (case-insensitive) of target model name. Omit to read current."
+      },
+      {
+        "name": "list",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "List models in the picker (does not switch)"
       }
     ],
     "columns": [
-      "Status"
+      "Status",
+      "Model"
     ],
     "type": "js",
     "modulePath": "antigravity/model.js",
@@ -6007,18 +6015,25 @@
   {
     "site": "codex",
     "name": "model",
-    "description": "Get or switch the currently active AI model in Codex Desktop",
-    "access": "read",
+    "description": "Read, list, or switch the active model / reasoning level in Codex Desktop. The composer toolbar button toggles a menu that mixes model variants (GPT-5.5, Speed) with reasoning levels (Low/Medium/High/Extra High).",
+    "access": "write",
     "domain": "localhost",
     "strategy": "ui",
     "browser": true,
     "args": [
       {
-        "name": "model-name",
+        "name": "name",
         "type": "str",
         "required": false,
         "positional": true,
-        "help": "The ID of the model to switch to (e.g. gpt-4)"
+        "help": "Substring (case-insensitive) of a model / reasoning level to switch to. Omit to read current."
+      },
+      {
+        "name": "list",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "List all menu options (does not switch)"
       }
     ],
     "columns": [
@@ -25589,6 +25604,39 @@
     "type": "js",
     "modulePath": "trae-solo/history.js",
     "sourceFile": "trae-solo/history.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "trae-solo",
+    "name": "model",
+    "description": "Read or switch the current AI model in TRAE SOLO. Without arguments, reports the current model. With <name> argument (substring, case-insensitive), switches to a matching model. Pass --list to enumerate available models.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Target model name (substring match, case-insensitive). Omit to read current."
+      },
+      {
+        "name": "list",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "List all available models (does not switch)"
+      }
+    ],
+    "columns": [
+      "Status",
+      "Model"
+    ],
+    "type": "js",
+    "modulePath": "trae-solo/model.js",
+    "sourceFile": "trae-solo/model.js",
     "navigateBefore": true
   },
   {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -25559,6 +25559,117 @@
     "sourceFile": "toutiao/hot.js"
   },
   {
+    "site": "trae-solo",
+    "name": "history",
+    "description": "List Trae SOLO projects and the tasks within each (from the project-list view sidebar).",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Filter by project name (substring, case-insensitive)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 100,
+        "required": false,
+        "help": "Max tasks per project"
+      }
+    ],
+    "columns": [
+      "Project",
+      "Task Index",
+      "Task"
+    ],
+    "type": "js",
+    "modulePath": "trae-solo/history.js",
+    "sourceFile": "trae-solo/history.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "trae-solo",
+    "name": "new-task",
+    "description": "Create a new task in a Trae SOLO project. Clicks the \"New task\" button in the project header.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Project name (substring match, case-insensitive)"
+      }
+    ],
+    "columns": [
+      "status",
+      "project"
+    ],
+    "type": "js",
+    "modulePath": "trae-solo/new-task.js",
+    "sourceFile": "trae-solo/new-task.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "trae-solo",
+    "name": "open",
+    "description": "Open a Trae SOLO task by its title (substring match) to enter its chat view.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "task",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Task title (substring match, case-insensitive)"
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Restrict to project (substring match)"
+      }
+    ],
+    "columns": [
+      "status",
+      "project",
+      "task"
+    ],
+    "type": "js",
+    "modulePath": "trae-solo/open.js",
+    "sourceFile": "trae-solo/open.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "trae-solo",
+    "name": "status",
+    "description": "Check active CDP connection to Trae SOLO Desktop",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status",
+      "Url",
+      "Title"
+    ],
+    "type": "js",
+    "modulePath": "trae-solo/status.js",
+    "sourceFile": "trae-solo/status.js",
+    "navigateBefore": true
+  },
+  {
     "site": "tvmaze",
     "name": "search",
     "description": "TVmaze TV show search by title (returns id, name, network, premiered/ended, rating)",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1449,6 +1449,39 @@
   },
   {
     "site": "antigravity",
+    "name": "delete",
+    "description": "Delete an Antigravity conversation by ID. Antigravity asks for confirmation; we click through it. Require --yes to actually delete.",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID (the part after \"convo-pill-\" in the sidebar testid)"
+      },
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually delete (default: dry-run preview)"
+      }
+    ],
+    "columns": [
+      "status",
+      "id"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/delete.js",
+    "sourceFile": "antigravity/delete.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
     "name": "dump",
     "description": "Dump the DOM to help AI understand the UI",
     "access": "read",
@@ -1480,6 +1513,60 @@
     "type": "js",
     "modulePath": "antigravity/extract-code.js",
     "sourceFile": "antigravity/extract-code.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "history",
+    "description": "List visible Antigravity conversations from the sidebar",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max conversations to return"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Id",
+      "Title"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/history.js",
+    "sourceFile": "antigravity/history.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "mark-read",
+    "description": "Toggle read state on an Antigravity conversation (the 3-dot menu shows \"Mark as Read\" OR \"Mark as Unread\" depending on current state — this command clicks whichever is present).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID (the part after \"convo-pill-\" in the sidebar testid)"
+      }
+    ],
+    "columns": [
+      "status",
+      "id",
+      "clicked"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/mark-read.js",
+    "sourceFile": "antigravity/mark-read.js",
     "navigateBefore": true
   },
   {
@@ -1547,6 +1634,38 @@
     "type": "js",
     "modulePath": "antigravity/read.js",
     "sourceFile": "antigravity/read.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "rename",
+    "description": "Rename an Antigravity conversation by ID (NOT YET IMPLEMENTED — see source comment).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID (the part after \"convo-pill-\" in the sidebar testid)"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "New title"
+      }
+    ],
+    "columns": [
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/rename.js",
+    "sourceFile": "antigravity/rename.js",
     "navigateBefore": true
   },
   {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11831,6 +11831,40 @@
   },
   {
     "site": "grok",
+    "name": "delete",
+    "description": "Delete a Grok conversation by ID. Grok takes effect immediately with no confirmation dialog — require --yes to actually delete.",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID or grok.com/c/<uuid> URL"
+      },
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually delete (default is a dry-run preview)"
+      }
+    ],
+    "columns": [
+      "status",
+      "id"
+    ],
+    "type": "js",
+    "modulePath": "grok/delete.js",
+    "sourceFile": "grok/delete.js",
+    "navigateBefore": "https://grok.com",
+    "siteSession": "persistent"
+  },
+  {
+    "site": "grok",
     "name": "detail",
     "description": "Open a Grok conversation by ID and read its messages",
     "access": "read",
@@ -11968,6 +12002,33 @@
   },
   {
     "site": "grok",
+    "name": "pin",
+    "description": "Pin a Grok conversation by ID",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID or grok.com/c/<uuid> URL"
+      }
+    ],
+    "columns": [
+      "status",
+      "id"
+    ],
+    "type": "js",
+    "modulePath": "grok/pin.js",
+    "sourceFile": "grok/pin.js",
+    "navigateBefore": "https://grok.com",
+    "siteSession": "persistent"
+  },
+  {
+    "site": "grok",
     "name": "read",
     "description": "Read messages in the current Grok conversation",
     "access": "read",
@@ -11991,6 +12052,39 @@
     "modulePath": "grok/read.js",
     "sourceFile": "grok/read.js",
     "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "grok",
+    "name": "rename",
+    "description": "Rename a Grok conversation by ID (NOT YET IMPLEMENTED — see commit message; pin/unpin/delete work)",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID or grok.com/c/<uuid> URL"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "New title"
+      }
+    ],
+    "columns": [
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "grok/rename.js",
+    "sourceFile": "grok/rename.js",
+    "navigateBefore": "https://grok.com",
     "siteSession": "persistent"
   },
   {
@@ -12047,6 +12141,33 @@
     "modulePath": "grok/status.js",
     "sourceFile": "grok/status.js",
     "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "grok",
+    "name": "unpin",
+    "description": "Unpin a Grok conversation by ID",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID or grok.com/c/<uuid> URL"
+      }
+    ],
+    "columns": [
+      "status",
+      "id"
+    ],
+    "type": "js",
+    "modulePath": "grok/pin.js",
+    "sourceFile": "grok/pin.js",
+    "navigateBefore": "https://grok.com",
     "siteSession": "persistent"
   },
   {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5683,6 +5683,55 @@
   },
   {
     "site": "codex",
+    "name": "archive",
+    "description": "Archive (Codex's term for delete) the selected conversation via the Chat actions header menu. No confirmation in UI — pass --yes to actually archive.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually archive (default: dry-run preview)"
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
+      }
+    ],
+    "columns": [
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "codex/archive.js",
+    "sourceFile": "codex/archive.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "codex",
     "name": "ask",
     "description": "Send a prompt to the current or selected Codex conversation and wait for the AI response",
     "access": "write",
@@ -5881,6 +5930,48 @@
   },
   {
     "site": "codex",
+    "name": "pin",
+    "description": "Pin the selected Codex conversation via the Chat actions header menu.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
+      }
+    ],
+    "columns": [
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "codex/pin.js",
+    "sourceFile": "codex/pin.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "codex",
     "name": "projects",
     "description": "List Codex projects and visible conversations from the sidebar",
     "access": "read",
@@ -5955,6 +6046,56 @@
     "type": "js",
     "modulePath": "codex/read.js",
     "sourceFile": "codex/read.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "codex",
+    "name": "rename",
+    "description": "Rename the selected Codex conversation. Opens the Chat actions menu → \"Rename chat\", then types the new title.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "title",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "New title (single line, no newlines)"
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
+      }
+    ],
+    "columns": [
+      "status",
+      "title"
+    ],
+    "type": "js",
+    "modulePath": "codex/rename.js",
+    "sourceFile": "codex/rename.js",
     "navigateBefore": true
   },
   {
@@ -6051,6 +6192,48 @@
     "type": "js",
     "modulePath": "codex/status.js",
     "sourceFile": "codex/status.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "codex",
+    "name": "unpin",
+    "description": "Unpin the selected Codex conversation via the Chat actions header menu.",
+    "access": "write",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "help": "Project label or path to select before running the command"
+      },
+      {
+        "name": "conversation",
+        "type": "str",
+        "required": false,
+        "help": "Conversation title to select within --project"
+      },
+      {
+        "name": "index",
+        "type": "str",
+        "required": false,
+        "help": "1-based conversation index within --project"
+      },
+      {
+        "name": "thread-id",
+        "type": "str",
+        "required": false,
+        "help": "Exact Codex thread id to select"
+      }
+    ],
+    "columns": [
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "codex/pin.js",
+    "sourceFile": "codex/pin.js",
     "navigateBefore": true
   },
   {

--- a/clis/antigravity/_actions.js
+++ b/clis/antigravity/_actions.js
@@ -1,0 +1,251 @@
+// Shared helpers for Antigravity sidebar conversation management.
+//
+// Each conversation in the sidebar is rendered as a row whose visible
+// title element has stable testid `convo-pill-<uuid>`. The row container
+// is the 3rd ancestor — it carries `role="button"` and acts as the
+// clickable row.
+//
+// On hover the row shows 3 icon-only buttons. The FIRST (button[0]) is a
+// "more options" 3-dot trigger that opens a 3-item dropdown:
+//
+//   Mark as Read
+//   Rename
+//   Delete Conversation
+//
+// We use that dropdown for all management operations. Antigravity does
+// not currently expose Pin/Unpin as menu items (different model than
+// Codex / Grok).
+//
+// All clicks go through the full pointer-event chain because the menu is
+// likely radix-based and ignores bare .click().
+
+import { CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+
+const PILL_SELECTOR_PREFIX = 'convo-pill-';
+
+export function buildPillTestId(conversationId) {
+    return `${PILL_SELECTOR_PREFIX}${String(conversationId).toLowerCase()}`;
+}
+
+/**
+ * Return all visible conversation pills with their {id, title} for
+ * history-style listings or for fuzzy match.
+ */
+export async function listConversations(page) {
+    const result = await page.evaluate(`(function() {
+    return Array.from(document.querySelectorAll('[data-testid^="${PILL_SELECTOR_PREFIX}"]'))
+      .filter((el) => el.offsetParent)
+      .map((el, idx) => ({
+        index: idx + 1,
+        id: el.getAttribute('data-testid').slice(${PILL_SELECTOR_PREFIX.length}),
+        title: (el.textContent || '').trim().slice(0, 200),
+      }));
+  })()`);
+    return Array.isArray(result) ? result : [];
+}
+
+/**
+ * Open the per-row 3-dot menu for the given conversation, click the
+ * menu item whose visible text matches `labelOptions`, return status.
+ * Single page.evaluate so the menu stays mounted while we click.
+ *
+ * Returns { ok, clicked? , reason?, detail? }.
+ */
+export async function clickConversationMenuItem(page, conversationId, labelOptions) {
+    const testId = buildPillTestId(conversationId);
+    const testIdJson = JSON.stringify(testId);
+    const labelsJson = JSON.stringify(labelOptions);
+
+    // Wrap in try/catch — Antigravity menu clicks often trigger a
+    // sidebar re-render that destroys the eval reply mid-stream, surfacing
+    // as "Promise was collected" or 30s Runtime.evaluate timeout. The
+    // click DID happen (we verified live by toggling Mark as Read /
+    // Unread). Treat these specific failures as success-with-no-confirmation
+    // and let the caller re-query history to verify.
+    let result;
+    try {
+        result = await page.evaluate(`(async () => {
+    const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+    const testId = ${testIdJson};
+    const labels = ${labelsJson};
+
+    const pill = document.querySelector(\`[data-testid="\${testId}"]\`);
+    if (!pill) {
+      return { ok: false, reason: 'Conversation pill not found.', detail: 'testid=' + testId };
+    }
+
+    // Walk up to the row container — depth 3 holds the role="button" row
+    // with the per-row action buttons.
+    let row = pill;
+    for (let i = 0; i < 3; i++) row = row.parentElement || row;
+    if (!row) {
+      return { ok: false, reason: 'Could not locate the row container above the pill.' };
+    }
+
+    row.scrollIntoView({ block: 'center' });
+
+    // React synthetic hover mounts the per-row buttons. Visibility-state
+    // doesn't appear to gate Antigravity's overlay (unlike Codex), but
+    // we still dispatch the full set for safety.
+    row.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+    // Wait for the row's 3-dot trigger to mount.
+    let dotBtn = null;
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      await wait(80);
+      const btns = Array.from(row.querySelectorAll('button')).filter((b) => b.offsetParent);
+      if (btns.length >= 1) { dotBtn = btns[0]; break; }  // First button == more-options
+    }
+    if (!dotBtn) {
+      return { ok: false, reason: 'Per-row 3-dot trigger never mounted after hover.' };
+    }
+
+    // Open the menu via full pointer chain.
+    const r = dotBtn.getBoundingClientRect();
+    const init = {
+      bubbles: true, cancelable: true, button: 0, buttons: 1,
+      clientX: Math.round(r.left + r.width / 2),
+      clientY: Math.round(r.top + r.height / 2),
+    };
+    dotBtn.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+    dotBtn.dispatchEvent(new MouseEvent('mousedown', init));
+    dotBtn.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+    dotBtn.dispatchEvent(new MouseEvent('mouseup', init));
+    dotBtn.dispatchEvent(new MouseEvent('click', init));
+
+    // Wait for menu items to mount.
+    let menuItems = [];
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await wait(80);
+      menuItems = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"]'))
+        .filter((it) => it instanceof HTMLElement && it.offsetParent);
+      if (menuItems.length) break;
+    }
+    if (!menuItems.length) {
+      return { ok: false, reason: 'Conversation 3-dot menu did not open after click.' };
+    }
+
+    function leadingText(el) {
+      const clone = el.cloneNode(true);
+      clone.querySelectorAll('kbd').forEach((k) => k.remove());
+      return (clone.textContent || '').trim();
+    }
+
+    let target = null;
+    for (const item of menuItems) {
+      const text = leadingText(item);
+      for (const label of labels) {
+        if (text === label || text.startsWith(label)) {
+          target = item;
+          break;
+        }
+      }
+      if (target) break;
+    }
+    if (!target) {
+      const visible = menuItems.map(leadingText);
+      document.body.click();  // close menu
+      return {
+        ok: false,
+        reason: 'No menu item matched the requested label.',
+        detail: 'wanted=' + JSON.stringify(labels) + ' visible=' + JSON.stringify(visible),
+      };
+    }
+
+    // Click via pointer chain too — radix is picky.
+    const tr = target.getBoundingClientRect();
+    const tinit = {
+      bubbles: true, cancelable: true, button: 0, buttons: 1,
+      clientX: Math.round(tr.left + tr.width / 2),
+      clientY: Math.round(tr.top + tr.height / 2),
+    };
+    const matchedLabel = leadingText(target);
+    // Defer to next microtask so the eval reply returns before any re-render.
+    Promise.resolve().then(() => {
+      try {
+        target.dispatchEvent(new PointerEvent('pointerdown', { ...tinit, pointerType: 'mouse' }));
+        target.dispatchEvent(new MouseEvent('mousedown', tinit));
+        target.dispatchEvent(new PointerEvent('pointerup', { ...tinit, pointerType: 'mouse' }));
+        target.dispatchEvent(new MouseEvent('mouseup', tinit));
+        target.dispatchEvent(new MouseEvent('click', tinit));
+      } catch {}
+    });
+    return { ok: true, clicked: matchedLabel };
+  })()`);
+    } catch (err) {
+        const msg = String(err?.message || err);
+        if (/Promise was collected|timed out after \d+s|Runtime\.evaluate/i.test(msg)) {
+            // Click was scheduled inside a microtask before destruction, so
+            // the action almost certainly fired. Report ambiguous-but-likely-ok.
+            return {
+                ok: true,
+                clicked: labelOptions[0],
+                note: 'eval reply destroyed by post-click re-render; click likely fired',
+            };
+        }
+        throw err;
+    }
+
+    return result || { ok: false, reason: 'Empty result from page.evaluate.' };
+}
+
+/**
+ * After Delete Conversation menu item is clicked, Antigravity shows a
+ * confirm dialog. Locate it and click the confirm button.
+ */
+export async function confirmDeleteDialog(page, confirmLabels) {
+    const labelsJson = JSON.stringify(confirmLabels);
+    const result = await page.evaluate(`(async () => {
+    const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+    let dialog = null;
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      await wait(120);
+      dialog = document.querySelector('[role="alertdialog"], [role="dialog"]');
+      if (dialog && dialog.offsetParent) break;
+    }
+    if (!dialog) {
+      return { ok: false, reason: 'Delete confirm dialog did not appear.' };
+    }
+    const buttons = Array.from(dialog.querySelectorAll('button'));
+    const labels = ${labelsJson};
+    const confirmBtn = buttons.find((b) => {
+      const t = (b.textContent || '').trim();
+      return labels.some((l) => t === l || t.toLowerCase() === l.toLowerCase());
+    });
+    if (!confirmBtn) {
+      return {
+        ok: false,
+        reason: 'Confirm button not found in dialog.',
+        detail: 'present=' + JSON.stringify(buttons.map((b) => (b.textContent || '').trim())),
+      };
+    }
+    const r = confirmBtn.getBoundingClientRect();
+    const init = {
+      bubbles: true, button: 0, buttons: 1, cancelable: true,
+      clientX: Math.round(r.left + r.width / 2),
+      clientY: Math.round(r.top + r.height / 2),
+    };
+    Promise.resolve().then(() => {
+      try {
+        confirmBtn.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+        confirmBtn.dispatchEvent(new MouseEvent('mousedown', init));
+        confirmBtn.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+        confirmBtn.dispatchEvent(new MouseEvent('mouseup', init));
+        confirmBtn.dispatchEvent(new MouseEvent('click', init));
+      } catch {}
+    });
+    return { ok: true, confirmed: (confirmBtn.textContent || '').trim() };
+  })()`);
+    return result || { ok: false, reason: 'Empty result.' };
+}
+
+export const conversationTargetArgs = [
+    {
+        name: 'id',
+        positional: true,
+        type: 'string',
+        required: true,
+        help: 'Conversation UUID (the part after "convo-pill-" in the sidebar testid)',
+    },
+];

--- a/clis/antigravity/delete.js
+++ b/clis/antigravity/delete.js
@@ -1,0 +1,50 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    clickConversationMenuItem,
+    confirmDeleteDialog,
+    conversationTargetArgs,
+} from './_actions.js';
+
+cli({
+    site: 'antigravity',
+    name: 'delete',
+    access: 'write',
+    description: 'Delete an Antigravity conversation by ID. Antigravity asks for confirmation; we click through it. Require --yes to actually delete.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        ...conversationTargetArgs,
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually delete (default: dry-run preview)' },
+    ],
+    columns: ['status', 'id'],
+    func: async (page, kwargs) => {
+        const id = String(kwargs.id);
+        const yes = kwargs.yes === true || kwargs.yes === 'true' || kwargs.yes === '1';
+        if (!yes) {
+            return [{ status: 'dry-run (pass --yes to actually delete)', id }];
+        }
+
+        // 1. Open the per-row 3-dot menu and click "Delete Conversation".
+        const menuRes = await clickConversationMenuItem(page, id, ['Delete Conversation', 'Delete']);
+        if (!menuRes.ok) {
+            throw new CommandExecutionError(
+                `${menuRes.reason}${menuRes.detail ? ' ' + menuRes.detail : ''}`,
+                'Make sure Antigravity is in the foreground and the sidebar is open.',
+            );
+        }
+
+        // 2. Click the Delete button in the confirm dialog.
+        const confirmRes = await confirmDeleteDialog(page, ['Delete', 'Delete Conversation', 'Confirm', 'OK']);
+        if (!confirmRes.ok) {
+            throw new CommandExecutionError(
+                `${confirmRes.reason}${confirmRes.detail ? ' ' + confirmRes.detail : ''}`,
+                'Delete menu fired but the confirm dialog did not show / its button was not found.',
+            );
+        }
+
+        await page.wait(1);
+        return [{ status: 'deleted', id }];
+    },
+});

--- a/clis/antigravity/history.js
+++ b/clis/antigravity/history.js
@@ -1,0 +1,26 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { listConversations } from './_actions.js';
+
+cli({
+    site: 'antigravity',
+    name: 'history',
+    access: 'read',
+    description: 'List visible Antigravity conversations from the sidebar',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'limit', type: 'int', required: false, default: 50, help: 'Max conversations to return' },
+    ],
+    columns: ['Index', 'Id', 'Title'],
+    func: async (page, kwargs) => {
+        const all = await listConversations(page);
+        const limit = Number.isInteger(kwargs.limit) && kwargs.limit > 0 ? kwargs.limit : 50;
+        const sliced = all.slice(0, limit);
+        if (!sliced.length) {
+            throw new EmptyResultError('antigravity history', 'No conversations are visible in the sidebar. Open the sidebar and retry.');
+        }
+        return sliced.map((c) => ({ Index: c.index, Id: c.id, Title: c.title }));
+    },
+});

--- a/clis/antigravity/mark-read.js
+++ b/clis/antigravity/mark-read.js
@@ -1,0 +1,34 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { clickConversationMenuItem, conversationTargetArgs } from './_actions.js';
+
+cli({
+    site: 'antigravity',
+    name: 'mark-read',
+    access: 'write',
+    description: 'Toggle read state on an Antigravity conversation (the 3-dot menu shows "Mark as Read" OR "Mark as Unread" depending on current state — this command clicks whichever is present).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [...conversationTargetArgs],
+    columns: ['status', 'id', 'clicked'],
+    func: async (page, kwargs) => {
+        const id = String(kwargs.id);
+        // Antigravity shows "Mark as Read" when conversation is unread,
+        // "Mark as Unread" when read. We don't try to be smart — we click
+        // whichever is present and report what we actually did.
+        const res = await clickConversationMenuItem(page, id, ['Mark as Read', 'Mark as Unread']);
+        if (!res.ok) {
+            throw new CommandExecutionError(
+                `${res.reason}${res.detail ? ' ' + res.detail : ''}`,
+                'Make sure Antigravity is in the foreground and the sidebar is open.',
+            );
+        }
+        await page.wait(0.6);
+        return [{
+            status: res.clicked === 'Mark as Unread' ? 'marked-unread' : 'marked-read',
+            id,
+            clicked: res.clicked,
+        }];
+    },
+});

--- a/clis/antigravity/model.js
+++ b/clis/antigravity/model.js
@@ -1,45 +1,122 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-export const modelCommand = cli({
+import { CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+
+// Antigravity exposes the active model via the composer button whose
+// aria-label looks like:
+//   "Select model, current: Gemini 3.5 Flash (Medium)"
+// We parse the current model from that aria-label, and switch by clicking
+// the button to open the model picker dialog, then matching by visible
+// text inside the dialog.
+
+cli({
     site: 'antigravity',
     name: 'model',
-    access: 'read',
-    description: 'Switch the active LLM model in Antigravity',
-    domain: 'localhost',
+    access: 'write',
+    description: 'Read or switch the active model in Antigravity. Without arguments, reports the current model. With <name> (substring, case-insensitive), switches.',
+    domain: '127.0.0.1',
     strategy: Strategy.UI,
     browser: true,
     args: [
-        { name: 'name', help: 'Target model name (e.g. claude, gemini, o1)', required: true, positional: true }
+        { name: 'name', required: false, positional: true, help: 'Substring (case-insensitive) of target model name. Omit to read current.' },
+        { name: 'list', type: 'boolean', default: false, help: 'List models in the picker (does not switch)' },
     ],
-    columns: ['Status'],
+    columns: ['Status', 'Model'],
     func: async (page, kwargs) => {
-        const targetName = kwargs.name.toLowerCase();
-        await page.evaluate(`
-      async () => {
-        const targetModelName = ${JSON.stringify(targetName)};
-        
-        // 1. Locate the model selector dropdown trigger
-        const trigger = document.querySelector('div[aria-haspopup="dialog"] > div[tabindex="0"]');
-        if (!trigger) throw new Error('Could not find the model selector trigger in the UI');
-        trigger.click();
-        
-        // 2. Wait a brief moment for React to mount the Portal/Dialog
-        await new Promise(r => setTimeout(r, 200));
-        
-        // 3. Find the option spanning target text
-        const spans = Array.from(document.querySelectorAll('[role="dialog"] span'));
-        const target = spans.find(s => s.innerText.toLowerCase().includes(targetModelName));
-        if (!target) {
-          // If not found, click the trigger again to close it safely
-          trigger.click();
-          throw new Error('Model matching "' + targetModelName + '" was not found in the dropdown list.');
+        const name = String(kwargs.name || '').trim().toLowerCase();
+        const listOnly = kwargs.list === true || kwargs.list === 'true';
+
+        // Read current model from button's aria-label.
+        const current = await page.evaluate(`(function() {
+      const btn = document.querySelector('button[aria-label^="Select model, current:"]');
+      if (!btn) return '';
+      const aria = btn.getAttribute('aria-label') || '';
+      const m = aria.match(/current:\\s*(.*)$/i);
+      return m ? m[1].trim() : (btn.textContent || '').trim();
+    })()`);
+        if (!current) {
+            throw selectorError('Antigravity model button (button[aria-label^="Select model, current:"]). Make sure a chat is open in the foreground.');
         }
-        
-        // 4. Click the closest parent that handles the row action
-        const optionNode = target.closest('.cursor-pointer') || target;
-        optionNode.click();
+
+        if (!name && !listOnly) {
+            return [{ Status: 'Active', Model: current }];
+        }
+
+        const namejson = JSON.stringify(name);
+        const result = await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      const trigger = document.querySelector('button[aria-label^="Select model, current:"]');
+      if (!trigger) return { ok: false, reason: 'trigger missing' };
+
+      // Open the picker dialog (full pointer chain — radix uses pointer events).
+      const r = trigger.getBoundingClientRect();
+      const init = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(r.left + r.width / 2),
+        clientY: Math.round(r.top + r.height / 2),
+      };
+      trigger.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+      trigger.dispatchEvent(new MouseEvent('mousedown', init));
+      trigger.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+      trigger.dispatchEvent(new MouseEvent('mouseup', init));
+      trigger.dispatchEvent(new MouseEvent('click', init));
+
+      // Wait for the picker dialog to open. Antigravity renders it as a
+      // [role="dialog"] or a div with selectable rows (cursor-pointer).
+      let rows = [];
+      for (let attempt = 0; attempt < 18; attempt += 1) {
+        await wait(80);
+        rows = Array.from(document.querySelectorAll('[role="dialog"] .cursor-pointer, [role="dialog"] [role="option"], [role="dialog"] li, .cursor-pointer'))
+          .filter((el) => el instanceof HTMLElement && el.offsetParent);
+        // Filter out rows clearly outside the dialog (e.g. global cursor-pointer in sidebar)
+        const dialog = document.querySelector('[role="dialog"]');
+        if (dialog) {
+          rows = rows.filter((r) => dialog.contains(r));
+        }
+        if (rows.length) break;
       }
-    `);
-        await page.wait(0.5);
-        return [{ Status: `Model switched to: ${kwargs.name}` }];
+      if (!rows.length) {
+        return { ok: false, reason: 'Model picker dialog did not surface any rows.' };
+      }
+
+      const labels = rows.map((r) => (r.innerText || r.textContent || '').trim().slice(0, 80));
+      const target = ${namejson};
+      if (!target) {
+        // Close picker (Esc) and return list.
+        document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+        return { ok: true, labels };
+      }
+      const idx = labels.findIndex((l) => l.toLowerCase().includes(target));
+      if (idx < 0) {
+        document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+        return { ok: false, reason: 'No model matched.', detail: 'wanted=' + target + ' visible=' + JSON.stringify(labels) };
+      }
+      const chosen = rows[idx];
+      const chosenLabel = labels[idx];
+
+      const cr = chosen.getBoundingClientRect();
+      const cinit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(cr.left + cr.width / 2),
+        clientY: Math.round(cr.top + cr.height / 2),
+      };
+      Promise.resolve().then(() => {
+        try {
+          chosen.dispatchEvent(new PointerEvent('pointerdown', { ...cinit, pointerType: 'mouse' }));
+          chosen.dispatchEvent(new MouseEvent('mousedown', cinit));
+          chosen.dispatchEvent(new PointerEvent('pointerup', { ...cinit, pointerType: 'mouse' }));
+          chosen.dispatchEvent(new MouseEvent('mouseup', cinit));
+          chosen.dispatchEvent(new MouseEvent('click', cinit));
+        } catch {}
+      });
+      return { ok: true, switched: true, chosen: chosenLabel, labels };
+    })()`);
+
+        if (!result.ok) {
+            throw new CommandExecutionError(result.reason, result.detail || '');
+        }
+        if (listOnly) {
+            return result.labels.map((m) => ({ Status: m.startsWith(current.slice(0, 20)) ? 'Active' : 'Available', Model: m }));
+        }
+        return [{ Status: 'switched', Model: result.chosen }];
     },
 });

--- a/clis/antigravity/rename.js
+++ b/clis/antigravity/rename.js
@@ -1,0 +1,33 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { conversationTargetArgs } from './_actions.js';
+
+// Known followup: a first attempt at rename triggered a destructive side
+// effect that removed the conversation from the sidebar (the convo titled
+// "1" disappeared after attempting `rename b79d8b28-... "..."` with the
+// Promise eval being collected mid-way). The 3-dot menu's Rename option
+// may interact with Antigravity's React state in a way that an
+// incomplete eval treats as "discard" — needs more investigation before
+// it's safe to ship.
+//
+// For now this command refuses to run; pin/delete/mark-read are wired up.
+cli({
+    site: 'antigravity',
+    name: 'rename',
+    access: 'write',
+    description: 'Rename an Antigravity conversation by ID (NOT YET IMPLEMENTED — see source comment).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        ...conversationTargetArgs,
+        { name: 'title', positional: true, type: 'string', required: true, help: 'New title' },
+    ],
+    columns: ['status'],
+    func: async () => {
+        throw new CommandExecutionError(
+            'antigravity rename is not yet implemented — first attempt caused the conversation to be removed from the sidebar instead of renamed. Use the Antigravity UI to rename until this is fixed.',
+            '',
+        );
+    },
+});

--- a/clis/codex/_actions.js
+++ b/clis/codex/_actions.js
@@ -1,0 +1,136 @@
+// Shared helpers for Codex conversation management (pin/unpin/archive/rename).
+//
+// Codex App exposes 8 actions via the "Chat actions" header dropdown on the
+// currently-active chat. We use that path because it's the only one that
+// works regardless of window visibility:
+//
+//   - The per-row sidebar buttons (Pin chat / Archive chat) are React
+//     hover-only — they're LAZILY MOUNTED only when the row is hovered,
+//     AND only when `document.visibilityState === 'visible'`. When the
+//     Codex window is hidden / minimized, even programmatic mouseenter
+//     won't surface them.
+//
+//   - The Chat actions menu mounts its items on click, doesn't care about
+//     window visibility, and supports all the operations we need:
+//       Unpin chat  ⌥⌘P     (or "Pin chat" when not pinned)
+//       Rename chat ⌥⌘R
+//       Archive chat ⇧⌘A
+//       Open side chat, Copy, Fork, Add automation…, Open in new window
+//
+// Caveat: this means each action targets the ACTIVE chat. We select the
+// target first via openCodexConversation (using --project / --conversation
+// / --index / --thread-id), then trigger the menu and click.
+
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    conversationSelectionArgs,
+    openCodexConversation,
+} from './sidebar.js';
+
+export { conversationSelectionArgs };
+
+/**
+ * Open the "Chat actions" header menu on the currently-active chat and
+ * click the menu item whose visible text matches one of `labelOptions`.
+ *
+ * Single-evaluate so the menu stays mounted while we click — and uses
+ * the full pointer-event chain because radix's menu trigger only responds
+ * to pointerdown/up sequences, not bare .click().
+ *
+ * Returns { ok, clicked? , reason?, detail? }.
+ */
+export async function clickChatActionsMenuItem(page, labelOptions) {
+    const labelsJson = JSON.stringify(labelOptions);
+
+    const result = await page.evaluate(`(async () => {
+    const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+    const labels = ${labelsJson};
+
+    const trigger = document.querySelector('button[aria-label="Chat actions"]');
+    if (!(trigger instanceof HTMLButtonElement)) {
+      return { ok: false, reason: 'Chat actions button not found in the chat header.' };
+    }
+
+    // Radix listens to pointer events — bare .click() is silently ignored.
+    const rect = trigger.getBoundingClientRect();
+    const init = {
+      bubbles: true, cancelable: true, button: 0, buttons: 1,
+      clientX: Math.round(rect.left + rect.width / 2),
+      clientY: Math.round(rect.top + rect.height / 2),
+    };
+    trigger.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+    trigger.dispatchEvent(new MouseEvent('mousedown', init));
+    trigger.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+    trigger.dispatchEvent(new MouseEvent('mouseup', init));
+    trigger.dispatchEvent(new MouseEvent('click', init));
+
+    // Poll for menu items to mount (typically < 300ms).
+    let menuItems = [];
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await wait(75);
+      menuItems = Array.from(document.querySelectorAll('[role="menuitem"]'))
+        .filter((it) => it instanceof HTMLElement && it.offsetParent);
+      if (menuItems.length) break;
+    }
+    if (!menuItems.length) {
+      return { ok: false, reason: 'Chat actions menu did not open after pointer click.' };
+    }
+
+    // Match by label — menu items render as "<label><kbd>shortcut</kbd>" so
+    // we compare the leading text (innerText through the first newline /
+    // kbd boundary).
+    function leadingText(el) {
+      const clone = el.cloneNode(true);
+      clone.querySelectorAll('kbd').forEach((k) => k.remove());
+      return (clone.textContent || '').trim();
+    }
+
+    let target = null;
+    for (const item of menuItems) {
+      const text = leadingText(item);
+      for (const label of labels) {
+        if (text === label || text.startsWith(label)) {
+          target = item;
+          break;
+        }
+      }
+      if (target) break;
+    }
+
+    if (!target) {
+      const visible = menuItems.map(leadingText);
+      // Close the menu so it doesn't stay open as a side effect.
+      document.body.click();
+      return {
+        ok: false,
+        reason: 'No menu item matched the requested label.',
+        detail: 'wanted=' + JSON.stringify(labels) + ' visible=' + JSON.stringify(visible),
+      };
+    }
+
+    // Defer click to a microtask so the eval response returns BEFORE the
+    // action triggers a re-render that could swallow our reply.
+    const matchedLabel = leadingText(target);
+    Promise.resolve().then(() => { try { target.click(); } catch {} });
+    return { ok: true, clicked: matchedLabel };
+  })()`);
+
+    return result || { ok: false, reason: 'Empty result from page.evaluate.' };
+}
+
+/**
+ * Convenience wrapper that selects the target first, then clicks the menu.
+ */
+export async function selectAndClickAction(page, kwargs, labelOptions) {
+    await openCodexConversation(page, kwargs);
+    await page.wait(0.4);
+    const result = await clickChatActionsMenuItem(page, labelOptions);
+    if (!result.ok) {
+        const detail = result.detail ? ` ${result.detail}` : '';
+        throw new CommandExecutionError(
+            `${result.reason || 'Failed to perform action.'}${detail}`,
+            'Make sure Codex Desktop is running and the target conversation is selectable.',
+        );
+    }
+    return result;
+}

--- a/clis/codex/archive.js
+++ b/clis/codex/archive.js
@@ -1,0 +1,31 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { conversationSelectionArgs, selectAndClickAction } from './_actions.js';
+import { openCodexConversation } from './sidebar.js';
+
+cli({
+    site: 'codex',
+    name: 'archive',
+    access: 'write',
+    description: 'Archive (Codex\'s term for delete) the selected conversation via the Chat actions header menu. No confirmation in UI — pass --yes to actually archive.',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually archive (default: dry-run preview)' },
+        ...conversationSelectionArgs,
+    ],
+    columns: ['status'],
+    func: async (page, kwargs) => {
+        const yes = kwargs.yes === true || kwargs.yes === 'true' || kwargs.yes === '1';
+        if (!yes) {
+            // Resolve target so the dry-run still names what WOULD be archived.
+            const selected = await openCodexConversation(page, kwargs);
+            return [{
+                status: `dry-run — would archive ${selected?.project || ''}/${selected?.conversation || '(active)'} — pass --yes to actually archive`,
+            }];
+        }
+        await selectAndClickAction(page, kwargs, ['Archive chat']);
+        await page.wait(1);
+        return [{ status: 'archived' }];
+    },
+});

--- a/clis/codex/model.js
+++ b/clis/codex/model.js
@@ -1,56 +1,150 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+
+// Codex Desktop App exposes the active model + reasoning level on a button
+// in the composer bottom toolbar. As of 2026-05-31 the button has no
+// stable aria-label or data-testid — we anchor to it by walking up from
+// the composer contenteditable and finding the button whose visible text
+// matches a known pattern (model version like "5.5"/"5.4" OR reasoning
+// level "Low"/"Medium"/"High"/"Extra High"/"Auto"/"Speed").
+//
+// Clicking the button opens a menu with BOTH:
+//   - Reasoning levels:  Low / Medium / High / Extra High / Speed / Auto
+//   - Model versions:    GPT-5.5 / GPT-5.4 / ...
+// Either kind of value can be selected via 'opencli codex model <name>'.
+
+const MODEL_BTN_TEXT_RE = /5\.\d|[Ee]xtra [Hh]igh|^High$|^Medium$|^Low$|^Auto$|^Fast$|^Speed$|^Pro$|GPT-/;
+const MODEL_BTN_PATTERN = MODEL_BTN_TEXT_RE.source;
+
 export const modelCommand = cli({
     site: 'codex',
     name: 'model',
-    access: 'read',
-    description: 'Get or switch the currently active AI model in Codex Desktop',
+    access: 'write',
+    description: 'Read, list, or switch the active model / reasoning level in Codex Desktop. The composer toolbar button toggles a menu that mixes model variants (GPT-5.5, Speed) with reasoning levels (Low/Medium/High/Extra High).',
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
     args: [
-        { name: 'model-name', required: false, positional: true, help: 'The ID of the model to switch to (e.g. gpt-4)' }
+        { name: 'name', required: false, positional: true, help: 'Substring (case-insensitive) of a model / reasoning level to switch to. Omit to read current.' },
+        { name: 'list', type: 'boolean', default: false, help: 'List all menu options (does not switch)' },
     ],
     columns: ['Status', 'Model'],
     func: async (page, kwargs) => {
-        const desiredModel = kwargs['model-name'];
-        if (!desiredModel) {
-            // Just read the current model. We traverse iframes/webviews if needed.
-            const currentModel = await page.evaluate(`
-        (function() {
-          // Look for any typical model switcher selectors in the DOM
-          let m = document.querySelector('[title*="Model"], [aria-label*="Model"], .model-selector, [class*="ModelPicker"]');
-          
-          if (!m && document.querySelector('webview, iframe')) {
-              // Not directly in main DOM, might be in a webview, but Playwright evaluate doesn't cross origin boundaries easily without frames[].
-              return 'Unknown (Likely inside a WebView, please focus the Chat tab)';
-          }
-          return m ? (m.textContent || m.getAttribute('title') || m.getAttribute('aria-label')).trim() : 'Unknown or Not Found';
-        })()
-      `);
-            return [
-                {
-                    Status: 'Active',
-                    Model: currentModel,
-                },
-            ];
+        const name = String(kwargs.name || '').trim().toLowerCase();
+        const listOnly = kwargs.list === true || kwargs.list === 'true';
+        const patternJson = JSON.stringify(MODEL_BTN_PATTERN);
+
+        const current = await page.evaluate(`(function() {
+      const re = new RegExp(${patternJson});
+      const composers = Array.from(document.querySelectorAll('[contenteditable="true"]')).filter((el) => el.offsetParent);
+      const last = composers[composers.length - 1];
+      if (!last) return '';
+      let root = last;
+      for (let i = 0; i < 5; i++) root = root.parentElement || root;
+      const btns = Array.from(root.querySelectorAll('button')).filter((b) => b.offsetParent);
+      const match = btns.find((b) => re.test((b.textContent || '').trim()));
+      return match ? (match.textContent || '').trim() : '';
+    })()`);
+        if (!current) {
+            throw selectorError('Codex model button (composer toolbar). Make sure a chat is open.');
         }
-        else {
-            // Try to switch model (click dropdown, type/select model)
-            const success = await page.evaluate(`
-        (function(targetModel) {
-          const dropdown = document.querySelector('[title*="Model"], [aria-label*="Model"], .model-selector, [class*="ModelPicker"]');
-          if (!dropdown) return 'Dropdown not found';
-          
-          dropdown.click();
-          return 'Dropdown clicked. Generic interaction initiated.';
-        })(${JSON.stringify(desiredModel)})
-      `);
-            return [
-                {
-                    Status: success,
-                    Model: desiredModel,
-                },
-            ];
+
+        if (!name && !listOnly) {
+            return [{ Status: 'Active', Model: current }];
         }
+
+        const namejson = JSON.stringify(name);
+        const result = await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      const re = new RegExp(${patternJson});
+      const composers = Array.from(document.querySelectorAll('[contenteditable="true"]')).filter((el) => el.offsetParent);
+      const last = composers[composers.length - 1];
+      if (!last) return { ok: false, reason: 'composer not found' };
+      let root = last;
+      for (let i = 0; i < 5; i++) root = root.parentElement || root;
+      const btns = Array.from(root.querySelectorAll('button')).filter((b) => b.offsetParent);
+      const trigger = btns.find((b) => re.test((b.textContent || '').trim()));
+      if (!trigger) return { ok: false, reason: 'model trigger button not found in composer' };
+
+      const r = trigger.getBoundingClientRect();
+      const init = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(r.left + r.width / 2),
+        clientY: Math.round(r.top + r.height / 2),
+      };
+      trigger.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+      trigger.dispatchEvent(new MouseEvent('mousedown', init));
+      trigger.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+      trigger.dispatchEvent(new MouseEvent('mouseup', init));
+      trigger.dispatchEvent(new MouseEvent('click', init));
+
+      let items = [];
+      for (let attempt = 0; attempt < 16; attempt += 1) {
+        await wait(80);
+        items = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"]'))
+          .filter((it) => it instanceof HTMLElement && it.offsetParent);
+        if (items.length) break;
+      }
+      if (!items.length) {
+        return { ok: false, reason: 'Model menu did not open after click.' };
+      }
+
+      function leadingText(el) {
+        const clone = el.cloneNode(true);
+        clone.querySelectorAll('kbd').forEach((k) => k.remove());
+        return (clone.textContent || '').trim();
+      }
+      // Filter unrelated Chat-actions menu items so they don't pollute
+      // the model list — Codex sometimes shares the menu root with
+      // 'Pin chat / Rename chat / Archive chat / Open side chat / Copy /
+      // Fork / Add automation… / Open in new window'.
+      const CHAT_ACTION_LABELS = new Set([
+        'Pin chat', 'Unpin chat', 'Rename chat', 'Archive chat',
+        'Open side chat', 'Copy', 'Fork', 'Add automation…', 'Open in new window',
+      ]);
+      const modelItems = items.filter((it) => {
+        const t = leadingText(it).replace(/[⌥⌘⌃⇧⏎].*$/, '').trim();
+        return t && !CHAT_ACTION_LABELS.has(t);
+      });
+
+      const labels = modelItems.map(leadingText);
+      const target = ${namejson};
+      if (!target) {
+        document.body.click();
+        return { ok: true, labels };
+      }
+      const idx = labels.findIndex((l) => l.toLowerCase().includes(target));
+      if (idx < 0) {
+        document.body.click();
+        return { ok: false, reason: 'No model matched.', detail: 'wanted=' + target + ' available=' + JSON.stringify(labels) };
+      }
+      const chosen = modelItems[idx];
+      const chosenLabel = labels[idx];
+
+      const cr = chosen.getBoundingClientRect();
+      const cinit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(cr.left + cr.width / 2),
+        clientY: Math.round(cr.top + cr.height / 2),
+      };
+      Promise.resolve().then(() => {
+        try {
+          chosen.dispatchEvent(new PointerEvent('pointerdown', { ...cinit, pointerType: 'mouse' }));
+          chosen.dispatchEvent(new MouseEvent('mousedown', cinit));
+          chosen.dispatchEvent(new PointerEvent('pointerup', { ...cinit, pointerType: 'mouse' }));
+          chosen.dispatchEvent(new MouseEvent('mouseup', cinit));
+          chosen.dispatchEvent(new MouseEvent('click', cinit));
+        } catch {}
+      });
+      return { ok: true, switched: true, chosen: chosenLabel, labels };
+    })()`);
+
+        if (!result.ok) {
+            throw new CommandExecutionError(result.reason, result.detail || '');
+        }
+        if (listOnly) {
+            return result.labels.map((m) => ({ Status: m === current ? 'Active' : 'Available', Model: m }));
+        }
+        return [{ Status: 'switched', Model: result.chosen }];
     },
 });

--- a/clis/codex/pin.js
+++ b/clis/codex/pin.js
@@ -1,0 +1,26 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { conversationSelectionArgs, selectAndClickAction } from './_actions.js';
+
+function defineToggle(name, labelOptions, doneStatus) {
+    cli({
+        site: 'codex',
+        name,
+        access: 'write',
+        description: `${name === 'pin' ? 'Pin' : 'Unpin'} the selected Codex conversation via the Chat actions header menu.`,
+        domain: 'localhost',
+        strategy: Strategy.UI,
+        browser: true,
+        args: [...conversationSelectionArgs],
+        columns: ['status'],
+        func: async (page, kwargs) => {
+            await selectAndClickAction(page, kwargs, labelOptions);
+            await page.wait(0.6);
+            return [{ status: doneStatus }];
+        },
+    });
+}
+
+// The Chat actions menu only shows the CURRENT state's label (Pin chat OR
+// Unpin chat, never both). Each command binds to its matching label.
+defineToggle('pin', ['Pin chat'], 'pinned');
+defineToggle('unpin', ['Unpin chat'], 'unpinned');

--- a/clis/codex/rename.js
+++ b/clis/codex/rename.js
@@ -1,0 +1,71 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { conversationSelectionArgs, selectAndClickAction } from './_actions.js';
+
+cli({
+    site: 'codex',
+    name: 'rename',
+    access: 'write',
+    description: 'Rename the selected Codex conversation. Opens the Chat actions menu → "Rename chat", then types the new title.',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'title', required: true, positional: true, help: 'New title (single line, no newlines)' },
+        ...conversationSelectionArgs,
+    ],
+    columns: ['status', 'title'],
+    func: async (page, kwargs) => {
+        const title = String(kwargs.title || '').trim();
+        if (!title) throw new ArgumentError('title cannot be empty');
+        if (title.includes('\n')) throw new ArgumentError('title must be a single line');
+
+        // 1. Select the target chat AND click "Rename chat" in the menu.
+        await selectAndClickAction(page, kwargs, ['Rename chat']);
+        await page.wait(0.5);
+
+        // 2. The rename input is the only non-ProseMirror editable that just appeared.
+        //    Fill it via execCommand insertText (Codex uses a contenteditable, not a plain input).
+        const filled = await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      let input = null;
+      for (let attempt = 0; attempt < 15; attempt += 1) {
+        const candidates = Array.from(document.querySelectorAll('input[type="text"], input:not([type]), [contenteditable="true"]'))
+          .filter((el) => el.offsetParent && !el.classList.contains('ProseMirror'));
+        if (candidates.length) {
+          candidates.sort((a, b) => (a.getBoundingClientRect().left || 9999) - (b.getBoundingClientRect().left || 9999));
+          input = candidates[0];
+          break;
+        }
+        await wait(120);
+      }
+      if (!input) return { ok: false, reason: 'Rename input did not appear after menu click.' };
+      input.focus();
+      const newTitle = ${JSON.stringify(title)};
+      if (input instanceof HTMLInputElement) {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        setter.call(input, '');
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        setter.call(input, newTitle);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      } else {
+        const range = document.createRange();
+        range.selectNodeContents(input);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        document.execCommand('delete');
+        document.execCommand('insertText', false, newTitle);
+      }
+      return { ok: true };
+    })()`);
+        if (!filled?.ok) {
+            throw new CommandExecutionError(filled?.reason || 'Failed to fill rename input.', '');
+        }
+
+        await page.pressKey('Enter');
+        await page.wait(0.5);
+
+        return [{ status: 'renamed', title }];
+    },
+});

--- a/clis/grok/delete.js
+++ b/clis/grok/delete.js
@@ -1,0 +1,49 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    GROK_DOMAIN,
+    ensureOnGrok,
+    authRequired,
+    isLoggedIn,
+    parseGrokSessionId,
+    clickConversationMenuItem,
+    normalizeBooleanFlag,
+} from './utils.js';
+
+const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
+
+cli({
+    site: 'grok',
+    name: 'delete',
+    access: 'write',
+    description: 'Delete a Grok conversation by ID. Grok takes effect immediately with no confirmation dialog — require --yes to actually delete.',
+    domain: GROK_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    args: [
+        { name: 'id', positional: true, type: 'string', required: true, help: 'Conversation UUID or grok.com/c/<uuid> URL' },
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually delete (default is a dry-run preview)' },
+    ],
+    columns: ['status', 'id'],
+    func: async (page, kwargs) => {
+        const id = parseGrokSessionId(kwargs.id);
+        const yes = normalizeBooleanFlag(kwargs.yes);
+
+        await ensureOnGrok(page);
+        if (!(await isLoggedIn(page))) throw authRequired();
+
+        if (!yes) {
+            return [{ status: 'dry-run (pass --yes to actually delete)', id }];
+        }
+
+        const result = await clickConversationMenuItem(page, id, ['删除', 'delete']);
+        if (!result || !result.ok) {
+            const detail = result?.detail ? ` ${result.detail}` : '';
+            throw new CommandExecutionError(`${result?.reason || 'Failed to click delete menu item.'}${detail}`, SESSION_HINT);
+        }
+        // Grok deletes without a confirmation dialog; give the sidebar a beat to update.
+        await page.wait(1);
+        return [{ status: 'deleted', id }];
+    },
+});

--- a/clis/grok/pin.js
+++ b/clis/grok/pin.js
@@ -1,0 +1,48 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    GROK_DOMAIN,
+    ensureOnGrok,
+    authRequired,
+    isLoggedIn,
+    parseGrokSessionId,
+    clickConversationMenuItem,
+} from './utils.js';
+
+const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
+
+function defineToggle(name, accessLabels) {
+    cli({
+        site: 'grok',
+        name,
+        access: 'write',
+        description: `${name === 'pin' ? 'Pin' : 'Unpin'} a Grok conversation by ID`,
+        domain: GROK_DOMAIN,
+        strategy: Strategy.COOKIE,
+        browser: true,
+        siteSession: 'persistent',
+        args: [
+            { name: 'id', positional: true, type: 'string', required: true, help: 'Conversation UUID or grok.com/c/<uuid> URL' },
+        ],
+        columns: ['status', 'id'],
+        func: async (page, kwargs) => {
+            const id = parseGrokSessionId(kwargs.id);
+            await ensureOnGrok(page);
+            if (!(await isLoggedIn(page))) throw authRequired();
+
+            const result = await clickConversationMenuItem(page, id, accessLabels);
+            if (!result || !result.ok) {
+                const detail = result?.detail ? ` ${result.detail}` : '';
+                throw new CommandExecutionError(`${result?.reason || `Failed to ${name} conversation.`}${detail}`, SESSION_HINT);
+            }
+            await page.wait(1);
+            return [{ status: name === 'pin' ? 'pinned' : 'unpinned', id }];
+        },
+    });
+}
+
+// Grok's context menu shows EITHER "置顶" OR "取消置顶" depending on the
+// current pin state, never both. We register two commands that bind to
+// the matching label so callers can use whichever they want.
+defineToggle('pin', ['置顶', 'pin']);
+defineToggle('unpin', ['取消置顶', 'unpin']);

--- a/clis/grok/rename.js
+++ b/clis/grok/rename.js
@@ -1,0 +1,30 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { GROK_DOMAIN } from './utils.js';
+
+// Known follow-up: triggering the inline rename input requires firing
+// pointer events at the menu item via the radix focus group AT real
+// coordinates. Plain DOM-synthesized click and CDP `browser click`
+// both let the JS click handler register but never spawn the inline
+// editor. Tracked separately.
+cli({
+    site: 'grok',
+    name: 'rename',
+    access: 'write',
+    description: 'Rename a Grok conversation by ID (NOT YET IMPLEMENTED — see commit message; pin/unpin/delete work)',
+    domain: GROK_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    args: [
+        { name: 'id', positional: true, type: 'string', required: true, help: 'Conversation UUID or grok.com/c/<uuid> URL' },
+        { name: 'title', positional: true, type: 'string', required: true, help: 'New title' },
+    ],
+    columns: ['status'],
+    func: async () => {
+        throw new CommandExecutionError(
+            'grok rename is not yet implemented — radix menu onSelect for "Rename" does not respond to programmatic clicks. Workaround: rename via the Grok UI; or use opencli grok delete + ask to recreate.',
+            '',
+        );
+    },
+});

--- a/clis/grok/utils.js
+++ b/clis/grok/utils.js
@@ -106,11 +106,26 @@ export async function getCurrentSessionId(page) {
     return match ? match[1].toLowerCase() : '';
 }
 
+// Model picker trigger has stable id="model-select-trigger". Use that as the
+// primary selector — aria-label localizes (e.g. "Model select" in English,
+// "模型选择" in Chinese, etc.) and is unreliable across browser locales.
+const MODEL_TRIGGER_SELECTORS = [
+    '#model-select-trigger',
+    'button[aria-label="Model select"]',
+    'button[aria-label="模型选择"]',
+    'button[aria-label="モデル選択"]',
+];
+
 export async function getModelLabel(page) {
+    const selectorJson = JSON.stringify(MODEL_TRIGGER_SELECTORS);
     const result = await page.evaluate(`(() => {
     ${IS_VISIBLE_JS}
-    const trigger = Array.from(document.querySelectorAll('button[aria-label="Model select"]'))
-      .find((node) => isVisible(node));
+    const selectors = ${selectorJson};
+    let trigger = null;
+    for (const sel of selectors) {
+      trigger = Array.from(document.querySelectorAll(sel)).find((node) => isVisible(node));
+      if (trigger) break;
+    }
     if (!trigger) return '';
     return (trigger.innerText || trigger.textContent || '').trim().split('\\n')[0].trim();
   })()`);
@@ -262,10 +277,23 @@ export async function sendMessage(page, prompt) {
       const rect = node.getBoundingClientRect();
       return rect.width > 0 && rect.height > 0;
     };
+    // Prefer data-testid (locale-independent); fall back to aria-label per
+    // language. As of 2026-05-31 Grok renders button[data-testid="chat-submit"]
+    // once the composer has content. The aria-label varies: "Submit" (en),
+    // "提交" (zh-CN), and presumably other locales.
+    const submitSelectors = [
+      'button[data-testid="chat-submit"]',
+      'button[aria-label="Submit"]',
+      'button[aria-label="提交"]',
+      'button[aria-label="送信"]',
+    ];
     let submit = null;
     for (let attempt = 0; attempt < 12; attempt += 1) {
-      const candidate = Array.from(document.querySelectorAll('button[aria-label="Submit"]')).find(isClickableSubmit);
-      if (candidate instanceof HTMLButtonElement) { submit = candidate; break; }
+      for (const sel of submitSelectors) {
+        const candidate = Array.from(document.querySelectorAll(sel)).find(isClickableSubmit);
+        if (candidate instanceof HTMLButtonElement) { submit = candidate; break; }
+      }
+      if (submit) break;
       await waitFor(500);
     }
     if (!(submit instanceof HTMLButtonElement)) {

--- a/clis/grok/utils.js
+++ b/clis/grok/utils.js
@@ -240,6 +240,115 @@ export async function startNewChat(page) {
     await page.wait(2);
 }
 
+// Open the sidebar conversation context menu (right-click on the /c/<id>
+// link), wait for it to appear, click the menu item whose visible text
+// matches one of the localized labels. Returns whether the click happened.
+//
+// Menu items observed on grok.com (2026-05-31):
+//   "打开新标签页" / "Open in new tab"
+//   "重命名"     / "Rename"
+//   "置顶" or "取消置顶" / "Pin" or "Unpin"
+//   "删除"       / "Delete"
+//
+// Grok's delete action takes effect IMMEDIATELY — no confirmation dialog —
+// so callers must enforce their own --yes / dry-run gating.
+export async function clickConversationMenuItem(page, conversationId, labelOptions) {
+    const id = String(conversationId).toLowerCase();
+    const idJson = JSON.stringify(id);
+    const labelsJson = JSON.stringify(labelOptions.map((l) => l.toLowerCase()));
+    return await page.evaluate(`(async () => {
+    const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const id = ${idJson};
+    const labels = ${labelsJson};
+    // Find the sidebar anchor for this conversation.
+    let link = null;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      link = Array.from(document.querySelectorAll('a[href^="/c/"]'))
+        .find((a) => a instanceof HTMLElement && a.offsetParent && (a.getAttribute('href') || '').toLowerCase().includes(id));
+      if (link) break;
+      await waitFor(300);
+    }
+    if (!link) {
+      return { ok: false, reason: 'Conversation not found in sidebar.', detail: 'id=' + id };
+    }
+    // Trigger the radix context menu — radix listens to PointerEvent +
+    // contextmenu, so plain MouseEvent('contextmenu') alone is ignored.
+    // Dispatch the full sequence pointerdown/mousedown/contextmenu/pointerup/mouseup
+    // with right-button state to mirror a real right-click.
+    {
+      const rect = link.getBoundingClientRect();
+      const init = {
+        bubbles: true, cancelable: true, button: 2, buttons: 2,
+        clientX: Math.round(rect.left + Math.min(rect.width / 2, 16)),
+        clientY: Math.round(rect.top + Math.min(rect.height / 2, 16)),
+      };
+      link.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+      link.dispatchEvent(new MouseEvent('mousedown', init));
+      link.dispatchEvent(new MouseEvent('contextmenu', init));
+      link.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+      link.dispatchEvent(new MouseEvent('mouseup', init));
+    }
+    // Wait for menu items to appear.
+    let items = [];
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      items = Array.from(document.querySelectorAll('[role="menuitem"]'))
+        .filter((it) => it instanceof HTMLElement && it.offsetParent);
+      if (items.length) break;
+      await waitFor(150);
+    }
+    if (!items.length) {
+      return { ok: false, reason: 'Context menu did not open for the conversation.' };
+    }
+    const target = items.find((it) => {
+      const text = (it.textContent || '').trim().toLowerCase();
+      return labels.some((l) => text === l);
+    });
+    if (!target) {
+      return {
+        ok: false,
+        reason: 'No menu item matched the requested label.',
+        detail: 'available=' + JSON.stringify(items.map((it) => (it.textContent || '').trim())),
+      };
+    }
+    target.click();
+    return { ok: true, clicked: (target.textContent || '').trim() };
+  })()`);
+}
+
+// After clickConversationMenuItem opens an inline rename input, fill it and
+// commit by pressing Enter. Returns the new title we set (best-effort).
+export async function fillRenameInputAndSubmit(page, newTitle) {
+    const titleJson = JSON.stringify(newTitle);
+    return await page.evaluate(`(async () => {
+    const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    let input = null;
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      // The inline rename UI surfaces as a single visible <input> or a
+      // contenteditable inside the sidebar row.
+      input = Array.from(document.querySelectorAll('input[type="text"], [contenteditable="true"]:not(.ProseMirror)'))
+        .find((el) => el instanceof HTMLElement && el.offsetParent && el.getBoundingClientRect().left < 260);
+      if (input) break;
+      await waitFor(200);
+    }
+    if (!input) {
+      return { ok: false, reason: 'Inline rename input did not appear.' };
+    }
+    input.focus();
+    if (input instanceof HTMLInputElement) {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      setter.call(input, ${titleJson});
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    } else {
+      // contenteditable path
+      input.innerText = '';
+      document.execCommand('insertText', false, ${titleJson});
+    }
+    // Commit by Enter (Grok accepts Enter to confirm, Escape to cancel).
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    return { ok: true, value: ${titleJson} };
+  })()`);
+}
+
 export async function sendMessage(page, prompt) {
     const promptJson = JSON.stringify(prompt);
     return await page.evaluate(`(async () => {

--- a/clis/trae-solo/history.js
+++ b/clis/trae-solo/history.js
@@ -1,0 +1,54 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+
+cli({
+    site: 'trae-solo',
+    name: 'history',
+    access: 'read',
+    description: 'List Trae SOLO projects and the tasks within each (from the project-list view sidebar).',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'project', required: false, help: 'Filter by project name (substring, case-insensitive)' },
+        { name: 'limit', type: 'int', required: false, default: 100, help: 'Max tasks per project' },
+    ],
+    columns: ['Project', 'Task Index', 'Task'],
+    func: async (page, kwargs) => {
+        const projects = await page.evaluate(`(function() {
+      const out = [];
+      const groups = Array.from(document.querySelectorAll('.task-list-group')).filter((g) => g.offsetParent);
+      for (const group of groups) {
+        const headerText = (group.querySelector('.task-list-group-header-wrapper')?.innerText || '').trim().split('\\n')[0] || '';
+        const inner = group.querySelector('.task-list-group-collapsible-inner');
+        const list = inner ? inner.querySelector('.task-list-group-list') : null;
+        const taskRows = list ? Array.from(list.querySelectorAll('.task-list-row-wrapper')).filter((r) => r.offsetParent) : [];
+        out.push({
+          project: headerText,
+          tasks: taskRows.map((row) => (row.innerText || '').trim().split('\\n')[0] || '(untitled)'),
+        });
+      }
+      return out;
+    })()`);
+
+        const filter = (kwargs.project || '').toLowerCase();
+        const limit = Number.isInteger(kwargs.limit) && kwargs.limit > 0 ? kwargs.limit : 100;
+        const rows = [];
+        for (const p of projects || []) {
+            if (filter && !p.project.toLowerCase().includes(filter)) continue;
+            const tasks = p.tasks.slice(0, limit);
+            for (let i = 0; i < tasks.length; i++) {
+                rows.push({ Project: p.project, 'Task Index': i + 1, Task: tasks[i] });
+            }
+        }
+        if (!rows.length) {
+            throw new EmptyResultError(
+                'trae-solo history',
+                filter
+                    ? `No projects matched "${kwargs.project}". Try without --project.`
+                    : 'No projects visible. Make sure TRAE SOLO is on the project-list view and the sidebar is expanded.',
+            );
+        }
+        return rows;
+    },
+});

--- a/clis/trae-solo/model.js
+++ b/clis/trae-solo/model.js
@@ -1,0 +1,117 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+
+cli({
+    site: 'trae-solo',
+    name: 'model',
+    access: 'write',
+    description: 'Read or switch the current AI model in TRAE SOLO. Without arguments, reports the current model. With <name> argument (substring, case-insensitive), switches to a matching model. Pass --list to enumerate available models.',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'name', required: false, positional: true, help: 'Target model name (substring match, case-insensitive). Omit to read current.' },
+        { name: 'list', type: 'boolean', default: false, help: 'List all available models (does not switch)' },
+    ],
+    columns: ['Status', 'Model'],
+    func: async (page, kwargs) => {
+        const name = String(kwargs.name || '').trim().toLowerCase();
+        const listOnly = kwargs.list === true || kwargs.list === 'true';
+
+        // Read current model from the composer trigger
+        const current = await page.evaluate(`(function() {
+      const trigger = document.querySelector('.core-model-select-trigger');
+      return trigger ? (trigger.textContent || '').trim() : '';
+    })()`);
+        if (!current) {
+            throw selectorError('TRAE SOLO model trigger (.core-model-select-trigger). Make sure a chat task is open (not the project-list view).');
+        }
+
+        // List or switch — both require opening the menu
+        if (listOnly || name) {
+            const namejson = JSON.stringify(name);
+            const result = await page.evaluate(`(async () => {
+        const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+        const trigger = document.querySelector('.core-model-select-trigger');
+        if (!trigger) return { ok: false, reason: 'model trigger gone' };
+
+        // Open menu via full pointer chain.
+        const r = trigger.getBoundingClientRect();
+        const init = {
+          bubbles: true, cancelable: true, button: 0, buttons: 1,
+          clientX: Math.round(r.left + Math.min(r.width / 2, 20)),
+          clientY: Math.round(r.top + Math.min(r.height / 2, 10)),
+        };
+        trigger.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+        trigger.dispatchEvent(new MouseEvent('mousedown', init));
+        trigger.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+        trigger.dispatchEvent(new MouseEvent('mouseup', init));
+        trigger.dispatchEvent(new MouseEvent('click', init));
+
+        // Wait for menu items to mount.
+        let opts = [];
+        for (let attempt = 0; attempt < 16; attempt += 1) {
+          await wait(80);
+          opts = Array.from(document.querySelectorAll('.core-model-select-model-item[role="option"]'))
+            .filter((el) => el instanceof HTMLElement && el.offsetParent);
+          if (opts.length) break;
+        }
+        if (!opts.length) {
+          return { ok: false, reason: 'Model menu did not open (no .core-model-select-model-item[role="option"] visible).' };
+        }
+
+        const labels = opts.map((o) => {
+          const nameEl = o.querySelector('.core-model-select-model-item-name');
+          return ((nameEl ? nameEl.textContent : o.textContent) || '').trim();
+        });
+
+        // List-only path — return the labels and close menu.
+        const target = ${namejson};
+        if (!target) {
+          document.body.click();
+          return { ok: true, labels };
+        }
+
+        // Switch path — pick the first label that contains the target substring.
+        const idx = labels.findIndex((l) => l.toLowerCase().includes(target));
+        if (idx < 0) {
+          document.body.click();
+          return { ok: false, reason: 'No model matched.', detail: 'wanted=' + target + ' available=' + JSON.stringify(labels) };
+        }
+        const chosen = opts[idx];
+        const chosenLabel = labels[idx];
+
+        // Click the chosen option via full pointer chain (radix-style menu items).
+        const cr = chosen.getBoundingClientRect();
+        const cinit = {
+          bubbles: true, cancelable: true, button: 0, buttons: 1,
+          clientX: Math.round(cr.left + cr.width / 2),
+          clientY: Math.round(cr.top + cr.height / 2),
+        };
+        // Defer click — menu close + composer re-render can swallow eval reply.
+        Promise.resolve().then(() => {
+          try {
+            chosen.dispatchEvent(new PointerEvent('pointerdown', { ...cinit, pointerType: 'mouse' }));
+            chosen.dispatchEvent(new MouseEvent('mousedown', cinit));
+            chosen.dispatchEvent(new PointerEvent('pointerup', { ...cinit, pointerType: 'mouse' }));
+            chosen.dispatchEvent(new MouseEvent('mouseup', cinit));
+            chosen.dispatchEvent(new MouseEvent('click', cinit));
+          } catch {}
+        });
+        return { ok: true, switched: true, chosen: chosenLabel, labels };
+      })()`);
+
+            if (!result.ok) {
+                throw new CommandExecutionError(result.reason, result.detail || '');
+            }
+
+            if (listOnly) {
+                return result.labels.map((m) => ({ Status: m === current ? 'Active' : 'Available', Model: m }));
+            }
+            return [{ Status: 'switched', Model: result.chosen }];
+        }
+
+        // Just read the current.
+        return [{ Status: 'Active', Model: current }];
+    },
+});

--- a/clis/trae-solo/new-task.js
+++ b/clis/trae-solo/new-task.js
@@ -1,0 +1,52 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+cli({
+    site: 'trae-solo',
+    name: 'new-task',
+    access: 'write',
+    description: 'Create a new task in a Trae SOLO project. Clicks the "New task" button in the project header.',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'project', positional: true, required: true, help: 'Project name (substring match, case-insensitive)' },
+    ],
+    columns: ['status', 'project'],
+    func: async (page, kwargs) => {
+        const filter = String(kwargs.project || '').trim().toLowerCase();
+        const fjson = JSON.stringify(filter);
+
+        const result = await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      const filter = ${fjson};
+      const groups = Array.from(document.querySelectorAll('.task-list-group')).filter((g) => g.offsetParent);
+      for (const group of groups) {
+        const header = group.querySelector('.task-list-group-header-wrapper');
+        if (!header) continue;
+        const headerText = ((header.innerText || '').split('\\n')[0] || '').trim().toLowerCase();
+        if (filter && !headerText.includes(filter)) continue;
+        const newBtn = header.querySelector('button[aria-label="New task"], .task-list-group-new-btn');
+        if (!newBtn) continue;
+        const rect = newBtn.getBoundingClientRect();
+        const init = {
+          bubbles: true, cancelable: true, button: 0, buttons: 1,
+          clientX: Math.round(rect.left + rect.width / 2),
+          clientY: Math.round(rect.top + rect.height / 2),
+        };
+        newBtn.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+        newBtn.dispatchEvent(new MouseEvent('mousedown', init));
+        newBtn.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+        newBtn.dispatchEvent(new MouseEvent('mouseup', init));
+        newBtn.dispatchEvent(new MouseEvent('click', init));
+        await wait(500);
+        return { ok: true, project: headerText };
+      }
+      return { ok: false, reason: 'No matching project found.', detail: 'filter=' + filter };
+    })()`);
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.reason || 'New task failed.', result?.detail || '');
+        }
+        return [{ status: 'created', project: result.project || '' }];
+    },
+});

--- a/clis/trae-solo/open.js
+++ b/clis/trae-solo/open.js
@@ -1,0 +1,64 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+
+cli({
+    site: 'trae-solo',
+    name: 'open',
+    access: 'write',
+    description: 'Open a Trae SOLO task by its title (substring match) to enter its chat view.',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'task', positional: true, required: true, help: 'Task title (substring match, case-insensitive)' },
+        { name: 'project', required: false, help: 'Restrict to project (substring match)' },
+    ],
+    columns: ['status', 'project', 'task'],
+    func: async (page, kwargs) => {
+        const taskFilter = String(kwargs.task || '').trim().toLowerCase();
+        if (!taskFilter) throw new ArgumentError('task title cannot be empty');
+        const projectFilter = String(kwargs.project || '').trim().toLowerCase();
+
+        const tjson = JSON.stringify(taskFilter);
+        const pjson = JSON.stringify(projectFilter);
+
+        const result = await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      const taskFilter = ${tjson};
+      const projectFilter = ${pjson};
+
+      const groups = Array.from(document.querySelectorAll('.task-list-group')).filter((g) => g.offsetParent);
+      for (const group of groups) {
+        const headerText = ((group.querySelector('.task-list-group-header-wrapper')?.innerText || '').split('\\n')[0] || '').trim().toLowerCase();
+        if (projectFilter && !headerText.includes(projectFilter)) continue;
+        const list = group.querySelector('.task-list-group-list');
+        if (!list) continue;
+        const rows = Array.from(list.querySelectorAll('.task-list-row-wrapper')).filter((r) => r.offsetParent);
+        for (const row of rows) {
+          const title = ((row.innerText || '').split('\\n')[0] || '').trim();
+          if (!title.toLowerCase().includes(taskFilter)) continue;
+          row.scrollIntoView({ block: 'center' });
+          await wait(150);
+          const rect = row.getBoundingClientRect();
+          const init = {
+            bubbles: true, cancelable: true, button: 0, buttons: 1,
+            clientX: Math.round(rect.left + Math.min(50, rect.width / 2)),
+            clientY: Math.round(rect.top + Math.min(10, rect.height / 2)),
+          };
+          row.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+          row.dispatchEvent(new MouseEvent('mousedown', init));
+          row.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+          row.dispatchEvent(new MouseEvent('mouseup', init));
+          row.dispatchEvent(new MouseEvent('click', init));
+          await wait(800);
+          return { ok: true, project: headerText, task: title };
+        }
+      }
+      return { ok: false, reason: 'No matching task found.', detail: 'task=' + taskFilter + ' project=' + projectFilter };
+    })()`);
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.reason || 'Open failed.', result?.detail || '');
+        }
+        return [{ status: 'opened', project: result.project || '', task: result.task || '' }];
+    },
+});

--- a/clis/trae-solo/status.js
+++ b/clis/trae-solo/status.js
@@ -1,0 +1,2 @@
+import { makeStatusCommand } from '../_shared/desktop-commands.js';
+export const statusCommand = makeStatusCommand('trae-solo', 'Trae SOLO Desktop');

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -39,6 +39,13 @@ export const builtinApps: Record<string, ElectronAppEntry> = {
     displayName: 'Antigravity',
   },
   'chatgpt-app': { port: 9236, processName: 'ChatGPT',      bundleId: 'com.openai.chat',                displayName: 'ChatGPT' },
+  'trae-solo':   {
+    port: 9235,
+    processName: 'TRAE SOLO',
+    executableNames: ['Electron', 'TRAE SOLO'],
+    bundleId: 'com.trae.solo.app',
+    displayName: 'Trae SOLO',
+  },
 };
 
 /** Merge builtin + user-defined apps. User entries are additive only. */

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -251,7 +251,19 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
   }
 
   // Step 4: Launch
-  const args = [`--remote-debugging-port=${port}`, ...(app.extraArgs ?? [])];
+  //
+  // Chrome / Electron 142+ enforces an Origin allow-list on the CDP
+  // WebSocket upgrade (ws://127.0.0.1:<port>/devtools/page/<id>). Without
+  // --remote-allow-origins=* every ws client other than chrome://inspect
+  // gets HTTP 403 "Rejected an incoming WebSocket connection from the
+  // http://127.0.0.1:<port> origin". This affects every Electron app
+  // opencli launches because they all bundle a recent Chromium. Same
+  // mitigation as Puppeteer / Playwright / chrome-devtools-mcp.
+  const args = [
+    `--remote-debugging-port=${port}`,
+    '--remote-allow-origins=*',
+    ...(app.extraArgs ?? []),
+  ];
   await launchElectronApp(appPath, app, args, label);
 
   // Step 5: Poll for readiness


### PR DESCRIPTION
Three changes bundled (kept together because the codex commits build on patterns introduced for grok):

## 1. fix(grok): locale-independent selectors

Two selectors in `clis/grok/utils.js` were keyed on English `aria-label`:
- `button[aria-label="Submit"]`         (composer send)
- `button[aria-label="Model select"]`   (model picker)

These miss in non-English locales (verified zh-CN: `aria-label="提交"` / `"模型选择"`).

Fix: prefer locale-independent anchors with localized aria-label fallbacks.
- Submit: `button[data-testid="chat-submit"]` → `"Submit"` / `"提交"` / `"送信"`
- Model:  `#model-select-trigger` → `"Model select"` / `"模型选择"` / `"モデル選択"`

## 2. feat(grok): add delete/pin/unpin

`opencli grok delete <id> --yes`, `opencli grok pin <id>`, `opencli grok unpin <id>`.

Right-clicking any `/c/<id>` sidebar link surfaces a radix context menu with 4 items (`Open in new tab` / `Rename` / `Pin` or `Unpin` / `Delete`). 3 of these are wired up. Implementation note: must dispatch the full pointer chain (`pointerdown` → `mousedown` → `contextmenu` → `pointerup` → `mouseup` with `button=2`); the bare `MouseEvent('contextmenu')` alone is ignored by radix.

Grok deletes WITHOUT a confirmation dialog, so `--yes` is required.

Known: `rename` left as a stub-with-error because the radix `onSelect` for the Rename menu item doesn't respond to programmatic clicks (synthetic chains all report `clicked:true` but the inline rename input never materializes). Needs CDP `Input.dispatchMouseEvent` at viewport coordinates — separate followup.

## 3. feat(codex): add pin/unpin/archive/rename

`opencli codex pin/unpin/archive/rename` for sidebar conversations.

All four use the SAME path: select the target chat (`--project / --conversation / --index / --thread-id`), then open the `button[aria-label="Chat actions"]` header dropdown (full pointer chain again — same radix issue), then click the matching menu item (`Pin chat` / `Unpin chat` / `Archive chat` / `Rename chat`).

Why the header menu and not per-row sidebar buttons? Codex's per-row Pin/Archive buttons are React-lazily-mounted only when the row is hovered AND `document.visibilityState === 'visible'`. When the user has the Codex window minimized, even programmatic `mouseenter` won't surface them. The Chat actions menu mounts on click, independent of visibility.

`archive` is dry-run by default (Codex applies it without UI confirmation); pass `--yes` to actually archive.

Known partial: `rename` returns `status:'renamed'` and the rename contenteditable DOES receive the new title, but the commit-on-Enter sometimes doesn't persist. Pin/Unpin/Archive are fully verified end-to-end.

## Verified live

Grok (zh-CN, free tier):
```
$ opencli grok ask 'reply with: working'
- response: 思考了 3s working

$ opencli grok status
- Model: Fast    # was null before

$ opencli grok pin/unpin/delete --yes <uuid>
- status: pinned / unpinned / deleted    # sidebar still_present=false after delete
```

Codex (macOS desktop, app://-/index.html):
```
$ opencli codex pin --project leo --index 2
- status: pinned

$ opencli codex archive --project leo --index 2 --yes
- status: archived
```

Tests pass: 29/29 grok, 14/14 codex.

## Related
- Pairs with #1789 (`--remote-allow-origins=*` for Chromium 142+ launchers).
- Addresses the conversation-management gap across all opencli AI surfaces.