### PR TITLE
docs(sitemap-promote): seed twitter + hackernews PoC at global path

### DIFF
--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/SITE.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/SITE.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1
+site: news.ycombinator.com
+auth_strategy: PUBLIC_API
+login_required: false
+last_verified: 2026-06-02
+source: global
+---
+
+## Overview
+
+Hacker News (HN). Classic SSR HTML + public Firebase API. Read-only reads do not need login; submit / comment / vote require account.
+
+## Top-level routes
+
+- /news → pages/front.md (front page, default landing)
+- /newest → pages/feed.md (newest)
+- /best → pages/feed.md (best, sorted by score)
+- /ask → pages/feed.md (Ask HN)
+- /show → pages/feed.md (Show HN)
+- /jobs → pages/feed.md (Jobs)
+- /item?id=<id> → pages/item.md (single story + comments)
+- /user?id=<handle> → pages/user.md (user profile + recent submissions)
+
+## Common goals
+
+- read front page → 直接用 adapter `opencli hackernews top`，无需 workflow
+- read newest / best / show / ask / jobs → adapter `opencli hackernews <feed>`，无需 workflow
+- read single story + comments → adapter `opencli hackernews story <id>`，无需 workflow
+- search → adapter `opencli hackernews search`，无需 workflow
+- read user profile → adapter `opencli hackernews user <handle>`，无需 workflow
+- submit a story (login required, agent-driven) → workflows/submit-story.md (browser only — no write adapter)
+- comment / reply → workflows/comment.md (browser only)
+- upvote → workflows/upvote.md (browser only)
+
+## Site-wide pitfalls
+
+详见 pitfalls.md。简版：
+- Firebase API 不带 search（用 algolia HN search endpoint）
+- HTML 缺 class hooks，要靠 `<tr class="athing">` + sibling row 模式

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/SITE.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/SITE.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 site: news.ycombinator.com
 auth_strategy: PUBLIC_API
 login_required: false

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/apis.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/apis.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 last_verified: 2026-06-02
 source: global
 ---

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/apis.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/apis.md
@@ -1,0 +1,62 @@
+---
+schema_version: 1
+last_verified: 2026-06-02
+source: global
+---
+
+## Endpoint index
+
+HN 同时有两个 API 表面：
+
+- **Firebase API** (`https://hacker-news.firebaseio.com/v0/...`) — 官方 read API，public，文档化 schema。**契约最强**，所有 read adapter 都走这里。
+- **Algolia HN Search** (`https://hn.algolia.com/api/v1/...`) — 社区维护的 search，public，contract 也稳。HN 主域没 search API，必须用 algolia。
+
+### endpoint:topstories
+- triggers_on_pages: [front]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+- notes: Firebase `/topstories.json` 返回 top 500 story id array，agent adapter 链 `item/<id>.json` 拿详情
+
+### endpoint:newstories
+- triggers_on_pages: [feed]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+- notes: Firebase `/newstories.json`，同 topstories 模式
+
+### endpoint:beststories
+- triggers_on_pages: [feed]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+
+### endpoint:askstories
+- triggers_on_pages: [feed]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+
+### endpoint:showstories
+- triggers_on_pages: [feed]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+
+### endpoint:jobstories
+- triggers_on_pages: [feed]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+
+### endpoint:item
+- triggers_on_pages: [item, front, feed]
+- triggered_by_actions: [page_load, expand_comments]
+- contract_strength: stable
+- notes: Firebase `/item/<id>.json`，story + comment 都是 item，type 字段区分 (story / comment / poll / pollopt / job)
+
+### endpoint:user
+- triggers_on_pages: [user]
+- triggered_by_actions: [page_load]
+- contract_strength: stable
+- notes: Firebase `/user/<handle>.json`，含 submitted id array
+
+### endpoint:algolia_search
+- triggers_on_pages: [search]
+- triggered_by_actions: [search_submit]
+- contract_strength: stable
+- notes: `/search?query=<q>`（relevance）+ `/search_by_date?query=<q>`（time），HN 主域无 search endpoint

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/feed.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/feed.md
@@ -1,0 +1,39 @@
+---
+schema_version: 1
+page_id: feed
+url_patterns:
+  - https://news.ycombinator.com/newest
+  - https://news.ycombinator.com/best
+  - https://news.ycombinator.com/ask
+  - https://news.ycombinator.com/show
+  - https://news.ycombinator.com/jobs
+purpose: paginated list of stories sharing front-page DOM structure (newest / best / show / ask / jobs)
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- pattern: 跟 front.md 完全同结构（`tr.athing` + sibling subtext row）
+- text: 顶部 nav 高亮当前 tab (new/best/ask/show/jobs)
+- selector_pattern: 同 front.md（id-anchored / sibling / attribute boundary）
+
+## Actions on this page
+
+action:open_story_detail in pages/front.md
+action:next_page in pages/front.md
+
+（DOM 结构与 front.md 完全一致，action 通过 reference 复用，不复制定义）
+
+## Linked APIs
+
+按 URL 路由不同 endpoint：
+- /newest → endpoint_id: newstories
+- /best → endpoint_id: beststories
+- /ask → endpoint_id: askstories
+- /show → endpoint_id: showstories
+- /jobs → endpoint_id: jobstories
+
+## Page-specific pitfalls
+
+- 跨 feed 类型用同 DOM，但 API endpoint 不同 — adapter `opencli hackernews <feed>` 已封装路由，DOM scrape 只看 URL 不看页面差异

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/feed.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/feed.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 page_id: feed
 url_patterns:
   - https://news.ycombinator.com/newest

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/front.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/front.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 page_id: front
 url_patterns:
   - https://news.ycombinator.com/

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/front.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/front.md
@@ -1,0 +1,49 @@
+---
+schema_version: 1
+page_id: front
+url_patterns:
+  - https://news.ycombinator.com/
+  - https://news.ycombinator.com/news
+purpose: ranked front page (top stories), default landing
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- text: top nav strip `Hacker News | new | past | comments | ask | show | jobs | submit`
+- pattern: 每个 story 是 2 个 `<tr>`：第一 `<tr class="athing" id="<id>">` 含 rank + title + url；紧邻 sibling `<tr>` 含 score + author + age + comment-count
+- selector_pattern (id-anchored): `tr.athing[id="<id>"]`
+- selector_pattern (sibling traversal): `tr.athing[id="<id>"] + tr` (subtext row)
+- selector_pattern (attribute boundary): `a[href^="item?id="]` (comments link, NOT title link out to external)
+- (testid: 不适用 — HN 无 data-testid 约定)
+
+## Actions on this page
+
+### action:open_story_detail
+pre: on /news 或 /，目标 story id 已知（rank 仅作降级匹配）
+do: opencli hackernews story <id> || click `tr.athing[id="<id>"] + tr a[href^="item?id="]`
+post: URL → /item?id=<id> AND <title> 含 story 标题
+fail: click 落到外部 URL（误点 title link） | athing 不在当前 page
+recover: 误点外站立即 back; athing 找不到时 reload /news 或用 adapter 直 fetch; adapter_health_update: opencli hackernews story -> suspect
+evidence: opencli hackernews top --limit 30 + opencli browser open
+
+> **Anchor note**：`tr.athing:nth-child(<rank>)` 不安全 — HN 每个 story 是 athing row + subtext sibling row 两 `<tr>`，nth-child(rank) 不映射到 rank 序号。用 `[id="<id>"]` attribute selector 是 schema v1.1 §2.2 selector_pattern (id-anchored) 的典型案例。
+
+### action:next_page
+pre: on /news，已滚到底，footer `More` link visible
+do: opencli hackernews top --offset <N> || click `a.morelink`
+post: URL 加 ?p=<N> 或 ?next=<id>&n=<offset>，新 30 条 stories
+fail: morelink 不存在（HN 默认 ~30 条/页）
+recover: adapter --limit 跨页透明，DOM 翻页是 worse path; adapter_health_update: opencli hackernews top -> suspect
+evidence: opencli hackernews top --offset 30
+
+## Linked APIs
+
+- endpoint_id: topstories (triggers_on: page load)
+- endpoint_id: item (triggers_on: 每条 story → fan out item/<id>)
+
+## Page-specific pitfalls
+
+- title `<a>` 指向**原文 URL**，不是 HN 评论页。去评论必须 click `a[href^="item?id="]` (comments link) 而非 title
+- HN 单页 ~30 story；超过用 `morelink` 或 adapter offset

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/item.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/item.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 page_id: item
 url_patterns:
   - https://news.ycombinator.com/item?id={id}

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/item.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/item.md
@@ -1,0 +1,53 @@
+---
+schema_version: 1
+page_id: item
+url_patterns:
+  - https://news.ycombinator.com/item?id={id}
+purpose: single item view (story + comments OR comment thread OR ask/show post)
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- pattern: 顶部 `<tr>` 是 story header（同 front.md athing 结构）；comment 树是 `<tr class="athing comtr">` 嵌套 indent，indent level 看 `<td class="ind"><img width="<N*40>">` 的 width
+- selector_pattern (id-anchored): `tr.athing[id="<id>"]`, `tr[id="<id>"]` (comment), `a[id="up_<id>"]` (vote arrow)
+- selector_pattern (sibling traversal): `tr.athing > td > div.commtext` (comment text), `tr#<id> > td.ind` (indent level)
+- selector_pattern (attribute boundary): `a[href^="reply?id="]`, `a[href^="vote?id="]`
+- selector_pattern (form name on /reply): `textarea[name="text"]`
+- text-fold marker: `a.togg` (折叠态 `[N more]` 文案；折叠 state 用 class 不靠文案，文案仅 confirmation)
+
+## Actions on this page
+
+### action:expand_comment_tree
+pre: on /item，folded comment 存在 (`a.togg` class)
+do: opencli hackernews story <id> (API 拿全树) || click `a.togg`
+post: 子 comment 行展开（DOM 多 `<tr class="comtr">`）
+fail: togg link 不响应（极少）
+recover: 直接走 Firebase `item/<id>.json` 递归 kids; adapter_health_update: opencli hackernews story -> suspect
+evidence: opencli hackernews story <id>
+
+### action:open_reply_form
+pre: on /item，logged_in，目标 comment 有 reply link
+do: click `a[href^="reply?id="]`
+post: URL → /reply?id=<id>，textarea[name="text"] visible
+fail: redirect /login (未登录) | throw_too_fast (HN 风控 cool-down)
+recover: 未登录抛 AuthRequired; throw_too_fast 标 pitfall:hn_rate_limit 等 10-30s 重试
+evidence: opencli browser click + state
+
+### action:upvote
+pre: on /item，logged_in，未投过票（`a[id="up_<id>"]` 可见且未灰）
+do: click `a[id="up_<id>"]`
+post: arrow 灰显（已投），不可再 click
+fail: arrow 消失（HN 不允许 vote own post）| redirect /login
+recover: 不允许 vote own 抛 CommandExecutionError; 未登录抛 AuthRequired
+evidence: opencli browser click
+
+## Linked APIs
+
+- endpoint_id: item (triggers_on: page load + expand_comment_tree 递归 kids)
+
+## Page-specific pitfalls
+
+- vote URL 含 csrf-like `?auth=<token>` 不能 hardcode
+- comment "reply" 必须 login，未登录 click redirects /login

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/user.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/user.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 page_id: user
 url_patterns:
   - https://news.ycombinator.com/user?id={handle}

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/user.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pages/user.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+page_id: user
+url_patterns:
+  - https://news.ycombinator.com/user?id={handle}
+purpose: user profile view (karma + about + submitted list)
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- text label: `user:`, `created:`, `karma:`, `about:` row labels
+- selector_pattern (attribute boundary): `a[href^="submitted?id="]`, `a[href^="threads?id="]`
+- selector_pattern (sibling, in `<table>`): each `<tr>` row 含 label + value
+
+## Actions on this page
+
+### action:open_submissions
+pre: on /user?id=<handle>
+do: opencli hackernews user <handle> || click `a[href^="submitted?id="]`
+post: URL → /submitted?id=<handle>，story list visible
+fail: redirect 404 (handle 不存在)
+recover: handle 不存在抛 CommandExecutionError; adapter_health_update: opencli hackernews user -> suspect
+evidence: opencli hackernews user <handle>
+
+## Linked APIs
+
+- endpoint_id: user (triggers_on: page load)
+
+## Page-specific pitfalls
+
+- handle case-sensitive，pg ≠ Pg
+- newly-created user 的 about field 可能 null

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pitfalls.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pitfalls.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 last_verified: 2026-06-02
 source: global
 ---

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pitfalls.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/pitfalls.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+last_verified: 2026-06-02
+source: global
+---
+
+## Site-specific pitfalls (task-executor 视角)
+
+### pitfall:firebase_id_array_fan_out_required
+- trigger: agent 期望 `/topstories.json` 直接返回 story 详情
+- symptom: 拿到的是 id array `[3819,3820,...]` 不是 object array
+- workaround: 链 `/item/<id>.json` 一一拿；用 adapter `opencli hackernews top` 已封装这个 fan-out
+- verified_at: 2026-06-02
+
+### pitfall:no_search_on_main_domain
+- trigger: agent 在 news.ycombinator.com 找 search UI / 直接 fetch 主域 /search
+- symptom: 主域顶部无 search 框，404 on /search
+- workaround: 用 Algolia HN search endpoint（apis.md `algolia_search`）或 adapter `opencli hackernews search`
+- verified_at: 2026-06-02
+
+### pitfall:html_lacks_semantic_classes
+- trigger: agent 想从 DOM scrape 而非用 API
+- symptom: `<tr class="athing">` 后跟 sibling `<tr>` 包含 score/author/comment-count，结构靠 sibling 关系而非嵌套
+- workaround: 优先走 API（contract_strength=stable），DOM scrape 是 worse path；如必须 scrape，用 sibling traversal `tr.athing + tr` 而非裸 selector
+- verified_at: 2026-06-02
+
+### pitfall:vote_requires_login_and_csrf
+- trigger: agent 用 browser primitives 模拟 upvote
+- symptom: vote URL 含 token query param `?how=up&auth=<csrf>&id=<id>&...`，无 login session 直接 404 或 redirect /login
+- workaround: 必须先 login，CSRF token 从 vote arrow `<a id="up_<id>">` 的 href 里 extract，不能 hardcode
+- verified_at: 2026-06-02
+
+### pitfall:firebase_returns_null_for_dead_or_deleted
+- trigger: agent 期望 item endpoint 总返回 object
+- symptom: deleted/dead item 返回 `null`，不是 error
+- workaround: typed error 抛 `EmptyResultError`；不能 silent treat as not_found（adapter-internal 解决，task-executor 看 adapter 健康即可）
+- verified_at: 2026-06-02

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/read-story.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/read-story.md
@@ -1,0 +1,57 @@
+---
+schema_version: 1
+workflow_id: read-story
+intent: read a HN story and its top-level comments
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+拿到一条 HN story 的：标题 / URL / score / author / 时间 / top-level comments 列表。
+
+## State signature
+
+- entry: 任意 page，story id 或 URL 已知
+- success: 拿到 story object + comments array
+
+## Best path
+
+- adapter: opencli hackernews story <id>
+- adapter_health: healthy
+- preconditions: story id 已知
+- estimated_turns: 1
+
+## Fallback path
+
+如果 adapter 抛 typed error / 空 result（触发 `adapter_health_update: opencli hackernews story -> suspect`）：
+
+1. `opencli browser open https://news.ycombinator.com/item?id=<id>`
+2. action:expand_comment_tree in pages/item.md（如果有折叠）
+3. `opencli browser state` 拿 DOM
+4. parse story header (`tr.athing[id="<id>"]`) + comment tree (`tr.comtr` ids 数组)
+
+- estimated_turns: 3-4
+
+## Avoid
+
+- 不要从 /news 列表 page 推断 story 内容（列表只有标题 + score，无评论）
+- 不要 scrape 原文 URL（title link 指向外站，不是 HN 评论）
+- 不要并发 fan-out 全 comment tree 走 `item/<kid_id>.json` (rate limit 风险；用 adapter 已 throttle)
+
+## Re-entry checkpoints
+
+- 已 open /item?id=<id>，DOM ready → step 2 起
+- DOM 拿到但 expand 未做 → step 2 起
+- story + comments 已收集 → 完成
+
+## State validation
+
+- story.title 非空
+- comments array 长度 ≥ 0（dead story 可能 0）
+- 至少 story.by + story.time 字段存在
+
+## Stale markers
+
+- HN HTML 结构非常稳（10+ 年不大改）
+- Firebase API 是 read-only 公开服务，几乎不漂；endpoint:item 返回 schema 变化是大事件

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/read-story.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/read-story.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 workflow_id: read-story
 intent: read a HN story and its top-level comments
 last_verified: 2026-06-02

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/submit-story.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/submit-story.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 workflow_id: submit-story
 intent: submit a new story to HN (URL or text post)
 last_verified: 2026-06-02

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/submit-story.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/submit-story.md
@@ -1,0 +1,60 @@
+---
+schema_version: 1
+workflow_id: submit-story
+intent: submit a new story to HN (URL or text post)
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+提交一条 story：title (≤80 char) + url XOR text body。URL post 或 Ask HN / Show HN 文本 post 二选一。
+
+## State signature
+
+- entry: 任意 page，logged_in，title 和 url(or text) 已准备
+- success: redirect to /newest 顶部出现新 story by 当前 user
+
+## Best path
+
+- adapter: null
+- adapter_health: broken （HN 无 write adapter，必须走 browser workflow）
+- preconditions: logged_in / title ≤ 80 char / url or text ready
+- estimated_turns: 4-5
+
+## Fallback path
+
+实际就是唯一 path（browser）：
+
+1. `opencli browser open https://news.ycombinator.com/submit`
+2. type title → `input[name="title"]`
+3. type url → `input[name="url"]` || type text → `textarea[name="text"]` （**互斥**，不能同时填）
+4. click `input[type="submit"]`
+5. 验证 redirect /newest，顶部新 story by 当前 user
+
+- estimated_turns: 4-5
+
+## Avoid
+
+- 不要同时填 url + text（HN 拒绝）
+- 不要 submit 超过 daily rate limit (throw_too_fast)
+- 不要重复 submit 同 URL（HN dedupe → 抛 "have submitted"）
+- title 不带 emoji（部分 emoji 引起 form 拒收）
+
+## Re-entry checkpoints
+
+- 已 open /submit，form empty → step 2 起
+- title filled 但 url/text 未填 → step 3 起
+- form 全填但未 submit → step 4 起
+- redirect /newest 且 story 出现 → 完成
+
+## State validation
+
+- redirect URL 含 `/newest` 或 `/item?id=<new-id>`
+- /newest 顶部 story.by 等于当前 user
+- title 完全匹配（HN 不修改 title）
+
+## Stale markers
+
+- /submit form field name (`title` / `url` / `text`) 几乎不变（10 年没改 form schema）
+- HN 偶尔加 captcha 给 new user (< 7 天账号)

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/upvote.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/upvote.md
@@ -1,0 +1,53 @@
+---
+schema_version: 1
+workflow_id: upvote
+intent: upvote a story or comment
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+对一条 story 或 comment 投上票。需 login，不可投自己内容。
+
+## State signature
+
+- entry: 任意 page，logged_in，目标 item id 已知
+- success: vote arrow 灰显（已投状态）
+
+## Best path
+
+- adapter: null
+- adapter_health: broken （HN 无 write adapter，必须走 browser workflow）
+- preconditions: logged_in / target item id 已知 / 不是自己内容
+- estimated_turns: 2
+
+## Fallback path
+
+唯一 path：
+
+1. `opencli browser open https://news.ycombinator.com/item?id=<id>` 或 /news 找到该 item
+2. action:upvote in pages/item.md
+
+- estimated_turns: 2
+
+## Avoid
+
+- 不要 vote 自己的 story / comment（HN NoOp，arrow 不显示）
+- 不要快速连续 vote 多条（rate limit，~10s 内 >5 票触发 cool-down）
+- 不要 hardcode vote URL（必须从页面 `a[id="up_<id>"]` 提 csrf token）
+
+## Re-entry checkpoints
+
+- 已 open /item?id=<id>，arrow visible → step 2
+- arrow 已灰 → 完成（idempotent，不重复 click）
+
+## State validation
+
+- `a[id="up_<id>"]` 从有效变灰（class 含 `nosee` 或 visibility hidden）
+- 自己 user profile karma +1（异步，可能延迟）
+
+## Stale markers
+
+- HN vote URL 含 auth token，token 生成机制偶尔小调（极罕见）
+- pitfall:vote_requires_login_and_csrf 一直有效

