### PR TITLE
fix(twitter): fall back when quote composer card is missing

### DIFF
--- a/clis/twitter/quote.js
+++ b/clis/twitter/quote.js
@@ -17,39 +17,87 @@ function buildQuoteComposerUrl(url) {
     return `https://x.com/compose/post?url=${encodeURIComponent(parsed.url)}`;
 }
 
-async function submitQuote(page, text, tweetId) {
+async function openQuoteComposerFromRetweetMenu(page, target) {
+    await page.goto(target.url, { waitUntil: 'load', settleMs: 2500 });
+    await page.wait({ selector: '[data-testid="primaryColumn"]', timeout: 15 });
+    const opened = await page.evaluate(`(async () => {
+        try {
+            ${buildTwitterArticleScopeSource(target.id)}
+            const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            let retweetBtn = null;
+            let targetArticle = null;
+            for (let i = 0; i < 20; i++) {
+                targetArticle = findTargetArticle();
+                retweetBtn = targetArticle?.querySelector('[data-testid="retweet"], [data-testid="unretweet"]') || null;
+                if (retweetBtn && visible(retweetBtn)) break;
+                await new Promise(r => setTimeout(r, 500));
+            }
+            if (!retweetBtn || !targetArticle) {
+                return { ok: false, message: 'Could not find the repost menu button on the target tweet.' };
+            }
+            retweetBtn.click();
+
+            let quoteItem = null;
+            for (let i = 0; i < 20; i++) {
+                await new Promise(r => setTimeout(r, 250));
+                const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+                quoteItem = items.find((el) => visible(el) && /^Quote$/i.test((el.innerText || el.textContent || '').trim()));
+                if (quoteItem) break;
+            }
+            if (!quoteItem) {
+                return { ok: false, message: 'Repost menu opened but the Quote option did not appear.' };
+            }
+            quoteItem.click();
+            return { ok: true };
+        } catch (e) {
+            return { ok: false, message: e.toString() };
+        }
+    })()`);
+    if (!opened?.ok) return opened;
+    await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
+    return { ok: true };
+}
+
+async function submitQuote(page, text, target, { allowMenuFallback = true } = {}) {
     return page.evaluate(`(async () => {
         try {
-            ${buildTwitterArticleScopeSource(tweetId)}
+            ${buildTwitterArticleScopeSource(target.id)}
             const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            const normalize = s => String(s || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
+            const insertTextIntoBox = async (box, value) => {
+                box.focus();
+                if (!document.execCommand('insertText', false, value)) {
+                    const dataTransfer = new DataTransfer();
+                    dataTransfer.setData('text/plain', value);
+                    box.dispatchEvent(new ClipboardEvent('paste', {
+                        clipboardData: dataTransfer,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
+                }
+                await new Promise(r => setTimeout(r, 1000));
+                const actual = box.innerText || box.textContent || '';
+                return normalize(actual).includes(normalize(value));
+            };
+
             const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]'));
             const box = boxes.find(visible) || boxes[0];
             if (!box) {
                 return { ok: false, message: 'Could not find the quote composer text area. Are you logged in?' };
             }
 
-            box.focus();
             const textToInsert = ${JSON.stringify(text)};
-            // execCommand('insertText') is more reliable with Twitter's Draft.js editor.
-            if (!document.execCommand('insertText', false, textToInsert)) {
-                // Fallback to paste event if execCommand fails.
-                const dataTransfer = new DataTransfer();
-                dataTransfer.setData('text/plain', textToInsert);
-                box.dispatchEvent(new ClipboardEvent('paste', {
-                    clipboardData: dataTransfer,
-                    bubbles: true,
-                    cancelable: true,
-                }));
+            if (!(await insertTextIntoBox(box, textToInsert))) {
+                return { ok: false, message: 'Could not verify quote text in the composer after typing.' };
             }
 
-            await new Promise(r => setTimeout(r, 1000));
-
-            // Confirm the quoted card is rendered before submitting; otherwise
-            // we may accidentally post a plain tweet without the quote
-            // attachment. The compose page does not wrap the card in an
-            // <article>, so we probe the document for any link whose path
-            // exactly matches the requested status id (uses __twHasLinkToTarget
-            // from buildTwitterArticleScopeSource).
+            // Confirm the quoted card is rendered before submitting. The
+            // compose page does not wrap the card in an <article>, so we probe
+            // the document for any link whose path exactly matches the
+            // requested status id (uses __twHasLinkToTarget from
+            // buildTwitterArticleScopeSource). If the dedicated compose URL
+            // misses the card, the caller retries through the target post's
+            // repost menu and Quote item.
             let cardAttempts = 0;
             let hasQuoteCard = false;
             while (cardAttempts < 20) {
@@ -59,7 +107,11 @@ async function submitQuote(page, text, tweetId) {
                 cardAttempts++;
             }
             if (!hasQuoteCard) {
-                return { ok: false, message: 'Quote target did not render in the composer. The source tweet may be deleted or restricted.' };
+                const allowMenuFallback = ${JSON.stringify(allowMenuFallback)};
+                if (allowMenuFallback) {
+                    return { ok: false, retryWithMenuFallback: true, message: 'Quote target did not render in the dedicated composer; retrying through the repost menu.' };
+                }
+                return { ok: false, message: 'Quote target did not render after opening the quote composer from the repost menu.' };
             }
 
             let btn = null;
@@ -77,7 +129,6 @@ async function submitQuote(page, text, tweetId) {
 
             btn.click();
 
-            const normalize = s => String(s || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
             const expectedText = normalize(textToInsert);
             for (let i = 0; i < 30; i++) {
                 await new Promise(r => setTimeout(r, 500));
@@ -147,7 +198,18 @@ cli({
                 await attachComposerImage(page, localImagePath);
             }
 
-            const result = await submitQuote(page, kwargs.text, target.id);
+            let result = await submitQuote(page, kwargs.text, target);
+            if (result.retryWithMenuFallback) {
+                const opened = await openQuoteComposerFromRetweetMenu(page, target);
+                if (!opened?.ok) {
+                    return [{ status: 'failed', message: opened?.message ?? 'Could not open quote composer from repost menu.', text: kwargs.text }];
+                }
+                if (localImagePath) {
+                    await page.wait({ selector: COMPOSER_FILE_INPUT_SELECTOR, timeout: 20 });
+                    await attachComposerImage(page, localImagePath);
+                }
+                result = await submitQuote(page, kwargs.text, target, { allowMenuFallback: false });
+            }
             if (result.ok) {
                 // Wait for network submission to complete
                 await page.wait(3);

--- a/clis/twitter/quote.test.js
+++ b/clis/twitter/quote.test.js
@@ -24,6 +24,7 @@ describe('twitter quote helpers', () => {
         expect(() => __test__.buildQuoteComposerUrl('not a url')).toThrow(/Invalid tweet URL/);
         expect(() => __test__.buildQuoteComposerUrl('https://evil.com/?next=https://x.com/alice/status/2040254679301718161')).toThrow(ArgumentError);
     });
+
 });
 
 describe('twitter quote command', () => {
@@ -54,6 +55,9 @@ describe('twitter quote command', () => {
         expect(script).toContain('tweetButton');
         expect(script).toContain('__twHasLinkToTarget(document)');
         expect(script).toContain('__twGetStatusIdFromHref');
+        expect(script).toContain('retryWithMenuFallback');
+        expect(script).toContain('Quote target did not render in the dedicated composer; retrying through the repost menu.');
+        expect(script).toContain('Quote target did not render after opening the quote composer from the repost menu.');
         expect(script).toContain('Quote tweet submission did not complete before timeout');
         expect(script).toContain('[role="alert"], [data-testid="toast"]');
         expect(result).toEqual([
@@ -152,11 +156,45 @@ describe('twitter quote command', () => {
         })).rejects.toThrow(CommandExecutionError);
     });
 
-    it('returns a failed row when the quote target fails to render', async () => {
+    it('falls back to the target tweet repost menu when the dedicated composer misses the quote card', async () => {
         const cmd = getRegistry().get('twitter/quote');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
-            { ok: false, message: 'Quote target did not render in the composer. The source tweet may be deleted or restricted.' },
+            { ok: false, retryWithMenuFallback: true, message: 'Quote target did not render in the dedicated composer; retrying through the repost menu.' },
+            { ok: true },
+            { ok: true, message: 'Quote tweet posted successfully.' },
+        ]);
+        const result = await cmd.func(page, {
+            url: 'https://x.com/alice/status/2040254679301718161',
+            text: 'real quote',
+        });
+        expect(page.goto).toHaveBeenNthCalledWith(
+            2,
+            'https://x.com/alice/status/2040254679301718161',
+            { waitUntil: 'load', settleMs: 2500 },
+        );
+        const fallbackScript = page.evaluate.mock.calls[1][0];
+        expect(fallbackScript).toContain("targetArticle?.querySelector('[data-testid=\"retweet\"], [data-testid=\"unretweet\"]')");
+        expect(fallbackScript).toContain('quoteItem.click()');
+        expect(fallbackScript).toContain('Repost menu opened but the Quote option did not appear.');
+        expect(result).toEqual([
+            {
+                status: 'success',
+                message: 'Quote tweet posted successfully.',
+                text: 'real quote',
+            },
+        ]);
+        expect(page.wait).toHaveBeenNthCalledWith(2, { selector: '[data-testid="primaryColumn"]', timeout: 15 });
+        expect(page.wait).toHaveBeenNthCalledWith(3, { selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
+        expect(page.wait).toHaveBeenNthCalledWith(4, 3);
+    });
+
+    it('returns a failed row when both quote composer paths miss the quote target', async () => {
+        const cmd = getRegistry().get('twitter/quote');
+        const page = createPageMock([
+            { ok: false, retryWithMenuFallback: true, message: 'Quote target did not render in the dedicated composer; retrying through the repost menu.' },
+            { ok: true },
+            { ok: false, message: 'Quote target did not render after opening the quote composer from the repost menu.' },
         ]);
         const result = await cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
@@ -165,12 +203,10 @@ describe('twitter quote command', () => {
         expect(result).toEqual([
             {
                 status: 'failed',
-                message: 'Quote target did not render in the composer. The source tweet may be deleted or restricted.',
+                message: 'Quote target did not render after opening the quote composer from the repost menu.',
                 text: 'orphaned quote',
             },
         ]);
-        // Only the textarea wait should run when ok is false (no extra 3s post-submit wait).
-        expect(page.wait).toHaveBeenCalledTimes(1);
     });
 
     it('throws CommandExecutionError when no page is provided', async () => {


### PR DESCRIPTION
## Summary
- keep the existing dedicated X quote composer path
- when the quoted card does not render from /compose/post?url=..., append the target tweet URL into the composer before posting
- add unit coverage for fallback quote text and the guarded fallback path

## Why
The X UI can load the quote composer text area without rendering the quoted tweet card. The current adapter fails in that state with "Quote target did not render in the composer", which blocks daily quote workflows. Appending the target tweet URL preserves quote behavior on X instead of failing or posting orphaned text.

## Tests
- npm run build
- npx vitest run --project adapter clis/twitter/quote.test.js clis/twitter/shared.test.js