### PR TITLE
fix(browser): prevent const redeclaration in evaluateWithArgs

### DIFF
--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -875,7 +875,7 @@ describe('BasePage native input routing', () => {
   });
 });
 
-describe('BasePage.evaluateWithArgs — IIFE scoping', () => {
+describe('BasePage.evaluateWithArgs scoping', () => {
   class EvalCapturePage extends BasePage {
     scripts: string[] = [];
     async goto(): Promise<void> {}
@@ -884,7 +884,8 @@ describe('BasePage.evaluateWithArgs — IIFE scoping', () => {
     async evaluate(input: string | BrowserEvaluateFunction<unknown[], unknown>): Promise<unknown> {
       const code = typeof input === 'string' ? input : input.toString();
       this.scripts.push(code);
-      return null;
+      if (typeof input !== 'string') return null;
+      return globalThis.eval(input);
     }
     async getCookies(): Promise<[]> { return []; }
     async screenshot(): Promise<string> { return ''; }
@@ -892,29 +893,37 @@ describe('BasePage.evaluateWithArgs — IIFE scoping', () => {
     async selectTab(): Promise<void> {}
   }
 
-  it('wraps declarations in an IIFE to avoid global const redeclaration', async () => {
+  it('wraps declarations in a lexical block to avoid global const redeclaration', async () => {
     const page = new EvalCapturePage();
-    await page.evaluateWithArgs('(() => markerAttr)()', { markerAttr: 'test-value' });
+    const result = await page.evaluateWithArgs('(() => markerAttr)()', { markerAttr: 'test-value' });
 
+    expect(result).toBe('test-value');
     expect(page.scripts).toHaveLength(1);
     const code = page.scripts[0];
-    // Must be wrapped in IIFE — not bare top-level const
-    expect(code).toMatch(/^\(\(\) => \{/);
+    // Must be wrapped in a lexical block, not bare top-level const.
+    expect(code).toMatch(/^\{\n/);
     expect(code).toContain('const markerAttr = "test-value"');
-    expect(code).toMatch(/return \(/);
   });
 
   it('allows same arg name across multiple calls without conflict', async () => {
     const page = new EvalCapturePage();
-    await page.evaluateWithArgs('(() => x)()', { x: 'first' });
-    await page.evaluateWithArgs('(() => x)()', { x: 'second' });
+    await expect(page.evaluateWithArgs('(() => x)()', { x: 'first' })).resolves.toBe('first');
+    await expect(page.evaluateWithArgs('(() => x)()', { x: 'second' })).resolves.toBe('second');
 
     expect(page.scripts).toHaveLength(2);
-    // Both should be self-contained IIFEs, not polluting global scope
+    // Both should be self-contained blocks, not polluting global scope.
     expect(page.scripts[0]).toContain('const x = "first"');
     expect(page.scripts[1]).toContain('const x = "second"');
-    // Both wrapped
-    expect(page.scripts[0]).toMatch(/^\(\(\) => \{/);
-    expect(page.scripts[1]).toMatch(/^\(\(\) => \{/);
+    expect(page.scripts[0]).toMatch(/^\{\n/);
+    expect(page.scripts[1]).toMatch(/^\{\n/);
+  });
+
+  it('preserves completion value semantics for statement snippets', async () => {
+    const page = new EvalCapturePage();
+
+    await expect(page.evaluateWithArgs(`
+      const local = value + 1;
+      local * 2
+    `, { value: 20 })).resolves.toBe(42);
   });
 });

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -874,3 +874,47 @@ describe('BasePage native input routing', () => {
     expect(page.scripts[0]).toContain('metaKey: true');
   });
 });
+
+describe('BasePage.evaluateWithArgs — IIFE scoping', () => {
+  class EvalCapturePage extends BasePage {
+    scripts: string[] = [];
+    async goto(): Promise<void> {}
+    async evaluate<T = unknown>(js: string): Promise<T>;
+    async evaluate<Args extends unknown[], T>(fn: BrowserEvaluateFunction<Args, T>, ...args: Args): Promise<Awaited<T>>;
+    async evaluate(input: string | BrowserEvaluateFunction<unknown[], unknown>): Promise<unknown> {
+      const code = typeof input === 'string' ? input : input.toString();
+      this.scripts.push(code);
+      return null;
+    }
+    async getCookies(): Promise<[]> { return []; }
+    async screenshot(): Promise<string> { return ''; }
+    async tabs(): Promise<unknown[]> { return []; }
+    async selectTab(): Promise<void> {}
+  }
+
+  it('wraps declarations in an IIFE to avoid global const redeclaration', async () => {
+    const page = new EvalCapturePage();
+    await page.evaluateWithArgs('(() => markerAttr)()', { markerAttr: 'test-value' });
+
+    expect(page.scripts).toHaveLength(1);
+    const code = page.scripts[0];
+    // Must be wrapped in IIFE — not bare top-level const
+    expect(code).toMatch(/^\(\(\) => \{/);
+    expect(code).toContain('const markerAttr = "test-value"');
+    expect(code).toMatch(/return \(/);
+  });
+
+  it('allows same arg name across multiple calls without conflict', async () => {
+    const page = new EvalCapturePage();
+    await page.evaluateWithArgs('(() => x)()', { x: 'first' });
+    await page.evaluateWithArgs('(() => x)()', { x: 'second' });
+
+    expect(page.scripts).toHaveLength(2);
+    // Both should be self-contained IIFEs, not polluting global scope
+    expect(page.scripts[0]).toContain('const x = "first"');
+    expect(page.scripts[1]).toContain('const x = "second"');
+    // Both wrapped
+    expect(page.scripts[0]).toMatch(/^\(\(\) => \{/);
+    expect(page.scripts[1]).toMatch(/^\(\(\) => \{/);
+  });
+});

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -152,12 +152,13 @@ export abstract class BasePage implements IPage {
   /**
    * Safely evaluate JS with pre-serialized arguments.
    * Each key in `args` becomes a `const` declaration with JSON-serialized value,
-   * wrapped in an IIFE to avoid polluting the global execution context.
+   * wrapped in a lexical block to avoid polluting the global execution context.
    *
-   * Why IIFE: Chrome's Runtime.evaluate shares a single global context per page.
+   * Why a block: Chrome's Runtime.evaluate shares a single global context per page.
    * Top-level `const` declarations persist across calls, so re-declaring the same
    * variable name (e.g. `markerAttr` in both click resolution and file upload)
-   * throws "SyntaxError: Identifier has already been declared".
+   * throws "SyntaxError: Identifier has already been declared". A block keeps
+   * the args scoped without forcing callers to pass expression-only code.
    *
    * Usage:
    *   page.evaluateWithArgs(`(async () => { return sym; })()`, { sym: userInput })
@@ -171,7 +172,7 @@ export abstract class BasePage implements IPage {
         return `const ${key} = ${JSON.stringify(value)};`;
       })
       .join('\n');
-    return this.evaluate(`(() => { ${declarations}\nreturn (${js}); })()`);
+    return this.evaluate(`{\n${declarations}\n${js}\n}`);
   }
 
   async fetchJson(url: string, opts: FetchJsonOptions = {}): Promise<unknown> {

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -152,7 +152,12 @@ export abstract class BasePage implements IPage {
   /**
    * Safely evaluate JS with pre-serialized arguments.
    * Each key in `args` becomes a `const` declaration with JSON-serialized value,
-   * prepended to the JS code. Prevents injection by design.
+   * wrapped in an IIFE to avoid polluting the global execution context.
+   *
+   * Why IIFE: Chrome's Runtime.evaluate shares a single global context per page.
+   * Top-level `const` declarations persist across calls, so re-declaring the same
+   * variable name (e.g. `markerAttr` in both click resolution and file upload)
+   * throws "SyntaxError: Identifier has already been declared".
    *
    * Usage:
    *   page.evaluateWithArgs(`(async () => { return sym; })()`, { sym: userInput })
@@ -166,7 +171,7 @@ export abstract class BasePage implements IPage {
         return `const ${key} = ${JSON.stringify(value)};`;
       })
       .join('\n');
-    return this.evaluate(`${declarations}\n${js}`);
+    return this.evaluate(`(() => { ${declarations}\nreturn (${js}); })()`);
   }
 
   async fetchJson(url: string, opts: FetchJsonOptions = {}): Promise<unknown> {


### PR DESCRIPTION
## Summary

- `evaluateWithArgs` now wraps its generated `const` declarations in an IIFE instead of emitting them as bare top-level statements
- Fixes `SyntaxError: Identifier 'markerAttr' has already been declared` when multiple browser commands run in sequence on the same page

## Problem

Chrome's `Runtime.evaluate` shares a single global execution context per page. Top-level `const` declarations persist across calls. When two methods both inject the same variable name via `evaluateWithArgs` (e.g. `markerAttr` in `tryCdpOnResolvedElement` and `uploadFile`), the second call fails:

```
SyntaxError: Identifier 'markerAttr' has already been declared
```

**Reproducer**: any `opencli browser <session> upload <ref> file.png` command — it calls click resolution (which injects `markerAttr`) then upload (which also injects `markerAttr`).

## Fix

Wrap the generated code in an IIFE so `const` declarations are function-scoped:

```typescript
// Before (leaks into global context)
return this.evaluate(`${declarations}\n${js}`);

// After (scoped to IIFE)
return this.evaluate(`(() => { ${declarations}\nreturn (${js}); })()`);
```

## Test plan

- [x] Added 2 unit tests verifying IIFE wrapping and safe repeated-name usage
- [x] All 41 existing tests pass (`vitest run --project unit src/browser/base-page.test.ts`)
- [x] Manually verified: `opencli browser <s> upload` now works on xiaohongshu creator center (was 100% repro before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)