### PR TITLE
fix(twitter): drop global tweetPhoto from hasMedia in post submit poll

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -235,7 +235,10 @@ async function submitTweet(page, text) {
 
             const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]')).filter(visible);
             const composerStillHasText = boxes.some((box) => normalize(box.innerText || box.textContent || '').includes(expectedText));
-            const hasMedia = !!document.querySelector('[data-testid="attachments"], [data-testid="tweetPhoto"]')
+            // Drop the global tweetPhoto query: tweetPhoto exists for every
+            // timeline tweet's image and would pin hasMedia true past the
+            // success path. attachments + blob: URLs are composer-only.
+            const hasMedia = !!document.querySelector('[data-testid="attachments"]')
                 || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0;
             if (!composerStillHasText && !hasMedia) {
                 return { ok: true, message: 'Tweet posted successfully.', ...statusUrl() };

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -217,6 +217,23 @@ describe('twitter post command', () => {
         expect(submitScript).toContain('your post was sent');
     });
 
+    it('does not let global timeline tweetPhoto nodes keep the submit poll pending', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ]);
+
+        await command.func(page, { text: 'global media should not block' });
+
+        const submitScript = page.evaluate.mock.calls[3][0];
+        expect(submitScript).toContain("document.querySelector('[data-testid=\"attachments\"]')");
+        expect(submitScript).not.toContain("[data-testid=\"attachments\"], [data-testid=\"tweetPhoto\"]");
+        expect(submitScript).not.toContain("document.querySelectorAll('[data-testid=\"tweetPhoto\"]");
+    });
+
     it('returns failed when image upload times out', async () => {
         const command = getCommand();
         const page = makePage([


### PR DESCRIPTION
## Description

`submitTweet` in `clis/twitter/post.js` polls after clicking the tweet button. The success path falls through to `!composerStillHasText && !hasMedia` once the composer clears, but `hasMedia` was queried against the entire document: `document.querySelector('[data-testid="attachments"], [data-testid="tweetPhoto"]')`. `tweetPhoto` is rendered for every tweet's image in the timeline, including the tweet that was just posted, so `hasMedia` pinned true past the success path and the poll ran until `Tweet submission did not complete before timeout.`, even though the tweet is live on the user's timeline.

Drop `tweetPhoto` from the query. `attachments` (the composer's attachment container) and `img[src^="blob:"]` / `video[src^="blob:"]` (the local preview URLs created by the composer's image picker) are composer-only signals and clear when the composer dismisses.

Related issue: fixes #1781.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Live verified on a logged-in twitter session on macOS 26.5 with opencli 1.8.1 + Browser Bridge v1.0.15. To force the buggy code path I temporarily replaced the toast-detection regex with one that never matches (so the success-toast short-circuit was disabled and the poll fell through to the `!composerStillHasText && !hasMedia` check):

| post.js variant | toast regex | Result |
|---|---|---|
| main (canonical 1.8.1) | disabled (`/__NEVER_MATCH/`) | `status: failed`, `Tweet submission did not complete before timeout.` after 19s, tweet IS live on timeline (reporter's exact symptom) |
| patched | disabled (`/__NEVER_MATCH/`) | `status: success`, returns URL, 5.8s |
| patched | unchanged | `status: success` via toast path (no regression on the happy path) |

All four test tweets were deleted from the account after the run. Full twitter suite continues to pass: 391/391.