### PR TITLE
fix(doubao): support current message DOM

### DIFF
--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -236,9 +236,6 @@ function getTurnsScript() {
         return text ? text + '\\n' + imageLines.join('\\n') : imageLines.join('\\n');
       };
 
-      const messageList = document.querySelector('[class*="message-list-"], .container-PvPoAn, .scroll-view-OEiNXD, [data-testid="message-list"]');
-      if (!messageList) return [];
-
       const itemSelectors = [
         // 2026-05 Doubao DOM refactor wrappers (prepended; outer ones win via
         // ancestor-keep dedup below).
@@ -252,15 +249,21 @@ function getTurnsScript() {
         '[class*="bg-g-receive-msg-bubble"]',
       ];
 
+      const messageLists = Array.from(document.querySelectorAll('[class*="message-list-"], .container-PvPoAn, .scroll-view-OEiNXD, [data-testid="message-list"]'))
+        .filter((el) => isVisible(el));
+      if (messageLists.length === 0) return [];
+
       const allRoots = [];
       const seen = new Set();
-      for (const sel of itemSelectors) {
-        messageList.querySelectorAll(sel).forEach((el) => {
-          if (!seen.has(el)) {
-            seen.add(el);
-            allRoots.push(el);
-          }
-        });
+      for (const messageList of messageLists) {
+        for (const sel of itemSelectors) {
+          messageList.querySelectorAll(sel).forEach((el) => {
+            if (!seen.has(el)) {
+              seen.add(el);
+              allRoots.push(el);
+            }
+          });
+        }
       }
       const roots = allRoots
         .filter((el) => isVisible(el) && !el.closest('script, style, noscript'))

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -166,11 +166,13 @@ function getTurnsScript() {
         // 2026-05 Doubao DOM refactor: no more receive-message / bg-g-receive-msg-bubble
         // markers on assistant turns. Wrappers are now [class*="inner-item-"] /
         // [class*="top-item-"] and the only reliable assistant signal is the
-        // .flow-markdown-body content container WITHOUT any send-bubble marker.
+        // .flow-markdown-body / .md-box-root content container WITHOUT any
+        // send-bubble marker.
         if (
           (root.matches('[class*="inner-item-"], [class*="top-item-"]')
             || root.closest('[class*="inner-item-"], [class*="top-item-"]'))
-          && (root.matches('.flow-markdown-body') || root.querySelector('.flow-markdown-body'))
+          && (root.matches('.flow-markdown-body, .md-box-root, [class*="md-box-root"]')
+            || root.querySelector('.flow-markdown-body, .md-box-root, [class*="md-box-root"]'))
           && !root.matches('[class*="bg-g-send-msg-bubble"]')
           && !root.querySelector('[class*="bg-g-send-msg-bubble"]')
         ) {
@@ -189,6 +191,8 @@ function getTurnsScript() {
         '[class*="bg-g-send-msg-bubble"]',
         '[class*="bg-g-receive-msg-bubble"]',
         '.flow-markdown-body',
+        '.md-box-root',
+        '[class*="md-box-root"]',
         '[class*="bubble"]',
       ];
       const messageImageSelector = messageTextSelectors.map((s) => s + ' img').join(', ');
@@ -232,7 +236,7 @@ function getTurnsScript() {
         return text ? text + '\\n' + imageLines.join('\\n') : imageLines.join('\\n');
       };
 
-      const messageList = document.querySelector('[class*="message-list-S2Fv2S"], .container-PvPoAn, .scroll-view-OEiNXD, [data-testid="message-list"]');
+      const messageList = document.querySelector('[class*="message-list-"], .container-PvPoAn, .scroll-view-OEiNXD, [data-testid="message-list"]');
       if (!messageList) return [];
 
       const itemSelectors = [

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -245,6 +245,31 @@ describe('doubao receive strategy', () => {
         ]);
     });
 
+    it('does not let a stale hidden hashed message list mask the visible current one', () => {
+        const turns = runTurnsScript(`
+          <main>
+            <section class="message-list-old" style="display:none">
+              <div class="inner-item-old">
+                <div class="bg-g-send-msg-bubble-bg">旧问题</div>
+              </div>
+            </section>
+            <section class="message-list-current">
+              <div class="inner-item-current">
+                <div class="bg-g-send-msg-bubble-bg">当前问题</div>
+              </div>
+              <div class="inner-item-current">
+                <div class="md-box-root"><p>当前回答</p></div>
+              </div>
+            </section>
+          </main>
+        `);
+
+        expect(turns).toEqual([
+            { Role: 'User', Text: '当前问题' },
+            { Role: 'Assistant', Text: '当前回答' },
+        ]);
+    });
+
     it('extends transcript-noise cleanup for the current zh-CN chrome copy', () => {
         const transcriptScript = __test__.getTranscriptLinesScript();
         expect(transcriptScript).toContain('请仔细甄别');

--- a/clis/doubao/utils.test.js
+++ b/clis/doubao/utils.test.js
@@ -170,7 +170,7 @@ describe('doubao receive strategy', () => {
 
     it('keeps both the new skin selectors and the older structural fallbacks in the turns script', () => {
         const turnsScript = __test__.getTurnsScript();
-        expect(turnsScript).toContain('[class*="message-list-S2Fv2S"]');
+        expect(turnsScript).toContain('[class*="message-list-"]');
         expect(turnsScript).toContain('.container-PvPoAn');
         expect(turnsScript).toContain('[data-testid="message-list"]');
         expect(turnsScript).toContain('[class*="bg-g-receive-msg-bubble"]');
@@ -191,6 +191,7 @@ describe('doubao receive strategy', () => {
         // bg-g-receive-msg-bubble markup. Only signal is .flow-markdown-body content
         // container without send-bubble.
         expect(turnsScript).toContain('.flow-markdown-body');
+        expect(turnsScript).toContain('.md-box-root');
     });
 
     it('extracts clean assistant turns from the 2026-05 wrapper DOM without using whole-page chrome', () => {
@@ -215,6 +216,32 @@ describe('doubao receive strategy', () => {
         expect(turns).toEqual([
             { Role: 'User', Text: '测试一下，只回复OK' },
             { Role: 'Assistant', Text: 'OK' },
+        ]);
+    });
+
+    it('extracts turns from the current hashed message list and markdown box DOM', () => {
+        const turns = runTurnsScript(`
+          <main>
+            <aside>历史对话</aside>
+            <section class="message-list-zLoNs1 opacity-100">
+              <div class="top-item-bAlX0F"></div>
+              <div class="inner-item-BjaxFt">
+                <div data-message-id="46370507058831106" class="flex-row flex w-full justify-end">
+                  <div class="bg-g-send-msg-bubble-bg">请联网查找太原红星天铂</div>
+                </div>
+              </div>
+              <div class="inner-item-BjaxFt">
+                <div data-message-id="46370507058842882" class="relative flex-row flex w-full">
+                  <div class="container-qX9Csx md-box-root"><h3>太原红星天铂公开信息整理</h3><p>项目位于南内环东街与东中环交汇处东北角。</p></div>
+                </div>
+              </div>
+            </section>
+          </main>
+        `);
+
+        expect(turns).toEqual([
+            { Role: 'User', Text: '请联网查找太原红星天铂' },
+            { Role: 'Assistant', Text: '太原红星天铂公开信息整理项目位于南内环东街与东中环交汇处东北角。' },
         ]);
     });
 


### PR DESCRIPTION
## Summary
- broaden Doubao chat message-list detection to tolerate current hashed `message-list-*` classes
- recognize the current `.md-box-root` assistant markdown container alongside `.flow-markdown-body`
- add a regression fixture for the current Doubao message DOM shape

## Tests
- `npx vitest run --project adapter clis/doubao/utils.test.js`
- `npm run typecheck`

## Notes
- `npm run test:adapter` was also run on Windows. The Doubao tests passed, but the full adapter suite has existing Windows-specific failures unrelated to this change, mostly POSIX path expectations and `/tmp` assumptions in instagram/twitter/xiaoyuzhou/suno tests.