### PR TITLE
docs(sitemap-author): SKILL.md guidelines from PoC

### DIFF
--- a/skills/opencli-sitemap-author/SKILL.md
+++ b/skills/opencli-sitemap-author/SKILL.md
@@ -36,6 +36,8 @@ sitemap/
 
 `references/sitemap-schema.md` §1.1 spec 硬 800 token，但 PoC 实测简单站单 page 1-2 action 自然落到 800-2000 token。强拆反碎，author 用下表决策：
 
+> spec 800 是 lazy-load 优化目标 + Phase 2 audit 阈值；下表是 author 实战决策辅助，**不替代 spec hard 限制**。超 800 的文件 audit 会 flag，author 解释（"5 个 cohesive UI primitive 一起放"）或拆。
+
 | 文件 token | 决策 |
 |---|---|
 | < 1500 | 自然 size，不动 |

--- a/skills/opencli-sitemap-author/SKILL.md
+++ b/skills/opencli-sitemap-author/SKILL.md
@@ -27,11 +27,22 @@ Recommended layout:
 sitemap/
   SITE.md                 # site purpose, auth assumptions, stable page ids
   pages/<page-id>.md      # page state signatures, actions, linked APIs
+  pages/_<partial>.md     # cross-page UI partial (e.g. _tweet_card.md)
   workflows/<task-id>.md  # best path, fallback path, avoid list
   pitfalls.md             # durable failure modes and stale areas
 ```
 
-Keep individual files under roughly 800 tokens. Split pages/workflows instead of making one giant document.
+### Size guidance（实测启发式）
+
+`references/sitemap-schema.md` §1.1 spec 硬 800 token，但 PoC 实测简单站单 page 1-2 action 自然落到 800-2000 token。强拆反碎，author 用下表决策：
+
+| 文件 token | 决策 |
+|---|---|
+| < 1500 | 自然 size，不动 |
+| 1500-3000 | 看 cohesion — 5 个 cohesive UI primitive 一起放 OK；mixed 内容拆 |
+| > 3000 | **必拆** sub-file 或 partial（agent lazy load budget 真有限制） |
+
+Phase 2 cron audit 按 token count 不按 byte count（CJK 中文 token-per-char 比 English 高 30-50%）。
 
 ---
 
@@ -64,6 +75,27 @@ Use this compact form by default. Use the longer Markdown form from `references/
 
 Do not promote an action without evidence. If a recovery path marks `adapter_health_update`, the browser-sitemap consumer must write that health update to the local overlay so the next agent does not retry a known-suspect adapter.
 
+### Partial pages（跨页通用 UI）
+
+partial 文件 (`_<name>.md`，`url_patterns: []`) 装跨页 UI 原语（如 `_tweet_card.md` 的 like/reply/repost/bookmark）。被多 page 通过 `action:<id> in pages/_<name>.md` 引用。
+
+**Partial scope rule**：partial 内所有 selector（testid / a11y / structural）**必须 scoped 到 partial root**，不能是 page-level first match。例如 `_tweet_card.md`:
+
+```yaml
+# ❌ 错：page-level first match，会点到 timeline 首条非 target card
+do: click [data-testid="like"]
+
+# ✅ 对：scoped 到 article root
+do: click [data-testid="like"] in article[role="article"] (card scope)
+```
+
+partial 文件顶部写明 scope root 一行：
+
+```md
+## Card scope rule
+所有 testid selector 必须 scoped 到 `article[role="article"]`，不能用 page-level first match。
+```
+
 ---
 
 ## Workflow Fields
@@ -78,6 +110,36 @@ Each workflow should answer:
 - **Stale markers**: last verified date and known layout/API drift signals.
 
 Endpoint/API knowledge should reference ids from `endpoints.json` when available. Do not duplicate full endpoint schemas inside sitemap files.
+
+### Fallback `on_adapter_fail:` convention（推荐）
+
+Fallback path 第一行声明触发条件 + adapter_health_update directive，把"为什么走 fallback"和"标 adapter suspect"放一起：
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli twitter post -> suspect
+  - opencli browser state (verify current page)
+  - if not on /home: goto /home
+  - action:open_compose in pages/home.md
+  - ...
+```
+
+比纯 step list 清晰：consumption skill 看到 `on_adapter_fail:` key 知道这是 adapter-trigger 而非 entry-point fallback，directive 先执行后续才走 steps。schema v1.2 candidate，目前作为 SKILL guideline 推荐。
+
+## SITE.md `Top-level routes` — 标 uncovered routes
+
+`SITE.md` 的 `Top-level routes` 不仅列已覆盖的 page，也应**显式标存在但 sitemap 不导航**的 route，避免 agent 默认"sitemap 没列 → 不存在"：
+
+```md
+## Top-level routes
+
+- /home → pages/home.md
+- /search → pages/search.md
+- /messages → pages/messages.md（DM，本 PoC v1 不覆盖）   # ← 显式 uncovered marker
+- /settings → 不在 sitemap scope，agent 自探         # ← 同上
+```
+
+不写 = agent 不知该 route 存在；写 + 标 uncovered = agent 知道存在但 sitemap 帮不上忙，自己探。
 
 ---
 


### PR DESCRIPTION
## Summary

4 author-facing SKILL.md guidelines distilled from the twitter + hackernews PoCs (#1823). No schema field changes — these are conventions on top of the v1.1 schema (#1822).

### Items

1. **Size guidance 3-tier** (< 1500 / 1500-3000 / > 3000 token) — supplements schema §1.1 hard 800 with realistic split-vs-keep heuristic. Simple sites' 1-2 action pages naturally fall in 800-2000 token; strict 800 would force unnecessary splits.

2. **Partial layout entry + scope rule** — partial files (`_<name>.md`, `url_patterns: []`) must scope all selectors to the partial root, not page-level first match. Otherwise `click [data-testid="like"]` consumed from `/home` flips the wrong card. Adopted from @opencli-user's twitter `_tweet_card.md` Card scope rule.

3. **Workflow Fallback `on_adapter_fail:` YAML sub-key convention** — wraps adapter-trigger + `adapter_health_update` directive + step list into one block. Consumption skills can distinguish adapter-triggered fallback from entry-point fallback. Schema v1.2 candidate; SKILL guideline for now. Adopted from @opencli-user's twitter `workflows/post.md`.

4. **SITE.md `Top-level routes` uncovered-route marker** — list routes that exist but the sitemap intentionally doesn't navigate (e.g. `/messages → pages/messages.md（DM，本 PoC v1 不覆盖）`). Without this, agents assume "not listed = doesn't exist"; with it, they know to probe themselves. Adopted from @opencli-user's twitter `SITE.md`.

## Reviewer

@opencli-user (since 3 of 4 conventions come from their twitter PoC content).

## Test plan

- [x] `npm run docs:build` clean
- [ ] CI green