### PR TITLE
feat(antigravity): history/delete/mark-read + model read/switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 OpenCLI gives you one surface for three different kinds of automation:
 
 - **Use built-in adapters** for sites like Bilibili, Zhihu, Xiaohongshu, Reddit, HackerNews, Twitter/X, and [many more](#built-in-commands).
-- **Browser User & Let AI Agents operate any website** — install the `opencli-browser` skill in your AI agent (Claude Code, Cursor, etc.), and it can navigate, click, type/fill, extract, and inspect any page through your logged-in browser via `opencli browser` primitives.
+- **Let AI Agents operate any website** — install the `opencli-browser` skill in your AI agent (Claude Code, Cursor, etc.), and it can navigate, click, type/fill, extract, and inspect any page through your logged-in browser via `opencli browser` primitives.
 - **Write new adapters** end-to-end with `opencli browser` + the `opencli-adapter-author` skill, which guides from first recon through field decoding, code, and `opencli browser verify`.
 
 It also works as a **CLI hub** for local tools such as `gh`, `docker`, `longbridge`, `tg`, `discord`, `wx`, `ntn` (Notion), and other binaries you register yourself, plus **desktop app adapters** for Electron apps like Cursor, Codex, Antigravity, and ChatGPT.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 OpenCLI 可以用同一套 CLI 做三类事情：
 
 - **直接使用现成适配器**：B站、知乎、小红书、Twitter/X、Reddit、HackerNews 等 [100+ 站点](#内置命令) 开箱即用。
-- **Browser User & 让 AI Agent 操作任意网站**：在你的 AI Agent（Claude Code、Cursor 等）中安装 `opencli-browser` skill，Agent 就能用你的已登录浏览器导航、点击、输入/填充、提取任意网页内容。
+- **让 AI Agent 操作任意网站**：在你的 AI Agent（Claude Code、Cursor 等）中安装 `opencli-browser` skill，Agent 就能用你的已登录浏览器导航、点击、输入/填充、提取任意网页内容。
 - **把新网站写成 CLI**：用 `opencli browser` 原语 + `opencli-adapter-author` skill，从站点侦察、API 发现、字段解码到 `opencli browser verify` 一条龙。
 
 除了网站能力，OpenCLI 还是一个 **CLI 枢纽**：你可以把 `gh`、`docker`、`longbridge`、`tg`、`discord`、`wx`、`ntn`（Notion）等本地工具统一注册到 `opencli` 下，也可以通过桌面端适配器控制 Cursor、Codex、Antigravity、ChatGPT 等 Electron 应用。

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1449,6 +1449,155 @@
   },
   {
     "site": "antigravity",
+    "name": "add-context",
+    "description": "Click the Add context button in the composer (opens file/URL picker for context attachment).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "cookies",
+    "description": "List cookies on the Antigravity renderer (JS-visible via document.cookie).",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "copy-code",
+    "description": "Return the text of a code block in the current conversation. Default: last code block; pass --index N (1-based from top) to pick a specific one.",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "index",
+        "type": "int",
+        "required": false,
+        "help": "1-based index of code block (default: last)"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "copy-message",
+    "description": "Return the text of the last assistant message (best-effort: walks up from the last visible Copy button).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "click-button",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Also click the in-UI Copy button"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "delete",
+    "description": "Delete an Antigravity conversation by ID. Antigravity asks for confirmation; we click through it. Require --yes to actually delete.",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID (the part after \"convo-pill-\" in the sidebar testid)"
+      },
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually delete (default: dry-run preview)"
+      }
+    ],
+    "columns": [
+      "status",
+      "id"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/delete.js",
+    "sourceFile": "antigravity/delete.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "display-options",
+    "description": "Open the Display Options menu and list its items.",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Index",
+      "Item"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
     "name": "dump",
     "description": "Dump the DOM to help AI understand the UI",
     "access": "read",
@@ -1484,27 +1633,144 @@
   },
   {
     "site": "antigravity",
-    "name": "model",
-    "description": "Switch the active LLM model in Antigravity",
+    "name": "history",
+    "description": "List visible Antigravity conversations from the sidebar",
     "access": "read",
-    "domain": "localhost",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max conversations to return"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Id",
+      "Title"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/history.js",
+    "sourceFile": "antigravity/history.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "idb-list",
+    "description": "List IndexedDB databases on the Antigravity renderer.",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "mark-read",
+    "description": "Mark an unread Antigravity conversation as read. Fails if the row is already read or the postcondition cannot be verified.",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID (the part after \"convo-pill-\" in the sidebar testid)"
+      }
+    ],
+    "columns": [
+      "status",
+      "id",
+      "clicked"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/mark-read.js",
+    "sourceFile": "antigravity/mark-read.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "model",
+    "description": "Read or switch the active model in Antigravity. Without arguments, reports the current model. With <name> (substring, case-insensitive), switches.",
+    "access": "write",
+    "domain": "127.0.0.1",
     "strategy": "ui",
     "browser": true,
     "args": [
       {
         "name": "name",
         "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Substring (case-insensitive) of target model name. Omit to read current."
+      },
+      {
+        "name": "list",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "List models in the picker (does not switch)"
+      }
+    ],
+    "columns": [
+      "Status",
+      "Model"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/model.js",
+    "sourceFile": "antigravity/model.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "nav",
+    "description": "Click Go Back or Go Forward (Antigravity in-app history).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "direction",
+        "type": "str",
         "required": true,
         "positional": true,
-        "help": "Target model name (e.g. claude, gemini, o1)"
+        "help": "back or forward"
       }
     ],
     "columns": [
       "Status"
     ],
     "type": "js",