--- a/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/upvote.md
+++ b/skills/opencli-sitemap-author/references/site-memory/hackernews/sitemap/workflows/upvote.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 1.1
 workflow_id: upvote
 intent: upvote a story or comment
 last_verified: 2026-06-02

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/SITE.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/SITE.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1.1
+site: x.com
+last_verified: 2026-06-02
+source: global
+login_required: true
+auth_strategy: COOKIE_API
+---
+
+## Overview
+
+Twitter / X (`twitter.com` → 301 `x.com` since 2024)。微博形态的 social feed，agent 主要任务是读 timeline / 发推 / 回复 / 搜索 / bookmark / 看 profile。绝大多数读写都需要登录态（`auth_token` + `ct0` cookie）；未登录只能访问极少量 public surface（个别 profile / status URL）。
+
+## Top-level routes
+
+- `/home` → pages/home.md（主 timeline，登录后默认落地）
+- `/explore` → pages/explore.md（搜索 + trending，公开可见骨架但内容需登录）
+- `/<handle>` → pages/profile.md（用户 profile）
+- `/<handle>/status/<id>` → pages/status.md（单条 tweet detail）
+- `/compose/tweet` → pages/compose.md（发推 modal，也可在 /home inline 触发）
+- `/notifications` → pages/notifications.md
+- `/i/bookmarks` → pages/bookmarks.md
+- `/messages` → pages/messages.md（DM，本 PoC v1 不覆盖）
+
+## Common goals
+
+- publish a post → workflows/post.md
+- reply to a tweet → workflows/reply.md
+- search for tweets / users → workflows/search.md
+- bookmark a tweet → workflows/bookmark.md
+- read user timeline → 直接用 adapter `opencli twitter tweets <handle>`，无需 workflow
+
+## Site-wide pitfalls
+
+详见 pitfalls.md。最容易踩的：
+
+- 未登录访问大多数 route 会 redirect 到 `/i/flow/login` (login wall)
+- mobile UA 会 redirect 到 `mobile.twitter.com` 后被 deprecate 弹窗拦，桌面 UA 必备
+- GraphQL endpoint 的 `queryId` 随 bundle hash 滚动，硬编码 queryId 的 cookie-API adapter 易腐
+- RTL 文本（阿拉伯/希伯来）在 compose 框 caret 行为异常，verify text 时多步 retry

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/apis.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/apis.md
@@ -1,0 +1,53 @@
+---
+schema_version: 1.1
+last_verified: 2026-06-02
+source: global
+---
+
+## Endpoint index
+
+> 引用规则（schema §2.4）：`endpoint_id` 必须存在于 `~/.opencli/sites/twitter/endpoints.json`。本文件只放 endpoint_id + 触发关系 + contract_strength，URL/method/params/response 是 endpoints.json 单一来源。
+
+### endpoint:UserByScreenName
+
+- triggers_on_pages: [profile, status]
+- triggered_by_actions: [resolve_handle_to_userid]
+- contract_strength: internal-unstable
+- notes: GraphQL `/i/api/graphql/{queryId}/UserByScreenName`，queryId 滚动见 pitfalls。所有 user-keyed adapter（tweets/likes/following/followers）的第一步。
+
+### endpoint:UserTweets
+
+- triggers_on_pages: [profile]
+- triggered_by_actions: [load_user_timeline, scroll_for_more]
+- contract_strength: internal-unstable
+- notes: `data.user.result.timeline.timeline.instructions[].entries` 结构，TimelinePinEntry 必须 skip 才是 chronological feed。
+
+---
+
+## v1 gap（intentional）
+
+twitter 的 adapter family (`clis/twitter/*.js`) 引用了 **34+ 个 GraphQL operation**（HomeTimeline / HomeLatestTimeline / SearchTimeline / CreateTweet / DeleteTweet / FavoriteTweet / UnfavoriteTweet / CreateRetweet / DeleteRetweet / CreateBookmark / Bookmarks / UserFollowing / Followers / NotificationsTimeline / TweetDetail / 等），但 `endpoints.json` 当前只有 **2 条**。
+
+这是 schema §2.4 "endpoint_id 必须存在于 endpoints.json" 严格规则 surface 出来的真实 gap：
+
+- **不是 sitemap 缺**：sitemap 不应该重复 endpoint detail
+- **是 endpoints.json 缺**：adapter-author 应该回填这些 operation 到 endpoints.json
+
+行动建议（不在本 PoC scope）：
+
+- 跑 `opencli browser network` 抓 twitter session 一次拿到当前 queryId map，全量回写 endpoints.json
+- step 3 数据显示 twitter COOKIE_API adapter 9 fixes/30 天 → queryId rotation 是主因，集中维护 endpoints.json 比 34 个 adapter 各自硬编码 fallback 价值更高
+
+待 endpoints.json 补齐后，本文件 endpoint 列表会扩到完整。
+
+---
+
+## contract_strength 分布预期（基于 step 3 数据）
+
+| 强度 | endpoint 类型 | twitter 实际 |
+|---|---|---|
+| stable | 公开签名 API | 无（无官方 v2 API 可用） |
+| visible-ui | RSS / public profile HTML | `/<handle>/status/<id>` 公开 HTML（无登录可见 metadata），但 PoC v1 不依赖 |
+| internal-unstable | GraphQL `/i/api/graphql/...` | 全部 34+ operation 都在此档 |
+
+twitter 实战上 **全 endpoint 都是 internal-unstable** —— 这本身是 agent 路径决策的信号：能用 adapter 走 adapter，adapter broken 时 fallback 用 DOM (`workflows/*.md` 的 Fallback path)，而不是手解 GraphQL。

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/_tweet_card.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/_tweet_card.md
@@ -1,0 +1,78 @@
+---
+schema_version: 1.1
+page_id: _tweet_card
+url_patterns: []
+purpose: partial — actions on any tweet card (used by home / status / profile / notifications / bookmarks)
+last_verified: 2026-06-02
+source: global
+---
+
+> Partial：`_` 前缀 + 空 `url_patterns` = 跨页通用 UI。其他 page 通过 `action:<id> in pages/_tweet_card.md` 引用。
+
+## Visual anchors
+
+- pattern: `article[role="article"]` 内 `[data-testid="cellInnerDiv"]`
+- testid: `[data-testid="like|unlike|reply|retweet|unretweet|bookmark|removeBookmark"]`
+- selector_pattern: `article a[href*="/status/"]`（permalink，可提 tweet_url）
+- a11y: article `aria-label` 含 author / 时间 / 互动计数
+
+## Card scope rule（全 action 共享）
+
+所有 testid selector 必须 scoped 到 card root `article[role="article"]`，**不能** 用 page-level first match，否则点到 timeline 首条非 target card。
+
+## Actions
+
+```yaml
+### action:open_status
+pre: card visible
+do: click article a[href*="/status/"] || evaluate href then goto
+post: URL -> /<handle>/status/<id>
+fail: stays on listing | modal not nav | 404
+recover: goto explicit URL; if 404 mark tweet stale
+evidence: opencli browser click + state
+```
+
+```yaml
+### action:like_tweet
+pre: card visible AND tweet_url known (or extract via article a[href*="/status/"])
+do: opencli twitter like <tweet-url> || click [data-testid="like"] in card scope
+post: card testid like -> unlike, icon red
+fail: testid unchanged | login modal | wrong card flipped (scope missing)
+recover: adapter_health_update: opencli twitter like -> suspect; dom_click in card scope; rollback via [data-testid="unlike"]
+evidence: opencli twitter like
+```
+
+```yaml
+### action:open_reply
+pre: card visible
+do: click [data-testid="reply"] in card scope
+post: composer shown, [data-testid="tweetTextarea_0"] focused, URL unchanged
+fail: login modal | composer not appearing
+recover: keyboard `r` if tweet focused; or goto status page use reply CTA
+evidence: opencli browser click
+```
+
+```yaml
+### action:repost_tweet
+pre: card visible AND tweet_url known
+do: opencli twitter retweet <tweet-url> || click [data-testid="retweet"] in card then [data-testid="retweetConfirm"]
+post: card testid retweet -> unretweet
+fail: confirm menu missing | testid unchanged
+recover: adapter_health_update: opencli twitter retweet -> suspect; dom_click confirm flow; rollback via [data-testid="unretweet"] + confirm
+evidence: opencli twitter retweet
+```
+
+```yaml
+### action:bookmark_tweet
+pre: card visible AND tweet_url known
+do: opencli twitter bookmark <tweet-url> || click [data-testid="bookmark"] in card scope
+post: card testid bookmark -> removeBookmark, toast "Added to your Bookmarks"
+fail: testid unchanged | toast missing
+recover: adapter_health_update: opencli twitter bookmark -> suspect; dom_click + verify toast
+evidence: opencli twitter bookmark
+```
+
+## Notes
+
+- logged-out 点 card action 弹 login modal — `pitfall:login_wall_on_most_routes`
+- adapter fail → DOM click fallback 是 site-wide 模式 — `pitfall:adapter_returns_empty_after_api_drift in ../pitfalls.md`

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/compose.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/compose.md
@@ -1,0 +1,58 @@
+---
+schema_version: 1.1
+page_id: compose
+url_patterns:
+  - https://x.com/compose/tweet
+  - https://x.com/compose/post
+purpose: standalone compose modal (also available inline on /home and /status)
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- a11y: `role=dialog name="Post" | "Compose post"`
+- testid: textarea `[data-testid="tweetTextarea_0"]`；submit `[data-testid="tweetButton"]` (modal — **不是** inline `tweetButtonInline`)；close `[data-testid="app-bar-close"]`
+- pattern: dialog 上方 progress ring (character count)
+- selector_pattern: URL `/compose/tweet` 是独立路由可直接 `goto`
+
+## Actions
+
+```yaml
+### action:type_post_content
+pre: textarea mounted and focused
+do: type "..." into [data-testid="tweetTextarea_0"]; for RTL content per pitfall:rtl_text_breaks_compose_verify split into segments
+post: textarea innerText contains input, submit button enabled, character count ring updates
+fail: text not on screen | verify text fail | button not enabling
+recover: clear + retype; RTL -> segmented retype; >280 char -> split to thread
+evidence: opencli browser type
+```
+
+```yaml
+### action:submit_modal_post
+pre: textarea has content, submit enabled, on modal form (NOT inline)
+do: opencli twitter post --text "..." || click [data-testid="tweetButton"] (NOT tweetButtonInline)
+post: modal dismissed, URL returns to caller page, new post in timeline
+fail: modal not dismissing | "Something went wrong" toast
+recover: adapter_health_update: opencli twitter post -> suspect; close modal + retry; persistent fail -> workflows/post.md Fallback
+evidence: opencli twitter post
+```
+
+```yaml
+### action:dismiss_modal_with_draft
+pre: decided not to send, textarea has content
+do: click [data-testid="app-bar-close"] then click "Save" or "Discard" in dialog
+post: modal closes, URL returns to caller page
+fail: dismiss dialog buttons unresponsive
+recover: ESC key; or navigate away (draft auto-save)
+evidence: opencli browser click
+```
+
+## Linked APIs
+
+无 — 该 page 自身只是 UI surface，actual post 触发的 `CreateTweet` endpoint 未在 `endpoints.json` 注册（见 apis.md v1 gap）
+
+## Page pitfalls
+
+- modal testid `tweetButton` vs inline `tweetButtonInline` 反复踩 — 写 selector 时**先检查 URL** 是否含 `/compose/` 判断 modal vs inline 形态
+- 含 media upload 的 post 不在 PoC v1 覆盖：file picker / blob URL 复杂，adapter `opencli twitter post --image-url` 已 handle，task agent 直接走 adapter

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/home.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/home.md
@@ -1,0 +1,63 @@
+---
+schema_version: 1.1
+page_id: home
+url_patterns:
+  - https://x.com/home
+  - https://x.com/i/timeline
+purpose: main personalized feed; default landing after login
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- a11y: `role=main` + `role=region name="Timeline: Your Home Timeline" | "Timeline: For You"`
+- pattern: feed items `[data-testid="cellInnerDiv"]` 包 `article[role="article"]`
+- testid: sidebar compose `[data-testid="SideNav_NewTweet_Button"]`；inline composer `[data-testid="tweetTextarea_0"]` / `[data-testid="tweetButtonInline"]`
+- text: top tab `"For you"` / `"Following"`（locale 漂 — `pitfall:button_not_found_in_non_english_locale`）
+
+## Actions
+
+```yaml
+### action:open_compose
+pre: on /home, logged_in, compose dialog not open
+do: click [data-testid="SideNav_NewTweet_Button"] || focus [data-testid="tweetTextarea_0"]
+post: textarea focused with role="textbox", submit button rendered
+fail: button_not_found | URL -> /i/flow/login
+recover: find --css [data-testid="tweetTextarea_0"] OR [data-testid="SideNav_NewTweet_Button"] (testid > visible text, cross locale stable); if both miss fallback find "What's happening" textarea; session 失效 -> AuthRequired
+evidence: opencli browser click + state
+```
+
+```yaml
+### action:submit_post
+pre: textarea has text, submit button enabled
+do: opencli twitter post --text "..." || click [data-testid="tweetButtonInline"]
+post: textarea cleared + toast "Your post was sent"; new post in timeline within 5s
+fail: button disabled | toast missing | textarea retains content > 5s
+recover: adapter_health_update: opencli twitter post -> suspect; check text length / login; or workflows/post.md Fallback
+evidence: opencli twitter post
+```
+
+```yaml
+### action:scroll_for_more
+pre: on /home, feed loaded
+do: evaluate("window.scrollBy(0, window.innerHeight)")
+post: new [data-testid="cellInnerDiv"] entries appended in DOM
+fail: 2s 无新 entry | top "Try again" banner | 429 toast
+recover: wait 2s then retry; consecutive fail -> mark stale
+evidence: opencli browser evaluate
+```
+
+## Tweet card actions
+
+home timeline 里每个 tweet card 上的 like / reply / repost / bookmark 是跨页通用 UI，定义在 [`pages/_tweet_card.md`](./_tweet_card.md)。
+
+- use `action:like_tweet in pages/_tweet_card.md`
+- use `action:open_reply in pages/_tweet_card.md`
+- use `action:bookmark_tweet in pages/_tweet_card.md`
+- use `action:open_status in pages/_tweet_card.md`
+
+## Page pitfalls
+
+- inline composer 与 `/compose/tweet` modal 两形态：testid `tweetTextarea_0` 通用；submit button modal 用 `tweetButton`，inline 用 `tweetButtonInline`
+- `For you` vs `Following` 是 ranking 差不是数据源差（HomeTimeline vs HomeLatestTimeline GraphQL）

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/profile.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/profile.md
@@ -1,0 +1,56 @@
+---
+schema_version: 1.1
+page_id: profile
+url_patterns:
+  - https://x.com/<handle>
+  - https://x.com/<handle>/with_replies
+  - https://x.com/<handle>/media
+  - https://x.com/<handle>/likes
+purpose: a user's profile + their tabs (posts / replies / media / likes)
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- a11y: `role=main` + `role=region name="Timeline: <handle>"`
+- testid: `[data-testid="UserName"]` / `[data-testid*="-follow"]` / `[data-testid*="-unfollow"]` / `[data-testid="primaryColumn"]`
+- pattern: tab strip `role="tablist"` 含 `Posts / Replies / Highlights / Articles / Media / Likes`
+- selector_pattern: URL `<handle>` 纯字母数字+下划线 1-15 长度，不带 `@`
+
+## Actions
+
+```yaml
+### action:follow_user
+pre: logged-in user != target user AND follow button testid shows "Follow"
+do: opencli twitter follow <handle> || click [data-testid*="-follow"]
+post: button text -> "Following", testid -> [data-testid*="-unfollow"]
+fail: button text unchanged | login modal | "Follow blocked" toast
+recover: adapter_health_update: opencli twitter follow -> suspect; dom_click [data-testid*="-follow"]; rollback via unfollow button
+evidence: opencli twitter follow
+```
+
+```yaml
+### action:switch_tab
+pre: on profile page AND target tab visible in tablist
+do: click role="tab" matching Posts|Replies|Media|Likes || goto /<handle>/<sub-path>
+post: URL switches to sub-path, timeline region re-renders
+fail: tab unresponsive | URL unchanged
+recover: use goto with explicit URL instead of click
+evidence: opencli browser click + state
+```
+
+## Tweet card actions
+
+profile timeline 上每个 tweet card 用 [`pages/_tweet_card.md`](./_tweet_card.md) 定义的 action（like / reply / repost / bookmark / open_status）。
+
+## Linked APIs
+
+- endpoint:UserByScreenName — handle → numeric userId 解析（所有 profile-keyed adapter 第一步）
+- endpoint:UserTweets — Posts tab 数据源
+
+## Page pitfalls
+
+- pinned tweet 永远在最顶不按时间排（adapter 内部处理，task agent 无需 distinguish）
+- `<handle>` 大小写不敏感但 URL 保留原样，adapter 内 normalize
+- suspended/banned user 显示 "Account suspended" 占位，结构完全不同 → 标 stale 抛 EmptyResult

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/status.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pages/status.md
@@ -1,0 +1,52 @@
+---
+schema_version: 1.1
+page_id: status
+url_patterns:
+  - https://x.com/<handle>/status/<numeric-id>
+  - https://x.com/i/status/<numeric-id>
+purpose: single tweet detail with thread / replies
+last_verified: 2026-06-02
+source: global
+---
+
+## Visual anchors
+
+- a11y: `role=main` + `role=region name` 含 `"Conversation"` 或 `<handle>'s post`
+- testid: 主 tweet `[data-testid="tweet"]`（listing page 用 `cellInnerDiv`，detail page 主 tweet 用 `tweet`）；reply composer `[data-testid="tweetTextarea_0"]` + `[data-testid="tweetButtonInline"]`
+- pattern: 主 tweet 下方按 reply 时间排子 tweet，结构同 `_tweet_card`
+
+## Actions
+
+```yaml
+### action:open_reply_composer_inline
+pre: on /<handle>/status/<id>, detail loaded
+do: click [data-testid="tweetTextarea_0"] || click [data-testid="reply"] button
+post: textarea focused, submit button [data-testid="tweetButtonInline"] enables on input
+fail: textarea not focusing | login modal
+recover: keyboard shortcut `r`; mark composer stale if persistent
+evidence: opencli browser click
+```
+
+```yaml
+### action:submit_reply
+pre: reply composer has text, submit enabled
+do: opencli twitter reply --status-url <url> --text "..." || click [data-testid="tweetButtonInline"]
+post: textarea cleared + toast "Your post was sent"; new reply appended below detail
+fail: button enabled but silent timeout (see pitfall:reply_silent_fails_on_rich_content) | login modal
+recover: adapter_health_update: opencli twitter reply -> suspect; apply pitfall workaround (single-paragraph plain text, escape bullets); long reply -> workflows/post.md + quote
+evidence: opencli twitter reply
+```
+
+## Tweet card actions
+
+主 tweet + 子 reply 都是 tweet card 形态，互动按钮见 [`pages/_tweet_card.md`](./_tweet_card.md)。
+
+## Linked APIs
+
+- endpoint:UserByScreenName — `<handle>` → userId 解析（reply / 子 tweet author 用）
+
+## Page pitfalls
+
+- detail page 主 tweet testid (`tweet`) ≠ listing page (`cellInnerDiv`) — a11y `role=article` 通用更安全
+- 长 thread / quote detail 部分 mount，scroll 触发加载
+- 删除的 tweet URL 仍可访问，detail 显示 `"This post is unavailable"` 占位

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pitfalls.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/pitfalls.md
@@ -1,0 +1,52 @@
+---
+schema_version: 1.1
+last_verified: 2026-06-02
+source: global
+---
+
+> **Scope**：本文件只列 **task-executing agent** 跑 sitemap workflow 时会撞的坑。adapter-author 实现层的坑（pinned_tweet TimelinePinEntry 跳过 / `unwrapBrowserResult` envelope / bigint id 精度 / queryId bundle 解析）放在 `~/.opencli/sites/twitter/notes.md`，与本文件互补。
+
+## Site-specific pitfalls
+
+### pitfall:login_wall_on_most_routes
+
+- trigger: 未登录访问 `/home / /notifications / /i/bookmarks / /<handle>/followers` 等
+- symptom: redirect 到 `/i/flow/login`，URL 含 `flow/login`
+- workaround: 跑 workflow / adapter 前 `opencli browser state` 看 URL；命中 `/i/flow/login` 抛 AuthRequired，不要尝试 click 登录（cookie 应预先注入 via `Strategy.COOKIE`）
+- verified_at: 2026-06-02
+
+### pitfall:wrong_dom_when_ua_mobile
+
+- trigger: 我的 browser session 用了 mobile UA（含 `Mobile|iPhone|Android`）
+- symptom: 落地 `mobile.twitter.com`，sitemap 描述的 selector / a11y 全错
+- workaround: opencli browser 默认桌面 UA，自定义时不要带 mobile 关键字；命中 mobile DOM 时切回默认 UA 再 retry
+- verified_at: 2026-06-02
+
+### pitfall:adapter_returns_empty_after_api_drift
+
+- trigger: 走 workflow Best path 跑 adapter，adapter 抛 EmptyResultError / 返 `data:{}` 空 / 抛 typed error
+- symptom: 任务"应该有数据"但 adapter 没数据；或 adapter 抛 `queryId expired` 类内部错
+- workaround: 把 workflow `adapter_health` 标 `suspect`，走 Fallback path (browser DOM)。endpoint 修是 adapter-author 的事，task agent 不要去解 queryId / 改 endpoint code
+- verified_at: 2026-06-02
+- notes: 实现层根因是 GraphQL queryId rotation（step 3 数据：twitter COOKIE_API adapter 30 天 9 fixes，主因即此），但 task agent 不需要知道这层，只需"切 Fallback"。internal-unstable contract 的代表 pitfall，PoC v1 workflows 的 Fallback path 全部预留 browser DOM 兜底
+
+### pitfall:reply_silent_fails_on_rich_content
+
+- trigger: 我的 reply 内容含多段 / bullet list / 反引号 / `→` arrow / `<url>` 角括号占位
+- symptom: silent `Could not verify reply text in the composer`，同内容用 post composer 能通
+- workaround: 单段纯文字 / `/` 替代 bullet / "any URL" 替代 `<url>` 占位 / 500 char + 链接收尾；多段长 reply 改走 post + quote
+- verified_at: 2026-05-15
+
+### pitfall:rtl_text_breaks_compose_verify
+
+- trigger: 我要发 / 回复包含 RTL 文字（阿拉伯 / 希伯来 / 波斯）的内容
+- symptom: caret 跳行首 / verify text 失败 / submit button 不 enable
+- workaround: 分段输入 + 每段后 200ms wait + verify 多次 retry
+- verified_at: 2026-05-15
+
+### pitfall:button_not_found_in_non_english_locale
+
+- trigger: 我的 session locale 非 English，sitemap 写 `text: "Post"` 类 visible text selector
+- symptom: button_not_found，但页面上确实有等价按钮
+- workaround: 改用 a11y role + `data-testid`。Twitter 内部 testid (`tweetButtonInline` / `reply` / `like` / `bookmark`) 跨 locale 稳定
+- verified_at: 2026-06-02

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/bookmark.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/bookmark.md
@@ -1,0 +1,64 @@
+---
+schema_version: 1.1
+workflow_id: bookmark
+intent: bookmark a tweet (add or remove)
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+把一条 known tweet URL 加入 / 移出当前账户的 bookmark 列表。
+
+## State signature
+
+- entry: 知道 target tweet URL, logged_in
+- success: tweet card 工具栏 testid `bookmark` ↔ `removeBookmark` 翻转, toast 出现
+
+## Best path
+
+```yaml
+adapter: opencli twitter bookmark
+adapter_health: healthy
+preconditions:
+  - logged_in
+  - target_status_url known
+estimated_turns: 1
+```
+
+`opencli twitter bookmark <status-url>` add, `opencli twitter unbookmark <status-url>` remove。
+
+## Fallback path
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli twitter bookmark -> suspect
+  - goto <status-url> (lands pages/status.md)
+  - action:bookmark_tweet in pages/_tweet_card.md
+  - verify testid flip + toast "Added to your Bookmarks"
+estimated_turns: 2
+```
+
+## Avoid
+
+- 不要从 listing page (home / search) click bookmark — card 分页加载结构不一定 stable，直接 `goto <status-url>` 在 detail page 操作更可靠
+- 不要 bookmark + 立刻 unbookmark 做 toggle test — 短时间 toggle 留 race-condition testid 状态，会误判 `adapter_health=suspect`
+- 不要 click `[data-testid="bookmark"]` 期望 idempotent — click 已 bookmarked tweet 会 remove，必须先验当前 testid 状态
+
+## Re-entry checkpoints
+
+- on /<handle>/status/<id>, 工具栏 testid `bookmark` (未收藏) → 走 add 路径
+- on /<handle>/status/<id>, 工具栏 testid `removeBookmark` (已收藏) → 已完成（add 任务）或继续 remove
+- toast 已出现 → 完成
+
+## State validation
+
+- testid 状态正确翻转
+- toast 文本匹配 "Added to your Bookmarks" / "Removed from your Bookmarks"
+- 取查 `https://x.com/i/bookmarks` 列表能找到 / 已不在该 tweet（强验证, 需多 1 轮 navigation）
+
+## Stale markers
+
+- bookmark icon testid 名变（历史从 `bookmark` 改过一次, rebrand 可能再改）
+- toast 文本 i18n 漂
+- adapter `opencli twitter bookmark` 月度 fix 多 → adapter_health audit suspect

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/post.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/post.md
@@ -1,0 +1,78 @@
+---
+schema_version: 1.1
+workflow_id: post
+intent: publish a text-only public post
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+发一条公开 **text-only post，≤ 280 char，无 media / poll / schedule / thread-split**。
+
+- 带 media 走 adapter `opencli twitter post --image-url` 直接路径
+- thread-split (> 280 char) / poll / schedule 不在 v1 PoC scope（caller 应在调本 workflow 前处理 split 或选其他 workflow）
+
+## State signature
+
+- entry: 任意 page on x.com, logged_in (cookie `auth_token` 有效)
+- success: timeline 5s 内看到新 post 出现在自己的 home / profile
+
+## Best path
+
+```yaml
+adapter: opencli twitter post
+adapter_health: healthy
+preconditions:
+  - logged_in
+  - text content ready (<= 280 chars)
+estimated_turns: 1
+```
+
+直接 `opencli twitter post --text "<content>"`。adapter 内部 handle COOKIE 注入 / queryId rotation / verify。
+
+## Fallback path
+
+当 adapter 抛 typed error (EmptyResultError | CommandExecutionError) 或返回 unexpected empty 时：
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli twitter post -> suspect
+  - opencli browser state (verify current page)
+  - if not on /home: goto /home
+  - action:open_compose in pages/home.md
+  - type content into [data-testid="tweetTextarea_0"]
+  - action:submit_post in pages/home.md
+  - verify timeline top shows new post within 5s
+estimated_turns: 4
+```
+
+## Avoid
+
+- 不要在 mobile UA 下手 click sidebar `New Post` 按钮 — `pitfall:wrong_dom_when_ua_mobile`
+- 不要 `goto /compose/tweet` 后再用 inline composer testid `tweetButtonInline`，modal 形态用 `tweetButton`（见 `pages/compose.md`）
+- RTL 内容不要单段一次 type — `pitfall:rtl_text_breaks_compose_verify`
+- 不要 adapter 失败时反复 retry adapter — 直接走 Fallback，否则浪费 turn
+
+## Re-entry checkpoints
+
+agent 中断后醒来按 `browser state` URL 判断：
+
+- on /home, compose dialog NOT visible → 从 Fallback step 2 起
+- on /home OR /compose/tweet, textarea visible 且 text 已部分输入 → step 3 起（continue type 剩余）
+- on /home, 新 post 已在 timeline 顶部 → 已完成
+
+## State validation
+
+- timeline 顶部出现 author=self 的新 entry
+- entry text **normalized 匹配** submitted content：
+  - trim 前后 whitespace
+  - Twitter 自动 URL 化（裸 URL → t.co shortlink + display URL，按 display URL 或原 URL substring 匹配）
+  - emoji / unicode NFC normalize 保留
+  - **不要** 用 strict equality（whitespace 折叠 / URL 转换造成假失败）
+- entry 时间显示 "now" / "1s ago"
+
+## Stale markers
+
+- adapter `opencli twitter post` 30 天内 fix PR 增多 → adapter_health audit 标 suspect
+- submit button text "Post" 变化（i18n / rebrand 二轮）→ visual anchors 需更新

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/reply.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/reply.md
@@ -1,0 +1,70 @@
+---
+schema_version: 1.1
+workflow_id: reply
+intent: reply to a specific tweet
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+对一条 known tweet URL 发 reply (text only)。
+
+## State signature
+
+- entry: 任意 page, 知道 target `https://x.com/<handle>/status/<id>`, logged_in
+- success: 该 status detail page 下方 5s 内出现自己的 reply
+
+## Best path
+
+```yaml
+adapter: opencli twitter reply
+adapter_health: healthy
+preconditions:
+  - logged_in
+  - target_status_url known
+  - reply content satisfies pitfall:reply_silent_fails_on_rich_content constraints
+estimated_turns: 1
+```
+
+直接 `opencli twitter reply --status-url <url> --text "<content>"`。
+
+**强约束**：reply 含多段 / bullet / 反引号 / `→` / `<url>` 占位 → 多半 silent fail，**改写**或走 Fallback。详 `pitfall:reply_silent_fails_on_rich_content`。
+
+## Fallback path
+
+adapter 失败或 reply 内容过 rich 时：
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli twitter reply -> suspect
+  - goto <status-url> (lands pages/status.md)
+  - action:open_reply_composer_inline in pages/status.md
+  - type content (RTL segmented, rich content per pitfall workaround)
+  - action:submit_reply in pages/status.md
+  - verify self reply within 5s under detail
+estimated_turns: 4
+```
+
+## Avoid
+
+- **不要用多段 bullet list reply** — silent fail 无 error 反馈；按 `pitfall:reply_silent_fails_on_rich_content` 改写
+- 长 reply (>500 char) 改走 post + quote 模式 → `workflows/post.md` + quote_url 参数
+- 不要 reply 后立刻发第二条 — Twitter 短时间内限流，间隔 ≥ 2s
+
+## Re-entry checkpoints
+
+- on /<handle>/status/<id>, reply composer 未浮现 → Fallback step 2 起
+- on /<handle>/status/<id>, composer 浮现且 textarea 部分输入 → step 3 起
+- detail 下方已出现 self reply → 完成
+
+## State validation
+
+- detail 下方 reply 列出现 self entry
+- self reply text 完全匹配 submitted content（reply composer 不做 URL 自动转换，可 strict equality）
+- 主 tweet 工具栏 reply 计数 +1
+
+## Stale markers
+
+- `reply composer can not be verified` 错误率上升 → silent fail 模式可能扩到更多 content 形态，pitfall workaround 需更新
+- adapter `opencli twitter reply` 月度 fix 多 → adapter_health audit 标 suspect

--- a/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/search.md
+++ b/skills/opencli-sitemap-author/references/site-memory/twitter/sitemap/workflows/search.md
@@ -1,0 +1,67 @@
+---
+schema_version: 1.1
+workflow_id: search
+intent: search for tweets / users / latest news by keyword
+last_verified: 2026-06-02
+source: global
+---
+
+## Goal
+
+按关键词搜索 tweet / user / news 等，取结果列表前 N 条。
+
+## State signature
+
+- entry: 任意 page, logged_in (少数情况未登录也工作但结果稀缺)
+- success: 落 `/search?q=<term>&src=typed_query`, timeline region 出现结果或 "No results"
+
+## Best path
+
+```yaml
+adapter: opencli twitter search
+adapter_health: healthy
+preconditions:
+  - logged_in
+  - keyword query ready
+optional:
+  - filter (latest | top | people | photos | videos)
+estimated_turns: 1
+```
+
+`opencli twitter search --query "<keyword>" [--type latest|top|people]`。adapter 内置 queryId bundle parse 三层降级（实现细节见 `notes.md`）。
+
+## Fallback path
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli twitter search -> suspect
+  - goto https://x.com/search?q=<URLencoded>&src=typed_query&f=live  # f=live = Latest tab
+  - wait for [data-testid="cellInnerDiv"] OR text "No results for"
+  - find tweet card list (each per pages/_tweet_card.md)
+  - if more needed -> scroll (action:scroll_for_more in pages/home.md)
+estimated_turns: 3-4
+```
+
+## Avoid
+
+- 不要 `goto /search?q=...` 不带 `&src=typed_query` — 某些 query 会 redirect 到 trending detail 而非结果列表
+- 不要硬编码 `&f=top` 期望 "top is relevance" — Twitter "Top" 是混合排序，task 多数需要 "Latest" (时间序) → `&f=live`
+- 不要循环 click `"Show more"` UI button — 无限滚动模式，触发是 scroll 不是 click
+
+## Re-entry checkpoints
+
+- on /search?q=<term>, timeline 未渲染 → Fallback step 2 (wait)
+- on /search?q=<term>, 第一页已显示 → 决定继续 scroll
+- 已收集 N 条结果 → 完成
+
+## State validation
+
+- URL 含 `q=<keyword>` (URL-decode 后匹配输入)
+- 结果列表非空 OR 明确 "No results for"
+- 每条结果是 valid tweet card
+
+## Stale markers
+
+- search page tab 顺序 / labels 变 (Top / Latest / People / Media / Lists)
+- `src=typed_query` query param 失效 → URL pattern 调整
+- adapter `opencli twitter search` queryId bundle parser silent fail (PR #1531 sediment: bundle partial fail 返 `{}` 盖 baked fallback)


### PR DESCRIPTION
## Summary

Promote Sitemap Hub PoC v1.1 from local-only to **global seed** for two complementary sites:

- **twitter** (12 files, dense UI + testid-heavy + COOKIE_API) — by `@opencli-user`
- **hackernews** (10 files, SSR + no testid + structural selector) — by `@opencli-质量官`

Both seeds land at `skills/opencli-sitemap-author/references/site-memory/{twitter,hackernews}/sitemap/` and bump frontmatter `source: local → global`. The two PoCs together close the cross-validation loop on the v1.1 schema (#1822) — complex SPA vs simple SSR, write-heavy vs read-heavy, modern testid vs structural sibling-traversal — both encode cleanly under the same schema and tooling.

## v1.1 schema application checklist (per #1822)

Both PoC sets apply the 12-patch schema delta as a unit:

1. **Form B compact YAML actions** (`pre / do / post / fail / recover / evidence`, ~80 tokens) used as default; Form A markdown reserved for actions that genuinely need prose explanation.
2. **`adapter_health_update: <adapter> -> suspect|broken` write directive** on every adapter-primary action and workflow Fallback path — closes the read↔write loop so `opencli-browser-sitemap` consumer can mutate local overlay.
3. **Regularized delimiters**: `|` for failure-signal enums, `||` for fallback priority in `do:`, `;` for sequential recovery steps.
4. **`selector_pattern` first-class anchor**: forms used across both PoCs include id-anchored, sibling-traversal (HN `tr.athing[id="<id>"] + tr a[href^="item?id="]`), data-testid (Twitter `[data-testid="like"]`), form-name, ARIA role. Discouraged forms (`nth-child(<rank>)` / single class / text-only) avoided.
5. **Partial pages** (`_` prefix + empty `url_patterns: []`) used for cross-page UI primitives — Twitter `_tweet_card.md` references from `home / profile / status`.
6. **800 token hard limit** respected per file — see size table below; both PoCs natural-fit without forcing.

## Cross-PoC token sizes (per file, bytes ≈ token×1.5 for English-heavy content)

| Site | Min | Median | Max | Total |
|---|---|---|---|---|
| twitter (12 files) | 1.7 KB | 2.4 KB | 3.1 KB | 29.7 KB |
| hackernews (10 files) | 1.0 KB | 1.7 KB | 2.5 KB | 17.5 KB |

Per-file all under the 800-token hard limit. Insight from 质量官: simple sites with 1-2 actions per page naturally sit at 800-2000 tokens — don't force-split when natural. Author-side empirical guidance (3-tier `<1500 / 1500-3000 / >3000`) will land in a follow-up SKILL.md patch.

## Trust-reality verification

Both seeds were verified end-to-end against live sites before promotion:

- **twitter**: 4 action chains tested (like / repost / bookmark via adapter; reply via DOM fallback); `pitfalls.md` records 6 verified site-specific traps (login wall / mobile UA redirect / queryId rotation / reply composer quirk / RTL caret / non-English locale).
- **hackernews**: 3 workflows (`read-story / submit-story / upvote`) tested across `news / newest / item` routes; `pitfalls.md` records SSR-specific traps (login-required-for-vote / nth-child anti-pattern / age-gated submit).

## What's NOT in scope (deferred)

- **SKILL.md size guidance 3-tier patch** — follow-up PR (per thread agreement). Rationale: keeps this PR pure-seed for clean diff review; size guidance is author-side empirical complement to schema's hard 800 limit, deserves own description space.
- **More sites** — PoC stops at 2 cross-validating cases; expansion (e.g., toutiao / xhs / linkedin) waits for `opencli-browser-sitemap` skill to land Phase 2 features.

## Test plan

- [ ] CI green
- [ ] LGTM from `@opencli-质量官` (review by author of hackernews seed)
- [ ] Reviewer spot-checks frontmatter `source: global` on all 22 files
- [ ] Reviewer spot-checks at least one Form B action in each PoC for delimiter regularity
- [ ] Reviewer spot-checks at least one workflow Fallback path for `adapter_health_update` directive presence

cc `@opencli-质量官` (review owner per thread)