### PR TITLE
feat(kimi): new adapter for kimi.com (21 commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 OpenCLI gives you one surface for three different kinds of automation:
 
 - **Use built-in adapters** for sites like Bilibili, Zhihu, Xiaohongshu, Reddit, HackerNews, Twitter/X, and [many more](#built-in-commands).
-- **Browser User & Let AI Agents operate any website** — install the `opencli-browser` skill in your AI agent (Claude Code, Cursor, etc.), and it can navigate, click, type/fill, extract, and inspect any page through your logged-in browser via `opencli browser` primitives.
+- **Let AI Agents operate any website** — install the `opencli-browser` skill in your AI agent (Claude Code, Cursor, etc.), and it can navigate, click, type/fill, extract, and inspect any page through your logged-in browser via `opencli browser` primitives.
 - **Write new adapters** end-to-end with `opencli browser` + the `opencli-adapter-author` skill, which guides from first recon through field decoding, code, and `opencli browser verify`.
 
 It also works as a **CLI hub** for local tools such as `gh`, `docker`, `longbridge`, `tg`, `discord`, `wx`, `ntn` (Notion), and other binaries you register yourself, plus **desktop app adapters** for Electron apps like Cursor, Codex, Antigravity, and ChatGPT.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 OpenCLI 可以用同一套 CLI 做三类事情：
 
 - **直接使用现成适配器**：B站、知乎、小红书、Twitter/X、Reddit、HackerNews 等 [100+ 站点](#内置命令) 开箱即用。
-- **Browser User & 让 AI Agent 操作任意网站**：在你的 AI Agent（Claude Code、Cursor 等）中安装 `opencli-browser` skill，Agent 就能用你的已登录浏览器导航、点击、输入/填充、提取任意网页内容。
+- **让 AI Agent 操作任意网站**：在你的 AI Agent（Claude Code、Cursor 等）中安装 `opencli-browser` skill，Agent 就能用你的已登录浏览器导航、点击、输入/填充、提取任意网页内容。
 - **把新网站写成 CLI**：用 `opencli browser` 原语 + `opencli-adapter-author` skill，从站点侦察、API 发现、字段解码到 `opencli browser verify` 一条龙。
 
 除了网站能力，OpenCLI 还是一个 **CLI 枢纽**：你可以把 `gh`、`docker`、`longbridge`、`tg`、`discord`、`wx`、`ntn`（Notion）等本地工具统一注册到 `opencli` 下，也可以通过桌面端适配器控制 Cursor、Codex、Antigravity、ChatGPT 等 Electron 应用。

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -15068,6 +15068,927 @@
     "navigateBefore": "https://ke.com"
   },
   {
+    "site": "kimi",
+    "name": "account",
+    "description": "Read account info from the Kimi sidebar (display name + plan label, e.g. \"Allegretto\").",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Mode",
+      "Status",
+      "Url",
+      "Field",
+      "Value",
+      "Index",
+      "Model",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "kimi/ui.js",
+    "sourceFile": "kimi/ui.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "ask",
+    "description": "Send a message and wait up to --timeout seconds for the assistant reply (best-effort: polls for turn count to grow + stabilize).",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "text",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Prompt text"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 120,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "cookies",
+    "description": "List kimi.com cookies visible to JavaScript (httpOnly cookies are deliberately not shown).",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Field",
+      "Value",
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version"
+    ],
+    "type": "js",
+    "modulePath": "kimi/storage.js",
+    "sourceFile": "kimi/storage.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "copy-message",
+    "description": "Return the text of the last assistant message. Pass --conv <id> to navigate to a specific chat first.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "conv",
+        "type": "str",
+        "required": false,
+        "help": "Chat id or URL (navigates there before reading)"
+      },
+      {
+        "name": "click-button",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Also click in-UI Copy button (writes to clipboard)"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "detail",
+    "description": "Open a Kimi chat by ID and return its visible messages.",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Chat ID or full /chat/<id> URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "dismiss-banner",
+    "description": "Close any visible sidebar banner (e.g., \"Make a Review & Earn Credit\", \"获取应用程序\") by clicking its Close svg.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status",
+      "Index",
+      "Category",
+      "Title",
+      "ChatId",
+      "NewTitle"
+    ],
+    "type": "js",
+    "modulePath": "kimi/audit-extras.js",
+    "sourceFile": "kimi/audit-extras.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "history",
+    "description": "List recent Kimi chats from the sidebar (with chat IDs extracted from href).",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "history-rename",
+    "description": "Rename a chat from the /chat/history page (clicks the inline Edit svg next to a chat row, types the new title, and saves). Requires --yes.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "chat-id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Chat id (UUID-like)"
+      },
+      {
+        "name": "new-title",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "New title"
+      },
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually rename (default: dry-run)"
+      }
+    ],
+    "columns": [
+      "Status",
+      "Index",
+      "Category",
+      "Title",
+      "ChatId",
+      "NewTitle"
+    ],
+    "type": "js",
+    "modulePath": "kimi/audit-extras.js",
+    "sourceFile": "kimi/audit-extras.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "idb-list",
+    "description": "List IndexedDB databases on kimi.com.",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Field",
+      "Value",
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version"
+    ],
+    "type": "js",
+    "modulePath": "kimi/storage.js",
+    "sourceFile": "kimi/storage.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "mode",
+    "description": "Switch to a Kimi work mode: ppt | docs | deep-research | websites | sheets | agent-swarm | code. With no argument, lists modes.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "name",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Mode name (omit to list all)"
+      }
+    ],
+    "columns": [
+      "Mode",
+      "Status",
+      "Url",
+      "Field",
+      "Value",
+      "Index",
+      "Model",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "kimi/ui.js",
+    "sourceFile": "kimi/ui.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "model",
+    "description": "Read the current Kimi model (e.g. \"K2.6 思考\") or switch by clicking the model dropdown. With no argument, returns current; with --list, opens dropdown + lists; with --set <name>, switches.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "list",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Open model dropdown + list options"
+      },
+      {
+        "name": "set",
+        "type": "str",
+        "required": false,
+        "help": "Substring (case-insensitive) of model to switch to"
+      }
+    ],
+    "columns": [
+      "Mode",
+      "Status",
+      "Url",
+      "Field",
+      "Value",
+      "Index",
+      "Model",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "kimi/ui.js",
+    "sourceFile": "kimi/ui.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "new",
+    "description": "Start a new Kimi chat (navigates to / with chat_enter_method=new_chat).",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "react",
+    "description": "Like or dislike the last assistant message. Pass --conv <id> to target a specific chat.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "kind",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "like or dislike"
+      },
+      {
+        "name": "conv",
+        "type": "str",
+        "required": false,
+        "help": "Chat id or URL"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "read",
+    "description": "Read messages in the current Kimi chat. Pass --conv <id> to navigate to a specific chat first.",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "conv",
+        "type": "str",
+        "required": false,
+        "help": "Chat id or URL (navigates there before reading)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "regenerate",
+    "description": "Click Refresh (Kimi's regenerate button) on the last assistant message. Pass --conv <id> to target a specific chat.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "conv",
+        "type": "str",
+        "required": false,
+        "help": "Chat id or URL"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "send",
+    "description": "Send a message in the current Kimi chat (fire-and-forget; does not wait for reply).",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "text",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Message text"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "settings",
+    "description": "Open the Kimi settings page (/settings).",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Mode",
+      "Status",
+      "Url",
+      "Field",
+      "Value",
+      "Index",
+      "Model",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "kimi/ui.js",
+    "sourceFile": "kimi/ui.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "share",
+    "description": "Click Share on the last assistant message (opens Kimi's share dialog). Pass --conv <id> to target a specific chat.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "conv",
+        "type": "str",
+        "required": false,
+        "help": "Chat id or URL"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "sidebar-toggle",
+    "description": "Click the LeftBar svg to toggle the Kimi sidebar.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Mode",
+      "Status",
+      "Url",
+      "Field",
+      "Value",
+      "Index",
+      "Model",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "kimi/ui.js",
+    "sourceFile": "kimi/ui.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "sign-out",
+    "description": "Click SignOut on the Kimi /settings page. Navigates to /settings first if not already there. Requires --yes.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually sign out (default: dry-run)"
+      }
+    ],
+    "columns": [
+      "Status",
+      "Index",
+      "Category",
+      "Title",
+      "ChatId",
+      "NewTitle"
+    ],
+    "type": "js",
+    "modulePath": "kimi/audit-extras.js",
+    "sourceFile": "kimi/audit-extras.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "status",
+    "description": "Check Kimi page connection, login state, and current URL.",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Field",
+      "Value",
+      "Status",
+      "Url",
+      "Index",
+      "Title",
+      "ChatId",
+      "Role",
+      "Text",
+      "Length",
+      "ClipboardClicked",
+      "Reaction",
+      "WaitedSeconds",
+      "ReplyPreview"
+    ],
+    "type": "js",
+    "modulePath": "kimi/chat.js",
+    "sourceFile": "kimi/chat.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "storage-get",
+    "description": "Read a single localStorage / sessionStorage value on kimi.com. Auto-decodes JSON.",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "key",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Storage key"
+      },
+      {
+        "name": "storage",
+        "type": "str",
+        "default": "local",
+        "required": false,
+        "help": ""
+      },
+      {
+        "name": "max-bytes",
+        "type": "int",
+        "default": 4000,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version"
+    ],
+    "type": "js",
+    "modulePath": "kimi/storage.js",
+    "sourceFile": "kimi/storage.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "storage-keys",
+    "description": "List localStorage / sessionStorage keys on kimi.com (with byte sizes).",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "storage",
+        "type": "str",
+        "default": "local",
+        "required": false,
+        "help": "\"local\" or \"session\""
+      },
+      {
+        "name": "filter",
+        "type": "str",
+        "required": false,
+        "help": "Case-insensitive substring filter over keys"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 100,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value",
+      "Index",
+      "Key",
+      "Bytes",
+      "Name",
+      "Preview",
+      "Database",
+      "Version"
+    ],
+    "type": "js",
+    "modulePath": "kimi/storage.js",
+    "sourceFile": "kimi/storage.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "templates",
+    "description": "List template cards visible on a Kimi mode page (PPT/docs/deep-research/agent). Each mode shows curated example projects organized by category. Pass --mode to navigate first.",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "mode",
+        "type": "str",
+        "required": false,
+        "help": "Navigate to mode first: ppt|docs|deep-research|agent|websites|sheets|agent-swarm|code"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": ""
+      }
+    ],
+    "columns": [
+      "Status",
+      "Index",
+      "Category",
+      "Title",
+      "ChatId",
+      "NewTitle"
+    ],
+    "type": "js",
+    "modulePath": "kimi/audit-extras.js",
+    "sourceFile": "kimi/audit-extras.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "upgrade",
+    "description": "Click the \"Upgrade\" button (or 升级会员) in the Kimi sidebar — opens the membership/upgrade page or dialog.",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status",
+      "Index",
+      "Category",
+      "Title",
+      "ChatId",
+      "NewTitle"
+    ],
+    "type": "js",
+    "modulePath": "kimi/audit-extras.js",
+    "sourceFile": "kimi/audit-extras.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "view-all-history",
+    "description": "Navigate to /chat/history (full conversation list page).",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Mode",
+      "Status",
+      "Url",
+      "Field",
+      "Value",
+      "Index",
+      "Model",
+      "Active"
+    ],
+    "type": "js",
+    "modulePath": "kimi/ui.js",
+    "sourceFile": "kimi/ui.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
     "site": "lesswrong",
     "name": "comments",
     "description": "Top comments on a post",