-    "modulePath": "antigravity/model.js",
-    "sourceFile": "antigravity/model.js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
     "navigateBefore": true
   },
   {
@@ -1522,6 +1788,32 @@
     "type": "js",
     "modulePath": "antigravity/new.js",
     "sourceFile": "antigravity/new.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "react",
+    "description": "Click \"Good response\" or \"Bad response\" on the LAST assistant message.",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "kind",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "good or bad"
+      }
+    ],
+    "columns": [
+      "Status",
+      "Reaction"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
     "navigateBefore": true
   },
   {
@@ -1547,6 +1839,100 @@
     "type": "js",
     "modulePath": "antigravity/read.js",
     "sourceFile": "antigravity/read.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "recent-paths",
+    "description": "Show Antigravity's recently-opened folders/files (history.recentlyOpenedPathsList).",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js"
+  },
+  {
+    "site": "antigravity",
+    "name": "rename",
+    "description": "Rename an Antigravity conversation by ID (NOT YET IMPLEMENTED — see source comment).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Conversation UUID (the part after \"convo-pill-\" in the sidebar testid)"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "New title"
+      }
+    ],
+    "columns": [
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/rename.js",
+    "sourceFile": "antigravity/rename.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "revert",
+    "description": "Click the revert button (per-message revert for agent changes). Requires --yes (this modifies your workspace).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually revert (default: dry-run)"
+      }
+    ],
+    "columns": [
+      "Status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
     "navigateBefore": true
   },
   {
@@ -1577,6 +1963,168 @@
   },
   {
     "site": "antigravity",
+    "name": "settings",
+    "description": "Click the Antigravity settings button (matched by data-testid=\"settings-button\").",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "settings-read",
+    "description": "Read Antigravity's user settings.json (theme, proxy, agCockpit, tfa.system.autoAccept, etc.).",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "local",
+    "browser": false,
+    "args": [],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js"
+  },
+  {
+    "site": "antigravity",
+    "name": "sidebar-toggle",
+    "description": "Click Toggle Sidebar (collapses/expands the Antigravity sidebar).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "state-get",
+    "description": "Read one value from Antigravity's state.vscdb. Pass --workspace <id> for per-workspace.",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Storage key name"
+      },
+      {
+        "name": "workspace",
+        "type": "str",
+        "required": false,
+        "help": "Workspace id (from workspaces-list) to query per-workspace DB"
+      },
+      {
+        "name": "max-bytes",
+        "type": "int",
+        "default": 8000,
+        "required": false,
+        "help": "Truncate value to this many chars"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js"
+  },
+  {
+    "site": "antigravity",
+    "name": "state-keys",
+    "description": "List keys in Antigravity's globalStorage state.vscdb (VSCode-style). Pass --workspace <id> to query a per-workspace DB. Works while Antigravity is closed.",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "filter",
+        "type": "str",
+        "required": false,
+        "help": "Case-insensitive substring filter over keys"
+      },
+      {
+        "name": "workspace",
+        "type": "str",
+        "required": false,
+        "help": "Workspace id (from workspaces-list) to query per-workspace DB"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 200,
+        "required": false,
+        "help": "Max rows to return"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js"
+  },
+  {
+    "site": "antigravity",
     "name": "status",
     "description": "Check Antigravity CDP connection and get current page state",
     "access": "read",
@@ -1592,6 +2140,126 @@
     "type": "js",
     "modulePath": "antigravity/status.js",
     "sourceFile": "antigravity/status.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "storage-get",
+    "description": "Read a single localStorage / sessionStorage value on the Antigravity renderer.",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Storage key name"
+      },
+      {
+        "name": "storage",
+        "type": "str",
+        "default": "local",
+        "required": false,
+        "help": "\"local\" or \"session\""
+      },
+      {
+        "name": "max-bytes",
+        "type": "int",
+        "default": 4000,
+        "required": false,
+        "help": "Truncate value to this many chars"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "storage-keys",
+    "description": "List localStorage / sessionStorage keys on the Antigravity renderer (CDP).",
+    "access": "read",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "storage",
+        "type": "str",
+        "default": "local",
+        "required": false,
+        "help": "\"local\" or \"session\""
+      },
+      {
+        "name": "filter",
+        "type": "str",
+        "required": false,
+        "help": "Case-insensitive substring filter"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 100,
+        "required": false,
+        "help": "Max rows to return"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "toggle-aux",
+    "description": "Toggle the Auxiliary Pane (Antigravity's secondary panel for code/preview).",
+    "access": "write",
+    "domain": "127.0.0.1",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/audit-extras.js",
+    "sourceFile": "antigravity/audit-extras.js",
     "navigateBefore": true
   },
   {
@@ -1616,6 +2284,43 @@
     "modulePath": "antigravity/watch.js",
     "sourceFile": "antigravity/watch.js",
     "navigateBefore": true
+  },
+  {
+    "site": "antigravity",
+    "name": "workspaces-list",
+    "description": "List Antigravity workspaceStorage entries (each represents a previously-opened folder).",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max rows to return"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version",
+      "Kind",
+      "Path",
+      "Workspace Id",
+      "Folder",
+      "Modified",
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "antigravity/storage.js",
+    "sourceFile": "antigravity/storage.js"
   },
   {
     "site": "apple-podcasts",

--- a/clis/antigravity/_actions.js
+++ b/clis/antigravity/_actions.js
@@ -1,0 +1,318 @@
+// Shared helpers for Antigravity sidebar conversation management.
+//
+// Each conversation in the sidebar is rendered as a row whose visible
+// title element has stable testid `convo-pill-<uuid>`. The row container
+// is the 3rd ancestor — it carries `role="button"` and acts as the
+// clickable row.
+//
+// On hover the row shows 3 icon-only buttons. The FIRST (button[0]) is a
+// "more options" 3-dot trigger that opens a 3-item dropdown:
+//
+//   Mark as Read
+//   Rename
+//   Delete Conversation
+//
+// We use that dropdown for all management operations. Antigravity does
+// not currently expose Pin/Unpin as menu items (different model than
+// Codex / Grok).
+//
+// All clicks go through the full pointer-event chain because the menu is
+// likely radix-based and ignores bare .click().
+
+import { CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+
+const PILL_SELECTOR_PREFIX = 'convo-pill-';
+
+export function unwrapEvaluateResult(payload) {
+    if (
+        payload
+        && typeof payload === 'object'
+        && Object.prototype.hasOwnProperty.call(payload, 'data')
+        && Object.prototype.hasOwnProperty.call(payload, 'session')
+    ) {
+        return payload.data;
+    }
+    return payload;
+}
+
+export function buildPillTestId(conversationId) {
+    return `${PILL_SELECTOR_PREFIX}${String(conversationId).toLowerCase()}`;
+}
+
+/**
+ * Return all visible conversation pills with their {id, title} for
+ * history-style listings or for fuzzy match.
+ */
+export async function listConversations(page) {
+    const result = unwrapEvaluateResult(await page.evaluate(`(function() {
+    return Array.from(document.querySelectorAll('[data-testid^="${PILL_SELECTOR_PREFIX}"]'))
+      .filter((el) => el.offsetParent)
+      .map((el, idx) => ({
+        index: idx + 1,
+        id: el.getAttribute('data-testid').slice(${PILL_SELECTOR_PREFIX.length}),
+        title: (el.textContent || '').trim().slice(0, 200),
+      }));
+  })()`));
+    return Array.isArray(result) ? result : [];
+}
+
+export async function conversationVisible(page, conversationId) {
+    const testId = buildPillTestId(conversationId);
+    return !!unwrapEvaluateResult(await page.evaluate(`(() => {
+    const el = document.querySelector(${JSON.stringify(`[data-testid="${testId}"]`)});
+    return !!(el && el.offsetParent);
+  })()`));
+}
+
+export async function getConversationMenuLabels(page, conversationId) {
+    const testId = buildPillTestId(conversationId);
+    const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+    const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+    const pill = document.querySelector(${JSON.stringify(`[data-testid="${testId}"]`)});
+    if (!pill) return { ok: false, reason: 'Conversation pill not found.', detail: 'testid=${testId}' };
+    let row = pill;
+    for (let i = 0; i < 3; i++) row = row.parentElement || row;
+    row.scrollIntoView({ block: 'center' });
+    row.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    let dotBtn = null;
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      await wait(80);
+      const btns = Array.from(row.querySelectorAll('button')).filter((b) => b.offsetParent);
+      if (btns.length >= 1) { dotBtn = btns[0]; break; }
+    }
+    if (!dotBtn) return { ok: false, reason: 'Per-row 3-dot trigger never mounted after hover.' };
+    const r = dotBtn.getBoundingClientRect();
+    const init = {
+      bubbles: true, cancelable: true, button: 0, buttons: 1,
+      clientX: Math.round(r.left + r.width / 2),
+      clientY: Math.round(r.top + r.height / 2),
+    };
+    dotBtn.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+    dotBtn.dispatchEvent(new MouseEvent('mousedown', init));
+    dotBtn.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+    dotBtn.dispatchEvent(new MouseEvent('mouseup', init));
+    dotBtn.dispatchEvent(new MouseEvent('click', init));
+    let menuItems = [];
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await wait(80);
+      menuItems = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"]'))
+        .filter((it) => it instanceof HTMLElement && it.offsetParent);
+      if (menuItems.length) break;
+    }
+    const labels = menuItems.map((it) => {
+      const clone = it.cloneNode(true);
+      clone.querySelectorAll('kbd').forEach((k) => k.remove());
+      return (clone.textContent || '').trim();
+    }).filter(Boolean);
+    document.body.click();
+    return { ok: true, labels };
+  })()`));
+    return result || { ok: false, reason: 'Empty result from page.evaluate.' };
+}
+
+/**
+ * Open the per-row 3-dot menu for the given conversation, click the
+ * menu item whose visible text matches `labelOptions`, return status.
+ * Single page.evaluate so the menu stays mounted while we click.
+ *
+ * Returns { ok, clicked? , reason?, detail? }.
+ */
+export async function clickConversationMenuItem(page, conversationId, labelOptions) {
+    const testId = buildPillTestId(conversationId);
+    const testIdJson = JSON.stringify(testId);
+    const labelsJson = JSON.stringify(labelOptions);
+
+    // Wrap in try/catch — Antigravity menu clicks often trigger a
+    // sidebar re-render that destroys the eval reply mid-stream, surfacing
+    // as "Promise was collected" or 30s Runtime.evaluate timeout. The
+    // click DID happen (we verified live by toggling Mark as Read /
+    // Unread). Treat these specific failures as success-with-no-confirmation
+    // and let the caller re-query history to verify.
+    let result;
+    try {
+        result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+    const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+    const testId = ${testIdJson};
+    const labels = ${labelsJson};
+
+    const pill = document.querySelector(\`[data-testid="\${testId}"]\`);
+    if (!pill) {
+      return { ok: false, reason: 'Conversation pill not found.', detail: 'testid=' + testId };
+    }
+
+    // Walk up to the row container — depth 3 holds the role="button" row
+    // with the per-row action buttons.
+    let row = pill;
+    for (let i = 0; i < 3; i++) row = row.parentElement || row;
+    if (!row) {
+      return { ok: false, reason: 'Could not locate the row container above the pill.' };
+    }
+
+    row.scrollIntoView({ block: 'center' });
+
+    // React synthetic hover mounts the per-row buttons. Visibility-state
+    // doesn't appear to gate Antigravity's overlay (unlike Codex), but
+    // we still dispatch the full set for safety.
+    row.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+    // Wait for the row's 3-dot trigger to mount.
+    let dotBtn = null;
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      await wait(80);
+      const btns = Array.from(row.querySelectorAll('button')).filter((b) => b.offsetParent);
+      if (btns.length >= 1) { dotBtn = btns[0]; break; }  // First button == more-options
+    }
+    if (!dotBtn) {
+      return { ok: false, reason: 'Per-row 3-dot trigger never mounted after hover.' };
+    }
+
+    // Open the menu via full pointer chain.
+    const r = dotBtn.getBoundingClientRect();
+    const init = {
+      bubbles: true, cancelable: true, button: 0, buttons: 1,
+      clientX: Math.round(r.left + r.width / 2),
+      clientY: Math.round(r.top + r.height / 2),
+    };
+    dotBtn.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+    dotBtn.dispatchEvent(new MouseEvent('mousedown', init));
+    dotBtn.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+    dotBtn.dispatchEvent(new MouseEvent('mouseup', init));
+    dotBtn.dispatchEvent(new MouseEvent('click', init));
+
+    // Wait for menu items to mount.
+    let menuItems = [];
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await wait(80);
+      menuItems = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"]'))
+        .filter((it) => it instanceof HTMLElement && it.offsetParent);
+      if (menuItems.length) break;
+    }
+    if (!menuItems.length) {
+      return { ok: false, reason: 'Conversation 3-dot menu did not open after click.' };
+    }
+
+    function leadingText(el) {
+      const clone = el.cloneNode(true);
+      clone.querySelectorAll('kbd').forEach((k) => k.remove());
+      return (clone.textContent || '').trim();
+    }
+
+    let target = null;
+    for (const item of menuItems) {
+      const text = leadingText(item);
+      for (const label of labels) {
+        if (text === label || text.startsWith(label)) {
+          target = item;
+          break;
+        }
+      }
+      if (target) break;
+    }
+    if (!target) {
+      const visible = menuItems.map(leadingText);
+      document.body.click();  // close menu
+      return {
+        ok: false,
+        reason: 'No menu item matched the requested label.',
+        detail: 'wanted=' + JSON.stringify(labels) + ' visible=' + JSON.stringify(visible),
+      };
+    }
+
+    // Click via pointer chain too — radix is picky.
+    const tr = target.getBoundingClientRect();
+    const tinit = {
+      bubbles: true, cancelable: true, button: 0, buttons: 1,
+      clientX: Math.round(tr.left + tr.width / 2),
+      clientY: Math.round(tr.top + tr.height / 2),
+    };
+    const matchedLabel = leadingText(target);
+    // Defer to next microtask so the eval reply returns before any re-render.
+    Promise.resolve().then(() => {
+      try {
+        target.dispatchEvent(new PointerEvent('pointerdown', { ...tinit, pointerType: 'mouse' }));
+        target.dispatchEvent(new MouseEvent('mousedown', tinit));
+        target.dispatchEvent(new PointerEvent('pointerup', { ...tinit, pointerType: 'mouse' }));
+        target.dispatchEvent(new MouseEvent('mouseup', tinit));
+        target.dispatchEvent(new MouseEvent('click', tinit));
+      } catch {}
+    });
+    return { ok: true, clicked: matchedLabel };
+  })()`));
+    } catch (err) {
+        const msg = String(err?.message || err);
+        if (/Promise was collected|timed out after \d+s|Runtime\.evaluate/i.test(msg)) {
+            // Click was scheduled inside a microtask before destruction, so
+            // the action almost certainly fired. Report ambiguous-but-likely-ok.
+            return {
+                ok: true,
+                clicked: labelOptions[0],
+                note: 'eval reply destroyed by post-click re-render; click likely fired',
+            };
+        }
+        throw err;
+    }
+
+    return result || { ok: false, reason: 'Empty result from page.evaluate.' };
+}
+
+/**
+ * After Delete Conversation menu item is clicked, Antigravity shows a
+ * confirm dialog. Locate it and click the confirm button.
+ */
+export async function confirmDeleteDialog(page, confirmLabels) {
+    const labelsJson = JSON.stringify(confirmLabels);
+    const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+    const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+    let dialog = null;
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      await wait(120);
+      dialog = document.querySelector('[role="alertdialog"], [role="dialog"]');
+      if (dialog && dialog.offsetParent) break;
+    }
+    if (!dialog) {
+      return { ok: false, reason: 'Delete confirm dialog did not appear.' };
+    }
+    const buttons = Array.from(dialog.querySelectorAll('button'));
+    const labels = ${labelsJson};
+    const confirmBtn = buttons.find((b) => {
+      const t = (b.textContent || '').trim();
+      return labels.some((l) => t === l || t.toLowerCase() === l.toLowerCase());
+    });
+    if (!confirmBtn) {
+      return {
+        ok: false,
+        reason: 'Confirm button not found in dialog.',
+        detail: 'present=' + JSON.stringify(buttons.map((b) => (b.textContent || '').trim())),
+      };
+    }
+    const r = confirmBtn.getBoundingClientRect();
+    const init = {
+      bubbles: true, button: 0, buttons: 1, cancelable: true,
+      clientX: Math.round(r.left + r.width / 2),
+      clientY: Math.round(r.top + r.height / 2),
+    };
+    Promise.resolve().then(() => {
+      try {
+        confirmBtn.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+        confirmBtn.dispatchEvent(new MouseEvent('mousedown', init));
+        confirmBtn.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+        confirmBtn.dispatchEvent(new MouseEvent('mouseup', init));
+        confirmBtn.dispatchEvent(new MouseEvent('click', init));
+      } catch {}
+    });
+    return { ok: true, confirmed: (confirmBtn.textContent || '').trim() };
+  })()`));
+    return result || { ok: false, reason: 'Empty result.' };
+}
+
+export const conversationTargetArgs = [
+    {
+        name: 'id',
+        positional: true,
+        type: 'string',
+        required: true,
+        help: 'Conversation UUID (the part after "convo-pill-" in the sidebar testid)',
+    },
+];

--- a/clis/antigravity/antigravity.test.js
+++ b/clis/antigravity/antigravity.test.js
@@ -106,6 +106,31 @@ describe('antigravity write postconditions', () => {
             .rejects.toBeInstanceOf(ArgumentError);
     });
 
+    it('model list mode never switches even when a name filter is supplied', async () => {
+        const page = makePage([
+            'Gemini 3.5 Flash',
+            { ok: true, labels: ['Gemini 3.5 Flash', 'Claude Sonnet'] },
+        ]);
+
+        await expect(modelCommand.func(page, { list: true, name: 'claude' })).resolves.toEqual([
+            { Status: 'Active', Model: 'Gemini 3.5 Flash' },
+            { Status: 'Available', Model: 'Claude Sonnet' },
+        ]);
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+    });
+
+    it('model accepts an exact match before falling back to ambiguous partial matching', async () => {
+        const page = makePage([
+            'Gemini 3.5 Flash',
+            { ok: true, switched: true, chosen: 'Gemini Pro', labels: ['Gemini Pro', 'Gemini Pro Extended'] },
+            'Gemini Pro',
+        ]);
+
+        await expect(modelCommand.func(page, { name: 'gemini pro' })).resolves.toEqual([
+            { Status: 'switched', Model: 'Gemini Pro' },
+        ]);
+    });
+
     it('model fails closed when read-back does not prove the target is active', async () => {
         const page = makePage([
             'Gemini 3.5 Flash',
@@ -132,5 +157,16 @@ describe('antigravity write postconditions', () => {
         await expect(storageKeysCommand.func(page, { storage: 'local' })).resolves.toEqual([
             { Index: 1, Key: 'alpha', Bytes: 12 },
         ]);
+    });
+
+    it('copy-message click-button fails closed when the in-UI copy click fails', async () => {
+        const copyMessageCommand = getRegistry().get('antigravity/copy-message');
+        const page = makePage([
+            { text: 'assistant response' },
+            { ok: false, reason: 'No matching visible element.' },
+        ]);
+
+        await expect(copyMessageCommand.func(page, { 'click-button': true }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/antigravity/antigravity.test.js
+++ b/clis/antigravity/antigravity.test.js
@@ -1,0 +1,136 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { listConversations } from './_actions.js';
+import './audit-extras.js';
+import './delete.js';
+import './history.js';
+import './mark-read.js';
+import './model.js';
+import './rename.js';
+import './storage.js';
+
+function makePage(evaluateResults = []) {
+    const queue = [...evaluateResults];
+    return {
+        evaluate: vi.fn(async () => (queue.length ? queue.shift() : null)),
+        wait: vi.fn(async () => {}),
+    };
+}
+
+describe('antigravity command registration', () => {
+    it('classifies commands by maximum side effect', () => {
+        const expected = {
+            history: 'read',
+            delete: 'write',
+            'mark-read': 'write',
+            model: 'write',
+            rename: 'write',
+            'copy-message': 'write',
+            'copy-code': 'read',
+            'state-keys': 'read',
+            'state-get': 'read',
+            'recent-paths': 'read',
+            'workspaces-list': 'read',
+            'settings-read': 'read',
+        };
+        for (const [name, access] of Object.entries(expected)) {
+            const command = getRegistry().get(`antigravity/${name}`);
+            expect(command, `antigravity/${name}`).toBeDefined();
+            expect(command.access).toBe(access);
+        }
+    });
+});
+
+describe('antigravity Browser Bridge envelopes', () => {
+    it('unwraps conversation listings returned as { session, data }', async () => {
+        const page = makePage([
+            { session: { id: 's1' }, data: [{ index: 1, id: 'abc', title: 'Demo' }] },
+        ]);
+
+        await expect(listConversations(page)).resolves.toEqual([
+            { index: 1, id: 'abc', title: 'Demo' },
+        ]);
+    });
+});
+
+describe('antigravity write postconditions', () => {
+    let deleteCommand;
+    let markReadCommand;
+    let modelCommand;
+    let storageKeysCommand;
+
+    beforeAll(() => {
+        deleteCommand = getRegistry().get('antigravity/delete');
+        markReadCommand = getRegistry().get('antigravity/mark-read');
+        modelCommand = getRegistry().get('antigravity/model');
+        storageKeysCommand = getRegistry().get('antigravity/storage-keys');
+    });
+
+    it('delete fails closed when the conversation remains visible after confirmation', async () => {
+        const page = makePage([
+            { ok: true, clicked: 'Delete Conversation' },
+            { ok: true, confirmed: 'Delete' },
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+        ]);
+
+        await expect(deleteCommand.func(page, { id: 'abc', yes: true }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('mark-read refuses to toggle already-read rows back to unread', async () => {
+        const page = makePage([
+            { ok: true, labels: ['Mark as Unread', 'Rename', 'Delete Conversation'] },
+        ]);
+
+        await expect(markReadCommand.func(page, { id: 'abc' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('model rejects ambiguous partial matches before clicking', async () => {
+        const page = makePage([
+            'Gemini 3.5 Flash',
+            { ok: false, reason: 'Ambiguous model match.', detail: 'wanted=gemini matches=["Gemini Pro","Gemini Flash"]' },
+        ]);
+
+        await expect(modelCommand.func(page, { name: 'gemini' }))
+            .rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('model fails closed when read-back does not prove the target is active', async () => {
+        const page = makePage([
+            'Gemini 3.5 Flash',
+            { ok: true, switched: true, chosen: 'Claude Sonnet', labels: ['Claude Sonnet'] },
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+            'Gemini 3.5 Flash',
+        ]);
+
+        await expect(modelCommand.func(page, { name: 'claude' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('storage-keys unwraps Browser Bridge envelopes before shaping rows', async () => {
+        const page = makePage([
+            { session: { id: 's1' }, data: [{ k: 'alpha', bytes: 12 }] },
+        ]);
+
+        await expect(storageKeysCommand.func(page, { storage: 'local' })).resolves.toEqual([
+            { Index: 1, Key: 'alpha', Bytes: 12 },
+        ]);
+    });
+});

--- a/clis/antigravity/audit-extras.js
+++ b/clis/antigravity/audit-extras.js
@@ -120,7 +120,10 @@ cli({
     })()`));
         if (!data) throw new EmptyResultError('antigravity copy-message', 'No Copy buttons visible — make sure an assistant reply is on screen.');
         if (kwargs?.['click-button'] === true || kwargs?.['click-button'] === 'true') {
-            unwrapEvaluateResult(await page.evaluate(clickLastScript(['button[aria-label="Copy"]'])));
+            const clickResult = unwrapEvaluateResult(await page.evaluate(clickLastScript(['button[aria-label="Copy"]'])));
+            if (!clickResult?.ok) {
+                throw new CommandExecutionError(clickResult?.reason || 'Copy button click failed', '');
+            }
         }
         return [
             { Field: 'Length', Value: String((data.text || '').length) + ' chars' },

--- a/clis/antigravity/audit-extras.js
+++ b/clis/antigravity/audit-extras.js
@@ -1,0 +1,338 @@
+// Deep-audit gap closers for Antigravity (port 9234).
+//
+// Live snapshot of CodexBar agent project (chat view) showed 49 visible
+// interactive elements / 28 unique labels. Beyond the 12 existing
+// commands, these 10 wrap the rest:
+//
+//   react <good|bad>      — Good response / Bad response
+//   copy-message          — text of last assistant turn (clicks last visible Copy)
+//   copy-code [--index N] — copy a specific code block (uses Copy code button)
+//   settings              — click the settings-button data-testid
+//   sidebar-toggle        — click Toggle Sidebar
+//   nav <back|forward>    — Go Back / Go Forward
+//   toggle-aux            — Toggle Auxiliary Pane
+//   display-options       — open Display Options menu + list items
+//   add-context           — click Add context (opens file/url picker)
+//   revert                — click revert-button (per-message revert)
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_actions.js';
+
+function clickFirstScript(sels) {
+    return `(() => {
+    const isVis = (el) => { const r = el.getBoundingClientRect(); return r.width > 1 && r.height > 1; };
+    for (const sel of ${JSON.stringify(sels)}) {
+      const t = Array.from(document.querySelectorAll(sel)).filter(isVis)[0];
+      if (t) {
+        const r = t.getBoundingClientRect();
+        const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };
+        t.dispatchEvent(new PointerEvent('pointerdown', opts));
+        t.dispatchEvent(new MouseEvent('mousedown', opts));
+        t.dispatchEvent(new PointerEvent('pointerup', opts));
+        t.dispatchEvent(new MouseEvent('mouseup', opts));
+        t.click();
+        return { ok: true, sel };
+      }
+    }
+    return { ok: false, reason: 'No matching visible element.' };
+  })()`;
+}
+
+function clickLastScript(sels) {
+    return `(() => {
+    const isVis = (el) => { const r = el.getBoundingClientRect(); return r.width > 1 && r.height > 1; };
+    for (const sel of ${JSON.stringify(sels)}) {
+      const found = Array.from(document.querySelectorAll(sel)).filter(isVis);
+      if (found.length) {
+        const t = found[found.length - 1];
+        const r = t.getBoundingClientRect();
+        const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };
+        t.dispatchEvent(new PointerEvent('pointerdown', opts));
+        t.dispatchEvent(new MouseEvent('mousedown', opts));
+        t.dispatchEvent(new PointerEvent('pointerup', opts));
+        t.dispatchEvent(new MouseEvent('mouseup', opts));
+        t.click();
+        return { ok: true, sel };
+      }
+    }
+    return { ok: false, reason: 'No matching visible element.' };
+  })()`;
+}
+
+// -------- react --------
+cli({
+    site: 'antigravity',
+    name: 'react',
+    access: 'write',
+    description: 'Click "Good response" or "Bad response" on the LAST assistant message.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'kind', positional: true, required: true, help: 'good or bad' },
+    ],
+    columns: ['Status', 'Reaction'],
+    func: async (page, kwargs) => {
+        const kind = String(kwargs?.kind || '').trim().toLowerCase();
+        if (kind !== 'good' && kind !== 'bad') throw new ArgumentError('kind', 'must be "good" or "bad"');
+        const label = kind === 'good' ? 'Good response' : 'Bad response';
+        const res = unwrapEvaluateResult(await page.evaluate(clickLastScript([`button[aria-label="${label}"]`])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || `${label} click failed`, '');
+        return [{ Status: 'clicked', Reaction: kind }];
+    },
+});
+
+// -------- copy-message --------
+cli({
+    site: 'antigravity',
+    name: 'copy-message',
+    access: 'write',
+    description: 'Return the text of the last assistant message (best-effort: walks up from the last visible Copy button).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'click-button', type: 'boolean', default: false, help: 'Also click the in-UI Copy button' },
+    ],
+    columns: ['Field', 'Value'],
+    func: async (page, kwargs) => {
+        const data = unwrapEvaluateResult(await page.evaluate(`(() => {
+      const isVis = (el) => { const r = el.getBoundingClientRect(); return r.width > 1 && r.height > 1; };
+      // Antigravity has both "Copy" (message) and "Copy code" (code block) buttons.
+      // We want the bottom-of-message Copy, not the code-block Copy.
+      const copies = Array.from(document.querySelectorAll('button[aria-label="Copy"]')).filter(isVis);
+      if (!copies.length) return null;
+      const lastCopy = copies[copies.length - 1];
+      let container = lastCopy;
+      let best = '';
+      for (let i = 0; i < 8 && container.parentElement; i++) {
+        container = container.parentElement;
+        const txt = (container.innerText || '').trim();
+        if (txt.length > best.length) best = txt;
+        if (best.length > 200) break;
+      }
+      return { text: best };
+    })()`));
+        if (!data) throw new EmptyResultError('antigravity copy-message', 'No Copy buttons visible — make sure an assistant reply is on screen.');
+        if (kwargs?.['click-button'] === true || kwargs?.['click-button'] === 'true') {
+            unwrapEvaluateResult(await page.evaluate(clickLastScript(['button[aria-label="Copy"]'])));
+        }
+        return [
+            { Field: 'Length', Value: String((data.text || '').length) + ' chars' },
+            { Field: 'ClipboardClicked', Value: (kwargs?.['click-button'] === true || kwargs?.['click-button'] === 'true') ? 'yes' : 'no' },
+            { Field: 'Text', Value: data.text || '' },
+        ];
+    },
+});
+
+// -------- copy-code --------
+cli({
+    site: 'antigravity',
+    name: 'copy-code',
+    access: 'read',
+    description: 'Return the text of a code block in the current conversation. Default: last code block; pass --index N (1-based from top) to pick a specific one.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'index', type: 'int', required: false, help: '1-based index of code block (default: last)' },
+    ],
+    columns: ['Field', 'Value'],
+    func: async (page, kwargs) => {
+        const idx = Number.isInteger(kwargs?.index) ? kwargs.index : null;
+        const data = unwrapEvaluateResult(await page.evaluate(`(() => {
+      const isVis = (el) => { const r = el.getBoundingClientRect(); return r.width > 1 && r.height > 1; };
+      const btns = Array.from(document.querySelectorAll('button[aria-label="Copy code"]')).filter(isVis);
+      if (!btns.length) return null;
+      const idx = ${idx === null ? 'btns.length - 1' : (idx - 1)};
+      const btn = btns[idx];
+      if (!btn) return { err: 'index ' + (${idx} ?? 'last') + ' out of range. Have ' + btns.length + ' code blocks.' };
+      // Find the <code> or <pre> element inside the parent block.
+      let container = btn;
+      for (let i = 0; i < 6 && container.parentElement; i++) container = container.parentElement;
+      const code = container.querySelector('pre, code');
+      return { text: code ? (code.innerText || '').trim() : (container.innerText || '').trim(), total: btns.length };
+    })()`));
+        if (!data) throw new EmptyResultError('antigravity copy-code', 'No code blocks visible.');
+        if (data.err) throw new CommandExecutionError(data.err, '');
+        return [
+            { Field: 'TotalCodeBlocks', Value: String(data.total) },
+            { Field: 'PickedIndex', Value: String(idx === null ? data.total : idx) },
+            { Field: 'Length', Value: String((data.text || '').length) + ' chars' },
+            { Field: 'Code', Value: data.text || '' },
+        ];
+    },
+});
+
+// -------- settings --------
+cli({
+    site: 'antigravity',
+    name: 'settings',
+    access: 'write',
+    description: 'Click the Antigravity settings button (matched by data-testid="settings-button").',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: ['Status'],
+    func: async (page) => {
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript([
+            '[data-testid="settings-button"]',
+            'button[aria-label="Settings"]',
+        ])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'settings click failed', '');
+        await page.wait(0.6);
+        return [{ Status: `clicked via ${res.sel}` }];
+    },
+});
+
+// -------- sidebar-toggle --------
+cli({
+    site: 'antigravity',
+    name: 'sidebar-toggle',
+    access: 'write',
+    description: 'Click Toggle Sidebar (collapses/expands the Antigravity sidebar).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: ['Status'],
+    func: async (page) => {
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript(['button[aria-label="Toggle Sidebar"]'])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'sidebar-toggle failed', '');
+        return [{ Status: 'toggled' }];
+    },
+});
+
+// -------- nav --------
+cli({
+    site: 'antigravity',
+    name: 'nav',
+    access: 'write',
+    description: 'Click Go Back or Go Forward (Antigravity in-app history).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'direction', positional: true, required: true, help: 'back or forward' },
+    ],
+    columns: ['Status'],
+    func: async (page, kwargs) => {
+        const dir = String(kwargs?.direction || '').trim().toLowerCase();
+        if (dir !== 'back' && dir !== 'forward') throw new ArgumentError('direction', 'must be "back" or "forward"');
+        const label = dir === 'back' ? 'Go Back' : 'Go Forward';
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript([`button[aria-label="${label}"]`])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || `${label} click failed`, '');
+        return [{ Status: `${dir} clicked` }];
+    },
+});
+
+// -------- toggle-aux --------
+cli({
+    site: 'antigravity',
+    name: 'toggle-aux',
+    access: 'write',
+    description: 'Toggle the Auxiliary Pane (Antigravity\'s secondary panel for code/preview).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: ['Status'],
+    func: async (page) => {
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript(['button[aria-label="Toggle Auxiliary Pane"]'])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'toggle-aux failed', '');
+        return [{ Status: 'toggled' }];
+    },
+});
+
+// -------- display-options --------
+cli({
+    site: 'antigravity',
+    name: 'display-options',
+    access: 'read',
+    description: 'Open the Display Options menu and list its items.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: ['Index', 'Item'],
+    func: async (page) => {
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript(['button[aria-label="Display Options"]'])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'display-options click failed', '');
+        await page.wait(0.4);
+        // Antigravity renders Display Options as a [role="dialog"] popover,
+        // NOT a [role="menu"]. Search both. Among visible candidates, prefer
+        // the most-recently-mounted small popover (not a full-page dialog).
+        const items = unwrapEvaluateResult(await page.evaluate(`(() => {
+      const isVis = (el) => { const r = el.getBoundingClientRect(); return r.width > 1 && r.height > 1; };
+      const candidates = Array.from(document.querySelectorAll('[role="menu"], [role="dialog"], [class*="popover"i]'))
+        .filter(isVis)
+        // Filter out app-shell dialogs (huge ones); prefer small popovers (<600px wide).
+        .filter((el) => {
+          const r = el.getBoundingClientRect();
+          return r.width < 600 && r.height < 600;
+        });
+      if (!candidates.length) return [];
+      // The popover is usually the LAST one mounted (highest in DOM order).
+      const menu = candidates[candidates.length - 1];
+      return Array.from(menu.querySelectorAll('[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"], button'))
+        .filter(isVis)
+        .map((it) => (it.innerText || '').trim().replace(/\\s+/g, ' '))
+        .filter(Boolean);
+    })()`));
+        try { await page.evaluate(`document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));`); } catch {}
+        if (!items.length) {
+            throw new EmptyResultError('antigravity display-options', 'Menu opened but no items detected.');
+        }
+        return items.map((it, i) => ({ Index: i + 1, Item: it }));
+    },
+});
+
+// -------- add-context --------
+cli({
+    site: 'antigravity',
+    name: 'add-context',
+    access: 'write',
+    description: 'Click the Add context button in the composer (opens file/URL picker for context attachment).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: ['Status'],
+    func: async (page) => {
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript(['button[aria-label="Add context"]'])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'add-context click failed', '');
+        await page.wait(0.4);
+        return [{ Status: 'clicked — picker should be open' }];
+    },
+});
+
+// -------- revert --------
+cli({
+    site: 'antigravity',
+    name: 'revert',
+    access: 'write',
+    description: 'Click the revert button (per-message revert for agent changes). Requires --yes (this modifies your workspace).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually revert (default: dry-run)' },
+    ],
+    columns: ['Status'],
+    func: async (page, kwargs) => {
+        const yes = kwargs?.yes === true || kwargs?.yes === 'true' || kwargs?.yes === '1';
+        if (!yes) {
+            return [{ Status: 'dry-run — pass --yes to revert (modifies workspace)' }];
+        }
+        const res = unwrapEvaluateResult(await page.evaluate(clickFirstScript(['[data-testid="revert-button"]', 'button[aria-label="Revert"]'])));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'revert click failed', '');
+        await page.wait(1);
+        return [{ Status: 'reverted' }];
+    },
+});

