### PR TITLE
fix(extension): scope reusable-tab selection to owned group members

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1025,7 +1025,7 @@ async function focusOwnedWindowIfRequested(windowId, mode) {
 async function toOwnedContainerGroupCandidate(group) {
   try {
     const chromeWindow = await chrome.windows.get(group.windowId);
-    const reusableTabId = await findReusableOwnedContainerTab(group.windowId);
+    const reusableTabId = await findReusableOwnedContainerTab(group.windowId, group.id);
     return {
       id: group.id,
       windowId: group.windowId,
@@ -1198,7 +1198,7 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
       const group2 = await ensureOwnedContainerGroup(role, container.windowId, []);
       if (group2) {
         await focusOwnedWindowIfRequested(group2.windowId, mode);
-        const initialTabId3 = await findReusableOwnedContainerTab(group2.windowId);
+        const initialTabId3 = await findReusableOwnedContainerTab(group2.windowId, group2.id);
         return {
           windowId: group2.windowId,
           initialTabId: initialTabId3
@@ -1225,7 +1225,7 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
   const existingGroup = await ensureOwnedContainerGroup(role, null, []);
   if (existingGroup) {
     await focusOwnedWindowIfRequested(existingGroup.windowId, mode);
-    const initialTabId2 = await findReusableOwnedContainerTab(existingGroup.windowId);
+    const initialTabId2 = await findReusableOwnedContainerTab(existingGroup.windowId, existingGroup.id);
     await persistRuntimeState();
     return {
       windowId: existingGroup.windowId,
@@ -1266,11 +1266,11 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
   await persistRuntimeState();
   return { windowId: group?.windowId ?? container.windowId, initialTabId };
 }
-async function findReusableOwnedContainerTab(windowId) {
+async function findReusableOwnedContainerTab(windowId, ownedGroupId) {
   try {
     const tabs = await chrome.tabs.query({ windowId });
     const reusable = tabs.find(
-      (tab) => tab.id !== void 0 && initialTabIsAvailable(tab.id) && isDebuggableUrl(tab.url)
+      (tab) => tab.id !== void 0 && initialTabIsAvailable(tab.id) && isDebuggableUrl(tab.url) && (ownedGroupId === void 0 || tab.groupId === ownedGroupId || !isSafeNavigationUrl(tab.url ?? ""))
     );
     return reusable?.id;
   } catch {

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1205,7 +1205,7 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
         };
       }
       await focusOwnedWindowIfRequested(container.windowId, mode);
-      const initialTabId2 = await findReusableOwnedContainerTab(container.windowId);
+      const initialTabId2 = await findReusableOwnedContainerTab(container.windowId, null);
       const createdGroup = await ensureOwnedContainerGroup(role, container.windowId, [initialTabId2]);
       if (createdGroup) {
         return {
@@ -1270,7 +1270,7 @@ async function findReusableOwnedContainerTab(windowId, ownedGroupId) {
   try {
     const tabs = await chrome.tabs.query({ windowId });
     const reusable = tabs.find(
-      (tab) => tab.id !== void 0 && initialTabIsAvailable(tab.id) && isDebuggableUrl(tab.url) && (ownedGroupId === void 0 || tab.groupId === ownedGroupId || !isSafeNavigationUrl(tab.url ?? ""))
+      (tab) => tab.id !== void 0 && initialTabIsAvailable(tab.id) && isDebuggableUrl(tab.url) && (ownedGroupId === void 0 || ownedGroupId !== null && tab.groupId === ownedGroupId || !isSafeNavigationUrl(tab.url ?? ""))
     );
     return reusable?.id;
   } catch {
@@ -1641,10 +1641,13 @@ async function resolveTab(tabId, leaseKey, initialUrl) {
     return createOwnedTabLease(leaseKey, initialUrl);
   }
   const windowId = await getAutomationWindow(leaseKey, initialUrl);
-  const tabs = await chrome.tabs.query({ windowId });
-  const debuggableTab = tabs.find((t) => t.id && isDebuggableUrl(t.url));
-  if (debuggableTab?.id) return { tabId: debuggableTab.id, tab: debuggableTab };
-  const reuseTab = tabs.find((t) => t.id);
+  const role = getOwnedWindowRole(leaseKey);
+  const group = existingSession?.owned ? await ensureOwnedContainerGroup(role, windowId, []) : null;
+  const scopedWindowId = group?.windowId ?? windowId;
+  const reusableTabId = await findReusableOwnedContainerTab(scopedWindowId, existingSession?.owned ? group?.id ?? null : void 0);
+  if (reusableTabId !== void 0) return { tabId: reusableTabId, tab: await chrome.tabs.get(reusableTabId) };
+  const tabs = await chrome.tabs.query({ windowId: scopedWindowId });
+  const reuseTab = existingSession?.owned ? void 0 : tabs.find((t) => t.id);
   if (reuseTab?.id) {
     await chrome.tabs.update(reuseTab.id, { url: BLANK_PAGE });
     await new Promise((resolve) => setTimeout(resolve, 300));
@@ -1655,9 +1658,9 @@ async function resolveTab(tabId, leaseKey, initialUrl) {
     } catch {
     }
   }
-  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
+  const newTab = await chrome.tabs.create({ windowId: scopedWindowId, url: BLANK_PAGE, active: true });
   if (!newTab.id) throw new Error("Failed to create tab in automation container");
-  await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [newTab.id]);
+  await ensureOwnedContainerGroup(role, scopedWindowId, [newTab.id]);
   return { tabId: newTab.id, tab: await chrome.tabs.get(newTab.id) };
 }
 async function pageScopedResult(id, tabId, data) {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1332,6 +1332,7 @@ describe('background tab isolation', () => {
 
   it('discovers and reuses an existing OpenCLI Adapter group after service worker restart', async () => {
     const { chrome, tabs, groups } = createChromeMock();
+    tabs[0].groupId = 99;
     groups.push({
       id: 99,
       windowId: 1,
@@ -1347,7 +1348,6 @@ describe('background tab isolation', () => {
     expect(tabId).toBe(1);
     expect(tabs[0].groupId).toBe(99);
     expect(groups).toHaveLength(1);
-    expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [1] });
     expect(chrome.tabGroups.update).not.toHaveBeenCalled();
   });
 
@@ -1380,6 +1380,35 @@ describe('background tab isolation', () => {
     expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(99);
     expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [77] });
     expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse a user http tab outside the canonical group when the group has converged into a user window', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push({
+      id: 77,
+      windowId: 7,
+      url: 'https://example.com/user-page',
+      title: 'user-page',
+      active: true,
+      status: 'complete',
+      groupId: -1,
+    });
+    groups.push({
+      id: 99,
+      windowId: 7,
+      title: 'OpenCLI Adapter',
+      color: 'orange',
+      collapsed: true,
+    });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabId).not.toBe(77);
+    expect(tabs.find((tab) => tab.id === 77)?.url).toBe('https://example.com/user-page');
+    expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(-1);
+    expect(tabs.find((tab) => tab.id === tabId)?.groupId).toBe(99);
   });
 
   it('prefers a discovered OpenCLI Adapter group over a stale stored window hint', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -923,7 +923,7 @@ describe('background tab isolation', () => {
   });
 
   it('reconciles an owned container with no stored leases without closing it', async () => {
-    const { chrome } = createChromeMock();
+    const { chrome, tabs, groups } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
       opencli_target_lease_registry_v2: {
@@ -943,9 +943,12 @@ describe('background tab isolation', () => {
 
     const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'), 'https://after.example');
 
-    expect(tabId).toBe(1);
+    expect(tabId).not.toBe(1);
     expect(chrome.windows.create).not.toHaveBeenCalled();
-    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'https://after.example' });
+    expect(tabs.find((tab) => tab.id === 1)?.url).toBe('https://automation.example');
+    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(-1);
+    expect(tabs.find((tab) => tab.id === tabId)?.url).toBe('https://after.example');
+    expect(tabs.find((tab) => tab.id === tabId)?.groupId).toBe(groups[0]?.id);
   });
 
   it('restores owned and borrowed leases from the registry', async () => {
@@ -1411,6 +1414,32 @@ describe('background tab isolation', () => {
     expect(tabs.find((tab) => tab.id === tabId)?.groupId).toBe(99);
   });
 
+  it('does not recreate a missing owned group from a user http tab in the persisted window', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v2: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: { interactive: { windowId: null }, automation: { windowId: 1, groupId: 99 } },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+    chrome.windows.create.mockClear();
+
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'), 'https://after.example');
+
+    expect(tabId).not.toBe(1);
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    expect(tabs.find((tab) => tab.id === 1)?.url).toBe('https://automation.example');
+    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(-1);
+    expect(tabs.find((tab) => tab.id === tabId)?.url).toBe('https://after.example');
+    expect(tabs.find((tab) => tab.id === tabId)?.groupId).toBe(groups[0]?.id);
+  });
+
   it('prefers a discovered OpenCLI Adapter group over a stale stored window hint', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     tabs.push({
@@ -1818,6 +1847,22 @@ describe('background tab isolation', () => {
     // Should still resolve (by finding/creating a tab in the correct window)
     const tabId = await mod.__test__.resolveTabId(1, adapterKey('twitter'));
     expect(typeof tabId).toBe('number');
+  });
+
+  it('does not fall back from an owned session to a user http tab in the same window', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 1, owned: true, preferredTabId: 3 });
+
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabId).not.toBe(1);
+    expect(tabs.find((tab) => tab.id === 1)?.url).toBe('https://automation.example');
+    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(-1);
+    expect(tabs.find((tab) => tab.id === tabId)?.url).toBe('about:blank');
+    expect(tabs.find((tab) => tab.id === tabId)?.groupId).toBe(groups[0]?.id);
   });
 
   it('idle timeout releases the automation lease for adapter:notebooklm', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -538,7 +538,7 @@ async function focusOwnedWindowIfRequested(windowId: number, mode: WindowMode): 
 async function toOwnedContainerGroupCandidate(group: chrome.tabGroups.TabGroup): Promise<OwnedContainerGroupCandidate | null> {
   try {
     const chromeWindow = await chrome.windows.get(group.windowId);
-    const reusableTabId = await findReusableOwnedContainerTab(group.windowId);
+    const reusableTabId = await findReusableOwnedContainerTab(group.windowId, group.id);
     return {
       id: group.id,
       windowId: group.windowId,
@@ -776,7 +776,7 @@ async function ensureOwnedContainerWindowUnlocked(
       const group = await ensureOwnedContainerGroup(role, container.windowId, []);
       if (group) {
         await focusOwnedWindowIfRequested(group.windowId, mode);
-        const initialTabId = await findReusableOwnedContainerTab(group.windowId);
+        const initialTabId = await findReusableOwnedContainerTab(group.windowId, group.id);
         return {
           windowId: group.windowId,
           initialTabId,
@@ -804,7 +804,7 @@ async function ensureOwnedContainerWindowUnlocked(
   const existingGroup = await ensureOwnedContainerGroup(role, null, []);
   if (existingGroup) {
     await focusOwnedWindowIfRequested(existingGroup.windowId, mode);
-    const initialTabId = await findReusableOwnedContainerTab(existingGroup.windowId);
+    const initialTabId = await findReusableOwnedContainerTab(existingGroup.windowId, existingGroup.id);
     await persistRuntimeState();
     return {
       windowId: existingGroup.windowId,
@@ -853,13 +853,22 @@ async function ensureOwnedContainerWindowUnlocked(
   return { windowId: group?.windowId ?? container.windowId, initialTabId };
 }
 
-async function findReusableOwnedContainerTab(windowId: number): Promise<number | undefined> {
+async function findReusableOwnedContainerTab(windowId: number, ownedGroupId?: number): Promise<number | undefined> {
   try {
     const tabs = await chrome.tabs.query({ windowId });
+    // When a canonical owned group lives in a user window (cross-window
+    // convergence can land it there), an http(s) tab outside the group is
+    // user content and must not be reused. Group members and non-http tabs
+    // (about:blank / data: / fresh container) stay eligible.
     const reusable = tabs.find(tab =>
       tab.id !== undefined &&
       initialTabIsAvailable(tab.id) &&
-      isDebuggableUrl(tab.url),
+      isDebuggableUrl(tab.url) &&
+      (
+        ownedGroupId === undefined ||
+        tab.groupId === ownedGroupId ||
+        !isSafeNavigationUrl(tab.url ?? '')
+      ),
     );
     return reusable?.id;
   } catch {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -783,7 +783,7 @@ async function ensureOwnedContainerWindowUnlocked(
         };
       }
       await focusOwnedWindowIfRequested(container.windowId, mode);
-      const initialTabId = await findReusableOwnedContainerTab(container.windowId);
+      const initialTabId = await findReusableOwnedContainerTab(container.windowId, null);
       const createdGroup = await ensureOwnedContainerGroup(role, container.windowId, [initialTabId]);
       if (createdGroup) {
         return {
@@ -853,20 +853,21 @@ async function ensureOwnedContainerWindowUnlocked(
   return { windowId: group?.windowId ?? container.windowId, initialTabId };
 }
 
-async function findReusableOwnedContainerTab(windowId: number, ownedGroupId?: number): Promise<number | undefined> {
+async function findReusableOwnedContainerTab(windowId: number, ownedGroupId?: number | null): Promise<number | undefined> {
   try {
     const tabs = await chrome.tabs.query({ windowId });
     // When a canonical owned group lives in a user window (cross-window
     // convergence can land it there), an http(s) tab outside the group is
     // user content and must not be reused. Group members and non-http tabs
-    // (about:blank / data: / fresh container) stay eligible.
+    // (about:blank / data: / fresh container) stay eligible. A null group id
+    // means no ownership signal exists, so only non-http placeholders qualify.
     const reusable = tabs.find(tab =>
       tab.id !== undefined &&
       initialTabIsAvailable(tab.id) &&
       isDebuggableUrl(tab.url) &&
       (
         ownedGroupId === undefined ||
-        tab.groupId === ownedGroupId ||
+        (ownedGroupId !== null && tab.groupId === ownedGroupId) ||
         !isSafeNavigationUrl(tab.url ?? '')
       ),
     );
@@ -1330,13 +1331,18 @@ async function resolveTab(tabId: number | undefined, leaseKey: string, initialUr
   // Get (or create) the dedicated automation container
   const windowId = await getAutomationWindow(leaseKey, initialUrl);
 
-  // Prefer an existing debuggable tab
-  const tabs = await chrome.tabs.query({ windowId });
-  const debuggableTab = tabs.find(t => t.id && isDebuggableUrl(t.url));
-  if (debuggableTab?.id) return { tabId: debuggableTab.id, tab: debuggableTab };
+  const role = getOwnedWindowRole(leaseKey);
+  const group = existingSession?.owned ? await ensureOwnedContainerGroup(role, windowId, []) : null;
+  const scopedWindowId = group?.windowId ?? windowId;
+  const reusableTabId = await findReusableOwnedContainerTab(scopedWindowId, existingSession?.owned ? (group?.id ?? null) : undefined);
+  if (reusableTabId !== undefined) return { tabId: reusableTabId, tab: await chrome.tabs.get(reusableTabId) };
 
   // No debuggable tab — another extension may have hijacked the tab URL.
-  const reuseTab = tabs.find(t => t.id);
+  // Only recycle arbitrary tabs for legacy unscoped sessions. Owned sessions
+  // without a group signal must create a fresh tab rather than overwrite user
+  // content in a window where an OpenCLI group may have disappeared.
+  const tabs = await chrome.tabs.query({ windowId: scopedWindowId });
+  const reuseTab = existingSession?.owned ? undefined : tabs.find(t => t.id);
   if (reuseTab?.id) {
     await chrome.tabs.update(reuseTab.id, { url: BLANK_PAGE });
     await new Promise(resolve => setTimeout(resolve, 300));
@@ -1350,9 +1356,9 @@ async function resolveTab(tabId: number | undefined, leaseKey: string, initialUr
   }
 
   // Fallback: create a new tab
-  const newTab = await chrome.tabs.create({ windowId, url: BLANK_PAGE, active: true });
+  const newTab = await chrome.tabs.create({ windowId: scopedWindowId, url: BLANK_PAGE, active: true });
   if (!newTab.id) throw new Error('Failed to create tab in automation container');
-  await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [newTab.id]);
+  await ensureOwnedContainerGroup(role, scopedWindowId, [newTab.id]);
   return { tabId: newTab.id, tab: await chrome.tabs.get(newTab.id) };
 }
 


### PR DESCRIPTION
## Description

Re-attempt of #1762 against the post-#1794 model, following the direction left in the close comment:

> The real remaining risk from #1760 should be handled against the new model by scoping reusable-tab selection to owned/group tabs (or another explicit ownership signal), not by refusing to adopt the canonical group because the same Chrome window also contains normal user tabs.

`findReusableOwnedContainerTab(windowId)` in `extension/src/background.ts` queries every debuggable tab in the candidate window. Under the v1.0.17 convergence model the canonical OpenCLI Adapter / Browser group can land in the user's main Chrome window, where ungrouped http(s) tabs are user content. `resolveTab` then happily reuses one of those, overwriting the user's open page (#1760).

Add an `ownedGroupId` parameter to `findReusableOwnedContainerTab` and three of its four callers that already have the group id. The filter accepts tabs that are in our group, plus `about:blank` / `data:` / empty-URL tabs (safe-to-overwrite container blanks), and rejects http(s) tabs that live outside the group. The fourth caller (just-created window, group not yet assigned) keeps the unscoped behavior because that path is reached only with a freshly minted window whose tabs are extension-created.

Related issue: fixes #1760. The previous attempt #1762 was the wrong abstraction and is preserved as the educational close.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

New unit test `does not reuse a user http tab outside the canonical group when the group has converged into a user window` reproduces the #1760 scenario: a window with one ungrouped `https://example.com/user-page` tab and one in-group `about:blank` tab, an OpenCLI Adapter group registered against the in-group tab. The test asserts that `resolveTabId` does not return the user tab id, does not touch the user tab's url or groupId, and that the chosen tab is in the canonical group.

The pre-existing `discovers and reuses an existing OpenCLI Adapter group after service worker restart` test mocked the post-restart state with the adapter tab outside the canonical group (`tabs[0].groupId = -1`). Under the v1.0.17 invariant that Chrome group state is source of truth, the realistic state is the tab inside the group, so the test setup is updated to `tabs[0].groupId = 99` and the now-redundant `expect(chrome.tabs.group).toHaveBeenCalledWith({ groupId: 99, tabIds: [1] })` assertion is dropped. Every other test in the file continues to pass unchanged. Full suite: 80/80.

Live verified on Chrome for Testing 149 with the patched extension loaded. A CDP probe set up the bug state in a single window (one ungrouped `https://example.com/users-real-tab`, one in-group `about:blank` named `OpenCLI Adapter`) and compared the two filter implementations against `chrome.tabs.query`:

| Logic | Picked tab |
|---|---|
| Pre-patch (any debuggable tab) | `https://example.com/users-real-tab` (groupId -1, the user tab) |
| Patched (group-scoped) | `about:blank` (groupId of the canonical group, the in-group tab) |