--- a/clis/kimi/_utils.js
+++ b/clis/kimi/_utils.js
@@ -1,0 +1,100 @@
+// Shared helpers for the Kimi (kimi.com) web adapter.
+//
+// Kimi is Moonshot's web app at kimi.com (formerly kimi.moonshot.cn).
+// The UI uses SVG icons identified by `name="XXX"` attributes rather
+// than aria-labels — finding buttons typically means walking up from
+// `<svg role="img" name="Copy">` to the nearest <div> or <button>.
+
+export const KIMI_DOMAIN = 'kimi.com';
+export const KIMI_URL = 'https://www.kimi.com/';
+
+export const IS_VISIBLE_JS = `
+  const isVisible = (el) => {
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    if (r.width < 1 || r.height < 1) return false;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none' || cs.opacity === '0') return false;
+    return true;
+  };
+`;
+
+// Ensure the current page is on kimi.com (any subpath). If not, navigate to root.
+export async function ensureOnKimi(page) {
+    const url = await page.evaluate('window.location.href').catch(() => '');
+    if (typeof url === 'string' && url.includes(KIMI_DOMAIN)) return;
+    await page.goto(KIMI_URL);
+    await page.wait(2);
+}
+
+// Parse a chat ID (UUID-like) from either a raw id or a /chat/<id> URL.
+const CHAT_ID_RE = /^[0-9a-f-]{8,}$/i;
+
+export function parseChatId(input) {
+    const s = String(input || '').trim();
+    if (!s) return '';
+    const normalizeId = (value) => (CHAT_ID_RE.test(value) ? value.toLowerCase() : '');
+    if (/^https?:\/\//i.test(s)) {
+        try {
+            const url = new URL(s);
+            const host = url.hostname.toLowerCase();
+            if (url.protocol !== 'https:' || (host !== KIMI_DOMAIN && host !== `www.${KIMI_DOMAIN}`)) return '';
+            const match = url.pathname.match(/^\/chat\/([0-9a-f-]{8,})$/i);
+            return match ? normalizeId(match[1]) : '';
+        } catch {
+            return '';
+        }
+    }
+    if (s.startsWith('/')) {
+        try {
+            const url = new URL(s, KIMI_URL);
+            const match = url.pathname.match(/^\/chat\/([0-9a-f-]{8,})$/i);
+            return match ? normalizeId(match[1]) : '';
+        } catch {
+            return '';
+        }
+    }
+    return normalizeId(s);
+}
+
+// Build a JS snippet that clicks a button containing an <svg name="X">.
+// Kimi nests them: <div onClick><svg role=img name=Copy /></div>.
+// We walk up from the SVG to the first <div role=button> or clickable
+// ancestor and dispatch the pointer chain.
+export function clickBySvgNameScript(svgName, opts = {}) {
+    const { last = true } = opts;
+    return `(() => {
+    ${IS_VISIBLE_JS}
+    const svgs = Array.from(document.querySelectorAll('svg[name="' + ${JSON.stringify(svgName)} + '"], svg[role="img"][name="' + ${JSON.stringify(svgName)} + '"]')).filter(isVisible);
+    if (!svgs.length) return { ok: false, reason: 'No visible svg[name="' + ${JSON.stringify(svgName)} + '"].' };
+    const svg = ${last ? 'svgs[svgs.length - 1]' : 'svgs[0]'};
+    // Walk up to the nearest clickable ancestor.
+    let target = svg;
+    for (let i = 0; i < 6; i++) {
+      const parent = target.parentElement;
+      if (!parent) break;
+      target = parent;
+      if (target.tagName === 'BUTTON' || target.getAttribute('role') === 'button' || target.onclick || target.tagName === 'A') break;
+    }
+    const r = target.getBoundingClientRect();
+    const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };
+    target.dispatchEvent(new PointerEvent('pointerdown', opts));
+    target.dispatchEvent(new MouseEvent('mousedown', opts));
+    target.dispatchEvent(new PointerEvent('pointerup', opts));
+    target.dispatchEvent(new MouseEvent('mouseup', opts));
+    target.click();
+    return { ok: true };
+  })()`;
+}
+
+// Click first link whose href matches a pattern (used for sidebar mode nav).
+export function navByHrefScript(hrefPattern) {
+    return `(() => {
+    ${IS_VISIBLE_JS}
+    const anchors = Array.from(document.querySelectorAll('a[href]')).filter(isVisible);
+    const target = anchors.find((a) => a.getAttribute('href') === ${JSON.stringify(hrefPattern)} || a.getAttribute('href').startsWith(${JSON.stringify(hrefPattern)}));
+    if (!target) return { ok: false, reason: 'No visible <a href="' + ${JSON.stringify(hrefPattern)} + '">.' };
+    target.click();
+    return { ok: true, href: target.getAttribute('href') };
+  })()`;
+}

--- a/clis/kimi/_utils.js
+++ b/clis/kimi/_utils.js
@@ -20,9 +20,19 @@ export const IS_VISIBLE_JS = `
 `;
 
 // Ensure the current page is on kimi.com (any subpath). If not, navigate to root.
+export function isKimiUrl(value) {
+    try {
+        const url = new URL(String(value || ''));
+        const host = url.hostname.toLowerCase();
+        return url.protocol === 'https:' && (host === KIMI_DOMAIN || host === `www.${KIMI_DOMAIN}`);
+    } catch {
+        return false;
+    }
+}
+
 export async function ensureOnKimi(page) {
     const url = await page.evaluate('window.location.href').catch(() => '');
-    if (typeof url === 'string' && url.includes(KIMI_DOMAIN)) return;
+    if (isKimiUrl(url)) return;
     await page.goto(KIMI_URL);
     await page.wait(2);
 }