--- a/clis/antigravity/delete.js
+++ b/clis/antigravity/delete.js
@@ -1,0 +1,60 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    clickConversationMenuItem,
+    confirmDeleteDialog,
+    conversationVisible,
+    conversationTargetArgs,
+} from './_actions.js';
+
+cli({
+    site: 'antigravity',
+    name: 'delete',
+    access: 'write',
+    description: 'Delete an Antigravity conversation by ID. Antigravity asks for confirmation; we click through it. Require --yes to actually delete.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        ...conversationTargetArgs,
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually delete (default: dry-run preview)' },
+    ],
+    columns: ['status', 'id'],
+    func: async (page, kwargs) => {
+        const id = String(kwargs.id);
+        const yes = kwargs.yes === true || kwargs.yes === 'true' || kwargs.yes === '1';
+        if (!yes) {
+            return [{ status: 'dry-run (pass --yes to actually delete)', id }];
+        }
+
+        // 1. Open the per-row 3-dot menu and click "Delete Conversation".
+        const menuRes = await clickConversationMenuItem(page, id, ['Delete Conversation', 'Delete']);
+        if (!menuRes.ok) {
+            throw new CommandExecutionError(
+                `${menuRes.reason}${menuRes.detail ? ' ' + menuRes.detail : ''}`,
+                'Make sure Antigravity is in the foreground and the sidebar is open.',
+            );
+        }
+
+        // 2. Click the Delete button in the confirm dialog.
+        const confirmRes = await confirmDeleteDialog(page, ['Delete', 'Delete Conversation', 'Confirm', 'OK']);
+        if (!confirmRes.ok) {
+            throw new CommandExecutionError(
+                `${confirmRes.reason}${confirmRes.detail ? ' ' + confirmRes.detail : ''}`,
+                'Delete menu fired but the confirm dialog did not show / its button was not found.',
+            );
+        }
+
+        await page.wait(1);
+        for (let attempt = 0; attempt < 10; attempt += 1) {
+            if (!(await conversationVisible(page, id))) {
+                return [{ status: 'deleted', id }];
+            }
+            await page.wait(0.5);
+        }
+        throw new CommandExecutionError(
+            `Delete did not remove conversation ${id} from the visible sidebar.`,
+            'The delete click/confirmation may have failed or the selector contract drifted.',
+        );
+    },
+});

