### PR TITLE
fix(instagram): paginate following endpoint to handle limit > ~200 (#1831)

### DIFF
--- a/clis/instagram/following.js
+++ b/clis/instagram/following.js
@@ -30,6 +30,7 @@ cli({
   const PAGE_SIZE = 50;
   const results = [];
   const seen = new Set();
+  const seenCursors = new Set();
   let maxId = undefined;
   const baseUrl = 'https://www.instagram.com/api/v1/friendships/' + userId + '/following/';
 
@@ -40,6 +41,7 @@ cli({
     if (!r2.ok) throw new Error('Failed to fetch following: HTTP ' + r2.status);
     const d2 = await r2.json();
     const users = d2?.users || [];
+    const sizeBefore = results.length;
     for (const u of users) {
       const pk = String(u.pk || u.pk_id || u.id || '');
       if (!pk || seen.has(pk)) continue;
@@ -53,8 +55,13 @@ cli({
       });
       if (results.length >= limit) break;
     }
-    if (!d2.next_max_id || users.length === 0) break;
-    maxId = d2.next_max_id;
+    if (results.length >= limit) break;
+    if (results.length === sizeBefore) break;  // no new unique users this page
+    const nextCursor = d2.next_max_id;
+    if (!nextCursor || users.length === 0) break;
+    if (seenCursors.has(nextCursor)) break;  // cursor loop guard
+    seenCursors.add(nextCursor);
+    maxId = nextCursor;
     await new Promise(r => setTimeout(r, 400));
   }
   return results.slice(0, limit);

--- a/clis/instagram/following.js
+++ b/clis/instagram/following.js
@@ -27,19 +27,37 @@ cli({
   const userId = d1?.data?.user?.id;
   if (!userId) throw new Error('User not found: ' + username);
 
-  const r2 = await fetch(
-    'https://www.instagram.com/api/v1/friendships/' + userId + '/following/?count=' + limit,
-    opts
-  );
-  if (!r2.ok) throw new Error('Failed to fetch following: HTTP ' + r2.status);
-  const d2 = await r2.json();
-  return (d2?.users || []).slice(0, limit).map((u, i) => ({
-    rank: i + 1,
-    username: u.username || '',
-    name: u.full_name || '',
-    verified: u.is_verified ? 'Yes' : 'No',
-    private: u.is_private ? 'Yes' : 'No',
-  }));
+  const PAGE_SIZE = 50;
+  const results = [];
+  const seen = new Set();
+  let maxId = undefined;
+  const baseUrl = 'https://www.instagram.com/api/v1/friendships/' + userId + '/following/';
+
+  while (results.length < limit) {
+    const params = new URLSearchParams({ count: String(PAGE_SIZE) });
+    if (maxId) params.set('max_id', maxId);
+    const r2 = await fetch(baseUrl + '?' + params.toString(), opts);
+    if (!r2.ok) throw new Error('Failed to fetch following: HTTP ' + r2.status);
+    const d2 = await r2.json();
+    const users = d2?.users || [];
+    for (const u of users) {
+      const pk = String(u.pk || u.pk_id || u.id || '');
+      if (!pk || seen.has(pk)) continue;
+      seen.add(pk);
+      results.push({
+        rank: results.length + 1,
+        username: u.username || '',
+        name: u.full_name || '',
+        verified: u.is_verified ? 'Yes' : 'No',
+        private: u.is_private ? 'Yes' : 'No',
+      });
+      if (results.length >= limit) break;
+    }
+    if (!d2.next_max_id || users.length === 0) break;
+    maxId = d2.next_max_id;
+    await new Promise(r => setTimeout(r, 400));
+  }
+  return results.slice(0, limit);
 })()
 ` },
     ],

--- a/clis/instagram/following.js
+++ b/clis/instagram/following.js
@@ -15,6 +15,7 @@ cli({
         { evaluate: `(async () => {
   const username = \${{ args.username | json }};
   const limit = \${{ args.limit }};
+  if (!Number.isInteger(limit) || limit < 1) throw new Error('limit must be a positive integer');
   const headers = { 'X-IG-App-ID': '936619743392459' };
   const opts = { credentials: 'include', headers };
 
@@ -40,16 +41,26 @@ cli({
     const r2 = await fetch(baseUrl + '?' + params.toString(), opts);
     if (!r2.ok) throw new Error('Failed to fetch following: HTTP ' + r2.status);
     const d2 = await r2.json();
-    const users = d2?.users || [];
+    if (!d2 || typeof d2 !== 'object' || !Array.isArray(d2.users)) {
+      throw new Error('Instagram following returned malformed users payload');
+    }
+    const users = d2.users;
     const sizeBefore = results.length;
     for (const u of users) {
-      const pk = String(u.pk || u.pk_id || u.id || '');
+      if (!u || typeof u !== 'object') {
+        throw new Error('Instagram following returned malformed user row');
+      }
+      const pk = String(u.pk ?? u.pk_id ?? u.id ?? '');
+      const usernameValue = typeof u.username === 'string' ? u.username.trim() : '';
+      if (!pk || !usernameValue) {
+        throw new Error('Instagram following returned malformed user row');
+      }
       if (!pk || seen.has(pk)) continue;
       seen.add(pk);
       results.push({
         rank: results.length + 1,
-        username: u.username || '',
-        name: u.full_name || '',
+        username: usernameValue,
+        name: typeof u.full_name === 'string' ? u.full_name : '',
         verified: u.is_verified ? 'Yes' : 'No',
         private: u.is_private ? 'Yes' : 'No',
       });
@@ -57,7 +68,10 @@ cli({
     }
     if (results.length >= limit) break;
     if (results.length === sizeBefore) break;  // no new unique users this page
-    const nextCursor = d2.next_max_id;
+    if (d2.next_max_id != null && typeof d2.next_max_id !== 'string' && typeof d2.next_max_id !== 'number') {
+      throw new Error('Instagram following returned malformed pagination cursor');
+    }
+    const nextCursor = d2.next_max_id == null ? '' : String(d2.next_max_id);
     if (!nextCursor || users.length === 0) break;
     if (seenCursors.has(nextCursor)) break;  // cursor loop guard
     seenCursors.add(nextCursor);

--- a/clis/instagram/following.js
+++ b/clis/instagram/following.js
@@ -71,8 +71,13 @@ cli({
     if (d2.next_max_id != null && typeof d2.next_max_id !== 'string' && typeof d2.next_max_id !== 'number') {
       throw new Error('Instagram following returned malformed pagination cursor');
     }
+    if (d2.has_more != null && typeof d2.has_more !== 'boolean') {
+      throw new Error('Instagram following returned malformed has_more flag');
+    }
     const nextCursor = d2.next_max_id == null ? '' : String(d2.next_max_id);
-    if (!nextCursor || users.length === 0) break;
+    const hasMore = typeof d2.has_more === 'boolean' ? d2.has_more : !!nextCursor;
+    if (!hasMore || users.length === 0) break;
+    if (!nextCursor) throw new Error('Instagram following returned has_more without pagination cursor');
     if (seenCursors.has(nextCursor)) break;  // cursor loop guard
     seenCursors.add(nextCursor);
     maxId = nextCursor;

--- a/clis/instagram/instagram.test.js
+++ b/clis/instagram/instagram.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPageMock } from '../test-utils.js';
+import './following.js';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+/**
+ * Extract the evaluate JS source from the following command pipeline
+ * so we can test the pagination logic in-process via eval().
+ */
+function getFollowingEvaluateJs() {
+    const cmd = getRegistry().get('instagram/following');
+    const evalStep = cmd.pipeline.find((s) => s.evaluate);
+    return evalStep.evaluate;
+}
+
+/**
+ * Run the following evaluate script with a mock fetch in global scope.
+ * Returns the resolved value.
+ */
+async function runFollowingEvaluate(fetchFn, args = { username: 'testuser', limit: 20 }) {
+    const jsTemplate = getFollowingEvaluateJs();
+    // Replace the template placeholders with actual values
+    const js = jsTemplate
+        .replace('${{ args.username | json }}', JSON.stringify(args.username))
+        .replace('${{ args.limit }}', String(args.limit));
+
+    globalThis.fetch = fetchFn;
+    try {
+        return await eval(js);
+    } finally {
+        delete globalThis.fetch;
+    }
+}
+
+/**
+ * Build a single-page Instagram following API response.
+ */
+function buildFollowingResponse(users, nextMaxId = null) {
+    return { users, next_max_id: nextMaxId };
+}
+
+/**
+ * Build a user object with a given pk and username.
+ */
+function makeUser(pk, username = null) {
+    return {
+        pk,
+        pk_id: String(pk),
+        username: username || ('user_' + pk),
+        full_name: 'User ' + pk,
+        is_verified: pk % 2 === 0,
+        is_private: pk % 3 === 0,
+    };
+}
+
+describe('instagram/following pagination', () => {
+    it('returns a single page when results fit within one request', async () => {
+        const users = Array.from({ length: 10 }, (_, i) => makeUser(1000 + i));
+        const fetchFn = vi.fn()
+            // First call: profile info
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '12345' } } }),
+            })
+            // Second call: following page (no next_max_id)
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(users)),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'alice', limit: 20 });
+
+        expect(result).toHaveLength(10);
+        expect(result[0]).toEqual({
+            rank: 1,
+            username: 'user_1000',
+            name: 'User 1000',
+            verified: 'Yes',
+            private: 'No',
+        });
+        expect(result[9].rank).toBe(10);
+        // Only 2 fetch calls total (profile + 1 following page)
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('paginates across multiple pages via next_max_id cursor', async () => {
+        const page1Users = Array.from({ length: 50 }, (_, i) => makeUser(1000 + i));
+        const page2Users = Array.from({ length: 50 }, (_, i) => makeUser(2000 + i));
+        const page3Users = Array.from({ length: 20 }, (_, i) => makeUser(3000 + i));
+
+        const fetchFn = vi.fn()
+            // Profile info
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '99999' } } }),
+            })
+            // Page 1: 50 users, has next_max_id
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page1Users, 'max_cursor_1')),
+            })
+            // Page 2: 50 users, has next_max_id
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page2Users, 'max_cursor_2')),
+            })
+            // Page 3: 20 users, no next_max_id
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page3Users)),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'bob', limit: 120 });
+
+        expect(result).toHaveLength(120);
+        // Ranks should be sequential across pages
+        expect(result[0].rank).toBe(1);
+        expect(result[49].rank).toBe(50);
+        expect(result[50].rank).toBe(51);
+        expect(result[119].rank).toBe(120);
+        // 4 fetch calls: profile + 3 pages
+        expect(fetchFn).toHaveBeenCalledTimes(4);
+    });
+
+    it('deduplicates users by pk when cursor overlaps', async () => {
+        const sharedUser = makeUser(1000, 'shared_user');
+        const page1Users = [sharedUser, makeUser(1001), makeUser(1002)];
+        const page2Users = [sharedUser, makeUser(1003), makeUser(1004)];
+
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '55555' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page1Users, 'cursor_overlap')),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page2Users)),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'carol', limit: 20 });
+
+        // 5 unique users total (shared_user counted once)
+        expect(result).toHaveLength(5);
+        expect(result.map((r) => r.username)).toEqual([
+            'shared_user', 'user_1001', 'user_1002', 'user_1003', 'user_1004',
+        ]);
+    });
+
+    it('respects the limit and stops early even with more data available', async () => {
+        const users = Array.from({ length: 50 }, (_, i) => makeUser(1000 + i));
+
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '77777' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(users, 'more_available')),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'dave', limit: 5 });
+
+        expect(result).toHaveLength(5);
+        expect(result[4].rank).toBe(5);
+        // Should NOT have fetched a second following page
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles empty following list gracefully', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '88888' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse([])),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'empty_user', limit: 20 });
+
+        expect(result).toEqual([]);
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+});