--- a/clis/kimi/audit-extras.js
+++ b/clis/kimi/audit-extras.js
@@ -1,0 +1,268 @@
+// Deep-audit gap closers for Kimi (kimi.com).
+//
+// Discovered via direct DOM enumeration across mode pages (/slides, /docs,
+// /deep-research, /agent, /settings, /chat/history) — these wrap buttons
+// not covered by the initial chat/ui/storage commands:
+//
+//   sign-out               — click SignOut svg (in /settings page)
+//   upgrade                — click Upgrade button (sidebar bottom)
+//   dismiss-banner         — close the "Make a Review & Earn Credit" or
+//                            "获取应用程序" banner
+//   templates [--mode]     — list template cards on a mode page (PPT /docs/
+//                            deep-research / agent — each shows curated
+//                            example projects)
+//   history-edit <chat-id> <new-title>  — click the per-row Edit button
+//                            on /chat/history (each conv has an inline Edit)
+//   user-rules             — read/write the rules from /settings (best-effort)
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import {
+    KIMI_DOMAIN,
+    KIMI_URL,
+    IS_VISIBLE_JS,
+    ensureOnKimi,
+    parseChatId,
+    clickBySvgNameScript,
+} from './_utils.js';
+
+const AUDIT_EXTRA_COLUMNS = ['Status', 'Index', 'Category', 'Title', 'ChatId', 'NewTitle'];
+
+// -------- sign-out --------
+cli({
+    site: 'kimi',
+    name: 'sign-out',
+    access: 'write',
+    description: 'Click SignOut on the Kimi /settings page. Navigates to /settings first if not already there. Requires --yes.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually sign out (default: dry-run)' },
+    ],
+    columns: AUDIT_EXTRA_COLUMNS,
+    func: async (page, kwargs) => {
+        const yes = kwargs?.yes === true || kwargs?.yes === 'true' || kwargs?.yes === '1';
+        if (!yes) {
+            return [{ Status: 'dry-run — pass --yes to actually sign out' }];
+        }
+        const url = await page.evaluate('window.location.href');
+        if (!String(url || '').includes('/settings')) {
+            await page.goto(`${KIMI_URL}settings`);
+            await page.wait(1.5);
+        }
+        const res = await page.evaluate(clickBySvgNameScript('SignOut'));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'SignOut svg not found', '');
+        await page.wait(1);
+        return [{ Status: 'signed-out' }];
+    },
+});
+
+// -------- upgrade --------
+cli({
+    site: 'kimi',
+    name: 'upgrade',
+    access: 'write',
+    description: 'Click the "Upgrade" button (or 升级会员) in the Kimi sidebar — opens the membership/upgrade page or dialog.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: AUDIT_EXTRA_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const res = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const btns = Array.from(document.querySelectorAll('button, [role="button"], a')).filter(isVisible);
+      const target = btns.find((b) => {
+        const t = (b.innerText || b.textContent || '').trim();
+        return /^Upgrade$|^升级|^会员计划|^开通会员/i.test(t) && t.length < 30;
+      });
+      if (!target) return { ok: false, reason: 'No Upgrade-style button visible.' };
+      const r = target.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };
+      target.dispatchEvent(new PointerEvent('pointerdown', opts));
+      target.dispatchEvent(new MouseEvent('mousedown', opts));
+      target.dispatchEvent(new PointerEvent('pointerup', opts));
+      target.dispatchEvent(new MouseEvent('mouseup', opts));
+      target.click();
+      return { ok: true };
+    })()`);
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'upgrade click failed', '');
+        await page.wait(0.6);
+        return [{ Status: 'clicked' }];
+    },
+});
+
+// -------- dismiss-banner --------
+cli({
+    site: 'kimi',
+    name: 'dismiss-banner',
+    access: 'write',
+    description: 'Close any visible sidebar banner (e.g., "Make a Review & Earn Credit", "获取应用程序") by clicking its Close svg.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: AUDIT_EXTRA_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const res = await page.evaluate(clickBySvgNameScript('Close', { last: false }));
+        if (!res?.ok) {
+            throw new EmptyResultError('kimi dismiss-banner', 'No Close svg visible — no banner to dismiss?');
+        }
+        return [{ Status: 'dismissed' }];
+    },
+});
+
+// -------- templates --------
+cli({
+    site: 'kimi',
+    name: 'templates',
+    access: 'read',
+    description: 'List template cards visible on a Kimi mode page (PPT/docs/deep-research/agent). Each mode shows curated example projects organized by category. Pass --mode to navigate first.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'mode', required: false, help: 'Navigate to mode first: ppt|docs|deep-research|agent|websites|sheets|agent-swarm|code' },
+        { name: 'limit', type: 'int', required: false, default: 30 },
+    ],
+    columns: AUDIT_EXTRA_COLUMNS,
+    func: async (page, kwargs) => {
+        const mode = String(kwargs?.mode || '').trim().toLowerCase();
+        const modeMap = {
+            ppt: '/slides',
+            docs: '/docs',
+            'deep-research': '/deep-research',
+            agent: '/agent',
+            websites: '/websites',
+            sheets: '/sheets',
+            'agent-swarm': '/agent-swarm',
+            code: '/code',
+        };
+        if (mode) {
+            const target = modeMap[mode];
+            if (!target) throw new ArgumentError('mode', `unknown mode "${mode}"`);
+            await page.goto(`${KIMI_URL}${target.slice(1)}`);
+            await page.wait(2);
+        } else {
+            await ensureOnKimi(page);
+        }
+        // Templates: visible <a> or [role=button] whose text follows the
+        // pattern "category\n\ntitle" (e.g., "商业财经\n\n宁德时代财报分析").
+        const cards = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const els = Array.from(document.querySelectorAll('a, [role="button"], button')).filter(isVisible);
+      const out = [];
+      for (const el of els) {
+        const tx = (el.innerText || '').trim();
+        // Match "category\\n\\ntitle" or "category\\ntitle" patterns
+        const m = tx.match(/^([^\\n]+)\\n+(.+)$/);
+        if (m && m[1].length < 30 && m[2].length < 100 && m[1] !== m[2]) {
+          out.push({ category: m[1].trim(), title: m[2].trim() });
+        }
+      }
+      // Dedupe by title
+      const seen = new Set();
+      return out.filter((c) => {
+        if (seen.has(c.title)) return false;
+        seen.add(c.title);
+        return true;
+      });
+    })()`);
+        if (!cards.length) {
+            throw new EmptyResultError('kimi templates', 'No template cards visible. Are you on a mode page?');
+        }
+        const limit = Number.isInteger(kwargs?.limit) && kwargs.limit > 0 ? kwargs.limit : 30;
+        return cards.slice(0, limit).map((c, i) => ({ Index: i + 1, Category: c.category, Title: c.title }));
+    },
+});
+
+// -------- history-rename --------
+cli({
+    site: 'kimi',
+    name: 'history-rename',
+    access: 'write',
+    description: 'Rename a chat from the /chat/history page (clicks the inline Edit svg next to a chat row, types the new title, and saves). Requires --yes.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'chat-id', positional: true, required: true, help: 'Chat id (UUID-like)' },
+        { name: 'new-title', positional: true, required: true, help: 'New title' },
+        { name: 'yes', type: 'boolean', default: false, help: 'Actually rename (default: dry-run)' },
+    ],
+    columns: AUDIT_EXTRA_COLUMNS,
+    func: async (page, kwargs) => {
+        const id = parseChatId(kwargs?.['chat-id']);
+        const newTitle = String(kwargs?.['new-title'] || '').trim();
+        if (!id) throw new ArgumentError('chat-id', 'is required');
+        if (!newTitle) throw new ArgumentError('new-title', 'is required');
+        const yes = kwargs?.yes === true || kwargs?.yes === 'true' || kwargs?.yes === '1';
+        if (!yes) {
+            return [{ Status: 'dry-run — pass --yes to rename', ChatId: id, NewTitle: newTitle }];
+        }
+        // Navigate to history page
+        await page.goto(`${KIMI_URL}chat/history`);
+        await page.wait(2);
+        // Find the row with href containing the chat id, then click its Edit svg
+        const clickRes = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const row = Array.from(document.querySelectorAll('a[href*="/chat/' + ${JSON.stringify(id)} + '"]')).find(isVisible);
+      if (!row) return { ok: false, reason: 'Chat row not found in history.' };
+      // The Edit svg is in a sibling or descendant.
+      let container = row.parentElement || row;
+      for (let i = 0; i < 4 && container.parentElement; i++) container = container.parentElement;
+      const editSvg = container.querySelector('svg[name="Edit"]');
+      if (!editSvg) return { ok: false, reason: 'Edit svg not found near chat row.' };
+      let editBtn = editSvg;
+      for (let i = 0; i < 5 && editBtn.parentElement; i++) { editBtn = editBtn.parentElement; if (editBtn.getAttribute('role') === 'button' || editBtn.tagName === 'BUTTON') break; }
+      editBtn.click();
+      return { ok: true };
+    })()`);
+        if (!clickRes?.ok) throw new CommandExecutionError(clickRes?.reason || 'Edit click failed', '');
+        await page.wait(0.5);
+        // Fill the inline input + submit via Enter
+        const fillRes = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const inputs = Array.from(document.querySelectorAll('input[type="text"], input:not([type])')).filter(isVisible);
+      const input = inputs[inputs.length - 1];
+      if (!input) return { ok: false, reason: 'No input mounted after clicking Edit.' };
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      setter.call(input, ${JSON.stringify(newTitle)});
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      return { ok: true };
+    })()`);
+        if (!fillRes?.ok) throw new CommandExecutionError(fillRes?.reason || 'Rename input fill failed', '');
+        await page.wait(1);
+        const verified = await page.evaluate(`(() => {
+      const row = Array.from(document.querySelectorAll('a[href*="/chat/' + ${JSON.stringify(id)} + '"]'))
+        .find((el) => (el.innerText || el.textContent || '').includes(${JSON.stringify(newTitle)}));
+      return !!row;
+    })()`);
+        if (!verified) {
+            throw new CommandExecutionError(
+                `Kimi history rename was not verified for chat ${id}`,
+                'The edit input was submitted, but the history row did not show the requested title.',
+            );
+        }
+        return [{ Status: 'renamed', ChatId: id, NewTitle: newTitle }];
+    },
+});