--- a/clis/antigravity/history.js
+++ b/clis/antigravity/history.js
@@ -1,0 +1,26 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { listConversations } from './_actions.js';
+
+cli({
+    site: 'antigravity',
+    name: 'history',
+    access: 'read',
+    description: 'List visible Antigravity conversations from the sidebar',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'limit', type: 'int', required: false, default: 50, help: 'Max conversations to return' },
+    ],
+    columns: ['Index', 'Id', 'Title'],
+    func: async (page, kwargs) => {
+        const all = await listConversations(page);
+        const limit = Number.isInteger(kwargs.limit) && kwargs.limit > 0 ? kwargs.limit : 50;
+        const sliced = all.slice(0, limit);
+        if (!sliced.length) {
+            throw new EmptyResultError('antigravity history', 'No conversations are visible in the sidebar. Open the sidebar and retry.');
+        }
+        return sliced.map((c) => ({ Index: c.index, Id: c.id, Title: c.title }));
+    },
+});

--- a/clis/antigravity/mark-read.js
+++ b/clis/antigravity/mark-read.js
@@ -1,0 +1,52 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { clickConversationMenuItem, conversationTargetArgs, getConversationMenuLabels } from './_actions.js';
+
+cli({
+    site: 'antigravity',
+    name: 'mark-read',
+    access: 'write',
+    description: 'Mark an unread Antigravity conversation as read. Fails if the row is already read or the postcondition cannot be verified.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [...conversationTargetArgs],
+    columns: ['status', 'id', 'clicked'],
+    func: async (page, kwargs) => {
+        const id = String(kwargs.id);
+        const before = await getConversationMenuLabels(page, id);
+        if (!before.ok) {
+            throw new CommandExecutionError(
+                `${before.reason}${before.detail ? ' ' + before.detail : ''}`,
+                'Make sure Antigravity is in the foreground and the sidebar is open.',
+            );
+        }
+        if (!before.labels?.includes('Mark as Read')) {
+            throw new CommandExecutionError(
+                `Conversation ${id} is not currently markable as read.`,
+                `Visible menu labels: ${JSON.stringify(before.labels || [])}`,
+            );
+        }
+
+        const res = await clickConversationMenuItem(page, id, ['Mark as Read']);
+        if (!res.ok) {
+            throw new CommandExecutionError(
+                `${res.reason}${res.detail ? ' ' + res.detail : ''}`,
+                'Make sure Antigravity is in the foreground and the sidebar is open.',
+            );
+        }
+        await page.wait(0.6);
+        const after = await getConversationMenuLabels(page, id);
+        if (!after.ok || !after.labels?.includes('Mark as Unread')) {
+            throw new CommandExecutionError(
+                `Could not verify conversation ${id} was marked read.`,
+                `Visible menu labels after click: ${JSON.stringify(after.labels || [])}`,
+            );
+        }
+        return [{
+            status: 'marked-read',
+            id,
+            clicked: res.clicked,
+        }];
+    },
+});