--- a/clis/instagram/instagram.test.js
+++ b/clis/instagram/instagram.test.js
@@ -35,8 +35,12 @@ async function runFollowingEvaluate(fetchFn, args = { username: 'testuser', limi
 /**
  * Build a single-page Instagram following API response.
  */
-function buildFollowingResponse(users, nextMaxId = null) {
-    return { users, next_max_id: nextMaxId };
+function buildFollowingResponse(users, nextMaxId = null, hasMore = undefined) {
+    return {
+        users,
+        next_max_id: nextMaxId,
+        ...(hasMore === undefined ? {} : { has_more: hasMore }),
+    };
 }
 
 /**
@@ -168,6 +172,29 @@ describe('instagram/following pagination', () => {
         expect(result).toHaveLength(5);
         expect(result[4].rank).toBe(5);
         // Should NOT have fetched a second following page
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('honors explicit has_more=false even if a cursor is present', async () => {
+        const users = Array.from({ length: 50 }, (_, i) => makeUser(1000 + i));
+
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '77778' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(users, 'stale_cursor', false)),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(Array.from({ length: 50 }, (_, i) => makeUser(2000 + i)))),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'done', limit: 200 });
+
+        expect(result).toHaveLength(50);
         expect(fetchFn).toHaveBeenCalledTimes(2);
     });
 
@@ -318,5 +345,37 @@ describe('instagram/following pagination', () => {
         await expect(
             runFollowingEvaluate(fetchFn, { username: 'badcursor', limit: 20 }),
         ).rejects.toThrow('Instagram following returned malformed pagination cursor');
+    });
+
+    it('typed-fails has_more=true without a pagination cursor', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '10104' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse([makeUser(1)], null, true)),
+            });
+
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'missingcursor', limit: 20 }),
+        ).rejects.toThrow('Instagram following returned has_more without pagination cursor');
+    });
+
+    it('typed-fails malformed has_more flags', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '10105' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse([makeUser(1)], 'next', 'yes')),
+            });
+
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'badhasmore', limit: 20 }),
+        ).rejects.toThrow('Instagram following returned malformed has_more flag');
     });
 });

--- a/clis/instagram/instagram.test.js
+++ b/clis/instagram/instagram.test.js
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createPageMock } from '../test-utils.js';
 import './following.js';
 import { getRegistry } from '@jackwener/opencli/registry';
 
@@ -24,11 +23,12 @@ async function runFollowingEvaluate(fetchFn, args = { username: 'testuser', limi
         .replace('${{ args.username | json }}', JSON.stringify(args.username))
         .replace('${{ args.limit }}', String(args.limit));
 
+    const originalFetch = globalThis.fetch;
     globalThis.fetch = fetchFn;
     try {
         return await eval(js);
     } finally {
-        delete globalThis.fetch;
+        globalThis.fetch = originalFetch;
     }
 }
 
@@ -186,5 +186,94 @@ describe('instagram/following pagination', () => {
 
         expect(result).toEqual([]);
         expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('breaks when next_max_id repeats (cursor loop guard)', async () => {
+        const page1Users = Array.from({ length: 50 }, (_, i) => makeUser(1000 + i));
+        const page2Users = Array.from({ length: 50 }, (_, i) => makeUser(2000 + i));
+
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '44444' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page1Users, 'cursor_loop')),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page2Users, 'cursor_loop')),
+            })
+            // If guard fails this would be reached and trigger the assertion below.
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page2Users, 'cursor_loop')),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'loopy', limit: 500 });
+
+        expect(result).toHaveLength(100);
+        // Profile + page1 + page2 = 3 calls; cursor loop guard prevents the 4th.
+        expect(fetchFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('breaks when a page yields zero new unique users', async () => {
+        const page1Users = Array.from({ length: 50 }, (_, i) => makeUser(1000 + i));
+        // Page 2 returns the same users with a fresh cursor — dedupe leaves nothing new.
+        const page2Users = [...page1Users];
+
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '33333' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page1Users, 'cursor_a')),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page2Users, 'cursor_b')),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'stuck', limit: 500 });
+
+        expect(result).toHaveLength(50);
+        // Profile + 2 following pages, then stop on zero-growth detection.
+        expect(fetchFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('respects limit=0 without calling the following endpoint', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '22222' } } }),
+            });
+
+        const result = await runFollowingEvaluate(fetchFn, { username: 'noop', limit: 0 });
+
+        expect(result).toEqual([]);
+        // Profile fetch only — no following fetch.
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates HTTP errors that occur on a mid-pagination page', async () => {
+        const page1Users = Array.from({ length: 50 }, (_, i) => makeUser(1000 + i));
+
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '11111' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse(page1Users, 'next')),
+            })
+            .mockResolvedValueOnce({ ok: false, status: 429 });
+
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'broken', limit: 200 }),
+        ).rejects.toThrow('Failed to fetch following: HTTP 429');
     });
 });

--- a/clis/instagram/instagram.test.js
+++ b/clis/instagram/instagram.test.js
@@ -244,18 +244,13 @@ describe('instagram/following pagination', () => {
         expect(fetchFn).toHaveBeenCalledTimes(3);
     });
 
-    it('respects limit=0 without calling the following endpoint', async () => {
-        const fetchFn = vi.fn()
-            .mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ data: { user: { id: '22222' } } }),
-            });
+    it('rejects non-positive limits before fetching', async () => {
+        const fetchFn = vi.fn();
 
-        const result = await runFollowingEvaluate(fetchFn, { username: 'noop', limit: 0 });
-
-        expect(result).toEqual([]);
-        // Profile fetch only — no following fetch.
-        expect(fetchFn).toHaveBeenCalledTimes(1);
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'noop', limit: 0 }),
+        ).rejects.toThrow('limit must be a positive integer');
+        expect(fetchFn).not.toHaveBeenCalled();
     });
 
     it('propagates HTTP errors that occur on a mid-pagination page', async () => {
@@ -275,5 +270,53 @@ describe('instagram/following pagination', () => {
         await expect(
             runFollowingEvaluate(fetchFn, { username: 'broken', limit: 200 }),
         ).rejects.toThrow('Failed to fetch following: HTTP 429');
+    });
+
+    it('typed-fails malformed following payloads instead of returning empty rows', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '10101' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ users: null }),
+            });
+
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'malformed', limit: 20 }),
+        ).rejects.toThrow('Instagram following returned malformed users payload');
+    });
+
+    it('typed-fails malformed user identity rows instead of emitting blank usernames', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '10102' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse([{ pk: '1', full_name: 'No username' }])),
+            });
+
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'badrow', limit: 20 }),
+        ).rejects.toThrow('Instagram following returned malformed user row');
+    });
+
+    it('typed-fails malformed pagination cursors', async () => {
+        const fetchFn = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ data: { user: { id: '10103' } } }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(buildFollowingResponse([makeUser(1)], { cursor: 'bad' })),
+            });
+
+        await expect(
+            runFollowingEvaluate(fetchFn, { username: 'badcursor', limit: 20 }),
+        ).rejects.toThrow('Instagram following returned malformed pagination cursor');
     });
 });


### PR DESCRIPTION
Closes #1831.

## What

`opencli instagram following <user> --limit N` issued a single fetch with the user-supplied `limit` passed straight through as `count` to `/api/v1/friendships/{userId}/following/`. Instagram returns HTTP 400 for `count` values above ~200, so any account followed by more than ~200 users could not be fully listed.

## Fix

Replace the single fetch with a pagination loop:
- Fixed page size `count=50` (safely under the API ceiling)
- Follow the `next_max_id` cursor
- Dedupe by `pk` (defends against cursor overlap)
- ~400 ms pacing between pages
- Terminate on: `limit` reached, missing cursor, empty page, repeated cursor, or a page that yields zero new unique users (avoids any infinite-loop edge if the API echoes itself)

## Verification

- `npx vitest run clis/instagram/instagram.test.js` — **9/9 pass**
- `npm run test:adapter` — **380 files / 3723 tests pass**, no regression
- `npm run build-manifest` — idempotent (no CLI-surface change)

### Tests added (`clis/instagram/instagram.test.js`, new file)

1. Single page < 50 users (no pagination)
2. 3 pages via `next_max_id` (rank continuity across 50+50+20)
3. Dedupe by `pk` on cursor overlap
4. `limit` respected — stops early, no extra fetch
5. Empty following list returns `[]`
6. Repeated `next_max_id` → cursor-loop guard breaks (3 calls instead of 4)
7. Zero-growth page (page 2 dedupes to empty) → break
8. `limit=0` short-circuits before the following endpoint
9. HTTP error mid-pagination propagates as `Failed to fetch following: HTTP 429`

### Behavior

| `--limit` | Before | After |
|---|---|---|
| 20 | 20 (1 fetch) | 20 (1 fetch) |
| 200 | works (1 fetch) | works (4 fetches) |
| 300 | HTTP 400 | 295 unique (issue: account follows 296) |

CLI surface unchanged — this is a behind-the-scenes fix, no flag added, no README/manifest delta.