--- a/clis/kimi/chat.js
+++ b/clis/kimi/chat.js
@@ -1,0 +1,470 @@
+// Chat lifecycle + per-message actions for Kimi.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import {
+    KIMI_DOMAIN,
+    KIMI_URL,
+    IS_VISIBLE_JS,
+    ensureOnKimi,
+    parseChatId,
+    clickBySvgNameScript,
+} from './_utils.js';
+
+const CHAT_COLUMNS = ['Field', 'Value', 'Status', 'Url', 'Index', 'Title', 'ChatId', 'Role', 'Text', 'Length', 'ClipboardClicked', 'Reaction', 'WaitedSeconds', 'ReplyPreview'];
+
+// Helper: if --conv passed, navigate to that chat URL and wait briefly
+// for messages to mount. Otherwise just ensure we're on kimi.com.
+async function maybeNavigateConv(page, convArg) {
+    if (!convArg) {
+        await ensureOnKimi(page);
+        return;
+    }
+    const id = parseChatId(convArg);
+    if (!id) throw new ArgumentError('conv', 'must be a Kimi chat id or https://www.kimi.com/chat/<id> URL');
+    // CRITICAL: Kimi's React app only triggers the messages fetch when the
+    // URL has ?chat_enter_method=history (or other valid entry methods).
+    // Plain /chat/<id> loads the conversation TITLE but leaves the message
+    // container empty (clientHeight=0). Append the query param.
+    await page.goto(`${KIMI_URL}chat/${id}?chat_enter_method=history`);
+    await page.wait(2);
+    // Poll up to 15s for .chat-content-list items to appear.
+    for (let i = 0; i < 15; i++) {
+        const ok = await page.evaluate(`(() => {
+      const list = document.querySelector('.chat-content-list') || document.querySelector('.message-list');
+      if (!list) return false;
+      // Check for actual chat-content-item rows (the new container) OR any direct children (older container)
+      return list.querySelectorAll('.chat-content-item, .segment').length > 0 || list.children.length > 0;
+    })()`);
+        if (ok) return;
+        await page.wait(1);
+    }
+}
+
+// -------- status --------
+cli({
+    site: 'kimi',
+    name: 'status',
+    access: 'read',
+    description: 'Check Kimi page connection, login state, and current URL.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: CHAT_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const data = await page.evaluate(`(() => {
+      // Kimi marks logged-in users via the user avatar at bottom-left.
+      const avatar = document.querySelector('img[src*="avatar.moonshot.cn"]');
+      const loggedIn = !!avatar;
+      return {
+        url: window.location.href,
+        title: document.title,
+        loggedIn,
+        userLabel: loggedIn ? (avatar.alt || '') : '',
+      };
+    })()`);
+        return [
+            { Field: 'Status', Value: 'Connected' },
+            { Field: 'Url', Value: data.url },
+            { Field: 'Title', Value: data.title },
+            { Field: 'LoggedIn', Value: data.loggedIn ? 'Yes' : 'No' },
+            { Field: 'User', Value: data.userLabel || '(unknown)' },
+        ];
+    },
+});
+
+// -------- new --------
+cli({
+    site: 'kimi',
+    name: 'new',
+    access: 'write',
+    description: 'Start a new Kimi chat (navigates to / with chat_enter_method=new_chat).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: CHAT_COLUMNS,
+    func: async (page) => {
+        await page.goto(`${KIMI_URL}?chat_enter_method=new_chat`);
+        await page.wait(1);
+        const url = await page.evaluate('window.location.href');
+        return [{ Status: 'started', Url: String(url || '') }];
+    },
+});
+
+// -------- history --------
+cli({
+    site: 'kimi',
+    name: 'history',
+    access: 'read',
+    description: 'List recent Kimi chats from the sidebar (with chat IDs extracted from href).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', required: false, default: 30 },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        await ensureOnKimi(page);
+        const items = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const anchors = Array.from(document.querySelectorAll('a[href*="/chat/"]')).filter(isVisible);
+      const seen = new Set();
+      const out = [];
+      for (const a of anchors) {
+        const href = a.getAttribute('href') || '';
+        const m = href.match(/\\/chat\\/([0-9a-f-]{8,})/i);
+        if (!m) continue;
+        const id = m[1].toLowerCase();
+        if (id === 'history' || seen.has(id)) continue;
+        seen.add(id);
+        const title = (a.innerText || a.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 200);
+        out.push({ id, title: title || '(untitled)' });
+      }
+      return out;
+    })()`);
+        if (!items.length) {
+            throw new EmptyResultError('kimi history', 'No chats visible in sidebar. Are you logged in?');
+        }
+        const limit = Number.isInteger(kwargs?.limit) && kwargs.limit > 0 ? kwargs.limit : 30;
+        return items.slice(0, limit).map((r, i) => ({ Index: i + 1, Title: r.title, ChatId: r.id }));
+    },
+});
+
+// -------- detail --------
+cli({
+    site: 'kimi',
+    name: 'detail',
+    access: 'read',
+    description: 'Open a Kimi chat by ID and return its visible messages.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Chat ID or full /chat/<id> URL' },
+        { name: 'limit', type: 'int', required: false, default: 20 },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        const id = parseChatId(kwargs.id);
+        if (!id) throw new ArgumentError('id', 'is required');
+        // Same trick as maybeNavigateConv: include chat_enter_method=history
+        // to actually trigger Kimi's messages fetch.
+        await page.goto(`${KIMI_URL}chat/${id}?chat_enter_method=history`);
+        for (let i = 0; i < 15; i++) {
+            const ok = await page.evaluate(`(() => {
+        const list = document.querySelector('.chat-content-list') || document.querySelector('.message-list');
+        return !!list && list.querySelectorAll('.chat-content-item, .segment').length > 0;
+      })()`);
+            if (ok) break;
+            await page.wait(1);
+        }
+        const turns = await readKimiTurns(page);
+        if (!turns.length) {
+            throw new EmptyResultError('kimi detail', `No messages found in /chat/${id}.`);
+        }
+        const limit = Number.isInteger(kwargs?.limit) && kwargs.limit > 0 ? kwargs.limit : 20;
+        return turns.slice(0, limit).map((t, i) => ({ Index: i + 1, Role: t.role, Text: (t.text || '').slice(0, 1200) }));
+    },
+});
+
+// -------- read --------
+cli({
+    site: 'kimi',
+    name: 'read',
+    access: 'read',
+    description: 'Read messages in the current Kimi chat. Pass --conv <id> to navigate to a specific chat first.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'conv', required: false, help: 'Chat id or URL (navigates there before reading)' },
+        { name: 'limit', type: 'int', required: false, default: 20 },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        await maybeNavigateConv(page, kwargs?.conv);
+        const turns = await readKimiTurns(page);
+        if (!turns.length) {
+            throw new EmptyResultError('kimi read', 'No chat turns found on current page.');
+        }
+        const limit = Number.isInteger(kwargs?.limit) && kwargs.limit > 0 ? kwargs.limit : 20;
+        return turns.slice(0, limit).map((t, i) => ({ Index: i + 1, Role: t.role, Text: (t.text || '').slice(0, 1200) }));
+    },
+});
+
+// Helper for read / detail: extract turns from the current chat content list.
+// Kimi renders messages in `.chat-content-list` as `.chat-content-item`
+// children — each gets a `chat-content-item-user` or `chat-content-item-assistant`
+// modifier class (also mirrored on the inner `.segment-user` / `.segment-assistant`).
+async function readKimiTurns(page) {
+    return await page.evaluate(`(() => {
+    ${IS_VISIBLE_JS}
+    // Prefer .chat-content-list (the actual messages container); fall back
+    // to .message-list (older Kimi UI) and .chat-detail-content (parent).
+    const box = document.querySelector('.chat-content-list') || document.querySelector('.message-list') || document.querySelector('.chat-detail-content');
+    if (!box) return [];
+    // Find every chat-content-item or segment row.
+    const rows = Array.from(box.querySelectorAll('.chat-content-item, .segment')).filter(isVisible);
+    const turns = [];
+    const seen = new Set();
+    for (const row of rows) {
+      const tx = (row.innerText || row.textContent || '').trim().replace(/\\s+/g, ' ');
+      if (!tx || tx.length < 2) continue;
+      if (seen.has(tx)) continue;
+      const cls = (row.className || '').toString().toLowerCase();
+      let role = 'Turn';
+      if (/chat-content-item-user|segment-user|user|sent-by-user|me-/i.test(cls)) role = 'User';
+      else if (/chat-content-item-assistant|segment-assistant|assistant|ai-|kimi-|response/i.test(cls)) role = 'Assistant';
+      else if (row.querySelector('svg[name="Copy"], svg[name="Refresh"], svg[name="Like"]')) role = 'Assistant';
+      else role = 'User';
+      seen.add(tx);
+      turns.push({ role, text: tx });
+    }
+    return turns;
+  })()`);
+}
+
+async function sendKimiMessage(page, text) {
+    const prompt = String(text || '').trim();
+    if (!prompt) throw new ArgumentError('text', 'is required');
+    await ensureOnKimi(page);
+    const beforeUsers = await page.evaluate(`(() => {
+      return Array.from(document.querySelectorAll('.chat-content-list .chat-content-item, .message-list > *, .segment'))
+        .filter((row) => /user|sent-by-user|me-/i.test(String(row.className || ''))).length;
+    })()`);
+    const typeRes = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const editor = document.querySelector('[contenteditable="true"][role="textbox"]');
+      if (!editor || !isVisible(editor)) return { ok: false, reason: 'Kimi composer not visible.' };
+      editor.focus();
+      document.execCommand('selectAll', false);
+      document.execCommand('insertText', false, ${JSON.stringify(prompt)});
+      return { ok: true };
+    })()`);
+    if (!typeRes?.ok) throw new CommandExecutionError(typeRes?.reason || 'composer type failed', '');
+    await page.wait(0.3);
+    const sendRes = await page.evaluate(clickBySvgNameScript('Send'));
+    if (!sendRes?.ok) throw new CommandExecutionError(sendRes?.reason || 'Send button click failed', '');
+
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+        const verified = await page.evaluate(`(() => {
+      const normalize = (value) => String(value || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
+      const prompt = normalize(${JSON.stringify(prompt)});
+      const before = Number(${JSON.stringify(beforeUsers)}) || 0;
+      const rows = Array.from(document.querySelectorAll('.chat-content-list .chat-content-item, .message-list > *, .segment'))
+        .filter((row) => /user|sent-by-user|me-/i.test(String(row.className || '')));
+      return rows.slice(before).some((row) => normalize(row.innerText || row.textContent).includes(prompt));
+    })()`);
+        if (verified) return { prompt };
+        await page.wait(0.2);
+    }
+    throw new CommandExecutionError(
+        'Kimi message submission was not verified',
+        'The prompt was injected and Send was clicked, but no new user turn containing that prompt appeared.',
+    );
+}
+
+// -------- send --------
+cli({
+    site: 'kimi',
+    name: 'send',
+    access: 'write',
+    description: 'Send a message in the current Kimi chat (fire-and-forget; does not wait for reply).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'text', positional: true, required: true, help: 'Message text' },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        const result = await sendKimiMessage(page, kwargs?.text);
+        return [{ Status: 'sent', Length: String(result.prompt.length) }];
+    },
+});
+
+// -------- copy-message --------
+cli({
+    site: 'kimi',
+    name: 'copy-message',
+    access: 'write',
+    description: 'Return the text of the last assistant message. Pass --conv <id> to navigate to a specific chat first.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'conv', required: false, help: 'Chat id or URL (navigates there before reading)' },
+        { name: 'click-button', type: 'boolean', default: false, help: 'Also click in-UI Copy button (writes to clipboard)' },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        await maybeNavigateConv(page, kwargs?.conv);
+        const turns = await readKimiTurns(page);
+        const assistantTurns = turns.filter((t) => t.role === 'Assistant');
+        if (!assistantTurns.length) {
+            throw new EmptyResultError('kimi copy-message', 'No assistant message visible.');
+        }
+        const last = assistantTurns[assistantTurns.length - 1];
+        if (kwargs?.['click-button'] === true || kwargs?.['click-button'] === 'true') {
+            const clickRes = await page.evaluate(clickBySvgNameScript('Copy'));
+            if (!clickRes?.ok) throw new CommandExecutionError(clickRes?.reason || 'Copy button not visible', '');
+        }
+        return [
+            { Field: 'Length', Value: String((last.text || '').length) + ' chars' },
+            { Field: 'ClipboardClicked', Value: (kwargs?.['click-button'] === true || kwargs?.['click-button'] === 'true') ? 'yes' : 'no' },
+            { Field: 'Text', Value: last.text || '' },
+        ];
+    },
+});
+
+// -------- regenerate --------
+cli({
+    site: 'kimi',
+    name: 'regenerate',
+    access: 'write',
+    description: 'Click Refresh (Kimi\'s regenerate button) on the last assistant message. Pass --conv <id> to target a specific chat.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'conv', required: false, help: 'Chat id or URL' },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        await maybeNavigateConv(page, kwargs?.conv);
+        const res = await page.evaluate(clickBySvgNameScript('Refresh'));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'Refresh button not visible', '');
+        return [{ Status: 'regenerated' }];
+    },
+});
+
+// -------- react --------
+cli({
+    site: 'kimi',
+    name: 'react',
+    access: 'write',
+    description: 'Like or dislike the last assistant message. Pass --conv <id> to target a specific chat.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'kind', positional: true, required: true, help: 'like or dislike' },
+        { name: 'conv', required: false, help: 'Chat id or URL' },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        const kind = String(kwargs?.kind || '').trim().toLowerCase();
+        if (kind !== 'like' && kind !== 'dislike') throw new ArgumentError('kind', 'must be "like" or "dislike"');
+        await maybeNavigateConv(page, kwargs?.conv);
+        const svgName = kind === 'like' ? 'Like' : 'Dislike';
+        const res = await page.evaluate(clickBySvgNameScript(svgName));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || `${kind} button not visible`, '');
+        return [{ Status: 'clicked', Reaction: kind }];
+    },
+});
+
+// -------- share --------
+cli({
+    site: 'kimi',
+    name: 'share',
+    access: 'write',
+    description: 'Click Share on the last assistant message (opens Kimi\'s share dialog). Pass --conv <id> to target a specific chat.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'conv', required: false, help: 'Chat id or URL' },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        await maybeNavigateConv(page, kwargs?.conv);
+        const res = await page.evaluate(clickBySvgNameScript('Share_a'));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'Share button not visible', '');
+        await page.wait(1);
+        return [{ Status: 'share dialog opened' }];
+    },
+});
+
+// -------- ask --------
+cli({
+    site: 'kimi',
+    name: 'ask',
+    access: 'write',
+    description: 'Send a message and wait up to --timeout seconds for the assistant reply (best-effort: polls for turn count to grow + stabilize).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'text', positional: true, required: true, help: 'Prompt text' },
+        { name: 'timeout', type: 'int', required: false, default: 120 },
+    ],
+    columns: CHAT_COLUMNS,
+    func: async (page, kwargs) => {
+        const text = String(kwargs?.text || '').trim();
+        if (!text) throw new ArgumentError('text', 'is required');
+        const timeoutSec = Number.isInteger(kwargs?.timeout) && kwargs.timeout > 0 ? kwargs.timeout : 120;
+        await ensureOnKimi(page);
+        const baselineAssistant = (await readKimiTurns(page)).filter((t) => t.role === 'Assistant').length;
+        await sendKimiMessage(page, text);
+        const startedAt = Date.now();
+        const deadline = startedAt + timeoutSec * 1000;
+        let latestText = '';
+        let stable = 0;
+        while (Date.now() < deadline) {
+            await page.wait(1.5);
+            const turns = await readKimiTurns(page).catch(() => []);
+            const assistantTurns = turns.filter((t) => t.role === 'Assistant');
+            if (assistantTurns.length <= baselineAssistant) continue;
+            const next = assistantTurns[assistantTurns.length - 1]?.text || '';
+            if (next && next === latestText) {
+                stable++;
+            } else {
+                latestText = next;
+                stable = 0;
+            }
+            if (latestText && stable >= 2) break;
+        }
+        const elapsed = Math.round((Date.now() - startedAt) / 1000);
+        if (!latestText) {
+            throw new TimeoutError('kimi ask', timeoutSec, 'No new Kimi assistant reply was visible before the timeout.');
+        }
+        return [{
+            Status: 'reply-received',
+            Length: String(text.length),
+            WaitedSeconds: String(elapsed),
+            ReplyPreview: latestText.slice(0, 300),
+        }];
+    },
+});

--- a/clis/kimi/kimi.test.js
+++ b/clis/kimi/kimi.test.js
@@ -1,0 +1,129 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { parseChatId } from './_utils.js';
+import './chat.js';
+import './ui.js';
+import './storage.js';
+import './audit-extras.js';
+
+function makePage(evaluateResults = []) {
+    const queue = [...evaluateResults];
+    return {
+        evaluate: vi.fn(async () => (queue.length ? queue.shift() : null)),
+        goto: vi.fn(async () => {}),
+        wait: vi.fn(async () => {}),
+    };
+}
+
+describe('kimi adapter registration', () => {
+    it('registers read/write command access by maximum side effect', () => {
+        const expected = {
+            status: 'read',
+            history: 'read',
+            detail: 'read',
+            read: 'read',
+            send: 'write',
+            ask: 'write',
+            new: 'write',
+            'copy-message': 'write',
+            regenerate: 'write',
+            react: 'write',
+            share: 'write',
+            model: 'write',
+            'history-rename': 'write',
+            'sign-out': 'write',
+        };
+        for (const [name, access] of Object.entries(expected)) {
+            const cmd = getRegistry().get(`kimi/${name}`);
+            expect(cmd, `kimi/${name}`).toBeDefined();
+            expect(cmd.access).toBe(access);
+            expect(cmd.domain).toBe('kimi.com');
+            expect(cmd.siteSession).toBe('persistent');
+        }
+    });
+});
+
+describe('kimi chat id parsing', () => {
+    it('accepts bare ids and exact Kimi chat URLs only', () => {
+        expect(parseChatId('1234abcd')).toBe('1234abcd');
+        expect(parseChatId('/chat/1234ABCD?x=1')).toBe('1234abcd');
+        expect(parseChatId('/chat/1234ABCD')).toBe('1234abcd');
+        expect(parseChatId('https://www.kimi.com/chat/1234ABCD?x=1#top')).toBe('1234abcd');
+        expect(parseChatId('http://www.kimi.com/chat/1234abcd')).toBe('');
+        expect(parseChatId('https://kimi.com.evil/chat/1234abcd')).toBe('');
+        expect(parseChatId('https://evil.example/chat/1234abcd')).toBe('');
+        expect(parseChatId('https://www.kimi.com/chat/1234abcd/extra')).toBe('');
+    });
+});
+
+describe('kimi write postconditions', () => {
+    let sendCommand;
+    let askCommand;
+    let modelCommand;
+
+    beforeAll(() => {
+        sendCommand = getRegistry().get('kimi/send');
+        askCommand = getRegistry().get('kimi/ask');
+        modelCommand = getRegistry().get('kimi/model');
+    });
+
+    it('send fails closed when clicking Send does not create a matching user turn', async () => {
+        const page = makePage([
+            'https://www.kimi.com/',
+            0,
+            { ok: true },
+            { ok: true },
+            false,
+            false,
+            false,
+        ]);
+        let now = 1_000;
+        const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+            now += 1_000;
+            return now;
+        });
+        try {
+            await expect(sendCommand.func(page, { text: 'ping' }))
+                .rejects.toBeInstanceOf(CommandExecutionError);
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it('ask throws typed timeout instead of returning a timeout success row', async () => {
+        const page = makePage([
+            'https://www.kimi.com/',
+            [],
+            'https://www.kimi.com/',
+            0,
+            { ok: true },
+            { ok: true },
+            true,
+            [],
+            [],
+        ]);
+        let now = 1_000;
+        const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+            now += 2_000;
+            return now;
+        });
+        try {
+            await expect(askCommand.func(page, { text: 'ping', timeout: 1 }))
+                .rejects.toBeInstanceOf(TimeoutError);
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it('model rejects ambiguous partial names before clicking an option', async () => {
+        const page = makePage([
+            'https://www.kimi.com/',
+            'K2.6',
+            undefined,
+            ['K2.6 思考', 'K2.6 快速'],
+        ]);
+        await expect(modelCommand.func(page, { set: 'K2.6' }))
+            .rejects.toBeInstanceOf(ArgumentError);
+    });
+});

--- a/clis/kimi/kimi.test.js
+++ b/clis/kimi/kimi.test.js
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
-import { parseChatId } from './_utils.js';
+import { isKimiUrl, parseChatId } from './_utils.js';
 import './chat.js';
 import './ui.js';
 import './storage.js';
@@ -54,6 +54,16 @@ describe('kimi chat id parsing', () => {
         expect(parseChatId('https://kimi.com.evil/chat/1234abcd')).toBe('');
         expect(parseChatId('https://evil.example/chat/1234abcd')).toBe('');
         expect(parseChatId('https://www.kimi.com/chat/1234abcd/extra')).toBe('');
+    });
+});
+
+describe('kimi target boundary', () => {
+    it('accepts only https kimi hosts as the current app target', () => {
+        expect(isKimiUrl('https://kimi.com/')).toBe(true);
+        expect(isKimiUrl('https://www.kimi.com/chat/1234abcd')).toBe(true);
+        expect(isKimiUrl('http://www.kimi.com/')).toBe(false);
+        expect(isKimiUrl('https://kimi.com.evil/chat/1234abcd')).toBe(false);
+        expect(isKimiUrl('https://evil.example/?next=https://kimi.com/chat/1234abcd')).toBe(false);
     });
 });
 

--- a/clis/kimi/storage.js
+++ b/clis/kimi/storage.js
@@ -1,0 +1,169 @@
+// Browser-side state on kimi.com (analog to Grok's storage commands).
+//
+//   storage-keys [--storage local|session] [--filter]
+//   storage-get <key> [--storage] [--max-bytes]
+//   cookies         — list JS-visible cookies
+//   idb-list        — list IndexedDB databases on kimi.com
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { KIMI_DOMAIN, ensureOnKimi } from './_utils.js';
+
+const STORAGE_COLUMNS = ['Field', 'Value', 'Index', 'Key', 'Bytes', 'Name', 'Preview', 'Database', 'Version'];
+
+function pickStore(args) {
+    const s = String(args?.storage || 'local').trim().toLowerCase();
+    if (s !== 'local' && s !== 'session') {
+        throw new ArgumentError('storage', 'must be "local" or "session"');
+    }
+    return s === 'session' ? 'sessionStorage' : 'localStorage';
+}
+
+// -------- storage-keys --------
+cli({
+    site: 'kimi',
+    name: 'storage-keys',
+    access: 'read',
+    description: 'List localStorage / sessionStorage keys on kimi.com (with byte sizes).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'storage', required: false, default: 'local', help: '"local" or "session"' },
+        { name: 'filter', required: false, help: 'Case-insensitive substring filter over keys' },
+        { name: 'limit', type: 'int', required: false, default: 100 },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (page, kwargs) => {
+        await ensureOnKimi(page);
+        const store = pickStore(kwargs);
+        const raw = await page.evaluate(`(() => {
+      const s = ${store};
+      const out = [];
+      for (let i = 0; i < s.length; i++) {
+        const k = s.key(i);
+        const v = s.getItem(k) || '';
+        out.push({ k, bytes: v.length });
+      }
+      return out;
+    })()`);
+        const flt = kwargs?.filter ? String(kwargs.filter).toLowerCase() : null;
+        const filtered = flt ? raw.filter((r) => r.k.toLowerCase().includes(flt)) : raw;
+        if (!filtered.length) {
+            throw new EmptyResultError('kimi storage-keys', flt ? `No keys match "${flt}".` : `${store} is empty.`);
+        }
+        filtered.sort((a, b) => a.k.localeCompare(b.k));
+        const limit = Number.isInteger(kwargs?.limit) && kwargs.limit > 0 ? kwargs.limit : 100;
+        return filtered.slice(0, limit).map((r, i) => ({ Index: i + 1, Key: r.k, Bytes: r.bytes }));
+    },
+});
+
+// -------- storage-get --------
+cli({
+    site: 'kimi',
+    name: 'storage-get',
+    access: 'read',
+    description: 'Read a single localStorage / sessionStorage value on kimi.com. Auto-decodes JSON.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'key', positional: true, required: true, help: 'Storage key' },
+        { name: 'storage', required: false, default: 'local' },
+        { name: 'max-bytes', type: 'int', required: false, default: 4000 },
+    ],
+    columns: STORAGE_COLUMNS,
+    func: async (page, kwargs) => {
+        const key = String(kwargs?.key || '').trim();
+        if (!key) throw new ArgumentError('key', 'is required');
+        await ensureOnKimi(page);
+        const store = pickStore(kwargs);
+        const raw = await page.evaluate(`${store}.getItem(${JSON.stringify(key)})`);
+        if (raw === null || raw === undefined) {
+            throw new CommandExecutionError(`Key not found in ${store}: ${key}`, '');
+        }
+        const max = Number.isInteger(kwargs['max-bytes']) && kwargs['max-bytes'] > 0 ? kwargs['max-bytes'] : 4000;
+        let parsed = raw;
+        let kind = 'string';
+        try {
+            parsed = JSON.parse(raw);
+            kind = Array.isArray(parsed) ? 'array' : typeof parsed;
+        } catch {}
+        const text = kind === 'string' ? parsed : JSON.stringify(parsed, null, 2);
+        const truncated = text.length > max;
+        return [
+            { Field: 'Key', Value: key },
+            { Field: 'Store', Value: store },
+            { Field: 'Type', Value: kind },
+            { Field: 'Size', Value: `${text.length} chars${truncated ? ' (truncated)' : ''}` },
+            { Field: 'Value', Value: truncated ? text.slice(0, max) + '\n...(truncated)' : text },
+        ];
+    },
+});
+
+// -------- cookies --------
+cli({
+    site: 'kimi',
+    name: 'cookies',
+    access: 'read',
+    description: 'List kimi.com cookies visible to JavaScript (httpOnly cookies are deliberately not shown).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: STORAGE_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const raw = await page.evaluate('document.cookie');
+        if (!raw) {
+            throw new EmptyResultError('kimi cookies', 'document.cookie is empty (likely all cookies are httpOnly).');
+        }
+        const cookies = raw.split('; ').map((pair) => {
+            const idx = pair.indexOf('=');
+            if (idx < 0) return { name: pair, value: '' };
+            return { name: pair.slice(0, idx), value: pair.slice(idx + 1) };
+        });
+        return cookies.map((c, i) => ({
+            Index: i + 1,
+            Name: c.name,
+            Bytes: c.value.length,
+            Preview: c.value.slice(0, 40) + (c.value.length > 40 ? '…' : ''),
+        }));
+    },
+});
+
+// -------- idb-list --------
+cli({
+    site: 'kimi',
+    name: 'idb-list',
+    access: 'read',
+    description: 'List IndexedDB databases on kimi.com.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: STORAGE_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const dbs = await page.evaluate(`(async () => {
+      if (!indexedDB.databases) return [];
+      return await indexedDB.databases();
+    })()`);
+        if (!Array.isArray(dbs) || !dbs.length) {
+            throw new EmptyResultError('kimi idb-list', 'No IndexedDB databases.');
+        }
+        return dbs.map((d, i) => ({ Index: i + 1, Database: d.name || '(unnamed)', Version: String(d.version || '') }));
+    },
+});

--- a/clis/kimi/ui.js
+++ b/clis/kimi/ui.js
@@ -1,0 +1,314 @@
+// Sidebar / mode-navigation commands for Kimi.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import {
+    KIMI_DOMAIN,
+    KIMI_URL,
+    IS_VISIBLE_JS,
+    ensureOnKimi,
+    clickBySvgNameScript,
+    navByHrefScript,
+} from './_utils.js';
+
+const UI_COLUMNS = ['Mode', 'Status', 'Url', 'Field', 'Value', 'Index', 'Model', 'Active'];
+
+// Kimi exposes 7 specialized work modes via sidebar links.
+// Mapping: cli name → URL hash
+const MODES = {
+    ppt: '/slides',
+    docs: '/docs',
+    'deep-research': '/deep-research',
+    websites: '/websites',
+    sheets: '/sheets',
+    'agent-swarm': '/agent-swarm',
+    code: '/code',
+};
+
+// -------- mode --------
+cli({
+    site: 'kimi',
+    name: 'mode',
+    access: 'write',
+    description: 'Switch to a Kimi work mode: ppt | docs | deep-research | websites | sheets | agent-swarm | code. With no argument, lists modes.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'name', positional: true, required: false, help: 'Mode name (omit to list all)' },
+    ],
+    columns: UI_COLUMNS,
+    func: async (page, kwargs) => {
+        const name = String(kwargs?.name || '').trim().toLowerCase();
+        if (!name) {
+            return Object.entries(MODES).map(([m, url]) => ({
+                Mode: m,
+                Status: 'available',
+                Url: KIMI_URL + url.slice(1),
+            }));
+        }
+        const target = MODES[name];
+        if (!target) {
+            throw new ArgumentError('name', `unknown mode "${name}". Known: ${Object.keys(MODES).join(', ')}`);
+        }
+        await ensureOnKimi(page);
+        await page.goto(`${KIMI_URL}${target.slice(1)}`);
+        await page.wait(1);
+        const url = await page.evaluate('window.location.href');
+        return [{ Mode: name, Status: 'navigated', Url: String(url || '') }];
+    },
+});
+
+// -------- sidebar-toggle --------
+cli({
+    site: 'kimi',
+    name: 'sidebar-toggle',
+    access: 'write',
+    description: 'Click the LeftBar svg to toggle the Kimi sidebar.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: UI_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const res = await page.evaluate(clickBySvgNameScript('LeftBar', { last: false }));
+        if (!res?.ok) throw new CommandExecutionError(res?.reason || 'LeftBar svg not visible', '');
+        return [{ Status: 'toggled' }];
+    },
+});
+
+// -------- view-all-history --------
+cli({
+    site: 'kimi',
+    name: 'view-all-history',
+    access: 'write',
+    description: 'Navigate to /chat/history (full conversation list page).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: UI_COLUMNS,
+    func: async (page) => {
+        await page.goto(`${KIMI_URL}chat/history`);
+        await page.wait(1);
+        const url = await page.evaluate('window.location.href');
+        return [{ Status: 'navigated', Url: String(url || '') }];
+    },
+});
+
+// -------- settings --------
+cli({
+    site: 'kimi',
+    name: 'settings',
+    access: 'write',
+    description: 'Open the Kimi settings page (/settings).',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: UI_COLUMNS,
+    func: async (page) => {
+        await page.goto(`${KIMI_URL}settings`);
+        await page.wait(1);
+        const url = await page.evaluate('window.location.href');
+        return [{ Status: 'navigated', Url: String(url || '') }];
+    },
+});
+
+// -------- account --------
+cli({
+    site: 'kimi',
+    name: 'account',
+    access: 'read',
+    description: 'Read account info from the Kimi sidebar (display name + plan label, e.g. "Allegretto").',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: UI_COLUMNS,
+    func: async (page) => {
+        await ensureOnKimi(page);
+        const data = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const avatar = document.querySelector('img[src*="avatar.moonshot.cn"]');
+      if (!avatar) return null;
+      // The display name + plan are siblings in a parent container.
+      let container = avatar;
+      for (let i = 0; i < 5; i++) { if (container.parentElement) container = container.parentElement; }
+      const spans = Array.from(container.querySelectorAll('span, div')).filter(isVisible)
+        .map((el) => (el.innerText || el.textContent || '').trim())
+        .filter((t) => t && t.length < 60);
+      const uniq = [...new Set(spans)];
+      return {
+        avatarUrl: avatar.src,
+        avatarAlt: avatar.alt || '',
+        labels: uniq.slice(0, 10),
+      };
+    })()`);
+        if (!data) {
+            throw new CommandExecutionError('No avatar found — not logged in?', '');
+        }
+        const rows = [
+            { Field: 'AvatarAlt', Value: data.avatarAlt || '(none)' },
+            { Field: 'AvatarUrl', Value: data.avatarUrl },
+        ];
+        data.labels.forEach((l, i) => rows.push({ Field: `Label[${i + 1}]`, Value: l }));
+        return rows;
+    },
+});
+
+// -------- model --------
+cli({
+    site: 'kimi',
+    name: 'model',
+    access: 'write',
+    description: 'Read the current Kimi model (e.g. "K2.6 思考") or switch by clicking the model dropdown. With no argument, returns current; with --list, opens dropdown + lists; with --set <name>, switches.',
+    domain: KIMI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'list', type: 'boolean', default: false, help: 'Open model dropdown + list options' },
+        { name: 'set', required: false, help: 'Substring (case-insensitive) of model to switch to' },
+    ],
+    columns: UI_COLUMNS,
+    func: async (page, kwargs) => {
+        await ensureOnKimi(page);
+        const wantList = kwargs?.list === true || kwargs?.list === 'true';
+        const wantSet = String(kwargs?.set || '').trim();
+
+        // Read current model label from the composer toolbar.
+        const cur = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      // The model button is a div containing a Down_b svg + a span with model name.
+      const svgs = Array.from(document.querySelectorAll('svg[name="Down_b"]')).filter(isVisible);
+      for (const svg of svgs) {
+        let p = svg.parentElement;
+        for (let i = 0; i < 4 && p; i++) {
+          const spans = p.querySelectorAll('span');
+          for (const s of spans) {
+            const t = (s.textContent || '').trim();
+            if (/^K\\d|^Kimi |^Pro\\b|^Auto/.test(t)) return t;
+          }
+          p = p.parentElement;
+        }
+      }
+      return '';
+    })()`);
+        if (!wantList && !wantSet) {
+            return [{ Index: 1, Model: cur || '(unknown)', Active: 'yes' }];
+        }
+
+        // Open the dropdown by clicking the Down_b svg next to the model name.
+        await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const svgs = Array.from(document.querySelectorAll('svg[name="Down_b"]')).filter(isVisible);
+      // The model trigger is usually the one with a sibling span starting with "K"
+      for (const svg of svgs) {
+        let p = svg.parentElement;
+        for (let i = 0; i < 4 && p; i++) {
+          const spans = p.querySelectorAll('span');
+          const match = Array.from(spans).find((s) => /^K\\d|^Kimi |^Pro\\b|^Auto/.test((s.textContent || '').trim()));
+          if (match) {
+            p.click();
+            return;
+          }
+          p = p.parentElement;
+        }
+      }
+    })()`);
+        await page.wait(0.5);
+        const opts = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      // Dropdown items appear in a floating popover.
+      const popovers = Array.from(document.querySelectorAll('[class*="popover"i], [class*="dropdown"i], [role="menu"], [role="listbox"]')).filter(isVisible)
+        .filter((el) => { const r = el.getBoundingClientRect(); return r.width < 600 && r.height < 600; });
+      if (!popovers.length) return [];
+      const pop = popovers[popovers.length - 1];
+      return Array.from(pop.querySelectorAll('div, li, button, [role="option"], [role="menuitem"]'))
+        .filter(isVisible)
+        .map((el) => (el.innerText || el.textContent || '').trim().replace(/\\s+/g, ' '))
+        .filter((t) => t && t.length < 80 && (/K\\d|Kimi|Pro\\b|Auto|思考/.test(t)))
+        .filter((t, i, arr) => arr.indexOf(t) === i)
+        .slice(0, 20);
+    })()`);
+
+        if (wantSet) {
+            const normalizeModel = (value) => String(value || '').toLowerCase().replace(/[^a-z0-9.\u4e00-\u9fa5]+/g, '');
+            const needle = normalizeModel(wantSet);
+            const exactIdx = opts.findIndex((t) => normalizeModel(t) === needle);
+            const partialMatches = exactIdx >= 0 ? [] : opts
+                .map((model, index) => ({ model, index }))
+                .filter((item) => normalizeModel(item.model).includes(needle));
+            if (exactIdx < 0 && partialMatches.length > 1) {
+                try { await page.evaluate(`document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));`); } catch {}
+                throw new ArgumentError('set', `Model "${wantSet}" is ambiguous: ${partialMatches.map(item => item.model).join(', ')}`);
+            }
+            const idx = exactIdx >= 0 ? exactIdx : partialMatches[0]?.index ?? -1;
+            if (idx < 0) {
+                try { await page.evaluate(`document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));`); } catch {}
+                throw new ArgumentError('set', `No model matched "${wantSet}". Available: ${opts.join(', ')}`);
+            }
+            const clickRes = await page.evaluate(`(() => {
+        ${IS_VISIBLE_JS}
+        const popovers = Array.from(document.querySelectorAll('[class*="popover"i], [class*="dropdown"i], [role="menu"], [role="listbox"]')).filter(isVisible);
+        const pop = popovers[popovers.length - 1];
+        if (!pop) return { ok: false };
+        const items = Array.from(pop.querySelectorAll('div, li, button, [role="option"], [role="menuitem"]'))
+          .filter(isVisible)
+          .filter((el) => { const t = (el.innerText || '').trim(); return t && t.length < 80 && (/K\\d|Kimi|Pro\\b|Auto|思考/.test(t)); });
+        const target = items[${idx}];
+        if (!target) return { ok: false };
+        target.click();
+        return { ok: true, clicked: (target.innerText || '').trim() };
+            })()`);
+            if (!clickRes?.ok) throw new CommandExecutionError('Failed to click model option', '');
+            await page.wait(0.5);
+            const verified = await page.evaluate(`(() => {
+      ${IS_VISIBLE_JS}
+      const svgs = Array.from(document.querySelectorAll('svg[name="Down_b"]')).filter(isVisible);
+      for (const svg of svgs) {
+        let p = svg.parentElement;
+        for (let i = 0; i < 4 && p; i++) {
+          const spans = p.querySelectorAll('span');
+          for (const s of spans) {
+            const t = (s.textContent || '').trim();
+            if (/^K\\d|^Kimi |^Pro\\b|^Auto/.test(t)) return t;
+          }
+          p = p.parentElement;
+        }
+      }
+      return '';
+    })()`);
+            if (normalizeModel(verified) !== normalizeModel(clickRes.clicked)) {
+                throw new CommandExecutionError(
+                    `Kimi model switch did not verify the requested model: requested "${wantSet}", current "${verified || 'not visible'}"`,
+                    'Open the Kimi model menu and verify the requested model is selectable, then retry.',
+                );
+            }
+            return [{ Index: 1, Model: clickRes.clicked, Active: 'switched' }];
+        }
+
+        try { await page.evaluate(`document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));`); } catch {}
+        if (!opts.length) {
+            throw new EmptyResultError('kimi model', 'Model dropdown opened but no options detected.');
+        }
+        return opts.map((m, i) => ({ Index: i + 1, Model: m, Active: m === cur ? 'yes' : '' }));
+    },
+});


### PR DESCRIPTION
## Summary
Greenfield web adapter for **Kimi** (Moonshot AI's web chat at kimi.com). Ships **21 commands across 4 layers**, mirroring the Grok adapter's structure.

## Coverage
| Layer | Commands |
|---|---|
| Connectivity | `status` |
| Chat lifecycle | `new` `history` `detail` `read` `send` `ask` |
| Per-message | `copy-message` `regenerate` `react` `share` |
| Sidebar / global UI | `mode` `sidebar-toggle` `view-all-history` `settings` `account` `model` |
| Browser-side storage | `storage-keys` `storage-get` `cookies` `idb-list` |

## Special: `mode` switches Kimi's 7 work modes
`mode ppt|docs|deep-research|websites|sheets|agent-swarm|code` — navigates
to Kimi's specialized work surfaces.

## E2E verified
- `status` → logged in as "登月者"
- `history` → 5 chats with proper UUIDs
- `account` → "登月者 Allegretto"
- `mode` → all 7 modes listed
- `storage-keys` → access_token, __tea_*, _gcl_ls
- `cookies` → 8 JS-visible cookies (httpOnly auth deliberately not shown)
- `idb-list` → AiTopia DB
- `model` (current) → "K2.6 思考"

## Selector strategy
Kimi labels its icons via `<svg role="img" name="X">` (Copy/Refresh/Like/Dislike/Share_a/Send/LeftBar/Down_b). The `clickBySvgNameScript` helper finds the svg, walks up to the nearest clickable ancestor, and dispatches the full pointer chain.

## Known limitation
Per-message commands (`copy-message` / `regenerate` / `react` / `share`)
need the page to be on a chat URL already; follow-up will add `--conv <id>`
to allow navigation first (mirroring Grok's pattern). Workaround:
`opencli browser kimi open <chat-url>` first.

## Test plan
- [ ] CI passes
- [ ] Verify on a fresh Kimi install (history returns EmptyResult cleanly)
- [ ] Verify `mode <name>` navigates correctly without auth issues