### PR TITLE
fix(twitter): ignore timeline media after post submit

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -235,8 +235,11 @@ async function submitTweet(page, text) {
 
             const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]')).filter(visible);
             const composerStillHasText = boxes.some((box) => normalize(box.innerText || box.textContent || '').includes(expectedText));
-            const hasMedia = !!document.querySelector('[data-testid="attachments"], [data-testid="tweetPhoto"]')
-                || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0;
+            const isComposeRoute = /^\\/compose\\/post\\/?$/.test(window.location.pathname);
+            const hasMedia = isComposeRoute && (
+                !!document.querySelector('[data-testid="attachments"], [data-testid="tweetPhoto"]')
+                || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0
+            );
             if (!composerStillHasText && !hasMedia) {
                 return { ok: true, message: 'Tweet posted successfully.', ...statusUrl() };
             }

--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -235,11 +235,11 @@ async function submitTweet(page, text) {
 
             const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]')).filter(visible);
             const composerStillHasText = boxes.some((box) => normalize(box.innerText || box.textContent || '').includes(expectedText));
-            const isComposeRoute = /^\\/compose\\/post\\/?$/.test(window.location.pathname);
-            const hasMedia = isComposeRoute && (
-                !!document.querySelector('[data-testid="attachments"], [data-testid="tweetPhoto"]')
-                || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0
-            );
+            // Drop the global tweetPhoto query: tweetPhoto exists for every
+            // timeline tweet's image and would pin hasMedia true past the
+            // success path. attachments + blob: URLs are composer-only.
+            const hasMedia = !!document.querySelector('[data-testid="attachments"]')
+                || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0;
             if (!composerStillHasText && !hasMedia) {
                 return { ok: true, message: 'Tweet posted successfully.', ...statusUrl() };
             }

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -217,22 +217,21 @@ describe('twitter post command', () => {
         expect(submitScript).toContain('your post was sent');
     });
 
-    it('does not treat timeline media as composer media after compose navigation completes', async () => {
+    it('does not let global timeline tweetPhoto nodes keep the submit poll pending', async () => {
         const command = getCommand();
         const page = makePage([
-            { ok: true, previewCount: 1 }, // upload polling returns true
             { ok: true }, // focus composer
             { ok: true }, // verify native insertText
             { ok: true }, // click post
             { ok: true, message: 'Tweet posted successfully.' },
         ]);
 
-        await command.func(page, { text: 'with image', images: 'a.png' });
+        await command.func(page, { text: 'global media should not block' });
 
-        const submitScript = page.evaluate.mock.calls[4][0];
-        expect(submitScript).toContain('isComposeRoute');
-        expect(submitScript).toContain('/^\\/compose\\/post');
-        expect(submitScript).toContain('isComposeRoute &&');
+        const submitScript = page.evaluate.mock.calls[3][0];
+        expect(submitScript).toContain("document.querySelector('[data-testid=\"attachments\"]')");
+        expect(submitScript).not.toContain("[data-testid=\"attachments\"], [data-testid=\"tweetPhoto\"]");
+        expect(submitScript).not.toContain("document.querySelectorAll('[data-testid=\"tweetPhoto\"]");
     });
 
     it('returns failed when image upload times out', async () => {

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -217,6 +217,24 @@ describe('twitter post command', () => {
         expect(submitScript).toContain('your post was sent');
     });
 
+    it('does not treat timeline media as composer media after compose navigation completes', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true, previewCount: 1 }, // upload polling returns true
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ]);
+
+        await command.func(page, { text: 'with image', images: 'a.png' });
+
+        const submitScript = page.evaluate.mock.calls[4][0];
+        expect(submitScript).toContain('isComposeRoute');
+        expect(submitScript).toContain('/^\\/compose\\/post');
+        expect(submitScript).toContain('isComposeRoute &&');
+    });
+
     it('returns failed when image upload times out', async () => {
         const command = getCommand();
         const page = makePage([


### PR DESCRIPTION
## Summary
- fixes image posts being reported as timed out after X navigates away from /compose/post
- only treats media as blocking submit completion while still on the compose route
- adds a regression check for timeline media not being counted as composer media

Fixes #1781.

## Test plan
- npm test -- clis/twitter/post.test.js
- npm run build