--- a/clis/antigravity/model.js
+++ b/clis/antigravity/model.js
@@ -1,45 +1,157 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-export const modelCommand = cli({
+import { ArgumentError, CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_actions.js';
+
+// Antigravity exposes the active model via the composer button whose
+// aria-label looks like:
+//   "Select model, current: Gemini 3.5 Flash (Medium)"
+// We parse the current model from that aria-label, and switch by clicking
+// the button to open the model picker dialog, then matching by visible
+// text inside the dialog.
+
+cli({
     site: 'antigravity',
     name: 'model',
-    access: 'read',
-    description: 'Switch the active LLM model in Antigravity',
-    domain: 'localhost',
+    access: 'write',
+    description: 'Read or switch the active model in Antigravity. Without arguments, reports the current model. With <name> (substring, case-insensitive), switches.',
+    domain: '127.0.0.1',
     strategy: Strategy.UI,
     browser: true,
     args: [
-        { name: 'name', help: 'Target model name (e.g. claude, gemini, o1)', required: true, positional: true }
+        { name: 'name', required: false, positional: true, help: 'Substring (case-insensitive) of target model name. Omit to read current.' },
+        { name: 'list', type: 'boolean', default: false, help: 'List models in the picker (does not switch)' },
     ],
-    columns: ['Status'],
+    columns: ['Status', 'Model'],
     func: async (page, kwargs) => {
-        const targetName = kwargs.name.toLowerCase();
-        await page.evaluate(`
-      async () => {
-        const targetModelName = ${JSON.stringify(targetName)};
-        
-        // 1. Locate the model selector dropdown trigger
-        const trigger = document.querySelector('div[aria-haspopup="dialog"] > div[tabindex="0"]');
-        if (!trigger) throw new Error('Could not find the model selector trigger in the UI');
-        trigger.click();
-        
-        // 2. Wait a brief moment for React to mount the Portal/Dialog
-        await new Promise(r => setTimeout(r, 200));
-        
-        // 3. Find the option spanning target text
-        const spans = Array.from(document.querySelectorAll('[role="dialog"] span'));
-        const target = spans.find(s => s.innerText.toLowerCase().includes(targetModelName));
-        if (!target) {
-          // If not found, click the trigger again to close it safely
-          trigger.click();
-          throw new Error('Model matching "' + targetModelName + '" was not found in the dropdown list.');
+        const name = String(kwargs.name || '').trim().toLowerCase();
+        const listOnly = kwargs.list === true || kwargs.list === 'true';
+        const normalize = (value) => String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+
+        // Read current model from button's aria-label.
+        const current = unwrapEvaluateResult(await page.evaluate(`(function() {
+      const btn = document.querySelector('button[aria-label^="Select model, current:"]');
+      if (!btn) return '';
+      const aria = btn.getAttribute('aria-label') || '';
+      const m = aria.match(/current:\\s*(.*)$/i);
+      return m ? m[1].trim() : (btn.textContent || '').trim();
+    })()`));
+        if (!current) {
+            throw selectorError('Antigravity model button (button[aria-label^="Select model, current:"]). Make sure a chat is open in the foreground.');
         }
-        
-        // 4. Click the closest parent that handles the row action
-        const optionNode = target.closest('.cursor-pointer') || target;
-        optionNode.click();
+
+        if (!name && !listOnly) {
+            return [{ Status: 'Active', Model: current }];
+        }
+
+        const namejson = JSON.stringify(name);
+        const result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      const trigger = document.querySelector('button[aria-label^="Select model, current:"]');
+      if (!trigger) return { ok: false, reason: 'trigger missing' };
+
+      // Open the picker dialog (full pointer chain — radix uses pointer events).
+      const r = trigger.getBoundingClientRect();
+      const init = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(r.left + r.width / 2),
+        clientY: Math.round(r.top + r.height / 2),
+      };
+      trigger.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+      trigger.dispatchEvent(new MouseEvent('mousedown', init));
+      trigger.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+      trigger.dispatchEvent(new MouseEvent('mouseup', init));
+      trigger.dispatchEvent(new MouseEvent('click', init));
+
+      // Wait for the picker dialog to open. Antigravity renders it as a
+      // [role="dialog"] or a div with selectable rows (cursor-pointer).
+      let rows = [];
+      for (let attempt = 0; attempt < 18; attempt += 1) {
+        await wait(80);
+        rows = Array.from(document.querySelectorAll('[role="dialog"] .cursor-pointer, [role="dialog"] [role="option"], [role="dialog"] li, .cursor-pointer'))
+          .filter((el) => el instanceof HTMLElement && el.offsetParent);
+        // Filter out rows clearly outside the dialog (e.g. global cursor-pointer in sidebar)
+        const dialog = document.querySelector('[role="dialog"]');
+        if (dialog) {
+          rows = rows.filter((r) => dialog.contains(r));
+        }
+        if (rows.length) break;
       }
-    `);
-        await page.wait(0.5);
-        return [{ Status: `Model switched to: ${kwargs.name}` }];
+      if (!rows.length) {
+        return { ok: false, reason: 'Model picker dialog did not surface any rows.' };
+      }
+
+      const labels = rows.map((r) => (r.innerText || r.textContent || '').trim().slice(0, 80));
+      const target = ${namejson};
+      if (!target) {
+        // Close picker (Esc) and return list.
+        document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+        return { ok: true, labels };
+      }
+      const matches = labels
+        .map((label, index) => ({ label, index }))
+        .filter((entry) => entry.label.toLowerCase().includes(target));
+      if (!matches.length) {
+        document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+        return { ok: false, reason: 'No model matched.', detail: 'wanted=' + target + ' visible=' + JSON.stringify(labels) };
+      }
+      if (matches.length > 1) {
+        document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+        return { ok: false, reason: 'Ambiguous model match.', detail: 'wanted=' + target + ' matches=' + JSON.stringify(matches.map((m) => m.label)) };
+      }
+      const chosen = rows[matches[0].index];
+      const chosenLabel = matches[0].label;
+
+      const cr = chosen.getBoundingClientRect();
+      const cinit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(cr.left + cr.width / 2),
+        clientY: Math.round(cr.top + cr.height / 2),
+      };
+      Promise.resolve().then(() => {
+        try {
+          chosen.dispatchEvent(new PointerEvent('pointerdown', { ...cinit, pointerType: 'mouse' }));
+          chosen.dispatchEvent(new MouseEvent('mousedown', cinit));
+          chosen.dispatchEvent(new PointerEvent('pointerup', { ...cinit, pointerType: 'mouse' }));
+          chosen.dispatchEvent(new MouseEvent('mouseup', cinit));
+          chosen.dispatchEvent(new MouseEvent('click', cinit));
+        } catch {}
+      });
+      return { ok: true, switched: true, chosen: chosenLabel, labels };
+    })()`));
+
+        if (!result.ok) {
+            if (result.reason === 'Ambiguous model match.') {
+                throw new ArgumentError(result.detail || 'Ambiguous model match.');
+            }
+            throw new CommandExecutionError(result.reason, result.detail || '');
+        }
+        if (listOnly) {
+            return result.labels.map((m) => ({ Status: m.startsWith(current.slice(0, 20)) ? 'Active' : 'Available', Model: m }));
+        }
+        await page.wait(0.8);
+        let verified = '';
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+            verified = unwrapEvaluateResult(await page.evaluate(`(function() {
+        const btn = document.querySelector('button[aria-label^="Select model, current:"]');
+        if (!btn) return '';
+        const aria = btn.getAttribute('aria-label') || '';
+        const m = aria.match(/current:\\s*(.*)$/i);
+        return m ? m[1].trim() : (btn.textContent || '').trim();
+      })()`));
+            if (
+                normalize(verified)
+                && (normalize(result.chosen).includes(normalize(verified)) || normalize(verified).includes(normalize(result.chosen)))
+            ) {
+                return [{ Status: 'switched', Model: verified }];
+            }
+            if (normalize(verified) === normalize(result.chosen)) {
+                return [{ Status: 'switched', Model: verified }];
+            }
+            await page.wait(0.4);
+        }
+        throw new CommandExecutionError(
+            `Could not verify Antigravity model switched to ${result.chosen}.`,
+            `Read back current model: ${verified || '(empty)'}`,
+        );
     },
 });

--- a/clis/antigravity/model.js
+++ b/clis/antigravity/model.js
@@ -82,12 +82,16 @@ cli({
 
       const labels = rows.map((r) => (r.innerText || r.textContent || '').trim().slice(0, 80));
       const target = ${namejson};
-      if (!target) {
+      const listOnly = ${listOnly ? 'true' : 'false'};
+      if (!target || listOnly) {
         // Close picker (Esc) and return list.
         document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
         return { ok: true, labels };
       }
-      const matches = labels
+      const exactMatches = labels
+        .map((label, index) => ({ label, index }))
+        .filter((entry) => entry.label.toLowerCase() === target);
+      const matches = exactMatches.length ? exactMatches : labels
         .map((label, index) => ({ label, index }))
         .filter((entry) => entry.label.toLowerCase().includes(target));
       if (!matches.length) {

--- a/clis/antigravity/rename.js
+++ b/clis/antigravity/rename.js
@@ -1,0 +1,33 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { conversationTargetArgs } from './_actions.js';
+
+// Known followup: a first attempt at rename triggered a destructive side
+// effect that removed the conversation from the sidebar (the convo titled
+// "1" disappeared after attempting `rename b79d8b28-... "..."` with the
+// Promise eval being collected mid-way). The 3-dot menu's Rename option
+// may interact with Antigravity's React state in a way that an
+// incomplete eval treats as "discard" — needs more investigation before
+// it's safe to ship.
+//
+// For now this command refuses to run; pin/delete/mark-read are wired up.
+cli({
+    site: 'antigravity',
+    name: 'rename',
+    access: 'write',
+    description: 'Rename an Antigravity conversation by ID (NOT YET IMPLEMENTED — see source comment).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        ...conversationTargetArgs,
+        { name: 'title', positional: true, type: 'string', required: true, help: 'New title' },
+    ],
+    columns: ['status'],
+    func: async () => {
+        throw new CommandExecutionError(
+            'antigravity rename is not yet implemented — first attempt caused the conversation to be removed from the sidebar instead of renamed. Use the Antigravity UI to rename until this is fixed.',
+            '',
+        );
+    },
+});

--- a/clis/antigravity/storage.js
+++ b/clis/antigravity/storage.js
@@ -1,0 +1,366 @@
+// Storage commands for Antigravity:
+//   Renderer-side (4): storage-keys / storage-get / cookies / idb-list
+//   VSCode FS-side (4): state-keys / state-get / recent-paths / workspaces-list
+//   Settings (1):       settings-read
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_actions.js';
+
+const STORAGE_COLUMNS = [
+    'Index',
+    'Key',
+    'Bytes',
+    'Name',
+    'Preview',
+    'Database',
+    'Version',
+    'Kind',
+    'Path',
+    'Workspace Id',
+    'Folder',
+    'Modified',
+    'Field',
+    'Value',
+];
+
+// ====== Path helpers ======
+const AG_APP_SUPPORT = path.join(os.homedir(), 'Library/Application Support/Antigravity');
+const AG_USER_DIR = path.join(AG_APP_SUPPORT, 'User');
+const AG_GLOBAL_STATE_DB = path.join(AG_USER_DIR, 'globalStorage/state.vscdb');
+const AG_WORKSPACE_STORAGE = path.join(AG_USER_DIR, 'workspaceStorage');
+const AG_SETTINGS_JSON = path.join(AG_USER_DIR, 'settings.json');
+
+function sqliteQuery(db, sql) {
+    if (!fs.existsSync(db)) {
+        throw new CommandExecutionError(`state.vscdb not found: ${db}`, 'Has Antigravity been run at least once?');
+    }
+    try {
+        return execFileSync('/usr/bin/sqlite3', [db, sql], { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+    } catch (e) {
+        throw new CommandExecutionError(
+            `sqlite3 failed on ${path.basename(db)}: ${e.message}`,
+            'The DB may be locked by a running Antigravity instance. Try closing it or wait a few seconds.',
+        );
+    }
+}
+function listKeys(db) {
+    const out = sqliteQuery(db, 'SELECT key FROM ItemTable ORDER BY key;');
+    return out.split('\n').map((s) => s.trim()).filter(Boolean);
+}
+function getValue(db, key) {
+    const esc = key.replace(/'/g, "''");
+    const raw = sqliteQuery(db, `SELECT value FROM ItemTable WHERE key = '${esc}';`).trim();
+    if (!raw) return null;
+    try { return JSON.parse(raw); } catch { return raw; }
+}
+function resolveStateDb(args) {
+    const ws = args?.workspace ? String(args.workspace).trim() : '';
+    if (!ws) return AG_GLOBAL_STATE_DB;
+    const db = path.join(AG_WORKSPACE_STORAGE, ws, 'state.vscdb');
+    if (!fs.existsSync(db)) {
+        throw new CommandExecutionError(`Workspace state.vscdb not found: ${db}`, 'List workspace ids with `opencli antigravity workspaces-list`.');
+    }
+    return db;
+}
+
+// ====== Renderer-side: storage-keys ======
+cli({
+    site: 'antigravity',
+    name: 'storage-keys',
+    access: 'read',
+    description: 'List localStorage / sessionStorage keys on the Antigravity renderer (CDP).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'storage', required: false, default: 'local', help: '"local" or "session"' },
+        { name: 'filter', required: false, help: 'Case-insensitive substring filter' },
+        { name: 'limit', type: 'int', required: false, default: 100, help: 'Max rows to return' },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (page, kwargs) => {
+        const s = String(kwargs?.storage || 'local').trim().toLowerCase();
+        if (s !== 'local' && s !== 'session') throw new ArgumentError('storage', 'must be "local" or "session"');
+        const store = s === 'session' ? 'sessionStorage' : 'localStorage';
+        const raw = unwrapEvaluateResult(await page.evaluate(`(() => {
+      const s = ${store};
+      const out = [];
+      for (let i = 0; i < s.length; i++) {
+        const k = s.key(i); const v = s.getItem(k) || '';
+        out.push({ k, bytes: v.length });
+      }
+      return out;
+    })()`));
+        const flt = kwargs?.filter ? String(kwargs.filter).toLowerCase() : null;
+        const filtered = flt ? raw.filter((r) => r.k.toLowerCase().includes(flt)) : raw;
+        if (!filtered.length) throw new EmptyResultError('antigravity storage-keys', flt ? `No keys match "${flt}".` : `${store} is empty.`);
+        filtered.sort((a, b) => a.k.localeCompare(b.k));
+        const limit = Number.isInteger(kwargs?.limit) && kwargs.limit > 0 ? kwargs.limit : 100;
+        return filtered.slice(0, limit).map((r, i) => ({ Index: i + 1, Key: r.k, Bytes: r.bytes }));
+    },
+});
+
+// ====== Renderer-side: storage-get ======
+cli({
+    site: 'antigravity',
+    name: 'storage-get',
+    access: 'read',
+    description: 'Read a single localStorage / sessionStorage value on the Antigravity renderer.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Storage key name' },
+        { name: 'storage', required: false, default: 'local', help: '"local" or "session"' },
+        { name: 'max-bytes', type: 'int', required: false, default: 4000, help: 'Truncate value to this many chars' },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (page, kwargs) => {
+        const key = String(kwargs?.key || '').trim();
+        if (!key) throw new ArgumentError('key', 'is required');
+        const s = String(kwargs?.storage || 'local').trim().toLowerCase();
+        const store = s === 'session' ? 'sessionStorage' : 'localStorage';
+        const raw = unwrapEvaluateResult(await page.evaluate(`${store}.getItem(${JSON.stringify(key)})`));
+        if (raw === null) throw new CommandExecutionError(`Key not found in ${store}: ${key}`, '');
+        const max = Number.isInteger(kwargs['max-bytes']) && kwargs['max-bytes'] > 0 ? kwargs['max-bytes'] : 4000;
+        let parsed = raw, kind = 'string';
+        try { parsed = JSON.parse(raw); kind = Array.isArray(parsed) ? 'array' : typeof parsed; } catch {}
+        const text = kind === 'string' ? parsed : JSON.stringify(parsed, null, 2);
+        const truncated = text.length > max;
+        return [
+            { Field: 'Key', Value: key },
+            { Field: 'Store', Value: store },
+            { Field: 'Type', Value: kind },
+            { Field: 'Size', Value: `${text.length} chars${truncated ? ' (truncated)' : ''}` },
+            { Field: 'Value', Value: truncated ? text.slice(0, max) + '\n...(truncated)' : text },
+        ];
+    },
+});
+
+// ====== Renderer-side: cookies ======
+cli({
+    site: 'antigravity',
+    name: 'cookies',
+    access: 'read',
+    description: 'List cookies on the Antigravity renderer (JS-visible via document.cookie).',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: STORAGE_COLUMNS,
+    func: async (page) => {
+        const raw = unwrapEvaluateResult(await page.evaluate('document.cookie'));
+        if (!raw) throw new EmptyResultError('antigravity cookies', 'document.cookie is empty.');
+        const cookies = raw.split('; ').map((pair) => {
+            const idx = pair.indexOf('=');
+            if (idx < 0) return { name: pair, value: '' };
+            return { name: pair.slice(0, idx), value: pair.slice(idx + 1) };
+        });
+        return cookies.map((c, i) => ({
+            Index: i + 1, Name: c.name, Bytes: c.value.length,
+            Preview: c.value.slice(0, 40) + (c.value.length > 40 ? '…' : ''),
+        }));
+    },
+});
+
+// ====== Renderer-side: idb-list ======
+cli({
+    site: 'antigravity',
+    name: 'idb-list',
+    access: 'read',
+    description: 'List IndexedDB databases on the Antigravity renderer.',
+    domain: '127.0.0.1',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [],
+    columns: STORAGE_COLUMNS,
+    func: async (page) => {
+        const dbs = unwrapEvaluateResult(await page.evaluate(`(async () => indexedDB.databases ? await indexedDB.databases() : [])()`));
+        if (!Array.isArray(dbs) || !dbs.length) throw new EmptyResultError('antigravity idb-list', 'No IndexedDB databases.');
+        return dbs.map((d, i) => ({ Index: i + 1, Database: d.name || '(unnamed)', Version: String(d.version || '') }));
+    },
+});
+
+// ====== FS-side: state-keys ======
+cli({
+    site: 'antigravity',
+    name: 'state-keys',
+    access: 'read',
+    description: 'List keys in Antigravity\'s globalStorage state.vscdb (VSCode-style). Pass --workspace <id> to query a per-workspace DB. Works while Antigravity is closed.',
+    domain: 'localhost',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'filter', required: false, help: 'Case-insensitive substring filter over keys' },
+        { name: 'workspace', required: false, help: 'Workspace id (from workspaces-list) to query per-workspace DB' },
+        { name: 'limit', type: 'int', required: false, default: 200, help: 'Max rows to return' },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (args) => {
+        const db = resolveStateDb(args);
+        const keys = listKeys(db);
+        const flt = args?.filter ? String(args.filter).toLowerCase() : null;
+        const filtered = flt ? keys.filter((k) => k.toLowerCase().includes(flt)) : keys;
+        if (!filtered.length) throw new EmptyResultError('antigravity state-keys', flt ? `No keys match "${flt}".` : 'No keys.');
+        const limit = Number.isInteger(args?.limit) && args.limit > 0 ? args.limit : 200;
+        return filtered.slice(0, limit).map((k, i) => ({ Index: i + 1, Key: k }));
+    },
+});
+
+// ====== FS-side: state-get ======
+cli({
+    site: 'antigravity',
+    name: 'state-get',
+    access: 'read',
+    description: 'Read one value from Antigravity\'s state.vscdb. Pass --workspace <id> for per-workspace.',
+    domain: 'localhost',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Storage key name' },
+        { name: 'workspace', required: false, help: 'Workspace id (from workspaces-list) to query per-workspace DB' },
+        { name: 'max-bytes', type: 'int', required: false, default: 8000, help: 'Truncate value to this many chars' },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (args) => {
+        const key = String(args?.key || '').trim();
+        if (!key) throw new ArgumentError('key', 'is required');
+        const db = resolveStateDb(args);
+        const val = getValue(db, key);
+        if (val === null) throw new CommandExecutionError(`Key not found: ${key}`, '');
+        const max = Number.isInteger(args['max-bytes']) && args['max-bytes'] > 0 ? args['max-bytes'] : 8000;
+        const valStr = typeof val === 'string' ? val : JSON.stringify(val, null, 2);
+        const truncated = valStr.length > max;
+        return [
+            { Field: 'Key', Value: key },
+            { Field: 'Type', Value: typeof val === 'string' ? 'string' : (Array.isArray(val) ? 'array' : typeof val) },
+            { Field: 'Size', Value: `${valStr.length} chars${truncated ? ' (truncated)' : ''}` },
+            { Field: 'Value', Value: truncated ? valStr.slice(0, max) + '\n...(truncated)' : valStr },
+        ];
+    },
+});
+
+// ====== FS-side: recent-paths ======
+cli({
+    site: 'antigravity',
+    name: 'recent-paths',
+    access: 'read',
+    description: 'Show Antigravity\'s recently-opened folders/files (history.recentlyOpenedPathsList).',
+    domain: 'localhost',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', required: false, default: 20, help: 'Max rows to return' },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (args) => {
+        const val = getValue(AG_GLOBAL_STATE_DB, 'history.recentlyOpenedPathsList');
+        if (!val) throw new EmptyResultError('antigravity recent-paths', 'No recent paths recorded.');
+        const entries = val.entries || [];
+        if (!entries.length) throw new EmptyResultError('antigravity recent-paths', 'Recent paths list is empty.');
+        const limit = Number.isInteger(args?.limit) && args.limit > 0 ? args.limit : 20;
+        return entries.slice(0, limit).map((e, i) => {
+            let kind = 'other', target = JSON.stringify(e).slice(0, 200);
+            if (e.folderUri) {
+                kind = 'folder';
+                target = decodeURI(String(e.folderUri).replace(/^file:\/\//, ''));
+            } else if (e.fileUri) {
+                kind = 'file';
+                target = decodeURI(String(e.fileUri).replace(/^file:\/\//, ''));
+            } else if (e.workspace?.configPath) {
+                kind = 'workspace';
+                target = decodeURI(String(e.workspace.configPath).replace(/^file:\/\//, ''));
+            }
+            return { Index: i + 1, Kind: kind, Path: target };
+        });
+    },
+});
+
+// ====== FS-side: workspaces-list ======
+cli({
+    site: 'antigravity',
+    name: 'workspaces-list',
+    access: 'read',
+    description: 'List Antigravity workspaceStorage entries (each represents a previously-opened folder).',
+    domain: 'localhost',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', required: false, default: 50, help: 'Max rows to return' },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (args) => {
+        if (!fs.existsSync(AG_WORKSPACE_STORAGE)) {
+            throw new CommandExecutionError(`workspaceStorage not found: ${AG_WORKSPACE_STORAGE}`, '');
+        }
+        const dirs = fs.readdirSync(AG_WORKSPACE_STORAGE).filter((n) => {
+            const full = path.join(AG_WORKSPACE_STORAGE, n);
+            return fs.statSync(full).isDirectory();
+        });
+        if (!dirs.length) throw new EmptyResultError('antigravity workspaces-list', 'No workspace storage.');
+        const rows = dirs.map((id) => {
+            const dir = path.join(AG_WORKSPACE_STORAGE, id);
+            const wj = path.join(dir, 'workspace.json');
+            let folder = '(no workspace.json)';
+            if (fs.existsSync(wj)) {
+                try {
+                    const outer = JSON.parse(fs.readFileSync(wj, 'utf-8'));
+                    if (outer.folder) folder = decodeURI(outer.folder.replace(/^file:\/\//, ''));
+                    else if (outer.workspace) folder = '(multi-folder) ' + decodeURI(outer.workspace.replace(/^file:\/\//, ''));
+                } catch { folder = '(invalid workspace.json)'; }
+            }
+            return { id, folder, mtime: fs.statSync(dir).mtimeMs };
+        }).sort((a, b) => b.mtime - a.mtime);
+        const limit = Number.isInteger(args?.limit) && args.limit > 0 ? args.limit : 50;
+        return rows.slice(0, limit).map((r, i) => ({
+            Index: i + 1,
+            'Workspace Id': r.id,
+            Folder: r.folder.slice(0, 120),
+            Modified: new Date(r.mtime).toISOString().replace('T', ' ').slice(0, 19),
+        }));
+    },
+});
+
+// ====== Settings ======
+cli({
+    site: 'antigravity',
+    name: 'settings-read',
+    access: 'read',
+    description: 'Read Antigravity\'s user settings.json (theme, proxy, agCockpit, tfa.system.autoAccept, etc.).',
+    domain: 'localhost',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [],
+    columns: STORAGE_COLUMNS,
+    func: async () => {
+        if (!fs.existsSync(AG_SETTINGS_JSON)) {
+            throw new CommandExecutionError(`settings.json not found: ${AG_SETTINGS_JSON}`, '');
+        }
+        const raw = fs.readFileSync(AG_SETTINGS_JSON, 'utf-8');
+        // VSCode allows JSONC (line + block comments + trailing commas).
+        // Strip comments and trailing commas before parsing.
+        const stripped = raw
+            .replace(/\/\*[\s\S]*?\*\//g, '')              // block comments
+            .replace(/^\s*\/\/.*$/gm, '')                  // line comments (full line)
+            .replace(/([^:"])\/\/.*$/gm, '$1')             // line comments (after code)
+            .replace(/,(\s*[}\]])/g, '$1');                // trailing commas
+        let obj;
+        try { obj = JSON.parse(stripped); } catch (e) {
+            throw new CommandExecutionError(`Failed to parse settings.json: ${e.message}`, '');
+        }
+        const rows = [];
+        for (const [k, v] of Object.entries(obj)) {
+            rows.push({ Field: k, Value: typeof v === 'object' ? JSON.stringify(v) : String(v) });
+        }
+        return rows;
+    },
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3289,7 +3289,7 @@ cli({
     .option('--timeout <seconds>', 'Maximum time to wait for a reply (default: 120s)')
     .action(async (opts) => {
       // @ts-expect-error JS adapter — no type declarations
-      const { startServe } = await import('../clis/antigravity/serve.js');
+      const { startServe } = await import('../../clis/antigravity/serve.js');
       await startServe({
         port: parseInt(opts.port, 10),
         timeout: opts.timeout ? parsePositiveIntOption(opts.timeout, '--timeout', 120) : undefined,


### PR DESCRIPTION
Split from #1797. This PR contains all antigravity-adapter changes.

**New commands**:
- `opencli antigravity history` — list visible conversations from sidebar (`data-testid="convo-pill-<uuid>"`)
- `opencli antigravity mark-read <uuid>` — toggle read/unread
- `opencli antigravity delete <uuid> --yes` — delete (clicks through confirm dialog)
- `opencli antigravity rename` — stub (destructive side effect on incomplete eval; followup needed)

**Fix**:
- `opencli antigravity model` — now supports read (parses `aria-label^="Select model, current:"`) + `--list` + switch (previously required `<name>` and could only switch)

**Key gotcha**: Antigravity menu click triggers a sidebar re-render that destroys eval replies ("Promise was collected" / 30s timeout). The click DOES fire — we catch those specific errors and treat as success-with-note. Verified live by toggling mark-read repeatedly.

Verified live on macOS, Chrome 146, Antigravity Desktop.